### PR TITLE
test: add gymnasium env contract coverage

### DIFF
--- a/robot_sf/gym_env/multi_robot_env.py
+++ b/robot_sf/gym_env/multi_robot_env.py
@@ -211,11 +211,16 @@ class MultiRobotEnv(MultiAgentEnv):
         Returns:
             Reset metadata dictionary with map and timing fields.
         """
+        sim_time = float(self.config.sim_config.sim_time_in_secs)
+        time_per_step = float(self.config.sim_config.time_per_step_in_secs)
+        max_sim_steps = getattr(self.config.sim_config, "max_sim_steps", None)
+        if max_sim_steps is None:
+            max_sim_steps = int(sim_time / time_per_step)
         return {
             "map_id": self._resolve_current_map_id(self.config, map_def),
-            "sim_time_in_secs": float(self.config.sim_config.sim_time_in_secs),
-            "time_per_step_in_secs": float(self.config.sim_config.time_per_step_in_secs),
-            "max_sim_steps": int(self.config.sim_config.max_sim_steps),
+            "sim_time_in_secs": sim_time,
+            "time_per_step_in_secs": time_per_step,
+            "max_sim_steps": int(max_sim_steps),
             "num_robots": self.num_agents,
             "seed": seed,
         }

--- a/robot_sf/gym_env/multi_robot_env.py
+++ b/robot_sf/gym_env/multi_robot_env.py
@@ -190,6 +190,50 @@ class MultiRobotEnv(MultiAgentEnv):
         any_terminated = any(terms)
         return obs_dict, total_reward, any_terminated, False, {"agents": masked_metas_tuple}
 
+    @staticmethod
+    def _resolve_current_map_id(config, map_def) -> str | None:
+        """Resolve the active map id from configuration and map definition.
+
+        Returns:
+            Optional map identifier from config or map pool by object identity.
+        """
+        configured_id = getattr(config, "map_id", None)
+        if configured_id:
+            return configured_id
+        try:
+            for map_id, candidate in config.map_pool.map_defs.items():
+                if candidate is map_def:
+                    return map_id
+        except (AttributeError, TypeError):
+            pass
+        return None
+
+    def _resolve_num_robots(self) -> int:
+        """Resolve the effective number of robots managed by this environment.
+
+        Returns:
+            The resolved robot count.
+        """
+        configured_num = getattr(self.config, "num_robots", None)
+        if configured_num is not None:
+            return int(configured_num)
+        return len(self._state_bindings)
+
+    def _build_reset_info(self, *, map_def, seed: int | None) -> dict[str, Any]:
+        """Build stable reset metadata for multi-robot environments.
+
+        Returns:
+            Reset metadata dictionary with map and timing fields.
+        """
+        return {
+            "map_id": self._resolve_current_map_id(self.config, map_def),
+            "sim_time_in_secs": float(self.config.sim_config.sim_time_in_secs),
+            "time_per_step_in_secs": float(self.config.sim_config.time_per_step_in_secs),
+            "max_sim_steps": int(self.config.sim_config.max_sim_steps),
+            "num_robots": self._resolve_num_robots(),
+            "seed": seed,
+        }
+
     def reset(
         self,
         *,
@@ -209,7 +253,10 @@ class MultiRobotEnv(MultiAgentEnv):
             OBS_DRIVE_STATE: np.array([o[OBS_DRIVE_STATE] for o in obs]),
             OBS_RAYS: np.array([o[OBS_RAYS] for o in obs]),
         }
-        return obs_dict, {}
+        return obs_dict, self._build_reset_info(
+            map_def=self.map_def,
+            seed=getattr(self, "applied_seed", None),
+        )
 
     def render(self, **kwargs) -> None:
         """Render the environment for each robot view."""

--- a/robot_sf/gym_env/multi_robot_env.py
+++ b/robot_sf/gym_env/multi_robot_env.py
@@ -19,6 +19,7 @@ from robot_sf.gym_env.env_util import (
     init_spaces,
     prepare_pedestrian_actions,
 )
+from robot_sf.gym_env.reset_metadata import build_reset_metadata
 from robot_sf.gym_env.reward import simple_reward
 from robot_sf.gym_env.unified_config import MultiRobotConfig
 from robot_sf.render.lidar_visual import render_lidar
@@ -190,40 +191,18 @@ class MultiRobotEnv(MultiAgentEnv):
         any_terminated = any(terms)
         return obs_dict, total_reward, any_terminated, False, {"agents": masked_metas_tuple}
 
-    @staticmethod
-    def _resolve_current_map_id(config, map_def) -> str | None:
-        """Resolve the active map id from configuration and map definition.
-
-        Returns:
-            Optional map identifier from map pool by object identity or config.
-        """
-        try:
-            for map_id, candidate in config.map_pool.map_defs.items():
-                if candidate is map_def:
-                    return map_id
-        except (AttributeError, TypeError):
-            pass
-        return getattr(config, "map_id", None)
-
     def _build_reset_info(self, *, map_def, seed: int | None) -> dict[str, Any]:
         """Build stable reset metadata for multi-robot environments.
 
         Returns:
             Reset metadata dictionary with map and timing fields.
         """
-        sim_time = float(self.config.sim_config.sim_time_in_secs)
-        time_per_step = float(self.config.sim_config.time_per_step_in_secs)
-        max_sim_steps = getattr(self.config.sim_config, "max_sim_steps", None)
-        if max_sim_steps is None:
-            max_sim_steps = int(sim_time / time_per_step)
-        return {
-            "map_id": self._resolve_current_map_id(self.config, map_def),
-            "sim_time_in_secs": sim_time,
-            "time_per_step_in_secs": time_per_step,
-            "max_sim_steps": int(max_sim_steps),
-            "num_robots": self.num_agents,
-            "seed": seed,
-        }
+        return build_reset_metadata(
+            self.config,
+            map_def=map_def,
+            seed=seed,
+            extra={"num_robots": self.num_agents},
+        )
 
     def reset(
         self,

--- a/robot_sf/gym_env/multi_robot_env.py
+++ b/robot_sf/gym_env/multi_robot_env.py
@@ -195,29 +195,15 @@ class MultiRobotEnv(MultiAgentEnv):
         """Resolve the active map id from configuration and map definition.
 
         Returns:
