### PR TITLE
docs: catalog carla evidence reports

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1814,3 +1814,19 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_1430_carla_live_parity_2026-05-21/parity_report.json
+    status: evidence
+    freshness: evidence
+    area: carla_external_sim
+  - path: docs/context/evidence/issue_1437_carla_robot_spawn_2026-05-21/parity_report.json
+    status: evidence
+    freshness: evidence
+    area: carla_external_sim
+  - path: docs/context/evidence/issue_1440_carla_spawn_projection_2026-05-21/parity_report.json
+    status: evidence
+    freshness: evidence
+    area: carla_external_sim
+  - path: docs/context/evidence/issue_1442_carla_native_spawn_probe_2026-05-24/parity_report_native_probe.json
+    status: evidence
+    freshness: evidence
+    area: carla_external_sim


### PR DESCRIPTION
## Summary

Adds another bounded Issue #3014 evidence-catalog tranche for CARLA evidence reports:

- `docs/context/evidence/issue_1430_carla_live_parity_2026-05-21/parity_report.json`
- `docs/context/evidence/issue_1437_carla_robot_spawn_2026-05-21/parity_report.json`
- `docs/context/evidence/issue_1440_carla_spawn_projection_2026-05-21/parity_report.json`
- `docs/context/evidence/issue_1442_carla_native_spawn_probe_2026-05-24/parity_report_native_probe.json`

This is catalog/discoverability hygiene only. It does not change CARLA parity claims, benchmark
results, metric definitions, planner rankings, or paper-facing claims.

## Validation

- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check`
- Full evidence-catalog backlog meter moved from 108 to 104.
- Targeted catalog-warning grep confirmed no remaining #1430/#1437/#1440/#1442 warnings.

## Downstream Propagation

- Parent issue: #3014 remains open for future bounded catalog/index cleanup slices.
- Claim map / benchmark report / leaderboard: NA, catalog-only discoverability change.
- Context index/catalog: updated `docs/context/catalog.yaml`.
- Deferred follow-up issue: NA, existing #3014 backlog remains the active cleanup surface.

## Research Result Guidance

- Target claim / hypothesis / blocker: NA, docs/catalog hygiene only.
- Comparator / baseline: pre-change evidence-catalog audit reported these four tracked CARLA
  evidence bundles as uncataloged.
- Evidence tier: docs validation.
- Result classification: discoverability cleanup, not benchmark evidence.
- Decision / stop rule: stop after one coherent small CARLA tranche and keep remaining backlog
  explicit.
- Synthesis surface / update target: #3014 evidence-catalog backlog remains current.
