### PR TITLE
fix: log benchmark runner exceptions

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -5416,6 +5416,11 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     _write_validated_to_handle(handle, schema, rec)
                     wrote += 1
                 except Exception as exc:  # pragma: no cover - error path
+                    logger.exception(
+                        "Map batch worker failed in serial execution: scenario={} seed={}",
+                        scenario.get("name", "unknown"),
+                        seed,
+                    )
                     failures.append(
                         {
                             "scenario_id": scenario.get("name", "unknown"),
@@ -5447,6 +5452,11 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     runtime_algorithm_contract = bridge_update.runtime_algorithm_contract
                     results_by_idx[idx] = rec
                 except Exception as exc:  # pragma: no cover
+                    logger.exception(
+                        "Map batch worker failed in parallel execution: scenario={} seed={}",
+                        scenario.get("name", "unknown"),
+                        seed,
+                    )
                     failures.append(
                         {
                             "scenario_id": scenario.get("name", "unknown"),
@@ -5462,6 +5472,14 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     wrote += 1
                 except Exception as exc:  # pragma: no cover - write/validate path
                     rec = results_by_idx[idx]
+                    logger.exception(
+                        (
+                            "Map batch write/validation failed for scenario={} seed={}; "
+                            "preserving fail-closed batch status."
+                        ),
+                        rec.get("scenario_id") or rec.get("scenario", {}).get("name", "unknown"),
+                        rec.get("seed", -1),
+                    )
                     failures.append(
                         {
                             "scenario_id": rec.get("scenario_id")

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -5418,7 +5418,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 except Exception as exc:  # pragma: no cover - error path
                     logger.exception(
                         "Map batch worker failed in serial execution: scenario={} seed={}",
-                        scenario.get("name", "unknown"),
+                        _scenario_id(scenario),
                         seed,
                     )
                     failures.append(
@@ -5454,7 +5454,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 except Exception as exc:  # pragma: no cover
                     logger.exception(
                         "Map batch worker failed in parallel execution: scenario={} seed={}",
-                        scenario.get("name", "unknown"),
+                        _scenario_id(scenario),
                         seed,
                     )
                     failures.append(
@@ -5477,7 +5477,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                             "Map batch write/validation failed for scenario={} seed={}; "
                             "preserving fail-closed batch status."
                         ),
-                        rec.get("scenario_id") or rec.get("scenario", {}).get("name", "unknown"),
+                        rec.get("scenario_id", "unknown"),
                         rec.get("seed", -1),
                     )
                     failures.append(

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -1027,8 +1027,14 @@ def _maybe_encode_video(
     except RuntimeError:
         # Budget enforcement: bubble up to runner to record a failure
         raise
-    except (TypeError, ValueError, OSError):  # pragma: no cover - defensive path
-        pass
+    except (TypeError, ValueError, OSError) as exc:  # pragma: no cover - defensive path
+        logger.opt(exception=exc).warning(
+            "Synthetic video encoding failure for episode_id={} scenario_id={} renderer={}; "
+            "continuing benchmark run.",
+            episode_id,
+            scenario_id,
+            video_renderer,
+        )
 
 
 def _simulate_episode_with_policy(
@@ -1495,6 +1501,11 @@ def _run_batch_sequential(
                 except Exception:  # pragma: no cover - progress best-effort
                     pass
         except Exception as e:  # pragma: no cover - error path
+            logger.exception(
+                "Benchmark batch job failed in serial execution: scenario_id={} seed={}",
+                sc.get("id", "unknown"),
+                seed,
+            )
             failures.append(
                 {
                     "scenario_id": sc.get("id", "unknown"),
@@ -1547,6 +1558,11 @@ def _run_batch_parallel(  # noqa: C901
                     except Exception:  # pragma: no cover
                         pass
             except Exception as e:  # pragma: no cover
+                logger.exception(
+                    "Benchmark batch job failed in parallel execution: scenario_id={} seed={}",
+                    sc.get("id", "unknown"),
+                    seed,
+                )
                 failures.append(
                     {
                         "scenario_id": sc.get("id", "unknown"),
@@ -1568,6 +1584,11 @@ def _run_batch_parallel(  # noqa: C901
             _write_validated_record(out_path, schema, results_by_idx[idx])
             wrote += 1
         except Exception as e:  # pragma: no cover - write/validate path
+            logger.exception(
+                "Benchmark batch write/validation failed for scenario_id={} seed={}",
+                results_by_idx[idx].get("scenario", {}).get("id", "unknown"),
+                results_by_idx[idx].get("seed", -1),
+            )
             failures.append(
                 {
                     "scenario_id": results_by_idx[idx].get("scenario", {}).get("id", "unknown"),

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -1586,7 +1586,7 @@ def _run_batch_parallel(  # noqa: C901
         except Exception as e:  # pragma: no cover - write/validate path
             logger.exception(
                 "Benchmark batch write/validation failed for scenario_id={} seed={}",
-                results_by_idx[idx].get("scenario", {}).get("id", "unknown"),
+                results_by_idx[idx].get("scenario_id", "unknown"),
                 results_by_idx[idx].get("seed", -1),
             )
             failures.append(

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -12,6 +12,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 import yaml
+from loguru import logger
 
 from robot_sf.benchmark import map_runner
 from robot_sf.benchmark.map_runner import (
@@ -3582,6 +3583,55 @@ def test_run_map_batch_parallel_write_failure_prefers_top_level_scenario_id(
         "record-s1",
         "record-s2",
     }
+
+
+def test_run_map_batch_worker_failure_logs_warning(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Worker failures should emit a warning before fail-closed summary returns."""
+    scenarios = [
+        {"name": "s1", "metadata": {"supported": True}},
+        {"name": "s2", "metadata": {"supported": True}},
+    ]
+    out_path = tmp_path / "episodes.jsonl"
+
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.validate_scenario_list", lambda _: [])
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.load_schema", lambda _: {})
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.ProcessPoolExecutor",
+        ThreadPoolExecutor,
+    )
+
+    def fake_run(job):
+        """Force map worker errors for the parallel failure test."""
+        scenario, _seed, _ = job
+        raise RuntimeError(f"forced map failure: {scenario['name']}")
+
+    monkeypatch.setattr("robot_sf.benchmark.map_runner._run_map_job_worker", fake_run)
+
+    captured: list = []
+
+    def capture_message(message):
+        """Collect warning messages for this failure test."""
+        captured.append(message)
+
+    handle = logger.add(capture_message, level="WARNING")
+    try:
+        result = run_map_batch(
+            scenarios,
+            out_path,
+            schema_path=tmp_path / "schema.json",
+            workers=2,
+            resume=False,
+        )
+    finally:
+        logger.remove(handle)
+
+    assert result["written"] == 0
+    assert result["failed_jobs"] == 2
+    assert any(
+        "Map batch worker failed in parallel execution" in msg.record["message"] for msg in captured
+    )
 
 
 def test_run_map_batch_filters_and_validation(

--- a/tests/benchmark/test_runner_exception_logging.py
+++ b/tests/benchmark/test_runner_exception_logging.py
@@ -1,0 +1,82 @@
+"""Regression tests for benchmark runner exception visibility."""
+
+from __future__ import annotations
+
+import numpy as np
+from loguru import logger
+
+from robot_sf.benchmark import runner
+
+
+def test_run_batch_sequential_worker_failure_logs_warning(tmp_path, monkeypatch) -> None:
+    """Worker exceptions in the serial batch path should be logged before being summarized."""
+    captured: list = []
+
+    def capture_message(message):
+        """Capture warning events emitted by runner."""
+        captured.append(message)
+
+    def fake_run_job(job):
+        """Fail worker execution to exercise exception logging."""
+        del job
+        raise RuntimeError("forced serial worker failure")
+
+    handle = logger.add(capture_message, level="WARNING")
+    monkeypatch.setattr(runner, "_run_job_worker", fake_run_job)
+    try:
+        wrote, failures = runner._run_batch_sequential(
+            [({"id": "scenario-1"}, 42)],
+            out_path=tmp_path / "episodes.jsonl",
+            schema={},
+            fixed_params={},
+            progress_cb=None,
+            fail_fast=False,
+        )
+    finally:
+        logger.remove(handle)
+
+    assert wrote == 0
+    assert len(failures) == 1
+    assert failures[0]["scenario_id"] == "scenario-1"
+    assert any(
+        "Benchmark batch job failed in serial execution" in msg.record["message"]
+        for msg in captured
+    )
+
+
+def test_maybe_encode_video_logs_nonfatal_errors(tmp_path, monkeypatch) -> None:
+    """Video helper failures should be logged but not raised."""
+    captured: list = []
+
+    def capture_message(message):
+        """Capture warning events emitted by runner."""
+        captured.append(message)
+
+    def fake_encode(*args, **kwargs):
+        """Force a nonfatal encode failure."""
+        del args, kwargs
+        raise TypeError("forced encode failure")
+
+    handle = logger.add(capture_message, level="WARNING")
+    monkeypatch.setattr(runner, "_try_encode_synthetic_video", fake_encode)
+    try:
+        runner._maybe_encode_video(
+            record={
+                "episode_id": "episode-1",
+                "scenario_id": "scenario-1",
+                "seed": 42,
+            },
+            robot_pos_traj=[np.array([0.0, 0.0])],
+            videos_dir=str(tmp_path),
+            video_enabled=True,
+            video_renderer="synthetic",
+            perf_start=0.0,
+        )
+    finally:
+        logger.remove(handle)
+
+    assert any(
+        "Synthetic video encoding failure for episode_id=episode-1 scenario_id=scenario-1 "
+        "renderer=synthetic; continuing benchmark run." in msg.record["message"]
+        for msg in captured
+    )

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -121,8 +121,9 @@ def test_analyze_body_collects_multiline_deferred_work() -> None:
     assert report.linked_issues == ("#2966",)
 
 
-def test_cli_reads_github_pull_request_event(tmp_path: Path) -> None:
+def test_cli_reads_github_pull_request_event(tmp_path: Path, monkeypatch) -> None:
     """The CLI can read pull_request.body from a GitHub event payload."""
+    monkeypatch.delenv("PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES", raising=False)
     event_path = tmp_path / "event.json"
     event_path.write_text(
         json.dumps(


### PR DESCRIPTION
## Summary
Logs benchmark runner exceptions that were previously converted into failure records with little or no visible exception context, while preserving fail-closed benchmark behavior. Also isolates a PR-readiness CLI test from inherited environment state discovered during final validation.

## Linked Issues
- Closes `#3015`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added Loguru exception/warning records for benchmark batch serial worker failures, parallel worker failures, write/validation failures, and non-fatal synthetic-video encode failures.
- Added regression coverage for runner and map-runner exception logging while preserving returned failure summaries.
- Isolated `tests/dev/test_check_pr_followups.py::test_cli_reads_github_pull_request_event` from `PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES` so PR readiness does not depend on a live fixture issue staying open.

## Why It Matters
- Added value: failed benchmark jobs now preserve exception context in logs instead of only producing compact failure records.
- Expected impact: easier diagnosis of benchmark failures without relaxing fail-closed result semantics.
- Why this is worth merging now: issue #3015 is a medium-priority benchmark bug and the final readiness gate exposed a small test isolation defect that would otherwise keep unrelated branches red.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: benchmark runner diagnostics should expose swallowed exception context.
- Comparator or baseline, if applicable: previous behavior appended failure records or ignored encode failures without logging the exception path.
- Evidence tier: targeted smoke plus full PR readiness suite.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: failure branches log exception context and targeted tests verify warning emission while failure summaries remain fail-closed.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #3015.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no new analysis tool; this is diagnostic logging/support behavior.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes; tests force benchmark worker and encode failures and assert emitted log messages.
- Did the intervention change command source, selected command, trajectory, or route progress? no; it only adds logging around existing failure paths.
- Did the scenario actually contain the targeted failure mode? yes; regression tests inject the targeted exceptions.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue; ready for review.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run ruff format --check robot_sf/benchmark/runner.py robot_sf/benchmark/map_runner.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_runner_exception_logging.py`
  - `uv run ruff check robot_sf/benchmark/runner.py robot_sf/benchmark/map_runner.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_runner_exception_logging.py`
  - `uv run pytest tests/benchmark/test_runner_exception_logging.py tests/benchmark/test_map_runner_utils.py::test_run_map_batch_worker_failure_logs_warning`
  - `uv run pytest tests/dev/test_check_pr_followups.py::test_cli_reads_github_pull_request_event -q`
  - `BASE_REF=origin/main PR_READY_MODE=final scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: targeted logging tests pass and final PR readiness passed at branch head `50ef02b43d1f5308b1a61e630c723fc4c9f50580` with `7023 passed, 9 skipped`.
- Benchmarks or smoke tests, if applicable: targeted benchmark runner/map-runner smoke tests plus full readiness suite.

## Risks / Rollout
- Compatibility risks: warning/exception log volume increases for failure-heavy benchmark batches.
- Failure modes: if downstream tooling parses logs strictly, new failure messages may appear in expected output.
- Rollback or fallback plan: revert the logging/test commits; benchmark failure summaries remain unchanged.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: delegated worker self-review note recorded privately under common Git dir `codex-agent-runs/notes/inbox/20260617-issue-3015-worker-self-review.md`.
- Any assumptions that need to be preserved: fail-closed failure records remain the benchmark outcome contract; logs are diagnostic evidence, not success evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR will close #3015.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: no benchmark results, models, configs, reports, or durable artifacts changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: the added logging uses Loguru `{}` formatting and should not alter existing failure-summary control flow.
- Any known limitations: final readiness generated ignored coverage output under `output/coverage`, intentionally left untracked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting with enhanced logging for batch job failures, capturing detailed exception information during serial execution, parallel workers, and validation.
  * Added warning logs for video encoding failures to provide better visibility into encoding errors.

* **Tests**
  * Added regression tests to validate that error messages are properly emitted in logs when batch operations and video encoding fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->