### PR TITLE
fix: fail closed on incomplete PR followups

### DIFF
--- a/scripts/dev/check_pr_followups.py
+++ b/scripts/dev/check_pr_followups.py
@@ -19,6 +19,19 @@ from pathlib import Path
 
 ISSUE_RE = re.compile(r"(?:#|/issues/)(\d+)\b")
 HEADING_RE = re.compile(r"^(#{1,6})\s+(.+?)\s*$", re.MULTILINE)
+CLOSING_KEYWORD_RE = re.compile(
+    r"\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+`?(?:#\d+|https?://\S+/issues/\d+)",
+    re.IGNORECASE,
+)
+RESIDUAL_SCOPE_RE = re.compile(
+    r"\b("
+    r"partial(?:ly)?|diagnostic[- ]only|blocked|degraded|residual scope|remaining work|"
+    r"still (?:needs|requires|missing)|deferred work|follow[- ]up (?:needed|required)|"
+    r"not (?:benchmark|paper)[- ](?:strength|facing|evidence)"
+    r")\b",
+    re.IGNORECASE,
+)
+WAIVER_RE = re.compile(r"\b(?:maintainer\s+)?waiver\b", re.IGNORECASE)
 EMPTY_OR_PLACEHOLDER = {
     "",
     "-",
@@ -65,9 +78,43 @@ def _is_empty_or_placeholder(text: str) -> bool:
 
 def _is_no_issue_reason(text: str) -> bool:
     value = _clean_value(text).lower()
-    if value in {"none", "no", "n/a", "na", "not applicable"}:
-        return True
-    return value.startswith(("none ", "none -", "none:", "na ", "na -", "n/a ", "n/a -"))
+    prefixes = ("none", "no", "n/a", "na", "not applicable")
+    for prefix in prefixes:
+        if value.startswith(f"{prefix} - ") or value.startswith(f"{prefix}: "):
+            return bool(value.removeprefix(prefix).lstrip(" -:").strip())
+    return False
+
+
+def _remove_section(body: str, heading: str) -> str:
+    """Return body text with a named Markdown section removed."""
+    target = _normalize_label(heading)
+    matches = list(HEADING_RE.finditer(body))
+    for index, match in enumerate(matches):
+        level, title = match.groups()
+        if _normalize_label(title) != target:
+            continue
+        section_end = len(body)
+        for next_match in matches[index + 1 :]:
+            if len(next_match.group(1)) <= len(level):
+                section_end = next_match.start()
+                break
+        return f"{body[: match.start()]}\n{body[section_end:]}"
+    return body
+
+
+def _has_closing_keyword(body: str) -> bool:
+    """Return true when a PR body declares issue-closing intent."""
+    return CLOSING_KEYWORD_RE.search(body) is not None
+
+
+def _has_residual_scope_outside_followups(body: str) -> bool:
+    """Return true when body text outside Follow-Up Issues declares residual scope."""
+    return RESIDUAL_SCOPE_RE.search(_remove_section(body, "Follow-Up Issues")) is not None
+
+
+def _has_explicit_maintainer_waiver(body: str, issue_value: str) -> bool:
+    """Return true when residual closure is explicitly waived."""
+    return WAIVER_RE.search(f"{body}\n{issue_value}") is not None
 
 
 def _extract_section(body: str, heading: str) -> str:
@@ -182,7 +229,25 @@ def analyze_body(body: str, *, source: str, require_open_issues: bool = False) -
             issue_state_errors=(),
             message="Follow-Up Issues section not found.",
         )
+    residual_closure = _has_closing_keyword(body) and _has_residual_scope_outside_followups(body)
     if _is_empty_or_placeholder(deferred):
