### PR TITLE
ci: add wheel install smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,6 +169,30 @@ jobs:
           CI_STEP_TIMEOUT_SECONDS: "300"
         run: bash scripts/dev/ci_step_timer.sh "Enforce artifact root policy" scripts/dev/ci_driver.sh artifact-policy
 
+  wheel-smoke-install:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Set up CI Python environment
+        uses: ./.github/actions/setup-ci-python
+
+      - name: Build wheel
+        run: uv build
+
+      - name: Clean wheel install/import smoke
+        run: bash scripts/validation/wheel_install_smoke.sh
+
+      - name: Upload wheel smoke report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: wheel-smoke-report
+          path: output/validation/wheel_install_smoke_report.json
+          if-no-files-found: warn
+
   examples-smoke:
     runs-on: ubuntu-latest
     timeout-minutes: 30
@@ -188,6 +212,7 @@ jobs:
     needs:
       - fast-feedback
       - smoke-artifacts
+      - wheel-smoke-install
       - examples-smoke
     if: always()
     steps:
@@ -195,6 +220,10 @@ jobs:
         run: |
           if [[ "${{ needs.fast-feedback.result }}" != "success" ]]; then
             echo "fast-feedback finished with ${{ needs.fast-feedback.result }}" >&2
+            exit 1
+          fi
+          if [[ "${{ needs.wheel-smoke-install.result }}" != "success" ]]; then
+            echo "wheel-smoke-install finished with ${{ needs.wheel-smoke-install.result }}" >&2
             exit 1
           fi
           if [[ "${{ needs.smoke-artifacts.result }}" != "success" ]]; then

--- a/README.md
+++ b/README.md
@@ -54,6 +54,19 @@ uv run python examples/quickstart/02_trained_model.py
 uv run python examples/quickstart/03_custom_map.py
 ```
 
+### Packaging smoke (wheel install smoke)
+
+To validate a wheel install path in a clean environment:
+
+```bash
+uv build
+scripts/validation/wheel_install_smoke.sh
+```
+
+The smoke installs the built wheel into a temporary venv, then verifies a minimal import
+with a small bootstrap dependency set (`loguru`, `numba`, `matplotlib`). This is a
+`clean install + import` guardrail, not a full runtime benchmark install.
+
 CARLA is not installed by `uv sync --all-extras`. On CARLA-capable Linux x86_64 hosts, opt into
 the pinned host-side client with `uv sync --all-extras --group carla` and check the Docker runtime
 with `scripts/dev/check_carla_runtime.sh`.

--- a/scripts/validation/wheel_install_smoke.sh
+++ b/scripts/validation/wheel_install_smoke.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BOOTSTRAP_DEPS="${ROBOT_SF_WHEEL_INSTALL_SMOKE_DEPS:-loguru numba matplotlib}"
+REPORT_FILE="output/validation/wheel_install_smoke_report.json"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+WHEEL_INPUT="${1:-${WHEEL_GLOB:-}}"
+WHEEL_PATH="$(python3 - "${REPO_ROOT}" "${WHEEL_INPUT}" <<'PY'
+import glob
+import os
+import sys
+
+repo_root, wheel_input = sys.argv[1:]
+if wheel_input:
+    wheel_pattern = wheel_input if os.path.isabs(wheel_input) else os.path.join(repo_root, wheel_input)
+else:
+    wheel_pattern = os.path.join(repo_root, "dist", "*.whl")
+
+matches = glob.glob(wheel_pattern)
+if matches:
+    print(max(matches, key=os.path.getmtime))
+elif os.path.isfile(wheel_pattern):
+    print(wheel_pattern)
+PY
+)"
+
+if [[ -z "${WHEEL_PATH}" ]]; then
+  echo "No wheel file found to validate."
+  echo "Set WHEEL_GLOB or pass a wheel path relative to the repository root: $0 <path-to-wheel>"
+  exit 1
+fi
+
+if [[ ! -f "${WHEEL_PATH}" ]]; then
+  echo "Wheel not found: ${WHEEL_PATH}"
+  exit 1
+fi
+
+WORK_DIR="$(mktemp -d)"
+cleanup() {
+  rm -rf "${WORK_DIR}"
+}
+trap cleanup EXIT
+
+VENV_DIR="${WORK_DIR}/smoke-venv"
+PIP_BIN="${VENV_DIR}/bin/pip"
+PYTHON_BIN="${VENV_DIR}/bin/python"
+
+python3 -m venv "${VENV_DIR}"
+
+echo "Installing wheel (no dependency resolution) in clean temp venv: ${WHEEL_PATH}"
+"${PIP_BIN}" install --no-cache-dir --no-deps "${WHEEL_PATH}"
+
+if [[ -n "${BOOTSTRAP_DEPS}" ]]; then
+  # shellcheck disable=SC2206
+  bootstrap_deps=(${BOOTSTRAP_DEPS})
+  echo "Installing bootstrap smoke deps: ${BOOTSTRAP_DEPS}"
+  "${PIP_BIN}" install --no-cache-dir "${bootstrap_deps[@]}"
+fi
+
+mkdir -p "${REPO_ROOT}/output/validation"
+python_check_output="$(cd /tmp && PYTHONPATH= PYTHONNOUSERSITE=1 "${PYTHON_BIN}" -c "import robot_sf; print(robot_sf.__file__)")"
+
+if [[ -z "${python_check_output}" ]]; then
+  echo "Wheel smoke import validation produced no module file output."
+  exit 1
+fi
+
+"${PYTHON_BIN}" - "${REPO_ROOT}/${REPORT_FILE}" "${WHEEL_PATH}" "${python_check_output}" "${BOOTSTRAP_DEPS}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report_path, wheel, module_file, bootstrap_deps = sys.argv[1:]
+Path(report_path).write_text(
+    json.dumps(
+        {
+            "wheel": wheel,
+            "status": "passed",
+            "install_mode": "wheel_no_deps_with_bootstrap_import_deps",
+            "module_file": module_file,
+            "command": "import robot_sf from clean wheel install",
+            "bootstrap_deps": bootstrap_deps,
+        },
+        indent=2,
+    )
+    + "\n",
+    encoding="utf-8",
+)
+PY
+
+echo "Wheel install smoke passed. Report: ${REPO_ROOT}/${REPORT_FILE}"

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -17,6 +17,7 @@ WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 CI_JOB_TIMEOUTS = {
     "fast-feedback": 45,
     "smoke-artifacts": 30,
+    "wheel-smoke-install": 20,
     "examples-smoke": 30,
     "ci": 5,
 }
@@ -193,6 +194,19 @@ def test_ci_workflow_examples_smoke_is_independent_and_required_by_aggregate() -
     assert _workflow_job_phases("examples-smoke") == {"examples-smoke"}
     assert "needs" not in workflow["jobs"]["examples-smoke"]
     assert "examples-smoke" in workflow["jobs"]["ci"]["needs"]
+
+
+def test_ci_workflow_wheel_smoke_is_independent_and_required_by_aggregate() -> None:
+    """Keep wheel install smoke in a separately timed job required by aggregate CI."""
+    workflow = yaml.safe_load(_workflow_text())
+    wheel_smoke_steps = workflow["jobs"]["wheel-smoke-install"]["steps"]
+    wheel_smoke_run_blocks = [step.get("run", "") for step in wheel_smoke_steps]
+
+    assert "wheel-smoke-install" in workflow["jobs"]
+    assert any("uv build" in run_block for run_block in wheel_smoke_run_blocks)
+    assert any("wheel_install_smoke.sh" in run_block for run_block in wheel_smoke_run_blocks)
+    assert "needs" not in workflow["jobs"]["wheel-smoke-install"]
+    assert "wheel-smoke-install" in workflow["jobs"]["ci"]["needs"]
 
 
 def test_ci_driver_test_phase_excludes_separately_timed_examples() -> None:


### PR DESCRIPTION
## Summary
Adds a clean wheel install/import smoke job to CI and documents the local packaging smoke command.

## Linked Issues
- Relates to `#2996`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/validation/wheel_install_smoke.sh`, which installs the built wheel into a temporary venv with `--no-deps`, adds a minimal bootstrap import dependency set, and verifies `import robot_sf` from outside the checkout.
- Added a `wheel-smoke-install` CI job and made aggregate `ci` require it.
- Documented the local wheel smoke workflow in `README.md`.
- Added CI workflow contract coverage for the new independent job and timeout.

