### PR TITLE
feat: add compact PR review thread snapshots

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -342,7 +342,7 @@ resolving lint or test failures locally before requesting review.
   `scripts/dev/snapshot_pr_queue.py --prs <number> --review-threads --json`; it emits bounded
   comment excerpts, label names, and omits raw `diff_hunk` payloads. Fetch full review-comment
   bodies or hunks only with an explicit artifact path such as
-  `--raw-review-comments-artifact .git/codex-agent-runs/.../raw-review-comments.json`.
+  `--raw-review-comments-artifact "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/.../raw-review-comments.json"`.
 - Before finalization, cover format/check, focused tests, changed-file coverage when practical, and a
   clean worktree check (`git status --short`) as part of the readied proof bundle.
 - Before broad status or inventory output, use

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,7 +338,11 @@ resolving lint or test failures locally before requesting review.
   and `scripts/dev/check_pr_ci_status.py --expected-head-sha <sha>`.
 - Treat `preflight.status == "stale"` lanes as invalid until refreshed.
 - If review/comment data is needed, start from compact `review_snapshot`/`comment_snapshot`/`checks`
-  output rather than raw `gh` payloads.
+  output rather than raw `gh` payloads. For PR review threads, use
+  `scripts/dev/snapshot_pr_queue.py --prs <number> --review-threads --json`; it emits bounded
+  comment excerpts, label names, and omits raw `diff_hunk` payloads. Fetch full review-comment
+  bodies or hunks only with an explicit artifact path such as
+  `--raw-review-comments-artifact .git/codex-agent-runs/.../raw-review-comments.json`.
 - Before finalization, cover format/check, focused tests, changed-file coverage when practical, and a
   clean worktree check (`git status --short`) as part of the readied proof bundle.
 - Before broad status or inventory output, use

--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -133,6 +133,11 @@ def _repo_owner_name(repo: str) -> tuple[str, str]:
     return owner, name
 
 
