### PR TITLE
ci: add xdist race validation route

### DIFF
--- a/.github/workflows/perf-nightly.yml
+++ b/.github/workflows/perf-nightly.yml
@@ -60,6 +60,21 @@ jobs:
         if: always()
         run: bash scripts/dev/ci_uv_sync_diag.sh "uv-cache-post-sync"
 
+      - name: Run xdist race validation
+        env:
+          XDIST_RACE_WORKERS: "32"
+          XDIST_RACE_TIMEOUT_SECONDS: "7200"
+          PYTEST_XDIST_DIST: worksteal
+        run: scripts/dev/run_xdist_race_validation.sh
+
+      - name: Upload xdist race validation artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: xdist-race-validation
+          path: output/validation/xdist-race/
+          if-no-files-found: warn
+
       - name: Restore trend history cache
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:

--- a/scripts/dev/check_xdist_race_artifacts.py
+++ b/scripts/dev/check_xdist_race_artifacts.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Check xdist stress runs for shared-output race artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "xdist_race_artifact_scan.v1"
+DEFAULT_SCAN_PATHS = (Path("output/tmp"), Path("output/coverage"))
+TEMP_SUFFIXES = (".lock", ".part", ".partial", ".pid", ".tmp")
+WORKER_PATTERN = re.compile(r"(^|[^A-Za-z0-9])gw\d+([^A-Za-z0-9]|$)")
+
+
+@dataclass(frozen=True)
+class ArtifactRecord:
+    """Stable metadata for one scanned file."""
+
+    path: str
+    size: int
+
+
+@dataclass(frozen=True)
+class ArtifactViolation:
+    """A generated artifact that suggests xdist shared-output races."""
+
+    code: str
+    path: str
+    detail: str
+
+
+def _git(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a git command in *cwd*."""
+    return subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True, check=False)
+
+
+def _repo_root(cwd: Path) -> Path:
+    """Return the enclosing git worktree root."""
+    result = _git(["rev-parse", "--show-toplevel"], cwd=cwd)
+    if result.returncode != 0 or not result.stdout.strip():
+        raise RuntimeError("check_xdist_race_artifacts.py requires a git worktree")
+    return Path(result.stdout.strip()).resolve()
+
+
+def _as_repo_relative(path: Path, *, repo_root: Path) -> str:
+    """Return *path* relative to *repo_root* using POSIX separators."""
+    return path.resolve().relative_to(repo_root).as_posix()
+
+
+def _resolve_scan_path(path: Path, *, repo_root: Path) -> Path:
+    """Resolve and validate one scan path."""
+    resolved = (repo_root / path).resolve()
+    try:
+        resolved.relative_to(repo_root)
+    except ValueError as exc:
+        raise ValueError(f"scan path is outside repository: {path}") from exc
+    return resolved
+
+
+def _collect_records(paths: list[Path], *, repo_root: Path) -> dict[str, ArtifactRecord]:
+    """Collect file records under the requested shared-output paths."""
+    records: dict[str, ArtifactRecord] = {}
+    for raw_path in paths:
+        root = _resolve_scan_path(raw_path, repo_root=repo_root)
+        if not root.exists():
+            continue
+        if root.is_file():
+            rel = _as_repo_relative(root, repo_root=repo_root)
+            records[rel] = ArtifactRecord(path=rel, size=root.stat().st_size)
+            continue
+        for child in sorted(item for item in root.rglob("*") if item.is_file()):
+            rel = _as_repo_relative(child, repo_root=repo_root)
+            records[rel] = ArtifactRecord(path=rel, size=child.stat().st_size)
+    return records
+
+
+def _load_baseline(path: Path | None) -> set[str]:
+    """Load a prior baseline manifest."""
+    if path is None or not path.exists():
+        return set()
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return {str(record["path"]) for record in payload.get("records", [])}
+
+
+def _write_manifest(path: Path, *, records: dict[str, ArtifactRecord], repo_root: Path) -> None:
+    """Write a baseline or scan manifest."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "schema": SCHEMA_VERSION,
+        "repo_root": str(repo_root),
+        "records": [asdict(record) for record in records.values()],
+    }
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def _is_under(path: str, prefix: str) -> bool:
+    """Return whether a repo-relative path is under a repo-relative prefix."""
+    normalized = prefix.strip("/")
+    return path == normalized or path.startswith(f"{normalized}/")
+
+
+def _default_allowed_prefixes(run_id: str) -> list[str]:
+    """Return output prefixes expected from the xdist race route."""
+    return [
+        f"output/tmp/xdist-race/{run_id}",
+        "output/coverage",
+    ]
+
+
+def _classify_violations(
+    *,
+    records: dict[str, ArtifactRecord],
+    baseline_paths: set[str],
+    run_id: str,
+    allowed_prefixes: list[str],
+) -> list[ArtifactViolation]:
+    """Classify new suspicious files produced during the stress run."""
+    isolated_prefix = f"output/tmp/xdist-race/{run_id}"
+    violations: list[ArtifactViolation] = []
+    for path, record in sorted(records.items()):
+        is_new = path not in baseline_paths
+        if not is_new:
+            continue
+        if record.size == 0:
+            violations.append(
+                ArtifactViolation(
+                    code="truncated_zero_byte",
+                    path=path,
+                    detail="new generated file is zero bytes",
+                )
+            )
+        if path.endswith(TEMP_SUFFIXES):
+            violations.append(
+                ArtifactViolation(
+                    code="orphaned_temp_file",
+                    path=path,
+                    detail=f"new generated file has a temporary suffix {TEMP_SUFFIXES}",
+                )
+            )
+        if WORKER_PATTERN.search(Path(path).name) and not _is_under(path, isolated_prefix):
+            violations.append(
+                ArtifactViolation(
+                    code="cross_worker_artifact",
+                    path=path,
+                    detail="worker-tagged file escaped the isolated xdist race artifact root",
+                )
+            )
+        if not any(_is_under(path, prefix) for prefix in allowed_prefixes) and not any(
+            _is_under(path, scan_prefix.as_posix()) for scan_prefix in DEFAULT_SCAN_PATHS
+        ):
+            violations.append(
+                ArtifactViolation(
+                    code="orphaned_shared_output",
+                    path=path,
+                    detail="new generated file is outside allowed xdist race output prefixes",
+                )
+            )
+    return violations
+
+
+def scan_xdist_race_artifacts(
+    *,
+    paths: list[Path],
+    run_id: str,
+    baseline_path: Path | None = None,
+    output_manifest: Path | None = None,
+    allowed_prefixes: list[str] | None = None,
+    cwd: Path | None = None,
+) -> dict[str, Any]:
+    """Scan shared-output paths and return a compact JSON-compatible result."""
+    repo_root = _repo_root(cwd or Path.cwd())
+    records = _collect_records(paths, repo_root=repo_root)
+    if output_manifest is not None:
+        _write_manifest(output_manifest, records=records, repo_root=repo_root)
+    baseline_paths = _load_baseline(baseline_path)
+    effective_prefixes = allowed_prefixes or _default_allowed_prefixes(run_id)
+    violations = _classify_violations(
+        records=records,
+        baseline_paths=baseline_paths,
+        run_id=run_id,
+        allowed_prefixes=effective_prefixes,
+    )
+    return {
+        "schema": SCHEMA_VERSION,
+        "status": "passed" if not violations else "failed",
+        "run_id": run_id,
+        "scan_paths": [path.as_posix() for path in paths],
+        "allowed_prefixes": effective_prefixes,
+        "baseline_path": str(baseline_path) if baseline_path else None,
+        "output_manifest": str(output_manifest) if output_manifest else None,
+        "scanned_file_count": len(records),
+        "new_file_count": len(set(records) - baseline_paths),
+        "violations": [asdict(violation) for violation in violations],
+    }
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--run-id",
+        default="local",
+        help="Stable run id used to identify the isolated xdist race artifact root.",
+    )
+    parser.add_argument(
+        "--baseline-json",
+        type=Path,
+        default=None,
+        help="Baseline manifest written before the stress run.",
+    )
+    parser.add_argument(
+        "--write-manifest",
+        type=Path,
+        default=None,
+        help="Write the current scan manifest to this path.",
+    )
+    parser.add_argument(
+        "--allowed-prefix",
+        action="append",
+        default=[],
+        help="Repo-relative prefix allowed for new files; may be repeated.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Print the full scan payload as JSON.",
+    )
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        type=Path,
+        default=list(DEFAULT_SCAN_PATHS),
+        help="Repo-relative shared-output paths to scan.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(argv)
+    try:
+        result = scan_xdist_race_artifacts(
+            paths=args.paths,
+            run_id=args.run_id,
+            baseline_path=args.baseline_json,
+            output_manifest=args.write_manifest,
+            allowed_prefixes=args.allowed_prefix or None,
+        )
+    except (RuntimeError, ValueError) as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+    else:
+        print(f"xdist_race_artifact_scan={result['status']}")
+        print(f"scanned_file_count={result['scanned_file_count']}")
+        print(f"new_file_count={result['new_file_count']}")
+        for violation in result["violations"]:
+            print(f"{violation['code']}: {violation['path']} ({violation['detail']})")
+    return 0 if result["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/check_xdist_race_artifacts.py
+++ b/scripts/dev/check_xdist_race_artifacts.py
@@ -119,9 +119,11 @@ def _classify_violations(
     baseline_paths: set[str],
     run_id: str,
     allowed_prefixes: list[str],
+    scan_paths: list[Path],
 ) -> list[ArtifactViolation]:
     """Classify new suspicious files produced during the stress run."""
     isolated_prefix = f"output/tmp/xdist-race/{run_id}"
+    scanned_prefixes = [path.as_posix() for path in scan_paths]
     violations: list[ArtifactViolation] = []
     for path, record in sorted(records.items()):
         is_new = path not in baseline_paths
@@ -152,7 +154,7 @@ def _classify_violations(
                 )
             )
         if not any(_is_under(path, prefix) for prefix in allowed_prefixes) and not any(
-            _is_under(path, scan_prefix.as_posix()) for scan_prefix in DEFAULT_SCAN_PATHS
+            _is_under(path, scan_prefix) for scan_prefix in scanned_prefixes
         ):
             violations.append(
                 ArtifactViolation(
@@ -185,6 +187,7 @@ def scan_xdist_race_artifacts(
         baseline_paths=baseline_paths,
         run_id=run_id,
         allowed_prefixes=effective_prefixes,
+        scan_paths=paths,
     )
     return {
         "schema": SCHEMA_VERSION,

--- a/scripts/dev/run_xdist_race_validation.sh
+++ b/scripts/dev/run_xdist_race_validation.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'EOF'
+Usage: scripts/dev/run_xdist_race_validation.sh [wrapper-options] [pytest-args...]
+
+Runs the full pytest suite through a high-concurrency xdist stress route, then
+checks shared generated-output paths for likely race artifacts.
+
+Wrapper options:
+  --workers <int>|auto       xdist workers [default: 32]
+  --timeout-seconds <secs>   Compact-validation timeout [default: 7200]
+  --artifact-dir <path>      Compact logs and scan manifests
+  -h, --help                 Show this help message
+
+Environment overrides:
+  XDIST_RACE_WORKERS=<int>|auto
+  XDIST_RACE_TIMEOUT_SECONDS=<secs>
+  XDIST_RACE_ARTIFACT_DIR=<path>
+  XDIST_RACE_RUN_ID=<id>
+  PYTEST_XDIST_DIST=load|worksteal|loadscope|loadfile|loadgroup
+
+Examples:
+  scripts/dev/run_xdist_race_validation.sh
+  scripts/dev/run_xdist_race_validation.sh --workers 32 tests fast-pysf/tests
+  scripts/dev/run_xdist_race_validation.sh --timeout-seconds 300 tests/dev
+EOF
+}
+
+if [[ "$#" -gt 0 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
+  show_help
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
+
+workers="${XDIST_RACE_WORKERS:-32}"
+timeout_seconds="${XDIST_RACE_TIMEOUT_SECONDS:-7200}"
+run_id="${XDIST_RACE_RUN_ID:-${GITHUB_RUN_ID:-local}-attempt-${GITHUB_RUN_ATTEMPT:-1}}"
+artifact_dir="${XDIST_RACE_ARTIFACT_DIR:-output/validation/xdist-race/${run_id}}"
+pytest_args=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --workers)
+      workers="${2:-}"
+      shift 2
+      ;;
+    --timeout-seconds)
+      timeout_seconds="${2:-}"
+      shift 2
+      ;;
+    --artifact-dir)
+      artifact_dir="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      pytest_args+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ -z "$workers" || -z "$timeout_seconds" || -z "$artifact_dir" ]]; then
+  echo "--workers, --timeout-seconds, and --artifact-dir require non-empty values." >&2
+  exit 2
+fi
+
+if [[ "$workers" != "auto" && ! "$workers" =~ ^[1-9][0-9]*$ ]]; then
+  echo "--workers must be a positive integer or 'auto'." >&2
+  exit 2
+fi
+
+cd "$REPO_ROOT"
+mkdir -p "$artifact_dir" "output/tmp/xdist-race/${run_id}" output/coverage
+
+baseline_json="$artifact_dir/baseline-artifacts.json"
+scan_json="$artifact_dir/post-run-artifacts.json"
+validation_status=0
+scan_status=0
+
+uv run python "$SCRIPT_DIR/check_xdist_race_artifacts.py" \
+  --run-id "$run_id" \
+  --write-manifest "$baseline_json" \
+  output/tmp output/coverage >/dev/null
+
+export PYTEST_NUM_WORKERS="$workers"
+export PYTEST_XDIST_DIST="${PYTEST_XDIST_DIST:-worksteal}"
+export PYTEST_FAST_FAIL="${PYTEST_FAST_FAIL:-0}"
+export PYTEST_ORDER_MODE="${PYTEST_ORDER_MODE:-none}"
+export COVERAGE_FILE="${COVERAGE_FILE:-output/coverage/.coverage.xdist-race-${run_id}}"
+
+echo "xdist race run id: $run_id" >&2
+echo "xdist race artifact dir: $artifact_dir" >&2
+echo "xdist race workers: $PYTEST_NUM_WORKERS" >&2
+echo "xdist race dist mode: $PYTEST_XDIST_DIST" >&2
+
+set +e
+uv run python "$SCRIPT_DIR/run_compact_validation.py" \
+  --artifact-dir "$artifact_dir" \
+  --timeout-seconds "$timeout_seconds" \
+  -- "$SCRIPT_DIR/run_tests_parallel.sh" "${pytest_args[@]}"
+validation_status=$?
+
+uv run python "$SCRIPT_DIR/check_xdist_race_artifacts.py" \
+  --run-id "$run_id" \
+  --baseline-json "$baseline_json" \
+  --write-manifest "$scan_json" \
+  --json \
+  output/tmp output/coverage
+scan_status=$?
+set -e
+
+if [[ "$validation_status" -ne 0 ]]; then
+  echo "xdist race validation failed with exit code $validation_status." >&2
+fi
+if [[ "$scan_status" -ne 0 ]]; then
+  echo "xdist race artifact scan failed with exit code $scan_status." >&2
+fi
+if [[ "$validation_status" -ne 0 ]]; then
+  exit "$validation_status"
+fi
+exit "$scan_status"

--- a/scripts/dev/run_xdist_race_validation.sh
+++ b/scripts/dev/run_xdist_race_validation.sh
@@ -33,6 +33,15 @@ if [[ "$#" -gt 0 && ( "$1" == "--help" || "$1" == "-h" ) ]]; then
   exit 0
 fi
 
+require_option_value() {
+  local option="$1"
+  local value="${2:-}"
+  if [[ -z "$value" || "$value" == --* ]]; then
+    echo "$option requires a non-empty value." >&2
+    exit 2
+  fi
+}
+
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(git -C "$SCRIPT_DIR" rev-parse --show-toplevel)"
 
@@ -45,14 +54,17 @@ pytest_args=()
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --workers)
+      require_option_value "$1" "${2:-}"
       workers="${2:-}"
       shift 2
       ;;
     --timeout-seconds)