## Why It Matters
- Added value: catches broken wheel build/import paths before release work.
- Expected impact: gives #2996 a concrete packaging guardrail without pulling heavyweight runtime dependency resolution into every CI run.
- Why this is worth merging now: it is bounded, cheap, and creates a base signal before the optional-extras split is attempted.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/release tooling guardrail, no research claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: wheel builds and imports from a clean temp venv; no full runtime dependency claim.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2996 progress comment after merge.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support/release tooling.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none; local `dist/` and `output/validation/wheel_install_smoke_report.json` artifacts are disposable validation outputs.
- Stop / revise / continue decision: continue #2996 with optional dependency split planning.
- Proposed child issue or existing follow-up: existing #2996 retains the deferred optional-extras split.

## Validation / Proof
- Commands run:
  - `rtk bash -n scripts/validation/wheel_install_smoke.sh`
  - `rtk uv build`
  - `rtk bash scripts/validation/wheel_install_smoke.sh`
  - `rtk uv run pytest tests/test_ci_driver_contract.py -q`
  - `rtk uv run ruff check tests/test_ci_driver_contract.py`
  - `rtk uv run ruff format --check tests/test_ci_driver_contract.py`
  - `rtk scripts/dev/check_docs_proof_consistency_diff.sh`
  - `rtk git diff --check`
- Evidence that the change works here: the script installed `dist/robot_sf-2.0.0-py3-none-any.whl` into a temp venv and imported `robot_sf` from site-packages, writing `install_mode: wheel_no_deps_with_bootstrap_import_deps` to the report.
- Benchmarks or smoke tests, if applicable: targeted wheel install/import smoke only; not a benchmark.

## Risks / Rollout
- Compatibility risks: this intentionally uses `--no-deps` plus bootstrap import deps, so it does not prove full dependency-complete runtime installation.
- Failure modes: pip resolver warnings are expected because the full runtime dependency set is not installed in this smoke mode.
- Rollback or fallback plan: remove the `wheel-smoke-install` job and script if CI environment package downloads become unstable.

## Docs / Provenance
- Updated docs: `README.md`
- Relevant design or provenance notes: local generated wheel/sdist/report remain ignored and disposable.
- Any assumptions that need to be preserved: this is a minimal import guardrail, not the optional-extras split itself.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - will update after merge.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - existing #2996 carries the remaining dependency-split work.
- Not applicable because: release/support tooling only; no benchmark or research artifact propagation.

## Follow-Up Issues
- Deferred work: optional dependency extras split and a possible opt-in full-deps wheel smoke remain in #2996.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the no-deps/bootstrap-deps boundary is deliberate and documented.
- Any known limitations: this does not validate heavyweight runtime extras, Torch install policy, or full benchmark execution from a wheel install.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated wheel package installation validation to the CI pipeline to ensure built packages can be installed and imported correctly.

* **Documentation**
  * Added wheel validation guide to the Quickstart section with instructions for local validation testing.

* **Tests**
  * Added contract tests to verify the wheel validation workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->