### PR TITLE
refactor: extract map runner policy resolution

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -12,7 +12,6 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, TextIO
 
 import numpy as np
-import yaml
 from loguru import logger
 
 from robot_sf.baselines.dr_mpc import DRMPCPlanner, build_dr_mpc_config
@@ -20,6 +19,7 @@ from robot_sf.baselines.drl_vo import DrlVoPlanner
 from robot_sf.baselines.ppo import PPOPlanner, PPOPlannerConfig
 from robot_sf.baselines.sac import SACPlanner
 from robot_sf.baselines.sicnav import SICNavPlanner, build_sicnav_config
+from robot_sf.benchmark import map_runner_policy_resolution as _policy_resolution
 from robot_sf.benchmark import planner_command_contract as planner_commands
 from robot_sf.benchmark.algorithm_metadata import (
     enrich_algorithm_metadata,
@@ -36,7 +36,6 @@ from robot_sf.benchmark.latency_stress import (
     load_latency_stress_profile,
     not_available_latency_metrics,
 )
-from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_artifacts
 from robot_sf.benchmark.map_runner_actions import DEFAULT_KINEMATICS as _DEFAULT_KINEMATICS
 from robot_sf.benchmark.map_runner_actions import (
     command_xy_payload as _command_xy_payload,  # noqa: F401 - compatibility re-export for tests.
@@ -219,10 +218,6 @@ from robot_sf.planner.mppi_social import (
 from robot_sf.planner.nmpc_social import (
     NMPCSocialPlannerAdapter,
     build_nmpc_social_config,
-)
-from robot_sf.planner.planner_selector_v2_diagnostic import (
-    PlannerSelectorV2DiagnosticAdapter,
-    build_planner_selector_v2_diagnostic_config,
 )
 from robot_sf.planner.policy_stack_v1 import (
     PolicyStackV1Adapter,
@@ -528,296 +523,22 @@ class _ExternalMPCAdapter:
         return linear, angular
 
 
-def _parse_algo_config(algo_config_path: str | None) -> dict[str, Any]:
-    """Load an optional planner YAML config.
-
-    Returns:
-        dict[str, Any]: Parsed config mapping, or an empty mapping when omitted.
-    """
-    if not algo_config_path:
-        return {}
-    path = Path(algo_config_path)
-    if not path.exists():
-        raise FileNotFoundError(f"Algorithm config file not found: {algo_config_path}")
-    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
-    if not isinstance(data, dict):
-        raise TypeError("Algorithm config must be a mapping (YAML dict).")
-    validate_no_local_model_artifacts(data, config_path=path)
-    return data
-
-
-def _deep_merge_config(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
-    """Merge nested planner config overrides without mutating either input.
-
-    Returns:
-        A new mapping containing ``base`` with ``overrides`` applied recursively.
-    """
-    merged = deepcopy(base)
-    for key, value in overrides.items():
-        current = merged.get(key)
-        if isinstance(current, dict) and isinstance(value, dict):
-            merged[key] = _deep_merge_config(current, value)
-        else:
-            merged[key] = deepcopy(value)
-    return merged
-
-
-def _resolve_config_path(anchor: Path | None, raw_path: Any) -> Path | None:
-    """Resolve candidate-manifest config paths from manifest-local or repo-root form.
-
-    Returns:
-        Resolved path, or ``None`` when the raw path is empty or not a string.
-    """
-    if not isinstance(raw_path, str) or not raw_path.strip():
-        return None
-    path = Path(raw_path)
-    if path.is_absolute():
-        return path.resolve()
-    if anchor is not None:
-        anchored = (anchor / path).resolve()
-        if anchored.exists():
-            return anchored
-    return path.resolve()
-
-
-def _scenario_family(scenario: dict[str, Any]) -> str:
-    """Classify a scenario into the report family used by benchmark summaries.
-
-    Returns:
-        str: Scenario family label.
-    """
-    scenario_id = _scenario_id(scenario)
-    if scenario_id.startswith("francis2023_"):
-        return "francis2023"
-    if scenario_id.startswith("classic_"):
-        return "classic"
-    return str(scenario.get("family") or scenario.get("metadata", {}).get("family") or "nominal")
-
-
-def _is_policy_search_candidate_manifest(config: dict[str, Any]) -> bool:
-    """Return whether a config has policy-search candidate manifest fields."""
-    return any(
-        key in config
-        for key in (
-            "base_config_path",
-            "params",
-            "family_overrides",
-            "scenario_overrides",
-            "scenario_algo_overrides",
-        )
-    )
-
-
-def _load_base_candidate_config(
-    manifest: dict[str, Any],
-    *,
-    config_anchor: Path | None,
-) -> dict[str, Any]:
-    """Load and merge a policy-search candidate's base config and params.
-
-    Returns:
-        dict[str, Any]: Effective candidate planner config.
-    """
-    base_cfg: dict[str, Any] = {}
-    base_path = _resolve_config_path(config_anchor, manifest.get("base_config_path"))
-    if base_path is not None:
-        base_cfg = _parse_algo_config(str(base_path))
-    params = manifest.get("params") or {}
-    if not isinstance(params, dict):
-        raise TypeError("Policy-search candidate params must be a mapping.")
-    return _deep_merge_config(base_cfg, params)
-
-
-def _scenario_algo_override_runtime(
-    override: dict[str, Any],
-    *,
-    default_algo: str,
-    scenario_key: str,
-    config_anchor: Path | None,
-) -> tuple[str, dict[str, Any]]:
-    """Resolve one scenario-level algorithm override.
-
-    Returns:
-        Effective algorithm key and flattened runtime config for the scenario.
-    """
-    algo = str(override.get("algo", default_algo)).strip().lower()
-    if not algo:
-        raise ValueError(f"Scenario algo override is missing algo: {scenario_key}")
-    base_cfg: dict[str, Any] = {}
-    base_path = _resolve_config_path(config_anchor, override.get("base_config_path"))
-    if base_path is not None:
-        base_cfg = _parse_algo_config(str(base_path))
-    params = override.get("params") or {}
-    if not isinstance(params, dict):
-        raise TypeError("Policy-search scenario_algo_overrides params must be a mapping.")
-    return algo, _deep_merge_config(base_cfg, params)
-
-
-def _resolve_policy_search_candidate_runtime(
-    *,
-    default_algo: str,
-    algo_config_path: str | None,
-    scenario: dict[str, Any],
-    algo_config: dict[str, Any] | None = None,
-) -> tuple[str, dict[str, Any]]:
-    """Resolve a policy-search candidate manifest to the runtime algo/config for a scenario.
-
-    Returns:
-        Effective algorithm key and flattened runtime config for the scenario.
-    """
-    manifest = (
-        dict(algo_config) if algo_config is not None else _parse_algo_config(algo_config_path)
-    )
-    if not _is_policy_search_candidate_manifest(manifest):
-        return default_algo, manifest
-
-    config_anchor = Path(algo_config_path).resolve().parent if algo_config_path else None
-    scenario_key = _scenario_id(scenario)
-    algo_overrides = manifest.get("scenario_algo_overrides")
-    if isinstance(algo_overrides, dict):
-        override = algo_overrides.get(scenario_key)
-        if isinstance(override, dict):
-            return _scenario_algo_override_runtime(
-                override,
-                default_algo=default_algo,
-                scenario_key=scenario_key,
-                config_anchor=config_anchor,
-            )
-
-    effective = _load_base_candidate_config(manifest, config_anchor=config_anchor)
-    family_overrides = manifest.get("family_overrides")
-    if isinstance(family_overrides, dict):
-        family_cfg = family_overrides.get(_scenario_family(scenario), {})
-        if isinstance(family_cfg, dict):
-            effective = _deep_merge_config(effective, family_cfg)
-    scenario_overrides = manifest.get("scenario_overrides")
-    if isinstance(scenario_overrides, dict):
-        scenario_cfg = scenario_overrides.get(scenario_key, {})
-        if isinstance(scenario_cfg, dict):
-            effective = _deep_merge_config(effective, scenario_cfg)
-    return default_algo, effective
-
-
-def _apply_planner_selector_v2_context(
-    algo: str,
-    policy_cfg: dict[str, Any],
-    *,
-    scenario: dict[str, Any],
-    seed: int,
-) -> dict[str, Any]:
-    """Attach selector-v2 scenario context wherever effective runtime config is materialized.
-
-    Returns:
-        Runtime config with selector context for planner-selector v2, otherwise the original config.
-    """
-    if str(algo).strip().lower() != "planner_selector_v2_diagnostic":
-        return policy_cfg
-    return _deep_merge_config(
-        policy_cfg,
-        {
-            "selector_context": {
-                "scenario_id": _scenario_id(scenario),
-                "scenario_family": _scenario_family(scenario),
-                "seed": int(seed),
-            }
-        },
-    )
-
-
-def _build_planner_selector_v2_child_adapter(
-    *,
-    candidate_name: str,
-    candidate_config_path: str,
-    scenario: dict[str, Any],
-) -> Any:
-    """Build one existing local candidate adapter for planner-selector v2.
-
-    Returns:
-        Adapter instance for a supported local child candidate.
-    """
-    path = Path(candidate_config_path)
-    if not path.is_absolute():
-        path = (Path.cwd() / path).resolve()
-    manifest = _parse_algo_config(str(path))
-    child_default_algo = str(manifest.get("algo", "")).strip().lower()
-    if not child_default_algo:
-        raise ValueError(f"Selector child candidate is missing algo: {candidate_name}")
-    child_algo, child_config = _resolve_policy_search_candidate_runtime(
-        default_algo=child_default_algo,
-        algo_config_path=str(path),
-        algo_config=manifest,
-        scenario=scenario,
-    )
-    if child_algo == "hybrid_rule_local_planner":
-        return HybridRuleLocalPlannerAdapter(
-            config=build_hybrid_rule_local_planner_config(child_config)
-        )
-    if child_algo == "orca":
-        return ORCAPlannerAdapter(
-            config=_build_socnav_config(child_config),
-            allow_fallback=bool(child_config.get("allow_fallback", False)),
-        )
-    raise ValueError(
-        "planner_selector_v2_diagnostic only supports existing local hybrid-rule/ORCA "
-        f"child candidates; {candidate_name!r} resolved to {child_algo!r}"
-    )
-
-
-def _build_planner_selector_v2_adapter(
-    algo_config: dict[str, Any],
-) -> PlannerSelectorV2DiagnosticAdapter:
-    """Build the diagnostic selector and all configured local child candidates.
-
-    Returns:
-        Configured planner-selector v2 adapter.
-    """
-    build = build_planner_selector_v2_diagnostic_config(algo_config)
-    scenario_stub = {
-        "name": build.selector.scenario_id,
-        "family": build.selector.scenario_family,
-    }
-    adapters = {
-        name: _build_planner_selector_v2_child_adapter(
-            candidate_name=name,
-            candidate_config_path=path,
-            scenario=scenario_stub,
-        )
-        for name, path in sorted(build.candidate_config_paths.items())
-    }
-    return PlannerSelectorV2DiagnosticAdapter(
-        config=build.selector,
-        candidate_adapters=adapters,
-    )
-
-
-def _prediction_planner_metadata_overrides(
-    algo_config: dict[str, Any],
-) -> dict[str, Any]:
-    """Expose predictive-planner search and uncertainty modes as first-class metadata.
-
-    Returns:
-        dict[str, Any]: Explicit mode labels for audit-friendly benchmark metadata.
-    """
-    uncertainty_mode = str(algo_config.get("predictive_uncertainty_mode", "deterministic")).strip()
-    search_mode = "mcts_lite"
-    if not bool(algo_config.get("predictive_mcts_enabled", False)):
-        search_mode = (
-            "sequence_beam"
-            if bool(algo_config.get("predictive_sequence_search_enabled", False))
-            else "lattice"
-        )
-    sample_count = int(algo_config.get("predictive_risk_sample_count", 1))
-    return {
-        "prediction_mode": "probabilistic"
-        if uncertainty_mode.lower() != "deterministic" or sample_count > 1
-        else "deterministic",
-        "predictive_uncertainty_mode": uncertainty_mode,
-        "predictive_risk_objective": str(
-            algo_config.get("predictive_risk_objective", "mean")
-        ).strip(),
-        "predictive_risk_sample_count": sample_count,
-        "predictive_search_mode": search_mode,
-    }
+_parse_algo_config = _policy_resolution._parse_algo_config
+_deep_merge_config = _policy_resolution._deep_merge_config
+_resolve_config_path = _policy_resolution._resolve_config_path
+_scenario_family = _policy_resolution._scenario_family
+_is_policy_search_candidate_manifest = _policy_resolution._is_policy_search_candidate_manifest
+_load_base_candidate_config = _policy_resolution._load_base_candidate_config
+_scenario_algo_override_runtime = _policy_resolution._scenario_algo_override_runtime
+_resolve_policy_search_candidate_runtime = (
+    _policy_resolution._resolve_policy_search_candidate_runtime
+)
+_apply_planner_selector_v2_context = _policy_resolution._apply_planner_selector_v2_context
+_build_planner_selector_v2_child_adapter = (
+    _policy_resolution._build_planner_selector_v2_child_adapter
+)
+_build_planner_selector_v2_adapter = _policy_resolution._build_planner_selector_v2_adapter
+_prediction_planner_metadata_overrides = _policy_resolution._prediction_planner_metadata_overrides
 
 
 def _is_socnav_algorithm(algo: str) -> bool:

--- a/robot_sf/benchmark/map_runner_policy_resolution.py
+++ b/robot_sf/benchmark/map_runner_policy_resolution.py
@@ -1,0 +1,336 @@
+"""Policy runtime resolution helpers extracted from :mod:`map_runner`.
+
+These helpers are used by the map benchmark runner when resolving policy-search
+candidate manifests, selector-v2 runtime wiring, and prediction metadata overrides.
+"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import fields
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_artifacts
+from robot_sf.benchmark.map_runner_trace import _scenario_id
+from robot_sf.planner.hybrid_rule_local_planner import (
+    HybridRuleLocalPlannerAdapter,
+    build_hybrid_rule_local_planner_config,
+)
+from robot_sf.planner.planner_selector_v2_diagnostic import (
+    PlannerSelectorV2DiagnosticAdapter,
+    build_planner_selector_v2_diagnostic_config,
+)
+from robot_sf.planner.socnav import ORCAPlannerAdapter, SocNavPlannerConfig
+
+
+def _parse_algo_config(algo_config_path: str | None) -> dict[str, Any]:
+    """Load an optional planner YAML config.
+
+    Returns:
+        dict[str, Any]: Parsed config mapping, or an empty mapping when omitted.
+    """
+    if not algo_config_path:
+        return {}
+    path = Path(algo_config_path)
+    if not path.exists():
+        raise FileNotFoundError(f"Algorithm config file not found: {algo_config_path}")
+    data = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(data, dict):
+        raise TypeError("Algorithm config must be a mapping (YAML dict).")
+    validate_no_local_model_artifacts(data, config_path=path)
+    return data
+
+
+def _deep_merge_config(base: dict[str, Any], overrides: dict[str, Any]) -> dict[str, Any]:
+    """Merge nested planner config overrides without mutating either input.
+
+    Returns:
+        A new mapping containing ``base`` with ``overrides`` applied recursively.
+    """
+    merged = deepcopy(base)
+    _deep_merge_inline(merged, overrides)
+    return merged
+
+
+def _deep_merge_inline(base: dict[str, Any], overrides: dict[str, Any]) -> None:
+    """Merge override values into an already isolated base mapping."""
+    for key, value in overrides.items():
+        current = base.get(key)
+        if isinstance(current, dict) and isinstance(value, dict):
+            _deep_merge_inline(current, value)
+        else:
+            base[key] = deepcopy(value)
+
+
+def _resolve_config_path(anchor: Path | None, raw_path: Any) -> Path | None:
+    """Resolve candidate-manifest config paths from manifest-local or repo-root form.
+
+    Returns:
+        Resolved path, or ``None`` when the raw path is empty or not a string.
+    """
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path.resolve()
+    if anchor is not None:
+        anchored = (anchor / path).resolve()
+        if anchored.exists():
+            return anchored
+    return path.resolve()
+
+
+def _scenario_family(scenario: dict[str, Any]) -> str:
+    """Classify a scenario into the report family used by benchmark summaries.
+
+    Returns:
+        str: Scenario family label.
+    """
+    scenario_id = _scenario_id(scenario)
+    if scenario_id.startswith("francis2023_"):
+        return "francis2023"
+    if scenario_id.startswith("classic_"):
+        return "classic"
+    return str(scenario.get("family") or scenario.get("metadata", {}).get("family") or "nominal")
+
+
+def _is_policy_search_candidate_manifest(config: dict[str, Any]) -> bool:
+    """Return whether a config has policy-search candidate manifest fields."""
+    return any(
+        key in config
+        for key in (
+            "base_config_path",
+            "params",
+            "family_overrides",
+            "scenario_overrides",
+            "scenario_algo_overrides",
+        )
+    )
+
+
+def _load_base_candidate_config(
+    manifest: dict[str, Any],
+    *,
+    config_anchor: Path | None,
+) -> dict[str, Any]:
+    """Load and merge a policy-search candidate's base config and params.
+
+    Returns:
+        dict[str, Any]: Effective candidate planner config.
+    """
+    base_cfg: dict[str, Any] = {}
+    base_path = _resolve_config_path(config_anchor, manifest.get("base_config_path"))
+    if base_path is not None:
+        base_cfg = _parse_algo_config(str(base_path))
+    params = manifest.get("params") or {}
+    if not isinstance(params, dict):
+        raise TypeError("Policy-search candidate params must be a mapping.")
+    return _deep_merge_config(base_cfg, params)
+
+
+def _scenario_algo_override_runtime(
+    override: dict[str, Any],
+    *,
+    default_algo: str,
+    scenario_key: str,
+    config_anchor: Path | None,
+) -> tuple[str, dict[str, Any]]:
+    """Resolve one scenario-level algorithm override.
+
+    Returns:
+        Effective algorithm key and flattened runtime config for the scenario.
+    """
+    algo = str(override.get("algo", default_algo)).strip().lower()
+    if not algo:
+        raise ValueError(f"Scenario algo override is missing algo: {scenario_key}")
+    base_cfg: dict[str, Any] = {}
+    base_path = _resolve_config_path(config_anchor, override.get("base_config_path"))
+    if base_path is not None:
+        base_cfg = _parse_algo_config(str(base_path))
+    params = override.get("params") or {}
+    if not isinstance(params, dict):
+        raise TypeError("Policy-search scenario_algo_overrides params must be a mapping.")
+    return algo, _deep_merge_config(base_cfg, params)
+
+
+def _resolve_policy_search_candidate_runtime(
+    *,
+    default_algo: str,
+    algo_config_path: str | None,
+    scenario: dict[str, Any],
+    algo_config: dict[str, Any] | None = None,
+) -> tuple[str, dict[str, Any]]:
+    """Resolve a policy-search candidate manifest to the runtime algo/config for a scenario.
+
+    Returns:
+        Effective algorithm key and flattened runtime config for the scenario.
+    """
+    manifest = (
+        dict(algo_config) if algo_config is not None else _parse_algo_config(algo_config_path)
+    )
+    if not _is_policy_search_candidate_manifest(manifest):
+        return default_algo, manifest
+
+    config_anchor = Path(algo_config_path).resolve().parent if algo_config_path else None
+    scenario_key = _scenario_id(scenario)
+    algo_overrides = manifest.get("scenario_algo_overrides")
+    if isinstance(algo_overrides, dict):
+        override = algo_overrides.get(scenario_key)
+        if isinstance(override, dict):
+            return _scenario_algo_override_runtime(
+                override,
+                default_algo=default_algo,
+                scenario_key=scenario_key,
+                config_anchor=config_anchor,
+            )
+
+    effective = _load_base_candidate_config(manifest, config_anchor=config_anchor)
+    family_overrides = manifest.get("family_overrides")
+    if isinstance(family_overrides, dict):
+        family_cfg = family_overrides.get(_scenario_family(scenario), {})
+        if isinstance(family_cfg, dict):
+            effective = _deep_merge_config(effective, family_cfg)
+    scenario_overrides = manifest.get("scenario_overrides")
+    if isinstance(scenario_overrides, dict):
+        scenario_cfg = scenario_overrides.get(scenario_key, {})
+        if isinstance(scenario_cfg, dict):
+            effective = _deep_merge_config(effective, scenario_cfg)
+    return default_algo, effective
+
+
+def _apply_planner_selector_v2_context(
+    algo: str,
+    policy_cfg: dict[str, Any],
+    *,
+    scenario: dict[str, Any],
+    seed: int,
+) -> dict[str, Any]:
+    """Attach selector-v2 scenario context wherever effective runtime config is materialized.
+
+    Returns:
+        Runtime config with selector context for planner-selector v2, otherwise the original config.
+    """
+    if str(algo).strip().lower() != "planner_selector_v2_diagnostic":
+        return policy_cfg
+    return _deep_merge_config(
+        policy_cfg,
+        {
+            "selector_context": {
+                "scenario_id": _scenario_id(scenario),
+                "scenario_family": _scenario_family(scenario),
+                "seed": int(seed),
+            }
+        },
+    )
+
+
+def _build_socnav_config(cfg: dict[str, Any]) -> SocNavPlannerConfig:
+    """Build a SocNav planner config from a loose mapping.
+
+    Returns:
+        SocNavPlannerConfig: Filtered planner configuration.
+    """
+    if not isinstance(cfg, dict):
+        return SocNavPlannerConfig()
+    allowed = {f.name for f in fields(SocNavPlannerConfig)}
+    filtered = {key: value for key, value in cfg.items() if key in allowed}
+    return SocNavPlannerConfig(**filtered)
+
+
+def _build_planner_selector_v2_child_adapter(
+    *,
+    candidate_name: str,
+    candidate_config_path: str,
+    scenario: dict[str, Any],
+) -> Any:
+    """Build one existing local candidate adapter for planner-selector v2.
+
+    Returns:
+        Adapter instance for a supported local child candidate.
+    """
+    path = Path(candidate_config_path)
+    if not path.is_absolute():
+        path = (Path.cwd() / path).resolve()
+    manifest = _parse_algo_config(str(path))
+    child_default_algo = str(manifest.get("algo", "")).strip().lower()
+    if not child_default_algo:
+        raise ValueError(f"Selector child candidate is missing algo: {candidate_name}")
+    child_algo, child_config = _resolve_policy_search_candidate_runtime(
+        default_algo=child_default_algo,
+        algo_config_path=str(path),
+        algo_config=manifest,
+        scenario=scenario,
+    )
+    if child_algo == "hybrid_rule_local_planner":
+        return HybridRuleLocalPlannerAdapter(
+            config=build_hybrid_rule_local_planner_config(child_config)
+        )
+    if child_algo == "orca":
+        return ORCAPlannerAdapter(
+            config=_build_socnav_config(child_config),
+            allow_fallback=bool(child_config.get("allow_fallback", False)),
+        )
+    raise ValueError(
+        "planner_selector_v2_diagnostic only supports existing local hybrid-rule/ORCA "
+        f"child candidates; {candidate_name!r} resolved to {child_algo!r}"
+    )
+
+
+def _build_planner_selector_v2_adapter(
+    algo_config: dict[str, Any],
+) -> PlannerSelectorV2DiagnosticAdapter:
+    """Build the diagnostic selector and all configured local child candidates.
+
+    Returns:
+        Configured planner-selector v2 adapter.
+    """
+    build = build_planner_selector_v2_diagnostic_config(algo_config)
+    scenario_stub = {
+        "name": build.selector.scenario_id,
+        "family": build.selector.scenario_family,
+    }
+    adapters = {
+        name: _build_planner_selector_v2_child_adapter(
+            candidate_name=name,
+            candidate_config_path=path,
+            scenario=scenario_stub,
+        )
+        for name, path in sorted(build.candidate_config_paths.items())
+    }
+    return PlannerSelectorV2DiagnosticAdapter(
+        config=build.selector,
+        candidate_adapters=adapters,
+    )
+
+
+def _prediction_planner_metadata_overrides(
+    algo_config: dict[str, Any],
+) -> dict[str, Any]:
+    """Expose predictive-planner search and uncertainty modes as first-class metadata.
+
+    Returns:
+        dict[str, Any]: Explicit mode labels for audit-friendly benchmark metadata.
+    """
+    uncertainty_mode = str(algo_config.get("predictive_uncertainty_mode", "deterministic")).strip()
+    search_mode = "mcts_lite"
+    if not bool(algo_config.get("predictive_mcts_enabled", False)):
+        search_mode = (
+            "sequence_beam"
+            if bool(algo_config.get("predictive_sequence_search_enabled", False))
+            else "lattice"
+        )
+    sample_count = int(algo_config.get("predictive_risk_sample_count", 1))
+    return {
+        "prediction_mode": "probabilistic"
+        if uncertainty_mode.lower() != "deterministic" or sample_count > 1
+        else "deterministic",
+        "predictive_uncertainty_mode": uncertainty_mode,
+        "predictive_risk_objective": str(
+            algo_config.get("predictive_risk_objective", "mean")
+        ).strip(),
+        "predictive_risk_sample_count": sample_count,
+        "predictive_search_mode": search_mode,
+    }


### PR DESCRIPTION
## Summary
- Extract policy-search/runtime resolution helpers from `robot_sf/benchmark/map_runner.py` into `robot_sf.benchmark.map_runner_policy_resolution`.
- Keep `map_runner.py` compatibility names for existing imports and monkeypatch points.
- Leave benchmark execution behavior unchanged; this is a focused issue #3006 decomposition slice.

## Validation
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policy_resolution.py` -> passed
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policy_resolution.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_prediction_planner_audit_contract.py -q` -> 131 passed
- `git diff --check` -> passed

## Compatibility Notes
- Existing `robot_sf.benchmark.map_runner` helper names remain available as aliases.
- Internal calls among the moved helpers now resolve inside `map_runner_policy_resolution`; this preserves runtime behavior but means monkeypatches of internals inside the new module should target the new module path.

## Downstream Propagation
NA - refactor-only extraction under issue #3006. No benchmark result, metric definition, schema, registry, or artifact interpretation changed.

## Research Result Guidance
NA - support/refactor-only PR with no research claim movement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal code organization restructured to improve modularity. Policy resolution logic consolidated into a dedicated module for better maintainability.

**Note:** This is an internal refactoring with no user-facing changes or new functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->