+      require_option_value "$1" "${2:-}"
       timeout_seconds="${2:-}"
       shift 2
       ;;
     --artifact-dir)
+      require_option_value "$1" "${2:-}"
       artifact_dir="${2:-}"
       shift 2
       ;;

--- a/tests/dev/test_check_xdist_race_artifacts.py
+++ b/tests/dev/test_check_xdist_race_artifacts.py
@@ -1,0 +1,114 @@
+"""Tests for xdist race artifact scanning."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+from scripts.dev.check_xdist_race_artifacts import scan_xdist_race_artifacts
+
+
+def _git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run git in a temporary repository."""
+    return subprocess.run(["git", *args], cwd=repo, capture_output=True, text=True, check=True)
+
+
+def _init_repo(repo: Path) -> None:
+    """Create a minimal git repository for scanner tests."""
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    _git(repo, "config", "user.email", "agent@example.invalid")
+    _git(repo, "config", "user.name", "Agent")
+    (repo / ".gitignore").write_text("output/\n", encoding="utf-8")
+    _git(repo, "add", ".gitignore")
+    _git(repo, "commit", "-m", "seed")
+
+
+def test_scan_writes_baseline_and_accepts_isolated_artifact(tmp_path: Path) -> None:
+    """New artifacts under the run-specific xdist directory are allowed."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    artifact_dir = repo / "output" / "tmp" / "xdist-race" / "run-1"
+    artifact_dir.mkdir(parents=True)
+    baseline = repo / "baseline.json"
+    post_run = repo / "post-run.json"
+
+    baseline_result = scan_xdist_race_artifacts(
+        paths=[Path("output/tmp"), Path("output/coverage")],
+        run_id="run-1",
+        output_manifest=baseline,
+        cwd=repo,
+    )
+    (artifact_dir / "pytest.log").write_text("ok\n", encoding="utf-8")
+    result = scan_xdist_race_artifacts(
+        paths=[Path("output/tmp"), Path("output/coverage")],
+        run_id="run-1",
+        baseline_path=baseline,
+        output_manifest=post_run,
+        cwd=repo,
+    )
+
+    assert baseline_result["status"] == "passed"
+    assert baseline.exists()
+    assert post_run.exists()
+    assert result["status"] == "passed"
+    assert result["new_file_count"] == 1
+    assert result["violations"] == []
+
+
+def test_scan_rejects_truncated_temp_and_cross_worker_artifacts(tmp_path: Path) -> None:
+    """Suspicious new shared-output files should fail closed."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    output_tmp = repo / "output" / "tmp"
+    output_tmp.mkdir(parents=True)
+    baseline = repo / "baseline.json"
+    scan_xdist_race_artifacts(
+        paths=[Path("output/tmp"), Path("output/coverage")],
+        run_id="run-2",
+        output_manifest=baseline,
+        cwd=repo,
+    )
+    (output_tmp / "gw0.partial").write_text("", encoding="utf-8")
+
+    result = scan_xdist_race_artifacts(
+        paths=[Path("output/tmp"), Path("output/coverage")],
+        run_id="run-2",
+        baseline_path=baseline,
+        cwd=repo,
+    )
+
+    codes = {violation["code"] for violation in result["violations"]}
+    assert result["status"] == "failed"
+    assert {
+        "truncated_zero_byte",
+        "orphaned_temp_file",
+        "cross_worker_artifact",
+    } <= codes
+
+
+def test_scan_allows_non_suspicious_shared_output_file(tmp_path: Path) -> None:
+    """Legitimate non-empty files in scanned shared roots should not fail by location alone."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    output_tmp = repo / "output" / "tmp"
+    output_tmp.mkdir(parents=True)
+    baseline = repo / "baseline.json"
+    scan_xdist_race_artifacts(
+        paths=[Path("output/tmp"), Path("output/coverage")],
+        run_id="run-3",
+        output_manifest=baseline,
+        cwd=repo,
+    )
+    (output_tmp / "diagnostic.json").write_text("{}\n", encoding="utf-8")
+
+    result = scan_xdist_race_artifacts(
+        paths=[Path("output/tmp"), Path("output/coverage")],
+        run_id="run-3",
+        baseline_path=baseline,
+        cwd=repo,
+    )
+
+    assert result["status"] == "passed"
+    assert result["new_file_count"] == 1
+    assert result["violations"] == []

--- a/tests/dev/test_ci_uv_sync_diag.py
+++ b/tests/dev/test_ci_uv_sync_diag.py
@@ -101,3 +101,18 @@ def test_workflow_uv_cache_paths_match_setup_uv_cache_dir() -> None:
         assert expected_archive in workflow_text, workflow_path
         assert expected_wheels in workflow_text, workflow_path
         assert "~/.cache/uv" not in workflow_text, workflow_path
+
+
+def test_perf_nightly_runs_xdist_race_validation_route() -> None:
+    """Nightly performance workflow should include the scheduled xdist stress lane."""
+    workflow_text = (_repo_root() / ".github/workflows/perf-nightly.yml").read_text(
+        encoding="utf-8"
+    )
+
+    assert "Run xdist race validation" in workflow_text
+    assert 'XDIST_RACE_WORKERS: "32"' in workflow_text
+    assert 'XDIST_RACE_TIMEOUT_SECONDS: "7200"' in workflow_text
+    assert "PYTEST_XDIST_DIST: worksteal" in workflow_text
+    assert "scripts/dev/run_xdist_race_validation.sh" in workflow_text
+    assert "Upload xdist race validation artifacts" in workflow_text
+    assert "path: output/validation/xdist-race/" in workflow_text

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -7,9 +7,9 @@ handle both forms as cheap success paths: exit 0, print usage to stdout,
 and return before sourcing common_setup.sh or invoking heavy dependencies
 (uv, ruff, pytest, gh, etc.).
 
-Covered scripts (8 total):
+Covered scripts (9 total):
   pr_ready_check.sh, gh_comment.sh, run_worktree_shared_venv.sh,
-  run_tests_parallel.sh, run_ci_local.sh, ci_driver.sh,
+  run_tests_parallel.sh, run_xdist_race_validation.sh, run_ci_local.sh, ci_driver.sh,
   check_runtime_requirements.sh, check_carla_runtime.sh
 
 Also covered (in tests/dev/): ci_step_timer.sh
@@ -37,6 +37,7 @@ CI_DRIVER = ROOT / "scripts" / "dev" / "ci_driver.sh"
 GH_COMMENT = ROOT / "scripts" / "dev" / "gh_comment.sh"
 PYPROJECT = ROOT / "pyproject.toml"
 RUN_TESTS_PARALLEL = ROOT / "scripts" / "dev" / "run_tests_parallel.sh"
+RUN_XDIST_RACE_VALIDATION = ROOT / "scripts" / "dev" / "run_xdist_race_validation.sh"
 RUN_CI_LOCAL = ROOT / "scripts" / "dev" / "run_ci_local.sh"
 PR_READY_CHECK = ROOT / "scripts" / "dev" / "pr_ready_check.sh"
 RUN_WORKTREE_SHARED_VENV = ROOT / "scripts" / "dev" / "run_worktree_shared_venv.sh"
@@ -136,6 +137,39 @@ def test_run_tests_parallel_invalid_dist_fails_before_worker_resolution() -> Non
     ) in result.stderr
     assert "Resolved pytest-xdist workers" not in result.stderr
     assert "resolve_pytest_workers.py" not in result.stderr
+
+
+def test_xdist_race_validation_wraps_parallel_tests_and_artifact_scan() -> None:
+    """The stress route should force high xdist concurrency and scan shared outputs."""
+
+    script_text = RUN_XDIST_RACE_VALIDATION.read_text(encoding="utf-8")
+
+    assert 'workers="${XDIST_RACE_WORKERS:-32}"' in script_text
+    assert 'export PYTEST_NUM_WORKERS="$workers"' in script_text
+    assert 'export PYTEST_XDIST_DIST="${PYTEST_XDIST_DIST:-worksteal}"' in script_text
+    assert 'export PYTEST_FAST_FAIL="${PYTEST_FAST_FAIL:-0}"' in script_text
+    assert 'export PYTEST_ORDER_MODE="${PYTEST_ORDER_MODE:-none}"' in script_text
+    assert "run_compact_validation.py" in script_text
+    assert '"$SCRIPT_DIR/run_tests_parallel.sh" "${pytest_args[@]}"' in script_text
+    assert "check_xdist_race_artifacts.py" in script_text
+    assert "--baseline-json" in script_text
+
+
+def test_xdist_race_validation_rejects_invalid_worker_value() -> None:
+    """Invalid stress worker counts should fail before running uv or pytest."""
+
+    result = subprocess.run(
+        [str(RUN_XDIST_RACE_VALIDATION), "--workers", "12bad", "tests/dev"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "--workers must be a positive integer or 'auto'." in result.stderr
+    assert "uv run" not in result.stderr
 
 
 def test_ci_driver_typecheck_phase_is_explicitly_advisory() -> None:
@@ -612,6 +646,7 @@ HELP_COVERED_SCRIPTS = [
     GH_COMMENT,
     RUN_WORKTREE_SHARED_VENV,
     RUN_TESTS_PARALLEL,
+    RUN_XDIST_RACE_VALIDATION,
     RUN_CI_LOCAL,
     CI_DRIVER,
     CHECK_RUNTIME_REQUIREMENTS,
@@ -747,6 +782,27 @@ def test_run_tests_parallel_help_does_not_invoke_pytest(tmp_path: Path) -> None:
     assert result.returncode == 0
     assert "Usage:" in result.stdout
     assert "COVERAGE_FILE" in result.stdout
+    assert "uv should not be called" not in result.stderr
+
+
+def test_run_xdist_race_validation_help_does_not_invoke_pytest(tmp_path: Path) -> None:
+    """run_xdist_race_validation.sh --help exits 0 before invoking uv."""
+    repo, script_dir, env = _make_help_fixture_repo(
+        tmp_path,
+        ("run_xdist_race_validation.sh", "common_setup.sh"),
+    )
+    result = subprocess.run(
+        [str(script_dir / "run_xdist_race_validation.sh"), "--help"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+    assert result.returncode == 0
+    assert "Usage:" in result.stdout
+    assert "XDIST_RACE_WORKERS" in result.stdout
     assert "uv should not be called" not in result.stderr
 
 

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -172,6 +172,23 @@ def test_xdist_race_validation_rejects_invalid_worker_value() -> None:
     assert "uv run" not in result.stderr
 
 
+def test_xdist_race_validation_rejects_missing_option_value() -> None:
+    """Stress wrapper options should fail cleanly when the value is omitted."""
+
+    result = subprocess.run(
+        [str(RUN_XDIST_RACE_VALIDATION), "--workers"],
+        cwd=ROOT,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "--workers requires a non-empty value." in result.stderr
+    assert "shift" not in result.stderr
+
+
 def test_ci_driver_typecheck_phase_is_explicitly_advisory() -> None:
     """Typecheck phase should report findings without becoming a merge gate."""
 


### PR DESCRIPTION
## Summary
Adds a scheduled/manual xdist race validation route for issue #3168. The route runs pytest through a 32-worker xdist stress wrapper by default, stores compact validation artifacts, and scans shared generated-output roots for likely race artifacts.

## Linked Issues
- Closes `#3168`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `scripts/dev/run_xdist_race_validation.sh` as the stress wrapper around `run_tests_parallel.sh` and `run_compact_validation.py`.
- Added `scripts/dev/check_xdist_race_artifacts.py` to baseline and scan `output/tmp` plus `output/coverage` for zero-byte files, temp fragments, and worker-tagged escapes.
- Wired the route into `.github/workflows/perf-nightly.yml` with `XDIST_RACE_WORKERS=32` and artifact upload.
- Added workflow/script/scanner contract tests.

## Why It Matters
- Added value: gives the repo a scheduled and manually invokable full xdist stress lane without making every PR wait on it.
- Expected impact: catches shared-output race regressions earlier and keeps failure logs compact enough to triage.
- Why this is worth merging now: #3002 closed without the requested full 32-worker proof path, and this creates the missing route.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/workflow helper; this adds a validation route rather than interpreting research evidence.
- Comparator or baseline, if applicable: Existing `run_tests_parallel.sh` PR path has configurable xdist but no scheduled/manual 32-worker race lane or artifact scan.
- Evidence tier: targeted smoke / stress-route launch packet
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: Route is acceptable when it can be invoked locally on a focused target, is scheduled/manual in workflow, and contract tests lock the route.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3168
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; scanner identifies validation artifacts and does not interpret benchmark outcomes.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support/workflow helper.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: yes - the nightly/manual workflow should run the full 32-worker lane on GitHub after merge.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: GitHub-hosted nightly artifact is not available until the workflow runs.
- Stop / revise / continue decision: continue; route is implemented and locally smoke-tested.
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `uv run pytest tests/dev/test_check_xdist_race_artifacts.py tests/dev/test_ci_uv_sync_diag.py tests/dev/test_resolve_pytest_workers.py tests/test_ci_script_contract.py -q`
  - `scripts/dev/run_xdist_race_validation.sh --workers 2 --timeout-seconds 120 --artifact-dir output/validation/xdist-race/local-smoke tests/dev/test_check_xdist_race_artifacts.py -q`
  - `uv run ruff format --check scripts/dev/check_xdist_race_artifacts.py tests/dev/test_check_xdist_race_artifacts.py tests/dev/test_ci_uv_sync_diag.py tests/test_ci_script_contract.py`
  - `uv run ruff check scripts/dev/check_xdist_race_artifacts.py tests/dev/test_check_xdist_race_artifacts.py tests/dev/test_ci_uv_sync_diag.py tests/test_ci_script_contract.py`
  - `bash -n scripts/dev/run_xdist_race_validation.sh`
  - `python -m py_compile scripts/dev/check_xdist_race_artifacts.py`
  - `git diff --check`
- Evidence that the change works here: targeted tests passed and the new wrapper completed a local 2-worker smoke while producing compact validation plus artifact-scan manifests.
- Benchmarks or smoke tests, if applicable: local focused smoke only; full 32-worker GitHub run is deferred to the scheduled/manual workflow lane.

## Risks / Rollout
- Compatibility risks: low; normal PR CI still uses the existing wrapper, while the new stress lane runs in `perf-nightly.yml`.
- Failure modes: the nightly route may expose pre-existing xdist flakiness or runner-time pressure; scanner may need tuning if a legitimate shared-output producer looks like a race artifact.
- Rollback or fallback plan: remove the workflow step or lower `XDIST_RACE_WORKERS`; the existing `run_tests_parallel.sh` remains unchanged.

## Docs / Provenance
- Updated docs: none; route is documented by script help and workflow/test contracts.
- Relevant design or provenance notes: private autopilot ledger records issue #3168 validation summaries.
- Any assumptions that need to be preserved: the stress lane is delayed/diagnostic, not a hot PR gate.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this closing PR.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: workflow/support route only; no benchmark or paper-facing claim is being published.

## Follow-Up Issues
- Deferred work: observe the first scheduled/manual GitHub run and tune scanner thresholds only if needed.
- Issues opened for follow-up: none

## Reviewer Notes
- Verify the workflow placement: this intentionally lives in `perf-nightly.yml`, not hot PR CI.
- Known limitation: local proof used `--workers 2` on a focused target; the full `XDIST_RACE_WORKERS=32` path is exercised by the scheduled/manual workflow.
