### PR TITLE
refactor: document runtime stub robot fallback

### DIFF
--- a/robot_sf/gym_env/_stub_robot_model.py
+++ b/robot_sf/gym_env/_stub_robot_model.py
@@ -1,6 +1,13 @@
-"""Shared lightweight stub robot model used as a fallback.
+"""Shared lightweight fallback robot model used by runtime pedestrian environments.
 
-Centralizing the stub avoids duplication across factories and environments.
+This module is part of runtime compatibility, not just tests.
+
+Historically both ``environment_factory`` and ``pedestrian_env`` defined inline
+fallback models when a concrete robot policy/model was not provided. Centralizing
+the fallback keeps this behavior consistent and protects existing examples and
+legacy scripts that still call ``PedestrianEnv(robot_model=None)`` or
+``make_pedestrian_env(robot_model=None)``.
+
 The stub intentionally performs a local NumPy import inside ``predict`` to keep
 module import cost negligible when the stub is unused.
 
@@ -30,9 +37,11 @@ def _get_numpy():
 
 
 class StubRobotModel:  # pragma: no cover - trivial
-    """Fallback model returning a zero action.
+    """Runtime fallback model returning a zero action.
 
-    The action dimensionality (2,) matches the historical expectation in tests.
+    The action dimensionality (2,) matches historical expectations for pedestrian
+    compatibility scenarios when the environment does not provide an action-space
+    shape before initialization.
     Returning ``(action, None)`` mirrors common RL model predict signatures
     (e.g., Stable Baselines returning (action, state)).
     """

--- a/robot_sf/gym_env/environment_factory.py
+++ b/robot_sf/gym_env/environment_factory.py
@@ -145,16 +145,17 @@ def _load_crowd_sim_env():
 
 
 def _load_stub_robot_model():
-    """Lazy-load the stub robot model class for testing.
+    """Lazy-load the runtime fallback stub robot model class.
 
     Returns a minimal robot model that produces zero actions, enabling pedestrian
-    environment initialization without requiring a trained policy.
+    environment initialization in backward-compatible runtime paths without a trained
+    policy.
 
     Returns:
         type: StubRobotModel class (callable) providing zero-action fallback.
 
     Raises:
-        ModuleNotFoundError: If _stub_robot_model module is not available.
+        ModuleNotFoundError: If ``robot_sf.gym_env._stub_robot_model`` is unavailable.
     """
     module = importlib.import_module("robot_sf.gym_env._stub_robot_model")
     return module.StubRobotModel
@@ -767,7 +768,8 @@ def make_pedestrian_env(  # noqa: PLR0913
       ``record_video=True`` (no implicit flip). Required by T012 test.
     * May auto-enable ``debug`` when effective recording is active to ensure frames
       are produced.
-    * Injects a stub robot model when ``robot_model`` is ``None`` for backward compatibility.
+    * Injects the shared runtime fallback stub robot model when ``robot_model`` is
+      ``None`` for backward compatibility and low-friction debugging.
 
     Parameters follow the same semantics; additional ones:
     robot_model : Any | None

--- a/robot_sf/gym_env/pedestrian_env.py
+++ b/robot_sf/gym_env/pedestrian_env.py
@@ -130,6 +130,8 @@ class PedestrianEnv(SingleAgentEnv):
         Args:
             env_config: Pedestrian simulation configuration (unified or legacy).
             robot_model: Pre-trained robot model for adversarial interaction.
+                When ``None``, the shared runtime fallback stub from
+                ``robot_sf.gym_env._stub_robot_model`` is used.
             reward_func: Reward function for pedestrian training.
             debug: Enable debug mode with visualization.
             recording_enabled: Enable state recording.
@@ -147,6 +149,8 @@ class PedestrianEnv(SingleAgentEnv):
 
         # Store robot model
         if robot_model is None:
+            # Runtime compatibility path: keep explicit None as a supported entrypoint
+            # for legacy examples/scripts that rely on zero-action defaults.
             robot_model = StubRobotModel()
         self.robot_model = robot_model
 

--- a/tests/test_pedestrian_env_compat.py
+++ b/tests/test_pedestrian_env_compat.py
@@ -64,6 +64,25 @@ def test_make_pedestrian_env_uses_stub_robot_model() -> None:
         env.exit()
 
 
+def test_runtime_stub_is_shared_between_env_and_factory_paths() -> None:
+    """Fallback ``None`` wiring resolves to the same runtime stub implementation."""
+    env_from_env_ctor = PedestrianEnv(robot_model=None)
+    try:
+        env_from_factory = make_pedestrian_env(robot_model=None)
+        try:
+            assert env_from_env_ctor.robot_model.__class__ is env_from_factory.robot_model.__class__
+            assert (
+                env_from_env_ctor.robot_model.__class__.__module__
+                == "robot_sf.gym_env._stub_robot_model"
+            )
+            assert isinstance(env_from_env_ctor.robot_model, StubRobotModel)
+            assert isinstance(env_from_factory.robot_model, StubRobotModel)
+        finally:
+            env_from_factory.exit()
+    finally:
+        env_from_env_ctor.exit()
+
+
 def test_pedestrian_env_does_not_mutate_input_config_for_deprecated_force_flag() -> None:
     """Deprecated force override should be isolated to the constructed environment."""
     config = PedestrianSimulationConfig()


### PR DESCRIPTION
## Summary
- Document `robot_sf.gym_env._stub_robot_model` as a runtime fallback module rather than a test-only fixture
- Clarify the `robot_model=None` fallback contract in `environment_factory` and `pedestrian_env`
- Add a compatibility test proving the direct env and factory paths share the same runtime stub implementation

Closes #3022

## Validation
- `rtk uv run ruff format robot_sf/gym_env/_stub_robot_model.py robot_sf/gym_env/environment_factory.py robot_sf/gym_env/pedestrian_env.py tests/test_pedestrian_env_compat.py --check`
- `rtk uv run ruff check robot_sf/gym_env/_stub_robot_model.py robot_sf/gym_env/environment_factory.py robot_sf/gym_env/pedestrian_env.py tests/test_pedestrian_env_compat.py`
- `rtk uv run pytest tests/test_pedestrian_env_compat.py -q`
- `rtk git diff --check`

## Downstream Propagation
- NA - low-risk runtime compatibility documentation/test cleanup. No benchmark, metric, artifact registry, context index, or model provenance surface changes.

## Research Result Guidance
- NA - support/refactor cleanup only; no research claim or benchmark result is introduced.
