### PR TITLE
ci: harden setup after apt stalls (#3099)

### DIFF
--- a/.github/actions/setup-ci-python/action.yml
+++ b/.github/actions/setup-ci-python/action.yml
@@ -35,7 +35,7 @@ runs:
         CI_STEP_TIMEOUT_SECONDS: "1200"
       run: >
         bash scripts/dev/ci_step_timer.sh "System packages for headless"
-        bash -lc
+        bash -c
         'sudo apt-get update && sudo apt-get install -y --no-install-recommends libglib2.0-0 libgl1 fonts-dejavu-core jq'
 
     - name: Free runner disk space

--- a/.github/actions/setup-ci-python/action.yml
+++ b/.github/actions/setup-ci-python/action.yml
@@ -31,9 +31,12 @@ runs:
 
     - name: System packages for headless
       shell: bash
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y --no-install-recommends ffmpeg libglib2.0-0 libgl1 fonts-dejavu-core jq
+      env:
+        CI_STEP_TIMEOUT_SECONDS: "1200"
+      run: >
+        bash scripts/dev/ci_step_timer.sh "System packages for headless"
+        bash -lc
+        'sudo apt-get update && sudo apt-get install -y --no-install-recommends libglib2.0-0 libgl1 fonts-dejavu-core jq'
 
     - name: Free runner disk space
       shell: bash

--- a/.github/actions/setup-ci-python/action.yml
+++ b/.github/actions/setup-ci-python/action.yml
@@ -35,8 +35,8 @@ runs:
         CI_STEP_TIMEOUT_SECONDS: "1200"
       run: >
         bash scripts/dev/ci_step_timer.sh "System packages for headless"
-        bash -c
-        'sudo apt-get update && sudo apt-get install -y --no-install-recommends libglib2.0-0 libgl1 fonts-dejavu-core jq'
+        bash scripts/dev/ci_install_headless_packages.sh
+        libglib2.0-0 libgl1 fonts-dejavu-core jq
 
     - name: Free runner disk space
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -104,6 +104,7 @@ jobs:
         uses: ./.github/actions/setup-ci-python
 
       - name: Validation smoke tests
+        id: smoke_tests
         run: scripts/dev/ci_driver.sh smoke
 
       - name: Upload map verification manifest
@@ -161,7 +162,9 @@ jobs:
           path: output/benchmarks/reproducibility_check.json
 
       - name: Enforce artifact root policy
-        if: always()
+        if: >-
+          ${{ always() && (steps.smoke_tests.outcome == 'success' ||
+          steps.smoke_tests.outcome == 'failure') }}
         env:
           CI_STEP_TIMEOUT_SECONDS: "300"
         run: bash scripts/dev/ci_step_timer.sh "Enforce artifact root policy" scripts/dev/ci_driver.sh artifact-policy

--- a/scripts/dev/ci_install_headless_packages.sh
+++ b/scripts/dev/ci_install_headless_packages.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -eq 1 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  echo "Usage: scripts/dev/ci_install_headless_packages.sh <package> [package...]"
+  echo "Installs only packages that are missing from the runner."
+  exit 0
+fi
+
+if [[ $# -lt 1 ]]; then
+  echo "Usage: scripts/dev/ci_install_headless_packages.sh <package> [package...]" >&2
+  exit 2
+fi
+
+missing=()
+for package_name in "$@"; do
+  if dpkg-query -W -f='${Status}' "${package_name}" 2>/dev/null | grep -q "install ok installed"; then
+    echo "ci_install_headless_packages present package=${package_name}"
+  else
+    echo "ci_install_headless_packages missing package=${package_name}"
+    missing+=("${package_name}")
+  fi
+done
+
+if [[ ${#missing[@]} -eq 0 ]]; then
+  echo "ci_install_headless_packages all requested packages already installed"
+  exit 0
+fi
+
+apt_options=(
+  -o Acquire::Retries=2
+  -o Acquire::http::Timeout=20
+  -o Acquire::https::Timeout=20
+  -o Dpkg::Use-Pty=0
+)
+
+export DEBIAN_FRONTEND=noninteractive
+export APT_LISTCHANGES_FRONTEND=none
+
+echo "ci_install_headless_packages installing packages=${missing[*]}"
+sudo apt-get "${apt_options[@]}" update
+sudo apt-get "${apt_options[@]}" install -y --no-install-recommends "${missing[@]}"

--- a/tests/dev/test_ci_install_headless_packages.py
+++ b/tests/dev/test_ci_install_headless_packages.py
@@ -1,0 +1,144 @@
+"""Tests for the CI headless package installer helper."""
+
+from __future__ import annotations
+
+import os
+import shlex
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+
+def _script_path() -> Path:
+    return (
+        Path(__file__).resolve().parents[2] / "scripts" / "dev" / "ci_install_headless_packages.sh"
+    )
+
+
+def _write_executable(path: Path, body: str) -> None:
+    path.write_text(body, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _shell_quote(path: Path) -> str:
+    return shlex.quote(str(path))
+
+
+def test_ci_install_headless_packages_shell_syntax() -> None:
+    """Validate that the package helper passes bash syntax checks."""
+    script = _script_path()
+    assert script.exists(), "ci_install_headless_packages.sh helper is missing"
+    assert subprocess.run(["bash", "-n", str(script)], check=False).returncode == 0
+
+
+def test_ci_install_headless_packages_help_flag() -> None:
+    """--help prints usage without attempting package inspection."""
+    result = subprocess.run(
+        ["bash", str(_script_path()), "--help"],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+
+
+def test_ci_install_headless_packages_requires_package() -> None:
+    """The helper requires at least one package name."""
+    result = subprocess.run(
+        ["bash", str(_script_path())],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    assert result.returncode == 2
+    assert "Usage:" in result.stderr
+
+
+def test_ci_install_headless_packages_skips_apt_when_all_packages_present(tmp_path: Path) -> None:
+    """Already-installed packages should not trigger apt update or install."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log_path = tmp_path / "commands.log"
+
+    _write_executable(
+        fake_bin / "dpkg-query",
+        "#!/usr/bin/env bash\n"
+        f"printf 'dpkg-query %s\\n' \"$*\" >> {_shell_quote(log_path)}\n"
+        "echo 'install ok installed'\n",
+    )
+    _write_executable(
+        fake_bin / "sudo",
+        f"#!/usr/bin/env bash\nprintf 'sudo %s\\n' \"$*\" >> {_shell_quote(log_path)}\nexit 99\n",
+    )
+
+    grep_path = shutil.which("grep")
+    bash_path = shutil.which("bash")
+    assert grep_path, "grep is required for this test"
+    assert bash_path, "bash is required for this test"
+    os.symlink(bash_path, fake_bin / "bash")
+    os.symlink(grep_path, fake_bin / "grep")
+
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin)
+    result = subprocess.run(
+        ["bash", str(_script_path()), "libgl1", "jq"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0
+    assert "all requested packages already installed" in result.stdout
+    assert "sudo" not in log_path.read_text(encoding="utf-8")
+
+
+def test_ci_install_headless_packages_installs_only_missing_packages(tmp_path: Path) -> None:
+    """Missing packages are installed with bounded apt network options."""
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    log_path = tmp_path / "commands.log"
+
+    _write_executable(
+        fake_bin / "dpkg-query",
+        f"""#!/usr/bin/env bash
+printf 'dpkg-query %s\\n' "$*" >> {_shell_quote(log_path)}
+case "$*" in
+  *libgl1*) echo 'install ok installed' ;;
+  *) exit 1 ;;
+esac
+""",
+    )
+    _write_executable(
+        fake_bin / "sudo",
+        f'#!/usr/bin/env bash\nprintf \'sudo %s\\n\' "$*" >> {_shell_quote(log_path)}\n"$@"\n',
+    )
+    _write_executable(
+        fake_bin / "apt-get",
+        f"#!/usr/bin/env bash\nprintf 'apt-get %s\\n' \"$*\" >> {_shell_quote(log_path)}\n",
+    )
+
+    grep_path = shutil.which("grep")
+    bash_path = shutil.which("bash")
+    assert grep_path, "grep is required for this test"
+    assert bash_path, "bash is required for this test"
+    os.symlink(bash_path, fake_bin / "bash")
+    os.symlink(grep_path, fake_bin / "grep")
+
+    env = os.environ.copy()
+    env["PATH"] = str(fake_bin)
+    result = subprocess.run(
+        ["bash", str(_script_path()), "libgl1", "jq"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+    )
+    assert result.returncode == 0
+    log_text = log_path.read_text(encoding="utf-8")
+    assert "apt-get -o Acquire::Retries=2" in log_text
+    assert "-o Acquire::http::Timeout=20" in log_text
+    assert "-o Acquire::https::Timeout=20" in log_text
+    assert "install -y --no-install-recommends jq" in log_text
+    assert "install -y --no-install-recommends libgl1" not in log_text


### PR DESCRIPTION
## Summary
Harden the shared CI setup path after apt mirror stalls by timing CI setup steps, skipping already-installed headless packages, bounding apt network retries/timeouts, and avoiding misleading artifact-policy failures when smoke never ran.

## Linked Issues
- Closes `#3099`
- Relates to `#3097`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Wrapped the shared `System packages for headless` step in `scripts/dev/ci_step_timer.sh`.
- Added `scripts/dev/ci_install_headless_packages.sh` so CI skips apt entirely when requested packages are already installed, and uses apt-level retries plus 20s HTTP/HTTPS timeouts when packages are missing.
- Removed `ffmpeg` from the shared headless package set used by regular PR CI setup.
- Added `id: smoke_tests` to the `smoke-artifacts` validation step.
- Gated artifact-policy on the smoke step having outcome `success` or `failure`, while preserving `always()` so normal smoke failures still run artifact-policy.
- Added focused tests for the new package helper.

## Why It Matters
- Added value: CI reports setup stalls as setup failures instead of misleading artifact-policy dependency import failures.
- Expected impact: Faster diagnosis and less wasted agent time when GitHub runner mirrors are slow.
- Why this is worth merging now: #3097 exposed this exact failure mode during goal-autopilot CI monitoring.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/workflow helper; no research claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: CI setup stalls should fail in setup/timer context; artifact-policy should run only after smoke actually ran.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3099
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; no research interpretation.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no; PR CI passed on the final head.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop for #3099 after merge.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run python - <<'PY' ... yaml.safe_load(...) ...`
  - `bash -n scripts/dev/ci_step_timer.sh`
  - `bash -n scripts/dev/ci_driver.sh`
  - `bash -n scripts/dev/ci_install_headless_packages.sh`
  - `CI_STEP_TIMEOUT_SECONDS=1 bash scripts/dev/ci_step_timer.sh "timeout test" bash -lc 'sleep 2'`
  - `uv run ruff check tests/dev/test_ci_install_headless_packages.py`
  - `uv run ruff format --check tests/dev/test_ci_install_headless_packages.py`
  - `uv run pytest tests/dev/test_ci_install_headless_packages.py tests/dev/test_ci_step_timer.py -q`
  - `git diff --check`
  - PR CI for head `38d84bdb8cdbbf5c4aac65cf9bfe790afe97726e`
- Evidence that the change works here:
  - Both touched YAML files parse successfully.
  - Workflow assertions verified the timer wrapper, `smoke_tests` id, `always()`, and both allowed smoke outcomes.
  - The timer smoke returned exit status `124` after the artificial stall.
  - New helper tests cover help output, argument validation, apt skip when packages are present, and bounded apt invocation for missing packages.
  - PR CI passed: `CodeRabbit`, `ci`, `examples-smoke`, `fast-feedback`, `promoted-planner-smoke`, and `smoke-artifacts`.
- Benchmarks or smoke tests, if applicable: GitHub PR CI smoke lanes passed.

## Risks / Rollout
- Compatibility risks: Low; workflow-only support helper.
- Failure modes: Severe runner network failures can still fail setup, but with apt-level bounds and setup-context diagnostics.
- Rollback or fallback plan: revert the workflow/action/helper changes.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: Issue #3099 documents the observed #3097 failure signature.
- Any assumptions that need to be preserved: Artifact-policy should still run after real smoke success or failure, but not after setup prevents smoke from running.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #3099.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: workflow-only support fix with no benchmark, registry, or paper-facing claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- The Gemini `bash -lc` review comment was addressed by routing through `bash scripts/dev/ci_install_headless_packages.sh`.
- `actionlint` was not installed locally; validation used YAML parsing plus targeted assertions and final PR CI.
