### PR TITLE
docs: clarify feature extractor import paths

### DIFF
--- a/docs/feature_extractors/README.md
+++ b/docs/feature_extractors/README.md
@@ -4,6 +4,13 @@ This directory contains documentation for the enhanced feature extraction system
 alternative feature extractors while keeping full backward compatibility with the original
 `DynamicsExtractor`.
 
+Import topology:
+
+- `robot_sf.feature_extractor` is the legacy compatibility module for the original
+  `DynamicsExtractor`.
+- `robot_sf.feature_extractors` is the canonical namespace for new extractor implementations,
+  presets, and configuration helpers.
+
 ## Quick Start
 
 ```python
@@ -27,7 +34,7 @@ model.learn(total_timesteps=100_000)
 ## Available Feature Extractors
 
 ### 1. Original DynamicsExtractor (Legacy)
-- **File**: `robot_sf/feature_extractor.py`
+- **File**: `robot_sf/feature_extractor.py` (legacy compatibility module)
 - **Description**: Original convolutional approach with multiple layers
 - **Parameters**: ~5K (conv mode) or 0 (flatten mode)
 - **Use Case**: Baseline comparison, established performance

--- a/docs/feature_extractors/usage_guide.md
+++ b/docs/feature_extractors/usage_guide.md
@@ -3,6 +3,13 @@
 This guide provides practical examples and best practices for using the enhanced feature extraction
 system.
 
+Import path guidance:
+
+- Legacy baseline path kept for backward compatibility:
+  `from robot_sf.feature_extractor import DynamicsExtractor`
+- Preferred namespace for new extractors and configuration:
+  `from robot_sf.feature_extractors...`
+
 ## Basic Usage Patterns
 
 ### 1. Quick Start with Presets

--- a/robot_sf/feature_extractor.py
+++ b/robot_sf/feature_extractor.py
@@ -1,4 +1,10 @@
-"""Feature extractors for processing observations in reinforcement learning."""
+"""Legacy feature extractor entrypoint kept for compatibility.
+
+The original ``DynamicsExtractor`` class is preserved here to avoid breaking
+historical imports, training configs, and serialized Stable-Baselines3 policy
+artifacts. The canonical modern feature-extractor namespace is now
+``robot_sf.feature_extractors``.
+"""
 # WARNING: don't move this script or else loading trained SB3 policies might not work
 
 import numpy as np

--- a/robot_sf/feature_extractors/__init__.py
+++ b/robot_sf/feature_extractors/__init__.py
@@ -2,8 +2,10 @@
 Alternative feature extractors for robot environments.
 
 This module provides various feature extraction architectures that can be used
-as alternatives to the original DynamicsExtractor while maintaining compatibility
-with StableBaselines3 and the sensor fusion system.
+as alternatives to the original ``DynamicsExtractor`` while maintaining
+compatibility with Stable-Baselines3 and the sensor fusion system. The legacy
+``DynamicsExtractor`` entrypoint is intentionally preserved in
+``robot_sf.feature_extractor`` for backward compatibility.
 
 All extractors implement the same interface and work with the same observation spaces.
 """

--- a/tests/test_feature_extractors.py
+++ b/tests/test_feature_extractors.py
@@ -10,6 +10,7 @@ import pytest
 import torch as th
 from gymnasium import spaces
 
+from robot_sf.feature_extractor import DynamicsExtractor
 from robot_sf.feature_extractors import (
     AttentionFeatureExtractor,
     LightweightCNNExtractor,
@@ -244,6 +245,19 @@ class TestFeatureExtractors:
             assert features.shape[0] == 2  # Batch size
             assert features.shape[1] == extractor.features_dim
 
+    def test_dynamics_legacy_import_stays_supported(self, observation_space, sample_observation):
+        """Test importing, instantiating, and running the legacy DynamicsExtractor entrypoint."""
+        extractor = DynamicsExtractor(observation_space)
+
+        assert isinstance(extractor, DynamicsExtractor)
+        assert extractor.features_dim > 0
+
+        features = extractor(sample_observation)
+        assert isinstance(features, th.Tensor)
+        assert features.shape[0] == 2
+        assert features.shape[1] == extractor.features_dim
+        assert not th.isnan(features).any()
+
 
 class TestFeatureExtractorConfig:
     """Test feature extractor configuration system."""
@@ -257,6 +271,11 @@ class TestFeatureExtractorConfig:
         assert config.extractor_type == FeatureExtractorType.MLP
         assert config.params["ray_hidden_dims"] == [128, 64]
         assert config.get_extractor_class() == MLPFeatureExtractor
+
+    def test_dynamics_config_routes_to_legacy_class(self):
+        """Test that dynamics config resolves to the legacy DynamicsExtractor class."""
+        config = FeatureExtractorConfig(extractor_type=FeatureExtractorType.DYNAMICS)
+        assert config.get_extractor_class() is DynamicsExtractor
 
     def test_config_policy_kwargs(self):
         """Test generating policy kwargs from config."""


### PR DESCRIPTION
## Summary
- Document `robot_sf.feature_extractor` as the legacy compatibility module for `DynamicsExtractor`
- Clarify that `robot_sf.feature_extractors` is the canonical namespace for new extractor implementations/config
- Add focused compatibility tests for legacy import and config routing

Closes #3021

## Validation
- `rtk uv run ruff format robot_sf/feature_extractor.py robot_sf/feature_extractors/__init__.py tests/test_feature_extractors.py --check`
- `rtk uv run ruff check robot_sf/feature_extractor.py robot_sf/feature_extractors/__init__.py tests/test_feature_extractors.py`
- `rtk uv run pytest tests/test_feature_extractors.py -q`
- `rtk uv run python scripts/validation/check_docs_proof_consistency.py --path docs/feature_extractors/README.md --path docs/feature_extractors/usage_guide.md`
- `rtk git diff --check`

## Downstream Propagation
- NA - documentation and compatibility-test cleanup only. No benchmark, metric, artifact registry, context index, or model provenance surface changes.

## Research Result Guidance
- NA - support/docs cleanup only; no research claim or benchmark result is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added clarification on import paths: legacy baseline import maintained for backward compatibility, new recommended namespace for future development
  * Updated feature extractor documentation to guide users toward the appropriate import path based on their use case

* **Tests**
  * Added tests to ensure legacy import compatibility remains supported for existing code and configurations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->