### PR TITLE
feat: add benchmark result provenance metadata

### DIFF
--- a/docs/context/issue_2994_result_metadata_contract.md
+++ b/docs/context/issue_2994_result_metadata_contract.md
@@ -1,0 +1,31 @@
+# Issue #2994: Episode Result Provenance Metadata Contract
+
+## Scope
+
+Issue #2994 adds optional per-episode provenance metadata on the canonical benchmark runner path (`robot_sf/benchmark/runner.py`).
+
+The provenance block captures the following execution information per episode:
+- `protocol_version`: retrieved from `robot_sf.benchmark.release_protocol.BENCHMARK_PROTOCOL_VERSION` (nominally `0.1.0`).
+- `commit_hash`: the Git commit reported by the benchmark runner at artifact generation time.
+- `base_seed`: the base seed supplied for the batch run.
+- `run_id`: a stable, per-run UUID generated once per `run_batch` execution.
+- `python_version`: the running Python version retrieved via `platform.python_version()`.
+- `invocation`: the command-line arguments used for executing the benchmark run (if available via `sys.argv`).
+- `config_identity`: a compact identity block with the schema path, algorithm name, optional
+  algorithm config path, scenario count, and scenario matrix hash.
+
+This metadata is embedded at the top level of each episode dictionary using a schema-compatible `"provenance"` key.
+
+## Evidence Boundary
+
+- Classification: `smoke/contract evidence`.
+- Purpose: Verifies that metadata tracking and run-level identifiers can be safely injected on the runner path without regression on existing metrics and while maintaining full schema compatibility.
+- Paper-Facing Claims: This does **not** constitute paper-grade benchmark evidence, metric validation, or dissertation-grade claim updates.
+
+## Validation
+
+Focused validation runs:
+- `uv run pytest tests/test_runner_smoke.py tests/contract/test_episode_schema.py -q`
+- `uv run ruff check robot_sf/benchmark/runner.py tests/test_runner_smoke.py`
+- `uv run ruff format --check robot_sf/benchmark/runner.py tests/test_runner_smoke.py`
+- `git diff --check`

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -18,7 +18,9 @@ import json
 import multiprocessing as mp
 import os
 import platform
+import sys
 import time
