### PR TITLE
feat: add warmup attribution to perf smoke

### DIFF
--- a/docs/performance_notes.md
+++ b/docs/performance_notes.md
@@ -57,6 +57,10 @@ Location: `scripts/validation/performance_smoke_test.py`
   - `step_loop.steady_step_loop_sec`
   - `step_loop.steps_per_sec`
   - `step_loop.steady_steps_per_sec`
+  - `step_loop.measurement_mode`
+  - `step_loop.warmup_excluded`
+  - `step_loop.warmup_first_step_sec`, `step_loop.warmup_step_loop_sec`, and
+    `step_loop.warmup_steps_per_sec` when explicit warmup attribution is requested
 
 Large-crowd profiling now emits an additive `step_profile` contract block:
 - `step_profile.advisory` (always `true` for this profile)
@@ -67,12 +71,19 @@ Large-crowd profiling now emits an additive `step_profile` contract block:
 - `step_profile.step_loop_sec`
 - `step_profile.steady_step_loop_sec`, `step_profile.steady_steps_per_sec`
 - `step_profile.steps_per_sec`
+- `step_profile.measurement_mode`, `step_profile.warmup_excluded`
+- `step_profile.warmup_first_step_sec`, `step_profile.warmup_step_loop_sec`, and
+  `step_profile.warmup_steps_per_sec` when explicit warmup attribution is requested
 - `step_profile.pedestrian_count` (when observed after reset/step)
 
 These fields are advisory and are for diagnostic reproducibility; they are not benchmark gates.
 
 The step-loop fields help classify local slowdowns but do not add hard smoke-test gates by
-default. Use `--step-samples` to tune the advisory sample count for local diagnosis.
+default. Use `--step-samples` to tune the advisory sample count for local diagnosis. By default,
+`first_step_sec`, `step_loop_sec`, and `steps_per_sec` measure the cold first step after reset.
+Use `--warmup-steps` only when you intentionally want warm-start attribution; warm-start output is
+flagged with `measurement_mode` and `warmup_excluded` so it cannot be mistaken for cold-start
+performance evidence.
 
 **Usage**:
 ```bash
@@ -89,6 +100,14 @@ DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \
     --scenario-name classic_group_crossing_high \
     --step-samples 3 --num-resets 1 \
     --json-output output/benchmarks/perf/issue_3025_smoke.json
+
+# Explicit warm-start attribution for startup/JIT diagnosis only; not a runtime speedup claim
+DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \
+  uv run python scripts/validation/performance_smoke_test.py \
+    --scenario configs/scenarios/archetypes/classic_group_crossing.yaml \
+    --scenario-name classic_group_crossing_high \
+    --step-samples 3 --warmup-steps 1 --num-resets 1 \
+    --json-output output/benchmarks/perf/issue_3025_warmup_attribution.json
 ```
 
 ### Cold/Warm Regression Suite

