### PR TITLE
feat: speed-based pedestrian behavior archetypes (#3230)

### DIFF
--- a/configs/research/pedestrian_archetypes_v1.yaml
+++ b/configs/research/pedestrian_archetypes_v1.yaml
@@ -1,0 +1,39 @@
+# Heterogeneous pedestrian behavior archetypes (speed-based MVP, issue #3230).
+#
+# Each archetype defines a `desired_speed_factor` that multiplies the spawn
+# config's base `initial_speed` to set a per-pedestrian desired/maximum speed.
+# The Social Force backend already derives per-agent max speed from initial
+# velocity magnitude, so this needs no physics change.
+#
+# IMPORTANT: these factors are clearly-labeled MODELING CHOICES (qualitatively
+# motivated: cautious walkers move slower, hurried walkers faster), NOT values
+# calibrated to any pedestrian dataset. Outputs are mechanism evidence, not
+# benchmark or real-world realism evidence. Dataset calibration is a separate
+# lane (see #3206 and the external-prior work).
+schema_version: pedestrian-archetypes.v1
+issue: 3230
+
+archetypes:
+  cautious:
+    desired_speed_factor: 0.7
+    note: Slower, more hesitant walkers (e.g. elderly, distracted, careful).
+  standard:
+    desired_speed_factor: 1.0
+    note: Baseline walker; matches the homogeneous default exactly.
+  hurried:
+    desired_speed_factor: 1.4
+    note: Faster, goal-driven walkers (e.g. commuters in a hurry).
+
+# Example population compositions (fractions per archetype, must sum to 1.0).
+# These are illustrative; callers pass a composition dict to PedSpawnConfig.
+example_compositions:
+  homogeneous_standard:
+    standard: 1.0
+  mixed_balanced:
+    cautious: 0.34
+    standard: 0.33
+    hurried: 0.33
+  rush_hour:
+    cautious: 0.2
+    standard: 0.3
+    hurried: 0.5

--- a/robot_sf/ped_npc/ped_archetypes.py
+++ b/robot_sf/ped_npc/ped_archetypes.py
@@ -1,0 +1,127 @@
+"""Heterogeneous pedestrian behavior archetypes (speed-based MVP).
+
+Issue #3230 (child of #3206). The Social Force backend already derives each
+pedestrian's desired/maximum speed from its *initial* velocity magnitude per
+agent (``fast-pysf`` ``DesiredForce`` uses ``self.peds.max_speeds``), so speed
+heterogeneity needs no physics change: assigning a per-pedestrian initial-speed
+multiplier is sufficient.
+
+This module is pure (no simulation state): it loads an archetype registry and
+deterministically assigns a per-pedestrian ``desired_speed_factor`` given a
+population composition. The factor multiplies the spawn config's base
+``initial_speed`` in :func:`robot_sf.ped_npc.ped_population.populate_ped_routes`.
+
+The archetypes are clearly-labeled *modeling choices*, not dataset-calibrated
+values; this is mechanism evidence, not benchmark or realism evidence.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import yaml
+
+# Composition fractions must sum to one within this absolute tolerance.
+_COMPOSITION_SUM_TOL = 1e-6
+
+
+def load_archetypes(path: str | Path) -> dict[str, float]:
+    """Load an archetype registry (``name -> desired_speed_factor``) from YAML.
+
+    The YAML shape is::
+
+        archetypes:
+          cautious:
+            desired_speed_factor: 0.7
+          ...
+
+    Returns:
+        Mapping of archetype name to its ``desired_speed_factor`` multiplier.
+    """
+    payload = yaml.safe_load(Path(path).read_text(encoding="utf-8"))
+    if not isinstance(payload, dict) or "archetypes" not in payload:
+        raise ValueError(f"archetype registry must be a mapping with 'archetypes': {path}")
+    archetypes = payload["archetypes"]
+    if not isinstance(archetypes, dict) or not archetypes:
+        raise ValueError(f"'archetypes' must be a non-empty mapping: {path}")
+    factors: dict[str, float] = {}
+    for name, spec in archetypes.items():
+        if not isinstance(spec, dict) or "desired_speed_factor" not in spec:
+            raise ValueError(f"archetype '{name}' must define 'desired_speed_factor'")
+        factor = float(spec["desired_speed_factor"])
+        if factor <= 0:
+            raise ValueError(f"archetype '{name}' desired_speed_factor must be > 0 (got {factor})")
+        factors[str(name)] = factor
+    return factors
+
+
+def validate_composition(
+    composition: dict[str, float],
+    speed_factors: dict[str, float],
+) -> None:
+    """Validate a population composition against an archetype registry.
+
+    Raises ``ValueError`` when fractions are non-positive, do not sum to one, or
+    reference an archetype absent from ``speed_factors``.
+    """
+    if not composition:
+        raise ValueError("archetype_composition must be a non-empty mapping")
+    missing = [name for name in composition if name not in speed_factors]
+    if missing:
+        raise ValueError(f"composition references unknown archetypes: {sorted(missing)}")
+    for name, frac in composition.items():
+        if frac <= 0:
+            raise ValueError(f"composition fraction for '{name}' must be > 0 (got {frac})")
+    total = float(sum(composition.values()))
+    if abs(total - 1.0) > _COMPOSITION_SUM_TOL:
+        raise ValueError(f"composition fractions must sum to 1.0 (got {total})")
+
+
+def allocate_archetype_counts(n: int, composition: dict[str, float]) -> dict[str, int]:
+    """Allocate ``n`` pedestrians across archetypes using largest-remainder rounding.
+
+    Deterministic and exact: the returned counts always sum to ``n``. Ties in the
+    fractional remainder are broken by archetype name for stable output.
+
+    Returns:
+        Mapping of archetype name to integer pedestrian count (summing to ``n``).
+    """
+    if n <= 0:
+        return dict.fromkeys(composition, 0)
+    raw = {name: frac * n for name, frac in composition.items()}
+    counts = {name: int(np.floor(value)) for name, value in raw.items()}
+    remainder = n - sum(counts.values())
+    # Distribute the remaining seats to the largest fractional parts (name-stable ties).
+    order = sorted(composition, key=lambda name: (-(raw[name] - counts[name]), name))
+    for i in range(remainder):
+        counts[order[i % len(order)]] += 1
+    return counts
+
+
+def assign_archetype_speed_factors(
+    n: int,
+    composition: dict[str, float],
+    speed_factors: dict[str, float],
+    *,
+    seed: int | None = None,
+) -> np.ndarray:
+    """Return a length-``n`` array of per-pedestrian desired-speed factors.
+
+    Counts per archetype follow :func:`allocate_archetype_counts`; the resulting
+    factors are shuffled with a seeded RNG so archetypes are not correlated with
+    spawn order (and thus not spatially clustered). Deterministic for a fixed
+    ``seed``.
+
+    Returns:
+        Float array of shape ``(n,)`` with each pedestrian's desired-speed factor.
+    """
+    if n <= 0:
+        return np.empty(0, dtype=float)
+    counts = allocate_archetype_counts(n, composition)
+    factors = np.concatenate(
+        [np.full(count, speed_factors[name], dtype=float) for name, count in counts.items()]
+    )
+    rng = np.random.default_rng(seed)
+    rng.shuffle(factors)
+    return factors

--- a/robot_sf/ped_npc/ped_archetypes.py
+++ b/robot_sf/ped_npc/ped_archetypes.py
@@ -17,6 +17,7 @@ values; this is mechanism evidence, not benchmark or realism evidence.
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 
 import numpy as np
@@ -50,8 +51,10 @@ def load_archetypes(path: str | Path) -> dict[str, float]:
         if not isinstance(spec, dict) or "desired_speed_factor" not in spec:
             raise ValueError(f"archetype '{name}' must define 'desired_speed_factor'")
         factor = float(spec["desired_speed_factor"])
-        if factor <= 0:
-            raise ValueError(f"archetype '{name}' desired_speed_factor must be > 0 (got {factor})")
+        if not math.isfinite(factor) or factor <= 0:
+            raise ValueError(
+                f"archetype '{name}' desired_speed_factor must be finite and > 0 (got {factor})"
+            )
         factors[str(name)] = factor
     return factors
 
@@ -70,10 +73,13 @@ def validate_composition(
     missing = [name for name in composition if name not in speed_factors]
     if missing:
         raise ValueError(f"composition references unknown archetypes: {sorted(missing)}")
-    for name, frac in composition.items():
-        if frac <= 0:
-            raise ValueError(f"composition fraction for '{name}' must be > 0 (got {frac})")
-    total = float(sum(composition.values()))
+    fractions = {name: float(frac) for name, frac in composition.items()}
+    for name, frac in fractions.items():
+        if not math.isfinite(frac) or frac <= 0:
+            raise ValueError(
+                f"composition fraction for '{name}' must be finite and > 0 (got {frac})"
+            )
+    total = float(sum(fractions.values()))
     if abs(total - 1.0) > _COMPOSITION_SUM_TOL:
         raise ValueError(f"composition fractions must sum to 1.0 (got {total})")
 
@@ -89,6 +95,8 @@ def allocate_archetype_counts(n: int, composition: dict[str, float]) -> dict[str
     """
     if n <= 0:
         return dict.fromkeys(composition, 0)
+    if not composition:
+        raise ValueError("archetype_composition must be non-empty when allocating pedestrians")
     raw = {name: frac * n for name, frac in composition.items()}
     counts = {name: int(np.floor(value)) for name, value in raw.items()}
     remainder = n - sum(counts.values())

--- a/robot_sf/ped_npc/ped_population.py
+++ b/robot_sf/ped_npc/ped_population.py
@@ -39,6 +39,7 @@ from shapely.prepared import PreparedGeometry
 
 from robot_sf.common.types import PedGrouping, PedState, Vec2D, Zone, ZoneAssignments
 from robot_sf.nav.map_config import GlobalRoute
+from robot_sf.ped_npc.ped_archetypes import assign_archetype_speed_factors, validate_composition
 from robot_sf.ped_npc.ped_behavior import (
     CrowdedZoneBehavior,
     FollowRouteBehavior,
@@ -139,6 +140,13 @@ class PedSpawnConfig:
     route_spawn_jitter_frac: float = 0.0
     route_spawn_seed: int | None = None
     reset_follow_route_at_start: bool = False
+    # Optional heterogeneous behavior archetypes (issue #3230). When
+    # ``archetype_composition`` is None (the default), spawning is homogeneous and
+    # byte-identical to the prior behavior. When set, each pedestrian's initial
+    # speed is multiplied by its sampled archetype ``desired_speed_factor``.
+    archetype_composition: dict[str, float] | None = None
+    archetype_speed_factors: dict[str, float] | None = None
+    archetype_seed: int | None = None
 
     def __post_init__(self):
         """
@@ -157,6 +165,12 @@ class PedSpawnConfig:
             )
         if self.route_spawn_jitter_frac < 0:
             raise ValueError("route_spawn_jitter_frac must be >= 0")
+        if self.archetype_composition is not None:
+            if self.archetype_speed_factors is None:
+                raise ValueError(
+                    "archetype_speed_factors must be provided when archetype_composition is set"
+                )
+            validate_composition(self.archetype_composition, self.archetype_speed_factors)
 
 
 def sample_route(
@@ -521,6 +535,20 @@ def populate_ped_routes(  # noqa: PLR0915
             ped_states[ped_ids, 4:6] = group_goal
 
             num_unassigned_peds -= num_peds_in_group
+
+    # Optional behavior heterogeneity (issue #3230): scale each pedestrian's
+    # initial velocity magnitude by its sampled archetype desired-speed factor.
+    # The spawn direction is preserved (only the magnitude changes). This is a
+    # no-op when no composition is configured, so the homogeneous default output
+    # is byte-identical to the prior behavior.
+    if config.archetype_composition and total_num_peds > 0:
+        speed_factors = assign_archetype_speed_factors(
+            total_num_peds,
+            config.archetype_composition,
+            config.archetype_speed_factors,
+            seed=config.archetype_seed,
+        )
+        ped_states[:, 2:4] *= speed_factors[:, np.newaxis]
 
     return ped_states, groups, route_assignments, initial_sections
 

--- a/tests/ped_npc/test_ped_archetypes.py
+++ b/tests/ped_npc/test_ped_archetypes.py
@@ -49,11 +49,14 @@ def test_load_archetypes_rejects_missing_factor(tmp_path: Path) -> None:
         load_archetypes(bad)
 
 
-def test_load_archetypes_rejects_nonpositive_factor(tmp_path: Path) -> None:
-    """A non-positive speed factor is rejected."""
+@pytest.mark.parametrize("factor", ["0", ".nan", ".inf", "-.inf"])
+def test_load_archetypes_rejects_nonpositive_or_nonfinite_factor(
+    tmp_path: Path, factor: str
+) -> None:
+    """A non-positive or non-finite speed factor is rejected."""
     bad = tmp_path / "bad.yaml"
-    bad.write_text("archetypes:\n  x:\n    desired_speed_factor: 0\n", encoding="utf-8")
-    with pytest.raises(ValueError, match="must be > 0"):
+    bad.write_text(f"archetypes:\n  x:\n    desired_speed_factor: {factor}\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="finite and > 0"):
         load_archetypes(bad)
 
 
@@ -69,7 +72,9 @@ def test_validate_composition_accepts_valid() -> None:
     ("composition", "match"),
     [
         ({"a": 0.5, "b": 0.4}, "sum to 1.0"),
-        ({"a": 0.0, "b": 1.0}, "must be > 0"),
+        ({"a": 0.0, "b": 1.0}, "finite and > 0"),
+        ({"a": float("nan"), "b": 1.0}, "finite and > 0"),
+        ({"a": float("inf"), "b": 1.0}, "finite and > 0"),
         ({"missing": 1.0}, "unknown archetypes"),
         ({}, "non-empty"),
     ],
@@ -96,6 +101,12 @@ def test_allocate_counts_is_deterministic() -> None:
     """Allocation is deterministic for the same inputs."""
     comp = {"a": 0.5, "b": 0.3, "c": 0.2}
     assert allocate_archetype_counts(13, comp) == allocate_archetype_counts(13, comp)
+
+
+def test_allocate_counts_rejects_empty_positive_population() -> None:
+    """Positive allocations require a non-empty composition."""
+    with pytest.raises(ValueError, match="non-empty"):
+        allocate_archetype_counts(1, {})
 
 
 def test_assign_speed_factors_distribution_and_determinism() -> None:

--- a/tests/ped_npc/test_ped_archetypes.py
+++ b/tests/ped_npc/test_ped_archetypes.py
@@ -1,0 +1,233 @@
+"""Tests for speed-based pedestrian behavior archetypes (issue #3230).
+
+Covers the pure archetype helpers, the shipped registry config, the
+``PedSpawnConfig`` validation, and end-to-end spawning through
+``populate_ped_routes`` — including the invariant that the homogeneous default
+(no composition) is unchanged.
+"""
+
+from __future__ import annotations
+
+from collections import Counter
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from robot_sf.nav.navigation import get_prepared_obstacles
+from robot_sf.nav.svg_map_parser import SvgMapConverter
+from robot_sf.ped_npc.ped_archetypes import (
+    allocate_archetype_counts,
+    assign_archetype_speed_factors,
+    load_archetypes,
+    validate_composition,
+)
+from robot_sf.ped_npc.ped_population import PedSpawnConfig, populate_ped_routes
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_ARCHETYPE_CONFIG = _REPO_ROOT / "configs" / "research" / "pedestrian_archetypes_v1.yaml"
+_CLASSIC_CROSSING_SVG = _REPO_ROOT / "maps" / "svg_maps" / "classic_crossing.svg"
+
+
+# --- registry loading -----------------------------------------------------
+
+
+def test_load_archetypes_real_config() -> None:
+    """The shipped registry exposes >=3 archetypes with the documented factors."""
+    factors = load_archetypes(_ARCHETYPE_CONFIG)
+    assert {"cautious", "standard", "hurried"} <= set(factors)
+    assert len(factors) >= 3
+    assert factors["standard"] == 1.0
+    assert factors["cautious"] < 1.0 < factors["hurried"]
+
+
+def test_load_archetypes_rejects_missing_factor(tmp_path: Path) -> None:
+    """An archetype without desired_speed_factor is rejected."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("archetypes:\n  x:\n    note: no factor\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="desired_speed_factor"):
+        load_archetypes(bad)
+
+
+def test_load_archetypes_rejects_nonpositive_factor(tmp_path: Path) -> None:
+    """A non-positive speed factor is rejected."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text("archetypes:\n  x:\n    desired_speed_factor: 0\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="must be > 0"):
+        load_archetypes(bad)
+
+
+# --- composition validation ----------------------------------------------
+
+
+def test_validate_composition_accepts_valid() -> None:
+    """A composition summing to one over known archetypes validates."""
+    validate_composition({"a": 0.5, "b": 0.5}, {"a": 1.0, "b": 1.2})
+
+
+@pytest.mark.parametrize(
+    ("composition", "match"),
+    [
+        ({"a": 0.5, "b": 0.4}, "sum to 1.0"),
+        ({"a": 0.0, "b": 1.0}, "must be > 0"),
+        ({"missing": 1.0}, "unknown archetypes"),
+        ({}, "non-empty"),
+    ],
+)
+def test_validate_composition_rejects(composition: dict[str, float], match: str) -> None:
+    """Invalid compositions raise with an explanatory message."""
+    with pytest.raises(ValueError, match=match):
+        validate_composition(composition, {"a": 1.0, "b": 1.0})
+
+
+# --- count allocation and factor assignment -------------------------------
+
+
+def test_allocate_counts_sum_to_n_exactly() -> None:
+    """Largest-remainder allocation always sums to n."""
+    comp = {"cautious": 0.34, "standard": 0.33, "hurried": 0.33}
+    for n in (0, 1, 2, 7, 10, 101):
+        counts = allocate_archetype_counts(n, comp)
+        assert sum(counts.values()) == n
+        assert all(c >= 0 for c in counts.values())
+
+
+def test_allocate_counts_is_deterministic() -> None:
+    """Allocation is deterministic for the same inputs."""
+    comp = {"a": 0.5, "b": 0.3, "c": 0.2}
+    assert allocate_archetype_counts(13, comp) == allocate_archetype_counts(13, comp)
+
+
+def test_assign_speed_factors_distribution_and_determinism() -> None:
+    """Assigned factors match the allocated counts and are seed-deterministic."""
+    comp = {"cautious": 0.5, "hurried": 0.5}
+    factors_map = {"cautious": 0.7, "hurried": 1.4}
+    n = 20
+    out = assign_archetype_speed_factors(n, comp, factors_map, seed=7)
+    assert out.shape == (n,)
+    counts = allocate_archetype_counts(n, comp)
+    value_counts = Counter(np.round(out, 6).tolist())
+    assert value_counts[0.7] == counts["cautious"]
+    assert value_counts[1.4] == counts["hurried"]
+    # Deterministic for a fixed seed, and order varies with seed.
+    assert np.array_equal(out, assign_archetype_speed_factors(n, comp, factors_map, seed=7))
+
+
+def test_assign_speed_factors_empty_population() -> None:
+    """Zero pedestrians yields an empty factor array."""
+    out = assign_archetype_speed_factors(0, {"a": 1.0}, {"a": 1.0}, seed=1)
+    assert out.shape == (0,)
+
+
+# --- PedSpawnConfig validation -------------------------------------------
+
+
+def test_spawn_config_requires_factors_with_composition() -> None:
+    """Setting a composition without speed factors is rejected at construction."""
+    with pytest.raises(ValueError, match="archetype_speed_factors must be provided"):
+        PedSpawnConfig(
+            peds_per_area_m2=0.05,
+            max_group_members=3,
+            archetype_composition={"standard": 1.0},
+        )
+
+
+def test_spawn_config_rejects_invalid_composition() -> None:
+    """An invalid composition is rejected at construction."""
+    with pytest.raises(ValueError, match="sum to 1.0"):
+        PedSpawnConfig(
+            peds_per_area_m2=0.05,
+            max_group_members=3,
+            archetype_composition={"standard": 0.5},
+            archetype_speed_factors={"standard": 1.0},
+        )
+
+
+def test_spawn_config_accepts_valid_archetypes() -> None:
+    """A valid composition + factors constructs without error."""
+    cfg = PedSpawnConfig(
+        peds_per_area_m2=0.05,
+        max_group_members=3,
+        archetype_composition={"cautious": 0.5, "hurried": 0.5},
+        archetype_speed_factors={"cautious": 0.7, "hurried": 1.4},
+    )
+    assert cfg.archetype_composition is not None
+
+
+# --- end-to-end spawning --------------------------------------------------
+
+
+def _crossing_routes():
+    """Load classic_crossing pedestrian routes + obstacles, or skip if unavailable."""
+    if not _CLASSIC_CROSSING_SVG.exists():
+        pytest.skip("classic_crossing.svg not available")
+    md = SvgMapConverter(str(_CLASSIC_CROSSING_SVG)).get_map_definition()
+    if not md.ped_routes:
+        pytest.skip("classic_crossing has no pedestrian routes")
+    return md
+
+
+def test_populate_homogeneous_default_unchanged() -> None:
+    """Without a composition, every pedestrian keeps the base initial speed."""
+    md = _crossing_routes()
+    cfg = PedSpawnConfig(
+        peds_per_area_m2=0.08,
+        max_group_members=3,
+        initial_speed=0.5,
+        route_spawn_distribution="spread",
+        route_spawn_seed=123,
+    )
+    ped_states, *_ = populate_ped_routes(cfg, md.ped_routes, get_prepared_obstacles(md))
+    assert ped_states.shape[0] > 0
+    speeds = np.linalg.norm(ped_states[:, 2:4], axis=1)
+    assert np.allclose(speeds, 0.5)
+
+
+def test_populate_with_archetypes_scales_per_pedestrian_speed() -> None:
+    """A composition scales each pedestrian's speed by its archetype factor."""
+    md = _crossing_routes()
+    base_speed = 0.5
+    composition = {"cautious": 0.34, "standard": 0.33, "hurried": 0.33}
+    speed_factors = {"cautious": 0.7, "standard": 1.0, "hurried": 1.4}
+    cfg = PedSpawnConfig(
+        peds_per_area_m2=0.12,
+        max_group_members=3,
+        initial_speed=base_speed,
+        route_spawn_distribution="spread",
+        route_spawn_seed=123,
+        archetype_composition=composition,
+        archetype_speed_factors=speed_factors,
+        archetype_seed=42,
+    )
+    ped_states, *_ = populate_ped_routes(cfg, md.ped_routes, get_prepared_obstacles(md))
+    n = ped_states.shape[0]
+    assert n > 0
+    speeds = np.linalg.norm(ped_states[:, 2:4], axis=1)
+
+    # Every speed corresponds to one archetype factor times the base speed.
+    expected_speeds = {round(base_speed * f, 6) for f in speed_factors.values()}
+    assert set(np.round(speeds, 6).tolist()) <= expected_speeds
+
+    # The per-archetype counts match the deterministic allocation.
+    counts = allocate_archetype_counts(n, composition)
+    value_counts = Counter(np.round(speeds, 6).tolist())
+    assert value_counts[round(base_speed * 0.7, 6)] == counts["cautious"]
+    assert value_counts[round(base_speed * 1.4, 6)] == counts["hurried"]
+
+
+def test_populate_with_archetypes_is_seed_deterministic() -> None:
+    """A fixed archetype seed yields identical per-pedestrian speeds."""
+    md = _crossing_routes()
+    kwargs = {
+        "peds_per_area_m2": 0.12,
+        "max_group_members": 3,
+        "initial_speed": 0.5,
+        "route_spawn_distribution": "spread",
+        "route_spawn_seed": 123,
+        "archetype_composition": {"cautious": 0.5, "hurried": 0.5},
+        "archetype_speed_factors": {"cautious": 0.7, "hurried": 1.4},
+        "archetype_seed": 99,
+    }
+    a, *_ = populate_ped_routes(PedSpawnConfig(**kwargs), md.ped_routes, get_prepared_obstacles(md))
+    b, *_ = populate_ped_routes(PedSpawnConfig(**kwargs), md.ped_routes, get_prepared_obstacles(md))
+    assert np.array_equal(a[:, 2:4], b[:, 2:4])


### PR DESCRIPTION
## Summary

Adds **speed-based heterogeneous pedestrian archetypes** as an optional scenario axis (issue #3230,
child of #3206). Pedestrians can be composed from named behavior archetypes that differ in desired
walking speed, so benchmark results can later be reported as a function of population composition.

## Linked Issues
- Closes `#3230`
- Refs `#3206` (parent); the benchmark smoke comparison and per-agent tau/sigma archetypes remain
  parent follow-ups.

## Key enabler (verified in code)
No Social Force physics change is needed for *speed* heterogeneity: `fast-pysf`'s `DesiredForce`
already uses `self.peds.max_speeds` **per-agent** (derived from each pedestrian's initial velocity
magnitude). Assigning a per-pedestrian initial-speed multiplier is therefore sufficient end-to-end.

## What Changed
- **`robot_sf/ped_npc/ped_archetypes.py`** (new, pure/no sim state): load an archetype registry, and
  deterministically assign per-pedestrian `desired_speed_factor`s via largest-remainder allocation +
  seeded shuffle. Includes composition validation.
- **`configs/research/pedestrian_archetypes_v1.yaml`** (new): ≥3 archetypes — `cautious` (0.7),
  `standard` (1.0), `hurried` (1.4) — clearly labeled **modeling choices**, not dataset-calibrated.
- **`PedSpawnConfig`**: optional `archetype_composition` / `archetype_speed_factors` /
  `archetype_seed` fields, validated in `__post_init__`. Default (`None`) ⇒ homogeneous, unchanged.
- **`populate_ped_routes`**: a single **guarded post-step** scales each pedestrian's initial velocity
  magnitude by its sampled archetype factor when a composition is set; a **no-op** otherwise, so the
  homogeneous default spawn output is byte-identical to before. The two spawn loops are untouched.
- **`tests/ped_npc/test_ped_archetypes.py`** (new): pure helpers (allocation/assignment/validation),
  the shipped registry, `PedSpawnConfig` validation, and SVG-map integration — including the
  **homogeneous-default-unchanged invariant** (every speed == base `initial_speed`) and seed
  determinism.

## Why It Matters
- Gives the simulation a first-class, composable behavioral-diversity axis (the homogeneous SFM
  collapses cautious/hurried walkers), which the distributional/fairness-disruption metrics can later
  measure against. Minimal blast radius: the default path is provably unchanged.

## Research Result Guidance
- Evidence tier: `mechanism` (not benchmark evidence). Result classification: `diagnostic-only` /
  mechanism foundation. No real-world realism or planner-ranking claim. Parent #3206 owns the
  benchmark smoke comparison that would turn this into benchmark evidence.

## Falsification / Non-Transfer Check
- `NA` — this PR adds a mechanism + tests, not a measured outcome.

## Next Empirical Action
- Parent #3206 follow-up: a fixed-seed smoke comparing homogeneous vs a heterogeneous mix, reporting
  the distributional-disruption metric deltas; and per-agent `tau`/`sigma` archetype parameters.

## Validation / Proof
- Commands run (worktree):
  - `pytest tests/ped_npc/test_ped_archetypes.py` → 18 passed.
  - `pytest tests/test_svg_classic_maps_format.py fast-pysf/tests` → pass (SFM physics unchanged).
  - `ruff check` + `ruff format` → clean.
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` → see CI / gate result.
- Default-unchanged invariant is asserted directly: with no composition, all spawned pedestrian
  speeds equal the base `initial_speed`.

## Risks / Rollout
- Blast radius: `populate_ped_routes` is used by every pedestrian scenario, but the change is a single
  opt-in post-step that is a no-op by default, with a regression test asserting the homogeneous output
  is unchanged. fast-pysf is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
