### PR TITLE
docs: catalog context evidence tranche

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -97,6 +97,22 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_1617_local_planner_repo_survey.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1677_sit_dataset_terms.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2962_blocked_external_assets.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2967_active_issue_portfolio.md
+    status: evidence
+    freshness: evidence
+    area: agent_workflow
   - path: docs/context/issue_1436_reproducibility_flaky_acceptance.md
     status: current
     freshness: policy


### PR DESCRIPTION
## Summary
- Add four clean evidence pointers to `docs/context/catalog.yaml` for a bounded #3014 cleanup tranche.
- Catalogs local-planner survey, SiT dataset terms, blocked external assets, and active issue portfolio evidence.
- Does not change benchmark semantics, evidence contents, or research claims.

Closes part of #3014.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
- `git diff --check origin/main...HEAD -- docs/context/catalog.yaml`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Full evidence-catalog audit was run as a tranche selector; it still exits nonzero for pre-existing uncatalogued evidence, but the four selected entries no longer appear in that output.

## Downstream Propagation
NA - docs/context catalog hygiene only. No benchmark, metric, model, schema, or paper-facing claim changes.

## Research Result Guidance
NA - support/docs hygiene. This PR improves evidence discoverability only and does not establish a research result.

## Risks
- The broader evidence catalog backlog remains; this PR intentionally handles one small reviewable tranche.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new catalog entries for benchmark-related and workflow-related artifacts with evidence tracking to support improved documentation organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->