### PR TITLE
perf: reduce step profile sampling overhead

### DIFF
--- a/docs/performance_notes.md
+++ b/docs/performance_notes.md
@@ -74,7 +74,14 @@ Large-crowd profiling now emits an additive `step_profile` contract block:
 - `step_profile.measurement_mode`, `step_profile.warmup_excluded`
 - `step_profile.warmup_first_step_sec`, `step_profile.warmup_step_loop_sec`, and
   `step_profile.warmup_steps_per_sec` when explicit warmup attribution is requested
-- `step_profile.pedestrian_count` (when observed after reset/step)
+- `step_profile.pedestrian_count` (when observed after reset/step). The fast path tracked in
+  [#3025](https://github.com/ll7/robot_sf_ll7/issues/3025) and
+  [PR #3114](https://github.com/ll7/robot_sf_ll7/pull/3114) reuses the first measured step's
+  pedestrian occupancy snapshot in
+  [`scripts/validation/performance_smoke_test.py`](../scripts/validation/performance_smoke_test.py),
+  with contract coverage in
+  [`tests/perf/test_large_crowd_step_profile_contract.py`](../tests/perf/test_large_crowd_step_profile_contract.py),
+  so the profiler avoids an extra env create/reset/step pass solely for count collection.
 
 These fields are advisory and are for diagnostic reproducibility; they are not benchmark gates.
 

--- a/scripts/validation/performance_smoke_test.py
+++ b/scripts/validation/performance_smoke_test.py
@@ -69,6 +69,7 @@ class StepLoopMetrics:
     warmup_step_loop_sec: float | None = None
     warmup_steps_per_sec: float | None = None
     measurement_mode: str = "cold_only"
+    first_step_pedestrian_count: int | None = None
 
     def to_dict(self) -> dict[str, float | int | bool | str | None]:
         """Serialize step-loop metrics to a JSON-friendly mapping."""
@@ -344,6 +345,7 @@ def measure_step_loop_performance(  # noqa: C901
         warmup_step_loop_sec = None
         warmup_steps_per_sec = None
         measurement_mode = "cold_only"
+        first_step_pedestrian_count = None
 
         terminated = False
         truncated = False
@@ -370,6 +372,7 @@ def measure_step_loop_performance(  # noqa: C901
         first_step_start = time.time()
         _, _, terminated, truncated, _ = env.step(action)
         first_step_sec = time.time() - first_step_start
+        first_step_pedestrian_count = _extract_pedestrian_count(env)
 
         steady_start = time.time()
         for index in range(1, step_samples):
@@ -410,6 +413,7 @@ def measure_step_loop_performance(  # noqa: C901
         warmup_first_step_sec=warmup_first_step_sec,
         warmup_step_loop_sec=warmup_step_loop_sec,
         warmup_steps_per_sec=warmup_steps_per_sec,
+        first_step_pedestrian_count=first_step_pedestrian_count,
         measurement_mode=measurement_mode,
     )
 
@@ -426,7 +430,9 @@ def measure_step_profile(
     loop_metrics = step_loop or measure_step_loop_performance(
         step_samples=step_samples, config=config
     )
-    pedestrian_count = _measure_profile_pedestrian_count(config=config)
+    pedestrian_count = loop_metrics.first_step_pedestrian_count
+    if pedestrian_count is None:
+        pedestrian_count = _measure_profile_pedestrian_count(config=config)
     return StepProfileMetrics(
         step_samples=loop_metrics.step_samples,
         first_step_sec=loop_metrics.first_step_sec,

--- a/tests/perf/test_large_crowd_step_profile_contract.py
+++ b/tests/perf/test_large_crowd_step_profile_contract.py
@@ -103,3 +103,40 @@ def test_large_crowd_step_profile_contract(monkeypatch) -> None:
     assert step_profile["pedestrian_count"] == 142
     assert step_profile["advisory"] is True
     assert step_profile["gating"] == "non-gating"
+
+
+def test_large_crowd_step_profile_reuses_first_step_ped_count(monkeypatch) -> None:
+    """Avoid extra simulation runs when step-loop already captured ped count."""
+
+    def explode_if_called(*_args: object, **_kwargs: object) -> int:
+        raise AssertionError("pedestrian count fallback should not be used")
+
+    monkeypatch.setattr(
+        performance_smoke_test,
+        "_measure_profile_pedestrian_count",
+        explode_if_called,
+    )
+
+    loop_metrics = performance_smoke_test.StepLoopMetrics(
+        step_samples=32,
+        first_step_sec=0.3,
+        step_loop_sec=3.0,
+        steady_step_loop_sec=2.7,
+        steps_per_sec=10.0,
+        steady_steps_per_sec=12.0,
+        warmup_excluded=False,
+        warmup_first_step_sec=None,
+        warmup_step_loop_sec=None,
+        warmup_steps_per_sec=None,
+        measurement_mode="cold_only",
+        first_step_pedestrian_count=17,
+    )
+
+    profile = performance_smoke_test.measure_step_profile(
+        step_samples=32,
+        config=performance_smoke_test.RobotSimulationConfig(),
+        step_loop=loop_metrics,
+        scenario_metadata=None,
+    )
+
+    assert profile.pedestrian_count == 17


### PR DESCRIPTION
## Summary

- reuse the first measured step's pedestrian-count snapshot when building `step_profile`
- avoid the profiler-only extra env create/reset/step pass used solely for count collection
- document the diagnostic-only fast path and add contract coverage for the fallback skip

This is a narrow diagnostic tooling cleanup for #3025. It does **not** claim a simulation-step
runtime speedup and intentionally leaves #3025 open for the real large-pedestrian per-step
bottleneck optimization.

## Evidence

Same command before/after:

```bash
DISPLAY= MPLBACKEND=Agg SDL_VIDEODRIVER=dummy \
  uv run python scripts/validation/performance_smoke_test.py \
  --scenario configs/scenarios/archetypes/classic_group_crossing.yaml \
  --scenario-name classic_group_crossing_high \
  --step-samples 32 \
  --num-resets 1 \
  --json-output output/benchmarks/perf/issue_3025_<baseline|after>.json
```

Observed diagnostic output:

- baseline: `environment_creation_sec=2.194`, `first_step_sec=3.091`, `step_loop_sec=3.099`, `pedestrian_count=4`
- after: `environment_creation_sec=2.016`, `first_step_sec=3.087`, `step_loop_sec=3.094`, `pedestrian_count=4`

Interpretation: the patch removes redundant profiler orchestration work, but the remaining first-step
cost is still a separate simulator startup/JIT/initialization bottleneck. The observed
`pedestrian_count=4` also means this run should not be treated as true large-count optimization
evidence.

## Validation

- `uv run ruff check scripts/validation/performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py`
- `uv run ruff format --check scripts/validation/performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py`
- `uv run pytest tests/perf/test_large_crowd_step_profile_contract.py -q`
- `uv run pytest tests/perf/test_simulation_speed_perf.py -q`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`

## Downstream Propagation

- #3025 remains open. Next evidence step should first identify a fixture with a genuinely high
  pedestrian count, then record top per-step hotspots before attempting a runtime-path optimization.

## Research Result Guidance

- Target claim/hypothesis: diagnostic profiler self-overhead can be reduced without changing the
  `step_profile` JSON contract.
- Evidence tier: diagnostic tooling evidence only.
- Result classification: partial tooling cleanup; not benchmark evidence and not a simulation speedup
  claim.
- Decision/stop rule: stop this PR at profiler overhead cleanup; do not close #3025.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated performance notes to clarify pedestrian count measurement optimization in the smoke test suite.

* **Tests**
  * Added contract test to verify pedestrian count reuse from initial measurement, ensuring the optimized fast path functions correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->