### PR TITLE
feat: add density runtime smoke diagnostic

### DIFF
--- a/docs/context/INDEX.md
+++ b/docs/context/INDEX.md
@@ -151,6 +151,11 @@ records that the available multi-scenario, multi-seed AMMV/default evidence is f
 the actuation-aware ranking signal remains one-scenario/one-seed only, so no general AMV
 feasibility ranking claim is justified yet.
 
+Recent pedestrian-density runtime smoke: [issue_3200_density_runtime_smoke_summary.json](evidence/issue_3200_density_runtime_smoke_summary.json)
+records the diagnostic-only same-seed smoke over top coverage-novel and lowest-novelty comparator
+rows. All four rows ended `horizon_exhausted`; no benchmark or paper-facing density claim is
+promoted.
+
 Recent evidence-catalog backlog: [issue_3014_evidence_catalog_backlog.md](issue_3014_evidence_catalog_backlog.md)
 records the 2026-06-19 full evidence-catalog hygiene scan, 116 uncovered tracked evidence bundles
 or files, and the bounded split strategy for future Issue #3014 catalog cleanup PRs.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -158,6 +158,10 @@ knowledge, not every transient iteration detail.
   records the scenario-diverse frozen-policy diagnostic forecast replay suite, full variant
   matrix row classifications, tracked #3164 evidence summary, and the negative result that
   non-`none` variants collapse under shared replay braking.
+* Issue #3200 pedestrian-density runtime smoke:
+  [issue_3200_density_runtime_smoke_summary.json](evidence/issue_3200_density_runtime_smoke_summary.json)
+  records the diagnostic-only same-seed smoke over top coverage-novel and lowest-novelty comparator
+  rows, with all rows classified `horizon_exhausted` and no benchmark claim promoted.
 * Issue #3014 Evidence Catalog Backlog 2026-06-19:
   [issue_3014_evidence_catalog_backlog.md](issue_3014_evidence_catalog_backlog.md)
   records the current uncovered evidence-bundle count and split strategy for catalog cleanup.

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -132,6 +132,10 @@ Policy caveats:
   three-pedestrian stress fixture; eight conditions expose forecast ambiguity while the full missed
   detection condition is classified as scenario-too-weak. Uses stored trace action proxies, not
   live planner replay or paper-facing benchmark evidence.
+- `issue_3200_density_runtime_smoke_summary.json`: diagnostic-only same-seed runtime smoke over
+  coverage-entropy-selected pedestrian-density candidates. The coverage report had no literal
+  redundant rows, so the comparator uses lowest-novelty review rows; all four rows ended
+  `horizon_exhausted` and count as no benchmark-success evidence.
 - `issue_2756_occluded_emergence_2026-06-13/`: smoke/diagnostic note for the
   deterministic occluded-emergence trace fixture. The fixture separates ground-truth and observed
   pedestrian state, records first visibility and conflict timing, and feeds observation-noise plus

--- a/docs/context/evidence/issue_3200_density_runtime_smoke_summary.json
+++ b/docs/context/evidence/issue_3200_density_runtime_smoke_summary.json
@@ -1,0 +1,142 @@
+{
+  "schema_version": "density_runtime_smoke_summary.v1",
+  "issue": 3200,
+  "title": "pedestrian-density coverage-entropy runtime smoke",
+  "evidence_status": "diagnostic-only",
+  "claim_boundary": "bounded same-seed goal-policy runtime smoke; not benchmark or paper evidence",
+  "source_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+  "generated_runtime_inputs": {
+    "coverage_json": "<ignored-output-root>/issue_3200_density_runtime_smoke/coverage_entropy.json",
+    "selected_matrix": "<ignored-output-root>/issue_3200_density_runtime_smoke/selected_matrix.yaml",
+    "runtime_smoke_json": "<ignored-output-root>/issue_3200_density_runtime_smoke/runtime_smoke.json",
+    "local_output_boundary": "ignored local outputs; reproducible from the commands in this summary"
+  },
+  "commands": [
+    "uv sync --frozen",
+    "uv sync --frozen --extra training",
+    "uv run python scripts/tools/scenario_coverage_entropy.py configs/scenarios/classic_interactions_francis2023.yaml --output-json <ignored-output-root>/issue_3200_density_runtime_smoke/coverage_entropy.json --output-markdown <ignored-output-root>/issue_3200_density_runtime_smoke/coverage_entropy.md",
+    "uv run python scripts/tools/density_runtime_smoke.py --matrix <ignored-output-root>/issue_3200_density_runtime_smoke/selected_matrix.yaml --coverage-json <ignored-output-root>/issue_3200_density_runtime_smoke/coverage_entropy.json --output-json <ignored-output-root>/issue_3200_density_runtime_smoke/runtime_smoke.json --top-k 2 --seed 3200 --horizon 80 --dt 0.1"
+  ],
+  "selection_summary": {
+    "coverage_scenario_count": 48,
+    "coverage_entropy": 0.553705,
+    "top_k": 2,
+    "novel_count": 2,
+    "comparator_count": 2,
+    "coverage_redundant_count": 0,
+    "comparator_source": "lowest_novelty_fallback",
+    "caveat": "The coverage report contained no merge_or_drop rows, so the smoke used the two lowest-novelty review rows as a redundant/typical comparator rather than literal redundant rows."
+  },
+  "runtime_controls": {
+    "seed": 3200,
+    "horizon": 80,
+    "dt": 0.1,
+    "policy": "simple goal-directed diagnostic policy"
+  },
+  "failure_semantics_counts": {
+    "horizon_exhausted": 4
+  },
+  "rows": [
+    {
+      "scenario_id": "classic_station_platform_medium",
+      "selection_group": "novel",
+      "novelty_score": 0.5,
+      "nearest_neighbor": "classic_cross_trap_medium",
+      "coverage_recommendation": "retain_or_investigate",
+      "termination_reason": "max_steps",
+      "failure_semantics": "horizon_exhausted",
+      "outcome": {
+        "success": false,
+        "collision": false,
+        "timeout": true
+      },
+      "metrics": {
+        "success": 0.0,
+        "collisions": 0.0,
+        "near_misses": 0.0,
+        "min_distance": 6.14409899484645,
+        "progress_ratio": 0.9995809472729765,
+        "steps": 80
+      },
+      "row_status": "diagnostic_only",
+      "counts_as_success_evidence": false
+    },
+    {
+      "scenario_id": "francis2023_circular_crossing",
+      "selection_group": "novel",
+      "novelty_score": 0.4,
+      "nearest_neighbor": "francis2023_parallel_traffic",
+      "coverage_recommendation": "retain_or_investigate",
+      "termination_reason": "max_steps",
+      "failure_semantics": "horizon_exhausted",
+      "outcome": {
+        "success": false,
+        "collision": false,
+        "timeout": true
+      },
+      "metrics": {
+        "success": 0.0,
+        "collisions": 0.0,
+        "near_misses": 0.0,
+        "min_distance": 3.2407787136718325,
+        "progress_ratio": 0.9996335567148534,
+        "steps": 80
+      },
+      "row_status": "diagnostic_only",
+      "counts_as_success_evidence": false
+    },
+    {
+      "scenario_id": "classic_group_crossing_high",
+      "selection_group": "redundant_comparator",
+      "novelty_score": 0.153846,
+      "nearest_neighbor": "classic_group_crossing_medium",
+      "coverage_recommendation": "review",
+      "termination_reason": "max_steps",
+      "failure_semantics": "horizon_exhausted",
+      "outcome": {
+        "success": false,
+        "collision": false,
+        "timeout": true
+      },
+      "metrics": {
+        "success": 0.0,
+        "collisions": 0.0,
+        "near_misses": 0.0,
+        "min_distance": 4.436254258602422,
+        "progress_ratio": 0.9994732937733182,
+        "steps": 80
+      },
+      "row_status": "diagnostic_only",
+      "counts_as_success_evidence": false
+    },
+    {
+      "scenario_id": "classic_group_crossing_medium",
+      "selection_group": "redundant_comparator",
+      "novelty_score": 0.153846,
+      "nearest_neighbor": "classic_group_crossing_high",
+      "coverage_recommendation": "review",
+      "termination_reason": "max_steps",
+      "failure_semantics": "horizon_exhausted",
+      "outcome": {
+        "success": false,
+        "collision": false,
+        "timeout": true
+      },
+      "metrics": {
+        "success": 0.0,
+        "collisions": 0.0,
+        "near_misses": 0.0,
+        "min_distance": 4.436254206156205,
+        "progress_ratio": 0.9994732937733182,
+        "steps": 80
+      },
+      "row_status": "diagnostic_only",
+      "counts_as_success_evidence": false
+    }
+  ],
+  "interpretation": {
+    "observed_evidence": "All four same-seed rows executed through the local environment path and ended by max_steps with no collisions and no near-miss timesteps.",
+    "diagnostic_conclusion": "This smoke did not distinguish top-novel from lowest-novelty comparator rows by the requested failure-semantics labels.",
+    "residual_risk": "The comparator is a lowest-novelty fallback because the coverage report had no literal redundant candidates; one seed, one simple goal policy, and horizon 80 are insufficient for benchmark claims."
+  }
+}

