### PR TITLE
research: record observation-noise live smoke diagnostic

### DIFF
--- a/configs/policy_search/issue_3201_observation_noise_funnel.yaml
+++ b/configs/policy_search/issue_3201_observation_noise_funnel.yaml
@@ -1,0 +1,15 @@
+stage_order:
+  - stress_slice
+
+stages:
+  stress_slice:
+    scenario_matrix: ../scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml
+    scenario_filter:
+      - dense_pedestrian_stress
+    seed_list:
+      - 2765
+    benchmark_profile: experimental
+    horizon: 50
+    dt: 0.1
+    workers: 1
+    requires_slurm: false

--- a/configs/scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml
+++ b/configs/scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml
@@ -1,0 +1,16 @@
+schema_version: robot_sf.scenario_matrix.v1
+includes:
+  - ../single/dense_pedestrian_stress.yaml
+select_scenarios:
+  - dense_pedestrian_stress
+scenario_overrides_by_name:
+  dense_pedestrian_stress:
+    seeds:
+      - 2765
+    metadata:
+      source_issue: https://github.com/ll7/robot_sf_ll7/issues/3201
+      diagnostic_role: pedestrian_dominated_observation_noise_retest
+      claim_boundary: >
+        Same-seed local smoke fixture for retesting the issue #2749
+        distant-pedestrian null. Diagnostic only; not benchmark-strength or
+        hardware-calibrated sensor evidence.

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1518,6 +1518,10 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_3201_observation_noise_live_smoke/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_2782_observation_noise_mechanisms/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -157,6 +157,11 @@ Policy caveats:
   perception-limited observation-noise step diagnostics for `hybrid_rule_v0_minimal` on a
   pedestrian-present stress-slice scenario; perturbation plumbing activated, but the distant
   pedestrian produced no measurable planner degradation.
+- `issue_3201_observation_noise_live_smoke/`: diagnostic-only same-seed clean vs perturbed
+  step-diagnostics replay on the `dense_pedestrian_stress` live matrix candidate. Perturbation
+  changed planner-input pedestrian observations, but commands and progress/risk summaries stayed
+  identical because the live scenario remained outside the intended 2 m near-field target. Not
+  benchmark or sensor-realism evidence.
 - `policy_search_h500_2026-05-06/`: h500 policy-search leader summaries and failure reports that
   support the v1 raw-success leader and v2 strict-gate promotion decision.
 - `issue_1023_scenario_horizons_preflight_2026-05-06/`: compact preflight artifacts for the

--- a/docs/context/evidence/issue_2762_negative_result_register/register.json
+++ b/docs/context/evidence/issue_2762_negative_result_register/register.json
@@ -67,8 +67,8 @@
         "docs/context/evidence/issue_3201_observation_noise_live_smoke/summary.json",
         "docs/context/evidence/issue_3201_observation_noise_live_smoke/README.md"
       ],
-      "recommended_next_action": "Author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.",
-      "linked_issues": [3201, 2749, 3067, 2777],
+      "recommended_next_action": "Follow-up #3233: author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.",
+      "linked_issues": [3201, 3233, 2749, 3067, 2777],
       "claim_boundary": "Diagnostic-only, not benchmark or paper evidence. Confirms live perturbation can change planner-input observations; does not show a planner behavior delta.",
       "created_at": "2026-06-20"
     },

