### PR TITLE
feat: batch issue claim lookups in snapshots

### DIFF
--- a/scripts/dev/snapshot_issue_batch.py
+++ b/scripts/dev/snapshot_issue_batch.py
@@ -11,7 +11,7 @@ import sys
 from datetime import UTC, datetime
 from typing import Any
 
-from scripts.dev.issue_claim import status_issue
+from scripts.dev.issue_claim import short_claim_ref, status_issue
 
 BODY_EXCERPT_CHARS = 300
 DEFAULT_CLAIMABLE_LIMIT = 20
@@ -101,6 +101,89 @@ def _issue_classification(
     return "claimable", "open, unassigned, and unclaimed"
 
 
+def _claim_payload(claim: dict[str, Any]) -> dict[str, Any]:
+    """Return the stable claim subset exposed in issue snapshots."""
+    return {
+        "ok": claim.get("ok"),
+        "claimed": claim.get("claimed"),
+        "claim_ref": claim.get("claim_ref"),
+        "sha": claim.get("sha"),
+    }
+
+
+def _claim_status_payload(
+    issue_number: int,
+    *,
+    remote: str,
+    ok: bool,
+    claimed: bool | None,
+    sha: str | None,
+    error: str = "",
+    command: list[str] | None = None,
+) -> dict[str, Any]:
+    """Return an issue-claim status payload matching ``status_issue`` shape."""
+    payload: dict[str, Any] = {
+        "schema": "issue_claim.v1",
+        "action": "status",
+        "ok": ok,
+        "claimed": claimed,
+        "issue": issue_number,
+        "remote": remote,
+        "claim_ref": short_claim_ref(issue_number),
+        "sha": sha,
+        "command": command or [],
+    }
+    if error:
+        payload["error"] = error
+    return payload
+
+
+def _batch_claim_statuses(issue_numbers: list[int], *, remote: str) -> dict[int, dict[str, Any]]:
+    """Fetch all issue-claim refs once and return status payloads for each issue."""
+    unique_numbers = sorted(set(issue_numbers))
+    if not unique_numbers:
+        return {}
+
+    command = ["git", "ls-remote", "--heads", remote, "refs/heads/agent-claims/issue-*"]
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        error = (result.stderr or result.stdout).strip()
+        return {
+            number: _claim_status_payload(
+                number,
+                remote=remote,
+                ok=False,
+                claimed=None,
+                sha=None,
+                error=error,
+                command=command,
+            )
+            for number in unique_numbers
+        }
+
+    claimed_refs: dict[int, str] = {}
+    ref_prefix = "refs/heads/agent-claims/issue-"
+    for line in (result.stdout or "").strip().splitlines():
+        parts = line.split()
+        if len(parts) < 2 or not parts[1].startswith(ref_prefix):
+            continue
+        issue_text = parts[1].removeprefix(ref_prefix)
+        if issue_text.isdigit():
+            claimed_refs[int(issue_text)] = parts[0]
+
+    return {
+        number: _claim_status_payload(
+            number,
+            remote=remote,
+            ok=True,
+            claimed=number in claimed_refs,
+            sha=claimed_refs.get(number),
+            command=command,
+        )
+        for number in unique_numbers
+    }
+
+
 def _is_blocked_external_issue(labels: list[str]) -> bool:
     """Return whether labels describe an issue blocked on external assets or input."""
     label_set = set(labels)
@@ -170,12 +253,7 @@ def fetch_issue(number: int, *, repo: str, body_limit: int, remote: str) -> dict
         "assignees": assignees,
         "body_excerpt": excerpt,
         "body_truncated": truncated,
-        "claim": {
-            "ok": claim.get("ok"),
-            "claimed": claim.get("claimed"),
-            "claim_ref": claim.get("claim_ref"),
-            "sha": claim.get("sha"),
-        },
+        "claim": _claim_payload(claim),
         "classification": classification,
         "reason": reason,
         "linked_prs": [],
@@ -185,7 +263,9 @@ def fetch_issue(number: int, *, repo: str, body_limit: int, remote: str) -> dict
     }
 
 
-def _snapshot_from_issue_list(issue: dict[str, Any], *, remote: str) -> dict[str, Any]:
+def _snapshot_from_issue_list(
+    issue: dict[str, Any], *, remote: str, claim_statuses: dict[int, dict[str, Any]] | None = None
+) -> dict[str, Any]:
     """Build an issue snapshot using preloaded issue fields."""
     try:
         number = int(issue.get("number"))
