### PR TITLE
refactor: standardize own-message logging to Loguru (#3211, partial)

### DIFF
--- a/robot_sf/benchmark/schemas/forecast_batch_schema.py
+++ b/robot_sf/benchmark/schemas/forecast_batch_schema.py
@@ -7,15 +7,12 @@ interface for schema validation and metadata extraction.
 """
 
 import json
-import logging
 import re
 from pathlib import Path
 from typing import Any
 
 import jsonschema
 from jsonschema import Draft202012Validator
-
-logger = logging.getLogger(__name__)
 
 
 class ForecastBatchSchema:

--- a/robot_sf/benchmark/snqi/weights_validation.py
+++ b/robot_sf/benchmark/snqi/weights_validation.py
@@ -18,17 +18,15 @@ with all values cast to float for downstream use.
 
 from __future__ import annotations
 
-import logging
 from typing import TYPE_CHECKING
 
 import numpy as np
+from loguru import logger
 
 from .compute import WEIGHT_NAMES
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
-
-logger = logging.getLogger(__name__)
 
 # Backward-compatible aliasing for weight names.
 #
@@ -55,9 +53,7 @@ def _apply_weight_aliases(working: dict[str, object]) -> None:
         if not has_canonical:
             working[canonical] = working[alias]
             logger.warning(
-                "Weight '%s' is deprecated; use '%s'. Mapping alias automatically.",
-                alias,
-                canonical,
+                f"Weight '{alias}' is deprecated; use '{canonical}'. Mapping alias automatically."
             )
             continue
         # Both present: check if numerically equal; if not, warn and prefer canonical.
@@ -66,16 +62,13 @@ def _apply_weight_aliases(working: dict[str, object]) -> None:
             canon_val = float(working[canonical])  # type: ignore[arg-type]
         except Exception:
             logger.warning(
-                "Alias '%s' provided alongside '%s'; ignoring alias due to non-numeric values",
-                alias,
-                canonical,
+                f"Alias '{alias}' provided alongside '{canonical}'; "
+                "ignoring alias due to non-numeric values"
             )
             continue
         if alias_val != canon_val:
             logger.warning(
-                "Alias '%s' provided alongside '%s'; ignoring alias (values differ)",
-                alias,
-                canonical,
+                f"Alias '{alias}' provided alongside '{canonical}'; ignoring alias (values differ)"
             )
 
 
@@ -99,7 +92,7 @@ def validate_weights_mapping(raw: Mapping[str, object]) -> dict[str, float]:
         raise ValueError(f"Missing weight keys: {missing}")
     extraneous = [k for k in working if k not in WEIGHT_NAMES and k not in _WEIGHT_ALIASES]
     if extraneous:
-        logger.warning("Extraneous weight keys will be ignored: %s", extraneous)
+        logger.warning(f"Extraneous weight keys will be ignored: {extraneous}")
     validated: dict[str, float] = {}
     for k in WEIGHT_NAMES:
         v = working[k]
@@ -111,7 +104,7 @@ def validate_weights_mapping(raw: Mapping[str, object]) -> dict[str, float]:
         if not np.isfinite(fv) or fv < 0:
             raise ValueError(f"Invalid weight value for {k}: {fv}")
         if fv > 10:
-            logger.warning("Weight %s unusually large (%.3f) > 10", k, fv)
+            logger.warning(f"Weight {k} unusually large ({fv:.3f}) > 10")
         validated[k] = fv
     return validated
 

--- a/robot_sf/nav/adversarial_route_generation.py
+++ b/robot_sf/nav/adversarial_route_generation.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import logging
 import math
 import random
 from dataclasses import dataclass
@@ -571,8 +570,9 @@ def optimize_route_set(
     Returns:
         OptimizationResult: Best candidate and optimizer diagnostics.
     """
+    # Optuna uses the stdlib logging module internally; its own verbosity API is the
+    # canonical way to silence it (no Loguru equivalent for third-party stdlib loggers).
     optuna.logging.set_verbosity(optuna.logging.WARNING)
-    logging.getLogger("optuna").setLevel(logging.WARNING)
     sampler = optuna.samplers.TPESampler(seed=config.seed)
     study = optuna.create_study(direction="maximize", sampler=sampler)
     candidate_by_trial: dict[int, CandidateRouteSet] = {}

--- a/robot_sf/nav/occupancy.py
+++ b/robot_sf/nav/occupancy.py
@@ -11,21 +11,19 @@ segments/pedestrians. It works for small numbers of obstacles/agents, but is not
 large maps or dense crowds.
 """
 
-import logging
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
 import numba
 import numpy as np
+from loguru import logger
 
 from robot_sf.common.geometry import euclid_dist
 from robot_sf.common.types import Circle2D, Line2D, RobotPose, Vec2D
 
 if TYPE_CHECKING:
     from robot_sf.nav.map_config import MapDefinition
-
-logger = logging.getLogger(__name__)
 
 # Squared-length cutoff below which a segment is treated as degenerate (a point).
 # Reaching the quadratic step with a == 0 would make the discriminant check trivially
@@ -213,7 +211,7 @@ def circle_collides_any_lines(circle: Circle2D, segments: Iterable[Line2D] | np.
             try:
                 s_x, s_y, e_x, e_y = seg  # type: ignore[misc]
             except (TypeError, ValueError):
-                logger.debug("Skipping unparseable segment at index %s: %r", idx, seg)
+                logger.debug(f"Skipping unparseable segment at index {idx}: {seg!r}")
                 continue
         if is_circle_line_intersection(circle, ((s_x, s_y), (e_x, e_y))):
             return True


### PR DESCRIPTION
## Summary

Migrates the **adequately-covered** modules that used the stdlib `logging` facade for their own
messages to Loguru, the canonical logging facade per `docs/dev_guide.md` (issue #3211). 4 of the 8
listed files are migrated here; 3 are deferred (coverage gate) and `benchmark/cli.py` is a documented
legitimate exception.

## Linked Issues
- Refs `#3211` (partial — see Scope below)

## What Changed
- **Own-message migrations → Loguru** (`from loguru import logger`, `%`-style args → f-strings):
  - `benchmark/snqi/weights_validation.py` (5 call sites)
  - `nav/occupancy.py` (1 call site)
- **Dead-logger removal** (defined `logger = logging.getLogger(__name__)` but never used; no external
  importers): `benchmark/schemas/forecast_batch_schema.py`.
- **`nav/adversarial_route_generation.py`**: removed `import logging` and the redundant
  `logging.getLogger("optuna").setLevel(logging.WARNING)`, keeping the equivalent optuna-native
  `optuna.logging.set_verbosity(optuna.logging.WARNING)` (the file already used Loguru for its own
  logging).

## Scope: why 4 of 8, not all
- **Deferred (3 files): `schema_loader.py`, `schema_reference.py`, `schemas/episode_schema.py`.**
  These have pre-existing whole-file coverage below the 80% changed-file gate (76.2% / 69.2% / 61.3%).
  Touching them for a trivial logging change trips the gate, which would require adding ~27 lines of
  unrelated schema-validation test coverage. Deferred to a focused follow-up that does the coverage
  uplift + migration together. (`schema_loader`/`episode_schema` only hold *dead* loggers; only
  `schema_reference` emits real log messages.)
- **Deliberate exception: `benchmark/cli.py`.** It matched the issue grep but emits **no own messages**
  via stdlib (0 `logger.x()` calls). All 45 `logging.*` references configure **third-party / root**
  stdlib loggers — `matplotlib`, `PIL`, `pygame`, `moviepy`, `tensorflow`, `numba`, `OpenGL` noise
  suppression, and the tested `_configure_logging` root setup. Loguru cannot set the level of a
  third-party library's stdlib logger, so this usage is correct and must remain. It does not violate
  the "own logging via Loguru" rule.

## Why It Matters
- The migrated modules' records now flow through the central Loguru sink configuration instead of
  bypassing it; removes one dead stdlib-logger definition.

## Research Result Guidance
- `NA - support helper`. Maintenance refactor (PATCH per dev_guide); no research/benchmark/metric/paper
  claim; no user-visible CLI/output or asserted-substring change.

## Falsification / Non-Transfer Check
- `NA` — maintenance refactor.

## Next Empirical Action
- A follow-up issue will migrate `schema_loader.py` / `schema_reference.py` /
  `schemas/episode_schema.py` together with the coverage uplift they need, and record the maintainer
  decision on `cli.py`'s third-party-logger exception.

## Validation / Proof
- Commands run (worktree):
  - `ruff check --fix` + `ruff format` on changed files → clean.
  - `pytest tests/benchmark tests/nav` (earlier, full migration) → all passed; these 4 files are a
    subset.
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` → see CI / gate result (all 4 changed files
    pass the changed-file coverage gate: forecast_batch_schema 91.9%, weights_validation 80.9%,
    adversarial 89.4%, occupancy 100%).
- Residual-stdlib grep over the 4 migrated files is empty (the only `*.logging.*` match is the optuna
  **API** `optuna.logging.set_verbosity`); no `%`-style interpolation remains.

## Risks / Rollout
- Compatibility risks: low. No user-visible CLI stdout or asserted log substrings changed; message
  text preserved except `%`→f-string interpolation. `cli.py` (the only logging-config-heavy, test-
  covered module) is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
