### PR TITLE
fix: compact generated status snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,10 @@ resolving lint or test failures locally before requesting review.
   output rather than raw `gh` payloads.
 - Before finalization, cover format/check, focused tests, changed-file coverage when practical, and a
   clean worktree check (`git status --short`) as part of the readied proof bundle.
+- Before broad status or inventory output, use
+  `uv run python scripts/dev/autopilot_state_snapshot.py --include-worktrees` or another compact
+  helper so generated `.venv`, `.opencode`, `node_modules`, and `output` trees are summarized
+  instead of dumped into agent context.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,
 commenting on, and triaging issues and PRs. Keep the GitHub CLI (`gh`) for scripted batch
 operations, auth debugging, and fallback when MCP coverage is insufficient.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -321,7 +321,9 @@ claim refs, issue queue rows, explicit PR headline state, compact tracked status
 presence, a `controller_checkpoint`, and freshness metadata. Use the checkpoint as the first
 resume artifact after compaction or automatic continuation: it should name the active branch/PR,
 known generated paths, stale claims, check state, and next action without reopening raw logs,
-issue queues, worktree inventories, or skill files. Run fresh focused `gh`/`git` checks before
+issue queues, worktree inventories, or skill files. Compact status omits generated untracked trees
+such as `.venv`, `.opencode`, `node_modules`, and `output`, reporting only the generated
+roots that are present. Run fresh focused `gh`/`git` checks before
 claim, push, PR, label, merge, or publication decisions. Raw logs and broad CLI output are
 appropriate when the snapshot reports `ok: false`, stale claims, missing state, or insufficient
 fields.
@@ -1802,6 +1804,8 @@ follow the higher-precedence source and make the smallest doc update needed to r
   `uv run python scripts/coverage/check_changed_files_coverage.py --base $BASE_REF --include "scripts/dev/*" --include "tests/dev/*"`.
 - Ensure the worktree is clean for final PR-ready evidence:
   `git status --short` should be empty, then rerun final proof with `PR_READY_MODE=final`.
+  Before running a broad `git status --short --untracked-files=normal`, use the compact state
+  snapshot helper to see tracked changes and generated roots without dumping generated trees.
 
 ### Per-Test Performance Budget
 

--- a/scripts/dev/autopilot_state_snapshot.py
+++ b/scripts/dev/autopilot_state_snapshot.py
@@ -25,7 +25,14 @@ FAILURE_CONCLUSIONS = {
     "timed_out",
 }
 PENDING_STATUSES = {"expected", "in_progress", "pending", "queued", "requested", "waiting"}
-GENERATED_STATUS_PATHS = (".venv", ".opencode", "node_modules", "output/coverage")
+GENERATED_STATUS_PATHS = (
+    ".venv",
+    ".opencode",
+    "node_modules",
+    "output",
+    ".pytest_cache",
+    "__pycache__",
+)
 STATUS_LINE_LIMIT = 30
 
 
@@ -141,6 +148,11 @@ def _bounded_lines(text: str, *, limit: int) -> tuple[list[str], bool]:
     return lines[:limit], len(lines) > limit
 
 
+def _generated_paths_present() -> list[str]:
+    """Return known generated roots that exist as files or directories."""
+    return [path for path in GENERATED_STATUS_PATHS if Path(path).exists()]
+
+
 def compact_status_snapshot() -> tuple[dict[str, Any], dict[str, Any], str | None]:
     """Return compact local status that avoids generated untracked trees."""
     result = _run(["git", "status", "--short", "--branch", "--untracked-files=no"])
