### PR TITLE
docs: catalog s10 h500 evidence reports

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1,5 +1,5 @@
 version: 1
-updated_at: 2026-06-19
+updated_at: 2026-06-20
 policy: context-catalog.v1
 description: >
   Machine-readable catalog for the current retrieval-first context index. This is not a full
@@ -1830,3 +1830,19 @@ entries:
     status: evidence
     freshness: evidence
     area: carla_external_sim
+  - path: docs/context/evidence/issue_1454_s10_preflight_2026-05-22/fixed_h100/matrix_summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1454_stage_a_fixed_h100_2026-05-22/reports/statistical_sufficiency.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1454_s10_h500_candidates_2026-05-23/reports/matrix_summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1462_s10_h500_failure_modes_2026-05-24/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence


### PR DESCRIPTION
## Summary

- catalog four issue #1454/#1462 S10/H500 evidence anchors in `docs/context/catalog.yaml`
- use tracked JSON anchors that avoid ignored `output/` and absolute local provenance
- refresh the catalog `updated_at` date

Refs #3014

## Validation

- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- `git diff --check HEAD~1..HEAD`
- `uv run --active python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog` remains nonzero because unrelated backlog remains, but the uncovered count moved from 104 to 100 and the selected issue #1454/#1462 paths no longer appear

## Downstream Propagation

- Context index/catalog updated: yes, `docs/context/catalog.yaml`
- Parent issue/claim map: #3014 continues to track the remaining evidence catalog backlog
- Benchmark report/leaderboard/model registry: NA - this PR catalogs existing tracked evidence only and does not change benchmark interpretation

## Research Result Guidance

- Target: improve discoverability of existing tracked S10/H500 benchmark-family evidence
- Baseline/Comparator: previous evidence-catalog checker reported 104 uncovered evidence paths
- Evidence Tier And Claim Boundary: docs/catalog metadata only; no benchmark claim changes
- Result Classification: support/tooling evidence-index cleanup
- Update Surface: `docs/context/catalog.yaml` and Issue #3014 backlog


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated catalog metadata with new benchmark evidence entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->