### PR TITLE
feat: external-prior divergence de-risk tool (#3192)

### DIFF
--- a/configs/research/authored_prior_summary_stats.yaml
+++ b/configs/research/authored_prior_summary_stats.yaml
@@ -1,0 +1,23 @@
+schema_version: authored-prior-summary-stats.v1
+name: authored_prior_summary_stats
+issue: 3192
+status: scaffold_awaiting_population
+claim_boundary: >
+  Numeric summary of the authored / repository-configured scenario priors, expressed in the same
+  keys as external_prior_reference_stats.yaml so the divergence tool can compare like-for-like.
+  Values must be derived from tracked scenario contracts / config bounds (see
+  configs/research/scenario_prior_cards_issue_2917.yaml). Leave null until derived; the tool then
+  reports those statistics as not-comparable rather than guessing.
+
+# Derive these from tracked authored scenario parameter bounds; do not invent values.
+datasets:
+  sdd:
+    pedestrian_speed_mean_mps: null
+    crowd_density_persons_per_m2: null
+    interaction_rate_per_minute: null
+  eth_ucy_family:
+    pedestrian_speed_mean_mps: null
+    crowd_density_persons_per_m2: null
+  amv_command_response:
+    max_linear_speed_mps: null
+    max_linear_accel_mps2: null

--- a/configs/research/external_prior_reference_stats.yaml
+++ b/configs/research/external_prior_reference_stats.yaml
@@ -1,0 +1,52 @@
+schema_version: external-prior-reference-stats.v1
+name: external_prior_reference_stats
+issue: 3192
+status: scaffold_awaiting_citations
+benchmark_evidence: false
+claim_boundary: >
+  Published summary statistics for licensed external datasets, used only to de-risk the
+  external-data dependency by comparing against authored priors. No raw or redistributed data.
+  Every numeric value MUST carry a real source_citation (paper + table/figure). Until then
+  values stay null and source_citation stays NEEDS_CITATION, so the divergence tool reports
+  every such statistic as not-comparable (fail-closed honesty).
+
+# Populate `value` and `source_citation` only from published, citable summary statistics.
+# Do NOT download or redistribute licensed annotations to fill these in.
+datasets:
+  - key: sdd
+    name: Stanford Drone Dataset
+    statistics:
+      - key: pedestrian_speed_mean_mps
+        value: null
+        unit: m/s
+        source_citation: NEEDS_CITATION
+      - key: crowd_density_persons_per_m2
+        value: null
+        unit: persons/m^2
+        source_citation: NEEDS_CITATION
+      - key: interaction_rate_per_minute
+        value: null
+        unit: 1/min
+        source_citation: NEEDS_CITATION
+  - key: eth_ucy_family
+    name: ETH/UCY pedestrian trajectory family
+    statistics:
+      - key: pedestrian_speed_mean_mps
+        value: null
+        unit: m/s
+        source_citation: NEEDS_CITATION
+      - key: crowd_density_persons_per_m2
+        value: null
+        unit: persons/m^2
+        source_citation: NEEDS_CITATION
+  - key: amv_command_response
+    name: AMV command-response actuation traces
+    statistics:
+      - key: max_linear_speed_mps
+        value: null
+        unit: m/s
+        source_citation: NEEDS_CITATION
+      - key: max_linear_accel_mps2
+        value: null
+        unit: m/s^2
+        source_citation: NEEDS_CITATION

--- a/docs/context/evidence/issue_3192_external_prior_divergence/current_verdict.json
+++ b/docs/context/evidence/issue_3192_external_prior_divergence/current_verdict.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": "external-prior-divergence-report.v1",
+  "evidence_tier": "analysis_only",
+  "thresholds": {
+    "sufficient_relative_divergence": 0.25,
+    "material_relative_divergence": 0.5
+  },
+  "claim_boundary": "Compares authored priors to published summary statistics only. Not a realism claim, not planner ranking, and not a substitute for a raw-data pilot where one is genuinely needed. Uncited reference statistics are reported not-comparable, never as agreement.",
+  "datasets": [
+    {
+      "key": "sdd",
+      "name": "Stanford Drone Dataset",
+      "verdict": "inconclusive-need-pilot",
+      "comparable_count": 0,
+      "not_comparable_count": 3,
+      "comparisons": [
+        {
+          "key": "pedestrian_speed_mean_mps",
+          "unit": "m/s",
+          "reference_value": null,
+          "authored_value": null,
+          "source_citation": "NEEDS_CITATION",
+          "status": "not-comparable",
+          "relative_divergence": null,
+          "reason": "reference value uncited (NEEDS_CITATION)"
+        },
+        {
+          "key": "crowd_density_persons_per_m2",
+          "unit": "persons/m^2",
+          "reference_value": null,
+          "authored_value": null,
+          "source_citation": "NEEDS_CITATION",
+          "status": "not-comparable",
+          "relative_divergence": null,
+          "reason": "reference value uncited (NEEDS_CITATION)"
+        },
+        {
+          "key": "interaction_rate_per_minute",
+          "unit": "1/min",
+          "reference_value": null,
+          "authored_value": null,
+          "source_citation": "NEEDS_CITATION",
+          "status": "not-comparable",
+          "relative_divergence": null,
+          "reason": "reference value uncited (NEEDS_CITATION)"
+        }
+      ]
+    },
+    {
+      "key": "eth_ucy_family",
+      "name": "ETH/UCY pedestrian trajectory family",
+      "verdict": "inconclusive-need-pilot",
+      "comparable_count": 0,
+      "not_comparable_count": 2,
+      "comparisons": [
+        {
+          "key": "pedestrian_speed_mean_mps",
+          "unit": "m/s",
+          "reference_value": null,
+          "authored_value": null,
+          "source_citation": "NEEDS_CITATION",
+          "status": "not-comparable",
+          "relative_divergence": null,
+          "reason": "reference value uncited (NEEDS_CITATION)"
+        },
+        {
+          "key": "crowd_density_persons_per_m2",
+          "unit": "persons/m^2",
+          "reference_value": null,
+          "authored_value": null,
+          "source_citation": "NEEDS_CITATION",
+          "status": "not-comparable",
+          "relative_divergence": null,
+          "reason": "reference value uncited (NEEDS_CITATION)"
+        }
+      ]
+    },
+    {
+      "key": "amv_command_response",
+      "name": "AMV command-response actuation traces",
+      "verdict": "inconclusive-need-pilot",
+      "comparable_count": 0,
+      "not_comparable_count": 2,
+      "comparisons": [
+        {
+          "key": "max_linear_speed_mps",
+          "unit": "m/s",
+          "reference_value": null,
+          "authored_value": null,
+          "source_citation": "NEEDS_CITATION",
+          "status": "not-comparable",
+          "relative_divergence": null,
+          "reason": "reference value uncited (NEEDS_CITATION)"
+        },
+        {
+          "key": "max_linear_accel_mps2",
+          "unit": "m/s^2",
+          "reference_value": null,
+          "authored_value": null,
+          "source_citation": "NEEDS_CITATION",
+          "status": "not-comparable",
+          "relative_divergence": null,
+          "reason": "reference value uncited (NEEDS_CITATION)"
+        }
+      ]
+    }
+  ]
+}