-            Optional map identifier from config or map pool by object identity.
+            Optional map identifier from map pool by object identity or config.
         """
-        configured_id = getattr(config, "map_id", None)
-        if configured_id:
-            return configured_id
         try:
             for map_id, candidate in config.map_pool.map_defs.items():
                 if candidate is map_def:
                     return map_id
         except (AttributeError, TypeError):
             pass
-        return None
-
-    def _resolve_num_robots(self) -> int:
-        """Resolve the effective number of robots managed by this environment.
-
-        Returns:
-            The resolved robot count.
-        """
-        configured_num = getattr(self.config, "num_robots", None)
-        if configured_num is not None:
-            return int(configured_num)
-        return len(self._state_bindings)
+        return getattr(config, "map_id", None)
 
     def _build_reset_info(self, *, map_def, seed: int | None) -> dict[str, Any]:
         """Build stable reset metadata for multi-robot environments.
@@ -230,7 +216,7 @@ class MultiRobotEnv(MultiAgentEnv):
             "sim_time_in_secs": float(self.config.sim_config.sim_time_in_secs),
             "time_per_step_in_secs": float(self.config.sim_config.time_per_step_in_secs),
             "max_sim_steps": int(self.config.sim_config.max_sim_steps),
-            "num_robots": self._resolve_num_robots(),
+            "num_robots": self.num_agents,
             "seed": seed,
         }
 

--- a/robot_sf/gym_env/pedestrian_env.py
+++ b/robot_sf/gym_env/pedestrian_env.py
@@ -25,6 +25,7 @@ from robot_sf.gym_env.env_util import (
     init_ped_spaces,
     prepare_pedestrian_actions,
 )