@@ -194,7 +274,20 @@ def _snapshot_from_issue_list(issue: dict[str, Any], *, remote: str) -> dict[str
 
     labels = _labels(issue)
     assignees = _assignees(issue)
-    claim = status_issue(number, remote=remote)
+    claim = (
+        claim_statuses.get(number)
+        if claim_statuses is not None
+        else status_issue(number, remote=remote)
+    )
+    if not isinstance(claim, dict):
+        claim = _claim_status_payload(
+            number,
+            remote=remote,
+            ok=False,
+            claimed=None,
+            sha=None,
+            error="claim status unavailable",
+        )
     classification, reason = _issue_classification(
         assignees=assignees,
         claim=claim,
@@ -208,12 +301,7 @@ def _snapshot_from_issue_list(issue: dict[str, Any], *, remote: str) -> dict[str
         "url": issue.get("url", ""),
         "labels": labels,
         "assignees": assignees,
-        "claim": {
-            "ok": claim.get("ok"),
-            "claimed": claim.get("claimed"),
-            "claim_ref": claim.get("claim_ref"),
-            "sha": claim.get("sha"),
-        },
+        "claim": _claim_payload(claim),
         "body_excerpt": "",
         "body_truncated": False,
         "classification": classification,
@@ -287,7 +375,16 @@ def snapshot_claimable_issues(
             ],
         }
 
-    snapshots = [_snapshot_from_issue_list(issue, remote=remote) for issue in listed]
+    issue_numbers = [
+        int(issue["number"])
+        for issue in listed
+        if isinstance(issue, dict) and str(issue.get("number", "")).isdigit()
+    ]
+    claim_statuses = _batch_claim_statuses(issue_numbers, remote=remote)
+    snapshots = [
+        _snapshot_from_issue_list(issue, remote=remote, claim_statuses=claim_statuses)
+        for issue in listed
+    ]
     issues = [
         issue
         for issue in snapshots
@@ -482,6 +579,8 @@ def _portfolio_classification(
         "benchmark" in label_set or "research" in label_set or "epic" in label_set
     ):
         return "paper_critical", "high-priority benchmark or research surface"
+    if claim.get("ok") is False:
+        return "needs_human_decision", "unable to read claim state; skip autonomous claim"
     if assignees or claim.get("claimed"):
         return "needs_human_decision", "assigned or already claimed; skip autonomous claim"
     return "executable_now", "unassigned, unclaimed, and not blocked by labels"
@@ -531,13 +630,30 @@ def _portfolio_next_action(classification: str) -> str:
     return actions[classification]
 
 
-def _active_portfolio_row(issue: dict[str, Any], *, remote: str) -> dict[str, Any]:
+def _active_portfolio_row(
+    issue: dict[str, Any], *, remote: str, claim_statuses: dict[int, dict[str, Any]] | None = None
+) -> dict[str, Any]:
     """Return one active-portfolio row for an open issue."""
     number = int(issue.get("number"))
     labels = _labels(issue)
     assignees = _assignees(issue)
-    claim_value = status_issue(number, remote=remote)
-    claim = claim_value if isinstance(claim_value, dict) else {}
+    claim_value = (
+        claim_statuses.get(number)
+        if claim_statuses is not None
+        else status_issue(number, remote=remote)
+    )
+    claim = (
+        claim_value
+        if isinstance(claim_value, dict)
+        else _claim_status_payload(
+            number,
+            remote=remote,
+            ok=False,
+            claimed=None,
+            sha=None,
+            error="claim status unavailable",
+        )
+    )
     title = "" if issue.get("title") is None else issue.get("title", "")
     url = "" if issue.get("url") is None else issue.get("url", "")
     classification, reason = _portfolio_classification(
@@ -626,8 +742,14 @@ def snapshot_active_issue_portfolio(
                     "error": "expected gh issue list JSON array",
                 }
             ]
+        issue_numbers = [
+            int(issue["number"])
+            for issue in listed
+            if isinstance(issue, dict) and str(issue.get("number", "")).isdigit()
+        ]
+        claim_statuses = _batch_claim_statuses(issue_numbers, remote=remote)
         rows = [
-            _active_portfolio_row(issue, remote=remote)
+            _active_portfolio_row(issue, remote=remote, claim_statuses=claim_statuses)
             for issue in listed
             if isinstance(issue, dict) and issue.get("number") is not None
         ]

--- a/tests/dev/test_snapshot_issue_batch.py
+++ b/tests/dev/test_snapshot_issue_batch.py
@@ -3,9 +3,11 @@
 from __future__ import annotations
 
 import json
+import subprocess
 from unittest.mock import MagicMock, patch
 
 from scripts.dev.snapshot_issue_batch import (
+    _batch_claim_statuses,
     expand_issue_numbers,
     main,
     snapshot_active_issue_portfolio,
@@ -13,6 +15,16 @@ from scripts.dev.snapshot_issue_batch import (
     snapshot_claimable_issues,
     snapshot_issues,
 )
+
+
+def _claim_status(number: int, *, claimed: bool = False, ok: bool = True, sha: str | None = None):
+    """Return a compact claim status payload for snapshot tests."""
+    return {
+        "ok": ok,
+        "claimed": claimed if ok else None,
+        "claim_ref": f"agent-claims/issue-{number}",
+        "sha": sha if claimed else None,
+    }
 
 
 def test_expand_issue_numbers_treats_two_values_as_range() -> None:
@@ -139,11 +151,11 @@ def test_snapshot_claimable_issues_includes_classification_without_body() -> Non
 
     with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
         mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
-        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
-            claim.side_effect = [
-                {"ok": True, "claimed": False, "claim_ref": "agent-claims/issue-2667", "sha": None},
-                {"ok": True, "claimed": False, "claim_ref": "agent-claims/issue-2668", "sha": None},
-            ]
+        with patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as claim:
+            claim.return_value = {
+                2667: _claim_status(2667),
+                2668: _claim_status(2668),
+            }
             payload = snapshot_claimable_issues(
                 repo="ll7/robot_sf_ll7",
                 remote="origin",
@@ -157,6 +169,100 @@ def test_snapshot_claimable_issues_includes_classification_without_body() -> Non
     assert payload["issues"][0]["body_truncated"] is False
     assert payload["issues"][1]["classification"] == "blocked_label"
     assert "reason" in payload["issues"][1]
+    claim.assert_called_once_with([2667, 2668], remote="origin")
+
+
+def test_snapshot_claimable_issues_uses_one_batch_claim_lookup() -> None:
+    """Claimable snapshots should not shell out once per listed issue."""
+    issue_list = [
+        {
+            "number": 2667,
+            "title": "claimable issue",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2667",
+            "labels": [],
+            "assignees": [],
+        },
+        {
+            "number": 2668,
+            "title": "claimed issue",
+            "state": "OPEN",
+            "url": "https://github.test/issues/2668",
+            "labels": [],
+            "assignees": [],
+        },
+    ]
+
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        with patch("scripts.dev.snapshot_issue_batch.status_issue") as per_issue_claim:
+            with patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as batch_claim:
+                batch_claim.return_value = {
+                    2667: _claim_status(2667),
+                    2668: _claim_status(2668, claimed=True, sha="abc123"),
+                }
+                payload = snapshot_claimable_issues(
+                    repo="ll7/robot_sf_ll7",
+                    remote="origin",
+                    body_limit=150,
+                    limit=2,
+                )
+
+    per_issue_claim.assert_not_called()
+    batch_claim.assert_called_once_with([2667, 2668], remote="origin")
+    assert [issue["classification"] for issue in payload["issues"]] == ["claimable", "claimed"]
+    assert payload["issues"][1]["claim"] == {
+        "ok": True,
+        "claimed": True,
+        "claim_ref": "agent-claims/issue-2668",
+        "sha": "abc123",
+    }
+
+
+def test_batch_claim_statuses_parses_claim_refs_once() -> None:
+    """Batch claim lookup should parse matching remote refs and synthesize unclaimed rows."""
+    stdout = (
+        "abc123\trefs/heads/agent-claims/issue-2668\n"
+        "def456\trefs/heads/agent-claims/issue-not-a-number\n"
+    )
+
+    with patch("scripts.dev.snapshot_issue_batch.subprocess.run") as run:
+        run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout=stdout,
+            stderr="",
+        )
+        statuses = _batch_claim_statuses([2667, 2668], remote="origin")
+
+    run.assert_called_once_with(
+        ["git", "ls-remote", "--heads", "origin", "refs/heads/agent-claims/issue-*"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert statuses[2667]["claimed"] is False
+    assert statuses[2667]["sha"] is None
+    assert statuses[2668]["claimed"] is True
+    assert statuses[2668]["sha"] == "abc123"
+
+
+def test_batch_claim_status_failure_fails_closed() -> None:
+    """Batch lookup failures should not falsely mark listed issues unclaimed."""
+    with patch("scripts.dev.snapshot_issue_batch.subprocess.run") as run:
+        run.return_value = subprocess.CompletedProcess(
+            args=[],
+            returncode=128,
+            stdout="",
+            stderr="network unavailable",
+        )
+        statuses = _batch_claim_statuses([2667, 2668], remote="origin")
+
+    assert statuses[2667]["ok"] is False
+    assert statuses[2667]["claimed"] is None
+    assert statuses[2667]["error"] == "network unavailable"
+    assert statuses[2668]["ok"] is False
+    assert statuses[2668]["claimed"] is None
 
 
 def test_snapshot_claimable_issues_excludes_blocked_external_by_default() -> None:
@@ -182,12 +288,10 @@ def test_snapshot_claimable_issues_excludes_blocked_external_by_default() -> Non
 
     with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
         mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
-        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+        with patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as claim:
             claim.return_value = {
-                "ok": True,
-                "claimed": False,
-                "claim_ref": "agent-claims/issue",
-                "sha": None,
+                2962: _claim_status(2962),
+                2415: _claim_status(2415),
             }
             payload = snapshot_claimable_issues(
                 repo="ll7/robot_sf_ll7",
@@ -216,13 +320,8 @@ def test_snapshot_claimable_issues_can_include_blocked_external() -> None:
 
     with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
         mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
-        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
-            claim.return_value = {
-                "ok": True,
-                "claimed": False,
-                "claim_ref": "agent-claims/issue-2415",
-                "sha": None,
-            }
+        with patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as claim:
+            claim.return_value = {2415: _claim_status(2415)}
             payload = snapshot_claimable_issues(
                 repo="ll7/robot_sf_ll7",
                 remote="origin",
@@ -388,12 +487,9 @@ def test_snapshot_active_issue_portfolio_classifies_and_writes_report(tmp_path) 
 
     with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
         mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
-        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
+        with patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as claim:
             claim.return_value = {
-                "ok": True,
-                "claimed": False,
-                "claim_ref": "agent-claims/issue",
-                "sha": None,
+                int(issue["number"]): _claim_status(int(issue["number"])) for issue in issue_list
             }
             payload = snapshot_active_issue_portfolio(
                 repo="ll7/robot_sf_ll7",
@@ -424,6 +520,7 @@ def test_snapshot_active_issue_portfolio_classifies_and_writes_report(tmp_path) 
     assert rows[2441]["classification"] == "executable_now"
     assert rows[2441]["owner_type"] == "Slurm"
     assert payload["classification_counts"]["blocked_external_asset"] == 1
+    claim.assert_called_once_with([2967, 2415, 1134, 2946, 2910, 2965, 2845, 2441], remote="origin")
     markdown = report_path.read_text(encoding="utf-8")
     assert "# Active Issue Portfolio" in markdown
     assert (
@@ -449,6 +546,64 @@ def test_snapshot_active_issue_portfolio_reports_unexpected_json_shape() -> None
     assert payload["errors"] == [{"status": "error", "error": "expected gh issue list JSON array"}]
 
 
+def test_snapshot_active_issue_portfolio_fails_closed_on_claim_lookup_error() -> None:
+    """Portfolio rows should avoid executable_now when claim state cannot be read."""
+    issue_list = [
+        {
+            "number": 3001,
+            "title": "workflow issue",
+            "state": "OPEN",
+            "url": "https://github.test/issues/3001",
+            "labels": [{"name": "workflow"}],
+            "assignees": [],
+        }
+    ]
+
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        with patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as claim:
+            claim.return_value = {3001: _claim_status(3001, ok=False)}
+            payload = snapshot_active_issue_portfolio(
+                repo="ll7/robot_sf_ll7",
+                remote="origin",
+                limit=1,
+            )
+
+    row = payload["rows"][0]
+    assert row["classification"] == "needs_human_decision"
+    assert row["reason"] == "unable to read claim state; skip autonomous claim"
+    assert row["owner_type"] == "maintainer"
+
+
+def test_snapshot_active_issue_portfolio_fails_closed_on_malformed_claim_status() -> None:
+    """Malformed batched claim values should not classify rows as executable."""
+    issue_list = [
+        {
+            "number": 3002,
+            "title": "workflow issue",
+            "state": "OPEN",
+            "url": "https://github.test/issues/3002",
+            "labels": [{"name": "workflow"}],
+            "assignees": [],
+        }
+    ]
+
+    with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
+        mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
+        with patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as claim:
+            claim.return_value = {3002: None}
+            payload = snapshot_active_issue_portfolio(
+                repo="ll7/robot_sf_ll7",
+                remote="origin",
+                limit=1,
+            )
+
+    row = payload["rows"][0]
+    assert row["classification"] == "needs_human_decision"
+    assert row["reason"] == "unable to read claim state; skip autonomous claim"
+    assert row["owner_type"] == "maintainer"
+
+
 def test_snapshot_active_issue_portfolio_preserves_null_optional_fields() -> None:
     """Explicit null title or URL fields should not leak as literal None strings."""
     issue_list = [
@@ -464,13 +619,8 @@ def test_snapshot_active_issue_portfolio_preserves_null_optional_fields() -> Non
 
     with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
         mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
-        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
-            claim.return_value = {
-                "ok": True,
-                "claimed": False,
-                "claim_ref": "agent-claims/issue-3000",
-                "sha": None,
-            }
+        with patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as claim:
+            claim.return_value = {3000: _claim_status(3000)}
             payload = snapshot_active_issue_portfolio(
                 repo="ll7/robot_sf_ll7",
                 remote="origin",
@@ -506,13 +656,8 @@ def test_main_claimable_mode_can_be_called_without_issue_numbers() -> None:  # t
     ]
     with patch("scripts.dev.snapshot_issue_batch._gh") as mock_gh:
         mock_gh.return_value = MagicMock(returncode=0, stdout=json.dumps(issue_list), stderr="")
-        with patch("scripts.dev.snapshot_issue_batch.status_issue") as claim:
-            claim.return_value = {
-                "ok": True,
-                "claimed": False,
-                "claim_ref": "agent-claims/issue-2669",
-                "sha": None,
-            }
+        with patch("scripts.dev.snapshot_issue_batch._batch_claim_statuses") as claim:
+            claim.return_value = {2669: _claim_status(2669)}
             rc = main(["--claimable", "--json", "--limit", "1"])
 
     assert rc == 0


### PR DESCRIPTION
## Summary
Batch issue-claim ref reads in list snapshot modes so `--claimable` and `--active-portfolio` avoid one `status_issue()` / `git ls-remote` call per listed issue.

## Linked Issues
- Closes `#2986`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added a batched `git ls-remote --heads origin refs/heads/agent-claims/issue-*` claim-status reader for issue-list snapshot modes.
- Preserved the public per-issue claim payload subset: `ok`, `claimed`, `claim_ref`, and `sha`.
- Kept explicit issue snapshots on the existing per-issue `status_issue()` path.
- Added tests for one-batch lookup, claimed/unclaimed classification, parsing, and fail-closed claim lookup errors.

## Why It Matters
- Added value: larger issue snapshots no longer spend one remote git call per issue just to classify claim state.
- Expected impact: lower latency and less orchestration overhead for goal-autopilot queue snapshots.
- Why this is worth merging now: it directly improves the token-efficient issue-routing loop used by autonomous runs.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support workflow helper only.
- Comparator or baseline, if applicable: existing per-issue `status_issue()` loop.
- Evidence tier: targeted smoke / support helper.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: merge if targeted tests and live smoke preserve claim classifications.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2986.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support tooling.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop after merge; issue contract satisfied.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
- `uv run pytest tests/dev/test_snapshot_issue_batch.py -q`
- `uv run ruff check scripts/dev/snapshot_issue_batch.py tests/dev/test_snapshot_issue_batch.py`
- `uv run ruff format --check scripts/dev/snapshot_issue_batch.py tests/dev/test_snapshot_issue_batch.py`
- `git diff --check`
- `uv run python scripts/dev/snapshot_issue_batch.py --claimable --limit 3 --json`
- `uv run python scripts/dev/snapshot_issue_batch.py --active-portfolio --limit 3 --json`
- Evidence that the change works here: targeted tests pass; live claimable smoke sees #2986 as claimed via the batched ref lookup; live portfolio smoke classifies claimed issues as non-executable.
- Benchmarks or smoke tests, if applicable: compact live CLI smokes above.

## Risks / Rollout
- Compatibility risks: low; explicit issue snapshots still use the old per-issue status path.
- Failure modes: if the batched ref read fails, list snapshots now fail closed instead of falsely treating issues as unclaimed.
- Rollback or fallback plan: revert this PR to restore per-issue lookup behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: #2986 issue body.
- Any assumptions that need to be preserved: `agent-claims/issue-*` remains the remote claim-ref naming convention.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2986.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: support helper only, no research artifact or benchmark claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify that list modes use `_batch_claim_statuses()` while explicit issue snapshots still call `status_issue()`.
- Known limitations: the batch helper intentionally fetches all `agent-claims/issue-*` refs for the remote once per snapshot.