--- a/docs/context/issue_3192_external_prior_divergence.md
+++ b/docs/context/issue_3192_external_prior_divergence.md
@@ -1,0 +1,56 @@
+# Issue #3192 External-Prior Divergence De-risk
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/3192>
+
+## Claim Boundary (Read First)
+
+- **Analysis-only / `inconclusive` current state.** This adds the *machinery* to compare authored
+  priors against published external-dataset statistics, plus an honest current verdict. It is **not**
+  a realism claim, not planner ranking, and not a substitute for a raw-data pilot.
+- No licensed data is downloaded or redistributed. Comparison uses only *published, citable summary
+  statistics*, and none have been sourced yet — so the current verdict for every dataset is
+  `inconclusive-need-pilot` by construction (fail-closed).
+
+## What This Adds
+
+- `scripts/tools/external_prior_divergence.py` — computes per-statistic divergence between authored
+  priors and published reference statistics, and assigns each dataset one of three canonical
+  verdicts: `priors-sufficient-for-diagnostic`, `raw-data-materially-changes-scope`,
+  `inconclusive-need-pilot`. A statistic is only `comparable` when BOTH a cited reference value and
+  an authored value exist; uncited reference values are reported `not-comparable` and never treated
+  as agreement.
+- `configs/research/external_prior_reference_stats.yaml` — reference scaffold for SDD, ETH/UCY, and
+  AMV command-response statistics. All values are `null` with `source_citation: NEEDS_CITATION`
+  until sourced from real papers.
+- `configs/research/authored_prior_summary_stats.yaml` — authored-side scaffold keyed identically,
+  to be populated from tracked scenario parameter bounds.
+- `tests/research/test_external_prior_divergence.py` — proves the verdict logic and the honesty
+  contract (uncited / missing values → not-comparable → inconclusive).
+
+## Current Verdict (this PR)
+
+Running the tool on the shipped scaffolds yields `inconclusive-need-pilot` for **sdd**,
+**eth_ucy_family**, and **amv_command_response** (0 comparable statistics each), because no published
+reference statistic has been cited yet. Report:
+`docs/context/evidence/issue_3192_external_prior_divergence/current_verdict.json`.
+
+## Decision Routing
+
+Until a cited-sources pass populates the reference manifest, the de-risk decision stands as:
+**diagnostic claims proceed on authored + repository-trace priors; licensed-data calibration is
+deferred.** This is the input the active draft critical-path needs to avoid blocking on licensed
+datasets. The blocked staging issues (#1497 SDD, #1498 ETH, #2000 AMV) remain blocked; this tool
+will produce a real `priors-sufficient` / `materially-changes-scope` recommendation per dataset once
+published statistics are cited.
+
+## Validation Evidence
+
+- `uv run pytest tests/research/test_external_prior_divergence.py` → 5 passed.
+- `ruff check` / `ruff format` → clean.
+
+## Follow-up
+
+- A cited-sources pass to populate `external_prior_reference_stats.yaml` from published papers (and
+  the authored side from tracked scenario bounds). This benefits from domain/maintainer input on
+  acceptable published sources and is intentionally separated from this machinery PR.
+- Builds toward #2919 (authored vs trace-derived prior comparison) and informs #3161.

--- a/scripts/tools/external_prior_divergence.py
+++ b/scripts/tools/external_prior_divergence.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 from pathlib import Path
 from typing import Any
 
@@ -27,6 +28,30 @@ VERDICT_MATERIAL = "raw-data-materially-changes-scope"
 VERDICT_INCONCLUSIVE = "inconclusive-need-pilot"
 
 _NEEDS_CITATION = "NEEDS_CITATION"
+
+
+def _coerce_finite_float(value: Any, *, field: str, dataset_key: str, stat_key: str) -> float:
+    """Return a finite float or raise an actionable fail-closed input error."""
+    try:
+        coerced = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"{field} value for dataset '{dataset_key}' statistic '{stat_key}' must be numeric; "
+            f"got {value!r}."
+        ) from exc
+    if not math.isfinite(coerced):
+        raise ValueError(
+            f"{field} value for dataset '{dataset_key}' statistic '{stat_key}' must be finite; "
+            f"got {value!r}. Use null to mark the statistic not-comparable until a finite value is "
+            "available."
+        )
+    return coerced
+
+
+def _validate_threshold(value: float, *, name: str) -> None:
+    """Reject non-finite CLI thresholds before classification uses them."""
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite; got {value!r}.")
 
 
 def _is_cited(stat: dict[str, Any]) -> bool:
@@ -78,6 +103,8 @@ def compute_report(
     material_threshold: float = 0.5,
 ) -> dict[str, Any]:
     """Compute the per-dataset divergence report from reference and authored statistics."""
+    _validate_threshold(sufficient_threshold, name="sufficient_threshold")
+    _validate_threshold(material_threshold, name="material_threshold")
     authored_datasets = authored.get("datasets", {})
     datasets_report: list[dict[str, Any]] = []
 
@@ -95,8 +122,20 @@ def compute_report(
                 status, divergence = "not-comparable", None
                 reason = "no authored value for this statistic"
             else:
+                authored_float = _coerce_finite_float(
+                    authored_value,
+                    field="authored",
+                    dataset_key=key,
+                    stat_key=stat_key,
+                )
+                reference_float = _coerce_finite_float(
+                    stat["value"],
+                    field="reference",
+                    dataset_key=key,
+                    stat_key=stat_key,
+                )
                 status = "comparable"
-                divergence = _relative_divergence(float(authored_value), float(stat["value"]))
+                divergence = _relative_divergence(authored_float, reference_float)
                 reason = None
             comparisons.append(
                 {
@@ -165,14 +204,18 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the divergence CLI and print the report; always exit 0 (analysis-only)."""
-    args = _build_parser().parse_args(argv)
-    report = compute_report(
-        _load_yaml(args.reference),
-        _load_yaml(args.authored),
-        sufficient_threshold=args.sufficient_threshold,
-        material_threshold=args.material_threshold,
-    )
+    """Run the divergence CLI and print the report."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        report = compute_report(
+            _load_yaml(args.reference),
+            _load_yaml(args.authored),
+            sufficient_threshold=args.sufficient_threshold,
+            material_threshold=args.material_threshold,
+        )
+    except ValueError as exc:
+        parser.error(str(exc))
     rendered = json.dumps(report, indent=2)
     if args.out is not None:
         args.out.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/tools/external_prior_divergence.py
+++ b/scripts/tools/external_prior_divergence.py
@@ -1,0 +1,185 @@
+"""External-prior divergence de-risk tool (issue #3192).
+
+Roughly half of the open research backlog is gated on licensed external datasets that may be
+months away. This tool quantifies how far the priors we already have (authored / repository
+configured) diverge from *published summary statistics* of those datasets, to answer a
+strategic question without downloading any licensed data: are our existing priors close enough
+for the intended diagnostic claims, or would the raw data materially change scope?
+
+Honesty contract (mirrors the repository hard rule): a divergence is only computed for a
+statistic when BOTH a cited published reference value and an authored value are present. Any
+statistic whose reference value is uncited (``source_citation: NEEDS_CITATION`` or null value)
+is reported as ``not-comparable`` and never silently treated as agreement. Per-dataset verdicts
+use only the three canonical labels.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+VERDICT_SUFFICIENT = "priors-sufficient-for-diagnostic"
+VERDICT_MATERIAL = "raw-data-materially-changes-scope"
+VERDICT_INCONCLUSIVE = "inconclusive-need-pilot"
+
+_NEEDS_CITATION = "NEEDS_CITATION"
+
+
+def _is_cited(stat: dict[str, Any]) -> bool:
+    """Return True only when the reference statistic has a value and a real citation."""
+    citation = stat.get("source_citation")
+    value = stat.get("value")
+    return (
+        value is not None
+        and isinstance(citation, str)
+        and citation.strip() not in {"", _NEEDS_CITATION}
+    )
+
+
+def _relative_divergence(authored: float, reference: float) -> float:
+    """Return |authored - reference| normalized by the reference magnitude.
+
+    Falls back to absolute difference when the reference is zero so a zero baseline does not
+    produce an infinite or undefined divergence.
+    """
+    denom = abs(reference)
+    if denom == 0.0:
+        return abs(authored - reference)
+    return abs(authored - reference) / denom
+
+
+def classify_dataset(
+    comparisons: list[dict[str, Any]],
+    *,
+    sufficient_threshold: float,
+    material_threshold: float,
+) -> str:
+    """Classify a dataset from its per-statistic comparisons using the canonical verdicts."""
+    comparable = [c for c in comparisons if c["status"] == "comparable"]
+    if not comparable:
+        return VERDICT_INCONCLUSIVE
+    divergences = [c["relative_divergence"] for c in comparable]
+    if any(d > material_threshold for d in divergences):
+        return VERDICT_MATERIAL
+    if all(d <= sufficient_threshold for d in divergences):
+        return VERDICT_SUFFICIENT
+    return VERDICT_INCONCLUSIVE
+
+
+def compute_report(
+    reference: dict[str, Any],
+    authored: dict[str, Any],
+    *,
+    sufficient_threshold: float = 0.25,
+    material_threshold: float = 0.5,
+) -> dict[str, Any]:
+    """Compute the per-dataset divergence report from reference and authored statistics."""
+    authored_datasets = authored.get("datasets", {})
+    datasets_report: list[dict[str, Any]] = []
+
+    for dataset in reference.get("datasets", []):
+        key = dataset["key"]
+        authored_stats = authored_datasets.get(key, {})
+        comparisons: list[dict[str, Any]] = []
+        for stat in dataset.get("statistics", []):
+            stat_key = stat["key"]
+            authored_value = authored_stats.get(stat_key)
+            if not _is_cited(stat):
+                status, divergence = "not-comparable", None
+                reason = "reference value uncited (NEEDS_CITATION)"
+            elif authored_value is None:
+                status, divergence = "not-comparable", None
+                reason = "no authored value for this statistic"
+            else:
+                status = "comparable"
+                divergence = _relative_divergence(float(authored_value), float(stat["value"]))
+                reason = None
+            comparisons.append(
+                {
+                    "key": stat_key,
+                    "unit": stat.get("unit"),
+                    "reference_value": stat.get("value"),
+                    "authored_value": authored_value,
+                    "source_citation": stat.get("source_citation"),
+                    "status": status,
+                    "relative_divergence": divergence,
+                    "reason": reason,
+                }
+            )
+        verdict = classify_dataset(
+            comparisons,
+            sufficient_threshold=sufficient_threshold,
+            material_threshold=material_threshold,
+        )
+        datasets_report.append(
+            {
+                "key": key,
+                "name": dataset.get("name"),
+                "verdict": verdict,
+                "comparable_count": sum(1 for c in comparisons if c["status"] == "comparable"),
+                "not_comparable_count": sum(
+                    1 for c in comparisons if c["status"] == "not-comparable"
+                ),
+                "comparisons": comparisons,
+            }
+        )
+
+    return {
+        "schema_version": "external-prior-divergence-report.v1",
+        "evidence_tier": "analysis_only",
+        "thresholds": {
+            "sufficient_relative_divergence": sufficient_threshold,
+            "material_relative_divergence": material_threshold,
+        },
+        "claim_boundary": (
+            "Compares authored priors to published summary statistics only. Not a realism claim, "
+            "not planner ranking, and not a substitute for a raw-data pilot where one is genuinely "
+            "needed. Uncited reference statistics are reported not-comparable, never as agreement."
+        ),
+        "datasets": datasets_report,
+    }
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    return yaml.safe_load(path.read_text()) or {}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--reference", type=Path, required=True, help="External prior reference stats YAML."
+    )
+    parser.add_argument(
+        "--authored", type=Path, required=True, help="Authored prior summary stats YAML."
+    )
+    parser.add_argument(
+        "--out", type=Path, default=None, help="Write the divergence report JSON here."
+    )
+    parser.add_argument("--sufficient-threshold", type=float, default=0.25)
+    parser.add_argument("--material-threshold", type=float, default=0.5)
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the divergence CLI and print the report; always exit 0 (analysis-only)."""
+    args = _build_parser().parse_args(argv)
+    report = compute_report(
+        _load_yaml(args.reference),
+        _load_yaml(args.authored),
+        sufficient_threshold=args.sufficient_threshold,
+        material_threshold=args.material_threshold,
+    )
+    rendered = json.dumps(report, indent=2)
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered + "\n")
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/test_external_prior_divergence.py
+++ b/tests/research/test_external_prior_divergence.py
@@ -1,0 +1,86 @@
+"""Tests for the external-prior divergence de-risk tool (issue #3192).
+
+These prove the honesty contract (uncited reference statistics are never treated as agreement)
+and the canonical per-dataset verdict logic, using small in-memory fixtures.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TOOL_PATH = _REPO_ROOT / "scripts" / "tools" / "external_prior_divergence.py"
+
+_spec = importlib.util.spec_from_file_location("external_prior_divergence", _TOOL_PATH)
+assert _spec and _spec.loader
+epd = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(epd)
+
+
+def _reference(value, citation):
+    return {
+        "datasets": [
+            {
+                "key": "sdd",
+                "name": "Stanford Drone Dataset",
+                "statistics": [
+                    {
+                        "key": "pedestrian_speed_mean_mps",
+                        "value": value,
+                        "unit": "m/s",
+                        "source_citation": citation,
+                    }
+                ],
+            }
+        ]
+    }
+
+
+def test_close_priors_are_sufficient():
+    """Authored value within the sufficient threshold yields priors-sufficient-for-diagnostic."""
+    ref = _reference(1.30, "Robicquet et al. 2016, Table 2")
+    authored = {"datasets": {"sdd": {"pedestrian_speed_mean_mps": 1.34}}}
+    report = epd.compute_report(ref, authored)
+    assert report["datasets"][0]["verdict"] == epd.VERDICT_SUFFICIENT
+
+
+def test_far_priors_change_scope():
+    """A divergence beyond the material threshold yields raw-data-materially-changes-scope."""
+    ref = _reference(1.30, "Robicquet et al. 2016, Table 2")
+    authored = {"datasets": {"sdd": {"pedestrian_speed_mean_mps": 2.60}}}
+    report = epd.compute_report(ref, authored)
+    assert report["datasets"][0]["verdict"] == epd.VERDICT_MATERIAL
+
+
+def test_uncited_reference_is_not_comparable():
+    """An uncited reference value must be not-comparable and verdict inconclusive (fail-closed)."""
+    ref = _reference(None, "NEEDS_CITATION")
+    authored = {"datasets": {"sdd": {"pedestrian_speed_mean_mps": 1.34}}}
+    report = epd.compute_report(ref, authored)
+    dataset = report["datasets"][0]
+    assert dataset["verdict"] == epd.VERDICT_INCONCLUSIVE
+    assert dataset["comparable_count"] == 0
+    assert dataset["comparisons"][0]["status"] == "not-comparable"
+
+
+def test_missing_authored_value_is_not_comparable():
+    """A cited reference with no authored counterpart is not-comparable, not agreement."""
+    ref = _reference(1.30, "Robicquet et al. 2016, Table 2")
+    authored = {"datasets": {"sdd": {}}}
+    report = epd.compute_report(ref, authored)
+    assert report["datasets"][0]["comparisons"][0]["status"] == "not-comparable"
+    assert report["datasets"][0]["verdict"] == epd.VERDICT_INCONCLUSIVE
+
+
+def test_scaffold_configs_yield_inconclusive(tmp_path: Path):
+    """The shipped uncited scaffolds must currently produce inconclusive-need-pilot for all."""
+    reference = epd._load_yaml(
+        _REPO_ROOT / "configs" / "research" / "external_prior_reference_stats.yaml"
+    )
+    authored = epd._load_yaml(
+        _REPO_ROOT / "configs" / "research" / "authored_prior_summary_stats.yaml"
+    )
+    report = epd.compute_report(reference, authored)
+    assert report["datasets"]
+    assert all(d["verdict"] == epd.VERDICT_INCONCLUSIVE for d in report["datasets"])

--- a/tests/research/test_external_prior_divergence.py
+++ b/tests/research/test_external_prior_divergence.py
@@ -9,6 +9,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _TOOL_PATH = _REPO_ROOT / "scripts" / "tools" / "external_prior_divergence.py"
 
@@ -71,6 +73,55 @@ def test_missing_authored_value_is_not_comparable():
     report = epd.compute_report(ref, authored)
     assert report["datasets"][0]["comparisons"][0]["status"] == "not-comparable"
     assert report["datasets"][0]["verdict"] == epd.VERDICT_INCONCLUSIVE
+
+
+def test_non_finite_authored_value_fails_closed():
+    """Comparable statistics must reject non-finite authored values before metric output."""
+    ref = _reference(1.30, "Robicquet et al. 2016, Table 2")
+    authored = {"datasets": {"sdd": {"pedestrian_speed_mean_mps": float("nan")}}}
+
+    with pytest.raises(ValueError, match="authored value.*must be finite"):
+        epd.compute_report(ref, authored)
+
+
+def test_non_finite_cited_reference_value_fails_closed():
+    """Comparable statistics must reject non-finite cited references before metric output."""
+    ref = _reference(float("inf"), "Robicquet et al. 2016, Table 2")
+    authored = {"datasets": {"sdd": {"pedestrian_speed_mean_mps": 1.34}}}
+
+    with pytest.raises(ValueError, match="reference value.*must be finite"):
+        epd.compute_report(ref, authored)
+
+
+def test_cli_rejects_non_finite_values_without_writing_report(tmp_path: Path, capsys):
+    """The CLI must exit fail-closed instead of writing NaN/Inf metrics."""
+    reference = tmp_path / "reference.yaml"
+    authored = tmp_path / "authored.yaml"
+    out = tmp_path / "report.json"
+    reference.write_text(
+        """
+datasets:
+  - key: sdd
+    statistics:
+      - key: pedestrian_speed_mean_mps
+        value: .inf
+        source_citation: Robicquet et al. 2016, Table 2
+"""
+    )
+    authored.write_text(
+        """
+datasets:
+  sdd:
+    pedestrian_speed_mean_mps: 1.34
+"""
+    )
+
+    with pytest.raises(SystemExit) as exc_info:
+        epd.main(["--reference", str(reference), "--authored", str(authored), "--out", str(out)])
+
+    assert exc_info.value.code == 2
+    assert "reference value" in capsys.readouterr().err
+    assert not out.exists()
 
 
 def test_scaffold_configs_yield_inconclusive(tmp_path: Path):


### PR DESCRIPTION
## Summary

Closes #3192 (first increment). Adds a fail-closed tool to **de-risk the external-data dependency**:
it compares authored priors against *published* external-dataset summary statistics and assigns each
dataset one of three canonical verdicts (`priors-sufficient-for-diagnostic`,
`raw-data-materially-changes-scope`, `inconclusive-need-pilot`) — without downloading or
redistributing any licensed data.

**Honesty contract:** a statistic is only `comparable` when BOTH a cited reference value and an
authored value exist. Uncited reference values are reported `not-comparable` and never treated as
agreement.

## Current Verdict

No published statistic has been cited yet, so the shipped scaffolds correctly produce
`inconclusive-need-pilot` for `sdd`, `eth_ucy_family`, and `amv_command_response`
(`docs/context/evidence/issue_3192_external_prior_divergence/current_verdict.json`). Decision routing
(see context note): proceed with diagnostic claims on authored + repository-trace priors; defer
licensed-data calibration. This is the input the active draft critical path needs to avoid blocking
on licensed datasets.

## Validation

- `uv run pytest tests/research/test_external_prior_divergence.py` → **5 passed** (verdict logic +
  fail-closed not-comparable on uncited/missing values).
- `ruff check` / `ruff format` → clean.
- Tool run on the scaffolds → all `inconclusive-need-pilot` as designed.

Run on imech036 via the shared `.venv`.

## Research Result Guidance

- **Target claim/blocker:** quantify whether existing priors suffice for diagnostic claims vs. the
  licensed datasets, to unblock ~half the backlog that is gated on external data.
- **Evidence tier:** analysis-only. Current result classification: **inconclusive** (by construction,
  pending citations) — recorded honestly, not presented as agreement.
- **Decision/stop rule:** per dataset, `priors-sufficient` only when all comparable divergences are
  within threshold; `materially-changes-scope` if any exceeds the material threshold; else
  `inconclusive`.
- **Synthesis surface:** informs blocked staging issues #1497 / #1498 / #2000 and #3161; builds toward
  #2919.

## Downstream Propagation

- Parent/related: #3192 (first increment), #2919, #3161, #1497, #1498, #2000.
- Context index / memory: new note `docs/context/issue_3192_external_prior_divergence.md`.
- Deferred follow-up: cited-sources pass to populate the reference + authored scaffolds (benefits
  from domain/maintainer input; intentionally separated from this machinery PR).

## Artifact policy

The verdict JSON is small, reviewable, and tracked under `docs/context/evidence/`.
