### PR TITLE
test: make pytest coverage opt-in

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1020,22 +1020,25 @@ uv run pytest fast-pysf/tests  # → 12 tests (all passing with map fixtures)
 
 → Consider documenting the edge case in code comments and archiving the test, rather than spending hours debugging environmental setup issues.
 
-### Coverage workflow (automatic collection)
+### Coverage workflow (explicit opt-in)
 
-**Coverage collection is enabled by default** — no extra commands needed! When you run tests, coverage data is automatically collected and reported.
+Coverage collection is no longer enabled by default. Run tests normally for fast execution,
+and enable coverage explicitly when needed.
 
 The test harness sets the ``ROBOT_SF_ARTIFACT_ROOT`` environment variable so that
 example scripts and helpers write into a temporary directory instead of the
 repository tree. This keeps the canonical ``output/`` hierarchy clean while
-preserving the examples' default behavior for normal runs. To opt-in manually,
-export the same variable before invoking scripts.
+preserving normal example behavior.
 
 Try to increase the test coverage over time by adding tests when touching code. See the must-have checklist below for guidance.
 
 #### Quick start
 ```bash
-# Run tests (coverage collected automatically)
+# Run tests (no coverage by default)
 uv run pytest tests
+
+# Run tests with coverage (CI and explicit opt-in local runs)
+ROBOT_SF_PYTEST_COVERAGE=1 scripts/dev/run_tests_parallel.sh tests
 
 # Run a focused local check and discard generated coverage output after success
 scripts/dev/run_focused_tests.sh tests/test_force_flags.py -q
@@ -1079,16 +1082,23 @@ TOTAL                                   10605    876  91.73%
 Configured in `pyproject.toml`:
 - `[tool.coverage.run]` — collection settings (source, omit patterns, parallel support)
 - `[tool.coverage.report]` — report formatting (precision, exclusions)
-- `[tool.pytest.ini_options]` — automatic pytest integration
+- `scripts/dev/run_tests_parallel.sh` — explicit pytest coverage opt-in for local wrapper and CI
+  runs
 
-No changes needed for normal development — defaults are production-ready.
+No changes needed for normal development — default pytest runs skip coverage output for faster
+feedback, while CI and explicit wrapper opt-in still generate reports.
 
 #### Advanced usage
 ```bash
-# Run with parallel workers (coverage merges automatically)
+# Run with parallel workers (faster local feedback)
 uv run pytest tests -n auto
 
+# Run with parallel workers and explicit coverage collection
+ROBOT_SF_PYTEST_COVERAGE=1 scripts/dev/run_tests_parallel.sh tests
+
 # Run specific test file with coverage
+ROBOT_SF_PYTEST_COVERAGE=1 scripts/dev/run_tests_parallel.sh tests/test_gym_env.py -v
+# Run specific test file without coverage
 uv run pytest tests/test_gym_env.py -v
 
 # View coverage data programmatically

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -455,9 +455,6 @@ show_contexts = false
 [tool.pytest.ini_options]
 addopts = [
     "--import-mode=importlib",
-    "--cov=robot_sf",
-    "--cov-report=html",
-    "--cov-report=json",
     "--durations=10",
 ]
 testpaths = ["tests", "fast-pysf/tests"]

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -123,7 +123,7 @@ fi
 uv run python "$SCRIPT_DIR/check_pr_followups.py"
 uv run python "$SCRIPT_DIR/check_fast_results_claim_map.py"
 "$SCRIPT_DIR/ruff_fix_format.sh"
-"$SCRIPT_DIR/run_tests_parallel.sh"
+ROBOT_SF_PYTEST_COVERAGE=1 "$SCRIPT_DIR/run_tests_parallel.sh"
 "$SCRIPT_DIR/check_changed_coverage.sh"
 "$SCRIPT_DIR/check_docstring_todos_diff.sh"
 "$SCRIPT_DIR/check_docstring_todos_ratchet.sh"

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -16,6 +16,8 @@ Wrapper options:
   -h, --help       Show this help message
 
 Environment overrides:
+  ROBOT_SF_PYTEST_COVERAGE=1
+    Explicit opt-in for coverage output when running this wrapper.
   COVERAGE_FILE=<path>
   PYTEST_FAST_FAIL=1|0
   PYTEST_XDIST_DIST=load|worksteal|loadscope|loadfile|loadgroup
@@ -106,6 +108,14 @@ fi
 echo "Resolved pytest-xdist workers: $worker_spec" >&2
 
 cmd=(uv run pytest -n "$worker_spec" --dist "$dist_mode")
+
+coverage_requested="${ROBOT_SF_PYTEST_COVERAGE:-}"
+if [[ "${CI:-}" == "true" ]] || [[ "$coverage_requested" == "1" ]] || \
+  [[ "$coverage_requested" == [Tt][Rr][Uu][Ee] ]] || \
+  [[ "$coverage_requested" == [Yy][Ee][Ss] ]] || \
+  [[ "$coverage_requested" == [Oo][Nn] ]]; then
+  cmd+=("--cov=robot_sf" "--cov-report=html" "--cov-report=json")
+fi
 
 if [[ "$fast_fail" == "1" ]]; then
   cmd+=("-x")

--- a/tests/perf_utils/test_enforce_mode.py
+++ b/tests/perf_utils/test_enforce_mode.py
@@ -12,6 +12,7 @@ in a temp directory to keep runtime minimal.
 from __future__ import annotations
 
 import os
+import shutil
 import subprocess
 import sys
 import textwrap
@@ -23,9 +24,9 @@ import pytest
 @pytest.mark.timeout(10)
 def test_enforce_mode_escalates():
     """Verify enforce mode converts soft breaches into failures."""
-    # Create a small test file under repo root so root conftest is loaded.
+    # Create a small test file under tests/ so tests/conftest.py is loaded.
     repo_root = Path(__file__).resolve().parents[2]
