### PR TITLE
feat: add active issue portfolio snapshot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -341,6 +341,9 @@ resolving lint or test failures locally before requesting review.
 - Default claimable issue snapshots should keep blocked external-data issues out of agent routing;
   use `scripts/dev/snapshot_issue_batch.py --blocked-external-report` for the parked human-action
   report, or `--include-blocked-external` only when explicitly auditing that queue.
+- Use `scripts/dev/snapshot_issue_batch.py --active-portfolio` when reviewing the broader open
+  issue portfolio for executable, human-decision, blocked-external, diagnostic-only, stale
+  synthesis, and paper-critical routing recommendations without applying labels automatically.
 - Treat `preflight.status == "stale"` lanes as invalid until refreshed.
 - If review/comment data is needed, start from compact `review_snapshot`/`comment_snapshot`/`checks`
   output rather than raw `gh` payloads. For PR review threads, use

--- a/docs/context/evidence/issue_2967_active_issue_portfolio.md
+++ b/docs/context/evidence/issue_2967_active_issue_portfolio.md
@@ -1,0 +1,54 @@
+# Active Issue Portfolio
+
+| Issue | Classification | Owner | Next action | Label recommendation |
+| --- | --- | --- | --- | --- |
+| #2967 workflow: generate active issue portfolio with parked/blocked demotion recommendations | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2966 prediction: run planner-consumed forecast slice after native replay smoke | needs_human_decision | maintainer | Maintainer should decide, relabel, or split before agent execution. | add `decision-required` |
+| #2965 benchmark: generate v0.1 release readiness dashboard | paper_critical | agent | Prioritize for release evidence review and claim-boundary checks. | add `paper-critical` |
+| #2961 workflow: turn fast-results claim map into executable issue queue | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2953 Audit Qwen-RobotNav metrics and benchmark evidence | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2952 Assess Qwen-RobotNav for Robot SF local navigation | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2946 analysis: produce first mechanism-evidence figure pack from existing traces | diagnostic_only | agent | Keep as diagnostic evidence unless a follow-up benchmark proof issue is opened. | none |
+| #2945 evidence: create one finalizer-to-evidence manifest bridge | executable_now | Slurm | Agent may claim and execute the issue contract. | none |
+| #2930 docs: create external benchmark positioning note | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2928 interop: compare Robot SF metrics against SocNavBench and HuNavSim concepts | diagnostic_only | agent | Keep as diagnostic evidence unless a follow-up benchmark proof issue is opened. | none |
+| #2927 perception: add observation-quality ODD model | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2926 scenario: add shared-space infrastructure elements | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2925 scenario: add cyclist and fast-micromobility actor fixtures | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2924 analysis: add counterfactual scenario-pair runner for mechanism hypotheses | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2921 adversarial: learned proposal model over failure archive | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2920 adversarial: certify candidate batches before planner comparison | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2919 analysis: compare authored trace-derived and dataset-backed scenario priors | needs_human_decision | maintainer | Maintainer should decide, relabel, or split before agent execution. | add `decision-required` |
+| #2918 data: pilot external pedestrian-prior extraction after dataset staging | blocked_external_asset | external data | Park until the required asset, data, license, or staging note exists. | add `state:blocked-external-input` |
+| #2917 data: create ScenarioPrior.v1 provenance cards | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2916 prediction: run same-seed closed-loop forecast-risk coupling gate | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2915 prediction: compare CV semantic-CV and interaction-aware baselines | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2914 workflow: add e2e safe-cleanup regression test preserving tracked output files | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2911 benchmark: add ODD hazard scenario coverage matrix | paper_critical | agent | Prioritize for release evidence review and claim-boundary checks. | add `paper-critical` |
+| #2910 epic: publish Robot SF validation/falsification benchmark v0.1 | stale_synthesis | maintainer | Refresh, supersede, or close the synthesis before new implementation work. | add `decision-required` |
+| #2909 workflow: audit scripts for raw GitHub payload overfetching | diagnostic_only | agent | Keep as diagnostic evidence unless a follow-up benchmark proof issue is opened. | none |
+| #2904 prediction: add forecast-risk eligibility fixtures before planner coupling | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2845 prediction: offline transformer or diffusion benchmark study | needs_human_decision | maintainer | Maintainer should decide, relabel, or split before agent execution. | add `decision-required` |
+| #2844 prediction: add learned probabilistic graph predictor v1 | needs_human_decision | maintainer | Maintainer should decide, relabel, or split before agent execution. | add `decision-required` |
+| #2835 epic: establish first-class forecast research lane for local navigation | stale_synthesis | maintainer | Refresh, supersede, or close the synthesis before new implementation work. | add `decision-required` |
+| #2790 analysis: compare trace-derived and live-replay evidence after #2777 | needs_human_decision | maintainer | Maintainer should decide, relabel, or split before agent execution. | add `decision-required` |
+| #2777 Follow up #2755 with live planner observation-noise replay | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2754 benchmark: add signalized-crossing failure-case pack with trace snapshots | diagnostic_only | agent | Keep as diagnostic evidence unless a follow-up benchmark proof issue is opened. | none |
+| #2726 data: calibrate scenario priors from benchmark trace clusters | diagnostic_only | agent | Keep as diagnostic evidence unless a follow-up benchmark proof issue is opened. | none |
+| #2681 workflow: adapt PR babysitter monitor for CI and review feedback | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2657 data: make SDD scenario-prior staging reproducible | blocked_external_asset | external data | Park until the required asset, data, license, or staging note exists. | add `state:blocked-external-input` |
+| #2655 training: add durable trace URI registry for oracle imitation artifacts | blocked_external_asset | external data | Park until the required asset, data, license, or staging note exists. | add `state:blocked-external-input`; remove `state:ready` |
+| #2649 workflow: add polite capacity-filling rules for SLURM batches | executable_now | Slurm | Agent may claim and execute the issue contract. | none |
+| #2648 workflow: allow capacity-aware SLURM experiment batches | executable_now | Slurm | Agent may claim and execute the issue contract. | none |
+| #2647 workflow: use one traceability checklist for SLURM experiments | executable_now | Slurm | Agent may claim and execute the issue contract. | none |
+| #2645 workflow: validate PR reviews against intended design and bounded follow-ups | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2642 workflow: align agent instructions around autonomous uncertainty-labeled cleanup | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2612 Clarify publication report collision and core-table semantics | paper_critical | agent | Prioritize for release evidence review and claim-boundary checks. | add `paper-critical` |
+| #2601 research: define adversarial manifest quality metrics after first planner smoke | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2557 slurm: run overnight issue-791 leader fixed-seed queue-fill replicas | executable_now | Slurm | Agent may claim and execute the issue contract. | none |
+| #2546 research: evaluate ScenarioBelief uncertainty effects on local policy observations | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2446 research: evaluate actuation feasibility as a diagnostic ranking dimension | diagnostic_only | agent | Keep as diagnostic evidence unless a follow-up benchmark proof issue is opened. | none |
+| #2445 research: classify ORCA-residual progress-probe target after v1 smoke | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2444 analysis: find AMMV trace pair with nonzero mechanism divergence | executable_now | agent | Agent may claim and execute the issue contract. | none |
+| #2441 slurm: submit and finalize oracle-imitation trace collection for #1470 | executable_now | Slurm | Agent may claim and execute the issue contract. | none |
+| #2417 blocked: keep AMV paper-facing unlock criteria gated on real source status | blocked_external_asset | external data | Park until the required asset, data, license, or staging note exists. | add `state:blocked-external-input` |

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -405,6 +405,9 @@ uv run python scripts/dev/snapshot_issue_batch.py 2665 2675 --json \
 uv run python scripts/dev/snapshot_issue_batch.py --claimable --json
 uv run python scripts/dev/snapshot_issue_batch.py --blocked-external-report \
   --report-path "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active/blocked-external-assets.md"
