### PR TITLE
feat: add blocker staleness checker

### DIFF
--- a/scripts/tools/check_blocker_staleness.py
+++ b/scripts/tools/check_blocker_staleness.py
@@ -1,0 +1,335 @@
+"""Detect open issues whose numbered blocker references have gone stale.
+
+The tool is intentionally read-only. It scans open issue bodies for numbered
+references in blocker-style sections, resolves those referenced issue states,
+and reports issues that are fully or partially unblocked.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import Any
+
+DEFAULT_REPO = "ll7/robot_sf_ll7"
+DEFAULT_LIMIT = 500
+DEPENDENCY_SECTION_TITLES = frozenset(
+    {
+        "blocked by",
+        "depends on",
+    }
+)
+HEADING_RE = re.compile(r"^(?P<marker>#{2,6})\s+(?P<title>.+?)\s*$", re.MULTILINE)
+ISSUE_REF_RE = re.compile(r"(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#(?P<number>[1-9]\d*)\b")
+STRIKETHROUGH_RE = re.compile(r"~~.*?~~", re.DOTALL)
+
+
+class BlockerClassification(StrEnum):
+    """Classification for an issue with parsed numbered blockers."""
+
+    FULLY_UNBLOCKED = "fully_unblocked"
+    PARTIALLY_UNBLOCKED = "partially_unblocked"
+    STILL_BLOCKED = "still_blocked"
+    UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True, slots=True)
+class IssueRef:
+    """Minimal issue payload needed by the staleness classifier."""
+
+    number: int
+    title: str = ""
+    state: str = "UNKNOWN"
+    url: str = ""
+
+
+@dataclass(frozen=True, slots=True)
+class BlockerAuditResult:
+    """Structured staleness result for one open issue."""
+
+    issue: IssueRef
+    blocker_numbers: tuple[int, ...]
+    closed_blockers: tuple[int, ...]
+    open_blockers: tuple[int, ...]
+    unknown_blockers: tuple[int, ...]
+    classification: BlockerClassification
+
+
+def _normalize_heading(title: str) -> str:
+    """Normalize a Markdown heading for blocker-section matching."""
+
+    cleaned = re.sub(r"[:：]+$", "", title.strip())
+    cleaned = re.sub(r"[-_]+", " ", cleaned)
+    return re.sub(r"\s+", " ", cleaned).casefold()
+
+
+def _dependency_section_spans(body: str) -> list[tuple[int, int]]:
+    """Return body spans under recognized blocker/dependency sections."""
+
+    matches = list(HEADING_RE.finditer(body))
+    spans: list[tuple[int, int]] = []
+    for index, match in enumerate(matches):
+        if _normalize_heading(match.group("title")) not in DEPENDENCY_SECTION_TITLES:
+            continue
+        heading_level = len(match.group("marker"))
+        section_start = match.end()
+        section_end = len(body)
+        for next_match in matches[index + 1 :]:
+            if len(next_match.group("marker")) <= heading_level:
+                section_end = next_match.start()
+                break
+        spans.append((section_start, section_end))
+    return spans
+
+
+def extract_blocker_numbers(body: str) -> tuple[int, ...]:
+    """Extract unique non-struck-through issue numbers from dependency sections."""
+
+    blocker_numbers: list[int] = []
+    seen: set[int] = set()
+    for start, end in _dependency_section_spans(body):
+        section = STRIKETHROUGH_RE.sub("", body[start:end])
+        for match in ISSUE_REF_RE.finditer(section):
+            number = int(match.group("number"))
+            if number not in seen:
+                blocker_numbers.append(number)
+                seen.add(number)
+    return tuple(blocker_numbers)
+
+
+def classify_blockers(
+    issue: IssueRef,
+    blocker_numbers: tuple[int, ...],
+    blocker_states: dict[int, str],
+) -> BlockerAuditResult:
+    """Classify one issue from parsed blocker numbers and resolved states."""
+
+    closed: list[int] = []
+    open_: list[int] = []
+    unknown: list[int] = []
+    for number in blocker_numbers:
+        state = blocker_states.get(number, "UNKNOWN").upper()
+        if state == "CLOSED":
+            closed.append(number)
+        elif state == "OPEN":
+            open_.append(number)
+        else:
+            unknown.append(number)
+
+    if unknown:
+        classification = BlockerClassification.UNKNOWN
+    elif blocker_numbers and len(closed) == len(blocker_numbers):
+        classification = BlockerClassification.FULLY_UNBLOCKED
+    elif closed:
+        classification = BlockerClassification.PARTIALLY_UNBLOCKED
+    else:
+        classification = BlockerClassification.STILL_BLOCKED
+
+    return BlockerAuditResult(
+        issue=issue,
+        blocker_numbers=blocker_numbers,
+        closed_blockers=tuple(closed),
+        open_blockers=tuple(open_),
+        unknown_blockers=tuple(unknown),
+        classification=classification,
+    )
+
+
+def audit_issue_bodies(
+    issues: list[IssueRef],
+    issue_bodies: dict[int, str],
+    blocker_states: dict[int, str],
+) -> list[BlockerAuditResult]:
+    """Audit issue bodies using already-resolved blocker states."""
+
+    results: list[BlockerAuditResult] = []
+    for issue in issues:
+        blocker_numbers = extract_blocker_numbers(issue_bodies.get(issue.number, ""))
+        if not blocker_numbers:
+            continue
+        results.append(classify_blockers(issue, blocker_numbers, blocker_states))
+    return results
+
+
+def _gh_json(args: list[str], *, timeout: int = 60) -> Any:
+    """Run a GitHub CLI command that returns JSON."""
+
+    result = subprocess.run(
+        ["gh", *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+        check=False,
+    )
+    if result.returncode != 0:
+        detail = (result.stderr or result.stdout).strip()
+        raise RuntimeError(f"gh {' '.join(args)} failed with {result.returncode}: {detail}")
+    return json.loads(result.stdout or "null")
+
+
+def fetch_open_issues(
+    *, repo: str, label: str | None, limit: int
+) -> tuple[list[IssueRef], dict[int, str]]:
+    """Fetch open issues and bodies through the GitHub CLI."""
+
+    args = [
+        "issue",
+        "list",
+        "--repo",
+        repo,
+        "--state",
+        "open",
+        "--limit",
+        str(limit),
+        "--json",
+        "number,title,body,state,url",
+    ]
+    if label:
+        args.extend(["--label", label])
+    payload = _gh_json(args)
+
+    issues: list[IssueRef] = []
+    bodies: dict[int, str] = {}
+    for row in payload:
+        number = int(row["number"])
+        issues.append(
+            IssueRef(
+                number=number,
+                title=str(row.get("title") or ""),
+                state=str(row.get("state") or "UNKNOWN"),
+                url=str(row.get("url") or ""),
+            )
+        )
+        bodies[number] = str(row.get("body") or "")
+    return issues, bodies
+
+
+def fetch_issue_states(numbers: set[int], *, repo: str) -> dict[int, str]:
+    """Resolve issue states for referenced blocker numbers."""
+
+    states: dict[int, str] = {}
+    for number in sorted(numbers):
+        payload = _gh_json(
+            [
+                "issue",
+                "view",
+                str(number),
+                "--repo",
+                repo,
+                "--json",
+                "number,state",
+            ]
+        )
+        states[int(payload["number"])] = str(payload.get("state") or "UNKNOWN")
+    return states
+
+
+def build_summary(results: list[BlockerAuditResult]) -> dict[str, Any]:
+    """Build the stable JSON summary emitted by the CLI."""
+
+    grouped = {
+        classification.value: [
+            asdict(result) for result in results if result.classification == classification
+        ]
+        for classification in BlockerClassification
+    }
+    return {
+        "schema_version": "blocker_staleness_report.v1",
+        "counts": {key: len(value) for key, value in grouped.items()},
+        "results": grouped,
+    }
+
+
+def _format_issue_line(result: BlockerAuditResult) -> str:
+    """Return one compact text report line."""
+
+    issue = result.issue
+    parts = [
+        f"#{issue.number}",
+        issue.title,
+        f"blockers={list(result.blocker_numbers)}",
+        f"closed={list(result.closed_blockers)}",
+        f"open={list(result.open_blockers)}",
+    ]
+    if result.unknown_blockers:
+        parts.append(f"unknown={list(result.unknown_blockers)}")
+    if issue.url:
+        parts.append(issue.url)
+    return " | ".join(part for part in parts if part)
+
+
+def render_text(summary: dict[str, Any]) -> str:
+    """Render a human-readable report from a summary payload."""
+
+    lines = ["# Blocker Staleness Report", ""]
+    for key in (
+        BlockerClassification.FULLY_UNBLOCKED.value,
+        BlockerClassification.PARTIALLY_UNBLOCKED.value,
+        BlockerClassification.UNKNOWN.value,
+        BlockerClassification.STILL_BLOCKED.value,
+    ):
+        rows = summary["results"][key]
+        lines.extend([f"## {key} ({len(rows)})", ""])
+        if not rows:
+            lines.append("- none")
+        else:
+            for row in rows:
+                result = BlockerAuditResult(
+                    issue=IssueRef(**row["issue"]),
+                    blocker_numbers=tuple(row["blocker_numbers"]),
+                    closed_blockers=tuple(row["closed_blockers"]),
+                    open_blockers=tuple(row["open_blockers"]),
+                    unknown_blockers=tuple(row["unknown_blockers"]),
+                    classification=BlockerClassification(row["classification"]),
+                )
+                lines.append(f"- {_format_issue_line(result)}")
+        lines.append("")
+    return "\n".join(lines).rstrip() + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the blocker-staleness detector."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", default=DEFAULT_REPO, help="Repository in OWNER/REPO form.")
+    parser.add_argument("--label", help="Only scan open issues with this label.")
+    parser.add_argument(
+        "--limit", type=int, default=DEFAULT_LIMIT, help="Maximum open issues to fetch."
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="Always exit 0 after reporting; useful for dry-run or dashboards.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Alias for --report-only. The tool never mutates GitHub state.",
+    )
+    args = parser.parse_args(argv)
+
+    issues, bodies = fetch_open_issues(repo=args.repo, label=args.label, limit=args.limit)
+    blocker_numbers = {
+        number for body in bodies.values() for number in extract_blocker_numbers(body)
+    }
+    blocker_states = fetch_issue_states(blocker_numbers, repo=args.repo)
+    summary = build_summary(audit_issue_bodies(issues, bodies, blocker_states))
+
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(render_text(summary), end="")
+
+    fully_unblocked = summary["counts"][BlockerClassification.FULLY_UNBLOCKED.value]
+    if fully_unblocked and not (args.report_only or args.dry_run):
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/check_blocker_staleness.py
+++ b/scripts/tools/check_blocker_staleness.py
@@ -24,7 +24,7 @@ DEPENDENCY_SECTION_TITLES = frozenset(
     }
 )
 HEADING_RE = re.compile(r"^(?P<marker>#{2,6})\s+(?P<title>.+?)\s*$", re.MULTILINE)
-ISSUE_REF_RE = re.compile(r"(?:[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#(?P<number>[1-9]\d*)\b")
+ISSUE_REF_RE = re.compile(r"(?:(?P<repo>[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(?P<number>[1-9]\d*)\b")
 STRIKETHROUGH_RE = re.compile(r"~~.*?~~", re.DOTALL)
 
 
@@ -62,9 +62,19 @@ class BlockerAuditResult:
 def _normalize_heading(title: str) -> str:
     """Normalize a Markdown heading for blocker-section matching."""
 
-    cleaned = re.sub(r"[:：]+$", "", title.strip())
+    cleaned = re.sub(r"[:\uff1a]+$", "", title.strip())
     cleaned = re.sub(r"[-_]+", " ", cleaned)
     return re.sub(r"\s+", " ", cleaned).casefold()
+
+
+def _is_dependency_heading(title: str) -> bool:
+    """Return whether a heading starts a blocker/dependency section."""
+
+    normalized = _normalize_heading(title)
+    return any(
+        normalized == dependency_title or normalized.startswith(f"{dependency_title} ")
+        for dependency_title in DEPENDENCY_SECTION_TITLES
+    )
 
 
 def _dependency_section_spans(body: str) -> list[tuple[int, int]]:
@@ -73,10 +83,10 @@ def _dependency_section_spans(body: str) -> list[tuple[int, int]]:
     matches = list(HEADING_RE.finditer(body))
     spans: list[tuple[int, int]] = []
     for index, match in enumerate(matches):
-        if _normalize_heading(match.group("title")) not in DEPENDENCY_SECTION_TITLES:
+        if not _is_dependency_heading(match.group("title")):
             continue
         heading_level = len(match.group("marker"))
-        section_start = match.end()
+        section_start = match.start("title")
         section_end = len(body)
         for next_match in matches[index + 1 :]:
             if len(next_match.group("marker")) <= heading_level:
@@ -86,7 +96,7 @@ def _dependency_section_spans(body: str) -> list[tuple[int, int]]:
     return spans
 
 
-def extract_blocker_numbers(body: str) -> tuple[int, ...]:
+def extract_blocker_numbers(body: str, *, repo: str = DEFAULT_REPO) -> tuple[int, ...]:
     """Extract unique non-struck-through issue numbers from dependency sections."""
 
     blocker_numbers: list[int] = []
@@ -94,6 +104,9 @@ def extract_blocker_numbers(body: str) -> tuple[int, ...]:
     for start, end in _dependency_section_spans(body):
         section = STRIKETHROUGH_RE.sub("", body[start:end])
         for match in ISSUE_REF_RE.finditer(section):
+            matched_repo = match.group("repo")
+            if matched_repo is not None and matched_repo.casefold() != repo.casefold():
+                continue
             number = int(match.group("number"))
             if number not in seen:
                 blocker_numbers.append(number)
@@ -143,12 +156,14 @@ def audit_issue_bodies(
     issues: list[IssueRef],
     issue_bodies: dict[int, str],
     blocker_states: dict[int, str],
+    *,
+    repo: str = DEFAULT_REPO,
 ) -> list[BlockerAuditResult]:
     """Audit issue bodies using already-resolved blocker states."""
 
     results: list[BlockerAuditResult] = []
     for issue in issues:
-        blocker_numbers = extract_blocker_numbers(issue_bodies.get(issue.number, ""))
+        blocker_numbers = extract_blocker_numbers(issue_bodies.get(issue.number, ""), repo=repo)
         if not blocker_numbers:
             continue
         results.append(classify_blockers(issue, blocker_numbers, blocker_states))
@@ -158,13 +173,16 @@ def audit_issue_bodies(
 def _gh_json(args: list[str], *, timeout: int = 60) -> Any:
     """Run a GitHub CLI command that returns JSON."""
 
-    result = subprocess.run(
-        ["gh", *args],
-        capture_output=True,
-        text=True,
-        timeout=timeout,
-        check=False,
-    )
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("gh is not installed or is not available on PATH") from exc
     if result.returncode != 0:
         detail = (result.stderr or result.stdout).strip()
         raise RuntimeError(f"gh {' '.join(args)} failed with {result.returncode}: {detail}")
@@ -213,17 +231,21 @@ def fetch_issue_states(numbers: set[int], *, repo: str) -> dict[int, str]:
 
     states: dict[int, str] = {}
     for number in sorted(numbers):
-        payload = _gh_json(
-            [
-                "issue",
-                "view",
-                str(number),
-                "--repo",
-                repo,
-                "--json",
-                "number,state",
-            ]
-        )
+        try:
+            payload = _gh_json(
+                [
+                    "issue",
+                    "view",
+                    str(number),
+                    "--repo",
+                    repo,
+                    "--json",
+                    "number,state",
+                ]
+            )
+        except RuntimeError:
+            states[number] = "UNKNOWN"
+            continue
         states[int(payload["number"])] = str(payload.get("state") or "UNKNOWN")
     return states
 
@@ -315,10 +337,12 @@ def main(argv: list[str] | None = None) -> int:
 
     issues, bodies = fetch_open_issues(repo=args.repo, label=args.label, limit=args.limit)
     blocker_numbers = {
-        number for body in bodies.values() for number in extract_blocker_numbers(body)
+        number
+        for body in bodies.values()
+        for number in extract_blocker_numbers(body, repo=args.repo)
     }
     blocker_states = fetch_issue_states(blocker_numbers, repo=args.repo)
-    summary = build_summary(audit_issue_bodies(issues, bodies, blocker_states))
+    summary = build_summary(audit_issue_bodies(issues, bodies, blocker_states, repo=args.repo))
 
     if args.json:
         print(json.dumps(summary, indent=2, sort_keys=True))

--- a/tests/tools/test_check_blocker_staleness.py
+++ b/tests/tools/test_check_blocker_staleness.py
@@ -29,12 +29,29 @@ Mention #10 outside the dependency section.
 
 Waiting for #104 and #105.
 
+## Blocked by #108
+
+Inline heading reference.
+
 ## Validation / Testing
 
 This section mentions #106 but is not a blocker.
 """
 
