### PR TITLE
fix: harden map runner trace coercions

### DIFF
--- a/robot_sf/benchmark/map_runner_trace.py
+++ b/robot_sf/benchmark/map_runner_trace.py
@@ -33,6 +33,22 @@ def _first_float(value: Any, default: float = 0.0) -> float:
     return default
 
 
+def _metadata_bool(value: Any, *, default: bool = False) -> bool:
+    """Return a conservative boolean for JSON/YAML metadata flags."""
+    if isinstance(value, bool | np.bool_):
+        return bool(value)
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"1", "true", "yes", "y", "on"}:
+            return True
+        if normalized in {"0", "false", "no", "n", "off", ""}:
+            return False
+        return default
+    if isinstance(value, int | np.integer):
+        return bool(value)
+    return default
+
+
 def _observation_heading(obs: Any, *, default: float = 0.0) -> float:
     """Extract robot heading from structured or flat observations.
 
@@ -334,12 +350,14 @@ def _signal_state_trace_payload(signal_state: Any, intent_phase: str) -> dict[st
         "conflict_zone_id": str(signal_state.get("conflict_zone_id") or "unknown_conflict_zone"),
         "phase": str(matching_phase.get("phase") or "unknown"),
         "intent_phase": intent_phase,
-        "robot_right_of_way": bool(matching_phase.get("robot_right_of_way", False)),
-        "pedestrian_right_of_way": bool(matching_phase.get("pedestrian_right_of_way", False)),
+        "robot_right_of_way": _metadata_bool(matching_phase.get("robot_right_of_way", False)),
+        "pedestrian_right_of_way": _metadata_bool(
+            matching_phase.get("pedestrian_right_of_way", False)
+        ),
         "legality_state": str(matching_phase.get("legality_state") or "unknown"),
-        "planner_observable": bool(signal_state.get("planner_observable", False)),
+        "planner_observable": _metadata_bool(signal_state.get("planner_observable", False)),
         "observation_mode": str(signal_state.get("observation_mode") or "trace_metadata_only"),
-        "benchmark_evidence": bool(signal_state.get("benchmark_evidence", False)),
+        "benchmark_evidence": _metadata_bool(signal_state.get("benchmark_evidence", False)),
         "claim_boundary": str(
             signal_state.get("claim_boundary")
             or "Proxy signal-state metadata only; not benchmark evidence."
@@ -405,8 +423,8 @@ def _signal_state_promotion_contract(signal_state: Any) -> dict[str, Any]:
     schema_version = str(signal_state.get("schema_version") or "")
     status = str(signal_state.get("status") or "")
     observation_mode = str(signal_state.get("observation_mode") or "")
-    planner_observable = bool(signal_state.get("planner_observable", False))
-    benchmark_evidence = bool(signal_state.get("benchmark_evidence", False))
+    planner_observable = _metadata_bool(signal_state.get("planner_observable", False))
+    benchmark_evidence = _metadata_bool(signal_state.get("benchmark_evidence", False))
     is_observable = (
         schema_version == _SIGNAL_STATE_OBSERVABLE_SCHEMA
         and status == _SIGNAL_STATE_OBSERVABLE_STATUS
@@ -663,11 +681,11 @@ def _intent_conditioned_behavior_summary(
                 "conflict_zone_id": str(
                     signal_state.get("conflict_zone_id") or "unknown_conflict_zone"
                 ),
-                "planner_observable": bool(signal_state.get("planner_observable", False)),
+                "planner_observable": _metadata_bool(signal_state.get("planner_observable", False)),
                 "observation_mode": str(
                     signal_state.get("observation_mode") or "trace_metadata_only"
                 ),
-                "benchmark_evidence": bool(signal_state.get("benchmark_evidence", False)),
+                "benchmark_evidence": _metadata_bool(signal_state.get("benchmark_evidence", False)),
                 "claim_boundary": "proxy_diagnostic",
             }
         )
@@ -740,7 +758,7 @@ def _vru_diagnostic_summary(
     }
 
 
-def _command_action_payload(command: Any) -> dict[str, float]:
+def _command_action_payload(command: Any) -> dict[str, Any]:
     """Normalize planner commands to trace-export selected_action fields.
 
     Returns:
@@ -749,6 +767,12 @@ def _command_action_payload(command: Any) -> dict[str, float]:
 
     if isinstance(command, np.ndarray):
         command = command.tolist()
