### PR TITLE
feat: add forecast baseline comparison tool (#3244)

### DIFF
--- a/robot_sf/benchmark/forecast_baseline_comparison.py
+++ b/robot_sf/benchmark/forecast_baseline_comparison.py
@@ -1,0 +1,152 @@
+"""Forecast-baseline comparison/leaderboard core (bounded #2915 child).
+
+Given per-baseline forecast metrics (ADE / FDE / miss-rate, ...), rank the
+baselines per metric and identify the best per metric, with fail-closed handling
+of missing metrics. This gives the parent's CV / semantic-CV / interaction-aware
+predictor outputs a consistent comparison surface.
+
+Forecast error metrics are lower-is-better by default; any metric outside the
+configured lower-is-better set is treated as higher-is-better. A baseline that
+lacks a metric is reported as *not-comparable* for that metric (it is never
+silently ranked as zero).
+
+Pure and deterministic: it consumes already-measured metrics and runs no
+forecasting. This is analysis tooling and makes no benchmark claim. Implementing
+the predictor classes and running the forecast eval lives with parent #2915.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Mapping
+
+FORECAST_BASELINE_COMPARISON_SCHEMA = "forecast_baseline_comparison.v1"
+
+# Standard forecast error metrics where a smaller value is better.
+DEFAULT_LOWER_IS_BETTER = ("ade", "fde", "min_ade", "min_fde", "miss_rate", "nll")
+
+
+@dataclass(frozen=True)
+class MetricRanking:
+    """Per-metric ranking of forecast baselines."""
+
+    metric: str
+    lower_is_better: bool
+    ranking: list[str]
+    best: str | None
+    not_comparable: list[str]
+    deltas_vs_best: dict[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe representation.
+
+        Returns:
+            Mapping with the metric, direction, ranking, best baseline,
+            not-comparable baselines, and deltas vs the best.
+        """
+        return {
+            "metric": self.metric,
+            "lower_is_better": self.lower_is_better,
+            "ranking": list(self.ranking),
+            "best": self.best,
+            "not_comparable": list(self.not_comparable),
+            "deltas_vs_best": dict(self.deltas_vs_best),
+        }
+
+
+@dataclass(frozen=True)
+class ForecastBaselineComparison:
+    """Comparison report across all metrics."""
+
+    baselines: list[str]
+    metrics: list[str]
+    rankings: list[MetricRanking]
+
+    def best_by_metric(self) -> dict[str, str | None]:
+        """Return the winning baseline per metric.
+
+        Returns:
+            Mapping of metric name to the best baseline (or ``None`` if none ranked).
+        """
+        return {ranking.metric: ranking.best for ranking in self.rankings}
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the ``forecast_baseline_comparison.v1`` JSON-safe payload.
+
+        Returns:
+            Mapping with the schema version, baselines, metrics, per-metric
+            rankings, and best-by-metric.
+        """
+        return {
+            "schema_version": FORECAST_BASELINE_COMPARISON_SCHEMA,
+            "baselines": list(self.baselines),
+            "metrics": list(self.metrics),
+            "best_by_metric": self.best_by_metric(),
+            "rankings": [ranking.to_dict() for ranking in self.rankings],
+        }
+
+
+def compare_forecast_baselines(
+    metrics_by_baseline: Mapping[str, Mapping[str, float]],
+    *,
+    metrics: Iterable[str] | None = None,
+    lower_is_better_metrics: Iterable[str] = DEFAULT_LOWER_IS_BETTER,
+) -> ForecastBaselineComparison:
+    """Rank forecast baselines per metric and pick the best per metric.
+
+    ``metrics_by_baseline`` maps baseline name to ``{metric -> value}``. Baselines
+    missing a metric are listed under that metric's ``not_comparable`` rather than
+    ranked. Ties are broken by baseline name for deterministic output.
+
+    Returns:
+        A :class:`ForecastBaselineComparison` with per-metric rankings.
+    """
+    if not metrics_by_baseline:
+        raise ValueError("metrics_by_baseline must contain at least one baseline")
+    baselines = sorted(metrics_by_baseline)
+    lower_set = set(lower_is_better_metrics)
+    if metrics is not None:
+        metric_names = list(metrics)
+    else:
+        metric_names = sorted({name for row in metrics_by_baseline.values() for name in row})
+
+    rankings: list[MetricRanking] = []
+    for metric in metric_names:
+        lower_is_better = metric in lower_set
+        present: dict[str, float] = {}
+        not_comparable: list[str] = []
+        for baseline in baselines:
+            value = metrics_by_baseline[baseline].get(metric)
+            if value is None:
+                not_comparable.append(baseline)
+            else:
+                present[baseline] = float(value)
+
+        ordered = sorted(
+            present,
+            key=lambda baseline: (
+                present[baseline] if lower_is_better else -present[baseline],
+                baseline,
+            ),
+        )
+        best = ordered[0] if ordered else None
+        deltas = (
+            {baseline: present[baseline] - present[best] for baseline in ordered}
+            if best is not None
+            else {}
+        )
+        rankings.append(
+            MetricRanking(
+                metric=metric,
+                lower_is_better=lower_is_better,
+                ranking=ordered,
+                best=best,
+                not_comparable=not_comparable,
+                deltas_vs_best=deltas,
+            )
+        )
+
+    return ForecastBaselineComparison(baselines=baselines, metrics=metric_names, rankings=rankings)

--- a/robot_sf/benchmark/forecast_baseline_comparison.py
+++ b/robot_sf/benchmark/forecast_baseline_comparison.py
@@ -109,7 +109,7 @@ def compare_forecast_baselines(
     baselines = sorted(metrics_by_baseline)
     lower_set = set(lower_is_better_metrics)
     if metrics is not None:
-        metric_names = list(metrics)
+        metric_names = list(dict.fromkeys(metrics))
     else:
         metric_names = sorted({name for row in metrics_by_baseline.values() for name in row})
 

--- a/tests/benchmark/test_forecast_baseline_comparison.py
+++ b/tests/benchmark/test_forecast_baseline_comparison.py
@@ -1,0 +1,85 @@
+"""Tests for the forecast-baseline comparison core (issue #3244, child of #2915)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.forecast_baseline_comparison import (
+    FORECAST_BASELINE_COMPARISON_SCHEMA,
+    compare_forecast_baselines,
+)
+
+_METRICS = {
+    "cv": {"ade": 0.50, "fde": 1.20, "miss_rate": 0.30},
+    "semantic_cv": {"ade": 0.40, "fde": 1.10, "miss_rate": 0.30},
+    "interaction_aware": {"ade": 0.35, "fde": 1.30, "miss_rate": 0.25},
+}
+
+
+def _ranking(comparison, metric):
+    return next(r for r in comparison.rankings if r.metric == metric)
+
+
+def test_lower_is_better_ranking_and_best() -> None:
+    """ADE is lower-is-better, so the smallest ADE ranks first."""
+    comparison = compare_forecast_baselines(_METRICS)
+    ade = _ranking(comparison, "ade")
+    assert ade.lower_is_better is True
+    assert ade.ranking == ["interaction_aware", "semantic_cv", "cv"]
+    assert ade.best == "interaction_aware"
+    assert comparison.best_by_metric()["fde"] == "semantic_cv"
+    assert comparison.best_by_metric()["miss_rate"] == "interaction_aware"
+
+
+def test_deltas_vs_best_are_relative_to_winner() -> None:
+    """Deltas are each baseline's value minus the best value for that metric."""
+    comparison = compare_forecast_baselines(_METRICS)
+    fde = _ranking(comparison, "fde")
+    assert fde.best == "semantic_cv"
+    assert fde.deltas_vs_best["semantic_cv"] == pytest.approx(0.0)
+    assert fde.deltas_vs_best["cv"] == pytest.approx(0.10)
+    assert fde.deltas_vs_best["interaction_aware"] == pytest.approx(0.20)
+
+
+def test_missing_metric_is_not_comparable() -> None:
+    """A baseline lacking a metric is not-comparable for it, not ranked as zero."""
+    metrics = {
+        "cv": {"ade": 0.5, "fde": 1.2},
+        "interaction_aware": {"ade": 0.4},  # no fde
+    }
+    comparison = compare_forecast_baselines(metrics)
+    fde = _ranking(comparison, "fde")
+    assert fde.not_comparable == ["interaction_aware"]
+    assert fde.ranking == ["cv"]
+    assert fde.best == "cv"
+
+
+def test_ties_broken_by_name() -> None:
+    """Equal metric values rank by baseline name for determinism."""
+    metrics = {"b_planner": {"ade": 0.5}, "a_planner": {"ade": 0.5}}
+    comparison = compare_forecast_baselines(metrics)
+    assert _ranking(comparison, "ade").ranking == ["a_planner", "b_planner"]
+
+
+def test_higher_is_better_metric_outside_default_set() -> None:
+    """A metric not in the lower-is-better set ranks descending."""
+    metrics = {"cv": {"coverage": 0.7}, "semantic_cv": {"coverage": 0.9}}
+    comparison = compare_forecast_baselines(metrics)
+    coverage = _ranking(comparison, "coverage")
+    assert coverage.lower_is_better is False
+    assert coverage.ranking == ["semantic_cv", "cv"]
+    assert coverage.best == "semantic_cv"
+
+
+def test_empty_input_raises() -> None:
+    """An empty comparison is rejected."""
+    with pytest.raises(ValueError, match="at least one baseline"):
+        compare_forecast_baselines({})
+
+
+def test_to_dict_schema() -> None:
+    """The payload carries the forecast_baseline_comparison.v1 schema."""
+    payload = compare_forecast_baselines(_METRICS).to_dict()
+    assert payload["schema_version"] == FORECAST_BASELINE_COMPARISON_SCHEMA
+    assert payload["best_by_metric"]["ade"] == "interaction_aware"
+    assert set(payload["baselines"]) == {"cv", "semantic_cv", "interaction_aware"}

--- a/tests/benchmark/test_forecast_baseline_comparison.py
+++ b/tests/benchmark/test_forecast_baseline_comparison.py
@@ -71,6 +71,13 @@ def test_higher_is_better_metric_outside_default_set() -> None:
     assert coverage.best == "semantic_cv"
 
 
+def test_explicit_metrics_are_deduplicated_in_order() -> None:
+    """Duplicate explicit metrics still emit one ranking per unique metric."""
+    comparison = compare_forecast_baselines(_METRICS, metrics=["fde", "ade", "fde"])
+    assert comparison.metrics == ["fde", "ade"]
+    assert [ranking.metric for ranking in comparison.rankings] == ["fde", "ade"]
+
+
 def test_empty_input_raises() -> None:
     """An empty comparison is rejected."""
     with pytest.raises(ValueError, match="at least one baseline"):


### PR DESCRIPTION
## Summary
Adds the bounded forecast-baseline comparison core for issue #3244: deterministic per-metric rankings, best-by-metric output, pairwise deltas vs the best, and fail-closed not-comparable handling for missing metrics.

## Linked Issues
- Closes #3244
- Relates to #2915

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: parent #2915 owns predictor implementation and forecast eval execution
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `robot_sf/benchmark/forecast_baseline_comparison.py` with the `forecast_baseline_comparison.v1` report model and `compare_forecast_baselines(...)`.
- Added `tests/benchmark/test_forecast_baseline_comparison.py` covering ranking, best-per-metric, missing metrics, tie-breaking, higher-is-better metrics, empty input rejection, and schema serialization.

## Why It Matters
- Added value: gives future forecast predictor outputs a consistent leaderboard/comparison surface.
- Expected impact: deterministic comparison behavior without running forecasts or creating benchmark claims.
- Why this is worth merging now: it completes the bounded comparison-tool child scope needed by parent #2915.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: comparison tooling exists for forecast baseline metrics; no benchmark result claim.
- Comparator or baseline, if applicable: committed fixture metrics for CV / semantic-CV / interaction-aware names.
- Evidence tier: targeted smoke / committed fixture proof.
- Result classification: diagnostic-only tooling support; no benchmark claim.
- Decision or stop rule, if applicable: merge when fixture tests prove ranking, best, missing-metric, and tie behavior.
- Parent issue, claim map, registry, context note, or synthesis surface to update: parent #2915 can use this when real predictor outputs exist.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use is covered by committed fixture tests in `tests/benchmark/test_forecast_baseline_comparison.py`; no durable `output/` artifact is required.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - analysis utility only.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: parent #2915 remains the follow-up for real forecast eval inputs.

## Next Empirical Action
- Rerun needed: no for this bounded fixture scope.
- Extractor or analysis tool needed: no for #3244; predictor/eval work remains in #2915.
- Artifact missing or unavailable: none for this PR.
- Stop / revise / continue decision: continue to review/merge this support tool; defer real forecast outputs to #2915.
- Proposed child issue or existing follow-up: #2915.

## Validation / Proof
- Commands run:
  - `git diff --check origin/main...HEAD`
  - `uv run python -m pytest tests/benchmark/test_forecast_baseline_comparison.py -q`
  - `uv run ruff check robot_sf/benchmark/forecast_baseline_comparison.py tests/benchmark/test_forecast_baseline_comparison.py`
  - `uv run ruff format --check robot_sf/benchmark/forecast_baseline_comparison.py tests/benchmark/test_forecast_baseline_comparison.py`
- Evidence that the change works here: 7 focused tests passed; Ruff check passed; Ruff format check reported both files already formatted.
- Benchmarks or smoke tests, if applicable: no benchmark run; this PR is a deterministic analysis-tool slice and makes no benchmark claim.

## Risks / Rollout
- Compatibility risks: low; new module is additive and currently imported only by its tests.
- Failure modes: callers must supply real per-baseline metric inputs; missing metrics are intentionally not comparable.
- Rollback or fallback plan: revert the additive module/test if the report contract needs a different shape before parent #2915 consumes it.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #3244 defines the bounded scope and acceptance criteria.
- Any assumptions that need to be preserved: metrics outside `DEFAULT_LOWER_IS_BETTER` are treated as higher-is-better unless configured otherwise.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; PR links #2915 and #3244.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - tool exists but no real leaderboard artifact is produced.
- Registry or config index updated (yes/no/NA): NA - no config or registry entry.
- Context index / memory note updated (yes/no/NA): NA - small bounded additive utility.
- Follow-up issue opened for deferred propagation (yes/no/NA): no; existing parent #2915 tracks predictor/eval integration.
- Not applicable because: this PR adds the comparison core and fixture proof only, with no durable benchmark output.

## Follow-Up Issues
- Deferred work: predictor classes and forecast evaluation remain with #2915.
- Issues opened for follow-up: none; #2915 already exists.

## Reviewer Notes
- Anything a reviewer should verify closely: report shape and signed delta semantics (`value - best_value`) match intended downstream consumers.
- Any known limitations: no real forecast run or generated leaderboard artifact is included by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added forecast baseline comparison and leaderboard functionality with per-metric ranking
  * Configurable metric directionality (lower/higher-is-better) for flexible evaluation
  * Graceful handling of missing metrics as non-comparable
  * Deterministic ranking with tie-breaking and JSON serialization support

* **Tests**
  * Added comprehensive test suite for baseline comparison logic

<!-- end of auto-generated comment: release notes by coderabbit.ai -->