### PR TITLE
feat: quarantine blocked external issue routing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -338,6 +338,9 @@ resolving lint or test failures locally before requesting review.
 - For delegated-worker routing, prefer a compact preflight ledger before implementation or review
   dispatch: `gh auth status`, `scripts/dev/snapshot_pr_queue.py --prs <number> --expected-head-sha <sha> --json`,
   and `scripts/dev/check_pr_ci_status.py --expected-head-sha <sha>`.
+- Default claimable issue snapshots should keep blocked external-data issues out of agent routing;
+  use `scripts/dev/snapshot_issue_batch.py --blocked-external-report` for the parked human-action
+  report, or `--include-blocked-external` only when explicitly auditing that queue.
 - Treat `preflight.status == "stale"` lanes as invalid until refreshed.
 - If review/comment data is needed, start from compact `review_snapshot`/`comment_snapshot`/`checks`
   output rather than raw `gh` payloads. For PR review threads, use

--- a/docs/context/evidence/issue_2962_blocked_external_assets.md
+++ b/docs/context/evidence/issue_2962_blocked_external_assets.md
@@ -1,0 +1,22 @@
+# Blocked External Assets Report
+
+| Issue | Owner | Human action | Monthly review | Label recommendation |
+| --- | --- | --- | --- | --- |
+| #2918 data: pilot external pedestrian-prior extraction after dataset staging | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #2657 data: make SDD scenario-prior staging reproducible | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #2655 training: add durable trace URI registry for oracle imitation artifacts | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input`; remove `state:ready` |
+| #2417 blocked: keep AMV paper-facing unlock criteria gated on real source status | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #2416 blocked: hold AMV profile implementation until source provenance is accepted | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #2415 data: stage real AMV command-response trace manifest through amv-calibration path | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #2414 data: validate SocNavBench ETH traversible manifest and run eth_first converter preflight | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #2413 data: validate staged SDD annotation manifest and importer readiness | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #2312 data: materialize durable learned-risk training traces for #1472 | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input`; remove `state:ready` |
+| #2000 data: collect real AMV command-response trace for calibrated actuation envelope | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #1764 data: recover or retire remaining local-only baseline configs | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input`; remove `state:ready` |
+| #1585 data: identify calibrated AMV actuation source provenance | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input`; remove `state:ready` |
+| #1559 benchmark: calibrate AMV actuation envelope before paper-facing use | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #1498 data: stage SocNavBench ETH traversible assets with provenance | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #1497 setup: stage licensed Stanford Drone Dataset annotations for benchmark use | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #1456 data-infra: restore SocNavBench control-pipeline assets | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #1134 map: convert SocNavBench ETH map after traversible asset staging | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |
+| #1126 bench: curate first real SDD-derived benchmark scenario set | external data | Stage or document the required external data/asset/license before agent execution. | 2026-07-01 | add `state:blocked-external-input` |

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -402,10 +402,18 @@ GitHub or repository reads:
 uv run python scripts/dev/snapshot_issue_batch.py 2665 2675 --json
 uv run python scripts/dev/snapshot_issue_batch.py 2665 2675 --json \
   --capsule-dir "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active"
