### PR TITLE
refactor: extract map runner identity helpers

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -43,6 +43,16 @@ from robot_sf.benchmark.latency_stress import (
     not_available_latency_metrics,
 )
 from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_artifacts
+from robot_sf.benchmark.map_runner_identity import compute_map_episode_id as _compute_map_episode_id
+from robot_sf.benchmark.map_runner_identity import resolve_seed_list as _resolve_seed_list
+from robot_sf.benchmark.map_runner_identity import (
+    scenario_identity_payload as _scenario_identity_payload,
+)
+from robot_sf.benchmark.map_runner_identity import (
+    scenario_with_episode_seed_defaults as _scenario_with_episode_seed_defaults,
+)
+from robot_sf.benchmark.map_runner_identity import select_seeds as _select_seeds
+from robot_sf.benchmark.map_runner_identity import suite_key as _suite_key
 from robot_sf.benchmark.metrics import (
     EpisodeData,
     compute_all_metrics,
@@ -2693,128 +2703,6 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
     return _policy, meta
 
 
-def _resolve_seed_list(path: Path) -> dict[str, list[int]]:
-    """Load named benchmark seed lists from YAML.
-
-    Returns:
-        dict[str, list[int]]: Seed lists keyed by suite name.
-    """
-    if not path.exists():
-        return {}
-    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    if not isinstance(data, dict):
-        return {}
-    return {str(k): [int(s) for s in v] for k, v in data.items() if isinstance(v, list)}
-
-
-def _suite_key(scenario_path: Path) -> str:
-    """Infer the seed-suite key from a scenario config filename.
-
-    Returns:
-        str: Suite key used for seed-list lookup.
-    """
-    stem = scenario_path.stem.lower()
-    if "classic" in stem:
-        return "classic_interactions"
-    if "francis" in stem:
-        return "francis2023"
-    return "default"
-
-
-def _select_seeds(
-    scenario: dict[str, Any],
-    *,
-    suite_seeds: dict[str, list[int]],
-    suite_key: str,
-) -> list[int]:
-    """Resolve per-scenario seeds with suite and default fallbacks.
-
-    Returns:
-        list[int]: Seeds to run for the scenario.
-    """
-    seeds = scenario.get("seeds")
-    if isinstance(seeds, list) and seeds:
-        return [int(s) for s in seeds]
-    if suite_seeds.get(suite_key):
-        return list(suite_seeds[suite_key])
-    if suite_seeds.get("default"):
-        return list(suite_seeds["default"])
-    return [0]
-
-
-def _scenario_identity_payload(  # noqa: PLR0913
-    scenario: dict[str, Any],
-    *,
-    algo: str,
-    algo_config: dict[str, Any],
-    horizon: int | None,
-    dt: float | None,
-    record_forces: bool,
-    observation_mode: str | None = None,
-    observation_level: str | None = None,
-    benchmark_track: str | None = None,
-    track_schema_version: str | None = None,
-    observation_noise: dict[str, Any] | None = None,
-    synthetic_actuation_profile: dict[str, Any] | None = None,
-    latency_stress_profile: dict[str, Any] | None = None,
-    record_simulation_step_trace: bool = False,
-) -> dict[str, Any]:
-    """Build the canonical scenario payload used for episode identity.
-
-    Resume safety relies on using the same identity dimensions at write-time and
-    skip-time. For map runs this includes algorithm and run-shaping options.
-
-    Returns:
-        dict[str, Any]: Identity payload consumed by ``compute_episode_id``.
-    """
-    payload = {key: value for key, value in scenario.items() if key not in {"seed", "seeds"}}
-    scenario_id = (
-        scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or "unknown"
-    )
-    payload.setdefault("id", scenario_id)
-    payload["algo"] = str(algo)
-    payload["algo_config_hash"] = _config_hash(algo_config)
-    payload["record_forces"] = bool(record_forces)
-    if observation_mode is not None:
-        payload["observation_mode"] = str(observation_mode)
-    if observation_level is not None:
-        payload["observation_level"] = str(observation_level)
-    if benchmark_track is not None:
-        payload["benchmark_track"] = str(benchmark_track)
-    if track_schema_version is not None:
-        payload["track_schema_version"] = str(track_schema_version)
-    noise_spec = normalize_observation_noise_spec(observation_noise)
-    if bool(noise_spec["enabled"]):
-        payload["observation_noise_profile"] = str(noise_spec["profile"])
-        payload["observation_noise_hash"] = observation_noise_hash(noise_spec)
-    if synthetic_actuation_profile is not None:
-        payload["synthetic_actuation_profile"] = dict(synthetic_actuation_profile)
-    if latency_stress_profile is not None:
-        payload["latency_stress_profile"] = dict(latency_stress_profile)
-    payload["record_simulation_step_trace"] = bool(record_simulation_step_trace)
-    if horizon is not None and int(horizon) > 0:
-        payload["run_horizon"] = int(horizon)
-    if dt is not None and float(dt) > 0.0:
-        payload["run_dt"] = float(dt)
-    return payload
-
-
-def _compute_map_episode_id(identity_payload: dict[str, Any], seed: int) -> str:
-    """Return a map-runner episode id scoped to algorithm + run dimensions.
-
-    The default benchmark ``compute_episode_id`` uses ``<scenario_id>--<seed>``.
-    Map-batch resume needs richer scoping for mixed algorithm/config runs.
-    """
-    scenario_id = (
-        identity_payload.get("id")
-        or identity_payload.get("name")
-        or identity_payload.get("scenario_id")
-        or "unknown"
-    )
-    identity_hash = _config_hash(identity_payload)
-    return f"{scenario_id}--{seed}--{identity_hash}"
-
-
 def _first_float(value: Any, default: float = 0.0) -> float:
     """Return the first finite numeric value from scalar-or-sequence inputs."""
 
@@ -4743,24 +4631,6 @@ def _run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         record["track_schema_version"] = track_schema_version
     ensure_metric_parameters(record)
     return record
-
-
-def _scenario_with_episode_seed_defaults(
-    scenario: dict[str, Any],
-    *,
-    seed: int,
-) -> dict[str, Any]:
-    """Return a scenario copy with seed-derived defaults for stochastic subcomponents.
-
-    Some scenario-level generators use their own NumPy ``default_rng`` instances.  When those
-    fields are left unset they bypass the episode seed and make benchmark rows depend on process
-    history.  Fill only missing values here so explicit scenario provenance remains unchanged.
-    """
-    updated = deepcopy(scenario)
-    sim_config = updated.setdefault("simulation_config", {})
-    if isinstance(sim_config, dict) and sim_config.get("route_spawn_seed") is None:
-        sim_config["route_spawn_seed"] = int(seed)
-    return updated
 
 
 def _write_validated(out_path: Path, schema: dict[str, Any], record: dict[str, Any]) -> None:

--- a/robot_sf/benchmark/map_runner_identity.py
+++ b/robot_sf/benchmark/map_runner_identity.py
@@ -1,0 +1,157 @@
+"""Seed and resume identity helpers for map-runner benchmark batches."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.observation_noise import (
+    normalize_observation_noise_spec,
+    observation_noise_hash,
+)
+from robot_sf.benchmark.utils import _config_hash
+
+
+def resolve_seed_list(path: Path) -> dict[str, list[int]]:
+    """Load named benchmark seed lists from YAML.
+
+    Returns:
+        dict[str, list[int]]: Seed lists keyed by suite name.
+    """
+    if not path.exists():
+        return {}
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): [int(s) for s in v] for k, v in data.items() if isinstance(v, list)}
+
+
+def suite_key(scenario_path: Path) -> str:
+    """Infer the seed-suite key from a scenario config filename.
+
+    Returns:
+        str: Suite key used for seed-list lookup.
+    """
+    stem = scenario_path.stem.lower()
+    if "classic" in stem:
+        return "classic_interactions"
+    if "francis" in stem:
+        return "francis2023"
+    return "default"
+
+
+def select_seeds(
+    scenario: dict[str, Any],
+    *,
+    suite_seeds: dict[str, list[int]],
+    suite_key: str,
+) -> list[int]:
+    """Resolve per-scenario seeds with suite and default fallbacks.
+
+    Returns:
+        list[int]: Seeds to run for the scenario.
+    """
+    seeds = scenario.get("seeds")
+    if isinstance(seeds, list) and seeds:
+        return [int(s) for s in seeds]
+    if suite_seeds.get(suite_key):
+        return list(suite_seeds[suite_key])
+    if suite_seeds.get("default"):
+        return list(suite_seeds["default"])
+    return [0]
+
+
+def scenario_identity_payload(  # noqa: PLR0913
+    scenario: dict[str, Any],
+    *,
+    algo: str,
+    algo_config: dict[str, Any],
+    horizon: int | None,
+    dt: float | None,
+    record_forces: bool,
+    observation_mode: str | None = None,
+    observation_level: str | None = None,
+    benchmark_track: str | None = None,
+    track_schema_version: str | None = None,
+    observation_noise: dict[str, Any] | None = None,
+    synthetic_actuation_profile: dict[str, Any] | None = None,
+    latency_stress_profile: dict[str, Any] | None = None,
+    record_simulation_step_trace: bool = False,
+) -> dict[str, Any]:
+    """Build the canonical scenario payload used for episode identity.
+
+    Resume safety relies on using the same identity dimensions at write-time and
+    skip-time. For map runs this includes algorithm and run-shaping options.
+
+    Returns:
+        dict[str, Any]: Identity payload consumed by ``compute_map_episode_id``.
+    """
+    payload = {key: value for key, value in scenario.items() if key not in {"seed", "seeds"}}
+    scenario_id = (
+        scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or "unknown"
+    )
+    payload.setdefault("id", scenario_id)
+    payload["algo"] = str(algo)
+    payload["algo_config_hash"] = _config_hash(algo_config)
+    payload["record_forces"] = bool(record_forces)
+    if observation_mode is not None:
+        payload["observation_mode"] = str(observation_mode)
+    if observation_level is not None:
+        payload["observation_level"] = str(observation_level)
+    if benchmark_track is not None:
+        payload["benchmark_track"] = str(benchmark_track)
+    if track_schema_version is not None:
+        payload["track_schema_version"] = str(track_schema_version)
+    noise_spec = normalize_observation_noise_spec(observation_noise)
+    if bool(noise_spec["enabled"]):
+        payload["observation_noise_profile"] = str(noise_spec["profile"])
+        payload["observation_noise_hash"] = observation_noise_hash(noise_spec)
+    if synthetic_actuation_profile is not None:
+        payload["synthetic_actuation_profile"] = dict(synthetic_actuation_profile)
+    if latency_stress_profile is not None:
+        payload["latency_stress_profile"] = dict(latency_stress_profile)
+    payload["record_simulation_step_trace"] = bool(record_simulation_step_trace)
+    if horizon is not None and int(horizon) > 0:
+        payload["run_horizon"] = int(horizon)
+    if dt is not None and float(dt) > 0.0:
+        payload["run_dt"] = float(dt)
+    return payload
+
+
+def compute_map_episode_id(identity_payload: dict[str, Any], seed: int) -> str:
+    """Return a map-runner episode id scoped to algorithm + run dimensions.
+
+    The default benchmark ``compute_episode_id`` uses ``<scenario_id>--<seed>``.
+    Map-batch resume needs richer scoping for mixed algorithm/config runs.
+    """
+    scenario_id = (
+        identity_payload.get("id")
+        or identity_payload.get("name")
+        or identity_payload.get("scenario_id")
+        or "unknown"
+    )
+    identity_hash = _config_hash(identity_payload)
+    return f"{scenario_id}--{seed}--{identity_hash}"
+
+
+def scenario_with_episode_seed_defaults(
+    scenario: dict[str, Any],
+    *,
+    seed: int,
+) -> dict[str, Any]:
+    """Return a scenario copy with seed-derived defaults for stochastic subcomponents.
+
+    Some scenario-level generators use their own NumPy ``default_rng`` instances. When those
+    fields are left unset they bypass the episode seed and make benchmark rows depend on process
+    history. Fill only missing values here so explicit scenario provenance remains unchanged.
+    """
+    updated = deepcopy(scenario)
+    sim_config = updated.setdefault("simulation_config", {})
+    if isinstance(sim_config, dict) and sim_config.get("route_spawn_seed") is None:
+        sim_config["route_spawn_seed"] = int(seed)
+    return updated


### PR DESCRIPTION
## Summary

Refs #3006 as the first behavior-preserving extraction slice.

- Added `robot_sf.benchmark.map_runner_identity` for seed selection, resume identity payloads, map episode IDs, and seed-derived scenario defaults.
- Re-imported those helpers into `map_runner.py` under the existing private names so current tests and downstream private hooks keep working.
- Reduced `robot_sf/benchmark/map_runner.py` from 5,625 to 5,495 lines without changing payload shape, hashing, seed fallback, action conversion, metrics, or schemas.

## Validation

- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_identity.py tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_map_runner_result_provenance.py tests/benchmark/test_map_runner_utils.py`
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_identity.py tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_map_runner_result_provenance.py tests/benchmark/test_map_runner_utils.py`
- `uv run pytest tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_map_runner_result_provenance.py tests/benchmark/test_map_runner_utils.py -q -k 'seed_selection or resolve_seed or resume_identity or map_result_provenance'` -> 14 passed, 108 deselected
- `uv run pytest tests/test_runner_smoke.py tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_map_runner_result_provenance.py -q` -> 18 passed
- `uv run pytest tests/benchmark/test_map_runner_utils.py -q` -> 108 passed

## Delegation

Read-only Spark scout identified the seed/resume identity helpers as the safest first extraction boundary and recommended `robot_sf/benchmark/map_runner_identity.py`. Accepted.

## Benchmark Safety

Move-only refactor for identity helpers. Existing private names remain available from `map_runner.py`; no benchmark semantics, metric definitions, scenario distributions, output schema, or provenance fields are intentionally changed.

## Downstream Propagation

NA for this slice - no benchmark result or artifact claim changes. #3006 should remain open for subsequent extraction slices such as diagnostic metadata helpers or env/action helper layers.

## Research Result Guidance

NA - maintenance/refactor only; no research claim, comparator, or benchmark conclusion is introduced.
