### PR TITLE
docs: reconcile experiment card issue state

### DIFF
--- a/experiments/issue_1108_bc_warm_start_ppo.yaml
+++ b/experiments/issue_1108_bc_warm_start_ppo.yaml
@@ -45,8 +45,10 @@ expected_artifacts:
     durable_reference_required: true
 evidence_grade: observed
 paper_relevance: paper_candidate
-status: in_progress_slurm
+status: closed
 notes: >
-  Issue #1108 is execution-gated on Auxme/SLURM and durable artifact promotion.
-  Local output paths are not paper evidence until replaced by W&B, registry, or
-  release pointers.
+  #1108 is closed and was classified by #1961 as `rerun_required`. The preserved
+  rescue chain recorded durable references only for a partial artifact set:
+  docs/context/issue_1961_bc_warm_start_recoverability.md and
+  docs/context/evidence/issue_1977_bc_warm_start_cancelled_2026-06-02/artifact_manifest.md.
+  The issue explicitly says this trail is not a valid base for fresh training.

--- a/experiments/issue_1108_bc_warm_start_ppo.yaml
+++ b/experiments/issue_1108_bc_warm_start_ppo.yaml
@@ -47,8 +47,8 @@ evidence_grade: observed
 paper_relevance: paper_candidate
 status: closed
 notes: >
-  #1108 is closed and was classified by #1961 as `rerun_required`. The preserved
-  rescue chain recorded durable references only for a partial artifact set:
+  Issue #1108 is closed and was classified by issue #1961 as `rerun_required`.
+  The preserved rescue chain recorded durable references only for a partial artifact set:
   docs/context/issue_1961_bc_warm_start_recoverability.md and
   docs/context/evidence/issue_1977_bc_warm_start_cancelled_2026-06-02/artifact_manifest.md.
   The issue explicitly says this trail is not a valid base for fresh training.

--- a/experiments/issue_1151_manual_control_mvp_collection.yaml
+++ b/experiments/issue_1151_manual_control_mvp_collection.yaml
@@ -35,7 +35,8 @@ expected_artifacts:
     path: output/manual_control/issue1151_mvp_sessions/bc_samples.jsonl
 evidence_grade: observed
 paper_relevance: exploratory
-status: blocked_on_issue_1219
+status: completed
 notes: >
-  #1151 remains a parent epic. This record tracks the future collection
-  protocol, while #1219 owns the executable runner.
+  #1151 is closed. Child issue #1219 is also closed with PR #1228 merged (local
+  Pygame runner surfaces in place), so this card no longer remains blocked on the
+  original child implementation dependency.

--- a/experiments/issue_1151_manual_control_mvp_collection.yaml
+++ b/experiments/issue_1151_manual_control_mvp_collection.yaml
@@ -37,6 +37,6 @@ evidence_grade: observed
 paper_relevance: exploratory
 status: completed
 notes: >
-  #1151 is closed. Child issue #1219 is also closed with PR #1228 merged (local
-  Pygame runner surfaces in place), so this card no longer remains blocked on the
-  original child implementation dependency.
+  Issue #1151 is closed. Child issue #1219 is also closed with PR #1228 merged
+  (local Pygame runner surfaces in place), so this card no longer remains blocked
+  on the original child implementation dependency.

--- a/experiments/issue_1236_adversarial_optimizer_sampler.yaml
+++ b/experiments/issue_1236_adversarial_optimizer_sampler.yaml
@@ -31,7 +31,7 @@ expected_artifacts:
     path: output/adversarial/issue1236_optimizer_sampler_pilot/best/
 evidence_grade: observed
 paper_relevance: exploratory
-status: planned
+status: closed
 notes: >
   This pilot is explicitly not paper-facing until repeated-seed evidence and
   durable replay bundles exist.

--- a/experiments/issue_1470_oracle_imitation_dataset_collection.yaml
+++ b/experiments/issue_1470_oracle_imitation_dataset_collection.yaml
@@ -52,7 +52,7 @@ status: blocked_on_issue_2441
 notes: >
   This card remains the launch packet for #1470. Execution/finalization for the
   corresponding trace-collection and evidence handoff is now actively tracked by
-  #2441 (status OPEN). PR #2989 references
+  issue #2441 (status OPEN). PR #2989 references
   `docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/`,
   which contains durable trace-collection evidence; downstream dataset materialization
   remains out of scope for this card.

--- a/experiments/issue_1470_oracle_imitation_dataset_collection.yaml
+++ b/experiments/issue_1470_oracle_imitation_dataset_collection.yaml
@@ -48,9 +48,11 @@ expected_artifacts:
     durable_reference_required: true
 evidence_grade: proposal
 paper_relevance: exploratory
-status: blocked_on_slurm
+status: blocked_on_issue_2441
 notes: >
-  This card is a launch packet only. Issue #1470 remains blocked until a SLURM-capable worker,
-  exact collection commit, and durable dataset destination are recorded. Generated worktree-local
-  output is not benchmark or training evidence until the manifest, checksums, split/leakage proof,
-  and artifact pointers exist.
+  This card remains the launch packet for #1470. Execution/finalization for the
+  corresponding trace-collection and evidence handoff is now actively tracked by
+  #2441 (status OPEN). PR #2989 references
+  `docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/`,
+  which contains durable trace-collection evidence; downstream dataset materialization
+  remains out of scope for this card.

--- a/experiments/issue_1475_orca_residual_bc_lineage_smoke.yaml
+++ b/experiments/issue_1475_orca_residual_bc_lineage_smoke.yaml
@@ -45,3 +45,6 @@ status: blocked_on_slurm
 notes: >
   Nominal escalation is disallowed until the smoke result records success, collision, residual
   clipping, guard veto/fallback rate, fallback/degraded status, and durable artifact pointer status.
