### PR TITLE
refactor: extract map runner policy metadata helpers

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -82,6 +82,18 @@ from robot_sf.benchmark.map_runner_metrics import (
 from robot_sf.benchmark.map_runner_metrics import (
     normalize_pedestrian_impact_controls as _normalize_pedestrian_impact_controls,
 )
+from robot_sf.benchmark.map_runner_policy_metadata import (
+    apply_direct_world_velocity_metadata as _apply_direct_world_velocity_metadata,
+)
+from robot_sf.benchmark.map_runner_policy_metadata import (
+    attach_planner_reset as _attach_planner_reset,
+)
+from robot_sf.benchmark.map_runner_policy_metadata import (
+    finalize_feasibility_metadata as _finalize_feasibility_metadata,
+)
+from robot_sf.benchmark.map_runner_policy_metadata import (
+    holonomic_world_velocity_command as _holonomic_world_velocity_command,
+)
 from robot_sf.benchmark.map_runner_static_deadlock import (
     static_deadlock_trace_fields as _static_deadlock_trace_fields,
 )
@@ -365,36 +377,6 @@ def _load_latency_stress_profile(payload: Any) -> LatencyStressProfile | None:
     return load_latency_stress_profile(payload)
 
 
-def _holonomic_world_velocity_command(vx: float, vy: float) -> dict[str, float | str]:
-    """Build an explicit world-frame holonomic velocity command payload.
-
-    Returns:
-        dict[str, float | str]: Structured command payload for holonomic env actions.
-    """
-    return {
-        "command_kind": "holonomic_vxy_world",
-        "vx": float(vx),
-        "vy": float(vy),
-    }
-
-
-def _apply_direct_world_velocity_metadata(
-    meta: dict[str, Any],
-    *,
-    adapter_boundary: str | None = None,
-) -> None:
-    """Mark planner metadata as direct world-velocity execution for holonomic benchmarks."""
-    planner_meta = meta.get("planner_kinematics")
-    if isinstance(planner_meta, dict):
-        planner_meta["planner_command_space"] = "holonomic_vxy_world"
-        planner_meta["benchmark_command_space"] = "holonomic_vxy_world"
-        planner_meta["projection_policy"] = "world_velocity_passthrough"
-        planner_meta["execution_detail"] = "direct_holonomic_world_velocity"
-    upstream_reference = meta.get("upstream_reference")
-    if isinstance(upstream_reference, dict) and adapter_boundary is not None:
-        upstream_reference["adapter_boundary"] = adapter_boundary
-
-
 def _build_adapter_policy(
     *,
     algo_key: str,
@@ -473,51 +455,6 @@ def _build_adapter_policy(
         _policy._planner_stats = _planner_stats
 
     return _policy, meta
-
-
-def _attach_planner_reset(policy: Callable[..., Any], adapter: Any) -> None:
-    """Attach a planner reset hook that tolerates adapters without seed support."""
-    reset = getattr(adapter, "reset", None)
-    if not callable(reset):
-        return
-
-    def _planner_reset(seed: int | None = None) -> None:
-        """Reset an adapter, using seed-aware reset when supported."""
-        if seed is None:
-            reset()
-            return
-        try:
-            reset(seed=seed)
-        except TypeError:
-            reset()
-
-    policy._planner_reset = _planner_reset
-
-
-def _finalize_feasibility_metadata(meta: dict[str, Any]) -> None:
-    """Finalize per-episode feasibility rates/means and strip internal accumulators."""
-    feasibility = meta.get("kinematics_feasibility")
-    if not isinstance(feasibility, dict):
-        return
-    total = int(feasibility.get("commands_evaluated", 0))
-    infeasible = int(feasibility.get("infeasible_native_count", 0))
-    projected = int(feasibility.get("projected_count", 0))
-    sum_linear = float(feasibility.pop("_sum_abs_delta_linear", 0.0))
-    sum_angular = float(feasibility.pop("_sum_abs_delta_angular", 0.0))
-    max_linear = float(feasibility.pop("_max_abs_delta_linear", 0.0))
-    max_angular = float(feasibility.pop("_max_abs_delta_angular", 0.0))
-    if total > 0:
-        feasibility["projection_rate"] = float(projected / total)
-        feasibility["infeasible_rate"] = float(infeasible / total)
-        feasibility["mean_abs_delta_linear"] = float(sum_linear / total)
-        feasibility["mean_abs_delta_angular"] = float(sum_angular / total)
-    else:
-        feasibility["projection_rate"] = 0.0
-        feasibility["infeasible_rate"] = 0.0
-        feasibility["mean_abs_delta_linear"] = 0.0
-        feasibility["mean_abs_delta_angular"] = 0.0
-    feasibility["max_abs_delta_linear"] = max_linear
-    feasibility["max_abs_delta_angular"] = max_angular
 
 
 class _ExternalMPCAdapter:

--- a/robot_sf/benchmark/map_runner_policy_metadata.py
+++ b/robot_sf/benchmark/map_runner_policy_metadata.py
@@ -1,0 +1,83 @@
+"""Policy metadata helpers for map-based benchmark runs."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def holonomic_world_velocity_command(vx: float, vy: float) -> dict[str, float | str]:
+    """Build an explicit world-frame holonomic velocity command payload.
+
+    Returns:
+        dict[str, float | str]: Structured command payload for holonomic env actions.
+    """
+    return {
+        "command_kind": "holonomic_vxy_world",
+        "vx": float(vx),
+        "vy": float(vy),
+    }
+
+
+def apply_direct_world_velocity_metadata(
+    meta: dict[str, Any],
+    *,
+    adapter_boundary: str | None = None,
+) -> None:
+    """Mark planner metadata as direct world-velocity execution for holonomic benchmarks."""
+    planner_meta = meta.get("planner_kinematics")
+    if isinstance(planner_meta, dict):
+        planner_meta["planner_command_space"] = "holonomic_vxy_world"
+        planner_meta["benchmark_command_space"] = "holonomic_vxy_world"
+        planner_meta["projection_policy"] = "world_velocity_passthrough"
+        planner_meta["execution_detail"] = "direct_holonomic_world_velocity"
+    upstream_reference = meta.get("upstream_reference")
+    if isinstance(upstream_reference, dict) and adapter_boundary is not None:
+        upstream_reference["adapter_boundary"] = adapter_boundary
+
+
+def attach_planner_reset(policy: Callable[..., Any], adapter: Any) -> None:
+    """Attach a planner reset hook that tolerates adapters without seed support."""
+    reset = getattr(adapter, "reset", None)
+    if not callable(reset):
+        return
+
+    def _planner_reset(seed: int | None = None) -> None:
+        """Reset an adapter, using seed-aware reset when supported."""
+        if seed is None:
+            reset()
+            return
+        try:
+            reset(seed=seed)
+        except TypeError:
+            reset()
+
+    policy._planner_reset = _planner_reset
+
+
+def finalize_feasibility_metadata(meta: dict[str, Any]) -> None:
+    """Finalize per-episode feasibility rates/means and strip internal accumulators."""
+    feasibility = meta.get("kinematics_feasibility")
+    if not isinstance(feasibility, dict):
+        return
+    total = int(feasibility.get("commands_evaluated", 0))
+    infeasible = int(feasibility.get("infeasible_native_count", 0))
+    projected = int(feasibility.get("projected_count", 0))
+    sum_linear = float(feasibility.pop("_sum_abs_delta_linear", 0.0))
+    sum_angular = float(feasibility.pop("_sum_abs_delta_angular", 0.0))
+    max_linear = float(feasibility.pop("_max_abs_delta_linear", 0.0))
+    max_angular = float(feasibility.pop("_max_abs_delta_angular", 0.0))
+    if total > 0:
+        feasibility["projection_rate"] = float(projected / total)
+        feasibility["infeasible_rate"] = float(infeasible / total)
+        feasibility["mean_abs_delta_linear"] = float(sum_linear / total)
+        feasibility["mean_abs_delta_angular"] = float(sum_angular / total)
+    else:
+        feasibility["projection_rate"] = 0.0
+        feasibility["infeasible_rate"] = 0.0
+        feasibility["mean_abs_delta_linear"] = 0.0
+        feasibility["mean_abs_delta_angular"] = 0.0
+    feasibility["max_abs_delta_linear"] = max_linear
+    feasibility["max_abs_delta_angular"] = max_angular


### PR DESCRIPTION
## Summary
- Extract map-runner policy metadata/reset helpers into `robot_sf/benchmark/map_runner_policy_metadata.py`
- Re-export the previous private helper names from `map_runner.py` so existing tests/imports remain compatible
- Preserve behavior; this is a move-only #3006 size-reduction slice

Refs #3006

## Validation
- `uv run pytest tests/benchmark/test_map_runner_utils.py -q`
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policy_metadata.py tests/benchmark/test_map_runner_utils.py`
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policy_metadata.py tests/benchmark/test_map_runner_utils.py`
- `git diff --check`

## Research Result Guidance
NA - support/refactor-only extraction; no benchmark, metric, or paper-facing claim is changed.

## Downstream Propagation
NA - no user-facing workflow, benchmark result, registry, or artifact contract changed.