### PR TITLE
feat: wire seed gate to campaign reports

### DIFF
--- a/docs/context/issue_3076_campaign_result_store_contract.md
+++ b/docs/context/issue_3076_campaign_result_store_contract.md
@@ -51,3 +51,36 @@ git diff --check
 This slice proves fixture round-trip through Parquet and DuckDB plus fail-closed provenance checks.
 The next result-store work should connect real campaign outputs to this contract and then build
 report generation on top of the validated store, not directly from ad hoc `output/` files.
+
+## Seed-Sufficiency Scheduling Consumer
+
+Issue [#3160](https://github.com/ll7/robot_sf_ll7/issues/3160) wires the S5/S10/S20
+seed-sufficiency gate into result-store consumers. A campaign result store may declare frozen gate
+inputs under `analysis.json`:
+
+```json
+{
+  "seed_sufficiency_gate": {
+    "schedule": "s5",
+    "ci_half_width": 0.2,
+    "target_ci_half_width": 0.1,
+    "rank_flip_observed": false,
+    "heldout_delta_abs": null,
+    "heldout_delta_threshold": null
+  }
+}
+```
+
+The gate derives `invalid_row_count` from `summary.json` row-status counts so fallback, degraded,
+failed, unavailable, or diagnostic-only rows cannot silently strengthen benchmark claims. The
+canonical scheduling command is:
+
+```bash
+uv run python scripts/tools/seed_sufficiency_gate.py \
+  --result-store <campaign-result-store> \
+  --output-json <decision.json>
+```
+
+`scripts/tools/build_campaign_comparison_report.py` also records the same decision when invoked with
+`--seed-gate-output-json`, keeping the report artifact and scheduling decision tied to the same
+validated result-store input.

--- a/scripts/tools/build_campaign_comparison_report.py
+++ b/scripts/tools/build_campaign_comparison_report.py
@@ -18,6 +18,7 @@ from scripts.tools.campaign_result_store import (
     read_parquet_frame,
     validate_result_store,
 )
+from scripts.tools.seed_sufficiency_gate import seed_gate_payload_from_result_store
 
 SCHEMA_VERSION = "campaign-comparison-report.v1"
 BENCHMARK_VALID_ROW_STATUSES = frozenset({"native", "adapter"})
@@ -60,6 +61,11 @@ def _finite_float(value: Any) -> float | None:
 def _load_summary(result_store: Path) -> dict[str, Any]:
     """Read the canonical result-store summary payload."""
     return json.loads((result_store / "summary.json").read_text(encoding="utf-8"))
+
+
+def _load_analysis(result_store: Path) -> dict[str, Any]:
+    """Read the canonical result-store analysis payload."""
+    return json.loads((result_store / "analysis.json").read_text(encoding="utf-8"))
 
 
 def _load_episode_frame(result_store: Path) -> pd.DataFrame:
@@ -187,6 +193,16 @@ def _row_status_section(frame: pd.DataFrame) -> dict[str, Any]:
     }
 
 
