### PR TITLE
docs: add architecture decision record process

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -58,6 +58,7 @@ thin: existing Markdown files remain the source of truth, and generated HTML und
   - [Ready-to-Use Workflows](#ready-to-use-workflows)
 - [📚 Documentation Index](#-documentation-index)
   - [Getting Started](#getting-started)
+  - [Architecture Decision Records](#architecture-decision-records)
   - [Benchmarking \& Metrics](#benchmarking--metrics)
   - [Tooling](#tooling)
   - [Architecture \& Refactoring](#architecture--refactoring)
@@ -187,6 +188,11 @@ thin: existing Markdown files remain the source of truth, and generated HTML und
 * **[Feature Extractors Guide](./feature_extractors/usage_guide.md)** - Configure and compare extractor presets, run multi-extractor training, and generate reports
 * **[Run Tracker & History CLI](./dev_guide.md#run-tracker--history-cli)** - Enable the failure-safe tracker on the imitation pipeline, monitor `status`/`watch` output, run telemetry perf-tests, mirror telemetry to TensorBoard, filter historical runs, and export Markdown/JSON summaries via the `scripts/tools/run_tracker_cli.py` commands (`status`, `watch`, `list`, `summary`, `export`, `perf-tests`, `enable-tensorboard`)
 * **[Issue #845 Slurm Utilization Probe](./context/issue_845_slurm_utilization_probe.md)** - Collect `sstat`/`sacct`/`seff` evidence for low CPU-utilization investigations without launching new jobs
+
+### Architecture Decision Records
+
+* **[ADR Index](./adr/README.md)** - Lightweight process and index for durable architecture and long-lived contract/process decisions
+* **[ADR Template](./adr/template.md)** - Copy-ready format for source-backed ADRs (status, context, alternatives, impacts)
 
 ### Benchmarking & Metrics
 

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,52 @@
+# Architecture Decision Records (ADR)
+
+This directory holds the lightweight record process for major design decisions that are
+intended to outlive a single issue or PR.
+
+## Why ADRs here
+
+- Capture long-lived architecture, contract, or dependency choices with clear rationale.
+- Provide a durable pointer before behavior changes become difficult to reverse.
+- Separate durable decisions from issue-level execution notes and ad-hoc run notes.
+
+## ADR scope
+
+Create an ADR for changes that affect:
+
+- public interfaces, contracts, or semantics that can invalidate downstream integrations
+- repository-wide simulation/benchmark architecture
+- dependency or runtime strategy with broad impact
+- evidence, provenance, or promotion workflow boundaries with non-trivial external meaning
+
+Prefer a context note for:
+
+- short-lived implementation logs
+- benchmark executions, reruns, and diagnostics
+- one-off bugfixes or local tuning decisions
+
+## How this differs from other notes
+
+- `docs/context/` notes are issue execution, validation, and handoff surfaces. They may
+  explain tradeoffs, but they are not the canonical home for a durable architecture decision
+  unless the decision remains issue-scoped.
+- `memory/` entries are compact cross-session facts and reusable knowledge for future agents.
+- ADRs in this directory are for durable architectural and process decisions; each ADR
+  should be short, source-backed, and cross-referenced from issues, PRs, or related notes.
+
+## Current index
+
+- [ADR Template](./template.md)
+- No durable ADRs have been recorded yet.
+
+## Creating a new ADR
+
+- Copy `template.md` and rename with a short, numeric filename (for example:
+  `0001-simulator-backend.md`).
+- Keep one decision per file.
+- Include at least:
+  - context and problem statement
+  - decision rationale
+  - alternatives considered
+  - concrete impacts
+  - what evidence or repository changes would invalidate the decision
+  - references to source docs, tests, PRs, or specs

--- a/docs/adr/template.md
+++ b/docs/adr/template.md
@@ -1,0 +1,42 @@
+# ADR-0000: [short descriptive title]
+
+## Status
+
+- Status: Proposed
+- Date: YYYY-MM-DD
+- Owner: [team/person]
+- Replaces: none
+- Superseded by: none
+
+## Context
+
+Describe the long-lived architectural/design decision context. Include links to
+source code, existing docs, specs, and relevant issue/PR threads.
+
+## Decision
+
+State the decision in one to three sentences.
+
+## Drivers
+
+- Problem/constraint 1
+- Problem/constraint 2
+- Problem/constraint 3
+
+## Alternatives Considered
+
+- Option A: [brief summary] - reason not chosen
+- Option B: [brief summary] - reason not chosen
+
+## Consequences
+
+- Expected benefits:
+- Expected risks:
+- Rollback or migration cost:
+
+## References
+
+- Related context notes:
+- Related specs/plans:
+- Validation evidence:
+- Follow-up actions:


### PR DESCRIPTION
## Summary

- Add `docs/adr/` as the lightweight Architecture Decision Record home.
- Add an ADR index/process guide and copy-ready template.
- Link the ADR process from `docs/README.md` so contributors can find it.

## Scope

- No initial ADRs were seeded because this PR only introduces the process; durable decisions should be added when they are source-backed by existing docs, issues, PRs, tests, or specs.
- No paper-facing, benchmark, or architecture claims are introduced.

Closes #3029.

## Validation

- `rtk git diff --check origin/main...HEAD`
- targeted path checks for `docs/adr/README.md`, `docs/adr/template.md`, `docs/context/README.md`, `memory/MEMORY.md`, and the new links from `docs/README.md`
- `rtk proxy uv run pytest -q tests/validation/test_check_docs_proof_consistency.py` (`33 passed`)

## Downstream Propagation

- Parent issue: #3029 is closed by this PR.
- Context index/catalog: not updated; this PR adds a new docs/process entry point rather than a context note.
- Memory note: not updated; no durable architecture decision was made yet.
- Follow-up: future source-backed ADRs should be added as separate narrow PRs when a major design decision needs a canonical record.

## Research Result Guidance

NA - docs/process-only change. No research, benchmark, metric, or paper-facing claim is created.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Architecture Decision Records section to documentation index and navigation
  * Introduced standardized template with fields for status, date, context, decision, alternatives, and consequences
  * Included scope criteria and creation guidance for new entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->