### PR TITLE
feat: add evidence catalog coverage check

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -363,6 +363,9 @@ checker is intentionally conservative: it only flags high-confidence issues such
 contain absolute local paths, and tracked evidence that links to ignored `output/` artifacts.
 It also validates the curated machine-readable context catalog at `docs/context/catalog.yaml` so
 indexed context entry points keep explicit status and freshness metadata.
+Run `uv run python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog`
+for the explicit full evidence-catalog hygiene pass; it scans tracked
+`docs/context/evidence/` bundles and reports bundles that have no catalog entry.
 When issue or PR text needs to classify proof strength, use the
 [artifact evidence vocabulary](context/artifact_evidence_vocabulary.md) so local `output/` paths are
 not promoted into durable benchmark or paper-facing claims.

--- a/scripts/validation/check_docs_proof_consistency.py
+++ b/scripts/validation/check_docs_proof_consistency.py
@@ -4,6 +4,24 @@
 This helper is intentionally conservative. It only reports high-confidence
 mechanical problems in changed files relative to a base ref (default:
 ``origin/main``).
+
+Modes
+-----
+Default (no flags):
+  Checks files in the branch diff / worktree edits against ``origin/main``.
+
+``--path <repo-rel-path>``:
+  Checks only the explicitly named file(s).
+
+``--check-evidence-catalog``:
+  Full evidence/catalog check — scans every tracked file under
+  ``docs/context/evidence/`` and reports evidence bundles (immediate
+  subdirectories) or standalone files that have no entry in
+  ``docs/context/catalog.yaml``.  This mode does *not* use the git diff;
+  it is safe to run independently as a standalone hygiene pass.
+  Run with::
+
+      uv run python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog
 """
 
 from __future__ import annotations
@@ -510,6 +528,100 @@ def _context_catalog_diagnostics(catalog_path: Path, *, repo_root: Path) -> list
     return diagnostics
 
 
+def _tracked_evidence_files(repo_root: Path) -> list[Path]:
+    """Return repository-relative paths for all Git-tracked files under docs/context/evidence/."""
+    proc = subprocess.run(
+        ["git", "ls-files", "--", _EVIDENCE_DIR.as_posix()],
+        cwd=str(repo_root),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if proc.returncode != 0:
+        return []
+    return [Path(line.strip()) for line in proc.stdout.splitlines() if line.strip()]
+
+
+def _catalog_paths_from_payload(payload: object) -> set[Path]:
+    """Return the set of valid path values declared in a catalog YAML payload."""
+    catalog_paths: set[Path] = set()
+    if not isinstance(payload, dict):
+        return catalog_paths
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        return catalog_paths
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        p = _catalog_path(entry.get("path"))
+        if p is not None:
+            catalog_paths.add(p)
+    return catalog_paths
+
+
+def _evidence_bundle_key(tracked_path: Path) -> Path:
+    """Return the evidence-bundle group key for a tracked evidence file.
+
+    For files directly inside ``docs/context/evidence/``, the key is the file
+    itself (standalone file).  For files nested inside a subdirectory, the key
+    is the immediate child directory of ``docs/context/evidence/``.
+    """
+    parts = tracked_path.relative_to(_EVIDENCE_DIR).parts
+    return _EVIDENCE_DIR / parts[0] if parts else tracked_path
+
+
+def _evidence_catalog_coverage_diagnostics(
+    *,
+    repo_root: Path,
+    catalog_path: Path = _CONTEXT_CATALOG,
+) -> list[Diagnostic]:
+    """Report evidence bundles or files with no catalog entry in docs/context/catalog.yaml.
+
+    Each immediate subdirectory under ``docs/context/evidence/`` is treated as
+    an *evidence bundle*.  A bundle is considered *covered* when the catalog
+    contains at least one entry whose path is at or below the bundle root.
+    Loose files directly under ``docs/context/evidence/`` are checked
+    individually.  Directories with no tracked files are ignored.
+
+    This function is designed for explicit ``--check-evidence-catalog`` runs
+    and does not modify or interact with the diff-scoped default checks.
+    """
+    full_catalog_path = repo_root / catalog_path
+    catalog_paths: set[Path] = set()
+    if full_catalog_path.exists():
+        try:
+            payload = _load_yaml(full_catalog_path)
+        except yaml.YAMLError:
+            payload = None
+        catalog_paths = _catalog_paths_from_payload(payload)
+
+    tracked = _tracked_evidence_files(repo_root)
+    if not tracked:
+        return []
+
+    # Group tracked files by their evidence bundle key.
+    bundle_keys: set[Path] = set()
+    for tracked_path in tracked:
+        if _is_within_dir(tracked_path, _EVIDENCE_DIR):
+            bundle_keys.add(_evidence_bundle_key(tracked_path))
+
+    diagnostics: list[Diagnostic] = []
+    for bundle_key in sorted(bundle_keys):
+        covered = any(_is_within_dir(p, bundle_key) for p in catalog_paths)
+        if not covered:
+            diagnostics.append(
+                Diagnostic(
+                    path=catalog_path,
+                    message=(
+                        f"tracked evidence has no catalog entry: {bundle_key.as_posix()}"
+                        " — add at least one entry under this path in"
+                        f" {catalog_path.as_posix()}"
+                    ),
+                )
+            )
+    return diagnostics
+
+
 def _validation_phrase_diagnostics(path: Path, text: str) -> list[Diagnostic]:
     """Flag notes that claim no validation ran while also listing executed commands."""
     if not _is_within_dir(path, _TOP_LEVEL_CONTEXT_DIR):
@@ -636,6 +748,16 @@ def _parse_args() -> argparse.Namespace:
         action="store_true",
         help="Emit diagnostics as JSON instead of human-readable text.",
     )
+    parser.add_argument(
+        "--check-evidence-catalog",
+        action="store_true",
+        dest="check_evidence_catalog",
+        help=(
+            "Run a full evidence/catalog coverage check: scan all tracked files under"
+            f" {_EVIDENCE_DIR.as_posix()} and report evidence bundles with no entry in"
+            f" {_CONTEXT_CATALOG.as_posix()}. Does not use the git diff."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -655,6 +777,25 @@ def main() -> int:
     """Run the docs/proof consistency checker."""
     args = _parse_args()
     repo_root = _repo_root()
+
+    if args.check_evidence_catalog:
+        diagnostics = _evidence_catalog_coverage_diagnostics(repo_root=repo_root)
+        if args.json:
+            payload = [
+                {"path": diagnostic.path.as_posix(), "message": diagnostic.message}
+                for diagnostic in diagnostics
+            ]
+            print(json.dumps(payload, indent=2))
+        elif diagnostics:
+            for diagnostic in diagnostics:
+                print(f"ERROR {diagnostic.path.as_posix()}: {diagnostic.message}")
+        else:
+            print(
+                "OK evidence/catalog coverage check passed:"
+                f" all tracked {_EVIDENCE_DIR.as_posix()} bundles have catalog entries."
+            )
+        return 1 if diagnostics else 0
+
     try:
         changed_files = _selected_files(args, repo_root)
     except ValueError as exc:

--- a/tests/validation/test_check_docs_proof_consistency.py
+++ b/tests/validation/test_check_docs_proof_consistency.py
@@ -14,6 +14,7 @@ from scripts.validation.check_docs_proof_consistency import (
     _context_catalog_diagnostics,
     _context_index_link_diagnostics,
     _context_readme_link_diagnostics,
+    _evidence_catalog_coverage_diagnostics,
     _parse_name_status,
     _selected_files,
 )
@@ -590,3 +591,168 @@ def test_context_catalog_reports_malformed_yaml(tmp_path: Path) -> None:
 
     assert len(diagnostics) == 1
     assert "context catalog is not a valid YAML file" in diagnostics[0].message
+
+
+# ---------------------------------------------------------------------------
+# Evidence catalog coverage checks  (--check-evidence-catalog mode)
+# ---------------------------------------------------------------------------
+
+
+def _make_git_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repo rooted at tmp_path and return it."""
+    subprocess.run(["git", "init"], cwd=tmp_path, check=True, capture_output=True)
+    subprocess.run(
+        ["git", "config", "user.name", "Test"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "config", "user.email", "t@t"],
+        cwd=tmp_path,
+        check=True,
+        capture_output=True,
+    )
+    return tmp_path
+
+
+def _git_add_commit(repo_root: Path, *paths: Path) -> None:
+    """Stage and commit the given paths in the tmp git repo."""
+    for p in paths:
+        subprocess.run(
+            ["git", "add", str(p.relative_to(repo_root))],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+        )
+    subprocess.run(
+        ["git", "commit", "-m", "fixture"],
+        cwd=repo_root,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_evidence_catalog_reports_uncovered_bundle(tmp_path: Path) -> None:
+    """An evidence bundle with no catalog entry should be reported."""
+    repo_root = _make_git_repo(tmp_path)
+    bundle = repo_root / "docs/context/evidence/issue_999_example"
+    bundle.mkdir(parents=True)
+    summary = bundle / "summary.json"
+    summary.write_text('{"status": "ok"}\n', encoding="utf-8")
+
+    # Catalog exists but has NO entry for the bundle.
+    catalog = repo_root / "docs/context/catalog.yaml"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
+        "version: 1\nentries: []\n",
+        encoding="utf-8",
+    )
+    _git_add_commit(repo_root, summary, catalog)
+
+    diagnostics = _evidence_catalog_coverage_diagnostics(repo_root=repo_root)
+
+    assert any("docs/context/evidence/issue_999_example" in d.message for d in diagnostics), (
+        diagnostics
+    )
+
+
+def test_evidence_catalog_passes_when_bundle_is_covered(tmp_path: Path) -> None:
+    """A bundle whose file is cataloged should produce no diagnostic."""
+    repo_root = _make_git_repo(tmp_path)
+    bundle = repo_root / "docs/context/evidence/issue_999_covered"
+    bundle.mkdir(parents=True)
+    summary = bundle / "summary.json"
+    summary.write_text('{"status": "ok"}\n', encoding="utf-8")
+
+    catalog = repo_root / "docs/context/catalog.yaml"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
+        "version: 1\nentries:\n"
+        "  - path: docs/context/evidence/issue_999_covered/summary.json\n"
+        "    status: evidence\n"
+        "    freshness: evidence\n",
+        encoding="utf-8",
+    )
+    _git_add_commit(repo_root, summary, catalog)
+
+    diagnostics = _evidence_catalog_coverage_diagnostics(repo_root=repo_root)
+
+    assert diagnostics == [], diagnostics
+
+
+def test_evidence_catalog_reports_uncovered_standalone_file(tmp_path: Path) -> None:
+    """A standalone tracked evidence file with no catalog entry should be reported."""
+    repo_root = _make_git_repo(tmp_path)
+    (repo_root / "docs/context/evidence").mkdir(parents=True)
+    standalone = repo_root / "docs/context/evidence/issue_1662_lidar_ppo_smoke_summary.json"
+    standalone.write_text('{"status": "ok"}\n', encoding="utf-8")
+
+    catalog = repo_root / "docs/context/catalog.yaml"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text("version: 1\nentries: []\n", encoding="utf-8")
+    _git_add_commit(repo_root, standalone, catalog)
+
+    diagnostics = _evidence_catalog_coverage_diagnostics(repo_root=repo_root)
+
+    assert any("issue_1662_lidar_ppo_smoke_summary.json" in d.message for d in diagnostics), (
+        diagnostics
+    )
+
+
+def test_evidence_catalog_covered_by_bundle_file_entry(tmp_path: Path) -> None:
+    """A catalog entry for one file in a bundle covers the bundle."""
+    repo_root = _make_git_repo(tmp_path)
+    bundle = repo_root / "docs/context/evidence/issue_999_root_entry"
+    bundle.mkdir(parents=True)
+    f1 = bundle / "a.json"
+    f2 = bundle / "b.json"
+    f1.write_text('{"a": 1}\n', encoding="utf-8")
+    f2.write_text('{"b": 2}\n', encoding="utf-8")
+
+    catalog = repo_root / "docs/context/catalog.yaml"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text(
+        "version: 1\nentries:\n"
+        "  - path: docs/context/evidence/issue_999_root_entry/a.json\n"
+        "    status: evidence\n"
+        "    freshness: evidence\n",
+        encoding="utf-8",
+    )
+    _git_add_commit(repo_root, f1, f2, catalog)
+
+    # Both files are in the same bundle; one entry suffices.
+    diagnostics = _evidence_catalog_coverage_diagnostics(repo_root=repo_root)
+
+    assert diagnostics == [], diagnostics
+
+
+def test_evidence_catalog_empty_evidence_dir_passes(tmp_path: Path) -> None:
+    """An empty evidence directory (no tracked files) should pass cleanly."""
+    repo_root = _make_git_repo(tmp_path)
+    (repo_root / "docs/context/evidence").mkdir(parents=True)
+
+    catalog = repo_root / "docs/context/catalog.yaml"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    catalog.write_text("version: 1\nentries: []\n", encoding="utf-8")
+    _git_add_commit(repo_root, catalog)
+
+    diagnostics = _evidence_catalog_coverage_diagnostics(repo_root=repo_root)
+
+    assert diagnostics == [], diagnostics
+
+
+def test_evidence_catalog_missing_catalog_file_passes(tmp_path: Path) -> None:
+    """When the catalog does not exist yet, evidence coverage check should not crash."""
+    repo_root = _make_git_repo(tmp_path)
+    bundle = repo_root / "docs/context/evidence/issue_999_no_catalog"
+    bundle.mkdir(parents=True)
+    summary = bundle / "summary.json"
+    summary.write_text('{"status": "ok"}\n', encoding="utf-8")
+    _git_add_commit(repo_root, summary)
+
+    # No catalog file at all.
+    diagnostics = _evidence_catalog_coverage_diagnostics(repo_root=repo_root)
+
+    # Without a catalog, every bundle is uncovered — should still report, not crash.
+    assert any("issue_999_no_catalog" in d.message for d in diagnostics), diagnostics


