### PR TITLE
refactor: extract map runner worker helper

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -123,6 +123,7 @@ from robot_sf.benchmark.map_runner_trace import (
     _single_pedestrian_vru_metadata,
     _trace_pedestrians,
 )
+from robot_sf.benchmark.map_runner_worker import execute_map_job as _execute_map_job
 from robot_sf.benchmark.metrics import (
     EpisodeData,
     compute_all_metrics,
@@ -3415,32 +3416,7 @@ def _run_map_job_worker(
     Returns:
         dict[str, Any]: Episode record returned by ``_run_map_episode``.
     """
-    scenario, seed, params = job
-    return _run_map_episode(
-        scenario,
-        seed,
-        horizon=params.get("horizon"),
-        dt=params.get("dt"),
-        record_forces=bool(params.get("record_forces", True)),
-        snqi_weights=params.get("snqi_weights"),
-        snqi_baseline=params.get("snqi_baseline"),
-        algo=str(params.get("algo", "goal")),
-        algo_config=params.get("algo_config"),
-        algo_config_path=params.get("algo_config_path"),
-        scenario_path=Path(params.get("scenario_path")),
-        adapter_impact_eval=bool(params.get("adapter_impact_eval", False)),
-        experimental_ped_impact=bool(params.get("experimental_ped_impact", False)),
-        ped_impact_radius_m=float(params.get("ped_impact_radius_m", 2.0)),
-        ped_impact_window_steps=int(params.get("ped_impact_window_steps", 5)),
-        observation_mode=params.get("observation_mode"),
-        observation_level=params.get("observation_level"),
-        benchmark_track=params.get("benchmark_track"),
-        track_schema_version=params.get("track_schema_version"),
-        observation_noise=params.get("observation_noise"),
-        synthetic_actuation_profile=params.get("synthetic_actuation_profile"),
-        latency_stress_profile=params.get("latency_stress_profile"),
-        record_simulation_step_trace=bool(params.get("record_simulation_step_trace", False)),
-    )
+    return _execute_map_job(job, run_map_episode=_run_map_episode)
 
 
 def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915

--- a/robot_sf/benchmark/map_runner_worker.py
+++ b/robot_sf/benchmark/map_runner_worker.py
@@ -1,0 +1,73 @@
+"""Serialized worker helpers for map-based benchmark runs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+def _param_or_default(params: dict[str, Any], key: str, default: Any) -> Any:
+    """Return a parameter value, treating explicit ``None`` as missing.
+
+    Returns:
+        The configured value when not ``None``; otherwise ``default``.
+    """
+    value = params.get(key)
+    return default if value is None else value
+
+
+def _required_path_param(params: dict[str, Any], key: str) -> Path:
+    """Return a required path parameter with an actionable error for missing values.
+
+    Returns:
+        Path built from the configured value.
+    """
+    value = params.get(key)
+    if value is None:
+        raise ValueError(f"{key} is required in map-runner job params")
+    return Path(value)
+
+
+def execute_map_job(
+    job: tuple[dict[str, Any], int, dict[str, Any]],
+    *,
+    run_map_episode: Callable[..., dict[str, Any]],
+) -> dict[str, Any]:
+    """Execute one serialized map-runner job with the supplied episode runner.
+
+    Returns:
+        dict[str, Any]: Episode record returned by ``run_map_episode``.
+    """
+    scenario, seed, params = job
+    algo = str(_param_or_default(params, "algo", "goal"))
+    record_forces = bool(_param_or_default(params, "record_forces", True))
+    ped_impact_radius_m = float(_param_or_default(params, "ped_impact_radius_m", 2.0))
+    ped_impact_window_steps = int(_param_or_default(params, "ped_impact_window_steps", 5))
+    return run_map_episode(
+        scenario,
+        seed,
+        horizon=params.get("horizon"),
+        dt=params.get("dt"),
+        record_forces=record_forces,
+        snqi_weights=params.get("snqi_weights"),
+        snqi_baseline=params.get("snqi_baseline"),
+        algo=algo,
+        algo_config=params.get("algo_config"),
+        algo_config_path=params.get("algo_config_path"),
+        scenario_path=_required_path_param(params, "scenario_path"),
+        adapter_impact_eval=bool(params.get("adapter_impact_eval", False)),
+        experimental_ped_impact=bool(params.get("experimental_ped_impact", False)),
+        ped_impact_radius_m=ped_impact_radius_m,
+        ped_impact_window_steps=ped_impact_window_steps,
+        observation_mode=params.get("observation_mode"),
+        observation_level=params.get("observation_level"),
+        benchmark_track=params.get("benchmark_track"),
+        track_schema_version=params.get("track_schema_version"),
+        observation_noise=params.get("observation_noise"),
+        synthetic_actuation_profile=params.get("synthetic_actuation_profile"),
+        latency_stress_profile=params.get("latency_stress_profile"),
+        record_simulation_step_trace=bool(params.get("record_simulation_step_trace", False)),
+    )

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -4197,6 +4197,69 @@ def test_run_map_job_worker_forwards_metadata_params(monkeypatch: pytest.MonkeyP
     assert record["algorithm_metadata"]["benchmark_track"]["benchmark_track"] == "lidar"
 
 
+def test_run_map_job_worker_normalizes_optional_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit None worker params should use defaults without replacing valid falsy values."""
+    captured: list[dict[str, object]] = []
+
+    def _fake_run_map_episode(_scenario, _seed, **kwargs):
+        """Capture worker-normalized keyword arguments."""
+        captured.append(dict(kwargs))
+        return {"episode_id": f"captured-{len(captured)}"}
+
+    monkeypatch.setattr("robot_sf.benchmark.map_runner._run_map_episode", _fake_run_map_episode)
+
+    _run_map_job_worker(
+        (
+            {"name": "none-defaults"},
+            1,
+            {
+                "scenario_path": "configs/scenarios/demo.yaml",
+                "algo": None,
+                "record_forces": None,
+                "ped_impact_radius_m": None,
+                "ped_impact_window_steps": None,
+            },
+        )
+    )
+    _run_map_job_worker(
+        (
+            {"name": "falsy-values"},
+            2,
+            {
+                "scenario_path": "configs/scenarios/demo.yaml",
+                "algo": "",
+                "record_forces": False,
+                "ped_impact_radius_m": 0.0,
+                "ped_impact_window_steps": 0,
+            },
+        )
+    )
+
+    assert captured[0]["algo"] == "goal"
+    assert captured[0]["record_forces"] is True
+    assert captured[0]["ped_impact_radius_m"] == 2.0
+    assert captured[0]["ped_impact_window_steps"] == 5
+    assert captured[1]["algo"] == ""
+    assert captured[1]["record_forces"] is False
+    assert captured[1]["ped_impact_radius_m"] == 0.0
+    assert captured[1]["ped_impact_window_steps"] == 0
+
+
+def test_run_map_job_worker_requires_scenario_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing serialized scenario paths should fail with an actionable error."""
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._run_map_episode",
+        lambda *_args, **_kwargs: {"episode_id": "unused"},
+    )
+
+    with pytest.raises(ValueError, match="scenario_path is required"):
+        _run_map_job_worker(({"name": "missing-path"}, 1, {"scenario_path": None}))
+
+
 def test_run_map_batch_hrvo_smoke_writes_episode_jsonl(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:


### PR DESCRIPTION
## Summary

- Extract the serialized map-runner worker argument forwarding into `robot_sf.benchmark.map_runner_worker`.
- Keep `_run_map_job_worker` as a top-level `map_runner.py` wrapper so multiprocessing pickling and existing monkeypatch tests keep targeting the same symbol.
- Leave JSONL writing and validation helpers in `map_runner.py` for a separate lower-risk slice.

## Issue Scope

Continues #3006.

This is a behavior-preserving refactor. It does not change benchmark semantics, metric definitions, output schema, or CLI behavior.

## Validation

- `uv run pytest tests/benchmark/test_map_runner_utils.py tests/benchmark/test_lidar_observation_track.py::test_stubbed_lidar_map_episode_records_track_metadata -q`
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_worker.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_lidar_observation_track.py`
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_worker.py tests/benchmark/test_map_runner_utils.py tests/benchmark/test_lidar_observation_track.py`
- `git diff --check`

## Compatibility Note

`run_map_batch` still submits `map_runner._run_map_job_worker` to the process pool. The wrapper delegates to `execute_map_job(..., run_map_episode=_run_map_episode)`, preserving the existing monkeypatch surface for tests that patch `robot_sf.benchmark.map_runner._run_map_episode`.

## Downstream Propagation

NA - internal refactor only. Existing private compatibility name remains available through `map_runner.py`.

## Research Result Guidance

NA - no benchmark claim or metric interpretation. This only reduces `map_runner.py` ownership surface for future benchmark work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured map job execution logic across modules for improved code organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->