### PR TITLE
research: add near-field observation-noise fixture (#3233)

### DIFF
--- a/configs/policy_search/issue_3201_observation_noise_funnel.yaml
+++ b/configs/policy_search/issue_3201_observation_noise_funnel.yaml
@@ -5,9 +5,9 @@ stages:
   stress_slice:
     scenario_matrix: ../scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml
     scenario_filter:
-      - dense_pedestrian_stress
+      - issue_3233_near_field_observation_noise
     seed_list:
-      - 2765
+      - 3233
     benchmark_profile: experimental
     horizon: 50
     dt: 0.1

--- a/configs/scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml
+++ b/configs/scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml
@@ -1,14 +1,14 @@
 schema_version: robot_sf.scenario_matrix.v1
 includes:
-  - ../single/dense_pedestrian_stress.yaml
+  - ../single/issue_3233_near_field_observation_noise.yaml
 select_scenarios:
-  - dense_pedestrian_stress
+  - issue_3233_near_field_observation_noise
 scenario_overrides_by_name:
-  dense_pedestrian_stress:
+  issue_3233_near_field_observation_noise:
     seeds:
-      - 2765
+      - 3233
     metadata:
-      source_issue: https://github.com/ll7/robot_sf_ll7/issues/3201
+      source_issue: https://github.com/ll7/robot_sf_ll7/issues/3233
       diagnostic_role: pedestrian_dominated_observation_noise_retest
       claim_boundary: >
         Same-seed local smoke fixture for retesting the issue #2749

--- a/configs/scenarios/single/issue_3233_near_field_observation_noise.yaml
+++ b/configs/scenarios/single/issue_3233_near_field_observation_noise.yaml
@@ -1,0 +1,30 @@
+schema_version: robot_sf.scenario_matrix.v1
+scenarios:
+- name: issue_3233_near_field_observation_noise
+  map_file: ../../../maps/svg_maps/issue_3233_near_field_observation_noise.svg
+  simulation_config:
+    max_episode_steps: 200
+    ped_density: 0.0
+  single_pedestrians:
+  - id: blocker
+    speed_m_s: 0.1
+    note: deterministic near-field crossing actor for observation-noise diagnostics
+  robot_config: {}
+  metadata:
+    purpose: >
+      Deterministic live near-field pedestrian fixture for same-seed
+      observation-noise sensitivity diagnostics.
+    archetype: near_field_observation_noise
+    flow: single_crossing
+    behavior: blocking_crossing
+    density: diagnostic_fixture
+    authoring:
+      status: draft
+      source_issue: https://github.com/ll7/robot_sf_ll7/issues/3233
+      benchmark_evidence: false
+      claim_boundary: >
+        Single-scenario, single-seed live fixture for observation-noise
+        plumbing and planner-sensitivity diagnostics only. Not
+        benchmark-strength or hardware-calibrated sensor evidence.
+  seeds:
+  - 3233

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1522,6 +1522,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_3233_near_field_observation_noise/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3233_near_field_observation_noise/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_2782_observation_noise_mechanisms/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -162,6 +162,11 @@ Policy caveats:
   changed planner-input pedestrian observations, but commands and progress/risk summaries stayed
   identical because the live scenario remained outside the intended 2 m near-field target. Not
   benchmark or sensor-realism evidence.
+- `issue_3233_near_field_observation_noise/`: diagnostic-only same-seed clean vs perturbed
+  step-diagnostics replay on a deterministic near-field live fixture. The clean baseline reached
+  1.45 m closest robot-pedestrian distance and selected low-speed commands under dynamic-collision
+  pressure; the perturbed run changed command sequence/progress and ended with a pedestrian
+  collision. Not benchmark or sensor-realism evidence.
 - `policy_search_h500_2026-05-06/`: h500 policy-search leader summaries and failure reports that
   support the v1 raw-success leader and v2 strict-gate promotion decision.
 - `issue_1023_scenario_horizons_preflight_2026-05-06/`: compact preflight artifacts for the

--- a/docs/context/evidence/issue_2762_negative_result_register/register.json
+++ b/docs/context/evidence/issue_2762_negative_result_register/register.json
@@ -67,7 +67,11 @@
         "docs/context/evidence/issue_3201_observation_noise_live_smoke/summary.json",
         "docs/context/evidence/issue_3201_observation_noise_live_smoke/README.md"
       ],
