### PR TITLE
fix: tolerate missing fast-pysf backend

### DIFF
--- a/robot_sf/gym_env/config_validation.py
+++ b/robot_sf/gym_env/config_validation.py
@@ -16,6 +16,8 @@ if TYPE_CHECKING:
 from robot_sf.sensor.registry import list_sensors
 from robot_sf.sim.registry import list_backends
 
+_OPTIONAL_BACKENDS_WITH_LEGACY_FALLBACK = {"fast-pysf"}
+
 
 def _get_valid_field_names(config: BaseSimulationConfig) -> set[str]:
     """Extract valid field names from a dataclass config.
@@ -85,6 +87,13 @@ def _check_backend_valid(config: BaseSimulationConfig) -> None:
     available = list_backends()
 
     if backend not in available:
+        if backend in _OPTIONAL_BACKENDS_WITH_LEGACY_FALLBACK:
+            logger.warning(
+                "Optional backend '{}' is not registered; environment construction may use the "
+                "legacy simulator fallback.",
+                backend,
+            )
+            return
         known = ", ".join(available)
         raise KeyError(f"Unknown backend '{backend}'. Available backends: {known}")
 

--- a/robot_sf/sim/registry.py
+++ b/robot_sf/sim/registry.py
@@ -5,6 +5,7 @@ Provides register/get/list helpers and registers the default "fast-pysf" backend
 
 from __future__ import annotations
 
+import importlib
 import os
 from typing import TYPE_CHECKING
 
@@ -19,6 +20,19 @@ _BACKEND_PERFORMANCE_ORDER = {
     "dummy": 100,
 }
 _DEFAULT_PERFORMANCE_SCORE = 1000
+_FAST_PYSF_IMPORT_PATHS = {
+    "robot_sf.sim.backends.fast_pysf_backend",
+    "robot_sf.sim.fast_pysf_backend",
+    "pysocialforce",
+}
+
+
+def _is_fast_pysf_dependency_error(error: ImportError) -> bool:
+    """Return whether an import error belongs to optional fast-pysf requirements."""
+    missing = getattr(error, "name", None)
+    if not isinstance(missing, str):
+        return False
+    return any(missing == path or missing.startswith(f"{path}.") for path in _FAST_PYSF_IMPORT_PATHS)
 
 
 def register_backend(key: str, factory: SimulatorFactory, *, override: bool = False) -> None:
@@ -116,14 +130,29 @@ def select_best_backend(preferred: str | None = None) -> str:
     return best
 
 
+def _register_optional_fast_pysf_backend() -> None:
+    """Register the default fast-pysf backend when optional dependencies exist."""
+    try:
+        fast_pysf_backend = importlib.import_module(
+            "robot_sf.sim.backends.fast_pysf_backend",
+        )
+        fast_pysf_factory = fast_pysf_backend.fast_pysf_factory
+        register_backend("fast-pysf", fast_pysf_factory, override=True)
+    except (ValueError, KeyError) as error:
+        logger.warning("Failed to register default fast-pysf backend: {}", error)
+    except ImportError as error:
+        if _is_fast_pysf_dependency_error(error):
+            logger.warning(
+                "fast-pysf backend is unavailable/skipped: dependency '{}' is missing.",
+                getattr(error, "name", "unknown"),
+            )
+            return
+        raise
+
+
 # Default backend registration (fast-pysf)
 # Register default backends on import
-try:
-    from robot_sf.sim.backends.fast_pysf_backend import fast_pysf_factory
-
-    register_backend("fast-pysf", fast_pysf_factory, override=True)
-except (ValueError, KeyError) as _e:  # pragma: no cover - defensive
-    logger.warning("Failed to register default fast-pysf backend: {}", _e)
+_register_optional_fast_pysf_backend()
 
 try:
     from robot_sf.sim.backends.dummy_backend import dummy_factory

--- a/robot_sf/sim/registry.py
+++ b/robot_sf/sim/registry.py
@@ -32,7 +32,9 @@ def _is_fast_pysf_dependency_error(error: ImportError) -> bool:
     missing = getattr(error, "name", None)
     if not isinstance(missing, str):
         return False
-    return any(missing == path or missing.startswith(f"{path}.") for path in _FAST_PYSF_IMPORT_PATHS)
+    return any(
+        missing == path or missing.startswith(f"{path}.") for path in _FAST_PYSF_IMPORT_PATHS
+    )
 
 
 def register_backend(key: str, factory: SimulatorFactory, *, override: bool = False) -> None:

--- a/tests/sim/test_backend_registry.py
+++ b/tests/sim/test_backend_registry.py
@@ -41,8 +41,7 @@ def test_fast_pysf_backend_missing_dependency_is_skipped(monkeypatch: pytest.Mon
     assert "dummy" in loaded_registry.list_backends()
     assert loaded_registry.select_best_backend() == "dummy"
     assert any(
-        "fast-pysf backend is unavailable/skipped" in str(message)
-        for message, _args in warnings
+        "fast-pysf backend is unavailable/skipped" in str(message) for message, _args in warnings
     )
 
 

--- a/tests/sim/test_backend_registry.py
+++ b/tests/sim/test_backend_registry.py
@@ -7,6 +7,13 @@ import pytest
 from robot_sf.sim import registry as loaded_registry
 
 
+@pytest.fixture(autouse=True)
+def _restore_loaded_registry_after_test():
+    """Restore registry module state after tests that reload it with mocked imports."""
+    yield
+    importlib.reload(loaded_registry)
+
+
 def test_default_backend_registered():
     """TODO docstring. Document this function."""
     backends = loaded_registry.list_backends()

--- a/tests/sim/test_backend_registry.py
+++ b/tests/sim/test_backend_registry.py
@@ -1,11 +1,64 @@
 """TODO docstring. Document this module."""
 
-from robot_sf.sim.registry import get_backend, list_backends
+import importlib
+
+import pytest
+
+from robot_sf.sim import registry as loaded_registry
 
 
 def test_default_backend_registered():
     """TODO docstring. Document this function."""
-    backends = list_backends()
-    assert "fast-pysf" in backends
-    factory = get_backend("fast-pysf")
-    assert callable(factory)
+    backends = loaded_registry.list_backends()
+    assert "dummy" in backends
+    assert callable(loaded_registry.get_backend("dummy"))
+    if "fast-pysf" in backends:
+        assert callable(loaded_registry.get_backend("fast-pysf"))
+
+
+def test_fast_pysf_backend_missing_dependency_is_skipped(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify missing fast-pysf dependencies do not fail registry import."""
+    warnings: list[tuple[object, tuple[object, ...]]] = []
+
+    def _capture_warning(message: object, *args: object, **_: object) -> None:
+        warnings.append((message, args))
+
+    def _missing_dependency_import(
+        name: str,
+        package: str | None = None,
+    ) -> object:
+        if name == "robot_sf.sim.backends.fast_pysf_backend":
+            raise ModuleNotFoundError("No module named 'pysocialforce'", name="pysocialforce")
+        return original_import_module(name, package=package)
+
+    original_import_module = loaded_registry.importlib.import_module
+    monkeypatch.setattr(loaded_registry.importlib, "import_module", _missing_dependency_import)
+    monkeypatch.setattr(loaded_registry.logger, "warning", _capture_warning)
+
+    importlib.reload(loaded_registry)
+
+    assert "fast-pysf" not in loaded_registry.list_backends()
+    assert "dummy" in loaded_registry.list_backends()
+    assert loaded_registry.select_best_backend() == "dummy"
+    assert any(
+        "fast-pysf backend is unavailable/skipped" in str(message)
+        for message, _args in warnings
+    )
+
+
+def test_unexpected_fast_pysf_import_error_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Unexpected fast-pysf import errors should still fail module import."""
+
+    def _unexpected_import_error(
+        name: str,
+        package: str | None = None,
+    ) -> object:
+        if name == "robot_sf.sim.backends.fast_pysf_backend":
+            raise ImportError("Unexpected import failure", name="unexpected_module")
+        return original_import_module(name, package=package)
+
+    original_import_module = loaded_registry.importlib.import_module
+    monkeypatch.setattr(loaded_registry.importlib, "import_module", _unexpected_import_error)
+
+    with pytest.raises(ImportError):
+        importlib.reload(loaded_registry)

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -59,7 +59,7 @@ class TestBackendValidation:
         config = RobotSimulationConfig()
         config.backend = "nonexistent_backend"
 
-        with pytest.raises(KeyError, match="Unknown backend.*Available backends"):
+        with pytest.raises(KeyError, match=r"Unknown backend.*Available backends"):
             _check_backend_valid(config)
 
     def test_valid_backend_accepted(self):

--- a/tests/test_config_validation.py
+++ b/tests/test_config_validation.py
@@ -5,6 +5,7 @@ Validates config validation logic, conflict detection, and resolved config loggi
 
 import pytest
 
+from robot_sf.gym_env import config_validation
 from robot_sf.gym_env.config_validation import (
     _check_backend_valid,
     _check_sensor_names_valid,
@@ -68,6 +69,25 @@ class TestBackendValidation:
 
         # Should not raise
         _check_backend_valid(config)
+
+    def test_optional_fast_pysf_backend_can_use_legacy_fallback(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Missing optional fast-pysf backend is accepted for legacy simulator fallback."""
+        config = RobotSimulationConfig()
+        config.backend = "fast-pysf"
+        monkeypatch.setattr(config_validation, "list_backends", lambda: ["dummy"])
+
+        _check_backend_valid(config)
+
+    def test_non_optional_missing_backend_still_raises(self, monkeypatch: pytest.MonkeyPatch):
+        """Only the canonical optional backend may bypass registry validation."""
+        config = RobotSimulationConfig()
+        config.backend = "nonexistent_backend"
+        monkeypatch.setattr(config_validation, "list_backends", lambda: ["dummy"])
+
+        with pytest.raises(KeyError, match="Unknown backend.*Available backends"):
+            _check_backend_valid(config)
 
 
 class TestSensorValidation:


### PR DESCRIPTION
## Summary
Make fast-pysf backend registration optional when its module/dependency is missing, while preserving fail-fast behavior for unrelated import failures.

## Linked Issues
- Closes #3013

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added optional fast-pysf registration handling in `robot_sf/sim/registry.py`.
- Skips only import failures whose missing module belongs to the fast-pysf backend/dependency path and logs an actionable warning.
- Keeps unexpected import errors re-raised.
- Added focused registry tests for missing optional backend fallback and unexpected import failure propagation.

## Why It Matters
- Added value: importing the simulator registry can still succeed when the optional fast-pysf backend is unavailable.
- Expected impact: better install/import ergonomics while keeping invalid backend states visible.
- Why this is worth merging now: #3013 identified the backend registration import path as a bounded bugfix.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - import/packaging bugfix; no research claim.
- Comparator or baseline, if applicable: NA.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: missing fast-pysf path degrades to dummy backend, unrelated import failures still raise.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3013.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for targeted backend registry proof; CI should run broader smoke.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue with review/CI.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `rtk uv run ruff check robot_sf/sim/registry.py tests/sim/test_backend_registry.py tests/sim/test_backend_selector.py`
  - `rtk uv run pytest tests/sim/test_backend_registry.py tests/sim/test_backend_selector.py -q`
  - `rtk uv run python - <<'PY' ...` normal registry import/list/select smoke.