@@ -160,7 +172,7 @@ def compact_status_snapshot() -> tuple[dict[str, Any], dict[str, Any], str | Non
     status_lines = [line for line in result.stdout.splitlines() if line.strip()]
     tracked_lines = [line for line in status_lines if not line.startswith("##")]
     lines, truncated = _bounded_lines("\n".join(tracked_lines), limit=STATUS_LINE_LIMIT)
-    generated_paths = [path for path in GENERATED_STATUS_PATHS if Path(path).is_file()]
+    generated_paths = _generated_paths_present()
     return (
         {
             "ok": True,

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -47,6 +47,40 @@ worktree_state() {
   fi
 }
 
+print_compact_worktree_status() {
+  local max_lines=30
+  local tracked_status
+  tracked_status=$(git status --short --untracked-files=no)
+  if [[ -n "$tracked_status" ]]; then
+    printf 'Tracked or staged changes:\n' >&2
+    printf '%s\n' "$tracked_status" | head -n "$max_lines" >&2
+    local total_lines
+    total_lines=$(printf '%s\n' "$tracked_status" | wc -l)
+    if (( total_lines > max_lines )); then
+      printf '... truncated (%d more tracked lines)\n' "$((total_lines - max_lines))" >&2
+    fi
+  fi
+  local generated_path
+  local generated_present=()
+  for generated_path in .venv .opencode node_modules output .pytest_cache __pycache__; do
+    if [[ -e "$generated_path" ]]; then
+      generated_present+=("$generated_path")
+    fi
+  done
+  if [[ ${#generated_present[@]} -gt 0 ]]; then
+    printf 'Generated paths present (contents not enumerated):\n' >&2
+    printf '%s\n' "${generated_present[@]}" >&2
+  fi
+  local porcelain_count
+  porcelain_count=$(git status --porcelain --untracked-files=normal | wc -l)
+  if (( porcelain_count > 0 )); then
+    printf 'Full untracked inventory omitted from this message (%d porcelain lines detected).\n' "$porcelain_count" >&2
+    printf 'Run `git status --short --untracked-files=normal` only when a full inventory is needed.\n' >&2
+  elif [[ -z "$tracked_status" && ${#generated_present[@]} -eq 0 ]]; then
+    printf 'No tracked changes or known generated paths detected.\n' >&2
+  fi
+}
+
 pr_ready_mode_lower=$(printf '%s' "$PR_READY_MODE" | tr '[:upper:]' '[:lower:]')
 case "$pr_ready_mode_lower" in
   "")
@@ -71,7 +105,7 @@ esac
 if [[ "$pr_ready_final" == "1" && "$(worktree_state)" != "clean" ]]; then
   printf 'Final PR readiness requires a clean non-ignored worktree before validation.\n' >&2
   printf 'Commit or remove local changes, or run without PR_READY_MODE=final for interim feedback.\n' >&2
-  git status --short --untracked-files=normal >&2
+  print_compact_worktree_status
   exit 2
 fi
 

--- a/tests/dev/test_autopilot_state_snapshot.py
+++ b/tests/dev/test_autopilot_state_snapshot.py
@@ -52,8 +52,9 @@ def test_parse_worktree_porcelain_summarizes_linked_worktrees() -> None:
     ]
 
 
-def test_build_snapshot_includes_queue_claim_pr_and_worktree_state(monkeypatch) -> None:
+def test_build_snapshot_includes_queue_claim_pr_and_worktree_state(monkeypatch, tmp_path) -> None:
     """A normal snapshot should include compact queue, claim, PR, and worktree state."""
+    monkeypatch.chdir(tmp_path)
     origin_main_sha = "6e55ea36affa82ea1b3c870c27f0133464295fd0"
     exact_results = {
         ("git", "branch", "--show-current"): _result(
@@ -174,15 +175,44 @@ def test_build_snapshot_includes_queue_claim_pr_and_worktree_state(monkeypatch) 
 def test_compact_status_omits_untracked_inventory_and_reports_generated_paths(
     monkeypatch, tmp_path
 ) -> None:
-    """Status snapshots should avoid generated untracked tree dumps."""
-    venv_file = tmp_path / ".venv"
-    opencode_file = tmp_path / ".opencode"
+    """Status snapshots should avoid generated untracked tree dumps and report generated roots."""
+    venv_dir = tmp_path / ".venv"
+    opencode_dir = tmp_path / ".opencode"
     node_modules_dir = tmp_path / "node_modules"
     output_coverage_dir = tmp_path / "output" / "coverage"
-    venv_file.touch()
-    opencode_file.touch()
+    pytest_cache_dir = tmp_path / ".pytest_cache"
+    pycache_dir = tmp_path / "__pycache__"
+    venv_dir.mkdir()
+    opencode_dir.mkdir()
     node_modules_dir.mkdir()
     output_coverage_dir.mkdir(parents=True)
+    pytest_cache_dir.mkdir()
+    pycache_dir.mkdir()
+
+    # Populate generated trees with child files so a directory-aware check still reports roots only.
+    (venv_dir / "bin").mkdir()
+    (venv_dir / "bin" / "python").touch()
+    site_packages_dir = venv_dir / "lib" / "python3.11" / "site-packages"
+    site_packages_dir.mkdir(parents=True)
+    (site_packages_dir / "pkg.py").touch()
+    opencode_node_modules = opencode_dir / "node_modules"
+    opencode_node_modules.mkdir()
+    (opencode_node_modules / "package.json").touch()
+    left_pad_dir = opencode_node_modules / "left-pad"
+    left_pad_dir.mkdir()
+    (left_pad_dir / "index.js").touch()
+    lodash_dir = node_modules_dir / "lodash"
+    lodash_dir.mkdir()
+    (lodash_dir / "index.js").touch()
+    vite_bin_dir = node_modules_dir / "vite" / "bin"
+    vite_bin_dir.mkdir(parents=True)
+    (vite_bin_dir / "vite.js").touch()
+    (output_coverage_dir / "coverage.xml").touch()
+    htmlcov_dir = output_coverage_dir / "htmlcov"
+    htmlcov_dir.mkdir()
+    (htmlcov_dir / "index.html").touch()
+    (pytest_cache_dir / "README.md").touch()
+    (pycache_dir / "module.cpython-313.pyc").touch()
 
     def fake_run(command: list[str], *, timeout: int = 30):
         del timeout
@@ -198,9 +228,19 @@ def test_compact_status_omits_untracked_inventory_and_reports_generated_paths(
     assert error is None
     assert source["name"] == "git.status_compact"
     assert status["tracked_or_staged_count"] == 1
-    assert status["generated_paths_present"] == [".venv", ".opencode"]
+    assert sorted(status["generated_paths_present"]) == sorted(
+        [".venv", ".opencode", "node_modules", "output", ".pytest_cache", "__pycache__"]
+    )
     assert status["tracked_or_staged"] == [" M docs/dev_guide.md"]
     assert status["full_untracked_inventory_omitted"] is True
+    # Child files of generated trees must not leak into the compact status payload.
+    payload_text = json.dumps(status)
+    assert "site-packages/pkg.py" not in payload_text
+    assert "left-pad/index.js" not in payload_text
+    assert "lodash/index.js" not in payload_text
+    assert "vite.js" not in payload_text
+    assert "htmlcov/index.html" not in payload_text
+    assert "module.cpython-313.pyc" not in payload_text
 
 
 def test_claim_snapshot_marks_stale_claim_against_origin_main(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Keeps goal-autopilot and PR-readiness status paths compact when generated environment directories exist. The snapshot helper now detects generated roots as directories, and final PR readiness dirty output reports bounded tracked changes plus generated roots instead of dumping full untracked trees.

## Linked Issues
- Closes `#2938`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Broadened `scripts/dev/autopilot_state_snapshot.py` generated-root detection from file-only `output/coverage` to directory-aware roots: `.venv`, `.opencode`, `node_modules`, `output`, `.pytest_cache`, and `__pycache__`.
- Replaced final-readiness dirty status printing in `scripts/dev/pr_ready_check.sh` with a bounded compact report that omits full untracked inventory.
- Expanded `tests/dev/test_autopilot_state_snapshot.py` to build generated trees with child files and assert child paths do not leak into compact status payloads.
- Updated `AGENTS.md` and `docs/dev_guide.md` to point agents to compact status before broad status/worktree inventory output.

## Why It Matters
- Added value: prevents generated dependency trees from flooding agent context during goal/autopilot workflows.
- Expected impact: lower token burn and cleaner workflow review when `.venv`, `.opencode/node_modules`, `node_modules`, `output`, or cache dirs exist.
- Why this is worth merging now: the issue reproduces in current delegated-agent worktrees and directly supports the repo's token-conservation workflow.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: workflow blocker-resolution for compact agent status evidence; no benchmark or research outcome claim.
- Comparator or baseline, if applicable: prior `Path(...).is_file()` missed generated directories and final readiness printed raw `git status --short --untracked-files=normal` on dirty trees.
- Evidence tier: targeted regression/smoke plus final PR readiness.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: compact status output remains bounded and final dirty detection still exits nonzero.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #2938 and docs/dev_guide.md.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - workflow/status helper.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - workflow helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? Yes, local generated `.opencode/node_modules` and `.venv` roots were present during validation; compact dirty output summarized roots without enumerating children.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/dev/test_autopilot_state_snapshot.py -q` -> 7 passed.
  - `uv run ruff check scripts/dev/autopilot_state_snapshot.py tests/dev/test_autopilot_state_snapshot.py` -> passed.
  - `uv run ruff format scripts/dev/autopilot_state_snapshot.py tests/dev/test_autopilot_state_snapshot.py` -> passed.
  - `bash -n scripts/dev/pr_ready_check.sh` -> passed.
  - Dirty final-readiness smoke: `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> exit 2 with compact output showing tracked files, generated roots, and omitted untracked inventory count.
  - `uv run python scripts/validation/check_docs_proof_consistency.py` -> passed for 5 changed files.
  - `git diff --check` -> passed.
  - `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after commit -> 6919 passed, 9 skipped, 9 warnings; clean tree, head `aa6e8608181925ae4d44ec637883e50430f24c96`.
- Evidence that the change works here: regression fixture creates generated dirs with child files and verifies compact payload contains roots only; dirty readiness smoke summarized `.venv`, `.opencode`, `output`, and `.pytest_cache` without child listings.
- Benchmarks or smoke tests, if applicable: NA.

## Risks / Rollout
- Compatibility risks: low; dirty detection still uses `git status --porcelain --untracked-files=normal`, only the printed failure detail is compacted.
- Failure modes: generated-root allowlist may need extension if another tool introduces a noisy top-level directory.
- Rollback or fallback plan: revert this PR to restore prior status printing.

## Docs / Provenance
- Updated docs: `AGENTS.md`, `docs/dev_guide.md`.
- Relevant design or provenance notes: generated outputs remain ignored/disposable; compact status is route evidence, not publication proof.
- Any assumptions that need to be preserved: use full untracked inventory only when explicitly needed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2938.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA - workflow docs updated in place.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: workflow hygiene change, not benchmark evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: `pr_ready_check.sh` still exits before final validation when the tree is dirty; the change only bounds the diagnostic output.
- Any known limitations: generated-root list is intentionally allowlist-based.

## Delegation
- `agy` Gemini Flash scout selected #2938 from the ready queue.
- `command-code` Kimi K2.7 Code diagnosed the right patch but first lacked write permission, then hit turn cap after partial edits; parent repaired and validated.
- `opencode-go/mimo-v2.5-pro` reviewed the diff and found no blockers; one consistency nit was addressed before final validation.
