### PR TITLE
docs: replace robot_sf TODO docstrings

### DIFF
--- a/robot_sf/gym_env/abstract_envs.py
+++ b/robot_sf/gym_env/abstract_envs.py
@@ -36,16 +36,16 @@ class BaseSimulationEnv(Env, ABC):
         video_fps: float | None = None,
         **kwargs,
     ):
-        """TODO docstring. Document this function.
+        """Initialize shared simulation environment state and invoke subclass setup.
 
         Args:
-            config: TODO docstring.
-            debug: TODO docstring.
-            recording_enabled: TODO docstring.
-            record_video: TODO docstring.
-            video_path: TODO docstring.
-            video_fps: TODO docstring.
-            kwargs: TODO docstring.
+            config: Base simulation configuration used by all environment instances.
+            debug: Whether debugging hooks and extra logging are enabled.
+            recording_enabled: Whether simulation state snapshots are recorded.
+            record_video: Whether visual frames are captured for playback/output.
+            video_path: Optional target path for video output when recording is enabled.
+            video_fps: Optional frame rate override used by video output.
+            kwargs: Extra configuration options consumed by concrete environment classes.
         """
         super().__init__()
         self.config = config
@@ -134,11 +134,11 @@ class SingleAgentEnv(BaseSimulationEnv, ABC):
     """
 
     def __init__(self, config: BaseSimulationConfig, **kwargs):
-        """TODO docstring. Document this function.
+        """Initialize single-agent state fields before shared base initialization.
 
         Args:
-            config: TODO docstring.
-            kwargs: TODO docstring.
+            config: Base simulation configuration.
+            kwargs: Extra base-environment settings forwarded to ``BaseSimulationEnv``.
         """
         self.state = None
         self.simulator = None
@@ -174,12 +174,12 @@ class MultiAgentEnv(BaseSimulationEnv, ABC):
     """
 
     def __init__(self, config: BaseSimulationConfig, num_agents: int, **kwargs):
-        """TODO docstring. Document this function.
+        """Initialize shared multi-agent state and defer setup to the base environment.
 
         Args:
-            config: TODO docstring.
-            num_agents: TODO docstring.
-            kwargs: TODO docstring.
+            config: Base simulation configuration.
+            num_agents: Fixed number of agents managed by this environment.
+            kwargs: Extra base-environment settings forwarded to ``BaseSimulationEnv``.
         """
         super().__init__(config, **kwargs)
         self.num_agents = num_agents

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -96,10 +96,10 @@ def _temporary_global_reset_seed(seed: int | None):
 # Helper to compute a stable, short hash for env_config
 # Placed near imports for reuse and clarity
 def _stable_config_hash(cfg: EnvSettings) -> str:
-    """TODO docstring. Document this function.
+    """Build a stable short hash of the environment settings.
 
     Args:
-        cfg: TODO docstring.
+        cfg: Environment settings to serialize for identity.
 
     Returns:
         16-character hexadecimal hash string representing the configuration.

--- a/robot_sf/ped_ego/unicycle_drive.py
+++ b/robot_sf/ped_ego/unicycle_drive.py
@@ -124,11 +124,10 @@ class UnicycleDrivePedestrian:
 
     @property
     def observation_space(self) -> spaces.Box:
-        """TODO docstring. Document this function.
-
+        """Action-independent observation bounds for the unicycle pedestrian.
 
         Returns:
-            TODO docstring.
+            spaces.Box: 2D continuous box for speed and steering-angle constraints.
         """
         high = np.array([self.config.max_velocity, self.config.max_steer], dtype=np.float32)
         low = np.array([self.config.min_velocity, -self.config.max_steer], dtype=np.float32)
@@ -136,11 +135,10 @@ class UnicycleDrivePedestrian:
 
     @property
     def action_space(self) -> spaces.Box:
-        """TODO docstring. Document this function.
-
+        """Action bounds accepted by the unicycle pedestrian.
 
         Returns:
-            TODO docstring.
+            spaces.Box: 2D continuous box with acceleration and steering limits.
         """
         high = np.array([self.config.max_accel, self.config.max_steer], dtype=np.float32)
         low = np.array([-self.config.max_accel, -self.config.max_steer], dtype=np.float32)
@@ -148,58 +146,43 @@ class UnicycleDrivePedestrian:
 
     @property
     def pos(self) -> Vec2D:
-        """TODO docstring. Document this function.
-
-
-        Returns:
-            TODO docstring.
-        """
+        """Current 2D position of the pedestrian in world coordinates."""
         return self.state.pose[0]
 
     @property
     def pose(self) -> PedPose:
-        """TODO docstring. Document this function.
-
-
-        Returns:
-            TODO docstring.
-        """
+        """Current pose as ``((x, y), heading)``."""
         return self.state.pose
 
     @property
     def current_speed(self) -> PolarVec2D:
-        """TODO docstring. Document this function.
-
-
-        Returns:
-            TODO docstring.
-        """
+        """Current speed (m/s) and travel direction."""
         return self.state.current_speed
 
     def apply_action(self, action: UnicycleAction, d_t: float):
-        """TODO docstring. Document this function.
+        """Integrate one control command for the configured time step.
 
         Args:
-            action: TODO docstring.
-            d_t: TODO docstring.
+            action: Unicycle control tuple ``(acceleration, steering)``.
+            d_t: Integration duration in seconds.
         """
         self.movement.move(self.state, action, d_t)
 
     def reset_state(self, new_pose: PedPose):
-        """TODO docstring. Document this function.
+        """Reset internal state to a pose and zero speed.
 
         Args:
