### PR TITLE
refactor: extract map runner profile loaders

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -32,8 +32,6 @@ from robot_sf.benchmark.algorithm_readiness import (
 )
 from robot_sf.benchmark.fallback_policy import availability_payload
 from robot_sf.benchmark.latency_stress import (
-    LatencyStressProfile,
-    load_latency_stress_profile,
     not_available_latency_metrics,
 )
 from robot_sf.benchmark.map_runner_actions import DEFAULT_KINEMATICS as _DEFAULT_KINEMATICS
@@ -102,6 +100,12 @@ from robot_sf.benchmark.map_runner_policy_metadata import (
 from robot_sf.benchmark.map_runner_policy_metadata import (
     holonomic_world_velocity_command as _holonomic_world_velocity_command,
 )
+from robot_sf.benchmark.map_runner_profile_metadata import (
+    load_latency_profile as _load_latency_profile,
+)
+from robot_sf.benchmark.map_runner_profile_metadata import (
+    load_synthetic_actuation_profile as _load_synthetic_actuation_profile_impl,
+)
 from robot_sf.benchmark.map_runner_provenance import (
     map_result_provenance as _map_result_provenance,
 )
@@ -143,10 +147,7 @@ from robot_sf.benchmark.scenario_schema import validate_scenario_list
 from robot_sf.benchmark.schema_validator import load_schema
 from robot_sf.benchmark.synthetic_actuation import (
     SyntheticActuationController,
-    SyntheticActuationProfile,
     not_available_saturation_metrics,
-    validate_actuation_profile_claim_boundary,
-    validate_synthetic_actuation_profile,
 )
 from robot_sf.benchmark.termination_reason import (
     build_outcome_payload,
@@ -342,46 +343,8 @@ _project_with_feasibility = planner_commands.project_with_feasibility
 _validate_planner_contract = planner_commands.validate_planner_contract
 
 
-def _load_synthetic_actuation_profile(payload: Any) -> SyntheticActuationProfile | None:
-    """Normalize optional synthetic-actuation payloads into the typed profile contract.
-
-    Returns:
-        A validated profile, or ``None`` when the payload is absent.
-    """
-    if payload is None:
-        return None
-    if isinstance(payload, SyntheticActuationProfile):
-        validate_synthetic_actuation_profile(payload)
-        return payload
-    if not isinstance(payload, dict):
-        raise TypeError("synthetic_actuation_profile must be a mapping when provided")
-    validate_actuation_profile_claim_boundary(payload)
-    claim_scope = str(payload.get("claim_scope", "synthetic-only")).strip() or "synthetic-only"
-    if claim_scope != "synthetic-only":
-        raise ValueError("synthetic_actuation_profile.claim_scope must be 'synthetic-only'")
-    profile = SyntheticActuationProfile(
-        name=str(payload.get("name", "")),
-        profile_version=str(payload.get("profile_version", "v0")),
-        claim_scope=claim_scope,
-        claim_boundary=str(payload.get("claim_boundary", "")),
-        max_linear_accel_m_s2=float(payload.get("max_linear_accel_m_s2")),
-        max_linear_decel_m_s2=float(payload.get("max_linear_decel_m_s2")),
-        max_yaw_rate_rad_s=float(payload.get("max_yaw_rate_rad_s")),
-        max_angular_accel_rad_s2=float(payload.get("max_angular_accel_rad_s2")),
-        latency_mode=str(payload.get("latency_mode", "")),
-        update_mode=str(payload.get("update_mode", "")),
-    )
-    validate_synthetic_actuation_profile(profile)
-    return profile
-
-
-def _load_latency_stress_profile(payload: Any) -> LatencyStressProfile | None:
-    """Normalize optional latency-stress payloads into the typed profile contract.
-
-    Returns:
-        A validated profile, or ``None`` when the payload is absent.
-    """
-    return load_latency_stress_profile(payload)
+_load_synthetic_actuation_profile = _load_synthetic_actuation_profile_impl
+_load_latency_stress_profile = _load_latency_profile
 
 
 def _build_adapter_policy(

--- a/robot_sf/benchmark/map_runner_profile_metadata.py
+++ b/robot_sf/benchmark/map_runner_profile_metadata.py
@@ -1,0 +1,54 @@
+"""Profile payload normalization helpers for map-based benchmark runs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from robot_sf.benchmark.latency_stress import LatencyStressProfile, load_latency_stress_profile
+from robot_sf.benchmark.synthetic_actuation import (
+    SyntheticActuationProfile,
+    validate_actuation_profile_claim_boundary,
+    validate_synthetic_actuation_profile,
+)
+
+
+def load_synthetic_actuation_profile(payload: Any) -> SyntheticActuationProfile | None:
+    """Normalize optional synthetic-actuation payloads into the typed profile contract.
+
+    Returns:
+        A validated profile, or ``None`` when the payload is absent.
+    """
+    if payload is None:
+        return None
+    if isinstance(payload, SyntheticActuationProfile):
+        validate_synthetic_actuation_profile(payload)
+        return payload
+    if not isinstance(payload, dict):
+        raise TypeError("synthetic_actuation_profile must be a mapping when provided")
+    validate_actuation_profile_claim_boundary(payload)
+    claim_scope = str(payload.get("claim_scope", "synthetic-only")).strip() or "synthetic-only"
+    if claim_scope != "synthetic-only":
+        raise ValueError("synthetic_actuation_profile.claim_scope must be 'synthetic-only'")
+    profile = SyntheticActuationProfile(
+        name=str(payload.get("name", "")),
+        profile_version=str(payload.get("profile_version", "v0")),
+        claim_scope=claim_scope,
+        claim_boundary=str(payload.get("claim_boundary", "")),
+        max_linear_accel_m_s2=float(payload.get("max_linear_accel_m_s2")),
+        max_linear_decel_m_s2=float(payload.get("max_linear_decel_m_s2")),
+        max_yaw_rate_rad_s=float(payload.get("max_yaw_rate_rad_s")),
+        max_angular_accel_rad_s2=float(payload.get("max_angular_accel_rad_s2")),
+        latency_mode=str(payload.get("latency_mode", "")),
+        update_mode=str(payload.get("update_mode", "")),
+    )
+    validate_synthetic_actuation_profile(profile)
+    return profile
+
+
+def load_latency_profile(payload: Any) -> LatencyStressProfile | None:
+    """Normalize optional latency-stress payloads into the typed profile contract.
+
+    Returns:
+        A validated profile, or ``None`` when the payload is absent.
+    """
+    return load_latency_stress_profile(payload)


### PR DESCRIPTION
## Summary
- Extract synthetic-actuation and latency profile payload normalization helpers from `map_runner.py` into `map_runner_profile_metadata.py`.
- Keep private compatibility aliases in `map_runner.py` for existing helper-name imports.
- Continue issue #3006 decomposition with a near-budget-stop, low-risk slice.

## Validation
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_profile_metadata.py` -> passed
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_profile_metadata.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py::test_run_map_batch_fail_closed_when_synthetic_actuation_profile_is_not_diff_drive tests/benchmark/test_map_runner_utils.py::test_run_map_batch_fail_closed_when_latency_action_delay_is_not_diff_drive tests/benchmark/test_map_runner_utils.py::test_run_map_episode_records_synthetic_actuation_metrics -q` -> 3 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_map_runner_preflight_profiles.py -q` -> 140 passed
- `git diff --check` -> passed

## Downstream Propagation
NA - refactor-only extraction under issue #3006. No benchmark result, metric definition, schema, registry, or artifact interpretation changed.

## Research Result Guidance
NA - support/refactor-only PR with no research claim movement.
