### PR TITLE
docs: add robot sf api reference

### DIFF
--- a/docs/api/index.rst
+++ b/docs/api/index.rst
@@ -1,0 +1,14 @@
+Robot SF API Reference
+======================
+
+This reference uses Sphinx autodoc for selected lightweight public package surfaces. Planner,
+training, and simulator internals remain covered by the topic guides until their optional
+dependencies are isolated enough for broad API generation.
+
+.. toctree::
+   :maxdepth: 1
+
+   robot_sf
+   robot_sf.common
+   robot_sf.research
+   robot_sf.telemetry

--- a/docs/api/robot_sf.common.rst
+++ b/docs/api/robot_sf.common.rst
@@ -1,0 +1,5 @@
+Common API
+==========
+
+.. automodule:: robot_sf.common
+   :members:

--- a/docs/api/robot_sf.research.rst
+++ b/docs/api/robot_sf.research.rst
@@ -1,0 +1,5 @@
+Research API
+============
+
+.. automodule:: robot_sf.research
+   :members:

--- a/docs/api/robot_sf.rst
+++ b/docs/api/robot_sf.rst
@@ -1,0 +1,6 @@
+Robot SF package
+================
+
+.. automodule:: robot_sf
+   :members:
+   :no-index:

--- a/docs/api/robot_sf.telemetry.rst
+++ b/docs/api/robot_sf.telemetry.rst
@@ -1,0 +1,5 @@
+Telemetry API
+=============
+
+.. automodule:: robot_sf.telemetry
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,6 +12,8 @@ copyright = "2026, Robot SF contributors"
 
 extensions = [
     "myst_parser",
+    "sphinx.ext.autodoc",
+    "sphinx.ext.napoleon",
 ]
 
 source_suffix = {
@@ -41,6 +43,18 @@ html_theme = "sphinx_rtd_theme"
 html_title = "Robot SF Documentation"
 html_short_title = "Robot SF"
 html_show_sourcelink = True
+
+autodoc_default_options = {
+    "members": True,
+    "show-inheritance": True,
+}
+
+# Keep docs import-time light-weight when optional extras are missing.
+autodoc_mock_imports = [
+    "stable_baselines3",
+    "tensorboard",
+    "torch",
+]
 
 myst_heading_anchors = 3
 myst_enable_extensions = [

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,6 +82,7 @@ references.
    :maxdepth: 1
 
    Developer Guide <dev_guide>
+   API Reference <api/index>
    Environment API <ENVIRONMENT>
    Observation Contract <dev/observation_contract>
    Helper Catalog <dev/helper_catalog>


### PR DESCRIPTION
## Summary

- add a lightweight Sphinx API reference entry point under `docs/api/`
- enable built-in `autodoc`/`napoleon` support without adding docs dependencies
- link the new API reference from the Developer/API Reference navigation

Closes #3018

## Validation

- `uv run --group docs python -m sphinx -b html docs docs/_build/html`
- checked Sphinx log for warnings/errors: clean, `build succeeded.`
- verified generated API HTML pages exist for `robot_sf`, `robot_sf.common`, `robot_sf.research`, and `robot_sf.telemetry`
- verified import sanity for those four documented modules
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`

## Downstream Propagation

- NA - docs navigation/API reference only; no benchmark, metric, schema, or runtime behavior changed.

## Research Result Guidance

- NA - documentation-only ergonomics improvement with no research claim.