### PR DESCRIPTION
## Summary
Adds an explicit evidence-catalog coverage mode to the existing docs/proof consistency checker so tracked `docs/context/evidence/` bundles without `docs/context/catalog.yaml` entries are discoverable.

## Linked Issues
- Closes `#2922`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `--check-evidence-catalog` to `scripts/validation/check_docs_proof_consistency.py`.
- The new mode scans Git-tracked files under `docs/context/evidence/`, groups nested files by evidence bundle, and reports bundles or loose evidence files with no catalog entry.
- Added targeted tests for uncovered bundles, covered bundles, loose evidence files, missing catalogs, and empty evidence directories.
- Documented the explicit run command in `docs/dev_guide.md`.

## Why It Matters
- Added value: makes evidence drift visible with one reproducible command.
- Expected impact: future agents and reviewers can find catalog coverage gaps without broad manual searches.
- Why this is worth merging now: evidence artifacts are growing, and this protects discoverability before the backlog gets harder to audit.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support tooling for evidence hygiene, no research claim.
- Comparator or baseline, if applicable: NA.
- Evidence tier: targeted smoke / support helper.
- Result classification: blocker-resolution for evidence-catalog drift detection.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: Issue #2922.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it reports catalog hygiene but does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: existing catalog coverage backlog remains; the new checker reports it.
- Stop / revise / continue decision: continue by backfilling catalog entries in follow-up work if desired.
- Proposed child issue or existing follow-up: none opened; this PR surfaces the backlog count.

