### PR TITLE
docs: unify SLURM traceability checklist

### DIFF
--- a/.agents/skills/goal-slurm-experiment/SKILL.md
+++ b/.agents/skills/goal-slurm-experiment/SKILL.md
@@ -139,11 +139,16 @@ about what the repository believes now rather than what to submit next.
    - Submit through existing wrappers such as `scripts/dev/sbatch_use_max_time.sh` or a
      candidate-specific helper under `scripts/dev/`.
    - Use a short skill-owned job name: `gse-<issue>-<slug>`.
-   - Capture job id, branch, commit, config path, SLURM script, output root, and stdout/stderr path.
+   - Capture job id, branch, commit, config path, SLURM script, output root, partition, and stdout/stderr path.
    - For long-running training, capture the predeclared early-stop criteria from the experiment card
      or launch packet: metric, threshold, check cadence, minimum runtime/timesteps, cancel
      condition, and diagnostic-preservation action.
-   - Immediately check `squeue`, `sacct`, and early stderr when the job starts.
+   - Immediately run health checks (`squeue`, `sacct`, and early stderr tail) after submission.
+   - Apply the shared traceability checklist in `docs/dev/slurm_submission.md`.
+     - A job is only `submitted` when the immediate health check and the issue/PR traceability update
+       (or private-ledger handoff) are complete.
+     - If immediate health or traceability update fails, classify the run as `partial_traceable` or
+       `blocked` instead of cleanly submitted.
 
 8. Monitor with long, low-churn intervals.
    - Estimate remaining wall time from observed timesteps/throughput, configured horizon, and eval
@@ -163,10 +168,13 @@ about what the repository believes now rather than what to submit next.
    - Keep interim metrics labeled as live training state, not benchmark or guarded-policy evidence.
 
 9. Record the handoff.
-   - Comment on the issue or update the relevant context note with the job id, branch, commit,
-     config, logs, output root, durable artifact status, validation status, and next action.
-   - Keep local `output/` paths labeled as non-durable until `artifact-provenance` classifies or
-     promotes them.
+   - Comment on the issue with the shared checklist fields (job id, partition, branch, commit,
+     config, logs/output root, immediate health check outcome, next action, ledger reference, and finalizer
+     status) and keep private mechanics in private ops records.
+   - Keep local `output/` paths labeled as non-durable until `artifact-provenance` classifies or promotes
+     them.
+   - Record finalizer result and artifact status in the run record so route completion is separated from
+     evidence maturity.
 
 ## Candidate Policy
 
@@ -215,6 +223,8 @@ Use `skill_run_summary.v1` or a compact equivalent. Include:
   `completed_needs_analysis`, `blocked_dependency`, or `analysis_only`.
 - `validation_route`: `local_preflight`, `slurm_pr_gate`, `training_submission`, plus what passed,
   failed, or was deferred.
-- `submission`: job id, command surface, output root, log paths, and immediate health check result
-  when a job was submitted.
+- `submission`: job id, command surface, partition, output root, log paths, immediate health check result,
+  and finalizer result when a job was submitted.
+- `submission_record`: issue/PR comment id, private ledger reference, artifact status, and submission
+  classification (`submitted`, `partial_traceable`, or `blocked`).
 - `next_action`: the one concrete follow-up for the user or next agent.

--- a/.agents/skills/slurm-campaign-submit/SKILL.md
+++ b/.agents/skills/slurm-campaign-submit/SKILL.md
@@ -52,9 +52,15 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
    shows the intended config, launcher, job name, output root, and duplicate-check evidence.
 8. Submit non-queue campaigns with explicit config and job name; capture job ID plus stdout/stderr paths.
 9. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
-10. Classify status as `submitted`, `blocked`, or `failed_preflight`; classify failures as config, cluster capacity, wrapper, dependency, or unknown.
-11. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
-12. After completion or predeclared cancellation, route results before rerunning:
+10. Classify pre-health status as `route_accepted`, `blocked`, or `failed_preflight`; classify
+    failures as config, cluster capacity, wrapper, dependency, or unknown.
+11. Immediately run a submission health check (`squeue`, `sacct`, initial stderr availability) and apply the
+    shared checklist in `docs/dev/slurm_submission.md`.
+12. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
+13. A clean `submitted` state requires both immediate health-check success and the checklist traceability update
+    (issue/PR comment plus private-ledger or handoff reference). `sbatch`/`sacct` acceptance alone is only
+    route evidence and does not imply benchmark or report proof.
+14. After completion or predeclared cancellation, route results before rerunning:
     - cancelled runs may be diagnostic evidence only when the early-stop criteria were declared and
       the configured preservation action captured logs, manifest, config, commit, and artifact
       status;
