### PR TITLE
feat: certify shared-space infrastructure zones

### DIFF
--- a/configs/scenarios/maps/issue_2926_pedestrian_only_cut.yaml
+++ b/configs/scenarios/maps/issue_2926_pedestrian_only_cut.yaml
@@ -1,0 +1,27 @@
+x_margin: [0.0, 12.0]
+y_margin: [0.0, 8.0]
+obstacles: []
+robot_spawn_zones:
+  - [[1.8, 1.8], [2.2, 1.8], [2.2, 2.2]]
+robot_goal_zones:
+  - [[9.8, 1.8], [10.2, 1.8], [10.2, 2.2]]
+ped_spawn_zones: []
+ped_goal_zones: []
+ped_crowded_zones: []
+robot_routes:
+  - spawn_id: 0
+    goal_id: 0
+    waypoints:
+      - [2.0, 2.0]
+      - [10.0, 2.0]
+ped_routes: []
+infrastructure_zones:
+  - id: pedestrian_only_cut
+    zone_type: pedestrian_only
+    vertices:
+      - [4.5, 1.2]
+      - [7.5, 1.2]
+      - [7.5, 2.8]
+      - [4.5, 2.8]
+    allowed_actor_types: [pedestrian]
+    note: AMVs must not use the pedestrian-only shortcut.

--- a/configs/scenarios/maps/issue_2926_signalized_crossing_wait_box.yaml
+++ b/configs/scenarios/maps/issue_2926_signalized_crossing_wait_box.yaml
@@ -1,0 +1,27 @@
+x_margin: [0.0, 12.0]
+y_margin: [0.0, 8.0]
+obstacles: []
+robot_spawn_zones:
+  - [[1.8, 1.8], [2.2, 1.8], [2.2, 2.2]]
+robot_goal_zones:
+  - [[9.8, 1.8], [10.2, 1.8], [10.2, 2.2]]
+ped_spawn_zones: []
+ped_goal_zones: []
+ped_crowded_zones: []
+robot_routes:
+  - spawn_id: 0
+    goal_id: 0
+    waypoints:
+      - [2.0, 2.0]
+      - [10.0, 2.0]
+ped_routes: []
+infrastructure_zones:
+  - id: signalized_crossing_wait_box
+    zone_type: signalized_crossing_zone
+    vertices:
+      - [4.5, 1.2]
+      - [7.5, 1.2]
+      - [7.5, 2.8]
+      - [4.5, 2.8]
+    allowed_actor_types: [pedestrian]
+    note: This certification fixture treats the crossing box as pedestrian-only.

--- a/configs/scenarios/maps/issue_2926_stair_access.yaml
+++ b/configs/scenarios/maps/issue_2926_stair_access.yaml
@@ -1,0 +1,27 @@
+x_margin: [0.0, 12.0]
+y_margin: [0.0, 8.0]
+obstacles: []
+robot_spawn_zones:
+  - [[1.8, 1.8], [2.2, 1.8], [2.2, 2.2]]
+robot_goal_zones:
+  - [[9.8, 1.8], [10.2, 1.8], [10.2, 2.2]]
+ped_spawn_zones: []
+ped_goal_zones: []
+ped_crowded_zones: []
+robot_routes:
+  - spawn_id: 0
+    goal_id: 0
+    waypoints:
+      - [2.0, 2.0]
+      - [10.0, 2.0]
+ped_routes: []
+infrastructure_zones:
+  - id: stair_access
+    zone_type: stairs
+    vertices:
+      - [4.5, 1.2]
+      - [7.5, 1.2]
+      - [7.5, 2.8]
+      - [4.5, 2.8]
+    allowed_actor_types: [pedestrian]
+    note: Stairs are nontraversable for AMV routes.

