### PR TITLE
feat: add PR babysitter snapshot helper

### DIFF
--- a/.agents/skills/gh-pr-comment-fixer/SKILL.md
+++ b/.agents/skills/gh-pr-comment-fixer/SKILL.md
@@ -15,6 +15,16 @@ output_schema: skill_run_summary.v1
 
 Use this on a writable PR branch when actionable review feedback exists.
 
+If you only need to detect whether review feedback, CI failure, stale head state, or mergeability
+needs attention, start with the read-only babysitter snapshot instead:
+
+```bash
+uv run python scripts/dev/pr_babysitter_snapshot.py <pr-number> --expected-head-sha <sha> --json
+```
+
+Use this skill after that snapshot recommends `process_review_comment` or when the user explicitly
+asks to fix known review comments.
+
 ## Scope
 
 - Fetch PR context for current branch.

--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -105,8 +105,8 @@ Avoid loops:
      and private artifacts instead of broad `rg -n .` or full file reads,
    - classify findings as fixable now, deferred, or blocker.
 
-Before choosing the next action for any PR, consult the compact snapshot and apply the
-machine-checkable state policy:
+Before choosing the next action for any PR, consult the compact snapshot. For ordinary review-loop
+triage, apply the machine-checkable state policy:
 
 ```bash
 uv run python scripts/dev/pr_loop_policy.py --snapshot <queue-snapshot.json> --json
@@ -115,6 +115,16 @@ uv run python scripts/dev/pr_loop_policy.py --snapshot <queue-snapshot.json> --j
 The policy classifies each PR into `pending_ci`, `failed_ci`, `missing_artifacts`,
 `stale_worktree`, `ready_to_merge`, or `no_action` and recommends one bounded action
 under the loop budget. Use the policy decision to avoid ad-hoc state inspection.
+
+For PR babysitting or handoff, prefer the conservative one-shot babysitter snapshot:
+
+```bash
+uv run python scripts/dev/pr_babysitter_snapshot.py <pr-number> --expected-head-sha <sha> --json
+```
+
+Use it when the next question is whether to wait, diagnose failed CI, process review feedback, stop
+because the PR closed or went stale, or perform a final merge-readiness review. The babysitter
+helper is route evidence only and does not perform GitHub-visible writes.
 
 4. Fix actionable items on writable branches; commit and push.
 5. Validate per required tier.

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -449,6 +449,7 @@ uv run python scripts/dev/snapshot_issue_batch.py --active-portfolio \
   --json
 uv run python scripts/dev/snapshot_pr_queue.py --prs 2677 2678 2679 --json \
   --expected-head-sha "$PR_HEAD_SHA"
+uv run python scripts/dev/pr_babysitter_snapshot.py 2679 --expected-head-sha "$SHA" --json
 uv run python scripts/dev/watch_pr_ci_status.py 2679 --expected-head-sha "$SHA" --json --once
 ```
 

