### PR TITLE
feat: add cold-start step profile mode

### DIFF
--- a/scripts/validation/performance_smoke_test.py
+++ b/scripts/validation/performance_smoke_test.py
@@ -53,6 +53,9 @@ _DEFAULT_STEP_SAMPLES = 10
 _LARGE_CROWD_PROFILE_SCENARIO = "configs/scenarios/single/dense_pedestrian_stress.yaml"
 _LARGE_CROWD_PROFILE_STEP_SAMPLES = 20
 _DEFAULT_STEP_PROFILE_LIMIT = 10
+_STEP_PROFILE_MODE_STEADY = "steady"
+_STEP_PROFILE_MODE_COLD_START = "cold-start"
+_STEP_PROFILE_MODES = {_STEP_PROFILE_MODE_STEADY, _STEP_PROFILE_MODE_COLD_START}
 
 
 @dataclass(slots=True)
@@ -620,6 +623,7 @@ def run_performance_smoke_test(  # noqa: PLR0913
     reset_soft: float | None = None,
     reset_hard: float | None = None,
     step_profile: bool = False,
+    step_profile_mode: str | None = None,
     step_profile_limit: int = _DEFAULT_STEP_PROFILE_LIMIT,
     enforce: bool | None = None,
     on_ci: bool | None = None,
@@ -643,6 +647,10 @@ def run_performance_smoke_test(  # noqa: PLR0913
         reset_soft: Soft threshold (resets/sec) for environment reset throughput.
         reset_hard: Hard threshold (resets/sec) for environment reset throughput.
         step_profile: Collect cProfile hotspots from the measured step loop.
+        step_profile_mode: Controls default warmup behavior for step-profile runs
+            when ``warmup_steps`` is omitted. ``steady`` performs one default
+            warmup step. ``cold-start`` uses zero warmup steps so first-step
+            timing includes setup/JIT overhead.
         step_profile_limit: Number of hottest profiler rows to retain.
         enforce: When True, treat soft breaches as failures.
         on_ci: Override CI detection (defaults to GITHUB_ACTIONS env var).
@@ -652,8 +660,11 @@ def run_performance_smoke_test(  # noqa: PLR0913
     """
     if step_samples <= 0:
         raise ValueError("step_samples must be greater than zero")
-    if warmup_steps is None:
-        warmup_steps = 1 if step_profile else 0
+    warmup_steps = _resolve_step_profile_warmup_steps(
+        step_profile=step_profile,
+        step_profile_mode=step_profile_mode,
+        warmup_steps=warmup_steps,
+    )
     if warmup_steps < 0:
         raise ValueError("warmup_steps must be non-negative")
 
@@ -792,8 +803,9 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help=(
             "Optional untimed simulator steps before measured attribution. "
-            "Defaults to 1 for --step-profile and 0 otherwise; explicit 0 keeps "
-            "cold-start profiling. Non-zero values populate warm-start fields and "
+            "When omitted, this default depends on --step-profile-mode; explicit "
+            "values still apply regardless. Non-zero values populate warm-start "
+            "fields and "
             "set warmup_excluded=true."
         ),
     )
@@ -835,8 +847,17 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help=(
             "Collect a compact cProfile hotspot slice from the measured step loop. "
-            "Profiling excludes environment setup/reset and uses one warmup step by "
-            "default unless --warmup-steps is explicit."
+            "Profiling excludes environment setup/reset by default."
+        ),
+    )
+    parser.add_argument(
+        "--step-profile-mode",
+        choices=("steady", "cold-start"),
+        default="steady",
+        help=(
+            "Step-profile warmup mode (default: steady). "
+            "'steady' runs one untimed warmup step before measured profiling; "
+            "'cold-start' runs the profiler without warmup."
         ),
     )
     parser.add_argument(
@@ -849,6 +870,27 @@ def parse_args() -> argparse.Namespace:
         ),
     )
     return parser.parse_args()
+
+
+def _resolve_step_profile_warmup_steps(
+    *,
+    step_profile: bool,
+    step_profile_mode: str | None,
+    warmup_steps: int | None,
+) -> int:
+    """Resolve omitted profile warmup defaults without replacing explicit values."""
+
+    if warmup_steps is not None:
+        return warmup_steps
+    if step_profile_mode is None:
+        step_profile_mode = _STEP_PROFILE_MODE_STEADY
+    if step_profile_mode not in _STEP_PROFILE_MODES:
+        raise ValueError("step_profile_mode must be one of: steady, cold-start")
+    if not step_profile:
+        return 0
+    if step_profile_mode == _STEP_PROFILE_MODE_COLD_START:
+        return 0
+    return 1
 
 
 def main() -> int:  # noqa: C901
@@ -886,6 +928,7 @@ def main() -> int:  # noqa: C901
         scenario=args.scenario,
         scenario_name=args.scenario_name,
         step_profile=args.step_profile,
+        step_profile_mode=args.step_profile_mode,
         step_profile_limit=args.step_profile_limit,
         include_recommendations=args.include_recommendations,
         creation_soft=creation_soft,

--- a/tests/validation/test_performance_smoke_test.py
+++ b/tests/validation/test_performance_smoke_test.py
@@ -185,8 +185,10 @@ def test_step_loop_warmup_fields_are_explicitly_separate(monkeypatch) -> None:
     assert payload["step_loop_sec"] == pytest.approx(1.7)
 
 
-def test_run_performance_smoke_profile_injects_single_warmup_step(monkeypatch) -> None:
-    """Profile runs should warm up one unreported step by default."""
+def test_run_performance_smoke_profile_injects_single_warmup_step_for_steady_mode(
+    monkeypatch,
+) -> None:
+    """Steady profile mode should warm up one unreported step by default."""
 
     called_args: dict[str, int] = {}
     _patch_profile_smoke_measurements(monkeypatch, called_args)
@@ -206,6 +208,30 @@ def test_run_performance_smoke_profile_injects_single_warmup_step(monkeypatch) -
     )
 
     assert called_args.get("warmup_steps") == 1
+
+
+def test_run_performance_smoke_profile_cold_start_mode_uses_zero_warmup(monkeypatch) -> None:
+    """Cold-start step-profile mode should route with zero warmup steps."""
+
+    called_args: dict[str, int] = {}
+    _patch_profile_smoke_measurements(monkeypatch, called_args)
+
+    performance_smoke_test.run_performance_smoke_test(
+        num_resets=2,
+        step_samples=20,
+        step_profile=True,
+        step_profile_mode="cold-start",
+        step_profile_limit=5,
+        include_recommendations=False,
+        creation_soft=3.0,
+        creation_hard=8.0,
+        reset_soft=0.5,
+        reset_hard=0.2,
+        enforce=False,
+        on_ci=False,
+    )
+
+    assert called_args.get("warmup_steps") == 0
 
 
 def test_run_performance_smoke_profile_preserves_explicit_warmup_steps(monkeypatch) -> None:
@@ -243,6 +269,44 @@ def test_run_performance_smoke_profile_preserves_explicit_zero_warmup(monkeypatc
         step_samples=20,
         warmup_steps=0,
         step_profile=True,
+        step_profile_limit=5,
+        include_recommendations=False,
+        creation_soft=3.0,
+        creation_hard=8.0,
+        reset_soft=0.5,
+        reset_hard=0.2,
+        enforce=False,
+        on_ci=False,
+    )
+
+    assert called_args.get("warmup_steps") == 0
+
+
+def test_run_performance_smoke_profile_rejects_unknown_mode() -> None:
+    """Unknown step-profile modes should fail before measurement starts."""
+
+    with pytest.raises(ValueError, match="step_profile_mode"):
+        performance_smoke_test.run_performance_smoke_test(
+            step_profile=True,
+            step_profile_mode="startup",
+            include_recommendations=False,
+        )
+
+
+def test_run_performance_smoke_profile_explicit_warmup_ignores_unknown_mode(
+    monkeypatch,
+) -> None:
+    """Explicit warmup settings should win before mode validation."""
+
+    called_args: dict[str, int] = {}
+    _patch_profile_smoke_measurements(monkeypatch, called_args)
+
+    performance_smoke_test.run_performance_smoke_test(
+        num_resets=2,
+        step_samples=20,
+        warmup_steps=0,
+        step_profile=True,
+        step_profile_mode="startup",
         step_profile_limit=5,
         include_recommendations=False,
         creation_soft=3.0,


### PR DESCRIPTION
## Summary

- add `--step-profile-mode {steady,cold-start}` to make cold-start step profiling explicit
- preserve the default steady profile behavior: omitted warmup plus `--step-profile` still uses one warmup step
- add focused tests for steady mode, cold-start mode, explicit warmup preservation, explicit zero warmup, and unknown-mode rejection

## Issue

Closes #3123. This is diagnostic tooling only; it does not claim a simulator speedup.

## Evidence

- `--step-profile-mode cold-start` now routes with zero warmup when `--warmup-steps` is omitted.
- `/tmp/3123_cold_start_profile.json` showed `measurement_mode=cold_only`, `warmup_excluded=false`, `first_step_sec=5.518s`, `step_loop_sec=5.529s`, `steady_step_loop_sec=0.011s`, scenario `dense_pedestrian_stress`, `pedestrian_count=17`, and top hotspot `robot_sf/gym_env/robot_env.py:819 step`.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py -q` (16 passed)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/performance_smoke_test.py tests/validation/test_performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/performance_smoke_test.py tests/validation/test_performance_smoke_test.py tests/perf/test_large_crowd_step_profile_contract.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/performance_smoke_test.py --large-crowd-profile --step-profile --step-profile-mode cold-start --json-output /tmp/3123_cold_start_profile.json`
- `git diff --check`

## Downstream Propagation

- #3123 should close on merge.
- Parent #3025 remains open because this adds the missing cold-start diagnostic mode; runtime optimization remains separate work.

## Research Result Guidance

- target claim/hypothesis/blocker: distinguish cold-start/JIT profile attribution from steady-step profile attribution for #3025.
- comparator/baseline: previous workflow required knowing to pass `--warmup-steps 0`; now a named mode expresses the intent.
- evidence tier: diagnostic tooling evidence only.
- result classification: support/tooling completion for #3123; no benchmark-strength speedup claim.
- decision/stop rule: cold-start mode emits `cold_only`/`warmup_excluded=false` and captures first-step hotspots.
- synthesis surface/update target: #3123 closed; #3025 remains the parent optimization surface.
