### PR TITLE
feat: validate executable claim map queue

### DIFF
--- a/docs/context/issue_2943_fast_results_claim_map_v0.md
+++ b/docs/context/issue_2943_fast_results_claim_map_v0.md
@@ -69,30 +69,30 @@ those modes must be labeled a caveat or exclusion, not claim-grade success.
 
 ### p0_now -- No blocking gates; work can start or land immediately
 
-| Item | Issue | Rationale | Evidence requirement |
-|---|---|---|---|
-| Resolve `seed_episode_rows collision=0.0` conflict | #2612 | Blocks secondary-table paper claims; ready label; narrowly scoped | Clarify core table semantics and confirm which field is authoritative |
-| Define `odd_hazard_coverage.v1` schema and gap matrix | #2911 | Required by #2910 suite freeze; open/ready; actionable scope | Schema definition + gap list for cyclist, signalized crossings, occlusion, stairs, dense crowds, narrow-lane conflicts, AMV actuation, sensor latency |
-| Wire additional `mechanism_trace.v1` producers | #2923 follow-up | Schema is live; `prediction_risk_gating`, `orca_residuals` are highest-value next emitters | Passing contract tests and at least one durable trace input |
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| Resolve `seed_episode_rows collision=0.0` conflict | #2612 | ready | Artifact: updated release 0.0.2 table-semantics context note and authoritative collision-field decision | Clarify core table semantics and confirm which field is authoritative | Missing until #2612 closes |
+| Define `odd_hazard_coverage.v1` schema and gap matrix | #2911 | ready | Artifact: `odd_hazard_coverage.v1` schema plus JSON/Markdown gap matrix | Schema definition checked against cyclist, signalized crossing, occlusion, stairs, dense crowd, narrow-lane conflict, AMV actuation, and sensor-latency scenario families | Missing until #2911 closes |
+| Wire first additional `mechanism_trace.v1` producer | #2976 | ready | Artifact: schema-valid `mechanism_trace.v1` producer payload from durable input or tracked fixture | Passing contract tests and at least one durable trace input for `prediction_risk_gating` or `orca_residuals` | Missing until #2976 closes |
 
 ### p1_after_gate -- Gated on a named p0 precondition
 
