### PR TITLE
feat: add large crowd profiling preset

### DIFF
--- a/scripts/validation/performance_smoke_test.py
+++ b/scripts/validation/performance_smoke_test.py
@@ -48,6 +48,10 @@ from robot_sf.training.scenario_loader import (
     select_scenario,
 )
 
+_DEFAULT_STEP_SAMPLES = 10
+_LARGE_CROWD_PROFILE_SCENARIO = "configs/scenarios/single/dense_pedestrian_stress.yaml"
+_LARGE_CROWD_PROFILE_STEP_SAMPLES = 20
+
 
 @dataclass(slots=True)
 class StepLoopMetrics:
@@ -609,7 +613,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--step-samples",
         type=int,
-        default=10,
+        default=None,
         help="Number of simulator steps for advisory startup/steady attribution (default: 10)",
     )
     parser.add_argument(
@@ -646,6 +650,14 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Emit recommendation guidance when thresholds breach",
     )
+    parser.add_argument(
+        "--large-crowd-profile",
+        action="store_true",
+        help=(
+            "Use the dense pedestrian diagnostic stress fixture and 20 measured steps "
+            "unless --scenario or --step-samples override them."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -660,6 +672,9 @@ def main() -> int:  # noqa: C901
     print("=" * 60)
 
     args = parse_args()
+    _apply_large_crowd_profile_preset(args)
+    if args.step_samples is None:
+        args.step_samples = _DEFAULT_STEP_SAMPLES
 
     creation_soft = _env_float("ROBOT_SF_PERF_CREATION_SOFT", 3.0)
     creation_hard = _env_float("ROBOT_SF_PERF_CREATION_HARD", 8.0)
@@ -757,6 +772,17 @@ def _default_summary_path() -> Path:
     """
     ensure_canonical_tree(categories=("benchmarks",))
     return get_artifact_category_path("benchmarks") / "performance_smoke_test.json"
+
+
+def _apply_large_crowd_profile_preset(args: argparse.Namespace) -> None:
+    """Apply the built-in high-density diagnostic profile preset in-place."""
+
+    if not args.large_crowd_profile:
+        return
+    if args.scenario is None:
+        args.scenario = _LARGE_CROWD_PROFILE_SCENARIO
+    if args.step_samples is None:
+        args.step_samples = _LARGE_CROWD_PROFILE_STEP_SAMPLES
 
 
 def _status_label(soft_ok: bool, hard_ok: bool, enforce: bool) -> str:

--- a/tests/perf/test_large_crowd_step_profile_contract.py
+++ b/tests/perf/test_large_crowd_step_profile_contract.py
@@ -1,5 +1,6 @@
 """Contract coverage for deterministic large-crowd step-profile telemetry."""
 
+from argparse import Namespace
 from pathlib import Path
 
 from scripts.validation import performance_smoke_test
@@ -9,13 +10,13 @@ def test_large_crowd_step_profile_contract(monkeypatch) -> None:
     """Smoke profile output includes deterministic scenario + advisory metadata."""
 
     repo_root = Path(__file__).resolve().parents[2]
-    scenario_path = repo_root / "configs/scenarios/archetypes/classic_group_crossing.yaml"
+    scenario_path = repo_root / "configs/scenarios/single/dense_pedestrian_stress.yaml"
     scenario_metadata = performance_smoke_test.ScenarioProfileMetadata(
-        scenario_id="classic_group_crossing_high",
-        scenario_name="classic_group_crossing_high",
+        scenario_id="dense_pedestrian_stress",
+        scenario_name="dense_pedestrian_stress",
         scenario_path=str(scenario_path),
         density="high",
-        density_advisory="high_density_stress",
+        density_advisory="diagnostic_stress_only",
     )
 
     monkeypatch.setattr(
@@ -53,23 +54,23 @@ def test_large_crowd_step_profile_contract(monkeypatch) -> None:
     monkeypatch.setattr(
         performance_smoke_test,
         "_measure_profile_pedestrian_count",
-        lambda config=None: 142,
+        lambda config=None: 17,
     )
     monkeypatch.setattr(
         performance_smoke_test,
         "_load_scenario_config",
         lambda scenario, *, scenario_name=None: (
             performance_smoke_test.RobotSimulationConfig(),
-            scenario_name or "classic_group_crossing_high",
+            scenario_name or "dense_pedestrian_stress",
             scenario_metadata,
         ),
     )
 
     result = performance_smoke_test.run_performance_smoke_test(
         num_resets=2,
-        step_samples=3,
+        step_samples=20,
         scenario=str(scenario_path),
-        scenario_name="classic_group_crossing_high",
+        scenario_name="dense_pedestrian_stress",
         include_recommendations=False,
         creation_soft=3.0,
         creation_hard=8.0,
@@ -82,14 +83,14 @@ def test_large_crowd_step_profile_contract(monkeypatch) -> None:
     payload = result.to_dict()
     step_profile = payload["step_profile"]
 
-    assert payload["scenario"] == "classic_group_crossing_high"
+    assert payload["scenario"] == "dense_pedestrian_stress"
     assert step_profile is not None
-    assert step_profile["scenario_id"] == "classic_group_crossing_high"
-    assert step_profile["scenario_name"] == "classic_group_crossing_high"
+    assert step_profile["scenario_id"] == "dense_pedestrian_stress"
+    assert step_profile["scenario_name"] == "dense_pedestrian_stress"
     assert step_profile["scenario_path"] == str(scenario_path)
     assert step_profile["density"] == "high"
-    assert step_profile["density_advisory"] == "high_density_stress"
-    assert step_profile["step_samples"] == 3
+    assert step_profile["density_advisory"] == "diagnostic_stress_only"
+    assert step_profile["step_samples"] == 20
     assert step_profile["first_step_sec"] == 0.2
     assert step_profile["step_loop_sec"] == 1.0
     assert step_profile["steady_step_loop_sec"] == 0.8
@@ -100,9 +101,39 @@ def test_large_crowd_step_profile_contract(monkeypatch) -> None:
     assert step_profile["warmup_step_loop_sec"] is None
     assert step_profile["warmup_steps_per_sec"] is None
     assert step_profile["measurement_mode"] == "cold_only"
-    assert step_profile["pedestrian_count"] == 142
+    assert step_profile["pedestrian_count"] == 17
     assert step_profile["advisory"] is True
     assert step_profile["gating"] == "non-gating"
+
+
+def test_large_crowd_profile_preset_selects_dense_diagnostic_fixture() -> None:
+    """The CLI preset names the reproducible dense stress profiling command."""
+
+    args = Namespace(
+        large_crowd_profile=True,
+        scenario=None,
+        step_samples=None,
+    )
+
+    performance_smoke_test._apply_large_crowd_profile_preset(args)
+
+    assert args.scenario == "configs/scenarios/single/dense_pedestrian_stress.yaml"
+    assert args.step_samples == 20
+
+
+def test_large_crowd_profile_preset_keeps_explicit_overrides() -> None:
+    """Explicit scenario and sample choices win over the convenience preset."""
+
+    args = Namespace(
+        large_crowd_profile=True,
+        scenario="configs/scenarios/archetypes/classic_group_crossing.yaml",
+        step_samples=10,
+    )
+
+    performance_smoke_test._apply_large_crowd_profile_preset(args)
+
+    assert args.scenario == "configs/scenarios/archetypes/classic_group_crossing.yaml"
+    assert args.step_samples == 10
 
 
 def test_large_crowd_step_profile_reuses_first_step_ped_count(monkeypatch) -> None:


### PR DESCRIPTION
## Summary
Adds a `--large-crowd-profile` preset to the performance smoke test so the #3025 dense pedestrian diagnostic baseline has a reproducible command surface.

## Linked Issues
- Relates to `#3025`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `--large-crowd-profile` to `scripts/validation/performance_smoke_test.py`.
- The preset selects `configs/scenarios/single/dense_pedestrian_stress.yaml` and 20 measured steps unless explicit CLI overrides are provided.
- Updated `tests/perf/test_large_crowd_step_profile_contract.py` to cover the dense diagnostic scenario metadata, pedestrian count contract, and preset override behavior.

## Why It Matters
- Added value: makes the high-density diagnostic profiling path easy to rerun and review.
- Expected impact: improves baseline reproducibility for #3025 without adding timing thresholds or performance claims.
- Why this is worth merging now: it establishes the command surface needed before any optimization PR can honestly compare before/after behavior.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3025 needs a reproducible step-profile baseline for higher-pedestrian diagnostic scenarios.
- Comparator or baseline, if applicable: existing ad hoc performance smoke invocation.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: no speedup claim until a later PR includes before/after timing evidence and correctness validation.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3025 remains the parent surface.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper/preset; it exposes an existing smoke path and does not interpret benchmark evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes; the preset selected `dense_pedestrian_stress` and reported `ped_count=17`.
- Did the intervention change command source, selected command, trajectory, or route progress? no; this only selects an existing diagnostic fixture for profiling.
- Did the scenario actually contain the targeted failure mode? diagnostic-only high-density fixture, not benchmark evidence.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #3025 should still do a profiler-backed hotspot pass before optimization.

## Next Empirical Action
- Rerun needed: yes, for any later optimization claim.
- Extractor or analysis tool needed: no for this preset.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue with profiler-backed hotspot analysis under #3025.
- Proposed child issue or existing follow-up: existing #3025.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/performance_smoke_test.py --large-crowd-profile --json-output /tmp/perf_large_crowd_preset_3025.json`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/perf/test_simulation_speed_perf.py tests/perf/test_large_crowd_step_profile_contract.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py`
  - `git diff --check`
- Evidence that the change works here: preset smoke run passed and emitted `scenario=dense_pedestrian_stress`, `ped_count=17`, `step_samples=20`, `gating=non-gating`.
- Benchmarks or smoke tests, if applicable: targeted diagnostic smoke only; no benchmark-strength claim.

## Risks / Rollout
- Compatibility risks: low; new flag is additive and explicit `--scenario` / `--step-samples` values still override the preset.
- Failure modes: fixture remains diagnostic-only and should not be mistaken for a benchmark result.
- Rollback or fallback plan: remove the preset and continue using explicit `--scenario ... --step-samples 20`.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: #3025 issue body.
- Any assumptions that need to be preserved: this PR is profiling-only and makes no optimization or speedup claim.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; PR links it.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: this is a support preset for an existing diagnostic fixture, not durable benchmark evidence.

## Follow-Up Issues
- Deferred work: #3025 still needs profiler-backed hotspot attribution and any optimization must include before/after timing evidence.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the preset should remain advisory/non-gating and explicit overrides should keep working.
- Any known limitations: `dense_pedestrian_stress` is a diagnostic stress fixture, not a validated benchmark scenario.