-            new_pose: TODO docstring.
+            new_pose: New pedestrian pose used to reinitialize state.
         """
         self.state = UnicycleDriveState(new_pose, 0)
 
     def parse_action(self, action: np.ndarray) -> UnicycleAction:
-        """TODO docstring. Document this function.
+        """Convert a 2-element action array to the unicycle action tuple.
 
         Args:
-            action: TODO docstring.
+            action: Array-like with ``[acceleration, steering]``.
 
         Returns:
-            TODO docstring.
+            UnicycleAction: Parsed acceleration and steering command tuple.
         """
         return (action[0], action[1])

--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -1,4 +1,8 @@
-"""TODO docstring. Document this module."""
+"""PyGame simulation renderer for RobotSF.
+
+This module renders simulator states to a pygame surface, handles playback
+interactions, and optionally records image sequences for visualization artifacts.
+"""
 
 import os
 import sys
@@ -762,7 +766,7 @@ class SimulationView:
             pygame.display.update()
 
     def _resize_window(self):
-        """TODO docstring. Document this function."""
+        """Recreate the render surface using current window dimensions."""
         logger.debug("Resizing the window.")
         old_surface = self.screen
         if self._use_display:
@@ -958,7 +962,7 @@ class SimulationView:
 
     def _draw_obstacles(self):
         # Iterate over each obstacle in the list of obstacles
-        """TODO docstring. Document this function."""
+        """Draw obstacle polygons from the loaded map."""
         for obstacle in self.map_def.obstacles:
             # Scale and offset the vertices of the obstacle
             scaled_vertices = [(self._scale_tuple((x, y))) for x, y in obstacle.vertices_np]
@@ -967,7 +971,7 @@ class SimulationView:
 
     def _draw_spawn_zones(self):
         # Iterate over each spawn_zone in the list of spawn_zones
-        """TODO docstring. Document this function."""
+        """Draw pedestrian spawn zones as filled polygons."""
         for spawn_zone in self.map_def.ped_spawn_zones:
             # Scale and offset the vertices of the zones
             vertices_np = np.array(spawn_zone)
@@ -977,7 +981,7 @@ class SimulationView:
 
     def _draw_goal_zones(self):
         # Iterate over each goal_zone in the list of goal_zones
-        """TODO docstring. Document this function."""
+        """Draw pedestrian goal zones as filled polygons."""
         for goal_zone in self.map_def.ped_goal_zones:
             # Scale and offset the vertices of the goal zones
             vertices_np = np.array(goal_zone)
@@ -1269,11 +1273,11 @@ class SimulationView:
         self.screen.blit(text, (x, y))
 
     def _add_text(self, timestep: int, state: VisualizableSimState):
-        """TODO docstring. Document this function.
+        """Render diagnostic overlay text for the current frame.
 
         Args:
-            timestep: TODO docstring.
-            state: TODO docstring.
+            timestep: Simulation step index shown in the overlay.
+            state: Current visualizable state used to build display lines.
         """
         info_lines = self._get_display_info_lines(state)
         text_lines = self._build_text_lines(timestep, state, info_lines)


### PR DESCRIPTION
## Summary
Replace remaining `TODO docstring` placeholders in the issue-scoped `robot_sf` public surfaces with concise behavior-focused docstrings.

## Linked Issues
- Closes #3009

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Updated docstrings in `robot_sf/gym_env/abstract_envs.py` for shared, single-agent, and multi-agent environment initialization.
- Updated `robot_sf/ped_ego/unicycle_drive.py` properties and action helpers with concrete behavior/return descriptions.
- Updated `robot_sf/render/sim_view.py` module and render helper docstrings.
- Updated `robot_sf/gym_env/robot_env.py` stable configuration hash docstring.

## Why It Matters
- Added value: public and integration-facing surfaces no longer expose placeholder documentation.
- Expected impact: improves contributor ergonomics and generated documentation quality without behavior changes.
- Why this is worth merging now: #3009 identified the remaining public TODO docstrings as a high-priority bounded cleanup.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - docs-only cleanup; no research claim.
- Comparator or baseline, if applicable: NA.
- Evidence tier: docs-only.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: no `TODO docstring` placeholders remain in touched `robot_sf` definitions.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3009.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue with review/CI.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `rtk rg -n 'TODO docstring' robot_sf/ped_ego/unicycle_drive.py robot_sf/gym_env/abstract_envs.py robot_sf/render/sim_view.py robot_sf/gym_env/robot_env.py` (no matches)
  - `rtk uv run ruff check robot_sf/gym_env/abstract_envs.py robot_sf/ped_ego/unicycle_drive.py robot_sf/render/sim_view.py robot_sf/gym_env/robot_env.py`
  - `rtk uv run python scripts/validation/check_docstring_todos.py --mode ratchet --baseline scripts/validation/docstring_todo_baseline.json`
  - `rtk uv run python scripts/validation/check_docstring_todos.py --mode diff --base origin/main --include 'robot_sf/**/*' --fail-on-warning`
- Evidence that the change works here: direct placeholder scan is clean; ruff passes; docstring ratchet and diff validation pass.
- Benchmarks or smoke tests, if applicable: NA - docs-only.

## Risks / Rollout
- Compatibility risks: none expected; docstrings only.
- Failure modes: docstrings could still be too terse for future generated API docs, but they now describe current behavior instead of placeholders.
- Rollback or fallback plan: revert the docs-only commit.

## Docs / Provenance
- Updated docs: inline Python docstrings only.
- Relevant design or provenance notes: issue #3009 contract.
- Any assumptions that need to be preserved: no behavior, signature, import, or control-flow changes intended.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR link.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: docs-only inline cleanup with no benchmark, registry, artifact, or paper-facing claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: docstring wording accuracy in the four touched surfaces.
- Any known limitations: no full test suite run because this is docs-only; targeted ruff and docstring validators passed.
