### PR TITLE
test: expand doctest allowlist (#3247)

### DIFF
--- a/robot_sf/nav/obstacle.py
+++ b/robot_sf/nav/obstacle.py
@@ -18,7 +18,7 @@ Typical usage:
     obstacle = Obstacle([(0, 0), (10, 0), (10, 10), (0, 10)])
 
     # Create from SVG rectangle
-    rect = SvgRectangle(x=5, y=5, width=20, height=15)
+    rect = SvgRectangle(x=5, y=5, width=20, height=15, label="wall", id_="wall-1")
     obstacle = obstacle_from_svgrectangle(rect)
 """
 
@@ -241,7 +241,7 @@ def obstacle_from_svgrectangle(svg_rectangle: SvgRectangle) -> Obstacle:
         and four edge line segments.
 
     Example:
-        >>> rect = SvgRectangle(x=10, y=20, width=50, height=30)
+        >>> rect = SvgRectangle(x=10, y=20, width=50, height=30, label="wall", id_="wall-1")
         >>> obstacle = obstacle_from_svgrectangle(rect)
         >>> len(obstacle.vertices)
         4

--- a/robot_sf/nav/occupancy_grid.py
+++ b/robot_sf/nav/occupancy_grid.py
@@ -1157,14 +1157,25 @@ class OccupancyGrid:
             RuntimeError: If grid has not been generated yet
 
         Example:
+            >>> from robot_sf.nav.occupancy_grid import GridChannel, GridConfig, OccupancyGrid
+            >>> config = GridConfig(
+            ...     resolution=0.1,
+            ...     width=10.0,
+            ...     height=10.0,
+            ...     channels=[
+            ...         GridChannel.OBSTACLES,
+            ...         GridChannel.PEDESTRIANS,
+            ...         GridChannel.ROBOT,
+            ...     ],
+            ... )
             >>> grid = OccupancyGrid(config)
-            >>> grid.generate(obstacles=obs, pedestrians=peds, robot_pose=pose)
+            >>> _ = grid.generate(obstacles=[], pedestrians=[], robot_pose=((5.0, 5.0), 0.0))
             >>> obs_array = grid.to_observation()
             >>> obs_array.shape  # (num_channels, height, width)
-            (3, 200, 200)
+            (3, 100, 100)
             >>> obs_array.dtype
             dtype('float32')
-            >>> (obs_array.min(), obs_array.max())
+            >>> float(obs_array.min()), float(obs_array.max())
             (0.0, 1.0)
 
         Notes:

--- a/robot_sf/nav/occupancy_grid_rasterization.py
+++ b/robot_sf/nav/occupancy_grid_rasterization.py
@@ -60,12 +60,13 @@ def rasterize_line_segment(
         O(max(|dx|, |dy|)) where dx, dy are grid cell distances
 
     Example:
+        >>> from robot_sf.nav.occupancy_grid import GridConfig
         >>> grid = np.zeros((100, 100))
         >>> config = GridConfig(resolution=0.1, width=10.0, height=10.0)
-        >>> line = Line2D((1.0, 1.0), (9.0, 9.0))
+        >>> line = ((1.0, 1.0), (9.0, 9.0))
         >>> rasterize_line_segment(line, grid, config)
-        >>> np.sum(grid > 0)  # Count occupied cells
-        80
+        >>> int(np.sum(grid > 0))  # Count occupied cells
+        81
     """
     start, end = line
 
@@ -224,19 +225,20 @@ def rasterize_circle(
         bounding box intersection testing.
 
     Example:
+        >>> from robot_sf.nav.occupancy_grid import GridConfig
         >>> grid = np.zeros((100, 100))
         >>> config = GridConfig(resolution=0.1, width=10.0, height=10.0)
         >>> # Circle fully inside
-        >>> circle = Circle2D((5.0, 5.0), 0.5)
+        >>> circle = ((5.0, 5.0), 0.5)
         >>> rasterize_circle(circle, grid, config)
-        >>> np.sum(grid > 0)  # Count occupied cells
-        ~78  # Approximately π * 5² cells
+        >>> int(np.sum(grid > 0))  # Count occupied cells
+        88
         >>> # Circle center outside but overlapping
         >>> grid2 = np.zeros((100, 100))
-        >>> circle2 = Circle2D((10.5, 5.0), 1.0)
+        >>> circle2 = ((10.5, 5.0), 1.0)
         >>> rasterize_circle(circle2, grid2, config)
-        >>> np.sum(grid2 > 0)  # Some cells from overlap
-        15
+        >>> int(np.sum(grid2 > 0))  # Some cells from overlap
+        78
     """
     center, radius = circle
 

--- a/robot_sf/nav/occupancy_grid_utils.py
+++ b/robot_sf/nav/occupancy_grid_utils.py
@@ -57,6 +57,7 @@ def world_to_grid_indices(
         - Col index increases rightward (X+ in world → col+ in grid)
 
     Example:
+        >>> from robot_sf.nav.occupancy_grid import GridConfig
         >>> config = GridConfig(resolution=0.1, width=10.0, height=10.0)
         >>> row, col = world_to_grid_indices(5.0, 5.0, config, 0.0, 0.0)
         >>> row, col
@@ -116,10 +117,11 @@ def grid_indices_to_world(
         - Returns center of the cell at (row, col)
 
     Example:
+        >>> from robot_sf.nav.occupancy_grid import GridConfig
         >>> config = GridConfig(resolution=0.1, width=10.0, height=10.0)
         >>> x, y = grid_indices_to_world(50, 50, config, 0.0, 0.0)
-        >>> x, y
-        (5.0, 5.0)
+        >>> round(x, 2), round(y, 2)
+        (5.05, 5.05)
     """
     if not (0 <= row < config.grid_height):
         raise ValueError(f"Row index {row} out of bounds [0, {config.grid_height - 1}]")
@@ -156,6 +158,7 @@ def is_within_grid(
         True if coordinates are within grid bounds, False otherwise
 
     Example:
+        >>> from robot_sf.nav.occupancy_grid import GridConfig
         >>> config = GridConfig(resolution=0.1, width=10.0, height=10.0)
         >>> is_within_grid(5.0, 5.0, config, 0.0, 0.0)
         True
@@ -189,10 +192,9 @@ def world_to_ego(
         - Ego frame: X+ forward, Y+ left, origin at robot center
 
     Example:
-        >>> import math
-        >>> pose = RobotPose(x=1.0, y=2.0, theta=0.0)
+        >>> pose = ((1.0, 2.0), 0.0)
         >>> ego_x, ego_y = world_to_ego(2.0, 2.0, pose)
-        >>> ego_x, ego_y
+        >>> round(float(ego_x), 1), round(float(ego_y), 1)
         (1.0, 0.0)
     """
     robot_x, robot_y, theta = _extract_pose(robot_pose)
@@ -231,9 +233,9 @@ def ego_to_world(
         - Rotation: θ = robot_pose.theta (forward rotation)
 
     Example:
-        >>> pose = RobotPose(x=1.0, y=2.0, theta=0.0)
+        >>> pose = ((1.0, 2.0), 0.0)
         >>> world_x, world_y = ego_to_world(1.0, 0.0, pose)
-        >>> world_x, world_y
+        >>> round(float(world_x), 1), round(float(world_y), 1)
         (2.0, 2.0)
     """
     robot_x, robot_y, theta = _extract_pose(robot_pose)
@@ -267,6 +269,7 @@ def get_grid_bounds(
         Tuple of (min_x, max_x, min_y, max_y) in world frame
 
     Example:
+        >>> from robot_sf.nav.occupancy_grid import GridConfig
         >>> config = GridConfig(resolution=0.1, width=10.0, height=10.0)
         >>> bounds = get_grid_bounds(config, 0.0, 0.0)
         >>> bounds
@@ -300,9 +303,10 @@ def clip_to_grid(
         Tuple of clipped (world_x, world_y)
 
     Example:
+        >>> from robot_sf.nav.occupancy_grid import GridConfig
         >>> config = GridConfig(resolution=0.1, width=10.0, height=10.0)
         >>> x, y = clip_to_grid(15.0, 5.0, config, 0.0, 0.0)
-        >>> x, y
+        >>> float(x), float(y)
         (10.0, 5.0)
     """
     min_x, max_x, min_y, max_y = get_grid_bounds(config, grid_origin_x, grid_origin_y)
@@ -344,15 +348,16 @@ def get_affected_cells(
         - Centers outside grid are clamped for iteration, closest point checked for overlap
 
     Example:
+        >>> from robot_sf.nav.occupancy_grid import GridConfig
         >>> config = GridConfig(resolution=0.1, width=10.0, height=10.0)
         >>> # Circle fully inside
         >>> cells = get_affected_cells(5.0, 5.0, 0.3, config)
-        >>> len(cells)  # Approx π * 3² = ~28 cells
-        28
+        >>> len(cells)
+        36
         >>> # Circle center outside but overlapping
         >>> cells2 = get_affected_cells(10.5, 5.0, 1.0, config)
-        >>> len(cells2)  # Partial overlap
-        15
+        >>> len(cells2)
+        78
     """
     if radius <= 0:
         return []

--- a/robot_sf/sensor/fusion_adapter.py
+++ b/robot_sf/sensor/fusion_adapter.py
@@ -84,12 +84,11 @@ def create_sensors_from_config(sensor_configs: list[dict[str, Any]]) -> list[Sen
     Examples
     --------
     >>> configs = [
-    ...     {"type": "lidar", "range": 10.0, "num_rays": 64},
-    ...     {"type": "camera", "resolution": (640, 480)},
+    ...     {"type": "dummy_constant", "value": 1.0},
     ... ]
     >>> sensors = create_sensors_from_config(configs)
     >>> len(sensors)
-    2
+    1
     """
     sensors = []
 
@@ -149,7 +148,7 @@ def validate_sensor_configs(sensor_configs: list[dict[str, Any]]) -> list[str]:
 
     Examples
     --------
-    >>> configs = [{"type": "lidar"}, {"missing": "type"}]
+    >>> configs = [{"type": "dummy_constant"}, {"missing": "type"}]
     >>> errors = validate_sensor_configs(configs)
     >>> len(errors)
     1

--- a/tests/docs/test_module_doctests.py
+++ b/tests/docs/test_module_doctests.py
@@ -1,9 +1,9 @@
 """Execute docstring doctests for a curated allowlist of pure ``robot_sf`` modules.
 
-``robot_sf/`` ships ~179 ``>>>`` doctest example lines across 23 modules, but nothing
-executes them: ``pyproject.toml`` does not enable ``--doctest-modules`` and no test
-collects them, so the examples can silently drift from the real API with no CI signal
-(issue #3210).
+``robot_sf/`` ships many ``>>>`` doctest example lines across 23 modules, but
+``pyproject.toml`` does not enable blanket ``--doctest-modules`` collection. Without
+this curated runner, examples can silently drift from the real API with no CI signal
+(issues #3210 and #3247).
 
 A blanket ``--doctest-modules`` is intentionally *not* used: it would import heavy,
 side-effecting modules (``robot_sf/sim/simulator.py``, ``robot_sf/benchmark/metrics.py``,
@@ -37,9 +37,14 @@ DOCTEST_OPTIONFLAGS = doctest.ELLIPSIS | doctest.NORMALIZE_WHITESPACE
 # Curated allowlist: pure, lightweight modules with deterministic, passing doctests.
 DOCTEST_MODULES = [
     "robot_sf.common.logging",
-    "robot_sf.research.logging_config",
-    "robot_sf.research.artifact_paths",
     "robot_sf.maps.verification.logging",
+    "robot_sf.nav.obstacle",
+    "robot_sf.nav.occupancy_grid",
+    "robot_sf.nav.occupancy_grid_rasterization",
+    "robot_sf.nav.occupancy_grid_utils",
+    "robot_sf.research.artifact_paths",
+    "robot_sf.research.logging_config",
+    "robot_sf.sensor.fusion_adapter",
     "robot_sf.sensor.registry",
 ]
 
@@ -48,16 +53,12 @@ DOCTEST_MODULES = [
 # candidates for a future faithful cleanup pass that converts illustrative examples to
 # fenced ``python`` blocks or makes them deterministic.
 #
-#   robot_sf.benchmark.metrics           - heavy import (tensorflow/torch), ~8s; no real doctests
-#   robot_sf.benchmark.utils             - file IO (ensure_directory) + env-dependent (fast-demo cap)
+#   robot_sf.benchmark.metrics           - heavy import (tensorflow/torch); inline comments only
+#   robot_sf.benchmark.utils             - heavy import + file IO + env-dependent fast-demo example
 #   robot_sf.common.matplotlib_utils     - matplotlib figure side effects
 #   robot_sf.gym_env.robot_env           - constructs a Gym env (sim startup)
 #   robot_sf.maps.osm_zones_config       - illustrative pseudocode + YAML file IO
 #   robot_sf.maps.verification           - package __init__ illustrative example
-#   robot_sf.nav.obstacle                - illustrative pseudocode (undefined rect/obstacle)
-#   robot_sf.nav.occupancy_grid          - illustrative array/grid pseudocode
-#   robot_sf.nav.occupancy_grid_rasterization - illustrative array pseudocode
-#   robot_sf.nav.occupancy_grid_utils    - illustrative array pseudocode
 #   robot_sf.nav.svg_map_parser          - illustrative pseudocode + map file IO
 #   robot_sf.ped_npc.ped_population       - illustrative pseudocode
 #   robot_sf.planner.classic_global_planner - illustrative pseudocode
@@ -73,17 +74,12 @@ EXCLUDED_MODULES = {
     "robot_sf.gym_env.robot_env",
     "robot_sf.maps.osm_zones_config",
     "robot_sf.maps.verification",
-    "robot_sf.nav.obstacle",
-    "robot_sf.nav.occupancy_grid",
-    "robot_sf.nav.occupancy_grid_rasterization",
-    "robot_sf.nav.occupancy_grid_utils",
     "robot_sf.nav.svg_map_parser",
     "robot_sf.ped_npc.ped_population",
     "robot_sf.planner.classic_global_planner",
     "robot_sf.research",
     "robot_sf.research.metadata",
     "robot_sf.research.schema_loader",
-    "robot_sf.sensor.fusion_adapter",
     "robot_sf.sim.simulator",
 }
 


### PR DESCRIPTION
## Summary
- expands the curated doctest allowlist from 5 to 10 lightweight modules
- fixes stale docstring examples for nav occupancy/grid helpers and the sensor fusion adapter
- updates the exclusion rationale to leave only genuinely heavy, side-effecting, file-IO, or illustrative modules excluded

Closes #3247

## Validation
- `uv run python -m pytest tests/docs/test_module_doctests.py -q` -> 11 passed
- `uv run ruff check tests/docs/test_module_doctests.py robot_sf/nav/obstacle.py robot_sf/nav/occupancy_grid.py robot_sf/nav/occupancy_grid_rasterization.py robot_sf/nav/occupancy_grid_utils.py robot_sf/sensor/fusion_adapter.py` -> passed
- `uv run ruff format --check tests/docs/test_module_doctests.py robot_sf/nav/obstacle.py robot_sf/nav/occupancy_grid.py robot_sf/nav/occupancy_grid_rasterization.py robot_sf/nav/occupancy_grid_utils.py robot_sf/sensor/fusion_adapter.py` -> 6 files already formatted
- `git diff --check` -> clean

## Notes
- Full `pr_ready_check` not run; this is low-risk docstring/test-only scope with focused validation.
- Remaining excluded doctest modules need separate faithful cleanup before they can be safely executed.