--- a/scripts/tools/density_runtime_smoke.py
+++ b/scripts/tools/density_runtime_smoke.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 import math
+import sys
 from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
@@ -41,6 +42,10 @@ def select_candidate_rows(
 ) -> tuple[list[dict[str, Any]], dict[str, Any]]:
     """Select top novelty rows plus redundant or lowest-novelty comparator rows."""
     rows_raw = coverage_report.get("scenario_rows")
+    if rows_raw is None:
+        rows_raw = []
+    if not isinstance(rows_raw, list):
+        raise ValueError("coverage report scenario_rows must be a list")
     rows = [dict(row) for row in rows_raw if isinstance(row, Mapping)]
     if top_k <= 0:
         raise ValueError("top_k must be positive")
@@ -49,25 +54,22 @@ def select_candidate_rows(
 
     novel = sorted(
         (row for row in rows if row.get("recommendation") == "retain_or_investigate"),
-        key=lambda row: (-float(row.get("novelty_score", 0.0)), str(row.get("scenario_id", ""))),
+        key=lambda row: (-_novelty_score(row), _scenario_id_from_row(row)),
     )[:top_k]
     if len(novel) < top_k:
         raise ValueError("coverage report does not contain enough novel candidates")
 
-    novel_ids = {str(row.get("scenario_id")) for row in novel}
+    novel_ids = {_scenario_id_from_row(row) for row in novel}
     redundant = sorted(
         (row for row in rows if row.get("recommendation") == "merge_or_drop"),
-        key=lambda row: (float(row.get("novelty_score", 0.0)), str(row.get("scenario_id", ""))),
+        key=lambda row: (_novelty_score(row), _scenario_id_from_row(row)),
     )[:top_k]
     comparator_source = "merge_or_drop"
     if len(redundant) < top_k:
         comparator_source = "lowest_novelty_fallback"
         redundant = sorted(
-            (row for row in rows if str(row.get("scenario_id")) not in novel_ids),
-            key=lambda row: (
-                float(row.get("novelty_score", 0.0)),
-                str(row.get("scenario_id", "")),
-            ),
+            (row for row in rows if _scenario_id_from_row(row) not in novel_ids),
+            key=lambda row: (_novelty_score(row), _scenario_id_from_row(row)),
         )[:top_k]
     if len(redundant) < top_k:
         raise ValueError("coverage report does not contain enough comparator candidates")
@@ -94,6 +96,28 @@ def select_candidate_rows(
             else None
         ),
     }
