### PR TITLE
validation: harden registry artifact policy

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -51,6 +51,9 @@ For legacy `experiment-record.v1` cards, use `status: proposal` for non-actionab
 still contain placeholder commands or expected artifacts. `planned` is treated as actionable by the
 validator, so required durable artifacts must have concrete `durable_reference` values and command
 or artifact paths must not contain placeholder tokens such as `<campaign-id>`.
+For `experiment-record.v2` cards, `state: idea` and `state: proposal` are the equivalent
+non-actionable proposal states; move the card to an implementation or execution state only after
+placeholder commands and durable artifact references are resolved.
 
 ### Control-plane dry-run report
 

--- a/experiments/README.md
+++ b/experiments/README.md
@@ -47,6 +47,10 @@ stopped_by_gate
 Closed GitHub issues are historical truth unless a new follow-up issue is opened. Stale cards
 should be corrected or superseded through a PR rather than silently treated as active work.
 Local `output/` paths and `:pending` artifact aliases are not durable evidence.
+For legacy `experiment-record.v1` cards, use `status: proposal` for non-actionable proposals that
+still contain placeholder commands or expected artifacts. `planned` is treated as actionable by the
+validator, so required durable artifacts must have concrete `durable_reference` values and command
+or artifact paths must not contain placeholder tokens such as `<campaign-id>`.
 
 ### Control-plane dry-run report
 

--- a/experiments/issue_2128_heldout_family_transfer_pilot.yaml
+++ b/experiments/issue_2128_heldout_family_transfer_pilot.yaml
@@ -63,7 +63,7 @@ expected_artifacts:
     durable_reference_required: true
 evidence_grade: proposal
 paper_relevance: exploratory
-status: planned
+status: proposal
 notes: >
   This record is proposal evidence only. Held-out transfer interpretation requires a completed
   leakage audit, native or explicitly eligible planner execution modes, durable artifact references,

--- a/experiments/issue_2135_seed_sufficiency_followup.yaml
+++ b/experiments/issue_2135_seed_sufficiency_followup.yaml
@@ -34,7 +34,7 @@ expected_artifacts:
     durable_reference_required: true
 evidence_grade: proposal
 paper_relevance: exploratory
-status: planned
+status: proposal
 notes: >
   This card is follow-through from the merged #2135 analyzer. It records the next durable-use path
   for existing campaign bundles; it does not run analysis or claim seed sufficiency by itself.

--- a/scripts/tools/create_experiment_card.py
+++ b/scripts/tools/create_experiment_card.py
@@ -177,7 +177,7 @@ def _template_benchmark_analysis(experiment_id: str, output_root: Path) -> Templ
         early_stop_criteria=_early_stop_criteria_template(),
         evidence_grade="proposal",
         paper_relevance="exploratory",
