### PR TITLE
docs: align autonomous workflow cleanup guidance

### DIFF
--- a/.agents/PLANS.md
+++ b/.agents/PLANS.md
@@ -44,12 +44,17 @@ Keep plans short and operational:
 
 - Restate the issue or user goal in repository terms, not generic assistant language.
 - Separate observed evidence from assumptions.
+- For bounded workflow cleanup, proceed autonomously when the maintainer direction is clear; label
+  uncertainty, assumptions, and evidence grade instead of pausing for routine confirmation.
 - Prefer canonical scripts and committed configs over ad-hoc commands.
 - When benchmark or planner claims are involved, include the exact docs/configs that anchor the claim.
 - State the proof obligation for any new planner, metric, skill, or test before implementation.
 - Close the plan only after that proof has been gathered or the remaining gap has been called out
   explicitly.
 - If scope expands, create a follow-up issue instead of silently broadening the implementation.
+- Use the `AGENTS.md` readiness matrix to choose validation depth. A small docs or workflow plan can
+  use cheap validation, but any stronger benchmark, metric, schema, model-provenance, or
+  paper-facing claim escalates to the proof tier for that claim.
 
 ## Review Expectations
 

--- a/.agents/README.md
+++ b/.agents/README.md
@@ -18,6 +18,11 @@ Tool-specific directories should point here when their formats allow it.
 Tool-specific instruction files, such as `.github/copilot-instructions.md` and `.cursorrules`,
 should be thin pointers to those sources plus only the tool-specific details that cannot live there.
 
+When canonical and compatibility surfaces disagree, follow the precedence rule in `AGENTS.md`.
+Patch the canonical source first, then update generated or mirrored compatibility surfaces when a
+sync command exists. If a broad mirror update would be risky, keep the canonical change bounded and
+open a follow-up issue that names the affected compatibility entry points.
+
 Stale compatibility surfaces should be removed when they no longer provide value. Claude cleanup is
 tracked in issue #1728.
 
@@ -27,6 +32,12 @@ Run the drift check after changing AI assistant surfaces:
 
 ```bash
 uv run python scripts/tools/sync_ai_config.py --check
+```
+
+For skill edits, also run the relevant skill preflight when one exists:
+
+```bash
+uv run python scripts/dev/check_skills.py --preflight <skill-name>
 ```
 
 If a supported compatibility symlink is missing or stale, repair it with:

--- a/.agents/skills/goal-issue-implementation/SKILL.md
+++ b/.agents/skills/goal-issue-implementation/SKILL.md
@@ -72,6 +72,13 @@ Record at start:
 - Stop condition: queue exhausted, time budget reached, ambiguous issue contract, environment/auth blocker,
   validation dead-end, user stop.
 - Exclusions: benchmarks blocked by environment, blocked/decision-required issues, external-only work.
+- Instruction precedence: current maintainer direction and `docs/maintainer_values.md` override stale
+  workflow prose. Treat Project #5 ordering as advisory when it conflicts with fresh maintainer
+  direction or evidence; record the override and defer Project metadata cleanup when quota or API
+  limits make it impractical.
+- Autonomy default: for bounded workflow cleanup, proceed without routine confirmation when
+  assumptions, uncertainty, evidence grade, and follow-up risks are labeled in the issue, PR, or
+  handoff.
 
 Do not ask for extra confirmation after this preflight.
 
@@ -382,7 +389,11 @@ Route remaining issues by their blocker:
 4. Make the successful claim visible in the issue/project surfaces: move the issue to `In progress`
    or `state:running`, assign the actor when practical, and add a concise issue comment with the
    claim ref, machine/thread, planned branch, and stale-claim cleanup condition.
-5. Create or update the active delegation ledger described in
+5. Use detached latest-main checkouts only for read-only discovery, duplicate checks, and GitHub
+   issue creation or update work. Before editing docs or code, running PR validation, pushing, or
+   publishing, create or switch to a branch/worktree so the proof bundle has a durable branch
+   context.
+6. Create or update the active delegation ledger described in
    `.agents/skills/goal-autopilot/SKILL.md` with the claim ref/status, issue, branch/worktree,
    owned files or modules, route/run IDs, validation plan, cleanup status, and next action. Update
    it after every delegated worker start/completion/failure, before any CI wait or compaction-prone