+def _dict_or_empty(value: Any) -> dict[str, Any]:
+    """Return *value* when it is a dictionary, otherwise an empty dictionary."""
+    return value if isinstance(value, dict) else {}
+
+
 def _review_thread_snapshot(
     pr_number: int,
     *,
@@ -195,12 +200,10 @@ query($owner:String!,$repo:String!,$number:Int!,$threads:Int!,$comments:Int!){
         payload = json.loads(result.stdout)
     except json.JSONDecodeError as exc:
         return {"status": "error", "error": f"invalid gh JSON: {exc}"}
-    threads = (
-        payload.get("data", {})
-        .get("repository", {})
-        .get("pullRequest", {})
-        .get("reviewThreads", {})
-    )
+    data = _dict_or_empty(payload.get("data"))
+    repository = _dict_or_empty(data.get("repository"))
+    pull_request = _dict_or_empty(repository.get("pullRequest"))
+    threads = _dict_or_empty(pull_request.get("reviewThreads"))
     nodes = [node for node in threads.get("nodes", []) or [] if isinstance(node, dict)]
     compact_threads: list[dict[str, Any]] = []
     unresolved_count = 0
@@ -556,6 +559,15 @@ def write_raw_review_comments_artifact(
         "repo": repo,
         "prs": {},
     }
+    if not owner or not name:
+        for number in numbers:
+            payload["prs"][str(number)] = {
+                "status": "error",
+                "error": "repo_owner_missing",
+            }
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        return
     for number in numbers:
         result = _gh(
             [

--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import subprocess
 import sys
+from pathlib import Path
 from typing import Any
 
 from scripts.dev.check_pr_ci_status import (
@@ -22,6 +23,8 @@ DEFAULT_ACTIVE_LIMIT = 20
 REVIEW_SUMMARY_LIMIT = 4
 COMMENT_SUMMARY_LIMIT = 4
 COMMENT_BODY_LIMIT = 180
+REVIEW_THREAD_LIMIT = 12
+REVIEW_THREAD_COMMENT_LIMIT = 2
 ROUTE_HEALTH_STATUSES = ("healthy", "stale", "blocked", "unknown")
 SCHEMA_VERSION = "pr_queue_snapshot.v1"
 
@@ -119,6 +122,125 @@ def _comment_snapshot(pr: dict[str, Any]) -> dict[str, Any]:
         "total": len(comments),
         "latest": latest,
         "contains_more": len(comments) > COMMENT_SUMMARY_LIMIT,
+    }
+
+
+def _repo_owner_name(repo: str) -> tuple[str, str]:
+    """Split an owner/name GitHub repository string."""
+    if "/" not in repo:
+        return "", repo
+    owner, name = repo.split("/", 1)
+    return owner, name
+
+
+def _review_thread_snapshot(
+    pr_number: int,
+    *,
+    repo: str,
+) -> dict[str, Any]:
+    """Return compact PR review-thread data without raw diff hunks or full bodies."""
+    owner, name = _repo_owner_name(repo)
+    if not owner or not name:
+        return {"status": "skipped", "reason": "repo_owner_missing"}
+    query = """
+query($owner:String!,$repo:String!,$number:Int!,$threads:Int!,$comments:Int!){
+  repository(owner:$owner,name:$repo){
+    pullRequest(number:$number){
+      reviewThreads(first:$threads){
+        totalCount
+        nodes{
+          id
+          isResolved
+          path
+          line
+          comments(first:$comments){
+            totalCount
+            nodes{
+              author{login}
+              body
+              createdAt
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+    result = _gh(
+        [
+            "api",
+            "graphql",
+            "-f",
+            f"query={query}",
+            "-F",
+            f"owner={owner}",
+            "-F",
+            f"repo={name}",
+            "-F",
+            f"number={pr_number}",
+            "-F",
+            f"threads={REVIEW_THREAD_LIMIT}",
+            "-F",
+            f"comments={REVIEW_THREAD_COMMENT_LIMIT}",
+        ],
+        timeout=45,
+    )
+    if result.returncode != 0:
+        return {
+            "status": "error",
+            "error": result.stderr.strip() or f"gh returned exit code {result.returncode}",
+        }
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        return {"status": "error", "error": f"invalid gh JSON: {exc}"}
+    threads = (
+        payload.get("data", {})
+        .get("repository", {})
+        .get("pullRequest", {})
+        .get("reviewThreads", {})
+    )
+    nodes = [node for node in threads.get("nodes", []) or [] if isinstance(node, dict)]
+    compact_threads: list[dict[str, Any]] = []
+    unresolved_count = 0
+    for node in nodes:
+        resolved = bool(node.get("isResolved"))
+        if not resolved:
+            unresolved_count += 1
+        comments = node.get("comments", {}) if isinstance(node.get("comments"), dict) else {}
+        comment_nodes = [
+            comment for comment in comments.get("nodes", []) or [] if isinstance(comment, dict)
+        ]
+        compact_threads.append(
+            {
+                "id": str(node.get("id", "")),
+                "resolved": resolved,
+                "path": str(node.get("path", "")),
+                "line": node.get("line"),
+                "comments_total": int(comments.get("totalCount", len(comment_nodes)) or 0),
+                "comments": [
+                    {
+                        "author": _author_login(comment.get("author")),
+                        "created_at": str(comment.get("createdAt", "")),
+                        "body_excerpt": _shorten_text(
+                            comment.get("body"), limit=COMMENT_BODY_LIMIT
+                        ),
+                        "body_omitted": len(str(comment.get("body") or "")) > COMMENT_BODY_LIMIT,
+                    }
+                    for comment in comment_nodes
+                ],
+                "diff_hunk_omitted": True,
+            }
+        )
+    total = int(threads.get("totalCount", len(nodes)) or 0)
+    return {
+        "status": "ok",
+        "total": total,
+        "unresolved": unresolved_count,
+        "threads": compact_threads,
+        "contains_more": total > REVIEW_THREAD_LIMIT,
+        "raw_diff_hunks_omitted": True,
     }
 
 
@@ -397,15 +519,72 @@ def snapshot_active_prs(*, repo: str, limit: int) -> dict[str, Any]:
     }
 
 
-def snapshot_prs(numbers: list[int], *, repo: str, expected_head_sha: str = "") -> dict[str, Any]:
+def snapshot_prs(
+    numbers: list[int],
+    *,
+    repo: str,
+    expected_head_sha: str = "",
+    include_review_threads: bool = False,
+) -> dict[str, Any]:
     """Return a compact PR queue snapshot."""
     prs = [fetch_pr(number, repo=repo, expected_head_sha=expected_head_sha) for number in numbers]
+    if include_review_threads:
+        for pr in prs:
+            if pr.get("status") == "ok" and isinstance(pr.get("number"), int):
+                pr["review_thread_snapshot"] = _review_thread_snapshot(
+                    int(pr["number"]),
+                    repo=repo,
+                )
     return {
         "schema": SCHEMA_VERSION,
         "repo": repo,
         "route_health_overview": _route_health_overview(prs),
         "prs": prs,
     }
+
+
+def write_raw_review_comments_artifact(
+    numbers: list[int],
+    *,
+    repo: str,
+    path: Path,
+) -> None:
+    """Write opt-in raw review-comment payloads, including diff hunks, to an artifact."""
+    owner, name = _repo_owner_name(repo)
+    payload: dict[str, Any] = {
+        "schema": "raw_pr_review_comments.v1",
+        "repo": repo,
+        "prs": {},
+    }
+    for number in numbers:
+        result = _gh(
+            [
+                "api",
+                f"repos/{owner}/{name}/pulls/{number}/comments",
+            ],
+            timeout=60,
+        )
+        if result.returncode != 0:
+            payload["prs"][str(number)] = {
+                "status": "error",
+                "error": result.stderr.strip() or f"gh returned exit code {result.returncode}",
+            }
+            continue
+        try:
+            comments = json.loads(result.stdout or "[]")
+        except json.JSONDecodeError as exc:
+            payload["prs"][str(number)] = {
+                "status": "error",
+                "error": f"invalid gh JSON: {exc}",
+            }
+            continue
+        payload["prs"][str(number)] = {
+            "status": "ok",
+            "comments": comments,
+            "contains_raw_diff_hunks": True,
+        }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
@@ -429,6 +608,19 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         default="",
         help="Optional PR head SHA expected for stale-lane invalidation in single-PR mode.",
     )
+    parser.add_argument(
+        "--review-threads",
+        action="store_true",
+        help="Include bounded review-thread excerpts without diff hunks or full bodies.",
+    )
+    parser.add_argument(
+        "--raw-review-comments-artifact",
+        type=Path,
+        help=(
+            "Opt-in path for raw review-comment payloads, including diff_hunk/full bodies; "
+            "artifact is written to disk and never printed to stdout."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     return parser.parse_args(argv)
 
@@ -438,6 +630,15 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
     if args.active and (args.prs_option is not None or args.prs):
         print("--active cannot be combined with explicit PR numbers", file=sys.stderr)
+        return 1
+    if args.active and args.review_threads:
+        print("--review-threads is only supported with explicit PR numbers", file=sys.stderr)
+        return 1
+    if args.active and args.raw_review_comments_artifact:
+        print(
+            "--raw-review-comments-artifact is only supported with explicit PR numbers",
+            file=sys.stderr,
+        )
         return 1
     numbers = args.prs_option if args.prs_option is not None else args.prs
     if args.expected_head_sha and not args.active and numbers and len(numbers) != 1:
@@ -454,8 +655,18 @@ def main(argv: list[str] | None = None) -> int:
             return 1
         else:
             payload = snapshot_prs(
-                numbers, repo=args.repo, expected_head_sha=args.expected_head_sha
+                numbers,
+                repo=args.repo,
+                expected_head_sha=args.expected_head_sha,
+                include_review_threads=args.review_threads,
             )
+            if args.raw_review_comments_artifact:
+                write_raw_review_comments_artifact(
+                    numbers,
+                    repo=args.repo,
+                    path=args.raw_review_comments_artifact,
+                )
+                payload["raw_review_comments_artifact"] = str(args.raw_review_comments_artifact)
     except FileNotFoundError:
         print("gh command not found", file=sys.stderr)
         return 1

--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -551,7 +551,7 @@ def write_raw_review_comments_artifact(
     *,
     repo: str,
     path: Path,
-) -> None:
+) -> dict[str, Any]:
     """Write opt-in raw review-comment payloads, including diff hunks, to an artifact."""
     owner, name = _repo_owner_name(repo)
     payload: dict[str, Any] = {
@@ -567,7 +567,7 @@ def write_raw_review_comments_artifact(
             }
         path.parent.mkdir(parents=True, exist_ok=True)
         path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-        return
+        return payload
     for number in numbers:
         result = _gh(
             [
@@ -597,6 +597,7 @@ def write_raw_review_comments_artifact(
         }
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return payload
 
 
 def _parse_args(argv: list[str] | None) -> argparse.Namespace:
@@ -673,12 +674,17 @@ def main(argv: list[str] | None = None) -> int:
                 include_review_threads=args.review_threads,
             )
             if args.raw_review_comments_artifact:
-                write_raw_review_comments_artifact(
+                artifact_payload = write_raw_review_comments_artifact(
                     numbers,
                     repo=args.repo,
                     path=args.raw_review_comments_artifact,
                 )
                 payload["raw_review_comments_artifact"] = str(args.raw_review_comments_artifact)
+                payload["raw_review_comments_artifact_status"] = (
+                    "error"
+                    if any(pr.get("status") == "error" for pr in artifact_payload["prs"].values())
+                    else "ok"
+                )
     except FileNotFoundError:
         print("gh command not found", file=sys.stderr)
         return 1
@@ -686,7 +692,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"snapshot command timed out: {exc}", file=sys.stderr)
         return 1
     print(json.dumps(payload, indent=2, sort_keys=True) if args.json else json.dumps(payload))
-    return 1 if any(pr.get("status") == "error" for pr in payload["prs"]) else 0
+    has_pr_errors = any(pr.get("status") == "error" for pr in payload["prs"])
+    has_artifact_errors = payload.get("raw_review_comments_artifact_status") == "error"
+    return 1 if has_pr_errors or has_artifact_errors else 0
 
 
 if __name__ == "__main__":

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -10,6 +10,7 @@ from scripts.dev.snapshot_pr_queue import (
     main,
     snapshot_active_prs,
     snapshot_prs,
+    write_raw_review_comments_artifact,
 )
 
 
@@ -157,6 +158,132 @@ def test_main_includes_compact_comment_review_evidence() -> None:
     assert pr["review_snapshot"]["latest"][0]["state"] == "COMMENTED"
 
 
+def test_snapshot_prs_can_include_bounded_review_threads() -> None:
+    """Review-thread mode should omit diff hunks and bound comment bodies."""
+    long_body = "review body " * 40
+    pr_payload = {
+        "number": 2692,
+        "title": "threaded PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "url": "https://github.test/pull/2692",
+        "labels": [{"name": "priority: high"}],
+        "headRefName": "feature",
+        "headRefOid": "abc999",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [{"name": "ci", "status": "completed", "conclusion": "success"}],
+        "reviews": [],
+        "comments": [],
+    }
+    thread_payload = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "totalCount": 1,
+                        "nodes": [
+                            {
+                                "id": "thread-1",
+                                "isResolved": False,
+                                "path": "scripts/dev/example.py",
+                                "line": 42,
+                                "comments": {
+                                    "totalCount": 1,
+                                    "nodes": [
+                                        {
+                                            "author": {"login": "reviewer"},
+                                            "body": long_body,
+                                            "createdAt": "2026-06-01T00:00:00Z",
+                                        }
+                                    ],
+                                },
+                            }
+                        ],
+                    }
+                }
+            }
+        }
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(thread_payload), stderr=""),
+        ]
+        payload = snapshot_prs([2692], repo="ll7/robot_sf_ll7", include_review_threads=True)
+
+    snapshot = payload["prs"][0]["review_thread_snapshot"]
+    thread = snapshot["threads"][0]
+    comment = thread["comments"][0]
+    assert snapshot["status"] == "ok"
+    assert snapshot["unresolved"] == 1
+    assert thread["diff_hunk_omitted"] is True
+    assert len(comment["body_excerpt"]) <= COMMENT_BODY_LIMIT
+    assert comment["body_omitted"] is True
+
+
+def test_raw_review_comments_artifact_writes_full_payload(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Raw review comments are opt-in and written to an artifact path."""
+    artifact = tmp_path / "raw-review-comments.json"
+    raw_comments = [
+        {
+            "id": 1,
+            "body": "full body",
+            "diff_hunk": "@@ -1 +1 @@\n-old\n+new",
+        }
+    ]
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(raw_comments), stderr="")
+        write_raw_review_comments_artifact([2693], repo="ll7/robot_sf_ll7", path=artifact)
+
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["prs"]["2693"]["status"] == "ok"
+    assert payload["prs"]["2693"]["contains_raw_diff_hunks"] is True
+    assert payload["prs"]["2693"]["comments"][0]["diff_hunk"].startswith("@@")
+
+
+def test_main_raw_review_artifact_keeps_hunks_out_of_stdout(
+    tmp_path,
+    capsys,
+) -> None:  # type: ignore[no-untyped-def]
+    """The CLI should report only the artifact path, not raw diff hunks."""
+    artifact = tmp_path / "raw-review-comments.json"
+    pr_payload = {
+        "number": 2694,
+        "title": "artifact PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "url": "https://github.test/pull/2694",
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc444",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [],
+        "reviews": [],
+        "comments": [],
+    }
+    raw_comments = [{"id": 1, "body": "full body", "diff_hunk": "@@ raw hunk"}]
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(raw_comments), stderr=""),
+        ]
+        rc = main(
+            [
+                "--prs",
+                "2694",
+                "--raw-review-comments-artifact",
+                str(artifact),
+                "--json",
+            ]
+        )
+
+    stdout = capsys.readouterr().out
+    assert rc == 0
+    assert str(artifact) in stdout
+    assert "@@ raw hunk" not in stdout
+    assert "@@ raw hunk" in artifact.read_text(encoding="utf-8")
+
+
 def test_main_requires_pr_number(capsys) -> None:  # type: ignore[no-untyped-def]
     """CLI should fail compactly when no PRs are provided."""
     rc = main(["--json"])
@@ -169,6 +296,13 @@ def test_main_rejects_expected_head_sha_for_batch(capsys) -> None:  # type: igno
     rc = main(["--prs", "1", "2", "--expected-head-sha", "abc123", "--json"])
     assert rc == 1
     assert "--expected-head-sha requires exactly one PR" in capsys.readouterr().err
+
+
+def test_main_rejects_active_review_thread_mode(capsys) -> None:  # type: ignore[no-untyped-def]
+    """Review-thread mode should stay explicit instead of broad active discovery."""
+    rc = main(["--active", "--review-threads", "--json"])
+    assert rc == 1
+    assert "--review-threads is only supported" in capsys.readouterr().err
 
 
 def test_main_active_mode_discovers_open_prs() -> None:

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -263,9 +263,10 @@ def test_raw_review_comments_artifact_writes_full_payload(tmp_path) -> None:  # 
     ]
     with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
         mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(raw_comments), stderr="")
