### PR TITLE
feat: derive experiment state label updates

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -44,6 +44,15 @@ superseded
 stopped_by_gate
 ```
 
+Derived GitHub state labels:
+
+| Record state | Derived issue label |
+| --- | --- |
+| `idea`, `protocol_frozen`, `implementation_ready`, `preflight_passed` | `state:ready` |
+| `submitted`, `running`, `finalized`, `evidence_promoted`, `claim_reviewed` | `state:running` |
+| `blocked_external`, `invalid_execution`, `negative_result`, `null_result`, `superseded`, `stopped_by_gate` | `state:blocked` |
+| `released` | remove `state:*` labels |
+
 Closed GitHub issues are historical truth unless a new follow-up issue is opened. Stale cards
 should be corrected or superseded through a PR rather than silently treated as active work.
 Local `output/` paths and `:pending` artifact aliases are not durable evidence.
@@ -61,8 +70,9 @@ uv run python scripts/tools/validate_experiment_registry.py \
 
 The issue-state snapshot is a compact JSON list or object with `number`, `state`, and `labels`.
 The report detects closed issues with nonterminal cards, closed blockers with blocked cards,
-state-label disagreement, missing config/input paths, pending artifact aliases, and expected
-artifacts that still need durable references.
+dry-run derived `state:*` label updates, missing config/input paths, pending artifact aliases, and
+expected artifacts that still need durable references. It reports `labels_to_add` and
+`labels_to_remove` but never mutates GitHub.
 This v2 control-plane guidance is part of the #3057 research-control-plane work and is exercised by
 `tests/tools/test_validate_experiment_registry.py`.
 

--- a/scripts/tools/validate_experiment_registry.py
+++ b/scripts/tools/validate_experiment_registry.py
@@ -297,7 +297,9 @@ def _issue_state_findings(
                 )
             )
     labels = set(issue_labels.get(issue, ())) if issue is not None else set()
-    expected_label = STATE_TO_LABEL.get(record_state)
+    if record_state not in STATE_TO_LABEL:
+        return findings
+    expected_label = STATE_TO_LABEL[record_state]
     current_state_labels = labels & STATE_LABELS
     if (
         issue is not None

--- a/scripts/tools/validate_experiment_registry.py
+++ b/scripts/tools/validate_experiment_registry.py
@@ -58,6 +58,25 @@ TERMINAL_STATES = {
 }
 VALID_RECORD_STATES = ACTIVE_STATES | TERMINAL_STATES
 LEGACY_TERMINAL_STATUSES = TERMINAL_STATES | {"completed", "released", "closed"}
+STATE_LABELS = {"state:ready", "state:running", "state:blocked"}
+STATE_TO_LABEL = {
+    "idea": "state:ready",
+    "protocol_frozen": "state:ready",
+    "implementation_ready": "state:ready",
+    "preflight_passed": "state:ready",
+    "submitted": "state:running",
+    "running": "state:running",
+    "finalized": "state:running",
+    "evidence_promoted": "state:running",
+    "claim_reviewed": "state:running",
+    "released": None,
+    "blocked_external": "state:blocked",
+    "invalid_execution": "state:blocked",
+    "negative_result": "state:blocked",
+    "null_result": "state:blocked",
+    "superseded": "state:blocked",
+    "stopped_by_gate": "state:blocked",
+}
 RUNNING_LABEL = "state:running"
 
 
@@ -135,6 +154,9 @@ def build_control_plane_report(
         "registry": registry_path.as_posix(),
         "finding_count": len(findings),
         "findings": findings,
+        "derived_update_count": sum(
+            1 for finding in findings if finding.get("kind") == "derived_issue_label_update"
+        ),
     }
 
 
@@ -275,13 +297,20 @@ def _issue_state_findings(
                 )
             )
     labels = set(issue_labels.get(issue, ())) if issue is not None else set()
-    if RUNNING_LABEL in labels and record_state not in {"running", "submitted"}:
+    expected_label = STATE_TO_LABEL.get(record_state)
+    current_state_labels = labels & STATE_LABELS
+    if (
+        issue is not None
+        and issue in issue_labels
+        and current_state_labels != _label_set(expected_label)
+    ):
         findings.append(
-            _finding(
-                "label_record_state_disagreement",
+            _derived_label_update(
                 display_path,
                 issue,
-                f"live label {RUNNING_LABEL!r} disagrees with record state {record_state!r}",
+                record_state=record_state,
+                current_labels=sorted(current_state_labels),
+                expected_label=expected_label,
             )
         )
     return findings
@@ -363,6 +392,36 @@ def _finding(kind: str, record: str, issue: int | None, message: str) -> dict[st
         "issue": issue,
         "message": message,
     }
+
+
+def _derived_label_update(
+    record: str,
+    issue: int,
+    *,
+    record_state: str,
+    current_labels: list[str],
+    expected_label: str | None,
+) -> dict[str, Any]:
+    """Return a dry-run label update derived from the authoritative card state."""
+    expected_labels = sorted(_label_set(expected_label))
+    labels_to_add = sorted(set(expected_labels) - set(current_labels))
+    labels_to_remove = sorted(set(current_labels) - set(expected_labels))
+    message = (
+        f"issue #{issue} state labels {current_labels} should derive from "
+        f"record state {record_state!r} as {expected_labels}"
+    )
+    finding = _finding("derived_issue_label_update", record, issue, message)
+    finding["expected_state_label"] = expected_label
+    finding["current_state_labels"] = current_labels
+    finding["labels_to_add"] = labels_to_add
+    finding["labels_to_remove"] = labels_to_remove
+    finding["dry_run_only"] = True
+    return finding
+
+
+def _label_set(label: str | None) -> set[str]:
+    """Return the normalized singleton label set used for state-label comparisons."""
+    return {label} if label else set()
 
 
 def _record_state(record: Mapping[str, Any]) -> str:

--- a/tests/tools/test_validate_experiment_registry.py
+++ b/tests/tools/test_validate_experiment_registry.py
@@ -364,6 +364,54 @@ def test_control_plane_report_derives_terminal_state_label_removal(tmp_path: Pat
     assert update["dry_run_only"] is True
 
 
+def test_control_plane_report_ignores_unknown_legacy_status_labels(tmp_path: Path) -> None:
+    """Legacy v1 statuses should not trigger state-label removal suggestions."""
+    registry = tmp_path / "experiments" / "registry.yaml"
+    _write_yaml(
+        registry,
+        """
+        schema_version: experiment-registry.v1
+        records:
+          - legacy_planned.yaml
+        """,
+    )
+    _write_yaml(
+        registry.parent / "legacy_planned.yaml",
+        """
+        schema_version: experiment-record.v1
+        experiment_id: legacy-planned-record
+        issue: 2002
+        issue_url: https://github.com/ll7/robot_sf_ll7/issues/2002
+        question: Does legacy planned status map to issue state labels?
+        hypothesis: Legacy status should not drive the v2 label control plane.
+        config:
+          - configs/exists.yaml
+        command: uv run true
+        inputs:
+          - path: configs/exists.yaml
+        outputs:
+          - path: output/experiments/legacy-planned
+        expected_artifacts:
+          - name: report
+            path: output/experiments/legacy-planned/report.json
+        evidence_grade: proposal
+        paper_relevance: exploratory
+        status: planned
+        """,
+    )
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "exists.yaml").write_text("ok: true\n", encoding="utf-8")
+
+    report = build_control_plane_report(
+        registry,
+        issue_states={2002: "OPEN"},
+        issue_labels={2002: ["state:ready", "type:analysis"]},
+    )
+
+    assert report["derived_update_count"] == 0
+    assert report["findings"] == []
+
+
 def test_validator_checks_scalar_config_paths(tmp_path: Path) -> None:
     """Scalar config paths should be validated like list-valued paths."""
     registry = tmp_path / "registry.yaml"

--- a/tests/tools/test_validate_experiment_registry.py
+++ b/tests/tools/test_validate_experiment_registry.py
@@ -283,10 +283,85 @@ def test_control_plane_report_detects_research_state_drift(tmp_path: Path) -> No
     kinds = {finding["kind"] for finding in report["findings"]}
     assert "closed_issue_with_nonterminal_record" in kinds
     assert "closed_blocker_with_blocked_record" in kinds
-    assert "label_record_state_disagreement" in kinds
+    assert "derived_issue_label_update" in kinds
     assert "missing_config_or_input_path" in kinds
     assert "pending_artifact_alias" in kinds
     assert "missing_required_durable_reference" in kinds
+    derived_updates = [
+        finding for finding in report["findings"] if finding["kind"] == "derived_issue_label_update"
+    ]
+    assert report["derived_update_count"] == len(derived_updates)
+    assert derived_updates == [
+        {
+            "kind": "derived_issue_label_update",
+            "severity": "warning",
+            "record": "label_disagreement.yaml",
+            "issue": 1475,
+            "message": (
+                "issue #1475 state labels ['state:running'] should derive from "
+                "record state 'implementation_ready' as ['state:ready']"
+            ),
+            "expected_state_label": "state:ready",
+            "current_state_labels": ["state:running"],
+            "labels_to_add": ["state:ready"],
+            "labels_to_remove": ["state:running"],
+            "dry_run_only": True,
+        }
+    ]
+
+
+def test_control_plane_report_derives_terminal_state_label_removal(tmp_path: Path) -> None:
+    """Released records should suggest removing state labels rather than mutating GitHub."""
+    registry = tmp_path / "experiments" / "registry.yaml"
+    _write_yaml(
+        registry,
+        """
+        schema_version: experiment-registry.v1
+        records:
+          - released.yaml
+        """,
+    )
+    _write_yaml(
+        registry.parent / "released.yaml",
+        """
+        schema_version: experiment-record.v2
+        experiment_id: released-record
+        issue: 2001
+        issue_url: https://github.com/ll7/robot_sf_ll7/issues/2001
+        question: Is this release state authoritative?
+        hypothesis: The dry-run report should remove live state labels.
+        config:
+          - configs/exists.yaml
+        command: uv run true
+        inputs:
+          - path: configs/exists.yaml
+        outputs:
+          - path: output/experiments/released
+        expected_artifacts:
+          - name: report
+            path: output/experiments/released/report.json
+        evidence_grade: proposal
+        paper_relevance: exploratory
+        state: released
+        """,
+    )
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "exists.yaml").write_text("ok: true\n", encoding="utf-8")
+
+    report = build_control_plane_report(
+        registry,
+        issue_states={2001: "OPEN"},
+        issue_labels={2001: ["state:running", "type:analysis"]},
+    )
+
+    assert report["derived_update_count"] == 1
+    update = report["findings"][0]
+    assert update["kind"] == "derived_issue_label_update"
+    assert update["expected_state_label"] is None
+    assert update["current_state_labels"] == ["state:running"]
+    assert update["labels_to_add"] == []
+    assert update["labels_to_remove"] == ["state:running"]
+    assert update["dry_run_only"] is True
 
 
 def test_validator_checks_scalar_config_paths(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #3073.

- add explicit `experiment-record.v2` state-to-`state:*` label mapping to the registry protocol docs
- extend the control-plane dry-run report with `derived_issue_label_update` findings, including `labels_to_add`, `labels_to_remove`, and `dry_run_only: true`
- cover active-state and released-state label derivation in focused registry validator tests

## Validation

- `uv run pytest tests/tools/test_validate_experiment_registry.py` (`10 passed`)
- `uv run ruff format --check scripts/tools/validate_experiment_registry.py tests/tools/test_validate_experiment_registry.py`
- `uv run ruff check scripts/tools/validate_experiment_registry.py tests/tools/test_validate_experiment_registry.py`
- `git diff --check`
- `uv run python scripts/tools/validate_experiment_registry.py experiments/registry.yaml --issue-state-json <private-fixture> --control-plane-report-json <private-report>` (`validated experiment registry`, report schema `experiment-control-plane-report.v1`, `derived_update_count: 1`)

## Research Result Guidance

- Target claim / hypothesis: experiment cards are the authoritative research-state source; GitHub labels are derived dry-run surfaces.
- Comparator / baseline: previous report detected limited label disagreement but did not publish a state-to-label mapping or structured add/remove suggestions.
- Evidence tier: protocol/tooling contract with focused fixture tests and checked-in registry validation; no benchmark result claim.
- Result classification: support/tooling guardrail.
- Decision / stop rule: report suggestions remain dry-run only; future automation may mutate GitHub only after separate approval and tests.
- Synthesis surface / update target: `experiments/README.md` and `scripts/tools/validate_experiment_registry.py`.

## Downstream Propagation

- Parent issue / claim map: #3073 under parent #3057.
- Registry / config index: no card migrations in this PR; protocol/report behavior only.
- Context / memory note: existing experiment registry README updated.
- Follow-up issues: none opened; full card-generation migration remains separate from this bounded protocol slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Experiment state validation now comprehensively checks GitHub issue labels, detecting when applied labels don't match the derived expected state.
  * Control-plane dry-run reports now explicitly detail state label updates needed without making actual changes.

* **Bug Fixes**
  * Improved label handling for terminal and released experiment states.

* **Documentation**
  * Expanded documentation with detailed experiment state-to-label mapping information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->