@@ -72,6 +78,7 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
 - Do not treat a queued job as completed evidence.
 - Do not cancel a low-signal training job as diagnostic evidence unless the early-stop rule was
   predeclared and the diagnostic-preservation action has been completed.
+- Do not treat `sbatch` output or acceptance as final submission proof.
 - Do not treat a `resource:slurm` issue as runnable when its latest comments require durable
   artifact pointers, exact commits, maintainer confirmation, or a concrete launcher first.
 - Do not let an issue's `slurm` label override the suitability gate. A `slurm` label means the
@@ -95,3 +102,6 @@ Use `campaign_submission.v1`. Include:
 - `runtime_basis`: the rows/seeds/scenarios/horizon/workers calculation or preflight source;
 - `local_default_overridden`: `true` only when a sub-1-hour run still has a compute-node-only reason;
 - `evidence_claim`: `smoke`, `compatibility`, `campaign`, or `blocked`.
+- `submission_record`: issue/PR reference, partition, finalizer outcome, private ledger reference,
+  final health-check status, and artifact status.
+- `submission_state`: `submitted`, `partial_traceable`, or `blocked`.

--- a/.agents/skills/slurm-campaign-submit/SKILL.md
+++ b/.agents/skills/slurm-campaign-submit/SKILL.md
@@ -53,12 +53,14 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
 8. Submit non-queue campaigns with explicit config and job name; capture job ID plus stdout/stderr paths.
 9. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
 10. Classify pre-health status as `route_accepted`, `blocked`, or `failed_preflight`; classify
-    failures as config, cluster capacity, wrapper, dependency, or unknown.
+    successful route acceptance with missing issue/PR or private-ledger traceability as
+    `partial_traceable`; classify failures as config, cluster capacity, wrapper, dependency, or unknown.
 11. Immediately run a submission health check (`squeue`, `sacct`, initial stderr availability) and apply the
     shared checklist in `docs/dev/slurm_submission.md`.
 12. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
 13. A clean `submitted` state requires both immediate health-check success and the checklist traceability update
-    (issue/PR comment plus private-ledger or handoff reference). `sbatch`/`sacct` acceptance alone is only
+    (issue/PR comment plus private-ledger or handoff reference). If route acceptance succeeds but
+    either traceability record is missing, keep `partial_traceable`. `sbatch`/`sacct` acceptance alone is only
     route evidence and does not imply benchmark or report proof.
 14. After completion or predeclared cancellation, route results before rerunning:
     - cancelled runs may be diagnostic evidence only when the early-stop criteria were declared and

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -150,7 +150,7 @@ fields in public surfaces and private-only fields in private surfaces.
 Submission state rules:
 
 - `sbatch`/`sacct` success or a job id is route evidence only.
-- `submitted` only when immediate health check plus issue/PR + private-ops traceability are both complete.
+- Use `submitted` only when the immediate health check succeeds and both traceability records are complete.
 - If either route traceability step is missing, use `partial_traceable` and keep status explicitly blocked.
 - Public issue/PR comments may include job id and partition for traceability, but must not include private host
   names, account/QoS details, scratch paths, or private retrieval mechanics.

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -62,8 +62,9 @@ launcher, seed set, commit or declared code version, target cluster, job name, o
 duplicate blocks `--submit`; reruns should use a new queue id, changed output root, and documented
 reason.
 
-Final reports should include the generated manifest path, job id, cluster/host, command, branch,
-commit SHA, config, launcher, seed set, output/log paths, skipped entries, and monitoring command.
+Final reports should include the generated manifest path, job id, public partition or cluster label,
+command, branch, commit SHA, config, launcher, seed set, output/log paths, skipped entries,
+monitoring command, and private ledger reference when applicable.
 
 ## Examples
 
@@ -113,6 +114,46 @@ scripts/dev/sbatch_use_max_time.sh --time 08:00:00 SLURM/templates/gpu_training.
   the wrapper can resolve the correct limit without extra flags.
 - If Slurm tools are unavailable in the current shell, fall back to a manual `sbatch`
   command with an explicit `--time`.
