### PR TITLE
fix: clarify ODD coverage provenance

### DIFF
--- a/docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json
+++ b/docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json
@@ -163,10 +163,11 @@
       "status": "weakly_covered"
     }
   ],
-  "generated_at_utc": "2026-06-17T04:14:29.508965+00:00",
+  "generated_at_utc": "2026-06-17T05:44:00.194026+00:00",
   "generation": {
+    "base_commit": "f7e62cdf8c9a",
     "command": "uv run python scripts/tools/generate_odd_hazard_coverage_matrix.py --config configs/benchmarks/odd_hazard_coverage.v1.yaml --out-json docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json --out-md docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md --repo-root .",
-    "commit": "d7656d7f8494"
+    "tree_state": "dirty"
   },
   "hazard_traceability_ref": {
     "contract_id": "low_speed_public_space_hazards_v1",

--- a/docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md
+++ b/docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md
@@ -1,9 +1,10 @@
 # ODD Hazard Coverage Matrix
 
 - Matrix id: `issue_2911_low_speed_public_space_v1`
-- Generated at: 2026-06-17T04:14:29.519494+00:00
+- Generated at: 2026-06-17T05:44:00.217919+00:00
 - Generation command: `uv run python scripts/tools/generate_odd_hazard_coverage_matrix.py --config configs/benchmarks/odd_hazard_coverage.v1.yaml --out-json docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json --out-md docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md --repo-root .`
-- Generation commit: `d7656d7f8494`
+- Source/base commit: `f7e62cdf8c9a`
+- Worktree state: `dirty`
 
 ## Claim Boundary
 

--- a/robot_sf/benchmark/odd_hazard_coverage_matrix.py
+++ b/robot_sf/benchmark/odd_hazard_coverage_matrix.py
@@ -262,6 +262,8 @@ def generate_json_report(
     reference_errors = validate_matrix_references(matrix, repo_root=repo_root)
     status_counts = _status_counts(matrix.coverage_rows)
     gap_status_counts = _gap_status_counts(matrix.known_gaps)
+    generation = _generation_provenance(repo_root=repo_root)
+    generation["command"] = command
     return {
         "schema_version": ODD_HAZARD_COVERAGE_SCHEMA_VERSION,
         "matrix_id": matrix.id,
@@ -282,10 +284,7 @@ def generate_json_report(
         "coverage_rows": [_coverage_row_to_dict(row) for row in matrix.coverage_rows],
         "known_gaps": [_gap_row_to_dict(row) for row in matrix.known_gaps],
         "provenance": asdict(matrix.provenance),
-        "generation": {
-            "command": command,
-            "commit": _git_commit(),
-        },
+        "generation": generation,
     }
 
 
@@ -300,6 +299,8 @@ def generate_markdown_report(
     reference_errors = validate_matrix_references(matrix, repo_root=repo_root)
     status_counts = _status_counts(matrix.coverage_rows)
     gap_status_counts = _gap_status_counts(matrix.known_gaps)
+    generation = _generation_provenance(repo_root=repo_root)
+    generation["command"] = command
 
     lines: list[str] = [
         "# ODD Hazard Coverage Matrix",
@@ -307,7 +308,8 @@ def generate_markdown_report(
         f"- Matrix id: `{matrix.id}`",
         f"- Generated at: {_utc_now()}",
         f"- Generation command: `{command or 'not recorded'}`",
-        f"- Generation commit: `{_git_commit()}`",
+        f"- Source/base commit: `{generation['base_commit']}`",
+        f"- Worktree state: `{generation['tree_state']}`",
         "",
         "## Claim Boundary",
         "",
@@ -584,18 +586,42 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _git_commit() -> str:
+def _git_commit(*, repo_root: Path) -> str:
     """Return the current Git commit, or ``unknown`` outside Git."""
 
     try:
         return subprocess.check_output(
-            ["git", "rev-parse", "--short=12", "HEAD"],
+            ["git", "-C", str(repo_root), "rev-parse", "--short=12", "HEAD"],
             text=True,
             stderr=subprocess.DEVNULL,
             timeout=5,
         ).strip()
     except (OSError, subprocess.SubprocessError):
         return "unknown"
+
+
+def _git_tree_state(*, repo_root: Path) -> str:
+    """Return the current git tree state, or ``unknown`` outside Git."""
+
+    try:
+        status = subprocess.check_output(
+            ["git", "-C", str(repo_root), "status", "--short", "--untracked-files=no"],
+            text=True,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+        )
+        return "dirty" if status.strip() else "clean"
+    except (OSError, subprocess.SubprocessError):
+        return "unknown"
+
+
+def _generation_provenance(*, repo_root: Path) -> dict[str, str]:
+    """Return explicit generation provenance metadata."""
+
+    return {
+        "base_commit": _git_commit(repo_root=repo_root),
+        "tree_state": _git_tree_state(repo_root=repo_root),
+    }
 
 
 def _json_pointer(path_elems: Iterable[Any]) -> str:

--- a/scripts/tools/generate_odd_hazard_coverage_matrix.py
+++ b/scripts/tools/generate_odd_hazard_coverage_matrix.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import shlex
 import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -27,12 +28,21 @@ if TYPE_CHECKING:
 def _build_command(args: argparse.Namespace) -> str:
     """Return a reproducible command string for provenance."""
 
-    return (
-        "uv run python scripts/tools/generate_odd_hazard_coverage_matrix.py "
-        f"--config {args.config.as_posix()} "
-        f"--out-json {args.out_json.as_posix()} "
-        f"--out-md {args.out_md.as_posix()} "
-        f"--repo-root {args.repo_root.as_posix()}"
+    return shlex.join(
+        [
+            "uv",
+            "run",
+            "python",
+            "scripts/tools/generate_odd_hazard_coverage_matrix.py",
+            "--config",
+            str(args.config),
+            "--out-json",
+            str(args.out_json),
+            "--out-md",
+            str(args.out_md),
+            "--repo-root",
+            str(args.repo_root),
+        ]
     )
 
 

--- a/tests/benchmark/test_odd_hazard_coverage_matrix.py
+++ b/tests/benchmark/test_odd_hazard_coverage_matrix.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import argparse
+import shlex
 from pathlib import Path
 
 import jsonschema
 import pytest
 
+from robot_sf.benchmark import odd_hazard_coverage_matrix as matrix_module
 from robot_sf.benchmark.odd_hazard_coverage_matrix import (
     ODD_HAZARD_COVERAGE_SCHEMA_VERSION,
     OddHazardCoverageValidationError,
@@ -16,6 +19,7 @@ from robot_sf.benchmark.odd_hazard_coverage_matrix import (
     load_odd_hazard_coverage_schema,
     validate_matrix_references,
 )
+from scripts.tools.generate_odd_hazard_coverage_matrix import _build_command
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 FIXTURE_PATH = REPO_ROOT / "configs/benchmarks/odd_hazard_coverage.v1.yaml"
@@ -145,7 +149,75 @@ def test_generated_json_report_is_machine_readable() -> None:
     assert report["summary"]["known_gap_count"] == 8
     assert "weakly_covered" in report["summary"]["status_counts"]
     assert report["generation"]["command"] == "test-cmd"
-    assert report["generation"]["commit"] != "unknown"
+    assert report["generation"]["base_commit"] != "unknown"
+    assert report["generation"]["tree_state"] in {"clean", "dirty", "unknown"}
+    assert "commit" not in report["generation"]
+
+
+def test_generated_json_report_marks_dirty_worktree_explicitly(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """JSON generation metadata should capture explicit source commit and tree state."""
+
+    matrix = load_odd_hazard_coverage_matrix(FIXTURE_PATH)
+    monkeypatch.setattr(
+        "robot_sf.benchmark.odd_hazard_coverage_matrix._git_commit",
+        lambda *, repo_root: "basecommit",
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.odd_hazard_coverage_matrix._git_tree_state",
+        lambda *, repo_root: "dirty",
+    )
+
+    report = generate_json_report(matrix, repo_root=REPO_ROOT, command="test-cmd")
+
+    assert report["generation"]["base_commit"] == "basecommit"
+    assert report["generation"]["tree_state"] == "dirty"
+    assert "commit" not in report["generation"]
+
+
+def test_git_tree_state_ignores_untracked_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Tree-state provenance should not depend on unrelated untracked local files."""
+
+    captured: dict[str, list[str]] = {}
+
+    def fake_check_output(cmd: list[str], **_: object) -> str:
+        captured["cmd"] = cmd
+        return ""
+
+    monkeypatch.setattr(matrix_module.subprocess, "check_output", fake_check_output)
+
+    assert matrix_module._git_tree_state(repo_root=REPO_ROOT) == "clean"
+    assert "--untracked-files=no" in captured["cmd"]
+
+
+def test_build_command_is_shell_safe() -> None:
+    """Generated command string should quote arguments with shell metacharacters safely."""
+
+    args = argparse.Namespace(
+        config=Path("/tmp/config dir/odd hazard coverage.yaml"),
+        out_json=Path("/tmp/output dir/coverage matrix.json"),
+        out_md=Path("/tmp/output dir/coverage matrix.md"),
+        repo_root=Path("/tmp/repo root"),
+    )
+
+    command = _build_command(args)
+    parts = shlex.split(command)
+
+    assert parts == [
+        "uv",
+        "run",
+        "python",
+        "scripts/tools/generate_odd_hazard_coverage_matrix.py",
+        "--config",
+        "/tmp/config dir/odd hazard coverage.yaml",
+        "--out-json",
+        "/tmp/output dir/coverage matrix.json",
+        "--out-md",
+        "/tmp/output dir/coverage matrix.md",
+        "--repo-root",
+        "/tmp/repo root",
+    ]
 
 
 def test_generated_markdown_report_has_claim_boundary_first() -> None:
@@ -163,3 +235,5 @@ def test_generated_markdown_report_has_claim_boundary_first() -> None:
     assert "blocked" in report
     assert "absent" in report
     assert "must not be described as covered" in report
+    assert "Source/base commit" in report
+    assert "Worktree state" in report


### PR DESCRIPTION
## Summary

- Replace ambiguous ODD hazard coverage generation `commit` metadata with explicit `base_commit` and `tree_state` fields.
- Build generator command provenance with `shlex.join` so paths with spaces or shell metacharacters round-trip safely.
- Regenerate the checked-in ODD hazard coverage evidence so it no longer contains `generation.commit`.

Closes #2982.

## Validation

- `rtk ruff format robot_sf/benchmark/odd_hazard_coverage_matrix.py scripts/tools/generate_odd_hazard_coverage_matrix.py tests/benchmark/test_odd_hazard_coverage_matrix.py`
- `rtk test uv run python scripts/tools/generate_odd_hazard_coverage_matrix.py --config configs/benchmarks/odd_hazard_coverage.v1.yaml --out-json docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.json --out-md docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.md --repo-root .`
- `rtk ruff check robot_sf/benchmark/odd_hazard_coverage_matrix.py scripts/tools/generate_odd_hazard_coverage_matrix.py tests/benchmark/test_odd_hazard_coverage_matrix.py`
- `rtk test uv run pytest tests/benchmark/test_odd_hazard_coverage_matrix.py`
- `rtk test uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
- `rtk git diff --check`

## Research Result Guidance

- Target claim/hypothesis/blocker: clarify provenance semantics for the ODD hazard coverage matrix evidence added by #2979.
- Comparator/baseline: previous generated artifact recorded only `generation.commit`, which could be read as the final PR head rather than the source/base checkout used for generation.
- Evidence tier: provenance/tooling fix plus regenerated checked-in evidence; no benchmark execution evidence is added.
- Result classification: support/provenance correction, not benchmark-strengthening evidence.
- Decision/stop rule: accept when generated JSON has `base_commit`, `tree_state`, shell-safe `command`, and no `generation.commit`.
- Synthesis surface/update target: `docs/context/evidence/issue_2911_odd_hazard_coverage_2026-06-17/coverage_matrix.{json,md}`.

## Downstream Propagation

- Parent issue / claim map / benchmark report: #2982 closes the provenance follow-up from #2979; no benchmark claim changes.
- Leaderboard / artifact catalog / registry / config index: NA, the config and catalog entries are unchanged.
- Context index / memory note: NA, the existing evidence artifact is regenerated in place and remains discoverable through the existing catalog entry.
- Follow-up issue: none required from this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated ODD Hazard Coverage Matrix with refreshed generation metadata, now tracking source commit and worktree state separately.

* **Chores**
  * Enhanced report generation infrastructure to explicitly capture worktree status (clean/dirty) alongside source commit information.

* **Tests**
  * Added test coverage for generation metadata format and command-line safety validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->