### PR TITLE
feat: apply registry-derived state labels

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -79,7 +79,23 @@ The issue-state snapshot is a compact JSON list or object with `number`, `state`
 The report detects closed issues with nonterminal cards, closed blockers with blocked cards,
 dry-run derived `state:*` label updates, missing config/input paths, pending artifact aliases, and
 expected artifacts that still need durable references. It reports `labels_to_add` and
-`labels_to_remove` but never mutates GitHub.
+`labels_to_remove` without mutating GitHub by default.
+
+To explicitly project derived registry state labels back to GitHub issues, rerun the same command
+with `--apply-labels` and a write cap:
+
+```bash
+uv run python scripts/tools/validate_experiment_registry.py \
+  experiments/registry.yaml \
+  --issue-state-json output/experiments/issue_state_snapshot.json \
+  --control-plane-report-json output/experiments/control_plane_report.json \
+  --apply-labels \
+  --max-writes 5
+```
+
+The apply path only touches `state:*` labels from existing `derived_issue_label_update` findings,
+checks `gh api rate_limit` before writing, honors `--max-writes`, and writes a disposable audit log
+under `output/issue_state_sync/`.
 This v2 control-plane guidance is part of the #3057 research-control-plane work and is exercised by
 `tests/tools/test_validate_experiment_registry.py`.
 

--- a/scripts/tools/validate_experiment_registry.py
+++ b/scripts/tools/validate_experiment_registry.py
@@ -189,19 +189,30 @@ def apply_derived_issue_label_updates(
         )
     rate_limit = _read_rate_limit(runner)
     remaining = rate_limit.get("remaining")
-    if isinstance(remaining, int) and remaining < min_rate_limit_remaining:
+    if not isinstance(remaining, int):
+        raise RuntimeError(
+            "refusing to apply label updates; unable to determine GitHub core rate limit remaining"
+        )
+    if remaining < min_rate_limit_remaining:
         raise RuntimeError(
             f"refusing to apply label updates; GitHub core rate limit remaining "
             f"{remaining} < {min_rate_limit_remaining}"
         )
 
     applied: list[dict[str, Any]] = []
+    error_to_raise: Exception | None = None
     for update in updates:
         command = _issue_label_edit_command(update)
