### PR TITLE
fix: remove robot_sf import path mutation

### DIFF
--- a/robot_sf/__init__.py
+++ b/robot_sf/__init__.py
@@ -1,13 +1,6 @@
 """Robot SF package bootstrap and telemetry exports."""
 
-import os
-import sys
-
-csfp = os.path.abspath(os.path.dirname(__file__))
-if csfp not in sys.path:
-    sys.path.insert(0, csfp)
-
-from robot_sf.telemetry import (  # noqa: E402 - telemetry depends on package path tweak
+from .telemetry import (
     ManifestWriter,
     RunRegistry,
     RunTrackerConfig,

--- a/tests/test_robot_sf_import_smoke.py
+++ b/tests/test_robot_sf_import_smoke.py
@@ -1,0 +1,22 @@
+"""Smoke tests for `robot_sf` package import behavior."""
+
+from __future__ import annotations
+
+import sys
+
+
+def test_robot_sf_import_does_not_mutate_sys_path():
+    """Verify importing `robot_sf` does not modify `sys.path`."""
+    before = list(sys.path)
+    if "robot_sf" in sys.modules:
+        del sys.modules["robot_sf"]
+
+    import robot_sf
+
+    assert list(sys.path) == before
+    assert robot_sf.__all__ == [
+        "ManifestWriter",
+        "RunRegistry",
+        "RunTrackerConfig",
+        "generate_run_id",
+    ]


### PR DESCRIPTION
## Summary
Remove the runtime `sys.path` mutation from `robot_sf` package import and preserve the telemetry exports through an explicit package-relative import.

## Linked Issues
- Closes #3010

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Removed `os`/`sys` path bootstrap logic from `robot_sf/__init__.py`.
- Replaced `from robot_sf.telemetry import ...` with `from .telemetry import ...`.
- Added `tests/test_robot_sf_import_smoke.py` to assert `import robot_sf` leaves `sys.path` unchanged and preserves `robot_sf.__all__`.

## Why It Matters
- Added value: package import no longer mutates host interpreter state.
- Expected impact: safer installs/imports and less surprising package behavior.
- Why this is worth merging now: #3010 identified this as a high-priority bounded packaging bug.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - packaging hygiene; no research claim.
- Comparator or baseline, if applicable: NA.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: import smoke passes without `sys.path` mutation.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3010.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for the targeted package smoke; broader PR readiness should run in CI.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: full local PR readiness did not complete; see validation notes.
- Stop / revise / continue decision: continue with PR review/CI.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `rtk uv run python -c "import sys; before=list(sys.path); import robot_sf; after=list(sys.path); assert before == after; print(robot_sf.__all__ if hasattr(robot_sf, __all__) else import-ok)"`
  - `rtk uv run pytest tests/test_robot_sf_import_smoke.py -q`
  - `rtk uv run ruff check robot_sf/__init__.py tests/test_robot_sf_import_smoke.py`
  - `rtk uv run pytest tests/test_robot_sf_import_smoke.py tests/test_tracking/test_telemetry.py -q`
  - `BASE_REF=origin/main rtk uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh` attempted twice: first failed before worktree bootstrap because `duckdb` was missing; after `rtk uv sync --all-extras`, the rerun was interrupted after several silent wait windows.
- Evidence that the change works here: targeted import smoke proves `sys.path` is unchanged across `import robot_sf`, and telemetry export tests still pass.
- Benchmarks or smoke tests, if applicable: targeted package/telemetry smoke only.

## Risks / Rollout
- Compatibility risks: callers relying on `import robot_sf` to place the package directory directly on `sys.path` would no longer get that side effect; that side effect is the bug this fixes.
- Failure modes: a hidden bare import could still rely on path mutation, but the touched public bootstrap now uses package-relative imports and focused import smoke passes.
- Rollback or fallback plan: revert this PR to restore the previous package bootstrap if CI exposes a missed import dependency.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #3010 contract.
- Any assumptions that need to be preserved: unrelated planner/baseline path shims are out of scope.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR link.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a package hygiene fix with no benchmark, registry, artifact, or paper-facing claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: whether any import path in CI still depended on `robot_sf/__init__.py` mutating `sys.path`.
- Any known limitations: full local PR readiness was attempted but not completed; rely on CI plus the targeted local checks above.
