### PR TITLE
feat: check deferred PR follow-ups

### DIFF
--- a/scripts/dev/check_pr_followups.py
+++ b/scripts/dev/check_pr_followups.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Check that declared deferred PR work has an explicit follow-up disposition.
+
+The check is intentionally bounded for agent PR-readiness runs.  It reads a PR
+body from an explicit file or GitHub pull-request event payload, scans the
+default template's Follow-Up Issues section, and prints a compact report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+ISSUE_RE = re.compile(r"(?:#|/issues/)(\d+)\b")
+HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+EMPTY_OR_PLACEHOLDER = {
+    "",
+    "-",
+    "n/a",
+    "na",
+    "none",
+    "no",
+    "not applicable",
+    "`#<id>`",
+    "#<id>",
+    "<id>",
+}
+
+
+@dataclass(frozen=True)
+class FollowupReport:
+    """Compact PR follow-up disposition report."""
+
+    status: str
+    source: str
+    deferred_work: str
+    linked_issues: tuple[str, ...]
+    explicit_no_issue_reason: str
+    issue_state_errors: tuple[str, ...]
+    message: str
+
+
+def _normalize_label(text: str) -> str:
+    return re.sub(r"[^a-z0-9]+", " ", text.lower()).strip()
+
+
+def _strip_bullet_prefix(text: str) -> str:
+    return re.sub(r"^\s*(?:[-*+]|\d+[.)])\s*", "", text).strip()
+
+
+def _clean_value(text: str) -> str:
+    return _strip_bullet_prefix(text).strip().strip("`").strip()
+
+
+def _is_empty_or_placeholder(text: str) -> bool:
+    value = _clean_value(text).lower()
+    return value in EMPTY_OR_PLACEHOLDER or value.startswith("#<")
+
+
+def _is_no_issue_reason(text: str) -> bool:
+    value = _clean_value(text).lower()
+    if value in {"none", "no", "n/a", "na", "not applicable"}:
+        return True
+    return value.startswith(("none ", "none -", "none:", "na ", "na -", "n/a ", "n/a -"))
+
+
+def _extract_section(body: str, heading: str) -> str:
+    target = _normalize_label(heading)
+    matches = list(HEADING_RE.finditer(body))
+    for index, match in enumerate(matches):
+        level, title = match.groups()
+        if _normalize_label(title) != target:
+            continue
+        section_end = len(body)
+        for next_match in matches[index + 1 :]:
+            if len(next_match.group(1)) <= len(level):
+                section_end = next_match.start()
+                break
+        return body[match.end() : section_end].strip()
+    return ""
+
+
+def _value_after_label(section: str, label: str) -> str:
+    target = _normalize_label(label)
+    lines = section.splitlines()
+    for index, line in enumerate(lines):
+        item = _strip_bullet_prefix(line)
+        if ":" not in item:
+            continue
+        key, value = item.split(":", 1)
+        if _normalize_label(key) != target:
+            continue
+        value = value.strip()
+        if value:
+            return value
+        continuation: list[str] = []
+        for following in lines[index + 1 :]:
+            stripped = following.strip()
+            if not stripped:
+                continue
+            clean = _strip_bullet_prefix(stripped)
+            if ":" in clean:
+                possible_key = clean.split(":", 1)[0]
+                if _normalize_label(possible_key) in {
+                    "issues opened for follow up",
+                    "issues opened for followup",
+                    "follow up issues",
+                }:
+                    break
+            if stripped.startswith("#"):
+                break
+            continuation.append(clean)
+            break
+        return " ".join(continuation).strip()
+    return ""
+
+
+def _linked_issues(text: str) -> tuple[str, ...]:
+    return tuple(f"#{match}" for match in sorted(set(ISSUE_RE.findall(text)), key=int))
+
+
+def _verify_open_issues(issues: tuple[str, ...]) -> tuple[str, ...]:
+    errors: list[str] = []
+    for issue in issues:
+        number = issue.removeprefix("#")
+        result = subprocess.run(
+            ["gh", "issue", "view", number, "--json", "state", "--jq", ".state"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            errors.append(f"{issue}: unable to verify open state ({detail})")
+            continue
+        state = result.stdout.strip().upper()
+        if state != "OPEN":
+            errors.append(f"{issue}: state is {state or 'unknown'}, expected OPEN")
+    return tuple(errors)
+
+
+def analyze_body(body: str, *, source: str, require_open_issues: bool = False) -> FollowupReport:
+    """Return a compact follow-up report for a PR body."""
+    section = _extract_section(body, "Follow-Up Issues")
+    deferred = _value_after_label(section, "Deferred work") if section else ""
+    issue_value = _value_after_label(section, "Issues opened for follow-up") if section else ""
+    linked_issues = _linked_issues(f"{section}\n{issue_value}")
+    issue_state_errors = _verify_open_issues(linked_issues) if require_open_issues else ()
+
+    if not section:
+        return FollowupReport(
+            status="missing_section",
+            source=source,
+            deferred_work="",
+            linked_issues=(),
+            explicit_no_issue_reason="",
+            issue_state_errors=(),
+            message="Follow-Up Issues section not found.",
+        )
+    if _is_empty_or_placeholder(deferred):
+        return FollowupReport(
+            status="ok",
+            source=source,
+            deferred_work="",
+            linked_issues=linked_issues,
+            explicit_no_issue_reason="",
+            issue_state_errors=issue_state_errors,
+            message="No deferred work declared.",
+        )
+    if linked_issues:
+        if issue_state_errors:
+            return FollowupReport(
+                status="issue_state_error",
+                source=source,
+                deferred_work=deferred,
+                linked_issues=linked_issues,
+                explicit_no_issue_reason="",
+                issue_state_errors=issue_state_errors,
+                message="Deferred work follow-up issue state could not be verified open.",
+            )
+        return FollowupReport(
+            status="ok",
+            source=source,
+            deferred_work=deferred,
+            linked_issues=linked_issues,
+            explicit_no_issue_reason="",
+            issue_state_errors=(),
+            message="Deferred work has linked follow-up issue(s).",
+        )
+    if _is_no_issue_reason(issue_value):
+        return FollowupReport(
+            status="ok",
+            source=source,
+            deferred_work=deferred,
+            linked_issues=(),
+            explicit_no_issue_reason=issue_value,
+            issue_state_errors=(),
+            message="Deferred work explicitly states no follow-up issue is needed.",
+        )
+    return FollowupReport(
+        status="missing_followup",
+        source=source,
+        deferred_work=deferred,
+        linked_issues=(),
+        explicit_no_issue_reason="",
+        issue_state_errors=(),
+        message="Deferred work is declared without a linked issue or explicit NA/none reason.",
+    )
+
+
+def _read_event_body(path: Path) -> str | None:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    pull_request = payload.get("pull_request")
+    if isinstance(pull_request, dict) and isinstance(pull_request.get("body"), str):
+        return pull_request["body"]
+    issue = payload.get("issue")
+    if isinstance(issue, dict) and isinstance(issue.get("body"), str):
+        return issue["body"]
+    return None
+
+
+def _load_body(args: argparse.Namespace) -> tuple[str | None, str]:
+    body_file = args.body_file or os.environ.get("PR_READY_PR_BODY_FILE")
+    if body_file:
+        path = Path(body_file)
+        return path.read_text(encoding="utf-8"), str(path)
+
+    event_path = args.github_event_path or os.environ.get("GITHUB_EVENT_PATH")
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    if event_path and (args.github_event_path or event_name == "pull_request"):
+        path = Path(event_path)
+        body = _read_event_body(path)
+        if body is not None:
+            return body, str(path)
+
+    return None, "none"
+
+
+def _format_report(report: FollowupReport) -> str:
+    issue_text = ", ".join(report.linked_issues) if report.linked_issues else "none"
+    deferred = report.deferred_work if report.deferred_work else "none"
+    no_issue = report.explicit_no_issue_reason if report.explicit_no_issue_reason else "none"
+    state_errors = "; ".join(report.issue_state_errors) if report.issue_state_errors else "none"
+    return (
+        "PR follow-up check: "
+        f"status={report.status}; source={report.source}; deferred={deferred!r}; "
+        f"linked_issues={issue_text}; no_issue_reason={no_issue!r}; "
+        f"issue_state_errors={state_errors!r}; {report.message}"
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--body-file", type=Path, help="Markdown PR body to check.")
+    parser.add_argument(
+        "--github-event-path",
+        type=Path,
+        help="GitHub event JSON containing pull_request.body.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument(
+        "--require-open-issues",
+        action="store_true",
+        help="Verify linked follow-up issues are open with gh issue view.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the PR follow-up check CLI."""
+    args = _build_parser().parse_args(argv)
+    body, source = _load_body(args)
+    if body is None:
+        report = FollowupReport(
+            status="skipped",
+            source=source,
+            deferred_work="",
+            linked_issues=(),
+            explicit_no_issue_reason="",
+            issue_state_errors=(),
+            message="No PR body source configured.",
+        )
+        if args.json:
+            print(json.dumps(report.__dict__, sort_keys=True))
+        else:
+            print(_format_report(report))
+        return 0
+
+    require_open = args.require_open_issues or os.environ.get(
+        "PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES", ""
+    ).lower() in {"1", "true", "yes", "on"}
+    report = analyze_body(body, source=source, require_open_issues=require_open)
+    if args.json:
+        print(json.dumps(report.__dict__, sort_keys=True))
+    else:
+        failing_statuses = {"missing_followup", "missing_section", "issue_state_error"}
+        stream = sys.stderr if report.status in failing_statuses else sys.stdout
+        print(_format_report(report), file=stream)
+    return 2 if report.status in {"missing_followup", "missing_section", "issue_state_error"} else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/check_pr_followups.py
+++ b/scripts/dev/check_pr_followups.py
@@ -86,6 +86,18 @@ def _extract_section(body: str, heading: str) -> str:
     return ""
 
 
+def _is_continuation_boundary(line: str, *, parent_indent: int, known_labels: set[str]) -> bool:
+    """Return whether *line* starts the next top-level field or section."""
+    stripped = line.strip()
+    indent = len(line) - len(line.lstrip())
+    if indent <= parent_indent and line.lstrip().startswith(("-", "*", "+")):
+        return True
+    clean = _strip_bullet_prefix(stripped)
+    if ":" in clean and _normalize_label(clean.split(":", 1)[0]) in known_labels:
+        return True
+    return stripped.startswith("#")
+
+
 def _value_after_label(section: str, label: str) -> str:
     target = _normalize_label(label)
     lines = section.splitlines()
@@ -106,17 +118,18 @@ def _value_after_label(section: str, label: str) -> str:
         if value:
             return value
         continuation: list[str] = []
+        parent_indent = len(line) - len(line.lstrip())
         for following in lines[index + 1 :]:
             stripped = following.strip()
             if not stripped:
                 continue
-            clean = _strip_bullet_prefix(stripped)
-            if ":" in clean:
-                possible_key = clean.split(":", 1)[0]
-                if _normalize_label(possible_key) in known_labels:
-                    break
-            if stripped.startswith("#"):
+            if _is_continuation_boundary(
+                following,
+                parent_indent=parent_indent,
+                known_labels=known_labels,
+            ):
                 break
+            clean = _strip_bullet_prefix(stripped)
             continuation.append(clean)
         return " ".join(continuation).strip()
     return ""

--- a/scripts/dev/check_pr_followups.py
+++ b/scripts/dev/check_pr_followups.py
@@ -89,6 +89,12 @@ def _extract_section(body: str, heading: str) -> str:
 def _value_after_label(section: str, label: str) -> str:
     target = _normalize_label(label)
     lines = section.splitlines()
+    known_labels = {
+        "deferred work",
+        "issues opened for follow up",
+        "issues opened for followup",
+        "follow up issues",
+    }
     for index, line in enumerate(lines):
         item = _strip_bullet_prefix(line)
         if ":" not in item:
@@ -107,16 +113,11 @@ def _value_after_label(section: str, label: str) -> str:
             clean = _strip_bullet_prefix(stripped)
             if ":" in clean:
                 possible_key = clean.split(":", 1)[0]
-                if _normalize_label(possible_key) in {
-                    "issues opened for follow up",
-                    "issues opened for followup",
-                    "follow up issues",
-                }:
+                if _normalize_label(possible_key) in known_labels:
                     break
             if stripped.startswith("#"):
                 break
             continuation.append(clean)
-            break
         return " ".join(continuation).strip()
     return ""
 
@@ -129,13 +130,17 @@ def _verify_open_issues(issues: tuple[str, ...]) -> tuple[str, ...]:
     errors: list[str] = []
     for issue in issues:
         number = issue.removeprefix("#")
-        result = subprocess.run(
-            ["gh", "issue", "view", number, "--json", "state", "--jq", ".state"],
-            capture_output=True,
-            text=True,
-            timeout=20,
-            check=False,
-        )
+        try:
+            result = subprocess.run(
+                ["gh", "issue", "view", number, "--json", "state", "--jq", ".state"],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+            )
+        except FileNotFoundError:
+            errors.append(f"{issue}: unable to verify open state (gh CLI not found)")
+            continue
         if result.returncode != 0:
             detail = (result.stderr or result.stdout).strip()
             errors.append(f"{issue}: unable to verify open state ({detail})")

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -20,6 +20,11 @@ Environment variables:
                       Ignored when PR_READY_MODE is set.
   PR_READY_SKIP_PREFLIGHT  Set to "1" to skip the cheap preflight check for
                       test-collection dependencies (duckdb, pyarrow).
+  PR_READY_PR_BODY_FILE  Optional markdown PR body. When set, readiness checks
+                      that deferred work has a linked issue or explicit NA.
+  PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES
+                      Set to "0" to skip open-state verification for linked
+                      follow-up issues when PR_READY_PR_BODY_FILE is set.
 EOF
 }
 
@@ -38,6 +43,8 @@ export GOAL_COVERAGE="${GOAL_COVERAGE:-100}"
 export PR_READY_FINAL="${PR_READY_FINAL:-0}"
 export PR_READY_MODE="${PR_READY_MODE:-}"
 export PR_READY_SKIP_PREFLIGHT="${PR_READY_SKIP_PREFLIGHT:-0}"
+export PR_READY_PR_BODY_FILE="${PR_READY_PR_BODY_FILE:-}"
+export PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES="${PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES:-1}"
 
 worktree_state() {
   if [[ -n "$(git status --porcelain --untracked-files=normal)" ]]; then
@@ -113,6 +120,7 @@ if [[ "$pr_ready_final" == "1" ]]; then
   preflight_check_test_deps
 fi
 
+uv run python "$SCRIPT_DIR/check_pr_followups.py"
 "$SCRIPT_DIR/ruff_fix_format.sh"
 "$SCRIPT_DIR/run_tests_parallel.sh"
 "$SCRIPT_DIR/check_changed_coverage.sh"

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -4,13 +4,14 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 
 from scripts.dev import check_pr_followups
 from scripts.dev.check_pr_followups import analyze_body
 
-SCRIPT = Path("scripts/dev/check_pr_followups.py")
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "check_pr_followups.py"
 
 
 def _body(*, deferred: str, issues: str = "") -> str:
@@ -84,6 +85,42 @@ def test_analyze_body_rejects_closed_followup_issue(monkeypatch) -> None:
     assert "#2966: state is CLOSED" in report.issue_state_errors[0]
 
 
+def test_analyze_body_rejects_unverifiable_issue_when_gh_is_missing(monkeypatch) -> None:
+    """Open-state verification reports a compact error when gh is unavailable."""
+
+    def fake_run(*args, **kwargs):
+        del args, kwargs
+        raise FileNotFoundError("gh")
+
+    monkeypatch.setattr(check_pr_followups.subprocess, "run", fake_run)
+
+    report = analyze_body(
+        _body(deferred="Run the broader benchmark sweep.", issues="#2966"),
+        source="fixture",
+        require_open_issues=True,
+    )
+
+    assert report.status == "issue_state_error"
+    assert "#2966: unable to verify open state (gh CLI not found)" in report.issue_state_errors
+
+
+def test_analyze_body_collects_multiline_deferred_work() -> None:
+    """Continuation lines belong to the deferred-work value until the next field."""
+    body = """## Follow-Up Issues
+- Deferred work:
+  - Run the broader benchmark sweep.
+  - Promote durable evidence.
+- Issues opened for follow-up: #2966
+"""
+
+    report = analyze_body(body, source="fixture")
+
+    assert report.status == "ok"
+    assert "Run the broader benchmark sweep" in report.deferred_work
+    assert "Promote durable evidence" in report.deferred_work
+    assert report.linked_issues == ("#2966",)
+
+
 def test_cli_reads_github_pull_request_event(tmp_path: Path) -> None:
     """The CLI can read pull_request.body from a GitHub event payload."""
     event_path = tmp_path / "event.json"
@@ -102,7 +139,7 @@ def test_cli_reads_github_pull_request_event(tmp_path: Path) -> None:
     )
 
     result = subprocess.run(
-        ["python", str(SCRIPT), "--github-event-path", str(event_path)],
+        [sys.executable, str(SCRIPT), "--github-event-path", str(event_path)],
         capture_output=True,
         text=True,
         timeout=30,
@@ -120,7 +157,7 @@ def test_cli_fails_for_deferred_work_without_disposition(tmp_path: Path) -> None
     body_path.write_text(_body(deferred="Open the remaining benchmark issues."), encoding="utf-8")
 
     result = subprocess.run(
-        ["python", str(SCRIPT), "--body-file", str(body_path)],
+        [sys.executable, str(SCRIPT), "--body-file", str(body_path)],
         capture_output=True,
         text=True,
         timeout=30,

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -1,0 +1,131 @@
+"""Tests for PR deferred-work follow-up readiness checks."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+from scripts.dev import check_pr_followups
+from scripts.dev.check_pr_followups import analyze_body
+
+SCRIPT = Path("scripts/dev/check_pr_followups.py")
+
+
+def _body(*, deferred: str, issues: str = "") -> str:
+    return f"""## Summary
+Example PR.
+
+## Follow-Up Issues
+- Deferred work: {deferred}
+- Issues opened for follow-up: {issues}
+"""
+
+
+def test_analyze_body_passes_when_no_deferred_work_is_declared() -> None:
+    """Empty or none deferred-work values are accepted."""
+    report = analyze_body(_body(deferred="none"), source="fixture")
+
+    assert report.status == "ok"
+    assert report.deferred_work == ""
+    assert report.message == "No deferred work declared."
+
+
+def test_analyze_body_requires_issue_when_deferred_work_is_declared() -> None:
+    """Deferred work without a disposition fails closed."""
+    report = analyze_body(_body(deferred="Add a broader benchmark sweep."), source="fixture")
+
+    assert report.status == "missing_followup"
+    assert "without a linked issue" in report.message
+
+
+def test_analyze_body_accepts_linked_followup_issue() -> None:
+    """Linked follow-up issues satisfy declared deferred work."""
+    report = analyze_body(
+        _body(deferred="Run the broader benchmark sweep.", issues="#2966"),
+        source="fixture",
+    )
+
+    assert report.status == "ok"
+    assert report.linked_issues == ("#2966",)
+
+
+def test_analyze_body_accepts_explicit_no_issue_reason() -> None:
+    """An explicit NA reason can replace a follow-up issue."""
+    report = analyze_body(
+        _body(
+            deferred="No additional work beyond reviewer verification.",
+            issues="NA - reviewer verification only",
+        ),
+        source="fixture",
+    )
+
+    assert report.status == "ok"
+    assert report.explicit_no_issue_reason == "NA - reviewer verification only"
+
+
+def test_analyze_body_rejects_closed_followup_issue(monkeypatch) -> None:
+    """Open-state verification rejects linked issues that are not open."""
+
+    def fake_run(*args, **kwargs):
+        del args, kwargs
+        return SimpleNamespace(returncode=0, stdout="CLOSED\n", stderr="")
+
+    monkeypatch.setattr(check_pr_followups.subprocess, "run", fake_run)
+
+    report = analyze_body(
+        _body(deferred="Run the broader benchmark sweep.", issues="#2966"),
+        source="fixture",
+        require_open_issues=True,
+    )
+
+    assert report.status == "issue_state_error"
+    assert "#2966: state is CLOSED" in report.issue_state_errors[0]
+
+
+def test_cli_reads_github_pull_request_event(tmp_path: Path) -> None:
+    """The CLI can read pull_request.body from a GitHub event payload."""
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "pull_request": {
+                    "body": _body(
+                        deferred="Run release readiness dashboard.",
+                        issues="https://github.com/ll7/robot_sf_ll7/issues/2965",
+                    )
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        ["python", str(SCRIPT), "--github-event-path", str(event_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "status=ok" in result.stdout
+    assert "#2965" in result.stdout
+
+
+def test_cli_fails_for_deferred_work_without_disposition(tmp_path: Path) -> None:
+    """The CLI exits nonzero for deferred work without an issue or NA reason."""
+    body_path = tmp_path / "body.md"
+    body_path.write_text(_body(deferred="Open the remaining benchmark issues."), encoding="utf-8")
+
+    result = subprocess.run(
+        ["python", str(SCRIPT), "--body-file", str(body_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "status=missing_followup" in result.stderr

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -13,6 +13,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCRIPTS_DEV = REPO_ROOT / "scripts" / "dev"
 
 _POST_PREFLIGHT_SCRIPTS = [
+    "check_pr_followups.py",
     "ruff_fix_format.sh",
     "run_tests_parallel.sh",
     "check_changed_coverage.sh",

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -175,6 +175,7 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
     script_text = PR_READY_CHECK.read_text(encoding="utf-8")
 
     expected_gates = [
+        'uv run python "$SCRIPT_DIR/check_pr_followups.py"',
         '"$SCRIPT_DIR/ruff_fix_format.sh"',
         '"$SCRIPT_DIR/run_tests_parallel.sh"',
         '"$SCRIPT_DIR/check_changed_coverage.sh"',
@@ -305,6 +306,7 @@ def test_pr_ready_check_help_long() -> None:
     assert "BASE_REF" in result.stdout
     assert "PR_READY_MODE" in result.stdout
     assert "PR_READY_FINAL" in result.stdout
+    assert "PR_READY_PR_BODY_FILE" in result.stdout
 
 
 def test_pr_ready_check_help_short() -> None:
@@ -385,6 +387,7 @@ def test_pr_ready_check_help_does_not_invoke_gates(tmp_path: Path) -> None:
     assert "BASE_REF" in result.stdout
     assert "PR_READY_MODE" in result.stdout
     assert "PR_READY_FINAL" in result.stdout
+    assert "PR_READY_PR_BODY_FILE" in result.stdout
     assert "uv should not be called" not in result.stderr
 
 


### PR DESCRIPTION
## Summary
Adds a PR readiness follow-up checker that scans PR bodies for declared deferred work and requires either linked open follow-up issues or an explicit no-issue reason.

## Linked Issues
- Closes #2963

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/dev/check_pr_followups.py` for compact PR body follow-up disposition checks.
- Wired the checker into `scripts/dev/pr_ready_check.sh` before expensive gates.
- Added parser, CLI, shell preflight, and wrapper contract tests.

## Why It Matters
- Added value: Deferred limitations in PRs now fail closed unless they have a concrete follow-up disposition.
- Expected impact: Lower risk of losing research or validation gaps after merge.
- Why this is worth merging now: It strengthens the agent PR-readiness path before the next autonomous batches create more deferred work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support helper only.
- Comparator or baseline, if applicable: NA
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: Checker rejects declared deferred work without a linked issue or explicit no-issue reason.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2963
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - workflow support helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop after review if CI passes
- Proposed child issue or existing follow-up: NA - no child issue needed for this support helper

## Validation / Proof
- Commands run:
  - `uv run pytest tests/dev/test_check_pr_followups.py tests/dev/test_pr_ready_preflight.py -q`
  - `uv run pytest tests/dev/test_check_pr_followups.py tests/dev/test_pr_ready_preflight.py tests/test_ci_script_contract.py::test_pr_ready_check_records_freshness_after_successful_gates tests/test_ci_script_contract.py::test_pr_ready_check_help_long tests/test_ci_script_contract.py::test_pr_ready_check_help_does_not_invoke_gates -q`
  - `uv run ruff check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/dev/test_pr_ready_preflight.py tests/test_ci_script_contract.py`
  - `uv run ruff format --check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/dev/test_pr_ready_preflight.py tests/test_ci_script_contract.py`
  - `bash -n scripts/dev/pr_ready_check.sh && python -m py_compile scripts/dev/check_pr_followups.py`
  - `uv run python scripts/dev/check_pr_followups.py --body-file <tmp> --require-open-issues` with `#2963`
  - `git diff --check`
- Evidence that the change works here: focused tests cover no-deferred, missing follow-up, linked issue, explicit NA reason, GitHub event body parsing, CLI failure, and closed issue rejection via mocked `gh` state.
- Benchmarks or smoke tests, if applicable: NA - workflow helper.

## Risks / Rollout
- Compatibility risks: Local PR readiness without a PR body source reports a compact skip and remains non-blocking.
- Failure modes: If a PR body declares deferred work and links an issue, open-state verification uses `gh issue view`; set `PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES=0` only for offline emergency checks.
- Rollback or fallback plan: Remove the `check_pr_followups.py` call from `pr_ready_check.sh` if the gate is too strict.

## Docs / Provenance
- Updated docs: `scripts/dev/pr_ready_check.sh --help` documents the new env vars.
- Relevant design or provenance notes: issue #2963.
- Any assumptions that need to be preserved: The check is scoped to explicit PR body/template sources, not broad prose inference.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR link
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: This is a workflow gate with no benchmark claim or durable artifact.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: NA - no deferred work remains for this scoped helper

## Reviewer Notes
- Anything a reviewer should verify closely: Whether failing on a missing `Follow-Up Issues` section is the desired behavior when a PR body source is explicitly supplied.
- Any known limitations: The check only reads `PR_READY_PR_BODY_FILE` or pull-request event payloads; ordinary local runs without either source are reported as skipped.
