### PR TITLE
chore: enforce ruff pre-commit failures (#3019)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,7 +5,7 @@ repos:
     hooks:
       # Run the linter.
       - id: ruff
-        args: [ --fix, --exit-zero ]
+        args: [ --fix ]
       # Run the formatter.
       - id: ruff-format
   - repo: local


### PR DESCRIPTION
## Summary
Removed Ruff hook `--exit-zero` from `.pre-commit-config.yaml` so local pre-commit lint failures now fail the hook instead of being advisory.

## Linked Issues
- Closes `#3019`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Kept the Ruff pre-commit hook in auto-fix mode with `args: [ --fix ]`.
- Removed only the fail-open `--exit-zero` flag.

## Why It Matters
- Added value: restores Ruff pre-commit as an enforcing local lint gate.
- Expected impact: contributors get immediate non-advisory lint failures before commit.
- Why this is worth merging now: `uv run ruff check .` and the Ruff pre-commit hook both pass on the branch, so the known lint backlog blocker is clear.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support workflow change, no research claim.
- Comparator or baseline, if applicable: previous Ruff hook used `--exit-zero`.
- Evidence tier: NA - support helper / workflow config.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: remove fail-open only after non-advisory Ruff passes.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#3019`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support workflow config; it does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop; issue scope is complete.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run python scripts/dev/run_compact_validation.py -- uv run ruff check .` -> pass
  - `uv run python scripts/dev/run_compact_validation.py -- uv run pre-commit run ruff --all-files` -> pass
  - `git diff --check` -> pass
- Evidence that the change works here: Ruff passes without relying on `--exit-zero`, and the actual pre-commit Ruff hook passes after the flag is removed.
- Benchmarks or smoke tests, if applicable: NA.
- Note: `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` was attempted through the compact validator, but the wrapper hung with an orphaned idle child and was interrupted; no failure summary or new artifact was produced. Focused proof above covers the changed hook behavior.

## Risks / Rollout
- Compatibility risks: low; contributors with local Ruff violations will now be blocked as intended.
- Failure modes: hidden future lint findings will fail local pre-commit instead of being silently advisory.
- Rollback or fallback plan: restore `--exit-zero` if maintainers intentionally want advisory Ruff again.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue `#3019`.
- Any assumptions that need to be preserved: Ruff backlog is clear under the current repo configuration.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR linkage.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a support workflow config change with no research, benchmark, metric, or artifact claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: confirm local policy should now enforce Ruff failures.
- Any known limitations: broad final PR readiness did not complete due to wrapper hang; focused hook validation passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pre-commit hook configuration to enforce stricter code quality validation during commits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->