+        if (
+            residual_closure
+            and not linked_issues
+            and not _has_explicit_maintainer_waiver(body, issue_value)
+        ):
+            return FollowupReport(
+                status="residual_scope_without_followup",
+                source=source,
+                deferred_work="",
+                linked_issues=(),
+                explicit_no_issue_reason="",
+                issue_state_errors=(),
+                message=(
+                    "PR closes an issue while declaring residual scope outside Follow-Up Issues; "
+                    "link an open follow-up issue or add an explicit maintainer waiver."
+                ),
+            )
         return FollowupReport(
             status="ok",
             source=source,
@@ -211,6 +276,16 @@ def analyze_body(body: str, *, source: str, require_open_issues: bool = False) -
             explicit_no_issue_reason="",
             issue_state_errors=(),
             message="Deferred work has linked follow-up issue(s).",
+        )
+    if residual_closure and _has_explicit_maintainer_waiver(body, issue_value):
+        return FollowupReport(
+            status="ok",
+            source=source,
+            deferred_work=deferred,
+            linked_issues=(),
+            explicit_no_issue_reason=issue_value,
+            issue_state_errors=(),
+            message="Residual scope is covered by an explicit maintainer waiver.",
         )
     if _is_no_issue_reason(issue_value):
         return FollowupReport(
@@ -284,6 +359,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
     parser.add_argument(
+        "--require-body",
+        action="store_true",
+        help="Fail closed when no PR body source is available.",
+    )
+    parser.add_argument(
         "--require-open-issues",
         action="store_true",
         help="Verify linked follow-up issues are open with gh issue view.",
@@ -297,19 +377,22 @@ def main(argv: list[str] | None = None) -> int:
     body, source = _load_body(args)
     if body is None:
         report = FollowupReport(
-            status="skipped",
+            status="missing_body" if args.require_body else "skipped",
             source=source,
             deferred_work="",
             linked_issues=(),
             explicit_no_issue_reason="",
             issue_state_errors=(),
-            message="No PR body source configured.",
+            message=(
+                "No PR body source configured; provide --body-file, PR_READY_PR_BODY_FILE, "
+                "or a pull_request GITHUB_EVENT_PATH."
+            ),
         )
         if args.json:
             print(json.dumps(report.__dict__, sort_keys=True))
         else:
             print(_format_report(report))
-        return 0
+        return 2 if args.require_body else 0
 
     require_open = args.require_open_issues or os.environ.get(
         "PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES", ""
@@ -318,10 +401,25 @@ def main(argv: list[str] | None = None) -> int:
     if args.json:
         print(json.dumps(report.__dict__, sort_keys=True))
     else:
-        failing_statuses = {"missing_followup", "missing_section", "issue_state_error"}
+        failing_statuses = {
+            "missing_followup",
+            "missing_section",
+            "issue_state_error",
+            "residual_scope_without_followup",
+        }
         stream = sys.stderr if report.status in failing_statuses else sys.stdout
         print(_format_report(report), file=stream)
-    return 2 if report.status in {"missing_followup", "missing_section", "issue_state_error"} else 0
+    return (
+        2
+        if report.status
+        in {
+            "missing_followup",
+            "missing_section",
+            "issue_state_error",
+            "residual_scope_without_followup",
+        }
+        else 0
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -120,7 +120,11 @@ if [[ "$pr_ready_final" == "1" ]]; then
   preflight_check_test_deps
 fi
 
-uv run python "$SCRIPT_DIR/check_pr_followups.py"
+followup_args=()
+if [[ "$pr_ready_final" == "1" ]]; then
+  followup_args+=(--require-body)
+fi
+uv run python "$SCRIPT_DIR/check_pr_followups.py" "${followup_args[@]}"
 uv run python "$SCRIPT_DIR/check_fast_results_claim_map.py"
 "$SCRIPT_DIR/ruff_fix_format.sh"
 ROBOT_SF_PYTEST_COVERAGE=1 "$SCRIPT_DIR/run_tests_parallel.sh"

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
+
 from scripts.dev import check_pr_followups
 from scripts.dev.check_pr_followups import analyze_body
 
@@ -64,6 +66,78 @@ def test_analyze_body_accepts_explicit_no_issue_reason() -> None:
 
     assert report.status == "ok"
     assert report.explicit_no_issue_reason == "NA - reviewer verification only"
+
+
+@pytest.mark.parametrize("issues", ["none", "no", "NA", "not applicable"])
+def test_analyze_body_rejects_bare_no_followup_disposition(issues: str) -> None:
+    """Bare NA/none/no values do not explain why deferred work needs no issue."""
+    report = analyze_body(
+        _body(
+            deferred="No additional work beyond reviewer verification.",
+            issues=issues,
+        ),
+        source="fixture",
+    )
+
+    assert report.status == "missing_followup"
+    assert "without a linked issue" in report.message
+
+
+def test_analyze_body_detects_residual_scope_outside_followup_section() -> None:
+    """Closing PRs cannot hide residual work in other sections."""
+    body = """## Summary
+Closes `#2993`.
+
+## Validation / Proof
+This is diagnostic-only and leaves the broader vector-env matrix as remaining work.
+
+## Follow-Up Issues
+- Deferred work: none
+- Issues opened for follow-up: NA - no follow-up needed
+"""
+
+    report = analyze_body(body, source="fixture")
+
+    assert report.status == "residual_scope_without_followup"
+    assert "declaring residual scope" in report.message
+
+
+def test_analyze_body_allows_residual_scope_with_linked_followup_issue() -> None:
+    """Residual-scope closure is allowed when an open follow-up is declared."""
+    body = """## Summary
+Closes #2993.
+
+## Validation / Proof
+This is diagnostic-only and leaves the broader vector-env matrix as remaining work.
+
+## Follow-Up Issues
+- Deferred work: Broader vector-env matrix remains.
+- Issues opened for follow-up: #3165
+"""
+
+    report = analyze_body(body, source="fixture")
+
+    assert report.status == "ok"
+    assert report.linked_issues == ("#3165",)
+
+
+def test_analyze_body_allows_residual_scope_with_explicit_maintainer_waiver() -> None:
+    """Maintainer waiver language is the explicit escape hatch."""
+    body = """## Summary
+Closes #2993.
+
+## Validation / Proof
+This is diagnostic-only and leaves remaining work.
+
+## Follow-Up Issues
+- Deferred work: Remaining work is intentionally waived.
+- Issues opened for follow-up: NA - maintainer waiver for this closure boundary
+"""
+
+    report = analyze_body(body, source="fixture")
+
+    assert report.status == "ok"
+    assert "waiver" in report.explicit_no_issue_reason
 
 
 def test_analyze_body_rejects_closed_followup_issue(monkeypatch) -> None:
@@ -167,3 +241,21 @@ def test_cli_fails_for_deferred_work_without_disposition(tmp_path: Path) -> None
 
     assert result.returncode == 2
     assert "status=missing_followup" in result.stderr
+
+
+def test_cli_require_body_fails_closed_without_pr_body_source(monkeypatch) -> None:
+    """Final readiness should not silently skip missing PR body input."""
+    monkeypatch.delenv("PR_READY_PR_BODY_FILE", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_PATH", raising=False)
+    monkeypatch.delenv("GITHUB_EVENT_NAME", raising=False)
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--require-body"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "status=missing_body" in result.stdout

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -191,7 +191,7 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
     script_text = PR_READY_CHECK.read_text(encoding="utf-8")
 
     expected_gates = [
-        'uv run python "$SCRIPT_DIR/check_pr_followups.py"',
+        'uv run python "$SCRIPT_DIR/check_pr_followups.py" "${followup_args[@]}"',
         '"$SCRIPT_DIR/ruff_fix_format.sh"',
         '"$SCRIPT_DIR/run_tests_parallel.sh"',
         '"$SCRIPT_DIR/check_changed_coverage.sh"',
@@ -206,6 +206,11 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
     assert freshness_call in script_text
     assert script_text.rfind(freshness_call) > max(
         script_text.rfind(gate) for gate in expected_gates
+    )
+    assert "followup_args=()" in script_text
+    assert "followup_args+=(--require-body)" in script_text
+    assert script_text.find("followup_args+=(--require-body)") < script_text.find(
+        'uv run python "$SCRIPT_DIR/check_pr_followups.py" "${followup_args[@]}"'
     )
 
 


### PR DESCRIPTION
## Summary
Tightens PR follow-up readiness so issue-closing PRs cannot silently pass with missing PR body data, bare no-follow-up placeholders, or residual-scope language outside the Follow-Up Issues section.

## Linked Issues
- Closes #3163

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `check_pr_followups.py --require-body` so final readiness fails closed when no PR body source is available.
- Tightened no-follow-up dispositions: bare `none`, `no`, `NA`, and `not applicable` no longer satisfy deferred-work disposition without a specific reason.
- Added conservative residual-scope detection for issue-closing PR bodies outside the structured Follow-Up Issues section.
- Wired `pr_ready_check.sh` final mode to pass `--require-body` while leaving interim mode lightweight.
- Added focused regression tests for missing body, bare no/NA, residual-scope contradictions, linked follow-ups, and maintainer waiver handling.

## Why It Matters
- Added value: prevents accidental issue closure when a PR still declares partial, diagnostic, blocked, degraded, or residual scope.
- Expected impact: final readiness now forces an open follow-up issue or explicit maintainer waiver for residual closure boundaries.
- Why this is worth merging now: it addresses concrete closure-audit gaps found on 2026-06-20.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: PR readiness catches incomplete issue-closure declarations before automatic closure.
- Comparator or baseline, if applicable: Prior checker could skip missing PR bodies and accept bare no/NA dispositions.
- Evidence tier: preflight
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: Stop once targeted regressions prove fail-closed missing body, bare disposition rejection, residual-scope detection, and linked follow-up/waiver escape hatches.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3163
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - workflow validation guard.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress? No runtime behavior change; PR readiness workflow only.
- Did the scenario actually contain the targeted failure mode? yes, tests and CLI smokes cover missing body, bare NA, and residual-scope closure.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: continue; ready for review.
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_check_pr_followups.py tests/test_ci_script_contract.py -q
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/test_ci_script_contract.py
  - scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/test_ci_script_contract.py
  - scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_followups.py --require-body
  - scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_followups.py --body-file <bare-NA-fixture>
  - scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_followups.py --body-file <linked-followup-fixture>
  - git diff --check
- Evidence that the change works here: 63 focused tests passed; CLI smokes produced missing_body exit 2, bare NA missing_followup exit 2, and linked follow-up status ok exit 0.
- Benchmarks or smoke tests, if applicable: workflow/preflight smoke only.

## Risks / Rollout
- Compatibility risks: final `pr_ready_check.sh` now requires PR body context; interim mode remains non-blocking when no body is available.
- Failure modes: residual-scope keyword detection is conservative but may require a maintainer waiver line for legitimate issue-closing diagnostic PRs.
- Rollback or fallback plan: run interim readiness locally, or add an explicit open follow-up / maintainer waiver in PR text.

## Docs / Provenance
- Updated docs: NA
- Relevant design or provenance notes: PR body repair messages name the missing body source and the follow-up/waiver options.
- Any assumptions that need to be preserved: bare `NA` is insufficient only when deferred work is declared or residual closure is detected; `Deferred work: none` still passes for ordinary no-residual PRs.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #3163
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: workflow guard only; no benchmark or paper-facing result.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: NA - all issue acceptance criteria are covered by this PR and focused regressions.

## Reviewer Notes
- Anything a reviewer should verify closely: residual-scope keyword list and the `--require-body` final-mode behavior.
- Any known limitations: this does not infer every issue acceptance item automatically; it detects conservative closure contradictions and missing dispositions.