+
+
+def _scenario_id_from_row(row: Mapping[str, Any]) -> str:
+    """Return a stable scenario id from a coverage row."""
+    value = row.get("scenario_id")
+    return str(value).strip() if value is not None else ""
+
+
+def _novelty_score(row: Mapping[str, Any]) -> float:
+    """Return a finite novelty score, defaulting missing values to zero."""
+    value = row.get("novelty_score", 0.0)
+    if value is None:
+        return 0.0
+    try:
+        score = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"invalid novelty_score for {row.get('scenario_id')!r}: {value!r}"
+        ) from exc
+    if not math.isfinite(score):
+        raise ValueError(f"invalid novelty_score for {row.get('scenario_id')!r}: {value!r}")
+    return score
 
 
 def classify_failure_semantics(
@@ -272,10 +296,13 @@ def run_smoke_episode(
 def run_density_smoke(args: argparse.Namespace) -> dict[str, Any]:
     """Run the selected density runtime smoke and return a JSON payload."""
     coverage = json.loads(args.coverage_json.read_text(encoding="utf-8"))
+    if not isinstance(coverage, Mapping):
+        raise ValueError("coverage JSON must contain an object")
     selected_rows, selection_summary = select_candidate_rows(coverage, top_k=int(args.top_k))
     scenarios = {
         _scenario_id(scenario): dict(scenario)
         for scenario in load_scenarios(args.matrix, base_dir=args.matrix)
+        if isinstance(scenario, Mapping)
     }
 
     row_payloads: list[dict[str, Any]] = []
@@ -351,7 +378,11 @@ def _build_parser() -> argparse.ArgumentParser:
 def main() -> int:
     """Run CLI."""
     args = _build_parser().parse_args()
-    payload = run_density_smoke(args)
+    try:
+        payload = run_density_smoke(args)
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        return 2
     args.output_json.parent.mkdir(parents=True, exist_ok=True)
     args.output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
     print(

--- a/scripts/tools/density_runtime_smoke.py
+++ b/scripts/tools/density_runtime_smoke.py
@@ -89,7 +89,10 @@ def select_candidate_rows(
         "novel_count": len(novel),
         "comparator_count": len(redundant),
         "comparator_source": comparator_source,
-        "coverage_redundant_count": int(summary_map.get("redundant_count", 0)),
+        "coverage_redundant_count": _optional_int(
+            summary_map.get("redundant_count"),
+            field_name="summary.redundant_count",
+        ),
         "caveat": (
             "No merge_or_drop rows were available; used lowest-novelty rows as comparators."
             if comparator_source == "lowest_novelty_fallback"
@@ -102,6 +105,16 @@ def _scenario_id_from_row(row: Mapping[str, Any]) -> str:
     """Return a stable scenario id from a coverage row."""
     value = row.get("scenario_id")
     return str(value).strip() if value is not None else ""
+
+
+def _optional_int(value: Any, *, field_name: str) -> int:
+    """Return an integer for optional numeric report fields, treating null as zero."""
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"invalid {field_name}: {value!r}") from exc
 
 
 def _novelty_score(row: Mapping[str, Any]) -> float:
@@ -308,7 +321,10 @@ def run_density_smoke(args: argparse.Namespace) -> dict[str, Any]:
     row_payloads: list[dict[str, Any]] = []
     missing: list[str] = []
     for selected in selected_rows:
-        scenario_id = str(selected.get("scenario_id"))
+        scenario_id = _scenario_id_from_row(selected)
+        if not scenario_id:
+            missing.append("<missing scenario_id>")
+            continue
         scenario = scenarios.get(scenario_id)
         if scenario is None:
             missing.append(scenario_id)
@@ -340,7 +356,10 @@ def run_density_smoke(args: argparse.Namespace) -> dict[str, Any]:
         status = "blocked"
     failure_counts: dict[str, int] = {}
     for row in row_payloads:
-        key = str(row.get("failure_semantics", "unknown"))
+        raw_semantics = row.get("failure_semantics")
+        key = raw_semantics.strip() if isinstance(raw_semantics, str) else "unknown"
+        if not key:
+            key = "unknown"
         failure_counts[key] = failure_counts.get(key, 0) + 1
     return {
         "schema_version": SCHEMA_VERSION,

--- a/scripts/tools/density_runtime_smoke.py
+++ b/scripts/tools/density_runtime_smoke.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Run a bounded diagnostic runtime smoke for density coverage-entropy candidates."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.map_runner_actions import (
+    policy_command_to_env_action,
+    vel_and_acc,
+)
+from robot_sf.benchmark.map_runner_env import build_env_config
+from robot_sf.benchmark.metrics import EpisodeData, compute_all_metrics
+from robot_sf.benchmark.termination_reason import resolve_termination_reason
+from robot_sf.gym_env.environment_factory import make_robot_env
+from robot_sf.training.scenario_loader import load_scenarios
+
+SCHEMA_VERSION = "density_runtime_smoke.v1"
+
+
+def _scenario_id(scenario: Mapping[str, Any]) -> str:
+    """Return the stable scenario identifier for matching coverage rows."""
+    for key in ("name", "scenario_id", "id"):
+        value = scenario.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "unknown"
+
+
+def select_candidate_rows(
+    coverage_report: Mapping[str, Any],
+    *,
+    top_k: int,
+) -> tuple[list[dict[str, Any]], dict[str, Any]]:
+    """Select top novelty rows plus redundant or lowest-novelty comparator rows."""
+    rows_raw = coverage_report.get("scenario_rows")
+    rows = [dict(row) for row in rows_raw if isinstance(row, Mapping)]
+    if top_k <= 0:
+        raise ValueError("top_k must be positive")
+    if not rows:
+        raise ValueError("coverage report has no scenario_rows")
+
+    novel = sorted(
+        (row for row in rows if row.get("recommendation") == "retain_or_investigate"),
+        key=lambda row: (-float(row.get("novelty_score", 0.0)), str(row.get("scenario_id", ""))),
+    )[:top_k]
+    if len(novel) < top_k:
+        raise ValueError("coverage report does not contain enough novel candidates")
+
+    novel_ids = {str(row.get("scenario_id")) for row in novel}
+    redundant = sorted(
+        (row for row in rows if row.get("recommendation") == "merge_or_drop"),
+        key=lambda row: (float(row.get("novelty_score", 0.0)), str(row.get("scenario_id", ""))),
+    )[:top_k]
+    comparator_source = "merge_or_drop"
+    if len(redundant) < top_k:
+        comparator_source = "lowest_novelty_fallback"
+        redundant = sorted(
+            (row for row in rows if str(row.get("scenario_id")) not in novel_ids),
+            key=lambda row: (
+                float(row.get("novelty_score", 0.0)),
+                str(row.get("scenario_id", "")),
+            ),
+        )[:top_k]
+    if len(redundant) < top_k:
+        raise ValueError("coverage report does not contain enough comparator candidates")
+
+    selected: list[dict[str, Any]] = []
+    for group, group_rows in (("novel", novel), ("redundant_comparator", redundant)):
+        for row in group_rows:
+            payload = dict(row)
+            payload["selection_group"] = group
+            payload["comparator_source"] = comparator_source if group != "novel" else "top_novelty"
+            selected.append(payload)
+
+    summary = coverage_report.get("summary")
+    summary_map = summary if isinstance(summary, Mapping) else {}
+    return selected, {
+        "top_k": top_k,
+        "novel_count": len(novel),
+        "comparator_count": len(redundant),
+        "comparator_source": comparator_source,
+        "coverage_redundant_count": int(summary_map.get("redundant_count", 0)),
+        "caveat": (
+            "No merge_or_drop rows were available; used lowest-novelty rows as comparators."
+            if comparator_source == "lowest_novelty_fallback"
+            else None
+        ),
+    }
+
+
+def classify_failure_semantics(
+    *,
+    success: bool,
+    collision: bool,
+    near_misses: float,
+    progress_ratio: float,
+    progress_stall_threshold: float,
+) -> str:
+    """Map runtime outcomes into issue #3200's diagnostic row labels."""
+    if collision:
+        return "collision"
+    if success:
+        return "success"
+    if near_misses > 0.0:
+        return "near-miss"
+    if progress_ratio <= progress_stall_threshold:
+        return "progress_stall"
+    return "horizon_exhausted"
+
+
+def _goal_command(env: Any, goal: np.ndarray, *, max_speed: float) -> tuple[float, float]:
+    """Return a simple goal-directed unicycle command."""
+    robot = env.simulator.robots[0]
+    robot_pos = np.asarray(env.simulator.robot_pos[0], dtype=float)
+    vec = goal - robot_pos
+    distance = float(np.linalg.norm(vec))
+    if distance < 1e-6:
+        return 0.0, 0.0
+    heading = float(robot.pose[1])
+    desired_heading = float(math.atan2(vec[1], vec[0]))
+    heading_error = math.atan2(
+        math.sin(desired_heading - heading),
+        math.cos(desired_heading - heading),
+    )
+    linear = float(min(max_speed, distance) * max(0.0, 1.0 - abs(heading_error) / math.pi))
+    angular = float(np.clip(heading_error, -1.0, 1.0))
+    return linear, angular
+
+
+def _stack_ped_positions(traj: list[np.ndarray]) -> np.ndarray:
+    """Stack variable pedestrian counts into an EpisodeData-compatible tensor."""
+    if not traj:
+        return np.zeros((0, 0, 2), dtype=float)
+    first_shape = traj[0].shape
+    if all(arr.shape == first_shape for arr in traj):
+        return np.stack(traj).astype(float, copy=False)
+    max_count = max(arr.shape[0] for arr in traj)
+    stacked = np.full((len(traj), max_count, 2), np.nan, dtype=float)
+    for index, arr in enumerate(traj):
+        if arr.size:
+            stacked[index, : arr.shape[0]] = arr
+    return stacked
+
+
+def run_smoke_episode(
+    scenario: Mapping[str, Any],
+    *,
+    matrix_path: Path,
+    seed: int,
+    horizon: int,
+    dt: float,
+    max_speed: float,
+    progress_stall_threshold: float,
+) -> dict[str, Any]:
+    """Run one diagnostic goal-policy episode for one scenario row."""
+    scenario_payload = dict(scenario)
+    scenario_id = _scenario_id(scenario_payload)
+    config = build_env_config(scenario_payload, scenario_path=matrix_path)
+    config.sim_config.time_per_step_in_secs = float(dt)
+
+    env = make_robot_env(config=config, seed=int(seed), debug=False)
+    robot_positions: list[np.ndarray] = []
+    ped_positions: list[np.ndarray] = []
+    collision_seen = False
+    success_seen = False
+    timeout_seen = False
+    termination_reason = "max_steps"
+    try:
+        _obs, _info = env.reset(seed=int(seed))
+        goal = np.asarray(env.simulator.goal_pos[0], dtype=float)
+        initial_robot_pos = np.asarray(env.simulator.robot_pos[0], dtype=float)
+        initial_goal_distance = float(np.linalg.norm(goal - initial_robot_pos))
+
+        for step_index in range(int(horizon)):
+            command = _goal_command(env, goal, max_speed=max_speed)
+            action = policy_command_to_env_action(env=env, config=config, command=command)
+            _obs, _reward, terminated, truncated, info = env.step(action)
+            robot_pos = np.asarray(env.simulator.robot_pos[0], dtype=float)
+            peds = np.asarray(env.simulator.ped_pos, dtype=float)
+            robot_positions.append(robot_pos.copy())
+            ped_positions.append(peds.copy())
+
+            meta = info.get("meta", {}) if isinstance(info, Mapping) else {}
+            step_collision = bool(info.get("collision")) if isinstance(info, Mapping) else False
+            step_success = bool(info.get("success")) if isinstance(info, Mapping) else False
+            step_timeout = bool(meta.get("is_timesteps_exceeded", False))
+            collision_seen = collision_seen or step_collision
+            success_seen = success_seen or (step_success and not step_collision)
+            timeout_seen = timeout_seen or step_timeout
+            if success_seen or collision_seen or terminated or truncated:
+                termination_reason = resolve_termination_reason(
+                    terminated=bool(terminated),
+                    truncated=bool(truncated),
+                    success=success_seen,
+                    collision=collision_seen,
+                    reached_max_steps=False,
+                )
+                break
+            if step_index == int(horizon) - 1:
+                timeout_seen = True
+    finally:
+        env.close()
+
+    robot_pos_arr = np.asarray(robot_positions, dtype=float)
+    final_robot_pos = robot_pos_arr[-1] if robot_pos_arr.size else initial_robot_pos
+    final_goal_distance = float(np.linalg.norm(goal - final_robot_pos))
+    progress_m = max(0.0, initial_goal_distance - final_goal_distance)
+    progress_ratio = progress_m / initial_goal_distance if initial_goal_distance > 1e-9 else 0.0
+    robot_vel_arr, robot_acc_arr = vel_and_acc(robot_pos_arr, float(dt))
+    ped_pos_arr = _stack_ped_positions(ped_positions)
+    ped_forces_arr = np.zeros_like(ped_pos_arr, dtype=float)
+    episode = EpisodeData(
+        robot_pos=robot_pos_arr,
+        robot_vel=robot_vel_arr,
+        robot_acc=robot_acc_arr,
+        peds_pos=ped_pos_arr,
+        ped_forces=ped_forces_arr,
+        obstacles=None,
+        goal=goal,
+        dt=float(dt),
+        reached_goal_step=0 if success_seen else None,
+        robot_radius=float(getattr(config.robot_config, "radius", 1.0)),
+        ped_radius=float(getattr(config.sim_config, "ped_radius", 0.4)),
+    )
+    metrics = compute_all_metrics(episode, horizon=int(horizon))
+    if collision_seen:
+        metrics["collisions"] = max(float(metrics.get("collisions", 0.0)), 1.0)
+    if success_seen:
+        metrics["success"] = 1.0
+    near_miss_count = float(metrics.get("near_misses", 0.0) or 0.0)
+    failure_semantics = classify_failure_semantics(
+        success=success_seen,
+        collision=collision_seen,
+        near_misses=near_miss_count,
+        progress_ratio=progress_ratio,
+        progress_stall_threshold=progress_stall_threshold,
+    )
+    return {
+        "scenario_id": scenario_id,
+        "seed": int(seed),
+        "status": "completed",
+        "row_status": "diagnostic_only",
+        "counts_as_success_evidence": False,
+        "termination_reason": termination_reason,
+        "failure_semantics": failure_semantics,
+        "outcome": {
+            "success": bool(success_seen),
+            "collision": bool(collision_seen),
+            "timeout": bool(timeout_seen or failure_semantics == "horizon_exhausted"),
+        },
+        "metrics": {
+            "success": float(metrics.get("success", 0.0) or 0.0),
+            "collisions": float(metrics.get("collisions", 0.0) or 0.0),
+            "near_misses": near_miss_count,
+            "min_distance": float(metrics.get("min_distance", float("nan"))),
+            "progress_m": progress_m,
+            "progress_ratio": progress_ratio,
+            "steps": int(robot_pos_arr.shape[0]),
+        },
+        "caveat": "one-seed goal-policy diagnostic smoke; not benchmark evidence",
+    }
+
+
+def run_density_smoke(args: argparse.Namespace) -> dict[str, Any]:
+    """Run the selected density runtime smoke and return a JSON payload."""
+    coverage = json.loads(args.coverage_json.read_text(encoding="utf-8"))
+    selected_rows, selection_summary = select_candidate_rows(coverage, top_k=int(args.top_k))
+    scenarios = {
+        _scenario_id(scenario): dict(scenario)
+        for scenario in load_scenarios(args.matrix, base_dir=args.matrix)
+    }
+
+    row_payloads: list[dict[str, Any]] = []
+    missing: list[str] = []
+    for selected in selected_rows:
+        scenario_id = str(selected.get("scenario_id"))
+        scenario = scenarios.get(scenario_id)
+        if scenario is None:
+            missing.append(scenario_id)
+            continue
+        runtime = run_smoke_episode(
+            scenario,
+            matrix_path=args.matrix,
+            seed=int(args.seed),
+            horizon=int(args.horizon),
+            dt=float(args.dt),
+            max_speed=float(args.max_speed),
+            progress_stall_threshold=float(args.progress_stall_threshold),
+        )
+        row_payloads.append(
+            {
+                "selection": {
+                    "group": selected["selection_group"],
+                    "comparator_source": selected["comparator_source"],
+                    "novelty_score": selected.get("novelty_score"),
+                    "nearest_neighbor": selected.get("nearest_neighbor"),
+                    "recommendation": selected.get("recommendation"),
+                },
+                **runtime,
+            }
+        )
+
+    status = "completed" if row_payloads and not missing else "blocked"
+    if missing:
+        status = "blocked"
+    failure_counts: dict[str, int] = {}
+    for row in row_payloads:
+        key = str(row.get("failure_semantics", "unknown"))
+        failure_counts[key] = failure_counts.get(key, 0) + 1
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 3200,
+        "status": status,
+        "evidence_status": "diagnostic-only",
+        "claim_boundary": "bounded same-seed runtime smoke; not benchmark or paper evidence",
+        "matrix": str(args.matrix),
+        "coverage_json": str(args.coverage_json),
+        "seed": int(args.seed),
+        "horizon": int(args.horizon),
+        "dt": float(args.dt),
+        "selection_summary": selection_summary,
+        "failure_semantics_counts": failure_counts,
+        "missing_scenarios": missing,
+        "rows": row_payloads,
+    }
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--matrix", type=Path, required=True)
+    parser.add_argument("--coverage-json", type=Path, required=True)
+    parser.add_argument("--output-json", type=Path, required=True)
+    parser.add_argument("--top-k", type=int, default=2)
+    parser.add_argument("--seed", type=int, default=3200)
+    parser.add_argument("--horizon", type=int, default=80)
+    parser.add_argument("--dt", type=float, default=0.1)
+    parser.add_argument("--max-speed", type=float, default=1.0)
+    parser.add_argument("--progress-stall-threshold", type=float, default=0.05)
+    return parser
+
+
+def main() -> int:
+    """Run CLI."""
+    args = _build_parser().parse_args()
+    payload = run_density_smoke(args)
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    print(
+        json.dumps(
+            {
+                "schema_version": payload["schema_version"],
+                "status": payload["status"],
+                "rows": len(payload["rows"]),
+                "failure_semantics_counts": payload["failure_semantics_counts"],
+                "output_json": str(args.output_json),
+            },
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0 if payload["status"] == "completed" else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tools/scenario_coverage_entropy.py
+++ b/scripts/tools/scenario_coverage_entropy.py
@@ -7,11 +7,29 @@ import argparse
 import json
 from pathlib import Path
 
-from robot_sf.benchmark.runner import load_scenario_matrix
 from robot_sf.benchmark.scenario_coverage import (
     build_scenario_coverage_report,
     write_scenario_coverage_report,
 )
+from robot_sf.training.scenario_loader import load_scenarios
+from robot_sf.training.task_bundles import is_task_bundle_reference
+
+
+def load_scenario_matrix(path: str | Path) -> list[dict]:
+    """Load scenario rows without importing benchmark runtime planners."""
+    if is_task_bundle_reference(path):
+        return [dict(scenario) for scenario in load_scenarios(path)]
+
+    import yaml
+
+    scenario_path = Path(path)
+    with scenario_path.open("r", encoding="utf-8") as handle:
+        docs = list(yaml.safe_load_all(handle))
+    if not docs:
+        raise ValueError(f"Scenario matrix '{scenario_path}' is empty.")
+    if len(docs) > 1:
+        return [dict(scenario) for scenario in docs]
+    return [dict(scenario) for scenario in load_scenarios(scenario_path, base_dir=scenario_path)]
 
 
 def parse_args() -> argparse.Namespace:

--- a/scripts/tools/scenario_coverage_entropy.py
+++ b/scripts/tools/scenario_coverage_entropy.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Mapping
 from pathlib import Path
 
 from robot_sf.benchmark.scenario_coverage import (
@@ -24,10 +25,19 @@ def load_scenario_matrix(path: str | Path) -> list[dict]:
 
     scenario_path = Path(path)
     with scenario_path.open("r", encoding="utf-8") as handle:
-        docs = list(yaml.safe_load_all(handle))
+        raw_docs = list(yaml.safe_load_all(handle))
+    docs = [doc for doc in raw_docs if doc is not None]
     if not docs:
         raise ValueError(f"Scenario matrix '{scenario_path}' is empty.")
-    if len(docs) > 1:
+    if len(raw_docs) > 1:
+        invalid_docs = [
+            index for index, scenario in enumerate(docs) if not isinstance(scenario, Mapping)
+        ]
+        if invalid_docs:
+            raise ValueError(
+                f"Scenario matrix '{scenario_path}' contains non-object YAML documents: "
+                f"{invalid_docs}"
+            )
         return [dict(scenario) for scenario in docs]
     return [dict(scenario) for scenario in load_scenarios(scenario_path, base_dir=scenario_path)]
 

--- a/tests/benchmark/test_scenario_coverage.py
+++ b/tests/benchmark/test_scenario_coverage.py
@@ -132,6 +132,29 @@ def test_station_platform_pack_report_uses_existing_distinct_probe_metadata() ->
     assert "wait_behavior" in waiting["distinct_features"]
 
 
+def test_load_scenario_matrix_skips_empty_yaml_documents(tmp_path: Path) -> None:
+    """Multi-document YAML matrices may include empty documents from separators."""
+    matrix = tmp_path / "matrix.yaml"
+    matrix.write_text(
+        """
+---
+---
+name: valid_doc
+map_file: maps/svg_maps/classic_station_platform.svg
+simulation_config:
+  ped_density: 0.02
+seeds: [1]
+---
+""",
+        encoding="utf-8",
+    )
+
+    scenarios = load_scenario_matrix(matrix)
+
+    assert len(scenarios) == 1
+    assert scenarios[0]["name"] == "valid_doc"
+
+
 def test_build_scenario_coverage_report_handles_minimal_legacy_rows() -> None:
     """Minimal legacy scenario rows should still produce an explicit diagnostic report."""
     report = build_scenario_coverage_report(

--- a/tests/benchmark/test_scenario_coverage.py
+++ b/tests/benchmark/test_scenario_coverage.py
@@ -8,12 +8,12 @@ from pathlib import Path
 
 import pytest
 
-from robot_sf.benchmark.runner import load_scenario_matrix
 from robot_sf.benchmark.scenario_coverage import (
     build_scenario_coverage_report,
     scenario_coverage_report_markdown,
     write_scenario_coverage_report,
 )
+from scripts.tools.scenario_coverage_entropy import load_scenario_matrix
 
 
 def _scenario(

--- a/tests/tools/test_density_runtime_smoke.py
+++ b/tests/tools/test_density_runtime_smoke.py
@@ -1,0 +1,103 @@
+"""Tests for the diagnostic density runtime smoke helper."""
+
+from __future__ import annotations
+
+from scripts.tools.density_runtime_smoke import (
+    classify_failure_semantics,
+    select_candidate_rows,
+)
+
+
+def test_select_candidate_rows_uses_lowest_novelty_when_no_redundant_rows() -> None:
+    """A complete report can still lack literal merge/drop rows."""
+    report = {
+        "summary": {"redundant_count": 0},
+        "scenario_rows": [
+            {
+                "scenario_id": "novel_a",
+                "novelty_score": 0.9,
+                "recommendation": "retain_or_investigate",
+            },
+            {
+                "scenario_id": "novel_b",
+                "novelty_score": 0.8,
+                "recommendation": "retain_or_investigate",
+            },
+            {
+                "scenario_id": "typical_a",
+                "novelty_score": 0.1,
+                "recommendation": "review",
+            },
+            {
+                "scenario_id": "typical_b",
+                "novelty_score": 0.2,
+                "recommendation": "review",
+            },
+        ],
+    }
+
+    selected, summary = select_candidate_rows(report, top_k=2)
+
+    assert summary["comparator_source"] == "lowest_novelty_fallback"
+    assert summary["coverage_redundant_count"] == 0
+    assert [row["scenario_id"] for row in selected] == [
+        "novel_a",
+        "novel_b",
+        "typical_a",
+        "typical_b",
+    ]
+    assert selected[-1]["selection_group"] == "redundant_comparator"
+
+
+def test_classify_failure_semantics_precedence() -> None:
+    """Collision and success take precedence over diagnostic stall labels."""
+    assert (
+        classify_failure_semantics(
+            success=False,
+            collision=True,
+            near_misses=10.0,
+            progress_ratio=0.0,
+            progress_stall_threshold=0.05,
+        )
+        == "collision"
+    )
+    assert (
+        classify_failure_semantics(
+            success=True,
+            collision=False,
+            near_misses=10.0,
+            progress_ratio=0.0,
+            progress_stall_threshold=0.05,
+        )
+        == "success"
+    )
+    assert (
+        classify_failure_semantics(
+            success=False,
+            collision=False,
+            near_misses=1.0,
+            progress_ratio=0.0,
+            progress_stall_threshold=0.05,
+        )
+        == "near-miss"
+    )
+    assert (
+        classify_failure_semantics(
+            success=False,
+            collision=False,
+            near_misses=0.0,
+            progress_ratio=0.01,
+            progress_stall_threshold=0.05,
+        )
+        == "progress_stall"
+    )
+    assert (
+        classify_failure_semantics(
+            success=False,
+            collision=False,
+            near_misses=0.0,
+            progress_ratio=0.5,
+            progress_stall_threshold=0.05,
+        )
+        == "horizon_exhausted"
+    )

--- a/tests/tools/test_density_runtime_smoke.py
+++ b/tests/tools/test_density_runtime_smoke.py
@@ -49,6 +49,34 @@ def test_select_candidate_rows_uses_lowest_novelty_when_no_redundant_rows() -> N
     assert selected[-1]["selection_group"] == "redundant_comparator"
 
 
+def test_select_candidate_rows_rejects_malformed_rows() -> None:
+    """Malformed coverage payloads should fail with clear ValueErrors."""
+    try:
+        select_candidate_rows({"scenario_rows": "not-a-list"}, top_k=1)
+    except ValueError as exc:
+        assert "scenario_rows must be a list" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for non-list scenario_rows")
+
+    try:
+        select_candidate_rows(
+            {
+                "scenario_rows": [
+                    {
+                        "scenario_id": "novel_bad",
+                        "novelty_score": "not-a-score",
+                        "recommendation": "retain_or_investigate",
+                    }
+                ]
+            },
+            top_k=1,
+        )
+    except ValueError as exc:
+        assert "invalid novelty_score" in str(exc)
+    else:
+        raise AssertionError("expected ValueError for malformed novelty_score")
+
+
 def test_classify_failure_semantics_precedence() -> None:
     """Collision and success take precedence over diagnostic stall labels."""
     assert (

--- a/tests/tools/test_density_runtime_smoke.py
+++ b/tests/tools/test_density_runtime_smoke.py
@@ -2,10 +2,20 @@
 
 from __future__ import annotations
 
+import argparse
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.tools import density_runtime_smoke
 from scripts.tools.density_runtime_smoke import (
     classify_failure_semantics,
+    run_density_smoke,
     select_candidate_rows,
 )
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def test_select_candidate_rows_uses_lowest_novelty_when_no_redundant_rows() -> None:
@@ -49,6 +59,36 @@ def test_select_candidate_rows_uses_lowest_novelty_when_no_redundant_rows() -> N
     assert selected[-1]["selection_group"] == "redundant_comparator"
 
 
+def test_select_candidate_rows_tolerates_null_report_fields() -> None:
+    """Nullable report fields should not fail score sorting or summary coercion."""
+    report = {
+        "summary": {"redundant_count": None},
+        "scenario_rows": [
+            {
+                "scenario_id": "novel_null",
+                "novelty_score": None,
+                "recommendation": "retain_or_investigate",
+            },
+            {
+                "scenario_id": "redundant_null",
+                "novelty_score": None,
+                "recommendation": "merge_or_drop",
+            },
+        ],
+    }
+
+    selected, summary = select_candidate_rows(report, top_k=1)
+
+    assert summary["coverage_redundant_count"] == 0
+    assert [row["scenario_id"] for row in selected] == ["novel_null", "redundant_null"]
+
+
+def test_select_candidate_rows_rejects_null_scenario_rows() -> None:
+    """Null scenario_rows should fail closed with the normal empty-report error."""
+    with pytest.raises(ValueError, match="has no scenario_rows"):
+        select_candidate_rows({"scenario_rows": None}, top_k=1)
+
+
 def test_select_candidate_rows_rejects_malformed_rows() -> None:
     """Malformed coverage payloads should fail with clear ValueErrors."""
     try:
@@ -75,6 +115,70 @@ def test_select_candidate_rows_rejects_malformed_rows() -> None:
         assert "invalid novelty_score" in str(exc)
     else:
         raise AssertionError("expected ValueError for malformed novelty_score")
+
+
+def test_run_density_smoke_does_not_stringify_null_ids_or_semantics(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Null selected ids and runtime semantics should be explicit missing/unknown values."""
+    coverage_json = tmp_path / "coverage.json"
+    coverage_json.write_text(
+        """
+{
+  "summary": {"redundant_count": null},
+  "scenario_rows": [
+    {
+      "scenario_id": null,
+      "novelty_score": 1.0,
+      "recommendation": "retain_or_investigate"
+    },
+    {
+      "scenario_id": "typical",
+      "novelty_score": 0.0,
+      "recommendation": "merge_or_drop"
+    }
+  ]
+}
+""",
+        encoding="utf-8",
+    )
+    matrix = tmp_path / "matrix.yaml"
+    matrix.write_text("[]\n", encoding="utf-8")
+
+    monkeypatch.setattr(
+        density_runtime_smoke,
+        "load_scenarios",
+        lambda *_args, **_kwargs: [{"name": "typical"}],
+    )
+    monkeypatch.setattr(
+        density_runtime_smoke,
+        "run_smoke_episode",
+        lambda *_args, **_kwargs: {
+            "scenario_id": "typical",
+            "status": "completed",
+            "row_status": "diagnostic_only",
+            "failure_semantics": None,
+        },
+    )
+
+    payload = run_density_smoke(
+        argparse.Namespace(
+            coverage_json=coverage_json,
+            matrix=matrix,
+            top_k=1,
+            seed=3200,
+            horizon=1,
+            dt=0.1,
+            max_speed=1.0,
+            progress_stall_threshold=0.05,
+        )
+    )
+
+    assert payload["status"] == "blocked"
+    assert payload["missing_scenarios"] == ["<missing scenario_id>"]
+    assert "None" not in payload["missing_scenarios"]
+    assert payload["failure_semantics_counts"] == {"unknown": 1}
+    assert payload["selection_summary"]["coverage_redundant_count"] == 0
 
 
 def test_classify_failure_semantics_precedence() -> None:


### PR DESCRIPTION
## Summary
Adds a bounded pedestrian-density runtime-smoke helper and records a diagnostic-only #3200 smoke over coverage-entropy-selected candidates. All four same-seed rows ran and ended `horizon_exhausted`; no benchmark or paper-facing density claim is promoted.

## Linked Issues
- Closes `#3200`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/tools/density_runtime_smoke.py` to select top coverage-novel rows plus comparator rows and run a simple bounded goal-policy diagnostic smoke.
- Decoupled `scripts/tools/scenario_coverage_entropy.py` from benchmark runner imports for config-only matrix loading.
- Added focused tests for candidate selection, failure-semantics classification, and existing scenario-coverage CLI behavior.
- Added `docs/context/evidence/issue_3200_density_runtime_smoke_summary.json` and linked it from context/evidence indexes.

## Why It Matters
- Added value: promotes the pedestrian-density coverage-entropy gap from config-only novelty into a small runtime-observed diagnostic result.
- Expected impact: clarifies that the selected novel/comparator rows execute locally but did not separate failure semantics under this smoke.
- Why this is worth merging now: it records a useful negative/diagnostic stop point for a top-ranked dissertation gap without overstating it as benchmark evidence.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: whether coverage-entropy novel pedestrian-density candidates produce distinct runtime failure semantics versus comparator rows.
- Comparator or baseline, if applicable: same-seed lowest-novelty comparator rows; no literal `merge_or_drop` redundant rows were available.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: diagnostic-only / inconclusive-negative for this simple smoke.
- Decision or stop rule, if applicable: all rows are `diagnostic_only`, `counts_as_success_evidence: false`; indistinguishable `horizon_exhausted` distribution means no density benchmark claim is promoted.
- Parent issue, claim map, registry, context note, or synthesis surface to update: tracked summary JSON and context/evidence indexes.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use is included as the tracked #3200 summary generated from checked-in config paths; local raw outputs remain ignored.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, all four rows executed through the local environment path.
- Did the intervention change command source, selected command, trajectory, or route progress? yes, the helper selected coverage-novel and comparator scenarios and ran the simple goal-policy path.
- Did the scenario actually contain the targeted failure mode? unknown/weak; this smoke did not produce distinct collision, near-miss, or progress-stall labels.
- Result route: revise / narrow.
- Follow-up question or issue for weak, negative, or non-transfer results: use stronger density stressors, planner-specific policies, or more seeds before attempting a benchmark claim.

## Next Empirical Action
- Rerun needed: yes, only if pursuing stronger density evidence.
- Extractor or analysis tool needed: no for this diagnostic slice.
- Artifact missing or unavailable: none for the tracked compact summary; raw local outputs are disposable and reproducible from summary commands.
- Stop / revise / continue decision: revise before benchmark promotion.
- Proposed child issue or existing follow-up: none opened in this PR; summary records the next proof boundary.

## Validation / Proof
- Commands run:
  - `uv sync --frozen`
  - `uv sync --frozen --extra training`
  - `uv run python scripts/tools/scenario_coverage_entropy.py configs/scenarios/classic_interactions_francis2023.yaml --output-json output/issue_3200_density_runtime_smoke/coverage_entropy.json --output-markdown output/issue_3200_density_runtime_smoke/coverage_entropy.md`
  - `uv run python scripts/tools/density_runtime_smoke.py --matrix configs/scenarios/classic_interactions_francis2023.yaml --coverage-json output/issue_3200_density_runtime_smoke/coverage_entropy.json --output-json output/issue_3200_density_runtime_smoke/runtime_smoke.json`
  - `rtk uv run pytest tests/tools/test_density_runtime_smoke.py tests/benchmark/test_scenario_coverage.py -q`
  - `rtk .venv/bin/ruff check scripts/tools/density_runtime_smoke.py scripts/tools/scenario_coverage_entropy.py tests/tools/test_density_runtime_smoke.py tests/benchmark/test_scenario_coverage.py`
  - `rtk .venv/bin/ruff format --check scripts/tools/density_runtime_smoke.py scripts/tools/scenario_coverage_entropy.py tests/tools/test_density_runtime_smoke.py tests/benchmark/test_scenario_coverage.py`
  - `BASE_REF=origin/main rtk scripts/dev/check_docs_proof_consistency_diff.sh`
  - `rtk git diff --check`
- Evidence that the change works here: runtime smoke completed 4 rows with failure semantics counts `{"horizon_exhausted": 4}`; tracked summary records all rows as non-success evidence.
- Benchmarks or smoke tests, if applicable: targeted diagnostic smoke only; no benchmark claim.

## Risks / Rollout
- Compatibility risks: helper uses a simple diagnostic goal-policy and local environment path, not a planner leaderboard path.
- Failure modes: missing scenario IDs return `blocked`; no literal redundant rows falls back to lowest-novelty comparator rows with an explicit caveat.
- Rollback or fallback plan: remove the new helper/tests/summary; no production runtime path depends on it.

## Docs / Provenance
- Updated docs: `docs/context/evidence/issue_3200_density_runtime_smoke_summary.json`, `docs/context/INDEX.md`, `docs/context/README.md`, `docs/context/evidence/README.md`.
- Relevant design or provenance notes: #3200 issue body, `docs/context/evidence/issue_2792_next_issue_shortlist/`, `docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.md`.
- Any assumptions that need to be preserved: this is one seed, one simple policy, and diagnostic-only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, PR links #3200.
- Claim map / benchmark report updated (yes/no/NA): NA; no benchmark claim moved.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): yes, context/evidence indexes.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: the result is diagnostic-only and negative/inconclusive for benchmark promotion.

## Follow-Up Issues
- Deferred work: stronger density stressors, planner comparisons, and multi-seed runs if this line is pursued further.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: failure-semantics precedence, comparator fallback wording, and that `counts_as_success_evidence` remains false.
- Any known limitations: no literal redundant bucket, one seed, simple goal-directed policy, all rows `horizon_exhausted`.
