### PR TITLE
docs: record large-crowd profiling scout

### DIFF
--- a/docs/context/issue_3025_large_crowd_step_profile.md
+++ b/docs/context/issue_3025_large_crowd_step_profile.md
@@ -50,12 +50,49 @@ claims.
 The issue is therefore still at profiling/diagnostic stage; no runtime optimization has been validated
 as a safe speedup yet.
 
+## Follow-up profiling scout on current main (2026-06-19)
+
+After PR #3140, a follow-up scout reran the steady large-crowd profile on current
+`origin/main` with the same diagnostic contract:
+
+```bash
+uv run python scripts/validation/performance_smoke_test.py \
+  --large-crowd-profile \
+  --step-profile \
+  --json-output <artifact-dir>/steady-profile.json \
+  --telemetry-output <artifact-dir>/steady-profile-telemetry.jsonl \
+  --num-resets 2 \
+  --step-samples 20 \
+  --step-profile-mode steady \
+  --step-profile-limit 8
+```
+
+Observed diagnostic summary:
+
+- scenario: `configs/scenarios/single/dense_pedestrian_stress.yaml`
+- pedestrian count: `17`
+- measured step samples: `20`
+- steady step loop: `0.011061429977416992 s`
+- steady throughput: `1717.68026727018 steps/sec`
+- top cumulative hotspots:
+  - `robot_sf/gym_env/robot_env.py:819` `step`: `0.011843816 s`
+  - `robot_sf/sim/simulator.py:279` `step_once`: `0.008182197 s`
+  - `fast-pysf/pysocialforce/simulator.py:246` `compute_forces`: `0.006406373 s`
+  - `fast-pysf/pysocialforce/simulator.py:57` `_sum_forces_explicitly`: `0.006397025 s`
+  - `fast-pysf/pysocialforce/forces.py:609` `__call__`: `0.00304015 s`
+
+This confirms the previous diagnostic: the dominant steady-step cost remains inside the fast-pysf
+force-computation chain, not in a clear low-risk Robot SF wrapper-only path. The wrapper-visible
+overhead should not be treated as a speedup target unless a same-contract before/after comparison
+first proves a semantics-preserving change.
+
 ## Follow-up boundary
 
 The next optimization boundary must be measured with a fresh baseline/target comparison on the same
 profiling contract:
 
-1. fix a single optimization target (e.g., hotspot owner) with `--step-profile` command and explicit mode,
+1. fix a single optimization target, preferably under the fast-pysf force-computation path identified
+   above, with `--step-profile` command and explicit mode,
 2. collect a baseline snapshot and a post-change snapshot with the same mode/warmup values,
 3. run correctness checks that the issue already uses in CI-contract tests,
 4. only then interpret direction of change.


### PR DESCRIPTION
## Summary

Refs #3025.

- records a current-main follow-up large-crowd profiling scout in `docs/context/issue_3025_large_crowd_step_profile.md`
- confirms the steady-step hotspot remains in the fast-pysf force-computation path
- narrows the next optimization boundary toward fast-pysf-level work and explicitly avoids a Robot SF wrapper speedup claim

## Validation

- `uv run python scripts/validation/performance_smoke_test.py --large-crowd-profile --step-profile --json-output <artifact-dir>/steady-profile.json --telemetry-output <artifact-dir>/steady-profile-telemetry.jsonl --num-resets 2 --step-samples 20 --step-profile-mode steady --step-profile-limit 8`
- `git diff --check -- docs/context/issue_3025_large_crowd_step_profile.md`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`

## Research Result Guidance

- Target claim/hypothesis/blocker: identify whether #3025 has a low-risk Robot SF wrapper optimization target after current-main profiling.
- Comparator/baseline: current-main steady large-crowd profile using the existing diagnostic contract.
- Evidence tier: diagnostic-only profiling note.
- Result classification: blocker-reduction / target narrowing.
- Decision/stop rule: no speedup claim; next implementation should target fast-pysf force computation only after same-contract before/after proof and correctness checks.
- Synthesis surface/update target: `docs/context/issue_3025_large_crowd_step_profile.md`.

## Downstream Propagation

- Parent issue #3025 remains open for a bounded fast-pysf-level optimization or follow-up split.
- No benchmark leaderboard, release artifact, registry, or paper-facing claim is updated by this PR.
