### PR TITLE
docs: catalog issue 1023 evidence tranche

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1694,3 +1694,23 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/camera_ready_all_planners_2026-05-04/reports/matrix_summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1023_scenario_horizons_preflight_2026-05-06/reports/matrix_summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1023_candidate_augmented_preflight_2026-05-06/reports/matrix_summary.csv
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1023_scenario_horizons_local_full_2026-05-06/reports/matrix_summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1023_candidate_augmented_local_full_2026-05-06/reports/matrix_summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence


### PR DESCRIPTION
## Summary

- Catalog another bounded tranche of existing context evidence for #3014.
- Add evidence-catalog entries for the camera-ready all-planners matrix summary and four Issue #1023 scenario-horizon/candidate matrix summaries.
- Use compact matrix-summary anchors instead of README anchors so the cataloged evidence paths do not point at local `output/` provenance.

## Validation

- `uv run python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog --json | grep -E "camera_ready_all_planners_2026-05-04|issue_1023_(scenario_horizons|candidate_augmented)_(preflight|local_full)_2026-05-06"` returned no matches for the selected tranche.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check origin/main...HEAD`
- Targeted YAML/path/content assertion verified each new catalog entry exists, the target file exists, and selected anchors avoid `output/`, `/home/luttkule`, and `worktrees` strings.

## Downstream Propagation

- Parent issue #3014 remains open for additional bounded cleanup slices.
- No benchmark, metric, schema, model-provenance, or paper-facing claim changes.
- Full evidence-catalog coverage still has pre-existing uncatalogued bundles outside this tranche.

## Research Result Guidance

NA - docs/catalog hygiene only; no research claim or benchmark result is introduced.
