### PR TITLE
benchmark: add ODD hazard coverage matrix

### DIFF
--- a/configs/benchmarks/odd_hazard_coverage.v1.yaml
+++ b/configs/benchmarks/odd_hazard_coverage.v1.yaml
@@ -1,0 +1,256 @@
+schema_version: odd_hazard_coverage.v1
+id: issue_2911_low_speed_public_space_v1
+claim_boundary: >
+  This matrix records which ODD conditions and hazard classes are represented by checked-in
+  configs only. It does not claim that any row has executed benchmark evidence, safety proof, or
+  paper-facing validity. Uncovered or blocked rows must not be cited as covered in benchmark wording.
+odd_contract_ref:
+  source: configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml
+  contract_id: low_speed_public_space_v1
+  required_for_benchmark_claim: true
+hazard_traceability_ref:
+  source: configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml
+  contract_id: low_speed_public_space_hazards_v1
+  required_for_benchmark_claim: false
+coverage_rows:
+  - odd_condition: low_speed_public_space_v1
+    hazard_class: robot_pedestrian_collision
+    scenario_family: station_platform
+    metrics:
+      - collision_rate
+    included_planners:
+      - goal
+      - orca
+      - social_force
+    evidence_tier: diagnostic
+    status: weakly_covered
+    gap_reason: >
+      Scenario contract exists, but no scenario_cert.v1 or executed benchmark evidence is checked in.
+    source_configs:
+      - configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml
+      - configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml
+    notes: Platform dwell/flow interactions are intended but not certified.
+
+  - odd_condition: low_speed_public_space_v1
+    hazard_class: near_miss
+    scenario_family: classic_crossing
+    metrics:
+      - min_ttc
+      - pet
+    included_planners:
+      - goal
+      - orca
+      - social_force
+      - teb
+      - dwa
+      - risk_dwa
+      - ppo
+    evidence_tier: candidate
+    status: weakly_covered
+    gap_reason: >
+      Included in paper_experiment_matrix_v1 checked-in config; durable runtime evidence is not committed.
+    source_configs:
+      - configs/benchmarks/paper_experiment_matrix_v1.yaml
+      - configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml
+    notes: Crossing family appears in the canonical paper matrix config.
+
+  - odd_condition: low_speed_public_space_v1
+    hazard_class: blind_corner_emergence
+    scenario_family: blind_corner
+    metrics:
+      - min_ttc
+      - clearance
+    included_planners:
+      - goal
+      - orca
+      - social_force
+    evidence_tier: diagnostic
+    status: weakly_covered
+    gap_reason: >
+      Smoke fixture exists; not integrated into a released benchmark campaign config with run evidence.
+    source_configs:
+      - configs/scenarios/single/observation_visibility_blind_corner_smoke.yaml
+      - configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml
+    notes: Visibility-limited emergence is probed but not benchmarked.
+
+  - odd_condition: low_speed_public_space_v1
+    hazard_class: pedestrian_flow_disruption
+    scenario_family: corridor
+    metrics:
+      - comfort_exposure_s
+      - path_efficiency
+    included_planners:
+      - goal
+      - orca
+      - social_force
+      - teb
+      - dwa
+      - risk_dwa
+      - ppo
+    evidence_tier: candidate
+    status: weakly_covered
+    gap_reason: >
+      Classic interactions matrix includes corridor family; no durable run evidence is committed.
+    source_configs:
+      - configs/benchmarks/paper_experiment_matrix_v1.yaml
+      - configs/scenarios/classic_interactions.yaml
+    notes: Corridor interactions are a core paper-matrix family.
+
+  - odd_condition: low_speed_public_space_v1
+    hazard_class: robot_pedestrian_collision
+    scenario_family: bottleneck
+    metrics:
+      - collision_rate
+    included_planners:
+      - goal
+      - orca
+      - social_force
+      - teb
+      - dwa
+      - risk_dwa
+      - ppo
+    evidence_tier: candidate
+    status: weakly_covered
+    gap_reason: >
+      Classic interactions matrix includes bottleneck family; no durable run evidence is committed.
+    source_configs:
+      - configs/benchmarks/paper_experiment_matrix_v1.yaml
+    notes: Bottleneck family is configured but not evidenced here.
+
+  - odd_condition: low_speed_public_space_v1
+    hazard_class: robot_pedestrian_collision
+    scenario_family: cross_trap
+    metrics:
+      - collision_rate
+      - near_miss
+    included_planners:
+      - goal
+      - orca
+      - social_force
+    evidence_tier: diagnostic
+    status: weakly_covered
+    gap_reason: >
+      Scenario contract exists for #1484 rows; executed evidence is not checked in.
+    source_configs:
+      - configs/scenarios/contracts/issue_2164_amv_cross_trap_contracts.yaml
+    notes: Cross-trap is an AMV-focused synthetic probe.
+
+  - odd_condition: low_speed_public_space_v1
+    hazard_class: robot_pedestrian_collision
+    scenario_family: dense_pedestrian
+    metrics:
+      - collision_rate
+      - comfort_exposure_s
+    included_planners:
+      - goal
+      - orca
+      - social_force
+    evidence_tier: diagnostic
+    status: weakly_covered
+    gap_reason: >
+      Dense-pedestrian stress fixture exists but is not a calibrated crowd benchmark.
+    source_configs:
+      - configs/scenarios/single/dense_pedestrian_stress.yaml
+    notes: Density is intentionally bounded in the fixture.
+
+known_gaps:
+  - gap_id: cyclist_vru_interaction
+    affected_hazard_classes:
+      - robot_vru_collision
+    affected_scenario_families:
+      - cyclist_interaction
+    status: absent
+    reason: >
+      No checked-in scenario contract or benchmark config exercises cyclist/VRU actors;
+      Issue #2473 remains proposal only.
+    tracking_issue: https://github.com/ll7/robot_sf_ll7/issues/2473
+
+  - gap_id: signalized_crossing
+    affected_hazard_classes:
+      - signal_violation
+      - pedestrian_flow_disruption
+    affected_scenario_families:
+      - signalized_crossing
+    status: blocked
+    reason: >
+      Signalized crossing config (Issue #2474) and signal-state contract (Issue #2662) exist, but
+      signal state is proxy-only and no planner-observable benchmark evidence is checked in.
+    tracking_issue: https://github.com/ll7/robot_sf_ll7/issues/2474
+
+  - gap_id: occluded_emergence_benchmark
+    affected_hazard_classes:
+      - blind_corner_emergence
+    affected_scenario_families:
+      - occluded_emergence
+    status: blocked
+    reason: >
+      Occluded-emergence fixtures exist but are not integrated into a released benchmark matrix
+      with executed run evidence.
+    tracking_issue: https://github.com/ll7/robot_sf_ll7/issues/2526
+
+  - gap_id: stairs
+    affected_hazard_classes:
+      - robot_fall_or_trip
+    affected_scenario_families:
+      - stairs
+    status: absent
+    reason: >
+      No stair scenario, map, or contract is checked in.
+
+  - gap_id: dense_crowds
+    affected_hazard_classes:
+      - pedestrian_flow_disruption
+    affected_scenario_families:
+      - dense_pedestrian
+    status: blocked
+    reason: >
+      Dense-pedestrian stress fixture is limited to a few deterministic pedestrians and is not a
+      calibrated crowd benchmark. This gap is distinct from the weakly_covered dense_pedestrian row,
+      which records only that a checked-in fixture exists.
+    tracking_issue: https://github.com/ll7/robot_sf_ll7/issues/1959
+
+  - gap_id: narrow_lane_conflict
+    affected_hazard_classes:
+      - near_miss
+      - robot_pedestrian_collision
+    affected_scenario_families:
+      - doorway
+      - t_intersection
+    status: blocked
+    reason: >
+      Narrow passages appear in archetypes, but no explicit narrow-lane conflict scenario family
+      is checked in.
+    tracking_issue: https://github.com/ll7/robot_sf_ll7/issues/1318
+
+  - gap_id: amv_actuation_limits
+    affected_hazard_classes:
+      - amv_actuation_limit
+    affected_scenario_families:
+      - amv_actuation
+    status: blocked
+    reason: >
+      Synthetic AMV actuation stress slices exist (Issue #1556, Issue #2011) but are not
+      hardware-calibrated or platform-class evidence.
+    tracking_issue: https://github.com/ll7/robot_sf_ll7/issues/2230
+
+  - gap_id: sensor_latency
+    affected_hazard_classes:
+      - observation_delay
+    affected_scenario_families:
+      - observation_noise
+    status: blocked
+    reason: >
+      Observation-noise/latency smoke configs exist, but no systematic closed-loop benchmark with
+      sensor-latency claims is checked in.
+    tracking_issue: https://github.com/ll7/robot_sf_ll7/issues/1744
+
+provenance:
+  source_issue: https://github.com/ll7/robot_sf_ll7/issues/2911
+  authored_by: robot_sf_ll7
+  source_files:
+    - configs/benchmarks/odd_hazard_coverage.v1.yaml
+    - configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml
+    - configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml
+  notes: >
+    Static coverage matrix for Issue #2911. All rows are metadata/candidate/diagnostic unless a
+    separate benchmark run produces durable evidence and updates this matrix.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -599,6 +599,8 @@ knowledge, not every transient iteration detail.
   [issue_2937_horizon_denominator_health.md](issue_2937_horizon_denominator_health.md)
 * Issue #2943 Fast-Results Milestone / Claim Map v0 (2026-06-16):
   [issue_2943_fast_results_claim_map_v0.md](issue_2943_fast_results_claim_map_v0.md)
+* Issue #2911 ODD Hazard Coverage Matrix v1 evidence (2026-06-17):
+  [coverage_matrix.md](evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md)
 * Issue #1239 human-model transfer robustness:
   [issue_1239_human_model_transfer.md](issue_1239_human_model_transfer.md)
 * Issue #1255 open-issue dependency graph:

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1568,3 +1568,11 @@ entries:
     status: proposal
     freshness: maintained
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence

--- a/docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json
+++ b/docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json
@@ -1,0 +1,306 @@
+{
+  "claim_boundary": "This matrix records which ODD conditions and hazard classes are represented by checked-in configs only. It does not claim that any row has executed benchmark evidence, safety proof, or paper-facing validity. Uncovered or blocked rows must not be cited as covered in benchmark wording.\n",
+  "coverage_rows": [
+    {
+      "evidence_tier": "diagnostic",
+      "gap_reason": "Scenario contract exists, but no scenario_cert.v1 or executed benchmark evidence is checked in.\n",
+      "hazard_class": "robot_pedestrian_collision",
+      "included_planners": [
+        "goal",
+        "orca",
+        "social_force"
+      ],
+      "metrics": [
+        "collision_rate"
+      ],
+      "notes": "Platform dwell/flow interactions are intended but not certified.",
+      "odd_condition": "low_speed_public_space_v1",
+      "scenario_family": "station_platform",
+      "source_configs": [
+        "configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml",
+        "configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml"
+      ],
+      "status": "weakly_covered"
+    },
+    {
+      "evidence_tier": "candidate",
+      "gap_reason": "Included in paper_experiment_matrix_v1 checked-in config; durable runtime evidence is not committed.\n",
+      "hazard_class": "near_miss",
+      "included_planners": [
+        "goal",
+        "orca",
+        "social_force",
+        "teb",
+        "dwa",
+        "risk_dwa",
+        "ppo"
+      ],
+      "metrics": [
+        "min_ttc",
+        "pet"
+      ],
+      "notes": "Crossing family appears in the canonical paper matrix config.",
+      "odd_condition": "low_speed_public_space_v1",
+      "scenario_family": "classic_crossing",
+      "source_configs": [
+        "configs/benchmarks/paper_experiment_matrix_v1.yaml",
+        "configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml"
+      ],
+      "status": "weakly_covered"
+    },
+    {
+      "evidence_tier": "diagnostic",
+      "gap_reason": "Smoke fixture exists; not integrated into a released benchmark campaign config with run evidence.\n",
+      "hazard_class": "blind_corner_emergence",
+      "included_planners": [
+        "goal",
+        "orca",
+        "social_force"
+      ],
+      "metrics": [
+        "min_ttc",
+        "clearance"
+      ],
+      "notes": "Visibility-limited emergence is probed but not benchmarked.",
+      "odd_condition": "low_speed_public_space_v1",
+      "scenario_family": "blind_corner",
+      "source_configs": [
+        "configs/scenarios/single/observation_visibility_blind_corner_smoke.yaml",
+        "configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml"
+      ],
+      "status": "weakly_covered"
+    },
+    {
+      "evidence_tier": "candidate",
+      "gap_reason": "Classic interactions matrix includes corridor family; no durable run evidence is committed.\n",
+      "hazard_class": "pedestrian_flow_disruption",
+      "included_planners": [
+        "goal",
+        "orca",
+        "social_force",
+        "teb",
+        "dwa",
+        "risk_dwa",
+        "ppo"
+      ],
+      "metrics": [
+        "comfort_exposure_s",
+        "path_efficiency"
+      ],
+      "notes": "Corridor interactions are a core paper-matrix family.",
+      "odd_condition": "low_speed_public_space_v1",
+      "scenario_family": "corridor",
+      "source_configs": [
+        "configs/benchmarks/paper_experiment_matrix_v1.yaml",
+        "configs/scenarios/classic_interactions.yaml"
+      ],
+      "status": "weakly_covered"
+    },
+    {
+      "evidence_tier": "candidate",
+      "gap_reason": "Classic interactions matrix includes bottleneck family; no durable run evidence is committed.\n",
+      "hazard_class": "robot_pedestrian_collision",
+      "included_planners": [
+        "goal",
+        "orca",
+        "social_force",
+        "teb",
+        "dwa",
+        "risk_dwa",
+        "ppo"
+      ],
+      "metrics": [
+        "collision_rate"
+      ],
+      "notes": "Bottleneck family is configured but not evidenced here.",
+      "odd_condition": "low_speed_public_space_v1",
+      "scenario_family": "bottleneck",
+      "source_configs": [
+        "configs/benchmarks/paper_experiment_matrix_v1.yaml"
+      ],
+      "status": "weakly_covered"
+    },
+    {
+      "evidence_tier": "diagnostic",
+      "gap_reason": "Scenario contract exists for #1484 rows; executed evidence is not checked in.\n",
+      "hazard_class": "robot_pedestrian_collision",
+      "included_planners": [
+        "goal",
+        "orca",
+        "social_force"
+      ],
+      "metrics": [
+        "collision_rate",
+        "near_miss"
+      ],
+      "notes": "Cross-trap is an AMV-focused synthetic probe.",
+      "odd_condition": "low_speed_public_space_v1",
+      "scenario_family": "cross_trap",
+      "source_configs": [
+        "configs/scenarios/contracts/issue_2164_amv_cross_trap_contracts.yaml"
+      ],
+      "status": "weakly_covered"
+    },
+    {
+      "evidence_tier": "diagnostic",
+      "gap_reason": "Dense-pedestrian stress fixture exists but is not a calibrated crowd benchmark.\n",
+      "hazard_class": "robot_pedestrian_collision",
+      "included_planners": [
+        "goal",
+        "orca",
+        "social_force"
+      ],
+      "metrics": [
+        "collision_rate",
+        "comfort_exposure_s"
+      ],
+      "notes": "Density is intentionally bounded in the fixture.",
+      "odd_condition": "low_speed_public_space_v1",
+      "scenario_family": "dense_pedestrian",
+      "source_configs": [
+        "configs/scenarios/single/dense_pedestrian_stress.yaml"
+      ],
+      "status": "weakly_covered"
+    }
+  ],
+  "generated_at_utc": "2026-06-17T04:14:29.508965+00:00",
+  "generation": {
+    "command": "uv run python scripts/tools/generate_odd_hazard_coverage_matrix.py --config configs/benchmarks/odd_hazard_coverage.v1.yaml --out-json docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json --out-md docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md --repo-root .",
+    "commit": "d7656d7f8494"
+  },
+  "hazard_traceability_ref": {
+    "contract_id": "low_speed_public_space_hazards_v1",
+    "required_for_benchmark_claim": false,
+    "source": "configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml"
+  },
+  "known_gaps": [
+    {
+      "affected_hazard_classes": [
+        "robot_vru_collision"
+      ],
+      "affected_scenario_families": [
+        "cyclist_interaction"
+      ],
+      "gap_id": "cyclist_vru_interaction",
+      "reason": "No checked-in scenario contract or benchmark config exercises cyclist/VRU actors; Issue #2473 remains proposal only.\n",
+      "status": "absent",
+      "tracking_issue": "https://github.com/ll7/robot_sf_ll7/issues/2473"
+    },
+    {
+      "affected_hazard_classes": [
+        "signal_violation",
+        "pedestrian_flow_disruption"
+      ],
+      "affected_scenario_families": [
+        "signalized_crossing"
+      ],
+      "gap_id": "signalized_crossing",
+      "reason": "Signalized crossing config (Issue #2474) and signal-state contract (Issue #2662) exist, but signal state is proxy-only and no planner-observable benchmark evidence is checked in.\n",
+      "status": "blocked",
+      "tracking_issue": "https://github.com/ll7/robot_sf_ll7/issues/2474"
+    },
+    {
+      "affected_hazard_classes": [
+        "blind_corner_emergence"
+      ],
+      "affected_scenario_families": [
+        "occluded_emergence"
+      ],
+      "gap_id": "occluded_emergence_benchmark",
+      "reason": "Occluded-emergence fixtures exist but are not integrated into a released benchmark matrix with executed run evidence.\n",
+      "status": "blocked",
+      "tracking_issue": "https://github.com/ll7/robot_sf_ll7/issues/2526"
+    },
+    {
+      "affected_hazard_classes": [
+        "robot_fall_or_trip"
+      ],
+      "affected_scenario_families": [
+        "stairs"
+      ],
+      "gap_id": "stairs",
+      "reason": "No stair scenario, map, or contract is checked in.\n",
+      "status": "absent"
+    },
+    {
+      "affected_hazard_classes": [
+        "pedestrian_flow_disruption"
+      ],
+      "affected_scenario_families": [
+        "dense_pedestrian"
+      ],
+      "gap_id": "dense_crowds",
+      "reason": "Dense-pedestrian stress fixture is limited to a few deterministic pedestrians and is not a calibrated crowd benchmark. This gap is distinct from the weakly_covered dense_pedestrian row, which records only that a checked-in fixture exists.\n",
+      "status": "blocked",
+      "tracking_issue": "https://github.com/ll7/robot_sf_ll7/issues/1959"
+    },
+    {
+      "affected_hazard_classes": [
+        "near_miss",
+        "robot_pedestrian_collision"
+      ],
+      "affected_scenario_families": [
+        "doorway",
+        "t_intersection"
+      ],
+      "gap_id": "narrow_lane_conflict",
+      "reason": "Narrow passages appear in archetypes, but no explicit narrow-lane conflict scenario family is checked in.\n",
+      "status": "blocked",
+      "tracking_issue": "https://github.com/ll7/robot_sf_ll7/issues/1318"
+    },
+    {
+      "affected_hazard_classes": [
+        "amv_actuation_limit"
+      ],
+      "affected_scenario_families": [
+        "amv_actuation"
+      ],
+      "gap_id": "amv_actuation_limits",
+      "reason": "Synthetic AMV actuation stress slices exist (Issue #1556, Issue #2011) but are not hardware-calibrated or platform-class evidence.\n",
+      "status": "blocked",
+      "tracking_issue": "https://github.com/ll7/robot_sf_ll7/issues/2230"
+    },
+    {
+      "affected_hazard_classes": [
+        "observation_delay"
+      ],
+      "affected_scenario_families": [
+        "observation_noise"
+      ],
+      "gap_id": "sensor_latency",
+      "reason": "Observation-noise/latency smoke configs exist, but no systematic closed-loop benchmark with sensor-latency claims is checked in.\n",
+      "status": "blocked",
+      "tracking_issue": "https://github.com/ll7/robot_sf_ll7/issues/1744"
+    }
+  ],
+  "matrix_id": "issue_2911_low_speed_public_space_v1",
+  "odd_contract_ref": {
+    "contract_id": "low_speed_public_space_v1",
+    "required_for_benchmark_claim": true,
+    "source": "configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml"
+  },
+  "provenance": {
+    "authored_by": "robot_sf_ll7",
+    "notes": "Static coverage matrix for Issue #2911. All rows are metadata/candidate/diagnostic unless a separate benchmark run produces durable evidence and updates this matrix.\n",
+    "source_files": [
+      "configs/benchmarks/odd_hazard_coverage.v1.yaml",
+      "configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml",
+      "configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml"
+    ],
+    "source_issue": "https://github.com/ll7/robot_sf_ll7/issues/2911"
+  },
+  "schema_version": "odd_hazard_coverage.v1",
+  "summary": {
+    "coverage_row_count": 7,
+    "gap_status_counts": {
+      "absent": 2,
+      "blocked": 6
+    },
+    "known_gap_count": 8,
+    "reference_errors": [],
+    "reference_valid": true,
+    "status_counts": {
+      "weakly_covered": 7
+    }
+  }
+}

--- a/docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md
+++ b/docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md
@@ -1,0 +1,63 @@
+# ODD Hazard Coverage Matrix
+
+- Matrix id: `issue_2911_low_speed_public_space_v1`
+- Generated at: 2026-06-17T04:14:29.519494+00:00
+- Generation command: `uv run python scripts/tools/generate_odd_hazard_coverage_matrix.py --config configs/benchmarks/odd_hazard_coverage.v1.yaml --out-json docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json --out-md docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md --repo-root .`
+- Generation commit: `d7656d7f8494`
+
+## Claim Boundary
+
+This matrix records which ODD conditions and hazard classes are represented by checked-in configs only. It does not claim that any row has executed benchmark evidence, safety proof, or paper-facing validity. Uncovered or blocked rows must not be cited as covered in benchmark wording.
+
+
+## Evidence Status Summary
+
+- Coverage rows: 7
+- Known gaps: 8
+- Coverage status counts: weakly_covered=7
+- Gap status counts: absent=2, blocked=6
+- Reference validation: passed
+
+## Coverage Rows
+
+| ODD condition | Hazard class | Scenario family | Status | Evidence tier | Metrics | Planners | Gap reason |
+|---|---|---|---|---|---|---|---|
+| low_speed_public_space_v1 | robot_pedestrian_collision | station_platform | weakly_covered | diagnostic | collision_rate | goal; orca; social_force | Scenario contract exists, but no scenario_cert.v1 or executed benchmark evidence is checked in.  |
+| low_speed_public_space_v1 | near_miss | classic_crossing | weakly_covered | candidate | min_ttc; pet | goal; orca; social_force; teb; dwa; risk_dwa; ppo | Included in paper_experiment_matrix_v1 checked-in config; durable runtime evidence is not committed.  |
+| low_speed_public_space_v1 | blind_corner_emergence | blind_corner | weakly_covered | diagnostic | min_ttc; clearance | goal; orca; social_force | Smoke fixture exists; not integrated into a released benchmark campaign config with run evidence.  |
+| low_speed_public_space_v1 | pedestrian_flow_disruption | corridor | weakly_covered | candidate | comfort_exposure_s; path_efficiency | goal; orca; social_force; teb; dwa; risk_dwa; ppo | Classic interactions matrix includes corridor family; no durable run evidence is committed.  |
+| low_speed_public_space_v1 | robot_pedestrian_collision | bottleneck | weakly_covered | candidate | collision_rate | goal; orca; social_force; teb; dwa; risk_dwa; ppo | Classic interactions matrix includes bottleneck family; no durable run evidence is committed.  |
+| low_speed_public_space_v1 | robot_pedestrian_collision | cross_trap | weakly_covered | diagnostic | collision_rate; near_miss | goal; orca; social_force | Scenario contract exists for #1484 rows; executed evidence is not checked in.  |
+| low_speed_public_space_v1 | robot_pedestrian_collision | dense_pedestrian | weakly_covered | diagnostic | collision_rate; comfort_exposure_s | goal; orca; social_force | Dense-pedestrian stress fixture exists but is not a calibrated crowd benchmark.  |
+
+## Known Gaps
+
+| Gap id | Status | Affected hazard classes | Affected scenario families | Reason | Tracking issue |
+|---|---|---|---|---|---|
+| cyclist_vru_interaction | absent | robot_vru_collision | cyclist_interaction | No checked-in scenario contract or benchmark config exercises cyclist/VRU actors; Issue #2473 remains proposal only.  | https://github.com/ll7/robot_sf_ll7/issues/2473 |
+| signalized_crossing | blocked | signal_violation; pedestrian_flow_disruption | signalized_crossing | Signalized crossing config (Issue #2474) and signal-state contract (Issue #2662) exist, but signal state is proxy-only and no planner-observable benchmark evidence is checked in.  | https://github.com/ll7/robot_sf_ll7/issues/2474 |
+| occluded_emergence_benchmark | blocked | blind_corner_emergence | occluded_emergence | Occluded-emergence fixtures exist but are not integrated into a released benchmark matrix with executed run evidence.  | https://github.com/ll7/robot_sf_ll7/issues/2526 |
+| stairs | absent | robot_fall_or_trip | stairs | No stair scenario, map, or contract is checked in.  | — |
+| dense_crowds | blocked | pedestrian_flow_disruption | dense_pedestrian | Dense-pedestrian stress fixture is limited to a few deterministic pedestrians and is not a calibrated crowd benchmark. This gap is distinct from the weakly_covered dense_pedestrian row, which records only that a checked-in fixture exists.  | https://github.com/ll7/robot_sf_ll7/issues/1959 |
+| narrow_lane_conflict | blocked | near_miss; robot_pedestrian_collision | doorway; t_intersection | Narrow passages appear in archetypes, but no explicit narrow-lane conflict scenario family is checked in.  | https://github.com/ll7/robot_sf_ll7/issues/1318 |
+| amv_actuation_limits | blocked | amv_actuation_limit | amv_actuation | Synthetic AMV actuation stress slices exist (Issue #1556, Issue #2011) but are not hardware-calibrated or platform-class evidence.  | https://github.com/ll7/robot_sf_ll7/issues/2230 |
+| sensor_latency | blocked | observation_delay | observation_noise | Observation-noise/latency smoke configs exist, but no systematic closed-loop benchmark with sensor-latency claims is checked in.  | https://github.com/ll7/robot_sf_ll7/issues/1744 |
+
+## Benchmark Wording Guard
+
+- Rows with status `covered` may be described as represented by checked-in configs only.
+- Rows with status `weakly_covered` must be described as config-only, candidate, or diagnostic.
+- Rows with status `blocked` or `absent` must not be described as covered, benchmark-success, or paper-facing evidence.
+- This report is schema/proposal evidence unless a separate benchmark run updates the evidence tier.
+
+## Provenance
+
+- Source issue: https://github.com/ll7/robot_sf_ll7/issues/2911
+- Authored by: robot_sf_ll7
+- Source files:
+  - configs/benchmarks/odd_hazard_coverage.v1.yaml
+  - configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml
+  - configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml
+
+Static coverage matrix for Issue #2911. All rows are metadata/candidate/diagnostic unless a separate benchmark run produces durable evidence and updates this matrix.
+

--- a/docs/context/issue_2943_fast_results_claim_map_v0.md
+++ b/docs/context/issue_2943_fast_results_claim_map_v0.md
@@ -54,13 +54,13 @@ those modes must be labeled a caveat or exclusion, not claim-grade success.
 
 | ID | Target table / surface | Required issue(s) | Evidence tier | Blocked dependency | Do-not-claim boundary |
 |---|---|---|---|---|---|
-| `cm-v0.benchmark_release.odd_coverage` | ODD/hazard-scenario coverage matrix for v0.1 release | #2911 (open/ready) | `schema` -> `candidate` | ODD schema `odd_hazard_coverage.v1` not yet defined | Do not claim gap coverage is closed until schema is checked against scenario family list |
+| `cm-v0.benchmark_release.odd_coverage` | ODD/hazard-scenario coverage matrix for v0.1 release | Issue #2911 (implemented in this PR) | `schema` | `odd_hazard_coverage.v1` schema and JSON/Markdown matrix exist, but all represented rows remain config-only/weakly-covered and several hazard families remain blocked or absent | Do not claim gap coverage is closed; use the Issue #2911 matrix to name uncovered and weakly-covered rows |
 | `cm-v0.benchmark_release.seed_table_semantics` | Release 0.0.2 secondary-report table semantics clarified | #2612 (open/ready) | `diagnostic` | `seed_episode_rows collision=0.0` conflicts with authoritative `campaign_table.csv`; must be resolved before any secondary-table paper claim | Do not cite secondary table in paper until collision-field conflict in #2612 is resolved |
 | `cm-v0.benchmark_release.row_claim_enforcement` | `benchmark_row_claim.v1` row-level enforcement on leaderboard sidecars | #2912 (closed; implemented) | `schema` | None; schema and validator are live | Do not add `fallback`/`degraded` planner rows with `row_status: successful_evidence` |
 | `cm-v0.prediction.denominator_health` | Horizon x timestep denominator-coverage audit | #2937 (closed; implemented) | `diagnostic` | None; 164/180 cells (91.1%) evaluated; `corridor_interaction` fixtures remain `trace_too_short` | Do not promote to forecast benchmark evidence; this audit does not prove navigation benefit or safety improvement |
 | `cm-v0.prediction.native_replay` | Forecast-variant closed-loop replay path is native (not fallback) | #2941 (closed; implemented) | `diagnostic` | Minimal brake-heuristic replay policy only; not a production planner | Do not claim cv improves safety/success/runtime; do not remove caveat that replay uses a simple forecast-brake heuristic |
 | `cm-v0.mechanism.trace_schema` | `mechanism_trace.v1` source contract for local-navigation intervention rows | #2923 (closed; implemented) | `schema` | Additional producers needed for `prediction_risk_gating`, `orca_residuals`, `signal_state_logic`, `amv_actuation_constraints` | Do not use `mechanism_trace.v1` rows for benchmark or paper-facing claims until durable trace inputs and producer integrations exist |
-| `cm-v0.benchmark_release.suite_freeze` | Nominal/stress/adversarial/AMV suite freeze for v0.1 release | #2910 epic (open) | `blocked` | Requires ODD coverage (#2911) and row-claim matrix frozen before suite can be marked frozen | Do not claim suite is paper-ready until freeze contract from #2910 is satisfied |
+| `cm-v0.benchmark_release.suite_freeze` | Nominal/stress/adversarial/AMV suite freeze for v0.1 release | #2910 epic (open) | `blocked` | Requires Issue #2911 coverage-matrix findings and row-claim matrix to be reconciled before suite can be marked frozen | Do not claim suite is paper-ready until freeze contract from #2910 is satisfied |
 | `cm-v0.prediction.full_planner_integration` | Forecast variant integrated into a real planner consuming `ProbabilisticPredictor` | #2960 (this PR; smoke implemented) | `smoke` | Single deterministic local-planner fixture only; no full-episode benchmark or scenario-matrix evidence yet | Do not claim forecast variant is benchmark-capable or beneficial; smoke proves planner consumption mechanics only |
 
 ---
@@ -72,14 +72,14 @@ those modes must be labeled a caveat or exclusion, not claim-grade success.
 | Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
 |---|---|---|---|---|---|
 | Resolve `seed_episode_rows collision=0.0` conflict | #2612 | ready | Artifact: updated release 0.0.2 table-semantics context note and authoritative collision-field decision | Clarify core table semantics and confirm which field is authoritative | Missing until #2612 closes |
-| Define `odd_hazard_coverage.v1` schema and gap matrix | #2911 | ready | Artifact: `odd_hazard_coverage.v1` schema plus JSON/Markdown gap matrix | Schema definition checked against cyclist, signalized crossing, occlusion, stairs, dense crowd, narrow-lane conflict, AMV actuation, and sensor-latency scenario families | Missing until #2911 closes |
+| Define `odd_hazard_coverage.v1` schema and gap matrix | Issue #2911 | completed | Artifact: `docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.{json,md}` | Schema definition checked against cyclist, signalized crossing, occlusion, stairs, dense crowd, narrow-lane conflict, AMV actuation, and sensor-latency scenario families | Present as schema/proposal evidence; not benchmark execution evidence |
 | Wire first additional `mechanism_trace.v1` producer | #2976 | ready | Artifact: schema-valid `mechanism_trace.v1` producer payload from durable input or tracked fixture | Passing contract tests and at least one durable trace input for `prediction_risk_gating` or `orca_residuals` | Missing until #2976 closes |
 
 ### p1_after_gate -- Gated on a named p0 precondition
 
 | Item | Owner issue | Status | Next command or artifact | Evidence gate | Durable evidence |
 |---|---|---|---|---|---|
-| ODD/AMV suite freeze for v0.1 | #2910 | blocked | Artifact: suite-freeze release note and frozen scenario-family list | p0: #2911 schema and gap matrix accepted | Missing until #2911 closes |
+| ODD/AMV suite freeze for v0.1 | #2910 | blocked | Artifact: suite-freeze release note and frozen scenario-family list | p0: Issue #2911 schema and gap matrix accepted, then suite freeze reconciles remaining blocked/absent hazards | Missing until suite-freeze decision lands |
 | Secondary-table paper promotion | #2612 | blocked | Artifact: paper-promotion note or release-table addendum | p0: #2612 collision-field conflict resolved | Missing until #2612 closes |
 | Forecast variant benchmark campaign | #2966 | blocked | Artifact: planner-consumed forecast slice report | p0: production planner integration and durable episode manifest accepted | Missing until #2966 unblocks and lands |
 | `mechanism_trace.v1` mechanism reports | #2976 | blocked | Artifact: mechanism report over durable producer payloads | p0: durable trace inputs and at least `prediction_risk_gating` emitter live | Missing until #2976 closes |
@@ -135,7 +135,7 @@ git diff --check
 
 This v0 map is intentionally narrow. Extend it when:
 
-1. Issue #2911 lands and `odd_hazard_coverage.v1` is defined -- add a `candidate` ODD coverage row.
+1. Issue #2911 lands and `odd_hazard_coverage.v1` is defined -- refresh this map with the accepted coverage artifact and keep uncovered rows out of benchmark claims.
 2. Issue #2612 is resolved -- move secondary-table claim from `diagnostic` to `candidate`.
 3. A full-episode benchmark or scenario-matrix run exercises the planner-consumed `forecast_variant` path -- consider moving `cm-v0.prediction.full_planner_integration` from `smoke` to `candidate`.
 4. The #2910 suite freeze happens -- update `cm-v0.benchmark_release.suite_freeze` from `blocked` to `candidate`.

--- a/robot_sf/benchmark/odd_hazard_coverage_matrix.py
+++ b/robot_sf/benchmark/odd_hazard_coverage_matrix.py
@@ -1,0 +1,628 @@
+"""Typed loader and report generator for ``odd_hazard_coverage.v1`` matrices."""
+
+# ruff: noqa: DOC201
+
+from __future__ import annotations
+
+import json
+import subprocess
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+
+ODD_HAZARD_COVERAGE_SCHEMA_VERSION = "odd_hazard_coverage.v1"
+ODD_HAZARD_COVERAGE_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "odd_hazard_coverage.v1.json"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class ContractRef:
+    """Reference to a checked-in contract file and contract id."""
+
+    source: str
+    contract_id: str
+    required_for_benchmark_claim: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class CoverageRow:
+    """One ODD condition x hazard class x scenario family coverage cell."""
+
+    odd_condition: str
+    hazard_class: str
+    scenario_family: str
+    metrics: list[str]
+    included_planners: list[str]
+    evidence_tier: str
+    status: str
+    gap_reason: str = ""
+    source_configs: list[str] | None = None
+    notes: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class GapRow:
+    """Explicitly uncovered or blocked ODD/hazard coverage gap."""
+
+    gap_id: str
+    status: str
+    reason: str
+    affected_hazard_classes: list[str] | None = None
+    affected_scenario_families: list[str] | None = None
+    tracking_issue: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class Provenance:
+    """Provenance metadata for a coverage matrix."""
+
+    source_issue: str
+    authored_by: str
+    source_files: list[str]
+    notes: str
+
+
+@dataclass(frozen=True, slots=True)
+class OddHazardCoverageMatrix:
+    """Typed ``odd_hazard_coverage.v1`` payload."""
+
+    schema_version: str
+    id: str
+    claim_boundary: str
+    odd_contract_ref: ContractRef
+    coverage_rows: list[CoverageRow]
+    known_gaps: list[GapRow]
+    provenance: Provenance
+    hazard_traceability_ref: ContractRef | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the matrix to JSON-safe primitives."""
+
+        payload = asdict(self)
+        if self.hazard_traceability_ref is None:
+            payload.pop("hazard_traceability_ref")
+        return payload
+
+
+class OddHazardCoverageValidationError(ValueError):
+    """Raised when an ODD hazard coverage matrix fails validation."""
+
+    def __init__(self, errors: list[str], *, source: str | Path | None = None):
+        """Build an actionable validation error."""
+
+        self.errors = tuple(errors)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(errors))
+
+
+@lru_cache(maxsize=1)
+def load_odd_hazard_coverage_schema() -> dict[str, Any]:
+    """Load the public ``odd_hazard_coverage.v1`` JSON schema."""
+
+    return json.loads(ODD_HAZARD_COVERAGE_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def load_odd_hazard_coverage_matrix(path: Path) -> OddHazardCoverageMatrix:
+    """Load and validate an ODD hazard coverage matrix from YAML or JSON."""
+
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise OddHazardCoverageValidationError(["expected a mapping payload"], source=path)
+    return odd_hazard_coverage_matrix_from_dict(raw, source=path)
+
+
+def odd_hazard_coverage_matrix_from_dict(
+    payload: Mapping[str, Any],
+    *,
+    source: str | Path | None = None,
+) -> OddHazardCoverageMatrix:
+    """Validate and convert a mapping into a typed ODD hazard coverage matrix."""
+
+    errors = _schema_validation_errors(payload)
+    errors.extend(_semantic_validation_errors(payload))
+    if errors:
+        raise OddHazardCoverageValidationError(errors, source=source)
+    return _matrix_from_payload(payload)
+
+
+def validate_matrix_references(
+    matrix: OddHazardCoverageMatrix,
+    *,
+    repo_root: Path = Path("."),
+) -> list[str]:
+    """Validate that referenced contracts and source configs exist and resolve.
+
+    Returns:
+        List of reference errors. An empty list means all references resolved.
+    """
+
+    root = repo_root.resolve()
+    errors = _validate_contract_refs(matrix, root)
+    errors.extend(_validate_odd_conditions(matrix, root))
+    errors.extend(_validate_hazard_classes(matrix, root))
+    errors.extend(_validate_source_configs(matrix, root))
+    errors.extend(_validate_provenance_sources(matrix, root))
+    return errors
+
+
+def _validate_contract_refs(
+    matrix: OddHazardCoverageMatrix,
+    root: Path,
+) -> list[str]:
+    """Validate that contract references resolve to existing ids."""
+
+    errors: list[str] = []
+    for ref, name in (
+        (matrix.odd_contract_ref, "odd_contract_ref"),
+        (matrix.hazard_traceability_ref, "hazard_traceability_ref"),
+    ):
+        if ref is None:
+            continue
+        path = root / ref.source
+        if not path.exists():
+            errors.append(f"{name}.source '{ref.source}' does not exist")
+            continue
+        try:
+            raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+        except (OSError, yaml.YAMLError) as exc:
+            errors.append(f"{name}.source '{ref.source}' could not be loaded: {exc}")
+            continue
+        ids = _contract_ids(raw)
+        if ref.contract_id not in ids:
+            errors.append(f"{name}.contract_id '{ref.contract_id}' was not found in {ref.source}")
+    return errors
+
+
+def _validate_hazard_classes(
+    matrix: OddHazardCoverageMatrix,
+    root: Path,
+) -> list[str]:
+    """Validate that coverage hazard classes are declared in the traceability mapping."""
+
+    errors: list[str] = []
+    if matrix.hazard_traceability_ref is None or not matrix.hazard_traceability_ref.source:
+        return errors
+    declared_hazards = _hazard_ids_from_traceability(root / matrix.hazard_traceability_ref.source)
+    for row in matrix.coverage_rows:
+        if row.hazard_class not in declared_hazards:
+            errors.append(
+                f"coverage_rows hazard_class '{row.hazard_class}' is not declared in "
+                f"{matrix.hazard_traceability_ref.source}"
+            )
+    return errors
+
+
+def _validate_odd_conditions(
+    matrix: OddHazardCoverageMatrix,
+    root: Path,
+) -> list[str]:
+    """Validate that coverage rows use the referenced ODD contract id."""
+
+    path = root / matrix.odd_contract_ref.source
+    if not path.exists():
+        return []
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return []
+    declared_ids = _contract_ids(raw)
+    if not declared_ids:
+        return []
+    return [
+        f"coverage_rows odd_condition '{row.odd_condition}' is not declared in "
+        f"{matrix.odd_contract_ref.source}"
+        for row in matrix.coverage_rows
+        if row.odd_condition not in declared_ids
+    ]
+
+
+def _validate_source_configs(
+    matrix: OddHazardCoverageMatrix,
+    root: Path,
+) -> list[str]:
+    """Validate that each coverage row's source config paths exist."""
+
+    errors: list[str] = []
+    for index, row in enumerate(matrix.coverage_rows):
+        for config in row.source_configs or []:
+            if not (root / config).exists():
+                errors.append(f"coverage_rows[{index}].source_configs '{config}' does not exist")
+    return errors
+
+
+def _validate_provenance_sources(
+    matrix: OddHazardCoverageMatrix,
+    root: Path,
+) -> list[str]:
+    """Validate that provenance source files exist."""
+
+    return [
+        f"provenance.source_files '{source}' does not exist"
+        for source in matrix.provenance.source_files
+        if not (root / source).exists()
+    ]
+
+
+def generate_json_report(
+    matrix: OddHazardCoverageMatrix,
+    *,
+    repo_root: Path = Path("."),
+    command: str = "",
+) -> dict[str, Any]:
+    """Generate a JSON-safe coverage report from a validated matrix."""
+
+    reference_errors = validate_matrix_references(matrix, repo_root=repo_root)
+    status_counts = _status_counts(matrix.coverage_rows)
+    gap_status_counts = _gap_status_counts(matrix.known_gaps)
+    return {
+        "schema_version": ODD_HAZARD_COVERAGE_SCHEMA_VERSION,
+        "matrix_id": matrix.id,
+        "generated_at_utc": _utc_now(),
+        "claim_boundary": matrix.claim_boundary,
+        "odd_contract_ref": asdict(matrix.odd_contract_ref),
+        "hazard_traceability_ref": (
+            asdict(matrix.hazard_traceability_ref) if matrix.hazard_traceability_ref else None
+        ),
+        "summary": {
+            "coverage_row_count": len(matrix.coverage_rows),
+            "status_counts": status_counts,
+            "known_gap_count": len(matrix.known_gaps),
+            "gap_status_counts": gap_status_counts,
+            "reference_errors": reference_errors,
+            "reference_valid": not reference_errors,
+        },
+        "coverage_rows": [_coverage_row_to_dict(row) for row in matrix.coverage_rows],
+        "known_gaps": [_gap_row_to_dict(row) for row in matrix.known_gaps],
+        "provenance": asdict(matrix.provenance),
+        "generation": {
+            "command": command,
+            "commit": _git_commit(),
+        },
+    }
+
+
+def generate_markdown_report(
+    matrix: OddHazardCoverageMatrix,
+    *,
+    repo_root: Path = Path("."),
+    command: str = "",
+) -> str:
+    """Generate a Markdown coverage report from a validated matrix."""
+
+    reference_errors = validate_matrix_references(matrix, repo_root=repo_root)
+    status_counts = _status_counts(matrix.coverage_rows)
+    gap_status_counts = _gap_status_counts(matrix.known_gaps)
+
+    lines: list[str] = [
+        "# ODD Hazard Coverage Matrix",
+        "",
+        f"- Matrix id: `{matrix.id}`",
+        f"- Generated at: {_utc_now()}",
+        f"- Generation command: `{command or 'not recorded'}`",
+        f"- Generation commit: `{_git_commit()}`",
+        "",
+        "## Claim Boundary",
+        "",
+        matrix.claim_boundary,
+        "",
+        "## Evidence Status Summary",
+        "",
+        f"- Coverage rows: {len(matrix.coverage_rows)}",
+        f"- Known gaps: {len(matrix.known_gaps)}",
+        f"- Coverage status counts: {_format_counts(status_counts)}",
+        f"- Gap status counts: {_format_counts(gap_status_counts)}",
+        f"- Reference validation: {'passed' if not reference_errors else 'failed'}",
+        "",
+    ]
+
+    if reference_errors:
+        lines.extend(
+            [
+                "### Reference Validation Errors",
+                "",
+                *["- " + error for error in reference_errors],
+                "",
+            ]
+        )
+
+    lines.extend(
+        [
+            "## Coverage Rows",
+            "",
+            "| ODD condition | Hazard class | Scenario family | Status | Evidence tier | Metrics | Planners | Gap reason |",
+            "|---|---|---|---|---|---|---|---|",
+        ]
+    )
+    for row in matrix.coverage_rows:
+        metrics = "; ".join(row.metrics)
+        planners = "; ".join(row.included_planners) if row.included_planners else "none"
+        gap_reason = row.gap_reason.replace("\n", " ") if row.gap_reason else "—"
+        lines.append(
+            f"| {row.odd_condition} | {row.hazard_class} | {row.scenario_family} | "
+            f"{row.status} | {row.evidence_tier} | {metrics} | {planners} | {gap_reason} |"
+        )
+    lines.append("")
+
+    lines.extend(
+        [
+            "## Known Gaps",
+            "",
+            "| Gap id | Status | Affected hazard classes | Affected scenario families | Reason | Tracking issue |",
+            "|---|---|---|---|---|---|",
+        ]
+    )
+    for gap in matrix.known_gaps:
+        hazards = "; ".join(gap.affected_hazard_classes or ["—"])
+        families = "; ".join(gap.affected_scenario_families or ["—"])
+        reason = gap.reason.replace("\n", " ")
+        issue = gap.tracking_issue or "—"
+        lines.append(
+            f"| {gap.gap_id} | {gap.status} | {hazards} | {families} | {reason} | {issue} |"
+        )
+    lines.append("")
+
+    lines.extend(
+        [
+            "## Benchmark Wording Guard",
+            "",
+            "- Rows with status `covered` may be described as represented by checked-in configs only.",
+            "- Rows with status `weakly_covered` must be described as config-only, candidate, or diagnostic.",
+            "- Rows with status `blocked` or `absent` must not be described as covered, benchmark-success, or paper-facing evidence.",
+            "- This report is schema/proposal evidence unless a separate benchmark run updates the evidence tier.",
+            "",
+            "## Provenance",
+            "",
+            f"- Source issue: {matrix.provenance.source_issue}",
+            f"- Authored by: {matrix.provenance.authored_by}",
+            "- Source files:",
+            *[f"  - {path}" for path in matrix.provenance.source_files],
+            "",
+            matrix.provenance.notes,
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _matrix_from_payload(payload: Mapping[str, Any]) -> OddHazardCoverageMatrix:
+    """Build a typed matrix from a schema-valid payload."""
+
+    return OddHazardCoverageMatrix(
+        schema_version=str(payload["schema_version"]),
+        id=str(payload["id"]),
+        claim_boundary=str(payload["claim_boundary"]),
+        odd_contract_ref=_contract_ref_from_payload(payload["odd_contract_ref"]),
+        hazard_traceability_ref=_optional_contract_ref(payload.get("hazard_traceability_ref")),
+        coverage_rows=[_coverage_row_from_payload(row) for row in payload["coverage_rows"]],
+        known_gaps=[_gap_row_from_payload(row) for row in payload["known_gaps"]],
+        provenance=_provenance_from_payload(payload["provenance"]),
+    )
+
+
+def _contract_ref_from_payload(payload: Mapping[str, Any]) -> ContractRef:
+    """Build a typed contract reference."""
+
+    return ContractRef(
+        source=str(payload["source"]),
+        contract_id=str(payload["contract_id"]),
+        required_for_benchmark_claim=bool(payload.get("required_for_benchmark_claim", False)),
+    )
+
+
+def _optional_contract_ref(payload: Any) -> ContractRef | None:
+    """Build a typed contract reference when present."""
+
+    if payload is None:
+        return None
+    return _contract_ref_from_payload(payload)
+
+
+def _coverage_row_from_payload(payload: Mapping[str, Any]) -> CoverageRow:
+    """Build a typed coverage row."""
+
+    return CoverageRow(
+        odd_condition=str(payload["odd_condition"]),
+        hazard_class=str(payload["hazard_class"]),
+        scenario_family=str(payload["scenario_family"]),
+        metrics=list(payload["metrics"]),
+        included_planners=list(payload.get("included_planners", [])),
+        evidence_tier=str(payload["evidence_tier"]),
+        status=str(payload["status"]),
+        gap_reason=str(payload.get("gap_reason", "")),
+        source_configs=list(payload.get("source_configs", [])) or None,
+        notes=str(payload.get("notes", "")),
+    )
+
+
+def _gap_row_from_payload(payload: Mapping[str, Any]) -> GapRow:
+    """Build a typed gap row."""
+
+    return GapRow(
+        gap_id=str(payload["gap_id"]),
+        status=str(payload["status"]),
+        reason=str(payload["reason"]),
+        affected_hazard_classes=list(payload.get("affected_hazard_classes", [])) or None,
+        affected_scenario_families=list(payload.get("affected_scenario_families", [])) or None,
+        tracking_issue=str(payload.get("tracking_issue", "")),
+    )
+
+
+def _provenance_from_payload(payload: Mapping[str, Any]) -> Provenance:
+    """Build typed provenance metadata."""
+
+    return Provenance(
+        source_issue=str(payload["source_issue"]),
+        authored_by=str(payload["authored_by"]),
+        source_files=list(payload["source_files"]),
+        notes=str(payload["notes"]),
+    )
+
+
+def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return sorted JSON Schema validation errors for one matrix payload."""
+
+    validator = Draft202012Validator(load_odd_hazard_coverage_schema())
+    return [
+        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
+    ]
+
+
+def _semantic_validation_errors(payload: Mapping[str, Any]) -> list[str]:
+    """Return cross-field validation errors not expressible in the JSON Schema."""
+
+    errors: list[str] = []
+    for index, row in enumerate(payload.get("coverage_rows", [])):
+        if not isinstance(row, Mapping):
+            continue
+        status = str(row.get("status", ""))
+        gap_reason = str(row.get("gap_reason", "")).strip()
+        if status != "covered" and not gap_reason:
+            errors.append(f"/coverage_rows/{index}/gap_reason: required when status is '{status}'")
+    return errors
+
+
+def _contract_ids(raw: Any) -> set[str]:
+    """Extract contract ids from a contract file payload."""
+
+    ids: set[str] = set()
+    if not isinstance(raw, Mapping):
+        return ids
+    contracts = raw.get("contracts", raw)
+    if isinstance(contracts, Mapping):
+        contracts = [contracts]
+    if not isinstance(contracts, list):
+        return ids
+    for contract in contracts:
+        if isinstance(contract, Mapping):
+            contract_id = contract.get("id")
+            if isinstance(contract_id, str):
+                ids.add(contract_id)
+    return ids
+
+
+def _hazard_ids_from_traceability(path: Path) -> set[str]:
+    """Extract declared hazard ids from a hazard traceability file."""
+
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return set()
+    if not isinstance(raw, Mapping):
+        return set()
+    hazards = raw.get("hazards", [])
+    if not isinstance(hazards, list):
+        return set()
+    return {
+        str(hazard["id"])
+        for hazard in hazards
+        if isinstance(hazard, Mapping) and isinstance(hazard.get("id"), str)
+    }
+
+
+def _coverage_row_to_dict(row: CoverageRow) -> dict[str, Any]:
+    """Convert a coverage row to a JSON-safe dictionary."""
+
+    payload = asdict(row)
+    if not row.source_configs:
+        payload.pop("source_configs")
+    if not row.notes:
+        payload.pop("notes")
+    if not row.gap_reason:
+        payload.pop("gap_reason")
+    return payload
+
+
+def _gap_row_to_dict(row: GapRow) -> dict[str, Any]:
+    """Convert a gap row to a JSON-safe dictionary."""
+
+    payload = asdict(row)
+    if not row.affected_hazard_classes:
+        payload.pop("affected_hazard_classes")
+    if not row.affected_scenario_families:
+        payload.pop("affected_scenario_families")
+    if not row.tracking_issue:
+        payload.pop("tracking_issue")
+    return payload
+
+
+def _status_counts(rows: Sequence[CoverageRow]) -> dict[str, int]:
+    """Count coverage row statuses."""
+
+    counts: dict[str, int] = {}
+    for row in rows:
+        counts[row.status] = counts.get(row.status, 0) + 1
+    return counts
+
+
+def _gap_status_counts(gaps: Sequence[GapRow]) -> dict[str, int]:
+    """Count gap row statuses."""
+
+    counts: dict[str, int] = {}
+    for gap in gaps:
+        counts[gap.status] = counts.get(gap.status, 0) + 1
+    return counts
+
+
+def _format_counts(counts: dict[str, int]) -> str:
+    """Render a status count dictionary for Markdown."""
+
+    return ", ".join(f"{key}={counts[key]}" for key in sorted(counts)) or "none"
+
+
+def _utc_now() -> str:
+    """Return the current UTC timestamp as an ISO string."""
+
+    return datetime.now(UTC).isoformat()
+
+
+def _git_commit() -> str:
+    """Return the current Git commit, or ``unknown`` outside Git."""
+
+    try:
+        return subprocess.check_output(
+            ["git", "rev-parse", "--short=12", "HEAD"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        ).strip()
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+
+
+def _json_pointer(path_elems: Iterable[Any]) -> str:
+    """Render a validation error path as an RFC6901-style JSON pointer."""
+
+    parts: list[str] = []
+    for part in path_elems:
+        if isinstance(part, int):
+            parts.append(str(part))
+        else:
+            parts.append(str(part).replace("~", "~0").replace("/", "~1"))
+    return "/" + "/".join(parts) if parts else ""
+
+
+__all__ = [
+    "ODD_HAZARD_COVERAGE_SCHEMA_FILE",
+    "ODD_HAZARD_COVERAGE_SCHEMA_VERSION",
+    "ContractRef",
+    "CoverageRow",
+    "GapRow",
+    "OddHazardCoverageMatrix",
+    "OddHazardCoverageValidationError",
+    "Provenance",
+    "generate_json_report",
+    "generate_markdown_report",
+    "load_odd_hazard_coverage_matrix",
+    "load_odd_hazard_coverage_schema",
+    "odd_hazard_coverage_matrix_from_dict",
+    "validate_matrix_references",
+]

--- a/robot_sf/benchmark/schemas/odd_hazard_coverage.v1.json
+++ b/robot_sf/benchmark/schemas/odd_hazard_coverage.v1.json
@@ -1,0 +1,248 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/odd_hazard_coverage.v1.json",
+  "title": "RobotSF ODD Hazard Coverage Matrix (v1)",
+  "description": "Static coverage matrix mapping ODD conditions and hazard classes to scenario families, metrics, planners, and evidence tiers. Gaps are explicit; no benchmark success claim is implied.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "id",
+    "claim_boundary",
+    "odd_contract_ref",
+    "coverage_rows",
+    "known_gaps",
+    "provenance"
+  ],
+  "properties": {
+    "schema_version": {
+      "description": "Schema version identifier.",
+      "const": "odd_hazard_coverage.v1"
+    },
+    "id": {
+      "description": "Stable identifier for this coverage matrix.",
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[a-zA-Z0-9_.:-]+$"
+    },
+    "claim_boundary": {
+      "description": "One-line conservative interpretation boundary for the whole matrix.",
+      "type": "string",
+      "minLength": 1
+    },
+    "odd_contract_ref": {
+      "description": "ODD contract that bounds every row in this matrix.",
+      "$ref": "#/$defs/contract_ref"
+    },
+    "hazard_traceability_ref": {
+      "description": "Optional hazard traceability mapping used to validate hazard classes.",
+      "$ref": "#/$defs/contract_ref"
+    },
+    "coverage_rows": {
+      "description": "Coverage rows, one per ODD condition x hazard class x scenario family combination.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/coverage_row"
+      }
+    },
+    "known_gaps": {
+      "description": "Machine-readable register of deliberately uncovered or blocked ODD/hazard rows.",
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/gap_row"
+      }
+    },
+    "provenance": {
+      "$ref": "#/$defs/provenance"
+    }
+  },
+  "$defs": {
+    "contract_ref": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source",
+        "contract_id"
+      ],
+      "properties": {
+        "source": {
+          "description": "Repository-relative path to the referenced contract file.",
+          "type": "string",
+          "minLength": 1
+        },
+        "contract_id": {
+          "description": "Contract identifier inside the referenced file.",
+          "type": "string",
+          "minLength": 1
+        },
+        "required_for_benchmark_claim": {
+          "description": "Whether the referenced contract must be valid before any benchmark claim can be made.",
+          "type": "boolean"
+        }
+      }
+    },
+    "coverage_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "odd_condition",
+        "hazard_class",
+        "scenario_family",
+        "metrics",
+        "included_planners",
+        "evidence_tier",
+        "status"
+      ],
+      "properties": {
+        "odd_condition": {
+          "description": "ODD condition or claim identifier from the referenced ODD contract.",
+          "type": "string",
+          "minLength": 1
+        },
+        "hazard_class": {
+          "description": "Hazard class identifier, preferably from a hazard_traceability.v1 mapping.",
+          "type": "string",
+          "minLength": 1
+        },
+        "scenario_family": {
+          "description": "Scenario family that is intended to exercise the hazard class.",
+          "type": "string",
+          "minLength": 1
+        },
+        "metrics": {
+          "description": "Metrics that would be needed to claim coverage for this row.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "included_planners": {
+          "description": "Planners included in checked-in benchmark configs that exercise this scenario family.",
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "evidence_tier": {
+          "description": "Highest evidence tier this row is allowed to support.",
+          "type": "string",
+          "enum": [
+            "schema",
+            "diagnostic",
+            "candidate",
+            "nominal_benchmark",
+            "paper_ready"
+          ]
+        },
+        "status": {
+          "description": "Coverage status. Only 'covered' supports a checked-in-config coverage statement; all other statuses are caveats or gaps.",
+          "type": "string",
+          "enum": [
+            "covered",
+            "weakly_covered",
+            "blocked",
+            "absent"
+          ]
+        },
+        "gap_reason": {
+          "description": "Required when status is not 'covered'; explains why the row is not fully covered.",
+          "type": "string",
+          "minLength": 1
+        },
+        "source_configs": {
+          "description": "Checked-in config paths that justify the row content.",
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "notes": {
+          "description": "Optional free-form annotation.",
+          "type": "string"
+        }
+      }
+    },
+    "gap_row": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "gap_id",
+        "status",
+        "reason"
+      ],
+      "properties": {
+        "gap_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "affected_hazard_classes": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "affected_scenario_families": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "status": {
+          "type": "string",
+          "enum": [
+            "absent",
+            "blocked"
+          ]
+        },
+        "reason": {
+          "type": "string",
+          "minLength": 1
+        },
+        "tracking_issue": {
+          "description": "Optional GitHub issue or document tracking when this gap will be addressed.",
+          "type": "string"
+        }
+      }
+    },
+    "provenance": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "source_issue",
+        "authored_by",
+        "source_files",
+        "notes"
+      ],
+      "properties": {
+        "source_issue": {
+          "type": "string",
+          "minLength": 1
+        },
+        "authored_by": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source_files": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          }
+        },
+        "notes": {
+          "type": "string",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/scripts/tools/generate_odd_hazard_coverage_matrix.py
+++ b/scripts/tools/generate_odd_hazard_coverage_matrix.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Generate JSON and Markdown reports from an ``odd_hazard_coverage.v1`` config.
+
+The input is a checked-in YAML/JSON config, not a local benchmark campaign output.
+Every weakly_covered, blocked, or absent row carries an explicit gap reason so that
+benchmark wording cannot claim uncovered ODD or hazard classes.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.odd_hazard_coverage_matrix import (
+    generate_json_report,
+    generate_markdown_report,
+    load_odd_hazard_coverage_matrix,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+
+def _build_command(args: argparse.Namespace) -> str:
+    """Return a reproducible command string for provenance."""
+
+    return (
+        "uv run python scripts/tools/generate_odd_hazard_coverage_matrix.py "
+        f"--config {args.config.as_posix()} "
+        f"--out-json {args.out_json.as_posix()} "
+        f"--out-md {args.out_md.as_posix()} "
+        f"--repo-root {args.repo_root.as_posix()}"
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the ODD hazard coverage matrix report generator."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("configs/benchmarks/odd_hazard_coverage.v1.yaml"),
+        help="Path to the odd_hazard_coverage.v1 YAML/JSON config.",
+    )
+    parser.add_argument(
+        "--out-json",
+        type=Path,
+        required=True,
+        help="Output path for the generated JSON report.",
+    )
+    parser.add_argument(
+        "--out-md",
+        type=Path,
+        required=True,
+        help="Output path for the generated Markdown report.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path("."),
+        help="Repository root used to resolve relative config references.",
+    )
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    try:
+        matrix = load_odd_hazard_coverage_matrix(args.config)
+        command = _build_command(args)
+        json_report = generate_json_report(matrix, repo_root=args.repo_root, command=command)
+        markdown_report = generate_markdown_report(
+            matrix, repo_root=args.repo_root, command=command
+        )
+    except Exception as exc:
+        parser.exit(2, f"{parser.prog}: error: {exc}\n")
+
+    args.out_json.parent.mkdir(parents=True, exist_ok=True)
+    args.out_md.parent.mkdir(parents=True, exist_ok=True)
+    args.out_json.write_text(
+        json.dumps(json_report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    args.out_md.write_text(markdown_report, encoding="utf-8")
+
+    sys.stdout.write(
+        json.dumps(
+            {
+                "json_report": args.out_json.as_posix(),
+                "markdown_report": args.out_md.as_posix(),
+                "reference_valid": json_report["summary"]["reference_valid"],
+            },
+            indent=2,
+        )
+        + "\n"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/test_odd_hazard_coverage_matrix.py
+++ b/tests/benchmark/test_odd_hazard_coverage_matrix.py
@@ -1,0 +1,165 @@
+"""Tests for the ``odd_hazard_coverage.v1`` schema, loader, and report generator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import jsonschema
+import pytest
+
+from robot_sf.benchmark.odd_hazard_coverage_matrix import (
+    ODD_HAZARD_COVERAGE_SCHEMA_VERSION,
+    OddHazardCoverageValidationError,
+    generate_json_report,
+    generate_markdown_report,
+    load_odd_hazard_coverage_matrix,
+    load_odd_hazard_coverage_schema,
+    validate_matrix_references,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FIXTURE_PATH = REPO_ROOT / "configs/benchmarks/odd_hazard_coverage.v1.yaml"
+
+
+def test_load_fixture_as_typed_matrix() -> None:
+    """The checked-in issue #2911 matrix should validate and expose typed rows."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+
+    assert matrix.schema_version == ODD_HAZARD_COVERAGE_SCHEMA_VERSION
+    assert matrix.id == "issue_2911_low_speed_public_space_v1"
+    assert matrix.odd_contract_ref.contract_id == "low_speed_public_space_v1"
+    assert matrix.hazard_traceability_ref is not None
+    assert matrix.hazard_traceability_ref.contract_id == "low_speed_public_space_hazards_v1"
+    assert len(matrix.coverage_rows) == 7
+    assert len(matrix.known_gaps) == 8
+    assert any(row.status == "weakly_covered" for row in matrix.coverage_rows)
+    assert any(gap.status == "absent" for gap in matrix.known_gaps)
+    assert any(gap.status == "blocked" for gap in matrix.known_gaps)
+
+    jsonschema.validate(matrix.to_dict(), load_odd_hazard_coverage_schema())
+
+
+def test_matrix_references_resolve_against_repo_root() -> None:
+    """Referenced contracts and source configs should exist in the repository."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+    errors = validate_matrix_references(matrix, repo_root=REPO_ROOT)
+
+    assert errors == []
+
+
+def test_hazard_classes_must_be_declared_in_traceability(tmp_path: Path) -> None:
+    """Coverage rows that name an unknown hazard class should fail reference validation."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+    payload = matrix.to_dict()
+    payload["coverage_rows"][0]["hazard_class"] = "unknown_hazard"
+
+    from robot_sf.benchmark.odd_hazard_coverage_matrix import (
+        odd_hazard_coverage_matrix_from_dict,
+    )
+
+    modified = odd_hazard_coverage_matrix_from_dict(payload)
+    errors = validate_matrix_references(modified, repo_root=REPO_ROOT)
+
+    assert any("unknown_hazard" in error for error in errors)
+
+
+def test_missing_source_config_is_reported(tmp_path: Path) -> None:
+    """Reference validation should fail closed on a missing source config path."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+    payload = matrix.to_dict()
+    payload["coverage_rows"][0]["source_configs"].append("configs/missing_file.yaml")
+
+    from robot_sf.benchmark.odd_hazard_coverage_matrix import (
+        odd_hazard_coverage_matrix_from_dict,
+    )
+
+    modified = odd_hazard_coverage_matrix_from_dict(payload)
+    errors = validate_matrix_references(modified, repo_root=REPO_ROOT)
+
+    assert any("configs/missing_file.yaml" in error for error in errors)
+
+
+def test_unknown_odd_condition_is_reported() -> None:
+    """Reference validation should fail closed on an unknown ODD condition."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+    payload = matrix.to_dict()
+    payload["coverage_rows"][0]["odd_condition"] = "unknown_odd"
+
+    from robot_sf.benchmark.odd_hazard_coverage_matrix import (
+        odd_hazard_coverage_matrix_from_dict,
+    )
+
+    modified = odd_hazard_coverage_matrix_from_dict(payload)
+    errors = validate_matrix_references(modified, repo_root=REPO_ROOT)
+
+    assert any("unknown_odd" in error for error in errors)
+
+
+def test_invalid_schema_version_is_rejected() -> None:
+    """A mismatched schema version should fail JSON Schema validation."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+    payload = matrix.to_dict()
+    payload["schema_version"] = "odd_hazard_coverage.v2"
+
+    with pytest.raises(OddHazardCoverageValidationError) as exc_info:
+        from robot_sf.benchmark.odd_hazard_coverage_matrix import (
+            odd_hazard_coverage_matrix_from_dict,
+        )
+
+        odd_hazard_coverage_matrix_from_dict(payload)
+
+    assert "/schema_version" in str(exc_info.value)
+
+
+def test_non_covered_row_requires_gap_reason() -> None:
+    """A weakly_covered/blocked/absent row without a gap reason should fail semantic validation."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+    payload = matrix.to_dict()
+    payload["coverage_rows"][0]["gap_reason"] = ""
+
+    with pytest.raises(OddHazardCoverageValidationError) as exc_info:
+        from robot_sf.benchmark.odd_hazard_coverage_matrix import (
+            odd_hazard_coverage_matrix_from_dict,
+        )
+
+        odd_hazard_coverage_matrix_from_dict(payload)
+
+    assert "/coverage_rows/0/gap_reason" in str(exc_info.value)
+
+
+def test_generated_json_report_is_machine_readable() -> None:
+    """The generated JSON report should expose status counts and gap lists."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+    report = generate_json_report(matrix, repo_root=REPO_ROOT, command="test-cmd")
+
+    assert report["schema_version"] == ODD_HAZARD_COVERAGE_SCHEMA_VERSION
+    assert report["summary"]["reference_valid"] is True
+    assert report["summary"]["known_gap_count"] == 8
+    assert "weakly_covered" in report["summary"]["status_counts"]
+    assert report["generation"]["command"] == "test-cmd"
+    assert report["generation"]["commit"] != "unknown"
+
+
+def test_generated_markdown_report_has_claim_boundary_first() -> None:
+    """The Markdown report should put claim boundary and evidence status before interpretation."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+    report = generate_markdown_report(matrix, repo_root=REPO_ROOT, command="test-cmd")
+
+    claim_pos = report.index("## Claim Boundary")
+    summary_pos = report.index("## Evidence Status Summary")
+    gaps_pos = report.index("## Known Gaps")
+    guard_pos = report.index("## Benchmark Wording Guard")
+    assert claim_pos < summary_pos < gaps_pos < guard_pos
+    assert "weakly_covered" in report
+    assert "blocked" in report
+    assert "absent" in report
+    assert "must not be described as covered" in report


### PR DESCRIPTION
## Summary
Adds `odd_hazard_coverage.v1`, a checked-in ODD/hazard coverage matrix, a JSON/Markdown report generator, and a durable evidence bundle for Issue #2911.

## Linked Issues
- Closes #2911
- Relates to #2910
- Relates to #2943
- Relates to #2965

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `configs/benchmarks/odd_hazard_coverage.v1.yaml` and `robot_sf/benchmark/schemas/odd_hazard_coverage.v1.json`.
- Added `robot_sf/benchmark/odd_hazard_coverage_matrix.py` plus `scripts/tools/generate_odd_hazard_coverage_matrix.py`.
- Added durable generated evidence under `docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/`.
- Added focused tests for schema validation, reference validation, report shape, and fail-closed gap handling.
- Updated `docs/context/issue_2943_fast_results_claim_map_v0.md`, `docs/context/README.md`, and `docs/context/catalog.yaml`.

## Why It Matters
- Added value: turns ODD/hazard coverage into a machine-readable contract instead of prose-only benchmark readiness.
- Expected impact: unblocks the v0.1 release dashboard and suite-freeze work from guessing which hazards are covered, weakly covered, blocked, or absent.
- Why this is worth merging now: the current fast-results claim map identifies #2911 as a p0 prerequisite for #2910 and #2965.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: ODD/hazard coverage visibility for the v0.1 benchmark release lane.
- Comparator or baseline, if applicable: prior claim-map status that listed `odd_hazard_coverage.v1` as missing.
- Evidence tier: schema / docs-only generated evidence.
- Result classification: blocker-resolution for coverage reporting; diagnostic-only for benchmark meaning.
- Decision or stop rule, if applicable: uncovered, blocked, and weakly covered rows must not be cited as covered benchmark evidence.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2943_fast_results_claim_map_v0.md` and `docs/context/catalog.yaml`.
- New research/benchmark/metric/paper-facing analysis tool, if any: `scripts/tools/generate_odd_hazard_coverage_matrix.py`; representative use is committed in `docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/`.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - schema/report generation, not planner behavior.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA; this matrix classifies checked-in config coverage and gaps.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: Issue #2910 must reconcile remaining blocked/absent hazards before suite freeze.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: benchmark execution evidence remains intentionally absent.
- Stop / revise / continue decision: continue to #2965 dashboard or #2910 suite-freeze work.
- Proposed child issue or existing follow-up: #2965 can consume this matrix for release readiness.

## Validation / Proof
- Commands run:
  - `uv run python scripts/tools/generate_odd_hazard_coverage_matrix.py --config configs/benchmarks/odd_hazard_coverage.v1.yaml --out-json docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json --out-md docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md --repo-root .`
  - `uv run pytest tests/benchmark/test_odd_hazard_coverage_matrix.py -q`
  - `uv run ruff check robot_sf/benchmark/odd_hazard_coverage_matrix.py scripts/tools/generate_odd_hazard_coverage_matrix.py tests/benchmark/test_odd_hazard_coverage_matrix.py`
  - `uv run ruff format --check robot_sf/benchmark/odd_hazard_coverage_matrix.py scripts/tools/generate_odd_hazard_coverage_matrix.py tests/benchmark/test_odd_hazard_coverage_matrix.py`
  - `uv run python scripts/validation/check_docs_proof_consistency.py --base origin/main`
  - `scripts/dev/check_docs_proof_consistency_diff.sh`
  - `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: generator reports `reference_valid: true`; focused tests pass; full readiness passed on `af9883f64bf6b99f499c57db9e218f7d87de22d4`.
- Benchmarks or smoke tests, if applicable: full readiness reported `6978 passed, 9 skipped, 10 warnings`; changed-file coverage warning only, new module at 88.5% against an 80% gate.

## Risks / Rollout
- Compatibility risks: low; new schema/generator path and tracked evidence.
- Failure modes: the matrix is static and must be refreshed when new scenario families or durable benchmark evidence land.
- Rollback or fallback plan: revert this commit or regenerate the evidence bundle from the checked-in YAML.

## Docs / Provenance
- Updated docs: `docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md`, `docs/context/README.md`, `docs/context/catalog.yaml`, `docs/context/issue_2943_fast_results_claim_map_v0.md`.
- Relevant design or provenance notes: generated evidence records command and commit.
- Any assumptions that need to be preserved: this is schema/proposal evidence, not benchmark execution or paper-grade evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes Issue #2911.
- Claim map / benchmark report updated (yes/no/NA): yes, #2943 claim map updated.
- Leaderboard / artifact catalog updated (yes/no/NA): NA for leaderboard; context catalog updated.
- Registry or config index updated (yes/no/NA): yes, config/schema/evidence are tracked.
- Context index / memory note updated (yes/no/NA): yes, context README and catalog updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): no; existing #2965 and #2910 consume this result.
- Not applicable because: no benchmark run or leaderboard row is produced.

## Follow-Up Issues
- Deferred work: #2965 release readiness dashboard; #2910 suite freeze.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the matrix rows are conservative and all represented rows remain `weakly_covered`.
- Any known limitations: no executed benchmark evidence is created; the evidence bundle is a checked-in schema/report artifact.
