### PR TITLE
docs: catalog recent context notes

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -149,6 +149,10 @@ knowledge, not every transient iteration detail.
   [issue_3062_campaign_manifest_flow.md](issue_3062_campaign_manifest_flow.md)
   records the reusable research-campaign manifest contract, example manifest, output boundary, and
   validation path before runner-specific automation treats manifests as benchmark evidence.
+* Issue #3142 fast-pysf force optimization:
+  [issue_3142_fast_pysf_force_optimization.md](issue_3142_fast_pysf_force_optimization.md)
+  records the bounded semantics-preserving force-computation cleanup, diagnostic performance
+  boundary, and tracked compact summary.
 * Issue #3146 forecast replay fixture suite:
   [issue_3146_forecast_replay_fixture_suite.md](issue_3146_forecast_replay_fixture_suite.md)
   records the scenario-diverse diagnostic forecast replay suite, full variant matrix row

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -822,6 +822,10 @@ entries:
     status: current
     freshness: maintained
     area: benchmark_release
+  - path: docs/context/issue_3142_fast_pysf_force_optimization.md
+    status: current
+    freshness: maintained
+    area: benchmark_release
   - path: docs/context/issue_3025_large_crowd_step_profile.md
     status: current
     freshness: maintained
@@ -1658,6 +1662,10 @@ entries:
     status: current
     freshness: maintained
     area: benchmark_evidence
+  - path: docs/context/issue_3062_campaign_manifest_flow.md
+    status: proposal
+    freshness: maintained
+    area: benchmark_evidence
   - path: docs/context/issue_3063_campaign_comparison_report.md
     status: current
     freshness: evidence
@@ -1683,6 +1691,18 @@ entries:
     freshness: evidence
     area: benchmark_evidence
   - path: docs/context/evidence/issue_3064_social_force_variant_matrix/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/issue_3146_forecast_replay_fixture_suite.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3146_forecast_replay_fixture_suite/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3146_forecast_replay_fixture_suite/summary.json
     status: evidence
     freshness: evidence
     area: benchmark_evidence


### PR DESCRIPTION
## Summary

- add Issue #3142 to `docs/context/README.md` so the recent fast-pysf optimization note is discoverable from the context workflow surface
- add curated `docs/context/catalog.yaml` rows for recent current/proposal/evidence notes from #3062, #3142, and #3146
- keep the cleanup bounded to index/catalog drift; no benchmark, metric, or paper-facing claims changed

## Validation

- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- targeted audit confirmed #3062, #3142, and #3146 are present in README/INDEX/catalog
- `uv run python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog` still reports a broad pre-existing evidence-catalog backlog; this PR does not try to migrate all historical evidence bundles

## Downstream Propagation

- `docs/context/README.md`: updated for #3142 discoverability.
- `docs/context/INDEX.md`: already linked the affected notes; no text change needed.
- `docs/context/catalog.yaml`: updated for the affected curated entries.
- Parent issue #3014 remains the broader stale/prune/re-index backlog; this PR is a bounded first pass.

## Research Result Guidance

NA - docs/index hygiene only. No research claim, benchmark result, metric definition, or model-provenance boundary changed.

Part of #3014.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added new documentation entries for force optimization and campaign manifest flow features
  * Expanded documentation catalog to include benchmark tracking for optimization, manifest, and forecast replay functionality
  * Updated context documentation with current and proposed feature references

<!-- end of auto-generated comment: release notes by coderabbit.ai -->