### PR TITLE
docs: catalog early evidence backlog anchors

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1846,3 +1846,19 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_1416_converted_map_cache_2026-05-20/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1428_orca_residual_lineage_2026-05-24/orca_residual_guarded_ppo_v0_smoke_summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1467_carla_replay_metrics_2026-05-24/parity_report_native_metric_probe.json
+    status: evidence
+    freshness: evidence
+    area: carla_external_sim
+  - path: docs/context/evidence/issue_1484_broader_cross_kinematics_2026-05-28/reports/matrix_summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence


### PR DESCRIPTION
## Summary
- catalog four additional tracked evidence bundles for #3014
- use clean JSON proof anchors that avoid ignored output or machine-local provenance
- reduce the uncataloged evidence backlog from 100 to 96 remaining anchors

## Validation
- BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh
- git diff --check
- uv run --active python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog (expected nonzero: remaining pre-existing backlog; selected paths no longer reported)

Refs #3014
