### PR TITLE
test: add dependency-complete wheel runtime smoke

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ dependencies = [
     "toml>=0.10.2",
     "shimmy>=1.0.0,<2.0.0",
     "moviepy>=2.0.0",
-    "pysocialforce",
     "jsonschema>=4.23.0",
     "shapely>=2.1.2",
     "networkx>=2.8,<3.0",
@@ -115,23 +114,19 @@ packages = [
     { include = "examples" },
     { include = "third_party" },
 ]
-
-[tool.hatch.build.targets.wheel]
-packages = [
-    "robot_sf",
-    "robot_sf_carla_bridge",
-    "examples",
-    "third_party",
-]
 include = ["examples/**"]
 
 [tool.hatchling.build.targets.wheel.shared-data]
 "robot_sf/maps" = "robot_sf/maps"
 
+[tool.hatch.build.targets.wheel.force-include]
+"fast-pysf/pysocialforce" = "pysocialforce"
+
 [tool.hatchling.build.targets.sdist]
 include = [
     "/robot_sf",
     "/robot_sf_carla_bridge",
+    "/fast-pysf/pysocialforce",
     "/examples",
     "/third_party",
     "/README.md",
@@ -143,7 +138,9 @@ exclude = [
     "/.git",
     "/.pytest_cache",
     "/__pycache__",
-    "/fast-pysf",
+    "/fast-pysf/tests",
+    "/fast-pysf/examples",
+    "/fast-pysf/benchmarks",
 ]
 
 [tool.hatch.metadata]

--- a/robot_sf/nav/navigation.py
+++ b/robot_sf/nav/navigation.py
@@ -16,7 +16,7 @@ from robot_sf.common.types import Vec2D
 from robot_sf.nav.free_space_sampling import sample_free_points_in_bounds
 from robot_sf.nav.map_config import MapDefinition
 from robot_sf.ped_npc.ped_zone import sample_zone
-from robot_sf.planner import PlanningError
+from robot_sf.planner.classic_global_planner import PlanningError
 from robot_sf.planner.visibility_planner import PlanningFailedError
 
 _PLANNER_RETRY_ATTEMPTS = 5

--- a/robot_sf/planner/__init__.py
+++ b/robot_sf/planner/__init__.py
@@ -1,74 +1,61 @@
 """Global planner package for SVG-based waypoint generation.
 
-This package provides two global planning approaches:
-
-1. VisibilityPlanner: Visibility graph-based planner for continuous path planning
-   - Uses pyvisgraph for visibility graph construction
-   - Operates on vector-based obstacle representations
-   - Suitable for sparse environments with clear line-of-sight paths
-
-2. ClassicGlobalPlanner: Grid-based planner using python_motion_planning
-   - Uses rasterized grid representation
-   - Supports algorithms like ThetaStar, A*
-   - Better for dense environments or narrow passages
+Public planner exports are resolved lazily so importing lightweight navigation or
+environment modules does not pull optional learned-risk/training dependencies
+such as PyTorch into core wheel installs.
 """
 
-from robot_sf.planner.classic_global_planner import (
-    ClassicGlobalPlanner,
-    ClassicPlannerConfig,
-    PlanningError,
-)
-from robot_sf.planner.classic_planner_adapter import (
-    PlannerActionAdapter,
-    attach_classic_global_planner,
-)
-from robot_sf.planner.learned_risk_surface import (
-    LocalRiskSurface,
-    LocalRiskSurfaceSpec,
-    RiskSurfacePlannerAdapter,
-    RiskSurfaceUnavailable,
-    attach_risk_surface_to_observation,
-    build_local_risk_surface_spec,
-    deterministic_pedestrian_risk_surface,
-)
-from robot_sf.planner.poi_sampler import POISampler
-from robot_sf.planner.policy_stack_v1 import PolicyStackV1Adapter, PolicyStackV1Config
-from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter, RiskDWAPlannerConfig
-from robot_sf.planner.teb_commitment import TEBCommitmentConfig, TEBCommitmentPlannerAdapter
-from robot_sf.planner.visibility_planner import (
-    PlannerConfig,
-    PlanningFailedError,
-    VisibilityPlanner,
-)
-from robot_sf.planner.visualization import plot_global_plan, plot_visibility_graph
+from __future__ import annotations
 
-# Backwards compatibility aliases
-GlobalPlanner = VisibilityPlanner
+from importlib import import_module
+from typing import Any
 
-__all__ = [
-    "ClassicGlobalPlanner",
-    "ClassicPlannerConfig",
-    "GlobalPlanner",
-    "LocalRiskSurface",
-    "LocalRiskSurfaceSpec",
-    "POISampler",
-    "PlannerActionAdapter",
-    "PlannerConfig",
-    "PlanningError",
-    "PlanningFailedError",
-    "PolicyStackV1Adapter",
-    "PolicyStackV1Config",
-    "RiskDWAPlannerAdapter",
-    "RiskDWAPlannerConfig",
-    "RiskSurfacePlannerAdapter",
-    "RiskSurfaceUnavailable",
-    "TEBCommitmentConfig",
-    "TEBCommitmentPlannerAdapter",
-    "VisibilityPlanner",
-    "attach_classic_global_planner",
-    "attach_risk_surface_to_observation",
-    "build_local_risk_surface_spec",
-    "deterministic_pedestrian_risk_surface",
-    "plot_global_plan",
-    "plot_visibility_graph",
-]
+_LAZY_EXPORTS = {
+    "ClassicGlobalPlanner": "robot_sf.planner.classic_global_planner",
+    "ClassicPlannerConfig": "robot_sf.planner.classic_global_planner",
+    "PlanningError": "robot_sf.planner.classic_global_planner",
+    "PlannerActionAdapter": "robot_sf.planner.classic_planner_adapter",
+    "attach_classic_global_planner": "robot_sf.planner.classic_planner_adapter",
+    "LocalRiskSurface": "robot_sf.planner.learned_risk_surface",
+    "LocalRiskSurfaceSpec": "robot_sf.planner.learned_risk_surface",
+    "RiskSurfacePlannerAdapter": "robot_sf.planner.learned_risk_surface",
+    "RiskSurfaceUnavailable": "robot_sf.planner.learned_risk_surface",
+    "attach_risk_surface_to_observation": "robot_sf.planner.learned_risk_surface",
+    "build_local_risk_surface_spec": "robot_sf.planner.learned_risk_surface",
+    "deterministic_pedestrian_risk_surface": "robot_sf.planner.learned_risk_surface",
+    "POISampler": "robot_sf.planner.poi_sampler",
+    "PolicyStackV1Adapter": "robot_sf.planner.policy_stack_v1",
+    "PolicyStackV1Config": "robot_sf.planner.policy_stack_v1",
+    "RiskDWAPlannerAdapter": "robot_sf.planner.risk_dwa",
+    "RiskDWAPlannerConfig": "robot_sf.planner.risk_dwa",
+    "TEBCommitmentConfig": "robot_sf.planner.teb_commitment",
+    "TEBCommitmentPlannerAdapter": "robot_sf.planner.teb_commitment",
+    "PlannerConfig": "robot_sf.planner.visibility_planner",
+    "PlanningFailedError": "robot_sf.planner.visibility_planner",
+    "VisibilityPlanner": "robot_sf.planner.visibility_planner",
+    "plot_global_plan": "robot_sf.planner.visualization",
+    "plot_visibility_graph": "robot_sf.planner.visualization",
+}
+
+__all__ = sorted([*_LAZY_EXPORTS, "GlobalPlanner"])  # noqa: PLE0605
+
+
+def __getattr__(name: str) -> Any:
+    """Resolve planner exports on first access.
+
+    Returns:
+        Exported planner class, function, or compatibility alias.
+    """
+
+    if name == "GlobalPlanner":
+        value = __getattr__("VisibilityPlanner")
+        globals()[name] = value
+        return value
+    try:
+        module_name = _LAZY_EXPORTS[name]
+    except KeyError as exc:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from exc
+
+    value = getattr(import_module(module_name), name)
+    globals()[name] = value
+    return value

--- a/robot_sf/sim/__init__.py
+++ b/robot_sf/sim/__init__.py
@@ -11,29 +11,45 @@ errors deeper in the call stack.
 
 from __future__ import annotations
 
+import importlib.util
 from pathlib import Path
 
 
-def _assert_fast_pysf_initialized() -> None:
+def _has_installed_pysocialforce() -> bool:
+    """Return whether an installed ``pysocialforce`` package is importable."""
+
+    return importlib.util.find_spec("pysocialforce") is not None
+
+
+def _assert_fast_pysf_initialized(repo_root: Path | None = None) -> None:
     """Raise a RuntimeError if the fast-pysf submodule looks uninitialized.
 
     Heuristic: repository root contains a `fast-pysf` directory with expected
-    Python package `pysocialforce`. If either directory or an expected file is
-    missing we assume the user forgot to initialize submodules.
+    Python package `pysocialforce`. Installed wheels do not include the source
+    checkout's `fast-pysf` directory, so they may satisfy this contract through
+    the declared package dependency instead.
     """
 
-    repo_root = Path(__file__).resolve().parents[2]
+    if repo_root is None:
+        repo_root = Path(__file__).resolve().parents[2]
     submodule_dir = repo_root / "fast-pysf"
     expected_pkg = submodule_dir / "pysocialforce"
+    is_source_checkout = (repo_root / "pyproject.toml").exists()
 
-    if not submodule_dir.exists() or not expected_pkg.exists():
-        raise RuntimeError(
-            "fast-pysf submodule not initialized or incomplete.\n"
-            "Expected directory: 'fast-pysf/pysocialforce'.\n"
-            "Fix by running: \n"
-            "  git submodule update --init --recursive\n\n"
-            "If this was intentional (e.g., lightweight docs build), avoid importing 'robot_sf.sim' modules.",
-        )
+    if submodule_dir.exists() and expected_pkg.exists():
+        return
+    if not is_source_checkout and _has_installed_pysocialforce():
+        return
+
+    raise RuntimeError(
+        "fast-pysf submodule not initialized or incomplete.\n"
+        "Expected directory: 'fast-pysf/pysocialforce'.\n"
+        "Fix source checkouts by running: \n"
+        "  git submodule update --init --recursive\n\n"
+        "Installed wheels should include a usable 'pysocialforce' package. "
+        "If this was intentional (e.g., lightweight docs build), avoid importing "
+        "'robot_sf.sim' modules.",
+    )
 
 
 # Execute guard on import so downstream modules can assume availability.

--- a/scripts/validation/wheel_install_smoke.sh
+++ b/scripts/validation/wheel_install_smoke.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-BOOTSTRAP_DEPS="${ROBOT_SF_WHEEL_INSTALL_SMOKE_DEPS:-loguru numba matplotlib}"
+EXTRAS_SMOKE="${ROBOT_SF_WHEEL_INSTALL_SMOKE_EXTRAS:-progress analysis analytics viz}"
 REPORT_FILE="output/validation/wheel_install_smoke_report.json"
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -49,39 +49,103 @@ PYTHON_BIN="${VENV_DIR}/bin/python"
 
 python3 -m venv "${VENV_DIR}"
 
-echo "Installing wheel (no dependency resolution) in clean temp venv: ${WHEEL_PATH}"
-"${PIP_BIN}" install --no-cache-dir --no-deps "${WHEEL_PATH}"
-
-if [[ -n "${BOOTSTRAP_DEPS}" ]]; then
-  # shellcheck disable=SC2206
-  bootstrap_deps=(${BOOTSTRAP_DEPS})
-  echo "Installing bootstrap smoke deps: ${BOOTSTRAP_DEPS}"
-  "${PIP_BIN}" install --no-cache-dir "${bootstrap_deps[@]}"
-fi
+echo "Installing wheel with dependency resolution in clean temp venv: ${WHEEL_PATH}"
+"${PIP_BIN}" install --no-cache-dir "${WHEEL_PATH}"
 
 mkdir -p "${REPO_ROOT}/output/validation"
-python_check_output="$(cd /tmp && PYTHONPATH= PYTHONNOUSERSITE=1 "${PYTHON_BIN}" -c "import robot_sf; print(robot_sf.__file__)")"
+python_check_output="$(
+  cd /tmp && PYTHONPATH= PYTHONNOUSERSITE=1 "${PYTHON_BIN}" <<'PY'
+import json
+
+import numpy as np
+
+import robot_sf
+from robot_sf.gym_env.environment_factory import make_crowd_sim_env
+
+env = make_crowd_sim_env(seed=123)
+try:
+    obs, info = env.reset(seed=123)
+    next_obs, reward, terminated, truncated, next_info = env.step()
+finally:
+    env.close()
+
+print(
+    json.dumps(
+        {
+            "module_file": robot_sf.__file__,
+            "env_factory": "make_crowd_sim_env",
+            "reset_positions_shape": list(np.asarray(obs["positions"]).shape),
+            "step_positions_shape": list(np.asarray(next_obs["positions"]).shape),
+            "reward": float(reward),
+            "terminated": bool(terminated),
+            "truncated": bool(truncated),
+            "map_id": info.get("map_id"),
+            "step_map_id": next_info.get("map_id"),
+        }
+    )
+)
+PY
+)"
 
 if [[ -z "${python_check_output}" ]]; then
-  echo "Wheel smoke import validation produced no module file output."
+  echo "Wheel runtime smoke validation produced no output."
   exit 1
 fi
 
-"${PYTHON_BIN}" - "${REPO_ROOT}/${REPORT_FILE}" "${WHEEL_PATH}" "${python_check_output}" "${BOOTSTRAP_DEPS}" <<'PY'
+extras_status_json="[]"
+if [[ -n "${EXTRAS_SMOKE}" ]]; then
+  extras_status_file="${WORK_DIR}/extras-status.jsonl"
+  # shellcheck disable=SC2206
+  extras=(${EXTRAS_SMOKE})
+  for extra in "${extras[@]}"; do
+    extra_venv="${WORK_DIR}/extra-${extra}-venv"
+    extra_pip="${extra_venv}/bin/pip"
+    extra_python="${extra_venv}/bin/python"
+    python3 -m venv "${extra_venv}"
+    echo "Installing optional extra independently: ${extra}"
+    "${extra_pip}" install --no-cache-dir "${WHEEL_PATH}[${extra}]"
+    cd /tmp && PYTHONPATH= PYTHONNOUSERSITE=1 "${extra_python}" - "${extra}" >>"${extras_status_file}" <<'PY'
+import json
+import sys
+
+import robot_sf
+
+extra = sys.argv[1]
+print(json.dumps({"extra": extra, "status": "passed", "module_file": robot_sf.__file__}))
+PY
+  done
+  extras_status_json="$("${PYTHON_BIN}" - "${extras_status_file}" <<'PY'
 import json
 import sys
 from pathlib import Path
 
-report_path, wheel, module_file, bootstrap_deps = sys.argv[1:]
+status_path = Path(sys.argv[1])
+if not status_path.exists():
+    print("[]")
+else:
+    print(json.dumps([json.loads(line) for line in status_path.read_text().splitlines() if line]))
+PY
+)"
+fi
+
+"${PYTHON_BIN}" - "${REPO_ROOT}/${REPORT_FILE}" "${WHEEL_PATH}" "${python_check_output}" "${EXTRAS_SMOKE}" "${extras_status_json}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+report_path, wheel, runtime_smoke_json, extras_smoke, extras_status_json = sys.argv[1:]
+runtime_smoke = json.loads(runtime_smoke_json)
 Path(report_path).write_text(
     json.dumps(
         {
             "wheel": wheel,
             "status": "passed",
-            "install_mode": "wheel_no_deps_with_bootstrap_import_deps",
-            "module_file": module_file,
-            "command": "import robot_sf from clean wheel install",
-            "bootstrap_deps": bootstrap_deps,
+            "install_mode": "wheel_with_dependency_resolution",
+            "module_file": runtime_smoke["module_file"],
+            "command": "import robot_sf; make_crowd_sim_env().reset(); env.step()",
+            "runtime_smoke": runtime_smoke,
+            "extras_smoke": extras_smoke.split(),
+            "extras": json.loads(extras_status_json),
         },
         indent=2,
     )

--- a/tests/sim/test_fast_pysf_initialization_guard.py
+++ b/tests/sim/test_fast_pysf_initialization_guard.py
@@ -1,0 +1,44 @@
+"""Tests for fast-pysf source checkout and wheel-install guards."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf import sim
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_fast_pysf_guard_accepts_initialized_source_checkout(tmp_path: Path) -> None:
+    """Source checkouts pass when the vendored fast-pysf package is present."""
+    repo_root = tmp_path
+    (repo_root / "pyproject.toml").write_text("[project]\nname = 'robot_sf'\n", encoding="utf-8")
+    (repo_root / "fast-pysf" / "pysocialforce").mkdir(parents=True)
+
+    sim._assert_fast_pysf_initialized(repo_root)
+
+
+def test_fast_pysf_guard_rejects_incomplete_source_checkout(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Source checkouts should still give submodule initialization guidance."""
+    repo_root = tmp_path
+    (repo_root / "pyproject.toml").write_text("[project]\nname = 'robot_sf'\n", encoding="utf-8")
+    monkeypatch.setattr(sim, "_has_installed_pysocialforce", lambda: True)
+
+    with pytest.raises(RuntimeError, match="git submodule update --init --recursive"):
+        sim._assert_fast_pysf_initialized(repo_root)
+
+
+def test_fast_pysf_guard_accepts_wheel_install_with_declared_dependency(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Installed wheels do not carry the source fast-pysf tree."""
+    monkeypatch.setattr(sim, "_has_installed_pysocialforce", lambda: True)
+
+    sim._assert_fast_pysf_initialized(tmp_path)

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from packaging.requirements import Requirement
 
 ROOT = Path(__file__).resolve().parents[1]
 CI_DRIVER = ROOT / "scripts" / "dev" / "ci_driver.sh"
@@ -243,11 +244,13 @@ def test_wheel_install_smoke_tests_optional_extras_independently() -> None:
 def test_wheel_metadata_vendors_compatible_fast_pysf_package() -> None:
     """Clean wheel installs must not resolve the incompatible PyPI pysocialforce package."""
     project = _pyproject()
-    dependencies = project["project"]["dependencies"]
+    dependency_names = {
+        Requirement(dependency).name for dependency in project["project"]["dependencies"]
+    }
     wheel_force_include = project["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
     sdist_includes = project["tool"]["hatchling"]["build"]["targets"]["sdist"]["include"]
 
-    assert "pysocialforce" not in dependencies
+    assert "pysocialforce" not in dependency_names
     assert wheel_force_include["fast-pysf/pysocialforce"] == "pysocialforce"
     assert "/fast-pysf/pysocialforce" in sdist_includes
 

--- a/tests/test_ci_driver_contract.py
+++ b/tests/test_ci_driver_contract.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import re
 import shlex
 import subprocess
+import tomllib
 from pathlib import Path
 from typing import Any
 
@@ -13,6 +14,8 @@ import yaml
 ROOT = Path(__file__).resolve().parents[1]
 CI_DRIVER = ROOT / "scripts" / "dev" / "ci_driver.sh"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+WHEEL_INSTALL_SMOKE = ROOT / "scripts" / "validation" / "wheel_install_smoke.sh"
+PYPROJECT = ROOT / "pyproject.toml"
 WORKFLOWS_DIR = ROOT / ".github" / "workflows"
 CI_JOB_TIMEOUTS = {
     "fast-feedback": 45,
@@ -131,6 +134,11 @@ def _workflow_jobs() -> dict[str, Any]:
     return workflow.get("jobs", {})
 
 
+def _pyproject() -> dict[str, Any]:
+    """Return parsed project metadata."""
+    return tomllib.loads(PYPROJECT.read_text(encoding="utf-8"))
+
+
 def test_extract_workflow_phases_handles_multiple_phase_args() -> None:
     """Capture all phase arguments from one workflow run stanza."""
 
@@ -207,6 +215,41 @@ def test_ci_workflow_wheel_smoke_is_independent_and_required_by_aggregate() -> N
     assert any("wheel_install_smoke.sh" in run_block for run_block in wheel_smoke_run_blocks)
     assert "needs" not in workflow["jobs"]["wheel-smoke-install"]
     assert "wheel-smoke-install" in workflow["jobs"]["ci"]["needs"]
+
+
+def test_wheel_install_smoke_uses_dependency_resolution_and_runtime_env_step() -> None:
+    """Wheel smoke should catch missing package metadata and core runtime dependencies."""
+    smoke_text = WHEEL_INSTALL_SMOKE.read_text(encoding="utf-8")
+
+    assert '"${PIP_BIN}" install --no-cache-dir "${WHEEL_PATH}"' in smoke_text
+    assert "--no-deps" not in smoke_text
+    assert "wheel_with_dependency_resolution" in smoke_text
+    assert "make_crowd_sim_env" in smoke_text
+    assert "env.reset(seed=123)" in smoke_text
+    assert "env.step()" in smoke_text
+    assert "PYTHONPATH= PYTHONNOUSERSITE=1" in smoke_text
+
+
+def test_wheel_install_smoke_tests_optional_extras_independently() -> None:
+    """Optional extras should be installable one at a time from the built wheel."""
+    smoke_text = WHEEL_INSTALL_SMOKE.read_text(encoding="utf-8")
+
+    assert "ROBOT_SF_WHEEL_INSTALL_SMOKE_EXTRAS" in smoke_text
+    assert "progress analysis analytics viz" in smoke_text
+    assert '"${extra_pip}" install --no-cache-dir "${WHEEL_PATH}[${extra}]"' in smoke_text
+    assert '"extras": json.loads(extras_status_json)' in smoke_text
+
+
+def test_wheel_metadata_vendors_compatible_fast_pysf_package() -> None:
+    """Clean wheel installs must not resolve the incompatible PyPI pysocialforce package."""
+    project = _pyproject()
+    dependencies = project["project"]["dependencies"]
+    wheel_force_include = project["tool"]["hatch"]["build"]["targets"]["wheel"]["force-include"]
+    sdist_includes = project["tool"]["hatchling"]["build"]["targets"]["sdist"]["include"]
+
+    assert "pysocialforce" not in dependencies
+    assert wheel_force_include["fast-pysf/pysocialforce"] == "pysocialforce"
+    assert "/fast-pysf/pysocialforce" in sdist_includes
 
 
 def test_ci_driver_test_phase_excludes_separately_timed_examples() -> None:

--- a/tests/test_planner/test_lazy_package_exports.py
+++ b/tests/test_planner/test_lazy_package_exports.py
@@ -1,0 +1,59 @@
+"""Planner package import regression tests."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_planner_package_import_does_not_preload_learned_risk_stack() -> None:
+    """Core imports should not load optional learned-risk dependencies."""
+    script = """
+import json
+import sys
+
+import robot_sf.planner
+
+print(json.dumps({
+    "learned_risk_surface": "robot_sf.planner.learned_risk_surface" in sys.modules,
+    "predictive_model": "robot_sf.planner.predictive_model" in sys.modules,
+    "risk_dwa": "robot_sf.planner.risk_dwa" in sys.modules,
+}))
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert result.stdout.strip() == (
+        '{"learned_risk_surface": false, "predictive_model": false, "risk_dwa": false}'
+    )
+
+
+def test_planner_package_preserves_legacy_global_planner_export() -> None:
+    """Lazy exports should keep the public planner import surface intact."""
+    script = """
+from robot_sf.planner import GlobalPlanner, VisibilityPlanner
+
+assert GlobalPlanner is VisibilityPlanner
+print(GlobalPlanner.__name__)
+"""
+    result = subprocess.run(
+        [sys.executable, "-c", script],
+        check=False,
+        capture_output=True,
+        text=True,
+        cwd=ROOT,
+        timeout=30,
+    )
+
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert result.stdout.strip() == "VisibilityPlanner"


### PR DESCRIPTION
## Summary
Adds a dependency-complete wheel smoke that installs the built wheel with normal pip dependency resolution, exercises a core environment reset/step outside the checkout, and installs lightweight optional extras independently. Also fixes the packaging/runtime issues this stronger smoke exposed by vendoring the compatible fast-pysf `pysocialforce` package and making planner exports lazy.

## Linked Issues
- Closes `#3167`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Changed `scripts/validation/wheel_install_smoke.sh` from `--no-deps` plus bootstrap deps to normal dependency resolution.
- Added a clean installed-wheel runtime smoke using `make_crowd_sim_env().reset()` and `env.step()` from `/tmp` with `PYTHONPATH=` and `PYTHONNOUSERSITE=1`.
- Added independent optional-extra install checks for `progress analysis analytics viz`, configurable via `ROBOT_SF_WHEEL_INSTALL_SMOKE_EXTRAS`.
- Vendored `fast-pysf/pysocialforce` into wheels and sdists, and removed the incompatible external `pysocialforce` dependency metadata.
- Kept source checkout fast-pysf guard strict while allowing installed wheels that contain an importable `pysocialforce` package.
- Made `robot_sf.planner` public exports lazy so core environment imports do not require optional learned-risk/training dependencies such as `torch`.

## Why It Matters
- Added value: CI can now catch broken wheel dependency metadata, missing packaged runtime files, and optional-extra install regressions.
- Expected impact: clean wheel installs exercise the same dependency path users get from pip instead of a manually bootstrapped import-only path.
- Why this is worth merging now: the stronger smoke found and fixes real packaging failures: missing compatible `pysocialforce` packaging and eager planner imports pulling `torch` into core runtime imports.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/tooling packaging smoke; no research claim.
- Comparator or baseline, if applicable: previous wheel smoke used `pip install --no-deps` plus manual bootstrap deps and only imported `robot_sf`.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: clean wheel install must dependency-resolve, import from outside checkout, reset/step a core environment, and install selected extras independently.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#3167` only.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it validates packaging/runtime installability, not research outcomes.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support/tooling PR.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this support contract; CI will rerun the wheel-smoke job.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: no durable artifact required; smoke report was local validation output.
- Stop / revise / continue decision: stop for `#3167` scope.
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - `bash -n scripts/validation/wheel_install_smoke.sh`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_ci_driver_contract.py tests/test_planner/test_lazy_package_exports.py tests/test_planner/test_planner_config.py tests/test_planner/test_global_planner.py tests/test_planner/test_navigation_integration.py tests/sim/test_fast_pysf_initialization_guard.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check pyproject.toml robot_sf/planner/__init__.py robot_sf/sim/__init__.py robot_sf/nav/navigation.py tests/test_planner/test_lazy_package_exports.py tests/sim/test_fast_pysf_initialization_guard.py tests/test_ci_driver_contract.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/planner/__init__.py robot_sf/sim/__init__.py robot_sf/nav/navigation.py tests/test_planner/test_lazy_package_exports.py tests/sim/test_fast_pysf_initialization_guard.py tests/test_ci_driver_contract.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv build`
  - `bash scripts/validation/wheel_install_smoke.sh`
  - `git diff --check`
- Evidence that the change works here: wheel smoke report passed with `install_mode=wheel_with_dependency_resolution`, `runtime_factory=make_crowd_sim_env`, reset/step shapes `[81, 2]`, and extras `progress`, `analysis`, `analytics`, `viz`.
- Benchmarks or smoke tests, if applicable: targeted wheel install smoke only; no benchmark claim.

## Risks / Rollout
- Compatibility risks: wheel contents now include the repo-compatible `pysocialforce` package; reviewers should check packaging expectations around vendoring versus external dependency metadata.
- Failure modes: selected extras add CI time because each extra installs in an isolated venv; list is configurable via `ROBOT_SF_WHEEL_INSTALL_SMOKE_EXTRAS`.
- Rollback or fallback plan: revert the packaging and smoke-script changes to restore the previous import-only smoke, though that would re-open the metadata gap.

## Docs / Provenance
- Updated docs: none; contract is encoded in the smoke script, CI contract tests, and PR validation notes.
- Relevant design or provenance notes: local smoke report is intentionally ignored under `output/validation/`.
- Any assumptions that need to be preserved: `progress analysis analytics viz` are the default lightweight extras; heavier extras remain opt-in.

## Downstream Propagation
- Parent issue updated (yes/no/NA): pending PR link / closes `#3167`
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: support/tooling packaging validation only; no research, benchmark, metric, or paper-facing claim.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Please check the packaging namespace carefully: active Hatch config is under `tool.hatch.build.targets.wheel.force-include`, while existing repo metadata also contains `tool.hatchling...` sections.
- The real wheel smoke is intentionally heavier than the old import-only smoke because it now validates dependency resolution and isolated extras.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved package installation reliability by properly bundling optional dependencies.
  * Enhanced dependency detection to support both pre-installed and bundled packages.

* **Chores**
  * Optimized internal package initialization performance through lazy loading.
  * Expanded validation testing for installation and dependency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->