### PR TITLE
benchmark: add planner readiness matrix

### DIFF
--- a/configs/benchmarks/planner_readiness_matrix_v1.yaml
+++ b/configs/benchmarks/planner_readiness_matrix_v1.yaml
@@ -107,6 +107,26 @@ rows:
     reason: ORCA is baseline-ready when the vendored RVO2 dependency is available; fallback rows remain exclusions.
     validation_command: uv run pytest tests/benchmark/test_algorithm_metadata_contract.py
 
+  - planner_id: hrvo
+    family: reciprocal_avoidance
+    representative_entrypoint: configs/algos/hrvo_camera_ready.yaml
+    tier: experimental
+    requires_explicit_opt_in: true
+    execution_mode: adapter
+    readiness_status: degraded
+    availability_status: available
+    row_status: degraded
+    counts_as_success_evidence: false
+    artifact_dependency: external_pointer
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - robot_sf/planner/socnav.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/algos/hrvo_camera_ready.yaml
+      - tests/benchmark/test_algorithm_metadata_contract.py
+    reason: Local HRVO is implemented for controlled experimental comparisons, but remains testing-only and not headline-ready.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_metadata_contract.py
+
   - planner_id: ppo
     family: ppo
     representative_entrypoint: configs/baselines/ppo_15m_grid_socnav.yaml

