### PR TITLE
docs: catalog h500 evidence tranche

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1714,3 +1714,19 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_1045_h500_solvability_mechanisms_2026-05-07/h500_solvability_mechanisms.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1049_h500_mechanism_pilot_2026-05-07/representative_trace_summary.csv
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1055_exposure_aware_h500_tables_2026-05-07/fixed_vs_h500_outcome_table.csv
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1065_route_clearance_audit_2026-05-09/route_clearance_warning_classification.csv
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence


### PR DESCRIPTION
## Summary

- Catalog another bounded #3014 evidence tranche.
- Add entries for compact H500/route-clearance evidence anchors under `docs/context/evidence/`.
- Use summary/table anchors that avoid local `output/` and absolute-path provenance strings.

## Validation

- `uv run python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog --json | grep -E "issue_1045_h500_solvability_mechanisms_2026-05-07|issue_1049_h500_mechanism_pilot_2026-05-07|issue_1055_exposure_aware_h500_tables_2026-05-07|issue_1065_route_clearance_audit_2026-05-09"` returned no matches for the selected tranche.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check origin/main...HEAD`
- Targeted YAML/path/content assertion verified each new catalog entry exists, the target file exists, and selected anchors avoid `output/`, `/home/luttkule`, and `worktrees` strings.

## Downstream Propagation

- Parent issue #3014 remains open for additional bounded cleanup slices.
- No benchmark, metric, schema, model-provenance, or paper-facing claim changes.
- Full evidence-catalog coverage still has pre-existing uncatalogued bundles outside this tranche.

## Research Result Guidance

NA - docs/catalog hygiene only; no research claim or benchmark result is introduced.
