### PR TITLE
fix: harden planner reset TypeError handling

### DIFF
--- a/robot_sf/benchmark/map_runner_policy_metadata.py
+++ b/robot_sf/benchmark/map_runner_policy_metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import inspect
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -43,18 +44,29 @@ def attach_planner_reset(policy: Callable[..., Any], adapter: Any) -> None:
     reset = getattr(adapter, "reset", None)
     if not callable(reset):
         return
+    try:
+        reset_accepts_seed = _callable_accepts_seed(reset)
+    except (TypeError, ValueError):
+        reset_accepts_seed = True
 
     def _planner_reset(seed: int | None = None) -> None:
         """Reset an adapter, using seed-aware reset when supported."""
-        if seed is None:
+        if seed is None or not reset_accepts_seed:
             reset()
             return
-        try:
-            reset(seed=seed)
-        except TypeError:
-            reset()
+        reset(seed=seed)
 
     policy._planner_reset = _planner_reset
+
+
+def _callable_accepts_seed(func: Callable[..., Any]) -> bool:
+    """Return whether a callable can bind a ``seed=...`` keyword argument."""
+    signature = inspect.signature(func)
+    try:
+        signature.bind(seed=0)
+    except TypeError:
+        return False
+    return True
 
 
 def finalize_feasibility_metadata(meta: dict[str, Any]) -> None:

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -17,6 +17,7 @@ from loguru import logger
 from robot_sf.benchmark import map_runner
 from robot_sf.benchmark.map_runner import (
     _apply_planner_selector_v2_context,
+    _attach_planner_reset,
     _build_policy,
     _build_socnav_config,
     _command_action_payload,
@@ -842,6 +843,49 @@ def test_build_policy_hrvo_reset_hook_tolerates_adapters_without_seed(
 
     policy._planner_reset(seed=7)
     assert reset_calls == ["reset"]
+
+
+def test_attach_planner_reset_tolerates_adapter_reset_without_seed() -> None:
+    """Direct reset hook wiring should support adapters without seed kwargs."""
+    reset_calls: list[str] = []
+
+    class _Adapter:
+        """Adapter reset double without seed support."""
+
+        def reset(self) -> None:
+            """Record unseeded reset fallback."""
+            reset_calls.append("reset")
+
+    def policy(_obs: dict[str, object]) -> tuple[float, float]:
+        """Minimal policy callable for reset-hook attachment."""
+        return 0.0, 0.0
+
+    _attach_planner_reset(policy, _Adapter())
+
+    policy._planner_reset(seed=7)
+
+    assert reset_calls == ["reset"]
+
+
+def test_attach_planner_reset_propagates_internal_type_error() -> None:
+    """Seed-aware reset hooks should not hide TypeErrors raised inside reset."""
+
+    class _Adapter:
+        """Adapter reset double that accepts seed but fails internally."""
+
+        def reset(self, *, seed: int | None = None) -> None:
+            """Raise an internal TypeError unrelated to seed binding."""
+            del seed
+            raise TypeError("internal reset failure")
+
+    def policy(_obs: dict[str, object]) -> tuple[float, float]:
+        """Minimal policy callable for reset-hook attachment."""
+        return 0.0, 0.0
+
+    _attach_planner_reset(policy, _Adapter())
+
+    with pytest.raises(TypeError, match="internal reset failure"):
+        policy._planner_reset(seed=7)
 
 
 def test_build_policy_orca_holonomic_vx_vy_uses_world_velocity_command(


### PR DESCRIPTION
## Summary
- Detect whether adapter reset hooks accept `seed` before calling them with a seed keyword
- Preserve fallback behavior for adapters that do not accept `seed`
- Propagate unrelated internal `TypeError`s from seed-aware reset implementations

Closes #3047

## Validation
- `uv run pytest tests/benchmark/test_map_runner_utils.py -q`
- `uv run ruff check robot_sf/benchmark/map_runner_policy_metadata.py tests/benchmark/test_map_runner_utils.py`
- `uv run ruff format --check robot_sf/benchmark/map_runner_policy_metadata.py tests/benchmark/test_map_runner_utils.py`
- `git diff --check`

## Research Result Guidance
NA - support/bugfix only; no benchmark, metric, or paper-facing claim is changed.

## Downstream Propagation
NA - no benchmark artifact, registry, or user-facing workflow changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of planner reset functionality with better seed parameter compatibility detection
  
* **Tests**
  * Added test coverage for planner reset behavior with various adapter configurations and error scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->