### PR TITLE
research: add fidelity sensitivity launch packet (#3207)

### DIFF
--- a/configs/research/fidelity_sensitivity_v1.yaml
+++ b/configs/research/fidelity_sensitivity_v1.yaml
@@ -1,0 +1,125 @@
+schema_version: fidelity-sensitivity.v1
+issue: 3207
+study_id: issue_3207_fidelity_sensitivity_v1
+status: launch_packet
+
+claim_boundary: >
+  Protocol and metric contract only. This config defines deliberate simulation-fidelity
+  sensitivity probes and the rank-stability/drift outputs required before benchmark claims
+  can state a validity boundary. It is not benchmark evidence, sensor-realism evidence,
+  sim-to-real evidence, or a paper-facing planner-ranking result until the sweep is run
+  and promoted through a compact evidence bundle.
+
+baseline:
+  key: nominal_fidelity
+  benchmark_config: configs/benchmarks/paper_experiment_matrix_v1.yaml
+  interpretation: current_nominal_benchmark_fidelity
+
+fixed_scope:
+  scenario_set: configs/benchmarks/paper_experiment_matrix_v1.yaml
+  seeds: [111, 112, 113]
+  planner_groups:
+    - orca
+    - default_social_force
+    - hybrid_rule_v0_minimal
+
+ranking:
+  metric: snqi
+  higher_is_better: true
+  stability_min_kendall_tau: 0.8
+  rank_flip_requires_caveat: true
+
+metrics:
+  - name: snqi
+    direction: higher_is_better
+  - name: success
+    direction: higher_is_better
+  - name: collisions
+    direction: lower_is_better
+  - name: near_misses
+    direction: lower_is_better
+  - name: time_to_goal_norm
+    direction: lower_is_better
+
+axes:
+  - key: integration_timestep
+    rationale: Detect whether planner rankings depend on the simulator integration step.
+    variants:
+      - key: dt_0_05
+        patch:
+          dt: 0.05
+      - key: dt_0_10_nominal
+        baseline: true
+        patch:
+          dt: 0.10
+      - key: dt_0_20
+        patch:
+          dt: 0.20
+  - key: social_force_speed_archetypes
+    rationale: Detect whether pedestrian speed heterogeneity changes ranking stability.
+    variants:
+      - key: homogeneous_standard_nominal
+        baseline: true
+        patch:
+          pedestrian_archetypes:
+            standard: 1.0
+      - key: mixed_balanced
+        patch:
+          pedestrian_archetypes:
+            cautious: 0.34
+            standard: 0.33
+            hurried: 0.33
+      - key: rush_hour
+        patch:
+          pedestrian_archetypes:
+            cautious: 0.20
+            standard: 0.30
+            hurried: 0.50
+  - key: observation_noise
+    rationale: Detect whether ranking stability depends on non-calibrated robustness noise.
+    variants:
+      - key: none_nominal
+        baseline: true
+        observation_noise:
+          profile: none
+      - key: pose_heading_low
+        observation_noise:
+          profile: pose_heading_low
+          pose_noise_std_m: 0.05
+          heading_noise_std_rad: 0.03
+      - key: pedestrian_dropout_low
+        observation_noise:
+          profile: pedestrian_dropout_low
+          pedestrian_false_negative_prob: 0.10
+  - key: clearance_radius
+    rationale: Detect whether planner rankings are brittle to collision/proxemic radius assumptions.
+    variants:
+      - key: radius_0_40_nominal
+        baseline: true
+        patch:
+          sim_config:
+            ped_radius: 0.40
+      - key: radius_0_30
+        patch:
+          sim_config:
+            ped_radius: 0.30
+      - key: radius_0_50
+        patch:
+          sim_config:
+            ped_radius: 0.50
+
+result_contract:
+  required_outputs:
+    - axis
+    - variant
+    - planner
+    - seed
+    - scenario_id
+    - metric_values
+    - rank_metric
+    - kendall_tau_vs_baseline
+    - rank_flip_count
+    - per_metric_drift_vs_baseline
+  caveat_rule: >
+    Any axis with a rank_flip_count greater than zero must be reported as a validity-boundary
+    caveat and calibration candidate before paper-facing benchmark use.

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1027,7 +1027,7 @@ knowledge, not every transient iteration detail.
   [Issue #2428 AMMV mechanism trace panels](evidence/issue_2428_mechanism_trace_panels_2026-06-06/README.md),
   [Issue #2432 AMMV trace selection evidence](evidence/issue_2432_ammv_trace_selection_2026-06-06/README.md),
   [Issue #2434 AMMV scenario sweep evidence](evidence/issue_2434_ammv_scenario_sweep_2026-06-06/README.md),
-  [Issue #3207 fidelity sensitivity launch packet](evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/README.md),
+  [Issue #3207 Fidelity Sensitivity Launch Packet 2026-06-20](evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/README.md),
   and the
   [May 4 camera-ready all-planners evidence](evidence/camera_ready_all_planners_2026-05-04/README.md).
 

--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1027,6 +1027,7 @@ knowledge, not every transient iteration detail.
   [Issue #2428 AMMV mechanism trace panels](evidence/issue_2428_mechanism_trace_panels_2026-06-06/README.md),
   [Issue #2432 AMMV trace selection evidence](evidence/issue_2432_ammv_trace_selection_2026-06-06/README.md),
   [Issue #2434 AMMV scenario sweep evidence](evidence/issue_2434_ammv_scenario_sweep_2026-06-06/README.md),
+  [Issue #3207 fidelity sensitivity launch packet](evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/README.md),
   and the
   [May 4 camera-ready all-planners evidence](evidence/camera_ready_all_planners_2026-05-04/README.md).
 

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -162,6 +162,9 @@ Policy caveats:
   changed planner-input pedestrian observations, but commands and progress/risk summaries stayed
   identical because the live scenario remained outside the intended 2 m near-field target. Not
   benchmark or sensor-realism evidence.
+- `issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/`: launch-packet-only simulation
+  fidelity sensitivity contract for #3207. Defines the tracked config, fidelity axes, required
+  rank-stability and metric-drift outputs, and no-evidence boundary before any sweep is run.
 - `policy_search_h500_2026-05-06/`: h500 policy-search leader summaries and failure reports that
   support the v1 raw-success leader and v2 strict-gate promotion decision.
 - `issue_1023_scenario_horizons_preflight_2026-05-06/`: compact preflight artifacts for the

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -165,6 +165,10 @@ Policy caveats:
 - `issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/`: launch-packet-only simulation
   fidelity sensitivity contract for #3207. Defines the tracked config, fidelity axes, required
   rank-stability and metric-drift outputs, and no-evidence boundary before any sweep is run.
+- `issue_3207_fidelity_sensitivity_smoke_2026-06-20/`: diagnostic-only two-planner live smoke for
+  #3207 over the same compact scenario surface. It materializes rank-stability and metric-drift
+  calculations across clean timestep variants and the existing observation-noise smoke profile; it
+  is not benchmark-strength planner-ranking, sensor-realism, or sim-to-real evidence.
 - `policy_search_h500_2026-05-06/`: h500 policy-search leader summaries and failure reports that
   support the v1 raw-success leader and v2 strict-gate promotion decision.
 - `issue_1023_scenario_horizons_preflight_2026-05-06/`: compact preflight artifacts for the

--- a/docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/README.md
+++ b/docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/README.md
@@ -1,0 +1,48 @@
+# Issue #3207 Fidelity Sensitivity Launch Packet
+
+- Status: `launch_packet_only`
+- Study: `issue_3207_fidelity_sensitivity_v1`
+- Config: `configs/research/fidelity_sensitivity_v1.yaml`
+- Git head: `ef1759cb`
+- Claim boundary: Protocol and metric contract only. This config defines deliberate simulation-fidelity sensitivity probes and the rank-stability/drift outputs required before benchmark claims can state a validity boundary. It is not benchmark evidence, sensor-realism evidence, sim-to-real evidence, or a paper-facing planner-ranking result until the sweep is run and promoted through a compact evidence bundle.
+
+
+## Scope
+
+- Scenario set: `configs/benchmarks/paper_experiment_matrix_v1.yaml`
+- Seeds: `111, 112, 113`
+- Planner groups: `orca, default_social_force, hybrid_rule_v0_minimal`
+- Ranking metric: `snqi`
+
+## Fidelity Axes
+
+| Axis | Variants | Baseline Variant | Rationale |
+|---|---:|---|---|
+| `integration_timestep` | 3 | `dt_0_10_nominal` | Detect whether planner rankings depend on the simulator integration step. |
+| `social_force_speed_archetypes` | 3 | `homogeneous_standard_nominal` | Detect whether pedestrian speed heterogeneity changes ranking stability. |
+| `observation_noise` | 3 | `none_nominal` | Detect whether ranking stability depends on non-calibrated robustness noise. |
+| `clearance_radius` | 3 | `radius_0_40_nominal` | Detect whether planner rankings are brittle to collision/proxemic radius assumptions. |
+
+## Result Contract
+
+Before this packet can support a validity-boundary claim, the sweep output must report:
+- `axis`
+- `variant`
+- `planner`
+- `seed`
+- `scenario_id`
+- `metric_values`
+- `rank_metric`
+- `kendall_tau_vs_baseline`
+- `rank_flip_count`
+- `per_metric_drift_vs_baseline`
+
+Any axis with `rank_flip_count > 0` is a caveat/calibration candidate.
+
+## Next Command Template
+
+```bash
+uv run python scripts/<fidelity_sweep>.py --config configs/research/fidelity_sensitivity_v1.yaml --out output/fidelity_sensitivity/
+```
+
+This packet is not benchmark evidence until a sweep is run and promoted with provenance.

--- a/docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/README.md
+++ b/docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/README.md
@@ -1,9 +1,9 @@
-# Issue #3207 Fidelity Sensitivity Launch Packet
+# Issue #3207 Fidelity Sensitivity Launch Packet 2026-06-20
 
 - Status: `launch_packet_only`
 - Study: `issue_3207_fidelity_sensitivity_v1`
 - Config: `configs/research/fidelity_sensitivity_v1.yaml`
-- Git head: `ef1759cb`
+- Git head: `c553e797c`
 - Claim boundary: Protocol and metric contract only. This config defines deliberate simulation-fidelity sensitivity probes and the rank-stability/drift outputs required before benchmark claims can state a validity boundary. It is not benchmark evidence, sensor-realism evidence, sim-to-real evidence, or a paper-facing planner-ranking result until the sweep is run and promoted through a compact evidence bundle.
 
 

--- a/docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/launch_packet.json
+++ b/docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/launch_packet.json
@@ -28,6 +28,7 @@
   "axis_count": 4,
   "claim_boundary": "Protocol and metric contract only. This config defines deliberate simulation-fidelity sensitivity probes and the rank-stability/drift outputs required before benchmark claims can state a validity boundary. It is not benchmark evidence, sensor-realism evidence, sim-to-real evidence, or a paper-facing planner-ranking result until the sweep is run and promoted through a compact evidence bundle.\n",
   "config_path": "configs/research/fidelity_sensitivity_v1.yaml",
+  "date": "2026-06-20",
   "fixed_scope": {
     "planner_groups": [
       "orca",
@@ -41,7 +42,7 @@
       113
     ]
   },
-  "git_head": "ef1759cb",
+  "git_head": "c553e797c",
   "issue": 3207,
   "metrics": [
     {

--- a/docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/launch_packet.json
+++ b/docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/launch_packet.json
@@ -1,0 +1,93 @@
+{
+  "axes": [
+    {
+      "baseline_variant": "dt_0_10_nominal",
+      "key": "integration_timestep",
+      "rationale": "Detect whether planner rankings depend on the simulator integration step.",
+      "variant_count": 3
+    },
+    {
+      "baseline_variant": "homogeneous_standard_nominal",
+      "key": "social_force_speed_archetypes",
+      "rationale": "Detect whether pedestrian speed heterogeneity changes ranking stability.",
+      "variant_count": 3
+    },
+    {
+      "baseline_variant": "none_nominal",
+      "key": "observation_noise",
+      "rationale": "Detect whether ranking stability depends on non-calibrated robustness noise.",
+      "variant_count": 3
+    },
+    {
+      "baseline_variant": "radius_0_40_nominal",
+      "key": "clearance_radius",
+      "rationale": "Detect whether planner rankings are brittle to collision/proxemic radius assumptions.",
+      "variant_count": 3
+    }
+  ],
+  "axis_count": 4,
+  "claim_boundary": "Protocol and metric contract only. This config defines deliberate simulation-fidelity sensitivity probes and the rank-stability/drift outputs required before benchmark claims can state a validity boundary. It is not benchmark evidence, sensor-realism evidence, sim-to-real evidence, or a paper-facing planner-ranking result until the sweep is run and promoted through a compact evidence bundle.\n",
+  "config_path": "configs/research/fidelity_sensitivity_v1.yaml",
+  "fixed_scope": {
+    "planner_groups": [
+      "orca",
+      "default_social_force",
+      "hybrid_rule_v0_minimal"
+    ],
+    "scenario_set": "configs/benchmarks/paper_experiment_matrix_v1.yaml",
+    "seeds": [
+      111,
+      112,
+      113
+    ]
+  },
+  "git_head": "ef1759cb",
+  "issue": 3207,
+  "metrics": [
+    {
+      "direction": "higher_is_better",
+      "name": "snqi"
+    },
+    {
+      "direction": "higher_is_better",
+      "name": "success"
+    },
+    {
+      "direction": "lower_is_better",
+      "name": "collisions"
+    },
+    {
+      "direction": "lower_is_better",
+      "name": "near_misses"
+    },
+    {
+      "direction": "lower_is_better",
+      "name": "time_to_goal_norm"
+    }
+  ],
+  "next_command_template": "uv run python scripts/<fidelity_sweep>.py --config configs/research/fidelity_sensitivity_v1.yaml --out output/fidelity_sensitivity/",
+  "ranking": {
+    "higher_is_better": true,
+    "metric": "snqi",
+    "rank_flip_requires_caveat": true,
+    "stability_min_kendall_tau": 0.8
+  },
+  "result_contract": {
+    "caveat_rule": "Any axis with a rank_flip_count greater than zero must be reported as a validity-boundary caveat and calibration candidate before paper-facing benchmark use.\n",
+    "required_outputs": [
+      "axis",
+      "variant",
+      "planner",
+      "seed",
+      "scenario_id",
+      "metric_values",
+      "rank_metric",
+      "kendall_tau_vs_baseline",
+      "rank_flip_count",
+      "per_metric_drift_vs_baseline"
+    ]
+  },
+  "schema_version": "fidelity-sensitivity-launch-packet.v1",
+  "status": "launch_packet_only",
+  "study_id": "issue_3207_fidelity_sensitivity_v1"
+}

--- a/docs/context/evidence/issue_3207_fidelity_sensitivity_smoke_2026-06-20/README.md
+++ b/docs/context/evidence/issue_3207_fidelity_sensitivity_smoke_2026-06-20/README.md
@@ -1,0 +1,31 @@
+# Issue #3207 Fidelity Sensitivity Diagnostic Smoke 2026-06-20
+
+- Status: `diagnostic_smoke`
+- Git head: `40702550`
+- Baseline variant: `dt_0_10_clean`
+- Ranking metric: `min_distance`
+- Claim boundary: diagnostic_smoke_not_benchmark_evidence: summarizes a small local same-scenario fidelity sensitivity smoke. It can show wiring, metric drift, and rank-stability calculation behavior, but it does not establish planner ranking, simulator realism, sim-to-real validity, or paper-facing benchmark evidence.
+
+## Variant Summary
+
+| Variant | Planner | Episodes | Seeds | Mean ranking metric |
+|---|---|---:|---|---:|
+| `dt_0_05_clean` | `simple_policy` | 3 | 101, 102, 103 | 6.17938 |
+| `dt_0_05_clean` | `social_force` | 3 | 101, 102, 103 | 5.91157 |
+| `dt_0_10_clean` | `simple_policy` | 3 | 101, 102, 103 | 5.25427 |
+| `dt_0_10_clean` | `social_force` | 3 | 101, 102, 103 | 4.73614 |
+| `dt_0_10_noise` | `simple_policy` | 3 | 101, 102, 103 | 5.25432 |
+| `dt_0_10_noise` | `social_force` | 3 | 101, 102, 103 | 4.74053 |
+| `dt_0_20_clean` | `simple_policy` | 3 | 101, 102, 103 | 2.89141 |
+| `dt_0_20_clean` | `social_force` | 3 | 101, 102, 103 | 2.66883 |
+
+## Rank Stability
+
+| Variant | Kendall tau | Rank flips | Stable? |
+|---|---:|---:|---|
+| `dt_0_05_clean` | 1 | 0 | `True` |
+| `dt_0_10_noise` | 1 | 0 | `True` |
+| `dt_0_20_clean` | 1 | 0 | `True` |
+
+This smoke is diagnostic only. It records sensitivity wiring, small-sample metric drift,
+and rank-stability calculations; it is not benchmark-strength evidence.

--- a/docs/context/evidence/issue_3207_fidelity_sensitivity_smoke_2026-06-20/smoke_report.json
+++ b/docs/context/evidence/issue_3207_fidelity_sensitivity_smoke_2026-06-20/smoke_report.json
@@ -1,0 +1,508 @@
+{
+  "baseline_variant": "dt_0_10_clean",
+  "claim_boundary": "diagnostic_smoke_not_benchmark_evidence: summarizes a small local same-scenario fidelity sensitivity smoke. It can show wiring, metric drift, and rank-stability calculation behavior, but it does not establish planner ranking, simulator realism, sim-to-real validity, or paper-facing benchmark evidence.",
+  "comparisons_vs_baseline": {
+    "dt_0_05_clean": {
+      "metric_drift_by_planner": {
+        "simple_policy": {
+          "collisions": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          },
+          "mean_distance": {
+            "absolute_delta": 0.3824748416850623,
+            "baseline": 6.031899657212961,
+            "relative_delta": 0.06340868771377818,
+            "variant": 6.414374498898023
+          },
+          "min_distance": {
+            "absolute_delta": 0.9251121423326207,
+            "baseline": 5.2542652496529145,
+            "relative_delta": 0.1760687933281883,
+            "variant": 6.179377391985535
+          },
+          "robot_ped_within_5m_frac": {
+            "absolute_delta": -0.09166666666666667,
+            "baseline": 0.425,
+            "relative_delta": -0.21568627450980393,
+            "variant": 0.3333333333333333
+          },
+          "success": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          }
+        },
+        "social_force": {
+          "collisions": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          },
+          "mean_distance": {
+            "absolute_delta": 0.3453636366862831,
+            "baseline": 5.8710512452696895,
+            "relative_delta": 0.0588248377093528,
+            "variant": 6.216414881955973
+          },
+          "min_distance": {
+            "absolute_delta": 1.1754288389702534,
+            "baseline": 4.736144535558522,
+            "relative_delta": 0.24818263677243074,
+            "variant": 5.911573374528776
+          },
+          "robot_ped_within_5m_frac": {
+            "absolute_delta": -0.25833333333333336,
+            "baseline": 0.5916666666666667,
+            "relative_delta": -0.4366197183098592,
+            "variant": 0.3333333333333333
+          },
+          "success": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          }
+        }
+      },
+      "rank_stability": {
+        "baseline_order": [
+          "simple_policy",
+          "social_force"
+        ],
+        "kendall_tau_vs_baseline": 1.0,
+        "rank_flip_count": 0,
+        "ranking_flipped": false,
+        "stable_by_tau_threshold": true,
+        "variant_order": [
+          "simple_policy",
+          "social_force"
+        ]
+      }
+    },
+    "dt_0_10_noise": {
+      "metric_drift_by_planner": {
+        "simple_policy": {
+          "collisions": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          },
+          "mean_distance": {
+            "absolute_delta": -6.926896887193834e-07,
+            "baseline": 6.031899657212961,
+            "relative_delta": -1.1483773406128588e-07,
+            "variant": 6.031898964523272
+          },
+          "min_distance": {
+            "absolute_delta": 5.9331055832778645e-05,
+            "baseline": 5.2542652496529145,
+            "relative_delta": 1.1291979565877061e-05,
+            "variant": 5.254324580708747
+          },
+          "robot_ped_within_5m_frac": {
+            "absolute_delta": 0.0,
+            "baseline": 0.425,
+            "relative_delta": 0.0,
+            "variant": 0.425
+          },
+          "success": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          }
+        },
+        "social_force": {
+          "collisions": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          },
+          "mean_distance": {
+            "absolute_delta": 0.0028911597853511495,
+            "baseline": 5.8710512452696895,
+            "relative_delta": 0.0004924432890413892,
+            "variant": 5.873942405055041
+          },
+          "min_distance": {
+            "absolute_delta": 0.0043829726924684564,
+            "baseline": 4.736144535558522,
+            "relative_delta": 0.0009254305183386011,
+            "variant": 4.740527508250991
+          },
+          "robot_ped_within_5m_frac": {
+            "absolute_delta": 0.0,
+            "baseline": 0.5916666666666667,
+            "relative_delta": 0.0,
+            "variant": 0.5916666666666667
+          },
+          "success": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          }
+        }
+      },
+      "rank_stability": {
+        "baseline_order": [
+          "simple_policy",
+          "social_force"
+        ],
+        "kendall_tau_vs_baseline": 1.0,
+        "rank_flip_count": 0,
+        "ranking_flipped": false,
+        "stable_by_tau_threshold": true,
+        "variant_order": [
+          "simple_policy",
+          "social_force"
+        ]
+      }
+    },
+    "dt_0_20_clean": {
+      "metric_drift_by_planner": {
+        "simple_policy": {
+          "collisions": {
+            "absolute_delta": 0.3333333333333333,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.3333333333333333
+          },
+          "mean_distance": {
+            "absolute_delta": -0.5916112794716222,
+            "baseline": 6.031899657212961,
+            "relative_delta": -0.09808042459130963,
+            "variant": 5.440288377741338
+          },
+          "min_distance": {
+            "absolute_delta": -2.362859476304279,
+            "baseline": 5.2542652496529145,
+            "relative_delta": -0.4497031200433523,
+            "variant": 2.8914057733486356
+          },
+          "robot_ped_within_5m_frac": {
+            "absolute_delta": 0.025925925925925963,
+            "baseline": 0.425,
+            "relative_delta": 0.061002178649237564,
+            "variant": 0.45092592592592595
+          },
+          "success": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          }
+        },
+        "social_force": {
+          "collisions": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          },
+          "mean_distance": {
+            "absolute_delta": -0.5453640065737941,
+            "baseline": 5.8710512452696895,
+            "relative_delta": -0.09289035026107026,
+            "variant": 5.325687238695895
+          },
+          "min_distance": {
+            "absolute_delta": -2.067317603557641,
+            "baseline": 4.736144535558522,
+            "relative_delta": -0.4364979970599328,
+            "variant": 2.6688269320008815
+          },
+          "robot_ped_within_5m_frac": {
+            "absolute_delta": -0.12500000000000006,
+            "baseline": 0.5916666666666667,
+            "relative_delta": -0.2112676056338029,
+            "variant": 0.4666666666666666
+          },
+          "success": {
+            "absolute_delta": 0.0,
+            "baseline": 0.0,
+            "relative_delta": null,
+            "variant": 0.0
+          }
+        }
+      },
+      "rank_stability": {
+        "baseline_order": [
+          "simple_policy",
+          "social_force"
+        ],
+        "kendall_tau_vs_baseline": 1.0,
+        "rank_flip_count": 0,
+        "ranking_flipped": false,
+        "stable_by_tau_threshold": true,
+        "variant_order": [
+          "simple_policy",
+          "social_force"
+        ]
+      }
+    }
+  },
+  "date": "2026-06-20",
+  "git_head": "40702550",
+  "inputs": {
+    "dt_0_05_clean": {
+      "simple_policy": "worktree-local ignored artifact summarized in this report (dt_0_05_clean_simple_policy.jsonl)",
+      "social_force": "worktree-local ignored artifact summarized in this report (dt_0_05_clean_social_force.jsonl)"
+    },
+    "dt_0_10_clean": {
+      "simple_policy": "worktree-local ignored artifact summarized in this report (dt_0_10_clean_simple_policy.jsonl)",
+      "social_force": "worktree-local ignored artifact summarized in this report (dt_0_10_clean_social_force.jsonl)"
+    },
+    "dt_0_10_noise": {
+      "simple_policy": "worktree-local ignored artifact summarized in this report (dt_0_10_noise_simple_policy.jsonl)",
+      "social_force": "worktree-local ignored artifact summarized in this report (dt_0_10_noise_social_force.jsonl)"
+    },
+    "dt_0_20_clean": {
+      "simple_policy": "worktree-local ignored artifact summarized in this report (dt_0_20_clean_simple_policy.jsonl)",
+      "social_force": "worktree-local ignored artifact summarized in this report (dt_0_20_clean_social_force.jsonl)"
+    }
+  },
+  "issue": 3207,
+  "planner_count": 2,
+  "planner_summaries": {
+    "dt_0_05_clean": {
+      "simple_policy": {
+        "episode_count": 3,
+        "metrics": {
+          "counts": {
+            "collisions": 3,
+            "mean_distance": 3,
+            "min_distance": 3,
+            "robot_ped_within_5m_frac": 3,
+            "success": 3
+          },
+          "means": {
+            "collisions": 0.0,
+            "mean_distance": 6.414374498898023,
+            "min_distance": 6.179377391985535,
+            "robot_ped_within_5m_frac": 0.3333333333333333,
+            "success": 0.0
+          }
+        },
+        "scenario_ids": [
+          "classic_cross_trap_low"
+        ],
+        "seeds": [
+          101,
+          102,
+          103
+        ]
+      },
+      "social_force": {
+        "episode_count": 3,
+        "metrics": {
+          "counts": {
+            "collisions": 3,
+            "mean_distance": 3,
+            "min_distance": 3,
+            "robot_ped_within_5m_frac": 3,
+            "success": 3
+          },
+          "means": {
+            "collisions": 0.0,
+            "mean_distance": 6.216414881955973,
+            "min_distance": 5.911573374528776,
+            "robot_ped_within_5m_frac": 0.3333333333333333,
+            "success": 0.0
+          }
+        },
+        "scenario_ids": [
+          "classic_cross_trap_low"
+        ],
+        "seeds": [
+          101,
+          102,
+          103
+        ]
+      }
+    },
+    "dt_0_10_clean": {
+      "simple_policy": {
+        "episode_count": 3,
+        "metrics": {
+          "counts": {
+            "collisions": 3,
+            "mean_distance": 3,
+            "min_distance": 3,
+            "robot_ped_within_5m_frac": 3,
+            "success": 3
+          },
+          "means": {
+            "collisions": 0.0,
+            "mean_distance": 6.031899657212961,
+            "min_distance": 5.2542652496529145,
+            "robot_ped_within_5m_frac": 0.425,
+            "success": 0.0
+          }
+        },
+        "scenario_ids": [
+          "classic_cross_trap_low"
+        ],
+        "seeds": [
+          101,
+          102,
+          103
+        ]
+      },
+      "social_force": {
+        "episode_count": 3,
+        "metrics": {
+          "counts": {
+            "collisions": 3,
+            "mean_distance": 3,
+            "min_distance": 3,
+            "robot_ped_within_5m_frac": 3,
+            "success": 3
+          },
+          "means": {
+            "collisions": 0.0,
+            "mean_distance": 5.8710512452696895,
+            "min_distance": 4.736144535558522,
+            "robot_ped_within_5m_frac": 0.5916666666666667,
+            "success": 0.0
+          }
+        },
+        "scenario_ids": [
+          "classic_cross_trap_low"
+        ],
+        "seeds": [
+          101,
+          102,
+          103
+        ]
+      }
+    },
+    "dt_0_10_noise": {
+      "simple_policy": {
+        "episode_count": 3,
+        "metrics": {
+          "counts": {
+            "collisions": 3,
+            "mean_distance": 3,
+            "min_distance": 3,
+            "robot_ped_within_5m_frac": 3,
+            "success": 3
+          },
+          "means": {
+            "collisions": 0.0,
+            "mean_distance": 6.031898964523272,
+            "min_distance": 5.254324580708747,
+            "robot_ped_within_5m_frac": 0.425,
+            "success": 0.0
+          }
+        },
+        "scenario_ids": [
+          "classic_cross_trap_low"
+        ],
+        "seeds": [
+          101,
+          102,
+          103
+        ]
+      },
+      "social_force": {
+        "episode_count": 3,
+        "metrics": {
+          "counts": {
+            "collisions": 3,
+            "mean_distance": 3,
+            "min_distance": 3,
+            "robot_ped_within_5m_frac": 3,
+            "success": 3
+          },
+          "means": {
+            "collisions": 0.0,
+            "mean_distance": 5.873942405055041,
+            "min_distance": 4.740527508250991,
+            "robot_ped_within_5m_frac": 0.5916666666666667,
+            "success": 0.0
+          }
+        },
+        "scenario_ids": [
+          "classic_cross_trap_low"
+        ],
+        "seeds": [
+          101,
+          102,
+          103
+        ]
+      }
+    },
+    "dt_0_20_clean": {
+      "simple_policy": {
+        "episode_count": 3,
+        "metrics": {
+          "counts": {
+            "collisions": 3,
+            "mean_distance": 3,
+            "min_distance": 3,
+            "robot_ped_within_5m_frac": 3,
+            "success": 3
+          },
+          "means": {
+            "collisions": 0.3333333333333333,
+            "mean_distance": 5.440288377741338,
+            "min_distance": 2.8914057733486356,
+            "robot_ped_within_5m_frac": 0.45092592592592595,
+            "success": 0.0
+          }
+        },
+        "scenario_ids": [
+          "classic_cross_trap_low"
+        ],
+        "seeds": [
+          101,
+          102,
+          103
+        ]
+      },
+      "social_force": {
+        "episode_count": 3,
+        "metrics": {
+          "counts": {
+            "collisions": 3,
+            "mean_distance": 3,
+            "min_distance": 3,
+            "robot_ped_within_5m_frac": 3,
+            "success": 3
+          },
+          "means": {
+            "collisions": 0.0,
+            "mean_distance": 5.325687238695895,
+            "min_distance": 2.6688269320008815,
+            "robot_ped_within_5m_frac": 0.4666666666666666,
+            "success": 0.0
+          }
+        },
+        "scenario_ids": [
+          "classic_cross_trap_low"
+        ],
+        "seeds": [
+          101,
+          102,
+          103
+        ]
+      }
+    }
+  },
+  "ranking": {
+    "higher_is_better": true,
+    "metric": "min_distance",
+    "min_tau": 0.8
+  },
+  "schema_version": "issue_3207_fidelity_sensitivity_diagnostic_smoke.v1",
+  "status": "diagnostic_smoke",
+  "variant_count": 4
+}

--- a/robot_sf/benchmark/fidelity_sensitivity.py
+++ b/robot_sf/benchmark/fidelity_sensitivity.py
@@ -147,8 +147,9 @@ def kendall_tau_from_orders(baseline_order: Sequence[str], variant_order: Sequen
     concordant = 0
     discordant = 0
     for i, item_i in enumerate(left):
-        for item_j in left[i + 1 :]:
-            baseline_delta = i - left.index(item_j)
+        for j in range(i + 1, n):
+            item_j = left[j]
+            baseline_delta = i - j
             variant_delta = right_rank[item_i] - right_rank[item_j]
             if baseline_delta * variant_delta > 0:
                 concordant += 1
@@ -226,6 +227,7 @@ def build_launch_packet(
     *,
     config_path: str,
     git_head: str,
+    date: str | None = None,
 ) -> dict[str, Any]:
     """Build a compact launch-packet summary for issue #3207.
 
@@ -234,6 +236,7 @@ def build_launch_packet(
     """
     validated = validate_fidelity_sensitivity_config(config)
     axes = validated["axes"]
+    claim_boundary = validated.get("claim_boundary")
     return {
         "schema_version": "fidelity-sensitivity-launch-packet.v1",
         "issue": int(validated.get("issue", 3207)),
@@ -241,7 +244,8 @@ def build_launch_packet(
         "status": "launch_packet_only",
         "config_path": config_path,
         "git_head": git_head,
-        "claim_boundary": str(validated.get("claim_boundary") or CLAIM_BOUNDARY),
+        "date": date,
+        "claim_boundary": str(claim_boundary) if claim_boundary is not None else CLAIM_BOUNDARY,
         "axis_count": len(axes),
         "axes": [
             {
@@ -270,8 +274,10 @@ def format_launch_packet_markdown(packet: Mapping[str, Any]) -> str:
         Markdown report text.
     """
     axes = packet["axes"]
+    issue = packet.get("issue", 3207)
+    date_suffix = f" {packet['date']}" if packet.get("date") else ""
     lines = [
-        "# Issue #3207 Fidelity Sensitivity Launch Packet",
+        f"# Issue #{issue} Fidelity Sensitivity Launch Packet{date_suffix}",
         "",
         f"- Status: `{packet['status']}`",
         f"- Study: `{packet['study_id']}`",

--- a/robot_sf/benchmark/fidelity_sensitivity.py
+++ b/robot_sf/benchmark/fidelity_sensitivity.py
@@ -23,6 +23,12 @@ CLAIM_BOUNDARY = (
     "sensitivity probes and rank-stability/drift metrics; does not establish planner "
     "ranking, sensor realism, sim-to-real validity, or paper-facing benchmark evidence."
 )
+DIAGNOSTIC_SMOKE_CLAIM_BOUNDARY = (
+    "diagnostic_smoke_not_benchmark_evidence: summarizes a small local same-scenario "
+    "fidelity sensitivity smoke. It can show wiring, metric drift, and rank-stability "
+    "calculation behavior, but it does not establish planner ranking, simulator realism, "
+    "sim-to-real validity, or paper-facing benchmark evidence."
+)
 
 
 def load_fidelity_sensitivity_config(path: str | Path) -> dict[str, Any]:
@@ -366,6 +372,7 @@ def _require_non_empty_list(mapping: Mapping[str, Any], key: str) -> None:
 
 __all__ = [
     "CLAIM_BOUNDARY",
+    "DIAGNOSTIC_SMOKE_CLAIM_BOUNDARY",
     "SCHEMA_VERSION",
     "build_launch_packet",
     "build_rank_stability_summary",

--- a/robot_sf/benchmark/fidelity_sensitivity.py
+++ b/robot_sf/benchmark/fidelity_sensitivity.py
@@ -1,0 +1,374 @@
+"""Utilities for simulation-fidelity sensitivity launch packets.
+
+The helpers in this module are deliberately pure. They validate the issue #3207
+study contract and compute rank-stability summaries for result rows, but they do
+not run benchmark episodes or promote any planner-ranking claim by themselves.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+SCHEMA_VERSION = "fidelity-sensitivity.v1"
+CLAIM_BOUNDARY = (
+    "launch_packet_only_not_benchmark_evidence: defines deliberate simulation-fidelity "
+    "sensitivity probes and rank-stability/drift metrics; does not establish planner "
+    "ranking, sensor realism, sim-to-real validity, or paper-facing benchmark evidence."
+)
+
+
+def load_fidelity_sensitivity_config(path: str | Path) -> dict[str, Any]:
+    """Load and validate a fidelity-sensitivity YAML config.
+
+    Returns:
+        Validated config mapping.
+    """
+    config_path = Path(path)
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"fidelity-sensitivity config must be a mapping: {config_path}")
+    return validate_fidelity_sensitivity_config(payload)
+
+
+def validate_fidelity_sensitivity_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the issue #3207 launch-packet config contract.
+
+    Returns:
+        Shallow-normalized dictionary with the original config values.
+    """
+    normalized = dict(config)
+    if normalized.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {SCHEMA_VERSION!r}")
+    _validate_axes(normalized.get("axes"))
+    _validate_fixed_scope(normalized.get("fixed_scope"))
+    _validate_metrics(normalized.get("ranking"), normalized.get("metrics"))
+    return normalized
+
+
+def _validate_axes(axes: Any) -> None:
+    """Validate the fidelity-axis list."""
+    if not isinstance(axes, list) or len(axes) < 3:
+        raise ValueError("fidelity-sensitivity config must define at least three axes")
+
+    for axis in axes:
+        if not isinstance(axis, dict):
+            raise ValueError("each fidelity axis must be a mapping")
+        axis_key = axis.get("key")
+        if not axis_key:
+            raise ValueError("each fidelity axis must define a key")
+        variants = axis.get("variants")
+        if not isinstance(variants, list) or len(variants) < 2:
+            raise ValueError(f"axis {axis_key!r} must define at least two variants")
+        baseline_count = _validate_axis_variants(axis_key=str(axis_key), variants=variants)
+        if baseline_count != 1:
+            raise ValueError(f"axis {axis_key!r} must mark exactly one baseline variant")
+
+
+def _validate_axis_variants(*, axis_key: str, variants: list[Any]) -> int:
+    """Validate one axis variant list.
+
+    Returns:
+        Number of variants marked as baseline.
+    """
+    baseline_count = 0
+    seen_variant_keys: set[str] = set()
+    for variant in variants:
+        if not isinstance(variant, dict):
+            raise ValueError(f"axis {axis_key!r} variants must be mappings")
+        variant_key = str(variant.get("key") or "")
+        if not variant_key:
+            raise ValueError(f"axis {axis_key!r} variant must define a key")
+        if variant_key in seen_variant_keys:
+            raise ValueError(f"axis {axis_key!r} repeats variant key {variant_key!r}")
+        seen_variant_keys.add(variant_key)
+        baseline_count += int(bool(variant.get("baseline", False)))
+    return baseline_count
+
+
+def _validate_fixed_scope(fixed_scope: Any) -> None:
+    """Validate fixed scenario/seed/planner scope."""
+    if not isinstance(fixed_scope, dict):
+        raise ValueError("fixed_scope must be a mapping")
+    _require_non_empty_list(fixed_scope, "seeds")
+    _require_non_empty_list(fixed_scope, "planner_groups")
+    if not fixed_scope.get("scenario_set"):
+        raise ValueError("fixed_scope.scenario_set must be set")
+
+
+def _validate_metrics(ranking: Any, metrics: Any) -> None:
+    """Validate ranking metric membership in the metric list."""
+    if not isinstance(ranking, dict) or not ranking.get("metric"):
+        raise ValueError("ranking.metric must be set")
+    if not isinstance(metrics, list) or not metrics:
+        raise ValueError("metrics must be a non-empty list")
+    metric_names = {str(item.get("name")) for item in metrics if isinstance(item, dict)}
+    if str(ranking["metric"]) not in metric_names:
+        raise ValueError("ranking.metric must appear in metrics")
+
+
+def rank_order(scores: Mapping[str, float], *, higher_is_better: bool) -> list[str]:
+    """Return a stable ranking order from a group-to-score mapping.
+
+    Returns:
+        Ordered group names, best first under the requested metric direction.
+    """
+    clean_scores = {str(key): _finite_float(value, key=str(key)) for key, value in scores.items()}
+    return sorted(
+        clean_scores,
+        key=lambda key: (
+            -clean_scores[key] if higher_is_better else clean_scores[key],
+            key,
+        ),
+    )
+
+
+def kendall_tau_from_orders(baseline_order: Sequence[str], variant_order: Sequence[str]) -> float:
+    """Compute Kendall tau for two complete rankings over the same items.
+
+    Returns:
+        Kendall tau in [-1, 1].
+    """
+    left = list(baseline_order)
+    right = list(variant_order)
+    if set(left) != set(right):
+        raise ValueError("rank orders must contain the same items")
+    n = len(left)
+    if n < 2:
+        return 1.0
+    right_rank = {item: rank for rank, item in enumerate(right)}
+    concordant = 0
+    discordant = 0
+    for i, item_i in enumerate(left):
+        for item_j in left[i + 1 :]:
+            baseline_delta = i - left.index(item_j)
+            variant_delta = right_rank[item_i] - right_rank[item_j]
+            if baseline_delta * variant_delta > 0:
+                concordant += 1
+            else:
+                discordant += 1
+    pairs = n * (n - 1) / 2
+    return float((concordant - discordant) / pairs)
+
+
+def rank_flip_count(baseline_order: Sequence[str], variant_order: Sequence[str]) -> int:
+    """Count groups whose rank position changes between two complete orders.
+
+    Returns:
+        Number of groups with changed ordinal rank.
+    """
+    if set(baseline_order) != set(variant_order):
+        raise ValueError("rank orders must contain the same items")
+    variant_rank = {item: rank for rank, item in enumerate(variant_order)}
+    return sum(1 for rank, item in enumerate(baseline_order) if variant_rank[item] != rank)
+
+
+def build_rank_stability_summary(
+    baseline_scores: Mapping[str, float],
+    variant_scores: Mapping[str, float],
+    *,
+    higher_is_better: bool,
+    min_tau: float = 0.8,
+) -> dict[str, Any]:
+    """Summarize rank stability for a variant against the nominal baseline.
+
+    Returns:
+        Ranking orders, Kendall tau, flip count, and stability flags.
+    """
+    baseline_order = rank_order(baseline_scores, higher_is_better=higher_is_better)
+    variant_order = rank_order(variant_scores, higher_is_better=higher_is_better)
+    tau = kendall_tau_from_orders(baseline_order, variant_order)
+    flips = rank_flip_count(baseline_order, variant_order)
+    return {
+        "baseline_order": baseline_order,
+        "variant_order": variant_order,
+        "kendall_tau_vs_baseline": tau,
+        "rank_flip_count": flips,
+        "ranking_flipped": flips > 0,
+        "stable_by_tau_threshold": tau >= float(min_tau),
+    }
+
+
+def metric_drift(
+    baseline_metrics: Mapping[str, float],
+    variant_metrics: Mapping[str, float],
+) -> dict[str, dict[str, float | None]]:
+    """Compute absolute and relative metric drift for common metric keys.
+
+    Returns:
+        Per-metric baseline, variant, absolute delta, and relative delta.
+    """
+    common_metrics = sorted(set(baseline_metrics) & set(variant_metrics))
+    drift: dict[str, dict[str, float | None]] = {}
+    for metric in common_metrics:
+        baseline = _finite_float(baseline_metrics[metric], key=metric)
+        variant = _finite_float(variant_metrics[metric], key=metric)
+        delta = variant - baseline
+        relative = None if baseline == 0.0 else delta / baseline
+        drift[metric] = {
+            "baseline": baseline,
+            "variant": variant,
+            "absolute_delta": delta,
+            "relative_delta": relative,
+        }
+    return drift
+
+
+def build_launch_packet(
+    config: Mapping[str, Any],
+    *,
+    config_path: str,
+    git_head: str,
+) -> dict[str, Any]:
+    """Build a compact launch-packet summary for issue #3207.
+
+    Returns:
+        JSON-serializable launch-packet payload.
+    """
+    validated = validate_fidelity_sensitivity_config(config)
+    axes = validated["axes"]
+    return {
+        "schema_version": "fidelity-sensitivity-launch-packet.v1",
+        "issue": int(validated.get("issue", 3207)),
+        "study_id": str(validated["study_id"]),
+        "status": "launch_packet_only",
+        "config_path": config_path,
+        "git_head": git_head,
+        "claim_boundary": str(validated.get("claim_boundary") or CLAIM_BOUNDARY),
+        "axis_count": len(axes),
+        "axes": [
+            {
+                "key": str(axis["key"]),
+                "variant_count": len(axis["variants"]),
+                "baseline_variant": _baseline_variant_key(axis),
+                "rationale": str(axis.get("rationale", "")),
+            }
+            for axis in axes
+        ],
+        "fixed_scope": validated["fixed_scope"],
+        "ranking": validated["ranking"],
+        "metrics": validated["metrics"],
+        "result_contract": validated["result_contract"],
+        "next_command_template": (
+            "uv run python scripts/<fidelity_sweep>.py --config "
+            f"{config_path} --out output/fidelity_sensitivity/"
+        ),
+    }
+
+
+def format_launch_packet_markdown(packet: Mapping[str, Any]) -> str:
+    """Format a fidelity-sensitivity launch packet as Markdown.
+
+    Returns:
+        Markdown report text.
+    """
+    axes = packet["axes"]
+    lines = [
+        "# Issue #3207 Fidelity Sensitivity Launch Packet",
+        "",
+        f"- Status: `{packet['status']}`",
+        f"- Study: `{packet['study_id']}`",
+        f"- Config: `{packet['config_path']}`",
+        f"- Git head: `{packet['git_head']}`",
+        f"- Claim boundary: {packet['claim_boundary']}",
+        "",
+        "## Scope",
+        "",
+        f"- Scenario set: `{packet['fixed_scope']['scenario_set']}`",
+        f"- Seeds: `{', '.join(str(seed) for seed in packet['fixed_scope']['seeds'])}`",
+        f"- Planner groups: `{', '.join(packet['fixed_scope']['planner_groups'])}`",
+        f"- Ranking metric: `{packet['ranking']['metric']}`",
+        "",
+        "## Fidelity Axes",
+        "",
+        "| Axis | Variants | Baseline Variant | Rationale |",
+        "|---|---:|---|---|",
+    ]
+    for axis in axes:
+        lines.append(
+            f"| `{axis['key']}` | {axis['variant_count']} | "
+            f"`{axis['baseline_variant']}` | {axis['rationale']} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Result Contract",
+            "",
+            "Before this packet can support a validity-boundary claim, the sweep output must report:",
+        ]
+    )
+    for field in packet["result_contract"]["required_outputs"]:
+        lines.append(f"- `{field}`")
+    lines.extend(
+        [
+            "",
+            "Any axis with `rank_flip_count > 0` is a caveat/calibration candidate.",
+            "",
+            "## Next Command Template",
+            "",
+            "```bash",
+            str(packet["next_command_template"]),
+            "```",
+            "",
+            "This packet is not benchmark evidence until a sweep is run and promoted with provenance.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_launch_packet(packet: Mapping[str, Any], output_dir: str | Path) -> None:
+    """Write JSON and Markdown launch-packet files."""
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "launch_packet.json").write_text(
+        json.dumps(packet, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (out / "README.md").write_text(format_launch_packet_markdown(packet), encoding="utf-8")
+
+
+def _baseline_variant_key(axis: Mapping[str, Any]) -> str:
+    for variant in axis["variants"]:
+        if variant.get("baseline", False):
+            return str(variant["key"])
+    raise ValueError(f"axis {axis.get('key')!r} has no baseline variant")
+
+
+def _finite_float(value: Any, *, key: str) -> float:
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{key} must be numeric") from exc
+    if not math.isfinite(numeric):
+        raise ValueError(f"{key} must be finite")
+    return numeric
+
+
+def _require_non_empty_list(mapping: Mapping[str, Any], key: str) -> None:
+    value = mapping.get(key)
+    if not isinstance(value, list) or not value:
+        raise ValueError(f"fixed_scope.{key} must be a non-empty list")
+
+
+__all__ = [
+    "CLAIM_BOUNDARY",
+    "SCHEMA_VERSION",
+    "build_launch_packet",
+    "build_rank_stability_summary",
+    "format_launch_packet_markdown",
+    "kendall_tau_from_orders",
+    "load_fidelity_sensitivity_config",
+    "metric_drift",
+    "rank_flip_count",
+    "rank_order",
+    "validate_fidelity_sensitivity_config",
+    "write_launch_packet",
+]

--- a/scripts/benchmark/build_fidelity_sensitivity_launch_packet.py
+++ b/scripts/benchmark/build_fidelity_sensitivity_launch_packet.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python3
+"""Build the issue #3207 simulation-fidelity sensitivity launch packet."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from robot_sf.benchmark.fidelity_sensitivity import (
+    build_launch_packet,
+    load_fidelity_sensitivity_config,
+    write_launch_packet,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _git_head() -> str:
+    result = subprocess.run(
+        ["git", "rev-parse", "--short", "HEAD"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=False,
+        timeout=5,
+    )
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default="configs/research/fidelity_sensitivity_v1.yaml",
+        help="Tracked fidelity-sensitivity config path.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20",
+        help="Directory for compact launch-packet JSON and Markdown.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entry point."""
+    args = parse_args()
+    config = load_fidelity_sensitivity_config(REPO_ROOT / args.config)
+    packet = build_launch_packet(config, config_path=args.config, git_head=_git_head())
+    write_launch_packet(packet, REPO_ROOT / args.output_dir)
+    print(f"wrote {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/build_fidelity_sensitivity_launch_packet.py
+++ b/scripts/benchmark/build_fidelity_sensitivity_launch_packet.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import re
 import subprocess
 from pathlib import Path
 
@@ -14,18 +15,28 @@ from robot_sf.benchmark.fidelity_sensitivity import (
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
+ISO_DATE_RE = re.compile(r"\d{4}-\d{2}-\d{2}")
 
 
 def _git_head() -> str:
-    result = subprocess.run(
-        ["git", "rev-parse", "--short", "HEAD"],
-        cwd=REPO_ROOT,
-        capture_output=True,
-        text=True,
-        check=False,
-        timeout=5,
-    )
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return "unknown"
     return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def _iso_date_from_output_dir(output_dir: str) -> str | None:
+    """Extract an ISO calendar date from an output directory path."""
+    match = ISO_DATE_RE.search(output_dir)
+    return match.group(0) if match else None
 
 
 def parse_args() -> argparse.Namespace:
@@ -48,7 +59,12 @@ def main() -> int:
     """CLI entry point."""
     args = parse_args()
     config = load_fidelity_sensitivity_config(REPO_ROOT / args.config)
-    packet = build_launch_packet(config, config_path=args.config, git_head=_git_head())
+    packet = build_launch_packet(
+        config,
+        config_path=args.config,
+        git_head=_git_head(),
+        date=_iso_date_from_output_dir(args.output_dir),
+    )
     write_launch_packet(packet, REPO_ROOT / args.output_dir)
     print(f"wrote {args.output_dir}")
     return 0

--- a/scripts/benchmark/build_fidelity_sensitivity_smoke_report.py
+++ b/scripts/benchmark/build_fidelity_sensitivity_smoke_report.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Build a diagnostic report from issue #3207 fidelity-sensitivity smoke rows."""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import math
+import pathlib
+import subprocess
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.fidelity_sensitivity import (
+    DIAGNOSTIC_SMOKE_CLAIM_BOUNDARY,
+    build_rank_stability_summary,
+    metric_drift,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCHEMA_VERSION = "issue_3207_fidelity_sensitivity_diagnostic_smoke.v1"
+DEFAULT_METRICS = (
+    "success",
+    "collisions",
+    "min_distance",
+    "mean_distance",
+    "robot_ped_within_5m_frac",
+)
+
+
+@dataclass(frozen=True)
+class SmokeReportOptions:
+    """Configuration for a diagnostic fidelity-sensitivity smoke report."""
+
+    baseline_variant: str
+    ranking_metric: str = "min_distance"
+    higher_is_better: bool = True
+    metrics: Sequence[str] = DEFAULT_METRICS
+    min_tau: float = 0.8
+    git_head: str = ""
+    date: str | None = None
+
+
+def _number(value: Any) -> float | None:
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _load_jsonl(path: pathlib.Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if not isinstance(row, dict):
+            raise ValueError(f"{path} contains a non-object JSONL row")
+        rows.append(row)
+    if not rows:
+        raise ValueError(f"{path} does not contain any rows")
+    return rows
+
+
+def _parse_result_spec(spec: str) -> tuple[str, str, pathlib.Path]:
+    parts = spec.split(":", 2)
+    if len(parts) != 3 or not all(parts):
+        raise ValueError("--result must use VARIANT:PLANNER:PATH")
+    return parts[0], parts[1], pathlib.Path(parts[2])
+
+
+def _input_ref(path: pathlib.Path) -> str:
+    try:
+        rel = path.resolve().relative_to(REPO_ROOT)
+    except ValueError:
+        return f"worktree-local ignored artifact summarized in this report ({path.name})"
+    return rel.as_posix()
+
+
+def _metric_means(rows: Sequence[Mapping[str, Any]], metrics: Sequence[str]) -> dict[str, Any]:
+    sums: dict[str, float] = dict.fromkeys(metrics, 0.0)
+    counts: dict[str, int] = dict.fromkeys(metrics, 0)
+    for row in rows:
+        row_metrics = row.get("metrics")
+        if not isinstance(row_metrics, dict):
+            row_metrics = {}
+        for metric in metrics:
+            value = _number(row_metrics.get(metric))
+            if value is None:
+                continue
+            sums[metric] += value
+            counts[metric] += 1
+    means = {
+        metric: (sums[metric] / counts[metric] if counts[metric] else None) for metric in metrics
+    }
+    return {"means": means, "counts": counts}
+
+
+def _non_null_means(summary: Mapping[str, Any]) -> dict[str, float]:
+    means = summary["means"]
+    return {str(key): float(value) for key, value in means.items() if value is not None}
+
+
+def build_report(
+    result_sets: Mapping[str, Mapping[str, Sequence[Mapping[str, Any]]]],
+    *,
+    inputs: Mapping[str, Mapping[str, str]],
+    options: SmokeReportOptions,
+) -> dict[str, Any]:
+    """Build a compact diagnostic smoke report."""
+    baseline_variant = options.baseline_variant
+    ranking_metric = options.ranking_metric
+    if baseline_variant not in result_sets:
+        raise ValueError(f"baseline variant {baseline_variant!r} is missing")
+
+    planner_summaries: dict[str, dict[str, Any]] = {}
+    for variant, by_planner in sorted(result_sets.items()):
+        if not by_planner:
+            raise ValueError(f"variant {variant!r} has no planner rows")
+        planner_summaries[variant] = {}
+        for planner, rows in sorted(by_planner.items()):
+            summary = _metric_means(rows, options.metrics)
+            if summary["means"].get(ranking_metric) is None:
+                raise ValueError(
+                    f"{variant}:{planner} is missing ranking metric {ranking_metric!r}"
+                )
+            planner_summaries[variant][planner] = {
+                "episode_count": len(rows),
+                "scenario_ids": sorted({str(row.get("scenario_id", "")) for row in rows}),
+                "seeds": sorted({row.get("seed") for row in rows}),
+                "metrics": summary,
+            }
+
+    baseline_planners = set(planner_summaries[baseline_variant])
+    baseline_scores = {
+        planner: planner_summaries[baseline_variant][planner]["metrics"]["means"][ranking_metric]
+        for planner in baseline_planners
+    }
+
+    comparisons: dict[str, Any] = {}
+    for variant, by_planner in planner_summaries.items():
+        if variant == baseline_variant:
+            continue
+        variant_planners = set(by_planner)
+        if variant_planners != baseline_planners:
+            raise ValueError(
+                f"variant {variant!r} planners {sorted(variant_planners)} do not match "
+                f"baseline planners {sorted(baseline_planners)}"
+            )
+        variant_scores = {
+            planner: by_planner[planner]["metrics"]["means"][ranking_metric]
+            for planner in variant_planners
+        }
+        comparisons[variant] = {
+            "rank_stability": build_rank_stability_summary(
+                baseline_scores,
+                variant_scores,
+                higher_is_better=options.higher_is_better,
+                min_tau=options.min_tau,
+            ),
+            "metric_drift_by_planner": {
+                planner: metric_drift(
+                    _non_null_means(planner_summaries[baseline_variant][planner]["metrics"]),
+                    _non_null_means(by_planner[planner]["metrics"]),
+                )
+                for planner in sorted(variant_planners)
+            },
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 3207,
+        "status": "diagnostic_smoke",
+        "date": options.date,
+        "git_head": options.git_head,
+        "claim_boundary": DIAGNOSTIC_SMOKE_CLAIM_BOUNDARY,
+        "baseline_variant": baseline_variant,
+        "ranking": {
+            "metric": ranking_metric,
+            "higher_is_better": options.higher_is_better,
+            "min_tau": options.min_tau,
+        },
+        "inputs": inputs,
+        "variant_count": len(planner_summaries),
+        "planner_count": len(baseline_planners),
+        "planner_summaries": planner_summaries,
+        "comparisons_vs_baseline": comparisons,
+    }
+
+
+def format_markdown(report: Mapping[str, Any]) -> str:
+    """Render a smoke report as concise Markdown."""
+    issue = report.get("issue", 3207)
+    date_suffix = f" {report['date']}" if report.get("date") else ""
+    lines = [
+        f"# Issue #{issue} Fidelity Sensitivity Diagnostic Smoke{date_suffix}",
+        "",
+        f"- Status: `{report['status']}`",
+        f"- Git head: `{report['git_head']}`",
+        f"- Baseline variant: `{report['baseline_variant']}`",
+        f"- Ranking metric: `{report['ranking']['metric']}`",
+        f"- Claim boundary: {report['claim_boundary']}",
+        "",
+        "## Variant Summary",
+        "",
+        "| Variant | Planner | Episodes | Seeds | Mean ranking metric |",
+        "|---|---|---:|---|---:|",
+    ]
+    ranking_metric = str(report["ranking"]["metric"])
+    for variant, by_planner in report["planner_summaries"].items():
+        for planner, summary in by_planner.items():
+            means = summary["metrics"]["means"]
+            rank_value = means.get(ranking_metric)
+            rank_text = f"{rank_value:.6g}" if isinstance(rank_value, float) else "`null`"
+            seeds = ", ".join(str(seed) for seed in summary["seeds"])
+            lines.append(
+                f"| `{variant}` | `{planner}` | {summary['episode_count']} | "
+                f"{seeds} | {rank_text} |"
+            )
+
+    lines.extend(["", "## Rank Stability", "", "| Variant | Kendall tau | Rank flips | Stable? |"])
+    lines.append("|---|---:|---:|---|")
+    for variant, comparison in report["comparisons_vs_baseline"].items():
+        stability = comparison["rank_stability"]
+        lines.append(
+            f"| `{variant}` | {stability['kendall_tau_vs_baseline']:.6g} | "
+            f"{stability['rank_flip_count']} | "
+            f"`{stability['stable_by_tau_threshold']}` |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "This smoke is diagnostic only. It records sensitivity wiring, small-sample metric drift,",
+            "and rank-stability calculations; it is not benchmark-strength evidence.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def write_report(report: Mapping[str, Any], output_dir: pathlib.Path) -> None:
+    """Write the JSON payload and Markdown summary."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "smoke_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "README.md").write_text(format_markdown(report), encoding="utf-8")
+
+
+def _git_head() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=REPO_ROOT,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        return "unknown"
+    return result.stdout.strip() or "unknown"
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--result",
+        action="append",
+        required=True,
+        help="Input JSONL in VARIANT:PLANNER:PATH form. Repeat once per pair.",
+    )
+    parser.add_argument("--baseline-variant", required=True)
+    parser.add_argument("--ranking-metric", default="min_distance")
+    parser.add_argument("--lower-is-better", action="store_true")
+    parser.add_argument("--min-tau", type=float, default=0.8)
+    parser.add_argument(
+        "--metric",
+        action="append",
+        dest="metrics",
+        help="Metric to summarize. Defaults to the compact smoke metric set.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="docs/context/evidence/issue_3207_fidelity_sensitivity_smoke_2026-06-20",
+    )
+    parser.add_argument("--date", default=dt.datetime.now(tz=dt.UTC).date().isoformat())
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Run the smoke-report builder CLI."""
+    args = _build_arg_parser().parse_args(argv)
+    result_sets: dict[str, dict[str, list[dict[str, Any]]]] = {}
+    inputs: dict[str, dict[str, str]] = {}
+    for spec in args.result:
+        variant, planner, path = _parse_result_spec(spec)
+        rows = _load_jsonl(path)
+        result_sets.setdefault(variant, {})[planner] = rows
+        inputs.setdefault(variant, {})[planner] = _input_ref(path)
+
+    metrics = tuple(args.metrics) if args.metrics else DEFAULT_METRICS
+    if args.ranking_metric not in metrics:
+        metrics = (*metrics, args.ranking_metric)
+    report = build_report(
+        result_sets,
+        inputs=inputs,
+        options=SmokeReportOptions(
+            baseline_variant=args.baseline_variant,
+            ranking_metric=args.ranking_metric,
+            higher_is_better=not args.lower_is_better,
+            metrics=metrics,
+            min_tau=args.min_tau,
+            git_head=_git_head(),
+            date=args.date,
+        ),
+    )
+    write_report(report, REPO_ROOT / args.output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_fidelity_sensitivity.py
+++ b/tests/benchmark/test_fidelity_sensitivity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib.util
+import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -35,11 +36,25 @@ def _load_launch_packet_builder() -> ModuleType:
     if spec is None or spec.loader is None:
         raise RuntimeError(f"could not load builder module from {module_path}")
     module = importlib.util.module_from_spec(spec)
+    sys.modules["fidelity_sensitivity_smoke_report_builder"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_smoke_report_builder() -> ModuleType:
+    module_path = REPO_ROOT / "scripts" / "benchmark" / "build_fidelity_sensitivity_smoke_report.py"
+    spec = importlib.util.spec_from_file_location(
+        "fidelity_sensitivity_smoke_report_builder", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load builder module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
 launch_packet_builder = _load_launch_packet_builder()
+smoke_report_builder = _load_smoke_report_builder()
 
 
 def test_load_repo_config_validates_three_or_more_axes() -> None:
@@ -164,3 +179,53 @@ def test_builder_git_head_handles_missing_git(monkeypatch: pytest.MonkeyPatch) -
     monkeypatch.setattr(launch_packet_builder.subprocess, "run", missing_git)
 
     assert launch_packet_builder._git_head() == "unknown"
+
+
+def test_smoke_report_builder_detects_rank_flip() -> None:
+    """Diagnostic smoke summaries should reuse the rank-stability contract."""
+    result_sets = {
+        "dt_0_10": {
+            "simple_policy": [{"metrics": {"min_distance": 3.0}, "seed": 101}],
+            "social_force": [{"metrics": {"min_distance": 2.0}, "seed": 101}],
+        },
+        "dt_0_20": {
+            "simple_policy": [{"metrics": {"min_distance": 1.0}, "seed": 101}],
+            "social_force": [{"metrics": {"min_distance": 4.0}, "seed": 101}],
+        },
+    }
+
+    report = smoke_report_builder.build_report(
+        result_sets,
+        inputs={},
+        options=smoke_report_builder.SmokeReportOptions(
+            baseline_variant="dt_0_10",
+            ranking_metric="min_distance",
+            higher_is_better=True,
+            git_head="abc1234",
+            date="2026-06-20",
+        ),
+    )
+
+    stability = report["comparisons_vs_baseline"]["dt_0_20"]["rank_stability"]
+    assert report["status"] == "diagnostic_smoke"
+    assert stability["ranking_flipped"] is True
+    assert stability["kendall_tau_vs_baseline"] == pytest.approx(-1.0)
+
+
+def test_smoke_report_builder_requires_matching_planners() -> None:
+    """Each variant must compare the same planner set as the baseline."""
+    result_sets = {
+        "dt_0_10": {"simple_policy": [{"metrics": {"min_distance": 3.0}}]},
+        "dt_0_20": {"social_force": [{"metrics": {"min_distance": 4.0}}]},
+    }
+
+    with pytest.raises(ValueError, match="do not match baseline planners"):
+        smoke_report_builder.build_report(
+            result_sets,
+            inputs={},
+            options=smoke_report_builder.SmokeReportOptions(
+                baseline_variant="dt_0_10",
+                ranking_metric="min_distance",
+                higher_is_better=True,
+            ),
+        )

--- a/tests/benchmark/test_fidelity_sensitivity.py
+++ b/tests/benchmark/test_fidelity_sensitivity.py
@@ -1,0 +1,85 @@
+"""Tests for issue #3207 fidelity-sensitivity launch-packet helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.fidelity_sensitivity import (
+    build_launch_packet,
+    build_rank_stability_summary,
+    kendall_tau_from_orders,
+    load_fidelity_sensitivity_config,
+    metric_drift,
+    rank_flip_count,
+    validate_fidelity_sensitivity_config,
+)
+
+
+def test_load_repo_config_validates_three_or_more_axes() -> None:
+    """The tracked issue #3207 config should satisfy the launch-packet contract."""
+    config = load_fidelity_sensitivity_config("configs/research/fidelity_sensitivity_v1.yaml")
+
+    assert config["schema_version"] == "fidelity-sensitivity.v1"
+    assert len(config["axes"]) >= 3
+    assert config["ranking"]["metric"] == "snqi"
+
+
+def test_validate_config_rejects_too_few_axes() -> None:
+    """Issue #3207 requires at least three fidelity axes."""
+    config = load_fidelity_sensitivity_config("configs/research/fidelity_sensitivity_v1.yaml")
+    config["axes"] = config["axes"][:2]
+
+    with pytest.raises(ValueError, match="at least three axes"):
+        validate_fidelity_sensitivity_config(config)
+
+
+def test_kendall_tau_and_flip_count_detect_reversed_ranking() -> None:
+    """Rank-stability helpers should flag a fully reversed three-planner ordering."""
+    baseline = ["orca", "social_force", "hybrid_rule"]
+    variant = ["hybrid_rule", "social_force", "orca"]
+
+    assert kendall_tau_from_orders(baseline, baseline) == pytest.approx(1.0)
+    assert kendall_tau_from_orders(baseline, variant) == pytest.approx(-1.0)
+    assert rank_flip_count(baseline, variant) == 2
+
+
+def test_build_rank_stability_summary_identifies_ranking_flip() -> None:
+    """A variant that changes planner order should become a caveat candidate."""
+    summary = build_rank_stability_summary(
+        {"orca": 0.8, "social_force": 0.6, "hybrid_rule": 0.3},
+        {"orca": 0.4, "social_force": 0.6, "hybrid_rule": 0.9},
+        higher_is_better=True,
+        min_tau=0.8,
+    )
+
+    assert summary["baseline_order"] == ["orca", "social_force", "hybrid_rule"]
+    assert summary["variant_order"] == ["hybrid_rule", "social_force", "orca"]
+    assert summary["ranking_flipped"] is True
+    assert summary["stable_by_tau_threshold"] is False
+
+
+def test_metric_drift_reports_absolute_and_relative_deltas() -> None:
+    """Metric drift should retain both absolute and relative deltas."""
+    drift = metric_drift(
+        {"snqi": 0.5, "collisions": 0.0},
+        {"snqi": 0.4, "collisions": 1.0},
+    )
+
+    assert drift["snqi"]["absolute_delta"] == pytest.approx(-0.1)
+    assert drift["snqi"]["relative_delta"] == pytest.approx(-0.2)
+    assert drift["collisions"]["absolute_delta"] == pytest.approx(1.0)
+    assert drift["collisions"]["relative_delta"] is None
+
+
+def test_build_launch_packet_preserves_no_evidence_boundary() -> None:
+    """Generated packets should be explicit launch packets, not result evidence."""
+    config = load_fidelity_sensitivity_config("configs/research/fidelity_sensitivity_v1.yaml")
+    packet = build_launch_packet(
+        config,
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="abc1234",
+    )
+
+    assert packet["status"] == "launch_packet_only"
+    assert packet["axis_count"] >= 3
+    assert "not benchmark evidence" in packet["claim_boundary"]

--- a/tests/benchmark/test_fidelity_sensitivity.py
+++ b/tests/benchmark/test_fidelity_sensitivity.py
@@ -2,17 +2,44 @@
 
 from __future__ import annotations
 
+import importlib.util
+from pathlib import Path
+from typing import TYPE_CHECKING
+
 import pytest
 
 from robot_sf.benchmark.fidelity_sensitivity import (
     build_launch_packet,
     build_rank_stability_summary,
+    format_launch_packet_markdown,
     kendall_tau_from_orders,
     load_fidelity_sensitivity_config,
     metric_drift,
     rank_flip_count,
     validate_fidelity_sensitivity_config,
 )
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_launch_packet_builder() -> ModuleType:
+    module_path = (
+        REPO_ROOT / "scripts" / "benchmark" / "build_fidelity_sensitivity_launch_packet.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "fidelity_sensitivity_launch_packet_builder", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load builder module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+launch_packet_builder = _load_launch_packet_builder()
 
 
 def test_load_repo_config_validates_three_or_more_axes() -> None:
@@ -78,8 +105,62 @@ def test_build_launch_packet_preserves_no_evidence_boundary() -> None:
         config,
         config_path="configs/research/fidelity_sensitivity_v1.yaml",
         git_head="abc1234",
+        date="2026-06-20",
     )
 
     assert packet["status"] == "launch_packet_only"
     assert packet["axis_count"] >= 3
+    assert packet["date"] == "2026-06-20"
     assert "not benchmark evidence" in packet["claim_boundary"]
+
+
+def test_build_launch_packet_preserves_empty_claim_boundary() -> None:
+    """Explicit falsy config values should not be replaced by defaults."""
+    config = load_fidelity_sensitivity_config("configs/research/fidelity_sensitivity_v1.yaml")
+    config["claim_boundary"] = ""
+
+    packet = build_launch_packet(
+        config,
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="abc1234",
+    )
+
+    assert packet["claim_boundary"] == ""
+
+
+def test_format_launch_packet_markdown_uses_issue_and_date_heading() -> None:
+    """Markdown headings should reflect packet metadata instead of hardcoded issue text."""
+    config = load_fidelity_sensitivity_config("configs/research/fidelity_sensitivity_v1.yaml")
+    packet = build_launch_packet(
+        config,
+        config_path="configs/research/fidelity_sensitivity_v1.yaml",
+        git_head="abc1234",
+        date="2026-06-20",
+    )
+    packet["issue"] = 9999
+
+    markdown = format_launch_packet_markdown(packet)
+
+    assert markdown.startswith("# Issue #9999 Fidelity Sensitivity Launch Packet 2026-06-20")
+
+
+def test_builder_extracts_iso_date_from_output_dir() -> None:
+    """The builder should preserve ISO dates embedded in output paths."""
+    assert (
+        launch_packet_builder._iso_date_from_output_dir(
+            "docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20"
+        )
+        == "2026-06-20"
+    )
+    assert launch_packet_builder._iso_date_from_output_dir("output/fidelity_sensitivity") is None
+
+
+def test_builder_git_head_handles_missing_git(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Minimal environments without git on PATH should still build a packet."""
+
+    def missing_git(*_args: object, **_kwargs: object) -> None:
+        raise FileNotFoundError("git")
+
+    monkeypatch.setattr(launch_packet_builder.subprocess, "run", missing_git)
+
+    assert launch_packet_builder._git_head() == "unknown"


### PR DESCRIPTION
## Summary
Adds a launch-packet-only implementation slice for the simulation-fidelity sensitivity study in #3207: a tracked config, pure config/rank-stability helpers, a packet generator, tests, and a compact generated evidence note.

## Linked Issues
- Relates to `#3207`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #3207 remains open for the actual sweep execution
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `configs/research/fidelity_sensitivity_v1.yaml` with four fidelity axes: integration timestep, social-force speed archetypes, observation noise, and clearance radius.
- Added `robot_sf.benchmark.fidelity_sensitivity` helpers for config validation, rank-order comparison, Kendall tau, rank-flip counting, metric drift, and packet formatting.
- Added `scripts/benchmark/build_fidelity_sensitivity_launch_packet.py` and generated a compact packet under `docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/`.
- Linked the packet from `docs/context/README.md` and `docs/context/evidence/README.md`.
- Added focused tests for the config contract and rank-stability helpers.

## Why It Matters
- Added value: turns #3207 from prose-only study intent into a tracked, testable launch contract.
- Expected impact: future sweep work can validate the same axes and report rank flips/metric drift consistently.
- Why this is worth merging now: it preserves the no-evidence boundary while making the next empirical step executable and reviewable.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: planner-ranking validity boundary under simulation-fidelity perturbations.
- Comparator or baseline, if applicable: nominal benchmark fidelity declared in `configs/research/fidelity_sensitivity_v1.yaml`.
- Evidence tier: launch packet.
- Result classification: diagnostic-only / launch-packet-only.
- Decision or stop rule, if applicable: any `rank_flip_count > 0` becomes a required validity-boundary caveat and calibration candidate.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3207 and `docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20/`.
- New research/benchmark/metric/paper-facing analysis tool, if any: support helper plus launch packet only; representative generation command was run on the tracked config.

## Falsification / Non-Transfer Check
- Did the mechanism activate? unknown; no sweep run in this PR.
- Did the intervention change command source, selected command, trajectory, or route progress? unknown; no benchmark episodes run.
- Did the scenario actually contain the targeted failure mode? unknown; scenario selection is specified but not executed here.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #3207 remains the execution issue for the actual sweep and validity-boundary result.

## Next Empirical Action
- Rerun needed: yes, run the actual fidelity sweep.
- Extractor or analysis tool needed: yes, wire the sweep runner/result-store ingestion to this contract.
- Artifact missing or unavailable: benchmark episode outputs and promoted result summary.
- Stop / revise / continue decision: continue.
- Proposed child issue or existing follow-up: existing #3207.

## Validation / Proof
- Commands run:
  - `uv run python scripts/benchmark/build_fidelity_sensitivity_launch_packet.py --config configs/research/fidelity_sensitivity_v1.yaml --output-dir docs/context/evidence/issue_3207_fidelity_sensitivity_launch_packet_2026-06-20`
  - `uv run ruff check robot_sf/benchmark/fidelity_sensitivity.py scripts/benchmark/build_fidelity_sensitivity_launch_packet.py tests/benchmark/test_fidelity_sensitivity.py`
  - `uv run ruff format --check robot_sf/benchmark/fidelity_sensitivity.py scripts/benchmark/build_fidelity_sensitivity_launch_packet.py tests/benchmark/test_fidelity_sensitivity.py`
  - `uv run python -m pytest tests/benchmark/test_fidelity_sensitivity.py -q`
  - `uv run python -m pytest tests/test_ranking.py tests/test_seed_variance.py tests/benchmark/test_seed_variance.py tests/benchmark/test_fidelity_sensitivity.py -q`
  - `git diff --cached --check`
- Evidence that the change works here: launch packet generation completed; focused test set passed with 23 tests.
- Benchmarks or smoke tests, if applicable: no benchmark sweep run; this is intentionally a launch-packet slice.
- Known validation gap: `uv run robot_sf_bench --help` and broad `uv run python -m pytest tests -k "seed_variance or fidelity or rank" -q` fail in this fresh worktree because existing benchmark imports require `torch`, which is absent from the local `.venv`.

## Risks / Rollout
- Compatibility risks: low; new helpers are additive and pure.
- Failure modes: future sweep implementation must map config patches to actual runner inputs instead of treating this packet as result evidence.
- Rollback or fallback plan: revert this additive PR; #3207 returns to issue-only planning.

## Docs / Provenance
- Updated docs: `docs/context/README.md`, `docs/context/evidence/README.md`, generated packet README/JSON.
- Relevant design or provenance notes: #3207 issue contract.
- Any assumptions that need to be preserved: launch packet is not benchmark evidence and must not be used as planner-ranking support.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via PR linkage; #3207 remains open.
- Claim map / benchmark report updated (yes/no/NA): no, no benchmark result exists yet.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes, evidence README index.
- Context index / memory note updated (yes/no/NA): yes, docs context index.
- Follow-up issue opened for deferred propagation (yes/no/NA): no, existing #3207 owns execution.
- Not applicable because: no result evidence was produced.

## Follow-Up Issues
- Deferred work: run the actual fidelity sweep and promote result evidence.
- Issues opened for follow-up: none.

## Reviewer Notes
- This is a draft because it intentionally does not complete #3207 acceptance criteria; it only establishes the tracked launch packet and rank-stability contract.
- Review especially that the generated packet and docs do not overclaim benchmark or sim-to-real evidence.