--- a/configs/scenarios/sets/issue_2926_shared_space_infrastructure_smoke.yaml
+++ b/configs/scenarios/sets/issue_2926_shared_space_infrastructure_smoke.yaml
@@ -1,0 +1,97 @@
+schema_version: robot_sf.scenario_matrix.v1
+scenarios:
+  - name: issue_2926_pedestrian_only_cut_rejected
+    map_file: ../maps/issue_2926_pedestrian_only_cut.yaml
+    simulation_config:
+      max_episode_steps: 40
+      ped_density: 0.0
+    robot_config: {}
+    metadata:
+      purpose: Certification smoke fixture for rejecting AMV traversal through pedestrian-only infrastructure.
+      archetype: shared_space_infrastructure
+      issue: 2926
+      generation_profile:
+        schema_version: scenario_generation_params.v1
+        seed_signature: 2926
+        parameters:
+          id: issue_2926_pedestrian_only_cut_rejected
+          preset: manual_shared_space_infrastructure_smoke
+          infrastructure_zone: pedestrian_only_cut
+          route_contract: illegal_amv_traversal_rejected
+      authoring:
+        status: draft
+        template: manual-shared-space-infrastructure-certification-smoke
+        source_issue: https://github.com/ll7/robot_sf_ll7/issues/2926
+        benchmark_evidence: false
+      infrastructure_semantics:
+        status: certification_only
+        target_zone_id: pedestrian_only_cut
+        expected_certification: invalid
+        claim_boundary: >
+          Certification smoke fixture only. This records route-validation semantics
+          for pedestrian-only infrastructure and does not establish benchmark
+          performance evidence.
+    seeds: [2926]
+  - name: issue_2926_stair_access_rejected
+    map_file: ../maps/issue_2926_stair_access.yaml
+    simulation_config:
+      max_episode_steps: 40
+      ped_density: 0.0
+    robot_config: {}
+    metadata:
+      purpose: Certification smoke fixture for rejecting AMV traversal through stair infrastructure.
+      archetype: shared_space_infrastructure
+      issue: 2926
+      generation_profile:
+        schema_version: scenario_generation_params.v1
+        seed_signature: 2927
+        parameters:
+          id: issue_2926_stair_access_rejected
+          preset: manual_shared_space_infrastructure_smoke
+          infrastructure_zone: stair_access
+          route_contract: illegal_amv_traversal_rejected
+      authoring:
+        status: draft
+        template: manual-shared-space-infrastructure-certification-smoke
+        source_issue: https://github.com/ll7/robot_sf_ll7/issues/2926
+        benchmark_evidence: false
+      infrastructure_semantics:
+        status: certification_only
+        target_zone_id: stair_access
+        expected_certification: invalid
+        claim_boundary: >
+          Certification smoke fixture only. This records route-validation semantics
+          for stair access and does not establish benchmark performance evidence.
+    seeds: [2927]
+  - name: issue_2926_signalized_crossing_zone_rejected
+    map_file: ../maps/issue_2926_signalized_crossing_wait_box.yaml
+    simulation_config:
+      max_episode_steps: 40
+      ped_density: 0.0
+    robot_config: {}
+    metadata:
+      purpose: Certification smoke fixture for rejecting AMV traversal through signalized crossing wait zones.
+      archetype: shared_space_infrastructure
+      issue: 2926
+      generation_profile:
+        schema_version: scenario_generation_params.v1
+        seed_signature: 2928
+        parameters:
+          id: issue_2926_signalized_crossing_zone_rejected
+          preset: manual_shared_space_infrastructure_smoke
+          infrastructure_zone: signalized_crossing_wait_box
+          route_contract: illegal_amv_traversal_rejected
+      authoring:
+        status: draft
+        template: manual-shared-space-infrastructure-certification-smoke
+        source_issue: https://github.com/ll7/robot_sf_ll7/issues/2926
+        benchmark_evidence: false
+      infrastructure_semantics:
+        status: certification_only
+        target_zone_id: signalized_crossing_wait_box
+        expected_certification: invalid
+        claim_boundary: >
+          Certification smoke fixture only. This records route-validation semantics
+          for signalized crossing wait zones and does not establish benchmark
+          performance evidence.
+    seeds: [2928]

--- a/docs/scenario_certification.md
+++ b/docs/scenario_certification.md
@@ -64,6 +64,17 @@ Dynamic checks:
 - static single pedestrians whose start position blocks the inflated robot route corridor classify
   the scenario as `dynamically_overconstrained`.
 
+Infrastructure checks:
+
+- map definitions may include optional `infrastructure_zones` metadata for public-space semantics
+  such as `pedestrian_only`, `stairs`, `pedestrian_exit`, `signalized_crossing_zone`, or
+  `shared_space_lane`,
+- each infrastructure zone names its polygon vertices and `allowed_actor_types`,
+- robot/AMV routes that intersect a zone whose allowed actors do not include `amv`, `robot`,
+  `vehicle`, or `all` fail closed as `invalid`,
+- these zones are certification-only metadata and do not change simulator physics, obstacle
+  collision, route planning, or benchmark execution by themselves.
+
 Scenario difficulty and planner residual analysis from
 [`docs/context/issue_692_scenario_difficulty_analysis.md`](./context/issue_692_scenario_difficulty_analysis.md)
 is linked as diagnostic evidence only. It is not treated as a replacement for validity or