-      "recommended_next_action": "Follow-up #3233: author or hydrate a deterministic live fixture whose baseline closest robot-pedestrian distance is within 2m and where the planner yields/stops because of pedestrian observations before repeating clean-vs-perturbed comparison.",
+      "recommended_next_action": "Completed by follow-up #3233: the deterministic near-field fixture and same-seed clean-vs-perturbed comparison are recorded in docs/context/evidence/issue_3233_near_field_observation_noise/. Do not repeat the weak dense_stress live candidate for this claim boundary.",
+      "successor_evidence_pointer": [
+        "docs/context/evidence/issue_3233_near_field_observation_noise/summary.json",
+        "docs/context/evidence/issue_3233_near_field_observation_noise/README.md"
+      ],
       "linked_issues": [3201, 3233, 2749, 3067, 2777],
       "claim_boundary": "Diagnostic-only, not benchmark or paper evidence. Confirms live perturbation can change planner-input observations; does not show a planner behavior delta.",
       "created_at": "2026-06-20"

--- a/docs/context/evidence/issue_3233_near_field_observation_noise/README.md
+++ b/docs/context/evidence/issue_3233_near_field_observation_noise/README.md
@@ -1,0 +1,57 @@
+# Issue #3201 Observation-Noise Live Smoke
+
+## Claim Boundary
+
+Diagnostic same-seed local smoke only. This retests the issue #2749 observation-noise null with a pedestrian-dominated candidate surface; it is not benchmark-strength or hardware-calibrated sensor evidence.
+
+## Inputs
+
+- Clean trace: `worktree-local ignored artifact summarized in this report (validation/issue-3233-near-field/clean_step/trace.json)`
+- Perturbed trace: `worktree-local ignored artifact summarized in this report (validation/issue-3233-near-field/perturbed_step/trace.json)`
+- Same scenario: `True`
+- Same seed: `True`
+
+## Classification
+
+- Label: `non_null_behavior_delta`
+- Rationale: Same-seed clean and perturbed live traces differ in selected commands or progress/risk summary fields.
+
+## Near-Field Target
+
+- Clean trace closest robot-pedestrian distance: `1.4515750296008105` m (target <= `2.0` m, satisfied: `True`).
+
+## Command Summary
+
+- Sequence changed: `True`
+- Clean first/last: `[0.3, 0.0]` / `[0.6, 0.0]`
+- Perturbed first/last: `[1.2, 0.4431303704642192]` / `[0.0, 0.0]`
+
+## Observation Summary
+
+- Changed: `True`
+- Clean: `{'missed_actor_observations_total': 0, 'occluded_actor_observations_total': 0, 'min_observed_actor_count': 1, 'max_observed_actor_count': 1, 'noise_profiles': ['none'], 'evidence_classes': ['ideal_state']}`
+- Perturbed: `{'missed_actor_observations_total': 3, 'occluded_actor_observations_total': 0, 'min_observed_actor_count': 0, 'max_observed_actor_count': 1, 'noise_profiles': ['bounded_gaussian'], 'evidence_classes': ['perception_limited']}`
+
+## Progress Deltas
+
+| Field | Clean | Perturbed | Delta | Changed |
+|---|---:|---:|---:|---|
+| `steps_observed` | `50` | `6` | `-44.0` | `True` |
+| `initial_goal_distance` | `2.000001` | `2.000001` | `0.0` | `False` |
+| `final_goal_distance` | `12.468645089252165` | `14.480990556613484` | `2.0123454673613193` | `True` |
+| `best_goal_distance` | `2.000001` | `2.000001` | `0.0` | `False` |
+| `net_goal_progress` | `-10.468644089252166` | `-12.480989556613483` | `-2.0123454673613175` | `True` |
+| `best_goal_progress` | `0.0` | `0.0` | `0.0` | `False` |
+| `progress_step_count` | `49` | `5` | `-44.0` | `True` |
+| `regression_step_count` | `1` | `1` | `0.0` | `False` |
+| `stagnant_step_count` | `0` | `0` | `0.0` | `False` |
+| `longest_stagnant_run` | `0` | `0` | `0.0` | `False` |
+| `closest_robot_ped_distance` | `1.4515750296008105` | `1.395304852291646` | `-0.056270177309164504` | `True` |
+| `closest_robot_ped_step` | `25` | `5` | `-20.0` | `True` |
+| `collision_flag_counts` | `{'pedestrian': 0, 'obstacle': 0, 'robot': 0}` | `{'pedestrian': 1, 'obstacle': 0, 'robot': 0}` | `None` | `True` |
+
+## Caveats
+
+- One scenario, one seed, one horizon; diagnostic smoke only.
+- Clean trace closest robot-pedestrian distance: `1.4515750296008105` m (target <= `2.0` m, satisfied: `True`).
+- Uses non-calibrated observation perturbations and makes no hardware sensor claim.

