### PR TITLE
refactor: extract map runner action helpers

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -42,6 +42,20 @@ from robot_sf.benchmark.latency_stress import (
     not_available_latency_metrics,
 )
 from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_artifacts
+from robot_sf.benchmark.map_runner_actions import DEFAULT_KINEMATICS as _DEFAULT_KINEMATICS
+from robot_sf.benchmark.map_runner_actions import (
+    command_xy_payload as _command_xy_payload,  # noqa: F401 - compatibility re-export for tests.
+)
+from robot_sf.benchmark.map_runner_actions import (
+    policy_command_to_env_action as _policy_command_to_env_action,
+)
+from robot_sf.benchmark.map_runner_actions import robot_kinematics_label as _robot_kinematics_label
+from robot_sf.benchmark.map_runner_actions import robot_max_speed as _robot_max_speed
+from robot_sf.benchmark.map_runner_actions import (
+    scenario_robot_kinematics_label as _scenario_robot_kinematics_label,
+)
+from robot_sf.benchmark.map_runner_actions import stack_ped_positions as _stack_ped_positions
+from robot_sf.benchmark.map_runner_actions import vel_and_acc as _vel_and_acc
 from robot_sf.benchmark.map_runner_env import (
     apply_active_observation_mode_to_env_config as _apply_active_observation_mode_to_env_config,
 )
@@ -127,7 +141,6 @@ from robot_sf.planner.adaptive_proxemic_selector import (
     AdaptiveProxemicSelectorAdapter,
     build_adaptive_proxemic_selector_config,
 )
