### PR TITLE
docs: add SLURM capacity filling policy

### DIFF
--- a/.agents/skills/goal-slurm-experiment/SKILL.md
+++ b/.agents/skills/goal-slurm-experiment/SKILL.md
@@ -23,6 +23,11 @@ output_schema: skill_run_summary.v1
 Use this skill for the always-on background training lane: keep at most one skill-owned learning or
 training SLURM job pending/running, and when none exists, find and prepare the best next experiment.
 
+This skill governs the single `gse-` background job lane only. It does not restrict explicit
+capacity-aware batch or campaign workflows that are submitted through `slurm-campaign-submit`
+under separate preconditions (live queue/capacity evidence, bounded scope, duplicate checks,
+traceability, and immediate health checks).
+
 It orchestrates:
 
 - `experiment-context` for canonical config, command, artifact, and validation routing.

--- a/.agents/skills/slurm-campaign-submit/SKILL.md
+++ b/.agents/skills/slurm-campaign-submit/SKILL.md
@@ -71,6 +71,33 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
     relevant analysis skill or context note, while `failed_preflight` or early wrapper failures must
     be fixed in a worktree before resubmission.
 
+## Capacity-aware / fill batches
+
+When the goal is to fill available cluster capacity rather than run a prioritised experiment, the
+batch may contain several unrelated ready experiments, but all preconditions in this section must be
+satisfied before `sbatch`:
+
+- Live queue evidence: refresh `squeue --me` and `squeue` cluster-wide (or partition-wide) so the
+  submission reflects current load, not stale logs.
+- Bounded scope: the batch must have a declared maximum job count, total GPU/CPU budget, or
+  wall-time cap derived from visible spare capacity.
+- Duplicate checks: each job in the batch passes the standard duplicate gate (same issue/objective
+  lane, config, seed set, commit, cluster, job name, output root).
+- Traceability: every submitted job gets the shared traceability checklist update (issue/PR comment
+  or private-ledger handoff plus immediate health check).
+- Immediate health check: verify `squeue` acceptance after each submission; halt the batch on the
+  first health-check failure.
+- Polite scheduling: where the scheduler supports it, use `--nice` factors or equivalent to avoid
+  displacing higher-priority work.
+- Avoid resource starvation: do not saturate a partition so heavily that other users' eligible jobs
+  cannot start within a reasonable window.
+- Cluster-specific leave-one-way rule (imech192): when submitting on imech192, always preserve at
+  least one GPUxCPU way free for other users unless the queue is empty or the maintainer explicitly
+  overrides.
+
+Fill batches are not mandatory proof of cluster citizenship; they are an optional capacity-filling
+mode. The single `gse-` background lane in `goal-slurm-experiment` remains independent.
+
 ## Guardrails
 
 - Do not infer live cluster capacity from stale logs.

--- a/.agents/skills/slurm-campaign-submit/SKILL.md
+++ b/.agents/skills/slurm-campaign-submit/SKILL.md
@@ -73,7 +73,7 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
 
 ## Capacity-aware / fill batches
 
-When the goal is to fill available cluster capacity rather than run a prioritised experiment, the
+When the goal is to fill available cluster capacity rather than run a prioritized experiment, the
 batch may contain several unrelated ready experiments, but all preconditions in this section must be
 satisfied before `sbatch`:
 

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -157,7 +157,7 @@ Submission state rules:
 
 ## Capacity-aware / fill batches
 
