### PR TITLE
docs: clarify publication report semantics

### DIFF
--- a/docs/benchmark_camera_ready.md
+++ b/docs/benchmark_camera_ready.md
@@ -510,6 +510,14 @@ Grouping semantics:
 * `reports/seed_variability_by_scenario.json` is the aggregate export grouped by
 `(scenario_id, planner_key)` across seeds
 
+* `reports/seed_episode_rows.csv` is a per-episode traceability export retained for legacy
+  compatibility with manuscript-side table tooling. In this release artifact family, the
+  `collision` column is the legacy per-episode **metric alias** sourced from
+  `metrics.collisions`; canonical event-level collision state remains
+  `outcome.collision_event` in the source `runs/<planner>/episodes.jsonl`, and the two
+  can diverge only if a planner/metric compatibility edge case is present in historical
+  releases.
+
 Confidence semantics:
 
 * the seed-variability export uses bootstrap over per-seed means
@@ -670,6 +678,15 @@ Core vs experimental partitions:
 `readiness_tier=baseline-ready` for non-paper runs).
 * `campaign_table_experimental.{csv,md}`:
   non-core rows ( `planner_group!=core` for paper-facing runs; non-baseline-ready otherwise).
+
+Interpretation note:
+
+- `campaign_table_core` is an implementation-maturity or policy-family slice, not
+  the manuscript main comparison set. For `orca`/`ppo`-style headline comparisons in release
+  or dissertation workflows, read from `campaign_table.csv` (or explicitly documented
+  alternative subset).
+- Release `0.0.2` used a scoped planner set where `ppo` was outside the core partition, so
+  its secondary-core table is expected not to contain the ppo row.
 
 Portability guarantee:
 

--- a/docs/context/issue_2686_release_0_0_2_table_bundle.md
+++ b/docs/context/issue_2686_release_0_0_2_table_bundle.md
@@ -29,6 +29,13 @@ existing `scripts/tools/benchmark_publication_bundle.py dissertation-bundle` wor
 | `tab:robot_sf_release_planner_results` | `tab_robot_sf_release_planner_results` | `reports/campaign_table.md` | `results` | Existing release-backed planner table only; no rerun or new ranking claim. |
 | `tab:release_failure_count_slices` | `tab_release_failure_count_slices` | `reports/scenario_family_breakdown.md` | `discussion` | Existing scenario-family outcome slices; not a new failure taxonomy. |
 
+Scope note for `campaign_table_core`:
+
+- This row set is the implementation-maturity `planner_group=core` partition from the
+  paper release contract, not the full manuscript-style orca-vs-ppo comparison table.
+- In release `0.0.2`, `ppo` is not present in `campaign_table_core` because it was outside
+  the scoped core set for that release.
+
 ## Durable Proof
 
 Small, reviewable proof copies are tracked under

--- a/docs/context/issue_595_seed_variability_contract.md
+++ b/docs/context/issue_595_seed_variability_contract.md
@@ -79,6 +79,10 @@ Required columns:
 - `time_to_goal`
 - `snqi`
 
+`collision` is the legacy per-episode metric alias from `metrics.collisions`.
+For canonical per-episode outcome, consumers should read `outcome.collision_event`
+from source episode records (`runs/<planner>/episodes.jsonl`).
+
 `repeat_index` is a deterministic zero-based index within each
 `(scenario_id, planner_key, seed)` group.
 

--- a/robot_sf/benchmark/seed_variance.py
+++ b/robot_sf/benchmark/seed_variance.py
@@ -436,6 +436,12 @@ def build_seed_episode_rows(
 ) -> list[dict[str, Any]]:
     """Build planner-aware per-episode seed traceability rows for paper tooling.
 
+    Note:
+        ``collision`` is derived from ``metrics.collisions`` in each flattened
+        episode metric payload for compatibility with legacy release artifacts.
+        For canonical per-episode collision status, consumers should read
+        ``outcome.collision_event`` from source ``episodes.jsonl``.
+
     Returns:
         One flat row per executed episode with deterministic repeat indices.
     """

--- a/tests/benchmark/test_seed_variance.py
+++ b/tests/benchmark/test_seed_variance.py
@@ -166,6 +166,33 @@ def test_build_seed_episode_rows_assigns_repeat_index_deterministically() -> Non
     assert rows[0]["time_to_goal"] == pytest.approx(0.90)
 
 