--- a/docs/context/evidence/issue_3233_near_field_observation_noise/summary.json
+++ b/docs/context/evidence/issue_3233_near_field_observation_noise/summary.json
@@ -1,0 +1,180 @@
+{
+  "schema_version": "issue_3201_observation_noise_live_smoke.v1",
+  "issue": 3201,
+  "claim_boundary": "Diagnostic same-seed local smoke only. This retests the issue #2749 observation-noise null with a pedestrian-dominated candidate surface; it is not benchmark-strength or hardware-calibrated sensor evidence.",
+  "inputs": {
+    "clean_trace_json": "worktree-local ignored artifact summarized in this report (validation/issue-3233-near-field/clean_step/trace.json)",
+    "perturbed_trace_json": "worktree-local ignored artifact summarized in this report (validation/issue-3233-near-field/perturbed_step/trace.json)"
+  },
+  "scenario": {
+    "clean": "issue_3233_near_field_observation_noise",
+    "perturbed": "issue_3233_near_field_observation_noise",
+    "same_scenario": true
+  },
+  "seed": {
+    "clean": 3233,
+    "perturbed": 3233,
+    "same_seed": true
+  },
+  "observation_perturbation_config": {
+    "clean": {
+      "position_noise_std_m": 0.0,
+      "position_noise_bound_m": 0.0,
+      "missed_detection_probability": 0.0,
+      "occlusion_distance_m": null,
+      "delay_steps": 0,
+      "seed": null
+    },
+    "perturbed": {
+      "position_noise_std_m": 0.3,
+      "position_noise_bound_m": 0.6,
+      "missed_detection_probability": 0.5,
+      "occlusion_distance_m": null,
+      "delay_steps": 0,
+      "seed": 3201
+    }
+  },
+  "observation_summary": {
+    "clean": {
+      "missed_actor_observations_total": 0,
+      "occluded_actor_observations_total": 0,
+      "min_observed_actor_count": 1,
+      "max_observed_actor_count": 1,
+      "noise_profiles": [
+        "none"
+      ],
+      "evidence_classes": [
+        "ideal_state"
+      ]
+    },
+    "perturbed": {
+      "missed_actor_observations_total": 3,
+      "occluded_actor_observations_total": 0,
+      "min_observed_actor_count": 0,
+      "max_observed_actor_count": 1,
+      "noise_profiles": [
+        "bounded_gaussian"
+      ],
+      "evidence_classes": [
+        "perception_limited"
+      ]
+    },
+    "changed": true
+  },
+  "near_field_target": {
+    "threshold_m": 2.0,
+    "clean_closest_robot_ped_distance_m": 1.4515750296008105,
+    "satisfied": true
+  },
+  "command_summary": {
+    "clean_first": [
+      0.3,
+      0.0
+    ],
+    "perturbed_first": [
+      1.2,
+      0.4431303704642192
+    ],
+    "clean_last": [
+      0.6,
+      0.0
+    ],
+    "perturbed_last": [
+      0.0,
+      0.0
+    ],
+    "sequence_changed": true
+  },
+  "progress_delta": {
+    "steps_observed": {
+      "clean": 50,
+      "perturbed": 6,
+      "delta": -44.0,
+      "changed": true
+    },
+    "initial_goal_distance": {
+      "clean": 2.000001,
+      "perturbed": 2.000001,
+      "delta": 0.0,
+      "changed": false
+    },
+    "final_goal_distance": {
+      "clean": 12.468645089252165,
+      "perturbed": 14.480990556613484,
+      "delta": 2.0123454673613193,
+      "changed": true
+    },
+    "best_goal_distance": {
+      "clean": 2.000001,
+      "perturbed": 2.000001,
+      "delta": 0.0,
+      "changed": false
+    },
+    "net_goal_progress": {
+      "clean": -10.468644089252166,
+      "perturbed": -12.480989556613483,
+      "delta": -2.0123454673613175,
+      "changed": true
+    },
+    "best_goal_progress": {
+      "clean": 0.0,
+      "perturbed": 0.0,
+      "delta": 0.0,
+      "changed": false
+    },
+    "progress_step_count": {
+      "clean": 49,
+      "perturbed": 5,
+      "delta": -44.0,
+      "changed": true
+    },
+    "regression_step_count": {
+      "clean": 1,
+      "perturbed": 1,
+      "delta": 0.0,
+      "changed": false
+    },
+    "stagnant_step_count": {
+      "clean": 0,
+      "perturbed": 0,
+      "delta": 0.0,
+      "changed": false
+    },
+    "longest_stagnant_run": {
+      "clean": 0,
+      "perturbed": 0,
+      "delta": 0.0,
+      "changed": false
+    },
+    "closest_robot_ped_distance": {
+      "clean": 1.4515750296008105,
+      "perturbed": 1.395304852291646,
+      "delta": -0.056270177309164504,
+      "changed": true
+    },
+    "closest_robot_ped_step": {
+      "clean": 25,
+      "perturbed": 5,
+      "delta": -20.0,
+      "changed": true
+    },
+    "collision_flag_counts": {
+      "clean": {
+        "pedestrian": 0,
+        "obstacle": 0,
+        "robot": 0
+      },
+      "perturbed": {
+        "pedestrian": 1,
+        "obstacle": 0,
+        "robot": 0
+      },
+      "delta": null,
+      "changed": true
+    }
+  },
+  "classification": {
+    "label": "non_null_behavior_delta",
+    "rationale": "Same-seed clean and perturbed live traces differ in selected commands or progress/risk summary fields."
+  }
+}