-from robot_sf.planner.classic_planner_adapter import PlannerActionAdapter
 from robot_sf.planner.crowdnav_height import (
     CrowdNavHeightAdapter,
     build_crowdnav_height_config,
@@ -237,13 +250,10 @@ from robot_sf.planner.topology_guided_local_policy import (
     TopologyGuidedHybridRulePlannerAdapter,
     build_topology_guided_local_policy_config,
 )
-from robot_sf.robot.action_adapters import holonomic_to_diff_drive_action
 from robot_sf.training.scenario_loader import load_scenarios
 
 if TYPE_CHECKING:
     from collections.abc import Callable
-
-    from robot_sf.gym_env.unified_config import RobotSimulationConfig
 
 
 _SOCNAV_ALGO_KEYS = {
@@ -295,7 +305,6 @@ _PPO_PAPER_REQUIRED_PROVENANCE = (
     "normalization_id",
     "deterministic_seed_set",
 )
-_DEFAULT_KINEMATICS = "differential_drive"
 _STRICT_LEARNED_POLICY_PROFILES = {"baseline-safe", "paper-baseline"}
 _PPO_ALLOWED_OBS_MODES = {"vector", "dict", "native_dict", "multi_input"}
 _PPO_ALLOWED_ACTION_SPACES = {"velocity", "unicycle"}
@@ -2745,200 +2754,6 @@ def _validate_behavior_sanity(scenario: dict[str, Any]) -> list[str]:
                     break
 
     return errors
-
-
-def _robot_kinematics_label(config: RobotSimulationConfig) -> str:
-    """Derive the runtime robot kinematics label from simulation config.
-
-    Returns:
-        Canonical kinematics label used in benchmark metadata.
-    """
-    robot_cfg = getattr(config, "robot_config", None)
-    if robot_cfg is None:
-        return _DEFAULT_KINEMATICS
-    cls_name = robot_cfg.__class__.__name__.lower()
-    if "bicycle" in cls_name:
-        return "bicycle_drive"
-    if "differential" in cls_name:
-        return "differential_drive"
-    if "holonomic" in cls_name or "omni" in cls_name:
-        return "holonomic"
-    return cls_name or _DEFAULT_KINEMATICS
-
-
-def _robot_max_speed(config: RobotSimulationConfig) -> float | None:
-    """Extract a positive robot max-speed setting from simulation config if available.
-
-    Returns:
-        Configured positive max speed, or ``None`` when not available.
-    """
-    robot_cfg = getattr(config, "robot_config", None)
-    if robot_cfg is None:
-        return None
-    for attr in ("max_linear_speed", "max_velocity", "max_speed"):
-        value = getattr(robot_cfg, attr, None)
-        if isinstance(value, (int, float)) and float(value) > 0:
-            return float(value)
-    return None
-
-
-def _scenario_robot_kinematics_label(scenario: dict[str, Any]) -> str:
-    """Derive the scenario-declared robot kinematics label from scenario metadata.
-
-    Returns:
-        Canonical kinematics label inferred from scenario robot configuration fields.
-    """
-    robot_cfg = scenario.get("robot_config")
-    if not isinstance(robot_cfg, dict):
-        return _DEFAULT_KINEMATICS
-    raw = str(robot_cfg.get("type") or robot_cfg.get("model") or "").strip().lower()
-    if "bicycle" in raw:
-        return "bicycle_drive"
-    if "holonomic" in raw or "omni" in raw:
-        return "holonomic"
-    if "differential" in raw or raw == "":
-        return _DEFAULT_KINEMATICS
-    return raw
-
-
-def _vel_and_acc(positions: np.ndarray, dt: float) -> tuple[np.ndarray, np.ndarray]:
-    """Compute finite-difference velocity and acceleration arrays.
-
-    Returns:
-        tuple[np.ndarray, np.ndarray]: Velocity and acceleration with input shape.
-    """
-    if positions.shape[0] < 2:
-        return np.zeros_like(positions), np.zeros_like(positions)
-    vel = np.gradient(positions, dt, axis=0)
-    acc = np.gradient(vel, dt, axis=0)
-    return vel, acc
-
-
-def _stack_ped_positions(traj: list[np.ndarray], *, fill_value: float = np.nan) -> np.ndarray:
-    """Stack variable-count pedestrian position arrays into one padded tensor.
-
-    Returns:
-        np.ndarray: Array shaped ``(time, max_pedestrians, 2)``.
-    """
-    if not traj:
-        return np.zeros((0, 0, 2), dtype=float)
-    first_shape = traj[0].shape
-    if all(arr.shape == first_shape for arr in traj):
-        return np.stack(traj).astype(float, copy=False)
-    max_k = max(p.shape[0] for p in traj)
-    stacked = np.full((len(traj), max_k, 2), fill_value, dtype=float)
-    for i, arr in enumerate(traj):
-        if arr.size == 0:
-            continue
-        stacked[i, : arr.shape[0]] = arr
-    return stacked
-
-
-def _command_xy_payload(command: tuple[float, float] | dict[str, Any]) -> np.ndarray:
-    """Extract a world-frame XY payload from tuple or structured commands.
-
-    Returns:
-        np.ndarray: Two-element world-frame XY payload.
-    """
-    if isinstance(command, dict):
-        return np.array(
-            [float(command.get("vx", 0.0)), float(command.get("vy", 0.0))],
-            dtype=float,
-        )
-    return np.array([float(command[0]), float(command[1])], dtype=float)
-
-
-def _policy_command_to_env_action(  # noqa: C901
-    *,
-    env: Any,
-    config: RobotSimulationConfig,
-    command: tuple[float, float] | dict[str, Any],
-) -> np.ndarray:
-    """Convert a policy command into the robot's native environment action space.
-
-    Returns:
-        np.ndarray: Action vector compatible with ``env.step``.
-    """
-    simulator = getattr(env, "simulator", None)
-    sim_robots = getattr(simulator, "robots", None)
-    if not isinstance(sim_robots, list) or not sim_robots:
-        return _command_xy_payload(command)
-    robot = sim_robots[0]
-    robot_cfg = getattr(config, "robot_config", None)
-    if robot_cfg is None:
-        return _command_xy_payload(command)
-
-    if isinstance(command, dict):
-        command_kind = str(command.get("command_kind", "")).strip().lower()
-        if command_kind != "holonomic_vxy_world":
-            raise ValueError(f"Unsupported structured policy command: {command}")
-        velocity_world = np.array(
-            [float(command.get("vx", 0.0)), float(command.get("vy", 0.0))],
-            dtype=float,
-        )
-        max_linear_speed = float(
-            getattr(robot_cfg, "max_linear_speed", getattr(robot_cfg, "max_speed", 0.0)) or 0.0
-        )
-        max_angular_speed = float(getattr(robot_cfg, "max_angular_speed", 0.0) or 0.0)
-
-    cls_name = robot_cfg.__class__.__name__.lower()
-    if isinstance(command, dict):
-        if "holonomic" in cls_name:
-            mode = str(getattr(robot_cfg, "command_mode", "vx_vy")).strip().lower()
-            if mode == "vx_vy":
-                return velocity_world
-            command_vw = holonomic_to_diff_drive_action(
-                velocity_world,
-                robot.pose,
-                max_linear_speed=max_linear_speed,
-                max_angular_speed=max_angular_speed,
-            )
-            return np.asarray(command_vw, dtype=float)
-
-        command_vw = holonomic_to_diff_drive_action(
-            velocity_world,
-            robot.pose,
-            max_linear_speed=max_linear_speed,
-            max_angular_speed=max_angular_speed,
-        )
-        if "bicycle" in cls_name:
-            adapter = PlannerActionAdapter(
-                robot=robot,
-                action_space=env.action_space,
-                time_step=float(config.sim_config.time_per_step_in_secs),
-            )
-            return np.asarray(
-                adapter.from_velocity_command(tuple(command_vw.tolist())), dtype=float
-            )
-        current_linear, current_angular = robot.current_speed
-        d_linear = float(command_vw[0]) - float(current_linear)
-        d_angular = float(command_vw[1]) - float(current_angular)
-        return np.array([d_linear, d_angular], dtype=float)
-
-    if "bicycle" in cls_name:
-        adapter = PlannerActionAdapter(
-            robot=robot,
-            action_space=env.action_space,
-            time_step=float(config.sim_config.time_per_step_in_secs),
-        )
-        return np.asarray(adapter.from_velocity_command(command), dtype=float)
-
-    if "holonomic" in cls_name:
-        mode = str(getattr(robot_cfg, "command_mode", "vx_vy")).strip().lower()
-        linear, angular = float(command[0]), float(command[1])
-        if mode == "vx_vy":
-            # Preserve turning intent by projecting at midpoint heading over this step.
-            step_dt = float(getattr(config.sim_config, "time_per_step_in_secs", 0.0) or 0.0)
-            heading = float(robot.pose[1]) + (angular * max(step_dt, 0.0) * 0.5)
-            vx = linear * math.cos(heading)
-            vy = linear * math.sin(heading)
-            return np.array([vx, vy], dtype=float)
-        return np.array([linear, angular], dtype=float)
-
-    current_linear, current_angular = robot.current_speed
-    d_linear = float(command[0]) - float(current_linear)
-    d_angular = float(command[1]) - float(current_angular)
-    return np.array([d_linear, d_angular], dtype=float)
 
 
 def _normalize_pedestrian_impact_controls(

--- a/robot_sf/benchmark/map_runner_actions.py
+++ b/robot_sf/benchmark/map_runner_actions.py
@@ -1,0 +1,211 @@
+"""Action and kinematics helpers for map-based benchmark runs."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from robot_sf.planner.classic_planner_adapter import PlannerActionAdapter
+from robot_sf.robot.action_adapters import holonomic_to_diff_drive_action
+
+if TYPE_CHECKING:
+    from robot_sf.gym_env.unified_config import RobotSimulationConfig
+
+
+DEFAULT_KINEMATICS = "differential_drive"
+
+
+def robot_kinematics_label(config: RobotSimulationConfig) -> str:
+    """Derive the runtime robot kinematics label from simulation config.
+
+    Returns:
+        Canonical kinematics label used in benchmark metadata.
+    """
+    robot_cfg = getattr(config, "robot_config", None)
+    if robot_cfg is None:
+        return DEFAULT_KINEMATICS
+    cls_name = robot_cfg.__class__.__name__.lower()
+    if "bicycle" in cls_name:
+        return "bicycle_drive"
+    if "differential" in cls_name:
+        return "differential_drive"
+    if "holonomic" in cls_name or "omni" in cls_name:
+        return "holonomic"
+    return cls_name or DEFAULT_KINEMATICS
+
+
+def robot_max_speed(config: RobotSimulationConfig) -> float | None:
+    """Extract a positive robot max-speed setting from simulation config if available.
+
+    Returns:
+        Configured positive max speed, or ``None`` when not available.
+    """
+    robot_cfg = getattr(config, "robot_config", None)
+    if robot_cfg is None:
+        return None
+    for attr in ("max_linear_speed", "max_velocity", "max_speed"):
+        value = getattr(robot_cfg, attr, None)
+        if isinstance(value, (int, float)) and float(value) > 0:
+            return float(value)
+    return None
+
+
+def scenario_robot_kinematics_label(scenario: dict[str, Any]) -> str:
+    """Derive the scenario-declared robot kinematics label from scenario metadata.
+
+    Returns:
+        Canonical kinematics label inferred from scenario robot configuration fields.
+    """
+    robot_cfg = scenario.get("robot_config")
+    if not isinstance(robot_cfg, dict):
+        return DEFAULT_KINEMATICS
+    raw = str(robot_cfg.get("type") or robot_cfg.get("model") or "").strip().lower()
+    if "bicycle" in raw:
+        return "bicycle_drive"
+    if "holonomic" in raw or "omni" in raw:
+        return "holonomic"
+    if "differential" in raw or raw == "":
+        return DEFAULT_KINEMATICS
+    return raw
+
+
+def vel_and_acc(positions: np.ndarray, dt: float) -> tuple[np.ndarray, np.ndarray]:
+    """Compute finite-difference velocity and acceleration arrays.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray]: Velocity and acceleration with input shape.
+    """
+    if positions.shape[0] < 2:
+        return np.zeros_like(positions), np.zeros_like(positions)
+    vel = np.gradient(positions, dt, axis=0)
+    acc = np.gradient(vel, dt, axis=0)
+    return vel, acc
+
+
+def stack_ped_positions(traj: list[np.ndarray], *, fill_value: float = np.nan) -> np.ndarray:
+    """Stack variable-count pedestrian position arrays into one padded tensor.
+
+    Returns:
+        np.ndarray: Array shaped ``(time, max_pedestrians, 2)``.
+    """
+    if not traj:
+        return np.zeros((0, 0, 2), dtype=float)
+    first_shape = traj[0].shape
+    if all(arr.shape == first_shape for arr in traj):
+        return np.stack(traj).astype(float, copy=False)
+    max_k = max(p.shape[0] for p in traj)
+    stacked = np.full((len(traj), max_k, 2), fill_value, dtype=float)
+    for i, arr in enumerate(traj):
+        if arr.size == 0:
+            continue
+        stacked[i, : arr.shape[0]] = arr
+    return stacked
+
+
+def command_xy_payload(command: tuple[float, float] | dict[str, Any]) -> np.ndarray:
+    """Extract a world-frame XY payload from tuple or structured commands.
+
+    Returns:
+        np.ndarray: Two-element world-frame XY payload.
+    """
+    if isinstance(command, dict):
+        return np.array(
+            [float(command.get("vx", 0.0)), float(command.get("vy", 0.0))],
+            dtype=float,
+        )
+    return np.array([float(command[0]), float(command[1])], dtype=float)
+
+
+def policy_command_to_env_action(  # noqa: C901
+    *,
+    env: Any,
+    config: RobotSimulationConfig,
+    command: tuple[float, float] | dict[str, Any],
+) -> np.ndarray:
+    """Convert a policy command into the robot's native environment action space.
+
+    Returns:
+        np.ndarray: Action vector compatible with ``env.step``.
+    """
+    simulator = getattr(env, "simulator", None)
+    sim_robots = getattr(simulator, "robots", None)
+    if not isinstance(sim_robots, list) or not sim_robots:
+        return command_xy_payload(command)
+    robot = sim_robots[0]
+    robot_cfg = getattr(config, "robot_config", None)
+    if robot_cfg is None:
+        return command_xy_payload(command)
+
+    if isinstance(command, dict):
+        command_kind = str(command.get("command_kind", "")).strip().lower()
+        if command_kind != "holonomic_vxy_world":
+            raise ValueError(f"Unsupported structured policy command: {command}")
+        velocity_world = np.array(
+            [float(command.get("vx", 0.0)), float(command.get("vy", 0.0))],
+            dtype=float,
+        )
+        max_linear_speed = float(
+            getattr(robot_cfg, "max_linear_speed", getattr(robot_cfg, "max_speed", 0.0)) or 0.0
+        )
+        max_angular_speed = float(getattr(robot_cfg, "max_angular_speed", 0.0) or 0.0)
+
+    cls_name = robot_cfg.__class__.__name__.lower()
+    if isinstance(command, dict):
+        if "holonomic" in cls_name:
+            mode = str(getattr(robot_cfg, "command_mode", "vx_vy")).strip().lower()
+            if mode == "vx_vy":
+                return velocity_world
+            command_vw = holonomic_to_diff_drive_action(
+                velocity_world,
+                robot.pose,
+                max_linear_speed=max_linear_speed,
+                max_angular_speed=max_angular_speed,
+            )
+            return np.asarray(command_vw, dtype=float)
+
+        command_vw = holonomic_to_diff_drive_action(
+            velocity_world,
+            robot.pose,
+            max_linear_speed=max_linear_speed,
+            max_angular_speed=max_angular_speed,
+        )
+        if "bicycle" in cls_name:
+            adapter = PlannerActionAdapter(
+                robot=robot,
+                action_space=env.action_space,
+                time_step=float(config.sim_config.time_per_step_in_secs),
+            )
+            return np.asarray(
+                adapter.from_velocity_command(tuple(command_vw.tolist())), dtype=float
+            )
+        current_linear, current_angular = robot.current_speed
+        d_linear = float(command_vw[0]) - float(current_linear)
+        d_angular = float(command_vw[1]) - float(current_angular)
+        return np.array([d_linear, d_angular], dtype=float)
+
+    if "bicycle" in cls_name:
+        adapter = PlannerActionAdapter(
+            robot=robot,
+            action_space=env.action_space,
+            time_step=float(config.sim_config.time_per_step_in_secs),
+        )
+        return np.asarray(adapter.from_velocity_command(command), dtype=float)
+
+    if "holonomic" in cls_name:
+        mode = str(getattr(robot_cfg, "command_mode", "vx_vy")).strip().lower()
+        linear, angular = float(command[0]), float(command[1])
+        if mode == "vx_vy":
+            # Preserve turning intent by projecting at midpoint heading over this step.
+            step_dt = float(getattr(config.sim_config, "time_per_step_in_secs", 0.0) or 0.0)
+            heading = float(robot.pose[1]) + (angular * max(step_dt, 0.0) * 0.5)
+            vx = linear * math.cos(heading)
+            vy = linear * math.sin(heading)
+            return np.array([vx, vy], dtype=float)
+        return np.array([linear, angular], dtype=float)
+
+    current_linear, current_angular = robot.current_speed
+    d_linear = float(command[0]) - float(current_linear)
+    d_angular = float(command[1]) - float(current_angular)
+    return np.array([d_linear, d_angular], dtype=float)


### PR DESCRIPTION
## Summary
- Extract map-runner action conversion and kinematics helpers into `robot_sf/benchmark/map_runner_actions.py`
- Re-export the previous private helper names from `map_runner.py` so existing tests/imports remain compatible
- Preserve behavior; this is a move-only #3006 size-reduction slice

Refs #3006

## Validation
- `uv run pytest tests/benchmark/test_map_runner_utils.py -q`
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_actions.py tests/benchmark/test_map_runner_utils.py`
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_actions.py tests/benchmark/test_map_runner_utils.py`
- `git diff --check`

## Research Result Guidance
NA - support/refactor-only extraction; no benchmark, metric, or paper-facing claim is changed.

## Downstream Propagation
NA - no user-facing workflow, benchmark result, registry, or artifact contract changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reorganized benchmark utilities for improved code maintainability and modularity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->