--- a/docs/context/evidence/issue_2762_negative_result_register/register.json
+++ b/docs/context/evidence/issue_2762_negative_result_register/register.json
@@ -55,6 +55,24 @@
       "created_at": "2026-06-13"
     },
     {
+      "id": "issue-3201-observation-noise-live-dense-stress",
+      "hypothesis": "A pedestrian-dominated live smoke fixture makes observation perturbations produce a same-seed planner behavior delta after the issue #2749 distant-pedestrian null.",
+      "tested_artifact": "hybrid_rule_v0_minimal step diagnostics with clean vs bounded-Gaussian/missed-detection pedestrian observations",
+      "scenario": "dense_pedestrian_stress live scenario matrix candidate, seed 2765, horizon 20. The live environment resolved 17 pedestrians but closest robot-pedestrian distance was 6.999m.",
+      "comparator": "Same-seed clean observation trace with ideal_state pedestrian observations",
+      "result_classification": "diagnostic_only",
+      "failure_mode": "scenario_too_weak",
+      "why_failed_or_inconclusive": "Perturbation plumbing activated (179 missed actor observations; observed actor count dropped from 17 to 5-12), but selected commands, progress/risk summary, collision flags, and closest-distance metrics were identical. The live scenario candidate did not satisfy the intended near-field pedestrian-dominated condition.",
+      "evidence_pointer": [
+        "docs/context/evidence/issue_3201_observation_noise_live_smoke/summary.json",
+        "docs/context/evidence/issue_3201_observation_noise_live_smoke/README.md"
+      ],
+      "recommended_next_action": "Author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.",
+      "linked_issues": [3201, 2749, 3067, 2777],
+      "claim_boundary": "Diagnostic-only, not benchmark or paper evidence. Confirms live perturbation can change planner-input observations; does not show a planner behavior delta.",
+      "created_at": "2026-06-20"
+    },
+    {
       "id": "issue-2760-dissertation-evidence-ledger-diagnostic-rows",
       "hypothesis": "The dissertation evidence ledger synthesizes all current thesis-area evidence into a claim-ready format.",
       "tested_artifact": "Ledger rows for topology_guidance, signalized_behavior, observation_robustness, prediction, pedestrian_density_stress, and exported_tables.",

--- a/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.json
+++ b/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.json
@@ -134,7 +134,7 @@
       "area": null,
       "entry_id": "issue-3201-observation-noise-live-dense-stress",
       "bucket": "negative_revise_only",
-      "promotion_step_or_reason": "Author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.",
+      "promotion_step_or_reason": "Follow-up #3233: author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.",
       "source": "register",
       "source_issue": 3201,
       "evidence_tier": null,

--- a/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.json
+++ b/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.json
@@ -1,6 +1,6 @@
 {
   "schema_version": "dissertation_gap_report.v1",
-  "generated_at": "2026-06-15",
+  "generated_at": "2026-06-20",
   "purpose": "synthesis/planning aid; not new benchmark, paper, dissertation, or safety evidence",
   "source_ledger": {
     "path": "docs/context/evidence/issue_2760_dissertation_evidence_ledger/ledger.json",
@@ -10,7 +10,7 @@
   "source_register": {
     "path": "docs/context/evidence/issue_2762_negative_result_register/register.json",
     "issue": 2762,
-    "entry_count": 3
+    "entry_count": 4
   },
   "gaps": [
     {
@@ -129,6 +129,19 @@
       "allowed_wording_or_boundary": "Diagnostic-only, not benchmark or paper evidence. Confirms perturbation infrastructure works; does not measure behavioral degradation.",
       "caveat": "Diagnostic-only, not benchmark or paper evidence. Confirms perturbation infrastructure works; does not measure behavioral degradation.",
       "claim_gap_or_reason": "All progress, risk, and planner metrics are identical between baseline and perception-limited. The single pedestrian is too far from the robot to influence planner decisions; the planner is dominated by static obstacle clearance. Perturbation plumbing is confirmed working (occlusion masking active, 1 missed detection at step 15) but no behavioral degradation is measurable."
+    },
+    {
+      "area": null,
+      "entry_id": "issue-3201-observation-noise-live-dense-stress",
+      "bucket": "negative_revise_only",
+      "promotion_step_or_reason": "Author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.",
+      "source": "register",
+      "source_issue": 3201,
+      "evidence_tier": null,
+      "result_classification": "diagnostic_only",
+      "allowed_wording_or_boundary": "Diagnostic-only, not benchmark or paper evidence. Confirms live perturbation can change planner-input observations; does not show a planner behavior delta.",
+      "caveat": "Diagnostic-only, not benchmark or paper evidence. Confirms live perturbation can change planner-input observations; does not show a planner behavior delta.",
+      "claim_gap_or_reason": "Perturbation plumbing activated (179 missed actor observations; observed actor count dropped from 17 to 5-12), but selected commands, progress/risk summary, collision flags, and closest-distance metrics were identical. The live scenario candidate did not satisfy the intended near-field pedestrian-dominated condition."
     },
     {
       "area": null,

--- a/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.md
+++ b/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.md
@@ -2,9 +2,9 @@
 
 **Purpose**: synthesis/planning aid; not new benchmark, paper, dissertation, or safety evidence.
 
-Generated: 2026-06-15  | Schema: dissertation_gap_report.v1
+Generated: 2026-06-20  | Schema: dissertation_gap_report.v1
 
-Sources: ledger #2760 (7 rows), register #2762 (3 entries)
+Sources: ledger #2760 (7 rows), register #2762 (4 entries)
 
 ## Supported (release-backed, current)
 
@@ -75,6 +75,14 @@ Sources: ledger #2760 (7 rows), register #2762 (3 entries)
 - **Allowed wording / boundary**: Diagnostic-only, not benchmark or paper evidence. Confirms perturbation infrastructure works; does not measure behavioral degradation.
 - **Caveat**: Diagnostic-only, not benchmark or paper evidence. Confirms perturbation infrastructure works; does not measure behavioral degradation.
 - **Claim gap / reason**: All progress, risk, and planner metrics are identical between baseline and perception-limited. The single pedestrian is too far from the robot to influence planner decisions; the planner is dominated by static obstacle clearance. Perturbation plumbing is confirmed working (occlusion masking active, 1 missed detection at step 15) but no behavioral degradation is measurable.
+
+### issue-3201-observation-noise-live-dense-stress [register]
+
+- **Tier/Classification**: diagnostic_only
+- **Promotion step or reason**: Author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.
+- **Allowed wording / boundary**: Diagnostic-only, not benchmark or paper evidence. Confirms live perturbation can change planner-input observations; does not show a planner behavior delta.
+- **Caveat**: Diagnostic-only, not benchmark or paper evidence. Confirms live perturbation can change planner-input observations; does not show a planner behavior delta.
+- **Claim gap / reason**: Perturbation plumbing activated (179 missed actor observations; observed actor count dropped from 17 to 5-12), but selected commands, progress/risk summary, collision flags, and closest-distance metrics were identical. The live scenario candidate did not satisfy the intended near-field pedestrian-dominated condition.
 
 ### issue-2760-dissertation-evidence-ledger-diagnostic-rows [register]
 

--- a/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.md
+++ b/docs/context/evidence/issue_2784_dissertation_gap_report/gap_report.md
@@ -79,7 +79,7 @@ Sources: ledger #2760 (7 rows), register #2762 (4 entries)
 ### issue-3201-observation-noise-live-dense-stress [register]
 
 - **Tier/Classification**: diagnostic_only
-- **Promotion step or reason**: Author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.
+- **Promotion step or reason**: Follow-up #3233: author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.
 - **Allowed wording / boundary**: Diagnostic-only, not benchmark or paper evidence. Confirms live perturbation can change planner-input observations; does not show a planner behavior delta.
 - **Caveat**: Diagnostic-only, not benchmark or paper evidence. Confirms live perturbation can change planner-input observations; does not show a planner behavior delta.
 - **Claim gap / reason**: Perturbation plumbing activated (179 missed actor observations; observed actor count dropped from 17 to 5-12), but selected commands, progress/risk summary, collision flags, and closest-distance metrics were identical. The live scenario candidate did not satisfy the intended near-field pedestrian-dominated condition.

--- a/docs/context/evidence/issue_3201_observation_noise_live_smoke/README.md
+++ b/docs/context/evidence/issue_3201_observation_noise_live_smoke/README.md
@@ -1,0 +1,53 @@
+# Issue #3201 Observation-Noise Live Smoke
+
+## Claim Boundary
+
+Diagnostic same-seed local smoke only. This retests the issue #2749 observation-noise null with a pedestrian-dominated candidate surface; it is not benchmark-strength or hardware-calibrated sensor evidence.
+
+## Inputs
+
+- Clean trace: `worktree-local ignored artifact summarized in this report (benchmarks/issue_3201_observation_noise_live_smoke/clean_step/trace.json)`
+- Perturbed trace: `worktree-local ignored artifact summarized in this report (benchmarks/issue_3201_observation_noise_live_smoke/perturbed_step/trace.json)`
+- Same scenario: `True`
+- Same seed: `True`
+
+## Classification
+
+- Label: `observation_only_scenario_too_weak`
+- Rationale: Perturbation changed planner-input pedestrian observations, but commands and progress/risk summaries were identical. The closest live robot-pedestrian distance was 7.00 m, above the 2 m near-field target.
+
+## Command Summary
+
+- Sequence changed: `False`
+- Clean first/last: `[1.2, 0.30000000000000004]` / `[2.0, 0.0]`
+- Perturbed first/last: `[1.2, 0.30000000000000004]` / `[2.0, 0.0]`
+
+## Observation Summary
+
+- Changed: `True`
+- Clean: `{'missed_actor_observations_total': 0, 'occluded_actor_observations_total': 0, 'min_observed_actor_count': 17, 'max_observed_actor_count': 17, 'noise_profiles': ['none'], 'evidence_classes': ['ideal_state']}`
+- Perturbed: `{'missed_actor_observations_total': 179, 'occluded_actor_observations_total': 0, 'min_observed_actor_count': 5, 'max_observed_actor_count': 12, 'noise_profiles': ['bounded_gaussian'], 'evidence_classes': ['perception_limited']}`
+
+## Progress Deltas
+
+| Field | Clean | Perturbed | Delta | Changed |
+|---|---:|---:|---:|---|
+| `steps_observed` | `20` | `20` | `0.0` | `False` |
+| `initial_goal_distance` | `3.5209472023792885` | `3.5209472023792885` | `0.0` | `False` |
+| `final_goal_distance` | `18.630464317750842` | `18.630464317750842` | `0.0` | `False` |
+| `best_goal_distance` | `2.0466035266377416` | `2.0466035266377416` | `0.0` | `False` |
+| `net_goal_progress` | `-15.109517115371554` | `-15.109517115371554` | `0.0` | `False` |
+| `best_goal_progress` | `1.474343675741547` | `1.474343675741547` | `0.0` | `False` |
+| `progress_step_count` | `19` | `19` | `0.0` | `False` |
+| `regression_step_count` | `1` | `1` | `0.0` | `False` |
+| `stagnant_step_count` | `0` | `0` | `0.0` | `False` |
+| `longest_stagnant_run` | `0` | `0` | `0.0` | `False` |
+| `closest_robot_ped_distance` | `6.999430016273784` | `6.999430016273784` | `0.0` | `False` |
+| `closest_robot_ped_step` | `19` | `19` | `0.0` | `False` |
+| `collision_flag_counts` | `{'pedestrian': 0, 'obstacle': 0, 'robot': 0}` | `{'pedestrian': 0, 'obstacle': 0, 'robot': 0}` | `None` | `False` |
+
+## Caveats
+
+- One scenario, one seed, one horizon; diagnostic smoke only.
+- The live scenario candidate remained outside the intended 2 m near-field threshold.
+- Uses non-calibrated observation perturbations and makes no hardware sensor claim.

--- a/docs/context/evidence/issue_3201_observation_noise_live_smoke/summary.json
+++ b/docs/context/evidence/issue_3201_observation_noise_live_smoke/summary.json
@@ -1,0 +1,175 @@
+{
+  "schema_version": "issue_3201_observation_noise_live_smoke.v1",
+  "issue": 3201,
+  "claim_boundary": "Diagnostic same-seed local smoke only. This retests the issue #2749 observation-noise null with a pedestrian-dominated candidate surface; it is not benchmark-strength or hardware-calibrated sensor evidence.",
+  "inputs": {
+    "clean_trace_json": "worktree-local ignored artifact summarized in this report (benchmarks/issue_3201_observation_noise_live_smoke/clean_step/trace.json)",
+    "perturbed_trace_json": "worktree-local ignored artifact summarized in this report (benchmarks/issue_3201_observation_noise_live_smoke/perturbed_step/trace.json)"
+  },
+  "scenario": {
+    "clean": "dense_pedestrian_stress",
+    "perturbed": "dense_pedestrian_stress",
+    "same_scenario": true
+  },
+  "seed": {
+    "clean": 2765,
+    "perturbed": 2765,
+    "same_seed": true
+  },
+  "observation_perturbation_config": {
+    "clean": {
+      "position_noise_std_m": 0.0,
+      "position_noise_bound_m": 0.0,
+      "missed_detection_probability": 0.0,
+      "occlusion_distance_m": null,
+      "delay_steps": 0,
+      "seed": null
+    },
+    "perturbed": {
+      "position_noise_std_m": 0.3,
+      "position_noise_bound_m": 0.6,
+      "missed_detection_probability": 0.5,
+      "occlusion_distance_m": null,
+      "delay_steps": 0,
+      "seed": 3201
+    }
+  },
+  "observation_summary": {
+    "clean": {
+      "missed_actor_observations_total": 0,
+      "occluded_actor_observations_total": 0,
+      "min_observed_actor_count": 17,
+      "max_observed_actor_count": 17,
+      "noise_profiles": [
+        "none"
+      ],
+      "evidence_classes": [
+        "ideal_state"
+      ]
+    },
+    "perturbed": {
+      "missed_actor_observations_total": 179,
+      "occluded_actor_observations_total": 0,
+      "min_observed_actor_count": 5,
+      "max_observed_actor_count": 12,
+      "noise_profiles": [
+        "bounded_gaussian"
+      ],
+      "evidence_classes": [
+        "perception_limited"
+      ]
+    },
+    "changed": true
+  },
+  "command_summary": {
+    "clean_first": [
+      1.2,
+      0.30000000000000004
+    ],
+    "perturbed_first": [
+      1.2,
+      0.30000000000000004
+    ],
+    "clean_last": [
+      2.0,
+      0.0
+    ],
+    "perturbed_last": [
+      2.0,
+      0.0
+    ],
+    "sequence_changed": false
+  },
+  "progress_delta": {
+    "steps_observed": {
+      "clean": 20,
+      "perturbed": 20,
+      "delta": 0.0,
+      "changed": false
+    },
+    "initial_goal_distance": {
+      "clean": 3.5209472023792885,
+      "perturbed": 3.5209472023792885,
+      "delta": 0.0,
+      "changed": false
+    },
+    "final_goal_distance": {
+      "clean": 18.630464317750842,
+      "perturbed": 18.630464317750842,
+      "delta": 0.0,
+      "changed": false
+    },
+    "best_goal_distance": {
+      "clean": 2.0466035266377416,
+      "perturbed": 2.0466035266377416,
+      "delta": 0.0,
+      "changed": false
+    },
+    "net_goal_progress": {
+      "clean": -15.109517115371554,
+      "perturbed": -15.109517115371554,
+      "delta": 0.0,
+      "changed": false
+    },
+    "best_goal_progress": {
+      "clean": 1.474343675741547,
+      "perturbed": 1.474343675741547,
+      "delta": 0.0,
+      "changed": false
+    },
+    "progress_step_count": {
+      "clean": 19,
+      "perturbed": 19,
+      "delta": 0.0,
+      "changed": false
+    },
+    "regression_step_count": {
+      "clean": 1,
+      "perturbed": 1,
+      "delta": 0.0,
+      "changed": false
+    },
+    "stagnant_step_count": {
+      "clean": 0,
+      "perturbed": 0,
+      "delta": 0.0,
+      "changed": false
+    },
+    "longest_stagnant_run": {
+      "clean": 0,
+      "perturbed": 0,
+      "delta": 0.0,
+      "changed": false
+    },
+    "closest_robot_ped_distance": {
+      "clean": 6.999430016273784,
+      "perturbed": 6.999430016273784,
+      "delta": 0.0,
+      "changed": false
+    },
+    "closest_robot_ped_step": {
+      "clean": 19,
+      "perturbed": 19,
+      "delta": 0.0,
+      "changed": false
+    },
+    "collision_flag_counts": {
+      "clean": {
+        "pedestrian": 0,
+        "obstacle": 0,
+        "robot": 0
+      },
+      "perturbed": {
+        "pedestrian": 0,
+        "obstacle": 0,
+        "robot": 0
+      },
+      "delta": null,
+      "changed": false
+    }
+  },
+  "classification": {
+    "label": "observation_only_scenario_too_weak",
+    "rationale": "Perturbation changed planner-input pedestrian observations, but commands and progress/risk summaries were identical. The closest live robot-pedestrian distance was 7.00 m, above the 2 m near-field target."
+  }
+}

--- a/scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py
+++ b/scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py
@@ -1,0 +1,529 @@
+#!/usr/bin/env python3
+"""Compare same-seed clean and perturbed observation-noise live smoke rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "issue_3201_observation_noise_live_smoke.v1"
+DEFAULT_METRICS = (
+    "success",
+    "min_distance",
+    "min_clearance",
+    "path_length",
+    "social_proxemic_intrusion_steps",
+    "social_proxemic_intrusion_frac",
+    "time_to_yield_s",
+    "robot_yield_distance_m",
+    "pedestrian_path_deviation_proxy_m",
+)
+TRACE_PROGRESS_FIELDS = (
+    "steps_observed",
+    "initial_goal_distance",
+    "final_goal_distance",
+    "best_goal_distance",
+    "net_goal_progress",
+    "best_goal_progress",
+    "progress_step_count",
+    "regression_step_count",
+    "stagnant_step_count",
+    "longest_stagnant_run",
+    "closest_robot_ped_distance",
+    "closest_robot_ped_step",
+    "collision_flag_counts",
+)
+
+
+def _load_single_row(path: Path) -> dict[str, Any]:
+    """Load exactly one JSONL row."""
+    rows = [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+    if len(rows) != 1:
+        raise ValueError(f"{path} must contain exactly one JSONL row, found {len(rows)}")
+    return rows[0]
+
+
+def _durable_input_ref(path: Path) -> str:
+    """Return a report-safe input reference that does not depend on ignored artifacts."""
+    parts = path.as_posix().split("/")
+    if "output" in parts:
+        tail = "/".join(parts[parts.index("output") + 1 :])
+        return f"worktree-local ignored artifact summarized in this report ({tail})"
+    return path.as_posix()
+
+
+def _number(value: Any) -> float | None:
+    """Normalize scalar numeric values for delta comparison."""
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _metric_delta(clean: dict[str, Any], perturbed: dict[str, Any]) -> dict[str, Any]:
+    """Return per-metric values and deltas for known scalar metrics."""
+    clean_metrics = clean.get("metrics", {})
+    perturbed_metrics = perturbed.get("metrics", {})
+    deltas: dict[str, Any] = {}
+    for metric in DEFAULT_METRICS:
+        clean_value = clean_metrics.get(metric)
+        perturbed_value = perturbed_metrics.get(metric)
+        clean_number = _number(clean_value)
+        perturbed_number = _number(perturbed_value)
+        delta = (
+            perturbed_number - clean_number
+            if clean_number is not None and perturbed_number is not None
+            else None
+        )
+        deltas[metric] = {
+            "clean": clean_value,
+            "perturbed": perturbed_value,
+            "delta": delta,
+        }
+    return deltas
+
+
+def _status_delta(clean: dict[str, Any], perturbed: dict[str, Any]) -> dict[str, Any]:
+    """Compare top-level episode status/outcome fields."""
+    fields = ("status", "termination_reason", "steps", "horizon", "outcome")
+    return {
+        field: {
+            "clean": clean.get(field),
+            "perturbed": perturbed.get(field),
+            "changed": clean.get(field) != perturbed.get(field),
+        }
+        for field in fields
+    }
+
+
+def _noise_stats_delta(clean: dict[str, Any], perturbed: dict[str, Any]) -> dict[str, Any]:
+    """Compare observation-noise counters."""
+    clean_stats = clean.get("observation_noise_stats", {})
+    perturbed_stats = perturbed.get("observation_noise_stats", {})
+    keys = sorted(set(clean_stats) | set(perturbed_stats))
+    return {
+        key: {
+            "clean": clean_stats.get(key),
+            "perturbed": perturbed_stats.get(key),
+            "delta": (
+                perturbed_stats.get(key, 0) - clean_stats.get(key, 0)
+                if isinstance(clean_stats.get(key, 0), int)
+                and isinstance(perturbed_stats.get(key, 0), int)
+                else None
+            ),
+        }
+        for key in keys
+    }
+
+
+def _has_metric_delta(metric_deltas: dict[str, Any], *, epsilon: float = 1e-9) -> bool:
+    """Return whether any comparable metric changed."""
+    return any(
+        item["delta"] is not None and abs(float(item["delta"])) > epsilon
+        for item in metric_deltas.values()
+    )
+
+
+def _has_status_delta(status_deltas: dict[str, Any]) -> bool:
+    """Return whether any compared top-level status field changed."""
+    return any(item["changed"] for item in status_deltas.values())
+
+
+def _has_noise_delta(noise_deltas: dict[str, Any]) -> bool:
+    """Return whether any observation-noise counter changed."""
+    return any(item["delta"] is not None and item["delta"] != 0 for item in noise_deltas.values())
+
+
+def _classification(
+    *,
+    metric_deltas: dict[str, Any],
+    status_deltas: dict[str, Any],
+    noise_deltas: dict[str, Any],
+) -> dict[str, str]:
+    """Classify the same-seed smoke result."""
+    if _has_metric_delta(metric_deltas) or _has_status_delta(status_deltas):
+        return {
+            "label": "non_null_behavior_delta",
+            "rationale": (
+                "Same-seed clean and perturbed rows differ on at least one "
+                "episode metric or top-level outcome/status field."
+            ),
+        }
+    if _has_noise_delta(noise_deltas):
+        return {
+            "label": "observation_only_delta",
+            "rationale": (
+                "Observation-noise counters changed, but compared behavior "
+                "metrics and top-level outcomes were identical."
+            ),
+        }
+    return {
+        "label": "null_policy_insensitive",
+        "rationale": (
+            "No compared metric, status, or observation-noise counter changed; "
+            "the smoke remains policy-insensitive."
+        ),
+    }
+
+
+def build_report(clean_path: Path, perturbed_path: Path) -> dict[str, Any]:
+    """Build the compact comparison report."""
+    clean = _load_single_row(clean_path)
+    perturbed = _load_single_row(perturbed_path)
+    metric_deltas = _metric_delta(clean, perturbed)
+    status_deltas = _status_delta(clean, perturbed)
+    noise_deltas = _noise_stats_delta(clean, perturbed)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 3201,
+        "claim_boundary": (
+            "Diagnostic same-seed local smoke only. This retests the issue #2749 "
+            "observation-noise null with a pedestrian-dominated fixture; it is "
+            "not benchmark-strength or hardware-calibrated sensor evidence."
+        ),
+        "inputs": {
+            "clean_jsonl": _durable_input_ref(clean_path),
+            "perturbed_jsonl": _durable_input_ref(perturbed_path),
+        },
+        "scenario": {
+            "clean": clean.get("scenario_id"),
+            "perturbed": perturbed.get("scenario_id"),
+            "same_scenario": clean.get("scenario_id") == perturbed.get("scenario_id"),
+        },
+        "seed": {
+            "clean": clean.get("seed"),
+            "perturbed": perturbed.get("seed"),
+            "same_seed": clean.get("seed") == perturbed.get("seed"),
+        },
+        "observation_noise": {
+            "clean": clean.get("observation_noise"),
+            "perturbed": perturbed.get("observation_noise"),
+            "stats_delta": noise_deltas,
+        },
+        "status_delta": status_deltas,
+        "metric_delta": metric_deltas,
+        "classification": _classification(
+            metric_deltas=metric_deltas,
+            status_deltas=status_deltas,
+            noise_deltas=noise_deltas,
+        ),
+    }
+
+
+def _load_trace(path: Path) -> dict[str, Any]:
+    """Load a policy-search step diagnostics trace."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload.get("steps"), list):
+        raise ValueError(f"{path} is not a step diagnostics trace")
+    return payload
+
+
+def _trace_progress_delta(clean: dict[str, Any], perturbed: dict[str, Any]) -> dict[str, Any]:
+    """Compare high-level progress summaries from step diagnostics."""
+    clean_summary = clean.get("progress_summary", {})
+    perturbed_summary = perturbed.get("progress_summary", {})
+    deltas: dict[str, Any] = {}
+    for field in TRACE_PROGRESS_FIELDS:
+        clean_value = clean_summary.get(field)
+        perturbed_value = perturbed_summary.get(field)
+        clean_number = _number(clean_value)
+        perturbed_number = _number(perturbed_value)
+        delta = (
+            perturbed_number - clean_number
+            if clean_number is not None and perturbed_number is not None
+            else None
+        )
+        deltas[field] = {
+            "clean": clean_value,
+            "perturbed": perturbed_value,
+            "delta": delta,
+            "changed": clean_value != perturbed_value,
+        }
+    return deltas
+
+
+def _trace_command_summary(trace: dict[str, Any]) -> list[Any]:
+    """Return the selected policy-command sequence."""
+    return [row.get("policy_command") for row in trace.get("steps", [])]
+
+
+def _trace_observation_summary(trace: dict[str, Any]) -> dict[str, Any]:
+    """Summarize observation perturbation effects across step rows."""
+    missed_total = 0
+    occluded_total = 0
+    observed_counts: list[int] = []
+    profiles: set[str] = set()
+    evidence_classes: set[str] = set()
+    for row in trace.get("steps", []):
+        meta = row.get("observation_perturbation", {})
+        missed_total += int(meta.get("missed_actor_count", 0) or 0)
+        occluded_total += int(meta.get("occluded_actor_count", 0) or 0)
+        observed_counts.append(int(meta.get("observed_actor_count", 0) or 0))
+        profiles.add(str(meta.get("noise_profile", "")))
+        evidence_classes.add(str(meta.get("evidence_class", "")))
+    return {
+        "missed_actor_observations_total": missed_total,
+        "occluded_actor_observations_total": occluded_total,
+        "min_observed_actor_count": min(observed_counts) if observed_counts else None,
+        "max_observed_actor_count": max(observed_counts) if observed_counts else None,
+        "noise_profiles": sorted(profile for profile in profiles if profile),
+        "evidence_classes": sorted(value for value in evidence_classes if value),
+    }
+
+
+def _trace_classification(
+    *,
+    progress_delta: dict[str, Any],
+    command_changed: bool,
+    observation_changed: bool,
+    closest_robot_ped_distance: float | None,
+) -> dict[str, str]:
+    """Classify paired step-diagnostics traces."""
+    progress_changed = any(item["changed"] for item in progress_delta.values())
+    if command_changed or progress_changed:
+        return {
+            "label": "non_null_behavior_delta",
+            "rationale": (
+                "Same-seed clean and perturbed live traces differ in selected "
+                "commands or progress/risk summary fields."
+            ),
+        }
+    if observation_changed:
+        if closest_robot_ped_distance is not None and closest_robot_ped_distance > 2.0:
+            return {
+                "label": "observation_only_scenario_too_weak",
+                "rationale": (
+                    "Perturbation changed planner-input pedestrian observations, "
+                    "but commands and progress/risk summaries were identical. "
+                    f"The closest live robot-pedestrian distance was "
+                    f"{closest_robot_ped_distance:.2f} m, above the 2 m near-field target."
+                ),
+            }
+        return {
+            "label": "observation_only_delta",
+            "rationale": (
+                "Perturbation changed planner-input pedestrian observations, "
+                "but commands and progress/risk summaries were identical."
+            ),
+        }
+    return {
+        "label": "null_policy_insensitive",
+        "rationale": "No compared observation, command, or progress/risk field changed.",
+    }
+
+
+def build_trace_report(clean_trace_path: Path, perturbed_trace_path: Path) -> dict[str, Any]:
+    """Build a compact report from paired step-diagnostics traces."""
+    clean = _load_trace(clean_trace_path)
+    perturbed = _load_trace(perturbed_trace_path)
+    progress_delta = _trace_progress_delta(clean, perturbed)
+    clean_commands = _trace_command_summary(clean)
+    perturbed_commands = _trace_command_summary(perturbed)
+    clean_observation = _trace_observation_summary(clean)
+    perturbed_observation = _trace_observation_summary(perturbed)
+    observation_changed = clean_observation != perturbed_observation
+    closest = _number(clean.get("progress_summary", {}).get("closest_robot_ped_distance"))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 3201,
+        "claim_boundary": (
+            "Diagnostic same-seed local smoke only. This retests the issue #2749 "
+            "observation-noise null with a pedestrian-dominated candidate surface; "
+            "it is not benchmark-strength or hardware-calibrated sensor evidence."
+        ),
+        "inputs": {
+            "clean_trace_json": _durable_input_ref(clean_trace_path),
+            "perturbed_trace_json": _durable_input_ref(perturbed_trace_path),
+        },
+        "scenario": {
+            "clean": clean.get("scenario_id"),
+            "perturbed": perturbed.get("scenario_id"),
+            "same_scenario": clean.get("scenario_id") == perturbed.get("scenario_id"),
+        },
+        "seed": {
+            "clean": clean.get("seed"),
+            "perturbed": perturbed.get("seed"),
+            "same_seed": clean.get("seed") == perturbed.get("seed"),
+        },
+        "observation_perturbation_config": {
+            "clean": clean.get("observation_perturbation_config"),
+            "perturbed": perturbed.get("observation_perturbation_config"),
+        },
+        "observation_summary": {
+            "clean": clean_observation,
+            "perturbed": perturbed_observation,
+            "changed": observation_changed,
+        },
+        "command_summary": {
+            "clean_first": clean_commands[0] if clean_commands else None,
+            "perturbed_first": perturbed_commands[0] if perturbed_commands else None,
+            "clean_last": clean_commands[-1] if clean_commands else None,
+            "perturbed_last": perturbed_commands[-1] if perturbed_commands else None,
+            "sequence_changed": clean_commands != perturbed_commands,
+        },
+        "progress_delta": progress_delta,
+        "classification": _trace_classification(
+            progress_delta=progress_delta,
+            command_changed=clean_commands != perturbed_commands,
+            observation_changed=observation_changed,
+            closest_robot_ped_distance=closest,
+        ),
+    }
+
+
+def _markdown(report: dict[str, Any]) -> str:
+    """Render a short Markdown summary."""
+    classification = report["classification"]
+    lines = [
+        "# Issue #3201 Observation-Noise Live Smoke",
+        "",
+        "## Claim Boundary",
+        "",
+        report["claim_boundary"],
+        "",
+        "## Inputs",
+        "",
+        f"- Clean JSONL: `{report['inputs']['clean_jsonl']}`",
+        f"- Perturbed JSONL: `{report['inputs']['perturbed_jsonl']}`",
+        f"- Same scenario: `{report['scenario']['same_scenario']}`",
+        f"- Same seed: `{report['seed']['same_seed']}`",
+        "",
+        "## Classification",
+        "",
+        f"- Label: `{classification['label']}`",
+        f"- Rationale: {classification['rationale']}",
+        "",
+        "## Metric Deltas",
+        "",
+        "| Metric | Clean | Perturbed | Delta |",
+        "|---|---:|---:|---:|",
+    ]
+    for metric, values in report["metric_delta"].items():
+        lines.append(
+            f"| `{metric}` | `{values['clean']}` | `{values['perturbed']}` | `{values['delta']}` |"
+        )
+    lines.extend(["", "## Observation-Noise Counter Deltas", ""])
+    lines.extend(["| Counter | Clean | Perturbed | Delta |", "|---|---:|---:|---:|"])
+    for key, values in report["observation_noise"]["stats_delta"].items():
+        lines.append(
+            f"| `{key}` | `{values['clean']}` | `{values['perturbed']}` | `{values['delta']}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Caveats",
+            "",
+            "- One scenario, one seed, one horizon; diagnostic smoke only.",
+            "- Uses non-calibrated observation noise and makes no hardware sensor claim.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _trace_markdown(report: dict[str, Any]) -> str:
+    """Render Markdown for paired step-diagnostics traces."""
+    classification = report["classification"]
+    lines = [
+        "# Issue #3201 Observation-Noise Live Smoke",
+        "",
+        "## Claim Boundary",
+        "",
+        report["claim_boundary"],
+        "",
+        "## Inputs",
+        "",
+        f"- Clean trace: `{report['inputs']['clean_trace_json']}`",
+        f"- Perturbed trace: `{report['inputs']['perturbed_trace_json']}`",
+        f"- Same scenario: `{report['scenario']['same_scenario']}`",
+        f"- Same seed: `{report['seed']['same_seed']}`",
+        "",
+        "## Classification",
+        "",
+        f"- Label: `{classification['label']}`",
+        f"- Rationale: {classification['rationale']}",
+        "",
+        "## Command Summary",
+        "",
+        f"- Sequence changed: `{report['command_summary']['sequence_changed']}`",
+        f"- Clean first/last: `{report['command_summary']['clean_first']}` / "
+        f"`{report['command_summary']['clean_last']}`",
+        f"- Perturbed first/last: `{report['command_summary']['perturbed_first']}` / "
+        f"`{report['command_summary']['perturbed_last']}`",
+        "",
+        "## Observation Summary",
+        "",
+        f"- Changed: `{report['observation_summary']['changed']}`",
+        f"- Clean: `{report['observation_summary']['clean']}`",
+        f"- Perturbed: `{report['observation_summary']['perturbed']}`",
+        "",
+        "## Progress Deltas",
+        "",
+        "| Field | Clean | Perturbed | Delta | Changed |",
+        "|---|---:|---:|---:|---|",
+    ]
+    for field, values in report["progress_delta"].items():
+        lines.append(
+            f"| `{field}` | `{values['clean']}` | `{values['perturbed']}` | "
+            f"`{values['delta']}` | `{values['changed']}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Caveats",
+            "",
+            "- One scenario, one seed, one horizon; diagnostic smoke only.",
+            "- The live scenario candidate remained outside the intended 2 m near-field threshold.",
+            "- Uses non-calibrated observation perturbations and makes no hardware sensor claim.",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    input_group = parser.add_mutually_exclusive_group(required=True)
+    input_group.add_argument("--clean-jsonl", type=Path)
+    input_group.add_argument("--clean-trace-json", type=Path)
+    parser.add_argument("--perturbed-jsonl", type=Path)
+    parser.add_argument("--perturbed-trace-json", type=Path)
+    parser.add_argument("--output-json", required=True, type=Path)
+    parser.add_argument("--output-md", required=True, type=Path)
+    args = parser.parse_args(argv)
+
+    if args.clean_trace_json is not None:
+        if args.perturbed_trace_json is None:
+            parser.error("--perturbed-trace-json is required with --clean-trace-json")
+        report = build_trace_report(args.clean_trace_json, args.perturbed_trace_json)
+        markdown = _trace_markdown(report)
+    else:
+        if args.perturbed_jsonl is None:
+            parser.error("--perturbed-jsonl is required with --clean-jsonl")
+        report = build_report(args.clean_jsonl, args.perturbed_jsonl)
+        markdown = _markdown(report)
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_md.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    args.output_md.write_text(markdown, encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "classification": report["classification"],
+                "output_json": args.output_json.as_posix(),
+                "output_md": args.output_md.as_posix(),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py
+++ b/scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py
@@ -55,6 +55,11 @@ def _durable_input_ref(path: Path) -> str:
     return path.as_posix()
 
 
+def _mapping(value: Any) -> dict[str, Any]:
+    """Return ``value`` as a mapping, treating explicit JSON null as empty."""
+    return value if isinstance(value, dict) else {}
+
+
 def _number(value: Any) -> float | None:
     """Normalize scalar numeric values for delta comparison."""
     if value is None or value == "" or isinstance(value, bool):
@@ -68,8 +73,8 @@ def _number(value: Any) -> float | None:
 
 def _metric_delta(clean: dict[str, Any], perturbed: dict[str, Any]) -> dict[str, Any]:
     """Return per-metric values and deltas for known scalar metrics."""
-    clean_metrics = clean.get("metrics", {})
-    perturbed_metrics = perturbed.get("metrics", {})
+    clean_metrics = _mapping(clean.get("metrics"))
+    perturbed_metrics = _mapping(perturbed.get("metrics"))
     deltas: dict[str, Any] = {}
     for metric in DEFAULT_METRICS:
         clean_value = clean_metrics.get(metric)
@@ -104,8 +109,8 @@ def _status_delta(clean: dict[str, Any], perturbed: dict[str, Any]) -> dict[str,
 
 def _noise_stats_delta(clean: dict[str, Any], perturbed: dict[str, Any]) -> dict[str, Any]:
     """Compare observation-noise counters."""
-    clean_stats = clean.get("observation_noise_stats", {})
-    perturbed_stats = perturbed.get("observation_noise_stats", {})
+    clean_stats = _mapping(clean.get("observation_noise_stats"))
+    perturbed_stats = _mapping(perturbed.get("observation_noise_stats"))
     keys = sorted(set(clean_stats) | set(perturbed_stats))
     return {
         key: {
@@ -226,8 +231,8 @@ def _load_trace(path: Path) -> dict[str, Any]:
 
 def _trace_progress_delta(clean: dict[str, Any], perturbed: dict[str, Any]) -> dict[str, Any]:
     """Compare high-level progress summaries from step diagnostics."""
-    clean_summary = clean.get("progress_summary", {})
-    perturbed_summary = perturbed.get("progress_summary", {})
+    clean_summary = _mapping(clean.get("progress_summary"))
+    perturbed_summary = _mapping(perturbed.get("progress_summary"))
     deltas: dict[str, Any] = {}
     for field in TRACE_PROGRESS_FIELDS:
         clean_value = clean_summary.get(field)
@@ -250,7 +255,7 @@ def _trace_progress_delta(clean: dict[str, Any], perturbed: dict[str, Any]) -> d
 
 def _trace_command_summary(trace: dict[str, Any]) -> list[Any]:
     """Return the selected policy-command sequence."""
-    return [row.get("policy_command") for row in trace.get("steps", [])]
+    return [_mapping(row).get("policy_command") for row in trace.get("steps", [])]
 
 
 def _trace_observation_summary(trace: dict[str, Any]) -> dict[str, Any]:
@@ -261,7 +266,7 @@ def _trace_observation_summary(trace: dict[str, Any]) -> dict[str, Any]:
     profiles: set[str] = set()
     evidence_classes: set[str] = set()
     for row in trace.get("steps", []):
-        meta = row.get("observation_perturbation", {})
+        meta = _mapping(_mapping(row).get("observation_perturbation"))
         missed_total += int(meta.get("missed_actor_count", 0) or 0)
         occluded_total += int(meta.get("occluded_actor_count", 0) or 0)
         observed_counts.append(int(meta.get("observed_actor_count", 0) or 0))
@@ -328,7 +333,7 @@ def build_trace_report(clean_trace_path: Path, perturbed_trace_path: Path) -> di
     clean_observation = _trace_observation_summary(clean)
     perturbed_observation = _trace_observation_summary(perturbed)
     observation_changed = clean_observation != perturbed_observation
-    closest = _number(clean.get("progress_summary", {}).get("closest_robot_ped_distance"))
+    closest = _number(_mapping(clean.get("progress_summary")).get("closest_robot_ped_distance"))
     return {
         "schema_version": SCHEMA_VERSION,
         "issue": 3201,

--- a/tests/benchmark/test_issue_3201_observation_noise_live_smoke.py
+++ b/tests/benchmark/test_issue_3201_observation_noise_live_smoke.py
@@ -149,6 +149,30 @@ def test_comparator_classifies_observation_only_delta(tmp_path: Path) -> None:
     assert report["classification"]["label"] == "observation_only_delta"
 
 
+def test_comparator_treats_null_metric_maps_as_empty(tmp_path: Path) -> None:
+    """Explicit JSON null maps should not crash comparison."""
+    clean = tmp_path / "clean.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    row = {
+        "scenario_id": "dense_pedestrian_stress",
+        "seed": 2765,
+        "status": "success",
+        "termination_reason": "success",
+        "steps": 10,
+        "horizon": 20,
+        "outcome": {"route_complete": True},
+        "metrics": None,
+        "observation_noise_stats": None,
+    }
+    _write_jsonl(clean, row)
+    _write_jsonl(perturbed, row)
+
+    report = _load_script().build_report(clean, perturbed)
+
+    assert report["metric_delta"]["success"]["delta"] is None
+    assert report["classification"]["label"] == "null_policy_insensitive"
+
+
 def test_comparator_cli_writes_json_and_markdown(tmp_path: Path) -> None:
     """CLI writes compact durable artifacts."""
     clean = tmp_path / "clean.jsonl"
@@ -244,6 +268,25 @@ def test_trace_comparator_classifies_observation_only_scenario_too_weak(tmp_path
     assert report["classification"]["label"] == "observation_only_scenario_too_weak"
     assert report["observation_summary"]["changed"] is True
     assert report["command_summary"]["sequence_changed"] is False
+
+
+def test_trace_comparator_treats_null_trace_maps_as_empty(tmp_path: Path) -> None:
+    """Explicit null progress or perturbation maps should be treated as absent metadata."""
+    clean_trace = tmp_path / "clean_trace.json"
+    perturbed_trace = tmp_path / "perturbed_trace.json"
+    payload = {
+        "scenario_id": "dense_pedestrian_stress",
+        "seed": 2765,
+        "progress_summary": None,
+        "steps": [{"policy_command": [1.0, 0.0], "observation_perturbation": None}],
+    }
+    clean_trace.write_text(json.dumps(payload), encoding="utf-8")
+    perturbed_trace.write_text(json.dumps(payload), encoding="utf-8")
+
+    report = _load_script().build_trace_report(clean_trace, perturbed_trace)
+
+    assert report["progress_delta"]["steps_observed"]["changed"] is False
+    assert report["classification"]["label"] == "null_policy_insensitive"
 
 
 def test_trace_comparator_cli_writes_trace_markdown(tmp_path: Path) -> None:

--- a/tests/benchmark/test_issue_3201_observation_noise_live_smoke.py
+++ b/tests/benchmark/test_issue_3201_observation_noise_live_smoke.py
@@ -1,0 +1,293 @@
+"""Tests for the issue #3201 observation-noise live smoke comparator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MATRIX_PATH = (
+    REPO_ROOT / "configs/scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml"
+)
+SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py"
+TRACE_FIXTURE_PATH = (
+    REPO_ROOT / "tests/fixtures/analysis_workbench/simulation_trace_export_v1/"
+    "dense_pedestrian_stress_episode_0000.json"
+)
+_LOADED_MOD = None
+
+
+def _load_script():
+    """Load the comparator script as a module."""
+    global _LOADED_MOD
+    if _LOADED_MOD is not None:
+        return _LOADED_MOD
+    spec = importlib.util.spec_from_file_location(
+        "compare_observation_noise_live_smoke_issue_3201", SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["compare_observation_noise_live_smoke_issue_3201"] = mod
+    spec.loader.exec_module(mod)
+    _LOADED_MOD = mod
+    return _LOADED_MOD
+
+
+def test_issue_3201_matrix_selects_dense_pedestrian_fixture() -> None:
+    """The #3201 scenario set should point at the pedestrian-dominated dense fixture."""
+    payload = yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == "robot_sf.scenario_matrix.v1"
+    assert "../single/dense_pedestrian_stress.yaml" in payload["includes"]
+    assert payload["select_scenarios"] == ["dense_pedestrian_stress"]
+    override = payload["scenario_overrides_by_name"]["dense_pedestrian_stress"]
+    assert override["seeds"] == [2765]
+    assert override["metadata"]["diagnostic_role"] == (
+        "pedestrian_dominated_observation_noise_retest"
+    )
+
+
+def test_report_input_refs_do_not_depend_on_ignored_artifacts() -> None:
+    """Cataloged summaries should not point readers at worktree-local raw artifacts."""
+    ref = _load_script()._durable_input_ref(
+        Path("output/benchmarks/issue_3201_observation_noise_live_smoke/clean_step/trace.json")
+    )
+
+    assert "output/" not in ref
+    assert "worktree-local ignored artifact" in ref
+
+
+def test_dense_trace_fixture_has_near_field_observed_pedestrians() -> None:
+    """The reused dense trace has observed near-field pedestrians and active action changes."""
+    trace = json.loads(TRACE_FIXTURE_PATH.read_text(encoding="utf-8"))
+    min_distance = min(
+        (
+            (ped["position"][0] - frame["robot"]["position"][0]) ** 2
+            + (ped["position"][1] - frame["robot"]["position"][1]) ** 2
+        )
+        ** 0.5
+        for frame in trace["frames"]
+        for ped in frame["pedestrians"]
+    )
+    events = [frame["planner"]["event"] for frame in trace["frames"]]
+    velocities = [
+        frame["planner"]["selected_action"]["linear_velocity"] for frame in trace["frames"]
+    ]
+
+    assert trace["source"]["scenario_id"] == "dense_pedestrian_stress"
+    assert all(len(frame["observed_pedestrians"]) == 3 for frame in trace["frames"])
+    assert min_distance < 0.5
+    assert "dense_critical" in events
+    assert min(velocities) < max(velocities)
+
+
+def _write_jsonl(path: Path, row: dict) -> None:
+    path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+
+
+def test_comparator_classifies_non_null_behavior_delta(tmp_path: Path) -> None:
+    """Metric or status differences should classify as non-null behavior deltas."""
+    clean = tmp_path / "clean.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    base = {
+        "scenario_id": "dense_pedestrian_stress",
+        "seed": 2765,
+        "status": "success",
+        "termination_reason": "success",
+        "steps": 10,
+        "horizon": 20,
+        "outcome": {"route_complete": True},
+        "metrics": {"success": 1.0, "min_distance": 0.4, "path_length": 2.0},
+        "observation_noise": {"enabled": False, "profile": "none"},
+        "observation_noise_stats": {"steps_with_noise": 0, "pedestrians_removed": 0},
+    }
+    noisy = {
+        **base,
+        "metrics": {"success": 0.0, "min_distance": 0.2, "path_length": 1.5},
+        "observation_noise": {"enabled": True, "profile": "robustness_smoke_v1"},
+        "observation_noise_stats": {"steps_with_noise": 5, "pedestrians_removed": 1},
+    }
+    _write_jsonl(clean, base)
+    _write_jsonl(perturbed, noisy)
+
+    report = _load_script().build_report(clean, perturbed)
+
+    assert report["classification"]["label"] == "non_null_behavior_delta"
+    assert report["metric_delta"]["success"]["delta"] == -1.0
+    assert report["observation_noise"]["stats_delta"]["steps_with_noise"]["delta"] == 5
+
+
+def test_comparator_classifies_observation_only_delta(tmp_path: Path) -> None:
+    """Noise-counter deltas without behavior deltas should be explicit."""
+    clean = tmp_path / "clean.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    base = {
+        "scenario_id": "dense_pedestrian_stress",
+        "seed": 2765,
+        "status": "success",
+        "termination_reason": "success",
+        "steps": 10,
+        "horizon": 20,
+        "outcome": {"route_complete": True},
+        "metrics": {"success": 1.0, "min_distance": 0.4, "path_length": 2.0},
+        "observation_noise": {"enabled": False, "profile": "none"},
+        "observation_noise_stats": {"steps_with_noise": 0, "pedestrians_removed": 0},
+    }
+    noisy = {
+        **base,
+        "observation_noise": {"enabled": True, "profile": "robustness_smoke_v1"},
+        "observation_noise_stats": {"steps_with_noise": 5, "pedestrians_removed": 1},
+    }
+    _write_jsonl(clean, base)
+    _write_jsonl(perturbed, noisy)
+
+    report = _load_script().build_report(clean, perturbed)
+
+    assert report["classification"]["label"] == "observation_only_delta"
+
+
+def test_comparator_cli_writes_json_and_markdown(tmp_path: Path) -> None:
+    """CLI writes compact durable artifacts."""
+    clean = tmp_path / "clean.jsonl"
+    perturbed = tmp_path / "perturbed.jsonl"
+    row = {
+        "scenario_id": "dense_pedestrian_stress",
+        "seed": 2765,
+        "status": "success",
+        "termination_reason": "success",
+        "steps": 10,
+        "horizon": 20,
+        "outcome": {"route_complete": True},
+        "metrics": {"success": 1.0, "min_distance": 0.4, "path_length": 2.0},
+        "observation_noise": {"enabled": False, "profile": "none"},
+        "observation_noise_stats": {"steps_with_noise": 0},
+    }
+    _write_jsonl(clean, row)
+    _write_jsonl(perturbed, row)
+    output_json = tmp_path / "summary.json"
+    output_md = tmp_path / "README.md"
+
+    assert (
+        _load_script().main(
+            [
+                "--clean-jsonl",
+                str(clean),
+                "--perturbed-jsonl",
+                str(perturbed),
+                "--output-json",
+                str(output_json),
+                "--output-md",
+                str(output_md),
+            ]
+        )
+        == 0
+    )
+
+    assert json.loads(output_json.read_text(encoding="utf-8"))["schema_version"].endswith(".v1")
+    assert "Issue #3201" in output_md.read_text(encoding="utf-8")
+
+
+def test_trace_comparator_classifies_observation_only_scenario_too_weak(tmp_path: Path) -> None:
+    """Trace comparison should preserve the live-scenario-too-weak distinction."""
+    clean_trace = tmp_path / "clean_trace.json"
+    perturbed_trace = tmp_path / "perturbed_trace.json"
+    base = {
+        "scenario_id": "dense_pedestrian_stress",
+        "seed": 2765,
+        "observation_perturbation_config": {"position_noise_std_m": 0.0},
+        "progress_summary": {
+            "steps_observed": 2,
+            "net_goal_progress": 1.0,
+            "closest_robot_ped_distance": 7.0,
+            "collision_flag_counts": {"pedestrian": 0, "obstacle": 0, "robot": 0},
+        },
+        "steps": [
+            {
+                "policy_command": [1.0, 0.0],
+                "observation_perturbation": {
+                    "noise_profile": "none",
+                    "evidence_class": "ideal_state",
+                    "missed_actor_count": 0,
+                    "occluded_actor_count": 0,
+                    "observed_actor_count": 3,
+                },
+            }
+        ],
+    }
+    perturbed = {
+        **base,
+        "observation_perturbation_config": {
+            "position_noise_std_m": 0.3,
+            "missed_detection_probability": 0.5,
+        },
+        "steps": [
+            {
+                "policy_command": [1.0, 0.0],
+                "observation_perturbation": {
+                    "noise_profile": "bounded_gaussian",
+                    "evidence_class": "perception_limited",
+                    "missed_actor_count": 2,
+                    "occluded_actor_count": 0,
+                    "observed_actor_count": 1,
+                },
+            }
+        ],
+    }
+    clean_trace.write_text(json.dumps(base), encoding="utf-8")
+    perturbed_trace.write_text(json.dumps(perturbed), encoding="utf-8")
+
+    report = _load_script().build_trace_report(clean_trace, perturbed_trace)
+
+    assert report["classification"]["label"] == "observation_only_scenario_too_weak"
+    assert report["observation_summary"]["changed"] is True
+    assert report["command_summary"]["sequence_changed"] is False
+
+
+def test_trace_comparator_cli_writes_trace_markdown(tmp_path: Path) -> None:
+    """Trace CLI mode writes the compact report and Markdown."""
+    clean_trace = tmp_path / "clean_trace.json"
+    perturbed_trace = tmp_path / "perturbed_trace.json"
+    payload = {
+        "scenario_id": "dense_pedestrian_stress",
+        "seed": 2765,
+        "observation_perturbation_config": {"position_noise_std_m": 0.0},
+        "progress_summary": {"steps_observed": 1, "closest_robot_ped_distance": 1.5},
+        "steps": [
+            {
+                "policy_command": [1.0, 0.0],
+                "observation_perturbation": {
+                    "noise_profile": "none",
+                    "evidence_class": "ideal_state",
+                    "missed_actor_count": 0,
+                    "occluded_actor_count": 0,
+                    "observed_actor_count": 1,
+                },
+            }
+        ],
+    }
+    clean_trace.write_text(json.dumps(payload), encoding="utf-8")
+    perturbed_trace.write_text(json.dumps(payload), encoding="utf-8")
+    output_json = tmp_path / "summary.json"
+    output_md = tmp_path / "README.md"
+
+    assert (
+        _load_script().main(
+            [
+                "--clean-trace-json",
+                str(clean_trace),
+                "--perturbed-trace-json",
+                str(perturbed_trace),
+                "--output-json",
+                str(output_json),
+                "--output-md",
+                str(output_md),
+            ]
+        )
+        == 0
+    )
+
+    assert json.loads(output_json.read_text(encoding="utf-8"))["inputs"]["clean_trace_json"]
+    assert "Progress Deltas" in output_md.read_text(encoding="utf-8")

--- a/tests/docs/test_dissertation_gap_report.py
+++ b/tests/docs/test_dissertation_gap_report.py
@@ -39,7 +39,7 @@ REQUIRED_GAP_FIELDS = {
 }
 VALID_BUCKETS = {"supported", "blocked", "negative_revise_only", "remove_weaken"}
 LEDGER_ROW_COUNT = 7
-REGISTER_ENTRY_COUNT = 3
+REGISTER_ENTRY_COUNT = 4
 
 
 def _load_json(path: Path) -> dict:
@@ -167,9 +167,9 @@ class TestSourceAccounting:
         assert buckets.get("blocked", 0) == 4, (
             f"Expected 4 blocked gaps, got {buckets.get('blocked', 0)}"
         )
-        # negative_revise_only: 4 (pedestrian_density_stress + NR-001 + NR-002 + NR-003)
-        assert buckets.get("negative_revise_only", 0) == 4, (
-            f"Expected 4 negative_revise_only gaps, got {buckets.get('negative_revise_only', 0)}"
+        # negative_revise_only: 5 (pedestrian_density_stress + 4 register diagnostics)
+        assert buckets.get("negative_revise_only", 0) == 5, (
+            f"Expected 5 negative_revise_only gaps, got {buckets.get('negative_revise_only', 0)}"
         )
         # remove_weaken: 1 (exported_tables, non-claimable)
         assert buckets.get("remove_weaken", 0) == 1, (


### PR DESCRIPTION
## Summary
Records the issue #3201 observation-noise retest as a diagnostic-only live smoke result: perturbation changed planner-input pedestrian observations, but did not change commands, progress/risk summaries, or collision flags because the live dense-stress candidate stayed outside the intended near-field target.

## Linked Issues
- Closes `#3201`
- Relates to `#2749`
- Follow-up `#3233`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: `#3233`
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added a pedestrian-dominated observation-noise scenario matrix and policy-search funnel for the `dense_pedestrian_stress` live candidate.
- Added `scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py` for same-seed clean vs perturbed JSONL or step-diagnostics trace comparisons.
- Added focused tests for the matrix, comparator classifications, trace mode, generated evidence, and ignored-artifact-safe report inputs.
- Added compact tracked evidence under `docs/context/evidence/issue_3201_observation_noise_live_smoke/`.
- Updated the negative-result register, dissertation gap report, context evidence catalog, and evidence README.
- Opened follow-up issue `#3233` for the deterministic near-field live fixture required before retesting for a behavioral delta.

## Why It Matters
- Added value: closes the #3201 stop-rule loop with concrete evidence instead of repeating the #2749 distant-pedestrian null.
- Expected impact: future observation-noise work can route directly to #3233 rather than treating the current live dense-stress candidate as benchmark-strength.
- Why this is worth merging now: it preserves a useful negative result and prevents accidental claim promotion from an observation-only perturbation.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: whether a pedestrian-dominated live smoke fixture makes observation perturbations produce a same-seed planner behavior delta after #2749.
- Comparator or baseline, if applicable: same-seed clean `hybrid_rule_v0_minimal` step diagnostics vs bounded-Gaussian/missed-detection observation perturbation.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only / scenario-too-weak.
- Decision or stop rule, if applicable: stop this fixture as a claim candidate; revise toward deterministic near-field fixture in `#3233`.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#3201`, negative-result register `#2762`, dissertation gap report `#2784`, evidence catalog.
- New research/benchmark/metric/paper-facing analysis tool, if any: the comparator is used in this PR on tracked summary evidence; follow-up `#3233` carries the next decision boundary.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, perturbation changed planner-input observations: `179` missed actor observations and observed actor count dropped from `17` to `5-12`.
- Did the intervention change command source, selected command, trajectory, or route progress? no; commands and progress/risk summaries were identical.
- Did the scenario actually contain the targeted failure mode? no; closest live robot-pedestrian distance was `6.999m`, above the intended `2m` near-field target.
- Result route: revise.
- Follow-up question or issue for weak, negative, or non-transfer results: `#3233`.

## Next Empirical Action
- Rerun needed: yes, after #3233 provides a deterministic near-field live fixture.
- Extractor or analysis tool needed: no new extractor; reuse the comparator or successor.
- Artifact missing or unavailable: a deterministic live fixture with baseline closest robot-pedestrian distance within `2m`.
- Stop / revise / continue decision: stop this fixture as diagnostic-only; revise scenario fixture.
- Proposed child issue or existing follow-up: `#3233`.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/run_policy_search_step_diagnostics.py --candidate hybrid_rule_v0_minimal --funnel-config configs/policy_search/issue_3201_observation_noise_funnel.yaml --stage stress_slice --scenario-name dense_pedestrian_stress --seed 2765 --horizon 20 --output-dir output/benchmarks/issue_3201_observation_noise_live_smoke/clean_step`
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/run_policy_search_step_diagnostics.py --candidate hybrid_rule_v0_minimal --funnel-config configs/policy_search/issue_3201_observation_noise_funnel.yaml --stage stress_slice --scenario-name dense_pedestrian_stress --seed 2765 --horizon 20 --output-dir output/benchmarks/issue_3201_observation_noise_live_smoke/perturbed_step --observation-noise-std-m 0.30 --observation-noise-bound-m 0.60 --missed-detection-probability 0.5 --observation-perturbation-seed 3201`
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py --clean-trace-json output/benchmarks/issue_3201_observation_noise_live_smoke/clean_step/trace.json --perturbed-trace-json output/benchmarks/issue_3201_observation_noise_live_smoke/perturbed_step/trace.json --output-json docs/context/evidence/issue_3201_observation_noise_live_smoke/summary.json --output-md docs/context/evidence/issue_3201_observation_noise_live_smoke/README.md`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py tests/benchmark/test_issue_3201_observation_noise_live_smoke.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py tests/benchmark/test_issue_3201_observation_noise_live_smoke.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_issue_3201_observation_noise_live_smoke.py tests/docs/test_negative_result_register.py tests/docs/test_dissertation_gap_report.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_docs_proof_consistency.py --path docs/context/evidence/README.md --path docs/context/evidence/issue_3201_observation_noise_live_smoke/README.md --path docs/context/catalog.yaml --path docs/context/evidence/issue_2762_negative_result_register/register.json --json`
  - `scripts/dev/run_worktree_shared_venv.sh -- python -c "from scripts.validation.check_docs_proof_consistency import uncovered_evidence_bundles, _repo_root; bad=[p.as_posix() for p in uncovered_evidence_bundles(_repo_root()) if 'issue_3201_observation_noise_live_smoke' in p.as_posix()]; assert not bad, bad; print('issue_3201 catalog coverage ok')"`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest 'tests/examples/test_examples_run.py::test_example_runs_without_error[advanced/01_backend_selection.py]' 'tests/examples/test_examples_run.py::test_example_runs_without_error[advanced/15_view_recording.py]' tests/test_visualization_performance.py::TestVisualizationPerformance::test_generate_benchmark_plots_performance -q`
- Evidence that the change works here: tracked `summary.json` classifies the result as `observation_only_scenario_too_weak`; scenario loader resolves the matrix to `dense_pedestrian_stress` seed `2765`; focused tests pass.
- Benchmarks or smoke tests, if applicable: local clean/perturbed step-diagnostics smoke ran for horizon 20. Full `pr_ready_check.sh` was attempted twice through compact validation. First run found the now-fixed dissertation-gap source-accounting failure. Second run reached broad tests but failed on load-sensitive timeouts/performance budgets (`advanced/01_backend_selection.py`, `advanced/15_view_recording.py`, visualization performance); those excerpted failures passed in isolated rerun (`3 passed in 33.02s`). Full logs:
  - `/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/compact-validation/validation-20260620T145220Z-2234509.log`
  - `/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/compact-validation/validation-20260620T145743Z-2241857.log`

## Risks / Rollout
- Compatibility risks: low; new comparator is additive and evidence/config scoped.
- Failure modes: future users could overread this as a robustness result; the register, evidence README, and PR text explicitly mark it diagnostic-only.
- Rollback or fallback plan: revert the additive comparator/config/evidence entries and remove the register/gap-report rows.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`, negative-result register, dissertation gap report.
- Relevant design or provenance notes: compact tracked evidence in `docs/context/evidence/issue_3201_observation_noise_live_smoke/`.
- Any assumptions that need to be preserved: raw step traces are worktree-local ignored artifacts; durable review evidence is the tracked summary/README and register entry.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR closing `#3201`.
- Claim map / benchmark report updated (yes/no/NA): yes, negative-result register and dissertation gap report updated.
- Leaderboard / artifact catalog updated (yes/no/NA): artifact catalog yes; leaderboard NA.
- Registry or config index updated (yes/no/NA): yes, scenario/funnel configs added and evidence catalog updated.
- Context index / memory note updated (yes/no/NA): evidence README updated; memory note NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, `#3233`.
- Not applicable because: no benchmark promotion or leaderboard row is claimed.

## Follow-Up Issues
- Deferred work: deterministic near-field live fixture and rerun.
- Issues opened for follow-up: `#3233`.

## Reviewer Notes
- Verify closely that the diagnostic-only wording remains intact.
- Known limitation: the current live candidate’s closest robot-pedestrian distance was `6.999m`, so this is not evidence of planner sensitivity to near-field pedestrian observation noise.
