### PR TITLE
feat: add step hotspot profiling

### DIFF
--- a/scripts/validation/performance_smoke_test.py
+++ b/scripts/validation/performance_smoke_test.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import argparse
 import copy
+import cProfile
 import json
 import os
 import sys
@@ -51,6 +52,7 @@ from robot_sf.training.scenario_loader import (
 _DEFAULT_STEP_SAMPLES = 10
 _LARGE_CROWD_PROFILE_SCENARIO = "configs/scenarios/single/dense_pedestrian_stress.yaml"
 _LARGE_CROWD_PROFILE_STEP_SAMPLES = 20
+_DEFAULT_STEP_PROFILE_LIMIT = 10
 
 
 @dataclass(slots=True)
@@ -126,8 +128,14 @@ class StepProfileMetrics:
     pedestrian_count: int | None = None
     advisory: bool = True
     gating: str = "non-gating"
+    step_profile_hotspots: list[dict[str, float | int | str | None]] | None = None
 
-    def to_dict(self) -> dict[str, float | int | bool | str | None]:
+    def to_dict(
+        self,
+    ) -> dict[
+        str,
+        float | int | bool | str | list[dict[str, float | int | str | None]] | None,
+    ]:
         """Serialize step-profile diagnostics to a JSON-friendly mapping."""
         return {
             "scenario_id": self.scenario_id,
@@ -149,6 +157,7 @@ class StepProfileMetrics:
             "pedestrian_count": self.pedestrian_count,
             "advisory": self.advisory,
             "gating": self.gating,
+            "step_profile_hotspots": self.step_profile_hotspots,
         }
 
 
@@ -320,17 +329,98 @@ def _measure_profile_pedestrian_count(config: RobotSimulationConfig | None = Non
         env.close()
 
 
-def measure_step_loop_performance(  # noqa: C901
+def _collect_step_profile_hotspots(
+    profile: cProfile.Profile,
+    *,
+    limit: int,
+) -> list[dict[str, float | int | str | None]]:
+    """Extract a deterministic, bounded list of profiler hotspots."""
+
+    if limit <= 0:
+        return []
+
+    if hasattr(profile, "create_stats"):
+        profile.create_stats()
+
+    raw_stats = getattr(profile, "stats", None)
+    if not isinstance(raw_stats, Mapping):
+        return []
+    hotspots: list[dict[str, float | int | str | None]] = []
+    for (file, line_no, func_name), data in raw_stats.items():
+        if not isinstance(file, str):
+            file = "<unknown>"
+        try:
+            raw_line = int(line_no)
+        except (TypeError, ValueError):
+            raw_line = 0
+        try:
+            _ccalls, ncalls, tottime, cumtime, *_ = data
+            ncalls = int(ncalls)
+            tottime = float(tottime)
+            cumtime = float(cumtime)
+        except (TypeError, ValueError):
+            continue
+        hotspots.append(
+            {
+                "file": _format_profile_file_path(file),
+                "line": raw_line,
+                "name": str(func_name),
+                "ncalls": ncalls,
+                "tottime": tottime,
+                "cumtime": cumtime,
+            },
+        )
+
+    hotspots.sort(
+        key=lambda row: (
+            -(row["cumtime"] if isinstance(row["cumtime"], (float, int)) else 0.0),
+            -(row["tottime"] if isinstance(row["tottime"], (float, int)) else 0.0),
+            row["file"],
+            row["line"],
+            row["name"],
+        ),
+    )
+    return hotspots[:limit]
+
+
+def _format_profile_file_path(file: str) -> str:
+    """Return a portable profiler file label without machine-local prefixes."""
+
+    if file.startswith("<") and file.endswith(">"):
+        return file
+    normalized = file.replace("\\", "/")
+    path = Path(normalized)
+    if path.is_absolute():
+        try:
+            return path.relative_to(Path.cwd()).as_posix()
+        except ValueError:
+            pass
+
+    parts = tuple(part for part in normalized.split("/") if part)
+    if "site-packages" in parts:
+        index = parts.index("site-packages")
+        return "/".join(parts[index:])
+    if ".venv" in parts:
+        index = parts.index(".venv")
+        return "/".join(parts[index + 1 :])
+    try:
+        return path.relative_to(Path.cwd()).as_posix()
+    except ValueError:
+        pass
+    if not path.is_absolute():
+        return normalized
+    return path.name
+
+
+def _run_step_loop_measurement(  # noqa: C901, PLR0915
     step_samples: int = 10,
     config: RobotSimulationConfig | None = None,
     warmup_steps: int = 0,
-) -> StepLoopMetrics:
-    """Measure first-step and steady step-loop attribution.
-
-    The result is advisory telemetry only. Existing smoke thresholds still gate
-    environment creation and reset throughput, while these fields help diagnose
-    whether future slowdowns are startup- or steady-step dominated.
-    """
+    step_profile_limit: int = _DEFAULT_STEP_PROFILE_LIMIT,
+    *,
+    profile: bool = False,
+) -> tuple[StepLoopMetrics, list[dict[str, float | int | str | None]] | None]:
+    """Measure first-step and steady step-loop attribution."""
 
     if step_samples <= 0:
         raise ValueError("step_samples must be greater than zero")
@@ -340,6 +430,7 @@ def measure_step_loop_performance(  # noqa: C901
     print("\n=== Step Loop Attribution ===")
     env = make_robot_env(config=copy.deepcopy(config or RobotSimulationConfig()), debug=False)
     action = (0.0, 0.0)
+    profiler = cProfile.Profile() if profile else None
 
     try:
         env.reset()
@@ -372,6 +463,9 @@ def measure_step_loop_performance(  # noqa: C901
             )
             env.reset()
 
+        if profiler is not None:
+            profiler.enable()
+
         loop_start = time.time()
         first_step_start = time.time()
         _, _, terminated, truncated, _ = env.step(action)
@@ -386,6 +480,8 @@ def measure_step_loop_performance(  # noqa: C901
         steady_step_loop_sec = time.time() - steady_start
         step_loop_sec = time.time() - loop_start
     finally:
+        if profiler is not None:
+            profiler.disable()
         env.close()
 
     steps_per_sec = step_samples / step_loop_sec if step_loop_sec > 0 else 0.0
@@ -406,20 +502,69 @@ def measure_step_loop_performance(  # noqa: C901
     else:
         print("Steady step loop: not available (single step sample)")
 
-    return StepLoopMetrics(
-        step_samples=step_samples,
-        first_step_sec=first_step_sec,
-        step_loop_sec=step_loop_sec,
-        steady_step_loop_sec=steady_step_loop_sec,
-        steps_per_sec=steps_per_sec,
-        steady_steps_per_sec=steady_steps_per_sec,
-        warmup_excluded=warmup_excluded,
-        warmup_first_step_sec=warmup_first_step_sec,
-        warmup_step_loop_sec=warmup_step_loop_sec,
-        warmup_steps_per_sec=warmup_steps_per_sec,
-        first_step_pedestrian_count=first_step_pedestrian_count,
-        measurement_mode=measurement_mode,
+    return (
+        StepLoopMetrics(
+            step_samples=step_samples,
+            first_step_sec=first_step_sec,
+            step_loop_sec=step_loop_sec,
+            steady_step_loop_sec=steady_step_loop_sec,
+            steps_per_sec=steps_per_sec,
+            steady_steps_per_sec=steady_steps_per_sec,
+            warmup_excluded=warmup_excluded,
+            warmup_first_step_sec=warmup_first_step_sec,
+            warmup_step_loop_sec=warmup_step_loop_sec,
+            warmup_steps_per_sec=warmup_steps_per_sec,
+            first_step_pedestrian_count=first_step_pedestrian_count,
+            measurement_mode=measurement_mode,
+        ),
+        (
+            _collect_step_profile_hotspots(profiler, limit=step_profile_limit)
+            if profiler is not None
+            else None
+        ),
     )
+
+
+def measure_step_loop_performance(
+    step_samples: int = 10,
+    config: RobotSimulationConfig | None = None,
+    warmup_steps: int = 0,
+) -> StepLoopMetrics:
+    """Measure first-step and steady step-loop attribution.
+
+    The result is advisory telemetry only. Existing smoke thresholds still gate
+    environment creation and reset throughput, while these fields help diagnose
+    whether future slowdowns are startup- or steady-step dominated.
+    """
+
+    metrics, _ = _run_step_loop_measurement(
+        step_samples=step_samples,
+        config=config,
+        warmup_steps=warmup_steps,
+    )
+    return metrics
+
+
+def measure_step_loop_performance_with_profile(
+    step_samples: int = 10,
+    config: RobotSimulationConfig | None = None,
+    warmup_steps: int = 0,
+    step_profile_limit: int = _DEFAULT_STEP_PROFILE_LIMIT,
+) -> tuple[StepLoopMetrics, list[dict[str, float | int | str | None]]]:
+    """Measure step-loop timings and collect a compact profiler hotspot list."""
+
+    metrics, hotspots = _run_step_loop_measurement(
+        step_samples=step_samples,
+        config=config,
+        warmup_steps=warmup_steps,
+        step_profile_limit=step_profile_limit,
+        profile=True,
+    )
+    if hotspots is None:
+        return metrics, []
+    if step_profile_limit <= 0:
+        return metrics, []
+    return metrics, hotspots[:step_profile_limit]
 
 
 def measure_step_profile(
@@ -428,6 +573,7 @@ def measure_step_profile(
     config: RobotSimulationConfig | None = None,
     step_loop: StepLoopMetrics | None = None,
     scenario_metadata: ScenarioProfileMetadata | None = None,
+    step_profile_hotspots: list[dict[str, float | int | str | None]] | None = None,
 ) -> StepProfileMetrics:
     """Build diagnostic step-profile metadata for the smoke test contract."""
 
@@ -457,6 +603,7 @@ def measure_step_profile(
         if scenario_metadata is not None
         else None,
         pedestrian_count=pedestrian_count,
+        step_profile_hotspots=step_profile_hotspots,
     )
 
 
@@ -472,6 +619,8 @@ def run_performance_smoke_test(  # noqa: PLR0913
     creation_hard: float | None = None,
     reset_soft: float | None = None,
     reset_hard: float | None = None,
+    step_profile: bool = False,
+    step_profile_limit: int = _DEFAULT_STEP_PROFILE_LIMIT,
     enforce: bool | None = None,
     on_ci: bool | None = None,
 ) -> SmokeTestResult:
@@ -490,6 +639,8 @@ def run_performance_smoke_test(  # noqa: PLR0913
         creation_hard: Hard threshold (seconds) for environment creation time.
         reset_soft: Soft threshold (resets/sec) for environment reset throughput.
         reset_hard: Hard threshold (resets/sec) for environment reset throughput.
+        step_profile: Collect cProfile hotspots from the measured step loop.
+        step_profile_limit: Number of hottest profiler rows to retain.
         enforce: When True, treat soft breaches as failures.
         on_ci: Override CI detection (defaults to GITHUB_ACTIONS env var).
 
@@ -521,21 +672,35 @@ def run_performance_smoke_test(  # noqa: PLR0913
         enforce if enforce is not None else os.environ.get("ROBOT_SF_PERF_ENFORCE", "0") == "1"
     )
     on_ci = on_ci if on_ci is not None else os.environ.get("GITHUB_ACTIONS", "").lower() == "true"
+    if step_profile and step_profile_limit <= 0:
+        raise ValueError("step_profile_limit must be greater than zero")
     config, scenario_label, scenario_metadata = _load_scenario_config(
         scenario, scenario_name=scenario_name
     )
     creation_time = measure_environment_creation(config)
     perf_metrics = measure_environment_performance(num_resets, config=config)
-    step_loop = measure_step_loop_performance(
-        step_samples,
-        config=config,
-        warmup_steps=warmup_steps,
-    )
-    step_profile = measure_step_profile(
+    step_profile_hotspots: list[dict[str, float | int | str | None]] | None = None
+    if step_profile:
+        step_loop, step_profile_hotspots = measure_step_loop_performance_with_profile(
+            step_samples=step_samples,
+            config=config,
+            warmup_steps=warmup_steps,
+            step_profile_limit=step_profile_limit,
+        )
+        if step_profile_hotspots is not None:
+            step_profile_hotspots = step_profile_hotspots[:step_profile_limit]
+    else:
+        step_loop = measure_step_loop_performance(
+            step_samples=step_samples,
+            config=config,
+            warmup_steps=warmup_steps,
+        )
+    step_profile_metrics = measure_step_profile(
         step_samples=step_samples,
         config=config,
         step_loop=step_loop,
         scenario_metadata=scenario_metadata,
+        step_profile_hotspots=step_profile_hotspots,
     )
     resets_per_sec = perf_metrics["resets_per_sec"]
 
@@ -589,7 +754,7 @@ def run_performance_smoke_test(  # noqa: PLR0913
         thresholds=thresholds,
         statuses=statuses,
         step_loop=step_loop,
-        step_profile=step_profile,
+        step_profile=step_profile_metrics,
         recommendations=recommendations,
         scenario=scenario_label or scenario,
         exit_code=exit_code,
@@ -658,6 +823,23 @@ def parse_args() -> argparse.Namespace:
             "unless --scenario or --step-samples override them."
         ),
     )
+    parser.add_argument(
+        "--step-profile",
+        action="store_true",
+        help=(
+            "Collect a compact cProfile hotspot slice from the measured step loop. "
+            "Profiling excludes warmup and environment setup/reset."
+        ),
+    )
+    parser.add_argument(
+        "--step-profile-limit",
+        type=int,
+        default=_DEFAULT_STEP_PROFILE_LIMIT,
+        help=(
+            f"Maximum number of profiler hotspots to include when --step-profile is set "
+            f"(default: {_DEFAULT_STEP_PROFILE_LIMIT})."
+        ),
+    )
     return parser.parse_args()
 
 
@@ -695,6 +877,8 @@ def main() -> int:  # noqa: C901
         warmup_steps=args.warmup_steps,
         scenario=args.scenario,
         scenario_name=args.scenario_name,
+        step_profile=args.step_profile,
+        step_profile_limit=args.step_profile_limit,
         include_recommendations=args.include_recommendations,
         creation_soft=creation_soft,
         creation_hard=creation_hard,
@@ -735,6 +919,13 @@ def main() -> int:  # noqa: C901
             f"Step profile: {result.step_profile.advisory=} gating={result.step_profile.gating} "
             f"scenario={result.step_profile.scenario_id} ped_count={result.step_profile.pedestrian_count}",
         )
+        if result.step_profile.step_profile_hotspots:
+            top = result.step_profile.step_profile_hotspots[0]
+            print(
+                "Top step hotspot: "
+                f"{top['name']} @ {top['file']}:{top['line']} "
+                f"cumtime={top['cumtime']:.3f}s ncalls={top['ncalls']}",
+            )
 
     if result.recommendations:
         print("\nRecommendations:")

--- a/tests/perf/test_large_crowd_step_profile_contract.py
+++ b/tests/perf/test_large_crowd_step_profile_contract.py
@@ -171,3 +171,171 @@ def test_large_crowd_step_profile_reuses_first_step_ped_count(monkeypatch) -> No
     )
 
     assert profile.pedestrian_count == 17
+
+
+def test_collect_step_profile_hotspots_is_stable_and_bounded() -> None:
+    """Ensure profiler hotspot ordering and truncation are deterministic."""
+
+    class _FakeProfile:
+        stats = {
+            ("pkg/a.py", 42, "low"): (0, 5, 0.010, 0.020, {}),
+            ("pkg/b.py", 12, "high"): (0, 2, 0.400, 0.600, {}),
+            ("pkg/c.py", 8, "mid"): (0, 3, 0.100, 0.600, {}),
+            ("pkg/d.py", 3, "other"): (0, 1, 0.050, 0.100, {}),
+            ("pkg/bad.py", 9, "bad"): ("invalid",),
+        }
+
+    hotspots = performance_smoke_test._collect_step_profile_hotspots(
+        _FakeProfile(),
+        limit=2,
+    )
+
+    assert len(hotspots) == 2
+    assert hotspots[0] == {
+        "file": "pkg/b.py",
+        "line": 12,
+        "name": "high",
+        "ncalls": 2,
+        "tottime": 0.4,
+        "cumtime": 0.6,
+    }
+    assert hotspots[1] == {
+        "file": "pkg/c.py",
+        "line": 8,
+        "name": "mid",
+        "ncalls": 3,
+        "tottime": 0.1,
+        "cumtime": 0.6,
+    }
+
+
+def test_collect_step_profile_hotspots_uses_portable_file_labels(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    """Profiler file labels should not leak machine-local absolute paths."""
+
+    monkeypatch.chdir(tmp_path)
+    repo_file = tmp_path / "robot_sf" / "gym_env" / "robot_env.py"
+    venv_file = (
+        tmp_path.parent
+        / "robot_sf_ll7"
+        / ".venv"
+        / "lib"
+        / "python3.12"
+        / "site-packages"
+        / "numba"
+        / "core"
+        / "dispatcher.py"
+    )
+    windows_venv_file = (
+        "C:\\Users\\runner\\robot_sf_ll7\\.venv\\Lib\\site-packages\\numpy\\core\\array.py"
+    )
+
+    class _FakeProfile:
+        stats = {
+            (str(repo_file), 819, "step"): (0, 20, 0.10, 1.00, {}),
+            (str(venv_file), 344, "_compile_for_args"): (0, 10, 0.20, 0.90, {}),
+            (windows_venv_file, 10, "array"): (0, 1, 0.05, 0.80, {}),
+        }
+
+    hotspots = performance_smoke_test._collect_step_profile_hotspots(
+        _FakeProfile(),
+        limit=3,
+    )
+
+    assert hotspots[0]["file"] == "robot_sf/gym_env/robot_env.py"
+    assert hotspots[1]["file"] == "site-packages/numba/core/dispatcher.py"
+    assert hotspots[2]["file"] == "site-packages/numpy/core/array.py"
+
+
+def test_large_crowd_step_profile_contract_with_step_profile_flag(monkeypatch) -> None:
+    """Step-profile mode appends top-k hotspots while preserving scenario metadata."""
+
+    repo_root = Path(__file__).resolve().parents[2]
+    scenario_path = repo_root / "configs/scenarios/single/dense_pedestrian_stress.yaml"
+    scenario_metadata = performance_smoke_test.ScenarioProfileMetadata(
+        scenario_id="dense_pedestrian_stress",
+        scenario_name="dense_pedestrian_stress",
+        scenario_path=str(scenario_path),
+        density="high",
+        density_advisory="diagnostic_stress_only",
+    )
+
+    monkeypatch.setattr(
+        performance_smoke_test,
+        "measure_environment_creation",
+        lambda config=None: 1.25,
+    )
+    monkeypatch.setattr(
+        performance_smoke_test,
+        "measure_environment_performance",
+        lambda num_resets=5, config=None: {
+            "resets_per_sec": 4.0,
+            "ms_per_reset": 250.0,
+            "total_resets": float(num_resets),
+            "total_time": 0.5,
+        },
+    )
+
+    loop_metrics = performance_smoke_test.StepLoopMetrics(
+        step_samples=20,
+        first_step_sec=0.2,
+        step_loop_sec=1.0,
+        steady_step_loop_sec=0.8,
+        steps_per_sec=20.0,
+        steady_steps_per_sec=23.75,
+        warmup_excluded=False,
+        warmup_first_step_sec=None,
+        warmup_step_loop_sec=None,
+        warmup_steps_per_sec=None,
+        measurement_mode="cold_only",
+        first_step_pedestrian_count=17,
+    )
+    profiler_hotspots = [
+        {"file": "sim.py", "line": 101, "name": "a", "ncalls": 1, "tottime": 0.20, "cumtime": 0.60},
+        {"file": "sim.py", "line": 50, "name": "c", "ncalls": 1, "tottime": 0.30, "cumtime": 0.60},
+        {"file": "sim.py", "line": 201, "name": "b", "ncalls": 2, "tottime": 0.05, "cumtime": 0.40},
+    ]
+
+    monkeypatch.setattr(
+        performance_smoke_test,
+        "measure_step_loop_performance_with_profile",
+        lambda step_samples=10, config=None, warmup_steps=0, step_profile_limit=10: (
+            loop_metrics,
+            profiler_hotspots,
+        ),
+    )
+    monkeypatch.setattr(
+        performance_smoke_test,
+        "_load_scenario_config",
+        lambda scenario, *, scenario_name=None: (
+            performance_smoke_test.RobotSimulationConfig(),
+            scenario_name or "dense_pedestrian_stress",
+            scenario_metadata,
+        ),
+    )
+
+    result = performance_smoke_test.run_performance_smoke_test(
+        num_resets=2,
+        step_samples=20,
+        scenario=str(scenario_path),
+        scenario_name="dense_pedestrian_stress",
+        step_profile=True,
+        step_profile_limit=2,
+        include_recommendations=False,
+        creation_soft=3.0,
+        creation_hard=8.0,
+        reset_soft=0.5,
+        reset_hard=0.2,
+        enforce=False,
+        on_ci=False,
+    )
+
+    payload = result.to_dict()
+    step_profile_payload = payload["step_profile"]
+    assert step_profile_payload is not None
+    assert step_profile_payload["step_profile_hotspots"][0]["name"] == "a"
+    assert step_profile_payload["step_profile_hotspots"][0]["cumtime"] == 0.6
+    assert step_profile_payload["step_profile_hotspots"][1]["name"] == "c"
+    assert len(step_profile_payload["step_profile_hotspots"]) == 2


### PR DESCRIPTION
## Summary
Adds optional `--step-profile` hotspot attribution to the performance smoke test so the #3025 large-crowd diagnostic path can report where measured step-loop time is spent.

## Linked Issues
- Relates to `#3025`

## Stack / Dependency
- Base dependency: PR #3121
- Required prior PRs: #3121
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: uses the `--large-crowd-profile` preset merged in #3121.

## What Changed
- Added `--step-profile` and `--step-profile-limit` to `scripts/validation/performance_smoke_test.py`.
- When enabled, the measured step loop is wrapped with `cProfile` and emits bounded `step_profile_hotspots` rows.
- Hotspot rows include portable `file`, `line`, `name`, `ncalls`, `tottime`, and `cumtime` fields.
- Extended `tests/perf/test_large_crowd_step_profile_contract.py` to cover ordering, truncation, portable path labels, and the end-to-end `step_profile` payload contract.

## Why It Matters
- Added value: turns the #3025 baseline from timing-only into actionable hotspot attribution.
- Expected impact: identifies whether cold-start/JIT, environment stepping, or downstream simulation calls dominate the large-crowd diagnostic path.
- Why this is worth merging now: it creates the evidence surface needed before choosing any optimization target.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3025 needs profiler-backed hotspot attribution before optimization.
- Comparator or baseline, if applicable: #3121 `--large-crowd-profile` timing-only baseline.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: do not optimize or claim speedup until a later PR includes before/after timing evidence.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3025 remains open.
- New research/benchmark/metric/paper-facing analysis tool, if any: support diagnostic helper; representative use is included below on tracked `configs/scenarios/single/dense_pedestrian_stress.yaml`.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes; `--step-profile` emitted 10 hotspot rows for `dense_pedestrian_stress`.
- Did the intervention change command source, selected command, trajectory, or route progress? no; it only records profiler metadata.
- Did the scenario actually contain the targeted failure mode? diagnostic-only high-density fixture; not benchmark evidence.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #3025 should use the hotspot output to choose a bounded optimization slice.

## Next Empirical Action
- Rerun needed: yes for any optimization claim, preferably with consistent warmup/sample settings.
- Extractor or analysis tool needed: no; this PR adds the hotspot extractor.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue with a small optimization PR only after reviewing hotspot stability.
- Proposed child issue or existing follow-up: existing #3025.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/performance_smoke_test.py --large-crowd-profile --step-profile --json-output /tmp/perf_large_crowd_step_hotspots_review.json`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/perf/test_large_crowd_step_profile_contract.py tests/validation/test_performance_smoke_test.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py tests/validation/test_performance_smoke_test.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py tests/validation/test_performance_smoke_test.py`
  - `git diff --check`
- Evidence that the change works here: smoke run passed with `scenario=dense_pedestrian_stress`, `ped_count=17`, 10 hotspot rows, and top hotspot `robot_sf/gym_env/robot_env.py:819`.
- Benchmarks or smoke tests, if applicable: targeted diagnostic smoke only; no benchmark-strength claim.

## Risks / Rollout
- Compatibility risks: low; profiling is opt-in and the default smoke path is unchanged.
- Failure modes: first-call JIT or import compilation can dominate rows; compare snapshots only with consistent warmup/sample settings.
- Rollback or fallback plan: omit `--step-profile` to retain the #3121 timing-only smoke behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: #3025 issue body.
- Any assumptions that need to be preserved: diagnostic-only; no optimization or speedup claim.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; PR links it.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: this is support diagnostic tooling, not durable benchmark evidence.

## Follow-Up Issues
- Deferred work: #3025 still needs an optimization slice with before/after timing and correctness validation.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: hotspot file labels should stay portable and bounded.
- Any known limitations: cProfile output is diagnostic and can be dominated by cold-start compilation unless warmup is used consistently.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional CPU profiling capability to performance measurements, enabling users to capture and analyze CPU hotspot data.
  * New CLI flags `--step-profile` and `--step-profile-limit` to enable profiling with configurable result limits.

* **Tests**
  * Added tests validating profiling determinism and cross-platform compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->