### PR TITLE
feat: add compact validation summaries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -213,6 +213,8 @@ Set up dependencies with `uv sync --all-extras` and install hooks via `uv run pr
 
 For shared local + VS Code + Codex workflows, prefer:
 - `scripts/dev/ruff_fix_format.sh`
+- `uv run python scripts/dev/run_compact_validation.py -- <command>` for bounded parent-thread validation output
+  with full logs and summary JSON under the common Git dir
 - `scripts/dev/run_tests_parallel.sh` (uses `pytest -n auto -x --failed-first` by default; supports wrapper flags `--new-first`, `--no-ordering`, `--no-fast-fail`)
 - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
 - `scripts/dev/gh_comment.sh` for multiline `gh` PR/issue comments (stdin or `--body-file`, avoids literal `\n` formatting issues)
@@ -345,6 +347,10 @@ resolving lint or test failures locally before requesting review.
   `--raw-review-comments-artifact "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/.../raw-review-comments.json"`.
 - Before finalization, cover format/check, focused tests, changed-file coverage when practical, and a
   clean worktree check (`git status --short`) as part of the readied proof bundle.
+- For failing validation commands, prefer `uv run python scripts/dev/run_compact_validation.py -- <command>` before
+  pasting raw test, lint, type-check, or docs output into an agent parent thread. The wrapper stores
+  the full log and `summary.json` under the common Git dir and prints only command, exit code,
+  elapsed time, artifact paths, failing pytest node ids when present, and bounded excerpts.
 - Before broad status or inventory output, use
   `uv run python scripts/dev/autopilot_state_snapshot.py --include-worktrees` or another compact
   helper so generated `.venv`, `.opencode`, `node_modules`, and `output` trees are summarized

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -416,6 +416,11 @@ for focused pytest targets. It stores the full pytest log under the common
 Git-dir agent-run artifacts and prints only a bounded pass/fail summary by
 default. Use `FOCUSED_TEST_FULL_OUTPUT=1` only when the raw pytest stream itself
 is the thing being debugged.
+For non-pytest gates or commands that may produce large failure logs, use
+`uv run python scripts/dev/run_compact_validation.py -- <command>`. It stores the full log and
+summary JSON under the common Git-dir agent-run artifacts and prints only the
+command, exit code, elapsed time, artifact paths, failing pytest node ids when
+present, and a bounded failure excerpt.
 
 After delegated worker runs, summarize route efficiency from one or more
 `scripts/dev/routed_worker_manifest.py` outputs without reading raw worker logs:

--- a/scripts/dev/run_compact_validation.py
+++ b/scripts/dev/run_compact_validation.py
@@ -50,18 +50,17 @@ def _quote_command(command: list[str]) -> str:
     return " ".join(shlex.quote(part) for part in command)
 
 
-def _matching_failure_line_count(text: str) -> int:
-    """Return the number of lines matching the failure summary filter."""
-    return sum(1 for line in text.splitlines() if FAILURE_PATTERNS.search(line))
-
-
-def _failure_lines(text: str, *, limit: int, width: int) -> list[str]:
-    """Extract bounded failure-oriented lines from command output."""
+def _failure_lines(text: str, *, limit: int, width: int) -> tuple[list[str], bool]:
+    """Extract bounded failure-oriented lines and whether output was truncated."""
     lines = text.splitlines()
     interesting = [line for line in lines if FAILURE_PATTERNS.search(line)]
     if not interesting:
-        interesting = lines[-limit:]
-    return [line[:width] for line in interesting[:limit]]
+        excerpt = lines[-limit:]
+        truncated = len(lines) > limit
+    else:
+        excerpt = interesting[:limit]
+        truncated = len(interesting) > limit
+    return [line[:width] for line in excerpt], truncated
 
 
 def _pytest_node_ids(text: str, *, limit: int = 40) -> list[str]:
@@ -97,12 +96,13 @@ def run_compact_validation(
     summary_path = artifact_dir / f"{base}.summary.json"
 
     started = time.monotonic()
-    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
+    result = subprocess.run(command, cwd=cwd, capture_output=True, check=False)
     elapsed = time.monotonic() - started
-    combined = result.stdout + result.stderr
+    stdout = result.stdout.decode("utf-8", errors="replace")
+    stderr = result.stderr.decode("utf-8", errors="replace")
+    combined = stdout + stderr
     log_path.write_text(combined, encoding="utf-8", errors="replace")
-    excerpt = _failure_lines(combined, limit=excerpt_lines, width=excerpt_width)
-    matching_lines = _matching_failure_line_count(combined)
+    excerpt, truncated = _failure_lines(combined, limit=excerpt_lines, width=excerpt_width)
     summary: dict[str, Any] = {
         "schema": SCHEMA_VERSION,
         "command": command,
@@ -113,7 +113,7 @@ def run_compact_validation(
         "log_path": str(log_path),
         "summary_path": str(summary_path),
         "excerpt_line_count": len(excerpt),
-        "excerpt_truncated": matching_lines > len(excerpt),
+        "excerpt_truncated": truncated,
         "failing_node_ids": _pytest_node_ids(combined),
         "failure_excerpt": excerpt,
     }

--- a/scripts/dev/run_compact_validation.py
+++ b/scripts/dev/run_compact_validation.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Run a validation command with bounded stdout and private full-log artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "compact_validation_summary.v1"
+DEFAULT_EXCERPT_LINES = 40
+DEFAULT_EXCERPT_WIDTH = 240
+
+FAILURE_PATTERNS = re.compile(
+    r"(FAILED|ERROR|FAILURES|Traceback|AssertionError|Exception|short test summary|"
+    r"^\s*__+|::test_|ruff|mypy|pyright|exit code)",
+    re.IGNORECASE,
+)
+PYTEST_NODE_PATTERN = re.compile(r"([\w./-]+\.py::[^\s]+)")
+
+
+def _repo_artifact_dir() -> Path:
+    """Return the private artifact directory for compact validation logs."""
+    result = subprocess.run(
+        ["git", "rev-parse", "--path-format=absolute", "--git-common-dir"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode == 0 and result.stdout.strip():
+        return Path(result.stdout.strip()) / "codex-agent-runs" / "active" / "compact-validation"
+    return Path("output") / "tmp" / "compact-validation"
+
+
+def _now_slug() -> str:
+    """Return a UTC timestamp safe for artifact file names."""
+    return datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _quote_command(command: list[str]) -> str:
+    """Return a shell-readable representation of *command*."""
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def _matching_failure_line_count(text: str) -> int:
+    """Return the number of lines matching the failure summary filter."""
+    return sum(1 for line in text.splitlines() if FAILURE_PATTERNS.search(line))
+
+
+def _failure_lines(text: str, *, limit: int, width: int) -> list[str]:
+    """Extract bounded failure-oriented lines from command output."""
+    lines = text.splitlines()
+    interesting = [line for line in lines if FAILURE_PATTERNS.search(line)]
+    if not interesting:
+        interesting = lines[-limit:]
+    return [line[:width] for line in interesting[:limit]]
+
+
+def _pytest_node_ids(text: str, *, limit: int = 40) -> list[str]:
+    """Extract unique pytest node ids from command output."""
+    node_ids: list[str] = []
+    seen: set[str] = set()
+    for match in PYTEST_NODE_PATTERN.finditer(text):
+        node_id = match.group(1).rstrip(":,")
+        if node_id not in seen:
+            seen.add(node_id)
+            node_ids.append(node_id)
+        if len(node_ids) >= limit:
+            break
+    return node_ids
+
+
+def run_compact_validation(
+    command: list[str],
+    *,
+    artifact_dir: Path | None = None,
+    excerpt_lines: int = DEFAULT_EXCERPT_LINES,
+    excerpt_width: int = DEFAULT_EXCERPT_WIDTH,
+    cwd: Path | None = None,
+) -> dict[str, Any]:
+    """Run *command*, save full output, and return a compact summary payload."""
+    if not command:
+        raise ValueError("command must not be empty")
+    cwd = cwd or Path.cwd()
+    artifact_dir = artifact_dir or _repo_artifact_dir()
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    base = f"validation-{_now_slug()}-{os.getpid()}"
+    log_path = artifact_dir / f"{base}.log"
+    summary_path = artifact_dir / f"{base}.summary.json"
+
+    started = time.monotonic()
+    result = subprocess.run(command, cwd=cwd, capture_output=True, text=True, check=False)
+    elapsed = time.monotonic() - started
+    combined = result.stdout + result.stderr
+    log_path.write_text(combined, encoding="utf-8", errors="replace")
+    excerpt = _failure_lines(combined, limit=excerpt_lines, width=excerpt_width)
+    matching_lines = _matching_failure_line_count(combined)
+    summary: dict[str, Any] = {
+        "schema": SCHEMA_VERSION,
+        "command": command,
+        "command_display": _quote_command(command),
+        "cwd": str(cwd),
+        "exit_code": result.returncode,
+        "elapsed_seconds": round(elapsed, 3),
+        "log_path": str(log_path),
+        "summary_path": str(summary_path),
+        "excerpt_line_count": len(excerpt),
+        "excerpt_truncated": matching_lines > len(excerpt),
+        "failing_node_ids": _pytest_node_ids(combined),
+        "failure_excerpt": excerpt,
+    }
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return summary
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--artifact-dir",
+        type=Path,
+        default=None,
+        help="Directory for full log and summary JSON; defaults under git common dir.",
+    )
+    parser.add_argument(
+        "--excerpt-lines",
+        type=int,
+        default=DEFAULT_EXCERPT_LINES,
+        help="Maximum failure-oriented lines to print.",
+    )
+    parser.add_argument(
+        "--excerpt-width",
+        type=int,
+        default=DEFAULT_EXCERPT_WIDTH,
+        help="Maximum characters per excerpt line.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print the compact summary as JSON.")
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Command to run after --.")
+    args = parser.parse_args(argv)
+    if args.command and args.command[0] == "--":
+        args.command = args.command[1:]
+    if not args.command:
+        parser.error("a validation command is required after --")
+    if args.excerpt_lines < 1:
+        parser.error("--excerpt-lines must be positive")
+    if args.excerpt_width < 20:
+        parser.error("--excerpt-width must be at least 20")
+    return args
+
+
+def _print_human_summary(summary: dict[str, Any]) -> None:
+    """Print a bounded human-readable validation summary."""
+    print(f"Command: {summary['command_display']}")
+    print(f"Exit code: {summary['exit_code']}")
+    print(f"Elapsed seconds: {summary['elapsed_seconds']}")
+    print(f"Full log: {summary['log_path']}")
+    print(f"Summary JSON: {summary['summary_path']}")
+    if summary["failing_node_ids"]:
+        print("Failing node ids:")
+        for node_id in summary["failing_node_ids"]:
+            print(f"- {node_id}")
+    print("Failure excerpt:")
+    for line in summary["failure_excerpt"]:
+        print(line)
+    if summary["excerpt_truncated"]:
+        print("... additional matching lines omitted; see full log")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    summary = run_compact_validation(
+        args.command,
+        artifact_dir=args.artifact_dir,
+        excerpt_lines=args.excerpt_lines,
+        excerpt_width=args.excerpt_width,
+    )
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        _print_human_summary(summary)
+    return int(summary["exit_code"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/dev/test_run_compact_validation.py
+++ b/tests/dev/test_run_compact_validation.py
@@ -72,6 +72,26 @@ def test_run_compact_validation_json_summary_for_success(tmp_path: Path, capsys)
     assert Path(payload["summary_path"]).exists()
 
 
+def test_run_compact_validation_marks_truncated_plain_output(tmp_path: Path) -> None:
+    """Large output without failure keywords should still report truncation."""
+    artifact_dir = tmp_path / "artifacts"
+    command = [
+        sys.executable,
+        "-c",
+        "for i in range(30): print(f'plain output line {i}')",
+    ]
+
+    summary = run_compact_validation(command, artifact_dir=artifact_dir, excerpt_lines=3)
+
+    assert summary["exit_code"] == 0
+    assert summary["excerpt_truncated"] is True
+    assert summary["failure_excerpt"] == [
+        "plain output line 27",
+        "plain output line 28",
+        "plain output line 29",
+    ]
+
+
 def test_run_compact_validation_rejects_empty_command() -> None:
     """The library helper should fail loudly for an empty command."""
     try:

--- a/tests/dev/test_run_compact_validation.py
+++ b/tests/dev/test_run_compact_validation.py
@@ -1,0 +1,82 @@
+"""Tests for compact validation command summaries."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from scripts.dev.run_compact_validation import main, run_compact_validation
+
+
+def test_run_compact_validation_bounds_failure_output(tmp_path: Path, capsys) -> None:
+    """Many failure lines should produce a bounded parent-thread summary."""
+    artifact_dir = tmp_path / "artifacts"
+    command = [
+        sys.executable,
+        "-c",
+        "\n".join(
+            [
+                "import sys",
+                "print('============================= FAILURES =============================')",
+                "for i in range(80):",
+                "    print(f'FAILED tests/dev/test_many.py::test_{i} - boom')",
+                "sys.exit(7)",
+            ]
+        ),
+    ]
+
+    rc = main(
+        [
+            "--artifact-dir",
+            str(artifact_dir),
+            "--excerpt-lines",
+            "5",
+            "--",
+            *command,
+        ]
+    )
+
+    stdout = capsys.readouterr().out
+    summaries = list(artifact_dir.glob("*.summary.json"))
+    logs = list(artifact_dir.glob("*.log"))
+    assert rc == 7
+    assert "Exit code: 7" in stdout
+    assert "Full log:" in stdout
+    assert "FAILED tests/dev/test_many.py::test_0 - boom" in stdout
+    assert "test_79" not in stdout
+    assert "additional matching lines omitted" in stdout
+    assert len(summaries) == 1
+    assert len(logs) == 1
+    assert "test_79" in logs[0].read_text(encoding="utf-8")
+    summary = json.loads(summaries[0].read_text(encoding="utf-8"))
+    assert summary["exit_code"] == 7
+    assert summary["excerpt_line_count"] == 5
+    assert summary["excerpt_truncated"] is True
+    assert summary["failing_node_ids"][0] == "tests/dev/test_many.py::test_0"
+
+
+def test_run_compact_validation_json_summary_for_success(tmp_path: Path, capsys) -> None:
+    """Successful commands should still save full logs and emit summary JSON."""
+    artifact_dir = tmp_path / "artifacts"
+    command = [sys.executable, "-c", "print('ok')"]
+
+    rc = main(["--artifact-dir", str(artifact_dir), "--json", "--", *command])
+
+    stdout = capsys.readouterr().out
+    payload = json.loads(stdout)
+    assert rc == 0
+    assert payload["exit_code"] == 0
+    assert payload["failure_excerpt"] == ["ok"]
+    assert Path(payload["log_path"]).read_text(encoding="utf-8") == "ok\n"
+    assert Path(payload["summary_path"]).exists()
+
+
+def test_run_compact_validation_rejects_empty_command() -> None:
+    """The library helper should fail loudly for an empty command."""
+    try:
+        run_compact_validation([])
+    except ValueError as exc:
+        assert "command must not be empty" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected ValueError")


### PR DESCRIPTION
## Summary
- add scripts/dev/run_compact_validation.py for bounded parent-thread validation output with full logs and summary JSON under the git common dir
- add tests proving large failing command output is bounded while full logs remain available
- document the wrapper in AGENTS.md and docs/dev_guide.md

Closes #2950

## Validation
- uv run pytest tests/dev/test_run_compact_validation.py tests/dev/test_run_focused_tests_cleanup.py -q
- uv run ruff check scripts/dev/run_compact_validation.py tests/dev/test_run_compact_validation.py
- uv run ruff format --check scripts/dev/run_compact_validation.py tests/dev/test_run_compact_validation.py
- python -m py_compile scripts/dev/run_compact_validation.py
- git diff --check

## Downstream Propagation
- AGENTS.md and docs/dev_guide.md now point agents to the compact wrapper before raw validation output.
- No benchmark artifacts, leaderboard, or model registry updates required.

## Research Result Guidance
NA - support/tooling only; this PR changes validation-output handling, not benchmark claims or metrics.