+  2026-06-17 live state confirms lineage validation succeeded (`status: valid`) and that
+  host-side submission is blocked by missing Slurm tooling (`sbatch` unavailable), so this
+  experiment remains blocked on execution.

--- a/experiments/issue_2441_oracle_imitation_trace_finalize.yaml
+++ b/experiments/issue_2441_oracle_imitation_trace_finalize.yaml
@@ -1,0 +1,44 @@
+schema_version: experiment-record.v1
+experiment_id: issue_2441_oracle_imitation_trace_finalize
+issue: 2441
+issue_url: https://github.com/ll7/robot_sf_ll7/issues/2441
+question: >
+  Can #1470's oracle-imitation trace collection be submitted and finalized on
+  Slurm with durable artifact handoff for downstream dataset materialization?
+hypothesis: >
+  Running the #2441 submission and finalization lane should produce a durable
+  trace-collection bundle without changing the split/leakage contract from
+  #1397.
+config:
+  - configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
+  - docs/context/issue_1397_oracle_imitation_launch_packet.md
+  - docs/context/policy_search/contracts/oracle_imitation_dataset_split.md
+command: |
+  uv run python scripts/validation/validate_oracle_imitation_launch_packet.py \
+    --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml \
+    --json
+  # On a Slurm-capable worker: submit the #1470 collection path, run the
+  # corresponding finalizer for durable artifact handoff, then record the artifact
+  # bundle for downstream materialization.
+inputs:
+  - path: configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
+  - path: docs/context/issue_1397_oracle_imitation_launch_packet.md
+  - path: docs/context/policy_search/contracts/oracle_imitation_dataset_split.md
+outputs:
+  - path: docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/
+    durable_reference: docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/
+    evidence_role: durable trace handoff bundle
+expected_artifacts:
+  - name: trace_collection_bundle
+    path: docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/
+    durable_reference_required: true
+  - name: artifact_checksum_manifest
+    path: docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/SHA256SUMS
+    durable_reference_required: true
+evidence_grade: observed
+paper_relevance: exploratory
+status: blocked_on_slurm
+notes: >
+  #2441 tracks the still-open submission/finalization lane for #1470. Merged PR
+  #2989 is the current evidence handoff path; downstream dataset materialization
+  and split-leakage promotion remain outside this card.

--- a/experiments/issue_2441_oracle_imitation_trace_finalize.yaml
+++ b/experiments/issue_2441_oracle_imitation_trace_finalize.yaml
@@ -8,7 +8,7 @@ question: >
 hypothesis: >
   Running the #2441 submission and finalization lane should produce a durable
   trace-collection bundle without changing the split/leakage contract from
-  #1397.
+  issue #1397.
 config:
   - configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
   - docs/context/issue_1397_oracle_imitation_launch_packet.md
@@ -39,6 +39,6 @@ evidence_grade: observed
 paper_relevance: exploratory
 status: blocked_on_slurm
 notes: >
-  #2441 tracks the still-open submission/finalization lane for #1470. Merged PR
-  #2989 is the current evidence handoff path; downstream dataset materialization
-  and split-leakage promotion remain outside this card.
+  Issue #2441 tracks the still-open submission/finalization lane for issue #1470.
+  Merged PR #2989 is the current evidence handoff path; downstream dataset
+  materialization and split-leakage promotion remain outside this card.

--- a/experiments/registry.yaml
+++ b/experiments/registry.yaml
@@ -8,6 +8,7 @@ records:
   - issue_1236_adversarial_optimizer_sampler.yaml
   - issue_1151_manual_control_mvp_collection.yaml
   - issue_1470_oracle_imitation_dataset_collection.yaml
+  - issue_2441_oracle_imitation_trace_finalize.yaml
   - issue_1475_orca_residual_bc_lineage_smoke.yaml
   - issue_1610_perturbation_criticality_synthesis.yaml
   - issue_1488_adversarial_search_synthesis.yaml


### PR DESCRIPTION
## Summary
- reconcile experiment cards against live issue state for the #3074 acceptance examples
- add a scoped #2441 card and registry entry to make the #1470/#2441 handoff explicit
- keep #1475 and #2441 blocked on execution/finalization rather than promoting claims

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/validate_experiment_registry.py experiments/registry.yaml`
- live issue checks for #1108, #1236, #1151, #1219, #1475, #1470, and #2441 via `gh issue view --json state,labels,url`
- checked PR #2989 state: merged on 2026-06-17

## Downstream Propagation
- Parent issue: closes #3074.
- Registry/card index: updated `experiments/registry.yaml` and the affected experiment cards.
- Context/evidence: references existing durable trace evidence under `docs/context/evidence/issue_1470_oracle_imitation_traces_12911_2026-06-17/`; no generated `output/` artifacts were created.
- Follow-up: #1475 and #2441 remain blocked on Slurm-capable execution/finalization and should not be promoted until executable evidence exists.

## Research Result Guidance
- Target claim/hypothesis/blocker: card/live-state drift for experiment records; not a new benchmark result.
- Comparator/baseline: current checked-in registry and live GitHub issue states.
- Evidence tier: metadata/control-plane validation plus live issue state checks.
- Result classification: workflow/card reconciliation only; no paper-facing or benchmark claim movement.
- Decision/stop rule: update deterministic stale card state, leave execution-dependent cards blocked.
- Synthesis surface/update target: `experiments/registry.yaml` and affected `experiments/issue_*.yaml` cards.