--- a/scripts/validation/performance_smoke_test.py
+++ b/scripts/validation/performance_smoke_test.py
@@ -51,7 +51,12 @@ from robot_sf.training.scenario_loader import (
 
 @dataclass(slots=True)
 class StepLoopMetrics:
-    """Advisory simulator step-loop attribution for performance smoke output."""
+    """Advisory simulator step-loop attribution for performance smoke output.
+
+    Cold-path metrics are always reported in ``first_step_sec``, ``step_loop_sec``,
+    and ``steps_per_sec`` and should correspond to the first real ``env.step``
+    after a reset.
+    """
 
     step_samples: int
     first_step_sec: float
@@ -59,8 +64,13 @@ class StepLoopMetrics:
     steady_step_loop_sec: float
     steps_per_sec: float
     steady_steps_per_sec: float
+    warmup_excluded: bool = False
+    warmup_first_step_sec: float | None = None
+    warmup_step_loop_sec: float | None = None
+    warmup_steps_per_sec: float | None = None
+    measurement_mode: str = "cold_only"
 
-    def to_dict(self) -> dict[str, float | int]:
+    def to_dict(self) -> dict[str, float | int | bool | str | None]:
         """Serialize step-loop metrics to a JSON-friendly mapping."""
         return {
             "step_samples": self.step_samples,
@@ -69,6 +79,11 @@ class StepLoopMetrics:
             "steady_step_loop_sec": self.steady_step_loop_sec,
             "steps_per_sec": self.steps_per_sec,
             "steady_steps_per_sec": self.steady_steps_per_sec,
+            "warmup_excluded": self.warmup_excluded,
+            "warmup_first_step_sec": self.warmup_first_step_sec,
+            "warmup_step_loop_sec": self.warmup_step_loop_sec,
+            "warmup_steps_per_sec": self.warmup_steps_per_sec,
+            "measurement_mode": self.measurement_mode,
         }
 
 
@@ -93,12 +108,17 @@ class StepProfileMetrics:
     steady_step_loop_sec: float
     steps_per_sec: float
     steady_steps_per_sec: float
-    scenario_id: str | None
-    scenario_name: str | None
-    scenario_path: str | None
-    density: str | None
-    density_advisory: str | None
-    pedestrian_count: int | None
+    warmup_excluded: bool = False
+    warmup_first_step_sec: float | None = None
+    warmup_step_loop_sec: float | None = None
+    warmup_steps_per_sec: float | None = None
+    measurement_mode: str = "cold_only"
+    scenario_id: str | None = None
+    scenario_name: str | None = None
+    scenario_path: str | None = None
+    density: str | None = None
+    density_advisory: str | None = None
+    pedestrian_count: int | None = None
     advisory: bool = True
     gating: str = "non-gating"
 
@@ -116,6 +136,11 @@ class StepProfileMetrics:
             "steady_step_loop_sec": self.steady_step_loop_sec,
             "steps_per_sec": self.steps_per_sec,
             "steady_steps_per_sec": self.steady_steps_per_sec,
+            "warmup_excluded": self.warmup_excluded,
+            "warmup_first_step_sec": self.warmup_first_step_sec,
+            "warmup_step_loop_sec": self.warmup_step_loop_sec,
+            "warmup_steps_per_sec": self.warmup_steps_per_sec,
+            "measurement_mode": self.measurement_mode,
             "pedestrian_count": self.pedestrian_count,
             "advisory": self.advisory,
             "gating": self.gating,
@@ -290,9 +315,10 @@ def _measure_profile_pedestrian_count(config: RobotSimulationConfig | None = Non
         env.close()
 
 
-def measure_step_loop_performance(
+def measure_step_loop_performance(  # noqa: C901
     step_samples: int = 10,
     config: RobotSimulationConfig | None = None,
+    warmup_steps: int = 0,
 ) -> StepLoopMetrics:
     """Measure first-step and steady step-loop attribution.
 
@@ -303,12 +329,42 @@ def measure_step_loop_performance(
 
     if step_samples <= 0:
         raise ValueError("step_samples must be greater than zero")
+    if warmup_steps < 0:
+        raise ValueError("warmup_steps must be non-negative")
 
     print("\n=== Step Loop Attribution ===")
     env = make_robot_env(config=copy.deepcopy(config or RobotSimulationConfig()), debug=False)
     action = (0.0, 0.0)
+
     try:
         env.reset()
+
+        warmup_excluded = False
+        warmup_first_step_sec = None
+        warmup_step_loop_sec = None
+        warmup_steps_per_sec = None
+        measurement_mode = "cold_only"
+
+        terminated = False
+        truncated = False
+        if warmup_steps > 0:
+            measurement_mode = "cold_with_warmup"
+            warmup_excluded = True
+            warm_start = time.time()
+            for sample in range(warmup_steps):
+                if sample > 0:
+                    # Keep the warmup run independent of the measured cold path.
+                    if terminated or truncated:
+                        env.reset()
+                step_start = time.time()
+                _, _, terminated, truncated, _ = env.step(action)
+                if sample == 0:
+                    warmup_first_step_sec = time.time() - step_start
+            warmup_step_loop_sec = time.time() - warm_start
+            warmup_steps_per_sec = (
+                warmup_steps / warmup_step_loop_sec if warmup_step_loop_sec > 0 else 0.0
+            )
+            env.reset()
 
         loop_start = time.time()
         first_step_start = time.time()
@@ -350,6 +406,11 @@ def measure_step_loop_performance(
         steady_step_loop_sec=steady_step_loop_sec,
         steps_per_sec=steps_per_sec,
         steady_steps_per_sec=steady_steps_per_sec,
+        warmup_excluded=warmup_excluded,
+        warmup_first_step_sec=warmup_first_step_sec,
+        warmup_step_loop_sec=warmup_step_loop_sec,
+        warmup_steps_per_sec=warmup_steps_per_sec,
+        measurement_mode=measurement_mode,
     )
 
 
@@ -373,6 +434,11 @@ def measure_step_profile(
         steady_step_loop_sec=loop_metrics.steady_step_loop_sec,
         steps_per_sec=loop_metrics.steps_per_sec,
         steady_steps_per_sec=loop_metrics.steady_steps_per_sec,
+        warmup_excluded=loop_metrics.warmup_excluded,
+        warmup_first_step_sec=loop_metrics.warmup_first_step_sec,
+        warmup_step_loop_sec=loop_metrics.warmup_step_loop_sec,
+        warmup_steps_per_sec=loop_metrics.warmup_steps_per_sec,
+        measurement_mode=loop_metrics.measurement_mode,
         scenario_id=scenario_metadata.scenario_id if scenario_metadata is not None else None,
         scenario_name=scenario_metadata.scenario_name if scenario_metadata is not None else None,
         scenario_path=scenario_metadata.scenario_path if scenario_metadata is not None else None,
@@ -388,6 +454,7 @@ def run_performance_smoke_test(  # noqa: PLR0913
     *,
     num_resets: int = 5,
     step_samples: int = 10,
+    warmup_steps: int = 0,
     scenario: str | None = None,
     scenario_name: str | None = None,
     include_recommendations: bool = True,
@@ -402,6 +469,10 @@ def run_performance_smoke_test(  # noqa: PLR0913
 
     Args:
         num_resets: Number of resets to run for throughput measurement.
+        step_samples: Number of measured simulator steps for advisory attribution.
+        warmup_steps: Optional untimed steps before the measured loop. When non-zero,
+            warm-start fields are populated and cold fields are flagged with
+            ``warmup_excluded`` so callers do not treat them as cold-start timings.
         scenario: Optional scenario config path used to load a custom config.
         scenario_name: Optional scenario name/id to select from a multi-scenario config.
         include_recommendations: Include guidance strings in the result payload.
@@ -417,6 +488,8 @@ def run_performance_smoke_test(  # noqa: PLR0913
     """
     if step_samples <= 0:
         raise ValueError("step_samples must be greater than zero")
+    if warmup_steps < 0:
+        raise ValueError("warmup_steps must be non-negative")
 
     creation_soft = (
         creation_soft
@@ -443,7 +516,11 @@ def run_performance_smoke_test(  # noqa: PLR0913
     )
     creation_time = measure_environment_creation(config)
     perf_metrics = measure_environment_performance(num_resets, config=config)
-    step_loop = measure_step_loop_performance(step_samples, config=config)
+    step_loop = measure_step_loop_performance(
+        step_samples,
+        config=config,
+        warmup_steps=warmup_steps,
+    )
     step_profile = measure_step_profile(
         step_samples=step_samples,
         config=config,
@@ -530,6 +607,15 @@ def parse_args() -> argparse.Namespace:
         help="Number of simulator steps for advisory startup/steady attribution (default: 10)",
     )
     parser.add_argument(
+        "--warmup-steps",
+        type=int,
+        default=0,
+        help=(
+            "Optional untimed simulator steps before measured attribution. "
+            "Non-zero values populate warm-start fields and set warmup_excluded=true."
+        ),
+    )
+    parser.add_argument(
         "--json-output",
         type=Path,
         help="Override the JSON summary path (defaults to output/benchmarks/performance_smoke_test.json)",
@@ -557,7 +643,7 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def main() -> int:
+def main() -> int:  # noqa: C901
     """TODO docstring. Document this function.
 
 
@@ -585,6 +671,7 @@ def main() -> int:
     result = run_performance_smoke_test(
         num_resets=args.num_resets,
         step_samples=args.step_samples,
+        warmup_steps=args.warmup_steps,
         scenario=args.scenario,
         scenario_name=args.scenario_name,
         include_recommendations=args.include_recommendations,
@@ -612,8 +699,16 @@ def main() -> int:
         f"loop={result.step_loop.step_loop_sec:.3f}s "
         f"({result.step_loop.steps_per_sec:.2f} steps/sec), "
         f"steady={result.step_loop.steady_step_loop_sec:.3f}s "
-        f"({result.step_loop.steady_steps_per_sec:.2f} steady steps/sec)",
+        f"({result.step_loop.steady_steps_per_sec:.2f} steady steps/sec), "
+        f"measurement_mode={result.step_loop.measurement_mode}, "
+        f"warmup_excluded={result.step_loop.warmup_excluded}",
     )
+    if result.step_loop.warmup_excluded:
+        print(
+            f"Warmup attribution: first={result.step_loop.warmup_first_step_sec:.3f}s "
+            f"loop={result.step_loop.warmup_step_loop_sec:.3f}s "
+            f"({result.step_loop.warmup_steps_per_sec:.2f} steps/sec)",
+        )
     if result.step_profile is not None:
         print(
             f"Step profile: {result.step_profile.advisory=} gating={result.step_profile.gating} "
@@ -757,6 +852,11 @@ def _write_telemetry_snapshot(path: Path, result: SmokeTestResult) -> None:
         "timestamp_ms": int(result.timestamp.timestamp() * 1000),
         "step_id": "performance_smoke_test",
         "steps_per_sec": result.resets_per_sec,
+        "measurement_mode": result.step_loop.measurement_mode,
+        "warmup_excluded": result.step_loop.warmup_excluded,
+        "warmup_first_step_sec": result.step_loop.warmup_first_step_sec,
+        "warmup_step_loop_sec": result.step_loop.warmup_step_loop_sec,
+        "warmup_steps_per_sec": result.step_loop.warmup_steps_per_sec,
         "first_step_sec": result.step_loop.first_step_sec,
         "step_loop_sec": result.step_loop.step_loop_sec,
         "steady_step_loop_sec": result.step_loop.steady_step_loop_sec,

--- a/tests/perf/test_large_crowd_step_profile_contract.py
+++ b/tests/perf/test_large_crowd_step_profile_contract.py
@@ -36,13 +36,18 @@ def test_large_crowd_step_profile_contract(monkeypatch) -> None:
     monkeypatch.setattr(
         performance_smoke_test,
         "measure_step_loop_performance",
-        lambda step_samples=10, config=None: performance_smoke_test.StepLoopMetrics(
+        lambda step_samples=10, config=None, warmup_steps=0: performance_smoke_test.StepLoopMetrics(
             step_samples=step_samples,
             first_step_sec=0.2,
             step_loop_sec=1.0,
             steady_step_loop_sec=0.8,
             steps_per_sec=3.0,
             steady_steps_per_sec=2.6666666666666665,
+            warmup_excluded=False,
+            warmup_first_step_sec=None,
+            warmup_step_loop_sec=None,
+            warmup_steps_per_sec=None,
+            measurement_mode="cold_only",
         ),
     )
     monkeypatch.setattr(
@@ -90,6 +95,11 @@ def test_large_crowd_step_profile_contract(monkeypatch) -> None:
     assert step_profile["steady_step_loop_sec"] == 0.8
     assert step_profile["steps_per_sec"] == 3.0
     assert step_profile["steady_steps_per_sec"] == 2.6666666666666665
+    assert step_profile["warmup_excluded"] is False
+    assert step_profile["warmup_first_step_sec"] is None
+    assert step_profile["warmup_step_loop_sec"] is None
+    assert step_profile["warmup_steps_per_sec"] is None
+    assert step_profile["measurement_mode"] == "cold_only"
     assert step_profile["pedestrian_count"] == 142
     assert step_profile["advisory"] is True
     assert step_profile["gating"] == "non-gating"

--- a/tests/validation/test_performance_smoke_test.py
+++ b/tests/validation/test_performance_smoke_test.py
@@ -2,7 +2,28 @@
 
 from __future__ import annotations
 
+import pytest
+
 from scripts.validation import performance_smoke_test
+
+
+class _FakeStepEnv:
+    """Small env double for step-loop attribution tests."""
+
+    def __init__(self) -> None:
+        self.resets = 0
+        self.steps = 0
+        self.closed = False
+
+    def reset(self) -> None:
+        self.resets += 1
+
+    def step(self, _action):
+        self.steps += 1
+        return None, 0.0, False, False, {}
+
+    def close(self) -> None:
+        self.closed = True
 
 
 def test_performance_smoke_result_includes_step_loop_attribution(monkeypatch) -> None:
@@ -26,7 +47,7 @@ def test_performance_smoke_result_includes_step_loop_attribution(monkeypatch) ->
     monkeypatch.setattr(
         performance_smoke_test,
         "measure_step_loop_performance",
-        lambda step_samples=10, config=None: performance_smoke_test.StepLoopMetrics(
+        lambda step_samples=10, config=None, warmup_steps=0: performance_smoke_test.StepLoopMetrics(
             step_samples=step_samples,
             first_step_sec=0.2,
             step_loop_sec=1.0,
@@ -58,7 +79,53 @@ def test_performance_smoke_result_includes_step_loop_attribution(monkeypatch) ->
         "steady_step_loop_sec": 0.8,
         "steps_per_sec": 4.0,
         "steady_steps_per_sec": 3.75,
+        "warmup_excluded": False,
+        "warmup_first_step_sec": None,
+        "warmup_step_loop_sec": None,
+        "warmup_steps_per_sec": None,
+        "measurement_mode": "cold_only",
     }
+
+
+def test_step_loop_warmup_fields_are_explicitly_separate(monkeypatch) -> None:
+    """Warm-start attribution should not silently replace cold field names."""
+
+    fake_env = _FakeStepEnv()
+    ticks = iter(
+        [
+            0.0,
+            0.5,
+            0.8,
+            1.0,
+            1.2,
+            1.7,
+            1.9,
+            2.2,
+            2.6,
+            2.9,
+        ],
+    )
+
+    monkeypatch.setattr(
+        performance_smoke_test, "make_robot_env", lambda config=None, debug=False: fake_env
+    )
+    monkeypatch.setattr(performance_smoke_test.time, "time", lambda: next(ticks))
+
+    metrics = performance_smoke_test.measure_step_loop_performance(
+        step_samples=2,
+        warmup_steps=1,
+    )
+    payload = metrics.to_dict()
+
+    assert fake_env.closed is True
+    assert fake_env.resets == 2
+    assert fake_env.steps == 3
+    assert payload["measurement_mode"] == "cold_with_warmup"
+    assert payload["warmup_excluded"] is True
+    assert payload["warmup_first_step_sec"] == pytest.approx(0.3)
+    assert payload["first_step_sec"] == pytest.approx(0.2)
+    assert payload["warmup_step_loop_sec"] == pytest.approx(1.0)
+    assert payload["step_loop_sec"] == pytest.approx(1.7)
 
 
 def test_telemetry_snapshot_includes_step_loop_attribution(tmp_path) -> None:
@@ -80,6 +147,11 @@ def test_telemetry_snapshot_includes_step_loop_attribution(tmp_path) -> None:
             steady_step_loop_sec=0.8,
             steps_per_sec=4.0,
             steady_steps_per_sec=3.75,
+            warmup_excluded=False,
+            warmup_first_step_sec=None,
+            warmup_step_loop_sec=None,
+            warmup_steps_per_sec=None,
+            measurement_mode="cold_only",
         ),
     )
 
@@ -89,6 +161,11 @@ def test_telemetry_snapshot_includes_step_loop_attribution(tmp_path) -> None:
     payload = performance_smoke_test.json.loads(output.read_text())
 
     assert payload["first_step_sec"] == 0.2
+    assert payload["measurement_mode"] == "cold_only"
+    assert payload["warmup_excluded"] is False
+    assert payload["warmup_first_step_sec"] is None
+    assert payload["warmup_step_loop_sec"] is None
+    assert payload["warmup_steps_per_sec"] is None
     assert payload["step_loop_sec"] == 1.0
     assert payload["steady_step_loop_sec"] == 0.8
     assert payload["sim_steps_per_sec"] == 4.0


### PR DESCRIPTION
## Summary
Adds explicit warm-start attribution to the performance smoke step-loop diagnostics while preserving the default cold first-step semantics.

## Linked Issues
- Relates to `#3025`

## Stack / Dependency
- Base dependency: `PR #3107`
- Required prior PRs: `#3107`
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: builds on the additive `step_profile` contract from #3107.

## What Changed
- Added `measurement_mode`, `warmup_excluded`, and warm-start timing fields to `step_loop`, `step_profile`, and telemetry output.
- Added `--warmup-steps` for explicit startup/JIT attribution without changing default cold measurements.
- Updated focused tests and `docs/performance_notes.md` so warm-start data cannot be mistaken for cold-start performance evidence.

## Why It Matters
- Added value: makes the large-crowd profiling path distinguish cold first-step overhead from warm steady-step behavior.
- Expected impact: better diagnostic evidence for #3025 without claiming a simulator speedup.
- Why this is worth merging now: it prevents misleading interpretation of JIT/warmup exclusion before any true optimization PR.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3025 needs reproducible profiling that separates startup/JIT overhead from steady step execution before optimization.
- Comparator or baseline, if applicable: default cold smoke output from #3107.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: do not treat warm-start fields as runtime speedup evidence; continue only to a real optimization when per-step bottleneck evidence is found.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #3025 progress thread after merge.
- New research/benchmark/metric/paper-facing analysis tool, if any: support diagnostic extension to existing smoke helper; representative local use listed below, output remains worktree-local and non-durable.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes: `--warmup-steps 1` populates warm-start fields and sets `warmup_excluded=true`.
- Did the intervention change command source, selected command, trajectory, or route progress? no; this is measurement attribution only.
- Did the scenario actually contain the targeted failure mode? partial/diagnostic: high-density scenario shows cold first-step startup/JIT overhead, not a proven steady-step bottleneck.
- Result route: narrow.
- Follow-up question or issue for weak, negative, or non-transfer results: #3025 remains open for a true bounded runtime optimization after hotspot evidence.

## Next Empirical Action
- Rerun needed: yes, for the later optimization claim.
- Extractor or analysis tool needed: no for this PR; current smoke helper now separates cold/warm attribution.
- Artifact missing or unavailable: no durable artifact is promoted; local JSON outputs are disposable smoke evidence.
- Stop / revise / continue decision: continue #3025 with a real bottleneck/optimization pass after this diagnostic contract lands.
- Proposed child issue or existing follow-up: existing #3025 remains the follow-up.

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/validation/test_performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py -q`
  - `rtk uv run pytest tests/perf/test_simulation_speed_perf.py -q`
  - `rtk uv run ruff check robot_sf/sim/simulator.py scripts/validation/performance_smoke_test.py tests/validation/test_performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py scripts/telemetry/run_perf_tests.py`
  - `rtk uv run ruff format --check scripts/validation/performance_smoke_test.py tests/validation/test_performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py`
  - `rtk scripts/dev/check_docs_proof_consistency_diff.sh`
  - `rtk git diff --check`
  - `rtk env DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python scripts/validation/performance_smoke_test.py --scenario configs/scenarios/archetypes/classic_group_crossing.yaml --scenario-name classic_group_crossing_high --step-samples 3 --num-resets 1 --json-output output/benchmarks/perf/issue_3025_cold.json`
  - `rtk env DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy uv run python scripts/validation/performance_smoke_test.py --scenario configs/scenarios/archetypes/classic_group_crossing.yaml --scenario-name classic_group_crossing_high --step-samples 3 --warmup-steps 1 --num-resets 1 --json-output output/benchmarks/perf/issue_3025_warm.json`
- Evidence that the change works here: cold JSON reports `measurement_mode=cold_only` and `warmup_excluded=false`; warm JSON reports `measurement_mode=cold_with_warmup`, `warmup_excluded=true`, and populated warm attribution.
- Benchmarks or smoke tests, if applicable: high-density smoke path passes in both modes; no runtime speedup claim is made.

## Risks / Rollout
- Compatibility risks: additive JSON keys may affect consumers that assert exact dictionaries.
- Failure modes: reviewers could misread warm-start output as runtime optimization unless PR/docs caveats are preserved.
- Rollback or fallback plan: remove the additive warm fields/CLI flag and keep #3107 cold-only diagnostics.

## Docs / Provenance
- Updated docs: `docs/performance_notes.md`.
- Relevant design or provenance notes: #3107 established the additive non-gating `step_profile` contract.
- Any assumptions that need to be preserved: `output/` smoke JSON is local disposable evidence, not durable benchmark proof.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, planned after merge.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no; #3025 remains open.
- Not applicable because: this is diagnostic support, not a benchmark result or optimizer claim.

## Follow-Up Issues
- Deferred work: true runtime optimization for #3025 after hotspot evidence.
- Issues opened for follow-up: none; #3025 remains active.

## Reviewer Notes
- Please verify that default `first_step_sec` remains cold (`warmup_excluded=false`) and that warm-start attribution is opt-in via `--warmup-steps`.
- Known limitation: this does not optimize simulator runtime; it prevents warmup/JIT attribution from being confused with optimization evidence.
