### PR TITLE
docs: catalog carla and h500 evidence tranche

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1730,3 +1730,19 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_1111_carla_setup_smoke_2026-05-18/setup_smoke.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1113_continuous_h500_2026-05-10/comparison.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1169_carla_live_replay_2026-05-18/live_replay_static_boundary_fixed.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1239_human_model_transfer_2026-05-18/preflight_matrix_summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence


### PR DESCRIPTION
## Summary
- Add four more `docs/context/catalog.yaml` evidence entries for a bounded #3014 cleanup tranche:
  - `issue_1111_carla_setup_smoke_2026-05-18/setup_smoke.json`
  - `issue_1113_continuous_h500_2026-05-10/comparison.json`
  - `issue_1169_carla_live_replay_2026-05-18/live_replay_static_boundary_fixed.json`
  - `issue_1239_human_model_transfer_2026-05-18/preflight_matrix_summary.json`
- Use compact JSON anchors that avoid local `output/`, `/home/...`, and worktree provenance strings.

## Validation
- Selected-tranche evidence-catalog grep returned no matches after the edit.
- `git diff --check origin/main...HEAD -- docs/context/catalog.yaml`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Targeted YAML/path/content assertion for the four added entries.

## Downstream Propagation
- Issue #3014 should remain open after this slice; this PR only handles one evidence-catalog tranche.

## Research Result Guidance
- NA - docs/catalog cleanup only; no benchmark claim is established or changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new benchmark evidence entries to the catalog, including test data from CARLA setup validation, continuous testing operations, simulation replay scenarios, and model transfer workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->