### PR TITLE
feat: fidelity rank-stability analysis tool (#3237, child of #3207)

### DIFF
--- a/configs/research/fidelity_sensitivity_v1.yaml
+++ b/configs/research/fidelity_sensitivity_v1.yaml
@@ -1,0 +1,48 @@
+# Simulation-fidelity sensitivity contract (bounded #3207 child).
+#
+# Declares the fidelity-perturbation axes and the ranking/drift contract consumed
+# by robot_sf.benchmark.fidelity_rank_stability. The fidelity SWEEP EXECUTION
+# (running the planners under each setting) lives with parent issue #3207; this
+# config is the analysis contract those runs are scored against.
+#
+# These axes vary INTERNAL simulator fidelity assumptions to measure planner-
+# ranking stability — an upper-bound proxy for simulator dependence, NOT a
+# sim-to-real claim.
+schema_version: fidelity-sensitivity.v1
+issue: 3207
+
+# Metric whose ranking defines the paper-facing planner comparison.
+primary_metric: success_rate
+higher_is_better: true
+
+# Metrics whose drift is reported per axis (absolute relative change vs nominal).
+drift_metrics:
+  - success_rate
+  - collision_rate
+  - min_clearance
+
+# Reference (nominal) fidelity used for current benchmark reporting.
+nominal:
+  description: nominal benchmark fidelity configuration (current reporting baseline)
+
+# >= 3 bounded fidelity perturbation axes. `values` are swept by the parent
+# campaign; the analysis tool consumes the resulting per-axis metric tables.
+fidelity_axes:
+  timestep:
+    description: integration timestep (seconds) for the physics/SFM update
+    nominal: 0.1
+    values: [0.05, 0.1, 0.2]
+  sfm_params:
+    description: multiplicative scaling of social-force interaction strength
+    nominal: 1.0
+    values: [0.8, 1.0, 1.2]
+  observation_noise:
+    description: additive sensor/observation noise standard deviation
+    nominal: 0.0
+    values: [0.0, 0.05, 0.1]
+
+decision_rule: >
+  If the planner ranking is stable across all axes (no rank flips), record the
+  validity boundary as benchmark-strengthening. Any ranking-flipping axis is a
+  required reporting caveat and a candidate calibration target before paper-facing
+  use.

--- a/robot_sf/benchmark/fidelity_rank_stability.py
+++ b/robot_sf/benchmark/fidelity_rank_stability.py
@@ -29,24 +29,41 @@ FIDELITY_RANK_STABILITY_SCHEMA = "fidelity_rank_stability.v1"
 
 
 def rank_planners(
-    table: Mapping[str, Mapping[str, float]],
+    table: Mapping[str, Mapping[str, object]],
     metric: str,
     *,
     higher_is_better: bool = True,
 ) -> list[str]:
     """Return planner names ordered best to worst by ``metric``.
 
-    Ties are broken by planner name for stable, deterministic output.
+    Ties are broken by planner name for stable, deterministic output. Rows
+    missing ``metric`` or carrying non-numeric/non-finite values sort last.
 
     Returns:
         Planner names ordered from best to worst on ``metric``.
     """
 
-    def sort_key(planner: str) -> tuple[float, str]:
-        value = float(table[planner][metric])
-        return (-value if higher_is_better else value, planner)
+    def sort_key(planner: str) -> tuple[int, float, str]:
+        value = _finite_metric_value(table[planner], metric)
+        if value is None:
+            return (1, 0.0, planner)
+        return (0, -value if higher_is_better else value, planner)
 
     return sorted(table, key=sort_key)
+
+
+def _finite_metric_value(metrics: Mapping[str, object], metric: str) -> float | None:
+    """Return a finite numeric metric value, or ``None`` when unavailable."""
+    raw_value = metrics.get(metric)
+    if raw_value is None or isinstance(raw_value, bool):
+        return None
+    try:
+        value = float(raw_value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(value):
+        return None
+    return value
 
 
 def _rank_vector(order: list[str], planners: list[str]) -> list[int]:
@@ -91,14 +108,14 @@ def count_rank_flips(order_a: list[str], order_b: list[str]) -> int:
 
 
 def metric_drift(
-    nominal: Mapping[str, Mapping[str, float]],
-    axis: Mapping[str, Mapping[str, float]],
+    nominal: Mapping[str, Mapping[str, object]],
+    axis: Mapping[str, Mapping[str, object]],
     metrics: Iterable[str],
 ) -> dict[str, float]:
     """Return mean absolute relative drift per metric (axis vs nominal).
 
     Drift for one planner/metric is ``|axis - nominal| / max(|nominal|, 1)``,
-    averaged across planners present in both tables.
+    averaged across planners present in both tables with finite numeric values.
 
     Returns:
         Mapping of metric name to mean absolute relative drift.
@@ -109,11 +126,11 @@ def metric_drift(
         for planner, nominal_metrics in nominal.items():
             if planner not in axis:
                 continue
-            base = nominal_metrics.get(metric)
-            current = axis[planner].get(metric)
+            base = _finite_metric_value(nominal_metrics, metric)
+            current = _finite_metric_value(axis[planner], metric)
             if base is None or current is None:
                 continue
-            denom = abs(base) if base != 0 else 1.0
+            denom = max(abs(base), 1.0)
             relatives.append(abs(current - base) / denom)
         drift[metric] = sum(relatives) / len(relatives) if relatives else 0.0
     return drift
@@ -176,8 +193,8 @@ class FidelitySensitivityReport:
 
 
 def analyze_fidelity_sensitivity(
-    nominal_table: Mapping[str, Mapping[str, float]],
-    axis_tables: Mapping[str, Mapping[str, Mapping[str, float]]],
+    nominal_table: Mapping[str, Mapping[str, object]],
+    axis_tables: Mapping[str, Mapping[str, Mapping[str, object]]],
     *,
     primary_metric: str,
     higher_is_better: bool = True,

--- a/robot_sf/benchmark/fidelity_rank_stability.py
+++ b/robot_sf/benchmark/fidelity_rank_stability.py
@@ -1,0 +1,238 @@
+"""Fidelity rank-stability and metric-drift analysis (bounded #3207 child).
+
+Given planner metric tables measured under a *nominal* simulation fidelity plus
+one table per *fidelity-perturbation axis* (the sweep output), this module reports
+whether the planner **ranking** is stable across fidelity assumptions and which
+axes flip it. That is the evidence behind a defensible benchmark validity
+boundary: a ranking that survives a bounded fidelity sweep is benchmark-
+strengthening; an axis that flips the ranking is a required reporting caveat and a
+calibration candidate.
+
+Pure and deterministic: it operates on already-measured metric tables and runs no
+simulation. It is analysis tooling and makes no benchmark or sim-to-real claim;
+fidelity perturbations are deliberate sensitivity probes, not fallback/degraded
+runs. The fidelity *sweep execution* lives with parent issue #3207.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from scipy.stats import kendalltau
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+FIDELITY_RANK_STABILITY_SCHEMA = "fidelity_rank_stability.v1"
+
+
+def rank_planners(
+    table: Mapping[str, Mapping[str, float]],
+    metric: str,
+    *,
+    higher_is_better: bool = True,
+) -> list[str]:
+    """Return planner names ordered best to worst by ``metric``.
+
+    Ties are broken by planner name for stable, deterministic output.
+
+    Returns:
+        Planner names ordered from best to worst on ``metric``.
+    """
+
+    def sort_key(planner: str) -> tuple[float, str]:
+        value = float(table[planner][metric])
+        return (-value if higher_is_better else value, planner)
+
+    return sorted(table, key=sort_key)
+
+
+def _rank_vector(order: list[str], planners: list[str]) -> list[int]:
+    """Return each planner's positional rank within ``order``."""
+    position = {planner: index for index, planner in enumerate(order)}
+    return [position[planner] for planner in planners]
+
+
+def kendall_tau(order_a: list[str], order_b: list[str]) -> float:
+    """Return Kendall tau between two orderings of the same planners.
+
+    ``1.0`` means identical order, ``-1.0`` fully reversed. Degenerate inputs
+    (fewer than two planners) return ``1.0``.
+
+    Returns:
+        Kendall tau-b rank correlation in ``[-1.0, 1.0]``.
+    """
+    planners = sorted(order_a)
+    if len(planners) < 2:
+        return 1.0
+    tau = kendalltau(_rank_vector(order_a, planners), _rank_vector(order_b, planners)).statistic
+    if tau is None or math.isnan(tau):
+        return 1.0
+    return float(tau)
+
+
+def count_rank_flips(order_a: list[str], order_b: list[str]) -> int:
+    """Return the number of discordant planner pairs between two orderings.
+
+    ``0`` means the two orderings agree on every pairwise comparison.
+
+    Returns:
+        Count of pairs whose relative order differs between ``order_a`` and ``order_b``.
+    """
+    position_b = {planner: index for index, planner in enumerate(order_b)}
+    flips = 0
+    for i in range(len(order_a)):
+        for j in range(i + 1, len(order_a)):
+            if position_b[order_a[i]] > position_b[order_a[j]]:
+                flips += 1
+    return flips
+
+
+def metric_drift(
+    nominal: Mapping[str, Mapping[str, float]],
+    axis: Mapping[str, Mapping[str, float]],
+    metrics: Iterable[str],
+) -> dict[str, float]:
+    """Return mean absolute relative drift per metric (axis vs nominal).
+
+    Drift for one planner/metric is ``|axis - nominal| / max(|nominal|, 1)``,
+    averaged across planners present in both tables.
+
+    Returns:
+        Mapping of metric name to mean absolute relative drift.
+    """
+    drift: dict[str, float] = {}
+    for metric in metrics:
+        relatives: list[float] = []
+        for planner, nominal_metrics in nominal.items():
+            if planner not in axis:
+                continue
+            base = nominal_metrics.get(metric)
+            current = axis[planner].get(metric)
+            if base is None or current is None:
+                continue
+            denom = abs(base) if base != 0 else 1.0
+            relatives.append(abs(current - base) / denom)
+        drift[metric] = sum(relatives) / len(relatives) if relatives else 0.0
+    return drift
+
+
+@dataclass(frozen=True)
+class AxisRankStability:
+    """Rank-stability + drift result for one fidelity-perturbation axis."""
+
+    axis: str
+    ranking: list[str]
+    kendall_tau: float
+    rank_flips: int
+    top1_changed: bool
+    metric_drift: dict[str, float]
+
+    def to_dict(self) -> dict[str, object]:
+        """Return JSON-safe representation.
+
+        Returns:
+            Mapping with the axis ranking, tau, rank flips, top-1 change, and drift.
+        """
+        return {
+            "axis": self.axis,
+            "ranking": list(self.ranking),
+            "kendall_tau": self.kendall_tau,
+            "rank_flips": self.rank_flips,
+            "top1_changed": self.top1_changed,
+            "metric_drift": dict(self.metric_drift),
+        }
+
+
+@dataclass(frozen=True)
+class FidelitySensitivityReport:
+    """Validity-boundary report across all fidelity axes."""
+
+    primary_metric: str
+    higher_is_better: bool
+    nominal_ranking: list[str]
+    axes: list[AxisRankStability]
+    flipping_axes: list[str]
+    rank_stable: bool
+
+    def to_dict(self) -> dict[str, object]:
+        """Return the ``fidelity_rank_stability.v1`` JSON-safe payload.
+
+        Returns:
+            Mapping with the schema version, nominal ranking, per-axis results,
+            flipping axes, and the validity-boundary verdict.
+        """
+        return {
+            "schema_version": FIDELITY_RANK_STABILITY_SCHEMA,
+            "primary_metric": self.primary_metric,
+            "higher_is_better": self.higher_is_better,
+            "nominal_ranking": list(self.nominal_ranking),
+            "rank_stable": self.rank_stable,
+            "flipping_axes": list(self.flipping_axes),
+            "axes": [axis.to_dict() for axis in self.axes],
+        }
+
+
+def analyze_fidelity_sensitivity(
+    nominal_table: Mapping[str, Mapping[str, float]],
+    axis_tables: Mapping[str, Mapping[str, Mapping[str, float]]],
+    *,
+    primary_metric: str,
+    higher_is_better: bool = True,
+    drift_metrics: Iterable[str] | None = None,
+) -> FidelitySensitivityReport:
+    """Analyze planner-ranking stability across fidelity-perturbation axes.
+
+    Each axis table must contain the same planner set as ``nominal_table``. The
+    nominal ranking (by ``primary_metric``) is the reference; each axis reports
+    Kendall tau, rank-flip count, top-1 change, and per-metric drift relative to
+    nominal. An axis with any rank flip is flagged as ranking-sensitive.
+
+    Returns:
+        A :class:`FidelitySensitivityReport` with per-axis results and the
+        overall ``rank_stable`` validity-boundary verdict.
+    """
+    if not nominal_table:
+        raise ValueError("nominal_table must contain at least one planner")
+    nominal_planners = set(nominal_table)
+    if drift_metrics is not None:
+        metrics = list(drift_metrics)
+    else:
+        metrics = sorted({name for row in nominal_table.values() for name in row})
+    nominal_ranking = rank_planners(
+        nominal_table, primary_metric, higher_is_better=higher_is_better
+    )
+
+    axes: list[AxisRankStability] = []
+    flipping_axes: list[str] = []
+    for axis_name, table in axis_tables.items():
+        if set(table) != nominal_planners:
+            raise ValueError(
+                f"fidelity axis '{axis_name}' planner set does not match nominal "
+                f"({sorted(table)} vs {sorted(nominal_planners)})"
+            )
+        ranking = rank_planners(table, primary_metric, higher_is_better=higher_is_better)
+        flips = count_rank_flips(nominal_ranking, ranking)
+        axes.append(
+            AxisRankStability(
+                axis=axis_name,
+                ranking=ranking,
+                kendall_tau=kendall_tau(nominal_ranking, ranking),
+                rank_flips=flips,
+                top1_changed=bool(nominal_ranking and ranking and nominal_ranking[0] != ranking[0]),
+                metric_drift=metric_drift(nominal_table, table, metrics),
+            )
+        )
+        if flips > 0:
+            flipping_axes.append(axis_name)
+
+    return FidelitySensitivityReport(
+        primary_metric=primary_metric,
+        higher_is_better=higher_is_better,
+        nominal_ranking=nominal_ranking,
+        axes=axes,
+        flipping_axes=flipping_axes,
+        rank_stable=not flipping_axes,
+    )

--- a/tests/benchmark/test_fidelity_rank_stability.py
+++ b/tests/benchmark/test_fidelity_rank_stability.py
@@ -39,6 +39,27 @@ def test_rank_planners_lower_is_better() -> None:
     assert rank_planners(table, "collision_rate", higher_is_better=False) == ["p_a", "p_b"]
 
 
+def test_rank_planners_sorts_missing_and_invalid_values_last() -> None:
+    """Missing, non-numeric, and non-finite metric values sort last deterministically."""
+    table = {
+        "valid_b": {"success_rate": 0.6},
+        "missing": {},
+        "invalid_text": {"success_rate": "not-a-number"},
+        "nan": {"success_rate": float("nan")},
+        "valid_a": {"success_rate": 0.9},
+        "inf": {"success_rate": float("inf")},
+    }
+
+    assert rank_planners(table, "success_rate", higher_is_better=True) == [
+        "valid_a",
+        "valid_b",
+        "inf",
+        "invalid_text",
+        "missing",
+        "nan",
+    ]
+
+
 def test_kendall_tau_identical_and_reversed() -> None:
     """Identical order gives 1.0, reversed gives -1.0, singletons give 1.0."""
     assert kendall_tau(["a", "b", "c"], ["a", "b", "c"]) == 1.0
@@ -57,6 +78,32 @@ def test_metric_drift_relative_change() -> None:
     """Drift is the mean absolute relative change per metric."""
     nominal = {"p": {"m": 1.0}}
     axis = {"p": {"m": 1.5}}
+    assert metric_drift(nominal, axis, ["m"]) == {"m": 0.5}
+
+
+def test_metric_drift_uses_documented_unit_floor_denominator() -> None:
+    """Sub-unit nominal values use max(abs(nominal), 1.0) as the denominator."""
+    nominal = {"p": {"success_rate": 0.02}}
+    axis = {"p": {"success_rate": 0.04}}
+    assert metric_drift(nominal, axis, ["success_rate"]) == {"success_rate": 0.02}
+
+
+def test_metric_drift_skips_missing_invalid_and_non_finite_values() -> None:
+    """Drift ignores rows that cannot produce a finite numeric comparison."""
+    nominal = {
+        "valid": {"m": 1.0},
+        "missing_axis_metric": {"m": 1.0},
+        "nan": {"m": float("nan")},
+        "text": {"m": "bad"},
+        "inf_axis": {"m": 1.0},
+    }
+    axis = {
+        "valid": {"m": 1.5},
+        "missing_axis_metric": {},
+        "nan": {"m": 1.0},
+        "text": {"m": 1.0},
+        "inf_axis": {"m": float("inf")},
+    }
     assert metric_drift(nominal, axis, ["m"]) == {"m": 0.5}
 
 

--- a/tests/benchmark/test_fidelity_rank_stability.py
+++ b/tests/benchmark/test_fidelity_rank_stability.py
@@ -1,0 +1,140 @@
+"""Tests for fidelity rank-stability analysis (issue #3237, child of #3207)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.fidelity_rank_stability import (
+    FIDELITY_RANK_STABILITY_SCHEMA,
+    analyze_fidelity_sensitivity,
+    count_rank_flips,
+    kendall_tau,
+    metric_drift,
+    rank_planners,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG = _REPO_ROOT / "configs" / "research" / "fidelity_sensitivity_v1.yaml"
+
+
+# --- primitives -----------------------------------------------------------
+
+
+def test_rank_planners_orders_best_first() -> None:
+    """Higher primary metric ranks first; ties broken by name."""
+    table = {
+        "p_a": {"success_rate": 0.9},
+        "p_b": {"success_rate": 0.7},
+        "p_c": {"success_rate": 0.9},
+    }
+    assert rank_planners(table, "success_rate", higher_is_better=True) == ["p_a", "p_c", "p_b"]
+
+
+def test_rank_planners_lower_is_better() -> None:
+    """Lower-is-better metrics rank ascending."""
+    table = {"p_a": {"collision_rate": 0.1}, "p_b": {"collision_rate": 0.3}}
+    assert rank_planners(table, "collision_rate", higher_is_better=False) == ["p_a", "p_b"]
+
+
+def test_kendall_tau_identical_and_reversed() -> None:
+    """Identical order gives 1.0, reversed gives -1.0, singletons give 1.0."""
+    assert kendall_tau(["a", "b", "c"], ["a", "b", "c"]) == 1.0
+    assert kendall_tau(["a", "b", "c"], ["c", "b", "a"]) == -1.0
+    assert kendall_tau(["a"], ["a"]) == 1.0
+
+
+def test_count_rank_flips() -> None:
+    """Discordant pairs are counted; identical order has zero flips."""
+    assert count_rank_flips(["a", "b", "c"], ["a", "b", "c"]) == 0
+    assert count_rank_flips(["a", "b", "c"], ["b", "a", "c"]) == 1
+    assert count_rank_flips(["a", "b", "c"], ["c", "b", "a"]) == 3
+
+
+def test_metric_drift_relative_change() -> None:
+    """Drift is the mean absolute relative change per metric."""
+    nominal = {"p": {"m": 1.0}}
+    axis = {"p": {"m": 1.5}}
+    assert metric_drift(nominal, axis, ["m"]) == {"m": 0.5}
+
+
+# --- end-to-end analysis --------------------------------------------------
+
+_NOMINAL = {
+    "planner_x": {"success_rate": 0.90, "collision_rate": 0.05},
+    "planner_y": {"success_rate": 0.80, "collision_rate": 0.10},
+    "planner_z": {"success_rate": 0.70, "collision_rate": 0.15},
+}
+
+
+def test_analyze_reports_rank_stable_when_order_preserved() -> None:
+    """Axes that preserve the nominal order yield a rank-stable verdict."""
+    axis_tables = {
+        "timestep": {
+            "planner_x": {"success_rate": 0.88, "collision_rate": 0.06},
+            "planner_y": {"success_rate": 0.79, "collision_rate": 0.11},
+            "planner_z": {"success_rate": 0.69, "collision_rate": 0.16},
+        },
+    }
+    report = analyze_fidelity_sensitivity(
+        _NOMINAL, axis_tables, primary_metric="success_rate", drift_metrics=["success_rate"]
+    )
+    assert report.nominal_ranking == ["planner_x", "planner_y", "planner_z"]
+    assert report.rank_stable is True
+    assert report.flipping_axes == []
+    axis = report.axes[0]
+    assert axis.kendall_tau == 1.0
+    assert axis.rank_flips == 0
+    assert axis.top1_changed is False
+    assert axis.metric_drift["success_rate"] > 0
+
+
+def test_analyze_flags_ranking_flipping_axis() -> None:
+    """An axis that reorders the top planners is flagged ranking-sensitive."""
+    axis_tables = {
+        "observation_noise": {  # noise flips x and y at the top
+            "planner_x": {"success_rate": 0.60, "collision_rate": 0.20},
+            "planner_y": {"success_rate": 0.85, "collision_rate": 0.08},
+            "planner_z": {"success_rate": 0.55, "collision_rate": 0.22},
+        },
+    }
+    report = analyze_fidelity_sensitivity(
+        _NOMINAL, axis_tables, primary_metric="success_rate", drift_metrics=["success_rate"]
+    )
+    assert report.rank_stable is False
+    assert "observation_noise" in report.flipping_axes
+    axis = report.axes[0]
+    assert axis.rank_flips > 0
+    assert axis.top1_changed is True
+    assert axis.kendall_tau < 1.0
+
+
+def test_analyze_rejects_planner_set_mismatch() -> None:
+    """An axis missing a nominal planner is rejected."""
+    axis_tables = {"bad": {"planner_x": {"success_rate": 0.9}}}
+    with pytest.raises(ValueError, match="planner set does not match"):
+        analyze_fidelity_sensitivity(_NOMINAL, axis_tables, primary_metric="success_rate")
+
+
+def test_report_to_dict_uses_schema() -> None:
+    """The report payload carries the fidelity_rank_stability.v1 schema."""
+    report = analyze_fidelity_sensitivity(
+        _NOMINAL, {}, primary_metric="success_rate", drift_metrics=["success_rate"]
+    )
+    payload = report.to_dict()
+    assert payload["schema_version"] == FIDELITY_RANK_STABILITY_SCHEMA
+    assert payload["nominal_ranking"] == ["planner_x", "planner_y", "planner_z"]
+    assert payload["rank_stable"] is True
+
+
+# --- shipped config -------------------------------------------------------
+
+
+def test_config_declares_three_axes_and_primary_metric() -> None:
+    """The shipped contract declares >=3 fidelity axes and a primary metric."""
+    data = yaml.safe_load(_CONFIG.read_text(encoding="utf-8"))
+    assert data["primary_metric"]
+    assert len(data["fidelity_axes"]) >= 3
+    assert {"timestep", "sfm_params", "observation_noise"} <= set(data["fidelity_axes"])


### PR DESCRIPTION
## Summary

Adds the bounded, pure **analysis core** for the simulation-fidelity sensitivity study (issue #3237,
child of #3207): given planner metric tables under a nominal fidelity plus one per fidelity-
perturbation axis, it reports whether the planner **ranking** is stable and which axes flip it — the
evidence behind a defensible benchmark validity boundary.

## Linked Issues
- Closes `#3237`
- Refs `#3207` (parent — owns the fidelity sweep execution)

## What Changed
- **`robot_sf/benchmark/fidelity_rank_stability.py`** (new): `rank_planners`, `kendall_tau` (via
  `scipy.stats.kendalltau`), `count_rank_flips`, `metric_drift`, and `analyze_fidelity_sensitivity`,
  which emits a `fidelity_rank_stability.v1` report with per-axis Kendall tau, rank-flip count, top-1
  change, per-metric drift, the list of ranking-flipping axes, and an overall `rank_stable` verdict.
- **`configs/research/fidelity_sensitivity_v1.yaml`** (new): the analysis contract — ≥3 fidelity axes
  (`timestep`, `sfm_params`, `observation_noise`), the primary ranking metric, and drift metrics.
- **`tests/benchmark/test_fidelity_rank_stability.py`** (new): primitives, a rank-stable case and a
  ranking-flipping case end to end, planner-set validation, schema, and the shipped config.

## Boundary (honest scope)
Pure and deterministic — it consumes already-measured metric tables and **runs no simulation**. The
fidelity **sweep execution** (running planners under each axis setting) stays with parent #3207. This
is analysis tooling; it makes no benchmark or sim-to-real claim, and fidelity perturbations are
labeled deliberate sensitivity probes, not fallback/degraded runs.

## Why It Matters
- Turns the parent's "rank-stability + metric-drift analysis" acceptance criterion into a reusable,
  tested tool, so the eventual sweep produces a validity-boundary verdict without bespoke analysis.
- (A parallel private `_kendall_tau` exists in `scripts/tools/analyze_snqi_vs_single_metric_ranking.py`
  for an SNQI-specific comparison; this is a general benchmark library module using scipy's tau-b. A
  future consolidation could share one implementation.)

## Research Result Guidance
- Evidence tier: `analysis-tool` (mechanism). No benchmark/metric/paper claim; the verdict depends on
  real sweep inputs supplied by #3207. Decision rule (in the config): stable ranking ⇒
  benchmark-strengthening validity boundary; any flipping axis ⇒ required caveat / calibration target.

## Falsification / Non-Transfer Check
- `NA` — adds a tool + tests, not a measured outcome.

## Next Empirical Action
- Parent #3207: run the bounded fidelity sweep, feed the per-axis tables to this tool, and record the
  validity-boundary statement as a context note.

## Validation / Proof
- `pytest tests/benchmark/test_fidelity_rank_stability.py` → 10 passed.
- `ruff check`/`format` → clean.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` → see CI / gate result.
- First use on a fixture is included in the tests (a synthetic rank-stable batch and a ranking-flipping
  batch); the real durable input is the #3207 sweep output.

## Risks / Rollout
- Compatibility risks: minimal. All-new module + config + tests; no existing runtime/benchmark path is
  touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