-When submitting a batch intended to fill spare cluster capacity (rather than a single prioritised
+When submitting a batch intended to fill spare cluster capacity (rather than a single prioritized
 experiment), the batch may include several unrelated ready experiments, but it must satisfy these
 public-safe preconditions before `sbatch`:
 

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -155,6 +155,34 @@ Submission state rules:
 - Public issue/PR comments may include job id and partition for traceability, but must not include private host
   names, account/QoS details, scratch paths, or private retrieval mechanics.
 
+## Capacity-aware / fill batches
+
+When submitting a batch intended to fill spare cluster capacity (rather than a single prioritised
+experiment), the batch may include several unrelated ready experiments, but it must satisfy these
+public-safe preconditions before `sbatch`:
+
+1. Live queue evidence: refresh `squeue --me` and partition-wide `squeue` so submissions reflect
+   current load.
+2. Bounded scope: declare a maximum job count, total GPU/CPU budget, or wall-time cap derived from
+   visible spare capacity.
+3. Duplicate checks: each job passes the standard duplicate gate (same issue/objective lane, config,
+   seed set, commit, cluster, job name, output root).
+4. Traceability: every job gets the shared traceability checklist (issue/PR comment or private-ledger
+   handoff plus immediate health check).
+5. Immediate health check: verify `squeue` acceptance after each submission; halt the batch on the
+   first failure.
+6. Polite scheduling: where the scheduler supports it, use `--nice` factors or equivalent to avoid
+   displacing higher-priority work.
+7. Avoid resource starvation: do not saturate a partition so heavily that other users' eligible jobs
+   cannot start within a reasonable window.
+8. Cluster-specific leave-one-way rule (imech192): when submitting on imech192, always preserve at
+   least one GPUxCPU way free for other users unless the queue is empty or the maintainer explicitly
+   overrides.
+
+Capacity-aware batches use the same shared traceability checklist and submission-state rules as any
+other SLURM submission. Private cluster mechanics (hostnames, QoS tuning, scratch paths) stay in the
+private operations overlay and must not appear in public issue/PR comments.
+
 ## Multiple branches from one login node
 
 When two active branches need to submit or monitor SLURM jobs from the same login node, prefer one


### PR DESCRIPTION
## Summary
Adds public SLURM capacity-filling guidance so agents can distinguish the single always-on `gse-` background lane from explicit capacity-aware batch/campaign submissions.

## Linked Issues
- Closes `#2648`
- Closes `#2649`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Clarified that `goal-slurm-experiment` governs only the single `gse-` background job lane.
- Added capacity-aware/fill-batch preconditions to `slurm-campaign-submit`.
- Added matching public-safe guidance to `docs/dev/slurm_submission.md`.

## Why It Matters
- Added value: agents can use spare cluster capacity without confusing capacity filling with benchmark evidence or the one-job background lane.
- Expected impact: clearer queue, duplicate, traceability, health-check, and cluster-citizenship requirements before `sbatch`.
- Why this is worth merging now: #2648/#2649 record current maintainer decisions that were not yet visible in the public workflow contract.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/workflow docs only; no research result claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: docs-only
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2648 and #2649.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support workflow docs; no analysis tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: NA - docs-only workflow clarification.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path .agents/skills/goal-slurm-experiment/SKILL.md --path .agents/skills/slurm-campaign-submit/SKILL.md --path docs/dev/slurm_submission.md`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/sync_ai_config.py --check`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_skills.py --preflight slurm-campaign-submit` (expected local environment limitation: `sbatch` not on PATH)
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_skills.py --preflight goal-slurm-experiment` (expected local environment limitation: `sbatch` not on PATH)
- Evidence that the change works here: docs/proof consistency and AI config link checks pass; skill preflight reaches declared requirements and fails only because this non-SLURM shell lacks `sbatch`.
- Benchmarks or smoke tests, if applicable: NA - docs/workflow only; no job submitted.

## Risks / Rollout
- Compatibility risks: low; wording-only changes to public skill/docs guidance.
- Failure modes: future agents could over-read capacity filling as permission to starve a partition; the added preconditions explicitly forbid that.
- Rollback or fallback plan: revert the docs/skill wording.

## Docs / Provenance
- Updated docs: `.agents/skills/goal-slurm-experiment/SKILL.md`, `.agents/skills/slurm-campaign-submit/SKILL.md`, `docs/dev/slurm_submission.md`.
- Relevant design or provenance notes: #2648 and #2649 maintainer decisions from 2026-06-12 and 2026-06-16 triage.
- Any assumptions that need to be preserved: private cluster mechanics stay in private ops; public docs keep only fair-use principles and the imech192 leave-one-GPUxCPU-way rule.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing keywords for #2648/#2649.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: support workflow docs only; no benchmark artifact or claim map changes.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: whether the public-safe capacity-filling preconditions capture the #2648/#2649 maintainer decisions without exposing private ops mechanics.
- Any known limitations: no SLURM jobs submitted; local skill preflight cannot pass on this machine because `sbatch` is unavailable.
