### PR TITLE
refactor: extract map-runner observation bridge

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -86,6 +86,19 @@ from robot_sf.benchmark.map_runner_metrics import (
 from robot_sf.benchmark.map_runner_metrics import (
     normalize_pedestrian_impact_controls as _normalize_pedestrian_impact_controls,
 )
+from robot_sf.benchmark.map_runner_observations import (
+    extract_ppo_dt as _extract_ppo_dt,  # noqa: F401 - compatibility re-export for tests.
+)
+from robot_sf.benchmark.map_runner_observations import (
+    extract_ppo_pedestrians as _extract_ppo_pedestrians,  # noqa: F401 - compatibility re-export.
+)
+from robot_sf.benchmark.map_runner_observations import (
+    normalize_xy_rows as _normalize_xy_rows,  # noqa: F401 - compatibility re-export for tests.
+)
+from robot_sf.benchmark.map_runner_observations import (
+    obs_to_external_mpc_format as _obs_to_external_mpc_format,
+)
+from robot_sf.benchmark.map_runner_observations import obs_to_ppo_format as _obs_to_ppo_format
 from robot_sf.benchmark.map_runner_policy_metadata import (
     apply_direct_world_velocity_metadata as _apply_direct_world_velocity_metadata,
 )
@@ -831,144 +844,6 @@ def _goal_policy(obs: dict[str, Any], *, max_speed: float = 1.0) -> tuple[float,
     angular = float(np.clip(heading_error, -1.0, 1.0))
     linear = float(np.clip(dist, 0.0, max_speed * max(0.0, 1.0 - abs(heading_error) / np.pi)))
     return linear, angular
-
-
-def _normalize_xy_rows(values: Any) -> np.ndarray:
-    """Normalize scalar/list/ndarray payloads to an ``(N, 2)`` float array.
-
-    Returns:
-        np.ndarray: ``(N, 2)`` array, or ``(0, 2)`` when input is empty/malformed.
-    """
-    arr = np.asarray(values, dtype=float)
-    if arr.size == 0:
-        return np.zeros((0, 2), dtype=float)
-    if arr.ndim == 1:
-        if arr.size % 2 != 0:
-            return np.zeros((0, 2), dtype=float)
-        return arr.reshape(-1, 2)
-    if arr.ndim == 2:
-        if arr.shape[1] == 2:
-            return arr
-        if arr.shape[1] > 2:
-            return arr[:, :2]
-        return np.pad(arr, ((0, 0), (0, 2 - arr.shape[1])), constant_values=0.0)
-    return np.zeros((0, 2), dtype=float)
-
-
-def _extract_ppo_pedestrians(
-    pedestrians: dict[str, Any],
-) -> tuple[np.ndarray, np.ndarray, float]:
-    """Extract count-aware pedestrian positions, velocities, and shared radius.
-
-    Returns:
-        tuple[np.ndarray, np.ndarray, float]: Pedestrian positions, velocities, and radius.
-    """
-    ped_pos = _normalize_xy_rows(pedestrians.get("positions", []))
-    ped_count_arr = np.asarray(pedestrians.get("count", [ped_pos.shape[0]]), dtype=float).reshape(
-        -1
-    )
-    ped_count = int(ped_count_arr[0]) if ped_count_arr.size else int(ped_pos.shape[0])
-    ped_count = max(0, min(ped_count, int(ped_pos.shape[0])))
-    ped_pos = ped_pos[:ped_count]
-
-    ped_vel = _normalize_xy_rows(pedestrians.get("velocities", []))
-    if ped_vel.shape[0] < ped_count:
-        ped_vel = np.pad(
-            ped_vel,
-            ((0, ped_count - ped_vel.shape[0]), (0, 0)),
-            constant_values=0.0,
-        )
-    ped_vel = ped_vel[:ped_count]
-
-    ped_radius_raw = np.asarray(pedestrians.get("radius", [0.35]), dtype=float).reshape(-1)
-    ped_radius = float(ped_radius_raw[0]) if ped_radius_raw.size else 0.35
-    return ped_pos, ped_vel, ped_radius
-
-
-def _extract_ppo_dt(obs: dict[str, Any]) -> float:
-    """Resolve PPO dt from structured sim metadata first, then fallback fields.
-
-    Returns:
-        float: Timestep for PPO planner observations.
-    """
-    sim_info = obs.get("sim")
-    if isinstance(sim_info, dict) and "timestep" in sim_info:
-        dt_source = sim_info.get("timestep")
-    else:
-        dt_source = obs.get("dt", 0.1)
-    dt_raw = np.asarray(0.1 if dt_source is None else dt_source, dtype=float).reshape(-1)
-    return float(dt_raw[0]) if dt_raw.size else 0.1
-
-
-def _obs_to_ppo_format(obs: dict[str, Any]) -> dict[str, Any]:
-    """Convert map-runner observations into the PPO baseline observation contract.
-
-    Returns:
-        Mapping compatible with ``robot_sf.baselines.ppo.PPOPlanner.step``.
-    """
-    robot = obs.get("robot", {}) if isinstance(obs.get("robot"), dict) else {}
-    goal = obs.get("goal", {}) if isinstance(obs.get("goal"), dict) else {}
-    pedestrians = obs.get("pedestrians", {}) if isinstance(obs.get("pedestrians"), dict) else {}
-
-    robot_pos = np.asarray(robot.get("position", [0.0, 0.0]), dtype=float).reshape(-1)
-    robot_vel = np.asarray(robot.get("velocity", [0.0, 0.0]), dtype=float).reshape(-1)
-    if robot_vel.size < 2:
-        speed = float(np.asarray(robot.get("speed", [0.0]), dtype=float).reshape(-1)[0])
-        heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
-        robot_vel = np.array([speed * np.cos(heading), speed * np.sin(heading)], dtype=float)
-    robot_goal = np.asarray(goal.get("current", [0.0, 0.0]), dtype=float).reshape(-1)
-    robot_heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
-    robot_radius = float(np.asarray(robot.get("radius", [0.3]), dtype=float).reshape(-1)[0])
-
-    ped_pos, ped_vel, ped_radius = _extract_ppo_pedestrians(pedestrians)
-
-    agents = []
-    for idx in range(ped_pos.shape[0]):
-        vel = ped_vel[idx] if idx < ped_vel.shape[0] else np.zeros(2, dtype=float)
-        agents.append(
-            {
-                "position": [float(ped_pos[idx, 0]), float(ped_pos[idx, 1])],
-                "velocity": [float(vel[0]), float(vel[1])],
-                "radius": ped_radius,
-            }
-        )
-
-    dt = _extract_ppo_dt(obs)
-    return {
-        "dt": dt,
-        "robot": {
-            "position": [float(robot_pos[0]), float(robot_pos[1])]
-            if robot_pos.size >= 2
-            else [0.0, 0.0],
-            "velocity": [float(robot_vel[0]), float(robot_vel[1])]
-            if robot_vel.size >= 2
-            else [0.0, 0.0],
-            "goal": [float(robot_goal[0]), float(robot_goal[1])]
-            if robot_goal.size >= 2
-            else [0.0, 0.0],
-            "heading": robot_heading,
-            "radius": robot_radius,
-        },
-        "agents": agents,
-        "obstacles": [],
-    }
-
-
-def _obs_to_external_mpc_format(obs: dict[str, Any]) -> dict[str, Any]:
-    """Convert map-runner observations into the external MPC wrapper contract.
-
-    Returns:
-        dict[str, Any]: Structured observation with obstacles preserved when present.
-
-    The external MPC wrappers use the same robot/human fields as the PPO bridge,
-    but they may also reason about obstacle payloads when the upstream contract
-    exposes them, so preserve the raw obstacle list when available.
-    """
-    payload = _obs_to_ppo_format(obs)
-    obstacles = obs.get("obstacles")
-    if isinstance(obstacles, list):
-        payload["obstacles"] = obstacles
-    return payload
 
 
 class _GoalFallbackAdapter:

--- a/robot_sf/benchmark/map_runner_observations.py
+++ b/robot_sf/benchmark/map_runner_observations.py
@@ -1,0 +1,145 @@
+"""Observation bridge helpers for map-runner policy adapters."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+
+def normalize_xy_rows(values: Any) -> np.ndarray:
+    """Normalize scalar/list/ndarray payloads to an ``(N, 2)`` float array.
+
+    Returns:
+        np.ndarray: ``(N, 2)`` array, or ``(0, 2)`` when input is empty/malformed.
+    """
+    arr = np.asarray(values, dtype=float)
+    if arr.size == 0:
+        return np.zeros((0, 2), dtype=float)
+    if arr.ndim == 1:
+        if arr.size % 2 != 0:
+            return np.zeros((0, 2), dtype=float)
+        return arr.reshape(-1, 2)
+    if arr.ndim == 2:
+        if arr.shape[1] == 2:
+            return arr
+        if arr.shape[1] > 2:
+            return arr[:, :2]
+        return np.pad(arr, ((0, 0), (0, 2 - arr.shape[1])), constant_values=0.0)
+    return np.zeros((0, 2), dtype=float)
+
+
+def extract_ppo_pedestrians(
+    pedestrians: dict[str, Any],
+) -> tuple[np.ndarray, np.ndarray, float]:
+    """Extract count-aware pedestrian positions, velocities, and shared radius.
+
+    Returns:
+        tuple[np.ndarray, np.ndarray, float]: Pedestrian positions, velocities, and radius.
+    """
+    ped_pos = normalize_xy_rows(pedestrians.get("positions", []))
+    ped_count_arr = np.asarray(pedestrians.get("count", [ped_pos.shape[0]]), dtype=float).reshape(
+        -1
+    )
+    ped_count = int(ped_count_arr[0]) if ped_count_arr.size else int(ped_pos.shape[0])
+    ped_count = max(0, min(ped_count, int(ped_pos.shape[0])))
+    ped_pos = ped_pos[:ped_count]
+
+    ped_vel = normalize_xy_rows(pedestrians.get("velocities", []))
+    if ped_vel.shape[0] < ped_count:
+        ped_vel = np.pad(
+            ped_vel,
+            ((0, ped_count - ped_vel.shape[0]), (0, 0)),
+            constant_values=0.0,
+        )
+    ped_vel = ped_vel[:ped_count]
+
+    ped_radius_raw = np.asarray(pedestrians.get("radius", [0.35]), dtype=float).reshape(-1)
+    ped_radius = float(ped_radius_raw[0]) if ped_radius_raw.size else 0.35
+    return ped_pos, ped_vel, ped_radius
+
+
+def extract_ppo_dt(obs: dict[str, Any]) -> float:
+    """Resolve PPO dt from structured sim metadata first, then fallback fields.
+
+    Returns:
+        float: Timestep for PPO planner observations.
+    """
+    sim_info = obs.get("sim")
+    if isinstance(sim_info, dict) and "timestep" in sim_info:
+        dt_source = sim_info.get("timestep")
+    else:
+        dt_source = obs.get("dt", 0.1)
+    dt_raw = np.asarray(0.1 if dt_source is None else dt_source, dtype=float).reshape(-1)
+    return float(dt_raw[0]) if dt_raw.size else 0.1
+
+
+def obs_to_ppo_format(obs: dict[str, Any]) -> dict[str, Any]:
+    """Convert map-runner observations into the PPO baseline observation contract.
+
+    Returns:
+        Mapping compatible with ``robot_sf.baselines.ppo.PPOPlanner.step``.
+    """
+    robot = obs.get("robot", {}) if isinstance(obs.get("robot"), dict) else {}
+    goal = obs.get("goal", {}) if isinstance(obs.get("goal"), dict) else {}
+    pedestrians = obs.get("pedestrians", {}) if isinstance(obs.get("pedestrians"), dict) else {}
+
+    robot_pos = np.asarray(robot.get("position", [0.0, 0.0]), dtype=float).reshape(-1)
+    robot_vel = np.asarray(robot.get("velocity", [0.0, 0.0]), dtype=float).reshape(-1)
+    if robot_vel.size < 2:
+        speed = float(np.asarray(robot.get("speed", [0.0]), dtype=float).reshape(-1)[0])
+        heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
+        robot_vel = np.array([speed * np.cos(heading), speed * np.sin(heading)], dtype=float)
+    robot_goal = np.asarray(goal.get("current", [0.0, 0.0]), dtype=float).reshape(-1)
+    robot_heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
+    robot_radius = float(np.asarray(robot.get("radius", [0.3]), dtype=float).reshape(-1)[0])
+
+    ped_pos, ped_vel, ped_radius = extract_ppo_pedestrians(pedestrians)
+
+    agents = []
+    for idx in range(ped_pos.shape[0]):
+        vel = ped_vel[idx] if idx < ped_vel.shape[0] else np.zeros(2, dtype=float)
+        agents.append(
+            {
+                "position": [float(ped_pos[idx, 0]), float(ped_pos[idx, 1])],
+                "velocity": [float(vel[0]), float(vel[1])],
+                "radius": ped_radius,
+            }
+        )
+
+    dt = extract_ppo_dt(obs)
+    return {
+        "dt": dt,
+        "robot": {
+            "position": [float(robot_pos[0]), float(robot_pos[1])]
+            if robot_pos.size >= 2
+            else [0.0, 0.0],
+            "velocity": [float(robot_vel[0]), float(robot_vel[1])]
+            if robot_vel.size >= 2
+            else [0.0, 0.0],
+            "goal": [float(robot_goal[0]), float(robot_goal[1])]
+            if robot_goal.size >= 2
+            else [0.0, 0.0],
+            "heading": robot_heading,
+            "radius": robot_radius,
+        },
+        "agents": agents,
+        "obstacles": [],
+    }
+
+
+def obs_to_external_mpc_format(obs: dict[str, Any]) -> dict[str, Any]:
+    """Convert map-runner observations into the external MPC wrapper contract.
+
+    Returns:
+        dict[str, Any]: Structured observation with obstacles preserved when present.
+
+    The external MPC wrappers use the same robot/human fields as the PPO bridge,
+    but they may also reason about obstacle payloads when the upstream contract
+    exposes them, so preserve the raw obstacle list when available.
+    """
+    payload = obs_to_ppo_format(obs)
+    obstacles = obs.get("obstacles")
+    if isinstance(obstacles, list):
+        payload["obstacles"] = obstacles
+    return payload

--- a/robot_sf/benchmark/map_runner_observations.py
+++ b/robot_sf/benchmark/map_runner_observations.py
@@ -7,12 +7,19 @@ from typing import Any
 import numpy as np
 
 
+def _default_if_none(value: Any, default: Any) -> Any:
+    """Return ``default`` when a parsed observation field is explicitly null."""
+    return default if value is None else value
+
+
 def normalize_xy_rows(values: Any) -> np.ndarray:
     """Normalize scalar/list/ndarray payloads to an ``(N, 2)`` float array.
 
     Returns:
         np.ndarray: ``(N, 2)`` array, or ``(0, 2)`` when input is empty/malformed.
     """
+    if values is None:
+        return np.zeros((0, 2), dtype=float)
     arr = np.asarray(values, dtype=float)
     if arr.size == 0:
         return np.zeros((0, 2), dtype=float)
@@ -37,15 +44,14 @@ def extract_ppo_pedestrians(
     Returns:
         tuple[np.ndarray, np.ndarray, float]: Pedestrian positions, velocities, and radius.
     """
-    ped_pos = normalize_xy_rows(pedestrians.get("positions", []))
-    ped_count_arr = np.asarray(pedestrians.get("count", [ped_pos.shape[0]]), dtype=float).reshape(
-        -1
-    )
+    ped_pos = normalize_xy_rows(_default_if_none(pedestrians.get("positions"), []))
+    ped_count_source = _default_if_none(pedestrians.get("count"), [ped_pos.shape[0]])
+    ped_count_arr = np.asarray(ped_count_source, dtype=float).reshape(-1)
     ped_count = int(ped_count_arr[0]) if ped_count_arr.size else int(ped_pos.shape[0])
     ped_count = max(0, min(ped_count, int(ped_pos.shape[0])))
     ped_pos = ped_pos[:ped_count]
 
-    ped_vel = normalize_xy_rows(pedestrians.get("velocities", []))
+    ped_vel = normalize_xy_rows(_default_if_none(pedestrians.get("velocities"), []))
     if ped_vel.shape[0] < ped_count:
         ped_vel = np.pad(
             ped_vel,
@@ -54,7 +60,8 @@ def extract_ppo_pedestrians(
         )
     ped_vel = ped_vel[:ped_count]
 
-    ped_radius_raw = np.asarray(pedestrians.get("radius", [0.35]), dtype=float).reshape(-1)
+    ped_radius_source = _default_if_none(pedestrians.get("radius"), [0.35])
+    ped_radius_raw = np.asarray(ped_radius_source, dtype=float).reshape(-1)
     ped_radius = float(ped_radius_raw[0]) if ped_radius_raw.size else 0.35
     return ped_pos, ped_vel, ped_radius
 
@@ -84,15 +91,29 @@ def obs_to_ppo_format(obs: dict[str, Any]) -> dict[str, Any]:
     goal = obs.get("goal", {}) if isinstance(obs.get("goal"), dict) else {}
     pedestrians = obs.get("pedestrians", {}) if isinstance(obs.get("pedestrians"), dict) else {}
 
-    robot_pos = np.asarray(robot.get("position", [0.0, 0.0]), dtype=float).reshape(-1)
-    robot_vel = np.asarray(robot.get("velocity", [0.0, 0.0]), dtype=float).reshape(-1)
+    robot_pos = np.asarray(
+        _default_if_none(robot.get("position"), [0.0, 0.0]), dtype=float
+    ).reshape(-1)
+    robot_vel = np.asarray(
+        _default_if_none(robot.get("velocity"), [0.0, 0.0]), dtype=float
+    ).reshape(-1)
     if robot_vel.size < 2:
-        speed = float(np.asarray(robot.get("speed", [0.0]), dtype=float).reshape(-1)[0])
-        heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
+        speed = float(
+            np.asarray(_default_if_none(robot.get("speed"), [0.0]), dtype=float).reshape(-1)[0]
+        )
+        heading = float(
+            np.asarray(_default_if_none(robot.get("heading"), [0.0]), dtype=float).reshape(-1)[0]
+        )
         robot_vel = np.array([speed * np.cos(heading), speed * np.sin(heading)], dtype=float)
-    robot_goal = np.asarray(goal.get("current", [0.0, 0.0]), dtype=float).reshape(-1)
-    robot_heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
-    robot_radius = float(np.asarray(robot.get("radius", [0.3]), dtype=float).reshape(-1)[0])
+    robot_goal = np.asarray(_default_if_none(goal.get("current"), [0.0, 0.0]), dtype=float).reshape(
+        -1
+    )
+    robot_heading = float(
+        np.asarray(_default_if_none(robot.get("heading"), [0.0]), dtype=float).reshape(-1)[0]
+    )
+    robot_radius = float(
+        np.asarray(_default_if_none(robot.get("radius"), [0.3]), dtype=float).reshape(-1)[0]
+    )
 
     ped_pos, ped_vel, ped_radius = extract_ppo_pedestrians(pedestrians)
 

--- a/tests/test_map_runner_ppo.py
+++ b/tests/test_map_runner_ppo.py
@@ -389,3 +389,32 @@ def test_obs_to_ppo_format_handles_malformed_flat_ped_arrays():
 
     formatted = map_runner._obs_to_ppo_format(obs)
     assert formatted["agents"] == []
+
+
+def test_obs_to_ppo_format_tolerates_explicit_null_fields():
+    """Explicit null observation fields should fall back to safe defaults."""
+    obs = _sample_obs()
+    obs["robot"] = {
+        "position": None,
+        "velocity": None,
+        "speed": None,
+        "heading": None,
+        "radius": None,
+    }
+    obs["goal"] = {"current": None}
+    obs["pedestrians"] = {
+        "positions": None,
+        "velocities": None,
+        "count": None,
+        "radius": None,
+    }
+
+    formatted = map_runner._obs_to_ppo_format(obs)
+
+    assert formatted["dt"] == pytest.approx(0.1)
+    assert formatted["robot"]["position"] == [0.0, 0.0]
+    assert formatted["robot"]["velocity"] == [0.0, 0.0]
+    assert formatted["robot"]["goal"] == [0.0, 0.0]
+    assert formatted["robot"]["heading"] == 0.0
+    assert formatted["robot"]["radius"] == 0.3
+    assert formatted["agents"] == []


### PR DESCRIPTION
## Summary

- Extract the map-runner PPO/external-MPC observation bridge helpers into `robot_sf/benchmark/map_runner_observations.py`.
- Keep the existing private `map_runner.py` helper names as compatibility imports for tests and downstream diagnostic scripts.
- Reduce `map_runner.py` by moving one cohesive policy-observation responsibility without changing benchmark semantics or output schemas.

Closes #3006

## Validation

- `uv run pytest tests/test_map_runner_ppo.py tests/test_map_runner_sac.py tests/benchmark/test_map_runner_utils.py -q`
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_observations.py`
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_observations.py`
- `git diff --check`

## Downstream Propagation

- No benchmark, metric, schema, or artifact semantics changed.
- No generated `output/` artifacts were created or promoted.
- This is a maintenance refactor slice for #3006; future slices can continue extracting batch orchestration or episode execution after this compatibility-preserving module boundary lands.

## Research Result Guidance

- NA - support refactor only. This PR does not make research, benchmark, metric, model-provenance, or paper-facing claims.
