### PR TITLE
refactor: centralize issue provenance constants (#3020)

### DIFF
--- a/robot_sf/benchmark/live_forecast_replay_gate.py
+++ b/robot_sf/benchmark/live_forecast_replay_gate.py
@@ -53,12 +53,13 @@ from robot_sf.benchmark.pedestrian_forecast import (
     semantic_cv_baseline,
 )
 from robot_sf.common.forecast_variants import FORECAST_VARIANT_CHOICES
+from robot_sf.common.issue_provenance import LIVE_FORECAST_REPLAY_GATE_CONTRACT_ISSUE
 from robot_sf.gym_env.unified_config import EnvSettings
 from robot_sf.nav.baseline_probabilistic_predictor import BaselineProbabilisticPredictor
 from robot_sf.nav.predictive_types import ProbabilisticPrediction, ProbabilisticPredictor
 
 LIVE_FORECAST_REPLAY_GATE_SCHEMA_VERSION = "LiveForecastReplayGate.v1"
-LIVE_FORECAST_REPLAY_GATE_ISSUE = 2941
+LIVE_FORECAST_REPLAY_GATE_ISSUE = LIVE_FORECAST_REPLAY_GATE_CONTRACT_ISSUE
 
 FORECAST_VARIANTS: tuple[str, ...] = FORECAST_VARIANT_CHOICES
 

--- a/robot_sf/common/__init__.py
+++ b/robot_sf/common/__init__.py
@@ -44,6 +44,14 @@ from robot_sf.common.hardware import (
     detect_hardware_capacity,
     recommend_env_runners,
 )
+from robot_sf.common.issue_provenance import (
+    ISSUE_PROVENANCE_BY_KEY,
+    LIVE_FORECAST_REPLAY_GATE_CONTRACT,
+    LIVE_FORECAST_REPLAY_GATE_CONTRACT_ISSUE,
+    SCENARIO_BELIEF_DESIGN_PARENT,
+    SCENARIO_BELIEF_DESIGN_PARENT_ISSUE,
+    IssueProvenance,
+)
 from robot_sf.common.math_utils import (
     normalize_angle_atan2,
     wrap_angle_pi,
@@ -112,6 +120,13 @@ __all__ = [  # noqa: RUF022 - Grouped by source module for clarity
     "HardwareCapacity",
     "detect_hardware_capacity",
     "recommend_env_runners",
+    # Issue provenance registry (from .issue_provenance)
+    "ISSUE_PROVENANCE_BY_KEY",
+    "LIVE_FORECAST_REPLAY_GATE_CONTRACT",
+    "LIVE_FORECAST_REPLAY_GATE_CONTRACT_ISSUE",
+    "SCENARIO_BELIEF_DESIGN_PARENT",
+    "SCENARIO_BELIEF_DESIGN_PARENT_ISSUE",
+    "IssueProvenance",
     # Matplotlib utilities (from .matplotlib_utils)
     "ensure_interactive_backend",
     "is_headless_environment",

--- a/robot_sf/common/issue_provenance.py
+++ b/robot_sf/common/issue_provenance.py
@@ -1,0 +1,47 @@
+"""Central issue-number provenance for code-owned diagnostic contracts.
+
+These identifiers are breadcrumbs to the issue contracts that introduced a
+runtime or report field. They are not mutable runtime configuration.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import MappingProxyType
+
+
+@dataclass(frozen=True)
+class IssueProvenance:
+    """Immutable metadata for an issue-backed code contract."""
+
+    issue: int
+    purpose: str
+
+
+SCENARIO_BELIEF_DESIGN_PARENT = IssueProvenance(
+    issue=1966,
+    purpose="ScenarioBelief design parent carried in debug projections.",
+)
+LIVE_FORECAST_REPLAY_GATE_CONTRACT = IssueProvenance(
+    issue=2941,
+    purpose="Native live forecast replay gate report contract.",
+)
+
+SCENARIO_BELIEF_DESIGN_PARENT_ISSUE = SCENARIO_BELIEF_DESIGN_PARENT.issue
+LIVE_FORECAST_REPLAY_GATE_CONTRACT_ISSUE = LIVE_FORECAST_REPLAY_GATE_CONTRACT.issue
+
+ISSUE_PROVENANCE_BY_KEY = MappingProxyType(
+    {
+        "scenario_belief_design_parent": SCENARIO_BELIEF_DESIGN_PARENT,
+        "live_forecast_replay_gate_contract": LIVE_FORECAST_REPLAY_GATE_CONTRACT,
+    }
+)
+
+__all__ = [
+    "ISSUE_PROVENANCE_BY_KEY",
+    "LIVE_FORECAST_REPLAY_GATE_CONTRACT",
+    "LIVE_FORECAST_REPLAY_GATE_CONTRACT_ISSUE",
+    "SCENARIO_BELIEF_DESIGN_PARENT",
+    "SCENARIO_BELIEF_DESIGN_PARENT_ISSUE",
+    "IssueProvenance",
+]

--- a/robot_sf/representation/scenario_belief.py
+++ b/robot_sf/representation/scenario_belief.py
@@ -14,10 +14,11 @@ from typing import Any
 
 import numpy as np
 
+from robot_sf.common.issue_provenance import SCENARIO_BELIEF_DESIGN_PARENT_ISSUE
 from robot_sf.sensor.socnav_observation import _map_position_cap
 
 SCENARIO_BELIEF_SCHEMA_VERSION = "scenario-belief.v1"
-DESIGN_PARENT_ISSUE = 1966
+DESIGN_PARENT_ISSUE = SCENARIO_BELIEF_DESIGN_PARENT_ISSUE
 
 
 class VisibilityState(StrEnum):

--- a/tests/benchmark/test_live_forecast_replay_gate.py
+++ b/tests/benchmark/test_live_forecast_replay_gate.py
@@ -34,6 +34,7 @@ from robot_sf.benchmark.live_forecast_replay_gate import (
     run_live_forecast_replay_gate,
     run_variant_closed_loop_replay,
 )
+from robot_sf.common.issue_provenance import LIVE_FORECAST_REPLAY_GATE_CONTRACT_ISSUE
 
 
 @pytest.fixture
@@ -88,6 +89,14 @@ class TestConstants:
         """Schema version should be stable."""
 
         assert LIVE_FORECAST_REPLAY_GATE_SCHEMA_VERSION == "LiveForecastReplayGate.v1"
+
+    def test_issue_provenance_constant(self) -> None:
+        """The exported compatibility alias should come from the shared provenance registry."""
+
+        assert (
+            live_forecast_replay_gate_module.LIVE_FORECAST_REPLAY_GATE_ISSUE
+            == LIVE_FORECAST_REPLAY_GATE_CONTRACT_ISSUE
+        )
 
     def test_valid_run_classifications(self) -> None:
         """Run classification contract must contain the four required labels."""

--- a/tests/representation/test_scenario_belief.py
+++ b/tests/representation/test_scenario_belief.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import numpy as np
 import pytest
 
+from robot_sf.common.issue_provenance import SCENARIO_BELIEF_DESIGN_PARENT_ISSUE
 from robot_sf.gym_env.unified_config import ObservationVisibilitySettings, RobotSimulationConfig
 from robot_sf.representation import (
     TrackedAgentMetadata,
@@ -15,6 +16,7 @@ from robot_sf.representation import (
     scenario_belief_from_simulator_oracle,
     scenario_belief_from_visibility_limited_simulator,
 )
+from robot_sf.representation.scenario_belief import DESIGN_PARENT_ISSUE
 
 
 def _simulator_fixture() -> SimpleNamespace:
@@ -118,7 +120,8 @@ def test_debug_projection_is_deterministic_and_exposes_uncertainty() -> None:
     debug_a = partial.to_debug_dict()
     debug_b = partial.to_debug_dict()
     assert debug_a == debug_b
-    assert debug_a["design_parent_issue"] == 1966
+    assert DESIGN_PARENT_ISSUE == SCENARIO_BELIEF_DESIGN_PARENT_ISSUE
+    assert debug_a["design_parent_issue"] == SCENARIO_BELIEF_DESIGN_PARENT_ISSUE
     assert debug_a["source_summary"]["adapter"] == "visibility_limited_simulator"
     assert debug_a["agents"][1]["visibility_state"] == "out_of_range"
     assert (


### PR DESCRIPTION
## Summary
Centralizes issue-number provenance for two code-owned diagnostic contracts while preserving the existing public constants and report/debug output values.

## Linked Issues
- Closes `#3020`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `robot_sf.common.issue_provenance` as an immutable registry for issue-backed code contract identifiers.
- Rewired `ScenarioBelief` and live forecast replay gate issue constants to use the shared provenance registry.
- Added tests that assert the existing compatibility aliases still resolve through the shared provenance source.
- Exported the provenance registry symbols from `robot_sf.common` for discoverability.

## Why It Matters
- Added value: avoids source-code issue numbers looking like scattered runtime configuration.
- Expected impact: maintenance-only; no benchmark, planner, metric, or runtime behavior change intended.
- Why this is worth merging now: it closes a bounded technical-debt item with a small, tested diff.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - maintenance refactor only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: targeted smoke.
- Result classification: NA - no research result claimed.
- Decision or stop rule, if applicable: preserve existing issue IDs and output values.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#3020`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no new analysis tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this maintenance scope.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop after review/CI if green.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run pytest tests/representation/test_scenario_belief.py tests/benchmark/test_live_forecast_replay_gate.py -q`
  - `uv run ruff check robot_sf/common/__init__.py robot_sf/common/issue_provenance.py robot_sf/representation/scenario_belief.py robot_sf/benchmark/live_forecast_replay_gate.py tests/representation/test_scenario_belief.py tests/benchmark/test_live_forecast_replay_gate.py`
  - `uv run ruff format --check robot_sf/common/__init__.py robot_sf/common/issue_provenance.py robot_sf/representation/scenario_belief.py robot_sf/benchmark/live_forecast_replay_gate.py tests/representation/test_scenario_belief.py tests/benchmark/test_live_forecast_replay_gate.py`
  - `uv run python - <<'PY' ...` import smoke for the registry and compatibility aliases
  - `git diff --check`
- Evidence that the change works here: focused tests passed after rebasing onto current `origin/main`; import smoke confirmed both legacy constants still equal the registry values.
- Benchmarks or smoke tests, if applicable: no benchmark run; this is a provenance refactor.
- Full readiness note: `uv run python scripts/dev/run_compact_validation.py -- timeout 1200 env PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` was interrupted after staying silent beyond the useful wait window on the old compact-validation wrapper. No full readiness pass is claimed. Follow-up wrapper fix is already in PR `#3096`.

## Risks / Rollout
- Compatibility risks: low; old module-level constants remain present and keep the same integer values.
- Failure modes: import-order or export mistakes; covered by Ruff, targeted tests, and import smoke.
- Rollback or fallback plan: revert the registry indirection and restore inline constants.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: `robot_sf.common.issue_provenance` now documents that these IDs are breadcrumbs, not mutable runtime configuration.
- Any assumptions that need to be preserved: issue IDs are contract provenance only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, claim/comment/PR link.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes, code provenance registry added.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark, paper-facing, artifact, or empirical claim changes.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that preserving `DESIGN_PARENT_ISSUE` and `LIVE_FORECAST_REPLAY_GATE_ISSUE` as aliases is the desired compatibility shape.
- Known limitation: full `pr_ready_check` did not complete under the old compact wrapper; the PR relies on focused proof plus CI.
