### PR TITLE
test: make PPO env factories spawn-pickleable

### DIFF
--- a/scripts/training/train_ppo.py
+++ b/scripts/training/train_ppo.py
@@ -1059,15 +1059,15 @@ class _TrainingEnvFactory:
     """Picklable callable that builds one PPO training environment."""
 
     seed: int | None
-    scenario: Mapping[str, Any] | None
-    scenario_definitions: Sequence[Mapping[str, Any]] | None
+    scenario: dict[str, Any] | None
+    scenario_definitions: tuple[dict[str, Any], ...] | None
     scenario_path: Path
     exclude_scenarios: tuple[str, ...]
     suite_name: str
     algorithm_name: str
-    env_overrides: Mapping[str, object]
-    env_factory_kwargs: Mapping[str, object]
-    scenario_sampling: Mapping[str, object]
+    env_overrides: dict[str, object]
+    env_factory_kwargs: dict[str, object]
+    scenario_sampling: dict[str, object]
 
     def _build_config(self, scenario_def: Mapping[str, Any]):
         """Build an environment config for one scenario definition."""
@@ -1151,8 +1151,12 @@ def _make_training_env(  # noqa: PLR0913
     """Create a picklable training environment factory (seeded when provided)."""
     return _TrainingEnvFactory(
         seed=seed,
-        scenario=scenario,
-        scenario_definitions=scenario_definitions,
+        scenario=dict(scenario) if scenario is not None else None,
+        scenario_definitions=(
+            tuple(dict(scenario_def) for scenario_def in scenario_definitions)
+            if scenario_definitions is not None
+            else None
+        ),
         scenario_path=scenario_path,
         exclude_scenarios=tuple(str(name) for name in exclude_scenarios),
         suite_name=suite_name,

--- a/scripts/training/train_ppo.py
+++ b/scripts/training/train_ppo.py
@@ -1054,6 +1054,87 @@ def _resolve_resume_checkpoint(
     return None
 
 
+@dataclass(frozen=True)
+class _TrainingEnvFactory:
+    """Picklable callable that builds one PPO training environment."""
+
+    seed: int | None
+    scenario: Mapping[str, Any] | None
+    scenario_definitions: Sequence[Mapping[str, Any]] | None
+    scenario_path: Path
+    exclude_scenarios: tuple[str, ...]
+    suite_name: str
+    algorithm_name: str
+    env_overrides: Mapping[str, object]
+    env_factory_kwargs: Mapping[str, object]
+    scenario_sampling: Mapping[str, object]
+
+    def _build_config(self, scenario_def: Mapping[str, Any]):
+        """Build an environment config for one scenario definition."""
+        env_config = build_robot_config_from_scenario(
+            scenario_def,
+            scenario_path=self.scenario_path,
+        )
+        _apply_env_overrides(env_config, self.env_overrides)
+        return env_config
+
+    def __call__(self) -> Any:
+        """Build one training environment instance."""
+        if self.scenario is not None:
+            env_config = self._build_config(self.scenario)
+            scenario_id = scenario_id_from_definition(self.scenario, index=0)
+            return make_robot_env(
+                config=env_config,
+                seed=self.seed,
+                suite_name=self.suite_name,
+                scenario_name=scenario_id,
+                algorithm_name=self.algorithm_name,
+                **self.env_factory_kwargs,
+            )
+        if self.scenario_definitions is None:
+            raise ValueError("scenario_definitions required when scenario is None.")
+
+        sampler = ScenarioSampler(
+            self.scenario_definitions,
+            include_scenarios=tuple(
+                str(name)
+                for name in self.scenario_sampling.get(  # type: ignore[union-attr]
+                    "include_scenarios",
+                    (),
+                )
+            ),
+            exclude_scenarios=self.exclude_scenarios
+            + tuple(
+                str(name)
+                for name in self.scenario_sampling.get(  # type: ignore[union-attr]
+                    "exclude_scenarios",
+                    (),
+                )
+            ),
+            weights=(
+                {
+                    str(key): float(value)
+                    for key, value in dict(
+                        self.scenario_sampling.get("weights", {})  # type: ignore[union-attr]
+                    ).items()
+                }
+                if isinstance(self.scenario_sampling.get("weights"), Mapping)
+                else None
+            ),
+            seed=self.seed,
+            strategy=str(self.scenario_sampling.get("strategy", "random")),  # type: ignore[union-attr]
+        )
+        return ScenarioSwitchingEnv(
+            scenario_sampler=sampler,
+            scenario_path=self.scenario_path,
+            config_builder=self._build_config,
+            suite_name=self.suite_name,
+            algorithm_name=self.algorithm_name,
+            env_factory_kwargs=self.env_factory_kwargs,
+            seed=self.seed,
+        )
+
+
 def _make_training_env(  # noqa: PLR0913
     seed: int | None,
     *,
@@ -1067,72 +1148,19 @@ def _make_training_env(  # noqa: PLR0913
     env_factory_kwargs: Mapping[str, object],
     scenario_sampling: Mapping[str, object],
 ) -> Callable[[], Any]:
-    """Create a training environment factory (seeded when provided)."""
-
-    def _factory() -> Any:
-        """Build one training environment instance.
-
-        Returns:
-            Robot training environment or scenario-switching wrapper.
-        """
-
-        def _build_config(scenario_def: Mapping[str, Any]):
-            """Build an environment config for one scenario definition.
-
-            Returns:
-                Robot environment config with training overrides applied.
-            """
-            env_config = build_robot_config_from_scenario(scenario_def, scenario_path=scenario_path)
-            _apply_env_overrides(env_config, env_overrides)
-            return env_config
-
-        if scenario is not None:
-            env_config = _build_config(scenario)
-            scenario_id = scenario_id_from_definition(scenario, index=0)
-            return make_robot_env(
-                config=env_config,
-                seed=seed,
-                suite_name=suite_name,
-                scenario_name=scenario_id,
-                algorithm_name=algorithm_name,
-                **env_factory_kwargs,
-            )
-        if scenario_definitions is None:
-            raise ValueError("scenario_definitions required when scenario is None.")
-
-        sampler = ScenarioSampler(
-            scenario_definitions,
-            include_scenarios=tuple(
-                str(name)
-                for name in scenario_sampling.get("include_scenarios", ())  # type: ignore[union-attr]
-            ),
-            exclude_scenarios=tuple(exclude_scenarios)
-            + tuple(
-                str(name)
-                for name in scenario_sampling.get("exclude_scenarios", ())  # type: ignore[union-attr]
-            ),
-            weights=(
-                {
-                    str(key): float(value)
-                    for key, value in dict(scenario_sampling.get("weights", {})).items()  # type: ignore[union-attr]
-                }
-                if isinstance(scenario_sampling.get("weights"), Mapping)
-                else None
-            ),
-            seed=seed,
-            strategy=str(scenario_sampling.get("strategy", "random")),  # type: ignore[union-attr]
-        )
-        return ScenarioSwitchingEnv(
-            scenario_sampler=sampler,
-            scenario_path=scenario_path,
-            config_builder=_build_config,
-            suite_name=suite_name,
-            algorithm_name=algorithm_name,
-            env_factory_kwargs=env_factory_kwargs,
-            seed=seed,
-        )
-
-    return _factory
+    """Create a picklable training environment factory (seeded when provided)."""
+    return _TrainingEnvFactory(
+        seed=seed,
+        scenario=scenario,
+        scenario_definitions=scenario_definitions,
+        scenario_path=scenario_path,
+        exclude_scenarios=tuple(str(name) for name in exclude_scenarios),
+        suite_name=suite_name,
+        algorithm_name=algorithm_name,
+        env_overrides=dict(env_overrides),
+        env_factory_kwargs=dict(env_factory_kwargs),
+        scenario_sampling=dict(scenario_sampling),
+    )
 
 
 _FEATURE_EXTRACTOR_REGISTRY: dict[str, type] = {

--- a/tests/training/test_train_expert_ppo_contract.py
+++ b/tests/training/test_train_expert_ppo_contract.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 
 def test_make_training_env_factory_is_pickleable_for_spawn(tmp_path: Path) -> None:
     """SubprocVecEnv spawn mode requires environment callables to be pickleable."""
-    factory = train_ppo._make_training_env(
+    single_scenario_factory = train_ppo._make_training_env(
         123,
         scenario={"id": "spawn-smoke"},
         scenario_definitions=None,
@@ -36,11 +36,26 @@ def test_make_training_env_factory_is_pickleable_for_spawn(tmp_path: Path) -> No
         env_factory_kwargs={},
         scenario_sampling={},
     )
+    switching_factory = train_ppo._make_training_env(
+        456,
+        scenario=None,
+        scenario_definitions=({"id": "spawn-a"}, {"id": "spawn-b"}),
+        scenario_path=tmp_path / "scenarios.yaml",
+        exclude_scenarios=("skip-me",),
+        suite_name="ppo_imitation",
+        algorithm_name="pickle_contract",
+        env_overrides={},
+        env_factory_kwargs={},
+        scenario_sampling={"strategy": "round_robin"},
+    )
 
-    restored = pickle.loads(pickle.dumps(factory))
+    restored_single = pickle.loads(pickle.dumps(single_scenario_factory))
+    restored_switching = pickle.loads(pickle.dumps(switching_factory))
 
-    assert type(restored) is type(factory)
-    assert restored.seed == 123
+    assert type(restored_single) is type(single_scenario_factory)
+    assert restored_single.seed == 123
+    assert type(restored_switching) is type(switching_factory)
+    assert restored_switching.seed == 456
 
 
 def test_warn_frequency_episodes_deprecated_warns_once(monkeypatch) -> None:

--- a/tests/training/test_train_expert_ppo_contract.py
+++ b/tests/training/test_train_expert_ppo_contract.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import pickle
 import subprocess
 import sys
 from typing import TYPE_CHECKING
@@ -19,6 +20,27 @@ from scripts.training import train_ppo
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def test_make_training_env_factory_is_pickleable_for_spawn(tmp_path: Path) -> None:
+    """SubprocVecEnv spawn mode requires environment callables to be pickleable."""
+    factory = train_ppo._make_training_env(
+        123,
+        scenario={"id": "spawn-smoke"},
+        scenario_definitions=None,
+        scenario_path=tmp_path / "scenarios.yaml",
+        exclude_scenarios=(),
+        suite_name="ppo_imitation",
+        algorithm_name="pickle_contract",
+        env_overrides={},
+        env_factory_kwargs={},
+        scenario_sampling={},
+    )
+
+    restored = pickle.loads(pickle.dumps(factory))
+
+    assert type(restored) is type(factory)
+    assert restored.seed == 123
 
 
 def test_warn_frequency_episodes_deprecated_warns_once(monkeypatch) -> None:


### PR DESCRIPTION
## Summary

- replace the PPO training env factory's nested closure with a top-level picklable callable
- keep existing single-scenario and scenario-switching behavior intact
- add a regression test for the spawn-mode pickling precondition required by `SubprocVecEnv`

## Validation

- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run pytest -q tests/training/test_train_expert_ppo_contract.py`
- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/training/train_ppo.py tests/training/test_train_expert_ppo_contract.py`
- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/training/train_ppo.py tests/training/test_train_expert_ppo_contract.py`
- `git diff --check`

## Notes

This is the first narrow slice of #2993. It proves and fixes the pickling precondition for the main PPO training env factory; broader dummy/subproc matrix coverage and the other legacy training entry points remain follow-up scope.

Fixes #2993