+
+## Shared SLURM Traceability Checklist
+
+Use this single checklist for public issue/PR comments and private-ops ledger/handoff updates.
+Do not duplicate fields into separate public/private lists; use the same checklist with public-safe
+fields in public surfaces and private-only fields in private surfaces.
+
+- Submission intent
+  - issue/PR reference
+  - experiment intent or hypothesis
+  - expected evidence tier (`smoke`, `probe`, `campaign`, or diagnostic)
+- Launch identity
+  - command surface and launcher path
+  - config path or exact snapshot
+  - branch, commit, and dirty-tree status
+  - partition and job name
+- Route and health evidence
+  - submitted job id
+  - immediate route check outcome (`squeue`, `sacct`, earliest stderr/early log tail)
+  - submitter finalizer command and exit/result
+  - queue/duplicate gate status (satisfied or reason blocked)
+- Public/Private trace
+  - issue/PR comment id and posted fields (job id, partition, branch, commit, config, outputs)
+  - private ops ledger/handoff reference (or equivalent private record)
+- Output and artifacts
+  - output root
+  - manifest path, checkpoints, report path, and artifact status (`non_durable`, `durable`,
+    `promoted`, or `discarded`)
+- Completion and follow-up
+  - run classification (`completed_needs_analysis`, `diagnostic`, `failed_preflight`, `blocked`,
+    `partial_traceable`)
+  - next action and rerun decision
+
+Submission state rules:
+
+- `sbatch`/`sacct` success or a job id is route evidence only.
+- `submitted` only when immediate health check plus issue/PR + private-ops traceability are both complete.
+- If either route traceability step is missing, use `partial_traceable` and keep status explicitly blocked.
+- Public issue/PR comments may include job id and partition for traceability, but must not include private host
+  names, account/QoS details, scratch paths, or private retrieval mechanics.
 
 ## Multiple branches from one login node
 


### PR DESCRIPTION
## Summary
Adds one shared SLURM traceability checklist and aligns the public SLURM skills around it.

Closes #2647.

## What Changed
- Added a shared SLURM traceability checklist to `docs/dev/slurm_submission.md`.
- Updated `goal-slurm-experiment` and `slurm-campaign-submit` so `submitted` means immediate health check plus issue/PR traceability and private ledger/handoff reference where applicable.
- Clarified that `sbatch`/`sacct` acceptance is route evidence only, not benchmark/report proof.
- Clarified that public issue/PR comments may include job id and partition, while private hostnames, account/QoS details, scratch paths, and private retrieval mechanics stay in private ops.
- Added finalizer result and artifact status to the run-record expectations.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow documentation and skill guidance only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: docs/workflow guidance.
- Result classification: NA - no research result claimed.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2647.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no tool added.

## Validation / Proof
- `git diff --check`
- `uv run python scripts/dev/check_skills.py`
- `uv run python scripts/tools/sync_ai_config.py --check`
- `uv run python scripts/dev/check_skills.py --preflight goal-slurm-experiment` failed as expected on this non-SLURM host because `sbatch` is not on PATH.
- `uv run python scripts/dev/check_skills.py --preflight slurm-campaign-submit` failed as expected on this non-SLURM host because `sbatch` is not on PATH.

## Risks / Rollout
- This is workflow documentation only; no SLURM jobs were submitted.
- The new checklist should be sanity-checked from a SLURM login node before treating the SLURM preflight route as fully proven.
- Private operational details were intentionally not copied into public docs.

## Docs / Provenance
- Updated docs: `docs/dev/slurm_submission.md`.
- Updated skills: `.agents/skills/goal-slurm-experiment/SKILL.md`, `.agents/skills/slurm-campaign-submit/SKILL.md`.
- Maintainer decisions from #2647 comments are preserved in the checklist semantics.

## Downstream Propagation
- Parent issue updated: PR closes #2647.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA - workflow docs/skills only.
- Follow-up issue opened for deferred propagation: none.
- Not applicable because: no research claim or benchmark artifact was produced.

## Follow-Up Issues
- Deferred work: sanity-check the preflight path on a SLURM login node during the next real SLURM submission.
- Issues opened for follow-up: none.
