### PR TITLE
refactor: type baseline observation conversion

### DIFF
--- a/robot_sf/baselines/dr_mpc.py
+++ b/robot_sf/baselines/dr_mpc.py
@@ -16,7 +16,11 @@ from typing import Any
 
 import numpy as np
 
-from robot_sf.baselines.interface import Observation
+from robot_sf.baselines.interface import (
+    Observation,
+    is_observation_mapping,
+    observation_from_mapping,
+)
 
 
 @dataclass
@@ -132,8 +136,8 @@ class DRMPCPlanner:
         Returns:
             A dictionary action in either velocity or unicycle format.
         """
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        if is_observation_mapping(obs):
+            obs = observation_from_mapping(obs)
 
         if self._policy is None:
             self._policy = self._build_policy()

--- a/robot_sf/baselines/drl_vo.py
+++ b/robot_sf/baselines/drl_vo.py
@@ -24,7 +24,11 @@ try:
 except ImportError:  # pragma: no cover - envs without PyTorch
     torch = None  # type: ignore[assignment]
 
-from robot_sf.baselines.interface import Observation
+from robot_sf.baselines.interface import (
+    Observation,
+    is_observation_mapping,
+    observation_from_mapping,
+)
 from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_path_value
 from robot_sf.common.errors import raise_fatal_with_remedy, warn_soft_degrade
 from robot_sf.common.math_utils import wrap_angle_pi
@@ -204,8 +208,8 @@ class DrlVoPlanner:
         Returns:
             Action dictionary in the configured action space.
         """
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        if is_observation_mapping(obs):
+            obs = observation_from_mapping(obs)
         if not isinstance(obs, Observation):
             raise TypeError(f"Unsupported observation type: {type(obs)}")
 

--- a/robot_sf/baselines/interface.py
+++ b/robot_sf/baselines/interface.py
@@ -8,7 +8,19 @@ SocialForce, PPO, Random, and future baselines.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Protocol
+from typing import TYPE_CHECKING, Any, Protocol, TypedDict, TypeGuard, cast
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+
+class ObservationKwargs(TypedDict, total=False):
+    """Keyword payload accepted by the planner-facing Observation constructor."""
+
+    dt: float
+    robot: dict[str, Any]
+    agents: list[dict[str, Any]]
+    obstacles: list[Any]
 
 
 @dataclass
@@ -24,6 +36,28 @@ class Observation:
     robot: dict[str, Any]
     agents: list[dict[str, Any]]
     obstacles: list[Any] = field(default_factory=list)
+
+
+def observation_from_mapping(obs: Mapping[str, Any]) -> Observation:
+    """Build an Observation from a dict-like benchmark payload.
+
+    Missing optional obstacles use the dataclass default, while missing required keys
+    or unexpected keys still raise TypeError.
+
+    Returns:
+        Observation: A planner-facing observation container.
+    """
+    payload = obs if isinstance(obs, dict) else dict(obs)
+    return Observation(**cast("ObservationKwargs", payload))
+
+
+def is_observation_mapping(obs: Observation | dict[str, Any]) -> TypeGuard[dict[str, Any]]:
+    """Return whether an observation payload is a mutable mapping input.
+
+    Returns:
+        bool: True when the payload should be converted through ``observation_from_mapping``.
+    """
+    return isinstance(obs, dict)
 
 
 @dataclass(frozen=True)

--- a/robot_sf/baselines/ppo.py
+++ b/robot_sf/baselines/ppo.py
@@ -41,7 +41,11 @@ try:  # Lazy import; not required for type-check only
 except ImportError:  # pragma: no cover - envs without SB3 installed
     PPO = None  # type: ignore
 
-from robot_sf.baselines.interface import Observation
+from robot_sf.baselines.interface import (
+    Observation,
+    is_observation_mapping,
+    observation_from_mapping,
+)
 from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_path_value
 from robot_sf.common.errors import raise_fatal_with_remedy, warn_soft_degrade
 from robot_sf.models import resolve_model_path