--- a/robot_sf/nav/map_config.py
+++ b/robot_sf/nav/map_config.py
@@ -274,6 +274,49 @@ class SinglePedestrianDefinition:
 
 
 @dataclass
+class InfrastructureZone:
+    """Semantic public-space zone used by certification and route-validation tools.
+
+    The zone is metadata only for runtime simulation. Certification consumes it to
+    reject AMV/robot routes through pedestrian-only or otherwise restricted areas.
+    """
+
+    id: str
+    zone_type: str
+    vertices: list[Vec2D]
+    allowed_actor_types: tuple[str, ...] = ("pedestrian",)
+    note: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize and validate the infrastructure-zone payload."""
+        if not isinstance(self.id, str) or not self.id.strip():
+            raise ValueError("InfrastructureZone id must be a non-empty string")
+        self.id = self.id.strip()
+        if not isinstance(self.zone_type, str) or not self.zone_type.strip():
+            raise ValueError(f"InfrastructureZone '{self.id}' zone_type must be non-empty")
+        self.zone_type = self.zone_type.strip().lower()
+        if len(self.vertices) < 3:
+            raise ValueError(f"InfrastructureZone '{self.id}' requires at least three vertices")
+        self.vertices = [(float(x), float(y)) for x, y in self.vertices]
+        polygon = self.polygon()
+        if polygon.is_empty or not polygon.is_valid or polygon.area <= 0:
+            raise ValueError(f"InfrastructureZone '{self.id}' must form a valid non-empty polygon")
+        allowed = tuple(str(actor).strip().lower() for actor in self.allowed_actor_types)
+        allowed = tuple(actor for actor in allowed if actor)
+        if not allowed:
+            raise ValueError(
+                f"InfrastructureZone '{self.id}' allowed_actor_types must not be empty"
+            )
+        self.allowed_actor_types = allowed
+        if self.note is not None:
+            self.note = str(self.note)
+
+    def polygon(self) -> Polygon:
+        """Return the zone as a Shapely polygon."""
+        return Polygon(self.vertices)
+
+
+@dataclass
 class MapDefinition:
     """
     A class to represent a map definition.
@@ -335,6 +378,9 @@ class MapDefinition:
     obstacle logic, or planner behaviour.  It is consumed by topology,
     prediction, and observation-noise diagnostics.
     """
+
+    infrastructure_zones: list[InfrastructureZone] = field(default_factory=list)
+    """Semantic public-space zones for certification-only route validation."""
 
     _poi_positions_by_label: dict[str, Vec2D] = field(init=False, default_factory=dict, repr=False)
     """Internal lookup table from POI label to position for faster access."""
@@ -652,6 +698,8 @@ class MapDefinition:
             self.single_pedestrians = []
         if not hasattr(self, "semantic_boundaries"):
             self.semantic_boundaries = []
+        if not hasattr(self, "infrastructure_zones"):
+            self.infrastructure_zones = []
         self._build_poi_lookup()
 
 
@@ -1037,6 +1085,49 @@ def _parse_single_pedestrians(
     return single_pedestrians
 
 
+def _parse_infrastructure_zones(
+    map_structure: dict,
+    *,
+    min_x: float,
+    min_y: float,
+) -> list[InfrastructureZone]:
+    """Parse optional infrastructure zones from map data.
+
+    Returns:
+        list[InfrastructureZone]: Parsed certification-only infrastructure zones.
+    """
+    zones = map_structure.get("infrastructure_zones", [])
+    if zones is None:
+        return []
+    if not isinstance(zones, list):
+        raise ValueError("infrastructure_zones must be a list")
+    parsed: list[InfrastructureZone] = []
+    for idx, zone in enumerate(zones):
+        if not isinstance(zone, dict):
+            raise ValueError(f"infrastructure_zones[{idx}] must be a mapping")
+        raw_vertices = zone.get("vertices")
+        if not isinstance(raw_vertices, list):
+            raise ValueError(f"infrastructure_zones[{idx}] missing vertices list")
+        vertices = [
+            _normalize_position(tuple(vertex), min_x=min_x, min_y=min_y) for vertex in raw_vertices
+        ]
+        allowed = zone.get("allowed_actor_types", ("pedestrian",))
+        if isinstance(allowed, str):
+            allowed_actor_types = (allowed,)
+        else:
+            allowed_actor_types = tuple(allowed)
+        parsed.append(
+            InfrastructureZone(
+                id=str(zone.get("id") or f"infrastructure_zone_{idx}"),
+                zone_type=str(zone.get("zone_type") or "restricted"),
+                vertices=vertices,
+                allowed_actor_types=allowed_actor_types,
+                note=zone.get("note"),
+            )
+        )
+    return parsed
+
+
 def _build_map_bounds(width: float, height: float) -> list[Line2D]:
     """Build boundary lines for a rectangular map.
 