-        write_raw_review_comments_artifact([2693], repo="ll7/robot_sf_ll7", path=artifact)
+        result = write_raw_review_comments_artifact([2693], repo="ll7/robot_sf_ll7", path=artifact)
 
     payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert result == payload
     assert payload["prs"]["2693"]["status"] == "ok"
     assert payload["prs"]["2693"]["contains_raw_diff_hunks"] is True
     assert payload["prs"]["2693"]["comments"][0]["diff_hunk"].startswith("@@")
@@ -275,9 +276,10 @@ def test_raw_review_comments_artifact_rejects_invalid_repo(tmp_path) -> None:  #
     """Invalid repo names should write an error artifact without calling gh."""
     artifact = tmp_path / "raw-review-comments.json"
     with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
-        write_raw_review_comments_artifact([2696], repo="robot_sf_ll7", path=artifact)
+        result = write_raw_review_comments_artifact([2696], repo="robot_sf_ll7", path=artifact)
 
     payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert result == payload
     assert payload["prs"]["2696"] == {
         "status": "error",
         "error": "repo_owner_missing",
@@ -326,6 +328,49 @@ def test_main_raw_review_artifact_keeps_hunks_out_of_stdout(
     assert str(artifact) in stdout
     assert "@@ raw hunk" not in stdout
     assert "@@ raw hunk" in artifact.read_text(encoding="utf-8")
+
+
+def test_main_raw_review_artifact_failure_sets_nonzero_exit(
+    tmp_path,
+    capsys,
+) -> None:  # type: ignore[no-untyped-def]
+    """Raw artifact failures should fail automation instead of only writing artifact errors."""
+    artifact = tmp_path / "raw-review-comments.json"
+    pr_payload = {
+        "number": 2697,
+        "title": "artifact failure PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "url": "https://github.test/pull/2697",
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc997",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [],
+        "reviews": [],
+        "comments": [],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr=""),
+            MagicMock(returncode=1, stdout="", stderr="not found"),
+        ]
+        rc = main(
+            [
+                "--prs",
+                "2697",
+                "--raw-review-comments-artifact",
+                str(artifact),
+                "--json",
+            ]
+        )
+
+    stdout = capsys.readouterr().out
+    output_payload = json.loads(stdout)
+    artifact_payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert rc == 1
+    assert output_payload["raw_review_comments_artifact_status"] == "error"
+    assert artifact_payload["prs"]["2697"] == {"status": "error", "error": "not found"}
 
 
 def test_main_requires_pr_number(capsys) -> None:  # type: ignore[no-untyped-def]

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -221,6 +221,36 @@ def test_snapshot_prs_can_include_bounded_review_threads() -> None:
     assert comment["body_omitted"] is True
 
 
+def test_snapshot_prs_handles_null_review_thread_graphql_fields() -> None:
+    """Null GraphQL response layers should not crash compact snapshots."""
+    pr_payload = {
+        "number": 2695,
+        "title": "null thread PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "url": "https://github.test/pull/2695",
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "abc995",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [{"name": "ci", "status": "completed", "conclusion": "success"}],
+        "reviews": [],
+        "comments": [],
+    }
+    thread_payload = {"data": {"repository": {"pullRequest": None}}}
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(thread_payload), stderr=""),
+        ]
+        payload = snapshot_prs([2695], repo="ll7/robot_sf_ll7", include_review_threads=True)
+
+    snapshot = payload["prs"][0]["review_thread_snapshot"]
+    assert snapshot["status"] == "ok"
+    assert snapshot["total"] == 0
+    assert snapshot["threads"] == []
+
+
 def test_raw_review_comments_artifact_writes_full_payload(tmp_path) -> None:  # type: ignore[no-untyped-def]
     """Raw review comments are opt-in and written to an artifact path."""
     artifact = tmp_path / "raw-review-comments.json"