--- a/scripts/dev/pr_babysitter_snapshot.py
+++ b/scripts/dev/pr_babysitter_snapshot.py
@@ -1,0 +1,311 @@
+#!/usr/bin/env python3
+"""Emit a conservative PR babysitter snapshot.
+
+This helper is intentionally read-only toward GitHub. It wraps the existing compact PR queue
+snapshot and adds a higher-level action recommendation for agents that need to babysit an open PR
+without manually stitching CI, review, mergeability, and retry-budget state together.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+from scripts.dev.snapshot_pr_queue import DEFAULT_REPO, snapshot_prs
+
+SCHEMA_VERSION = "pr_babysitter_snapshot.v1"
+DEFAULT_RETRY_BUDGET = 1
+
+
+def _state_key(pr: dict[str, Any]) -> str:
+    """Return the retry-state key for a PR/head pair."""
+    return f"{pr.get('number')}:{pr.get('head_sha', '')}"
+
+
+def load_retry_state(path: Path | None) -> dict[str, Any]:
+    """Load retry state from disk, returning an empty state when absent."""
+    if path is None or not path.exists():
+        return {"schema": "pr_babysitter_retry_state.v1", "prs": {}}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {"schema": "pr_babysitter_retry_state.v1", "prs": {}}
+    if not isinstance(payload, dict):
+        return {"schema": "pr_babysitter_retry_state.v1", "prs": {}}
+    payload.setdefault("schema", "pr_babysitter_retry_state.v1")
+    payload.setdefault("prs", {})
+    if not isinstance(payload["prs"], dict):
+        payload["prs"] = {}
+    return payload
+
+
+def save_retry_state(path: Path, state: dict[str, Any]) -> None:
+    """Persist retry state to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(state, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def retry_budget_for_pr(
+    pr: dict[str, Any],
+    *,
+    retry_state: dict[str, Any],
+    retry_budget: int,
+) -> dict[str, Any]:
+    """Return bounded retry accounting for a PR/head pair."""
+    key = _state_key(pr)
+    entry = retry_state.get("prs", {}).get(key, {})
+    attempts = int(entry.get("retry_recommendations", 0) or 0) if isinstance(entry, dict) else 0
+    budget = max(retry_budget, 0)
+    remaining = max(budget - attempts, 0)
+    return {
+        "key": key,
+        "budget": budget,
+        "retry_recommendations": attempts,
+        "remaining": remaining,
+        "exhausted": remaining <= 0,
+    }
+
+
+def record_retry_recommendation(pr: dict[str, Any], *, retry_state: dict[str, Any]) -> None:
+    """Increment retry recommendation state for a PR/head pair."""
+    key = _state_key(pr)
+    prs = retry_state.setdefault("prs", {})
+    entry = prs.setdefault(key, {})
+    entry["retry_recommendations"] = int(entry.get("retry_recommendations", 0) or 0) + 1
+    entry["pr"] = pr.get("number")
+    entry["head_sha"] = pr.get("head_sha", "")
+
+
+def _trusted_author(author: str, trusted_authors: set[str] | None) -> bool:
+    """Return whether an author is trusted for actionable babysitter feedback."""
+    return trusted_authors is None or author in trusted_authors
+
+
+def _string_or_default(value: Any, default: str = "") -> str:
+    """Stringify a value, treating only None as missing."""
+    return str(value if value is not None else default)
+
+
+def _review_feedback(
+    pr: dict[str, Any],
+    *,
+    trusted_authors: set[str] | None = None,
+) -> dict[str, Any]:
+    """Return review/comment state relevant to babysitting."""
+    thread_snapshot = pr.get("review_thread_snapshot", {})
+    unresolved = 0
+    trusted_unresolved = 0
+    thread_snapshot_complete = False
+    if isinstance(thread_snapshot, dict):
+        unresolved = int(thread_snapshot.get("unresolved", 0) or 0)
+        thread_snapshot_complete = str(thread_snapshot.get("status", "")) == "ok"
+        threads = [
+            thread
+            for thread in thread_snapshot.get("threads", []) or []
+            if isinstance(thread, dict)
+        ]
+        if unresolved > 0 and not threads:
+            trusted_unresolved = unresolved
+        for thread in threads:
+            if not isinstance(thread, dict) or bool(thread.get("resolved")):
+                continue
+            comments = [
+                comment for comment in thread.get("comments", []) or [] if isinstance(comment, dict)
+            ]
+            if not comments or any(
+                _trusted_author(str(comment.get("author", "")), trusted_authors)
+                for comment in comments
+            ):
+                trusted_unresolved += 1
+    reviews = pr.get("reviews", {}) if isinstance(pr.get("reviews"), dict) else {}
+    comment_snapshot = (
+        pr.get("comment_snapshot") if isinstance(pr.get("comment_snapshot"), dict) else {}
+    )
+    comment_total = comment_snapshot.get("total")
+    comment_count = int(comment_total if comment_total is not None else 0)
+    commented_reviews = int(reviews.get("COMMENTED", 0) or 0)
+    actionable_review = trusted_unresolved > 0 or (
+        commented_reviews > 0 and not thread_snapshot_complete
+    )
+    return {
+        "unresolved_threads": unresolved,
+        "trusted_unresolved_threads": trusted_unresolved,
+        "submitted_review_counts": reviews,
+        "issue_comments": comment_count,
+        "has_actionable_feedback": actionable_review or comment_count > 0,
+    }
+
+
+def classify_pr_action(
+    pr: dict[str, Any],
+    *,
+    retry_state: dict[str, Any],
+    retry_budget: int = DEFAULT_RETRY_BUDGET,
+    trusted_authors: set[str] | None = None,
+) -> dict[str, Any]:
+    """Classify the next safe babysitter action for one PR."""
+    checks = pr.get("checks", {}) if isinstance(pr.get("checks"), dict) else {}
+    feedback = _review_feedback(pr, trusted_authors=trusted_authors)
+    retry = retry_budget_for_pr(pr, retry_state=retry_state, retry_budget=retry_budget)
+    reasons: list[str] = []
+    action = "wait"
+
+    state = _string_or_default(pr.get("state")).upper()
+    preflight = pr.get("preflight", {}) if isinstance(pr.get("preflight"), dict) else {}
+    preflight_status = _string_or_default(preflight.get("status"))
+    checks_overall = _string_or_default(checks.get("overall"), "pending")
+    mergeable = _string_or_default(pr.get("mergeable"))
+
+    if state and state != "OPEN":
+        action = "stop_pr_closed"
+        reasons.append(f"state:{state.lower()}")
+    elif preflight_status == "stale":
+        action = "stop_stale_head"
+        reasons.extend(str(reason) for reason in preflight.get("reasons", []) or ["stale"])
+    elif preflight_status == "blocked" and mergeable == "CONFLICTING":
+        action = "stop_user_help_required"
+        reasons.append("merge_conflict")
+    elif checks_overall == "failure":
+        action = "diagnose_ci_failure"
+        reasons.append("ci_failure")
+    elif feedback["has_actionable_feedback"]:
+        action = "process_review_comment"
+        reasons.append("review_feedback")
+    elif checks_overall == "pending":
+        action = "wait"
+        reasons.append("ci_pending")
+    elif checks_overall == "success" and mergeable == "MERGEABLE":
+        action = "review_for_merge_ready"
+        reasons.append("ci_success_mergeable")
+    else:
+        action = "wait"
+        reasons.append("no_safe_write_action")
+
+    after_diagnosis_action = None
+    if action == "diagnose_ci_failure":
+        after_diagnosis_action = (
+            "retry_failed_checks" if retry["remaining"] > 0 else "stop_retry_budget_exhausted"
+        )
+
+    return {
+        "action": action,
+        "reasons": reasons,
+        "after_diagnosis_action": after_diagnosis_action,
+        "retry_budget": retry,
+        "review_feedback": feedback,
+        "mutation_guardrails": {
+            "github_writes": False,
+            "auto_reply_to_humans": False,
+            "auto_resolve_threads": False,
+            "auto_merge": False,
+        },
+    }
+
+
+def build_babysitter_snapshot(
+    numbers: list[int],
+    *,
+    repo: str = DEFAULT_REPO,
+    expected_head_sha: str = "",
+    retry_state: dict[str, Any] | None = None,
+    retry_budget: int = DEFAULT_RETRY_BUDGET,
+    record_retry_recommendations: bool = False,
+    trusted_authors: set[str] | None = None,
+) -> dict[str, Any]:
+    """Return a PR babysitter snapshot for explicit PR numbers."""
+    state = retry_state if retry_state is not None else load_retry_state(None)
+    queue_snapshot = snapshot_prs(
+        numbers,
+        repo=repo,
+        expected_head_sha=expected_head_sha,
+        include_review_threads=True,
+    )
+    babysat_prs: list[dict[str, Any]] = []
+    for pr in queue_snapshot.get("prs", []):
+        recommendation = classify_pr_action(
+            pr,
+            retry_state=state,
+            retry_budget=retry_budget,
+            trusted_authors=trusted_authors,
+        )
+        if (
+            record_retry_recommendations
+            and recommendation.get("after_diagnosis_action") == "retry_failed_checks"
+        ):
+            record_retry_recommendation(pr, retry_state=state)
+            recommendation = classify_pr_action(
+                pr,
+                retry_state=state,
+                retry_budget=retry_budget,
+                trusted_authors=trusted_authors,
+            )
+        babysat_prs.append(
+            {
+                "number": pr.get("number"),
+                "title": pr.get("title", ""),
+                "state": pr.get("state", ""),
+                "head_branch": pr.get("head_branch", ""),
+                "head_sha": pr.get("head_sha", ""),
+                "mergeable": pr.get("mergeable", ""),
+                "checks": pr.get("checks", {}),
+                "preflight": pr.get("preflight", {}),
+                "review_snapshot": pr.get("review_snapshot", {}),
+                "comment_snapshot": pr.get("comment_snapshot", {}),
+                "review_thread_snapshot": pr.get("review_thread_snapshot", {}),
+                "recommendation": recommendation,
+            }
+        )
+    return {
+        "schema": SCHEMA_VERSION,
+        "repo": repo,
+        "source_schema": queue_snapshot.get("schema"),
+        "route_evidence_only": True,
+        "prs": babysat_prs,
+    }
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("prs", nargs="+", type=int, help="PR numbers to snapshot.")
+    parser.add_argument("--repo", default=DEFAULT_REPO)
+    parser.add_argument("--expected-head-sha", default="")
+    parser.add_argument("--retry-budget", type=int, default=DEFAULT_RETRY_BUDGET)
+    parser.add_argument("--retry-state-file", type=Path)
+    parser.add_argument(
+        "--trusted-author",
+        action="append",
+        default=None,
+        help="Trusted review/comment author login. Repeat to provide an allowlist.",
+    )
+    parser.add_argument(
+        "--record-retry-recommendation",
+        action="store_true",
+        help="Persist one retry recommendation for failed checks after this snapshot.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit pretty JSON.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    retry_state = load_retry_state(args.retry_state_file)
+    payload = build_babysitter_snapshot(
+        args.prs,
+        repo=args.repo,
+        expected_head_sha=args.expected_head_sha,
+        retry_state=retry_state,
+        retry_budget=args.retry_budget,
+        record_retry_recommendations=args.record_retry_recommendation,
+        trusted_authors=set(args.trusted_author) if args.trusted_author else None,
+    )
+    if args.retry_state_file and args.record_retry_recommendation:
+        save_retry_state(args.retry_state_file, retry_state)
+    print(json.dumps(payload, indent=2, sort_keys=True) if args.json else json.dumps(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/snapshot_pr_queue.py
+++ b/scripts/dev/snapshot_pr_queue.py
@@ -253,14 +253,31 @@ def _checks(pr: dict[str, Any]) -> dict[str, Any]:
     conclusions: dict[str, int] = {}
     statuses: dict[str, int] = {}
     names: set[str] = set()
+    failed: list[dict[str, str]] = []
+    pending: list[dict[str, str]] = []
     for check in rollup:
         if not isinstance(check, dict):
             continue
         conclusion = _rollup_conclusion(check)
         status = _rollup_status(check)
+        details_url = check.get("detailsUrl")
+        if details_url is None:
+            details_url = check.get("targetUrl")
+        if details_url is None:
+            details_url = ""
+        detail = {
+            "name": _rollup_name(check),
+            "status": status,
+            "conclusion": conclusion,
+            "details_url": str(details_url),
+        }
         conclusions[conclusion] = conclusions.get(conclusion, 0) + 1
         statuses[status] = statuses.get(status, 0) + 1
-        names.add(_rollup_name(check))
+        names.add(detail["name"])
+        if conclusion in FAILURE_CONCLUSIONS:
+            failed.append(detail)
+        elif status in PENDING_STATUSES:
+            pending.append(detail)
     failure_count = sum(conclusions.get(conclusion, 0) for conclusion in FAILURE_CONCLUSIONS)
     pending_count = sum(statuses.get(status, 0) for status in PENDING_STATUSES)
     if failure_count:
@@ -275,6 +292,8 @@ def _checks(pr: dict[str, Any]) -> dict[str, Any]:
         "by_conclusion": conclusions,
         "by_status": statuses,
         "names": sorted(names),
+        "failed": failed,
+        "pending": pending,
     }
 
 

--- a/tests/dev/test_pr_babysitter_snapshot.py
+++ b/tests/dev/test_pr_babysitter_snapshot.py
@@ -1,0 +1,212 @@
+"""Tests for conservative PR babysitter snapshots."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from scripts.dev.pr_babysitter_snapshot import (
+    build_babysitter_snapshot,
+    classify_pr_action,
+    load_retry_state,
+    save_retry_state,
+)
+
+
+def _base_pr(**overrides):  # type: ignore[no-untyped-def]
+    pr = {
+        "number": 2999,
+        "title": "example",
+        "state": "OPEN",
+        "head_branch": "feature",
+        "head_sha": "abc123",
+        "mergeable": "MERGEABLE",
+        "checks": {"overall": "success", "total": 1, "by_conclusion": {"success": 1}},
+        "reviews": {},
+        "review_snapshot": {"total": 0},
+        "comment_snapshot": {"total": 0},
+        "review_thread_snapshot": {"status": "ok", "unresolved": 0, "threads": []},
+        "preflight": {"status": "healthy", "reasons": ["ok"]},
+    }
+    pr.update(overrides)
+    return pr
+
+
+def test_successful_mergeable_pr_routes_to_review_for_merge_ready() -> None:
+    """Green mergeable PRs still need local merge-readiness review."""
+    recommendation = classify_pr_action(_base_pr(), retry_state={"prs": {}})
+
+    assert recommendation["action"] == "review_for_merge_ready"
+    assert recommendation["mutation_guardrails"]["auto_merge"] is False
+
+
+def test_unresolved_review_thread_routes_to_comment_processing() -> None:
+    """Submitted unresolved review threads should take priority over green CI."""
+    pr = _base_pr(review_thread_snapshot={"status": "ok", "unresolved": 1, "threads": []})
+
+    recommendation = classify_pr_action(pr, retry_state={"prs": {}})
+
+    assert recommendation["action"] == "process_review_comment"
+    assert recommendation["review_feedback"]["unresolved_threads"] == 1
+    assert recommendation["mutation_guardrails"]["auto_reply_to_humans"] is False
+
+
+def test_resolved_thread_suppresses_comment_review_noise() -> None:
+    """Resolved review threads should not keep COMMENTED reviews actionable forever."""
+    pr = _base_pr(
+        reviews={"COMMENTED": 1},
+        review_thread_snapshot={"status": "ok", "unresolved": 0, "threads": []},
+    )
+
+    recommendation = classify_pr_action(pr, retry_state={"prs": {}})
+
+    assert recommendation["action"] == "review_for_merge_ready"
+    assert recommendation["review_feedback"]["has_actionable_feedback"] is False
+
+
+def test_trusted_author_filter_ignores_untrusted_review_threads() -> None:
+    """Optional trusted-author filtering should suppress untrusted review threads."""
+    pr = _base_pr(
+        review_thread_snapshot={
+            "status": "ok",
+            "unresolved": 1,
+            "threads": [
+                {
+                    "resolved": False,
+                    "comments": [{"author": "unknown-reviewer"}],
+                }
+            ],
+        }
+    )
+
+    recommendation = classify_pr_action(
+        pr,
+        retry_state={"prs": {}},
+        trusted_authors={"trusted-reviewer"},
+    )
+
+    assert recommendation["action"] == "review_for_merge_ready"
+    assert recommendation["review_feedback"]["trusted_unresolved_threads"] == 0
+
+
+def test_trusted_author_filter_accepts_trusted_review_threads() -> None:
+    """Trusted unresolved review threads should route to comment processing."""
+    pr = _base_pr(
+        review_thread_snapshot={
+            "status": "ok",
+            "unresolved": 1,
+            "threads": [
+                {
+                    "resolved": False,
+                    "comments": [{"author": "trusted-reviewer"}],
+                }
+            ],
+        }
+    )
+
+    recommendation = classify_pr_action(
+        pr,
+        retry_state={"prs": {}},
+        trusted_authors={"trusted-reviewer"},
+    )
+
+    assert recommendation["action"] == "process_review_comment"
+    assert recommendation["review_feedback"]["trusted_unresolved_threads"] == 1
+
+
+def test_failed_ci_recommends_diagnosis_before_bounded_retry() -> None:
+    """Failed CI should diagnose logs before any retry recommendation is acted on."""
+    pr = _base_pr(checks={"overall": "failure", "by_conclusion": {"failure": 1}})
+
+    recommendation = classify_pr_action(pr, retry_state={"prs": {}}, retry_budget=1)
+
+    assert recommendation["action"] == "diagnose_ci_failure"
+    assert recommendation["after_diagnosis_action"] == "retry_failed_checks"
+    assert recommendation["retry_budget"]["remaining"] == 1
+
+
+def test_retry_budget_exhaustion_stops_retry_recommendation() -> None:
+    """Retry recommendations are keyed by PR and head SHA."""
+    pr = _base_pr(checks={"overall": "failure", "by_conclusion": {"failure": 1}})
+    retry_state = {"prs": {"2999:abc123": {"retry_recommendations": 1}}}
+
+    recommendation = classify_pr_action(pr, retry_state=retry_state, retry_budget=1)
+
+    assert recommendation["action"] == "diagnose_ci_failure"
+    assert recommendation["after_diagnosis_action"] == "stop_retry_budget_exhausted"
+    assert recommendation["retry_budget"]["exhausted"] is True
+
+
+def test_closed_pr_stops_babysitting() -> None:
+    """Closed or merged PRs are terminal for the babysitter."""
+    recommendation = classify_pr_action(_base_pr(state="MERGED"), retry_state={"prs": {}})
+
+    assert recommendation["action"] == "stop_pr_closed"
+
+
+def test_none_fields_do_not_stringify_to_none_or_crash() -> None:
+    """Explicit None values from API JSON should be treated as missing."""
+    pr = _base_pr(
+        state=None,
+        mergeable=None,
+        checks={"overall": None},
+        preflight={"status": None},
+        comment_snapshot=None,
+    )
+
+    recommendation = classify_pr_action(pr, retry_state={"prs": {}})
+
+    assert recommendation["action"] == "wait"
+    assert recommendation["review_feedback"]["issue_comments"] == 0
+
+
+def test_build_snapshot_wraps_compact_pr_queue_and_records_retry(tmp_path) -> None:  # type: ignore[no-untyped-def]
+    """The wrapper should reuse compact queue snapshots and persist retry accounting."""
+    state_file = tmp_path / "retry-state.json"
+    pr_payload = {
+        "number": 3001,
+        "title": "failed PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "url": "https://github.test/pull/3001",
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "def456",
+        "mergeable": "MERGEABLE",
+        "statusCheckRollup": [{"name": "ci", "status": "completed", "conclusion": "failure"}],
+        "reviews": [],
+        "comments": [],
+    }
+    thread_payload = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "totalCount": 0,
+                        "nodes": [],
+                    }
+                }
+            }
+        }
+    }
+    retry_state = load_retry_state(state_file)
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.side_effect = [
+            MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr=""),
+            MagicMock(returncode=0, stdout=json.dumps(thread_payload), stderr=""),
+        ]
+        payload = build_babysitter_snapshot(
+            [3001],
+            repo="ll7/robot_sf_ll7",
+            retry_state=retry_state,
+            retry_budget=1,
+            record_retry_recommendations=True,
+        )
+    save_retry_state(state_file, retry_state)
+
+    pr = payload["prs"][0]
+    assert payload["schema"] == "pr_babysitter_snapshot.v1"
+    assert pr["recommendation"]["action"] == "diagnose_ci_failure"
+    assert pr["recommendation"]["after_diagnosis_action"] == "stop_retry_budget_exhausted"
+    persisted = load_retry_state(state_file)
+    assert persisted["prs"]["3001:def456"]["retry_recommendations"] == 1

--- a/tests/dev/test_snapshot_pr_queue.py
+++ b/tests/dev/test_snapshot_pr_queue.py
@@ -85,8 +85,44 @@ def test_snapshot_prs_pending_next_action() -> None:
 
     pr = payload["prs"][0]
     assert pr["checks"]["overall"] == "pending"
+    assert pr["checks"]["pending"] == [
+        {"name": "ci", "status": "in_progress", "conclusion": "pending", "details_url": ""}
+    ]
     assert pr["next_action"] == "await_ci_or_start_read_only_monitor"
     assert payload["route_health_overview"]["healthy"] == 1
+
+
+def test_snapshot_prs_details_url_none_falls_back_without_none_string() -> None:
+    """Explicit null detailsUrl should not become the literal string None."""
+    pr_payload = {
+        "number": 2682,
+        "title": "pending PR",
+        "state": "OPEN",
+        "isDraft": False,
+        "labels": [],
+        "headRefName": "feature",
+        "headRefOid": "def457",
+        "mergeable": "UNKNOWN",
+        "statusCheckRollup": [
+            {
+                "name": "ci",
+                "status": "completed",
+                "conclusion": "failure",
+                "detailsUrl": None,
+                "targetUrl": "",
+            }
+        ],
+        "reviews": [],
+        "comments": [],
+    }
+    with patch("scripts.dev.snapshot_pr_queue._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(pr_payload), stderr="")
+        payload = snapshot_prs([2682], repo="ll7/robot_sf_ll7")
+
+    pr = payload["prs"][0]
+    assert pr["checks"]["failed"] == [
+        {"name": "ci", "status": "completed", "conclusion": "failure", "details_url": ""}
+    ]
 
 
 def test_snapshot_prs_stale_if_head_sha_mismatch() -> None:


### PR DESCRIPTION
## Summary

- Add `scripts/dev/pr_babysitter_snapshot.py`, a read-only PR babysitter wrapper over the compact PR queue snapshot.
- Add bounded recommendations for `wait`, `diagnose_ci_failure`, `process_review_comment`, `review_for_merge_ready`, `stop_pr_closed`, and stale/help stop states.
- Add local retry-budget accounting by PR/head SHA plus optional trusted-author filtering for review feedback.
- Extend compact PR queue checks with bounded failed/pending check details and document the helper in review/comment-fixer guidance.

Closes #2681.

## Validation

- `uv run pytest tests/dev/test_pr_babysitter_snapshot.py tests/dev/test_snapshot_pr_queue.py -q` - 23 passed
- `uv run ruff check scripts/dev/pr_babysitter_snapshot.py tests/dev/test_pr_babysitter_snapshot.py scripts/dev/snapshot_pr_queue.py tests/dev/test_snapshot_pr_queue.py`
- `uv run ruff format --check scripts/dev/pr_babysitter_snapshot.py tests/dev/test_pr_babysitter_snapshot.py scripts/dev/snapshot_pr_queue.py tests/dev/test_snapshot_pr_queue.py`
- `git diff --check`
- Read-only smoke: `uv run python scripts/dev/pr_babysitter_snapshot.py 2990 --json`

## Downstream Propagation

- Updated `.agents/skills/goal-pr-review/SKILL.md`, `.agents/skills/gh-pr-comment-fixer/SKILL.md`, and `docs/dev_guide.md` to point at the new helper.
- No benchmark report or artifact registry update needed; this is workflow/tooling support.

## Research Result Guidance

NA - workflow/tooling helper only; no benchmark, metric, model, schema, or paper-facing claim is introduced.