-    target_dir = repo_root / "output" / "tmp" / "enforce_tmp"
+    target_dir = Path(__file__).resolve().parent / f"_tmp_enforce_{os.getpid()}"
     target_dir.mkdir(parents=True, exist_ok=True)
     test_file = target_dir / "test_sleep_enforce.py"
     test_file.write_text(
@@ -69,5 +70,9 @@ def test_enforce_mode_escalates():
     finally:
         try:
             test_file.unlink(missing_ok=True)  # type: ignore[arg-type]
+        except Exception:
+            pass
+        try:
+            shutil.rmtree(target_dir, ignore_errors=True)
         except Exception:
             pass

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -82,6 +82,22 @@ def test_run_tests_parallel_exposes_xdist_distribution_mode() -> None:
     assert "PYTEST_XDIST_DIST=load|worksteal|loadscope|loadfile|loadgroup" in script_text
 
 
+def test_pytest_coverage_is_explicit_opt_in() -> None:
+    """Default pytest runs should stay fast while the wrapper preserves coverage opt-in."""
+    pyproject = tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+    addopts = pyproject["tool"]["pytest"]["ini_options"]["addopts"]
+    script_text = RUN_TESTS_PARALLEL.read_text(encoding="utf-8")
+    pr_ready_text = PR_READY_CHECK.read_text(encoding="utf-8")
+
+    assert "--cov=robot_sf" not in addopts
+    assert "--cov-report=html" not in addopts
+    assert "--cov-report=json" not in addopts
+    assert "ROBOT_SF_PYTEST_COVERAGE" in script_text
+    assert "${coverage_requested,,}" not in script_text
+    assert 'cmd+=("--cov=robot_sf" "--cov-report=html" "--cov-report=json")' in script_text
+    assert 'ROBOT_SF_PYTEST_COVERAGE=1 "$SCRIPT_DIR/run_tests_parallel.sh"' in pr_ready_text
+
+
 def test_run_tests_parallel_validates_dist_mode_before_resolving_workers() -> None:
     """Invalid dist mode must fail before resolve_pytest_workers.py is invoked."""
 


### PR DESCRIPTION
## Summary
Makes pytest coverage collection explicit instead of default for ordinary local pytest runs, while preserving CI and PR-readiness coverage reporting through the shared test wrapper.

## Linked Issues
- Closes `#3016`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Removed `--cov=robot_sf`, `--cov-report=html`, and `--cov-report=json` from default `pyproject.toml` pytest addopts.
- Added explicit coverage opt-in to `scripts/dev/run_tests_parallel.sh` via `ROBOT_SF_PYTEST_COVERAGE=1` or `CI=true`.
- Updated `scripts/dev/pr_ready_check.sh` so final readiness still runs the shared test wrapper with coverage enabled.
- Updated `docs/dev_guide.md` coverage workflow docs.
- Added script-contract coverage for the opt-in behavior and fixed the performance enforcement subprocess fixture so it loads `tests/conftest.py` from under `tests/`.

## Why It Matters
- Added value: local focused pytest runs avoid writing coverage output unless requested.
- Expected impact: faster and cleaner local test feedback, less routine `output/coverage` churn.
- Why this is worth merging now: issue #3016 is a bounded performance/test ergonomics improvement and final readiness still proves CI coverage behavior.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/test workflow ergonomics, no research claim.
- Comparator or baseline, if applicable: previous default pytest addopts always enabled coverage reports.
- Evidence tier: targeted smoke plus full PR readiness suite.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: default pytest produces no coverage output; wrapper/CI opt-in still generates coverage reports.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #3016.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper/workflow configuration.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes; default pytest no longer creates `output/coverage`, explicit wrapper and CI env paths do.
- Did the intervention change command source, selected command, trajectory, or route progress? no runtime/planner behavior; only pytest coverage invocation behavior changed.
- Did the scenario actually contain the targeted failure mode? yes; `pyproject.toml` had global coverage addopts.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue; ready for review.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/test_ci_script_contract.py -q`
  - `uv run pytest tests/perf_utils/test_enforce_mode.py::test_enforce_mode_escalates -q`
  - `bash -n scripts/dev/run_tests_parallel.sh scripts/dev/pr_ready_check.sh`
  - `rm -rf output/coverage && uv run pytest tests/test_ci_script_contract.py -q && ! test -e output/coverage`
  - `rm -rf output/coverage && ROBOT_SF_PYTEST_COVERAGE=1 scripts/dev/run_tests_parallel.sh tests/test_ci_script_contract.py -q && test -f output/coverage/coverage.json`
  - `rm -rf output/coverage && CI=true scripts/dev/run_tests_parallel.sh tests/test_ci_script_contract.py -q && test -f output/coverage/coverage.json`
  - `BASE_REF=origin/main PR_READY_MODE=final scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: final readiness passed at `5557b942302b9d00b99931431946670745e36020` with `7025 passed, 9 skipped`.
- Benchmarks or smoke tests, if applicable: targeted script-contract and performance enforcement tests; full readiness suite.

## Risks / Rollout
- Compatibility risks: developers who expected bare `uv run pytest` to emit coverage reports must now opt in via the wrapper/env var.
- Failure modes: direct custom pytest invocations need explicit `--cov` flags or wrapper opt-in when coverage artifacts are required.
- Rollback or fallback plan: restore pytest coverage addopts or set `ROBOT_SF_PYTEST_COVERAGE=1` in the desired wrapper path.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md` coverage workflow section.
- Relevant design or provenance notes: worker self-review note recorded privately under common Git dir `codex-agent-runs/notes/inbox/20260617-issue-3016-worker-self-review.md`.
- Any assumptions that need to be preserved: CI and PR readiness should continue using explicit coverage collection.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR will close #3016.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a support/test workflow change with no benchmark result or durable artifact.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: `run_tests_parallel.sh` intentionally enables coverage only for `CI=true` or truthy `ROBOT_SF_PYTEST_COVERAGE`; `pr_ready_check.sh` sets the opt-in explicitly.
- Any known limitations: bare `uv run pytest` no longer emits coverage by design.