+uv run python scripts/dev/snapshot_issue_batch.py --active-portfolio \
+  --report-path "$(git rev-parse --path-format=absolute --git-common-dir)/codex-agent-runs/active/active-issue-portfolio.md" \
+  --json
 uv run python scripts/dev/snapshot_pr_queue.py --prs 2677 2678 2679 --json \
   --expected-head-sha "$PR_HEAD_SHA"
 uv run python scripts/dev/watch_pr_ci_status.py 2679 --expected-head-sha "$SHA" --json --once
@@ -413,7 +416,9 @@ uv run python scripts/dev/watch_pr_ci_status.py 2679 --expected-head-sha "$SHA" 
 Default `--claimable` issue snapshots omit issues classified as blocked on external data, assets,
 licenses, or human staging input. Use `--include-blocked-external` only when deliberately auditing
 that parked queue, or `--blocked-external-report` to generate a compact human-action report with
-monthly review dates.
+monthly review dates. Use `--active-portfolio` for a compact non-mutating open-issue portfolio
+that classifies executable, human-decision, blocked-external, diagnostic-only, stale synthesis, and
+paper-critical rows with owner types and label-change recommendations.
 
 Use the snapshot JSON to seed worker prompts and active ledgers. Redirect broad
 search output or raw GitHub bodies to private agent-run artifacts; return only

