### PR TITLE
docs: extend scenario prior provenance cards

### DIFF
--- a/configs/research/scenario_prior_cards_issue_2917.yaml
+++ b/configs/research/scenario_prior_cards_issue_2917.yaml
@@ -139,9 +139,89 @@ cards:
       - docs/context/issue_2479_real_trajectory_scenario_prior.md
       - docs/context/issue_1091_sdd_importer.md
 
+  - card_id: adversarial_search_generated_scenario_prior
+    prior_family: adversarial/search-generated scenario prior family
+    classification: repository_trace_derived
+    source_type: repository_authored_configs_and_scripts
+    dataset_license_status: not_applicable_generated_synthetic
+    source_traces:
+      - robot_sf/adversarial/scenario_manifest.py
+      - configs/adversarial/crossing_ttc_space.yaml
+      - configs/scenarios/templates/crossing_ttc.yaml
+      - scripts/tools/generate_adversarial_scenario_manifests.py
+      - tests/adversarial/test_adversarial_search.py
+      - tests/adversarial/test_adversarial_scenario_manifest.py
+      - docs/context/evidence/issue_2562_adversarial_manifest_smoke/summary.json
+      - docs/context/evidence/issue_2567_adversarial_manifest_quality/summary.json
+    feature_extraction_method: >
+      Programmatic search generates adversarial_scenario_manifest.v1 candidates from a bounded
+      search space, validated against schema, control-hash, and degenerate-condition checks.
+      The generation tooling and validators are repository-trace-derived; no real-world data
+      is used.
+    parameter_bounds:
+      representation: adversarial_search_space.v1
+      units: position=m, velocity=m/s, time=s, seed=int
+      enforcement: robot_sf/adversarial/scenario_manifest.py validation and search-space config
+    excluded_populations:
+      - real-world pedestrian trajectories
+      - external datasets not staged through provenance manifests
+      - hardware-calibrated sensor populations
+    unsupported_claims:
+      - learned_prior_realism
+      - benchmark_usefulness
+      - cross_dataset_generalization
+      - planner_performance_improvement
+      - license_safe_redistribution_of_raw_data
+    odd_conditions:
+      - search space bounds defined in configs/adversarial/crossing_ttc_space.yaml
+      - generated candidates remain diagnostic-only until separately certified
+      - no planner performance or adversarial coverage claim
+    related_surfaces:
+      - docs/context/evidence/issue_2562_adversarial_manifest_smoke/summary.json
+      - docs/context/evidence/issue_2567_adversarial_manifest_quality/summary.json
+
+  - card_id: counterfactual_scenario_pair_mechanism_prior
+    prior_family: counterfactual scenario-pair mechanism prior family
+    classification: repository_trace_derived
+    source_type: repository_authored_scripts_and_configs
+    dataset_license_status: not_applicable_generated_synthetic
+    source_traces:
+      - scripts/tools/create_counterfactual_scenario_pair.py
+      - docs/context/issue_2547_counterfactual_mechanism_taxonomy.md
+      - docs/context/evidence/issue_2547_counterfactual_mechanism_taxonomy/summary.json
+      - tests/tools/test_create_counterfactual_scenario_pair.py
+    feature_extraction_method: >
+      Controlled counterfactual scenario pairs are generated via repository tooling that holds
+      scenario, seed, and planner fixed while varying a single perturbation feature (currently
+      robot_route_offset). The pair manifests include mechanism taxonomy rows and preflight
+      validation; no real-world data is used.
+    parameter_bounds:
+      representation: counterfactual_scenario_pair.v1
+      units: dx_m=m, dy_m=m, max_magnitude_m=m, seed=int
+      enforcement: scripts/tools/create_counterfactual_scenario_pair.py and perturbation preflight
+    excluded_populations:
+      - real-world trajectories
+      - external datasets not staged through provenance manifests
+      - hardware-calibrated sensor populations
+    unsupported_claims:
+      - learned_prior_realism
+      - benchmark_usefulness
+      - cross_dataset_generalization
+      - planner_performance_improvement
+      - license_safe_redistribution_of_raw_data
+      - causal_mechanism_evidence
+    odd_conditions:
+      - only robot_route_offset feature currently supported
+      - single pair is a mechanism hypothesis input, not causal evidence
+      - preflight validation required before execution
+    related_surfaces:
+      - docs/context/issue_2547_counterfactual_mechanism_taxonomy.md
+      - docs/context/evidence/issue_2547_counterfactual_mechanism_taxonomy/summary.json
+
 remaining_work:
   - Add cards for any future repository-trace-derived priors after an extraction tool exists.
   - Add external-dataset-derived cards only after source, license, checksum, and coordinate-frame
     provenance are recorded.
   - Link cards directly from future scenario contracts or ForecastBatch records when those schemas
     grow prior-family references.
+  - Consider adding additional counterfactual features beyond robot_route_offset as the taxonomy expands.

--- a/docs/context/issue_2917_scenario_prior_cards.md
+++ b/docs/context/issue_2917_scenario_prior_cards.md
@@ -17,11 +17,14 @@ already visible in the repository:
 
 - authored scenario contracts and perturbation pilots;
 - the #2523 proxy `scenario_prior.v1` smoke fixture;
-- the #2479 SDD scenario-distribution candidate.
+- the #2479 SDD scenario-distribution candidate;
+- repository-trace-derived adversarial/search-generated scenario prior family;
+- repository-trace-derived counterfactual scenario-pair mechanism prior family.
 
 The registry records source type, license/provenance status, source traces, extraction method,
 parameter-bound source, excluded populations, unsupported claims, and ODD conditions for each
-family.
+family. The two new repository-trace-derived families are diagnostic or smoke-level only;
+they do not constitute benchmark evidence, causality evidence, or real-world representativeness.
 
 ## Claim Boundary
 

