### PR TITLE
docs: clean profiling synthesis whitespace

### DIFF
--- a/docs/context/issue_3025_large_crowd_step_profile.md
+++ b/docs/context/issue_3025_large_crowd_step_profile.md
@@ -1,11 +1,11 @@
 # Issue #3025 Large-Crowd Step Profile
 
-Date: 2026-06-19  
+Date: 2026-06-19
 Status: diagnostic synthesis; no speedup claim.
 
 ## Scope
 
-Parent issue: <https://github.com/ll7/robot_sf_ll7/issues/3025>  
+Parent issue: <https://github.com/ll7/robot_sf_ll7/issues/3025>
 Supporting PRs: <https://github.com/ll7/robot_sf_ll7/pull/3121>, <https://github.com/ll7/robot_sf_ll7/pull/3122>, <https://github.com/ll7/robot_sf_ll7/pull/3124>, <https://github.com/ll7/robot_sf_ll7/pull/3125>
 
 The merged PRs added a dedicated profiling surface in


### PR DESCRIPTION
## Summary
Removes two trailing Markdown hard-break spaces from the Issue #3025 profiling synthesis note merged in #3128.

## Linked Issues
- Relates to #3025
- Follow-up to #3128

## What Changed
- Cleaned trailing whitespace in `docs/context/issue_3025_large_crowd_step_profile.md`.
- No semantic documentation content changed.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml --path docs/context/README.md --path docs/context/INDEX.md --path docs/context/issue_3025_large_crowd_step_profile.md`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check origin/main...HEAD`

## Risk
- Low; docs-only whitespace cleanup.
