### PR TITLE
refactor: extract map runner provenance helper

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -4,11 +4,7 @@ from __future__ import annotations
 
 import json
 import math
-import platform
-import shlex
-import sys
 import time
-import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from copy import deepcopy
 from dataclasses import fields
@@ -105,6 +101,9 @@ from robot_sf.benchmark.map_runner_policy_metadata import (
 )
 from robot_sf.benchmark.map_runner_policy_metadata import (
     holonomic_world_velocity_command as _holonomic_world_velocity_command,
+)
+from robot_sf.benchmark.map_runner_provenance import (
+    map_result_provenance as _map_result_provenance,
 )
 from robot_sf.benchmark.map_runner_static_deadlock import (
     static_deadlock_trace_fields as _static_deadlock_trace_fields,
@@ -3442,48 +3441,6 @@ def _run_map_job_worker(
         latency_stress_profile=params.get("latency_stress_profile"),
         record_simulation_step_trace=bool(params.get("record_simulation_step_trace", False)),
     )
-
-
-def _map_result_provenance(  # noqa: PLR0913
-    *,
-    schema_path: str | Path,
-    scenario_path: Path,
-    scenarios: list[dict[str, Any]],
-    algo: str,
-    algo_config_path: str | None,
-    benchmark_profile: str,
-    suite_key: str,
-    total_jobs: int,
-    written: int,
-    artifact_pointer_status: str,
-) -> dict[str, Any]:
-    """Return self-describing provenance for map-runner summary artifacts."""
-    from robot_sf.benchmark.release_protocol import BENCHMARK_PROTOCOL_VERSION  # noqa: PLC0415
-
-    provenance: dict[str, Any] = {
-        "protocol_version": BENCHMARK_PROTOCOL_VERSION,
-        "commit_hash": _git_hash_fallback(),
-        "run_id": uuid.uuid4().hex,
-        "python_version": platform.python_version(),
-        "artifact_pointer_status": artifact_pointer_status,
-        "config_identity": {
-            "schema_path": str(schema_path),
-            "scenario_path": str(scenario_path),
-            "scenario_count": len(scenarios),
-            "scenario_matrix_hash": _config_hash(scenarios),
-            "algo": str(algo),
-            "algo_config_path": str(algo_config_path) if algo_config_path is not None else None,
-            "benchmark_profile": str(benchmark_profile),
-        },
-        "seed_identity": {
-            "suite_key": suite_key,
-            "total_jobs": int(total_jobs),
-            "written": int(written),
-        },
-    }
-    if hasattr(sys, "argv") and sys.argv:
-        provenance["invocation"] = shlex.join(sys.argv)
-    return provenance
 
 
 def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915

--- a/robot_sf/benchmark/map_runner_provenance.py
+++ b/robot_sf/benchmark/map_runner_provenance.py
@@ -1,0 +1,56 @@
+"""Result provenance helpers for map-based benchmark runs."""
+
+from __future__ import annotations
+
+import platform
+import shlex
+import sys
+import uuid
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.utils import _config_hash, _git_hash_fallback
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def map_result_provenance(  # noqa: PLR0913
+    *,
+    schema_path: str | Path,
+    scenario_path: Path,
+    scenarios: list[dict[str, Any]],
+    algo: str,
+    algo_config_path: str | None,
+    benchmark_profile: str,
+    suite_key: str,
+    total_jobs: int,
+    written: int,
+    artifact_pointer_status: str,
+) -> dict[str, Any]:
+    """Return self-describing provenance for map-runner summary artifacts."""
+    from robot_sf.benchmark.release_protocol import BENCHMARK_PROTOCOL_VERSION  # noqa: PLC0415
+
+    provenance: dict[str, Any] = {
+        "protocol_version": BENCHMARK_PROTOCOL_VERSION,
+        "commit_hash": _git_hash_fallback(),
+        "run_id": uuid.uuid4().hex,
+        "python_version": platform.python_version(),
+        "artifact_pointer_status": artifact_pointer_status,
+        "config_identity": {
+            "schema_path": str(schema_path),
+            "scenario_path": str(scenario_path),
+            "scenario_count": len(scenarios),
+            "scenario_matrix_hash": _config_hash(scenarios),
+            "algo": str(algo),
+            "algo_config_path": str(algo_config_path) if algo_config_path is not None else None,
+            "benchmark_profile": str(benchmark_profile),
+        },
+        "seed_identity": {
+            "suite_key": suite_key,
+            "total_jobs": int(total_jobs),
+            "written": int(written),
+        },
+    }
+    if hasattr(sys, "argv") and sys.argv:
+        provenance["invocation"] = shlex.join(sys.argv)
+    return provenance


### PR DESCRIPTION
## Summary

- Extract map-runner result provenance construction into `robot_sf.benchmark.map_runner_provenance`.
- Keep `_map_result_provenance` available from `map_runner.py` as a compatibility import for existing tests and callers.
- Leave worker execution and JSONL writing in `map_runner.py`; this slice avoids multiprocessing and monkeypatch-heavy paths.

## Issue Scope

Continues #3006.

This is a behavior-preserving refactor. It does not change benchmark semantics, metric definitions, output schema, or CLI behavior.

## Validation

- `uv run pytest tests/benchmark/test_map_runner_result_provenance.py tests/benchmark/test_map_runner_utils.py -q`
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_provenance.py tests/benchmark/test_map_runner_result_provenance.py tests/benchmark/test_map_runner_utils.py`
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_provenance.py tests/benchmark/test_map_runner_result_provenance.py tests/benchmark/test_map_runner_utils.py`
- `git diff --check`

## Delegate Outcome

Started a read-only Spark scout for the broader runtime/provenance extraction, but closed it before result because this narrower provenance-only slice was already locally proven and avoided the high-risk worker/pickling paths.

## Downstream Propagation

NA - internal refactor only. The existing private compatibility name remains available through `map_runner.py`.

## Research Result Guidance

NA - no benchmark claim or metric interpretation. This only reduces `map_runner.py` ownership surface for future benchmark work.