+uv run python scripts/dev/snapshot_issue_batch.py --claimable --json
+uv run python scripts/dev/snapshot_issue_batch.py --blocked-external-report \
+  --report-path "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active/blocked-external-assets.md"
 uv run python scripts/dev/snapshot_pr_queue.py --prs 2677 2678 2679 --json \
   --expected-head-sha "$PR_HEAD_SHA"
 uv run python scripts/dev/watch_pr_ci_status.py 2679 --expected-head-sha "$SHA" --json --once
 ```
+
+Default `--claimable` issue snapshots omit issues classified as blocked on external data, assets,
+licenses, or human staging input. Use `--include-blocked-external` only when deliberately auditing
+that parked queue, or `--blocked-external-report` to generate a compact human-action report with
+monthly review dates.
 
 Use the snapshot JSON to seed worker prompts and active ledgers. Redirect broad
 search output or raw GitHub bodies to private agent-run artifacts; return only

--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -394,6 +394,14 @@ def snapshot_blocked_external_issues(
         except json.JSONDecodeError as exc:
             listed = []
             errors = [{"status": "error", "error": f"invalid gh JSON: {exc}"}]
+        if not errors and not isinstance(listed, list):
+            listed = []
+            errors = [
+                {
+                    "status": "error",
+                    "error": "expected gh issue list JSON array",
+                }
+            ]
         rows = [
             _blocked_external_row(issue, now=now)
             for issue in listed
@@ -524,6 +532,12 @@ def main(argv: list[str] | None = None) -> int:
     if args.claimable and args.issues:
         print(
             "--claimable cannot be combined with explicit issue numbers",
+            file=sys.stderr,
+        )
+        return 1
+    if args.include_blocked_external and not args.claimable:
+        print(
+            "--include-blocked-external requires --claimable",
             file=sys.stderr,
         )
         return 1

--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -8,6 +8,7 @@ import json
 import pathlib
 import subprocess
 import sys
+from datetime import UTC, datetime
 from typing import Any
 
 from scripts.dev.issue_claim import status_issue
@@ -16,6 +17,14 @@ BODY_EXCERPT_CHARS = 300
 DEFAULT_CLAIMABLE_LIMIT = 20
 DEFAULT_REPO = "ll7/robot_sf_ll7"
 DEFAULT_REMOTE = "origin"
+BLOCKED_EXTERNAL_INPUT_LABEL = "state:blocked-external-input"
+EXTERNAL_RESOURCE_LABEL = "resource:external-data"
+EXTERNAL_BLOCKER_LABELS = {
+    BLOCKED_EXTERNAL_INPUT_LABEL,
+    "blocked",
+    "evidence:blocked",
+    "state:blocked",
+}
 UNCLAIMABLE_LABELS = {
     "blocked",
     "decision-required",
@@ -73,6 +82,8 @@ def _issue_classification(
     """Return a short claimability classification and rationale."""
     if assignees:
         return "assigned", "assigned; skip auto-claim"
+    if _is_blocked_external_issue(labels):
+        return "blocked_external", "external input required; omit from default agent queue"
     if any(label in UNCLAIMABLE_LABELS for label in labels):
         return "blocked_label", "label suggests skip in autonomous claim mode"
     if claim.get("ok") is False:
@@ -80,6 +91,14 @@ def _issue_classification(
     if claim.get("claimed"):
         return "claimed", "already claimed by another worker"
     return "claimable", "open, unassigned, and unclaimed"
+
+
+def _is_blocked_external_issue(labels: list[str]) -> bool:
+    """Return whether labels describe an issue blocked on external assets or input."""
+    label_set = set(labels)
+    if BLOCKED_EXTERNAL_INPUT_LABEL in label_set:
+        return True
+    return EXTERNAL_RESOURCE_LABEL in label_set and bool(EXTERNAL_BLOCKER_LABELS & label_set)
 
 
 def _body_excerpt(body: Any, *, limit: int) -> tuple[str, bool]:
@@ -196,7 +215,12 @@ def _snapshot_from_issue_list(issue: dict[str, Any], *, remote: str) -> dict[str
 
 
 def snapshot_claimable_issues(
-    *, repo: str, remote: str, body_limit: int, limit: int
+    *,
+    repo: str,
+    remote: str,
+    body_limit: int,
+    limit: int,
+    include_blocked_external: bool = False,
 ) -> dict[str, Any]:
     """Return a compact claimable/open issue snapshot."""
     result = _gh(
@@ -255,7 +279,12 @@ def snapshot_claimable_issues(
             ],
         }
 
-    issues = [_snapshot_from_issue_list(issue, remote=remote) for issue in listed]
+    snapshots = [_snapshot_from_issue_list(issue, remote=remote) for issue in listed]
+    issues = [
+        issue
+        for issue in snapshots
+        if include_blocked_external or issue.get("classification") != "blocked_external"
+    ]
     if body_limit <= 0:
         body_limit = BODY_EXCERPT_CHARS
     return {
@@ -263,7 +292,128 @@ def snapshot_claimable_issues(
         "repo": repo,
         "body_excerpt_chars": body_limit,
         "mode": "claimable",
+        "include_blocked_external": include_blocked_external,
+        "excluded_counts": {
+            "blocked_external": sum(
+                1 for issue in snapshots if issue.get("classification") == "blocked_external"
+            ),
+        },
         "issues": issues,
+    }
+
+
+def _next_monthly_review_date(now: datetime | None = None) -> str:
+    """Return a stable monthly review date, using the first UTC day of next month."""
+    current = now or datetime.now(UTC)
+    year = current.year + (1 if current.month == 12 else 0)
+    month = 1 if current.month == 12 else current.month + 1
+    return f"{year:04d}-{month:02d}-01"
+
+
+def _blocked_external_row(issue: dict[str, Any]) -> dict[str, Any]:
+    """Return one human-review row for a blocked external-asset issue."""
+    labels = _labels(issue)
+    label_set = set(labels)
+    recommendations: list[str] = []
+    if BLOCKED_EXTERNAL_INPUT_LABEL not in label_set:
+        recommendations.append(f"add `{BLOCKED_EXTERNAL_INPUT_LABEL}`")
+    if "state:ready" in label_set:
+        recommendations.append("remove `state:ready`")
+    return {
+        "number": issue.get("number"),
+        "title": issue.get("title", ""),
+        "url": issue.get("url", ""),
+        "labels": labels,
+        "owner_type": "external data",
+        "human_action": (
+            "Stage or document the required external data/asset/license before agent execution."
+        ),
+        "monthly_review_date": _next_monthly_review_date(),
+        "label_recommendation": "; ".join(recommendations) if recommendations else "none",
+    }
+
+
+def _blocked_external_markdown(rows: list[dict[str, Any]]) -> str:
+    """Return a compact Markdown report for human review."""
+    lines = [
+        "# Blocked External Assets Report",
+        "",
+        "| Issue | Owner | Human action | Monthly review | Label recommendation |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        issue = f"#{row['number']} {row['title']}".replace("|", "\\|")
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    issue,
+                    row["owner_type"],
+                    row["human_action"],
+                    row["monthly_review_date"],
+                    row["label_recommendation"],
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def snapshot_blocked_external_issues(
+    *, repo: str, report_path: str = "", limit: int
+) -> dict[str, Any]:
+    """Return a compact blocked external-assets report."""
+    result = _gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--label",
+            EXTERNAL_RESOURCE_LABEL,
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,state,labels,url,assignees",
+        ]
+    )
+    if result.returncode != 0:
+        rows: list[dict[str, Any]] = []
+        errors = [
+            {
+                "status": "error",
+                "error": result.stderr.strip() or f"gh returned exit code {result.returncode}",
+            }
+        ]
+    else:
+        errors = []
+        try:
+            listed = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            listed = []
+            errors = [{"status": "error", "error": f"invalid gh JSON: {exc}"}]
+        rows = [
+            _blocked_external_row(issue)
+            for issue in listed
+            if isinstance(issue, dict) and _is_blocked_external_issue(_labels(issue))
+        ]
+    markdown = _blocked_external_markdown(rows)
+    if report_path:
+        path = pathlib.Path(report_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(markdown, encoding="utf-8")
+    return {
+        "schema": "blocked_external_assets_report.v1",
+        "repo": repo,
+        "mode": "blocked_external_report",
+        "recommended_state_label": BLOCKED_EXTERNAL_INPUT_LABEL,
+        "rows": rows,
+        "row_count": len(rows),
+        "report_path": report_path,
+        "markdown": markdown,
+        "errors": errors,
     }
 
 
@@ -330,6 +480,21 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         action="store_true",
         help="Discover bounded open claimable issues without explicit issue numbers.",
     )
+    parser.add_argument(
+        "--include-blocked-external",
+        action="store_true",
+        help="Include blocked external-input issues in --claimable output.",
+    )
+    parser.add_argument(
+        "--blocked-external-report",
+        action="store_true",
+        help="Generate a compact blocked external-assets report instead of claim routing.",
+    )
+    parser.add_argument(
+        "--report-path",
+        default="",
+        help="Optional Markdown path for --blocked-external-report.",
+    )
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--remote", default=DEFAULT_REMOTE)
     parser.add_argument("--body-chars", type=int, default=BODY_EXCERPT_CHARS)
@@ -362,14 +527,27 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
+    if args.blocked_external_report and (args.claimable or args.issues):
+        print(
+            "--blocked-external-report cannot be combined with --claimable or issue numbers",
+            file=sys.stderr,
+        )
+        return 1
     numbers = expand_issue_numbers(args.issues, expand_range=not args.no_expand_range)
     try:
-        if args.claimable:
+        if args.blocked_external_report:
+            payload = snapshot_blocked_external_issues(
+                repo=args.repo,
+                report_path=args.report_path,
+                limit=max(args.limit, 1),
+            )
+        elif args.claimable:
             payload = snapshot_claimable_issues(
                 repo=args.repo,
                 remote=args.remote,
                 body_limit=max(args.body_chars, 0),
                 limit=max(args.limit, 1),
+                include_blocked_external=args.include_blocked_external,
             )
         elif args.issues:
             payload = snapshot_issues(
@@ -392,7 +570,9 @@ def main(argv: list[str] | None = None) -> int:
         print(f"snapshot command timed out: {exc}", file=sys.stderr)
         return 1
     print(json.dumps(payload, indent=2, sort_keys=True) if args.json else json.dumps(payload))
-    return 1 if any(issue.get("status") == "error" for issue in payload["issues"]) else 0
+    if "issues" in payload:
+        return 1 if any(issue.get("status") == "error" for issue in payload["issues"]) else 0
+    return 1 if payload.get("errors") else 0
 
 
 if __name__ == "__main__":

--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -310,7 +310,7 @@ def _next_monthly_review_date(now: datetime | None = None) -> str:
     return f"{year:04d}-{month:02d}-01"
 
 
-def _blocked_external_row(issue: dict[str, Any]) -> dict[str, Any]:
+def _blocked_external_row(issue: dict[str, Any], now: datetime | None = None) -> dict[str, Any]:
     """Return one human-review row for a blocked external-asset issue."""
     labels = _labels(issue)
     label_set = set(labels)
@@ -328,7 +328,7 @@ def _blocked_external_row(issue: dict[str, Any]) -> dict[str, Any]:
         "human_action": (
             "Stage or document the required external data/asset/license before agent execution."
         ),
-        "monthly_review_date": _next_monthly_review_date(),
+        "monthly_review_date": _next_monthly_review_date(now),
         "label_recommendation": "; ".join(recommendations) if recommendations else "none",
     }
 
@@ -360,7 +360,7 @@ def _blocked_external_markdown(rows: list[dict[str, Any]]) -> str:
 
 
 def snapshot_blocked_external_issues(
-    *, repo: str, report_path: str = "", limit: int
+    *, repo: str, report_path: str = "", limit: int, now: datetime | None = None
 ) -> dict[str, Any]:
     """Return a compact blocked external-assets report."""
     result = _gh(
@@ -395,7 +395,7 @@ def snapshot_blocked_external_issues(
             listed = []
             errors = [{"status": "error", "error": f"invalid gh JSON: {exc}"}]
         rows = [
-            _blocked_external_row(issue)
+            _blocked_external_row(issue, now=now)
             for issue in listed
             if isinstance(issue, dict) and _is_blocked_external_issue(_labels(issue))
         ]

--- a/tests/dev/test_snapshot_issue_batch.py
+++ b/tests/dev/test_snapshot_issue_batch.py
@@ -237,6 +237,8 @@ def test_snapshot_claimable_issues_can_include_blocked_external() -> None:
 
 def test_snapshot_blocked_external_issues_writes_human_report(tmp_path) -> None:  # type: ignore[no-untyped-def]
     """Blocked external report should provide one action and monthly review date per row."""
+    from datetime import UTC, datetime
+
     report_path = tmp_path / "blocked-assets.md"
     issue_list = [
         {
@@ -267,6 +269,7 @@ def test_snapshot_blocked_external_issues_writes_human_report(tmp_path) -> None:
             repo="ll7/robot_sf_ll7",
             report_path=str(report_path),
             limit=10,
+            now=datetime(2026, 6, 15, tzinfo=UTC),
         )
 
     assert payload["schema"] == "blocked_external_assets_report.v1"
@@ -275,7 +278,7 @@ def test_snapshot_blocked_external_issues_writes_human_report(tmp_path) -> None:
     row = payload["rows"][0]
     assert row["number"] == 2415
     assert row["human_action"].count(".") == 1
-    assert row["monthly_review_date"].endswith("-01")
+    assert row["monthly_review_date"] == "2026-07-01"
     assert "add `state:blocked-external-input`" in row["label_recommendation"]
     assert "remove `state:ready`" in row["label_recommendation"]
     assert "#2415 data: stage external asset" in report_path.read_text(encoding="utf-8")

--- a/tests/dev/test_snapshot_issue_batch.py
+++ b/tests/dev/test_snapshot_issue_batch.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from scripts.dev.snapshot_issue_batch import (
     expand_issue_numbers,
     main,
+    snapshot_blocked_external_issues,
     snapshot_claimable_issues,
     snapshot_issues,
 )
@@ -155,6 +156,129 @@ def test_snapshot_claimable_issues_includes_classification_without_body() -> Non
     assert payload["issues"][0]["body_truncated"] is False
     assert payload["issues"][1]["classification"] == "blocked_label"
     assert "reason" in payload["issues"][1]
+
+
+def test_snapshot_claimable_issues_excludes_blocked_external_by_default() -> None:
+    """Default claim routing should quarantine external-data blockers."""
+    issue_list = [
+        {
+            "number": 2962,
+            "title": "workflow issue",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2962",
+            "labels": [{"name": "workflow"}],
+            "assignees": [],
+        },
+        {
+            "number": 2415,
+            "title": "data: stage external asset",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2415",
+            "labels": [{"name": "resource:external-data"}, {"name": "state:blocked"}],
+            "assignees": [],
+        },
+    ]
+
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+            claim.return_value = {
+                "ok": True,
+                "claimed": False,
+                "claim_ref": "agent-claims/issue",
+                "sha": None,
+            }
+            payload = snapshot_claimable_issues(
+                repo="ll7/robot_sf_ll7",
+                remote="origin",
+                body_limit=150,
+                limit=2,
+            )
+
+    assert [issue["number"] for issue in payload["issues"]] == [2962]
+    assert payload["excluded_counts"] == {"blocked_external": 1}
+    assert payload["include_blocked_external"] is False
+
+
+def test_snapshot_claimable_issues_can_include_blocked_external() -> None:
+    """Explicit routing should expose quarantined external blockers."""
+    issue_list = [
+        {
+            "number": 2415,
+            "title": "data: stage external asset",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2415",
+            "labels": [{"name": "resource:external-data"}, {"name": "state:blocked"}],
+            "assignees": [],
+        }
+    ]
+
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+            claim.return_value = {
+                "ok": True,
+                "claimed": False,
+                "claim_ref": "agent-claims/issue-2415",
+                "sha": None,
+            }
+            payload = snapshot_claimable_issues(
+                repo="ll7/robot_sf_ll7",
+                remote="origin",
+                body_limit=150,
+                limit=1,
+                include_blocked_external=True,
+            )
+
+    assert payload["include_blocked_external"] is True
+    assert payload["issues"][0]["classification"] == "blocked_external"
+    assert payload["excluded_counts"] == {"blocked_external": 1}
+
+
+def test_snapshot_blocked_external_issues_writes_human_report(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Blocked external report should provide one action and monthly review date per row."""
+    report_path = tmp_path / "blocked-assets.md"
+    issue_list = [
+        {
+            "number": 2415,
+            "title": "data: stage external asset",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2415",
+            "labels": [
+                {"name": "resource:external-data"},
+                {"name": "state:blocked"},
+                {"name": "state:ready"},
+            ],
+            "assignees": [],
+        },
+        {
+            "number": 2962,
+            "title": "workflow: executable now",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2962",
+            "labels": [{"name": "resource:external-data"}, {"name": "state:ready"}],
+            "assignees": [],
+        },
+    ]
+
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        payload = snapshot_blocked_external_issues(
+            repo="ll7/robot_sf_ll7",
+            report_path=str(report_path),
+            limit=10,
+        )
+
+    assert payload["schema"] == "blocked_external_assets_report.v1"
+    assert payload["recommended_state_label"] == "state:blocked-external-input"
+    assert payload["row_count"] == 1
+    row = payload["rows"][0]
+    assert row["number"] == 2415
+    assert row["human_action"].count(".") == 1
+    assert row["monthly_review_date"].endswith("-01")
+    assert "add `state:blocked-external-input`" in row["label_recommendation"]
+    assert "remove `state:ready`" in row["label_recommendation"]
+    assert "#2415 data: stage external asset" in report_path.read_text(encoding="utf-8")
 
 
 def test_main_claimable_mode_can_be_called_without_issue_numbers() -> None:  # type: ignore[no-untyped-def]

--- a/tests/dev/test_snapshot_issue_batch.py
+++ b/tests/dev/test_snapshot_issue_batch.py
@@ -277,11 +277,38 @@ def test_snapshot_blocked_external_issues_writes_human_report(tmp_path) -> None:
     assert payload["row_count"] == 1
     row = payload["rows"][0]
     assert row["number"] == 2415
-    assert row["human_action"].count(".") == 1
+    assert row["human_action"] == (
+        "Stage or document the required external data/asset/license before agent execution."
+    )
     assert row["monthly_review_date"] == "2026-07-01"
     assert "add `state:blocked-external-input`" in row["label_recommendation"]
     assert "remove `state:ready`" in row["label_recommendation"]
     assert "#2415 data: stage external asset" in report_path.read_text(encoding="utf-8")
+
+
+def test_snapshot_blocked_external_issues_reports_unexpected_json_shape() -> None:
+    """Blocked external report should fail closed on unexpected gh JSON shape."""
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"message": "not an issue list"}),
+            stderr="",
+        )
+        payload = snapshot_blocked_external_issues(
+            repo="ll7/robot_sf_ll7",
+            limit=10,
+        )
+
+    assert payload["row_count"] == 0
+    assert payload["errors"] == [{"status": "error", "error": "expected gh issue list JSON array"}]
+
+
+def test_main_rejects_include_blocked_external_without_claimable(capsys) -> None:  # type: ignore[no-untyped-def]
+    """CLI should not silently ignore --include-blocked-external outside claimable mode."""
+    rc = main(["--include-blocked-external", "--json"])
+
+    assert rc == 1
+    assert "--include-blocked-external requires --claimable" in capsys.readouterr().err
 
 
 def test_main_claimable_mode_can_be_called_without_issue_numbers() -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary
- add `state:blocked-external-input` as the explicit quarantine label for externally blocked issue lanes
- update compact issue snapshots so default `--claimable` output omits blocked external-asset issues unless `--include-blocked-external` is requested
- add `--blocked-external-report` with one human action, monthly review date, and label recommendation per parked row
- add generated report at `docs/context/evidence/issue_2962_blocked_external_assets.md`

Closes #2962

## Validation
- `uv run pytest tests/dev/test_snapshot_issue_batch.py -q`
- `uv run ruff check scripts/dev/snapshot_issue_batch.py tests/dev/test_snapshot_issue_batch.py`
- `uv run ruff format --check scripts/dev/snapshot_issue_batch.py tests/dev/test_snapshot_issue_batch.py`
- `python -m py_compile scripts/dev/snapshot_issue_batch.py`
- `git diff --check`
- live smoke: `uv run python scripts/dev/snapshot_issue_batch.py --blocked-external-report --limit 50 --report-path docs/context/evidence/issue_2962_blocked_external_assets.md --json` produced 18 rows and no errors
- live smoke: `uv run python scripts/dev/snapshot_issue_batch.py --claimable --limit 30 --json` omitted blocked external rows by default and reported `excluded_counts.blocked_external=1` in the sampled queue
- label verification: `state:blocked-external-input` exists on GitHub

## Downstream Propagation
- `AGENTS.md` and `docs/dev_guide.md` now document default quarantine routing and explicit audit/report modes.
- `docs/context/evidence/issue_2962_blocked_external_assets.md` is the compact durable report for maintainer review.
- No benchmark leaderboard, model registry, or metric claim updates required.

## Research Result Guidance
NA - workflow/tooling change. It improves issue routing and blocked-asset visibility but does not create benchmark or metric evidence.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on handling blocked external issues in agent routing workflows
  * Created a new report documenting blocked external assets with ownership and review tracking
  * Updated development guide with snapshot command examples and clarifications on default filtering behavior

* **New Features**
  * New snapshot report mode for generating blocked external assets reports
  * Added command-line flags to control filtering and inclusion of blocked issues in snapshots

<!-- end of auto-generated comment: release notes by coderabbit.ai -->