+def _seed_gate_section(
+    result_store: Path,
+    analysis: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Build an optional seed-sufficiency scheduling decision from result-store inputs."""
+    if analysis.get("seed_sufficiency_gate") is None:
+        return None
+    return seed_gate_payload_from_result_store(result_store)
+
+
 def _visual_summary(planner_rows: list[dict[str, Any]], metrics: list[str]) -> list[dict[str, Any]]:
     """Build compact bar-summary payloads for Markdown rendering."""
     summaries: list[dict[str, Any]] = []
@@ -287,6 +303,7 @@ def build_report(
     """Build a comparison report payload from a campaign result store."""
     frame = _load_episode_frame(result_store)
     summary = _load_summary(result_store)
+    analysis = _load_analysis(result_store)
     metrics = _available_metrics(frame)
     planner_rows = _summarize_groups(frame, group_fields=("planner",), metrics=metrics)
     scenario_family_rows = _summarize_groups(
@@ -315,6 +332,7 @@ def build_report(
         "scenario_family_summaries": scenario_family_rows,
         "metric_visual_summaries": _visual_summary(planner_rows, metrics),
         "statistical_hooks": _statistical_hooks(planner_rows, metrics, min_sample=min_sample),
+        "seed_sufficiency_gate": _seed_gate_section(result_store, analysis),
         "limitations": [
             "confidence intervals are normal-approximation descriptive intervals, not a "
             "significance claim",
@@ -405,6 +423,20 @@ def build_markdown(payload: dict[str, Any]) -> str:
             )
     else:
         lines.append("| NA | NA | NA | NA | underpowered | no comparable metric pairs |")
+    seed_gate = payload.get("seed_sufficiency_gate")
+    if isinstance(seed_gate, dict):
+        decision = seed_gate.get("decision", {})
+        lines.extend(
+            [
+                "",
+                "## Seed Sufficiency Gate",
+                "",
+                f"- Decision: `{decision.get('decision', 'unknown')}`",
+                f"- Current schedule: `{decision.get('current_schedule', 'unknown')}`",
+                f"- Next schedule: `{decision.get('next_schedule') or 'NA'}`",
+                f"- Reason: {decision.get('reason', 'unknown')}",
+            ]
+        )
     lines.extend(["", "## Limitations", ""])
     for limitation in payload.get("limitations", []):
         lines.append(f"- {limitation}")
@@ -420,12 +452,26 @@ def _write_outputs(payload: dict[str, Any], *, output_json: Path, output_md: Pat
     output_md.write_text(build_markdown(payload), encoding="utf-8")
 
 
+def _write_seed_gate_output(payload: dict[str, Any], output_json: Path) -> None:
+    """Write the optional seed-gate scheduling decision artifact."""
+    seed_gate = payload.get("seed_sufficiency_gate")
+    if not isinstance(seed_gate, dict):
+        raise ValueError("result store analysis.json does not declare seed_sufficiency_gate")
+    output_json.parent.mkdir(parents=True, exist_ok=True)
+    output_json.write_text(json.dumps(seed_gate, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse command-line arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--result-store", type=Path, required=True)
     parser.add_argument("--output-json", type=Path, required=True)
     parser.add_argument("--output-md", type=Path, required=True)
+    parser.add_argument(
+        "--seed-gate-output-json",
+        type=Path,
+        help="Optional durable seed-sufficiency decision JSON derived from the result store.",
+    )
     parser.add_argument(
         "--input-label",
         default=None,
@@ -467,6 +513,12 @@ def main(argv: list[str] | None = None) -> int:
         print(str(exc), file=sys.stderr)
         return 1
     _write_outputs(payload, output_json=args.output_json, output_md=args.output_md)
+    if args.seed_gate_output_json is not None:
+        try:
+            _write_seed_gate_output(payload, args.seed_gate_output_json)
+        except ValueError as exc:
+            print(str(exc), file=sys.stderr)
+            return 1
     return 0
 
 

--- a/scripts/tools/seed_sufficiency_gate.py
+++ b/scripts/tools/seed_sufficiency_gate.py
@@ -7,9 +7,10 @@ import argparse
 import json
 from dataclasses import asdict, dataclass, fields
 from pathlib import Path
-from typing import Literal
+from typing import Any, Literal
 
 SCHEDULES = ("s5", "s10", "s20")
+BENCHMARK_VALID_ROW_STATUSES = frozenset({"native", "adapter"})
 Decision = Literal["escalate", "stop_confirmed", "diagnostic_only"]
 
 
@@ -82,10 +83,56 @@ def decide_seed_gate(inputs: SeedGateInput) -> SeedGateDecision:
     )
 
 
+def seed_gate_payload_from_result_store(result_store: Path) -> dict[str, Any]:
+    """Build a seed-sufficiency decision payload from a canonical result store."""
+    summary = json.loads((result_store / "summary.json").read_text(encoding="utf-8"))
+    analysis = json.loads((result_store / "analysis.json").read_text(encoding="utf-8"))
+    gate_payload = analysis.get("seed_sufficiency_gate")
+    if not isinstance(gate_payload, dict):
+        raise ValueError("analysis.json seed_sufficiency_gate must be a mapping")
+
+    gate_fields = {field.name for field in fields(SeedGateInput)}
+    raw_input = {key: value for key, value in gate_payload.items() if key in gate_fields}
+    raw_input["invalid_row_count"] = _invalid_row_count_from_summary(summary)
+    decision = decide_seed_gate(SeedGateInput(**raw_input))
+    return {
+        "schema_version": "campaign-seed-sufficiency-schedule.v1",
+        "source": "campaign_result_store.analysis_json",
+        "input": raw_input,
+        "decision": asdict(decision),
+    }
+
+
+def _invalid_row_count_from_summary(summary: dict[str, Any]) -> int:
+    """Return result-store rows that cannot strengthen benchmark claims."""
+    counts = summary.get("row_status_counts", {})
+    if not isinstance(counts, dict):
+        return 0
+    return sum(
+        int(count) for status, count in counts.items() if status not in BENCHMARK_VALID_ROW_STATUSES
+    )
+
+
+def _seed_gate_payload_from_input_json(input_json: Path) -> dict[str, Any]:
+    """Build a seed-sufficiency decision payload from a frozen gate input JSON."""
+    payload = json.loads(input_json.read_text(encoding="utf-8"))
+    gate_fields = {field.name for field in fields(SeedGateInput)}
+    raw_input = {key: value for key, value in payload.items() if key in gate_fields}
+    decision = decide_seed_gate(SeedGateInput(**raw_input))
+    return {
+        "schema_version": "seed-sufficiency-gate.v1",
+        "source": "seed_gate_input_json",
+        "input": raw_input,
+        "decision": asdict(decision),
+    }
+
+
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--input-json", type=Path, required=True, help="Seed gate input JSON.")
+    source = parser.add_mutually_exclusive_group(required=True)
+    source.add_argument("--input-json", type=Path, help="Seed gate input JSON.")
+    source.add_argument("--result-store", type=Path, help="Canonical campaign result-store path.")
     parser.add_argument("--output-json", type=Path, help="Optional decision JSON path.")
     return parser.parse_args(argv)
 
@@ -93,18 +140,18 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 def main(argv: list[str] | None = None) -> int:
     """Run the seed-sufficiency gate from JSON."""
     args = _parse_args(argv)
-    payload = json.loads(args.input_json.read_text(encoding="utf-8"))
-    gate_fields = {field.name for field in fields(SeedGateInput)}
-    decision = decide_seed_gate(
-        SeedGateInput(**{key: value for key, value in payload.items() if key in gate_fields})
+    result = (
+        seed_gate_payload_from_result_store(args.result_store)
+        if args.result_store is not None
+        else _seed_gate_payload_from_input_json(args.input_json)
     )
-    result = asdict(decision)
     text = json.dumps(result, indent=2, sort_keys=True) + "\n"
     if args.output_json is not None:
         args.output_json.parent.mkdir(parents=True, exist_ok=True)
         args.output_json.write_text(text, encoding="utf-8")
     print(text, end="")
-    return 0 if decision.decision != "diagnostic_only" else 1
+    decision = result["decision"]["decision"]
+    return 0 if decision != "diagnostic_only" else 1
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_build_campaign_comparison_report.py
+++ b/tests/tools/test_build_campaign_comparison_report.py
@@ -15,7 +15,7 @@ from scripts.tools.build_campaign_comparison_report import (
 from scripts.tools.campaign_result_store import write_result_store
 
 
-def _write_fixture_store(path: Path) -> None:
+def _write_fixture_store(path: Path, *, analysis: dict | None = None) -> None:
     """Create a small result store with valid and limited rows."""
     fixture = Path("tests/fixtures/campaign_result_store/issue_3063_episode_rows.json")
     rows = json.loads(fixture.read_text(encoding="utf-8"))
@@ -25,6 +25,40 @@ def _write_fixture_store(path: Path) -> None:
         study_id="issue-3063-fixture",
         command="uv run python scripts/tools/build_campaign_comparison_report.py ...",
         source_commit="abc123",
+        analysis=analysis,
+    )
+
+
+def _write_native_seed_gate_store(
+    path: Path,
+    *,
+    analysis: dict,
+) -> None:
+    """Create a canonical result store with only benchmark-valid native rows."""
+    rows = [
+        {
+            "run_id": f"run-{seed}",
+            "episode_id": f"run-{seed}-001",
+            "planner": "orca",
+            "scenario_id": "crossing",
+            "scenario_family": "crossing",
+            "seed": seed,
+            "row_status": "native",
+            "artifact_uri": f"wandb://robot-sf/run-{seed}/episodes/run-{seed}-001.jsonl",
+            "artifact_sha256": str(seed) * 64,
+            "success": seed % 2 == 0,
+            "collision": False,
+            "snqi": 0.5,
+        }
+        for seed in (5, 6, 7, 8, 9)
+    ]
+    write_result_store(
+        path,
+        rows,
+        study_id="issue-3160-seed-gate-fixture",
+        command="uv run python scripts/tools/build_campaign_comparison_report.py ...",
+        source_commit="abc123",
+        analysis=analysis,
     )
 
 
@@ -46,6 +80,7 @@ def test_build_report_surfaces_uncertainty_denominators_and_caveats(tmp_path: Pa
         == "tests/fixtures/campaign_result_store/issue_3063_episode_rows.json"
     )
     assert payload["input"]["result_store"] == "transient_local_result_store"
+    assert payload["seed_sufficiency_gate"] is None
     assert payload["row_status"]["benchmark_valid_episode_count"] == 2
     assert payload["row_status"]["excluded_or_limited_episode_count"] == 2
     caveats = {row["row_status"]: row["interpretation"] for row in payload["row_status"]["caveats"]}
@@ -107,6 +142,136 @@ def test_main_writes_json_and_markdown_outputs(
         == "tests/fixtures/campaign_result_store/issue_3063_episode_rows.json"
     )
     assert "Campaign Comparison Report" in output_md.read_text(encoding="utf-8")
+
+
+def test_build_report_embeds_seed_gate_escalation_from_result_store(tmp_path: Path) -> None:
+    """Scheduling consumers should derive escalation from canonical result-store inputs."""
+    result_store = tmp_path / "result-store"
+    _write_native_seed_gate_store(
+        result_store,
+        analysis={
+            "seed_sufficiency_gate": {
+                "schedule": "s5",
+                "ci_half_width": 0.2,
+                "target_ci_half_width": 0.1,
+            }
+        },
+    )
+
+    payload = build_report(result_store, min_sample=1)
+
+    seed_gate = payload["seed_sufficiency_gate"]
+    assert seed_gate["source"] == "campaign_result_store.analysis_json"
+    assert seed_gate["input"]["invalid_row_count"] == 0
+    assert seed_gate["decision"]["decision"] == "escalate"
+    assert seed_gate["decision"]["next_schedule"] == "s10"
+
+
+def test_build_report_embeds_seed_gate_stop_from_result_store(tmp_path: Path) -> None:
+    """Stable result-store inputs should let scheduling stop without manual JSON."""
+    result_store = tmp_path / "result-store"
+    _write_native_seed_gate_store(
+        result_store,
+        analysis={
+            "seed_sufficiency_gate": {
+                "schedule": "s10",
+                "ci_half_width": 0.05,
+                "target_ci_half_width": 0.1,
+            }
+        },
+    )
+
+    payload = build_report(result_store, min_sample=1)
+
+    seed_gate = payload["seed_sufficiency_gate"]
+    assert seed_gate["decision"]["decision"] == "stop_confirmed"
+    assert seed_gate["decision"]["next_schedule"] is None
+
+
+def test_build_report_keeps_limited_rows_diagnostic_only_for_seed_gate(
+    tmp_path: Path,
+) -> None:
+    """Excluded or limited result-store rows should prevent escalation claim strength."""
+    result_store = tmp_path / "result-store"
+    _write_fixture_store(
+        result_store,
+        analysis={
+            "seed_sufficiency_gate": {
+                "schedule": "s5",
+                "ci_half_width": 0.05,
+                "target_ci_half_width": 0.1,
+            }
+        },
+    )
+
+    payload = build_report(result_store, min_sample=1)
+
+    seed_gate = payload["seed_sufficiency_gate"]
+    assert seed_gate["input"]["invalid_row_count"] == 2
+    assert seed_gate["decision"]["decision"] == "diagnostic_only"
+    assert seed_gate["decision"]["next_schedule"] is None
+
+
+def test_main_writes_seed_gate_decision_output(tmp_path: Path) -> None:
+    """CLI should record a durable seed-gate decision artifact when requested."""
+    result_store = tmp_path / "result-store"
+    _write_native_seed_gate_store(
+        result_store,
+        analysis={
+            "seed_sufficiency_gate": {
+                "schedule": "s5",
+                "ci_half_width": 0.2,
+                "target_ci_half_width": 0.1,
+            }
+        },
+    )
+    output_json = tmp_path / "report.json"
+    output_md = tmp_path / "report.md"
+    seed_gate_json = tmp_path / "seed-gate-decision.json"
+
+    assert (
+        main(
+            [
+                "--result-store",
+                str(result_store),
+                "--output-json",
+                str(output_json),
+                "--output-md",
+                str(output_md),
+                "--seed-gate-output-json",
+                str(seed_gate_json),
+            ]
+        )
+        == 0
+    )
+
+    seed_gate = json.loads(seed_gate_json.read_text(encoding="utf-8"))
+    assert seed_gate["decision"]["decision"] == "escalate"
+    assert "## Seed Sufficiency Gate" in output_md.read_text(encoding="utf-8")
+
+
+def test_main_fails_when_seed_gate_output_requested_without_store_config(
+    tmp_path: Path,
+) -> None:
+    """Seed-gate scheduling output should not fall back to ad hoc empty decisions."""
+    result_store = tmp_path / "result-store"
+    _write_fixture_store(result_store)
+
+    assert (
+        main(
+            [
+                "--result-store",
+                str(result_store),
+                "--output-json",
+                str(tmp_path / "report.json"),
+                "--output-md",
+                str(tmp_path / "report.md"),
+                "--seed-gate-output-json",
+                str(tmp_path / "seed-gate-decision.json"),
+            ]
+        )
+        == 1
+    )
 
 
 def test_main_fails_closed_for_incomplete_result_store(tmp_path: Path) -> None:

--- a/tests/tools/test_seed_sufficiency_gate.py
+++ b/tests/tools/test_seed_sufficiency_gate.py
@@ -3,8 +3,13 @@
 from __future__ import annotations
 
 import json
+from typing import TYPE_CHECKING
 
+from scripts.tools.campaign_result_store import write_result_store
 from scripts.tools.seed_sufficiency_gate import SeedGateInput, decide_seed_gate, main
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_seed_gate_escalates_when_uncertainty_exceeds_target() -> None:
@@ -73,3 +78,41 @@ def test_seed_gate_cli_ignores_extra_input_keys(tmp_path) -> None:
     )
 
     assert main(["--input-json", str(input_json)]) == 0
+
+
+def test_seed_gate_cli_reads_canonical_result_store(tmp_path: Path) -> None:
+    """Result-store scheduling should not require hand-authored gate input JSON."""
+    result_store = tmp_path / "result-store"
+    write_result_store(
+        result_store,
+        [
+            {
+                "run_id": "run-a",
+                "episode_id": "run-a-001",
+                "planner": "orca",
+                "scenario_id": "crossing",
+                "scenario_family": "crossing",
+                "seed": 5,
+                "row_status": "native",
+                "artifact_uri": "wandb://robot-sf/run-a/episodes/run-a-001.jsonl",
+                "artifact_sha256": "a" * 64,
+            }
+        ],
+        study_id="issue-3160-seed-gate",
+        command="uv run python scripts/tools/seed_sufficiency_gate.py --result-store ...",
+        analysis={
+            "seed_sufficiency_gate": {
+                "schedule": "s5",
+                "ci_half_width": 0.2,
+                "target_ci_half_width": 0.1,
+            }
+        },
+    )
+    output_json = tmp_path / "decision.json"
+
+    assert main(["--result-store", str(result_store), "--output-json", str(output_json)]) == 0
+
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["source"] == "campaign_result_store.analysis_json"
+    assert payload["input"]["invalid_row_count"] == 0
+    assert payload["decision"]["decision"] == "escalate"


### PR DESCRIPTION
## Summary
Wires the S5/S10/S20 seed-sufficiency gate into canonical campaign result-store consumers. The gate can now read `--result-store`, and campaign comparison reports can emit a durable seed-gate decision JSON from the same validated store.

## Linked Issues
- Closes #3160
- Relates to #3077
- Relates to #3057

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/tools/seed_sufficiency_gate.py --result-store` so scheduling decisions can be derived from canonical `summary.json` and `analysis.json` instead of hand-authored gate JSON.
- Added `--seed-gate-output-json` to `scripts/tools/build_campaign_comparison_report.py` and embedded the same decision in report payloads/Markdown.
- Added tests covering `escalate`, `stop_confirmed`, and `diagnostic_only` result-store paths.
- Updated the result-store contract note with the `analysis.json.seed_sufficiency_gate` shape and canonical commands.

## Why It Matters
- Added value: campaign scheduling can consume gate output directly from retained campaign result stores.
- Expected impact: #3078/#3079/#3080-style package runs have a concrete stop/escalate/diagnostic-only JSON surface.
- Why this is worth merging now: it closes the gap left by #3077/#3082 without changing the gate logic or escalation schedule.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Seed-sufficiency scheduling decisions are reproducibly derived from canonical result-store inputs.
- Comparator or baseline, if applicable: Prior workflow required ad hoc/manual gate input JSON for consumers.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: Stop once the consumer emits valid decisions for escalate, stop_confirmed, and diagnostic_only from result stores.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3160 and docs/context/issue_3076_campaign_result_store_contract.md
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - this is scheduling/workflow wiring over an existing gate.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress? No runtime planner behavior changes; only campaign scheduling/report decision artifacts.
- Did the scenario actually contain the targeted failure mode? yes, tests cover unstable, stable, and limited-row result-store inputs.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: #3077 can be closed after this merges if maintainers agree no residual acceptance remains.

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none for the smoke contract.
- Stop / revise / continue decision: continue; ready for review.
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - scripts/dev/run_worktree_shared_venv.sh -- uv run --extra analytics pytest tests/tools/test_build_campaign_comparison_report.py tests/tools/test_seed_sufficiency_gate.py tests/tools/test_campaign_result_store.py -q
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/build_campaign_comparison_report.py scripts/tools/seed_sufficiency_gate.py tests/tools/test_build_campaign_comparison_report.py tests/tools/test_seed_sufficiency_gate.py
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/tools/build_campaign_comparison_report.py scripts/tools/seed_sufficiency_gate.py tests/tools/test_build_campaign_comparison_report.py tests/tools/test_seed_sufficiency_gate.py
  - scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/seed_sufficiency_gate.py --input-json <tmp>/gate-input.json --output-json <tmp>/decision.json
  - git diff --check
- Evidence that the change works here: 24 focused tests passed; direct gate CLI smoke emitted `decision=escalate`, `next_schedule=s10`.
- Benchmarks or smoke tests, if applicable: targeted workflow smoke only; not benchmark evidence.

## Risks / Rollout
- Compatibility risks: `--input-json` remains supported; the new `--result-store` path is additive.
- Failure modes: requesting report `--seed-gate-output-json` without `analysis.json.seed_sufficiency_gate` now fails closed instead of inventing a decision.
- Rollback or fallback plan: omit `--seed-gate-output-json` or keep using `seed_sufficiency_gate.py --input-json`.

## Docs / Provenance
- Updated docs: docs/context/issue_3076_campaign_result_store_contract.md
- Relevant design or provenance notes: invalid row count is derived from canonical result-store `row_status_counts` so limited/excluded rows force diagnostic-only behavior.
- Any assumptions that need to be preserved: this does not change gate logic, only the consumer/input path.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #3160
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): yes, result-store contract note updated
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is workflow wiring with focused smoke evidence, not a benchmark result.

## Follow-Up Issues
- Deferred work: close/reconcile #3077 after this merges if its remaining acceptance is satisfied.
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: whether every non-native/non-adapter row should count as invalid for seed-gate escalation. This branch uses the conservative benchmark-valid denominator policy.
- Any known limitations: no real campaign package is executed here; the proof is targeted fixture/smoke coverage over the canonical result-store contract.