--- a/configs/benchmarks/planner_readiness_matrix_v1.yaml
+++ b/configs/benchmarks/planner_readiness_matrix_v1.yaml
@@ -1,0 +1,254 @@
+schema_version: planner-readiness-matrix.v1
+issue: 3060
+generated_from: docs/benchmark_planner_family_coverage.md
+validation_date: "2026-06-18"
+policy_sources:
+  - docs/context/issue_691_benchmark_fallback_policy.md
+  - .agents/skills/schemas/benchmark_row_status.v1.yaml
+  - robot_sf/benchmark/algorithm_readiness.py
+status_vocabulary:
+  execution_mode:
+    - native
+    - adapter
+    - mixed
+    - unknown
+  readiness_status:
+    - native
+    - adapter
+    - fallback
+    - degraded
+  availability_status:
+    - available
+    - partial-failure
+    - failed
+    - not_available
+  row_status:
+    - successful_evidence
+    - accepted_unavailable
+    - unexpected_failure
+    - fallback
+    - degraded
+    - blocked
+success_rule: >
+  A row counts as benchmark-strength success evidence only when row_status is
+  successful_evidence, availability_status is available, and readiness_status is native or adapter.
+  Fallback, degraded, blocked, accepted_unavailable, and unexpected_failure rows are visible
+  exclusions or caveats, not successful benchmark outcomes.
+rows:
+  - planner_id: goal
+    family: random_goal
+    representative_entrypoint: algo=goal
+    tier: baseline-ready
+    requires_explicit_opt_in: false
+    execution_mode: native
+    readiness_status: native
+    availability_status: available
+    row_status: successful_evidence
+    counts_as_success_evidence: true
+    artifact_dependency: none
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml
+    reason: Goal-following heuristic baseline is baseline-ready and needs no model artifact.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_readiness_contract.py
+
+  - planner_id: random
+    family: random_goal
+    representative_entrypoint: configs/baselines/random.yaml
+    tier: diagnostic
+    requires_explicit_opt_in: true
+    execution_mode: native
+    readiness_status: degraded
+    availability_status: not_available
+    row_status: degraded
+    counts_as_success_evidence: false
+    artifact_dependency: none
+    source_paths:
+      - configs/baselines/random.yaml
+      - tests/benchmark/test_algorithm_metadata_contract.py
+    reason: Random policy is a stochastic diagnostic reference, not a benchmark-strength planner row.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_metadata_contract.py
+
+  - planner_id: social_force
+    family: social_force
+    representative_entrypoint: algo=social_force
+    tier: baseline-ready
+    requires_explicit_opt_in: false
+    execution_mode: adapter
+    readiness_status: adapter
+    availability_status: available
+    row_status: successful_evidence
+    counts_as_success_evidence: true
+    artifact_dependency: none
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml
+    reason: Social-force adapter is a canonical baseline-ready planner row.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_readiness_contract.py
+
+  - planner_id: orca
+    family: reciprocal_avoidance
+    representative_entrypoint: algo=orca
+    tier: baseline-ready
+    requires_explicit_opt_in: false
+    execution_mode: adapter
+    readiness_status: adapter
+    availability_status: available
+    row_status: successful_evidence
+    counts_as_success_evidence: true
+    artifact_dependency: external_pointer
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml
+      - third_party/python-rvo2/README.md
+    reason: ORCA is baseline-ready when the vendored RVO2 dependency is available; fallback rows remain exclusions.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_metadata_contract.py
+
+  - planner_id: ppo
+    family: ppo
+    representative_entrypoint: configs/baselines/ppo_15m_grid_socnav.yaml
+    tier: experimental
+    requires_explicit_opt_in: false
+    execution_mode: mixed
+    readiness_status: native
+    availability_status: available
+    row_status: successful_evidence
+    counts_as_success_evidence: true
+    artifact_dependency: durable_manifest
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/baselines/ppo_15m_grid_socnav.yaml
+      - configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml
+    reason: PPO is benchmarkable when the provenance and quality gates in its baseline config are satisfied.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_readiness_contract.py
+
+  - planner_id: guarded_ppo
+    family: ppo
+    representative_entrypoint: configs/algos/guarded_ppo_camera_ready.yaml
+    tier: experimental
+    requires_explicit_opt_in: false
+    execution_mode: mixed
+    readiness_status: degraded
+    availability_status: not_available
+    row_status: degraded
+    counts_as_success_evidence: false
+    artifact_dependency: durable_manifest
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/algos/guarded_ppo_camera_ready.yaml
+    reason: Safety-guarded PPO is experimental; guard fallback/veto behavior must be reported as a caveat before benchmark-strength use.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_readiness_contract.py
+
+  - planner_id: risk_dwa
+    family: orca_dwa_style
+    representative_entrypoint: configs/algos/risk_surface_dwa_v0.yaml
+    tier: experimental
+    requires_explicit_opt_in: true
+    execution_mode: adapter
+    readiness_status: degraded
+    availability_status: not_available
+    row_status: blocked
+    counts_as_success_evidence: false
+    artifact_dependency: none
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/algos/risk_surface_dwa_v0.yaml
+      - docs/context/issue_596_testing_only_planner_promotion_matrix.md
+    reason: Risk-DWA style planners are testing-only and require explicit opt-in plus promotion proof.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_readiness_contract.py
+
+  - planner_id: hybrid_rule_local_planner
+    family: hybrid_planner_candidate
+    representative_entrypoint: configs/algos/hybrid_rule_v3_static_margin0_waypoint2.yaml
+    tier: experimental
+    requires_explicit_opt_in: true
+    execution_mode: adapter
+    readiness_status: degraded
+    availability_status: not_available
+    row_status: blocked
+    counts_as_success_evidence: false
+    artifact_dependency: none
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/algos/hybrid_rule_v3_static_margin0_waypoint2.yaml
+    reason: Hybrid-rule local planners are controlled R&D candidates, not baseline comparability evidence.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_readiness_contract.py
+
+  - planner_id: hybrid_portfolio
+    family: hybrid_planner_candidate
+    representative_entrypoint: configs/algos/hybrid_portfolio_camera_ready.yaml
+    tier: experimental
+    requires_explicit_opt_in: true
+    execution_mode: mixed
+    readiness_status: fallback
+    availability_status: not_available
+    row_status: fallback
+    counts_as_success_evidence: false
+    artifact_dependency: none
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/algos/hybrid_portfolio_camera_ready.yaml
+    reason: Portfolio mode explicitly permits fallback; fallback execution is not benchmark success evidence.
+    validation_command: uv run pytest tests/benchmark/test_fallback_policy.py
+
+  - planner_id: prediction_planner
+    family: hybrid_planner_candidate
+    representative_entrypoint: configs/algos/prediction_planner_camera_ready.yaml
+    tier: experimental
+    requires_explicit_opt_in: false
+    execution_mode: adapter
+    readiness_status: degraded
+    availability_status: not_available
+    row_status: blocked
+    counts_as_success_evidence: false
+    artifact_dependency: local_output_only
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/algos/prediction_planner_camera_ready.yaml
+    reason: Predictive planner rows remain checkpoint/provenance dependent until durable model artifacts are named.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_metadata_contract.py
+
+  - planner_id: sacadrl
+    family: ppo
+    representative_entrypoint: algo=sacadrl
+    tier: experimental
+    requires_explicit_opt_in: false
+    execution_mode: adapter
+    readiness_status: degraded
+    availability_status: not_available
+    row_status: blocked
+    counts_as_success_evidence: false
+    artifact_dependency: external_pointer
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml
+    reason: SA-CADRL adapter is dependency/model-sensitive and not part of the baseline-ready set.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_readiness_contract.py
+
+  - planner_id: socnav_bench
+    family: hybrid_planner_candidate
+    representative_entrypoint: algo=socnav_bench
+    tier: experimental
+    requires_explicit_opt_in: false
+    execution_mode: unknown
+    readiness_status: degraded
+    availability_status: not_available
+    row_status: accepted_unavailable
+    counts_as_success_evidence: false
+    artifact_dependency: external_pointer
+    source_paths:
+      - robot_sf/benchmark/algorithm_readiness.py
+      - docs/benchmark_planner_family_coverage.md
+      - configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml
+    reason: SocNavBench remains a dependency-sensitive bridge/proxy until re-entry proof is available.
+    validation_command: uv run pytest tests/benchmark/test_algorithm_readiness_contract.py

