### PR TITLE
docs: classify AMV actuation feasibility ranking

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -133,6 +133,11 @@ records the analysis-only report path from canonical campaign result stores, wit
 evidence showing row-status caveats, denominators, metric summaries, visual summaries, and
 descriptive statistical hooks.
 
+Recent AMV actuation feasibility ranking: [issue_2446_amv_feasibility_ranking.md](issue_2446_amv_feasibility_ranking.md)
+records the diagnostic-only conclusion that actuation feasibility is a secondary ranking signal for
+the matched AMV actuation-smoke pair, not planner-improvement, benchmark, hardware-calibration, or
+paper-facing evidence.
+
 ## Context-Pack Manifests
 
 Generated packs are temporary artifacts and should stay under ignored paths such as

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1086,6 +1086,9 @@ knowledge, not every transient iteration detail.
 * [Issue #2443 AMV Actuation Trace Review](issue_2443_amv_trace_review.md)
   records the compact progress-vs-clipping review for the matched AMV actuation-smoke pair and
   fails closed on missing raw frame/event IDs.
+* [Issue #2446 AMV Actuation Feasibility Ranking](issue_2446_amv_feasibility_ranking.md)
+  classifies actuation feasibility as a diagnostic secondary ranking signal for the matched AMV
+  actuation-smoke pair without upgrading it to planner-improvement or benchmark evidence.
 * [Issue #2440 AMV Timeout Closure](issue_2440_amv_timeout_closure.md)
   closes the timeout-driver classification as `feasibility_improved_but_route_blocked` and keeps
   actuation-aware scoring diagnostic-only for planner improvement.

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -309,6 +309,10 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/issue_2446_amv_feasibility_ranking.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/issue_2522_why_first_diagnostics.md
     status: current
     freshness: evidence

--- a/docs/context/issue_2446_amv_feasibility_ranking.md
+++ b/docs/context/issue_2446_amv_feasibility_ranking.md
@@ -1,0 +1,97 @@
+# Issue #2446 AMV Actuation Feasibility Ranking 2026-06-19
+
+Status: diagnostic-only analysis (`analysis_only`), not benchmark or paper-facing evidence.
+
+Related:
+- GitHub issue: https://github.com/ll7/robot_sf_ll7/issues/2446
+- Timeout-driver closure: [issue_2440_amv_timeout_closure.md](issue_2440_amv_timeout_closure.md)
+- Trace review predecessor: [issue_2443_amv_trace_review.md](issue_2443_amv_trace_review.md)
+- AMV trace-boundary decision: [issue_2531_amv_trace_boundary.md](issue_2531_amv_trace_boundary.md)
+
+```yaml
+amv_feasibility_dimension:
+  source_issues:
+    - 2224
+    - 2259
+    - 2268
+    - 2308
+    - 2404
+    - 2440
+    - 2443
+    - 2522
+    - 2531
+  compared_candidates:
+    scenario: classic_cross_trap_high
+    seed: 101
+    stage: amv_actuation_smoke
+    horizon: 80
+    synthetic_actuation_profile: amv-actuation-stress-v0
+    baseline:
+      candidate: hybrid_rule_v3_fast_progress
+      success_rate: 0.0
+      collision_rate: 0.0
+      timeout_mode: timeout_low_progress
+      command_clip_fraction: 0.2750
+      command_clip_steps: 22
+      yaw_saturation_fraction: 0.0
+      mean_avg_speed_m_s: 1.662309936770821
+      final_route_progress_m: 12.904024665994093
+      final_distance_to_goal_m: 3.6078725186171776
+    intervention:
+      candidate: actuation_aware_hybrid_rule_v0
+      success_rate: 0.0
+      collision_rate: 0.0
+      timeout_mode: timeout_low_progress
+      command_clip_fraction: 0.1875
+      command_clip_steps: 15
+      yaw_saturation_fraction: 0.0
+      mean_avg_speed_m_s: 1.667037499328765
+      final_route_progress_m: 12.87191147075262
+      final_distance_to_goal_m: 3.639985713858651
+    deltas_intervention_minus_baseline:
+      command_clip_fraction: -0.0875
+      command_clip_steps: -7
+      yaw_saturation_fraction: 0.0
+      mean_avg_speed_m_s: +0.004727562557943961
+      final_route_progress_m: -0.032113195241472634
+      final_distance_to_goal_m: +0.03211319524147352
+      last_10_step_progress_delta_m: +0.12100258841798175
+  success_ordering:
+    outcome: no_ranking_difference
+    reason: both candidates failed on identical mechanism class and success metrics
+    ordered_candidates:
+      - hybrid_rule_v3_fast_progress
+      - actuation_aware_hybrid_rule_v0
+    note: equal on success, collision, and timeout mode for this matched row
+  feasibility_ordering:
+    ordering:
+      - actuation_aware_hybrid_rule_v0
+      - hybrid_rule_v3_fast_progress
+    reason: feasibility metrics improved (fewer clips, lower clip fraction) while terminal metrics stayed static
+  disagreement_cases:
+    - type: feasibility_success_divergence
+      summary: command clipping improved (-0.0875 fraction, -7 steps) but timeout mode and success remained identical
+    - type: feasibility_speed_vs_progress
+      summary: mean speed was nearly unchanged (+0.0047 m/s), yet final progress/distance moved slightly against the intervention (+0.0321 m farther from goal)
+    - type: feasibility_trace_limit
+      summary: route/task progress blocking appears primary; raw simulation_trace_export.v1 frame/event IDs are blocked in compact artifacts
+  diagnostic_value: diagnostic ranking signal
+  planner_objective_recommendation:
+    objective_fit: diagnostic-only_feasibility_ranking
+    recommendation:
+      - keep actuation-aware candidate as a feasibility-aware secondary ranking axis under a fixed success/collision/timeout objective
+      - do not treat feasibility gains as planner improvement until route-progress geometry or task-completion blocker is addressed
+      - no planner-ranking or paper-facing claim from this slice
+```
+
+This issue-level synthesis is diagnostic-only and uses existing tracked artifacts from #2440, #2443, and related AMV actuation closure/decomposition threads. Feasibility remains informative for secondary ordering among tied terminal outcomes, but it does **not** invert success interpretation on this matched slice.
+
+## Interpretation Boundary
+
+- The source row is a matched `classic_cross_trap_high` seed `101` AMV actuation-smoke slice, not a
+  broad benchmark rerun.
+- The feasibility ordering is useful only as a secondary diagnostic dimension when primary
+  terminal outcomes are tied.
+- The compact artifacts do not include raw `simulation_trace_export.v1` frame/event IDs, so the
+  route-blocker interpretation remains summary-timeline-limited.
+- This note makes no calibrated AMV hardware, planner-ranking, or paper-facing claim.


### PR DESCRIPTION
## Summary
Adds a diagnostic-only AMV actuation-feasibility ranking note for issue #2446.

Closes #2446.

## What Changed
- Added `docs/context/issue_2446_amv_feasibility_ranking.md` with the required `amv_feasibility_dimension` YAML shape.
- Classified feasibility metrics as a secondary diagnostic ranking signal on the matched AMV actuation-smoke row.
- Linked the new note from `docs/context/INDEX.md`, `docs/context/README.md`, and `docs/context/catalog.yaml`.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: whether AMV actuation-feasibility metrics change interpretation relative to success/collision/timeout alone.
- Comparator or baseline: `hybrid_rule_v3_fast_progress` vs `actuation_aware_hybrid_rule_v0` on `classic_cross_trap_high` seed `101`.
- Evidence tier: analysis-only.
- Result classification: diagnostic ranking signal.
- Decision or stop rule: use feasibility as a secondary tiebreaking/evaluation dimension only; do not treat this slice as planner-improvement, benchmark, hardware-calibration, or paper-facing evidence.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #2446 and `docs/context/` discoverability surfaces.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no tool added.

## Validation / Proof
- `git diff --check`
- `scripts/dev/check_docs_proof_consistency_diff.sh`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/issue_2446_amv_feasibility_ranking.md --path docs/context/INDEX.md --path docs/context/README.md --path docs/context/catalog.yaml`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -c 'from pathlib import Path; import re, yaml; text=Path("docs/context/issue_2446_amv_feasibility_ranking.md").read_text(); m=re.search(r"```yaml\n(.*?)\n```", text, re.S); assert m; data=yaml.safe_load(m.group(1)); assert data["amv_feasibility_dimension"]["diagnostic_value"] == "diagnostic ranking signal"; print("yaml_parse_ok")'`

## Risks / Rollout
- This PR is docs/evidence only and makes no runtime or benchmark-runner changes.
- Active PR #3127 also touches `docs/context/INDEX.md`, `docs/context/README.md`, and `docs/context/catalog.yaml`; whichever PR merges second may need a small refresh from `origin/main`.
- The source artifacts are compact summaries without raw `simulation_trace_export.v1` frame/event IDs, so the route-blocker interpretation remains summary-timeline-limited.

## Downstream Propagation
- Parent issue updated: PR closes #2446.
- Claim map / benchmark report updated: NA - analysis-only diagnostic note.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: yes, `docs/context/INDEX.md`, `docs/context/README.md`, and `docs/context/catalog.yaml`.
- Follow-up issue opened for deferred propagation: none.
