### PR TITLE
feat: add simulation timeline artifact export

### DIFF
--- a/robot_sf/analysis_workbench/schemas/simulation_timeline.v1.json
+++ b/robot_sf/analysis_workbench/schemas/simulation_timeline.v1.json
@@ -30,8 +30,7 @@
       "required": ["schema_version", "trace_id", "source"],
       "properties": {
         "schema_version": {
-          "type": "string",
-          "minLength": 1
+          "const": "simulation_trace_export.v1"
         },
         "trace_id": {
           "type": "string",

--- a/robot_sf/analysis_workbench/schemas/simulation_timeline.v1.json
+++ b/robot_sf/analysis_workbench/schemas/simulation_timeline.v1.json
@@ -1,0 +1,143 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://robot-sf.local/schemas/simulation_timeline.v1.json",
+  "title": "Robot SF Simulation Timeline v1",
+  "description": "Renderer-neutral timeline artifact for analysis-workbench playback and review. This schema intentionally describes ordered state and event data, not any pygame, browser, or Three.js rendering surface.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "timeline_id",
+    "source_trace",
+    "evidence_boundary",
+    "coordinate_frame",
+    "units",
+    "frames",
+    "events"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "simulation_timeline.v1"
+    },
+    "timeline_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source_trace": {
+      "type": "object",
+      "description": "Provenance copied from the validated simulation_trace_export.v1 source artifact.",
+      "additionalProperties": true,
+      "required": ["schema_version", "trace_id", "source"],
+      "properties": {
+        "schema_version": {
+          "type": "string",
+          "minLength": 1
+        },
+        "trace_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "object",
+          "additionalProperties": true,
+          "required": ["scenario_id", "seed", "planner_id", "episode_id", "generated_by"],
+          "properties": {
+            "scenario_id": {"type": "string", "minLength": 1},
+            "seed": {"type": "integer"},
+            "planner_id": {"type": "string", "minLength": 1},
+            "episode_id": {"type": "string", "minLength": 1},
+            "generated_by": {"type": "string", "minLength": 1}
+          }
+        }
+      }
+    },
+    "evidence_boundary": {
+      "const": "analysis_workbench_only"
+    },
+    "coordinate_frame": {
+      "type": "string",
+      "minLength": 1
+    },
+    "units": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["position", "heading", "time", "velocity"],
+      "properties": {
+        "position": {"type": "string", "minLength": 1},
+        "heading": {"type": "string", "minLength": 1},
+        "time": {"type": "string", "minLength": 1},
+        "velocity": {"type": "string", "minLength": 1}
+      }
+    },
+    "frames": {
+      "type": "array",
+      "description": "Ordered renderer-neutral timeline frames. Ordering is produced by the converter and encoded with frame_index, step, and time_s.",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "additionalProperties": false,
+        "required": ["frame_index", "step", "time_s", "state"],
+        "properties": {
+          "frame_index": {"type": "integer", "minimum": 0},
+          "step": {"type": "integer", "minimum": 0},
+          "time_s": {"type": "number", "minimum": 0},
+          "state": {
+            "type": "object",
+            "description": "Per-frame internal state slots used by downstream renderers and review tools.",
+            "additionalProperties": true,
+            "required": [
+              "planner_decision",
+              "policy",
+              "sensors",
+              "reward",
+              "collision",
+              "route",
+              "robot",
+              "pedestrians"
+            ],
+            "properties": {
+              "planner_decision": {"$ref": "#/$defs/slot"},
+              "policy": {"$ref": "#/$defs/nullable_slot"},
+              "sensors": {"$ref": "#/$defs/slot"},
+              "reward": {"$ref": "#/$defs/nullable_slot"},
+              "collision": {"$ref": "#/$defs/slot"},
+              "route": {"$ref": "#/$defs/nullable_slot"},
+              "robot": {"$ref": "#/$defs/slot"},
+              "pedestrians": {
+                "type": "array",
+                "items": {"$ref": "#/$defs/slot"}
+              }
+            }
+          }
+        }
+      }
+    },
+    "events": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "additionalProperties": true,
+        "required": ["event_id", "event_type", "frame_index", "step"],
+        "properties": {
+          "event_id": {"type": "string", "minLength": 1},
+          "event_type": {"type": "string", "minLength": 1},
+          "frame_index": {"type": "integer", "minimum": 0},
+          "step": {"type": "integer", "minimum": 0},
+          "time_s": {"type": "number", "minimum": 0}
+        }
+      }
+    }
+  },
+  "$defs": {
+    "slot": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "nullable_slot": {
+      "anyOf": [
+        {"type": "object", "additionalProperties": true},
+        {"type": "null"}
+      ]
+    }
+  }
+}