+from robot_sf.gym_env.reset_metadata import build_reset_metadata
 from robot_sf.gym_env.reward import simple_ped_reward
 from robot_sf.gym_env.robot_env import _build_step_info
 from robot_sf.gym_env.unified_config import (
@@ -83,31 +84,10 @@ def _reward_function_name(reward_func: Callable[..., object]) -> str:
     return getattr(reward_func, "__name__", type(reward_func).__name__)
 
 
-def _resolve_map_id(config, map_def) -> str | None:
-    """Resolve a configured map id from the configuration and map definition.
-
-    Returns:
-        Optional map identifier resolved from the map pool or configured map id.
-    """
-    try:
-        for map_id, candidate in config.map_pool.map_defs.items():
-            if candidate is map_def:
-                return map_id
-    except (AttributeError, TypeError):
-        pass
-    return getattr(config, "map_id", None)
-
-
 def _build_reset_info(config, *, map_def, seed: int | None = None) -> dict[str, Any]:
     """Return stable reset metadata for pedestrian environments."""
 
-    return {
-        "map_id": _resolve_map_id(config, map_def),
-        "sim_time_in_secs": float(config.sim_config.sim_time_in_secs),
-        "time_per_step_in_secs": float(config.sim_config.time_per_step_in_secs),
-        "max_sim_steps": int(config.sim_config.max_sim_steps),
-        "seed": seed,
-    }
+    return build_reset_metadata(config, map_def=map_def, seed=seed)
 
 
 class PedestrianEnv(SingleAgentEnv):

--- a/robot_sf/gym_env/pedestrian_env.py
+++ b/robot_sf/gym_env/pedestrian_env.py
@@ -83,6 +83,36 @@ def _reward_function_name(reward_func: Callable[..., object]) -> str:
     return getattr(reward_func, "__name__", type(reward_func).__name__)
 
 
+def _resolve_map_id(config, map_def) -> str | None:
+    """Resolve a configured map id from the configuration and map definition.
+
+    Returns:
+        Optional map identifier resolved from the configured map id or map pool.
+    """
+    configured = getattr(config, "map_id", None)
+    if configured:
+        return configured
+    try:
+        for map_id, candidate in config.map_pool.map_defs.items():
+            if candidate is map_def:
+                return map_id
+    except (AttributeError, TypeError):
+        pass
+    return None
+
+
+def _build_reset_info(config, *, map_def, seed: int | None = None) -> dict[str, Any]:
+    """Return stable reset metadata for pedestrian environments."""
+
+    return {
+        "map_id": _resolve_map_id(config, map_def),
+        "sim_time_in_secs": float(config.sim_config.sim_time_in_secs),
+        "time_per_step_in_secs": float(config.sim_config.time_per_step_in_secs),
+        "max_sim_steps": int(config.sim_config.max_sim_steps),
+        "seed": seed,
+    }
+
+
 class PedestrianEnv(SingleAgentEnv):
     """
     Pedestrian environment using the refactored single-agent architecture.
@@ -444,7 +474,11 @@ class PedestrianEnv(SingleAgentEnv):
             self.save_recording()
 
         # Preserve legacy info payload shape.
-        return obs_ped, {"info": "test"}
+        return obs_ped, _build_reset_info(
+            self.config,
+            map_def=self.map_def,
+            seed=getattr(self, "applied_seed", None),
+        )
 
     def render(self, **kwargs):
         """Render the environment."""

--- a/robot_sf/gym_env/pedestrian_env.py
+++ b/robot_sf/gym_env/pedestrian_env.py
@@ -87,18 +87,15 @@ def _resolve_map_id(config, map_def) -> str | None:
     """Resolve a configured map id from the configuration and map definition.
 
     Returns:
-        Optional map identifier resolved from the configured map id or map pool.
+        Optional map identifier resolved from the map pool or configured map id.
     """
-    configured = getattr(config, "map_id", None)
-    if configured:
-        return configured
     try:
         for map_id, candidate in config.map_pool.map_defs.items():
             if candidate is map_def:
                 return map_id
     except (AttributeError, TypeError):
         pass
-    return None
+    return getattr(config, "map_id", None)
 
 
 def _build_reset_info(config, *, map_def, seed: int | None = None) -> dict[str, Any]:

--- a/robot_sf/gym_env/reset_metadata.py
+++ b/robot_sf/gym_env/reset_metadata.py
@@ -1,0 +1,50 @@
+"""Shared Gymnasium reset metadata helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def resolve_map_id(config: Any, map_def: Any) -> str | None:
+    """Resolve the active map id from a map definition, then fall back to config.
+
+    Returns:
+        Optional map identifier resolved from the active map or configuration.
+    """
+    try:
+        for map_id, candidate in config.map_pool.map_defs.items():
+            if candidate is map_def:
+                return map_id
+    except (AttributeError, TypeError):
+        pass
+    return getattr(config, "map_id", None)
+
+
+def build_reset_metadata(
+    config: Any,
+    *,
+    map_def: Any,
+    seed: int | None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build stable map/timing reset metadata for Gymnasium environments.
+
+    Returns:
+        Reset metadata dictionary with map, timing, seed, and optional extra fields.
+    """
+    sim_time = float(config.sim_config.sim_time_in_secs)
+    time_per_step = float(config.sim_config.time_per_step_in_secs)
+    max_sim_steps = getattr(config.sim_config, "max_sim_steps", None)
+    if max_sim_steps is None:
+        max_sim_steps = int(sim_time / time_per_step)
+
+    metadata: dict[str, Any] = {
+        "map_id": resolve_map_id(config, map_def),
+        "sim_time_in_secs": sim_time,
+        "time_per_step_in_secs": time_per_step,
+        "max_sim_steps": int(max_sim_steps),
+        "seed": seed,
+    }
+    if extra:
+        metadata.update(extra)
+    return metadata

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -353,6 +353,45 @@ def _coerce_finite_float(value: Any) -> float | None:
     return result
 
 
+def _resolve_current_map_id(env_config: EnvSettings, map_def) -> str | None:
+    """Resolve the active map id from configuration and map definition.
+
+    When callers set ``map_id`` explicitly we return it directly; otherwise infer the
+    id by searching the configured map pool for the active ``map_def`` instance.
+
+    Returns:
+        Optional map identifier resolved from config or map pool.
+    """
+
+    configured_id = getattr(env_config, "map_id", None)
+    if configured_id:
+        return configured_id
+
+    try:
+        for map_id, candidate in env_config.map_pool.map_defs.items():
+            if candidate is map_def:
+                return map_id
+    except (AttributeError, TypeError):
+        pass
+    return None
+
+
+def _build_reset_info(env_config: EnvSettings, *, map_def, applied_seed: int | None) -> dict[str, Any]:
+    """Return a stable, non-placeholder reset metadata payload.
+
+    The payload intentionally keeps only lightweight, serializable fields useful for
+    downstream debugging and reproducibility.
+    """
+
+    return {
+        "map_id": _resolve_current_map_id(env_config, map_def),
+        "sim_time_in_secs": float(env_config.sim_config.sim_time_in_secs),
+        "time_per_step_in_secs": float(env_config.sim_config.time_per_step_in_secs),
+        "max_sim_steps": int(env_config.sim_config.max_sim_steps),
+        "seed": applied_seed,
+    }
+
+
 def _extract_reward_terms(meta: dict[str, Any]) -> dict[str, float]:
     """Extract finite reward-term scalars for telemetry replay.
 
@@ -1004,8 +1043,11 @@ class RobotEnv(BaseEnv):
                     # Legacy pickle recording
                     self.save_recording()
 
-            # info is necessary for the gym environment, but useless at the moment
-            info = {"info": "test"}
+            info = _build_reset_info(
+                self.config,
+                map_def=self.map_def,
+                applied_seed=self.applied_seed,
+            )
             # Reset telemetry timing on new episode
             self._last_wall_time = time.perf_counter()
             self._frame_idx = 0

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -356,24 +356,19 @@ def _coerce_finite_float(value: Any) -> float | None:
 def _resolve_current_map_id(env_config: EnvSettings, map_def) -> str | None:
     """Resolve the active map id from configuration and map definition.
 
-    When callers set ``map_id`` explicitly we return it directly; otherwise infer the
-    id by searching the configured map pool for the active ``map_def`` instance.
+    Prefer the active ``map_def`` instance when it can be matched to the configured
+    map pool, then fall back to an explicit configured map id.
 
     Returns:
         Optional map identifier resolved from config or map pool.
     """
-
-    configured_id = getattr(env_config, "map_id", None)
-    if configured_id:
-        return configured_id
-
     try:
         for map_id, candidate in env_config.map_pool.map_defs.items():
             if candidate is map_def:
                 return map_id
     except (AttributeError, TypeError):
         pass
-    return None
+    return getattr(env_config, "map_id", None)
 
 
 def _build_reset_info(

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -376,7 +376,9 @@ def _resolve_current_map_id(env_config: EnvSettings, map_def) -> str | None:
     return None
 
 
-def _build_reset_info(env_config: EnvSettings, *, map_def, applied_seed: int | None) -> dict[str, Any]:
+def _build_reset_info(
+    env_config: EnvSettings, *, map_def, applied_seed: int | None
+) -> dict[str, Any]:
     """Return a stable, non-placeholder reset metadata payload.
 
     The payload intentionally keeps only lightweight, serializable fields useful for

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -37,6 +37,7 @@ from robot_sf.gym_env.env_util import (
     prepare_pedestrian_actions,
 )
 from robot_sf.gym_env.observation_mode import ObservationMode
+from robot_sf.gym_env.reset_metadata import build_reset_metadata
 from robot_sf.gym_env.reward import route_completion_v2_reward
 from robot_sf.gym_env.snqi_proxy import StepSNQIProxy
 from robot_sf.nav.obstacle import Obstacle
@@ -353,24 +354,6 @@ def _coerce_finite_float(value: Any) -> float | None:
     return result
 
 
-def _resolve_current_map_id(env_config: EnvSettings, map_def) -> str | None:
-    """Resolve the active map id from configuration and map definition.
-
-    Prefer the active ``map_def`` instance when it can be matched to the configured
-    map pool, then fall back to an explicit configured map id.
-
-    Returns:
-        Optional map identifier resolved from config or map pool.
-    """
-    try:
-        for map_id, candidate in env_config.map_pool.map_defs.items():
-            if candidate is map_def:
-                return map_id
-    except (AttributeError, TypeError):
-        pass
-    return getattr(env_config, "map_id", None)
-
-
 def _build_reset_info(
     env_config: EnvSettings, *, map_def, applied_seed: int | None
 ) -> dict[str, Any]:
@@ -380,13 +363,7 @@ def _build_reset_info(
     downstream debugging and reproducibility.
     """
 
-    return {
-        "map_id": _resolve_current_map_id(env_config, map_def),
-        "sim_time_in_secs": float(env_config.sim_config.sim_time_in_secs),
-        "time_per_step_in_secs": float(env_config.sim_config.time_per_step_in_secs),
-        "max_sim_steps": int(env_config.sim_config.max_sim_steps),
-        "seed": applied_seed,
-    }
+    return build_reset_metadata(env_config, map_def=map_def, seed=applied_seed)
 
 
 def _extract_reward_terms(meta: dict[str, Any]) -> dict[str, float]:

--- a/tests/test_gymnasium_env_contracts.py
+++ b/tests/test_gymnasium_env_contracts.py
@@ -149,6 +149,10 @@ def test_image_factory_smoke_path_keeps_gymnasium_tuple_shape():
         assert len(result) == 2
         reset_info = result[1]
         assert isinstance(reset_info, Mapping)
+        _assert_contract_metadata_keys(
+            reset_info,
+            {"map_id", "sim_time_in_secs", "time_per_step_in_secs", "max_sim_steps", "seed"},
+        )
 
         action = env.action_space.sample()
         step_result = env.step(action)

--- a/tests/test_gymnasium_env_contracts.py
+++ b/tests/test_gymnasium_env_contracts.py
@@ -1,0 +1,157 @@
+"""Gymnasium API contracts for public factory-produced environments."""
+
+from collections.abc import Mapping
+
+import pytest
+from gymnasium import spaces
+from gymnasium.utils.env_checker import (
+    check_action_space,
+    check_observation_space,
+    check_reset_return_type,
+)
+from gymnasium.utils.passive_env_checker import (
+    check_obs,
+    env_reset_passive_checker,
+    env_step_passive_checker,
+)
+
+from robot_sf.gym_env.crowd_sim_env import CrowdSimulationConfig
+from robot_sf.gym_env.environment_factory import (
+    make_crowd_sim_env,
+    make_image_robot_env,
+    make_multi_robot_env,
+    make_pedestrian_env,
+    make_robot_env,
+)
+from robot_sf.gym_env.unified_config import (
+    MultiRobotConfig,
+    PedestrianSimulationConfig,
+    RobotSimulationConfig,
+)
+
+
+def _assert_contract_metadata_keys(info: Mapping[str, object], required: set[str]) -> None:
+    """Assert observed reset payload contains at least the required stable keys."""
+    for key in required:
+        assert key in info
+
+
+def _assert_step_contract(
+    step_result: tuple[object, float, bool, bool, Mapping[str, object]],
+) -> None:
+    """Assert 5-tuple Gymnasium step contract for terminated/truncated semantics."""
+    assert len(step_result) == 5
+    _, _reward, terminated, truncated, info = step_result
+    assert isinstance(terminated, bool)
+    assert isinstance(truncated, bool)
+    assert isinstance(info, Mapping)
+
+
+@pytest.mark.parametrize(
+    "factory,factory_kwargs,required_reset_keys,supports_env_checker",
+    [
+        (
+            make_robot_env,
+            {
+                "config": RobotSimulationConfig(map_id="uni_campus_big"),
+            },
+            {"map_id", "sim_time_in_secs", "time_per_step_in_secs", "max_sim_steps", "seed"},
+            True,
+        ),
+        (
+            make_pedestrian_env,
+            {
+                "config": PedestrianSimulationConfig(map_id="uni_campus_big"),
+                "robot_model": None,
+            },
+            {"map_id", "sim_time_in_secs", "time_per_step_in_secs", "max_sim_steps", "seed"},
+            True,
+        ),
+        (
+            make_multi_robot_env,
+            {
+                "num_robots": 2,
+                "config": MultiRobotConfig(map_id="uni_campus_big"),
+            },
+            {
+                "map_id",
+                "sim_time_in_secs",
+                "time_per_step_in_secs",
+                "max_sim_steps",
+                "num_robots",
+                "seed",
+            },
+            False,
+        ),
+        (
+            make_crowd_sim_env,
+            {
+                "config": CrowdSimulationConfig(map_id="uni_campus_big"),
+            },
+            {
+                "map_id",
+                "time_per_step_in_secs",
+                "sim_time_in_secs",
+                "max_sim_steps",
+                "num_pedestrians",
+            },
+            True,
+        ),
+    ],
+)
+def test_public_factories_adhere_to_gymnasium_step_reset_contract(
+    factory,
+    factory_kwargs,
+    required_reset_keys,
+    supports_env_checker,
+):
+    """Run Gymnasium contract checks for public factories excluding image-specific render constraints."""
+    env = factory(**factory_kwargs)
+    try:
+        check_action_space(env.action_space)
+        if supports_env_checker:
+            check_observation_space(env.observation_space)
+            check_reset_return_type(env)
+
+            reset_result = env_reset_passive_checker(env)
+            reset_obs, reset_info = reset_result
+            check_obs(reset_obs, env.observation_space, "reset")
+        else:
+            reset_result = env.reset()
+            reset_obs, reset_info = reset_result
+            _assert_contract_metadata_keys(reset_info, required_reset_keys)
+
+        assert isinstance(reset_result, tuple)
+        assert len(reset_result) == 2
+        assert isinstance(reset_info, Mapping)
+        _assert_contract_metadata_keys(reset_info, required_reset_keys)
+
+        action = env.action_space.sample()
+        if supports_env_checker:
+            step_result = env_step_passive_checker(env, action)
+        else:
+            step_result = env.step(action)
+        _assert_step_contract(step_result)
+    finally:
+        env.close()
+
+
+def test_image_factory_smoke_path_keeps_gymnasium_tuple_shape():
+    """Smoke test for image envs, which still need a focused manual check."""
+    env = make_image_robot_env(config=RobotSimulationConfig(map_id="uni_campus_big"))
+    try:
+        assert isinstance(env.action_space, spaces.Space)
+        check_action_space(env.action_space)
+        check_observation_space(env.observation_space)
+
+        result = env.reset()
+        assert isinstance(result, tuple)
+        assert len(result) == 2
+        reset_info = result[1]
+        assert isinstance(reset_info, Mapping)
+
+        action = env.action_space.sample()
+        step_result = env.step(action)
+        _assert_step_contract(step_result)
+    finally:
+        env.close()

--- a/tests/test_gymnasium_env_contracts.py
+++ b/tests/test_gymnasium_env_contracts.py
@@ -119,7 +119,6 @@ def test_public_factories_adhere_to_gymnasium_step_reset_contract(
         else:
             reset_result = env.reset()
             reset_obs, reset_info = reset_result
-            _assert_contract_metadata_keys(reset_info, required_reset_keys)
 
         assert isinstance(reset_result, tuple)
         assert len(reset_result) == 2

--- a/tests/test_multi_robot_env_recording.py
+++ b/tests/test_multi_robot_env_recording.py
@@ -260,7 +260,14 @@ def test_multi_robot_env_step_reset_render_and_step_agents(monkeypatch) -> None:
         reset_obs, reset_info = env.reset(seed=13)
         assert OBS_DRIVE_STATE in reset_obs
         assert OBS_RAYS in reset_obs
-        assert reset_info == {}
+        assert reset_info == {
+            "map_id": "uni_campus_big",
+            "sim_time_in_secs": 5.0,
+            "time_per_step_in_secs": 0.1,
+            "max_sim_steps": 50,
+            "num_robots": 2,
+            "seed": 13,
+        }
         assert env.applied_seed == 13
 
         env.render()

--- a/tests/test_pedestrian_env_compat.py
+++ b/tests/test_pedestrian_env_compat.py
@@ -159,7 +159,13 @@ def test_pedestrian_env_records_and_resets(tmp_path, monkeypatch) -> None:
     env = PedestrianEnv(robot_model=None, recording_enabled=True)
     try:
         _obs, info = env.reset()
-        assert "info" in info
+        assert set(info.keys()) >= {
+            "map_id",
+            "sim_time_in_secs",
+            "time_per_step_in_secs",
+            "max_sim_steps",
+            "seed",
+        }
 
         action = env.action_space.sample()
         _obs, _reward, _terminated, _truncated, step_info = env.step(action)


### PR DESCRIPTION
Closes #2995.

## Summary
- replace placeholder Gymnasium reset info in robot, pedestrian, and multi-robot envs with stable map/timing/seed metadata
- add focused Gymnasium reset/step contract tests for public factory-produced envs
- keep MultiRobotEnv on a manual contract subset because it does not expose a Gymnasium observation_space

## Validation
- All checks passed!
- ============================= test session starts ==============================
platform linux -- Python 3.13.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/luttkule/git/robot_sf_ll7.worktrees/issue-2995-gymnasium-env-check
configfile: pyproject.toml
plugins: cov-7.0.0, xdist-3.8.0, anyio-4.12.1
collected 35 items

tests/test_environment_factory_signatures.py ..................          [ 51%]
tests/test_pedestrian_env_compat.py ............                         [ 85%]
tests/test_gymnasium_env_contracts.py .....                              [100%]

============================= slowest 10 durations =============================
4.21s call     tests/test_pedestrian_env_compat.py::test_pedestrian_env_handles_mismatched_model_action_space
2.55s call     tests/test_pedestrian_env_compat.py::test_pedestrian_env_uses_stub_robot_model
0.50s call     tests/test_gymnasium_env_contracts.py::test_public_factories_adhere_to_gymnasium_step_reset_contract[make_robot_env-factory_kwargs0-required_reset_keys0-True]
0.46s setup    tests/test_environment_factory_signatures.py::test_make_robot_env_signature_explicit
0.28s call     tests/test_gymnasium_env_contracts.py::test_public_factories_adhere_to_gymnasium_step_reset_contract[make_multi_robot_env-factory_kwargs2-required_reset_keys2-False]
0.10s call     tests/test_gymnasium_env_contracts.py::test_public_factories_adhere_to_gymnasium_step_reset_contract[make_crowd_sim_env-factory_kwargs3-required_reset_keys3-True]
0.10s call     tests/test_pedestrian_env_compat.py::test_make_pedestrian_env_uses_stub_robot_model
0.07s call     tests/test_gymnasium_env_contracts.py::test_image_factory_smoke_path_keeps_gymnasium_tuple_shape
0.05s call     tests/test_pedestrian_env_compat.py::test_pedestrian_env_records_and_resets
0.05s call     tests/test_gymnasium_env_contracts.py::test_public_factories_adhere_to_gymnasium_step_reset_contract[make_pedestrian_env-factory_kwargs1-required_reset_keys1-True]

Slow Test Report (soft<20s hard=60s, top 10)
1) tests/test_pedestrian_env_compat.py::test_pedestrian_env_handles_mismatched_model_action_space  4.21s
2) tests/test_pedestrian_env_compat.py::test_pedestrian_env_uses_stub_robot_model  2.55s
3) tests/test_gymnasium_env_contracts.py::test_public_factories_adhere_to_gymnasium_step_reset_contract[make_robot_env-factory_kwargs0-required_reset_keys0-True]  0.50s
4) tests/test_gymnasium_env_contracts.py::test_public_factories_adhere_to_gymnasium_step_reset_contract[make_multi_robot_env-factory_kwargs2-required_reset_keys2-False]  0.28s
5) tests/test_gymnasium_env_contracts.py::test_public_factories_adhere_to_gymnasium_step_reset_contract[make_crowd_sim_env-factory_kwargs3-required_reset_keys3-True]  0.10s
6) tests/test_pedestrian_env_compat.py::test_make_pedestrian_env_uses_stub_robot_model  0.10s
7) tests/test_gymnasium_env_contracts.py::test_image_factory_smoke_path_keeps_gymnasium_tuple_shape  0.07s
8) tests/test_pedestrian_env_compat.py::test_pedestrian_env_records_and_resets  0.05s
9) tests/test_gymnasium_env_contracts.py::test_public_factories_adhere_to_gymnasium_step_reset_contract[make_pedestrian_env-factory_kwargs1-required_reset_keys1-True]  0.05s
10) tests/test_pedestrian_env_compat.py::test_pedestrian_env_does_not_mutate_input_config_for_deprecated_force_flag  0.05s

============================== 35 passed in 8.83s ============================== (35 passed)
- ok fetched (1 new refs)
Already up to date. (already up to date)
-  (no output artifacts)

## Downstream Propagation
- Parent issue: #2995 will close via this PR.
- Claim map / benchmark report / leaderboard / artifact catalog: NA - this is Gymnasium API contract/test coverage, not benchmark evidence.
- Registry/config index: NA - no runtime config or artifact registry change.
- Context index or memory note: NA - focused code/test change; validation is in this PR.

## Research Result Guidance
- Target claim/hypothesis/blocker: NA - support/API compatibility implementation, no research claim.
- Comparator/baseline: previous reset info included placeholders or empty dicts for several envs.
- Evidence tier: targeted unit/API contract tests.
- Result classification: implementation support, not benchmark evidence.
- Decision/stop rule: targeted env factory checks and ruff pass.
- Synthesis surface/update target: NA.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Environment reset operations now return detailed metadata including the active map ID, simulation timing parameters, robot count, and applied seed value instead of empty information.

* **Tests**
  * Added comprehensive test suite validating environment API compliance with Gymnasium standards, including reset and step contract verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->