+def test_build_seed_episode_rows_collision_remains_legacy_metric_alias() -> None:
+    """Compatibility export keeps collision sourced from metrics, not outcome events."""
+    rows = build_seed_episode_rows(
+        [
+            {
+                "episode_id": "ep-legacy-collision",
+                "scenario_id": "classic_cross_trap_low",
+                "seed": 111,
+                "algo": "orca",
+                "planner_key": "orca",
+                "kinematics": "differential_drive",
+                "metrics": {
+                    "success": 1.0,
+                    "collisions": 0.0,
+                    "near_misses": 0.0,
+                    "time_to_goal_norm": 0.20,
+                },
+                "outcome": {
+                    "collision_event": True,
+                },
+            }
+        ]
+    )
+
+    assert rows[0]["collision"] == 0.0
+
+
 def test_build_seed_episode_rows_groups_repeat_index_by_kinematics() -> None:
     """Repeat indices should restart when the same planner runs under other kinematics."""
     records = _sample_records() + [


### PR DESCRIPTION
## Summary
Clarifies publication report semantics for the AMV release tables without changing archived release artifacts or manuscript claims.

## Linked Issues
- Closes `#2612`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Documented `seed_episode_rows.csv` `collision` as the legacy `metrics.collisions` metric alias, with `outcome.collision_event` as canonical event-level collision state in source episode records.
- Clarified that `campaign_table_core` is an implementation-maturity / planner-group core slice, not the full manuscript headline comparison table.
- Added a regression test pinning the compatibility behavior for `build_seed_episode_rows`.

## Why It Matters
- Added value: removes ambiguity in secondary publication outputs that could otherwise be misread during release or paper review.
- Expected impact: downstream consumers can distinguish canonical collision evidence from legacy compatibility columns.
- Why this is worth merging now: high-priority release-facing issue with small, low-risk scope.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for secondary report semantics; no benchmark claim change.
- Comparator or baseline, if applicable: NA.
- Evidence tier: targeted smoke plus docs-only release-contract clarification.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: close once the collision-field and core-table semantics are explicitly documented and regression-covered.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2612; `docs/benchmark_camera_ready.md`; `docs/context/issue_595_seed_variability_contract.md`; `docs/context/issue_2686_release_0_0_2_table_bundle.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no new analysis tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - docs/schema clarification.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: stop.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: stop for #2612 after merge.
- Proposed child issue or existing follow-up: NA.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_seed_variance.py`
  - `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/benchmark_camera_ready.md --path docs/context/issue_595_seed_variability_contract.md --path docs/context/issue_2686_release_0_0_2_table_bundle.md`
  - `git diff --check`
  - `uv run ruff check robot_sf/benchmark/seed_variance.py tests/benchmark/test_seed_variance.py`
  - `uv run ruff format --check robot_sf/benchmark/seed_variance.py tests/benchmark/test_seed_variance.py`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Evidence that the change works here: targeted seed-variance test suite passes with a new regression proving `seed_episode_rows.csv` `collision` remains sourced from `metrics.collisions` even when `outcome.collision_event` differs.
- Benchmarks or smoke tests, if applicable: targeted regression only; no benchmark run because this preserves report semantics without changing benchmark outputs.

## Risks / Rollout
- Compatibility risks: intentionally preserves archived `0.0.2` values and current compatibility behavior.
- Failure modes: future generator changes could intentionally migrate `collision` to `outcome.collision_event`; if so, these docs and the regression should be updated together.
- Rollback or fallback plan: revert the docs/test/docstring commit; no generated artifacts are rewritten.

## Docs / Provenance
- Updated docs: `docs/benchmark_camera_ready.md`, `docs/context/issue_595_seed_variability_contract.md`, `docs/context/issue_2686_release_0_0_2_table_bundle.md`.
- Relevant design or provenance notes: `docs/context/issue_2686_release_0_0_2_table_bundle.md` now carries the release `0.0.2` core-table caveat.
- Any assumptions that need to be preserved: `campaign_table.csv` and source episode JSONL `outcome.collision_event` remain authoritative for manuscript collision evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR closing #2612.
- Claim map / benchmark report updated (yes/no/NA): NA; no claim changes.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA; existing context notes were updated directly.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this clarifies existing release/report contracts and does not introduce a new benchmark result or artifact.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the semantics decision: `seed_episode_rows.csv` `collision` remains a legacy `metrics.collisions` alias, while `outcome.collision_event` remains canonical for event-level collision evidence.
- Known limitation: archived release artifacts are not rewritten.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified metric column meanings and table interpretation guidance for benchmark reports.
  * Added scope notes explaining dataset partitions and planner coverage in exported tables.

* **Tests**
  * Added backward-compatibility test for legacy collision metric behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->