### PR TITLE
refactor: extract map runner identity helpers

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -74,8 +74,6 @@ from robot_sf.benchmark.map_runner_env import (
 from robot_sf.benchmark.map_runner_identity import (
     _compute_map_episode_id,
     _resolve_seed_list,
-    _scenario_family,  # noqa: F401 - compatibility re-export for tests.
-    _scenario_id,
     _scenario_identity_payload,
     _scenario_with_episode_seed_defaults,
     _select_seeds,
@@ -119,6 +117,7 @@ from robot_sf.benchmark.map_runner_trace import (
     _fast_bicycle_actor_summary,
     _intent_conditioned_behavior_summary,
     _observation_heading,
+    _scenario_id,
     _signal_state_for_metric_metadata,  # noqa: F401 - compatibility re-export for tests.
     _signal_state_promotion_contract,  # noqa: F401 - compatibility re-export for tests.
     _signal_state_proxy_wrapper,  # noqa: F401 - compatibility re-export for tests.
@@ -488,6 +487,7 @@ class _ExternalMPCAdapter:
 _parse_algo_config = _policy_resolution._parse_algo_config
 _deep_merge_config = _policy_resolution._deep_merge_config
 _resolve_config_path = _policy_resolution._resolve_config_path
+_scenario_family = _policy_resolution._scenario_family
 _is_policy_search_candidate_manifest = _policy_resolution._is_policy_search_candidate_manifest
 _load_base_candidate_config = _policy_resolution._load_base_candidate_config
 _scenario_algo_override_runtime = _policy_resolution._scenario_algo_override_runtime

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -71,16 +71,16 @@ from robot_sf.benchmark.map_runner_env import build_env_config as _build_env_con
 from robot_sf.benchmark.map_runner_env import (
     validate_sensor_fusion_adapter_config as _validate_sensor_fusion_adapter_config,
 )
-from robot_sf.benchmark.map_runner_identity import compute_map_episode_id as _compute_map_episode_id
-from robot_sf.benchmark.map_runner_identity import resolve_seed_list as _resolve_seed_list
 from robot_sf.benchmark.map_runner_identity import (
-    scenario_identity_payload as _scenario_identity_payload,
+    _compute_map_episode_id,
+    _resolve_seed_list,
+    _scenario_family,  # noqa: F401 - compatibility re-export for tests.
+    _scenario_id,
+    _scenario_identity_payload,
+    _scenario_with_episode_seed_defaults,
+    _select_seeds,
+    _suite_key,
 )
-from robot_sf.benchmark.map_runner_identity import (
-    scenario_with_episode_seed_defaults as _scenario_with_episode_seed_defaults,
-)
-from robot_sf.benchmark.map_runner_identity import select_seeds as _select_seeds
-from robot_sf.benchmark.map_runner_identity import suite_key as _suite_key
 from robot_sf.benchmark.map_runner_jsonl import write_validated_to_handle as _write_jsonl_record
 from robot_sf.benchmark.map_runner_metrics import (
     floor_collision_metrics_from_flags as _floor_collision_metrics_from_flags,
@@ -119,7 +119,6 @@ from robot_sf.benchmark.map_runner_trace import (
     _fast_bicycle_actor_summary,
     _intent_conditioned_behavior_summary,
     _observation_heading,
-    _scenario_id,
     _signal_state_for_metric_metadata,  # noqa: F401 - compatibility re-export for tests.
     _signal_state_promotion_contract,  # noqa: F401 - compatibility re-export for tests.
     _signal_state_proxy_wrapper,  # noqa: F401 - compatibility re-export for tests.
@@ -489,7 +488,6 @@ class _ExternalMPCAdapter:
 _parse_algo_config = _policy_resolution._parse_algo_config
 _deep_merge_config = _policy_resolution._deep_merge_config
 _resolve_config_path = _policy_resolution._resolve_config_path
-_scenario_family = _policy_resolution._scenario_family
 _is_policy_search_candidate_manifest = _policy_resolution._is_policy_search_candidate_manifest
 _load_base_candidate_config = _policy_resolution._load_base_candidate_config
 _scenario_algo_override_runtime = _policy_resolution._scenario_algo_override_runtime

--- a/robot_sf/benchmark/map_runner_identity.py
+++ b/robot_sf/benchmark/map_runner_identity.py
@@ -10,6 +10,8 @@ if TYPE_CHECKING:
 
 import yaml
 
+from robot_sf.benchmark.map_runner_policy_resolution import _scenario_family
+from robot_sf.benchmark.map_runner_trace import _scenario_id
 from robot_sf.benchmark.observation_noise import (
     normalize_observation_noise_spec,
     observation_noise_hash,
@@ -17,7 +19,7 @@ from robot_sf.benchmark.observation_noise import (
 from robot_sf.benchmark.utils import _config_hash
 
 
-def resolve_seed_list(path: Path) -> dict[str, list[int]]:
+def _resolve_seed_list(path: Path) -> dict[str, list[int]]:
     """Load named benchmark seed lists from YAML.
 
     Returns:
@@ -31,7 +33,7 @@ def resolve_seed_list(path: Path) -> dict[str, list[int]]:
     return {str(k): [int(s) for s in v] for k, v in data.items() if isinstance(v, list)}
 
 
-def suite_key(scenario_path: Path) -> str:
+def _suite_key(scenario_path: Path) -> str:
     """Infer the seed-suite key from a scenario config filename.
 
     Returns:
@@ -45,7 +47,7 @@ def suite_key(scenario_path: Path) -> str:
     return "default"
 
 
-def select_seeds(
+def _select_seeds(
     scenario: dict[str, Any],
     *,
     suite_seeds: dict[str, list[int]],
@@ -66,7 +68,7 @@ def select_seeds(
     return [0]
 
 
-def scenario_identity_payload(  # noqa: PLR0913
+def _scenario_identity_payload(  # noqa: PLR0913
     scenario: dict[str, Any],
     *,
     algo: str,
@@ -123,7 +125,7 @@ def scenario_identity_payload(  # noqa: PLR0913
     return payload
 
 
-def compute_map_episode_id(identity_payload: dict[str, Any], seed: int) -> str:
+def _compute_map_episode_id(identity_payload: dict[str, Any], seed: int) -> str:
     """Return a map-runner episode id scoped to algorithm + run dimensions.
 
     The default benchmark ``compute_episode_id`` uses ``<scenario_id>--<seed>``.
@@ -139,7 +141,7 @@ def compute_map_episode_id(identity_payload: dict[str, Any], seed: int) -> str:
     return f"{scenario_id}--{seed}--{identity_hash}"
 
 
-def scenario_with_episode_seed_defaults(
+def _scenario_with_episode_seed_defaults(
     scenario: dict[str, Any],
     *,
     seed: int,
@@ -155,3 +157,13 @@ def scenario_with_episode_seed_defaults(
     if isinstance(sim_config, dict) and sim_config.get("route_spawn_seed") is None:
         sim_config["route_spawn_seed"] = int(seed)
     return updated
+
+
+resolve_seed_list = _resolve_seed_list
+suite_key = _suite_key
+select_seeds = _select_seeds
+scenario_identity_payload = _scenario_identity_payload
+compute_map_episode_id = _compute_map_episode_id
+scenario_with_episode_seed_defaults = _scenario_with_episode_seed_defaults
+scenario_id = _scenario_id
+scenario_family = _scenario_family

--- a/robot_sf/benchmark/map_runner_identity.py
+++ b/robot_sf/benchmark/map_runner_identity.py
@@ -10,8 +10,6 @@ if TYPE_CHECKING:
 
 import yaml
 
-from robot_sf.benchmark.map_runner_policy_resolution import _scenario_family
-from robot_sf.benchmark.map_runner_trace import _scenario_id
 from robot_sf.benchmark.observation_noise import (
     normalize_observation_noise_spec,
     observation_noise_hash,
@@ -165,5 +163,3 @@ select_seeds = _select_seeds
 scenario_identity_payload = _scenario_identity_payload
 compute_map_episode_id = _compute_map_episode_id
 scenario_with_episode_seed_defaults = _scenario_with_episode_seed_defaults
-scenario_id = _scenario_id
-scenario_family = _scenario_family


### PR DESCRIPTION
Part of #3006.

## Summary
- extract map-runner seed, suite, scenario identity, and episode-id helpers into `robot_sf/benchmark/map_runner_identity.py`
- keep compatibility aliases/imports available through `robot_sf.benchmark.map_runner`
- leave planner construction, metrics, simulation flow, resume semantics, and output schemas unchanged

## Validation
- `rtk uv run pytest tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_map_runner_utils.py::test_suite_seed_selection_and_behavior_sanity tests/benchmark/test_map_runner_utils.py::test_build_socnav_config_and_seed_loading tests/benchmark/test_map_runner_utils.py::test_run_map_batch_serial_and_resume -q` (14 passed)
- `rtk uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_identity.py`
- `rtk uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_identity.py`
- `rtk git fetch origin main && rtk git merge origin/main` (already up to date)
- `[ -d output ] && git status --ignored --short -uall output || true` (no output artifacts)

## Downstream Propagation
- Parent issue: #3006 remains open; this is only the first bounded refactor slice.
- Claim map / benchmark report / leaderboard / artifact catalog: NA - behavior-preserving refactor, no benchmark evidence or result artifact.
- Registry/config index: NA - no config or schema changes.
- Context index or memory note: NA for this slice; PR text records validation and boundaries.

## Research Result Guidance
- Target claim/hypothesis/blocker: reduce `map_runner.py` god-file pressure without changing benchmark semantics.
- Comparator/baseline: previous helper implementations lived/imported through `map_runner.py` and existing `map_runner_identity.py` public helper names.
- Evidence tier: focused regression tests covering resume identity and seed selection behavior.
- Result classification: support refactor; not benchmark evidence.
- Decision/stop rule: target helpers extracted/centralized and focused validation passes.
- Synthesis surface/update target: #3006 for remaining slices.
