### PR TITLE
refactor: consolidate rank metric helpers (#3246)

### DIFF
--- a/robot_sf/benchmark/fidelity_rank_stability.py
+++ b/robot_sf/benchmark/fidelity_rank_stability.py
@@ -20,7 +20,7 @@ import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from scipy.stats import kendalltau
+from robot_sf.benchmark.rank_metrics import kendall_tau as _shared_kendall_tau
 
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
@@ -66,12 +66,6 @@ def _finite_metric_value(metrics: Mapping[str, object], metric: str) -> float | 
     return value
 
 
-def _rank_vector(order: list[str], planners: list[str]) -> list[int]:
-    """Return each planner's positional rank within ``order``."""
-    position = {planner: index for index, planner in enumerate(order)}
-    return [position[planner] for planner in planners]
-
-
 def kendall_tau(order_a: list[str], order_b: list[str]) -> float:
     """Return Kendall tau between two orderings of the same planners.
 
@@ -81,10 +75,7 @@ def kendall_tau(order_a: list[str], order_b: list[str]) -> float:
     Returns:
         Kendall tau-b rank correlation in ``[-1.0, 1.0]``.
     """
-    planners = sorted(order_a)
-    if len(planners) < 2:
-        return 1.0
-    tau = kendalltau(_rank_vector(order_a, planners), _rank_vector(order_b, planners)).statistic
+    tau = _shared_kendall_tau(order_a, order_b, degenerate=1.0)
     if tau is None or math.isnan(tau):
         return 1.0
     return float(tau)

--- a/robot_sf/benchmark/rank_metrics.py
+++ b/robot_sf/benchmark/rank_metrics.py
@@ -1,0 +1,277 @@
+"""Shared deterministic rank and rank-correlation helpers.
+
+The helpers centralize the benchmark tooling convention used for Spearman and
+Kendall comparisons: average ranks for tied metric values, deterministic key
+ordering for reported rank lists, and caller-selected degenerate-input results
+so legacy analysis surfaces keep their documented behavior.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Hashable, Mapping, Sequence
+
+
+def rank_by(
+    values_by_key: Mapping[Hashable, float],
+    *,
+    higher_is_better: bool,
+    tie_abs_tol: float = 0.0,
+) -> dict[Hashable, float]:
+    """Return one-based average ranks for keyed metric values.
+
+    Rank ``1.0`` is the best value. Ties are averaged using exact equality by
+    default; pass ``tie_abs_tol`` for legacy helpers that treated near-equal
+    floating-point values as ties.
+    """
+    ordered = sorted(
+        values_by_key.items(),
+        key=lambda item: (-float(item[1]) if higher_is_better else float(item[1]), str(item[0])),
+    )
+    ranks: dict[Hashable, float] = {}
+    index = 0
+    while index < len(ordered):
+        value = float(ordered[index][1])
+        tie_end = index + 1
+        while tie_end < len(ordered) and _tied(
+            float(ordered[tie_end][1]), value, tie_abs_tol=tie_abs_tol
+        ):
+            tie_end += 1
+        average_rank = (index + 1 + tie_end) / 2.0
+        for tied_key, _value in ordered[index:tie_end]:
+            ranks[tied_key] = average_rank
+        index = tie_end
+    return ranks
+
+
+def rank_order(
+    values_by_key: Mapping[Hashable, float],
+    *,
+    higher_is_better: bool,
+) -> list[Hashable]:
+    """Return keys ordered from best to worst by metric value."""
+    return [
+        key
+        for key, _value in sorted(
+            values_by_key.items(),
+            key=lambda item: (
+                -float(item[1]) if higher_is_better else float(item[1]),
+                str(item[0]),
+            ),
+        )
+    ]
+
+
+def top_tied(
+    values_by_key: Mapping[Hashable, float],
+    *,
+    higher_is_better: bool,
+    tie_abs_tol: float = 0.0,
+) -> bool:
+    """Return whether more than one key shares the best metric value."""
+    if len(values_by_key) < 2:
+        return False
+    ordered = rank_order(values_by_key, higher_is_better=higher_is_better)
+    best_value = float(values_by_key[ordered[0]])
+    return (
+        sum(
+            _tied(float(value), best_value, tie_abs_tol=tie_abs_tol)
+            for value in values_by_key.values()
+        )
+        > 1
+    )
+
+
+def spearman(
+    left: Sequence[float],
+    right: Sequence[float],
+    *,
+    degenerate: float | None = 0.0,
+    tie_abs_tol: float = 0.0,
+) -> float | None:
+    """Return Spearman rank correlation for paired numeric sequences.
+
+    Values are ranked ascending with average ranks for ties. ``degenerate`` is
+    returned when the vectors are unequal length, contain fewer than two values,
+    or one ranked vector has zero variance.
+    """
+    if len(left) != len(right) or len(left) < 2:
+        return degenerate
+    left_ranks = _rank_sequence(left, tie_abs_tol=tie_abs_tol)
+    right_ranks = _rank_sequence(right, tie_abs_tol=tie_abs_tol)
+    return _pearson(left_ranks, right_ranks, degenerate=degenerate)
+
+
+def spearman_by_value(
+    left_values: Mapping[Hashable, float],
+    right_values: Mapping[Hashable, float],
+    *,
+    higher_is_better: bool,
+    degenerate: float | None = None,
+    tie_abs_tol: float = 0.0,
+) -> float | None:
+    """Return Spearman correlation over common keyed metric values."""
+    common = sorted(set(left_values) & set(right_values), key=str)
+    if len(common) < 2:
+        return degenerate
+    left_ranks = rank_by(
+        {key: left_values[key] for key in common},
+        higher_is_better=higher_is_better,
+        tie_abs_tol=tie_abs_tol,
+    )
+    right_ranks = rank_by(
+        {key: right_values[key] for key in common},
+        higher_is_better=higher_is_better,
+        tie_abs_tol=tie_abs_tol,
+    )
+    return _pearson(
+        [left_ranks[key] for key in common],
+        [right_ranks[key] for key in common],
+        degenerate=degenerate,
+    )
+
+
+def spearman_from_order(
+    order_a: Sequence[Hashable],
+    order_b: Sequence[Hashable],
+    *,
+    degenerate: float | None = 0.0,
+) -> float | None:
+    """Return Spearman correlation between two explicit orderings."""
+    if len(order_a) < 2 or set(order_a) != set(order_b):
+        return degenerate
+    index_b = {key: index for index, key in enumerate(order_b)}
+    return spearman(
+        list(range(len(order_a))),
+        [index_b[key] for key in order_a],
+        degenerate=degenerate,
+    )
+
+
+def spearman_from_rank_maps(
+    left_ranks: Mapping[Hashable, float],
+    right_ranks: Mapping[Hashable, float],
+    *,
+    degenerate: float | None = None,
+) -> float | None:
+    """Return Spearman rho from caller-provided rank positions.
+
+    This preserves legacy callers that compare absolute rank positions over the
+    overlapping keys instead of re-ranking the overlap.
+    """
+    common = sorted(set(left_ranks) & set(right_ranks), key=str)
+    n = len(common)
+    if n < 2:
+        return degenerate
+    d_squared = math.fsum((float(left_ranks[key]) - float(right_ranks[key])) ** 2 for key in common)
+    return float(1.0 - ((6.0 * d_squared) / (n * (n * n - 1))))
+
+
+def kendall_tau(
+    order_a: Sequence[Hashable],
+    order_b: Sequence[Hashable],
+    *,
+    degenerate: float | None = 0.0,
+) -> float | None:
+    """Return Kendall tau-a correlation between two explicit orderings."""
+    if len(order_a) < 2 or set(order_a) != set(order_b):
+        return degenerate
+    index_a = {key: index for index, key in enumerate(order_a)}
+    index_b = {key: index for index, key in enumerate(order_b)}
+    concordant = 0
+    discordant = 0
+    for left_index, left in enumerate(order_a):
+        for right in order_a[left_index + 1 :]:
+            product = (index_a[left] - index_a[right]) * (index_b[left] - index_b[right])
+            if product > 0:
+                concordant += 1
+            elif product < 0:
+                discordant += 1
+    total = concordant + discordant
+    if total == 0:
+        return degenerate
+    return float((concordant - discordant) / total)
+
+
+def kendall_tau_by_value(
+    left_values: Mapping[Hashable, float],
+    right_values: Mapping[Hashable, float],
+    *,
+    higher_is_better: bool,
+    degenerate: float | None = None,
+    tie_abs_tol: float = 1e-12,
+) -> float | None:
+    """Return Kendall tau over common keyed metric values, skipping ties."""
+    common = sorted(set(left_values) & set(right_values), key=str)
+    if len(common) < 2:
+        return degenerate
+    concordant = 0
+    discordant = 0
+    multiplier = 1.0 if higher_is_better else -1.0
+    for index, left in enumerate(common):
+        for right in common[index + 1 :]:
+            left_delta = multiplier * (float(left_values[left]) - float(left_values[right]))
+            right_delta = multiplier * (float(right_values[left]) - float(right_values[right]))
+            if abs(left_delta) <= tie_abs_tol or abs(right_delta) <= tie_abs_tol:
+                continue
+            if left_delta * right_delta > 0:
+                concordant += 1
+            else:
+                discordant += 1
+    total = concordant + discordant
+    if total == 0:
+        return degenerate
+    return float((concordant - discordant) / total)
+
+
+def _rank_sequence(values: Sequence[float], *, tie_abs_tol: float) -> list[float]:
+    """Return one-based average ranks in the original sequence order."""
+    indexed = sorted(enumerate(values), key=lambda item: float(item[1]))
+    ranks = [0.0] * len(values)
+    index = 0
+    while index < len(indexed):
+        value = float(indexed[index][1])
+        tie_end = index + 1
+        while tie_end < len(indexed) and _tied(
+            float(indexed[tie_end][1]), value, tie_abs_tol=tie_abs_tol
+        ):
+            tie_end += 1
+        average_rank = (index + 1 + tie_end) / 2.0
+        for original_index, _value in indexed[index:tie_end]:
+            ranks[original_index] = average_rank
+        index = tie_end
+    return ranks
+
+
+def _pearson(
+    left: Sequence[float],
+    right: Sequence[float],
+    *,
+    degenerate: float | None,
+) -> float | None:
+    """Return Pearson correlation, or the caller-selected degenerate value."""
+    if len(left) != len(right) or len(left) < 2:
+        return degenerate
+    left_mean = math.fsum(left) / len(left)
+    right_mean = math.fsum(right) / len(right)
+    left_centered = [value - left_mean for value in left]
+    right_centered = [value - right_mean for value in right]
+    numerator = math.fsum(
+        left_value * right_value
+        for left_value, right_value in zip(left_centered, right_centered, strict=True)
+    )
+    left_norm = math.sqrt(math.fsum(value * value for value in left_centered))
+    right_norm = math.sqrt(math.fsum(value * value for value in right_centered))
+    if left_norm <= 0.0 or right_norm <= 0.0:
+        return degenerate
+    return float(numerator / (left_norm * right_norm))
+
+
+def _tied(left: float, right: float, *, tie_abs_tol: float) -> bool:
+    """Return whether two values are tied under the requested tolerance."""
+    if tie_abs_tol <= 0.0:
+        return left == right
+    return math.isclose(left, right, rel_tol=0.0, abs_tol=tie_abs_tol)

--- a/robot_sf/benchmark/scenario_difficulty.py
+++ b/robot_sf/benchmark/scenario_difficulty.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 
 import yaml
 
+from robot_sf.benchmark.rank_metrics import rank_by, spearman_from_rank_maps
+
 if TYPE_CHECKING:
     from pathlib import Path
 
@@ -168,25 +170,10 @@ def _normalized_ranks(
     """
     if not values_by_key:
         return {}
-    if higher_is_harder:
-        ordered = sorted(values_by_key.items(), key=lambda item: (item[1], item[0]))
-    else:
-        ordered = sorted(values_by_key.items(), key=lambda item: (-item[1], item[0]))
-    if len(ordered) == 1:
-        return {ordered[0][0]: 0.0}
-
-    out: dict[str, float] = {}
-    start = 0
-    while start < len(ordered):
-        end = start + 1
-        while end < len(ordered) and ordered[end][1] == ordered[start][1]:
-            end += 1
-        average_rank = (start + end - 1) / 2.0
-        normalized = float(average_rank / (len(ordered) - 1))
-        for key, _value in ordered[start:end]:
-            out[key] = normalized
-        start = end
-    return out
+    if len(values_by_key) == 1:
+        return {next(iter(values_by_key)): 0.0}
+    ranks = rank_by(values_by_key, higher_is_better=not higher_is_harder)
+    return {key: float((rank - 1.0) / (len(values_by_key) - 1)) for key, rank in ranks.items()}
 
 
 def _planner_row_index(planner_rows: Sequence[Mapping[str, Any]]) -> dict[str, dict[str, Any]]:
@@ -468,34 +455,6 @@ def _planner_quality_rows(
     return output
 
 
-def _spearman_rank_correlation(
-    full_rows: Sequence[Mapping[str, Any]],
-    subset_rows: Sequence[Mapping[str, Any]],
-) -> float | None:
-    """Compare planner ordering between full and subset summary rows.
-
-    Returns:
-        float | None: Spearman rank correlation, or ``None`` with fewer than two
-        overlapping planner keys.
-    """
-    full_ranks = {
-        str(row.get("planner_key")): index + 1
-        for index, row in enumerate(full_rows)
-        if isinstance(row.get("planner_key"), str)
-    }
-    subset_ranks = {
-        str(row.get("planner_key")): index + 1
-        for index, row in enumerate(subset_rows)
-        if isinstance(row.get("planner_key"), str)
-    }
-    common = sorted(set(full_ranks) & set(subset_ranks))
-    n = len(common)
-    if n < 2:
-        return None
-    d_squared = sum((full_ranks[key] - subset_ranks[key]) ** 2 for key in common)
-    return float(1.0 - ((6.0 * d_squared) / (n * (n * n - 1))))
-
-
 def _planner_selection_rows(
     scenario_rows: Sequence[Mapping[str, Any]],
     planner_index: Mapping[str, Mapping[str, Any]],
@@ -571,7 +530,17 @@ def _verified_simple_assessment(
     ]
     full_planner_rows = _planner_quality_rows(selected_full_rows)
     subset_planner_rows = _planner_quality_rows(selected_subset_rows)
-    rank_correlation = _spearman_rank_correlation(full_planner_rows, subset_planner_rows)
+    full_ranks = {
+        str(row.get("planner_key")): index + 1
+        for index, row in enumerate(full_planner_rows)
+        if isinstance(row.get("planner_key"), str)
+    }
+    subset_ranks = {
+        str(row.get("planner_key")): index + 1
+        for index, row in enumerate(subset_planner_rows)
+        if isinstance(row.get("planner_key"), str)
+    }
+    rank_correlation = spearman_from_rank_maps(full_ranks, subset_ranks, degenerate=None)
 
     full_noise = _mean(
         _safe_float(row.get("seed_success_ci_half_width")) for row in selected_full_rows

--- a/robot_sf/benchmark/snqi/bootstrap.py
+++ b/robot_sf/benchmark/snqi/bootstrap.py
@@ -14,6 +14,8 @@ from collections import defaultdict
 from collections.abc import Iterable, Mapping
 from typing import Any
 
+from robot_sf.benchmark.rank_metrics import rank_by, spearman
+
 __all__ = ["bootstrap_stability"]
 
 
@@ -62,7 +64,8 @@ def bootstrap_stability(
 
     baseline_means = {group: _mean(scores) for group, scores in grouped.items()}
     baseline_ordering = _ordering(baseline_means)
-    baseline_ranks = _rank_vector(baseline_ordering, baseline_means)
+    baseline_ranks_by_group = rank_by(baseline_means, higher_is_better=True, tie_abs_tol=1e-12)
+    baseline_ranks = [baseline_ranks_by_group[group] for group in baseline_ordering]
     correlations: list[float] = []
     sampled_orderings: list[list[str]] = []
     for _ in range(samples):
@@ -71,8 +74,14 @@ def bootstrap_stability(
         }
         sample_ordering = _ordering(sample_means)
         sampled_orderings.append(sample_ordering)
-        sample_ranks = _rank_vector(baseline_ordering, sample_means)
-        correlations.append(_spearman(baseline_ranks, sample_ranks))
+        sample_ranks_by_group = rank_by(sample_means, higher_is_better=True, tie_abs_tol=1e-12)
+        sample_ranks = [sample_ranks_by_group[group] for group in baseline_ordering]
+        correlation = spearman(baseline_ranks, sample_ranks, degenerate=None, tie_abs_tol=1e-12)
+        correlations.append(
+            float(correlation)
+            if correlation is not None
+            else (1.0 if baseline_ranks == sample_ranks else 0.0)
+        )
 
     raw_mean = _mean(correlations)
     normalized = (raw_mean + 1.0) / 2.0
@@ -157,45 +166,6 @@ def _mean(values: Iterable[float]) -> float:
 def _ordering(means: Mapping[str, float]) -> list[str]:
     """Return deterministic descending SNQI ordering."""
     return sorted(means, key=lambda group: (-float(means[group]), group))
-
-
-def _rank_vector(ordering: list[str], means: Mapping[str, float]) -> list[float]:
-    """Return average ranks for groups in baseline-ordering order."""
-    sorted_groups = _ordering(means)
-    ranks_by_group: dict[str, float] = {}
-    position = 0
-    while position < len(sorted_groups):
-        group = sorted_groups[position]
-        value = float(means[group])
-        end = position + 1
-        while end < len(sorted_groups) and math.isclose(
-            float(means[sorted_groups[end]]),
-            value,
-            rel_tol=0.0,
-            abs_tol=1e-12,
-        ):
-            end += 1
-        average_rank = (position + 1 + end) / 2.0
-        for tied_group in sorted_groups[position:end]:
-            ranks_by_group[tied_group] = average_rank
-        position = end
-    return [ranks_by_group[group] for group in ordering]
-
-
-def _spearman(left: list[float], right: list[float]) -> float:
-    """Return Spearman correlation for two rank vectors."""
-    if len(left) != len(right) or len(left) < 2:
-        raise ValueError("Spearman correlation requires equal vectors with at least two entries")
-    left_mean = _mean(left)
-    right_mean = _mean(right)
-    left_centered = [value - left_mean for value in left]
-    right_centered = [value - right_mean for value in right]
-    numerator = sum(a * b for a, b in zip(left_centered, right_centered, strict=True))
-    left_norm = math.sqrt(sum(value * value for value in left_centered))
-    right_norm = math.sqrt(sum(value * value for value in right_centered))
-    if left_norm == 0.0 or right_norm == 0.0:
-        return 1.0 if left == right else 0.0
-    return float(numerator / (left_norm * right_norm))
 
 
 def _clamp01(value: float) -> float:

--- a/robot_sf/benchmark/snqi/campaign_contract.py
+++ b/robot_sf/benchmark/snqi/campaign_contract.py
@@ -10,6 +10,7 @@ from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from robot_sf.benchmark.rank_metrics import spearman
 from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES, compute_snqi, normalize_metric
 
 if TYPE_CHECKING:
@@ -223,53 +224,14 @@ def compute_baseline_stats_from_episodes(
     return sanitized, warnings
 
 
-def _rank(values: Sequence[float]) -> list[float]:
-    """Return one-based tie-aware ranks for Spearman correlation.
-
-    Returns:
-        list[float]: Ranks in the original value order, averaging ties.
-    """
-    indexed = sorted(enumerate(values), key=lambda item: item[1])
-    ranks = [0.0] * len(values)
-    i = 0
-    while i < len(indexed):
-        j = i
-        while j + 1 < len(indexed) and indexed[j + 1][1] == indexed[i][1]:
-            j += 1
-        avg_rank = (i + j + 2) / 2.0
-        for k in range(i, j + 1):
-            ranks[indexed[k][0]] = avg_rank
-        i = j + 1
-    return ranks
-
-
-def _pearson(x: Sequence[float], y: Sequence[float]) -> float:
-    """Compute Pearson correlation over two numeric sequences.
-
-    Returns:
-        float: Correlation coefficient, or ``0.0`` for degenerate inputs.
-    """
-    if len(x) != len(y) or len(x) < 2:
-        return 0.0
-    mx = sum(x) / len(x)
-    my = sum(y) / len(y)
-    cov = sum((a - mx) * (b - my) for a, b in zip(x, y, strict=False))
-    vx = sum((a - mx) ** 2 for a in x)
-    vy = sum((b - my) ** 2 for b in y)
-    if vx <= 0.0 or vy <= 0.0:
-        return 0.0
-    return float(cov / math.sqrt(vx * vy))
-
-
 def spearman_correlation(x: Sequence[float], y: Sequence[float]) -> float:
     """Compute Spearman rank correlation without SciPy dependency.
 
     Returns:
         Correlation coefficient in ``[-1, 1]``.
     """
-    if len(x) != len(y) or len(x) < 2:
-        return 0.0
-    return _pearson(_rank(list(x)), _rank(list(y)))
+    result = spearman(x, y, degenerate=0.0)
+    return float(result)
 
 
 def _target_quality(row: Mapping[str, Any]) -> float:

--- a/scripts/tools/analyze_seed_sufficiency.py
+++ b/scripts/tools/analyze_seed_sufficiency.py
@@ -14,6 +14,8 @@ from typing import Any
 
 import matplotlib
 
+from robot_sf.benchmark.rank_metrics import rank_order
+
 matplotlib.use("Agg")
 from matplotlib import pyplot as plt
 
@@ -210,7 +212,12 @@ def _build_rank_rows(campaigns: list[dict[str, Any]], *, rank_metric: str) -> li
     rows: list[dict[str, Any]] = []
     for campaign in campaigns:
         values = _planner_metric_values(campaign, rank_metric)
-        ranks = _rank_values(values, higher_is_better=_higher_is_better(rank_metric))
+        ranks = {
+            planner: index + 1
+            for index, planner in enumerate(
+                rank_order(values, higher_is_better=_higher_is_better(rank_metric))
+            )
+        }
         for planner_key in sorted(values):
             previous_rank = previous_ranks.get(planner_key)
             rank = ranks[planner_key]
@@ -319,29 +326,10 @@ def _family_planner_values(campaign: dict[str, Any], metric: str) -> dict[str, d
     }
 
 
-def _rank_values(values: dict[str, float], *, higher_is_better: bool) -> dict[str, int]:
-    """Assign deterministic competition ranks."""
-
-    ordered = sorted(
-        values,
-        key=lambda planner: (
-            -values[planner] if higher_is_better else values[planner],
-            planner,
-        ),
-    )
-    return {planner: index + 1 for index, planner in enumerate(ordered)}
-
-
 def _winner(values: dict[str, float], *, higher_is_better: bool) -> str:
     """Return the deterministic winning planner for a value mapping."""
 
-    return sorted(
-        values,
-        key=lambda planner: (
-            -values[planner] if higher_is_better else values[planner],
-            planner,
-        ),
-    )[0]
+    return rank_order(values, higher_is_better=higher_is_better)[0]
 
 
 def _metric_summary(row: dict[str, Any], metric: str) -> dict[str, Any]:

--- a/scripts/tools/analyze_snqi_vs_single_metric_ranking.py
+++ b/scripts/tools/analyze_snqi_vs_single_metric_ranking.py
@@ -28,7 +28,12 @@ import sys
 from pathlib import Path
 from typing import Any
 
-from robot_sf.benchmark.snqi.campaign_contract import spearman_correlation
+from robot_sf.benchmark.rank_metrics import (
+    kendall_tau,
+    rank_order,
+    spearman_from_order,
+    top_tied,
+)
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -101,7 +106,9 @@ def _load_planner_rows(campaign_root: Path, *, core_only: bool) -> list[dict[str
     return rows
 
 
-def _rank_by(rows: list[dict[str, Any]], *, key: str, ascending: bool) -> tuple[list[str], bool]:
+def _metric_order_and_top_tie(
+    rows: list[dict[str, Any]], *, key: str, ascending: bool
+) -> tuple[list[str], bool]:
     """Return the planner_key ranking and whether the top raw value is tied.
 
     ``ascending=True`` means smaller raw value is better (e.g. collisions);
@@ -110,85 +117,55 @@ def _rank_by(rows: list[dict[str, Any]], *, key: str, ascending: bool) -> tuple[
     ``top_tied`` lets consumers distinguish real winner disagreements from
     alphabetical tie-breaking.
     """
-    indexed = list(rows)
-    indexed.sort(
-        key=lambda row: (row[key] if ascending else -row[key], row["planner_key"]),
-    )
-    if not indexed:
+    values = {str(row["planner_key"]): float(row[key]) for row in rows}
+    if not values:
         return [], False
-    best_value = indexed[0][key]
-    top_tied = sum(math.isclose(row[key], best_value, abs_tol=1e-12) for row in indexed) > 1
-    return [row["planner_key"] for row in indexed], top_tied
-
-
-def _kendall_tau(order_a: list[str], order_b: list[str]) -> float:
-    """Kendall tau between two rankings of the same planner set.
-
-    Computed directly from the rank indices so we avoid depending on SciPy.
-    Returns 0.0 when fewer than two planners are present.
-    """
-    if len(order_a) < 2 or set(order_a) != set(order_b):
-        return 0.0
-    index_b = {planner: idx for idx, planner in enumerate(order_b)}
-    ranks_a = list(range(len(order_a)))
-    ranks_b = [index_b[planner] for planner in order_a]
-    concordant = 0
-    discordant = 0
-    n = len(order_a)
-    for i in range(n):
-        for j in range(i + 1, n):
-            diff_a = ranks_a[i] - ranks_a[j]
-            diff_b = ranks_b[i] - ranks_b[j]
-            product = diff_a * diff_b
-            if product > 0:
-                concordant += 1
-            elif product < 0:
-                discordant += 1
-    total = concordant + discordant
-    if total == 0:
-        return 0.0
-    return (concordant - discordant) / total
-
-
-def _spearman_rank(order_a: list[str], order_b: list[str]) -> float:
-    """Spearman rho between two planner orderings."""
-    if len(order_a) < 2 or set(order_a) != set(order_b):
-        return 0.0
-    index_b = {planner: idx for idx, planner in enumerate(order_b)}
-    x = list(range(len(order_a)))
-    y = [index_b[planner] for planner in order_a]
-    return spearman_correlation(x, y)
+    higher_is_better = not ascending
+    return (
+        [str(planner) for planner in rank_order(values, higher_is_better=higher_is_better)],
+        top_tied(values, higher_is_better=higher_is_better, tie_abs_tol=1e-12),
+    )
 
 
 def _build_analysis(rows: list[dict[str, Any]]) -> dict[str, Any]:
     """Build the cross-ranking comparison payload."""
-    snqi_order, snqi_top_tied = _rank_by(rows, key="snqi_mean", ascending=False)
-    success_order, success_top_tied = _rank_by(rows, key="success_mean", ascending=False)
-    collisions_order, collisions_top_tied = _rank_by(rows, key="collisions_mean", ascending=True)
-    near_misses_order, near_misses_top_tied = _rank_by(rows, key="near_misses_mean", ascending=True)
+    snqi_order, snqi_top_tied = _metric_order_and_top_tie(rows, key="snqi_mean", ascending=False)
+    success_order, success_top_tied = _metric_order_and_top_tie(
+        rows, key="success_mean", ascending=False
+    )
+    collisions_order, collisions_top_tied = _metric_order_and_top_tie(
+        rows, key="collisions_mean", ascending=True
+    )
+    near_misses_order, near_misses_top_tied = _metric_order_and_top_tie(
+        rows, key="near_misses_mean", ascending=True
+    )
     comparisons = {
         "success_mean": {
             "description": "Ranking by mean success (higher is better).",
             "order": success_order,
             "top_tied": success_top_tied,
-            "kendall_tau_vs_snqi": _kendall_tau(snqi_order, success_order),
-            "spearman_rho_vs_snqi": _spearman_rank(snqi_order, success_order),
+            "kendall_tau_vs_snqi": kendall_tau(snqi_order, success_order, degenerate=0.0),
+            "spearman_rho_vs_snqi": spearman_from_order(snqi_order, success_order, degenerate=0.0),
             "winner_agrees_with_snqi": success_order[0] == snqi_order[0],
         },
         "collisions_mean": {
             "description": "Ranking by mean collisions (lower is better).",
             "order": collisions_order,
             "top_tied": collisions_top_tied,
-            "kendall_tau_vs_snqi": _kendall_tau(snqi_order, collisions_order),
-            "spearman_rho_vs_snqi": _spearman_rank(snqi_order, collisions_order),
+            "kendall_tau_vs_snqi": kendall_tau(snqi_order, collisions_order, degenerate=0.0),
+            "spearman_rho_vs_snqi": spearman_from_order(
+                snqi_order, collisions_order, degenerate=0.0
+            ),
             "winner_agrees_with_snqi": collisions_order[0] == snqi_order[0],
         },
         "near_misses_mean": {
             "description": "Ranking by mean near-misses (lower is better).",
             "order": near_misses_order,
             "top_tied": near_misses_top_tied,
-            "kendall_tau_vs_snqi": _kendall_tau(snqi_order, near_misses_order),
-            "spearman_rho_vs_snqi": _spearman_rank(snqi_order, near_misses_order),
+            "kendall_tau_vs_snqi": kendall_tau(snqi_order, near_misses_order, degenerate=0.0),
+            "spearman_rho_vs_snqi": spearman_from_order(
+                snqi_order, near_misses_order, degenerate=0.0
+            ),
             "winner_agrees_with_snqi": near_misses_order[0] == snqi_order[0],
         },
     }

--- a/scripts/tools/compare_seed_schedule_campaigns.py
+++ b/scripts/tools/compare_seed_schedule_campaigns.py
@@ -11,6 +11,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
+from robot_sf.benchmark.rank_metrics import kendall_tau_by_value, spearman_by_value
+
 _SEED_METRICS: tuple[str, ...] = (
     "success",
     "collisions",
@@ -432,110 +434,6 @@ def _aggregate_metric_means(
     }
 
 
-def _rank_values(
-    values: dict[tuple[str, str], float], *, higher_is_better: bool
-) -> dict[tuple[str, str], float]:
-    """Assign average ranks to planner values with tie handling.
-
-    Returns:
-        Mapping from planner key to rank.
-    """
-    ordered = sorted(
-        values.items(),
-        key=lambda item: (-item[1] if higher_is_better else item[1], item[0][0], item[0][1]),
-    )
-    ranks: dict[tuple[str, str], float] = {}
-    index = 0
-    while index < len(ordered):
-        value = ordered[index][1]
-        tie_end = index + 1
-        while tie_end < len(ordered) and ordered[tie_end][1] == value:
-            tie_end += 1
-        average_rank = (index + 1 + tie_end) / 2.0
-        for tied_index in range(index, tie_end):
-            ranks[ordered[tied_index][0]] = average_rank
-        index = tie_end
-    return ranks
-
-
-def _pearson(xs: list[float], ys: list[float]) -> float | None:
-    """Compute Pearson correlation for paired values.
-
-    Returns:
-        Correlation coefficient, or ``None`` for insufficient/constant data.
-    """
-    if len(xs) != len(ys) or len(xs) < 2:
-        return None
-    x_mean = sum(xs) / len(xs)
-    y_mean = sum(ys) / len(ys)
-    x_centered = [value - x_mean for value in xs]
-    y_centered = [value - y_mean for value in ys]
-    numerator = sum(x * y for x, y in zip(x_centered, y_centered, strict=True))
-    x_den = math.sqrt(sum(x * x for x in x_centered))
-    y_den = math.sqrt(sum(y * y for y in y_centered))
-    if x_den <= 1e-12 or y_den <= 1e-12:
-        return None
-    return float(numerator / (x_den * y_den))
-
-
-def _spearman(
-    base_values: dict[tuple[str, str], float],
-    candidate_values: dict[tuple[str, str], float],
-    *,
-    higher_is_better: bool,
-) -> float | None:
-    """Compute Spearman rank correlation for paired planner metrics.
-
-    Returns:
-        Rank correlation, or ``None`` when unavailable.
-    """
-    common = sorted(set(base_values) & set(candidate_values))
-    if len(common) < 2:
-        return None
-    base_ranks = _rank_values(
-        {key: base_values[key] for key in common},
-        higher_is_better=higher_is_better,
-    )
-    candidate_ranks = _rank_values(
-        {key: candidate_values[key] for key in common},
-        higher_is_better=higher_is_better,
-    )
-    return _pearson([base_ranks[key] for key in common], [candidate_ranks[key] for key in common])
-
-
-def _kendall_tau(
-    base_values: dict[tuple[str, str], float],
-    candidate_values: dict[tuple[str, str], float],
-    *,
-    higher_is_better: bool,
-) -> float | None:
-    """Compute Kendall tau over common planner metric values.
-
-    Returns:
-        Kendall tau, or ``None`` when there are no comparable pairs.
-    """
-    common = sorted(set(base_values) & set(candidate_values))
-    if len(common) < 2:
-        return None
-    concordant = 0
-    discordant = 0
-    multiplier = 1.0 if higher_is_better else -1.0
-    for index, left in enumerate(common):
-        for right in common[index + 1 :]:
-            base_delta = multiplier * (base_values[left] - base_values[right])
-            candidate_delta = multiplier * (candidate_values[left] - candidate_values[right])
-            if abs(base_delta) <= 1e-12 or abs(candidate_delta) <= 1e-12:
-                continue
-            if base_delta * candidate_delta > 0:
-                concordant += 1
-            else:
-                discordant += 1
-    total = concordant + discordant
-    if total == 0:
-        return None
-    return float((concordant - discordant) / total)
-
-
 def _ranking_stability(
     base_planner_rows: dict[tuple[str, str], dict[str, Any]],
     candidate_planner_rows: dict[tuple[str, str], dict[str, Any]],
@@ -585,8 +483,19 @@ def _ranking_stability(
             ),
         )
     ]
-    tau = _kendall_tau(base_values, candidate_values, higher_is_better=higher_is_better)
-    rho = _spearman(base_values, candidate_values, higher_is_better=higher_is_better)
+    tau = kendall_tau_by_value(
+        base_values,
+        candidate_values,
+        higher_is_better=higher_is_better,
+        degenerate=None,
+        tie_abs_tol=1e-12,
+    )
+    rho = spearman_by_value(
+        base_values,
+        candidate_values,
+        higher_is_better=higher_is_better,
+        degenerate=None,
+    )
     status = "insufficient_data"
     if tau is not None:
         status = "stable" if tau >= min_tau else "unstable"

--- a/tests/benchmark/test_rank_metrics.py
+++ b/tests/benchmark/test_rank_metrics.py
@@ -1,0 +1,96 @@
+"""Characterization tests for shared rank-correlation helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.rank_metrics import (
+    kendall_tau,
+    kendall_tau_by_value,
+    rank_by,
+    rank_order,
+    spearman,
+    spearman_by_value,
+    spearman_from_order,
+    spearman_from_rank_maps,
+    top_tied,
+)
+
+
+def test_rank_by_uses_average_ties_and_direction() -> None:
+    """Average-rank semantics match the legacy benchmark helper convention."""
+    values = {"beta": 2.0, "alpha": 2.0, "gamma": 1.0}
+
+    assert rank_by(values, higher_is_better=True) == {
+        "alpha": 1.5,
+        "beta": 1.5,
+        "gamma": 3.0,
+    }
+    assert rank_by(values, higher_is_better=False) == {
+        "gamma": 1.0,
+        "alpha": 2.5,
+        "beta": 2.5,
+    }
+
+
+def test_rank_order_and_top_tied_preserve_metric_ranking_script_behavior() -> None:
+    """Ordering stays deterministic while top-tie detection ignores name tie-breaks."""
+    values = {"zulu": 1.0, "alpha": 1.0, "middle": 0.5}
+
+    assert rank_order(values, higher_is_better=True) == ["alpha", "zulu", "middle"]
+    assert top_tied(values, higher_is_better=True, tie_abs_tol=1e-12) is True
+    assert top_tied({"zulu": 1.0, "alpha": 0.9}, higher_is_better=True) is False
+
+
+def test_spearman_matches_legacy_degenerate_and_tie_contracts() -> None:
+    """Numeric Spearman keeps the SNQI campaign contract degenerate behavior."""
+    assert spearman([1.0, 2.0, 3.0], [1.0, 2.0, 3.0]) == pytest.approx(1.0)
+    assert spearman([1.0, 2.0, 3.0], [3.0, 2.0, 1.0]) == pytest.approx(-1.0)
+    assert spearman([1.0], [1.0], degenerate=0.0) == 0.0
+    assert spearman([1.0, 1.0], [1.0, 2.0], degenerate=None) is None
+
+
+def test_order_correlations_match_prior_order_index_helpers() -> None:
+    """Order-based helpers match the prior script-local index comparison."""
+    left = ["a", "b", "c"]
+    swapped = ["b", "a", "c"]
+
+    assert spearman_from_order(left, swapped, degenerate=0.0) == pytest.approx(0.5)
+    assert kendall_tau(left, swapped, degenerate=0.0) == pytest.approx(1.0 / 3.0)
+    assert kendall_tau(left, list(reversed(left)), degenerate=0.0) == pytest.approx(-1.0)
+    assert kendall_tau(["a"], ["a"], degenerate=1.0) == 1.0
+
+
+def test_rank_map_spearman_preserves_absolute_rank_position_contract() -> None:
+    """Rank-map Spearman keeps scenario-difficulty's prior non-renormalized overlap behavior."""
+    assert spearman_from_rank_maps({"b": 2, "c": 3}, {"b": 1, "c": 2}, degenerate=None) == -1.0
+    assert spearman_from_rank_maps({"only": 1}, {"only": 1}, degenerate=None) is None
+
+
+def test_value_correlations_preserve_seed_schedule_tie_handling() -> None:
+    """Value-map helpers preserve average Spearman ranks and tie-skipping Kendall tau."""
+    base = {("alpha", "dd"): 1.0, ("beta", "dd"): 1.0, ("gamma", "dd"): 3.0}
+    candidate = {("alpha", "dd"): 1.0, ("beta", "dd"): 2.0, ("gamma", "dd"): 3.0}
+
+    assert spearman_by_value(
+        base,
+        candidate,
+        higher_is_better=True,
+        degenerate=None,
+    ) == pytest.approx(0.8660254038)
+    assert kendall_tau_by_value(
+        base,
+        candidate,
+        higher_is_better=True,
+        degenerate=None,
+        tie_abs_tol=1e-12,
+    ) == pytest.approx(1.0)
+    assert (
+        kendall_tau_by_value(
+            {"alpha": 1.0, "beta": 1.0},
+            {"alpha": 2.0, "beta": 2.0},
+            higher_is_better=True,
+            degenerate=None,
+        )
+        is None
+    )

--- a/tests/benchmark/test_scenario_difficulty.py
+++ b/tests/benchmark/test_scenario_difficulty.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from robot_sf.benchmark.rank_metrics import spearman_from_rank_maps
 from robot_sf.benchmark.scenario_difficulty import (
     _build_seed_index,
     _difficulty_weighted_score,
@@ -24,7 +25,6 @@ from robot_sf.benchmark.scenario_difficulty import (
     _safe_float,
     _scenario_family,
     _seed_field,
-    _spearman_rank_correlation,
     _verified_simple_assessment,
     build_scenario_difficulty_analysis,
 )
@@ -538,13 +538,7 @@ def test_planner_quality_and_selection_helpers_cover_sparse_inputs() -> None:
     assert reason == "all planners (fallback: no eligible core set)"
     assert selected[0]["planner_key"] == "goal"
 
-    assert (
-        _spearman_rank_correlation(
-            [{"planner_key": "goal"}],
-            [{"planner_key": "goal"}],
-        )
-        is None
-    )
+    assert spearman_from_rank_maps({"goal": 1}, {"goal": 1}, degenerate=None) is None
 
 
 def test_benchmark_success_and_consensus_filters_cover_failure_modes() -> None:


### PR DESCRIPTION
## Summary
- adds shared `robot_sf.benchmark.rank_metrics` helpers for rank ordering, Spearman, and Kendall tau variants
- migrates scenario difficulty, SNQI bootstrap/contract, fidelity rank stability, seed sufficiency, SNQI comparison, and seed-schedule comparison call sites away from duplicated private helpers
- adds characterization tests for tie handling, degenerate behavior, order correlations, rank-map behavior, and value-map correlations

Closes #3246

## Validation
- `uv run python -m pytest tests/benchmark/test_rank_metrics.py tests/benchmark/test_scenario_difficulty.py tests/test_snqi/test_bootstrap_stability.py tests/tools/test_compare_seed_schedule_campaigns.py tests/tools/test_analyze_snqi_vs_single_metric_ranking.py tests/benchmark/test_fidelity_rank_stability.py -q` -> 45 passed
- `uv run ruff check robot_sf/benchmark/rank_metrics.py robot_sf/benchmark/fidelity_rank_stability.py robot_sf/benchmark/scenario_difficulty.py robot_sf/benchmark/snqi/bootstrap.py robot_sf/benchmark/snqi/campaign_contract.py scripts/tools/analyze_seed_sufficiency.py scripts/tools/analyze_snqi_vs_single_metric_ranking.py scripts/tools/compare_seed_schedule_campaigns.py tests/benchmark/test_rank_metrics.py tests/benchmark/test_scenario_difficulty.py` -> passed
- `uv run ruff format --check robot_sf/benchmark/rank_metrics.py robot_sf/benchmark/fidelity_rank_stability.py robot_sf/benchmark/scenario_difficulty.py robot_sf/benchmark/snqi/bootstrap.py robot_sf/benchmark/snqi/campaign_contract.py scripts/tools/analyze_seed_sufficiency.py scripts/tools/analyze_snqi_vs_single_metric_ranking.py scripts/tools/compare_seed_schedule_campaigns.py tests/benchmark/test_rank_metrics.py tests/benchmark/test_scenario_difficulty.py` -> 10 files already formatted
- `git diff --check` -> clean

## Notes
- Full `pr_ready_check` not run locally; this is a benchmark-tooling refactor with focused rank/SNQI/scenario/seed-schedule validation plus GitHub CI.