@@ -259,11 +263,11 @@ class PPOPlanner:
         Returns:
             Action dict in either velocity or unicycle format.
         """
-        if isinstance(obs, dict) and self._uses_dict_observation():
+        if is_observation_mapping(obs) and self._uses_dict_observation():
             return self._step_dict_obs(obs)
 
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        if is_observation_mapping(obs):
+            obs = observation_from_mapping(obs)
         assert isinstance(obs, Observation)
 
         # Try model predict

--- a/robot_sf/baselines/random_policy.py
+++ b/robot_sf/baselines/random_policy.py
@@ -13,7 +13,11 @@ from typing import Any
 
 import numpy as np
 
-from robot_sf.baselines.interface import Observation
+from robot_sf.baselines.interface import (
+    Observation,
+    is_observation_mapping,
+    observation_from_mapping,
+)
 
 
 @dataclass
@@ -91,8 +95,8 @@ class RandomPlanner:
         Returns:
             Action dict in configured action space.
         """
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        if is_observation_mapping(obs):
+            obs = observation_from_mapping(obs)
 
         if self.config.mode == "velocity":
             # Sample vx, vy uniformly in a disk scaled to v_max

--- a/robot_sf/baselines/sac.py
+++ b/robot_sf/baselines/sac.py
@@ -14,7 +14,11 @@ try:
 except ImportError:  # pragma: no cover - runtime-only dependency
     SAC = None  # type: ignore
 
-from robot_sf.baselines.interface import Observation
+from robot_sf.baselines.interface import (
+    Observation,
+    is_observation_mapping,
+    observation_from_mapping,
+)
 from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_path_value
 from robot_sf.common.errors import raise_fatal_with_remedy, warn_soft_degrade
 from robot_sf.models import resolve_model_path
@@ -158,10 +162,10 @@ class SACPlanner:
         Returns:
             dict[str, float]: SAC action in the configured output space.
         """
-        if isinstance(obs, dict) and self._uses_dict_observation():
+        if is_observation_mapping(obs) and self._uses_dict_observation():
             return self._step_dict_obs(obs)
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        if is_observation_mapping(obs):
+            obs = observation_from_mapping(obs)
         if not isinstance(obs, Observation):
             raise TypeError(f"Expected Observation or dict input, got {type(obs).__name__}")
         try:

--- a/robot_sf/baselines/sicnav.py
+++ b/robot_sf/baselines/sicnav.py
@@ -20,7 +20,11 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
-from robot_sf.baselines.interface import Observation
+from robot_sf.baselines.interface import (
+    Observation,
+    is_observation_mapping,
+    observation_from_mapping,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
@@ -234,8 +238,8 @@ class SICNavPlanner:
         Returns:
             A dictionary action in either velocity or unicycle format.
         """
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        if is_observation_mapping(obs):
+            obs = observation_from_mapping(obs)
 
         if self._policy is None:
             self._policy = self._build_policy()

--- a/robot_sf/baselines/social_force.py
+++ b/robot_sf/baselines/social_force.py
@@ -27,7 +27,11 @@ from pysocialforce.config import (
 )
 from pysocialforce.config import SocialForceConfig as PySFSocialForceConfig
 
-from robot_sf.baselines.interface import Observation
+from robot_sf.baselines.interface import (
+    Observation,
+    is_observation_mapping,
+    observation_from_mapping,
+)
 from robot_sf.sim.fast_pysf_wrapper import FastPysfWrapper
 
 if TYPE_CHECKING:
@@ -256,8 +260,8 @@ class SocialForcePlanner(BasePolicy):
         Returns:
             Action dict in configured action space.
         """
-        if isinstance(obs, dict):
-            obs = Observation(**obs)  # type: ignore[arg-type]
+        if is_observation_mapping(obs):
+            obs = observation_from_mapping(obs)
         assert isinstance(obs, Observation)
 
         robot_pos = np.asarray(obs.robot["position"], dtype=float)

--- a/tests/unit/test_planner_interface.py
+++ b/tests/unit/test_planner_interface.py
@@ -8,9 +8,42 @@ import numpy as np
 import pytest
 
 from robot_sf.baselines import get_baseline
-from robot_sf.baselines.interface import ActionContract, ObservationContract, PlannerMetadata
+from robot_sf.baselines.interface import (
+    ActionContract,
+    ObservationContract,
+    PlannerMetadata,
+    observation_from_mapping,
+)
 from robot_sf.baselines.social_force import Observation
 from robot_sf.benchmark.algorithm_metadata import planner_contract_for_algorithm
+
+
+class TestObservationConversion:
+    """Tests for the shared dict-to-Observation conversion boundary."""
+
+    def test_observation_from_mapping_uses_obstacles_default(self) -> None:
+        """Dict payloads without obstacles should use the Observation default."""
+        obs = observation_from_mapping(
+            {
+                "dt": 0.1,
+                "robot": {"position": [0.0, 0.0]},
+                "agents": [{"position": [1.0, 0.0]}],
+            },
+        )
+
+        assert obs.obstacles == []
+
+    def test_observation_from_mapping_rejects_unexpected_keys(self) -> None:
+        """Unexpected keys should still fail like Observation(**payload)."""
+        with pytest.raises(TypeError, match="unexpected keyword argument"):
+            observation_from_mapping(
+                {
+                    "dt": 0.1,
+                    "robot": {"position": [0.0, 0.0]},
+                    "agents": [],
+                    "unexpected": True,
+                },
+            )
 
 
 class TestPlannerInterfaceCompliance:


### PR DESCRIPTION
## Summary

Closes #3011.

- Added a shared `observation_from_mapping` conversion boundary plus `is_observation_mapping` TypeGuard in `robot_sf.baselines.interface`.
- Replaced the seven repeated `Observation(**obs)  # type: ignore[arg-type]` baseline adapter call sites with the shared typed path.
- Added unit coverage for default obstacle handling and unexpected-key constructor parity.

## Validation

- `uv run ruff check robot_sf/baselines tests/unit/test_planner_interface.py`
- `uv run ruff format --check robot_sf/baselines tests/unit/test_planner_interface.py`
- `uv run pytest tests/unit/test_planner_interface.py tests/baselines/test_random_policy.py tests/baselines/test_social_force.py tests/baselines/test_external_mpc_wrappers.py tests/baselines/test_ppo_planner.py tests/baselines/test_sac_planner.py tests/planner/test_drl_vo.py -q -k 'not runner_integration_policy'` -> 120 passed, 1 deselected
- `uvx ty check robot_sf/baselines/interface.py tests/unit/test_planner_interface.py --exit-zero` -> clean
- `uv run python scripts/dev/run_compact_validation.py -- scripts/dev/ci_driver.sh typecheck` -> advisory full-repo typecheck exit 0 with pre-existing unrelated findings

Note: running the same targeted pytest set with `tests/planner/test_drl_vo.py::test_drl_vo_runner_integration_policy` included printed `121 passed, 1 warning`, then hung during multiprocessing atexit cleanup and was interrupted. The final targeted run excluded that shutdown-hanging node.

## Downstream Propagation

NA - low-risk typing cleanup in baseline adapter input normalization. No benchmark claims, artifact registry entries, or context notes need propagation.

## Research Result Guidance

NA - support/refactor PR only; no research claim, comparator, benchmark result, or paper-facing conclusion is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced observation handling consistency across multiple baseline planners, allowing more flexible input format support.
  * Introduced shared utility functions for observation payload conversion and validation.

* **Tests**
  * Added comprehensive test coverage for observation conversion logic, including validation of default values and error handling for unexpected inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->