-| Item | Issue | Gate condition | Why gated |
-|---|---|---|---|
-| ODD/AMV suite freeze for v0.1 | #2910 | p0: #2911 schema and gap matrix accepted | Suite cannot be marked frozen without hazard coverage matrix |
-| Secondary-table paper promotion | (release 0.0.2 work) | p0: #2612 collision-field conflict resolved | Secondary table semantics are ambiguous until #2612 is closed |
-| Forecast variant benchmark campaign | (follow-up from #2941) | p0: production planner integration; durable episode manifest | Current replay is minimal heuristic; not benchmark-candidate until real planner integration exists |
-| `mechanism_trace.v1` mechanism reports | (follow-up from #2923) | p0: durable trace inputs and at least `prediction_risk_gating` emitter live | Schema-only rows are not report-ready |
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| ODD/AMV suite freeze for v0.1 | #2910 | blocked | Artifact: suite-freeze release note and frozen scenario-family list | p0: #2911 schema and gap matrix accepted | Missing until #2911 closes |
+| Secondary-table paper promotion | #2612 | blocked | Artifact: paper-promotion note or release-table addendum | p0: #2612 collision-field conflict resolved | Missing until #2612 closes |
+| Forecast variant benchmark campaign | #2966 | blocked | Artifact: planner-consumed forecast slice report | p0: production planner integration and durable episode manifest accepted | Missing until #2966 unblocks and lands |
+| `mechanism_trace.v1` mechanism reports | #2976 | blocked | Artifact: mechanism report over durable producer payloads | p0: durable trace inputs and at least `prediction_risk_gating` emitter live | Missing until #2976 closes |
 
 ### parked_blocked -- Explicitly blocked; do not route until gate is named and unblocked
 
-| Item | Blocker | Caveat |
-|---|---|---|
-| CARLA replay transfer evidence | CARLA parity unproven; `sensor_perception_replay` unavailable in current diagnostics (#2158, #2276) | Block until native/aligned fixture semantics are closed |
-| AMV calibrated-actuation paper claim | Runtime/provenance fields missing; yaw, angular acceleration, latency, update rate remain synthetic or unavailable (#2230, #2259) | Do not promote until hardware-calibrated or accepted proxy-source fields are resolved |
-| SocNavBench planner rows | SocNavBench control pipeline not currently available (#2397, #1584) | Rows must be labeled `not_available` / `accepted_unavailable_only`; not benchmark evidence |
-| Full benchmark claim matrix for #2910 release | Requires #2911 + #2612 + suite freeze; depends on p0 items above | Block until all three prerequisites land |
-| Forecast variant safety/success claims | Minimal replay heuristic, single-fixture evidence (#2941) | Evidence is mechanism-trace quality only; not a production-planner or benchmark-candidate result |
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| CARLA replay transfer evidence | #2158 | do-not-claim | Artifact: CARLA transfer eligibility note | CARLA parity proven and `sensor_perception_replay` available with native/aligned fixture semantics | Not available under current diagnostics; see #2158 and #2276 |
+| AMV calibrated-actuation paper claim | #2230 | do-not-claim | Artifact: calibrated-actuation provenance note | Runtime/provenance fields for yaw, angular acceleration, latency, and update rate are hardware-calibrated or accepted proxy-source fields | Not available; see #2230 and #2259 |
+| SocNavBench planner rows | #2397 | do-not-claim | Artifact: SocNavBench unavailable-row note | SocNavBench control pipeline available natively or explicitly accepted as unavailable-only | Not available; rows must stay `not_available` / `accepted_unavailable_only` |
+| Full benchmark claim matrix for #2910 release | #2910 | blocked | Artifact: v0.1 benchmark claim matrix | #2911, #2612, and suite-freeze prerequisites all landed | Missing until p0 prerequisites land |
+| Forecast variant safety/success claims | #2966 | do-not-claim | Artifact: forecast safety/success benchmark report | Planner-consumed forecast benchmark run with comparator, scenario matrix, and durable manifest | Not available; #2941 remains mechanism-trace quality only |
 
 ---
 
@@ -121,6 +121,8 @@ This note is a tracked synthesis document. It does not create or depend on local
 ```bash
 # Check that linked context-note paths resolve
 grep -RiIn "issue_2943_fast_results_claim_map_v0" docs/context/
+# Check executable priority-queue fields
+uv run python scripts/dev/check_fast_results_claim_map.py --json
 # Proof-consistency diff
 BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
 # No trailing whitespace

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -34,6 +34,19 @@ uv run python -c "from robot_sf.gym_env.environment_factory import make_robot_en
 Host tools and optional machine capabilities that are not installed by `uv` are tracked in
 [`docs/dev_runtime_requirements.md`](dev_runtime_requirements.md).
 
+### Claim-map validation
+
+The fast-results claim map is an executable issue queue, not only a context note. Before changing
+`docs/context/issue_2943_fast_results_claim_map_v0.md`, run:
+
+```bash
+uv run python scripts/dev/check_fast_results_claim_map.py --json
+```
+
+This check is also part of `scripts/dev/pr_ready_check.sh`. It verifies that each priority row has
+a status, p0 rows have exactly one owner issue and one next command or artifact, and completed rows
+point at durable evidence instead of worktree-local `output/`.
+
 ### Fresh linked-worktree bootstrap
 
 When creating a new linked worktree, prefer a sibling container next to the main checkout rather

--- a/scripts/dev/check_fast_results_claim_map.py
+++ b/scripts/dev/check_fast_results_claim_map.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Validate the fast-results claim map as an executable issue queue."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CLAIM_MAP = REPO_ROOT / "docs/context/issue_2943_fast_results_claim_map_v0.md"
+ISSUE_RE = re.compile(r"(?:#|/issues/)(\d+)\b")
+PLACEHOLDERS = {"", "-", "none", "n/a", "na", "tbd", "todo", "missing"}
+ALLOWED_STATUSES = {
+    "ready",
+    "blocked",
+    "running",
+    "completed",
+    "diagnostic-only",
+    "do-not-claim",
+}
+SECTION_HEADINGS = ("p0_now", "p1_after_gate", "parked_blocked")
+REQUIRED_COLUMNS = {
+    "item",
+    "owner issue",
+    "status",
+    "next command or artifact",
+    "evidence gate",
+    "durable evidence",
+}
+
+
+@dataclass(frozen=True)
+class ClaimMapError:
+    """A single claim-map validation error."""
+
+    section: str
+    row: int
+    field: str
+    message: str
+
+
+@dataclass(frozen=True)
+class MarkdownTable:
+    """A parsed Markdown table, including empty but well-formed tables."""
+
+    found: bool
+    header: tuple[str, ...] = ()
+    rows: tuple[dict[str, str], ...] = ()
+
+
+def _normalize_header(value: str) -> str:
+    return re.sub(r"\s+", " ", value.strip().lower())
+
+
+def _clean_cell(value: str) -> str:
+    return value.strip().replace("<br>", " ").replace("<br/>", " ").replace("<br />", " ")
+
+
+def _is_placeholder(value: str) -> bool:
+    cleaned = _clean_cell(value).strip("`").strip().lower()
+    return cleaned in PLACEHOLDERS
+
+
+def _split_markdown_row(line: str) -> list[str]:
+    stripped = line.strip()
+    if not stripped.startswith("|") or not stripped.endswith("|") or len(stripped) < 2:
+        return []
+    return [_clean_cell(cell) for cell in stripped[1:-1].split("|")]
+
+
+def _is_separator_row(cells: list[str]) -> bool:
+    return bool(cells) and all(re.fullmatch(r":?-+:?", cell.strip()) for cell in cells)
+
+
+def _extract_table(markdown: str, heading: str) -> MarkdownTable:
+    lines = markdown.splitlines()
+    heading_re = re.compile(rf"^###\s+{re.escape(heading)}\b")
+    start = next((index for index, line in enumerate(lines) if heading_re.match(line)), None)
+    if start is None:
+        return MarkdownTable(found=False)
+
+    table_lines: list[str] = []
+    for line in lines[start + 1 :]:
+        if line.startswith("### "):
+            break
+        if line.strip().startswith("|"):
+            table_lines.append(line)
+        elif table_lines and line.strip():
+            break
+
+    if len(table_lines) < 2:
+        return MarkdownTable(found=False)
+    header = [_normalize_header(cell) for cell in _split_markdown_row(table_lines[0])]
+    separator = _split_markdown_row(table_lines[1])
+    if not _is_separator_row(separator):
+        return MarkdownTable(found=False)
+
+    rows: list[dict[str, str]] = []
+    for line in table_lines[2:]:
+        cells = _split_markdown_row(line)
+        if len(cells) != len(header):
+            rows.append({"__parse_error__": line})
+            continue
+        rows.append(dict(zip(header, cells, strict=True)))
+    return MarkdownTable(found=True, header=tuple(header), rows=tuple(rows))
+
+
+def _issue_refs(value: str) -> tuple[str, ...]:
+    return tuple(f"#{match}" for match in sorted(set(ISSUE_RE.findall(value)), key=int))
+
+
+def _next_step_kinds(value: str) -> tuple[str, ...]:
+    lowered = value.lower()
+    kinds: list[str] = []
+    if "command:" in lowered:
+        kinds.append("command")
+    if "artifact:" in lowered:
+        kinds.append("artifact")
+    return tuple(kinds)
+
+
+def _is_local_output_only(value: str) -> bool:
+    lowered = value.lower()
+    return "output/" in lowered and not any(
+        marker in lowered for marker in ("docs/context/evidence", "tracked", "external", "wandb")
+    )
+
+
+def _validate_status(section: str, row_index: int, row: dict[str, str]) -> list[ClaimMapError]:
+    status = row["status"].strip("`").strip().lower()
+    if status in ALLOWED_STATUSES:
+        return []
+    return [
+        ClaimMapError(
+            section=section,
+            row=row_index,
+            field="status",
+            message=f"status must be one of {sorted(ALLOWED_STATUSES)}",
+        )
+    ]
+
+
+def _validate_owner_issue(section: str, row_index: int, row: dict[str, str]) -> list[ClaimMapError]:
+    if section != "p0_now" or len(_issue_refs(row["owner issue"])) == 1:
+        return []
+    return [
+        ClaimMapError(
+            section=section,
+            row=row_index,
+            field="owner issue",
+            message="p0 rows must link exactly one owner issue",
+        )
+    ]
+
+
+def _validate_next_step(section: str, row_index: int, row: dict[str, str]) -> list[ClaimMapError]:
+    next_step = row["next command or artifact"]
+    errors: list[ClaimMapError] = []
+    if _is_placeholder(next_step):
+        errors.append(
+            ClaimMapError(
+                section=section,
+                row=row_index,
+                field="next command or artifact",
+                message="next step must not be empty or placeholder",
+            )
+        )
+    if section == "p0_now" and len(_next_step_kinds(next_step)) != 1:
+        errors.append(
+            ClaimMapError(
+                section=section,
+                row=row_index,
+                field="next command or artifact",
+                message="p0 rows must declare exactly one of Command: or Artifact:",
+            )
+        )
+    return errors
+
+
+def _validate_evidence_gate(
+    section: str, row_index: int, row: dict[str, str]
+) -> list[ClaimMapError]:
+    if not _is_placeholder(row["evidence gate"]):
+        return []
+    return [
+        ClaimMapError(
+            section=section,
+            row=row_index,
+            field="evidence gate",
+            message="evidence gate must not be empty or placeholder",
+        )
+    ]
+
+
+def _validate_durable_evidence(
+    section: str, row_index: int, row: dict[str, str]
+) -> list[ClaimMapError]:
+    status = row["status"].strip("`").strip().lower()
+    durable_evidence = row["durable evidence"]
+    if status != "completed" or (
+        not _is_placeholder(durable_evidence) and not _is_local_output_only(durable_evidence)
+    ):
+        return []
+    return [
+        ClaimMapError(
+            section=section,
+            row=row_index,
+            field="durable evidence",
+            message="completed rows must link durable evidence, not local output only",
+        )
+    ]
+
+
+def _validate_row(section: str, row_index: int, row: dict[str, str]) -> list[ClaimMapError]:
+    errors: list[ClaimMapError] = []
+    if "__parse_error__" in row:
+        return [
+            ClaimMapError(
+                section=section,
+                row=row_index,
+                field="table",
+                message="row has a different number of cells than the header",
+            )
+        ]
+    errors.extend(_validate_status(section, row_index, row))
+    errors.extend(_validate_owner_issue(section, row_index, row))
+    errors.extend(_validate_next_step(section, row_index, row))
+    errors.extend(_validate_evidence_gate(section, row_index, row))
+    errors.extend(_validate_durable_evidence(section, row_index, row))
+    return errors
+
+
+def validate_claim_map(path: Path = DEFAULT_CLAIM_MAP) -> dict[str, object]:
+    """Validate *path* and return a compact machine-readable report."""
+    markdown = path.read_text(encoding="utf-8")
+    errors: list[ClaimMapError] = []
+    sections: dict[str, MarkdownTable] = {}
+
+    for heading in SECTION_HEADINGS:
+        table = _extract_table(markdown, heading)
+        sections[heading] = table
+        if not table.found:
+            errors.append(
+                ClaimMapError(
+                    section=heading,
+                    row=0,
+                    field="table",
+                    message="missing executable priority table",
+                )
+            )
+            continue
+
+        observed_columns = set(table.header)
+        missing_columns = REQUIRED_COLUMNS - observed_columns
+        for column in sorted(missing_columns):
+            errors.append(
+                ClaimMapError(
+                    section=heading,
+                    row=0,
+                    field=column,
+                    message="required column missing",
+                )
+            )
+        if missing_columns:
+            continue
+
+        for row_index, row in enumerate(table.rows, start=1):
+            errors.extend(_validate_row(heading, row_index, row))
+
+    return {
+        "schema": "fast_results_claim_map_check.v1",
+        "path": str(path),
+        "ok": not errors,
+        "sections": {
+            heading: {
+                "row_count": len(table.rows),
+                "statuses": sorted(
+                    {row.get("status", "").strip("`").strip() for row in table.rows}
+                ),
+            }
+            for heading, table in sections.items()
+        },
+        "errors": [asdict(error) for error in errors],
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the claim-map validator."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--claim-map", type=Path, default=DEFAULT_CLAIM_MAP)
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of a text summary.")
+    args = parser.parse_args(argv)
+
+    report = validate_claim_map(args.claim_map)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif report["ok"]:
+        print(f"OK: {args.claim_map} is an executable claim queue")
+    else:
+        print(f"FAIL: {args.claim_map} has {len(report['errors'])} claim-map issue(s)")
+        for error in report["errors"]:
+            print(f"- {error['section']} row {error['row']} {error['field']}: {error['message']}")
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -121,6 +121,7 @@ if [[ "$pr_ready_final" == "1" ]]; then
 fi
 
 uv run python "$SCRIPT_DIR/check_pr_followups.py"
+uv run python "$SCRIPT_DIR/check_fast_results_claim_map.py"
 "$SCRIPT_DIR/ruff_fix_format.sh"
 "$SCRIPT_DIR/run_tests_parallel.sh"
 "$SCRIPT_DIR/check_changed_coverage.sh"

--- a/tests/dev/test_check_fast_results_claim_map.py
+++ b/tests/dev/test_check_fast_results_claim_map.py
@@ -1,0 +1,151 @@
+"""Tests for the fast-results claim-map queue validator."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.dev.check_fast_results_claim_map import main, validate_claim_map
+
+
+def test_validate_claim_map_accepts_executable_priority_tables(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """The happy path should require owner issues, statuses, and gates."""
+    claim_map = tmp_path / "claim_map.md"
+    claim_map.write_text(
+        """# Claim Map
+
+### p0_now -- No blocking gates
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| Resolve table conflict | #2612 | ready | Artifact: context note update | Diff proof | Missing until #2612 closes |
+
+### p1_after_gate -- Gated
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| Suite freeze | #2910 | blocked | Artifact: freeze note | #2911 accepted | Missing until gate closes |
+
+### parked_blocked -- Parked
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| External row | #2397 | do-not-claim | Artifact: unavailable note | External runtime available | Not available |
+""",
+        encoding="utf-8",
+    )
+
+    report = validate_claim_map(claim_map)
+
+    assert report["ok"] is True
+    assert report["sections"]["p0_now"]["row_count"] == 1
+
+
+def test_validate_claim_map_rejects_p0_without_exactly_one_owner_issue(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """p0 rows must name exactly one executable owner issue."""
+    claim_map = tmp_path / "claim_map.md"
+    claim_map.write_text(
+        """# Claim Map
+
+### p0_now -- No blocking gates
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| Missing owner | #1 and #2 | ready | Artifact: context note update | Diff proof | Missing until close |
+
+### p1_after_gate -- Gated
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| Gate | #3 | blocked | Artifact: gate note | Gate proof | Missing until close |
+
+### parked_blocked -- Parked
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| Parked | #4 | do-not-claim | Artifact: park note | Gate proof | Missing until close |
+""",
+        encoding="utf-8",
+    )
+
+    report = validate_claim_map(claim_map)
+
+    assert report["ok"] is False
+    assert any(error["field"] == "owner issue" for error in report["errors"])
+
+
+def test_validate_claim_map_accepts_empty_well_formed_priority_tables(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Empty but well-formed priority tables should be valid."""
+    claim_map = tmp_path / "claim_map.md"
+    claim_map.write_text(
+        """# Claim Map
+
+### p0_now -- No blocking gates
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+
+### p1_after_gate -- Gated
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+
+### parked_blocked -- Parked
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+""",
+        encoding="utf-8",
+    )
+
+    report = validate_claim_map(claim_map)
+
+    assert report["ok"] is True
+    assert report["sections"]["p0_now"]["row_count"] == 0
+    assert report["sections"]["p1_after_gate"]["row_count"] == 0
+    assert report["sections"]["parked_blocked"]["row_count"] == 0
+
+
+def test_validate_claim_map_rejects_completed_local_output_only_evidence(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """Completed rows must not point only at worktree-local output."""
+    claim_map = tmp_path / "claim_map.md"
+    claim_map.write_text(
+        """# Claim Map
+
+### p0_now -- No blocking gates
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| Done badly | #2612 | completed | Artifact: result note | Diff proof | output/run/report.json |
+
+### p1_after_gate -- Gated
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| Gate | #3 | blocked | Artifact: gate note | Gate proof | Missing until close |
+
+### parked_blocked -- Parked
+
+| Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
+|---|---|---|---|---|---|
+| Parked | #4 | do-not-claim | Artifact: park note | Gate proof | Missing until close |
+""",
+        encoding="utf-8",
+    )
+
+    report = validate_claim_map(claim_map)
+
+    assert report["ok"] is False
+    assert any(error["field"] == "durable evidence" for error in report["errors"])
+
+
+def test_main_emits_json_report(tmp_path, capsys) -> None:  # type: ignore[no-untyped-def]
+    """CLI JSON mode should be stable for CI consumption."""
+    claim_map = tmp_path / "claim_map.md"
+    claim_map.write_text("# Claim Map\n", encoding="utf-8")
+
+    rc = main(["--claim-map", str(claim_map), "--json"])
+
+    assert rc == 1
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == "fast_results_claim_map_check.v1"
+    assert payload["ok"] is False


### PR DESCRIPTION
## Summary

- Turn the fast-results claim map priority queue into an executable issue queue with owner issue, status, next step, evidence gate, and durable-evidence fields.
- Add `scripts/dev/check_fast_results_claim_map.py` and focused tests so p0 rows must have exactly one owner issue plus one command/artifact path, and completed rows cannot rely on local `output/` evidence.
- Wire the check into `scripts/dev/pr_ready_check.sh` and document the workflow in `docs/dev_guide.md`.

Closes #2961.
Follow-up issue created: #2976 for the missing mechanism_trace.v1 producer owner.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_check_fast_results_claim_map.py -q` -> 4 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/check_fast_results_claim_map.py tests/dev/test_check_fast_results_claim_map.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/check_fast_results_claim_map.py tests/dev/test_check_fast_results_claim_map.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_fast_results_claim_map.py --json` -> ok, p0=3, p1=4, parked=5, errors=[]
- `python -m py_compile scripts/dev/check_fast_results_claim_map.py` -> passed
- `bash -n scripts/dev/pr_ready_check.sh` -> passed
- `git diff --check` -> passed

## Downstream Propagation

- Parent issue / claim map / synthesis surface: updated `docs/context/issue_2943_fast_results_claim_map_v0.md`.
- Follow-up issue: #2976 created for the previously placeholder `#2923 follow-up` p0 row.
- Artifact catalog / registry: NA - workflow/check script and tracked context-note update only.
- Context index / memory: existing context index already links the claim-map note.

## Research Result Guidance

- Target claim / hypothesis / blocker: makes the fast-results claim map executable and checkable; does not create new benchmark evidence.
- Comparator / baseline: prior claim-map queue had narrative p0/p1/parked tables and a placeholder `#2923 follow-up` owner.
- Evidence tier: schema/workflow guard only.
- Result classification: workflow readiness improvement, not benchmark evidence.
- Decision / stop rule: p0 rows now fail CI/readiness if they lack exactly one owner issue, one next command/artifact, or an evidence gate.
- Synthesis surface/update target: `docs/context/issue_2943_fast_results_claim_map_v0.md`.

## Follow-Up Issues

- Deferred work: implement the mechanism_trace.v1 producer integration named by the claim map.
- Issues opened for follow-up: #2976


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added claim-map validation command with JSON output support

* **Documentation**
  * Added guidance on claim-map validation requirements and validation command usage

* **Chores**
  * Integrated claim-map validation into PR readiness checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->