@@ -239,6 +269,20 @@ def test_raw_review_comments_artifact_writes_full_payload(tmp_path) -> None:  # 
     assert payload["prs"]["2693"]["status"] == "ok"
     assert payload["prs"]["2693"]["contains_raw_diff_hunks"] is True
     assert payload["prs"]["2693"]["comments"][0]["diff_hunk"].startswith("@@")
+
+
+def test_raw_review_comments_artifact_rejects_invalid_repo(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Invalid repo names should write an error artifact without calling gh."""
+    artifact = tmp_path / "raw-review-comments.json"
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        write_raw_review_comments_artifact([2696], repo="robot_sf_ll7", path=artifact)
+
+    payload = json.loads(artifact.read_text(encoding="utf-8"))
+    assert payload["prs"]["2696"] == {
+        "status": "error",
+        "error": "repo_owner_missing",
+    }
+    mock_gh.assert_not_called()
 
 
 def test_main_raw_review_artifact_keeps_hunks_out_of_stdout(


### PR DESCRIPTION
## Summary
Adds compact PR review-thread snapshots to `snapshot_pr_queue.py` and keeps raw review-comment hunks behind an explicit artifact path.

## Linked Issues
- Closes #2951

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `--review-threads` for bounded review-thread excerpts without raw diff hunks or full bodies.
- Added `--raw-review-comments-artifact <path>` for opt-in raw review-comment payloads written to disk instead of stdout.
- Updated agent workflow guidance to prefer the compact path before raw GitHub payloads.
- Added tests for bounded thread snapshots, raw artifact writing, and stdout safety.

## Why It Matters
- Added value: Review/comment inspection can now stay compact even when PRs have large review bodies or diff hunks.
- Expected impact: Lower parent-thread token usage and clearer actionable review routing.
- Why this is worth merging now: It supports the ongoing autonomous PR-review loop without changing benchmark semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support helper only.
- Comparator or baseline, if applicable: NA
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: compact output omits raw hunks; full payloads require explicit artifact path.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2951
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - workflow support helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop after review if CI passes
- Proposed child issue or existing follow-up: NA - no child issue needed for this support helper

## Validation / Proof
- Commands run:
  - `uv run pytest tests/dev/test_snapshot_pr_queue.py -q`
  - `uv run ruff check scripts/dev/snapshot_pr_queue.py tests/dev/test_snapshot_pr_queue.py`
  - `uv run ruff format --check scripts/dev/snapshot_pr_queue.py tests/dev/test_snapshot_pr_queue.py`
  - `python -m py_compile scripts/dev/snapshot_pr_queue.py`
  - `git diff --check`
  - live smoke: `uv run python scripts/dev/snapshot_pr_queue.py --prs 2971 --review-threads --json`
  - live smoke: `uv run python scripts/dev/snapshot_pr_queue.py --prs 2971 --raw-review-comments-artifact <tmp> --json`
- Evidence that the change works here: tests verify bounded review-thread comment excerpts, hunk omission, raw artifact writing, active-mode guardrails, and no raw hunk leakage to stdout.
- Benchmarks or smoke tests, if applicable: NA - workflow helper.

## Risks / Rollout
- Compatibility risks: `--review-threads` adds one GraphQL request per explicit PR and is disabled for broad active discovery.
- Failure modes: raw artifact fetch can fail if GitHub CLI auth/network is unavailable; compact snapshot still works without the raw artifact option.
- Rollback or fallback plan: keep using existing `review_snapshot`/`comment_snapshot` fields.

## Docs / Provenance
- Updated docs: `AGENTS.md`
- Relevant design or provenance notes: issue #2951
- Any assumptions that need to be preserved: raw review-comment payloads are opt-in and must go to a private artifact path, not parent-thread stdout.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR link
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: This is workflow/token-efficiency tooling with no research claim.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: NA - no deferred work remains for this scoped helper

## Reviewer Notes
- Anything a reviewer should verify closely: `--review-threads` stays explicit and is rejected for broad `--active` mode.
- Any known limitations: raw artifact fetch stores REST review comments for the requested PRs only; it is intentionally not part of default stdout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added capture and display of PR review thread snapshots with bounded comment excerpts
  * Added optional export of full raw review comments (including diff hunks) to artifact files
  * Introduced CLI flags `--review-threads` and `--raw-review-comments-artifact` for granular control

* **Tests**
  * Added test coverage for review thread snapshot behavior, raw comments export, and CLI validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->