@@ -1118,6 +1209,11 @@ def serialize_map(map_structure: dict) -> MapDefinition:
     robot_routes = robot_routes + [_reverse_route(route) for route in robot_routes]
 
     single_pedestrians = _parse_single_pedestrians(map_structure, min_x=min_x, min_y=min_y)
+    infrastructure_zones = _parse_infrastructure_zones(
+        map_structure,
+        min_x=min_x,
+        min_y=min_y,
+    )
     map_bounds = _build_map_bounds(width, height)
 
     return MapDefinition(
@@ -1133,4 +1229,5 @@ def serialize_map(map_structure: dict) -> MapDefinition:
         ped_crowded_zones,
         ped_routes,
         single_pedestrians,
+        infrastructure_zones=infrastructure_zones,
     )

--- a/robot_sf/scenario_certification/v1.py
+++ b/robot_sf/scenario_certification/v1.py
@@ -378,6 +378,22 @@ def _certify_route(
             evidence=evidence,
         )
 
+    infrastructure_reasons, infrastructure_checks = _infrastructure_checks(
+        map_def,
+        route_line=route_line,
+    )
+    checks["infrastructure"] = infrastructure_checks
+    if infrastructure_reasons:
+        reasons.extend(infrastructure_reasons)
+        return _route_certificate(
+            route,
+            route_id=route_id,
+            status=INVALID,
+            reasons=reasons,
+            checks=checks,
+            evidence=evidence,
+        )
+
     dynamic_reasons, dynamic_checks = _dynamic_checks(
         map_def,
         planned_line=planned_line,
@@ -766,6 +782,44 @@ def _circumradius(p0: Vec2D, p1: Vec2D, p2: Vec2D) -> float | None:
     if a <= 1e-9 or b <= 1e-9 or c <= 1e-9 or area2 <= 1e-9:
         return None
     return float((a * b * c) / (2.0 * area2))
+
+
+def _infrastructure_checks(
+    map_def: MapDefinition,
+    *,
+    route_line: LineString,
+) -> tuple[list[str], dict[str, Any]]:
+    """Check certification-only public-space restrictions for AMV routes.
+
+    Returns:
+        tuple[list[str], dict[str, Any]]: Invalidity reasons and diagnostics.
+    """
+    zones = list(getattr(map_def, "infrastructure_zones", []))
+    checks: dict[str, Any] = {
+        "zone_count": len(zones),
+        "intersected_zone_ids": [],
+        "illegal_amv_zone_ids": [],
+    }
+    if not zones:
+        return [], checks
+
+    illegal: list[dict[str, str]] = []
+    intersected: list[str] = []
+    for zone in zones:
+        if not route_line.intersects(zone.polygon()):
+            continue
+        intersected.append(zone.id)
+        allowed = set(zone.allowed_actor_types)
+        if allowed.isdisjoint({"all", "amv", "robot", "vehicle"}):
+            illegal.append({"id": zone.id, "zone_type": zone.zone_type})
+
+    checks["intersected_zone_ids"] = intersected
+    checks["illegal_amv_zone_ids"] = [entry["id"] for entry in illegal]
+    checks["illegal_amv_zones"] = illegal
+    if not illegal:
+        return [], checks
+    labels = ", ".join(f"{entry['id']}({entry['zone_type']})" for entry in illegal)
+    return [f"illegal_amv_infrastructure_traversal: {labels}"], checks
 
 
 def _dynamic_checks(

--- a/tests/scenario_certification/test_scenario_certification_v1.py
+++ b/tests/scenario_certification/test_scenario_certification_v1.py
@@ -9,7 +9,12 @@ import jsonschema
 import pytest
 
 from robot_sf.nav.global_route import GlobalRoute
-from robot_sf.nav.map_config import MapDefinition, SinglePedestrianDefinition
+from robot_sf.nav.map_config import (
+    InfrastructureZone,
+    MapDefinition,
+    SinglePedestrianDefinition,
+    serialize_map,
+)
 from robot_sf.nav.obstacle import Obstacle
 from robot_sf.robot.bicycle_drive import BicycleDriveSettings
 from robot_sf.robot.differential_drive import DifferentialDriveSettings
@@ -53,6 +58,21 @@ def _obstacle(
     return Obstacle([(min_x, min_y), (max_x, min_y), (max_x, max_y), (min_x, max_y)])
 
 
+def _infrastructure_zone(
+    zone_id: str,
+    zone_type: str,
+    *,
+    allowed_actor_types: tuple[str, ...] = ("pedestrian",),
+) -> InfrastructureZone:
+    """Return a restricted infrastructure zone crossing the default straight route."""
+    return InfrastructureZone(
+        id=zone_id,
+        zone_type=zone_type,
+        vertices=[(4.5, 1.2), (7.5, 1.2), (7.5, 2.8), (4.5, 2.8)],
+        allowed_actor_types=allowed_actor_types,
+    )
+
+
 def _map(
     route_points: list[tuple[float, float]],
     *,
@@ -60,6 +80,7 @@ def _map(
     height: float = 8.0,
     obstacles: list[Obstacle] | None = None,
     pedestrians: list[SinglePedestrianDefinition] | None = None,
+    infrastructure_zones: list[InfrastructureZone] | None = None,
 ) -> MapDefinition:
     """Build a minimal map definition around one robot route."""
     route = GlobalRoute(
@@ -82,6 +103,7 @@ def _map(
         ped_crowded_zones=[],
         ped_routes=[],
         single_pedestrians=pedestrians or [],
+        infrastructure_zones=infrastructure_zones or [],
     )
 
 
@@ -164,6 +186,94 @@ def test_dynamic_crossing_is_hard_but_solvable() -> None:
         pedestrians=[SinglePedestrianDefinition(id="p0", start=(5.0, 0.5), goal=(5.0, 4.0))],
     )
     assert _classify(crossing) == HARD_BUT_SOLVABLE
+
+
+@pytest.mark.parametrize(
+    ("zone_id", "zone_type"),
+    [
+        ("ped_only_cut", "pedestrian_only"),
+        ("stair_exit", "stairs"),
+        ("signal_crossing", "signalized_crossing_zone"),
+    ],
+)
+def test_restricted_infrastructure_zone_rejects_illegal_amv_traversal(
+    zone_id: str,
+    zone_type: str,
+) -> None:
+    """AMV routes through pedestrian-only infrastructure fail closed."""
+
+    certificate = certify_map_definition(
+        _map(
+            [(2.0, 2.0), (10.0, 2.0)],
+            infrastructure_zones=[_infrastructure_zone(zone_id, zone_type)],
+        ),
+        robot_config=DifferentialDriveSettings(radius=0.4),
+    )
+
+    assert certificate.classification == INVALID
+    assert any("illegal_amv_infrastructure_traversal" in reason for reason in certificate.reasons)
+    route_checks = certificate.route_certificates[0].checks["infrastructure"]
+    assert route_checks["illegal_amv_zone_ids"] == [zone_id]
+
+
+def test_amv_allowed_infrastructure_zone_remains_certifiable() -> None:
+    """Infrastructure metadata does not reject routes through AMV-allowed zones."""
+
+    allowed = _map(
+        [(2.0, 2.0), (10.0, 2.0)],
+        infrastructure_zones=[
+            _infrastructure_zone(
+                "shared_lane",
+                "shared_space_lane",
+                allowed_actor_types=("pedestrian", "amv"),
+            )
+        ],
+    )
+
+    certificate = certify_map_definition(
+        allowed,
+        robot_config=DifferentialDriveSettings(radius=0.4),
+    )
+
+    assert certificate.classification == VALID
+    route_checks = certificate.route_certificates[0].checks["infrastructure"]
+    assert route_checks["intersected_zone_ids"] == ["shared_lane"]
+    assert route_checks["illegal_amv_zone_ids"] == []
+
+
+def test_serialized_map_infrastructure_zones_feed_certification() -> None:
+    """YAML/JSON map payloads can carry infrastructure semantics into certification."""
+
+    map_def = serialize_map(
+        {
+            "x_margin": [0.0, 12.0],
+            "y_margin": [0.0, 8.0],
+            "obstacles": [],
+            "robot_spawn_zones": [[(1.8, 1.8), (2.2, 1.8), (2.2, 2.2)]],
+            "robot_goal_zones": [[(9.8, 1.8), (10.2, 1.8), (10.2, 2.2)]],
+            "ped_spawn_zones": [],
+            "ped_goal_zones": [],
+            "ped_crowded_zones": [],
+            "robot_routes": [{"spawn_id": 0, "goal_id": 0, "waypoints": [(2.0, 2.0), (10.0, 2.0)]}],
+            "ped_routes": [],
+            "infrastructure_zones": [
+                {
+                    "id": "pedestrian_exit_a",
+                    "zone_type": "pedestrian_exit",
+                    "vertices": [(4.5, 1.2), (7.5, 1.2), (7.5, 2.8), (4.5, 2.8)],
+                    "allowed_actor_types": ["pedestrian"],
+                }
+            ],
+        }
+    )
+
+    certificate = certify_map_definition(
+        map_def,
+        robot_config=DifferentialDriveSettings(radius=0.4),
+    )
+
+    assert certificate.classification == INVALID
+    assert certificate.route_certificates[0].checks["infrastructure"]["zone_count"] == 1
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
Adds certification-only shared-space infrastructure zones and rejects AMV/robot routes through zones that do not allow AMV traversal.

## Linked Issues
- Closes #2926

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added InfrastructureZone metadata parsing to MapDefinition/serialize_map.
- Added scenario certification checks that fail closed when an AMV route intersects pedestrian-only, stairs, or other restricted infrastructure zones.
- Added three draft smoke scenario fixtures for pedestrian-only, stair, and signalized crossing wait-zone semantics.
- Added focused certification tests and documented the certification-only contract.

## Why It Matters
- Added value: authors can represent infrastructure semantics that are not physical obstacles but should invalidate AMV benchmark routes.
- Expected impact: illegal AMV traversal through pedestrian-only/stair-like zones is excluded during scenario certification.
- Why this is worth merging now: it closes the issue acceptance with a narrow, test-backed route-validation contract.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Scenario certification can reject illegal AMV traversal through authored shared-space infrastructure zones.
- Comparator or baseline, if applicable: Prior certification ignored these infrastructure semantics.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: Stop once focused unit tests and three committed draft scenario fixtures fail closed with explicit illegal infrastructure reasons.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2926
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - this adds certification metadata/checks and smoke fixtures, not an analysis tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress? It changes certification classification only; simulator physics/planner execution are unchanged.
- Did the scenario actually contain the targeted failure mode? yes, each smoke fixture contains one restricted infrastructure polygon intersecting the route.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: continue; ready for review as certification-scope support.
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/validate_scenario.py configs/scenarios/sets/issue_2926_shared_space_infrastructure_smoke.yaml
  - scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/certify_scenarios.py configs/scenarios/sets/issue_2926_shared_space_infrastructure_smoke.yaml --jsonl
  - scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_scenario_certification_v1.py tests/maps/test_station_platform_map.py -q
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/nav/map_config.py robot_sf/scenario_certification/v1.py tests/scenario_certification/test_scenario_certification_v1.py
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/nav/map_config.py robot_sf/scenario_certification/v1.py tests/scenario_certification/test_scenario_certification_v1.py
  - git diff --check
- Evidence that the change works here: focused tests passed (21 tests); scenario validator accepted 3 draft smoke scenarios; certifier returned invalid classifications with illegal_amv_infrastructure_traversal reasons for pedestrian_only_cut, stair_access, and signalized_crossing_wait_box.
- Benchmarks or smoke tests, if applicable: targeted certification smoke only; not benchmark evidence.

## Risks / Rollout
- Compatibility risks: MapDefinition gains a defaulted field and __setstate__ fallback for older pickled objects.
- Failure modes: authored infrastructure polygons that overlap a route will fail closed unless allowed_actor_types includes amv, robot, vehicle, or all.
- Rollback or fallback plan: remove/ignore infrastructure_zones metadata to return to prior certification behavior.

## Docs / Provenance
- Updated docs: docs/scenario_certification.md
- Relevant design or provenance notes: configs/scenarios/sets/issue_2926_shared_space_infrastructure_smoke.yaml records draft/non-benchmark status.
- Any assumptions that need to be preserved: Infrastructure zones are certification-only metadata and do not alter simulator physics, planner costs, or benchmark execution by themselves.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #2926
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is a certification-scope feature with committed smoke fixtures and no benchmark/paper claim.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: whether allowed_actor_types should use a broader or narrower set of AMV aliases.
- Any known limitations: zone semantics are explicit YAML/map metadata only; existing diagnostic semantic_boundaries are not repurposed here.