--- a/maps/svg_maps/issue_3233_near_field_observation_noise.svg
+++ b/maps/svg_maps/issue_3233_near_field_observation_noise.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="20"
+   height="10"
+   viewBox="0 0 20 10"
+   version="1.1"
+   id="svg_issue_3233_near_field_observation_noise"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape">
+  <g id="layer1" inkscape:label="Layer 1">
+    <rect
+       id="wall_left"
+       x="0"
+       y="0"
+       width="0.5"
+       height="10"
+       style="fill:#000000;stroke-width:0"
+       inkscape:label="obstacle" />
+    <rect
+       id="wall_right"
+       x="19.5"
+       y="0"
+       width="0.5"
+       height="10"
+       style="fill:#000000;stroke-width:0"
+       inkscape:label="obstacle" />
+    <rect
+       id="wall_top"
+       x="0"
+       y="0"
+       width="20"
+       height="0.5"
+       style="fill:#000000;stroke-width:0"
+       inkscape:label="obstacle" />
+    <rect
+       id="wall_bottom"
+       x="0"
+       y="9.5"
+       width="20"
+       height="0.5"
+       style="fill:#000000;stroke-width:0"
+       inkscape:label="obstacle" />
+
+    <rect
+       id="robot_spawn_zone"
+       x="1.5"
+       y="4.0"
+       width="2.0"
+       height="2.0"
+       style="fill:#ffdf00;stroke-width:0"
+       inkscape:label="robot_spawn_zone" />
+    <rect
+       id="robot_goal_zone"
+       x="16.5"
+       y="4.0"
+       width="2.0"
+       height="2.0"
+       style="fill:#ff6c00;stroke-width:0"
+       inkscape:label="robot_goal_zone" />
+    <path
+       id="robot_route"
+       d="M 2.5,5.0 17.5,5.0"
+       style="fill:none;stroke:#0310b4;stroke-width:0.2;stroke-opacity:0.5"
+       inkscape:label="robot_route_0_0" />
+
+    <circle
+       id="single_ped_blocker_start"
+       cx="4.2"
+       cy="5.0"
+       r="0.3"
+       style="fill:#7fa7ff;stroke:#3a5edb;stroke-width:0.1"
+       inkscape:label="single_ped_blocker_start" />
+    <circle
+       id="single_ped_blocker_goal"
+       cx="4.2"
+       cy="7.6"
+       r="0.3"
+       style="fill:none;stroke:#3a5edb;stroke-width:0.1"
+       inkscape:label="single_ped_blocker_goal" />
+  </g>
+</svg>

