### PR TITLE
refactor: extract map runner batch summary helpers

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from dataclasses import fields
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, TextIO
+from typing import TYPE_CHECKING, Any, TextIO
 
 import numpy as np
 import yaml
@@ -56,6 +56,18 @@ from robot_sf.benchmark.map_runner_actions import (
 )
 from robot_sf.benchmark.map_runner_actions import stack_ped_positions as _stack_ped_positions
 from robot_sf.benchmark.map_runner_actions import vel_and_acc as _vel_and_acc
+from robot_sf.benchmark.map_runner_batch_summary import (
+    WorkerMetadataBridgeUpdate as _WorkerMetadataBridgeUpdate,  # noqa: F401 - compatibility export.
+)
+from robot_sf.benchmark.map_runner_batch_summary import (
+    accumulate_batch_metadata as _accumulate_batch_metadata,  # noqa: F401 - compatibility export.
+)
+from robot_sf.benchmark.map_runner_batch_summary import (
+    apply_worker_metadata_bridge as _apply_worker_metadata_bridge,
+)
+from robot_sf.benchmark.map_runner_batch_summary import (
+    merge_runtime_algorithm_contract as _merge_runtime_algorithm_contract,
+)
 from robot_sf.benchmark.map_runner_env import (
     apply_active_observation_mode_to_env_config as _apply_active_observation_mode_to_env_config,
 )
@@ -3430,159 +3442,6 @@ def _run_map_job_worker(
         latency_stress_profile=params.get("latency_stress_profile"),
         record_simulation_step_trace=bool(params.get("record_simulation_step_trace", False)),
     )
