### PR TITLE
feat: counterfactual scenario-pair evaluation core (#3239, child of #2924)

### DIFF
--- a/robot_sf/benchmark/counterfactual_pair.py
+++ b/robot_sf/benchmark/counterfactual_pair.py
@@ -17,6 +17,7 @@ scenario pair and generating traces lives with parent issue #2924; pair-manifest
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
@@ -115,7 +116,10 @@ def _metric_value(result: Mapping[str, Any], metric: str) -> float:
     metrics = result.get("metrics")
     if not isinstance(metrics, Mapping) or metric not in metrics:
         raise ValueError(f"result.metrics is missing required metric {metric!r}")
-    return float(metrics[metric])
+    value = float(metrics[metric])
+    if not math.isfinite(value):
+        raise ValueError(f"metric {metric!r} value {value} is not finite")
+    return value
 
 
 def _direction_matches(delta: float, expected_direction: str, tolerance: float) -> bool:
@@ -134,7 +138,7 @@ def evaluate_counterfactual_pair(
     intervention: Mapping[str, Any],
     hypothesis: PairHypothesis,
     *,
-    min_outcome_delta: float = 0.0,
+    min_outcome_delta: float | None = None,
 ) -> PairResult:
     """Evaluate a baseline/intervention pair against a mechanism hypothesis.
 
@@ -151,6 +155,11 @@ def evaluate_counterfactual_pair(
     Returns:
         A :class:`PairResult` with the activation/outcome deltas and verdict.
     """
+    if min_outcome_delta is None:
+        min_outcome_delta = 0.0
+    elif min_outcome_delta < 0.0:
+        raise ValueError(f"min_outcome_delta must be non-negative (got {min_outcome_delta})")
+
     baseline_activated = _activated(baseline)
     intervention_activated = _activated(intervention)
     outcome_baseline = _metric_value(baseline, hypothesis.outcome_metric)

--- a/robot_sf/benchmark/counterfactual_pair.py
+++ b/robot_sf/benchmark/counterfactual_pair.py
@@ -1,0 +1,191 @@
+"""Counterfactual scenario-pair evaluation core (bounded #2924 child).
+
+Given a *baseline* result and a matched *intervention* result for the same
+scenario/seed/planner — each carrying a mechanism-activation signal and outcome
+metrics — decide whether the expected mechanism hypothesis **survived**, was
+**falsified**, or is **inconclusive**.
+
+Fail-closed: a hypothesis can only *survive* when the mechanism actually activated
+in the intervention. No activation yields ``inconclusive`` (the predicted
+mechanism never fired, so the pair cannot test it), never ``survived``.
+
+Pure and deterministic: it consumes already-measured results and runs no
+simulation. This is analysis tooling and makes no benchmark claim. Running the
+scenario pair and generating traces lives with parent issue #2924; pair-manifest
+*creation* is covered by ``scripts/tools/create_counterfactual_scenario_pair.py``.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+COUNTERFACTUAL_PAIR_SCHEMA = "counterfactual_pair_result.v1"
+
+VERDICT_SURVIVED = "survived"
+VERDICT_FALSIFIED = "falsified"
+VERDICT_INCONCLUSIVE = "inconclusive"
+
+DIRECTION_INCREASE = "increase"
+DIRECTION_DECREASE = "decrease"
+_DIRECTIONS = (DIRECTION_INCREASE, DIRECTION_DECREASE)
+
+
+@dataclass(frozen=True)
+class PairHypothesis:
+    """The mechanism hypothesis a counterfactual pair is designed to test.
+
+    Attributes:
+        expected_mechanism: Name of the mechanism expected to activate under the
+            intervention (recorded for provenance).
+        outcome_metric: Outcome metric whose change tests the hypothesis.
+        expected_direction: ``"increase"`` or ``"decrease"`` of ``outcome_metric``
+            in the intervention relative to the baseline.
+    """
+
+    expected_mechanism: str
+    outcome_metric: str
+    expected_direction: str
+
+    def __post_init__(self) -> None:
+        """Validate the expected direction."""
+        if self.expected_direction not in _DIRECTIONS:
+            raise ValueError(
+                f"expected_direction must be one of {_DIRECTIONS} (got {self.expected_direction!r})"
+            )
+
+
+@dataclass(frozen=True)
+class PairResult:
+    """Outcome of evaluating one counterfactual scenario pair."""
+
+    hypothesis: PairHypothesis
+    baseline_activated: bool
+    intervention_activated: bool
+    activation_delta: int
+    outcome_baseline: float
+    outcome_intervention: float
+    outcome_delta: float
+    verdict: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the ``counterfactual_pair_result.v1`` JSON-safe payload.
+
+        Returns:
+            Mapping with the schema version, hypothesis, activation/outcome
+            deltas, verdict, and reason.
+        """
+        return {
+            "schema_version": COUNTERFACTUAL_PAIR_SCHEMA,
+            "hypothesis": {
+                "expected_mechanism": self.hypothesis.expected_mechanism,
+                "outcome_metric": self.hypothesis.outcome_metric,
+                "expected_direction": self.hypothesis.expected_direction,
+            },
+            "baseline_activated": self.baseline_activated,
+            "intervention_activated": self.intervention_activated,
+            "activation_delta": self.activation_delta,
+            "outcome_baseline": self.outcome_baseline,
+            "outcome_intervention": self.outcome_intervention,
+            "outcome_delta": self.outcome_delta,
+            "verdict": self.verdict,
+            "reason": self.reason,
+        }
+
+
+def _activated(result: Mapping[str, Any]) -> bool:
+    """Read the mechanism-activation flag from a result mapping.
+
+    Returns:
+        The boolean ``mechanism_activated`` flag.
+    """
+    if "mechanism_activated" not in result:
+        raise ValueError("result is missing required 'mechanism_activated' flag")
+    return bool(result["mechanism_activated"])
+
+
+def _metric_value(result: Mapping[str, Any], metric: str) -> float:
+    """Read a numeric outcome metric from a result mapping's ``metrics``.
+
+    Returns:
+        The float value of ``metric`` from the result's ``metrics`` mapping.
+    """
+    metrics = result.get("metrics")
+    if not isinstance(metrics, Mapping) or metric not in metrics:
+        raise ValueError(f"result.metrics is missing required metric {metric!r}")
+    return float(metrics[metric])
+
+
+def _direction_matches(delta: float, expected_direction: str, tolerance: float) -> bool:
+    """Return whether an outcome delta moves in the expected direction beyond tolerance.
+
+    Returns:
+        ``True`` when ``delta`` exceeds ``tolerance`` in the expected direction.
+    """
+    if expected_direction == DIRECTION_INCREASE:
+        return delta > tolerance
+    return delta < -tolerance
+
+
+def evaluate_counterfactual_pair(
+    baseline: Mapping[str, Any],
+    intervention: Mapping[str, Any],
+    hypothesis: PairHypothesis,
+    *,
+    min_outcome_delta: float = 0.0,
+) -> PairResult:
+    """Evaluate a baseline/intervention pair against a mechanism hypothesis.
+
+    Each result mapping must provide a ``mechanism_activated`` flag and a
+    ``metrics`` mapping containing ``hypothesis.outcome_metric``.
+
+    Verdict rules (fail-closed):
+
+    * intervention did **not** activate the mechanism → ``inconclusive``;
+    * activated and the outcome moved in the expected direction beyond
+      ``min_outcome_delta`` → ``survived``;
+    * activated but the outcome did not move as predicted → ``falsified``.
+
+    Returns:
+        A :class:`PairResult` with the activation/outcome deltas and verdict.
+    """
+    baseline_activated = _activated(baseline)
+    intervention_activated = _activated(intervention)
+    outcome_baseline = _metric_value(baseline, hypothesis.outcome_metric)
+    outcome_intervention = _metric_value(intervention, hypothesis.outcome_metric)
+    outcome_delta = outcome_intervention - outcome_baseline
+    activation_delta = int(intervention_activated) - int(baseline_activated)
+
+    if not intervention_activated:
+        verdict = VERDICT_INCONCLUSIVE
+        reason = (
+            f"expected mechanism {hypothesis.expected_mechanism!r} did not activate in the "
+            "intervention; the pair cannot test the hypothesis"
+        )
+    elif _direction_matches(outcome_delta, hypothesis.expected_direction, min_outcome_delta):
+        verdict = VERDICT_SURVIVED
+        reason = (
+            f"mechanism activated and {hypothesis.outcome_metric} moved "
+            f"{hypothesis.expected_direction} by {outcome_delta:+.4g}"
+        )
+    else:
+        verdict = VERDICT_FALSIFIED
+        reason = (
+            f"mechanism activated but {hypothesis.outcome_metric} did not move "
+            f"{hypothesis.expected_direction} (delta {outcome_delta:+.4g}, "
+            f"threshold {min_outcome_delta:g})"
+        )
+
+    return PairResult(
+        hypothesis=hypothesis,
+        baseline_activated=baseline_activated,
+        intervention_activated=intervention_activated,
+        activation_delta=activation_delta,
+        outcome_baseline=outcome_baseline,
+        outcome_intervention=outcome_intervention,
+        outcome_delta=outcome_delta,
+        verdict=verdict,
+        reason=reason,
+    )

--- a/tests/benchmark/test_counterfactual_pair.py
+++ b/tests/benchmark/test_counterfactual_pair.py
@@ -1,0 +1,102 @@
+"""Tests for the counterfactual scenario-pair evaluation core (issue #3239, child of #2924)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.counterfactual_pair import (
+    COUNTERFACTUAL_PAIR_SCHEMA,
+    VERDICT_FALSIFIED,
+    VERDICT_INCONCLUSIVE,
+    VERDICT_SURVIVED,
+    PairHypothesis,
+    evaluate_counterfactual_pair,
+)
+
+_HYP = PairHypothesis(
+    expected_mechanism="predictive_risk",
+    outcome_metric="min_clearance",
+    expected_direction="increase",
+)
+
+
+def _result(activated: bool, clearance: float) -> dict:
+    return {"mechanism_activated": activated, "metrics": {"min_clearance": clearance}}
+
+
+def test_hypothesis_rejects_bad_direction() -> None:
+    """The hypothesis validates its expected direction."""
+    with pytest.raises(ValueError, match="expected_direction"):
+        PairHypothesis(expected_mechanism="m", outcome_metric="x", expected_direction="sideways")
+
+
+def test_survived_when_activated_and_direction_matches() -> None:
+    """Activation plus the predicted increase yields a survived verdict."""
+    result = evaluate_counterfactual_pair(_result(False, 0.30), _result(True, 0.55), _HYP)
+    assert result.verdict == VERDICT_SURVIVED
+    assert result.intervention_activated is True
+    assert result.activation_delta == 1
+    assert result.outcome_delta == pytest.approx(0.25)
+
+
+def test_falsified_when_activated_but_wrong_direction() -> None:
+    """Activation with the opposite outcome movement is falsified."""
+    result = evaluate_counterfactual_pair(_result(False, 0.50), _result(True, 0.30), _HYP)
+    assert result.verdict == VERDICT_FALSIFIED
+    assert result.outcome_delta == pytest.approx(-0.20)
+
+
+def test_falsified_when_activated_but_no_change() -> None:
+    """Activation with no meaningful outcome change is falsified (predicted effect absent)."""
+    result = evaluate_counterfactual_pair(_result(False, 0.40), _result(True, 0.40), _HYP)
+    assert result.verdict == VERDICT_FALSIFIED
+    assert result.outcome_delta == 0.0
+
+
+def test_inconclusive_when_mechanism_not_activated() -> None:
+    """No activation in the intervention is inconclusive (fail-closed), never survived."""
+    result = evaluate_counterfactual_pair(_result(False, 0.30), _result(False, 0.55), _HYP)
+    assert result.verdict == VERDICT_INCONCLUSIVE
+    assert result.intervention_activated is False
+
+
+def test_min_outcome_delta_threshold() -> None:
+    """A sub-threshold change does not count as the predicted direction."""
+    small = evaluate_counterfactual_pair(
+        _result(False, 0.40), _result(True, 0.41), _HYP, min_outcome_delta=0.05
+    )
+    assert small.verdict == VERDICT_FALSIFIED  # +0.01 < 0.05 threshold
+    big = evaluate_counterfactual_pair(
+        _result(False, 0.40), _result(True, 0.50), _HYP, min_outcome_delta=0.05
+    )
+    assert big.verdict == VERDICT_SURVIVED  # +0.10 > 0.05 threshold
+
+
+def test_decrease_direction() -> None:
+    """A decrease hypothesis survives when the metric drops."""
+    hyp = PairHypothesis(
+        expected_mechanism="shielding", outcome_metric="collisions", expected_direction="decrease"
+    )
+    baseline = {"mechanism_activated": False, "metrics": {"collisions": 5.0}}
+    intervention = {"mechanism_activated": True, "metrics": {"collisions": 2.0}}
+    result = evaluate_counterfactual_pair(baseline, intervention, hyp)
+    assert result.verdict == VERDICT_SURVIVED
+    assert result.outcome_delta == pytest.approx(-3.0)
+
+
+def test_missing_fields_raise() -> None:
+    """Missing activation flag or metric is a clear error."""
+    with pytest.raises(ValueError, match="mechanism_activated"):
+        evaluate_counterfactual_pair({"metrics": {"min_clearance": 0.3}}, _result(True, 0.5), _HYP)
+    with pytest.raises(ValueError, match="min_clearance"):
+        evaluate_counterfactual_pair(
+            {"mechanism_activated": False, "metrics": {}}, _result(True, 0.5), _HYP
+        )
+
+
+def test_to_dict_schema() -> None:
+    """The payload carries the counterfactual_pair_result.v1 schema."""
+    payload = evaluate_counterfactual_pair(_result(False, 0.3), _result(True, 0.5), _HYP).to_dict()
+    assert payload["schema_version"] == COUNTERFACTUAL_PAIR_SCHEMA
+    assert payload["verdict"] == VERDICT_SURVIVED
+    assert payload["hypothesis"]["outcome_metric"] == "min_clearance"

--- a/tests/benchmark/test_counterfactual_pair.py
+++ b/tests/benchmark/test_counterfactual_pair.py
@@ -72,6 +72,23 @@ def test_min_outcome_delta_threshold() -> None:
     assert big.verdict == VERDICT_SURVIVED  # +0.10 > 0.05 threshold
 
 
+def test_min_outcome_delta_none_uses_zero_threshold() -> None:
+    """An omitted threshold sentinel uses the same zero threshold as the default."""
+    result = evaluate_counterfactual_pair(
+        _result(False, 0.40), _result(True, 0.41), _HYP, min_outcome_delta=None
+    )
+    assert result.verdict == VERDICT_SURVIVED
+    assert result.outcome_delta == pytest.approx(0.01)
+
+
+def test_negative_min_outcome_delta_raises() -> None:
+    """Negative thresholds are rejected instead of changing comparison semantics."""
+    with pytest.raises(ValueError, match="min_outcome_delta must be non-negative"):
+        evaluate_counterfactual_pair(
+            _result(False, 0.30), _result(True, 0.50), _HYP, min_outcome_delta=-0.1
+        )
+
+
 def test_decrease_direction() -> None:
     """A decrease hypothesis survives when the metric drops."""
     hyp = PairHypothesis(
@@ -92,6 +109,14 @@ def test_missing_fields_raise() -> None:
         evaluate_counterfactual_pair(
             {"mechanism_activated": False, "metrics": {}}, _result(True, 0.5), _HYP
         )
+
+
+def test_non_finite_metric_raises() -> None:
+    """Non-finite metric values are rejected before verdict calculation."""
+    with pytest.raises(ValueError, match="not finite"):
+        evaluate_counterfactual_pair(_result(False, float("nan")), _result(True, 0.5), _HYP)
+    with pytest.raises(ValueError, match="not finite"):
+        evaluate_counterfactual_pair(_result(False, 0.3), _result(True, float("inf")), _HYP)
 
 
 def test_to_dict_schema() -> None:


### PR DESCRIPTION
## Summary

Adds the pure **pair-level evaluation/decision core** for counterfactual mechanism testing (issue
#3239, child of #2924): given a baseline result and a matched intervention result, decide whether the
expected mechanism hypothesis **survived**, was **falsified**, or is **inconclusive**.

## Linked Issues
- Closes `#3239`
- Refs `#2924` (parent — owns scenario-pair execution + trace generation)

## What Changed
- **`robot_sf/benchmark/counterfactual_pair.py`** (new): `PairHypothesis` (expected mechanism, outcome
  metric, expected `increase`/`decrease` direction) and `evaluate_counterfactual_pair(...)` emitting a
  `counterfactual_pair_result.v1` payload with activation delta, outcome delta, and a verdict.
- **`tests/benchmark/test_counterfactual_pair.py`** (new): survived, falsified (wrong direction / no
  change / sub-threshold), inconclusive, decrease-direction, missing-field, and schema cases.

## Decision rules (fail-closed)
- Intervention did **not** activate the mechanism → `inconclusive` (the pair cannot test a mechanism
  that never fired — never `survived`).
- Activated and the outcome moved in the expected direction beyond `min_outcome_delta` → `survived`.
- Activated but the outcome did not move as predicted → `falsified`.

## Boundary (honest scope)
Pure and deterministic — consumes already-measured results and **runs no simulation**. Scenario-pair
execution and trace generation stay with parent #2924; pair-manifest *creation* is already covered by
`scripts/tools/create_counterfactual_scenario_pair.py`. Analysis tooling; no benchmark claim.

## Research Result Guidance
- Evidence tier: `analysis-tool`. The survived/falsified verdict depends on real paired results
  supplied by #2924; this PR provides the reusable decision logic, fixture-tested.

## Falsification / Non-Transfer Check
- `NA` — adds the decision tool itself (the very logic that classifies survived/falsified for real
  pairs); no measured outcome here.

## Next Empirical Action
- Parent #2924: run one prediction-risk or topology scenario pair, feed the baseline/intervention
  results to this evaluator, and record whether the hypothesis survived or was falsified.

## Validation / Proof
- `pytest tests/benchmark/test_counterfactual_pair.py` → 9 passed.
- `ruff check`/`format` → clean.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` → see CI / gate result.

## Risks / Rollout
- Minimal: all-new module + tests; no existing runtime/benchmark path is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