-        result = runner(command)
-        stdout = getattr(result, "stdout", "")
-        stderr = getattr(result, "stderr", "")
-        returncode = int(getattr(result, "returncode", 1))
+        try:
+            result = runner(command)
+            stdout = getattr(result, "stdout", "")
+            stderr = getattr(result, "stderr", "")
+            returncode = int(getattr(result, "returncode", 1))
+        except Exception as exc:
+            stdout = ""
+            stderr = str(exc)
+            returncode = 1
+            error_to_raise = exc
         applied.append(
             {
                 "issue": update["issue"],
@@ -214,11 +225,13 @@ def apply_derived_issue_label_updates(
                 "stderr": stderr,
             }
         )
-        if returncode != 0:
-            raise RuntimeError(
+        if returncode != 0 and error_to_raise is None:
+            error_to_raise = RuntimeError(
                 f"gh issue edit failed for issue #{update['issue']} with {returncode}: "
                 f"{(stderr or stdout).strip()}"
             )
+        if error_to_raise is not None:
+            break
 
     audit = {
         "schema_version": "experiment-state-label-apply.v1",
@@ -226,11 +239,13 @@ def apply_derived_issue_label_updates(
         "max_writes": max_writes,
         "min_rate_limit_remaining": min_rate_limit_remaining,
         "rate_limit": rate_limit,
-        "applied_count": len(applied),
+        "applied_count": sum(1 for entry in applied if entry["returncode"] == 0),
         "applied": applied,
     }
     audit_log_path.parent.mkdir(parents=True, exist_ok=True)
     audit_log_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    if error_to_raise is not None:
+        raise error_to_raise
     return audit
 
 
@@ -448,7 +463,14 @@ def _read_rate_limit(gh_runner: Any) -> dict[str, Any]:
         payload = json.loads(stdout or "{}")
     except json.JSONDecodeError as exc:
         raise RuntimeError(f"gh api rate_limit returned invalid JSON: {exc}") from exc
-    core = payload.get("resources", {}).get("core", {})
+    if not isinstance(payload, dict):
+        payload = {}
+    resources = payload.get("resources")
+    if not isinstance(resources, dict):
+        resources = {}
+    core = resources.get("core")
+    if not isinstance(core, dict):
+        core = {}
     return {
         "remaining": core.get("remaining"),
         "limit": core.get("limit"),

--- a/scripts/tools/validate_experiment_registry.py
+++ b/scripts/tools/validate_experiment_registry.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import subprocess
 import sys
 from collections.abc import Iterable, Mapping
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -80,6 +82,7 @@ STATE_TO_LABEL = {
 RUNNING_LABEL = "state:running"
 PROPOSAL_RECORD_STATES = {"idea", "proposal"}
 ANGLE_PLACEHOLDER_RE = re.compile(r"<[A-Za-z0-9][A-Za-z0-9_.:/-]*>")
+DEFAULT_STATE_LABEL_AUDIT_DIR = Path("output/issue_state_sync")
 
 
 def validate_registry(registry_path: Path) -> list[str]:
@@ -160,6 +163,75 @@ def build_control_plane_report(
             1 for finding in findings if finding.get("kind") == "derived_issue_label_update"
         ),
     }
+
+
+def apply_derived_issue_label_updates(
+    report: Mapping[str, Any],
+    *,
+    max_writes: int,
+    audit_log_path: Path,
+    min_rate_limit_remaining: int = 25,
+    gh_runner: Any | None = None,
+) -> dict[str, Any]:
+    """Apply derived `state:*` label updates from a control-plane report.
+
+    The control plane remains dry-run by default. This function is the explicit
+    write boundary for `--apply-labels`: it only consumes existing
+    `derived_issue_label_update` findings, only touches labels in `STATE_LABELS`,
+    checks GitHub API quota before the batch, and writes an audit log.
+    """
+
+    runner = gh_runner or _run_gh
+    updates = _derived_label_updates_from_report(report)
+    if len(updates) > max_writes:
+        raise RuntimeError(
+            f"refusing to apply {len(updates)} label updates; --max-writes is {max_writes}"
+        )
+    rate_limit = _read_rate_limit(runner)
+    remaining = rate_limit.get("remaining")
+    if isinstance(remaining, int) and remaining < min_rate_limit_remaining:
+        raise RuntimeError(
+            f"refusing to apply label updates; GitHub core rate limit remaining "
+            f"{remaining} < {min_rate_limit_remaining}"
+        )
+
+    applied: list[dict[str, Any]] = []
+    for update in updates:
+        command = _issue_label_edit_command(update)
+        result = runner(command)
+        stdout = getattr(result, "stdout", "")
+        stderr = getattr(result, "stderr", "")
+        returncode = int(getattr(result, "returncode", 1))
+        applied.append(
+            {
+                "issue": update["issue"],
+                "record": update["record"],
+                "labels_to_add": update["labels_to_add"],
+                "labels_to_remove": update["labels_to_remove"],
+                "command": ["gh", *command],
+                "returncode": returncode,
+                "stdout": stdout,
+                "stderr": stderr,
+            }
+        )
+        if returncode != 0:
+            raise RuntimeError(
+                f"gh issue edit failed for issue #{update['issue']} with {returncode}: "
+                f"{(stderr or stdout).strip()}"
+            )
+
+    audit = {
+        "schema_version": "experiment-state-label-apply.v1",
+        "created_at_utc": datetime.now(UTC).isoformat(),
+        "max_writes": max_writes,
+        "min_rate_limit_remaining": min_rate_limit_remaining,
+        "rate_limit": rate_limit,
+        "applied_count": len(applied),
+        "applied": applied,
+    }
+    audit_log_path.parent.mkdir(parents=True, exist_ok=True)
+    audit_log_path.write_text(json.dumps(audit, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return audit
 
 
 def _validate_record(
@@ -299,6 +371,89 @@ def _control_plane_findings_for_record(
     findings.extend(_artifact_alias_findings(record, display_path, issue=issue))
     findings.extend(_durable_reference_findings(record, display_path, issue=issue))
     return findings
+
+
+def _derived_label_updates_from_report(report: Mapping[str, Any]) -> list[dict[str, Any]]:
+    """Return applicable label-update findings from a control-plane report."""
+
+    updates: list[dict[str, Any]] = []
+    findings = report.get("findings", [])
+    if not isinstance(findings, list):
+        return updates
+    for finding in findings:
+        if not isinstance(finding, Mapping):
+            continue
+        if finding.get("kind") != "derived_issue_label_update":
+            continue
+        labels_to_add = _validate_state_label_list(finding.get("labels_to_add"), "labels_to_add")
+        labels_to_remove = _validate_state_label_list(
+            finding.get("labels_to_remove"), "labels_to_remove"
+        )
+        if not labels_to_add and not labels_to_remove:
+            continue
+        issue = _issue_number(finding.get("issue"))
+        if issue is None:
+            raise RuntimeError(f"derived label update has invalid issue: {finding!r}")
+        updates.append(
+            {
+                "issue": issue,
+                "record": finding.get("record"),
+                "labels_to_add": labels_to_add,
+                "labels_to_remove": labels_to_remove,
+            }
+        )
+    return updates
+
+
+def _validate_state_label_list(value: Any, field_name: str) -> list[str]:
+    """Return validated `state:*` labels from a report field."""
+
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        raise RuntimeError(f"{field_name} must be a list, got {value!r}")
+    labels = [str(label) for label in value]
+    invalid = sorted(set(labels) - STATE_LABELS)
+    if invalid:
+        raise RuntimeError(f"{field_name} contains non-state labels: {invalid}")
+    return sorted(labels)
+
+
+def _issue_label_edit_command(update: Mapping[str, Any]) -> list[str]:
+    """Build a `gh issue edit` command for one derived label update."""
+
+    command = ["issue", "edit", str(update["issue"])]
+    for label in update["labels_to_add"]:
+        command.extend(["--add-label", label])
+    for label in update["labels_to_remove"]:
+        command.extend(["--remove-label", label])
+    return command
+
+
+def _run_gh(args: list[str]) -> subprocess.CompletedProcess[str]:
+    """Run a GitHub CLI command for label application."""
+
+    return subprocess.run(["gh", *args], capture_output=True, text=True, check=False)
+
+
+def _read_rate_limit(gh_runner: Any) -> dict[str, Any]:
+    """Return compact GitHub API rate-limit state for apply guards."""
+
+    result = gh_runner(["api", "rate_limit"])
+    stdout = getattr(result, "stdout", "")
+    stderr = getattr(result, "stderr", "")
+    if int(getattr(result, "returncode", 1)) != 0:
+        raise RuntimeError(f"gh api rate_limit failed: {(stderr or stdout).strip()}")
+    try:
+        payload = json.loads(stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"gh api rate_limit returned invalid JSON: {exc}") from exc
+    core = payload.get("resources", {}).get("core", {})
+    return {
+        "remaining": core.get("remaining"),
+        "limit": core.get("limit"),
+        "reset": core.get("reset"),
+    }
 
 
 def _issue_state_findings(
@@ -705,6 +860,42 @@ def _parse_issue_label_names(label_values: Iterable[Any]) -> list[str]:
     return parsed_labels
 
 
+def _apply_labels_from_cli_args(
+    args: argparse.Namespace,
+    report: dict[str, Any] | None,
+    errors: list[str],
+) -> None:
+    """Apply derived label updates for CLI mode, appending errors instead of raising."""
+
+    if not args.apply_labels:
+        return
+    if args.control_plane_report_json is None:
+        errors.append("--apply-labels requires --control-plane-report-json")
+    if args.issue_state_json is None:
+        errors.append("--apply-labels requires --issue-state-json with current labels")
+    if args.max_writes < 1:
+        errors.append("--apply-labels requires --max-writes greater than 0")
+    if report is None or errors:
+        return
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    audit_log = args.label_audit_log or (DEFAULT_STATE_LABEL_AUDIT_DIR / f"{timestamp}.json")
+    try:
+        audit = apply_derived_issue_label_updates(
+            report,
+            max_writes=args.max_writes,
+            audit_log_path=audit_log,
+            min_rate_limit_remaining=args.min_rate_limit_remaining,
+        )
+    except RuntimeError as exc:
+        errors.append(str(exc))
+        return
+    print(
+        f"applied {audit['applied_count']} derived issue state-label updates; "
+        f"audit log: {audit_log}"
+    )
+
+
 def main(argv: list[str] | None = None) -> int:
     """Run the experiment registry validator CLI."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -725,9 +916,32 @@ def main(argv: list[str] | None = None) -> int:
         type=Path,
         help="Write a dry-run research control-plane drift report.",
     )
+    parser.add_argument(
+        "--apply-labels",
+        action="store_true",
+        help="Apply derived state:* label updates from the control-plane report via gh.",
+    )
+    parser.add_argument(
+        "--max-writes",
+        type=int,
+        default=0,
+        help="Maximum issue-label writes allowed with --apply-labels.",
+    )
+    parser.add_argument(
+        "--min-rate-limit-remaining",
+        type=int,
+        default=25,
+        help="Minimum GitHub core API quota required before --apply-labels writes.",
+    )
+    parser.add_argument(
+        "--label-audit-log",
+        type=Path,
+        help="Optional audit-log path for --apply-labels.",
+    )
     args = parser.parse_args(argv)
 
     errors = validate_registry(args.registry)
+    report: dict[str, Any] | None = None
     if args.control_plane_report_json is not None:
         issue_states: dict[int, str] = {}
         issue_labels: dict[int, list[str]] = {}
@@ -749,6 +963,12 @@ def main(argv: list[str] | None = None) -> int:
             f"wrote control-plane report: {args.control_plane_report_json} "
             f"({report['finding_count']} findings)"
         )
+        if report["derived_update_count"] and not args.apply_labels:
+            errors.append(
+                f"derived issue state-label updates pending: {report['derived_update_count']} "
+                "updates; rerun with --apply-labels and --max-writes to apply"
+            )
+    _apply_labels_from_cli_args(args, report, errors)
     if errors:
         for error in errors:
             print(error, file=sys.stderr)

--- a/tests/tools/test_validate_experiment_registry.py
+++ b/tests/tools/test_validate_experiment_registry.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from textwrap import dedent
+from types import SimpleNamespace
 
+from scripts.tools import validate_experiment_registry as registry_validator
 from scripts.tools.validate_experiment_registry import (
     _load_issue_state_snapshot,
+    apply_derived_issue_label_updates,
     build_control_plane_report,
     main,
     validate_registry,
@@ -675,3 +679,254 @@ def test_issue_state_snapshot_errors_are_reported_by_cli(tmp_path: Path) -> None
 
     assert exit_code == 1
     assert report.is_file()
+
+
+def test_apply_derived_issue_label_updates_uses_guarded_gh_boundary(tmp_path: Path) -> None:
+    """Applying state-label drift should only edit derived `state:*` labels."""
+
+    report = {
+        "findings": [
+            {
+                "kind": "derived_issue_label_update",
+                "record": "label.yaml",
+                "issue": 1475,
+                "labels_to_add": ["state:ready"],
+                "labels_to_remove": ["state:running"],
+            }
+        ]
+    }
+    commands: list[list[str]] = []
+
+    def fake_gh(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        if args == ["api", "rate_limit"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"resources": {"core": {"remaining": 100, "limit": 5000}}}),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    audit = apply_derived_issue_label_updates(
+        report,
+        max_writes=1,
+        audit_log_path=tmp_path / "audit.json",
+        gh_runner=fake_gh,
+    )
+
+    assert commands == [
+        ["api", "rate_limit"],
+        [
+            "issue",
+            "edit",
+            "1475",
+            "--add-label",
+            "state:ready",
+            "--remove-label",
+            "state:running",
+        ],
+    ]
+    assert audit["applied_count"] == 1
+    assert json.loads((tmp_path / "audit.json").read_text())["applied"][0]["issue"] == 1475
+
+
+def test_apply_derived_issue_label_updates_rejects_non_state_labels(tmp_path: Path) -> None:
+    """The apply path must not mutate labels outside the state-label projection."""
+
+    report = {
+        "findings": [
+            {
+                "kind": "derived_issue_label_update",
+                "record": "label.yaml",
+                "issue": 1475,
+                "labels_to_add": ["state:ready", "priority:high"],
+                "labels_to_remove": [],
+            }
+        ]
+    }
+
+    try:
+        apply_derived_issue_label_updates(
+            report,
+            max_writes=1,
+            audit_log_path=tmp_path / "audit.json",
+            gh_runner=lambda args: SimpleNamespace(returncode=0, stdout="{}", stderr=""),
+        )
+    except RuntimeError as exc:
+        assert "non-state labels" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected non-state label rejection")
+
+
+def test_main_apply_labels_requires_explicit_report_snapshot_and_write_cap(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """CLI apply mode should be opt-in and use the mocked gh boundary."""
+
+    registry = tmp_path / "experiments" / "registry.yaml"
+    record = registry.parent / "label.yaml"
+    issue_state = tmp_path / "issues.json"
+    report = tmp_path / "report.json"
+    audit = tmp_path / "audit.json"
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "exists.yaml").write_text("ok: true\n", encoding="utf-8")
+    _write_yaml(
+        registry,
+        """
+        schema_version: experiment-registry.v1
+        records:
+          - label.yaml
+        """,
+    )
+    _write_yaml(
+        record,
+        """
+        schema_version: experiment-record.v2
+        experiment_id: label-apply
+        issue: 1475
+        issue_url: https://github.com/ll7/robot_sf_ll7/issues/1475
+        question: Do labels agree with the card?
+        hypothesis: They should derive from the card.
+        config:
+          - configs/exists.yaml
+        command: uv run true
+        inputs:
+          - path: configs/exists.yaml
+        outputs:
+          - path: output/experiments/label
+        expected_artifacts:
+          - name: report
+            path: output/experiments/label/report.json
+        evidence_grade: proposal
+        paper_relevance: exploratory
+        state: implementation_ready
+        """,
+    )
+    issue_state.write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "number": 1475,
+                        "state": "OPEN",
+                        "labels": ["state:running", "type:analysis"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    commands: list[list[str]] = []
+
+    def fake_gh(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        if args == ["api", "rate_limit"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"resources": {"core": {"remaining": 100, "limit": 5000}}}),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(registry_validator, "_run_gh", fake_gh)
+
+    exit_code = main(
+        [
+            str(registry),
+            "--issue-state-json",
+            str(issue_state),
+            "--control-plane-report-json",
+            str(report),
+            "--apply-labels",
+            "--max-writes",
+            "1",
+            "--label-audit-log",
+            str(audit),
+        ]
+    )
+
+    assert exit_code == 0
+    assert report.is_file()
+    assert audit.is_file()
+    assert commands[-1] == [
+        "issue",
+        "edit",
+        "1475",
+        "--add-label",
+        "state:ready",
+        "--remove-label",
+        "state:running",
+    ]
+
+
+def test_main_dry_run_exits_nonzero_when_derived_label_drift_exists(tmp_path: Path) -> None:
+    """Dry-run report mode should fail closed when state-label projection drift exists."""
+
+    registry = tmp_path / "experiments" / "registry.yaml"
+    record = registry.parent / "label.yaml"
+    issue_state = tmp_path / "issues.json"
+    report = tmp_path / "report.json"
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "configs" / "exists.yaml").write_text("ok: true\n", encoding="utf-8")
+    _write_yaml(
+        registry,
+        """
+        schema_version: experiment-registry.v1
+        records:
+          - label.yaml
+        """,
+    )
+    _write_yaml(
+        record,
+        """
+        schema_version: experiment-record.v2
+        experiment_id: label-dry-run
+        issue: 1475
+        issue_url: https://github.com/ll7/robot_sf_ll7/issues/1475
+        question: Do labels agree with the card?
+        hypothesis: They should derive from the card.
+        config:
+          - configs/exists.yaml
+        command: uv run true
+        inputs:
+          - path: configs/exists.yaml
+        outputs:
+          - path: output/experiments/label
+        expected_artifacts:
+          - name: report
+            path: output/experiments/label/report.json
+        evidence_grade: proposal
+        paper_relevance: exploratory
+        state: implementation_ready
+        """,
+    )
+    issue_state.write_text(
+        json.dumps(
+            {
+                "issues": [
+                    {
+                        "number": 1475,
+                        "state": "OPEN",
+                        "labels": ["state:running"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    exit_code = main(
+        [
+            str(registry),
+            "--issue-state-json",
+            str(issue_state),
+            "--control-plane-report-json",
+            str(report),
+        ]
+    )
+
+    assert exit_code == 1
+    payload = json.loads(report.read_text())
+    assert payload["derived_update_count"] == 1

--- a/tests/tools/test_validate_experiment_registry.py
+++ b/tests/tools/test_validate_experiment_registry.py
@@ -758,6 +758,91 @@ def test_apply_derived_issue_label_updates_rejects_non_state_labels(tmp_path: Pa
         raise AssertionError("expected non-state label rejection")
 
 
+def test_apply_derived_issue_label_updates_fails_closed_without_rate_limit(
+    tmp_path: Path,
+) -> None:
+    """Indeterminate rate-limit payloads must not allow GitHub mutations."""
+
+    report = {
+        "findings": [
+            {
+                "kind": "derived_issue_label_update",
+                "record": "label.yaml",
+                "issue": 1475,
+                "labels_to_add": ["state:ready"],
+                "labels_to_remove": ["state:running"],
+            }
+        ]
+    }
+    commands: list[list[str]] = []
+
+    def fake_gh(args: list[str]) -> SimpleNamespace:
+        commands.append(args)
+        return SimpleNamespace(
+            returncode=0, stdout=json.dumps({"resources": {"core": {}}}), stderr=""
+        )
+
+    try:
+        apply_derived_issue_label_updates(
+            report,
+            max_writes=1,
+            audit_log_path=tmp_path / "audit.json",
+            gh_runner=fake_gh,
+        )
+    except RuntimeError as exc:
+        assert "unable to determine GitHub core rate limit remaining" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected indeterminate rate-limit rejection")
+
+    assert commands == [["api", "rate_limit"]]
+    assert not (tmp_path / "audit.json").exists()
+
+
+def test_apply_derived_issue_label_updates_writes_audit_before_write_failure(
+    tmp_path: Path,
+) -> None:
+    """Partial GitHub write failures should leave a local audit trail."""
+
+    report = {
+        "findings": [
+            {
+                "kind": "derived_issue_label_update",
+                "record": "label.yaml",
+                "issue": 1475,
+                "labels_to_add": ["state:ready"],
+                "labels_to_remove": ["state:running"],
+            }
+        ]
+    }
+
+    def fake_gh(args: list[str]) -> SimpleNamespace:
+        if args == ["api", "rate_limit"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=json.dumps({"resources": {"core": {"remaining": 100, "limit": 5000}}}),
+                stderr="",
+            )
+        return SimpleNamespace(returncode=2, stdout="", stderr="permission denied")
+
+    try:
+        apply_derived_issue_label_updates(
+            report,
+            max_writes=1,
+            audit_log_path=tmp_path / "audit.json",
+            gh_runner=fake_gh,
+        )
+    except RuntimeError as exc:
+        assert "gh issue edit failed for issue #1475" in str(exc)
+    else:  # pragma: no cover - defensive assertion
+        raise AssertionError("expected GitHub write failure")
+
+    audit = json.loads((tmp_path / "audit.json").read_text())
+    assert audit["applied_count"] == 0
+    assert audit["applied"][0]["issue"] == 1475
+    assert audit["applied"][0]["returncode"] == 2
+    assert audit["applied"][0]["stderr"] == "permission denied"
+
+
 def test_main_apply_labels_requires_explicit_report_snapshot_and_write_cap(
     tmp_path: Path,
     monkeypatch,


### PR DESCRIPTION
## Summary
Adds an explicit, guarded `--apply-labels` path to `scripts/tools/validate_experiment_registry.py` so registry-derived `state:*` label drift can be projected back to GitHub issues when requested.

Closes #3188.

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `apply_derived_issue_label_updates()` as the sole GitHub mutation boundary for derived `state:*` label updates.
- Added `--apply-labels`, `--max-writes`, `--min-rate-limit-remaining`, and `--label-audit-log` CLI options.
- Dry-run report mode now fails closed when derived state-label drift exists unless `--apply-labels` is used.
- Apply mode checks `gh api rate_limit`, honors `--max-writes`, touches only `state:*` labels, and writes a disposable audit log under `output/issue_state_sync/` by default.
- Updated `experiments/README.md` with dry-run-default and explicit apply instructions.
- Added mocked-`gh` tests for apply behavior, non-state-label rejection, CLI opt-in, and dry-run nonzero drift behavior.

## Why It Matters
- Added value: turns the registry state machine into the authoritative source for issue state labels without making label writes implicit.
- Expected impact: reduces drift between experiment-record.v2 cards and GitHub issue labels.
- Why this is worth merging now: the repo already detects derived label drift; this adds the guarded apply path requested by #3188.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: workflow control-plane hygiene; no research result.
- Comparator or baseline, if applicable: NA.
- Evidence tier: workflow/tooling validation.
- Result classification: support tooling; not benchmark evidence.
- Decision or stop rule, if applicable: apply only when dry-run report shows derived label updates and caller passes explicit write cap.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3188 / #3073 control-plane workflow.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; does not interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - workflow tooling.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: continue using registry-derived issue-label projection when explicitly requested.
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop for this issue.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run --no-sync pytest tests/tools/test_validate_experiment_registry.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run --no-sync ruff check scripts/tools/validate_experiment_registry.py tests/tools/test_validate_experiment_registry.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run --no-sync python scripts/tools/validate_experiment_registry.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run --no-sync python scripts/tools/validate_experiment_registry.py --control-plane-report-json /tmp/issue3188-control-plane-report.json`
  - `UV_NO_SYNC=1 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` via `scripts/dev/run_worktree_shared_venv.sh`
- Evidence that the change works here:
  - focused validator suite: 18 passed
  - real registry validation passed
  - no-snapshot control-plane report wrote successfully with `derived_update_count: 0`
  - full readiness passed at `e8dd7c9d61d509e7b960ffe15aedbdd48bad6932`: 7217 passed, 11 skipped
- Benchmarks or smoke tests, if applicable: NA - workflow tooling.

## Risks / Rollout
- Compatibility risks: low; apply mode is opt-in and dry-run remains default.
- Failure modes: bad issue-state snapshot data can produce wrong derived updates; mitigated by state-label-only scope, write cap, rate-limit check, and audit log.
- Rollback or fallback plan: revert this commit; no label writes were performed by this PR.

## Docs / Provenance
- Updated docs: `experiments/README.md`
- Relevant design or provenance notes: experiment-record.v2 state machine in `experiments/README.md`.
- Any assumptions that need to be preserved: audit logs under `output/issue_state_sync/` are disposable; durable effect is GitHub label state when apply mode is run.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via closing PR.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): docs updated in `experiments/README.md`.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: workflow tool only; no benchmark or paper-facing claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- No real label writes were run during implementation; tests use a mocked `gh` boundary.