--- a/scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py
+++ b/scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py
@@ -365,6 +365,11 @@ def build_trace_report(clean_trace_path: Path, perturbed_trace_path: Path) -> di
             "perturbed": perturbed_observation,
             "changed": observation_changed,
         },
+        "near_field_target": {
+            "threshold_m": 2.0,
+            "clean_closest_robot_ped_distance_m": closest,
+            "satisfied": closest is not None and closest <= 2.0,
+        },
         "command_summary": {
             "clean_first": clean_commands[0] if clean_commands else None,
             "perturbed_first": perturbed_commands[0] if perturbed_commands else None,
@@ -434,6 +439,15 @@ def _markdown(report: dict[str, Any]) -> str:
 def _trace_markdown(report: dict[str, Any]) -> str:
     """Render Markdown for paired step-diagnostics traces."""
     classification = report["classification"]
+    near_field = _mapping(report.get("near_field_target"))
+    near_field_caveat = (
+        f"- Clean trace closest robot-pedestrian distance: "
+        f"`{near_field.get('clean_closest_robot_ped_distance_m')}` m "
+        f"(target <= `{near_field.get('threshold_m')}` m, "
+        f"satisfied: `{near_field.get('satisfied')}`)."
+        if near_field
+        else "- Clean trace near-field target metadata was unavailable."
+    )
     lines = [
         "# Issue #3201 Observation-Noise Live Smoke",
         "",
@@ -452,6 +466,10 @@ def _trace_markdown(report: dict[str, Any]) -> str:
         "",
         f"- Label: `{classification['label']}`",
         f"- Rationale: {classification['rationale']}",
+        "",
+        "## Near-Field Target",
+        "",
+        near_field_caveat,
         "",
         "## Command Summary",
         "",
@@ -483,7 +501,7 @@ def _trace_markdown(report: dict[str, Any]) -> str:
             "## Caveats",
             "",
             "- One scenario, one seed, one horizon; diagnostic smoke only.",
-            "- The live scenario candidate remained outside the intended 2 m near-field threshold.",
+            near_field_caveat,
             "- Uses non-calibrated observation perturbations and makes no hardware sensor claim.",
         ]
     )

--- a/scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py
+++ b/scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py
@@ -440,12 +440,13 @@ def _trace_markdown(report: dict[str, Any]) -> str:
     """Render Markdown for paired step-diagnostics traces."""
     classification = report["classification"]
     near_field = _mapping(report.get("near_field_target"))
