### PR TITLE
research: add pedestrian archetype reporting packet (#3206)

### DIFF
--- a/configs/scenarios/sets/issue_3206_heterogeneous_pedestrian_smoke.yaml
+++ b/configs/scenarios/sets/issue_3206_heterogeneous_pedestrian_smoke.yaml
@@ -1,0 +1,77 @@
+## Issue #3206 heterogeneous-pedestrian smoke matrix
+#
+# Purpose:
+#   Run a tiny paired homogeneous-vs-heterogeneous pedestrian composition smoke on the same map,
+#   route-spawn seed, planner, and episode seeds. This is smoke evidence only: it proves the
+#   scenario-composition knob reaches runtime and can produce reviewable metric deltas; it is not a
+#   full benchmark campaign and does not claim real-world pedestrian-behavior realism.
+#
+# Canonical smoke command shape:
+#   robot_sf_bench --quiet run --matrix configs/scenarios/sets/issue_3206_heterogeneous_pedestrian_smoke.yaml \
+#     --out output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/episodes.jsonl \
+#     --algo simple_policy --workers 1 --horizon 80 --dt 0.1 --no-video --video-renderer none \
+#     --no-resume --benchmark-profile baseline-safe --structured-output json
+#   robot_sf_bench --quiet aggregate \
+#     --in output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/episodes.jsonl \
+#     --out output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/aggregate_by_condition.json \
+#     --group-by scenario_params.metadata.archetype_condition
+
+schema_version: robot_sf.scenario_matrix.v1
+scenarios:
+  - name: issue_3206_classic_crossing_homogeneous
+    map_file: ../../../maps/svg_maps/classic_crossing.svg
+    simulation_config:
+      max_episode_steps: 80
+      ped_density: 0.02
+      route_spawn_distribution: spread
+      route_spawn_seed: 3206
+      max_peds_per_group: 3
+      archetype_composition:
+        standard: 1.0
+      archetype_speed_factors:
+        cautious: 0.7
+        standard: 1.0
+        hurried: 1.4
+      archetype_seed: 3206
+    robot_config: {}
+    metadata:
+      issue: 3206
+      archetype: crossing
+      archetype_condition: homogeneous_standard
+      density: low
+      evidence_tier: smoke
+      claim_boundary: >
+        Smoke-only comparison; not benchmark-strength evidence, not a planner-ranking claim,
+        and not a real-world pedestrian-behavior realism claim.
+    seeds: [101, 102, 103]
+  - name: issue_3206_classic_crossing_mixed
+    map_file: ../../../maps/svg_maps/classic_crossing.svg
+    simulation_config:
+      max_episode_steps: 80
+      ped_density: 0.02
+      route_spawn_distribution: spread
+      route_spawn_seed: 3206
+      max_peds_per_group: 3
+      archetype_composition:
+        cautious: 0.34
+        standard: 0.33
+        hurried: 0.33
+      archetype_speed_factors:
+        cautious: 0.7
+        standard: 1.0
+        hurried: 1.4
+      archetype_seed: 3206
+    robot_config: {}
+    metadata:
+      issue: 3206
+      archetype: crossing
+      archetype_condition: mixed_balanced
+      density: low
+      evidence_tier: smoke
+      claim_boundary: >
+        Smoke-only comparison; not benchmark-strength evidence, not a planner-ranking claim,
+        and not a real-world pedestrian-behavior realism claim.
+    seeds: [101, 102, 103]
+
+map_search_paths:
+  - ../../../maps/svg_maps

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -162,6 +162,9 @@ Policy caveats:
   changed planner-input pedestrian observations, but commands and progress/risk summaries stayed
   identical because the live scenario remained outside the intended 2 m near-field target. Not
   benchmark or sensor-realism evidence.
+- `issue_3206_pedestrian_archetype_reporting_2026-06-20/`: composition-report-only packet for
+  the shipped pedestrian speed-archetype MVP. Records deterministic counts, speed factors, and
+  no-result boundaries for later homogeneous-vs-heterogeneous smoke runs.
 - `policy_search_h500_2026-05-06/`: h500 policy-search leader summaries and failure reports that
   support the v1 raw-success leader and v2 strict-gate promotion decision.
 - `issue_1023_scenario_horizons_preflight_2026-05-06/`: compact preflight artifacts for the

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -455,3 +455,8 @@ Policy caveats:
   remain unchanged.
   claim_boundary=analysis_only_not_navigation_evidence. Not a safety, closed-loop, benchmark,
   or paper-facing claim.
+- `issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/`: smoke-only paired
+  homogeneous-vs-mixed pedestrian composition run on classic crossing with one seed. It proves the
+  archetype composition scenario knob reaches benchmark runtime and can produce reviewable metric
+  deltas. Not benchmark-strength evidence, planner ranking, or a real-world pedestrian-behavior
+  realism claim.

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -456,7 +456,8 @@ Policy caveats:
   claim_boundary=analysis_only_not_navigation_evidence. Not a safety, closed-loop, benchmark,
   or paper-facing claim.
 - `issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/`: smoke-only paired
-  homogeneous-vs-mixed pedestrian composition run on classic crossing with one seed. It proves the
-  archetype composition scenario knob reaches benchmark runtime and can produce reviewable metric
-  deltas. Not benchmark-strength evidence, planner ranking, or a real-world pedestrian-behavior
-  realism claim.
+  homogeneous-vs-mixed pedestrian composition run on classic crossing with three seeds per
+  condition. It proves the archetype composition scenario knob reaches benchmark runtime and can
+  produce reviewable metric deltas. The distributional-disruption blocks are present but not
+  computable because the smoke has no control trace support. Not benchmark-strength evidence,
+  planner ranking, real-world fairness evidence, or a real-world pedestrian-behavior realism claim.

--- a/docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/README.md
+++ b/docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/README.md
@@ -1,16 +1,14 @@
-# Issue #3206 Heterogeneous Pedestrian Smoke
+# Issue #3206 Heterogeneous Pedestrian Smoke Report
 
-Status: `smoke_complete`
-
-This packet records a tiny paired homogeneous-vs-heterogeneous pedestrian composition smoke.
-It is not a full benchmark campaign, not a planner-ranking claim, and not a real-world
-pedestrian-behavior realism claim.
+- Status: `diagnostic_smoke_report`
+- Source episode git hash(es): `5dd029bd2b5672dc846b5a138077712a2f393ff4`
+- Input rows: worktree-local ignored artifact summarized in this report (episodes.jsonl)
+- Claim boundary: diagnostic_smoke_not_benchmark_evidence: summarizes a tiny homogeneous-vs-mixed pedestrian composition smoke. It records metric deltas and distributional-metric readiness limits; it does not establish pedestrian realism, real-world fairness, planner ranking, or a limitation-replacement decision.
+- Per-archetype distributional status: `not_computable_from_current_smoke`
 
 ## Provenance
 
 - Branch: `issue-3206-archetype-reporting`
-- Source commit at run time: `95e42c514c0f00baf624084ec86e625f11c35f2a` plus the runtime wiring
-  changes in this PR branch.
 - Matrix: `configs/scenarios/sets/issue_3206_heterogeneous_pedestrian_smoke.yaml`
 - Planner: `simple_policy`
 - Horizon: `80`
@@ -27,30 +25,26 @@ scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench --quiet run \
   --algo simple_policy --workers 1 --horizon 80 --dt 0.1 --no-video --video-renderer none \
   --no-resume --benchmark-profile baseline-safe --structured-output json
 
-scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench --quiet aggregate \
-  --in output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/episodes.jsonl \
-  --out output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/aggregate_by_condition.json \
-  --group-by scenario_params.metadata.archetype_condition
+scripts/dev/run_worktree_shared_venv.sh -- python scripts/benchmark/build_heterogeneous_pedestrian_smoke_report.py \
+  --episodes output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/episodes.jsonl \
+  --output-dir docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20
 ```
 
-## Smoke Result
+## Condition Metrics
 
-| Condition | Success | Collisions | Min distance mean | Mean distance mean | Robot within 5 m frac | Interpretation |
-| --- | ---: | ---: | ---: | ---: | ---: | --- |
-| `homogeneous_standard` | 0.0 | 0.0 | 3.226 | 4.750 | 0.571 | Timeout, no collision, route interaction exposure present. |
-| `mixed_balanced` | 0.0 | 0.0 | 5.010 | 5.706 | 0.042 | Timeout, no collision, larger clearance in this three-seed smoke. |
+| Condition | Episodes | Success | Collisions | Min distance mean | Mean distance mean | Robot within 5 m frac | Distributional status |
+|---|---:|---:|---:|---:|---:|---:|---|
+| `homogeneous_standard` | 3 | 0.000 | 0.000 | 3.226 | 4.750 | 0.571 | `not_computable` |
+| `mixed_balanced` | 3 | 0.000 | 0.000 | 5.010 | 5.706 | 0.042 | `not_computable` |
 
-Observed deltas (`mixed_balanced - homogeneous_standard`):
+## Planned Composition
 
-- `min_distance.mean`: `+1.784`
-- `mean_distance.mean`: `+0.956`
-- `robot_ped_within_5m_frac.mean`: `-0.529`
-- `success.mean`: `0.000`
-- `collisions.mean`: `0.000`
+- `homogeneous_standard`: `{"standard": 1.0}`
+- `mixed_balanced`: `{"cautious": 0.34, "hurried": 0.33, "standard": 0.33}`
 
-## Claim Boundary
+## Distributional/Fairness Boundary
 
-This is enough to show that the homogeneous-vs-heterogeneous scenario axis reaches benchmark runtime
-and can produce reviewable metric deltas on a fixed seed.
-It is not enough to claim robust composition dependence, pedestrian realism, or planner ranking.
-A larger seed/scenario slice is required before promotion beyond smoke evidence.
+The current smoke carries `distributional_disruption` blocks, but support counts are zero
+because no control trace was provided. That means per-archetype displacement or delay
+fairness-style metrics are not computable from this smoke. The result remains useful as
+a runtime and metric-delta smoke only.

--- a/docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/README.md
+++ b/docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/README.md
@@ -1,0 +1,56 @@
+# Issue #3206 Heterogeneous Pedestrian Smoke
+
+Status: `smoke_complete`
+
+This packet records a tiny paired homogeneous-vs-heterogeneous pedestrian composition smoke.
+It is not a full benchmark campaign, not a planner-ranking claim, and not a real-world
+pedestrian-behavior realism claim.
+
+## Provenance
+
+- Branch: `issue-3206-archetype-reporting`
+- Source commit at run time: `95e42c514c0f00baf624084ec86e625f11c35f2a` plus the runtime wiring
+  changes in this PR branch.
+- Matrix: `configs/scenarios/sets/issue_3206_heterogeneous_pedestrian_smoke.yaml`
+- Planner: `simple_policy`
+- Horizon: `80`
+- Time step: `0.1`
+- Seeds: scenario seeds `101`, `102`, `103`; route spawn seed `3206`; archetype seed `3206`
+- Raw episodes: generated under local `output/` or `/tmp`; intentionally not committed.
+
+## Commands
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench --quiet run \
+  --matrix configs/scenarios/sets/issue_3206_heterogeneous_pedestrian_smoke.yaml \
+  --out output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/episodes.jsonl \
+  --algo simple_policy --workers 1 --horizon 80 --dt 0.1 --no-video --video-renderer none \
+  --no-resume --benchmark-profile baseline-safe --structured-output json
+
+scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench --quiet aggregate \
+  --in output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/episodes.jsonl \
+  --out output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/aggregate_by_condition.json \
+  --group-by scenario_params.metadata.archetype_condition
+```
+
+## Smoke Result
+
+| Condition | Success | Collisions | Min distance mean | Mean distance mean | Robot within 5 m frac | Interpretation |
+| --- | ---: | ---: | ---: | ---: | ---: | --- |
+| `homogeneous_standard` | 0.0 | 0.0 | 3.226 | 4.750 | 0.571 | Timeout, no collision, route interaction exposure present. |
+| `mixed_balanced` | 0.0 | 0.0 | 5.010 | 5.706 | 0.042 | Timeout, no collision, larger clearance in this three-seed smoke. |
+
+Observed deltas (`mixed_balanced - homogeneous_standard`):
+
+- `min_distance.mean`: `+1.784`
+- `mean_distance.mean`: `+0.956`
+- `robot_ped_within_5m_frac.mean`: `-0.529`
+- `success.mean`: `0.000`
+- `collisions.mean`: `0.000`
+
+## Claim Boundary
+
+This is enough to show that the homogeneous-vs-heterogeneous scenario axis reaches benchmark runtime
+and can produce reviewable metric deltas on a fixed seed.
+It is not enough to claim robust composition dependence, pedestrian realism, or planner ranking.
+A larger seed/scenario slice is required before promotion beyond smoke evidence.

--- a/docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/aggregate_by_condition.json
+++ b/docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/aggregate_by_condition.json
@@ -1,0 +1,56 @@
+{
+  "homogeneous_standard": {
+    "avg_speed": {
+      "mean": 0.9795916847173137
+    },
+    "collisions": {
+      "mean": 0.0
+    },
+    "energy": {
+      "mean": 4.650305773024978
+    },
+    "mean_distance": {
+      "mean": 4.749983020094316
+    },
+    "min_distance": {
+      "mean": 3.2255220900031887
+    },
+    "robot_ped_within_5m_frac": {
+      "mean": 0.5708333333333333
+    },
+    "success": {
+      "mean": 0.0
+    }
+  },
+  "mixed_balanced": {
+    "avg_speed": {
+      "mean": 0.9795916847173137
+    },
+    "collisions": {
+      "mean": 0.0
+    },
+    "energy": {
+      "mean": 4.650305773024978
+    },
+    "mean_distance": {
+      "mean": 5.705592807446085
+    },
+    "min_distance": {
+      "mean": 5.0100017932340135
+    },
+    "robot_ped_within_5m_frac": {
+      "mean": 0.041666666666666664
+    },
+    "success": {
+      "mean": 0.0
+    }
+  },
+  "delta_mixed_minus_homogeneous": {
+    "collisions": 0.0,
+    "mean_distance": 0.9556097873517695,
+    "min_distance": 1.7844797032308248,
+    "robot_ped_within_5m_frac": -0.5291666666666667,
+    "success": 0.0
+  },
+  "schema_version": "issue-3206-heterogeneous-pedestrian-smoke.v1"
+}

--- a/docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/smoke_report.json
+++ b/docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20/smoke_report.json
@@ -1,0 +1,184 @@
+{
+  "baseline_condition": "homogeneous_standard",
+  "claim_boundary": "diagnostic_smoke_not_benchmark_evidence: summarizes a tiny homogeneous-vs-mixed pedestrian composition smoke. It records metric deltas and distributional-metric readiness limits; it does not establish pedestrian realism, real-world fairness, planner ranking, or a limitation-replacement decision.",
+  "conditions": {
+    "homogeneous_standard": {
+      "distributional_disruption": {
+        "block_count": 3,
+        "limitation": "Distributional-disruption blocks are present, but all support counts are zero. The current smoke did not provide the control trace required for per-cohort displacement or delay support.",
+        "missing_reasons": {
+          "extreme_speed_tier": {
+            "No control trace provided": 3
+          },
+          "fast_speed_tier": {
+            "No control trace provided": 3
+          },
+          "slow_speed_tier": {
+            "No control trace provided": 3
+          }
+        },
+        "status": "not_computable",
+        "support_counts": {
+          "extreme_speed_tier": 0,
+          "fast_speed_tier": 0,
+          "slow_speed_tier": 0
+        }
+      },
+      "episode_count": 3,
+      "metrics": {
+        "collisions": {
+          "count": 3,
+          "mean": 0.0
+        },
+        "mean_distance": {
+          "count": 3,
+          "mean": 4.749983020094316
+        },
+        "min_distance": {
+          "count": 3,
+          "mean": 3.2255220900031887
+        },
+        "robot_ped_within_5m_frac": {
+          "count": 3,
+          "mean": 0.5708333333333333
+        },
+        "success": {
+          "count": 3,
+          "mean": 0.0
+        }
+      },
+      "planned_archetype_population": {
+        "archetype_seed": 3206,
+        "composition": {
+          "standard": 1.0
+        },
+        "realized_counts_status": "not_recorded_in_episode_rows",
+        "speed_factors": {
+          "cautious": 0.7,
+          "hurried": 1.4,
+          "standard": 1.0
+        }
+      },
+      "scenario_ids": [
+        "issue_3206_classic_crossing_homogeneous"
+      ],
+      "seeds": [
+        101,
+        102,
+        103
+      ]
+    },
+    "mixed_balanced": {
+      "distributional_disruption": {
+        "block_count": 3,
+        "limitation": "Distributional-disruption blocks are present, but all support counts are zero. The current smoke did not provide the control trace required for per-cohort displacement or delay support.",
+        "missing_reasons": {
+          "extreme_speed_tier": {
+            "No control trace provided": 3
+          },
+          "fast_speed_tier": {
+            "No control trace provided": 3
+          },
+          "slow_speed_tier": {
+            "No control trace provided": 3
+          }
+        },
+        "status": "not_computable",
+        "support_counts": {
+          "extreme_speed_tier": 0,
+          "fast_speed_tier": 0,
+          "slow_speed_tier": 0
+        }
+      },
+      "episode_count": 3,
+      "metrics": {
+        "collisions": {
+          "count": 3,
+          "mean": 0.0
+        },
+        "mean_distance": {
+          "count": 3,
+          "mean": 5.705592807446085
+        },
+        "min_distance": {
+          "count": 3,
+          "mean": 5.0100017932340135
+        },
+        "robot_ped_within_5m_frac": {
+          "count": 3,
+          "mean": 0.041666666666666664
+        },
+        "success": {
+          "count": 3,
+          "mean": 0.0
+        }
+      },
+      "planned_archetype_population": {
+        "archetype_seed": 3206,
+        "composition": {
+          "cautious": 0.34,
+          "hurried": 0.33,
+          "standard": 0.33
+        },
+        "realized_counts_status": "not_recorded_in_episode_rows",
+        "speed_factors": {
+          "cautious": 0.7,
+          "hurried": 1.4,
+          "standard": 1.0
+        }
+      },
+      "scenario_ids": [
+        "issue_3206_classic_crossing_mixed"
+      ],
+      "seeds": [
+        101,
+        102,
+        103
+      ]
+    }
+  },
+  "delta_variant_minus_baseline": {
+    "collisions": {
+      "absolute_delta": 0.0,
+      "baseline": 0.0,
+      "relative_delta": null,
+      "variant": 0.0
+    },
+    "mean_distance": {
+      "absolute_delta": 0.9556097873517695,
+      "baseline": 4.749983020094316,
+      "relative_delta": 0.20118172703126733,
+      "variant": 5.705592807446085
+    },
+    "min_distance": {
+      "absolute_delta": 1.7844797032308248,
+      "baseline": 3.2255220900031887,
+      "relative_delta": 0.5532374770464091,
+      "variant": 5.0100017932340135
+    },
+    "robot_ped_within_5m_frac": {
+      "absolute_delta": -0.5291666666666667,
+      "baseline": 0.5708333333333333,
+      "relative_delta": -0.9270072992700731,
+      "variant": 0.041666666666666664
+    },
+    "success": {
+      "absolute_delta": 0.0,
+      "baseline": 0.0,
+      "relative_delta": null,
+      "variant": 0.0
+    }
+  },
+  "inputs": {
+    "episodes_jsonl": "worktree-local ignored artifact summarized in this report (episodes.jsonl)",
+    "raw_episodes_committed": false
+  },
+  "issue": 3206,
+  "per_archetype_distributional_status": "not_computable_from_current_smoke",
+  "schema_version": "issue_3206_heterogeneous_pedestrian_smoke_report.v1",
+  "source_episode_git_hashes": [
+    "5dd029bd2b5672dc846b5a138077712a2f393ff4"
+  ],
+  "status": "diagnostic_smoke_report",
+  "variant_condition": "mixed_balanced"
+}

--- a/docs/context/evidence/issue_3206_pedestrian_archetype_reporting_2026-06-20/README.md
+++ b/docs/context/evidence/issue_3206_pedestrian_archetype_reporting_2026-06-20/README.md
@@ -1,0 +1,17 @@
+# Issue #3206 Pedestrian Archetype Reporting Packet
+
+- Status: `composition_report_only`
+- Config: `configs/research/pedestrian_archetypes_v1.yaml`
+- Population size per composition: `30`
+- Claim boundary: No benchmark, realism, or planner-ranking claim. This packet only records deterministic composition assumptions for the shipped speed-archetype MVP.
+
+## Composition Reports
+
+| Composition | Archetypes | Speed factor range | Assignment digest |
+|---|---:|---|---|
+| `homogeneous_standard` | 1 | 1-1 | `d445fb25af0e` |
+| `mixed_balanced` | 3 | 0.7-1.4 | `50feea1c23ac` |
+| `rush_hour` | 3 | 0.7-1.4 | `6b37896db37d` |
+
+This packet records deterministic population-composition assumptions only.
+It is not a homogeneous-vs-heterogeneous benchmark smoke and does not report metric deltas.

--- a/docs/context/evidence/issue_3206_pedestrian_archetype_reporting_2026-06-20/summary.json
+++ b/docs/context/evidence/issue_3206_pedestrian_archetype_reporting_2026-06-20/summary.json
@@ -1,0 +1,100 @@
+{
+  "claim_boundary": "No benchmark, realism, or planner-ranking claim. This packet only records deterministic composition assumptions for the shipped speed-archetype MVP.",
+  "config_path": "configs/research/pedestrian_archetypes_v1.yaml",
+  "population_size": 30,
+  "reports": {
+    "homogeneous_standard": {
+      "archetypes": {
+        "standard": {
+          "desired_speed_factor": 1.0,
+          "initial_speed_m_s": 0.5,
+          "intended_fraction": 1.0,
+          "realized_count": 30,
+          "realized_fraction": 1.0
+        }
+      },
+      "assignment_order_sha1": "d445fb25af0e",
+      "claim_boundary": "No benchmark, realism, or planner-ranking claim. This report only records deterministic population composition and speed-factor assumptions for later smoke/campaign runs.",
+      "initial_speed_m_s": 0.5,
+      "population_size": 30,
+      "schema_version": "pedestrian-archetype-population-report.v1",
+      "seed": 3206,
+      "speed_factor_max": 1.0,
+      "speed_factor_mean": 1.0,
+      "speed_factor_min": 1.0,
+      "status": "composition_report_only"
+    },
+    "mixed_balanced": {
+      "archetypes": {
+        "cautious": {
+          "desired_speed_factor": 0.7,
+          "initial_speed_m_s": 0.35,
+          "intended_fraction": 0.34,
+          "realized_count": 10,
+          "realized_fraction": 0.3333333333333333
+        },
+        "hurried": {
+          "desired_speed_factor": 1.4,
+          "initial_speed_m_s": 0.7,
+          "intended_fraction": 0.33,
+          "realized_count": 10,
+          "realized_fraction": 0.3333333333333333
+        },
+        "standard": {
+          "desired_speed_factor": 1.0,
+          "initial_speed_m_s": 0.5,
+          "intended_fraction": 0.33,
+          "realized_count": 10,
+          "realized_fraction": 0.3333333333333333
+        }
+      },
+      "assignment_order_sha1": "50feea1c23ac",
+      "claim_boundary": "No benchmark, realism, or planner-ranking claim. This report only records deterministic population composition and speed-factor assumptions for later smoke/campaign runs.",
+      "initial_speed_m_s": 0.5,
+      "population_size": 30,
+      "schema_version": "pedestrian-archetype-population-report.v1",
+      "seed": 3206,
+      "speed_factor_max": 1.4,
+      "speed_factor_mean": 1.033333333333333,
+      "speed_factor_min": 0.7,
+      "status": "composition_report_only"
+    },
+    "rush_hour": {
+      "archetypes": {
+        "cautious": {
+          "desired_speed_factor": 0.7,
+          "initial_speed_m_s": 0.35,
+          "intended_fraction": 0.2,
+          "realized_count": 6,
+          "realized_fraction": 0.2
+        },
+        "hurried": {
+          "desired_speed_factor": 1.4,
+          "initial_speed_m_s": 0.7,
+          "intended_fraction": 0.5,
+          "realized_count": 15,
+          "realized_fraction": 0.5
+        },
+        "standard": {
+          "desired_speed_factor": 1.0,
+          "initial_speed_m_s": 0.5,
+          "intended_fraction": 0.3,
+          "realized_count": 9,
+          "realized_fraction": 0.3
+        }
+      },
+      "assignment_order_sha1": "6b37896db37d",
+      "claim_boundary": "No benchmark, realism, or planner-ranking claim. This report only records deterministic population composition and speed-factor assumptions for later smoke/campaign runs.",
+      "initial_speed_m_s": 0.5,
+      "population_size": 30,
+      "schema_version": "pedestrian-archetype-population-report.v1",
+      "seed": 3206,
+      "speed_factor_max": 1.4,
+      "speed_factor_mean": 1.1400000000000001,
+      "speed_factor_min": 0.7,
+      "status": "composition_report_only"
+    }
+  },
+  "schema_version": "pedestrian-archetype-reporting-packet.v1",
+  "status": "composition_report_only"
+}

--- a/robot_sf/ped_npc/ped_archetypes.py
+++ b/robot_sf/ped_npc/ped_archetypes.py
@@ -17,8 +17,11 @@ values; this is mechanism evidence, not benchmark or realism evidence.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import math
 from pathlib import Path
+from typing import Any
 
 import numpy as np
 import yaml
@@ -124,12 +127,82 @@ def assign_archetype_speed_factors(
     Returns:
         Float array of shape ``(n,)`` with each pedestrian's desired-speed factor.
     """
+    labels = assign_archetype_labels(n, composition, seed=seed)
+    return np.asarray([speed_factors[label] for label in labels], dtype=float)
+
+
+def assign_archetype_labels(
+    n: int,
+    composition: dict[str, float],
+    *,
+    seed: int | None = None,
+) -> np.ndarray:
+    """Return a length-``n`` array of sampled archetype labels.
+
+    The label order matches :func:`assign_archetype_speed_factors` for the same
+    ``n``, composition, and seed, so downstream reports can join per-pedestrian
+    labels to speed factors without re-sampling.
+
+    Returns:
+        String array of shape ``(n,)`` with each pedestrian's archetype label.
+    """
     if n <= 0:
-        return np.empty(0, dtype=float)
+        return np.empty(0, dtype=str)
     counts = allocate_archetype_counts(n, composition)
-    factors = np.concatenate(
-        [np.full(count, speed_factors[name], dtype=float) for name, count in counts.items()]
-    )
+    labels = np.concatenate([np.full(count, name, dtype=object) for name, count in counts.items()])
     rng = np.random.default_rng(seed)
-    rng.shuffle(factors)
-    return factors
+    rng.shuffle(labels)
+    return labels.astype(str)
+
+
+def build_archetype_population_report(
+    *,
+    n: int,
+    composition: dict[str, float],
+    speed_factors: dict[str, float],
+    initial_speed: float,
+    seed: int | None = None,
+) -> dict[str, Any]:
+    """Build a deterministic, no-result report for one population composition.
+
+    Returns:
+        JSON-serializable summary of intended and realized composition counts,
+        desired-speed factors, and initial-speed assumptions.
+    """
+    validate_composition(composition, speed_factors)
+    labels = assign_archetype_labels(n, composition, seed=seed)
+    factors = np.asarray([speed_factors[label] for label in labels], dtype=float)
+    counts = {name: int(np.count_nonzero(labels == name)) for name in composition}
+    realized_total = max(1, int(n))
+    return {
+        "schema_version": "pedestrian-archetype-population-report.v1",
+        "status": "composition_report_only",
+        "claim_boundary": (
+            "No benchmark, realism, or planner-ranking claim. This report only "
+            "records deterministic population composition and speed-factor "
+            "assumptions for later smoke/campaign runs."
+        ),
+        "population_size": int(n),
+        "seed": seed,
+        "initial_speed_m_s": float(initial_speed),
+        "archetypes": {
+            name: {
+                "intended_fraction": float(composition[name]),
+                "realized_count": counts[name],
+                "realized_fraction": float(counts[name] / realized_total) if n > 0 else 0.0,
+                "desired_speed_factor": float(speed_factors[name]),
+                "initial_speed_m_s": float(initial_speed * speed_factors[name]),
+            }
+            for name in sorted(composition)
+        },
+        "assignment_order_sha1": _assignment_digest(labels.tolist()),
+        "speed_factor_mean": float(np.mean(factors)) if factors.size else 0.0,
+        "speed_factor_min": float(np.min(factors)) if factors.size else 0.0,
+        "speed_factor_max": float(np.max(factors)) if factors.size else 0.0,
+    }
+
+
+def _assignment_digest(labels: list[str]) -> str:
+    """Return a stable digest for the sampled label order."""
+    encoded = json.dumps(labels, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha1(encoded).hexdigest()[:12]

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -60,6 +60,13 @@ class SimulationSettings:
     route_spawn_seed: int | None = None
     """Optional RNG seed for route spawn placement/jitter."""
 
+    archetype_composition: dict[str, float] | None = None
+    """Optional pedestrian behavior-archetype composition for route/crowd spawning."""
+    archetype_speed_factors: dict[str, float] | None = None
+    """Optional archetype desired-speed factors used with ``archetype_composition``."""
+    archetype_seed: int | None = None
+    """Optional RNG seed for deterministic archetype assignment."""
+
     peds_reset_follow_route_at_start: bool = False
     """Whether pedestrians following routes should reset to the start of their routes"""
     debug_without_robot_movement: bool = False

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -172,6 +172,9 @@ class Simulator:
             route_spawn_jitter_frac=self.config.route_spawn_jitter_frac,
             route_spawn_seed=self.config.route_spawn_seed,
             reset_follow_route_at_start=self.config.peds_reset_follow_route_at_start,
+            archetype_composition=self.config.archetype_composition,
+            archetype_speed_factors=self.config.archetype_speed_factors,
+            archetype_seed=self.config.archetype_seed,
         )
         self.pysf_state, self.groups, self.peds_behaviors = populate_simulation(
             pysf_config.scene_config.tau,
@@ -439,6 +442,9 @@ class PedSimulator(Simulator):
             route_spawn_jitter_frac=self.config.route_spawn_jitter_frac,
             route_spawn_seed=self.config.route_spawn_seed,
             reset_follow_route_at_start=self.config.peds_reset_follow_route_at_start,
+            archetype_composition=self.config.archetype_composition,
+            archetype_speed_factors=self.config.archetype_speed_factors,
+            archetype_seed=self.config.archetype_seed,
         )
         self.pysf_state, self.groups, self.peds_behaviors = populate_simulation(
             pysf_config.scene_config.tau,

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -1958,6 +1958,9 @@ def _apply_simulation_overrides(
         "route_spawn_distribution",
         "route_spawn_jitter_frac",
         "route_spawn_seed",
+        "archetype_composition",
+        "archetype_speed_factors",
+        "archetype_seed",
     ):
         if attr in overrides:
             setattr(config.sim_config, attr, overrides[attr])

--- a/scripts/benchmark/build_heterogeneous_pedestrian_smoke_report.py
+++ b/scripts/benchmark/build_heterogeneous_pedestrian_smoke_report.py
@@ -1,0 +1,359 @@
+#!/usr/bin/env python3
+"""Build a diagnostic report for issue #3206 heterogeneous-pedestrian smoke rows."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCHEMA_VERSION = "issue_3206_heterogeneous_pedestrian_smoke_report.v1"
+DEFAULT_METRICS = (
+    "success",
+    "collisions",
+    "min_distance",
+    "mean_distance",
+    "robot_ped_within_5m_frac",
+)
+CLAIM_BOUNDARY = (
+    "diagnostic_smoke_not_benchmark_evidence: summarizes a tiny homogeneous-vs-mixed "
+    "pedestrian composition smoke. It records metric deltas and distributional-metric "
+    "readiness limits; it does not establish pedestrian realism, real-world fairness, "
+    "planner ranking, or a limitation-replacement decision."
+)
+
+
+def _number(value: Any) -> float | None:
+    """Return a finite float for numeric-like scalars."""
+    if value is None or value == "":
+        return None
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load episode records from a JSONL file."""
+    rows: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        row = json.loads(line)
+        if not isinstance(row, dict):
+            raise ValueError(f"{path} contains a non-object JSONL row")
+        rows.append(row)
+    if not rows:
+        raise ValueError(f"{path} contains no episode rows")
+    return rows
+
+
+def _metadata(row: Mapping[str, Any]) -> dict[str, Any]:
+    scenario_params = row.get("scenario_params")
+    if not isinstance(scenario_params, dict):
+        return {}
+    metadata = scenario_params.get("metadata")
+    return metadata if isinstance(metadata, dict) else {}
+
+
+def _simulation_config(row: Mapping[str, Any]) -> dict[str, Any]:
+    scenario_params = row.get("scenario_params")
+    if not isinstance(scenario_params, dict):
+        return {}
+    sim_config = scenario_params.get("simulation_config")
+    return sim_config if isinstance(sim_config, dict) else {}
+
+
+def _condition(row: Mapping[str, Any]) -> str:
+    metadata = _metadata(row)
+    return str(metadata.get("archetype_condition") or row.get("scenario_id") or "unknown")
+
+
+def _mean_metrics(rows: Sequence[Mapping[str, Any]], metrics: Sequence[str]) -> dict[str, Any]:
+    out: dict[str, dict[str, float | int | None]] = {}
+    for metric in metrics:
+        values: list[float] = []
+        for row in rows:
+            row_metrics = row.get("metrics")
+            if not isinstance(row_metrics, dict):
+                continue
+            value = _number(row_metrics.get(metric))
+            if value is not None:
+                values.append(value)
+        out[metric] = {
+            "mean": sum(values) / len(values) if values else None,
+            "count": len(values),
+        }
+    return out
+
+
+def _distributional_status(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    support_counts: dict[str, int] = {}
+    missing_reasons: dict[str, dict[str, int]] = {}
+    block_count = 0
+    for row in rows:
+        metrics = row.get("metrics")
+        if not isinstance(metrics, dict):
+            continue
+        block = metrics.get("distributional_disruption")
+        if not isinstance(block, dict):
+            continue
+        block_count += 1
+        for cohort, count in (block.get("support_counts") or {}).items():
+            if isinstance(count, int):
+                support_counts[str(cohort)] = support_counts.get(str(cohort), 0) + count
+        for cohort, missing in (block.get("missing_data") or {}).items():
+            if not isinstance(missing, dict):
+                continue
+            reason = str(missing.get("reason") or "unspecified")
+            bucket = missing_reasons.setdefault(str(cohort), {})
+            bucket[reason] = bucket.get(reason, 0) + 1
+
+    supported_total = sum(support_counts.values())
+    if block_count == 0:
+        status = "absent"
+        limitation = "No distributional_disruption block was present in the episode rows."
+    elif supported_total == 0:
+        status = "not_computable"
+        limitation = (
+            "Distributional-disruption blocks are present, but all support counts are zero. "
+            "The current smoke did not provide the control trace required for per-cohort "
+            "displacement or delay support."
+        )
+    else:
+        status = "computable"
+        limitation = ""
+    return {
+        "status": status,
+        "block_count": block_count,
+        "support_counts": support_counts,
+        "missing_reasons": missing_reasons,
+        "limitation": limitation,
+    }
+
+
+def _planned_composition(row: Mapping[str, Any]) -> dict[str, Any]:
+    sim_config = _simulation_config(row)
+    composition = sim_config.get("archetype_composition")
+    speed_factors = sim_config.get("archetype_speed_factors")
+    return {
+        "composition": composition if isinstance(composition, dict) else {},
+        "speed_factors": speed_factors if isinstance(speed_factors, dict) else {},
+        "archetype_seed": sim_config.get("archetype_seed"),
+        "realized_counts_status": "not_recorded_in_episode_rows",
+    }
+
+
+def _metric_deltas(
+    baseline: Mapping[str, Mapping[str, float | int | None]],
+    variant: Mapping[str, Mapping[str, float | int | None]],
+) -> dict[str, dict[str, float | None]]:
+    deltas: dict[str, dict[str, float | None]] = {}
+    for metric in sorted(set(baseline) & set(variant)):
+        baseline_mean = baseline[metric].get("mean")
+        variant_mean = variant[metric].get("mean")
+        if isinstance(baseline_mean, (int, float)) and isinstance(variant_mean, (int, float)):
+            absolute = float(variant_mean) - float(baseline_mean)
+            relative = None if float(baseline_mean) == 0.0 else absolute / float(baseline_mean)
+        else:
+            absolute = None
+            relative = None
+        deltas[metric] = {
+            "baseline": float(baseline_mean) if isinstance(baseline_mean, (int, float)) else None,
+            "variant": float(variant_mean) if isinstance(variant_mean, (int, float)) else None,
+            "absolute_delta": absolute,
+            "relative_delta": relative,
+        }
+    return deltas
+
+
+def build_report(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    baseline_condition: str = "homogeneous_standard",
+    variant_condition: str = "mixed_balanced",
+    metrics: Sequence[str] = DEFAULT_METRICS,
+    input_ref: str = "",
+) -> dict[str, Any]:
+    """Build a compact heterogeneous-pedestrian smoke report."""
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for row in rows:
+        grouped.setdefault(_condition(row), []).append(row)
+    if baseline_condition not in grouped:
+        raise ValueError(f"baseline condition {baseline_condition!r} is missing")
+    if variant_condition not in grouped:
+        raise ValueError(f"variant condition {variant_condition!r} is missing")
+
+    conditions: dict[str, Any] = {}
+    for condition, condition_rows in sorted(grouped.items()):
+        first = condition_rows[0]
+        conditions[condition] = {
+            "episode_count": len(condition_rows),
+            "seeds": sorted({row.get("seed") for row in condition_rows}),
+            "scenario_ids": sorted({str(row.get("scenario_id", "")) for row in condition_rows}),
+            "planned_archetype_population": _planned_composition(first),
+            "metrics": _mean_metrics(condition_rows, metrics),
+            "distributional_disruption": _distributional_status(condition_rows),
+        }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 3206,
+        "status": "diagnostic_smoke_report",
+        "claim_boundary": CLAIM_BOUNDARY,
+        "inputs": {
+            "episodes_jsonl": input_ref,
+            "raw_episodes_committed": False,
+        },
+        "source_episode_git_hashes": sorted(
+            {str(row.get("git_hash")) for row in rows if row.get("git_hash")}
+        ),
+        "baseline_condition": baseline_condition,
+        "variant_condition": variant_condition,
+        "conditions": conditions,
+        "delta_variant_minus_baseline": _metric_deltas(
+            conditions[baseline_condition]["metrics"],
+            conditions[variant_condition]["metrics"],
+        ),
+        "per_archetype_distributional_status": (
+            "not_computable_from_current_smoke"
+            if any(
+                condition["distributional_disruption"]["status"] != "computable"
+                for condition in conditions.values()
+            )
+            else "computable"
+        ),
+    }
+
+
+def format_markdown(report: Mapping[str, Any]) -> str:
+    """Render the smoke report as Markdown."""
+    source_hashes = ", ".join(report["source_episode_git_hashes"]) or "unknown"
+    lines = [
+        "# Issue #3206 Heterogeneous Pedestrian Smoke Report",
+        "",
+        f"- Status: `{report['status']}`",
+        f"- Source episode git hash(es): `{source_hashes}`",
+        f"- Input rows: {report['inputs']['episodes_jsonl']}",
+        f"- Claim boundary: {report['claim_boundary']}",
+        f"- Per-archetype distributional status: `{report['per_archetype_distributional_status']}`",
+        "",
+        "## Provenance",
+        "",
+        "- Branch: `issue-3206-archetype-reporting`",
+        "- Matrix: `configs/scenarios/sets/issue_3206_heterogeneous_pedestrian_smoke.yaml`",
+        "- Planner: `simple_policy`",
+        "- Horizon: `80`",
+        "- Time step: `0.1`",
+        "- Seeds: scenario seeds `101`, `102`, `103`; route spawn seed `3206`; archetype seed `3206`",
+        "- Raw episodes: generated under local `output/` or `/tmp`; intentionally not committed.",
+        "",
+        "## Commands",
+        "",
+        "```bash",
+        "scripts/dev/run_worktree_shared_venv.sh -- robot_sf_bench --quiet run \\",
+        "  --matrix configs/scenarios/sets/issue_3206_heterogeneous_pedestrian_smoke.yaml \\",
+        "  --out output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/episodes.jsonl \\",
+        "  --algo simple_policy --workers 1 --horizon 80 --dt 0.1 --no-video --video-renderer none \\",
+        "  --no-resume --benchmark-profile baseline-safe --structured-output json",
+        "",
+        "scripts/dev/run_worktree_shared_venv.sh -- python scripts/benchmark/build_heterogeneous_pedestrian_smoke_report.py \\",
+        "  --episodes output/benchmarks/issue_3206_heterogeneous_pedestrian_smoke/episodes.jsonl \\",
+        "  --output-dir docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20",
+        "```",
+        "",
+        "## Condition Metrics",
+        "",
+        "| Condition | Episodes | Success | Collisions | Min distance mean | Mean distance mean | Robot within 5 m frac | Distributional status |",
+        "|---|---:|---:|---:|---:|---:|---:|---|",
+    ]
+    for condition, summary in report["conditions"].items():
+        metrics = summary["metrics"]
+        lines.append(
+            f"| `{condition}` | {summary['episode_count']} | "
+            f"{_fmt(metrics['success']['mean'])} | {_fmt(metrics['collisions']['mean'])} | "
+            f"{_fmt(metrics['min_distance']['mean'])} | "
+            f"{_fmt(metrics['mean_distance']['mean'])} | "
+            f"{_fmt(metrics['robot_ped_within_5m_frac']['mean'])} | "
+            f"`{summary['distributional_disruption']['status']}` |"
+        )
+
+    lines.extend(["", "## Planned Composition", ""])
+    for condition, summary in report["conditions"].items():
+        composition = summary["planned_archetype_population"]["composition"]
+        lines.append(f"- `{condition}`: `{json.dumps(composition, sort_keys=True)}`")
+
+    lines.extend(
+        [
+            "",
+            "## Distributional/Fairness Boundary",
+            "",
+            "The current smoke carries `distributional_disruption` blocks, but support counts are zero",
+            "because no control trace was provided. That means per-archetype displacement or delay",
+            "fairness-style metrics are not computable from this smoke. The result remains useful as",
+            "a runtime and metric-delta smoke only.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _fmt(value: Any) -> str:
+    number = _number(value)
+    return "`null`" if number is None else f"{number:.3f}"
+
+
+def write_report(report: Mapping[str, Any], output_dir: Path) -> None:
+    """Write JSON and Markdown report files."""
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "smoke_report.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    (output_dir / "README.md").write_text(format_markdown(report), encoding="utf-8")
+
+
+def _input_ref(path: Path) -> str:
+    try:
+        return path.resolve().relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return f"worktree-local ignored artifact summarized in this report ({path.name})"
+
+
+def _build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--episodes", required=True, help="Episode JSONL from the smoke run.")
+    parser.add_argument("--baseline-condition", default="homogeneous_standard")
+    parser.add_argument("--variant-condition", default="mixed_balanced")
+    parser.add_argument(
+        "--output-dir",
+        default="docs/context/evidence/issue_3206_heterogeneous_pedestrian_smoke_2026-06-20",
+    )
+    return parser
+
+
+def main() -> int:
+    """Run the smoke-report builder CLI."""
+    args = _build_arg_parser().parse_args()
+    episodes = Path(args.episodes)
+    report = build_report(
+        _load_jsonl(episodes),
+        baseline_condition=args.baseline_condition,
+        variant_condition=args.variant_condition,
+        input_ref=_input_ref(episodes),
+    )
+    write_report(report, REPO_ROOT / args.output_dir)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/build_pedestrian_archetype_report.py
+++ b/scripts/benchmark/build_pedestrian_archetype_report.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Build compact no-result reports for pedestrian archetype compositions."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.ped_npc.ped_archetypes import (
+    build_archetype_population_report,
+    load_archetypes,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default="configs/research/pedestrian_archetypes_v1.yaml",
+        help="Pedestrian archetype registry YAML.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="docs/context/evidence/issue_3206_pedestrian_archetype_reporting_2026-06-20",
+        help="Output directory for compact reports.",
+    )
+    parser.add_argument("--population-size", type=int, default=30)
+    parser.add_argument("--initial-speed", type=float, default=0.5)
+    parser.add_argument("--seed", type=int, default=3206)
+    return parser.parse_args()
+
+
+def _load_example_compositions(path: Path) -> dict[str, dict[str, float]]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    compositions = payload.get("example_compositions")
+    if not isinstance(compositions, dict) or not compositions:
+        raise ValueError(f"{path} must define non-empty example_compositions")
+    out: dict[str, dict[str, float]] = {}
+    for name, composition in compositions.items():
+        if not isinstance(composition, dict):
+            raise ValueError(f"example composition {name!r} must be a mapping")
+        out[str(name)] = {str(k): float(v) for k, v in composition.items()}
+    return out
+
+
+def _format_markdown(summary: dict[str, Any]) -> str:
+    lines = [
+        "# Issue #3206 Pedestrian Archetype Reporting Packet",
+        "",
+        f"- Status: `{summary['status']}`",
+        f"- Config: `{summary['config_path']}`",
+        f"- Population size per composition: `{summary['population_size']}`",
+        f"- Claim boundary: {summary['claim_boundary']}",
+        "",
+        "## Composition Reports",
+        "",
+        "| Composition | Archetypes | Speed factor range | Assignment digest |",
+        "|---|---:|---|---|",
+    ]
+    for name, report in summary["reports"].items():
+        lines.append(
+            f"| `{name}` | {len(report['archetypes'])} | "
+            f"{report['speed_factor_min']:.3g}-{report['speed_factor_max']:.3g} | "
+            f"`{report['assignment_order_sha1']}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "This packet records deterministic population-composition assumptions only.",
+            "It is not a homogeneous-vs-heterogeneous benchmark smoke and does not report metric deltas.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """CLI entry point."""
+    args = parse_args()
+    config_path = REPO_ROOT / args.config
+    speed_factors = load_archetypes(config_path)
+    compositions = _load_example_compositions(config_path)
+    reports = {
+        name: build_archetype_population_report(
+            n=args.population_size,
+            composition=composition,
+            speed_factors=speed_factors,
+            initial_speed=args.initial_speed,
+            seed=args.seed,
+        )
+        for name, composition in compositions.items()
+    }
+    summary = {
+        "schema_version": "pedestrian-archetype-reporting-packet.v1",
+        "status": "composition_report_only",
+        "config_path": args.config,
+        "population_size": args.population_size,
+        "claim_boundary": (
+            "No benchmark, realism, or planner-ranking claim. This packet only "
+            "records deterministic composition assumptions for the shipped speed-archetype MVP."
+        ),
+        "reports": reports,
+    }
+    out = REPO_ROOT / args.output_dir
+    out.mkdir(parents=True, exist_ok=True)
+    (out / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    (out / "README.md").write_text(_format_markdown(summary), encoding="utf-8")
+    print(f"wrote {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_heterogeneous_pedestrian_smoke_report.py
+++ b/tests/benchmark/test_heterogeneous_pedestrian_smoke_report.py
@@ -1,0 +1,119 @@
+"""Tests for issue #3206 heterogeneous-pedestrian smoke reporting."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_builder() -> ModuleType:
+    module_path = REPO_ROOT / "scripts/benchmark/build_heterogeneous_pedestrian_smoke_report.py"
+    spec = importlib.util.spec_from_file_location(
+        "build_heterogeneous_pedestrian_smoke_report", module_path
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["build_heterogeneous_pedestrian_smoke_report"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+builder = _load_builder()
+
+
+def _row(condition: str, seed: int, min_distance: float, support: int = 0) -> dict[str, object]:
+    return {
+        "scenario_id": f"scenario_{condition}",
+        "seed": seed,
+        "git_hash": "abc123",
+        "scenario_params": {
+            "metadata": {"archetype_condition": condition},
+            "simulation_config": {
+                "archetype_composition": (
+                    {"standard": 1.0}
+                    if condition == "homogeneous_standard"
+                    else {"cautious": 0.34, "standard": 0.33, "hurried": 0.33}
+                ),
+                "archetype_speed_factors": {
+                    "cautious": 0.7,
+                    "standard": 1.0,
+                    "hurried": 1.4,
+                },
+                "archetype_seed": 3206,
+            },
+        },
+        "metrics": {
+            "success": False,
+            "collisions": 0,
+            "min_distance": min_distance,
+            "mean_distance": min_distance + 1.0,
+            "robot_ped_within_5m_frac": 0.5,
+            "distributional_disruption": {
+                "support_counts": {
+                    "slow_speed_tier": support,
+                    "fast_speed_tier": 0,
+                    "extreme_speed_tier": 0,
+                },
+                "missing_data": {
+                    "slow_speed_tier": {
+                        "status": "unavailable",
+                        "reason": "No control trace provided",
+                    }
+                },
+            },
+        },
+    }
+
+
+def test_smoke_report_records_metric_delta_and_unavailable_distributional_support() -> None:
+    """The report should keep deltas separate from fairness-readiness claims."""
+    rows = [
+        _row("homogeneous_standard", 101, 3.0),
+        _row("homogeneous_standard", 102, 5.0),
+        _row("mixed_balanced", 101, 7.0),
+        _row("mixed_balanced", 102, 9.0),
+    ]
+
+    report = builder.build_report(rows)
+
+    assert report["status"] == "diagnostic_smoke_report"
+    assert report["delta_variant_minus_baseline"]["min_distance"][
+        "absolute_delta"
+    ] == pytest.approx(4.0)
+    assert (
+        report["conditions"]["mixed_balanced"]["distributional_disruption"]["status"]
+        == "not_computable"
+    )
+    assert report["per_archetype_distributional_status"] == "not_computable_from_current_smoke"
+
+
+def test_smoke_report_marks_distributional_status_computable_when_support_exists() -> None:
+    """Positive distributional support counts should not be hidden as unavailable."""
+    rows = [
+        _row("homogeneous_standard", 101, 3.0, support=2),
+        _row("mixed_balanced", 101, 4.0, support=3),
+    ]
+
+    report = builder.build_report(rows)
+
+    assert (
+        report["conditions"]["homogeneous_standard"]["distributional_disruption"]["status"]
+        == "computable"
+    )
+    assert report["per_archetype_distributional_status"] == "computable"
+
+
+def test_smoke_report_requires_baseline_and_variant_conditions() -> None:
+    """Missing comparison conditions should fail loudly."""
+    with pytest.raises(ValueError, match="variant condition"):
+        builder.build_report([_row("homogeneous_standard", 101, 3.0)])

--- a/tests/ped_npc/test_ped_archetypes.py
+++ b/tests/ped_npc/test_ped_archetypes.py
@@ -18,7 +18,9 @@ from robot_sf.nav.navigation import get_prepared_obstacles
 from robot_sf.nav.svg_map_parser import SvgMapConverter
 from robot_sf.ped_npc.ped_archetypes import (
     allocate_archetype_counts,
+    assign_archetype_labels,
     assign_archetype_speed_factors,
+    build_archetype_population_report,
     load_archetypes,
     validate_composition,
 )
@@ -124,10 +126,43 @@ def test_assign_speed_factors_distribution_and_determinism() -> None:
     assert np.array_equal(out, assign_archetype_speed_factors(n, comp, factors_map, seed=7))
 
 
+def test_assign_labels_align_with_speed_factors() -> None:
+    """Label assignment should preserve the sampled order used by speed factors."""
+    comp = {"cautious": 0.5, "hurried": 0.5}
+    factors_map = {"cautious": 0.7, "hurried": 1.4}
+
+    labels = assign_archetype_labels(8, comp, seed=11)
+    factors = assign_archetype_speed_factors(8, comp, factors_map, seed=11)
+
+    assert labels.shape == (8,)
+    assert factors.tolist() == [factors_map[label] for label in labels]
+    assert set(labels.tolist()) == {"cautious", "hurried"}
+
+
 def test_assign_speed_factors_empty_population() -> None:
     """Zero pedestrians yields an empty factor array."""
     out = assign_archetype_speed_factors(0, {"a": 1.0}, {"a": 1.0}, seed=1)
     assert out.shape == (0,)
+
+
+def test_build_archetype_population_report_is_no_result_contract() -> None:
+    """Population reports should summarize assumptions without benchmark claims."""
+    report = build_archetype_population_report(
+        n=10,
+        composition={"cautious": 0.4, "standard": 0.3, "hurried": 0.3},
+        speed_factors={"cautious": 0.7, "standard": 1.0, "hurried": 1.4},
+        initial_speed=0.5,
+        seed=3206,
+    )
+
+    assert report["schema_version"] == "pedestrian-archetype-population-report.v1"
+    assert report["status"] == "composition_report_only"
+    assert "No benchmark" in report["claim_boundary"]
+    assert report["population_size"] == 10
+    assert report["archetypes"]["cautious"]["realized_count"] == 4
+    assert report["archetypes"]["hurried"]["initial_speed_m_s"] == pytest.approx(0.7)
+    assert report["speed_factor_min"] == pytest.approx(0.7)
+    assert report["speed_factor_max"] == pytest.approx(1.4)
 
 
 # --- PedSpawnConfig validation -------------------------------------------

--- a/tests/training/test_scenario_loader.py
+++ b/tests/training/test_scenario_loader.py
@@ -248,6 +248,25 @@ scenario_overrides_by_name:
     }
 
 
+def test_build_robot_config_applies_archetype_simulation_overrides(tmp_path: Path) -> None:
+    """Scenario YAML can carry pedestrian archetype composition into runtime config."""
+    scenario = {
+        "name": "archetype-runtime-smoke",
+        "simulation_config": {
+            "ped_density": 0.08,
+            "archetype_composition": {"cautious": 0.5, "hurried": 0.5},
+            "archetype_speed_factors": {"cautious": 0.7, "hurried": 1.4},
+            "archetype_seed": 3206,
+        },
+    }
+
+    config = build_robot_config_from_scenario(scenario, scenario_path=tmp_path / "scenario.yaml")
+
+    assert config.sim_config.archetype_composition == {"cautious": 0.5, "hurried": 0.5}
+    assert config.sim_config.archetype_speed_factors == {"cautious": 0.7, "hurried": 1.4}
+    assert config.sim_config.archetype_seed == 3206
+
+
 def test_load_scenarios_allows_duplicate_names_outside_named_overrides(
     tmp_path: Path,
 ) -> None:


### PR DESCRIPTION
## Summary
Adds a bounded reporting/protocol slice for #3206: deterministic archetype labels aligned with existing speed-factor sampling, a compact composition-report generator, a generated no-result packet, and focused tests.

## Linked Issues
- Relates to `#3206`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #3206 remains open for the actual homogeneous-vs-heterogeneous benchmark smoke.
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `assign_archetype_labels(...)` so the speed-archetype MVP can report deterministic per-pedestrian archetype labels using the same seeded order as speed factors.
- Added `build_archetype_population_report(...)` for no-result composition reporting.
- Added `scripts/benchmark/build_pedestrian_archetype_report.py` and generated a compact packet under `docs/context/evidence/issue_3206_pedestrian_archetype_reporting_2026-06-20/`.
- Added tests for label/factor alignment and the no-result report boundary.

## Why It Matters
- Added value: makes the existing speed-archetype MVP auditable as a population-composition input before running benchmark smoke comparisons.
- Expected impact: future #3206 smoke/campaign runs can report deterministic archetype counts and speed assumptions instead of only unnamed speed factors.
- Why this is worth merging now: it reduces reporting ambiguity while preserving the no-benchmark/no-realism boundary.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: heterogeneous pedestrian composition as a benchmark scenario axis.
- Comparator or baseline, if applicable: existing homogeneous/default pedestrian population.
- Evidence tier: composition-report-only launch support.
- Result classification: diagnostic-only / no-result protocol support.
- Decision or stop rule, if applicable: no composition effect can only be assessed after the deferred smoke comparison.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3206 and `docs/context/evidence/issue_3206_pedestrian_archetype_reporting_2026-06-20/`.
- New research/benchmark/metric/paper-facing analysis tool, if any: support helper only; representative generation command was run against the tracked archetype config.

## Falsification / Non-Transfer Check
- Did the mechanism activate? unknown; no benchmark run in this PR.
- Did the intervention change command source, selected command, trajectory, or route progress? unknown; no episode replay/run.
- Did the scenario actually contain the targeted failure mode? unknown; this PR only reports composition assumptions.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: existing #3206 owns the homogeneous-vs-heterogeneous smoke comparison.

## Next Empirical Action
- Rerun needed: yes, run the fixed-seed homogeneous-vs-heterogeneous smoke.
- Extractor or analysis tool needed: yes, wire benchmark outputs to report metric deltas by composition/archetype where available.
- Artifact missing or unavailable: benchmark smoke output and promoted metric-delta summary.
- Stop / revise / continue decision: continue.
- Proposed child issue or existing follow-up: existing #3206.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/benchmark/build_pedestrian_archetype_report.py --config configs/research/pedestrian_archetypes_v1.yaml --output-dir docs/context/evidence/issue_3206_pedestrian_archetype_reporting_2026-06-20`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/ped_npc/ped_archetypes.py scripts/benchmark/build_pedestrian_archetype_report.py tests/ped_npc/test_ped_archetypes.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/ped_npc/ped_archetypes.py scripts/benchmark/build_pedestrian_archetype_report.py tests/ped_npc/test_ped_archetypes.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/ped_npc/test_ped_archetypes.py -q`
  - `git diff --cached --check`
- Evidence that the change works here: report generation completed and focused archetype tests passed with 26 tests.
- Benchmarks or smoke tests, if applicable: no benchmark smoke run; this is intentionally a reporting/protocol slice.
- Known validation gap: full PR readiness stamp is missing; `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` reports `reason: missing`.

## Risks / Rollout
- Compatibility risks: low; default speed-factor API remains available and now delegates through deterministic labels.
- Failure modes: future benchmark smoke must not treat this composition packet as metric-delta evidence.
- Rollback or fallback plan: revert the additive helper/reporting changes.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md` and the generated packet README/JSON.
- Relevant design or provenance notes: #3206 issue contract and `configs/research/pedestrian_archetypes_v1.yaml`.
- Any assumptions that need to be preserved: archetype factors are modeling choices, not dataset-calibrated realism.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via PR linkage; #3206 remains open.
- Claim map / benchmark report updated (yes/no/NA): no, no benchmark result exists yet.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes, evidence README index.
- Context index / memory note updated (yes/no/NA): no central context index entry; evidence bundle index updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): no, existing #3206 owns execution.
- Not applicable because: no result evidence was produced.

## Follow-Up Issues
- Deferred work: run the actual homogeneous-vs-heterogeneous smoke and report metric deltas.
- Issues opened for follow-up: none.

## Reviewer Notes
- This is a draft because it does not satisfy the full #3206 smoke-comparison acceptance criteria.
- Review especially that packet wording preserves the no-result/no-realism boundary.