- Evidence that the change works here: focused tests cover optional fast-pysf dependency skip, dummy backend fallback, and unexpected import error propagation; normal environment still registers/selects `fast-pysf`.
- Benchmarks or smoke tests, if applicable: targeted backend registry smoke only.

## Risks / Rollout
- Compatibility risks: if a future optional fast-pysf dependency has a new module name, the allowlist may need to be extended.
- Failure modes: overly broad import filtering would hide real bugs; tests now guard against unrelated import errors being masked.
- Rollback or fallback plan: revert the registry helper and focused tests.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #3013 contract.
- Any assumptions that need to be preserved: missing optional backend dependencies should degrade; unexpected backend import failures should remain visible.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR link.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: import bugfix with no benchmark, registry, artifact, or paper-facing claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: `_FAST_PYSF_IMPORT_PATHS` is intentionally narrow to avoid masking unrelated import errors.
- Any known limitations: full PR readiness was not run locally; targeted registry tests and ruff passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added legacy fallback support for optional backends when dependencies are unavailable.

* **Bug Fixes**
  * Improved backend validation to gracefully handle missing optional dependencies instead of crashing.
  * Added warning logs when optional backends are unavailable due to missing dependencies.

* **Tests**
  * Enhanced test coverage for conditional backend registration and dependency handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->