+import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from concurrent.futures import TimeoutError as FuturesTimeoutError
 from datetime import (
@@ -1171,6 +1173,7 @@ def _build_episode_record(
     ts_start: str,
     termination_reason: str,
     outcome: dict[str, bool],
+    provenance: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Assemble a JSON-serializable episode record.
 
@@ -1217,6 +1220,8 @@ def _build_episode_record(
         "outcome": outcome,
         "integrity": {"contradictions": contradictions},
     }
+    if provenance is not None:
+        record["provenance"] = provenance
     algo_value = scenario_params.get("algo")
     if algo_value is not None:
         record["algo"] = algo_value
@@ -1248,6 +1253,7 @@ def run_episode(  # noqa: PLR0913
     experimental_ped_impact: bool = False,
     ped_impact_radius_m: float = 2.0,
     ped_impact_window_steps: int = 5,
+    provenance: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Run a single episode and return a metrics record dict.
 
@@ -1349,6 +1355,7 @@ def run_episode(  # noqa: PLR0913
         ts_start,
         termination_reason,
         outcome,
+        provenance=provenance,
     )
 
     steps_taken = max(0, len(robot_pos_traj) - 1)
@@ -1445,6 +1452,7 @@ def _run_job_worker(job: tuple[dict[str, Any], int, dict[str, Any]]) -> dict[str
         experimental_ped_impact=bool(params.get("experimental_ped_impact", False)),
         ped_impact_radius_m=float(params.get("ped_impact_radius_m", 2.0)),
         ped_impact_window_steps=int(params.get("ped_impact_window_steps", 5)),
+        provenance=params.get("provenance"),
     )
 
 
@@ -1614,6 +1622,7 @@ def _setup_fixed_params(  # noqa: PLR0913
     experimental_ped_impact: bool = False,
     ped_impact_radius_m: float = 2.0,
     ped_impact_window_steps: int = 5,
+    provenance: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Set up the fixed parameters dict for job execution.
 
@@ -1635,6 +1644,7 @@ def _setup_fixed_params(  # noqa: PLR0913
         "experimental_ped_impact": bool(experimental_ped_impact),
         "ped_impact_radius_m": float(ped_impact_radius_m),
         "ped_impact_window_steps": int(ped_impact_window_steps),
+        "provenance": provenance,
     }
 
 
@@ -1874,6 +1884,25 @@ def run_batch(  # noqa: PLR0913
     jobs = _expand_jobs(scenarios, base_seed=base_seed, repeats_override=repeats_override)
 
     # Set up fixed parameters
+    from robot_sf.benchmark.release_protocol import BENCHMARK_PROTOCOL_VERSION  # noqa: PLC0415
+
+    provenance = {
+        "protocol_version": BENCHMARK_PROTOCOL_VERSION,
+        "commit_hash": _git_hash_fallback(),
+        "base_seed": base_seed,
+        "run_id": uuid.uuid4().hex,
+        "python_version": platform.python_version(),
+        "config_identity": {
+            "schema_path": str(schema_path),
+            "algo": str(algo),
+            "algo_config_path": str(algo_config_path) if algo_config_path is not None else None,
+            "scenario_count": len(scenarios),
+            "scenario_matrix_hash": _config_hash(scenarios),
+        },
+    }
+    if hasattr(sys, "argv") and sys.argv:
+        provenance["invocation"] = " ".join(sys.argv)
+
     fixed_params = _setup_fixed_params(
         out_path,
         horizon,
@@ -1888,6 +1917,7 @@ def run_batch(  # noqa: PLR0913
         experimental_ped_impact,
         ped_impact_radius_m,
         ped_impact_window_steps,
+        provenance=provenance,
     )
 
     # Filter jobs for resume

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -18,6 +18,7 @@ import json
 import multiprocessing as mp
 import os
 import platform
+import shlex
 import sys
 import time
 import uuid
@@ -1901,7 +1902,7 @@ def run_batch(  # noqa: PLR0913
         },
     }
     if hasattr(sys, "argv") and sys.argv:
-        provenance["invocation"] = " ".join(sys.argv)
+        provenance["invocation"] = shlex.join(sys.argv)
 
     fixed_params = _setup_fixed_params(
         out_path,

--- a/tests/test_runner_smoke.py
+++ b/tests/test_runner_smoke.py
@@ -6,9 +6,12 @@ Runs a single tiny episode and validates JSON record against schema.
 from __future__ import annotations
 
 import json
+import shlex
+import sys
 from typing import TYPE_CHECKING
 
 import numpy as np
+import pytest
 
 from robot_sf.benchmark import runner as runner_mod
 from robot_sf.benchmark.runner import run_batch, run_episode, validate_and_write
@@ -172,7 +175,9 @@ def test_run_batch_repeated_runs_produce_stable_metrics(tmp_path: Path) -> None:
     assert _normalize_episode_record(rec1) == _normalize_episode_record(rec2)
 
 
-def test_run_batch_provenance_fields_present(tmp_path: Path) -> None:
+def test_run_batch_provenance_fields_present(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Validate that provenance fields are generated correctly on a run_batch run."""
     scenario = {
         "id": "repro-sample",
@@ -186,6 +191,8 @@ def test_run_batch_provenance_fields_present(tmp_path: Path) -> None:
         "repeats": 1,
     }
     out = tmp_path / "provenance_run.jsonl"
+    invocation = ["runner smoke", "--label", "value with spaces"]
+    monkeypatch.setattr(sys, "argv", invocation)
     run_batch(
         [scenario],
         out_path=out,
@@ -209,7 +216,7 @@ def test_run_batch_provenance_fields_present(tmp_path: Path) -> None:
     assert "run_id" in prov
     assert len(prov["run_id"]) > 0
     assert "python_version" in prov
-    assert "invocation" in prov
+    assert prov["invocation"] == shlex.join(invocation)
     config_identity = prov["config_identity"]
     assert config_identity["schema_path"] == str(SCHEMA_PATH)
     assert config_identity["algo"] == "simple_policy"

--- a/tests/test_runner_smoke.py
+++ b/tests/test_runner_smoke.py
@@ -106,6 +106,10 @@ def _normalize_episode_record(record: dict[str, object]) -> dict[str, object]:
     normalized.pop("timestamps", None)
     normalized.pop("wall_time_sec", None)
     normalized.pop("timing", None)
+    if "provenance" in normalized and isinstance(normalized["provenance"], dict):
+        prov = dict(normalized["provenance"])
+        prov.pop("run_id", None)
+        normalized["provenance"] = prov
     return normalized
 
 
@@ -166,3 +170,50 @@ def test_run_batch_repeated_runs_produce_stable_metrics(tmp_path: Path) -> None:
 
     # Then verify semantic equality (ignoring runtime metadata)
     assert _normalize_episode_record(rec1) == _normalize_episode_record(rec2)
+
+
+def test_run_batch_provenance_fields_present(tmp_path: Path) -> None:
+    """Validate that provenance fields are generated correctly on a run_batch run."""
+    scenario = {
+        "id": "repro-sample",
+        "density": "low",
+        "flow": "uni",
+        "obstacle": "open",
+        "groups": 0.0,
+        "speed_var": "low",
+        "goal_topology": "point",
+        "robot_context": "embedded",
+        "repeats": 1,
+    }
+    out = tmp_path / "provenance_run.jsonl"
+    run_batch(
+        [scenario],
+        out_path=out,
+        schema_path=SCHEMA_PATH,
+        base_seed=123,
+        horizon=5,
+        dt=0.1,
+        record_forces=False,
+        append=False,
+        workers=1,
+        resume=False,
+    )
+    raw = out.read_text(encoding="utf-8").splitlines()[0]
+    rec = json.loads(raw)
+
+    assert "provenance" in rec
+    prov = rec["provenance"]
+    assert "protocol_version" in prov
+    assert "commit_hash" in prov
+    assert prov["base_seed"] == 123
+    assert "run_id" in prov
+    assert len(prov["run_id"]) > 0
+    assert "python_version" in prov
+    assert "invocation" in prov
+    config_identity = prov["config_identity"]
+    assert config_identity["schema_path"] == str(SCHEMA_PATH)
+    assert config_identity["algo"] == "simple_policy"
+    assert config_identity["algo_config_path"] is None
+    assert config_identity["scenario_count"] == 1
+    assert isinstance(config_identity["scenario_matrix_hash"], str)
+    assert len(config_identity["scenario_matrix_hash"]) == 16


### PR DESCRIPTION
## Summary

Closes #2994.

- add an optional per-episode `provenance` block on the canonical `run_batch` benchmark runner path
- include protocol version, commit hash, base seed, run ID, Python version, invocation, and compact config identity metadata
- add a fixed-seed smoke regression that verifies provenance fields while preserving existing schema compatibility
- document the smoke/contract evidence boundary in `docs/context/issue_2994_result_metadata_contract.md`

## Validation

- `uv run pytest tests/test_runner_smoke.py tests/contract/test_episode_schema.py -q` -> 12 passed
- `uv run ruff check robot_sf/benchmark/runner.py tests/test_runner_smoke.py` -> passed
- `uv run ruff format --check robot_sf/benchmark/runner.py tests/test_runner_smoke.py` -> passed
- `git diff --check` -> passed

## Downstream Propagation

- Parent issue: #2994 is directly addressed.
- Context notes: added `docs/context/issue_2994_result_metadata_contract.md`.
- Benchmark/report surfaces: no leaderboard or paper-facing benchmark claims updated; this is metadata plumbing plus smoke/contract evidence.
- Artifact registry/model provenance: not applicable for this support change.

## Research Result Guidance

- Target blocker: benchmark result artifacts need self-describing provenance for reproducibility.
- Evidence tier: smoke/contract evidence on the lightweight canonical runner path.
- Comparator/baseline: previous JSONL episode records lacked run-level provenance metadata.
- Result classification: support/tooling improvement, not paper-grade benchmark evidence.
- Decision/stop rule: accept if provenance is emitted, schema validation still passes, and fixed-seed smoke behavior remains stable except for the intentionally unique `run_id`.