+    if isinstance(command, dict) and command.get("command_kind") == "holonomic_vxy_world":
+        return {
+            "command_kind": "holonomic_vxy_world",
+            "vx": _first_float(command.get("vx")),
+            "vy": _first_float(command.get("vy")),
+        }
     if isinstance(command, (list, tuple)) and len(command) >= 2:
         return {
             "linear_velocity": _first_float(command[0]),

--- a/tests/benchmark/test_issue_2527_waiting_crossing_fixture.py
+++ b/tests/benchmark/test_issue_2527_waiting_crossing_fixture.py
@@ -220,6 +220,47 @@ def test_proxy_signal_state_cannot_be_interpreted_as_planner_observable() -> Non
     assert contract["benchmark_evidence"] is False
 
 
+def test_signal_state_string_false_flags_fail_closed() -> None:
+    """String-like false values must not promote proxy metadata into benchmark evidence."""
+    contract = _signal_state_promotion_contract(
+        {
+            "schema_version": "signal-state-observable.v1",
+            "status": "planner_observable_signal_state",
+            "observation_mode": "planner_observable",
+            "planner_observable": "false",
+            "benchmark_evidence": "0",
+        }
+    )
+
+    assert contract["contract_state"] == "proxy_diagnostic"
+    assert contract["benchmark_evidence"] is False
+
+    proxy = _signal_state_proxy_wrapper(
+        {
+            "phase_timeline": [
+                {
+                    "phase": "pedestrian_walk_robot_red",
+                    "intent_phase": "crossing",
+                    "robot_right_of_way": "false",
+                    "pedestrian_right_of_way": np.bool_(True),
+                    "legality_state": "pedestrian_crossing_allowed",
+                }
+            ],
+            "planner_observable": "false",
+            "benchmark_evidence": "0",
+        },
+        "crossing",
+        "waiting_then_crossing",
+        "authored_scenario_metadata",
+    )
+
+    assert proxy is not None
+    assert proxy["robot_right_of_way"] is False
+    assert proxy["pedestrian_right_of_way"] is True
+    assert proxy["planner_observable"] is False
+    assert proxy["benchmark_evidence"] is False
+
+
 def test_explicit_observable_signal_state_names_planner_consumed_fields() -> None:
     """Only the explicit observable schema/status can promote signal fields to planner inputs."""
     contract = _signal_state_promotion_contract(

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -19,6 +19,7 @@ from robot_sf.benchmark.map_runner import (
     _apply_planner_selector_v2_context,
     _build_policy,
     _build_socnav_config,
+    _command_action_payload,
     _default_robot_command_space,
     _extract_ppo_pedestrians,
     _finalize_feasibility_metadata,
@@ -83,6 +84,23 @@ class _KinematicsStub:
         """Return empty kinematics diagnostics for the stub."""
         del command, projected
         return {}
+
+
+def test_command_action_payload_preserves_structured_holonomic_trace_fields() -> None:
+    """Structured holonomic commands should keep x/y velocity in trace selected_action."""
+    payload = _command_action_payload(
+        {
+            "command_kind": "holonomic_vxy_world",
+            "vx": 0.6,
+            "vy": -0.2,
+        }
+    )
+
+    assert payload == {
+        "command_kind": "holonomic_vxy_world",
+        "vx": pytest.approx(0.6),
+        "vy": pytest.approx(-0.2),
+    }
 
 
 def test_parse_algo_config_validates_yaml(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Preserve structured `holonomic_vxy_world` command dictionaries in trace `selected_action` payloads.
- Parse signal-state boolean metadata fail-closed so string-like false values do not promote proxy metadata into benchmark evidence.
- Add focused regression tests for both review findings from #3039.

Closes #3040

## Validation
- Red tests before fix: `uv run pytest tests/benchmark/test_map_runner_utils.py::test_command_action_payload_preserves_structured_holonomic_trace_fields tests/benchmark/test_issue_2527_waiting_crossing_fixture.py::test_signal_state_string_false_flags_fail_closed -q` failed for the intended old behavior.
- `uv run pytest tests/benchmark/test_map_runner_utils.py::test_command_action_payload_preserves_structured_holonomic_trace_fields tests/benchmark/test_issue_2527_waiting_crossing_fixture.py::test_signal_state_string_false_flags_fail_closed -q`
- `uv run ruff check robot_sf/benchmark/map_runner_trace.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py`
- `uv run ruff format --check robot_sf/benchmark/map_runner_trace.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py`
- `uv run pytest tests/benchmark/test_issue_2527_waiting_crossing_fixture.py tests/benchmark/test_map_runner_utils.py -q`
- `uv run pytest tests/benchmark/test_issue_2526_cyclist_vru_smoke.py tests/benchmark/test_issue_2727_fast_bicycle_actor.py tests/benchmark/test_signalized_crossing_benchmark_manifest.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py -q`
- `git diff --check`

## Downstream Propagation
NA - targeted trace metadata helper fix; no schema files, benchmark reports, model provenance, or durable artifacts changed.

## Research Result Guidance
NA - correctness fix for trace metadata serialization/coercion; no new benchmark result or research claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved robustness of boolean metadata value handling to accept various input formats (strings, integers, and native boolean types).
  * Added support for holonomic velocity commands (`vx`/`vy`) in action payloads.

* **Tests**
  * Expanded test coverage for metadata value normalization and holonomic command handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->