-
-
-def _accumulate_batch_metadata(
-    rec: dict[str, Any],
-    *,
-    feasibility_totals: dict[str, float],
-) -> tuple[bool, int, int]:
-    """Aggregate adapter-impact and feasibility counters from one episode record.
-
-    Returns:
-        tuple[bool, int, int]: ``(adapter_requested_seen, native_steps, adapted_steps)`` deltas.
-    """
-    impact_meta = (rec.get("algorithm_metadata") or {}).get("adapter_impact") or {}
-    feasibility_meta = (rec.get("algorithm_metadata") or {}).get("kinematics_feasibility") or {}
-    adapter_requested_seen = False
-    adapter_native_steps = 0
-    adapter_adapted_steps = 0
-    if isinstance(impact_meta, dict):
-        adapter_requested_seen = bool(impact_meta.get("requested", False))
-        adapter_native_steps = int(impact_meta.get("native_steps", 0) or 0)
-        adapter_adapted_steps = int(impact_meta.get("adapted_steps", 0) or 0)
-    if isinstance(feasibility_meta, dict):
-        commands_evaluated = int(feasibility_meta.get("commands_evaluated", 0) or 0)
-        feasibility_totals["commands_evaluated"] += commands_evaluated
-        feasibility_totals["infeasible_native_count"] += int(
-            feasibility_meta.get("infeasible_native_count", 0) or 0
-        )
-        feasibility_totals["projected_count"] += int(
-            feasibility_meta.get("projected_count", 0) or 0
-        )
-        feasibility_totals["sum_abs_delta_linear"] += (
-            float(feasibility_meta.get("mean_abs_delta_linear", 0.0)) * commands_evaluated
-        )
-        feasibility_totals["sum_abs_delta_angular"] += (
-            float(feasibility_meta.get("mean_abs_delta_angular", 0.0)) * commands_evaluated
-        )
-        feasibility_totals["max_abs_delta_linear"] = max(
-            float(feasibility_totals["max_abs_delta_linear"]),
-            float(feasibility_meta.get("max_abs_delta_linear", 0.0) or 0.0),
-        )
-        feasibility_totals["max_abs_delta_angular"] = max(
-            float(feasibility_totals["max_abs_delta_angular"]),
-            float(feasibility_meta.get("max_abs_delta_angular", 0.0) or 0.0),
-        )
-    return adapter_requested_seen, adapter_native_steps, adapter_adapted_steps
-
-
-class _WorkerMetadataBridgeUpdate(NamedTuple):
-    """Normalized metadata update emitted by either direct or serialized worker paths."""
-
-    runtime_algorithm_contract: dict[str, Any]
-    adapter_requested_seen: bool
-    adapter_native_steps: int
-    adapter_adapted_steps: int
-
-
-def _apply_worker_metadata_bridge(
-    rec: dict[str, Any],
-    *,
-    feasibility_totals: dict[str, float],
-    runtime_algorithm_contract: dict[str, Any] | None,
-) -> _WorkerMetadataBridgeUpdate:
-    """Fold one worker episode record into the batch-level metadata contract.
-
-    This is the explicit bridge between per-episode worker payloads and the batch summary.  It is
-    used by both direct function-call execution and serialized worker execution so metadata-only
-    additions have one testable hop.
-
-    Returns:
-        Worker metadata update with merged runtime contract and adapter-impact deltas.
-    """
-    requested_seen, native_steps, adapted_steps = _accumulate_batch_metadata(
-        rec,
-        feasibility_totals=feasibility_totals,
-    )
-    merged_runtime_contract = _merge_runtime_algorithm_contract(
-        runtime_algorithm_contract or {},
-        rec.get("algorithm_metadata"),
-    )
-    return _WorkerMetadataBridgeUpdate(
-        runtime_algorithm_contract=merged_runtime_contract,
-        adapter_requested_seen=requested_seen,
-        adapter_native_steps=native_steps,
-        adapter_adapted_steps=adapted_steps,
-    )
-
-
-def _merge_runtime_algorithm_contract(  # noqa: C901
-    base_contract: dict[str, Any],
-    runtime_algorithm_metadata: Any,
-) -> dict[str, Any]:
-    """Merge runtime-resolved algorithm contract fields into a batch summary contract.
-
-    Returns:
-        dict[str, Any]: The merged contract mapping, or the original input on mismatch.
-    """
-    if not isinstance(base_contract, dict) or not isinstance(runtime_algorithm_metadata, dict):
-        return base_contract
-
-    def _merge_mapping(target: dict[str, Any], source: dict[str, Any]) -> None:
-        """Merge authoritative runtime contract values into a nested mapping."""
-        authoritative_keys = {
-            "robot_kinematics",
-            "execution_mode",
-            "adapter_name",
-            "planner_command_space",
-            "benchmark_command_space",
-            "projection_policy",
-            "execution_detail",
-            "adapter_boundary",
-        }
-
-        def _is_placeholder(value: Any) -> bool:
-            """Return whether a contract value should be replaced by runtime data."""
-            if value is None:
-                return True
-            if isinstance(value, str):
-                normalized = value.strip().lower()
-                return normalized in {"", "unknown", "unspecified", "mixed"}
-            return False
-
-        for key, value in source.items():
-            current = target.get(key)
-            if _is_placeholder(current):
-                target[key] = value
-                continue
-            if isinstance(current, dict) and isinstance(value, dict):
-                _merge_mapping(current, value)
-                continue
-            if _is_placeholder(value) or current == value:
-                continue
-            if key in authoritative_keys:
-                target[key] = value
-                continue
-            target[key] = "mixed"
-
-    runtime_planner_kinematics = runtime_algorithm_metadata.get("planner_kinematics")
-    if isinstance(runtime_planner_kinematics, dict):
-        planner_kinematics = base_contract.get("planner_kinematics")
-        if not isinstance(planner_kinematics, dict):
-            planner_kinematics = {}
-            base_contract["planner_kinematics"] = planner_kinematics
-        _merge_mapping(planner_kinematics, runtime_planner_kinematics)
-
-    runtime_upstream_reference = runtime_algorithm_metadata.get("upstream_reference")
-    if isinstance(runtime_upstream_reference, dict):
-        upstream_reference = base_contract.get("upstream_reference")
-        if not isinstance(upstream_reference, dict):
-            upstream_reference = {}
-            base_contract["upstream_reference"] = upstream_reference
-        _merge_mapping(upstream_reference, runtime_upstream_reference)
-
-    return base_contract
 
 
 def _map_result_provenance(  # noqa: PLR0913

--- a/robot_sf/benchmark/map_runner_batch_summary.py
+++ b/robot_sf/benchmark/map_runner_batch_summary.py
@@ -1,0 +1,167 @@
+"""Batch-summary metadata helpers for map-based benchmark runs."""
+
+from __future__ import annotations
+
+from typing import Any, NamedTuple
+
+
+def _float_metadata_value(value: Any, default: float = 0.0) -> float:
+    """Convert optional numeric metadata without treating valid falsy values as missing.
+
+    Returns:
+        Float-converted ``value`` or ``default`` when the value is explicitly ``None``.
+    """
+    return float(default if value is None else value)
+
+
+def accumulate_batch_metadata(
+    rec: dict[str, Any],
+    *,
+    feasibility_totals: dict[str, float],
+) -> tuple[bool, int, int]:
+    """Aggregate adapter-impact and feasibility counters from one episode record.
+
+    Returns:
+        tuple[bool, int, int]: ``(adapter_requested_seen, native_steps, adapted_steps)`` deltas.
+    """
+    impact_meta = (rec.get("algorithm_metadata") or {}).get("adapter_impact") or {}
+    feasibility_meta = (rec.get("algorithm_metadata") or {}).get("kinematics_feasibility") or {}
+    adapter_requested_seen = False
+    adapter_native_steps = 0
+    adapter_adapted_steps = 0
+    if isinstance(impact_meta, dict):
+        adapter_requested_seen = bool(impact_meta.get("requested", False))
+        adapter_native_steps = int(impact_meta.get("native_steps", 0) or 0)
+        adapter_adapted_steps = int(impact_meta.get("adapted_steps", 0) or 0)
+    if isinstance(feasibility_meta, dict):
+        commands_evaluated = int(feasibility_meta.get("commands_evaluated", 0) or 0)
+        feasibility_totals["commands_evaluated"] += commands_evaluated
+        feasibility_totals["infeasible_native_count"] += int(
+            feasibility_meta.get("infeasible_native_count", 0) or 0
+        )
+        feasibility_totals["projected_count"] += int(
+            feasibility_meta.get("projected_count", 0) or 0
+        )
+        mean_abs_delta_linear = _float_metadata_value(feasibility_meta.get("mean_abs_delta_linear"))
+        mean_abs_delta_angular = _float_metadata_value(
+            feasibility_meta.get("mean_abs_delta_angular")
+        )
+        feasibility_totals["sum_abs_delta_linear"] += mean_abs_delta_linear * commands_evaluated
+        feasibility_totals["sum_abs_delta_angular"] += mean_abs_delta_angular * commands_evaluated
+        feasibility_totals["max_abs_delta_linear"] = max(
+            float(feasibility_totals["max_abs_delta_linear"]),
+            _float_metadata_value(feasibility_meta.get("max_abs_delta_linear")),
+        )
+        feasibility_totals["max_abs_delta_angular"] = max(
+            float(feasibility_totals["max_abs_delta_angular"]),
+            _float_metadata_value(feasibility_meta.get("max_abs_delta_angular")),
+        )
+    return adapter_requested_seen, adapter_native_steps, adapter_adapted_steps
+
+
+class WorkerMetadataBridgeUpdate(NamedTuple):
+    """Normalized metadata update emitted by either direct or serialized worker paths."""
+
+    runtime_algorithm_contract: dict[str, Any]
+    adapter_requested_seen: bool
+    adapter_native_steps: int
+    adapter_adapted_steps: int
+
+
+def apply_worker_metadata_bridge(
+    rec: dict[str, Any],
+    *,
+    feasibility_totals: dict[str, float],
+    runtime_algorithm_contract: dict[str, Any] | None,
+) -> WorkerMetadataBridgeUpdate:
+    """Fold one worker episode record into the batch-level metadata contract.
+
+    This is the explicit bridge between per-episode worker payloads and the batch summary.  It is
+    used by both direct function-call execution and serialized worker execution so metadata-only
+    additions have one testable hop.
+
+    Returns:
+        Worker metadata update with merged runtime contract and adapter-impact deltas.
+    """
+    requested_seen, native_steps, adapted_steps = accumulate_batch_metadata(
+        rec,
+        feasibility_totals=feasibility_totals,
+    )
+    merged_runtime_contract = merge_runtime_algorithm_contract(
+        runtime_algorithm_contract or {},
+        rec.get("algorithm_metadata"),
+    )
+    return WorkerMetadataBridgeUpdate(
+        runtime_algorithm_contract=merged_runtime_contract,
+        adapter_requested_seen=requested_seen,
+        adapter_native_steps=native_steps,
+        adapter_adapted_steps=adapted_steps,
+    )
+
+
+def merge_runtime_algorithm_contract(  # noqa: C901
+    base_contract: dict[str, Any],
+    runtime_algorithm_metadata: Any,
+) -> dict[str, Any]:
+    """Merge runtime-resolved algorithm contract fields into a batch summary contract.
+
+    Returns:
+        dict[str, Any]: The merged contract mapping, or the original input on mismatch.
+    """
+    if not isinstance(base_contract, dict) or not isinstance(runtime_algorithm_metadata, dict):
+        return base_contract
+
+    def _merge_mapping(target: dict[str, Any], source: dict[str, Any]) -> None:
+        """Merge authoritative runtime contract values into a nested mapping."""
+        authoritative_keys = {
+            "robot_kinematics",
+            "execution_mode",
+            "adapter_name",
+            "planner_command_space",
+            "benchmark_command_space",
+            "projection_policy",
+            "execution_detail",
+            "adapter_boundary",
+        }
+
+        def _is_placeholder(value: Any) -> bool:
+            """Return whether a contract value should be replaced by runtime data."""
+            if value is None:
+                return True
+            if isinstance(value, str):
+                normalized = value.strip().lower()
+                return normalized in {"", "unknown", "unspecified", "mixed"}
+            return False
+
+        for key, value in source.items():
+            current = target.get(key)
+            if _is_placeholder(current):
+                target[key] = value
+                continue
+            if isinstance(current, dict) and isinstance(value, dict):
+                _merge_mapping(current, value)
+                continue
+            if _is_placeholder(value) or current == value:
+                continue
+            if key in authoritative_keys:
+                target[key] = value
+                continue
+            target[key] = "mixed"
+
+    runtime_planner_kinematics = runtime_algorithm_metadata.get("planner_kinematics")
+    if isinstance(runtime_planner_kinematics, dict):
+        planner_kinematics = base_contract.get("planner_kinematics")
+        if not isinstance(planner_kinematics, dict):
+            planner_kinematics = {}
+            base_contract["planner_kinematics"] = planner_kinematics
+        _merge_mapping(planner_kinematics, runtime_planner_kinematics)
+
+    runtime_upstream_reference = runtime_algorithm_metadata.get("upstream_reference")
+    if isinstance(runtime_upstream_reference, dict):
+        upstream_reference = base_contract.get("upstream_reference")
+        if not isinstance(upstream_reference, dict):
+            upstream_reference = {}
+            base_contract["upstream_reference"] = upstream_reference
+        _merge_mapping(upstream_reference, runtime_upstream_reference)
+
+    return base_contract

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -16,6 +16,7 @@ from loguru import logger
 
 from robot_sf.benchmark import map_runner
 from robot_sf.benchmark.map_runner import (
+    _accumulate_batch_metadata,
     _apply_planner_selector_v2_context,
     _attach_planner_reset,
     _build_policy,
@@ -4085,6 +4086,52 @@ def test_run_map_batch_parallel_preserves_runtime_metadata_bridge(
     assert meta["kinematics_feasibility"]["commands_evaluated"] == 6
     assert meta["kinematics_feasibility"]["projected_count"] == 2
     assert meta["kinematics_feasibility"]["mean_abs_delta_linear"] == pytest.approx(0.2)
+
+
+def test_accumulate_batch_metadata_preserves_falsy_optional_values() -> None:
+    """Falsy numeric feasibility metadata should not be replaced by fallback values."""
+    feasibility_totals = {
+        "commands_evaluated": 0.0,
+        "infeasible_native_count": 0.0,
+        "projected_count": 0.0,
+        "sum_abs_delta_linear": 1.25,
+        "sum_abs_delta_angular": 2.5,
+        "max_abs_delta_linear": 0.0,
+        "max_abs_delta_angular": 0.0,
+    }
+    rec = {
+        "algorithm_metadata": {
+            "adapter_impact": {
+                "requested": True,
+                "native_steps": 0,
+                "adapted_steps": 0,
+            },
+            "kinematics_feasibility": {
+                "commands_evaluated": 4,
+                "infeasible_native_count": 0,
+                "projected_count": 0,
+                "mean_abs_delta_linear": 0.0,
+                "mean_abs_delta_angular": None,
+                "max_abs_delta_linear": 0.0,
+                "max_abs_delta_angular": None,
+            },
+        }
+    }
+
+    requested, native_steps, adapted_steps = _accumulate_batch_metadata(
+        rec,
+        feasibility_totals=feasibility_totals,
+    )
+
+    assert requested is True
+    assert native_steps == 0
+    assert adapted_steps == 0
+    assert feasibility_totals["commands_evaluated"] == 4
+    assert feasibility_totals["projected_count"] == 0
+    assert feasibility_totals["sum_abs_delta_linear"] == pytest.approx(1.25)
+    assert feasibility_totals["sum_abs_delta_angular"] == pytest.approx(2.5)
+    assert feasibility_totals["max_abs_delta_linear"] == 0.0
+    assert feasibility_totals["max_abs_delta_angular"] == 0.0
 
 
 def test_run_map_job_worker_forwards_metadata_params(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

- Extract map-runner batch summary metadata helpers into `robot_sf.benchmark.map_runner_batch_summary`.
- Keep the existing private names re-exported from `map_runner.py` so current tests and monkeypatches keep working.
- Leave worker execution, JSONL writing, and provenance helpers in `map_runner.py` for this slice to avoid changing multiprocessing or failure-path behavior.

## Issue Scope

Continues #3006.

This is a behavior-preserving refactor slice. It does not change benchmark semantics, metrics, output schema, or CLI behavior.

## Validation

- `uv run pytest tests/benchmark/test_map_runner_utils.py -q`
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_summary.py tests/benchmark/test_map_runner_utils.py`
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_summary.py tests/benchmark/test_map_runner_utils.py`
- `git diff --check`

## Decomposition Note

Accepted slice:

- `robot_sf/benchmark/map_runner_batch_summary.py`
  - `accumulate_batch_metadata`
  - `WorkerMetadataBridgeUpdate`
  - `apply_worker_metadata_bridge`
  - `merge_runtime_algorithm_contract`

Rejected/deferred from delegate recommendation:

- Moving `_run_map_job_worker`, `_write_validated*`, and `_map_result_provenance` in this PR, because those touch multiprocessing picklability, monkeypatch-heavy tests, JSONL write failure behavior, and lazy provenance imports.

## Downstream Propagation

NA - internal refactor only. Existing private compatibility names remain available through `map_runner.py`.

## Research Result Guidance

NA - no benchmark claim or metric interpretation. This only reduces the `map_runner.py` ownership surface for future benchmark work.