## Validation / Proof
- Commands run:
  - `uv run ruff format scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py`
  - `uv run ruff check scripts/validation/check_docs_proof_consistency.py tests/validation/test_check_docs_proof_consistency.py`
  - `uv run pytest tests/validation/test_check_docs_proof_consistency.py -q`
  - `uv run python scripts/validation/check_docs_proof_consistency.py --base origin/main`
  - `uv run python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog --json`
  - `scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted tests passed (`33 passed`); default diff checker passed for 3 changed files; the explicit full-catalog mode reported 123 existing uncovered evidence bundles with actionable catalog paths.
- Benchmarks or smoke tests, if applicable: full PR readiness passed for `ed38c9bc17aaf3566ccaa48f50d68a73cf1996bd` with `6925 passed, 9 skipped, 9 warnings`.

## Risks / Rollout
- Compatibility risks: low; the new full-catalog check is opt-in and does not alter default diff-scoped behavior.
- Failure modes: enabling this flag as a hard CI gate immediately would fail on the current backlog of 123 uncovered evidence bundles.
- Rollback or fallback plan: remove the flag/helper/tests or keep using the existing diff-scoped checker only.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md` names the explicit command.
- Relevant design or provenance notes: the checker uses Git-tracked files, not ignored local `output/`, to avoid local-machine false positives.
- Any assumptions that need to be preserved: one catalog entry under an evidence bundle covers that bundle; per-file catalog coverage can be added later if needed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2922.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): no; this PR adds the checker but does not backfill catalog entries.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA; dev guide updated instead.
- Follow-up issue opened for deferred propagation (yes/no/NA): no; existing backlog is reported by the new command and can be triaged separately.
- Not applicable because: support tooling only, no benchmark or paper-facing claim.

## Follow-Up Issues
- Deferred work: optionally backfill `docs/context/catalog.yaml` for the 123 uncovered evidence bundles and decide when to wire the flag into CI.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify the bundle-level coverage assumption: any catalog entry inside an evidence bundle marks that bundle discoverable.
- Known limitation: the full-catalog mode exits nonzero today because it correctly reports the existing backlog.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced evidence catalog validation to identify tracked documentation bundles missing catalog entries.

* **Documentation**
  * Enhanced developer guide with guidance for running documentation catalog consistency checks.

* **Tests**
  * Expanded test suite to cover evidence catalog validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->