### PR TITLE
docs: record closed state label cleanup (#3098)

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -100,6 +100,9 @@ records the workflow-helper field audit for `scripts/dev/` GitHub calls. Current
 payloads are mostly required or intentionally opt-in; repeated issue-claim checks are the main
 future optimization candidate.
 
+Recent closed-issue state-label cleanup: [issue_3098_closed_state_label_hygiene.md](issue_3098_closed_state_label_hygiene.md)
+records the 2026-06-18 REST-backed removal of stale live `state:*` labels from closed issues.
+
 Recent research-engine gap audit: [issue_3058_research_engine_gap_audit.md](issue_3058_research_engine_gap_audit.md)
 records live issue/card/artifact mismatches before new empirical campaigns start. It routes
 existing conflicts to card correction, label cleanup, follow-up validation policy, or fail-closed

--- a/docs/context/issue_3098_closed_state_label_hygiene.md
+++ b/docs/context/issue_3098_closed_state_label_hygiene.md
@@ -1,4 +1,4 @@
-# Issue #3098 Closed-State Label Hygiene
+# Issue #3098 Closed-State Label Hygiene 2026-06-18
 
 Status: Current
 

--- a/docs/context/issue_3098_closed_state_label_hygiene.md
+++ b/docs/context/issue_3098_closed_state_label_hygiene.md
@@ -1,0 +1,77 @@
+# Issue #3098 Closed-State Label Hygiene
+
+Status: Current
+
+Issue: [#3098](https://github.com/ll7/robot_sf_ll7/issues/3098)
+
+## Summary
+
+On 2026-06-18, a fresh run of `scripts/dev/closed_state_label_hygiene.py` found 134
+closed issues that still carried live routing labels. The cleanup removed only these stale
+`state:*` labels from closed issues through REST issue-label deletes. It did not reopen issues,
+change Project #5 fields, change issue scores, or modify benchmark metadata.
+
+## Before
+
+Command:
+
+```bash
+uv run python scripts/dev/closed_state_label_hygiene.py --repo ll7/robot_sf_ll7 --limit 200
+```
+
+Result:
+
+- stale closed issues: 134
+- labels removed:
+  - `state:ready`: 109
+  - `state:running`: 19
+  - `state:blocked`: 6
+
+The private per-issue source report for this run is stored in the common Git-dir artifact
+`codex-agent-runs/active/issue-3098/before.json`.
+
+## Cleanup
+
+Each issue-label removal used the REST endpoint:
+
+```text
+DELETE /repos/ll7/robot_sf_ll7/issues/{issue_number}/labels/{label_name}
+```
+
+Attempted removals: 134.
+
+Failed removals: 0.
+
+Skipped cases: none.
+
+The private REST write result is stored in
+`codex-agent-runs/active/issue-3098/remove_labels_result.json`.
+
+## After
+
+Command:
+
+```bash
+uv run python scripts/dev/closed_state_label_hygiene.py --repo ll7/robot_sf_ll7 --limit 200
+```
+
+Result:
+
+- `ok`: true
+- stale closed issues: 0
+
+The private after-report is stored in `codex-agent-runs/active/issue-3098/after.json`.
+
+## Spot Checks
+
+Representative issues were checked after cleanup:
+
+- #1108: closed issue that previously had `state:blocked`; no live state label remains.
+- #2259: closed issue that previously had `state:ready`; no live state label remains.
+- #2382: closed issue that previously had `state:running`; no live state label remains.
+
+## Boundary
+
+This note records routing-hygiene evidence only. It is not benchmark evidence, research evidence,
+or a change to issue taxonomy semantics. Future cleanup should continue to treat live `state:*`
+labels on closed issues as stale queue metadata unless a specific issue documents an exception.


### PR DESCRIPTION
## Summary
Removed stale live `state:*` labels from closed issues using REST-backed issue-label deletes, then recorded a compact audit note for #3098.

## Linked Issues
- Closes `#3098`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Removed 134 stale live state labels from closed GitHub issues: 109 `state:ready`, 19 `state:running`, and 6 `state:blocked`.
- Added `docs/context/issue_3098_closed_state_label_hygiene.md` with before/after counts, REST cleanup scope, spot checks, and skipped-case status.
- Linked the new note from `docs/context/INDEX.md`.

## Why It Matters
- Added value: reduces stale queue-routing signals for future agents.
- Expected impact: closed issues should no longer appear executable because of live state labels.
- Why this is worth merging now: the goal-autopilot hygiene guard found this stale metadata during active issue routing.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow metadata cleanup only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: docs-only / metadata cleanup.
- Result classification: blocker-resolution for routing hygiene.
- Decision or stop rule, if applicable: stale count is zero after cleanup.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3098 and `docs/context/issue_3098_closed_state_label_hygiene.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool or research claim.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: NA.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop for #3098 after review/merge.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run python scripts/dev/closed_state_label_hygiene.py --repo ll7/robot_sf_ll7 --limit 200` before cleanup: 134 stale labels.
  - REST `DELETE /repos/ll7/robot_sf_ll7/issues/{issue_number}/labels/{label_name}` for each captured stale label: 134 attempted, 0 failed.
  - `uv run python scripts/dev/closed_state_label_hygiene.py --repo ll7/robot_sf_ll7 --limit 200` after cleanup: `stale_count: 0`, `project_writes: false`.
  - Spot checks: #1108, #2259, and #2382 no longer carry their former live state labels.
  - `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`.
  - `git diff --check origin/main...HEAD`.
  - Python assertions for the new context note and index link.
- Evidence that the change works here: the same hygiene helper now reports zero stale live state labels on closed issues.
- Benchmarks or smoke tests, if applicable: NA - workflow metadata/docs cleanup.
- Full `pr_ready_check`: not run; docs-only metadata/audit change used the cheaper official validation path.

## Risks / Rollout
- Compatibility risks: low; only live `state:*` labels were removed from already-closed issues.
- Failure modes: a closed issue could have intentionally preserved a state label, but #3098 scoped live labels on closed issues as stale routing metadata; no skipped exceptions were found.
- Rollback or fallback plan: labels can be re-added manually to any specific issue if a documented exception is discovered.

## Docs / Provenance
- Updated docs: `docs/context/issue_3098_closed_state_label_hygiene.md`, `docs/context/INDEX.md`.
- Relevant design or provenance notes: private per-issue cleanup artifacts are under the common Git-dir `codex-agent-runs/active/issue-3098/`.
- Any assumptions that need to be preserved: no Project #5 fields, issue score labels, benchmark metadata, or taxonomy semantics were changed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, #3098 has a claim comment and this PR closes it.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): yes, context index updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a workflow metadata cleanup with no benchmark, registry, or paper-facing propagation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: confirm the note accurately reflects the REST cleanup and the after-audit command reports zero stale labels.
- Any known limitations: the private per-issue REST result is not committed; the tracked note keeps only compact counts and spot checks.
