### PR TITLE
docs: catalog early benchmark evidence

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1802,3 +1802,15 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_1318_teb_corridor_deadlock_2026-05-20/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1344_paired_amv_primary_2026-05-20/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1353_broader_amv_2026-05-26/nominal/amv_coverage_summary.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence


### PR DESCRIPTION
## Summary

Adds another bounded Issue #3014 evidence-catalog tranche for early benchmark evidence:

- `docs/context/evidence/issue_1318_teb_corridor_deadlock_2026-05-20/summary.json`
- `docs/context/evidence/issue_1344_paired_amv_primary_2026-05-20/README.md`
- `docs/context/evidence/issue_1353_broader_amv_2026-05-26/nominal/amv_coverage_summary.md`

This is catalog/discoverability hygiene only. It does not change benchmark results, metric
definitions, planner rankings, or paper-facing claims.

## Validation

- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`
- Full evidence-catalog backlog meter moved from 111 to 108.
- Targeted catalog-warning grep confirmed no remaining #1318/#1344/#1353 warnings.

## Downstream Propagation

- Parent issue: #3014 remains open for future bounded catalog/index cleanup slices.
- Claim map / benchmark report / leaderboard: NA, catalog-only discoverability change.
- Context index/catalog: updated `docs/context/catalog.yaml`.
- Deferred follow-up issue: NA, existing #3014 backlog remains the active cleanup surface.

## Research Result Guidance

- Target claim / hypothesis / blocker: NA, docs/catalog hygiene only.
- Comparator / baseline: pre-change evidence-catalog audit reported these three tracked evidence
  bundles as uncataloged.
- Evidence tier: docs validation.
- Result classification: discoverability cleanup, not benchmark evidence.
- Decision / stop rule: stop after one coherent small tranche and keep remaining backlog explicit.
- Synthesis surface / update target: #3014 evidence-catalog backlog remains current.
