### PR TITLE
docs: catalog AMMV evidence README anchors

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1394,7 +1394,15 @@ entries:
     status: evidence
     freshness: evidence
     area: manual_control_trace
+  - path: docs/context/evidence/issue_2430_ammv_trace_annotation_2026-06-06/README.md
+    status: evidence
+    freshness: evidence
+    area: manual_control_trace
   - path: docs/context/evidence/issue_2432_ammv_trace_selection_2026-06-06/README.md
+    status: evidence
+    freshness: evidence
+    area: manual_control_trace
+  - path: docs/context/evidence/issue_2434_ammv_scenario_sweep_2026-06-06/README.md
     status: evidence
     freshness: evidence
     area: manual_control_trace


### PR DESCRIPTION
## Summary

- Adds two missing `docs/context/catalog.yaml` entries for AMMV evidence README anchors already referenced by `docs/context/INDEX.md` and `docs/context/README.md`.
- Keeps the slice catalog-only; no benchmark, metric, or research-result claim text changed.

Refs #3014 for this bounded cleanup slice; the parent issue can remain open if more context-catalog tranches are desired.

## Validation

- `git diff --check`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Targeted checks: verified both README paths exist, catalog paths are unique, and the added evidence README/catalog surfaces introduce no `/home/`, `worktrees`, `output/`, or `results/` provenance strings.

## Delegation

- Routed worker attempted the docs cleanup but was stopped after silent execution without compact artifacts.
- Parent accepted only the narrow `docs/context/catalog.yaml` diff after direct review and local validation.
- Self-review note recorded privately under the common Git-dir inbox.

## Downstream Propagation

- Context index and README already linked these evidence README anchors; this PR only brings `catalog.yaml` into alignment.
- No Project #5, benchmark report, leaderboard, artifact registry, or memory update needed for this docs-only catalog tranche.

## Research Result Guidance

NA - docs-only catalog hygiene; no research, benchmark, metric, schema, model-provenance, or paper-facing claim is introduced or changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation catalog with new entries for trace annotation and scenario sweep features in manual control trace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->