--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -25,6 +25,14 @@ EXTERNAL_BLOCKER_LABELS = {
     "evidence:blocked",
     "state:blocked",
 }
+PORTFOLIO_CLASSIFICATIONS = {
+    "blocked_external_asset",
+    "diagnostic_only",
+    "executable_now",
+    "needs_human_decision",
+    "paper_critical",
+    "stale_synthesis",
+}
 UNCLAIMABLE_LABELS = {
     "blocked",
     "decision-required",
@@ -359,6 +367,12 @@ def _blocked_external_markdown(rows: list[dict[str, Any]]) -> str:
     return "\n".join(lines) + "\n"
 
 
+def _markdown_cell(value: Any) -> str:
+    """Return a table-safe compact Markdown cell."""
+    value_text = "" if value is None else str(value)
+    return value_text.replace("|", "\\|").replace("\n", " ")
+
+
 def snapshot_blocked_external_issues(
     *, repo: str, report_path: str = "", limit: int, now: datetime | None = None
 ) -> dict[str, Any]:
@@ -419,6 +433,221 @@ def snapshot_blocked_external_issues(
         "recommended_state_label": BLOCKED_EXTERNAL_INPUT_LABEL,
         "rows": rows,
         "row_count": len(rows),
+        "report_path": report_path,
+        "markdown": markdown,
+        "errors": errors,
+    }
+
+
+def _portfolio_owner_type(labels: list[str], classification: str) -> str:
+    """Return the likely next owner type for an active issue portfolio row."""
+    label_set = set(labels)
+    if classification == "blocked_external_asset":
+        return "external data"
+    if classification in {"needs_human_decision", "stale_synthesis"}:
+        return "maintainer"
+    if (
+        "slurm" in label_set
+        or "resource:slurm" in label_set
+        or "training" in label_set
+        or "state:running" in label_set
+    ):
+        return "Slurm"
+    return "agent"
+
+
+def _portfolio_classification(
+    *, labels: list[str], title: str, assignees: list[str], claim: dict[str, Any]
+) -> tuple[str, str]:
+    """Classify one open issue for compact active-portfolio routing."""
+    label_set = set(labels)
+    title_text = title.lower()
+    if _is_blocked_external_issue(labels):
+        return "blocked_external_asset", "external asset, data, license, or staging input required"
+    if (
+        "blocked" in label_set
+        or "decision-required" in label_set
+        or "state:blocked" in label_set
+        or "state:hold" in label_set
+    ):
+        return "needs_human_decision", "maintainer decision label blocks autonomous execution"
+    if "evidence:analysis-only" in label_set or "diagnostic" in title_text:
+        return (
+            "diagnostic_only",
+            "analysis or diagnostic evidence only; do not present as benchmark proof",
+        )
+    if "type:synthesis" in label_set and "state:ready" not in label_set:
+        return "stale_synthesis", "synthesis issue lacks ready-state routing"
+    if "priority: high" in label_set and (
+        "benchmark" in label_set or "research" in label_set or "epic" in label_set
+    ):
+        return "paper_critical", "high-priority benchmark or research surface"
+    if assignees or claim.get("claimed"):
+        return "needs_human_decision", "assigned or already claimed; skip autonomous claim"
+    return "executable_now", "unassigned, unclaimed, and not blocked by labels"
+
+
+def _portfolio_label_recommendation(labels: list[str], classification: str) -> str:
+    """Return label-only recommendations for one portfolio row."""
+    label_set = set(labels)
+    recommendation_rules = {
+        "blocked_external_asset": lambda: [
+            (
+                BLOCKED_EXTERNAL_INPUT_LABEL not in label_set,
+                f"add `{BLOCKED_EXTERNAL_INPUT_LABEL}`",
+            ),
+            ("state:ready" in label_set, "remove `state:ready`"),
+        ],
+        "needs_human_decision": lambda: [
+            ("decision-required" not in label_set, "add `decision-required`"),
+            ("state:ready" in label_set, "remove `state:ready`"),
+        ],
+        "diagnostic_only": lambda: [
+            ("evidence:analysis-only" not in label_set, "add `evidence:analysis-only`")
+        ],
+        "stale_synthesis": lambda: [
+            ("decision-required" not in label_set, "add `decision-required`")
+        ],
+        "paper_critical": lambda: [("paper-critical" not in label_set, "add `paper-critical`")],
+        "executable_now": lambda: [("state:ready" not in label_set, "add `state:ready`")],
+    }
+    rules = recommendation_rules.get(classification, lambda: [])()
+    recommendations = [
+        recommendation for should_recommend, recommendation in rules if should_recommend
+    ]
+    return "; ".join(recommendations) if recommendations else "none"
+
+
+def _portfolio_next_action(classification: str) -> str:
+    """Return one compact next action for a portfolio row."""
+    actions = {
+        "blocked_external_asset": "Park until the required asset, data, license, or staging note exists.",
+        "diagnostic_only": "Keep as diagnostic evidence unless a follow-up benchmark proof issue is opened.",
+        "executable_now": "Agent may claim and execute the issue contract.",
+        "needs_human_decision": "Maintainer should decide, relabel, or split before agent execution.",
+        "paper_critical": "Prioritize for release evidence review and claim-boundary checks.",
+        "stale_synthesis": "Refresh, supersede, or close the synthesis before new implementation work.",
+    }
+    return actions[classification]
+
+
+def _active_portfolio_row(issue: dict[str, Any], *, remote: str) -> dict[str, Any]:
+    """Return one active-portfolio row for an open issue."""
+    number = int(issue.get("number"))
+    labels = _labels(issue)
+    assignees = _assignees(issue)
+    claim_value = status_issue(number, remote=remote)
+    claim = claim_value if isinstance(claim_value, dict) else {}
+    title = "" if issue.get("title") is None else issue.get("title", "")
+    url = "" if issue.get("url") is None else issue.get("url", "")
+    classification, reason = _portfolio_classification(
+        labels=labels,
+        title=str(title),
+        assignees=assignees,
+        claim=claim,
+    )
+    return {
+        "number": number,
+        "title": title,
+        "url": url,
+        "labels": labels,
+        "classification": classification,
+        "reason": reason,
+        "owner_type": _portfolio_owner_type(labels, classification),
+        "next_action": _portfolio_next_action(classification),
+        "label_recommendation": _portfolio_label_recommendation(labels, classification),
+    }
+
+
+def _active_portfolio_markdown(rows: list[dict[str, Any]]) -> str:
+    """Return a compact Markdown portfolio table for maintainer review."""
+    lines = [
+        "# Active Issue Portfolio",
+        "",
+        "| Issue | Classification | Owner | Next action | Label recommendation |",
+        "| --- | --- | --- | --- | --- |",
+    ]
+    for row in rows:
+        issue = f"#{row['number']} {row['title']}"
+        lines.append(
+            "| "
+            + " | ".join(
+                [
+                    _markdown_cell(issue),
+                    _markdown_cell(row["classification"]),
+                    _markdown_cell(row["owner_type"]),
+                    _markdown_cell(row["next_action"]),
+                    _markdown_cell(row["label_recommendation"]),
+                ]
+            )
+            + " |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def snapshot_active_issue_portfolio(
+    *, repo: str, remote: str, report_path: str = "", limit: int
+) -> dict[str, Any]:
+    """Return a compact active issue portfolio for routing and demotion review."""
+    result = _gh(
+        [
+            "issue",
+            "list",
+            "--repo",
+            repo,
+            "--state",
+            "open",
+            "--limit",
+            str(limit),
+            "--json",
+            "number,title,state,labels,url,assignees",
+        ]
+    )
+    if result.returncode != 0:
+        rows: list[dict[str, Any]] = []
+        errors = [
+            {
+                "status": "error",
+                "error": result.stderr.strip() or f"gh returned exit code {result.returncode}",
+            }
+        ]
+    else:
+        errors = []
+        try:
+            listed = json.loads(result.stdout)
+        except json.JSONDecodeError as exc:
+            listed = []
+            errors = [{"status": "error", "error": f"invalid gh JSON: {exc}"}]
+        if not errors and not isinstance(listed, list):
+            listed = []
+            errors = [
+                {
+                    "status": "error",
+                    "error": "expected gh issue list JSON array",
+                }
+            ]
+        rows = [
+            _active_portfolio_row(issue, remote=remote)
+            for issue in listed
+            if isinstance(issue, dict) and issue.get("number") is not None
+        ]
+    counts = dict.fromkeys(sorted(PORTFOLIO_CLASSIFICATIONS), 0)
+    for row in rows:
+        classification = str(row.get("classification", ""))
+        if classification in counts:
+            counts[classification] += 1
+    markdown = _active_portfolio_markdown(rows)
+    if report_path:
+        path = pathlib.Path(report_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(markdown, encoding="utf-8")
+    return {
+        "schema": "active_issue_portfolio.v1",
+        "repo": repo,
+        "mode": "active_portfolio",
+        "rows": rows,
+        "row_count": len(rows),
+        "classification_counts": counts,
         "report_path": report_path,
         "markdown": markdown,
         "errors": errors,
@@ -499,6 +728,11 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
         help="Generate a compact blocked external-assets report instead of claim routing.",
     )
     parser.add_argument(
+        "--active-portfolio",
+        action="store_true",
+        help="Generate a compact active issue portfolio with label recommendations.",
+    )
+    parser.add_argument(
         "--report-path",
         default="",
         help="Optional Markdown path for --blocked-external-report.",
@@ -526,9 +760,8 @@ def _parse_args(argv: list[str] | None) -> argparse.Namespace:
     return parser.parse_args(argv)
 
 
-def main(argv: list[str] | None = None) -> int:
-    """CLI entry point."""
-    args = _parse_args(argv)
+def _validate_args(args: argparse.Namespace) -> int:
+    """Return nonzero after printing a CLI contract error."""
     if args.claimable and args.issues:
         print(
             "--claimable cannot be combined with explicit issue numbers",
@@ -547,36 +780,66 @@ def main(argv: list[str] | None = None) -> int:
             file=sys.stderr,
         )
         return 1
+    if args.active_portfolio and (args.claimable or args.blocked_external_report or args.issues):
+        print(
+            "--active-portfolio cannot be combined with --claimable, "
+            "--blocked-external-report, or issue numbers",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+def _build_payload(args: argparse.Namespace, numbers: list[int]) -> dict[str, Any]:
+    """Build the requested CLI payload after argument validation."""
+    if args.active_portfolio:
+        return snapshot_active_issue_portfolio(
+            repo=args.repo,
+            remote=args.remote,
+            report_path=args.report_path,
+            limit=max(args.limit, 1),
+        )
+    if args.blocked_external_report:
+        return snapshot_blocked_external_issues(
+            repo=args.repo,
+            report_path=args.report_path,
+            limit=max(args.limit, 1),
+        )
+    if args.claimable:
+        return snapshot_claimable_issues(
+            repo=args.repo,
+            remote=args.remote,
+            body_limit=max(args.body_chars, 0),
+            limit=max(args.limit, 1),
+            include_blocked_external=args.include_blocked_external,
+        )
+    return snapshot_issues(
+        numbers,
+        repo=args.repo,
+        body_limit=max(args.body_chars, 0),
+        remote=args.remote,
+        capsule_dir=args.capsule_dir,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    validation_error = _validate_args(args)
+    if validation_error:
+        return validation_error
     numbers = expand_issue_numbers(args.issues, expand_range=not args.no_expand_range)
     try:
-        if args.blocked_external_report:
-            payload = snapshot_blocked_external_issues(
-                repo=args.repo,
-                report_path=args.report_path,
-                limit=max(args.limit, 1),
-            )
-        elif args.claimable:
-            payload = snapshot_claimable_issues(
-                repo=args.repo,
-                remote=args.remote,
-                body_limit=max(args.body_chars, 0),
-                limit=max(args.limit, 1),
-                include_blocked_external=args.include_blocked_external,
-            )
-        elif args.issues:
-            payload = snapshot_issues(
-                numbers,
-                repo=args.repo,
-                body_limit=max(args.body_chars, 0),
-                remote=args.remote,
-                capsule_dir=args.capsule_dir,
-            )
-        else:
+        if not (
+            args.active_portfolio or args.blocked_external_report or args.claimable or args.issues
+        ):
             print(
-                "at least one issue number is required unless --claimable is used",
+                "at least one issue number is required unless --claimable, "
+                "--blocked-external-report, or --active-portfolio is used",
                 file=sys.stderr,
             )
             return 1
+        payload = _build_payload(args, numbers)
     except FileNotFoundError:
         print("gh or git command not found", file=sys.stderr)
         return 1

--- a/tests/dev/test_snapshot_issue_batch.py
+++ b/tests/dev/test_snapshot_issue_batch.py
@@ -8,6 +8,7 @@ from unittest.mock import MagicMock, patch
 from scripts.dev.snapshot_issue_batch import (
     expand_issue_numbers,
     main,
+    snapshot_active_issue_portfolio,
     snapshot_blocked_external_issues,
     snapshot_claimable_issues,
     snapshot_issues,
@@ -309,6 +310,186 @@ def test_main_rejects_include_blocked_external_without_claimable(capsys) -> None
 
     assert rc == 1
     assert "--include-blocked-external requires --claimable" in capsys.readouterr().err
+
+
+def test_snapshot_active_issue_portfolio_classifies_and_writes_report(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Active portfolio report should classify rows and recommend label changes only."""
+    report_path = tmp_path / "portfolio.md"
+    issue_list = [
+        {
+            "number": 2967,
+            "title": "workflow: generate active issue portfolio",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2967",
+            "labels": [{"name": "workflow"}, {"name": "state:ready"}],
+            "assignees": [],
+        },
+        {
+            "number": 2415,
+            "title": "data: stage external asset",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2415",
+            "labels": [
+                {"name": "resource:external-data"},
+                {"name": "state:blocked"},
+                {"name": "state:ready"},
+            ],
+            "assignees": [],
+        },
+        {
+            "number": 1134,
+            "title": "map: needs decision",
+            "state": "OPEN",
+            "url": "https://github.test/issues/1134",
+            "labels": [{"name": "decision-required"}, {"name": "state:ready"}],
+            "assignees": [],
+        },
+        {
+            "number": 2946,
+            "title": "analysis: diagnostic figure pack",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2946",
+            "labels": [{"name": "research"}],
+            "assignees": [],
+        },
+        {
+            "number": 2910,
+            "title": "epic: validation benchmark",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2910",
+            "labels": [{"name": "type:synthesis"}, {"name": "priority: high"}],
+            "assignees": [],
+        },
+        {
+            "number": 2965,
+            "title": "benchmark: release readiness dashboard",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2965",
+            "labels": [{"name": "benchmark"}, {"name": "priority: high"}, {"name": "state:ready"}],
+            "assignees": [],
+        },
+        {
+            "number": 2845,
+            "title": "prediction: blocked local study",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2845",
+            "labels": [{"name": "state:blocked"}],
+            "assignees": [],
+        },
+        {
+            "number": 2441,
+            "title": "slurm: finalize trace collection",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2441",
+            "labels": [{"name": "resource:slurm"}, {"name": "state:ready"}],
+            "assignees": [],
+        },
+    ]
+
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+            claim.return_value = {
+                "ok": True,
+                "claimed": False,
+                "claim_ref": "agent-claims/issue",
+                "sha": None,
+            }
+            payload = snapshot_active_issue_portfolio(
+                repo="ll7/robot_sf_ll7",
+                remote="origin",
+                report_path=str(report_path),
+                limit=10,
+            )
+
+    assert payload["schema"] == "active_issue_portfolio.v1"
+    assert payload["row_count"] == 8
+    rows = {row["number"]: row for row in payload["rows"]}
+    assert rows[2967]["classification"] == "executable_now"
+    assert rows[2967]["owner_type"] == "agent"
+    assert rows[2415]["classification"] == "blocked_external_asset"
+    assert rows[2415]["owner_type"] == "external data"
+    assert rows[2415]["label_recommendation"] == (
+        "add `state:blocked-external-input`; remove `state:ready`"
+    )
+    assert rows[1134]["classification"] == "needs_human_decision"
+    assert rows[1134]["owner_type"] == "maintainer"
+    assert rows[2946]["classification"] == "diagnostic_only"
+    assert rows[2946]["label_recommendation"] == "add `evidence:analysis-only`"
+    assert rows[2910]["classification"] == "stale_synthesis"
+    assert rows[2965]["classification"] == "paper_critical"
+    assert rows[2965]["label_recommendation"] == "add `paper-critical`"
+    assert rows[2845]["classification"] == "needs_human_decision"
+    assert rows[2845]["owner_type"] == "maintainer"
+    assert rows[2441]["classification"] == "executable_now"
+    assert rows[2441]["owner_type"] == "Slurm"
+    assert payload["classification_counts"]["blocked_external_asset"] == 1
+    markdown = report_path.read_text(encoding="utf-8")
+    assert "# Active Issue Portfolio" in markdown
+    assert (
+        "| #2967 workflow: generate active issue portfolio | executable_now | agent |" in markdown
+    )
+
+
+def test_snapshot_active_issue_portfolio_reports_unexpected_json_shape() -> None:
+    """Active portfolio should fail closed when gh returns an unexpected JSON shape."""
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"message": "not an issue list"}),
+            stderr="",
+        )
+        payload = snapshot_active_issue_portfolio(
+            repo="ll7/robot_sf_ll7",
+            remote="origin",
+            limit=10,
+        )
+
+    assert payload["row_count"] == 0
+    assert payload["errors"] == [{"status": "error", "error": "expected gh issue list JSON array"}]
+
+
+def test_snapshot_active_issue_portfolio_preserves_null_optional_fields() -> None:
+    """Explicit null title or URL fields should not leak as literal None strings."""
+    issue_list = [
+        {
+            "number": 3000,
+            "title": None,
+            "state": "OPEN",
+            "url": None,
+            "labels": [],
+            "assignees": [],
+        }
+    ]
+
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+            claim.return_value = {
+                "ok": True,
+                "claimed": False,
+                "claim_ref": "agent-claims/issue-3000",
+                "sha": None,
+            }
+            payload = snapshot_active_issue_portfolio(
+                repo="ll7/robot_sf_ll7",
+                remote="origin",
+                limit=1,
+            )
+
+    row = payload["rows"][0]
+    assert row["title"] == ""
+    assert row["url"] == ""
+    assert "None" not in payload["markdown"]
+    assert "#3000 " in payload["markdown"]
+
+
+def test_main_rejects_active_portfolio_with_claimable(capsys) -> None:  # type: ignore[no-untyped-def]
+    """Portfolio mode should be a distinct bounded report mode."""
+    rc = main(["--active-portfolio", "--claimable", "--json"])
+
+    assert rc == 1
+    assert "--active-portfolio cannot be combined" in capsys.readouterr().err
 
 
 def test_main_claimable_mode_can_be_called_without_issue_numbers() -> None:  # type: ignore[no-untyped-def]


### PR DESCRIPTION
## Summary

- Add `scripts/dev/snapshot_issue_batch.py --active-portfolio` for compact open-issue portfolio routing.
- Classify rows as executable now, needs human decision, blocked external asset, diagnostic-only, stale synthesis, or paper-critical.
- Emit JSON plus a Markdown table with owner type, next action, and label-change recommendations only.
- Add durable live evidence at `docs/context/evidence/issue_2967_active_issue_portfolio.md`.

Closes #2967.

## Validation

- `uv run pytest tests/dev/test_snapshot_issue_batch.py -q` (14 passed)
- `uv run ruff check scripts/dev/snapshot_issue_batch.py tests/dev/test_snapshot_issue_batch.py`
- `uv run ruff format --check scripts/dev/snapshot_issue_batch.py tests/dev/test_snapshot_issue_batch.py`
- `python -m py_compile scripts/dev/snapshot_issue_batch.py`
- `git diff --check`
- Live smoke: `uv run python scripts/dev/snapshot_issue_batch.py --active-portfolio --limit 50 --report-path docs/context/evidence/issue_2967_active_issue_portfolio.md --json`

## Research Result Guidance

- Target claim/hypothesis/blocker: active issue routing should distinguish executable work from blocked external input, maintainer-decision, diagnostic-only, stale synthesis, and paper-critical rows.
- Comparator/baseline: previous `--claimable` and `--blocked-external-report` snapshots covered claimability and external blockers separately, but not a compact portfolio view.
- Evidence tier: workflow/reporting evidence with unit tests and live GitHub snapshot.
- Result classification: support/tooling for research queue quality; not benchmark outcome evidence.
- Decision/stop rule: complete when the CLI produces JSON and Markdown with the requested categories, owner types, next actions, and label-only recommendations.
- Synthesis/update target: `docs/context/evidence/issue_2967_active_issue_portfolio.md`.

## Downstream Propagation

- Parent issue/claim map: #2967 is closed by this PR.
- Benchmark report/leaderboard: NA - this changes routing metadata only, not benchmark results.
- Artifact catalog/registry: compact evidence report added under `docs/context/evidence/`.
- Context index/memory: NA - the evidence file is directly referenced from this PR and generated by the documented command.
- Follow-up issues: none required; recommendations are emitted only, not applied automatically.