--- a/docs/ai/planner_zoo_context.md
+++ b/docs/ai/planner_zoo_context.md
@@ -16,7 +16,8 @@ that are:
 ## Current Planner Readiness Frame
 
 Use `docs/benchmark_planner_family_coverage.md` as the source of truth for readiness categories and
-benchmark-facing terminology.
+benchmark-facing terminology. Use `configs/benchmarks/planner_readiness_matrix_v1.yaml` when a
+machine-checkable campaign-planning surface is needed.
 
 Implemented and benchmarkable families today:
 

--- a/docs/benchmark_planner_family_coverage.md
+++ b/docs/benchmark_planner_family_coverage.md
@@ -4,6 +4,11 @@ This document maps the current `robot_sf_ll7` planner/config stack to Alyassi-st
 families for benchmark-facing use. It is intended to prevent manuscript-side repos from overclaiming
 support that is only partial, experimental, or still roadmap-only.
 
+For machine-checkable campaign planning, use
+`configs/benchmarks/planner_readiness_matrix_v1.yaml`. The YAML matrix records the same conservative
+readiness boundary with explicit `execution_mode`, `readiness_status`, `availability_status`,
+`row_status`, and `counts_as_success_evidence` fields.
+
 Use this matrix conservatively:
 
 * Treat `implemented and benchmarkable` rows as the only rows safe to cite as currently runnable

--- a/tests/benchmark/test_planner_readiness_matrix.py
+++ b/tests/benchmark/test_planner_readiness_matrix.py
@@ -1,0 +1,89 @@
+"""Tests for the baseline planner readiness matrix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+REPO_ROOT = Path(__file__).parents[2]
+MATRIX_PATH = REPO_ROOT / "configs/benchmarks/planner_readiness_matrix_v1.yaml"
+REQUIRED_FAMILIES = {
+    "ppo",
+    "social_force",
+    "reciprocal_avoidance",
+    "orca_dwa_style",
+    "random_goal",
+    "hybrid_planner_candidate",
+}
+REQUIRED_FIELDS = {
+    "planner_id",
+    "family",
+    "tier",
+    "requires_explicit_opt_in",
+    "execution_mode",
+    "readiness_status",
+    "availability_status",
+    "row_status",
+    "counts_as_success_evidence",
+    "artifact_dependency",
+    "source_paths",
+    "reason",
+    "validation_command",
+}
+SUCCESS_STATUSES = {"successful_evidence"}
+
+
+def _load_matrix() -> dict[str, Any]:
+    """Load the checked-in readiness matrix."""
+    payload = yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_planner_readiness_matrix_covers_issue_3060_families() -> None:
+    """The matrix should cover the planner families named in issue #3060."""
+    matrix = _load_matrix()
+    rows = matrix["rows"]
+    families = {row["family"] for row in rows}
+    planner_ids = {row["planner_id"] for row in rows}
+
+    assert matrix["schema_version"] == "planner-readiness-matrix.v1"
+    assert matrix["issue"] == 3060
+    assert REQUIRED_FAMILIES <= families
+    assert {"goal", "random", "social_force", "orca", "ppo", "risk_dwa"} <= planner_ids
+    assert {"hybrid_rule_local_planner", "hybrid_portfolio"} <= planner_ids
+
+
+def test_planner_readiness_matrix_rows_use_fail_closed_status_axes() -> None:
+    """Rows should use explicit status axes and never count caveats as success evidence."""
+    matrix = _load_matrix()
+    vocab = matrix["status_vocabulary"]
+
+    for row in matrix["rows"]:
+        assert REQUIRED_FIELDS <= set(row)
+        assert row["execution_mode"] in vocab["execution_mode"]
+        assert row["readiness_status"] in vocab["readiness_status"]
+        assert row["availability_status"] in vocab["availability_status"]
+        assert row["row_status"] in vocab["row_status"]
+        if row["counts_as_success_evidence"]:
+            assert row["row_status"] in SUCCESS_STATUSES
+            assert row["availability_status"] == "available"
+            assert row["readiness_status"] in {"native", "adapter"}
+        else:
+            assert row["row_status"] not in SUCCESS_STATUSES
+
+
+def test_planner_readiness_matrix_source_paths_exist_and_avoid_output_dependencies() -> None:
+    """Matrix evidence should point at tracked sources, not disposable output artifacts."""
+    matrix = _load_matrix()
+
+    for path in matrix["policy_sources"]:
+        assert not path.startswith("output/")
+        assert (REPO_ROOT / path).exists(), path
+
+    for row in matrix["rows"]:
+        for path in row["source_paths"]:
+            assert not path.startswith("output/")
+            assert (REPO_ROOT / path).exists(), f"{row['planner_id']}: {path}"

