### PR TITLE
fix: emit ORCA residual smoke evidence fields

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -2126,6 +2126,11 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             "stop_best_effort": 0,
             "goal_reached": 0,
         }
+        meta["residual_clipping_stats"] = {
+            "schema_version": "orca-residual-clipping-stats.v1",
+            "decision_count": 0,
+            "clipped_count": 0,
+        }
         meta["safety_shield_contract"] = shield_contract_metadata(
             shield_name="GuardedPPOAdapter",
             prediction_source="short_horizon_rollout",
@@ -2182,6 +2187,23 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             shield_stats = meta.get("shield_stats")
             if isinstance(shield_stats, dict):
                 update_shield_stats(shield_stats, shield_decision)
+            residual_stats = meta.get("residual_clipping_stats")
+            if isinstance(residual_stats, dict):
+                decision_metadata = shield_decision.to_metadata()
+                fallback_state = decision_metadata.get("fallback_controller_state")
+                action_adaptation = (
+                    fallback_state.get("action_adaptation")
+                    if isinstance(fallback_state, dict)
+                    else None
+                )
+                if isinstance(action_adaptation, dict):
+                    residual_stats["decision_count"] = (
+                        int(residual_stats.get("decision_count", 0)) + 1
+                    )
+                    if bool(action_adaptation.get("residual_clipped", False)):
+                        residual_stats["clipped_count"] = (
+                            int(residual_stats.get("clipped_count", 0)) + 1
+                        )
             _update_adapter_impact_metrics(
                 meta,
                 conversion_mode,

--- a/scripts/validation/run_policy_search_candidate.py
+++ b/scripts/validation/run_policy_search_candidate.py
@@ -333,6 +333,184 @@ def decide_stage_status(stage_name: str, stage_cfg: dict[str, Any], summary: dic
     return "pass"
 
 
+def _as_optional_float(value: Any) -> float | None:
+    """Coerce numeric evidence values while preserving missing/invalid values."""
+    try:
+        if value is None or value == "":
+            return None
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _mean(values: list[float]) -> float | None:
+    """Return the arithmetic mean for non-empty float lists."""
+    return sum(values) / len(values) if values else None
+
+
+def _row_residual_clipping_rate(row: Mapping[str, Any]) -> tuple[float | None, str]:
+    """Return residual clipping rate evidence for one policy-search row."""
+    metrics = row.get("metrics")
+    if isinstance(metrics, Mapping):
+        metric_rate = _as_optional_float(metrics.get("residual_clipping_rate"))
+        if metric_rate is not None:
+            return metric_rate, "metrics.residual_clipping_rate"
+
+    metadata = row.get("algorithm_metadata")
+    if not isinstance(metadata, Mapping):
+        return None, "missing_algorithm_metadata"
+    stats = metadata.get("residual_clipping_stats")
+    if isinstance(stats, Mapping):
+        decisions = _as_optional_float(stats.get("decision_count"))
+        clipped = _as_optional_float(stats.get("clipped_count"))
+        if decisions is not None and decisions > 0.0 and clipped is not None:
+            return clipped / decisions, "algorithm_metadata.residual_clipping_stats"
+
+    shield_stats = metadata.get("shield_stats")
+    last_decision = shield_stats.get("last_decision") if isinstance(shield_stats, Mapping) else None
+    fallback_state = (
+        last_decision.get("fallback_controller_state")
+        if isinstance(last_decision, Mapping)
+        else None
+    )
+    action_adaptation = (
+        fallback_state.get("action_adaptation") if isinstance(fallback_state, Mapping) else None
+    )
+    if isinstance(action_adaptation, Mapping) and "residual_clipped" in action_adaptation:
+        return (
+            1.0 if bool(action_adaptation.get("residual_clipped")) else 0.0,
+            "algorithm_metadata.shield_stats.last_decision.action_adaptation",
+        )
+    return None, "missing_residual_clipping_evidence"
+
+
+def _row_guard_veto_rate(row: Mapping[str, Any]) -> tuple[float | None, str]:
+    """Return guard veto/intervention rate evidence for one policy-search row."""
+    metrics = row.get("metrics")
+    if isinstance(metrics, Mapping):
+        for key in ("guard_veto_rate", "shield_intervention_rate", "shield_override_rate"):
+            value = _as_optional_float(metrics.get(key))
+            if value is not None:
+                return value, f"metrics.{key}"
+    metadata = row.get("algorithm_metadata")
+    shield_stats = metadata.get("shield_stats") if isinstance(metadata, Mapping) else None
+    if isinstance(shield_stats, Mapping):
+        decisions = _as_optional_float(shield_stats.get("decision_count"))
+        interventions = _as_optional_float(shield_stats.get("intervention_count"))
+        if decisions is not None and decisions > 0.0 and interventions is not None:
+            return interventions / decisions, "algorithm_metadata.shield_stats"
+    return None, "missing_guard_veto_evidence"
+
+
+def _row_is_fallback_or_degraded(row: Mapping[str, Any]) -> bool:
+    """Return whether row metadata reports fallback/degraded execution."""
+    status_values: list[str] = []
+    for key in ("fallback_degraded_status", "status"):
+        value = row.get(key)
+        if isinstance(value, str):
+            status_values.append(value.lower())
+    metadata = row.get("algorithm_metadata")
+    if isinstance(metadata, Mapping):
+        for key in ("fallback_degraded_status", "status"):
+            value = metadata.get(key)
+            if isinstance(value, str):
+                status_values.append(value.lower())
+        adapter_impact = metadata.get("adapter_impact")
+        if isinstance(adapter_impact, Mapping):
+            value = adapter_impact.get("status")
+            if isinstance(value, str):
+                status_values.append(value.lower())
+    return any("fallback" in value or "degraded" in value for value in status_values)
+
+
+def _artifact_pointer_status(
+    summary: Mapping[str, Any],
+    jsonl_path: Path,
+    *,
+    missing_jsonl: bool,
+    rows: list[Mapping[str, Any]],
+) -> str:
+    """Classify whether the smoke stage recorded a usable artifact pointer."""
+    artifact_status = summary.get("stage_artifact_status")
+    if isinstance(artifact_status, Mapping):
+        status = str(artifact_status.get("status", "")).strip()
+        if status:
+            return status
+    if missing_jsonl or not rows:
+        return "not_available"
+    return "local_jsonl_present" if jsonl_path.exists() else "missing"
+
+
+def _attach_orca_residual_smoke_evidence(
+    summary: dict[str, Any],
+    rows: list[Mapping[str, Any]],
+    jsonl_path: Path,
+    *,
+    missing_jsonl: bool,
+) -> None:
+    """Attach required ORCA-residual smoke evidence fields to a stage summary."""
+    residual_values: list[float] = []
+    residual_sources: set[str] = set()
+    guard_values: list[float] = []
+    guard_sources: set[str] = set()
+    degraded_count = 0
+    for row in rows:
+        residual_rate, residual_source = _row_residual_clipping_rate(row)
+        residual_sources.add(residual_source)
+        if residual_rate is not None:
+            residual_values.append(residual_rate)
+        guard_rate, guard_source = _row_guard_veto_rate(row)
+        guard_sources.add(guard_source)
+        if guard_rate is not None:
+            guard_values.append(guard_rate)
+        if _row_is_fallback_or_degraded(row):
+            degraded_count += 1
+
+    residual_clipping_rate = _mean(residual_values)
+    guard_veto_rate = _mean(guard_values)
+    fallback_degraded_status = (
+        "not_available" if not rows else "degraded" if degraded_count > 0 else "clear"
+    )
+    artifact_pointer_status = _artifact_pointer_status(
+        summary,
+        jsonl_path,
+        missing_jsonl=missing_jsonl,
+        rows=rows,
+    )
+    missing_fields = [
+        field
+        for field, value in (
+            ("residual_clipping_rate", residual_clipping_rate),
+            ("guard_veto_rate", guard_veto_rate),
+            ("fallback_degraded_status", fallback_degraded_status),
+            ("artifact_pointer_status", artifact_pointer_status),
+        )
+        if value is None or value == ""
+    ]
+    summary["residual_clipping_rate"] = residual_clipping_rate
+    summary["guard_veto_rate"] = guard_veto_rate
+    summary["fallback_degraded_status"] = fallback_degraded_status
+    summary["artifact_pointer_status"] = artifact_pointer_status
+    summary["orca_residual_smoke_evidence"] = {
+        "schema_version": "orca-residual-smoke-evidence.v1",
+        "residual_clipping_rate": residual_clipping_rate,
+        "residual_clipping_source": (
+            "not_available" if not residual_sources else "+".join(sorted(residual_sources))
+        ),
+        "guard_veto_rate": guard_veto_rate,
+        "guard_veto_source": (
+            "not_available" if not guard_sources else "+".join(sorted(guard_sources))
+        ),
+        "fallback_degraded_status": fallback_degraded_status,
+        "fallback_degraded_rows": degraded_count,
+        "artifact_pointer_status": artifact_pointer_status,
+        "missing_required_fields": missing_fields,
+        "nominal_escalation_allowed": not missing_fields
+        and fallback_degraded_status == "clear"
+        and artifact_pointer_status not in {"missing", "not_available"},
+    }
+
+
 def _git_hash() -> str | None:
     """Read the current git commit for provenance metadata.
 
@@ -616,6 +794,12 @@ def _run_stage_eval(  # noqa: PLR0913
             availability = batch_summary.get("benchmark_availability")
             if isinstance(availability, Mapping):
                 summary["benchmark_availability"] = dict(availability)
+    _attach_orca_residual_smoke_evidence(
+        summary,
+        rows,
+        jsonl_path,
+        missing_jsonl=missing_jsonl,
+    )
     summary["runtime_sec"] = float(max(time.perf_counter() - started, 0.0))
     return {
         "records": rows,
@@ -872,6 +1056,26 @@ def _write_markdown_report(  # noqa: C901, PLR0913
                 f"(`{artifact_status.get('reason', 'unknown')}`)",
                 f"- Path: `{artifact_status.get('jsonl_path', 'unknown')}`",
                 f"- Note: {artifact_status.get('message', 'n/a')}",
+            ]
+        )
+    smoke_evidence_raw = summary.get("orca_residual_smoke_evidence")
+    smoke_evidence = smoke_evidence_raw if isinstance(smoke_evidence_raw, Mapping) else {}
+    if smoke_evidence:
+        lines.extend(
+            [
+                "",
+                "## ORCA-Residual Smoke Evidence",
+                "",
+                f"- Residual clipping rate: "
+                f"{_format_optional_float(smoke_evidence.get('residual_clipping_rate'))}",
+                f"- Guard veto rate: "
+                f"{_format_optional_float(smoke_evidence.get('guard_veto_rate'))}",
+                f"- Fallback/degraded status: "
+                f"`{smoke_evidence.get('fallback_degraded_status', 'unknown')}`",
+                f"- Artifact pointer status: "
+                f"`{smoke_evidence.get('artifact_pointer_status', 'unknown')}`",
+                f"- Nominal escalation allowed: "
+                f"`{bool(smoke_evidence.get('nominal_escalation_allowed', False))}`",
             ]
         )
     evidence_adjusted_raw = summary.get("evidence_adjusted")

--- a/scripts/validation/run_policy_search_candidate.py
+++ b/scripts/validation/run_policy_search_candidate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 import time
 from collections.abc import Mapping
@@ -338,9 +339,10 @@ def _as_optional_float(value: Any) -> float | None:
     try:
         if value is None or value == "":
             return None
-        return float(value)
+        converted = float(value)
     except (TypeError, ValueError):
         return None
+    return converted if math.isfinite(converted) else None
 
 
 def _mean(values: list[float]) -> float | None:
@@ -509,6 +511,17 @@ def _attach_orca_residual_smoke_evidence(
         and fallback_degraded_status == "clear"
         and artifact_pointer_status not in {"missing", "not_available"},
     }
+
+
+def _refresh_orca_residual_smoke_evidence(summary_payload: dict[str, Any]) -> None:
+    """Refresh ORCA-residual evidence after any summary rebuild path."""
+    rows = summary_payload.get("records")
+    _attach_orca_residual_smoke_evidence(
+        summary_payload["summary"],
+        rows if isinstance(rows, list) else [],
+        Path(str(summary_payload["jsonl_path"])),
+        missing_jsonl=not Path(str(summary_payload["jsonl_path"])).exists(),
+    )
 
 
 def _git_hash() -> str | None:
@@ -727,6 +740,17 @@ def _apply_stage_exclusions(
     updated["records"] = annotated
     updated["summary"] = summarize_policy_search_records(annotated)
     return updated
+
+
+def _finalize_summary_payload(
+    *,
+    stage_cfg: Mapping[str, Any],
+    summary_payload: dict[str, Any],
+) -> dict[str, Any]:
+    """Apply late summary rebuilds and refresh required smoke evidence fields."""
+    finalized = _apply_stage_exclusions(stage_cfg=stage_cfg, summary_payload=summary_payload)
+    _refresh_orca_residual_smoke_evidence(finalized)
+    return finalized
 
 
 def _run_stage_eval(  # noqa: PLR0913
@@ -1278,7 +1302,7 @@ def main() -> int:
             synthetic_actuation_profile=synthetic_actuation_profile,
         )
 
-    summary_payload = _apply_stage_exclusions(
+    summary_payload = _finalize_summary_payload(
         stage_cfg=stage_cfg,
         summary_payload=summary_payload,
     )

--- a/tests/test_map_runner_ppo.py
+++ b/tests/test_map_runner_ppo.py
@@ -223,6 +223,7 @@ class _DummyGuardedPPOAdapter:
     """Test double for guarded PPO arbitration."""
 
     instances: ClassVar[list[_DummyGuardedPPOAdapter]] = []
+    residual_clipped: ClassVar[bool] = False
 
     def __init__(self, config=None, *, fallback_adapter=None, prior_adapter=None):
         self.config = config
@@ -233,6 +234,22 @@ class _DummyGuardedPPOAdapter:
         self.reset_seeds = []
         self.closed = False
         self.__class__.instances.append(self)
+
+    def choose_command_decision(self, obs, ppo_command):
+        """Return a structured guard decision with residual adaptation metadata."""
+        self.last_command = (obs, ppo_command)
+        return map_runner.ShieldDecision(
+            proposed_action=(float(ppo_command[0]), float(ppo_command[1])),
+            filtered_action=(0.1, -0.2),
+            decision_label="fallback_safe",
+            intervention_reason="test_guard_decision",
+            fallback_controller_state={
+                "action_adaptation": {
+                    "mode": "prior_residual",
+                    "residual_clipped": bool(self.__class__.residual_clipped),
+                }
+            },
+        )
 
     def choose_command(self, obs, ppo_command):
         """Return a fallback command while recording arbitration inputs.
@@ -259,6 +276,7 @@ class _DummyGuardedPPOAdapter:
 def test_build_policy_guarded_ppo_arbitrates_and_tracks_guard_stats(monkeypatch):
     """Guarded PPO should route PPO output through the guard and record intervention counts."""
     _DummyGuardedPPOAdapter.instances = []
+    monkeypatch.setattr(_DummyGuardedPPOAdapter, "residual_clipped", True)
     monkeypatch.setattr(map_runner, "PPOPlanner", _DummyPPOPlanner)
     monkeypatch.setattr(map_runner, "GuardedPPOAdapter", _DummyGuardedPPOAdapter)
     monkeypatch.setattr(map_runner, "build_guarded_ppo_fallback", lambda cfg: object())
@@ -276,6 +294,10 @@ def test_build_policy_guarded_ppo_arbitrates_and_tracks_guard_stats(monkeypatch)
     guard_stats = meta.get("guard_stats")
     assert isinstance(guard_stats, dict)
     assert guard_stats["fallback_safe"] == 1
+    residual_stats = meta.get("residual_clipping_stats")
+    assert isinstance(residual_stats, dict)
+    assert residual_stats["decision_count"] == 1
+    assert residual_stats["clipped_count"] == 1
 
     guard = _DummyGuardedPPOAdapter.instances[-1]
     env = object()

--- a/tests/validation/test_run_policy_search_candidate.py
+++ b/tests/validation/test_run_policy_search_candidate.py
@@ -573,8 +573,8 @@ def test_run_stage_eval_records_missing_jsonl_as_fail_closed(
     assert summary["stage_artifact_status"]["reason"] == "missing_jsonl"
     assert summary["preflight"]["compatibility_status"] == "incompatible"
     assert summary["benchmark_availability"]["status"] == "not_available"
-    assert "residual_clipping_rate" in summary
-    assert "guard_veto_rate" in summary
+    assert summary["residual_clipping_rate"] is None
+    assert summary["guard_veto_rate"] is None
     assert summary["fallback_degraded_status"] == "not_available"
     assert summary["artifact_pointer_status"] == "not_available"
     smoke_evidence = summary["orca_residual_smoke_evidence"]
@@ -639,6 +639,34 @@ def test_run_stage_eval_records_orca_residual_smoke_evidence(
     assert smoke_evidence["residual_clipping_source"] == (
         "algorithm_metadata.residual_clipping_stats"
     )
+
+
+def test_orca_residual_smoke_evidence_treats_non_finite_rates_as_missing() -> None:
+    """Non-finite rate values should not satisfy required smoke evidence."""
+    summary: dict[str, object] = {}
+    rows = [
+        {
+            "scenario_id": "planner_sanity_simple",
+            "metrics": {
+                "residual_clipping_rate": "nan",
+                "shield_intervention_rate": "inf",
+            },
+        }
+    ]
+
+    candidate_runner._attach_orca_residual_smoke_evidence(
+        summary,
+        rows,
+        Path("smoke.jsonl"),
+        missing_jsonl=False,
+    )
+
+    assert summary["residual_clipping_rate"] is None
+    assert summary["guard_veto_rate"] is None
+    assert summary["orca_residual_smoke_evidence"]["missing_required_fields"] == [
+        "residual_clipping_rate",
+        "guard_veto_rate",
+    ]
 
 
 def test_run_stage_eval_passes_candidate_observation_override(

--- a/tests/validation/test_run_policy_search_candidate.py
+++ b/tests/validation/test_run_policy_search_candidate.py
@@ -573,7 +573,72 @@ def test_run_stage_eval_records_missing_jsonl_as_fail_closed(
     assert summary["stage_artifact_status"]["reason"] == "missing_jsonl"
     assert summary["preflight"]["compatibility_status"] == "incompatible"
     assert summary["benchmark_availability"]["status"] == "not_available"
+    assert "residual_clipping_rate" in summary
+    assert "guard_veto_rate" in summary
+    assert summary["fallback_degraded_status"] == "not_available"
+    assert summary["artifact_pointer_status"] == "not_available"
+    smoke_evidence = summary["orca_residual_smoke_evidence"]
+    assert smoke_evidence["missing_required_fields"] == [
+        "residual_clipping_rate",
+        "guard_veto_rate",
+    ]
+    assert smoke_evidence["nominal_escalation_allowed"] is False
     assert decide_stage_status("smoke", {}, summary) == "revise"
+
+
+def test_run_stage_eval_records_orca_residual_smoke_evidence(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Smoke summaries should expose ORCA-residual evidence fields for finalizers."""
+
+    def fake_run_map_batch(*args: object, **kwargs: object) -> dict[str, object]:
+        jsonl_path = Path(args[1])
+        jsonl_path.write_text(
+            "\n".join(
+                [
+                    (
+                        '{"scenario_id":"planner_sanity_simple","seed":111,'
+                        '"termination_reason":"success",'
+                        '"metrics":{"success":1.0,"shield_intervention_rate":0.25},'
+                        '"algorithm_metadata":{'
+                        '"status":"ok",'
+                        '"residual_clipping_stats":{"decision_count":4,"clipped_count":1},'
+                        '"shield_stats":{"decision_count":4,"intervention_count":1}'
+                        "}}"
+                    )
+                ]
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return {"written": 1, "successful_jobs": 1, "failed_jobs": 0}
+
+    monkeypatch.setattr(candidate_runner, "run_map_batch", fake_run_map_batch)
+
+    result = candidate_runner._run_stage_eval(
+        scenarios_or_path=[{"name": "planner_sanity_simple", "map_file": "unused.svg"}],
+        algo="orca_residual_guarded_ppo",
+        algo_cfg={"model_path": "/tmp/model.zip"},
+        out_dir=tmp_path,
+        tag="smoke__cand",
+        horizon=1,
+        dt=0.1,
+        workers=1,
+        benchmark_profile="experimental",
+    )
+
+    summary = result["summary"]
+    assert summary["residual_clipping_rate"] == pytest.approx(0.25)
+    assert summary["guard_veto_rate"] == pytest.approx(0.25)
+    assert summary["fallback_degraded_status"] == "clear"
+    assert summary["artifact_pointer_status"] == "local_jsonl_present"
+    smoke_evidence = summary["orca_residual_smoke_evidence"]
+    assert smoke_evidence["missing_required_fields"] == []
+    assert smoke_evidence["nominal_escalation_allowed"] is True
+    assert smoke_evidence["residual_clipping_source"] == (
+        "algorithm_metadata.residual_clipping_stats"
+    )
 
 
 def test_run_stage_eval_passes_candidate_observation_override(


### PR DESCRIPTION
## Summary

- record guarded-PPO residual clipping aggregate metadata in benchmark episode rows
- emit `residual_clipping_rate`, `guard_veto_rate`, `fallback_degraded_status`, and `artifact_pointer_status` from the public policy-search smoke summary/finalizer
- add focused tests for fail-closed missing-JSONL evidence and populated guarded ORCA-residual smoke evidence

## Validation

- `uv run pytest tests/validation/test_run_policy_search_candidate.py tests/test_map_runner_ppo.py -q`
- `uv run ruff check scripts/validation/run_policy_search_candidate.py robot_sf/benchmark/map_runner.py tests/validation/test_run_policy_search_candidate.py tests/test_map_runner_ppo.py`
- `uv run ruff format --check scripts/validation/run_policy_search_candidate.py robot_sf/benchmark/map_runner.py tests/validation/test_run_policy_search_candidate.py tests/test_map_runner_ppo.py`
- `git diff --check`
- `uv run python - <<'PY' ...` helper check against the archived #1475 JSONL shape confirmed the summary now emits all four requested top-level fields; historical evidence still lacks aggregate residual clipping, while reruns will get `residual_clipping_stats` from `map_runner`.

## Downstream Propagation

- Issue #1475 smoke rerun remains the next action after this patch lands.
- No benchmark claim is made here; this is instrumentation/finalizer support so the rerun can emit the missing evidence fields.

## Research Result Guidance

- Target blocker: missing ORCA-residual smoke evidence fields prevented nominal escalation after the prior smoke run.
- Evidence tier: targeted unit coverage plus historical-shape helper check; not benchmark evidence.
- Result classification: support/tooling patch for a bounded rerun.
- Stop rule: after merge, rerun exactly one bounded #1475 smoke job and inspect the emitted evidence fields before any nominal/larger job.

Closes no issue directly; unblocks #1475.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added residual clipping statistics tracking to monitor policy adaptation behavior.
  * Enhanced ORCA-residual smoke evidence reporting with clipping rates, guard intervention metrics, and fallback/degraded execution detection.

* **Tests**
  * Updated tests to validate residual adaptation metadata and evidence reporting in policy validation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->