-    assert staleness.extract_blocker_numbers(body) == (101, 102, 107, 104, 105)
+    assert staleness.extract_blocker_numbers(body) == (101, 102, 107, 104, 105, 108)
+
+
+def test_extract_blocker_numbers_ignores_other_repository_references() -> None:
+    """Cross-repository refs should not be resolved against the selected repository."""
+
+    body = """## Depends On #201
+
+- ll7/robot_sf_ll7#202
+- other/repo#203
+- #204
+"""
+
+    assert staleness.extract_blocker_numbers(body, repo="ll7/robot_sf_ll7") == (201, 202, 204)
 
 
 def test_classify_blockers_reports_fully_partially_and_still_blocked() -> None:
@@ -84,6 +101,23 @@ def test_audit_issue_bodies_omits_issues_without_numbered_blockers() -> None:
 
     assert [result.issue.number for result in results] == [200]
     assert results[0].classification == staleness.BlockerClassification.PARTIALLY_UNBLOCKED
+
+
+def test_fetch_issue_states_keeps_missing_blockers_unknown(monkeypatch) -> None:
+    """A missing/private blocker should not abort the whole stale-blocker report."""
+
+    def fake_gh_json(args: list[str]):
+        number = int(args[2])
+        if number == 101:
+            return {"number": 101, "state": "CLOSED"}
+        raise RuntimeError("not found")
+
+    monkeypatch.setattr(staleness, "_gh_json", fake_gh_json)
+
+    assert staleness.fetch_issue_states({101, 102}, repo="owner/repo") == {
+        101: "CLOSED",
+        102: "UNKNOWN",
+    }
 
 
 def test_main_exits_nonzero_only_for_enforced_fully_unblocked(

--- a/tests/tools/test_check_blocker_staleness.py
+++ b/tests/tools/test_check_blocker_staleness.py
@@ -1,0 +1,124 @@
+"""Tests for the blocker-staleness issue audit helper."""
+
+from __future__ import annotations
+
+import json
+
+from scripts.tools import check_blocker_staleness as staleness
+
+
+def test_extract_blocker_numbers_from_dependency_sections() -> None:
+    """The parser should only read numbered blockers from recognized sections."""
+
+    body = """## Goal / Problem
+
+Mention #10 outside the dependency section.
+
+## Blocked-By
+
+- #101
+- ll7/robot_sf_ll7#102
+- ~~#103~~
+- duplicate #101
+
+### Nested detail
+
+- #107
+
+## Depends On:
+
+Waiting for #104 and #105.
+
+## Validation / Testing
+
+This section mentions #106 but is not a blocker.
+"""
+
+    assert staleness.extract_blocker_numbers(body) == (101, 102, 107, 104, 105)
+
+
+def test_classify_blockers_reports_fully_partially_and_still_blocked() -> None:
+    """Resolved issue states should map to the expected stale-blocker buckets."""
+
+    issue = staleness.IssueRef(number=200, title="candidate")
+
+    fully = staleness.classify_blockers(issue, (101, 102), {101: "CLOSED", 102: "CLOSED"})
+    partial = staleness.classify_blockers(issue, (101, 102), {101: "CLOSED", 102: "OPEN"})
+    still = staleness.classify_blockers(issue, (101, 102), {101: "OPEN", 102: "OPEN"})
+
+    assert fully.classification == staleness.BlockerClassification.FULLY_UNBLOCKED
+    assert fully.closed_blockers == (101, 102)
+    assert partial.classification == staleness.BlockerClassification.PARTIALLY_UNBLOCKED
+    assert partial.closed_blockers == (101,)
+    assert partial.open_blockers == (102,)
+    assert still.classification == staleness.BlockerClassification.STILL_BLOCKED
+
+
+def test_classify_blockers_keeps_unknown_states_separate() -> None:
+    """Unknown blocker state should not be reported as safely unblocked."""
+
+    result = staleness.classify_blockers(
+        staleness.IssueRef(number=200),
+        (101, 102),
+        {101: "CLOSED"},
+    )
+
+    assert result.classification == staleness.BlockerClassification.UNKNOWN
+    assert result.closed_blockers == (101,)
+    assert result.unknown_blockers == (102,)
+
+
+def test_audit_issue_bodies_omits_issues_without_numbered_blockers() -> None:
+    """Issues without parsed numbered blockers are not stale-blocker candidates."""
+
+    issues = [
+        staleness.IssueRef(number=200, title="has blockers"),
+        staleness.IssueRef(number=201, title="no blockers"),
+    ]
+    bodies = {
+        200: "## Blocked by\n\n- #101\n- #102\n",
+        201: "## Blocked by\n\n- external data upload\n",
+    }
+
+    results = staleness.audit_issue_bodies(issues, bodies, {101: "CLOSED", 102: "OPEN"})
+
+    assert [result.issue.number for result in results] == [200]
+    assert results[0].classification == staleness.BlockerClassification.PARTIALLY_UNBLOCKED
+
+
+def test_main_exits_nonzero_only_for_enforced_fully_unblocked(
+    monkeypatch,
+    capsys,
+) -> None:
+    """The default CLI enforces fully-unblocked findings, while report-only stays zero."""
+
+    def fake_fetch_open_issues(*, repo: str, label: str | None, limit: int):
+        assert repo == "owner/repo"
+        assert label == "state:blocked"
+        assert limit == 10
+        return [staleness.IssueRef(number=200, title="ready")], {200: "## Blocked by\n\n- #101\n"}
+
+    monkeypatch.setattr(staleness, "fetch_open_issues", fake_fetch_open_issues)
+    monkeypatch.setattr(staleness, "fetch_issue_states", lambda numbers, *, repo: {101: "CLOSED"})
+
+    exit_code = staleness.main(
+        ["--repo", "owner/repo", "--label", "state:blocked", "--limit", "10"]
+    )
+    assert exit_code == 1
+    assert "fully_unblocked (1)" in capsys.readouterr().out
+
+    exit_code = staleness.main(
+        [
+            "--repo",
+            "owner/repo",
+            "--label",
+            "state:blocked",
+            "--limit",
+            "10",
+            "--report-only",
+            "--json",
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["counts"]["fully_unblocked"] == 1


### PR DESCRIPTION
## Summary
Adds a read-only blocker-staleness checker that scans open issue bodies for numbered `Blocked by` / `Depends On` references, resolves referenced issue states, and reports fully or partially unblocked issues.

## Linked Issues
- Closes `#3183`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/tools/check_blocker_staleness.py` with parser, classifier, JSON/text output, label filtering, read-only GitHub CLI fetching, `--report-only`, and `--dry-run`.
- Added `tests/tools/test_check_blocker_staleness.py` covering parser behavior, strikethrough skipping, full-repo issue refs, nested headings, classification buckets, unknown states, and CLI enforcement/report-only exit behavior.

## Why It Matters
- Added value: catches issues stuck in `state:blocked` after all numbered blockers close.
- Expected impact: enables cron/CI or agent workflows to detect stale blocker labels without mutating GitHub state.
- Why this is worth merging now: a live `state:blocked` report found current stale blockers, so the tool addresses an observed workflow gap.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow support helper; no research claim.
- Comparator or baseline, if applicable: NA.
- Evidence tier: targeted smoke / support-helper validation.
- Result classification: blocker-resolution support.
- Decision or stop rule, if applicable: default mode exits nonzero when fully unblocked issues are found.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#3183`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it detects issue-workflow staleness and does not interpret benchmark or research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop; issue scope is implemented.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_check_blocker_staleness.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/check_blocker_staleness.py tests/tools/test_check_blocker_staleness.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/check_blocker_staleness.py --label state:blocked --report-only --json`
  - `scripts/dev/run_worktree_shared_venv.sh -- bash -c 'uv run python scripts/tools/check_blocker_staleness.py --label state:blocked --json > /tmp/check_blocker_staleness_enforced.json; code=$?; printf "exit=%s\n" "$code"; test "$code" -eq 1'`
  - `scripts/dev/run_worktree_shared_venv.sh -- bash -c 'BASE_REF=origin/main scripts/dev/pr_ready_check.sh'`
- Evidence that the change works here: focused tests passed; live report-only scan found 4 fully unblocked and 1 partially unblocked `state:blocked` issues; default enforcement scan exited `1` as expected; full PR readiness passed with 7218 passed, 11 skipped.
- Benchmarks or smoke tests, if applicable: NA - support helper.

## Risks / Rollout
- Compatibility risks: uses `gh issue list/view`; environments without authenticated `gh` will fail with an explicit command error.
- Failure modes: only numbered blockers in recognized sections are classified; vague prose blockers remain out of scope by design.
- Rollback or fallback plan: remove the script/tests; no persistent data or GitHub mutation is performed.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue `#3183`; validation stamp written locally to ignored `output/validation/pr_ready/issue-3183-blocker-staleness.json`.
- Any assumptions that need to be preserved: local `output/` coverage/readiness artifacts are disposable ignored proof, not durable source artifacts.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via linked closing PR.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a workflow support helper with no benchmark, registry, claim-map, or paper-facing propagation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: parser scope intentionally ignores vague prose blockers and struck-through references.
- Any known limitations: live fetching resolves blocker states one issue at a time for simplicity; this is acceptable for the default bounded issue queue size.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a CLI tool that scans open GitHub issues for blocker references, classifies their status (fully/partially/still blocked or unknown), and generates JSON or Markdown reports.

* **Tests**
  * Added comprehensive test coverage for blocker classification, extraction, and auditing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->