--- a/tests/benchmark/test_planner_readiness_matrix.py
+++ b/tests/benchmark/test_planner_readiness_matrix.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import shlex
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).parents[2]
@@ -39,8 +41,23 @@ def _assert_tracked_source_file(path_str: str, *, label: str) -> None:
     """Require matrix source references to resolve to checked-in files."""
     path = Path(path_str)
     assert not path.is_absolute(), f"{label}: {path_str}"
+    assert ".." not in path.parts, f"{label}: {path_str}"
     assert not path.parts or path.parts[0] != "output", f"{label}: {path_str}"
     assert (REPO_ROOT / path).is_file(), f"{label}: {path_str}"
+
+
+def _assert_validation_command(command: str, *, label: str) -> None:
+    """Require matrix validation commands to point at checked-in pytest targets."""
+    parts = shlex.split(command)
+    assert parts[:3] == ["uv", "run", "pytest"], f"{label}: {command}"
+    assert len(parts) >= 4, f"{label}: {command}"
+    for target in parts[3:]:
+        if target.startswith("-"):
+            continue
+        target_path = Path(target.split("::", maxsplit=1)[0])
+        assert not target_path.is_absolute(), f"{label}: {command}"
+        assert ".." not in target_path.parts, f"{label}: {command}"
+        assert (REPO_ROOT / target_path).exists(), f"{label}: {command}"
 
 
 def _load_matrix() -> dict[str, Any]:
@@ -60,7 +77,7 @@ def test_planner_readiness_matrix_covers_issue_3060_families() -> None:
     assert matrix["schema_version"] == "planner-readiness-matrix.v1"
     assert matrix["issue"] == 3060
     assert REQUIRED_FAMILIES <= families
-    assert {"goal", "random", "social_force", "orca", "ppo", "risk_dwa"} <= planner_ids
+    assert {"goal", "random", "social_force", "orca", "hrvo", "ppo", "risk_dwa"} <= planner_ids
     assert {"hybrid_rule_local_planner", "hybrid_portfolio"} <= planner_ids
 
 
@@ -93,3 +110,20 @@ def test_planner_readiness_matrix_source_paths_exist_and_avoid_output_dependenci
     for row in matrix["rows"]:
         for path in row["source_paths"]:
             _assert_tracked_source_file(path, label=row["planner_id"])