--- a/tests/research/test_issue_2917_scenario_prior_cards.py
+++ b/tests/research/test_issue_2917_scenario_prior_cards.py
@@ -82,3 +82,36 @@ def test_cards_reject_unsupported_prior_claims() -> None:
         assert required_rejections.issubset(unsupported), card["card_id"]
         assert card["excluded_populations"], card["card_id"]
         assert card["odd_conditions"], card["card_id"]
+
+
+def test_repository_trace_derived_cards_have_correct_classification() -> None:
+    """The adversarial and counterfactual cards should be repository_trace_derived."""
+    registry = _registry()
+    cards = {card["card_id"]: card for card in registry["cards"]}
+    expected_cards = {
+        "adversarial_search_generated_scenario_prior",
+        "counterfactual_scenario_pair_mechanism_prior",
+    }
+
+    assert expected_cards <= cards.keys()
+    assert {cards[card_id]["classification"] for card_id in expected_cards} == {
+        "repository_trace_derived"
+    }
+
+
+def test_counterfactual_card_rejects_causal_mechanism_evidence() -> None:
+    """The counterfactual card should explicitly reject causal mechanism evidence claims."""
+    registry = _registry()
+    cards = {card["card_id"]: card for card in registry["cards"]}
+
+    counterfactual = cards["counterfactual_scenario_pair_mechanism_prior"]
+    unsupported = set(counterfactual["unsupported_claims"])
+    required_claims = {
+        "causal_mechanism_evidence",
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data",
+    }
+    assert required_claims <= unsupported


### PR DESCRIPTION
## Summary
Extends the ScenarioPrior.v1 provenance-card registry with two repository-trace-derived diagnostic/smoke-level prior families.

## Linked Issues
- Closes #3139

## Stack / Dependency
- Base dependency: #3138
- Required prior PRs: #3138
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: builds on the initial registry merged in #3138.

## What Changed
- Added `adversarial_search_generated_scenario_prior` as a repository-trace-derived diagnostic card backed by tracked adversarial scenario manifest tooling, configs, tests, and compact evidence.
- Added `counterfactual_scenario_pair_mechanism_prior` as a repository-trace-derived smoke-level card backed by tracked counterfactual scenario-pair tooling, taxonomy, tests, and evidence.
- Updated the ScenarioPrior context note to describe the new repository-generated families and their claim limits.
- Extended focused tests for the new card classifications and unsupported-claim boundaries.

## Why It Matters
- Added value: expands the provenance registry beyond authored/proxy/candidate surfaces while staying tied to tracked, durable repository evidence.
- Expected impact: makes generated scenario-prior families easier to audit without upgrading them into benchmark, causality, or real-world representativeness evidence.
- Why this is worth merging now: it closes the immediate follow-up from #3138 with a small, tested registry extension.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: ScenarioPrior families need provenance cards before they can support research interpretation.
- Comparator or baseline, if applicable: #3138 initial registry.
- Evidence tier: proposal-interface / diagnostic-only registry evidence.
- Result classification: blocker-reduction.
- Decision or stop rule, if applicable: stop before claiming benchmark usefulness, causal mechanism evidence, real-world representativeness, planner-performance improvement, or cross-dataset generalization.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3139, `configs/research/scenario_prior_cards_issue_2917.yaml`, `docs/context/issue_2917_scenario_prior_cards.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - registry/config/docs/test update only.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - registry/docs/test update only.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: future cards still need extraction/provenance before being added.

## Next Empirical Action
- Rerun needed: no for this registry slice.
- Extractor or analysis tool needed: yes for future real trace-derived/external-data cards.
- Artifact missing or unavailable: external SDD staging remains blocked outside this PR.
- Stop / revise / continue decision: continue only when additional provenance surfaces exist.
- Proposed child issue or existing follow-up: existing #2726 and #2657 remain related upstream work.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/research/test_issue_2917_scenario_prior_cards.py -q --confcutdir=tests/research`
  - `uv run ruff check tests/research/test_issue_2917_scenario_prior_cards.py`
  - `git diff --check origin/main...HEAD`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - targeted YAML/source-trace assertion
- Evidence that the change works here: focused tests now prove the new repository-trace-derived cards exist, preserve claim boundaries, and reference tracked source traces.
- Benchmarks or smoke tests, if applicable: NA - no benchmark execution or claim.

## Risks / Rollout
- Compatibility risks: low; docs/config/test-only surface.
- Failure modes: the new cards could be overread as benchmark or causality evidence if their unsupported claims are ignored.
- Rollback or fallback plan: revert the registry, note, and test additions.

## Docs / Provenance
- Updated docs: `docs/context/issue_2917_scenario_prior_cards.md`.
- Relevant design or provenance notes: adversarial manifest and counterfactual mechanism evidence surfaces linked in the registry source traces.
- Any assumptions that need to be preserved: these generated families remain diagnostic/smoke-level only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, #3139 claimed for this slice.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no benchmark artifact.
- Registry or config index updated (yes/no/NA): yes, existing ScenarioPrior registry extended.
- Context index / memory note updated (yes/no/NA): existing context note updated; no index change needed.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: no benchmark, leaderboard, or paper-facing claim is established.

## Follow-Up Issues
- Deferred work: add future cards only when additional extraction/provenance surfaces exist.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that the new cards remain diagnostic/smoke-level registry entries only.
- The counterfactual card explicitly rejects causal mechanism evidence claims.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Extended scenario prior card registry with two new entries for adversarial search-generated and counterfactual scenario pair mechanisms.

* **Documentation**
  * Updated documentation to describe new prior families and clarify their diagnostic/smoke-level classification status.

* **Tests**
  * Added validation tests for new scenario prior card registry entries and their classification properties.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->