-        status="planned",
+        status="proposal",
         notes=(
             "TODO: Replace placeholders in curly braces before running. "
             "Local output paths are not durable evidence until promoted "
@@ -247,7 +247,7 @@ def _template_planner_ablation(experiment_id: str, output_root: Path) -> Templat
         early_stop_criteria=_early_stop_criteria_template(),
         evidence_grade="proposal",
         paper_relevance="exploratory",
-        status="planned",
+        status="proposal",
         notes=(
             "TODO: Replace placeholders in curly braces before running. "
             "Planner ablation must include at least three seeds per condition. "
@@ -315,7 +315,7 @@ def _template_figure_table_pack(experiment_id: str, output_root: Path) -> Templa
         early_stop_criteria={},
         evidence_grade="proposal",
         paper_relevance="exploratory",
-        status="planned",
+        status="proposal",
         notes=(
             "TODO: Replace placeholders in curly braces before running. "
             "All figures and tables must carry durable_reference before "

--- a/scripts/tools/validate_experiment_registry.py
+++ b/scripts/tools/validate_experiment_registry.py
@@ -59,6 +59,8 @@ TERMINAL_STATES = {
 VALID_RECORD_STATES = ACTIVE_STATES | TERMINAL_STATES
 LEGACY_TERMINAL_STATUSES = TERMINAL_STATES | {"completed", "released", "closed"}
 RUNNING_LABEL = "state:running"
+PROPOSAL_RECORD_STATES = {"idea", "proposal"}
+ANGLE_PLACEHOLDER_RE = re.compile(r"<[A-Za-z0-9][A-Za-z0-9_.:/-]*>")
 
 
 def validate_registry(registry_path: Path) -> list[str]:
@@ -191,6 +193,7 @@ def _validate_record(
             _validate_paper_facing_artifact(artifact, display_path, errors)
         for artifact in _iter_artifact_items(record.get("expected_artifacts")):
             _validate_paper_facing_artifact(artifact, display_path, errors)
+    _validate_actionable_artifact_policy(record, display_path, errors)
 
 
 def _validate_paper_facing_artifact(
@@ -208,6 +211,45 @@ def _validate_paper_facing_artifact(
             f"{display_path}: paper-facing record references local-only output/ artifact "
             f"without durable_reference: {artifact_path}"
         )
+
+
+def _validate_actionable_artifact_policy(
+    record: Mapping[str, Any],
+    display_path: str,
+    errors: list[str],
+) -> None:
+    """Reject actionable records that still point at unresolved artifact placeholders."""
+    if not _is_actionable_record(record):
+        return
+
+    for artifact in _iter_artifact_items(record.get("outputs")):
+        _validate_actionable_required_durable_reference(artifact, display_path, errors)
+    for artifact in _iter_artifact_items(record.get("expected_artifacts")):
+        _validate_actionable_required_durable_reference(artifact, display_path, errors)
+
+    for field_name, value in _iter_actionable_placeholder_values(record):
+        if _has_unresolved_artifact_placeholder(value):
+            errors.append(
+                f"{display_path}: actionable record contains unresolved placeholder in "
+                f"{field_name}: {value}"
+            )
+
+
+def _validate_actionable_required_durable_reference(
+    artifact: Mapping[str, Any],
+    display_path: str,
+    errors: list[str],
+) -> None:
+    """Reject required durable artifacts that do not name the durable reference."""
+    if artifact.get("durable_reference_required") is not True:
+        return
+    if not _is_missing(artifact.get("durable_reference")):
+        return
+    artifact_name = artifact.get("name") or artifact.get("path") or "<unnamed>"
+    errors.append(
+        f"{display_path}: actionable record requires durable_reference for artifact "
+        f"{artifact_name}"
+    )
 
 
 def _control_plane_findings_for_record(
@@ -383,6 +425,16 @@ def _is_terminal_record_state(record: Mapping[str, Any]) -> bool:
     return state in LEGACY_TERMINAL_STATUSES
 
 
+def _is_actionable_record(record: Mapping[str, Any]) -> bool:
+    """Return whether a record claims it is ready for concrete execution or evidence use."""
+    state = _record_state(record)
+    if _is_terminal_record_state(record):
+        return False
+    if _looks_blocked(state):
+        return False
+    return state not in PROPOSAL_RECORD_STATES
+
+
 def _looks_blocked(state: str) -> bool:
     """Return whether a state/status token is a blocked nonterminal."""
     return "blocked" in state
@@ -427,6 +479,29 @@ def _iter_config_paths(record: Mapping[str, Any]) -> Iterable[Path]:
             yield Path(raw_path)
 
 
+def _iter_actionable_placeholder_values(record: Mapping[str, Any]) -> Iterable[tuple[str, str]]:
+    """Yield command and artifact path values that must be concrete for actionable records."""
+    command = record.get("command")
+    if isinstance(command, str):
+        yield "command", command
+    for field_name in ("config", "inputs", "outputs", "expected_artifacts"):
+        for path in _iter_path_strings(record.get(field_name)):
+            yield field_name, path
+
+
+def _iter_path_strings(value: Any) -> Iterable[str]:
+    """Yield path strings from scalar, list, and mapping path fields."""
+    if isinstance(value, str):
+        yield value
+    elif isinstance(value, Mapping):
+        path = value.get("path")
+        if isinstance(path, str):
+            yield path
+    elif isinstance(value, list):
+        for child in value:
+            yield from _iter_path_strings(child)
+
+
 def _skip_path_existence_check(path: str) -> bool:
     """Return whether a path is intentionally not checked as repo-local input."""
     return (
@@ -451,6 +526,11 @@ def _iter_string_values(value: Any) -> Iterable[str]:
 def _is_pending_artifact_alias(value: str) -> bool:
     """Return whether a string looks like an unresolved artifact alias."""
     return "wandb-artifact://" in value and (":pending" in value or "/pending/" in value)
+
+
+def _has_unresolved_artifact_placeholder(value: str) -> bool:
+    """Return whether a command or path still contains a placeholder artifact token."""
+    return bool(ANGLE_PLACEHOLDER_RE.search(value)) or _is_pending_artifact_alias(value)
 
 
 def _is_closed_issue_state(value: str | None) -> bool:

--- a/scripts/tools/validate_experiment_registry.py
+++ b/scripts/tools/validate_experiment_registry.py
@@ -247,8 +247,7 @@ def _validate_actionable_required_durable_reference(
         return
     artifact_name = artifact.get("name") or artifact.get("path") or "<unnamed>"
     errors.append(
-        f"{display_path}: actionable record requires durable_reference for artifact "
-        f"{artifact_name}"
+        f"{display_path}: actionable record requires durable_reference for artifact {artifact_name}"
     )
 
 

--- a/tests/tools/test_create_experiment_card.py
+++ b/tests/tools/test_create_experiment_card.py
@@ -155,6 +155,20 @@ def test_output_and_expected_artifacts_have_artifact_ids() -> None:
             )
 
 
+def test_draft_templates_are_proposal_state_until_placeholders_are_filled() -> None:
+    """Generated draft cards should stay non-actionable until TODO fields are replaced."""
+    for template_name in TEMPLATE_NAMES:
+        record = _build_record(
+            experiment_id=f"test_{template_name.replace('-', '_')}",
+            issue="9999",
+            issue_url="https://example.com/9999",
+            template_name=template_name,
+            output_root=Path("output/experiments"),
+        )
+        assert record["evidence_grade"] == "proposal"
+        assert record["status"] == "proposal"
+
+
 def test_training_templates_include_slurm_early_stop_criteria() -> None:
     """Training-oriented experiment cards should predeclare Slurm stop rules."""
     expected_fields = {

--- a/tests/tools/test_validate_experiment_registry.py
+++ b/tests/tools/test_validate_experiment_registry.py
@@ -103,6 +103,126 @@ def test_validator_rejects_paper_facing_local_only_outputs(tmp_path: Path) -> No
     ) in errors
 
 
+def test_validator_allows_explicit_non_actionable_missing_durable_references(
+    tmp_path: Path,
+) -> None:
+    """Blocked or proposal-only records may declare future durable artifacts."""
+    registry = tmp_path / "registry.yaml"
+    _write_yaml(
+        registry,
+        """
+        schema_version: experiment-registry.v1
+        records:
+          - blocked.yaml
+          - proposal.yaml
+        """,
+    )
+    _write_yaml(
+        registry.parent / "blocked.yaml",
+        """
+        schema_version: experiment-record.v1
+        experiment_id: blocked-artifacts
+        issue: 1475
+        issue_url: https://github.com/ll7/robot_sf_ll7/issues/1475
+        question: Is this blocked until external execution exists?
+        hypothesis: The card is not actionable while blocked.
+        config: configs/<config-id>.yaml
+        command: uv run python scripts/example.py --output output/<campaign-id>
+        inputs:
+          - path: data/<input-id>.json
+        outputs:
+          - path: output/blocked/<campaign-id>
+        expected_artifacts:
+          - name: report
+            path: output/blocked/<campaign-id>/report.json
+            durable_reference_required: true
+        evidence_grade: proposal
+        paper_relevance: exploratory
+        status: blocked_on_slurm
+        """,
+    )
+    _write_yaml(
+        registry.parent / "proposal.yaml",
+        """
+        schema_version: experiment-record.v1
+        experiment_id: proposal-artifacts
+        issue: 2135
+        issue_url: https://github.com/ll7/robot_sf_ll7/issues/2135
+        question: Is this still only a proposal?
+        hypothesis: Proposal cards may describe future artifacts.
+        config: configs/example.yaml
+        command: uv run python scripts/example.py --output output/<campaign-id>
+        inputs:
+          - path: configs/example.yaml
+        outputs:
+          - path: output/proposal/<campaign-id>
+        expected_artifacts:
+          - name: report
+            path: output/proposal/<campaign-id>/report.json
+            durable_reference_required: true
+        evidence_grade: proposal
+        paper_relevance: exploratory
+        status: proposal
+        """,
+    )
+
+    assert validate_registry(registry) == []
+
+
+def test_validator_rejects_actionable_missing_durable_references_and_placeholders(
+    tmp_path: Path,
+) -> None:
+    """Actionable cards should not contain placeholder outputs or missing durable refs."""
+    registry = tmp_path / "registry.yaml"
+    _write_yaml(
+        registry,
+        """
+        schema_version: experiment-registry.v1
+        records:
+          - planned.yaml
+        """,
+    )
+    _write_yaml(
+        registry.parent / "planned.yaml",
+        """
+        schema_version: experiment-record.v1
+        experiment_id: planned-placeholders
+        issue: 2135
+        issue_url: https://github.com/ll7/robot_sf_ll7/issues/2135
+        question: Is this actionable?
+        hypothesis: Planned cards should name concrete artifact paths.
+        config: configs/<config-id>.yaml
+        command: |
+          uv run python scripts/example.py \\
+            --campaign-root <existing-campaign-report-root>
+        inputs:
+          - path: data/<input-id>.json
+        outputs:
+          - path: output/analysis/<campaign-id>
+        expected_artifacts:
+          - name: report
+            path: output/analysis/<campaign-id>/report.json
+            durable_reference_required: true
+          - name: pending_alias
+            path: wandb-artifact://pending/issue-2135/report:latest
+        evidence_grade: proposal
+        paper_relevance: exploratory
+        status: planned
+        """,
+    )
+
+    errors = validate_registry(registry)
+
+    assert (
+        "planned.yaml: actionable record requires durable_reference for artifact report"
+    ) in errors
+    assert any("unresolved placeholder in command" in error for error in errors)
+    assert any("configs/<config-id>.yaml" in error for error in errors)
+    assert any("data/<input-id>.json" in error for error in errors)
+    assert any("output/analysis/<campaign-id>" in error for error in errors)
+    assert any("wandb-artifact://pending/issue-2135/report:latest" in error for error in errors)
+
+
 def test_validator_accepts_experiment_record_v2_state(tmp_path: Path) -> None:
     """New records may use the v2 authoritative state field instead of legacy status."""
     registry = tmp_path / "experiments" / "registry.yaml"
@@ -183,6 +303,51 @@ def test_validator_rejects_unknown_experiment_record_v2_state(tmp_path: Path) ->
     errors = validate_registry(registry)
 
     assert "bad.yaml: state must be one of" in errors[0]
+
+
+def test_validator_rejects_active_v2_missing_durable_reference(tmp_path: Path) -> None:
+    """Active v2 states must not declare required artifacts without durable references."""
+    registry = tmp_path / "experiments" / "registry.yaml"
+    record = registry.parent / "active.yaml"
+    _write_yaml(
+        registry,
+        """
+        schema_version: experiment-registry.v1
+        records:
+          - active.yaml
+        """,
+    )
+    _write_yaml(
+        record,
+        """
+        schema_version: experiment-record.v2
+        experiment_id: active-artifacts
+        issue: 3073
+        issue_url: https://github.com/ll7/robot_sf_ll7/issues/3073
+        question: Is this active?
+        hypothesis: Active cards need concrete durable artifact references.
+        config:
+          - experiments/registry.yaml
+        command: uv run true
+        inputs:
+          - path: experiments/registry.yaml
+        outputs:
+          - path: output/experiments/active
+        expected_artifacts:
+          - name: report
+            path: output/experiments/active/report.json
+            durable_reference_required: true
+        evidence_grade: proposal
+        paper_relevance: exploratory
+        state: implementation_ready
+        """,
+    )
+
+    errors = validate_registry(registry)
+
+    assert (
+        "active.yaml: actionable record requires durable_reference for artifact report"
+    ) in errors
 
 
 def test_control_plane_report_detects_research_state_drift(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #3084.

- harden `validate_experiment_registry.py` so actionable records fail when `durable_reference_required: true` artifacts do not provide a `durable_reference`
- reject unresolved artifact placeholders in actionable record commands and output/expected-artifact paths, including `<campaign-id>` style placeholders and pending W&B aliases
- document the legacy policy boundary: `status: planned` is actionable; proposal-only cards must use `status: proposal`
- correct #2128 and #2135 cards from `planned` to `proposal` because they intentionally describe future/proposal evidence with unresolved durable artifact requirements

## Validation

- `uv run pytest tests/tools/test_validate_experiment_registry.py` (`12 passed`)
- `uv run python scripts/tools/validate_experiment_registry.py experiments/registry.yaml`
- `ruff check scripts/tools/validate_experiment_registry.py tests/tools/test_validate_experiment_registry.py`
- `git diff --check`

## Research Result Guidance

- Target claim / hypothesis: NA - validator hardening and registry state hygiene only.
- Comparator / baseline: previous validator accepted actionable records with unresolved durable-reference and placeholder artifact policy gaps.
- Evidence tier: focused unit tests plus checked-in registry validation.
- Result classification: support/tooling guardrail; no benchmark or paper-facing result claim.
- Decision / stop rule: actionable cards now fail closed until durable references and concrete artifact paths are provided, while explicitly blocked/proposal/terminal cards remain valid.
- Synthesis surface / update target: `experiments/README.md` documents the policy.

## Downstream Propagation

- Parent issue / claim map: #3084 closed by this PR.
- Registry / config index: `experiments/registry.yaml` still validates; #2128 and #2135 status fields corrected to `proposal`.
- Context / memory note: no durable context-note update needed; this is validator policy plus focused card hygiene.
- Follow-up issues: none opened.