+
+
+def test_planner_readiness_matrix_source_path_guard_rejects_traversal() -> None:
+    """Source references should not escape the repository-relative path contract."""
+    with pytest.raises(AssertionError, match=r"\.\./pyproject.toml"):
+        _assert_tracked_source_file("../pyproject.toml", label="escape")
+
+    with pytest.raises(AssertionError, match=r"configs/\.\./pyproject.toml"):
+        _assert_tracked_source_file("configs/../pyproject.toml", label="escape")
+
+
+def test_planner_readiness_matrix_validation_commands_reference_existing_pytest_targets() -> None:
+    """Validation commands should stay attached to checked-in pytest targets."""
+    matrix = _load_matrix()
+
+    for row in matrix["rows"]:
+        _assert_validation_command(row["validation_command"], label=row["planner_id"])

--- a/tests/benchmark/test_planner_readiness_matrix.py
+++ b/tests/benchmark/test_planner_readiness_matrix.py
@@ -35,6 +35,14 @@ REQUIRED_FIELDS = {
 SUCCESS_STATUSES = {"successful_evidence"}
 
 
+def _assert_tracked_source_file(path_str: str, *, label: str) -> None:
+    """Require matrix source references to resolve to checked-in files."""
+    path = Path(path_str)
+    assert not path.is_absolute(), f"{label}: {path_str}"
+    assert not path.parts or path.parts[0] != "output", f"{label}: {path_str}"
+    assert (REPO_ROOT / path).is_file(), f"{label}: {path_str}"
+
+
 def _load_matrix() -> dict[str, Any]:
     """Load the checked-in readiness matrix."""
     payload = yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))
@@ -80,10 +88,8 @@ def test_planner_readiness_matrix_source_paths_exist_and_avoid_output_dependenci
     matrix = _load_matrix()
 
     for path in matrix["policy_sources"]:
-        assert not path.startswith("output/")
-        assert (REPO_ROOT / path).exists(), path
+        _assert_tracked_source_file(path, label="policy_sources")
 
     for row in matrix["rows"]:
         for path in row["source_paths"]:
-            assert not path.startswith("output/")
-            assert (REPO_ROOT / path).exists(), f"{row['planner_id']}: {path}"
+            _assert_tracked_source_file(path, label=row["planner_id"])


### PR DESCRIPTION
## Summary

Closes #3060.

- add `configs/benchmarks/planner_readiness_matrix_v1.yaml`, a machine-checkable baseline planner readiness matrix for campaign planning
- classify required planner families: PPO, social-force, ORCA/reciprocal avoidance, HRVO, DWA-style local planners, random/goal references, and hybrid/planner candidates
- encode fail-closed status axes: `execution_mode`, `readiness_status`, `availability_status`, `row_status`, and `counts_as_success_evidence`
- point `docs/benchmark_planner_family_coverage.md` and `docs/ai/planner_zoo_context.md` at the structured matrix
- add focused tests that verify family coverage, status vocabulary, fail-closed success semantics, tracked source-path references, path-traversal rejection, and validation-command targets

## Validation

- `uv run pytest tests/benchmark/test_planner_readiness_matrix.py` (`5 passed`)
- `uv run pytest tests/benchmark/test_algorithm_readiness_contract.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_fallback_policy.py` (`50 passed`)
- `ruff check tests/benchmark/test_planner_readiness_matrix.py`
- `git diff --check`
- GitHub CI for head `46b387d91e62e93ae2b4f38501b2981c956880a8`: `CodeRabbit`, `ci`, `examples-smoke`, `fast-feedback`, `promoted-planner-smoke`, and `smoke-artifacts` passed.

## Research Result Guidance

- Target claim / hypothesis: baseline planner readiness can be inspected before expensive research campaigns.
- Comparator / baseline: prior readiness lived mostly in prose and algorithm metadata, without one campaign-planning matrix.
- Evidence tier: proposal/preflight matrix plus schema-style tests; not benchmark result evidence.
- Result classification: support/tooling guardrail.
- Decision / stop rule: rows that are fallback, degraded, blocked, accepted-unavailable, or unexpected-failure explicitly set `counts_as_success_evidence: false`.
- Synthesis surface / update target: `docs/benchmark_planner_family_coverage.md` remains the human-facing surface; `configs/benchmarks/planner_readiness_matrix_v1.yaml` is the machine-checkable companion.

## Downstream Propagation

- Parent issue / claim map: closes #3060.
- Registry / config index: new benchmark config matrix under `configs/benchmarks/`.
- Context / memory note: no separate context note needed; the tracked YAML plus existing planner-family doc are the durable surfaces.
- Follow-up issues: none opened.