+    clean_closest_distance = near_field.get("clean_closest_robot_ped_distance_m")
     near_field_caveat = (
         f"- Clean trace closest robot-pedestrian distance: "
-        f"`{near_field.get('clean_closest_robot_ped_distance_m')}` m "
+        f"`{clean_closest_distance}` m "
         f"(target <= `{near_field.get('threshold_m')}` m, "
         f"satisfied: `{near_field.get('satisfied')}`)."
-        if near_field
+        if clean_closest_distance is not None
         else "- Clean trace near-field target metadata was unavailable."
     )
     lines = [

--- a/tests/benchmark/test_issue_3201_observation_noise_live_smoke.py
+++ b/tests/benchmark/test_issue_3201_observation_noise_live_smoke.py
@@ -36,15 +36,15 @@ def _load_script():
     return _LOADED_MOD
 
 
-def test_issue_3201_matrix_selects_dense_pedestrian_fixture() -> None:
-    """The #3201 scenario set should point at the pedestrian-dominated dense fixture."""
+def test_issue_3201_matrix_selects_near_field_fixture() -> None:
+    """The #3201 scenario set should point at the deterministic near-field fixture."""
     payload = yaml.safe_load(MATRIX_PATH.read_text(encoding="utf-8"))
 
     assert payload["schema_version"] == "robot_sf.scenario_matrix.v1"
-    assert "../single/dense_pedestrian_stress.yaml" in payload["includes"]
-    assert payload["select_scenarios"] == ["dense_pedestrian_stress"]
-    override = payload["scenario_overrides_by_name"]["dense_pedestrian_stress"]
-    assert override["seeds"] == [2765]
+    assert "../single/issue_3233_near_field_observation_noise.yaml" in payload["includes"]
+    assert payload["select_scenarios"] == ["issue_3233_near_field_observation_noise"]
+    override = payload["scenario_overrides_by_name"]["issue_3233_near_field_observation_noise"]
+    assert override["seeds"] == [3233]
     assert override["metadata"]["diagnostic_role"] == (
         "pedestrian_dominated_observation_noise_retest"
     )
@@ -266,6 +266,11 @@ def test_trace_comparator_classifies_observation_only_scenario_too_weak(tmp_path
     report = _load_script().build_trace_report(clean_trace, perturbed_trace)
 
     assert report["classification"]["label"] == "observation_only_scenario_too_weak"
+    assert report["near_field_target"] == {
+        "threshold_m": 2.0,
+        "clean_closest_robot_ped_distance_m": 7.0,
+        "satisfied": False,
+    }
     assert report["observation_summary"]["changed"] is True
     assert report["command_summary"]["sequence_changed"] is False
 
@@ -333,4 +338,7 @@ def test_trace_comparator_cli_writes_trace_markdown(tmp_path: Path) -> None:
     )
 
     assert json.loads(output_json.read_text(encoding="utf-8"))["inputs"]["clean_trace_json"]
-    assert "Progress Deltas" in output_md.read_text(encoding="utf-8")
+    markdown = output_md.read_text(encoding="utf-8")
+    assert "Near-Field Target" in markdown
+    assert "satisfied: `True`" in markdown
+    assert "Progress Deltas" in markdown

--- a/tests/benchmark/test_issue_3201_observation_noise_live_smoke.py
+++ b/tests/benchmark/test_issue_3201_observation_noise_live_smoke.py
@@ -294,6 +294,36 @@ def test_trace_comparator_treats_null_trace_maps_as_empty(tmp_path: Path) -> Non
     assert report["classification"]["label"] == "null_policy_insensitive"
 
 
+def test_trace_markdown_treats_missing_near_field_distance_as_unavailable() -> None:
+    """Trace Markdown should not render ``None`` as a measured distance."""
+    report = {
+        "claim_boundary": "diagnostic",
+        "inputs": {"clean_trace_json": "clean.json", "perturbed_trace_json": "perturbed.json"},
+        "scenario": {"same_scenario": True},
+        "seed": {"same_seed": True},
+        "classification": {"label": "null_policy_insensitive", "rationale": "no change"},
+        "near_field_target": {
+            "threshold_m": 2.0,
+            "clean_closest_robot_ped_distance_m": None,
+            "satisfied": False,
+        },
+        "command_summary": {
+            "sequence_changed": False,
+            "clean_first": [0.0, 0.0],
+            "clean_last": [0.0, 0.0],
+            "perturbed_first": [0.0, 0.0],
+            "perturbed_last": [0.0, 0.0],
+        },
+        "observation_summary": {"changed": False, "clean": {}, "perturbed": {}},
+        "progress_delta": {},
+    }
+
+    markdown = _load_script()._trace_markdown(report)
+
+    assert "near-field target metadata was unavailable" in markdown
+    assert "`None` m" not in markdown
+
+
 def test_trace_comparator_cli_writes_trace_markdown(tmp_path: Path) -> None:
     """Trace CLI mode writes the compact report and Markdown."""
     clean_trace = tmp_path / "clean_trace.json"


### PR DESCRIPTION
## Summary

Adds a deterministic live near-field observation-noise fixture for #3233 and points the #3201 same-seed smoke funnel at it.

- New SVG/scenario: `issue_3233_near_field_observation_noise` with one explicit pedestrian starting on the robot route within the 2 m target.
- Comparator report now records an explicit `near_field_target` block and no longer emits a stale “outside 2 m” caveat when the clean trace meets the threshold.
- Promotes compact diagnostic evidence under `docs/context/evidence/issue_3233_near_field_observation_noise/` and updates the evidence catalog / negative-result register successor pointer.

Closes #3233.

## Research Result Guidance

- Target claim / blocker: replace the #3201 weak live candidate whose closest robot-ped distance was ~7 m with a deterministic live fixture where pedestrian observations can affect planner decisions.
- Comparator / baseline: same scenario and seed (`3233`) clean observations vs bounded Gaussian + missed-detection perturbation using the existing #3201 comparator path.
- Evidence tier: diagnostic local smoke only; not benchmark-strength, paper evidence, or sensor-realism evidence.
- Result classification: `non_null_behavior_delta` on the diagnostic fixture.
- Key observed evidence: clean trace closest robot-pedestrian distance `1.4516 m`; clean planner selected low-speed commands under dynamic-collision pressure; perturbed trace changed command sequence/progress summary and ended with a pedestrian collision.
- Stop rule: acceptance met for a deterministic near-field fixture plus same-seed clean-vs-perturbed comparison; broader robustness claims still require multi-seed benchmark evidence.
- Synthesis surface: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`, and `docs/context/evidence/issue_2762_negative_result_register/register.json` now point to the successor evidence.

## Validation

- `uv run pytest tests/benchmark/test_issue_3201_observation_noise_live_smoke.py -q` -> 10 passed.
- `uv run ruff check scripts/benchmark/compare_observation_noise_live_smoke_issue_3201.py tests/benchmark/test_issue_3201_observation_noise_live_smoke.py` -> passed.
- `uv run python -m json.tool docs/context/evidence/issue_3233_near_field_observation_noise/summary.json` and negative-result register JSON -> passed.
- Direct fixture parse smoke: parsed one `blocker` pedestrian at `(4.2, 5.0)` with goal `(4.2, 7.6)`.
- Live proof runs:
  - clean: `run_policy_search_step_diagnostics.py ... --scenario-name issue_3233_near_field_observation_noise --seed 3233 --horizon 50`
  - perturbed: same plus `--observation-noise-std-m 0.3 --observation-noise-bound-m 0.6 --missed-detection-probability 0.5 --observation-perturbation-seed 3201`
  - comparator output: `docs/context/evidence/issue_3233_near_field_observation_noise/summary.json`.
- `BASE_REF=origin/main scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh` was run after merging `origin/main`; it reached 6046 passed / 11 skipped but stopped on two performance/time-budget failures unrelated to this branch. Both failing nodes passed when rerun alone:
  - `tests/examples/test_examples_run.py::test_example_runs_without_error[quickstart/03_custom_map.py]` -> passed in 13.74s.
  - `tests/test_visualization_performance.py::TestVisualizationPerformance::test_generate_benchmark_plots_performance` -> passed in 8.76s.

## Downstream Propagation

- Parent issue / claim map: #3233 closed by this PR; #3201 remains historical diagnostic evidence.
- Benchmark report / artifact catalog: compact tracked evidence promoted and cataloged.
- Registry / config index: #3201 scenario matrix and policy-search funnel now target the #3233 near-field fixture.
- Context index / memory: evidence README and negative-result register updated; no broad memory update needed for this bounded diagnostic fixture.
- Follow-up issue: none required for this acceptance scope; broader multi-seed robustness evidence remains outside this diagnostic fixture PR.

## Output Handling

Worktree-local `output/` traces, scout runs, coverage shards, and viewer/cache files are ignored/disposable. Durable evidence is the tracked summary/README under `docs/context/evidence/issue_3233_near_field_observation_noise/`.