--- a/.agents/skills/pr-ready-check/SKILL.md
+++ b/.agents/skills/pr-ready-check/SKILL.md
@@ -20,17 +20,31 @@ Run the canonical local readiness gates that mirror repo PR policy before handof
 
 ## Workflow
 
-1. Confirm repo guidance (`docs/dev_guide.md`, `.specify/memory/constitution.md`) when uncertain.
-2. Ensure environment has `.venv` loaded or `source .venv/bin/activate` is available.
-3. Run: `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
-4. If needed, use overrides, e.g. `MIN_COVERAGE`, `GOAL_COVERAGE`.
-5. Fix failures and rerun the same command until stable green.
-6. If benchmark outputs or model artifacts are involved, check artifact persistence policy before handoff.
+1. Confirm repo guidance (`AGENTS.md`, `docs/dev_guide.md`, `.specify/memory/constitution.md`) when uncertain.
+2. Classify the change using the `AGENTS.md` readiness matrix:
+   - docs-only or instruction-only: inspect the diff, verify changed links or paths where practical,
+     and run available lightweight markdown, index, skill, or sync checks.
+   - workflow/tooling docs or skills: also run relevant checks such as
+     `uv run python scripts/dev/check_skills.py --preflight <skill-name>` and
+     `uv run python scripts/tools/sync_ai_config.py --check`.
+   - runtime, benchmark, metric, schema, model-provenance, or paper-facing work: run executable
+     proof appropriate to the claim.
+3. Escalate to the full readiness pipeline when scripts, schemas, generated indexes, routing
+   behavior, automation, runtime behavior, benchmark/metric/schema semantics, model provenance, or
+   paper-facing claims are touched.
+4. Ensure environment has `.venv` loaded or `source .venv/bin/activate` is available.
+5. Run: `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`.
+6. If needed, use overrides, e.g. `MIN_COVERAGE`, `GOAL_COVERAGE`.
+7. Fix failures and rerun the same command until stable green.
+8. If benchmark outputs or model artifacts are involved, check artifact persistence policy before handoff.
 
 ## Guardrails
 
 - This skill runs validation; it does not perform PR creation or issue edits on its own.
-- Do not stop at lint green: ensure parallel tests and diff gates are also clean.
+- Do not require full PR readiness for low-risk docs/instruction-only changes unless the matrix
+  escalation rules apply; record the cheap validation commands instead.
+- When full readiness is required, do not stop at lint green: ensure parallel tests and diff gates
+  are also clean.
 - Treat benchmark fallback execution as unresolved unless explicitly scoped.
 
 ## Output

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,34 @@ documentation, and process in proportion to risk:
   conflict with the user's current priority, follow the current priority, call out the conflict, and
   propose or make the smallest doc update needed to remove the drift.
 
+When instruction surfaces conflict, use this precedence order:
+
+1. Current maintainer direction in the active issue, PR, or thread.
+2. `docs/maintainer_values.md`.
+3. `AGENTS.md`.
+4. `.agents/README.md`, `.agents/PLANS.md`, and repo-local skill docs under `.agents/skills/`.
+5. `docs/dev_guide.md`, context notes, and tool-specific compatibility pointers.
+
+If this order resolves a recurring workflow conflict, make the conflict visible where practical:
+update the active issue/PR, patch the stale instruction, or open a bounded follow-up issue. Routine
+workflow cleanup should proceed autonomously when the scope is bounded; label assumptions,
+uncertainty, and evidence grade instead of pausing for confirmation. Treat Project #5 ordering and
+scores as advisory when they conflict with fresh maintainer direction or newly observed evidence;
+record the override and update Project metadata later when quota and API limits allow.
+
+Use validation proportional to the file/change type, with claim strength as an escalation override:
+
+| Change class | Minimum proof | Full `pr_ready_check` required when |
+| --- | --- | --- |
+| Docs-only or instruction-only | Inspect diff; verify changed links or paths where practical; run available lightweight markdown, index, or sync checks. | The text changes generated indexes, compatibility surfaces, or makes evidence-sensitive claims. |
+| Workflow/tooling docs or skills | Cheap docs proof plus relevant skill/schema/sync checks such as `uv run python scripts/dev/check_skills.py --preflight <skill>` or `uv run python scripts/tools/sync_ai_config.py --check`. | Scripts, schemas, generated indexes, routing behavior, or automation behavior changes. |
+| Runtime code | Focused tests for changed behavior plus lint/format gates. | The change is user-facing, cross-module, release-facing, or affects shared execution paths. |
+| Benchmark, metric, schema, model-provenance | Executable proof on the intended contract with provenance and fallback/degraded exclusions. | Almost always; skip only for explicit diagnostic-only docs with no semantic change. |
+| Paper-facing or public claims | Reproducible evidence matching the claim boundary, caveats, uncertainty, and artifact provenance. | Always before treating the claim as established. |
+
+Claim strength overrides the nominal row: a docs or workflow edit that asserts a benchmark, metric,
+schema, model-provenance, or paper-facing result must use the stronger proof tier for that claim.
+
 ## Agent Context Stack
 Treat the following files as the repository-native context stack for Agent-style agents:
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -34,6 +34,32 @@ uv run python -c "from robot_sf.gym_env.environment_factory import make_robot_en
 Host tools and optional machine capabilities that are not installed by `uv` are tracked in
 [`docs/dev_runtime_requirements.md`](dev_runtime_requirements.md).
 
+### Instruction precedence and proportional readiness
+
+Use the maintainer hierarchy and readiness matrix in `AGENTS.md` before older workflow prose or
+tool-specific compatibility pointers. In short: active maintainer direction wins over stale
+instructions, `docs/maintainer_values.md` defines the hard contracts, and Project #5 scores are
+advisory when fresh evidence or maintainer direction conflicts with them.
+
+Routine workflow cleanup can proceed without extra confirmation when it is bounded and the PR or
+handoff clearly labels assumptions, uncertainty, evidence grade, and any deferred follow-up issue.
+Use a detached checkout at latest `origin/main` only for read-only discovery, duplicate checks, and
+issue creation or update work. Create or switch to a branch/worktree before editing docs or code,
+running validation for a PR, pushing, or publishing.
+
+Docs-only and instruction-only changes normally use the cheap validation path: inspect the diff,
+verify changed links or paths where practical, and run available lightweight checks. Skill or AI
+workflow edits should also run the relevant skill and sync checks, for example:
+
+```bash
+uv run python scripts/dev/check_skills.py --preflight <skill-name>
+uv run python scripts/tools/sync_ai_config.py --check
+```
+
+Escalate to `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` when the change touches scripts,
+schemas, generated indexes, routing behavior, automation, runtime behavior, benchmark/metric/schema
+semantics, model provenance, or paper-facing claims.
+
 ### Claim-map validation
 
 The fast-results claim map is an executable issue queue, not only a context note. Before changing


### PR DESCRIPTION
## Summary

- Add a compact instruction-precedence rule and proportional readiness matrix to `AGENTS.md`.
- Link the rule from `docs/dev_guide.md`, `.agents/PLANS.md`, `.agents/README.md`, and the high-traffic implementation/readiness skills.
- Clarify autonomous bounded workflow cleanup, detached latest-main read-only use, Project #5 advisory handling, and skill/sync validation expectations.

Closes #2642.

## Validation

- `git diff --check`
- `uv run python scripts/dev/check_skills.py --preflight goal-issue-implementation`
- `uv run python scripts/dev/check_skills.py --preflight pr-ready-check`
- `uv run python scripts/tools/sync_ai_config.py --check`
- Targeted `grep` for new precedence/readiness/detached/sync guidance across changed files

## Downstream Propagation

- Updated canonical agent/workflow instruction surfaces directly.
- `scripts/tools/sync_ai_config.py --check` reported all supported AI config symlinks valid, so no mirror repair was needed.
- No benchmark report, artifact registry, or context note update needed; this is workflow/instruction guidance only.

## Research Result Guidance

NA - instruction/workflow guidance only; no benchmark, metric, model, schema, or paper-facing claim is introduced.
