### PR TITLE
feat: add context note freshness checker

### DIFF
--- a/scripts/tools/check_context_note_freshness.py
+++ b/scripts/tools/check_context_note_freshness.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Check context-note freshness, supersession integrity, and index coverage."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+CONTEXT_DIR = Path("docs/context")
+CATALOG_PATH = CONTEXT_DIR / "catalog.yaml"
+INDEX_PATH = CONTEXT_DIR / "INDEX.md"
+EVIDENCE_DIR = CONTEXT_DIR / "evidence"
+ARCHIVE_DIR = CONTEXT_DIR / "archive"
+MARKDOWN_LINK_RE = re.compile(r"\[[^\]]+\]\(([^)]+)\)|<((?:\./)?[^ >]+)>")
+
+
+@dataclass(frozen=True, slots=True)
+class Finding:
+    """One context-note freshness finding."""
+
+    rule: str
+    severity: str
+    path: str
+    message: str
+    status: str | None = None
+    freshness: str | None = None
+    replacement: str | None = None
+    last_touched_at: str | None = None
+    age_days: int | None = None
+
+
+def _run(cmd: list[str], *, cwd: Path) -> str:
+    """Run a command and return stdout."""
+
+    result = subprocess.run(cmd, cwd=str(cwd), capture_output=True, text=True, check=False)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"Command failed ({result.returncode}): {' '.join(cmd)}\n{result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def _repo_root() -> Path:
+    """Return the current repository root."""
+
+    return Path(_run(["git", "rev-parse", "--show-toplevel"], cwd=Path.cwd())).resolve()
+
+
+def _load_yaml(path: Path) -> object:
+    """Load a YAML file."""
+
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def _safe_repo_path(raw_path: object) -> Path | None:
+    """Return a safe repository-relative path value, if present."""
+
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return None
+    path = Path(raw_path.strip())
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+def _catalog_entries(catalog_path: Path) -> list[dict[str, Any]]:
+    """Return catalog entry mappings from the context catalog."""
+
+    payload = _load_yaml(catalog_path)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{catalog_path.as_posix()} must be a YAML mapping")
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError(f"{catalog_path.as_posix()} entries must be a list")
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _markdown_targets(text: str) -> set[str]:
+    """Return normalized Markdown link targets without anchors or query strings."""
+
+    targets: set[str] = set()
+    for first, second in MARKDOWN_LINK_RE.findall(text):
+        target = (first or second).strip()
+        if not target:
+            continue
+        if "://" in target or target.startswith("mailto:"):
+            continue
+        target = target.split("#", maxsplit=1)[0].split("?", maxsplit=1)[0]
+        while target.startswith("./"):
+            target = target[2:]
+        if target:
+            targets.add(target)
+    return targets
+
+
+def _index_references(index_path: Path, *, context_dir: Path) -> set[Path]:
+    """Return context note paths referenced by docs/context/INDEX.md."""
+
+    if not index_path.exists():
+        return set()
+    targets = _markdown_targets(index_path.read_text(encoding="utf-8"))
+    references: set[Path] = set()
+    for target in targets:
+        path = Path(target)
+        if path.suffix != ".md":
+            continue
+        if path.parts[:2] == ("docs", "context"):
+            references.add(path)
+        else:
+            references.add(context_dir / path)
+    return references
+
+
+def _tracked_context_notes(repo_root: Path, context_dir: Path) -> set[Path]:
+    """Return tracked Markdown context notes, excluding evidence and archive trees."""
+
+    output = _run(["git", "ls-files", "--", context_dir.as_posix()], cwd=repo_root)
+    evidence_dir = context_dir / "evidence"
+    archive_dir = context_dir / "archive"
+    notes: set[Path] = set()
+    for line in output.splitlines():
+        path = Path(line.strip())
+        if path.suffix != ".md":
+            continue
+        if evidence_dir in path.parents or archive_dir in path.parents:
+            continue
+        notes.add(path)
+    return notes
+
+
+def _last_touch(repo_root: Path, path: Path) -> datetime | None:
+    """Return the last committed touch time for a path, if available."""
+
+    output = _run(["git", "log", "-1", "--format=%cI", "--", path.as_posix()], cwd=repo_root)
+    if not output:
+        return None
+    return datetime.fromisoformat(output.replace("Z", "+00:00")).astimezone(UTC)
+
+
+def _superseded_replacement_findings(
+    entries: list[dict[str, Any]], *, catalog_path: Path
+) -> list[Finding]:
+    """Return hard errors for superseded entries without replacement metadata."""
+
+    findings: list[Finding] = []
+    for index, entry in enumerate(entries):
+        path = _safe_repo_path(entry.get("path"))
+        status = entry.get("status")
+        if status != "superseded":
+            continue
+        freshness = entry.get("freshness")
+        replacement = _safe_repo_path(entry.get("replacement"))
+        if replacement is not None:
+            continue
+        entry_path = (
+            path.as_posix() if path is not None else f"{catalog_path.as_posix()}:entries[{index}]"
+        )
+        findings.append(
+            Finding(
+                rule="superseded_replacement",
+                severity="error",
+                path=entry_path,
+                message="superseded catalog entry must name a replacement",
+                status=str(status),
+                freshness=str(freshness) if freshness is not None else None,
+            )
+        )
+    return findings
+
+
+def _catalog_paths(entries: list[dict[str, Any]]) -> set[Path]:
+    """Return safe catalog path values from entries."""
+
+    return {path for entry in entries if (path := _safe_repo_path(entry.get("path"))) is not None}
+
+
+def _stale_current_dated_findings(
+    entries: list[dict[str, Any]],
+    *,
+    repo_root: Path,
+    index_references: set[Path],
+    max_age_days: int,
+    now: datetime,
+) -> list[Finding]:
+    """Return warnings for old current+dated notes outside the active index."""
+
+    findings: list[Finding] = []
+    for entry in entries:
+        path = _safe_repo_path(entry.get("path"))
+        if entry.get("status") != "current" or entry.get("freshness") != "dated" or path is None:
+            continue
+        if not (repo_root / path).is_file():
+            continue
+        touched_at = _last_touch(repo_root, path)
+        if touched_at is None:
+            continue
+        age_days = int((now - touched_at).days)
+        if age_days <= max_age_days or path in index_references:
+            continue
+        findings.append(
+            Finding(
+                rule="stale_current_dated",
+                severity="warning",
+                path=path.as_posix(),
+                message=f"current dated context note is older than {max_age_days} days",
+                status="current",
+                freshness="dated",
+                last_touched_at=touched_at.isoformat(),
+                age_days=age_days,
+            )
+        )
+    return findings
+
+
+def _orphan_context_note_findings(
+    *,
+    tracked_notes: set[Path],
+    catalog_paths: set[Path],
+    index_references: set[Path],
+) -> list[Finding]:
+    """Return warnings for tracked notes absent from catalog and index."""
+
+    findings: list[Finding] = []
+    for path in sorted(tracked_notes):
+        if path in catalog_paths or path in index_references:
+            continue
+        findings.append(
+            Finding(
+                rule="orphan_context_note",
+                severity="warning",
+                path=path.as_posix(),
+                message="context note is absent from both docs/context/INDEX.md and catalog.yaml",
+            )
+        )
+    return findings
+
+
+def check_freshness(
+    *,
+    repo_root: Path,
+    catalog_path: Path = CATALOG_PATH,
+    context_dir: Path = CONTEXT_DIR,
+    index_path: Path = INDEX_PATH,
+    max_age_days: int = 180,
+    now: datetime | None = None,
+) -> list[Finding]:
+    """Return context-note freshness findings."""
+
+    now = (now or datetime.now(UTC)).astimezone(UTC)
+    catalog_full_path = repo_root / catalog_path
+    entries = _catalog_entries(catalog_full_path)
+
+    indexed_paths = _index_references(repo_root / index_path, context_dir=context_dir)
+    findings = _superseded_replacement_findings(entries, catalog_path=catalog_path)
+    findings.extend(
+        _stale_current_dated_findings(
+            entries,
+            repo_root=repo_root,
+            index_references=indexed_paths,
+            max_age_days=max_age_days,
+            now=now,
+        )
+    )
+    findings.extend(
+        _orphan_context_note_findings(
+            tracked_notes=_tracked_context_notes(repo_root, context_dir),
+            catalog_paths=_catalog_paths(entries),
+            index_references=indexed_paths,
+        )
+    )
+    return findings
+
+
+def _summary(findings: list[Finding], *, strict: bool) -> dict[str, Any]:
+    """Return a compact JSON-ready summary."""
+
+    counts: dict[str, int] = {}
+    for finding in findings:
+        counts[finding.rule] = counts.get(finding.rule, 0) + 1
+    has_errors = any(finding.severity == "error" for finding in findings)
+    has_strict_warnings = strict and any(finding.severity == "warning" for finding in findings)
+    return {
+        "schema_version": "context_note_freshness.v1",
+        "strict": strict,
+        "counts": counts,
+        "exit_code": 1 if has_errors or has_strict_warnings else 0,
+        "findings": [asdict(finding) for finding in findings],
+    }
+
+
+def _print_human_report(findings: list[Finding], *, max_findings: int) -> None:
+    """Print a grouped, bounded human-readable report."""
+
+    if not findings:
+        print("OK context note freshness check passed")
+        return
+
+    grouped: dict[str, list[Finding]] = {}
+    for finding in findings:
+        grouped.setdefault(finding.rule, []).append(finding)
+    for rule, group in sorted(grouped.items()):
+        print(f"{rule}: {len(group)} finding(s)")
+        for finding in group[:max_findings]:
+            level = "ERROR" if finding.severity == "error" else "WARN"
+            print(f"  {level} {finding.path}: {finding.message}")
+        omitted = len(group) - max_findings
+        if omitted > 0:
+            print(f"  ... {omitted} more; use --json-output for full detail")
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description="Check docs/context note freshness and catalog/index coverage."
+    )
+    parser.add_argument("--max-age-days", type=int, default=180)
+    parser.add_argument("--strict", action="store_true", help="Treat warning findings as errors.")
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Write a JSON report to this path. Use '-' to print JSON to stdout.",
+    )
+    parser.add_argument("--catalog", type=Path, default=CATALOG_PATH)
+    parser.add_argument("--context-dir", type=Path, default=CONTEXT_DIR)
+    parser.add_argument("--index", type=Path, default=INDEX_PATH)
+    parser.add_argument(
+        "--max-human-findings",
+        type=int,
+        default=50,
+        help="Maximum findings to print per rule in human-readable output.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the context-note freshness checker."""
+
+    args = _parse_args()
+    repo_root = _repo_root()
+    findings = check_freshness(
+        repo_root=repo_root,
+        catalog_path=args.catalog,
+        context_dir=args.context_dir,
+        index_path=args.index,
+        max_age_days=args.max_age_days,
+    )
+    payload = _summary(findings, strict=bool(args.strict))
+    if args.json_output:
+        text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        if str(args.json_output) == "-":
+            print(text, end="")
+        else:
+            output_path = repo_root / args.json_output
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(text, encoding="utf-8")
+    else:
+        _print_human_report(findings, max_findings=max(0, int(args.max_human_findings)))
+    return int(payload["exit_code"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/test_check_context_note_freshness.py
+++ b/tests/tools/test_check_context_note_freshness.py
@@ -1,0 +1,264 @@
+"""Tests for context-note freshness checks."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime
+from pathlib import Path
+
+import yaml
+
+from scripts.tools import check_context_note_freshness as checker
+
+
+def _run(repo: Path, *args: str, env: dict[str, str] | None = None) -> None:
+    subprocess.run(
+        list(args),
+        cwd=repo,
+        env=env,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _write(repo: Path, path: str, text: str) -> None:
+    full_path = repo / path
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.write_text(text, encoding="utf-8")
+
+
+def _commit(repo: Path, message: str, *, iso_date: str) -> None:
+    env = {
+        "GIT_AUTHOR_DATE": iso_date,
+        "GIT_COMMITTER_DATE": iso_date,
+        "GIT_AUTHOR_NAME": "Test Author",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test Author",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    _run(repo, "git", "add", ".")
+    _run(repo, "git", "commit", "-m", message, env=env)
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(repo, "git", "init")
+    _run(repo, "git", "config", "user.name", "Test Author")
+    _run(repo, "git", "config", "user.email", "test@example.com")
+    _write(repo, "docs/context/INDEX.md", "# Index\n")
+    _write(repo, "docs/context/README.md", "# Context\n")
+    _write(
+        repo,
+        "docs/context/catalog.yaml",
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "path": "docs/context/README.md",
+                        "status": "current",
+                        "freshness": "maintained",
+                    },
+                    {
+                        "path": "docs/context/INDEX.md",
+                        "status": "current",
+                        "freshness": "maintained",
+                    },
+                ],
+            },
+            sort_keys=False,
+        ),
+    )
+    _commit(repo, "base", iso_date="2026-01-01T00:00:00+00:00")
+    return repo
+
+
+def _write_catalog(repo: Path, entries: list[dict[str, object]]) -> None:
+    base_entries = [
+        {
+            "path": "docs/context/README.md",
+            "status": "current",
+            "freshness": "maintained",
+        },
+        {
+            "path": "docs/context/INDEX.md",
+            "status": "current",
+            "freshness": "maintained",
+        },
+    ]
+    _write(
+        repo,
+        "docs/context/catalog.yaml",
+        yaml.safe_dump({"version": 1, "entries": [*base_entries, *entries]}, sort_keys=False),
+    )
+
+
+def test_markdown_target_normalization_preserves_parent_segments() -> None:
+    """Markdown link normalization must not silently rewrite parent-relative paths."""
+
+    assert "../evidence/example.md" in checker._markdown_targets("[bad](../evidence/example.md)")
+
+
+def test_superseded_without_replacement_is_hard_error(tmp_path: Path) -> None:
+    """Superseded catalog rows must name their replacement."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+            }
+        ],
+    )
+    _commit(repo, "superseded note", iso_date="2026-01-02T00:00:00+00:00")
+
+    findings = checker.check_freshness(repo_root=repo)
+    summary = checker._summary(findings, strict=False)
+
+    assert summary["exit_code"] == 1
+    assert findings[0].rule == "superseded_replacement"
+    assert findings[0].severity == "error"
+
+
+def test_custom_context_paths_drive_index_catalog_and_exclusions(tmp_path: Path) -> None:
+    """Custom context directories must not fall back to docs/context constants."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "custom/context/INDEX.md", "[active](active.md)\n")
+    _write(repo, "custom/context/README.md", "# Custom\n")
+    _write(repo, "custom/context/active.md", "# Active\n")
+    _write(repo, "custom/context/orphan.md", "# Orphan\n")
+    _write(repo, "custom/context/evidence/ignored.md", "# Ignored evidence\n")
+    _write(
+        repo,
+        "custom/context/catalog.yaml",
+        yaml.safe_dump(
+            {
+                "version": 1,
+                "entries": [
+                    {
+                        "path": "custom/context/README.md",
+                        "status": "current",
+                        "freshness": "maintained",
+                    },
+                    {
+                        "path": "custom/context/active.md",
+                        "status": "current",
+                        "freshness": "dated",
+                    },
+                    {
+                        "status": "superseded",
+                        "freshness": "dated",
+                    },
+                ],
+            },
+            sort_keys=False,
+        ),
+    )
+    _commit(repo, "custom context", iso_date="2025-01-01T00:00:00+00:00")
+
+    findings = checker.check_freshness(
+        repo_root=repo,
+        catalog_path=Path("custom/context/catalog.yaml"),
+        context_dir=Path("custom/context"),
+        index_path=Path("custom/context/INDEX.md"),
+        max_age_days=180,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+    by_path = {finding.path: finding.rule for finding in findings}
+
+    assert by_path["custom/context/catalog.yaml:entries[2]"] == "superseded_replacement"
+    assert by_path["custom/context/orphan.md"] == "orphan_context_note"
+    assert "custom/context/active.md" not in by_path
+    assert "custom/context/evidence/ignored.md" not in by_path
+
+
+def test_current_dated_note_uses_git_last_touch_for_staleness(tmp_path: Path) -> None:
+    """Current dated entries use committed touch dates for stale-note warnings."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/dated.md", "# Dated\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/dated.md",
+                "status": "current",
+                "freshness": "dated",
+            }
+        ],
+    )
+    _commit(repo, "dated note", iso_date="2025-01-01T00:00:00+00:00")
+
+    findings = checker.check_freshness(
+        repo_root=repo,
+        max_age_days=180,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    assert [finding.rule for finding in findings] == ["stale_current_dated"]
+    assert findings[0].age_days == 365
+    assert findings[0].last_touched_at == "2025-01-01T00:00:00+00:00"
+
+
+def test_index_reference_suppresses_current_dated_staleness_warning(tmp_path: Path) -> None:
+    """Indexed dated notes remain active entry points even when old."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/INDEX.md", "[dated](dated.md)\n")
+    _write(repo, "docs/context/dated.md", "# Dated\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/dated.md",
+                "status": "current",
+                "freshness": "dated",
+            }
+        ],
+    )
+    _commit(repo, "indexed dated note", iso_date="2025-01-01T00:00:00+00:00")
+
+    findings = checker.check_freshness(
+        repo_root=repo,
+        max_age_days=180,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    assert findings == []
+
+
+def test_orphan_context_note_warns_when_absent_from_index_and_catalog(tmp_path: Path) -> None:
+    """Tracked context notes absent from both routing surfaces are warnings."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/orphan.md", "# Orphan\n")
+    _commit(repo, "orphan note", iso_date="2026-01-02T00:00:00+00:00")
+
+    findings = checker.check_freshness(repo_root=repo)
+
+    assert any(
+        finding.rule == "orphan_context_note"
+        and finding.path == "docs/context/orphan.md"
+        and finding.severity == "warning"
+        for finding in findings
+    )
+
+
+def test_strict_mode_promotes_warnings_to_nonzero_exit(tmp_path: Path) -> None:
+    """Strict mode turns warning-only reports into a failing exit code."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/orphan.md", "# Orphan\n")
+    _commit(repo, "orphan note", iso_date="2026-01-02T00:00:00+00:00")
+
+    findings = checker.check_freshness(repo_root=repo)
+
+    assert checker._summary(findings, strict=False)["exit_code"] == 0
+    assert checker._summary(findings, strict=True)["exit_code"] == 1


### PR DESCRIPTION
## Summary
- Adds `scripts/tools/check_context_note_freshness.py` for context catalog freshness hygiene.
- Implements the checker-first slice of #3190: superseded replacement hard errors, current+dated staleness warnings from git last-touch dates, and orphan context-note warnings against `INDEX.md` plus `catalog.yaml`.
- Adds focused fixture tests that exercise each rule in a temporary git repository.

## Scope
- In scope: checker + tests, grouped human output, `--strict`, `--max-age-days`, and `--json-output`.
- Out of scope: archival sweep or moving/deleting notes. Current real-repo output is warning-only and intended to feed a later review-gated sweep.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run --no-sync pytest tests/tools/test_check_context_note_freshness.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run --no-sync ruff check scripts/tools/check_context_note_freshness.py tests/tools/test_check_context_note_freshness.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run --no-sync ruff format --check scripts/tools/check_context_note_freshness.py tests/tools/test_check_context_note_freshness.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run --no-sync python scripts/tools/check_context_note_freshness.py --max-age-days 180 --max-human-findings 3` -> default exit 0 with 626 `orphan_context_note` warnings.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run --no-sync python scripts/tools/check_context_note_freshness.py --strict --json-output output/note_freshness_strict.json` -> strict exit 1 with 626 warnings promoted.

## Research Result Guidance
NA - workflow hygiene checker. It surfaces context-note retrieval debt but does not make benchmark, metric, model-provenance, or paper-facing claims.

## Downstream Propagation
- Parent issue: #3190.
- Follow-up: archival sweep remains a separate review-gated PR using the checker output.
- Generated `output/note_freshness*.json` files are disposable local reports and are not tracked.
