### PR TITLE
feat: warm large-crowd step profiling

### DIFF
--- a/scripts/validation/performance_smoke_test.py
+++ b/scripts/validation/performance_smoke_test.py
@@ -611,7 +611,7 @@ def run_performance_smoke_test(  # noqa: PLR0913
     *,
     num_resets: int = 5,
     step_samples: int = 10,
-    warmup_steps: int = 0,
+    warmup_steps: int | None = None,
     scenario: str | None = None,
     scenario_name: str | None = None,
     include_recommendations: bool = True,
@@ -632,6 +632,9 @@ def run_performance_smoke_test(  # noqa: PLR0913
         warmup_steps: Optional untimed steps before the measured loop. When non-zero,
             warm-start fields are populated and cold fields are flagged with
             ``warmup_excluded`` so callers do not treat them as cold-start timings.
+            When omitted, step-profile runs default this to one warmup step so
+            profiler hotspots emphasize steady-step work instead of first-step
+            compilation/setup; non-profile runs default to zero warmup steps.
         scenario: Optional scenario config path used to load a custom config.
         scenario_name: Optional scenario name/id to select from a multi-scenario config.
         include_recommendations: Include guidance strings in the result payload.
@@ -649,6 +652,8 @@ def run_performance_smoke_test(  # noqa: PLR0913
     """
     if step_samples <= 0:
         raise ValueError("step_samples must be greater than zero")
+    if warmup_steps is None:
+        warmup_steps = 1 if step_profile else 0
     if warmup_steps < 0:
         raise ValueError("warmup_steps must be non-negative")
 
@@ -784,10 +789,12 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--warmup-steps",
         type=int,
-        default=0,
+        default=None,
         help=(
             "Optional untimed simulator steps before measured attribution. "
-            "Non-zero values populate warm-start fields and set warmup_excluded=true."
+            "Defaults to 1 for --step-profile and 0 otherwise; explicit 0 keeps "
+            "cold-start profiling. Non-zero values populate warm-start fields and "
+            "set warmup_excluded=true."
         ),
     )
     parser.add_argument(
@@ -828,7 +835,8 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help=(
             "Collect a compact cProfile hotspot slice from the measured step loop. "
-            "Profiling excludes warmup and environment setup/reset."
+            "Profiling excludes environment setup/reset and uses one warmup step by "
+            "default unless --warmup-steps is explicit."
         ),
     )
     parser.add_argument(

--- a/tests/validation/test_performance_smoke_test.py
+++ b/tests/validation/test_performance_smoke_test.py
@@ -26,6 +26,63 @@ class _FakeStepEnv:
         self.closed = True
 
 
+def _patch_profile_smoke_measurements(
+    monkeypatch: pytest.MonkeyPatch,
+    called_args: dict[str, int],
+) -> None:
+    """Patch smoke-test dependencies so profile warmup routing can be asserted."""
+
+    def fake_measure_step_loop(
+        step_samples: int = 10,
+        config: object | None = None,
+        warmup_steps: int = 0,
+        step_profile_limit: int = 10,
+    ) -> tuple[performance_smoke_test.StepLoopMetrics, list[dict[str, object]]]:
+        called_args["warmup_steps"] = warmup_steps
+        return (
+            performance_smoke_test.StepLoopMetrics(
+                step_samples=step_samples,
+                first_step_sec=0.2,
+                step_loop_sec=0.1,
+                steady_step_loop_sec=0.1,
+                steps_per_sec=200.0,
+                steady_steps_per_sec=200.0,
+                warmup_excluded=True,
+                warmup_first_step_sec=0.1,
+                warmup_step_loop_sec=0.1,
+                warmup_steps_per_sec=10.0,
+                measurement_mode="cold_with_warmup",
+            ),
+            [],
+        )
+
+    monkeypatch.setattr(
+        performance_smoke_test,
+        "measure_environment_creation",
+        lambda config=None: 1.25,
+    )
+    monkeypatch.setattr(
+        performance_smoke_test,
+        "measure_environment_performance",
+        lambda num_resets=5, config=None: {
+            "resets_per_sec": 4.0,
+            "ms_per_reset": 250.0,
+            "total_resets": float(num_resets),
+            "total_time": 0.5,
+        },
+    )
+    monkeypatch.setattr(
+        performance_smoke_test,
+        "measure_step_loop_performance_with_profile",
+        fake_measure_step_loop,
+    )
+    monkeypatch.setattr(
+        performance_smoke_test,
+        "_measure_profile_pedestrian_count",
+        lambda config=None: 17,
+    )
+
+
 def test_performance_smoke_result_includes_step_loop_attribution(monkeypatch) -> None:
     """Smoke JSON should expose advisory startup/steady step attribution."""
 
@@ -126,6 +183,77 @@ def test_step_loop_warmup_fields_are_explicitly_separate(monkeypatch) -> None:
     assert payload["first_step_sec"] == pytest.approx(0.2)
     assert payload["warmup_step_loop_sec"] == pytest.approx(1.0)
     assert payload["step_loop_sec"] == pytest.approx(1.7)
+
+
+def test_run_performance_smoke_profile_injects_single_warmup_step(monkeypatch) -> None:
+    """Profile runs should warm up one unreported step by default."""
+
+    called_args: dict[str, int] = {}
+    _patch_profile_smoke_measurements(monkeypatch, called_args)
+
+    performance_smoke_test.run_performance_smoke_test(
+        num_resets=2,
+        step_samples=20,
+        step_profile=True,
+        step_profile_limit=5,
+        include_recommendations=False,
+        creation_soft=3.0,
+        creation_hard=8.0,
+        reset_soft=0.5,
+        reset_hard=0.2,
+        enforce=False,
+        on_ci=False,
+    )
+
+    assert called_args.get("warmup_steps") == 1
+
+
+def test_run_performance_smoke_profile_preserves_explicit_warmup_steps(monkeypatch) -> None:
+    """Explicit profile warmup settings should not be replaced by the default."""
+
+    called_args: dict[str, int] = {}
+    _patch_profile_smoke_measurements(monkeypatch, called_args)
+
+    performance_smoke_test.run_performance_smoke_test(
+        num_resets=2,
+        step_samples=20,
+        warmup_steps=3,
+        step_profile=True,
+        step_profile_limit=5,
+        include_recommendations=False,
+        creation_soft=3.0,
+        creation_hard=8.0,
+        reset_soft=0.5,
+        reset_hard=0.2,
+        enforce=False,
+        on_ci=False,
+    )
+
+    assert called_args.get("warmup_steps") == 3
+
+
+def test_run_performance_smoke_profile_preserves_explicit_zero_warmup(monkeypatch) -> None:
+    """Explicit zero warmup should keep cold-start profile attribution available."""
+
+    called_args: dict[str, int] = {}
+    _patch_profile_smoke_measurements(monkeypatch, called_args)
+
+    performance_smoke_test.run_performance_smoke_test(
+        num_resets=2,
+        step_samples=20,
+        warmup_steps=0,
+        step_profile=True,
+        step_profile_limit=5,
+        include_recommendations=False,
+        creation_soft=3.0,
+        creation_hard=8.0,
+        reset_soft=0.5,
+        reset_hard=0.2,
+        enforce=False,
+        on_ci=False,
+    )
+
+    assert called_args.get("warmup_steps") == 0
 
 
 def test_telemetry_snapshot_includes_step_loop_attribution(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- make `--step-profile` automatically run one untimed warmup step when no explicit `--warmup-steps` is provided
- document the profile-mode warmup behavior in the function contract and CLI help
- add tests covering default profile warmup injection and preservation of explicit warmup counts

## Issue

Refs #3025. This is a diagnostic-only continuation: it makes large-crowd step profiling surface steady-step hotspots instead of first-step compilation overhead. It does not claim a simulator speedup.

## Evidence

- Before this slice, the large-crowd step profile was dominated by first-step compilation paths (`numba/core/dispatcher.py`), with top `robot_sf/gym_env/robot_env.py:819 step` around 5.49s cumulative.
- After this slice, `/tmp/3025_hotspot_after_reviewfix.json` showed `measurement_mode=cold_with_warmup`, `warmup_first_step_sec=3.189s`, measured `first_step_sec=0.001s`, `step_loop_sec=0.012s`, scenario `dense_pedestrian_stress`, `pedestrian_count=17`, and steady-step hotspots under `robot_sf/gym_env/robot_env.py` and `robot_sf/sim/simulator.py`.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/perf/test_large_crowd_step_profile_contract.py tests/validation/test_performance_smoke_test.py -q` (13 passed)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py tests/validation/test_performance_smoke_test.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py tests/validation/test_performance_smoke_test.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/performance_smoke_test.py --large-crowd-profile --step-profile --json-output /tmp/3025_hotspot_after_reviewfix.json`
- `git diff --check`

## Downstream Propagation

- Parent issue #3025 remains open because this only clarifies steady-step profiling; it does not implement a runtime optimization.
- Follow-up created: #3123 tracks an explicit cold-start/first-step profile mode for JIT/setup overhead rather than steady-step hotspots.

## Research Result Guidance

- target claim/hypothesis/blocker: #3025 hypothesis that large-crowd step bottlenecks can be identified before optimization.
- comparator/baseline: existing `--large-crowd-profile --step-profile` output, which was dominated by first-step compilation overhead.
- evidence tier: diagnostic tooling evidence only.
- result classification: diagnostic progress; no benchmark-strength speedup claim.
- decision/stop rule: steady-step hotspots are now visible; runtime optimization remains a later #3025 slice.
- synthesis surface/update target: parent issue #3025 and follow-up issue #3123.