--- a/scripts/analysis/export_trace_timeline_issue_1646.py
+++ b/scripts/analysis/export_trace_timeline_issue_1646.py
@@ -178,8 +178,11 @@ def _mapping_slot(planner: Mapping[str, Any], *keys: str) -> dict[str, Any]:
 def _optional_mapping_slot(planner: Mapping[str, Any], *keys: str) -> dict[str, Any] | None:
     """Return the first mapping-valued slot for ``keys``, or ``None`` when unavailable."""
 
-    value = _mapping_slot(planner, *keys)
-    return value or None
+    for key in keys:
+        value = planner.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+    return None
 
 
 def _collision_slot(planner: Mapping[str, Any]) -> dict[str, Any]:
@@ -211,6 +214,7 @@ def _timeline_event(frame: SimulationTraceFrame, *, frame_index: int) -> dict[st
         "event_type": event_type,
         "frame_index": frame_index,
         "step": frame.step,
+        "time_s": frame.time_s,
     }
 
 

--- a/scripts/analysis/export_trace_timeline_issue_1646.py
+++ b/scripts/analysis/export_trace_timeline_issue_1646.py
@@ -89,8 +89,7 @@ def build_simulation_timeline(input_path: Path) -> dict[str, Any]:
         "coordinate_frame": trace.coordinate_frame,
         "units": trace.units,
         "frames": [
-            _timeline_frame(frame, frame_index=index)
-            for index, frame in enumerate(trace.frames)
+            _timeline_frame(frame, frame_index=index) for index, frame in enumerate(trace.frames)
         ],
         "events": [
             event

--- a/scripts/analysis/export_trace_timeline_issue_1646.py
+++ b/scripts/analysis/export_trace_timeline_issue_1646.py
@@ -1,0 +1,268 @@
+"""Export renderer-neutral ``simulation_timeline.v1`` artifacts from trace exports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from collections.abc import Mapping
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+from robot_sf.analysis_workbench.simulation_trace_export import (
+    SIMULATION_TRACE_EXPORT_SCHEMA_VERSION,
+    SimulationTraceExport,
+    SimulationTraceExportValidationError,
+    SimulationTraceFrame,
+    load_simulation_trace_export,
+)
+
+SIMULATION_TIMELINE_SCHEMA_VERSION = "simulation_timeline.v1"
+SIMULATION_TIMELINE_SCHEMA_FILE = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "analysis_workbench"
+    / "schemas"
+    / "simulation_timeline.v1.json"
+)
+DEFAULT_FIXTURE = (
+    Path(__file__).resolve().parents[2]
+    / "tests"
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_trace_export_v1"
+    / "planner_sanity_open_episode_0000.json"
+)
+
+
+class SimulationTimelineValidationError(ValueError):
+    """Raised when a ``simulation_timeline.v1`` payload fails schema validation."""
+
+    def __init__(self, errors: list[str], *, source: str | Path | None = None):
+        """Build an actionable validation error."""
+
+        self.errors = tuple(errors)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(errors))
+
+
+@lru_cache(maxsize=1)
+def load_simulation_timeline_schema() -> dict[str, Any]:
+    """Load the public ``simulation_timeline.v1`` JSON schema."""
+
+    return json.loads(SIMULATION_TIMELINE_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+def validate_simulation_timeline(
+    payload: Mapping[str, Any],
+    *,
+    source: str | Path | None = None,
+) -> None:
+    """Validate a timeline payload against the public JSON schema."""
+
+    validator = Draft202012Validator(load_simulation_timeline_schema())
+    errors = [
+        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        for error in sorted(
+            validator.iter_errors(payload),
+            key=lambda err: list(err.absolute_path),
+        )
+    ]
+    if errors:
+        raise SimulationTimelineValidationError(errors, source=source)
+
+
+def build_simulation_timeline(input_path: Path) -> dict[str, Any]:
+    """Build a renderer-neutral timeline artifact from a trace export JSON file."""
+
+    trace = load_simulation_trace_export(input_path)
+    payload: dict[str, Any] = {
+        "schema_version": SIMULATION_TIMELINE_SCHEMA_VERSION,
+        "timeline_id": f"{trace.trace_id}-timeline",
+        "source_trace": _source_trace_metadata(trace),
+        "evidence_boundary": trace.evidence_boundary,
+        "coordinate_frame": trace.coordinate_frame,
+        "units": trace.units,
+        "frames": [
+            _timeline_frame(frame, frame_index=index)
+            for index, frame in enumerate(trace.frames)
+        ],
+        "events": [
+            event
+            for index, frame in enumerate(trace.frames)
+            if (event := _timeline_event(frame, frame_index=index)) is not None
+        ],
+    }
+    validate_simulation_timeline(payload, source=input_path)
+    return payload
+
+
+def write_simulation_timeline(input_path: Path, output_path: Path) -> Path:
+    """Write a schema-valid timeline artifact."""
+
+    payload = build_simulation_timeline(input_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return output_path
+
+
+def _source_trace_metadata(trace: SimulationTraceExport) -> dict[str, Any]:
+    """Return source-trace metadata copied from the validated trace export."""
+
+    return {
+        "schema_version": SIMULATION_TRACE_EXPORT_SCHEMA_VERSION,
+        "trace_id": trace.trace_id,
+        "source": {
+            "scenario_id": trace.source.scenario_id,
+            "seed": trace.source.seed,
+            "planner_id": trace.source.planner_id,
+            "episode_id": trace.source.episode_id,
+            "generated_by": trace.source.generated_by,
+        },
+    }
+
+
+def _timeline_frame(frame: SimulationTraceFrame, *, frame_index: int) -> dict[str, Any]:
+    """Convert one trace frame into renderer-neutral timeline state."""
+
+    return {
+        "frame_index": frame_index,
+        "step": frame.step,
+        "time_s": frame.time_s,
+        "state": {
+            "planner_decision": _planner_decision(frame.planner),
+            "policy": _optional_mapping_slot(frame.planner, "policy", "policy_state"),
+            "sensors": _mapping_slot(frame.planner, "sensors", "sensor_state"),
+            "reward": _optional_mapping_slot(frame.planner, "reward", "reward_state"),
+            "collision": _collision_slot(frame.planner),
+            "route": _optional_mapping_slot(frame.planner, "route", "route_state"),
+            "robot": dict(frame.robot),
+            "pedestrians": [dict(pedestrian) for pedestrian in frame.pedestrians],
+        },
+    }
+
+
+def _planner_decision(planner: Mapping[str, Any]) -> dict[str, Any]:
+    """Return planner-decision fields without duplicating known optional state slots."""
+
+    excluded = {
+        "policy",
+        "policy_state",
+        "sensors",
+        "sensor_state",
+        "reward",
+        "reward_state",
+        "collision",
+        "collision_state",
+        "route",
+        "route_state",
+    }
+    return {str(key): value for key, value in planner.items() if str(key) not in excluded}
+
+
+def _mapping_slot(planner: Mapping[str, Any], *keys: str) -> dict[str, Any]:
+    """Return the first mapping-valued slot for ``keys``, or an empty slot."""
+
+    for key in keys:
+        value = planner.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+    return {}
+
+
+def _optional_mapping_slot(planner: Mapping[str, Any], *keys: str) -> dict[str, Any] | None:
+    """Return the first mapping-valued slot for ``keys``, or ``None`` when unavailable."""
+
+    value = _mapping_slot(planner, *keys)
+    return value or None
+
+
+def _collision_slot(planner: Mapping[str, Any]) -> dict[str, Any]:
+    """Return collision state while making unknown evidence explicit."""
+
+    for key in ("collision", "collision_state"):
+        value = planner.get(key)
+        if isinstance(value, Mapping):
+            return dict(value)
+        if isinstance(value, bool):
+            return {"status": "observed" if value else "none", "value": value}
+    return {"status": "unknown"}
+
+
+def _timeline_event(frame: SimulationTraceFrame, *, frame_index: int) -> dict[str, Any] | None:
+    """Return a stable event record when the planner frame declares an event."""
+
+    raw_event = frame.planner.get("event")
+    if not isinstance(raw_event, str) or not raw_event:
+        return None
+    event_type = raw_event.strip()
+    if not event_type:
+        return None
+    event_id = frame.planner.get("event_id")
+    if not isinstance(event_id, str) or not event_id:
+        event_id = f"frame-{frame_index:04d}-{_slug(event_type)}"
+    return {
+        "event_id": event_id,
+        "event_type": event_type,
+        "frame_index": frame_index,
+        "step": frame.step,
+    }
+
+
+def _slug(value: str) -> str:
+    """Return a compact identifier fragment."""
+
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value.strip().lower()).strip("-")
+    return slug or "event"
+
+
+def _json_pointer(path: Any) -> str:
+    """Render a JSON Schema error path as an RFC6901-style pointer."""
+
+    parts = [str(part).replace("~", "~0").replace("/", "~1") for part in path]
+    return "/" + "/".join(parts) if parts else "/"
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build CLI parser for timeline export generation."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=DEFAULT_FIXTURE,
+        help=(
+            "Input simulation_trace_export.v1 JSON. Defaults to the tracked "
+            "planner_sanity_open trace-export fixture."
+        ),
+    )
+    parser.add_argument("--out", type=Path, required=True, help="Output timeline JSON path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the conversion command."""
+
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    try:
+        output = write_simulation_timeline(args.input, args.out)
+    except (
+        OSError,
+        json.JSONDecodeError,
+        SimulationTraceExportValidationError,
+        SimulationTimelineValidationError,
+    ) as exc:
+        print(f"{exc}", file=sys.stderr)
+        return 1
+    print(f"wrote simulation timeline to {output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/analysis/export_trace_timeline_issue_1646.py
+++ b/scripts/analysis/export_trace_timeline_issue_1646.py
@@ -206,7 +206,9 @@ def _timeline_event(frame: SimulationTraceFrame, *, frame_index: int) -> dict[st
     if not event_type:
         return None
     event_id = frame.planner.get("event_id")
-    if not isinstance(event_id, str) or not event_id:
+    if isinstance(event_id, str):
+        event_id = event_id.strip()
+    if not event_id:
         event_id = f"frame-{frame_index:04d}-{_slug(event_type)}"
     return {
         "event_id": event_id,

--- a/tests/analysis_workbench/test_simulation_timeline_export.py
+++ b/tests/analysis_workbench/test_simulation_timeline_export.py
@@ -79,6 +79,22 @@ def test_materialized_timeline_fixture_regenerates_from_trace_export() -> None:
     assert [frame["step"] for frame in materialized["frames"]] == [1, 2, 3]
 
 
+def test_simulation_timeline_preserves_explicit_empty_optional_slots(
+    tmp_path: Path,
+) -> None:
+    """Explicit empty planner mappings should stay explicit instead of becoming null."""
+
+    trace_payload = json.loads(TRACE_FIXTURE_PATH.read_text(encoding="utf-8"))
+    trace_payload["frames"][0]["planner"]["policy"] = {}
+    source = tmp_path / "trace.json"
+    source.write_text(json.dumps(trace_payload), encoding="utf-8")
+
+    timeline = build_simulation_timeline(source)
+
+    assert timeline["frames"][0]["state"]["policy"] == {}
+    assert timeline["frames"][1]["state"]["policy"] is None
+
+
 def test_simulation_timeline_schema_rejects_missing_required_shape() -> None:
     """The schema should fail closed when required top-level fields are absent."""
 
@@ -122,11 +138,22 @@ def test_export_trace_timeline_cli_writes_valid_artifact(tmp_path: Path) -> None
     assert result.returncode == 0, result.stderr
     assert output_path.exists()
     payload = json.loads(output_path.read_text(encoding="utf-8"))
-    Draft202012Validator(json.loads(SIMULATION_TIMELINE_SCHEMA_FILE.read_text())).validate(
-        payload
-    )
+    schema = json.loads(SIMULATION_TIMELINE_SCHEMA_FILE.read_text(encoding="utf-8"))
+    Draft202012Validator(schema).validate(payload)
     assert payload["timeline_id"] == "fixture_trace_001-timeline"
     assert payload["events"] == [
-        {"event_id": "frame-0000-start", "event_type": "start", "frame_index": 0, "step": 0},
-        {"event_id": "frame-0001-advance", "event_type": "advance", "frame_index": 1, "step": 1},
+        {
+            "event_id": "frame-0000-start",
+            "event_type": "start",
+            "frame_index": 0,
+            "step": 0,
+            "time_s": 0.0,
+        },
+        {
+            "event_id": "frame-0001-advance",
+            "event_type": "advance",
+            "frame_index": 1,
+            "step": 1,
+            "time_s": 0.1,
+        },
     ]

--- a/tests/analysis_workbench/test_simulation_timeline_export.py
+++ b/tests/analysis_workbench/test_simulation_timeline_export.py
@@ -95,6 +95,19 @@ def test_simulation_timeline_preserves_explicit_empty_optional_slots(
     assert timeline["frames"][1]["state"]["policy"] is None
 
 
+def test_simulation_timeline_normalizes_blank_event_ids(tmp_path: Path) -> None:
+    """Whitespace-only source event IDs should use deterministic fallback IDs."""
+
+    trace_payload = json.loads(TRACE_FIXTURE_PATH.read_text(encoding="utf-8"))
+    trace_payload["frames"][0]["planner"]["event_id"] = "  "
+    source = tmp_path / "trace.json"
+    source.write_text(json.dumps(trace_payload), encoding="utf-8")
+
+    timeline = build_simulation_timeline(source)
+
+    assert timeline["events"][0]["event_id"] == "frame-0000-start"
+
+
 def test_simulation_timeline_schema_rejects_missing_required_shape() -> None:
     """The schema should fail closed when required top-level fields are absent."""
 
@@ -113,6 +126,22 @@ def test_simulation_timeline_schema_rejects_missing_required_shape() -> None:
     assert any(error.validator == "required" and "timeline_id" in error.message for error in errors)
     assert any(
         error.validator == "required" and "source_trace" in error.message for error in errors
+    )
+
+
+def test_simulation_timeline_schema_rejects_wrong_source_schema_version() -> None:
+    """Timeline provenance should fail closed for non-trace-export sources."""
+
+    schema = load_simulation_timeline_schema()
+    timeline = build_simulation_timeline(TRACE_FIXTURE_PATH)
+    timeline["source_trace"]["schema_version"] = "other_trace.v1"
+
+    errors = list(Draft202012Validator(schema).iter_errors(timeline))
+
+    assert any(
+        list(error.absolute_path) == ["source_trace", "schema_version"]
+        and error.validator == "const"
+        for error in errors
     )
 
 

--- a/tests/analysis_workbench/test_simulation_timeline_export.py
+++ b/tests/analysis_workbench/test_simulation_timeline_export.py
@@ -1,0 +1,132 @@
+"""Contract tests for ``simulation_timeline.v1`` trace slices."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from jsonschema import Draft202012Validator
+
+from scripts.analysis.export_trace_timeline_issue_1646 import (
+    SIMULATION_TIMELINE_SCHEMA_FILE,
+    SIMULATION_TIMELINE_SCHEMA_VERSION,
+    build_simulation_timeline,
+    load_simulation_timeline_schema,
+    validate_simulation_timeline,
+)
+
+TRACE_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_trace_export_v1"
+    / "minimal_trace.json"
+)
+MATERIALIZED_TRACE_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_trace_export_v1"
+    / "planner_sanity_open_episode_0000.json"
+)
+TIMELINE_FIXTURE_PATH = (
+    Path(__file__).resolve().parents[1]
+    / "fixtures"
+    / "analysis_workbench"
+    / "simulation_timeline_v1"
+    / "planner_sanity_open_episode_0000_timeline.json"
+)
+CLI_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "analysis"
+    / "export_trace_timeline_issue_1646.py"
+)
+
+
+def test_simulation_timeline_schema_accepts_converted_trace_fixture() -> None:
+    """A renderer-neutral timeline should validate from an existing trace export fixture."""
+
+    timeline = build_simulation_timeline(TRACE_FIXTURE_PATH)
+
+    validate_simulation_timeline(timeline)
+    assert timeline["schema_version"] == SIMULATION_TIMELINE_SCHEMA_VERSION
+    assert timeline["source_trace"]["schema_version"] == "simulation_trace_export.v1"
+    assert timeline["source_trace"]["trace_id"] == "fixture_trace_001"
+    assert [frame["frame_index"] for frame in timeline["frames"]] == [0, 1]
+    assert timeline["frames"][0]["state"]["planner_decision"] == {
+        "selected_action": {"linear_velocity": 0.1, "angular_velocity": 0.0},
+        "event": "start",
+    }
+    assert timeline["frames"][0]["state"]["collision"] == {"status": "unknown"}
+    assert timeline["frames"][0]["state"]["pedestrians"][0]["id"] == "ped_1"
+    assert timeline["events"][0]["event_type"] == "start"
+
+
+def test_materialized_timeline_fixture_regenerates_from_trace_export() -> None:
+    """The durable timeline artifact should regenerate from its tracked trace source."""
+
+    timeline = build_simulation_timeline(MATERIALIZED_TRACE_FIXTURE_PATH)
+    materialized = json.loads(TIMELINE_FIXTURE_PATH.read_text(encoding="utf-8"))
+
+    validate_simulation_timeline(materialized)
+    assert timeline == materialized
+    assert materialized["source_trace"]["trace_id"] == (
+        "planner_sanity_open-ep0-seed7-source-aae87cf6"
+    )
+    assert [frame["step"] for frame in materialized["frames"]] == [1, 2, 3]
+
+
+def test_simulation_timeline_schema_rejects_missing_required_shape() -> None:
+    """The schema should fail closed when required top-level fields are absent."""
+
+    schema = load_simulation_timeline_schema()
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(
+            {
+                "schema_version": SIMULATION_TIMELINE_SCHEMA_VERSION,
+                "frames": [],
+                "events": [],
+            }
+        ),
+        key=lambda error: list(error.absolute_path),
+    )
+
+    assert any(error.validator == "required" and "timeline_id" in error.message for error in errors)
+    assert any(
+        error.validator == "required" and "source_trace" in error.message for error in errors
+    )
+
+
+def test_export_trace_timeline_cli_writes_valid_artifact(tmp_path: Path) -> None:
+    """The CLI should write a schema-valid timeline artifact from a trace export."""
+
+    output_path = tmp_path / "timeline.json"
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(CLI_PATH),
+            "--input",
+            str(TRACE_FIXTURE_PATH),
+            "--out",
+            str(output_path),
+        ],
+        cwd=Path(__file__).resolve().parents[2],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert output_path.exists()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    Draft202012Validator(json.loads(SIMULATION_TIMELINE_SCHEMA_FILE.read_text())).validate(
+        payload
+    )
+    assert payload["timeline_id"] == "fixture_trace_001-timeline"
+    assert payload["events"] == [
+        {"event_id": "frame-0000-start", "event_type": "start", "frame_index": 0, "step": 0},
+        {"event_id": "frame-0001-advance", "event_type": "advance", "frame_index": 1, "step": 1},
+    ]

--- a/tests/fixtures/analysis_workbench/simulation_timeline_v1/planner_sanity_open_episode_0000_timeline.json
+++ b/tests/fixtures/analysis_workbench/simulation_timeline_v1/planner_sanity_open_episode_0000_timeline.json
@@ -5,19 +5,22 @@
       "event_id": "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0000",
       "event_type": "step",
       "frame_index": 0,
-      "step": 1
+      "step": 1,
+      "time_s": 1.0
     },
     {
       "event_id": "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0001",
       "event_type": "step",
       "frame_index": 1,
-      "step": 2
+      "step": 2,
+      "time_s": 2.0
     },
     {
       "event_id": "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0002",
       "event_type": "step",
       "frame_index": 2,
-      "step": 3
+      "step": 3,
+      "time_s": 3.0
     }
   ],
   "evidence_boundary": "analysis_workbench_only",

--- a/tests/fixtures/analysis_workbench/simulation_timeline_v1/planner_sanity_open_episode_0000_timeline.json
+++ b/tests/fixtures/analysis_workbench/simulation_timeline_v1/planner_sanity_open_episode_0000_timeline.json
@@ -1,0 +1,147 @@
+{
+  "coordinate_frame": "world",
+  "events": [
+    {
+      "event_id": "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0000",
+      "event_type": "step",
+      "frame_index": 0,
+      "step": 1
+    },
+    {
+      "event_id": "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0001",
+      "event_type": "step",
+      "frame_index": 1,
+      "step": 2
+    },
+    {
+      "event_id": "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0002",
+      "event_type": "step",
+      "frame_index": 2,
+      "step": 3
+    }
+  ],
+  "evidence_boundary": "analysis_workbench_only",
+  "frames": [
+    {
+      "frame_index": 0,
+      "state": {
+        "collision": {
+          "status": "unknown"
+        },
+        "pedestrians": [],
+        "planner_decision": {
+          "event": "step",
+          "event_id": "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0000",
+          "selected_action": {
+            "angular_velocity": 0.0,
+            "linear_velocity": 0.0
+          }
+        },
+        "policy": null,
+        "reward": null,
+        "robot": {
+          "heading": 0.04605550691485405,
+          "position": [
+            3.156921863555908,
+            5.2030253410339355
+          ],
+          "velocity": [
+            0.0,
+            0.0
+          ]
+        },
+        "route": null,
+        "sensors": {}
+      },
+      "step": 1,
+      "time_s": 1.0
+    },
+    {
+      "frame_index": 1,
+      "state": {
+        "collision": {
+          "status": "unknown"
+        },
+        "pedestrians": [],
+        "planner_decision": {
+          "event": "step",
+          "event_id": "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0001",
+          "selected_action": {
+            "angular_velocity": 0.06711794808506966,
+            "linear_velocity": 0.183714802839615
+          }
+        },
+        "policy": null,
+        "reward": null,
+        "robot": {
+          "heading": 0.1131734549999237,
+          "position": [
+            3.340054750442505,
+            5.2176361083984375
+          ],
+          "velocity": [
+            0.18313288688659668,
+            0.014610767364501953
+          ]
+        },
+        "route": null,
+        "sensors": {}
+      },
+      "step": 2,
+      "time_s": 2.0
+    },
+    {
+      "frame_index": 2,
+      "state": {
+        "collision": {
+          "status": "unknown"
+        },
+        "pedestrians": [],
+        "planner_decision": {
+          "event": "step",
+          "event_id": "issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000-frame-0002",
+          "selected_action": {
+            "angular_velocity": 0.006137087941169739,
+            "linear_velocity": 0.2000000755288823
+          }
+        },
+        "policy": null,
+        "reward": null,
+        "robot": {
+          "heading": 0.11931054294109344,
+          "position": [
+            3.5387051105499268,
+            5.240832328796387
+          ],
+          "velocity": [
+            0.19865036010742188,
+            0.02319622039794922
+          ]
+        },
+        "route": null,
+        "sensors": {}
+      },
+      "step": 3,
+      "time_s": 3.0
+    }
+  ],
+  "schema_version": "simulation_timeline.v1",
+  "source_trace": {
+    "schema_version": "simulation_trace_export.v1",
+    "source": {
+      "episode_id": "0",
+      "generated_by": "scripts.tools.build_simulation_trace_export from issue_1859_planner_sanity_open_trace_fixture_gen_7_ep0000.jsonl source_sha256:aae87cf69fbf",
+      "planner_id": "trace_fixture_gen",
+      "scenario_id": "planner_sanity_open",
+      "seed": 7
+    },
+    "trace_id": "planner_sanity_open-ep0-seed7-source-aae87cf6"
+  },
+  "timeline_id": "planner_sanity_open-ep0-seed7-source-aae87cf6-timeline",
+  "units": {
+    "heading": "rad",
+    "position": "m",
+    "time": "s",
+    "velocity": "m/s"
+  }
+}


### PR DESCRIPTION
## Summary
- Closes #3223 by adding a renderer-neutral `simulation_timeline.v1` schema for analysis-workbench timeline artifacts.
- Adds `scripts/analysis/export_trace_timeline_issue_1646.py` to convert a validated `simulation_trace_export.v1` trace into a schema-validated timeline JSON artifact.
- Adds a small tracked timeline fixture regenerated from the existing `planner_sanity_open` trace-export fixture, plus focused tests.

## Validation
- `uv run python scripts/analysis/export_trace_timeline_issue_1646.py --help`
- `uv run python -m pytest tests/analysis_workbench/ -k "timeline" -q`
- `uv run ruff check scripts/analysis/export_trace_timeline_issue_1646.py tests/analysis_workbench/test_simulation_timeline_export.py`
- `python -m json.tool robot_sf/analysis_workbench/schemas/simulation_timeline.v1.json`
- `python -m json.tool tests/fixtures/analysis_workbench/simulation_timeline_v1/planner_sanity_open_episode_0000_timeline.json`

## Evidence Boundary
The new timeline artifact is `analysis_workbench_only`. It supports renderer/UI work under #1646/#1645 and does not claim benchmark success or planner performance.

## Downstream Propagation
- Parent issue/epic: #1646 is unblocked for renderer/UI work that consumes `simulation_timeline.v1`.
- Artifact catalog/context index: not updated; the durable artifact is a small tracked test fixture under `tests/fixtures/analysis_workbench/simulation_timeline_v1/`.
- Registry/config index: not applicable.
- Deferred follow-up: browser/Three.js rendering remains out of scope and should continue under #1645 or a child issue.

## Research Result Guidance
- Target blocker: #1646 needed a renderer-neutral timeline artifact before UI work.
- Comparator/baseline: existing `simulation_trace_export.v1` trace-export fixture.
- Evidence tier: local schema/CLI/test proof.
- Result classification: support artifact, not benchmark evidence.
- Stop rule: schema-valid timeline fixture regenerates from tracked trace-export source and CLI/test validation passes.
- Synthesis/update target: #1646/#1645 follow-up work can consume the timeline schema.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added simulation timeline export capability to convert trace data into a standardized timeline artifact format.
  * Introduced new simulation timeline schema with structured frame and event definitions.

* **Tests**
  * Added comprehensive test coverage for timeline export functionality and schema validation.
  * Added timeline fixture for validation testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->