### PR TITLE
training: add crossing-conflict predictive mixing spec (#3214)

### DIFF
--- a/configs/training/predictive/predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml
+++ b/configs/training/predictive/predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml
@@ -1,0 +1,33 @@
+# Crossing-conflict hard-case predictive mixing spec for issue #3214.
+#
+# Scope boundary: this is launch/config/tooling only. It does not publish a
+# retrained checkpoint, hard-seed benchmark evidence, or a model-improvement
+# claim. A later SLURM training run must record its own dataset summary,
+# checkpoint provenance, and closed-loop benchmark evidence before making any
+# result claim.
+
+profile_id: crossing_conflict_hardcase_repeat_v1
+issue: "#3214"
+scope: launch_config_tooling_only
+claim_boundary: >
+  Launch/config/tooling only: no retrained checkpoint, no hard-seed benchmark
+  evidence, and no predictive model-improvement claim.
+
+weighting:
+  rule: repeat_hardcase_rows
+  hardcase_family: crossing_conflict
+  hardcase_repeat: 8
+  shuffle_seed: 3214
+
+compatibility_contract:
+  require_feature_schema_json_for_ego_conditioned: true
+  require_matching_predictive_feature_schema: true
+  require_matching_ego_motion_channel_producer: true
+  summary_fields:
+    - base_count
+    - hard_case_count
+    - output_count
+    - weighting_profile
+    - weighting_rule
+    - shuffle_seed
+    - feature_compatibility

--- a/scripts/training/build_predictive_mixed_dataset.py
+++ b/scripts/training/build_predictive_mixed_dataset.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 import numpy as np
+import yaml
 
 from robot_sf.planner.obstacle_features import (
     PREDICTIVE_EGO_FEATURE_DIM,
@@ -17,20 +18,94 @@ from robot_sf.planner.obstacle_features import (
     predictive_ego_motion_channel_producer_key,
 )
 
+DEFAULT_HARDCASE_REPEAT = 2
+DEFAULT_SHUFFLE_SEED = 42
+DEFAULT_WEIGHTING_PROFILE_ID = "cli_hardcase_repeat_v1"
+
 
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments for dataset mixing."""
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--base-dataset", type=Path, required=True)
     parser.add_argument("--hardcase-dataset", type=Path, required=True)
-    parser.add_argument("--hardcase-repeat", type=int, default=2)
+    parser.add_argument("--hardcase-repeat", type=int)
+    parser.add_argument(
+        "--weighting-spec",
+        type=Path,
+        help=(
+            "Optional YAML/JSON spec describing the hard-case weighting profile. "
+            "Explicit --hardcase-repeat and --shuffle-seed values override spec values."
+        ),
+    )
     parser.add_argument(
         "--output",
         type=Path,
         default=Path("output/tmp/predictive_planner/datasets/predictive_rollouts_mixed_v1.npz"),
     )
-    parser.add_argument("--shuffle-seed", type=int, default=42)
+    parser.add_argument("--shuffle-seed", type=int)
     return parser.parse_args()
+
+
+def _read_weighting_spec(path: Path) -> dict[str, Any]:
+    """Read a hard-case weighting spec from YAML or JSON and return a mapping."""
+    with path.open(encoding="utf-8") as handle:
+        if path.suffix.lower() == ".json":
+            payload = json.load(handle)
+        else:
+            payload = yaml.safe_load(handle)
+    if not isinstance(payload, dict):
+        raise TypeError(f"Weighting spec must be a mapping: {path}")
+    return payload
+
+
+def _resolve_weighting_profile(args: argparse.Namespace) -> dict[str, Any]:
+    """Resolve CLI/spec weighting into one deterministic profile summary."""
+    spec_path = getattr(args, "weighting_spec", None)
+    spec = _read_weighting_spec(spec_path) if spec_path is not None else {}
+    weighting = spec.get("weighting", {})
+    if not isinstance(weighting, dict):
+        raise TypeError(f"weighting must be a mapping in weighting spec: {spec_path}")
+
+    rule = str(weighting.get("rule") or "repeat_hardcase_rows")
+    if rule != "repeat_hardcase_rows":
+        raise ValueError(
+            f"Unsupported hard-case weighting rule {rule!r}; expected 'repeat_hardcase_rows'."
+        )
+
+    hardcase_repeat_raw = (
+        args.hardcase_repeat
+        if getattr(args, "hardcase_repeat", None) is not None
+        else weighting.get("hardcase_repeat", DEFAULT_HARDCASE_REPEAT)
+    )
+    shuffle_seed_raw = (
+        args.shuffle_seed
+        if getattr(args, "shuffle_seed", None) is not None
+        else weighting.get("shuffle_seed", DEFAULT_SHUFFLE_SEED)
+    )
+    hardcase_repeat = int(hardcase_repeat_raw)
+    shuffle_seed = int(shuffle_seed_raw)
+    if hardcase_repeat < 1:
+        raise ValueError("--hardcase-repeat must be >= 1")
+
+    profile_id = str(
+        spec.get("profile_id") or weighting.get("profile_id") or DEFAULT_WEIGHTING_PROFILE_ID
+    )
+    hardcase_family = str(weighting.get("hardcase_family") or "unspecified")
+    claim_boundary = str(
+        spec.get("claim_boundary")
+        or "launch/config/tooling only; no retrained checkpoint, hard-seed benchmark evidence, "
+        "or model-improvement claim"
+    )
+    return {
+        "profile_id": profile_id,
+        "spec_path": str(spec_path) if spec_path is not None else None,
+        "rule": rule,
+        "hardcase_repeat": hardcase_repeat,
+        "hardcase_family": hardcase_family,
+        "shuffle_seed": shuffle_seed,
+        "claim_boundary": claim_boundary,
+        "source": "weighting_spec" if spec_path is not None else "cli_defaults",
+    }
 
 
 def _load_optional_feature_schema_metadata(raw: Any, *, path: Path) -> dict[str, Any] | None:
@@ -188,8 +263,7 @@ def _load_npz(
 def main() -> int:
     """Create mixed dataset and write metadata sidecar."""
     args = parse_args()
-    if int(args.hardcase_repeat) < 1:
-        raise ValueError("--hardcase-repeat must be >= 1")
+    weighting_profile = _resolve_weighting_profile(args)
 
     base_state, base_target, base_mask, base_target_mask, base_feature_schema = _load_npz(
         args.base_dataset
@@ -217,13 +291,35 @@ def main() -> int:
         base_input_dim=int(base_state.shape[2]),
         hardcase_input_dim=int(hard_state.shape[2]),
     )
+    feature_compatibility = {
+        "status": "compatible",
+        "base_input_dim": int(base_state.shape[2]),
+        "hardcase_input_dim": int(hard_state.shape[2]),
+        "feature_schema_required": bool(
+            _is_ego_conditioned_schema(base_feature_schema, input_dim=int(base_state.shape[2]))
+            or _is_ego_conditioned_schema(
+                hard_feature_schema,
+                input_dim=int(hard_state.shape[2]),
+            )
+        ),
+        "feature_schema_present": {
+            "base": base_feature_schema is not None,
+            "hardcase": hard_feature_schema is not None,
+        },
+        "feature_schema_contract": (
+            _feature_schema_contract(mixed_feature_schema)
+            if mixed_feature_schema is not None
+            else None
+        ),
+        "ego_motion_channel_producer": producer_summary,
+    }
     feature_schema_json = (
         json.dumps(mixed_feature_schema, sort_keys=True)
         if mixed_feature_schema is not None
         else None
     )
 
-    hard_rep = int(args.hardcase_repeat)
+    hard_rep = int(weighting_profile["hardcase_repeat"])
     state = np.concatenate([base_state, np.repeat(hard_state, hard_rep, axis=0)], axis=0)
     target = np.concatenate([base_target, np.repeat(hard_target, hard_rep, axis=0)], axis=0)
     mask = np.concatenate([base_mask, np.repeat(hard_mask, hard_rep, axis=0)], axis=0)
@@ -232,7 +328,7 @@ def main() -> int:
         axis=0,
     )
 
-    rng = np.random.default_rng(int(args.shuffle_seed))
+    rng = np.random.default_rng(int(weighting_profile["shuffle_seed"]))
     idx = np.arange(state.shape[0])
     rng.shuffle(idx)
     state = state[idx]
@@ -257,14 +353,20 @@ def main() -> int:
     summary = {
         "base_dataset": str(args.base_dataset),
         "hardcase_dataset": str(args.hardcase_dataset),
+        "base_count": int(base_state.shape[0]),
+        "hard_case_count": int(hard_state.shape[0]),
+        "output_count": int(state.shape[0]),
         "hardcase_repeat": hard_rep,
         "num_base_samples": int(base_state.shape[0]),
         "num_hardcase_samples": int(hard_state.shape[0]),
         "num_output_samples": int(state.shape[0]),
+        "weighting_profile": weighting_profile["profile_id"],
+        "weighting_rule": weighting_profile,
         "active_agent_ratio": float(np.mean(mask)),
         "active_target_ratio": float(np.mean(target_mask)),
-        "shuffle_seed": int(args.shuffle_seed),
+        "shuffle_seed": int(weighting_profile["shuffle_seed"]),
         "output": str(args.output),
+        "feature_compatibility": feature_compatibility,
         "feature_schema": mixed_feature_schema,
         "feature_schema_json": feature_schema_json,
         "ego_motion_channel_producer": producer_summary,

--- a/scripts/training/run_predictive_training_pipeline.py
+++ b/scripts/training/run_predictive_training_pipeline.py
@@ -815,23 +815,29 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
     mixing_cfg = cfg.get("mixing", {})
     if not isinstance(mixing_cfg, dict):
         raise TypeError("mixing must be a mapping")
-    _run(
-        [
-            sys.executable,
-            "scripts/training/build_predictive_mixed_dataset.py",
-            "--base-dataset",
-            str(paths.base_dataset),
-            "--hardcase-dataset",
-            str(paths.hardcase_dataset),
-            "--hardcase-repeat",
-            str(int(mixing_cfg.get("hardcase_repeat", 2))),
-            "--shuffle-seed",
-            str(int(mixing_cfg.get("shuffle_seed", 42))),
-            "--output",
-            str(paths.mixed_dataset),
-        ],
-        log_level=args.log_level,
-    )
+    mixed_builder_cmd = [
+        sys.executable,
+        "scripts/training/build_predictive_mixed_dataset.py",
+        "--base-dataset",
+        str(paths.base_dataset),
+        "--hardcase-dataset",
+        str(paths.hardcase_dataset),
+        "--output",
+        str(paths.mixed_dataset),
+    ]
+    weighting_spec_raw = mixing_cfg.get("weighting_spec")
+    if weighting_spec_raw is not None:
+        mixed_builder_cmd.extend(
+            [
+                "--weighting-spec",
+                str(_resolve(weighting_spec_raw, base=config_path.parent)),
+            ]
+        )
+    if "hardcase_repeat" in mixing_cfg:
+        mixed_builder_cmd.extend(["--hardcase-repeat", str(int(mixing_cfg["hardcase_repeat"]))])
+    if "shuffle_seed" in mixing_cfg:
+        mixed_builder_cmd.extend(["--shuffle-seed", str(int(mixing_cfg["shuffle_seed"]))])
+    _run(mixed_builder_cmd, log_level=args.log_level)
     mixed_dataset_manifest = _write_dataset_manifest(
         dataset_path=paths.mixed_dataset,
         summary_path=paths.mixed_dataset.with_suffix(".json"),

--- a/tests/training/test_build_predictive_mixed_dataset.py
+++ b/tests/training/test_build_predictive_mixed_dataset.py
@@ -25,10 +25,14 @@ def _write_dataset(
     *,
     input_dim: int,
     feature_schema: dict[str, object] | None = None,
+    sample_offset: int = 0,
 ) -> None:
     """Write a compact predictive dataset fixture with optional embedded schema metadata."""
+    state = np.zeros((2, 3, input_dim), dtype=np.float32)
+    for sample_idx in range(state.shape[0]):
+        state[sample_idx, :, 0] = sample_offset + sample_idx
     payload: dict[str, object] = {
-        "state": np.zeros((2, 3, input_dim), dtype=np.float32),
+        "state": state,
         "target": np.zeros((2, 3, 5, 2), dtype=np.float32),
         "mask": np.ones((2, 3), dtype=np.float32),
         "target_mask": np.ones((2, 3, 5), dtype=np.float32),
@@ -47,6 +51,33 @@ def _ego_feature_schema(producer: str | None) -> dict[str, object]:
     )
 
 
+def _run_builder(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    base_path: Path,
+    hardcase_path: Path,
+    output_path: Path,
+    hardcase_repeat: int | None = 2,
+    shuffle_seed: int | None = 7,
+    weighting_spec: Path | None = None,
+) -> None:
+    """Run the mixed-dataset builder through a compact monkeypatched CLI namespace."""
+    monkeypatch.setattr(
+        mixed_builder,
+        "parse_args",
+        lambda: mixed_builder.argparse.Namespace(
+            base_dataset=base_path,
+            hardcase_dataset=hardcase_path,
+            hardcase_repeat=hardcase_repeat,
+            output=output_path,
+            shuffle_seed=shuffle_seed,
+            weighting_spec=weighting_spec,
+        ),
+    )
+
+    assert mixed_builder.main() == 0
+
+
 def test_mixed_builder_propagates_matching_ego_feature_schema_metadata(
     monkeypatch,
     tmp_path: Path,
@@ -59,19 +90,12 @@ def test_mixed_builder_propagates_matching_ego_feature_schema_metadata(
     _write_dataset(base_path, input_dim=9, feature_schema=schema)
     _write_dataset(hardcase_path, input_dim=9, feature_schema=schema)
 
-    monkeypatch.setattr(
-        mixed_builder,
-        "parse_args",
-        lambda: mixed_builder.argparse.Namespace(
-            base_dataset=base_path,
-            hardcase_dataset=hardcase_path,
-            hardcase_repeat=2,
-            output=output_path,
-            shuffle_seed=7,
-        ),
+    _run_builder(
+        monkeypatch,
+        base_path=base_path,
+        hardcase_path=hardcase_path,
+        output_path=output_path,
     )
-
-    assert mixed_builder.main() == 0
     with np.load(output_path) as raw:
         mixed_schema = json.loads(str(raw["feature_schema_json"].item()))
     summary = json.loads(output_path.with_suffix(".json").read_text(encoding="utf-8"))
@@ -159,6 +183,101 @@ def test_mixed_builder_preserves_legacy_compatibility_without_schema(
     _write_dataset(base_path, input_dim=4, feature_schema=None)
     _write_dataset(hardcase_path, input_dim=4, feature_schema=None)
 
+    _run_builder(
+        monkeypatch,
+        base_path=base_path,
+        hardcase_path=hardcase_path,
+        output_path=output_path,
+    )
+    with np.load(output_path) as raw:
+        assert "feature_schema_json" not in raw
+    summary = json.loads(output_path.with_suffix(".json").read_text(encoding="utf-8"))
+    assert summary["feature_schema"] is None
+    assert summary["feature_schema_json"] is None
+    assert summary["ego_motion_channel_producer"] is None
+
+
+def test_mixed_builder_applies_crossing_conflict_weighting_spec_deterministically(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Crossing-conflict hard-case weighting should be explicit and deterministic."""
+    base_path = tmp_path / "predictive_rollouts_base.npz"
+    hardcase_path = tmp_path / "predictive_rollouts_crossing_conflict.npz"
+    output_a = tmp_path / "predictive_rollouts_mixed_a.npz"
+    output_b = tmp_path / "predictive_rollouts_mixed_b.npz"
+    spec_path = tmp_path / "crossing_conflict_weighting.yaml"
+    schema = _ego_feature_schema(PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME)
+    _write_dataset(base_path, input_dim=9, feature_schema=schema, sample_offset=10)
+    _write_dataset(hardcase_path, input_dim=9, feature_schema=schema, sample_offset=100)
+    spec_path.write_text(
+        "\n".join(
+            [
+                "profile_id: crossing_conflict_hardcase_repeat_test",
+                "claim_boundary: launch/config/tooling only; no model-improvement claim",
+                "weighting:",
+                "  rule: repeat_hardcase_rows",
+                "  hardcase_family: crossing_conflict",
+                "  hardcase_repeat: 3",
+                "  shuffle_seed: 3214",
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    _run_builder(
+        monkeypatch,
+        base_path=base_path,
+        hardcase_path=hardcase_path,
+        output_path=output_a,
+        hardcase_repeat=None,
+        shuffle_seed=None,
+        weighting_spec=spec_path,
+    )
+    _run_builder(
+        monkeypatch,
+        base_path=base_path,
+        hardcase_path=hardcase_path,
+        output_path=output_b,
+        hardcase_repeat=None,
+        shuffle_seed=None,
+        weighting_spec=spec_path,
+    )
+
+    with np.load(output_a) as raw_a, np.load(output_b) as raw_b:
+        np.testing.assert_array_equal(raw_a["state"], raw_b["state"])
+        mixed_sample_ids = raw_a["state"][:, 0, 0].astype(int).tolist()
+    summary = json.loads(output_a.with_suffix(".json").read_text(encoding="utf-8"))
+
+    assert mixed_sample_ids.count(10) == 1
+    assert mixed_sample_ids.count(11) == 1
+    assert mixed_sample_ids.count(100) == 3
+    assert mixed_sample_ids.count(101) == 3
+    assert summary["base_count"] == 2
+    assert summary["hard_case_count"] == 2
+    assert summary["output_count"] == 8
+    assert summary["weighting_profile"] == "crossing_conflict_hardcase_repeat_test"
+    assert summary["weighting_rule"]["rule"] == "repeat_hardcase_rows"
+    assert summary["weighting_rule"]["hardcase_family"] == "crossing_conflict"
+    assert summary["weighting_rule"]["hardcase_repeat"] == 3
+    assert summary["shuffle_seed"] == 3214
+    assert summary["feature_compatibility"]["status"] == "compatible"
+    assert summary["feature_compatibility"]["feature_schema_required"] is True
+
+
+def test_mixed_builder_rejects_mismatched_feature_schema_contract(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Predictive schemas with different contracts must fail closed before mixing."""
+    base_path = tmp_path / "predictive_rollouts_base.npz"
+    hardcase_path = tmp_path / "predictive_rollouts_hardcase.npz"
+    base_schema = _ego_feature_schema(PREDICTIVE_EGO_MOTION_PRODUCER_RUNTIME)
+    hardcase_schema = dict(base_schema)
+    hardcase_schema["base_schema"] = "predictive_legacy_v1"
+    _write_dataset(base_path, input_dim=9, feature_schema=base_schema)
+    _write_dataset(hardcase_path, input_dim=9, feature_schema=hardcase_schema)
+
     monkeypatch.setattr(
         mixed_builder,
         "parse_args",
@@ -166,18 +285,14 @@ def test_mixed_builder_preserves_legacy_compatibility_without_schema(
             base_dataset=base_path,
             hardcase_dataset=hardcase_path,
             hardcase_repeat=2,
-            output=output_path,
+            output=tmp_path / "predictive_rollouts_mixed.npz",
             shuffle_seed=7,
+            weighting_spec=None,
         ),
     )
 
-    assert mixed_builder.main() == 0
-    with np.load(output_path) as raw:
-        assert "feature_schema_json" not in raw
-    summary = json.loads(output_path.with_suffix(".json").read_text(encoding="utf-8"))
-    assert summary["feature_schema"] is None
-    assert summary["feature_schema_json"] is None
-    assert summary["ego_motion_channel_producer"] is None
+    with pytest.raises(ValueError, match="feature schema mismatch"):
+        mixed_builder.main()
 
 
 def test_mixed_builder_rejects_schema_input_dim_that_disagrees_with_array_width(

--- a/tests/training/test_run_predictive_training_pipeline.py
+++ b/tests/training/test_run_predictive_training_pipeline.py
@@ -352,6 +352,89 @@ def test_pipeline_collection_commands_pass_ego_conditioning(monkeypatch, tmp_pat
     assert mixed_manifest["extra"]["producer_metadata_preflight_status"] == "ok"
 
 
+def test_pipeline_passes_resolved_weighting_spec_to_mixed_builder(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Pipeline mixing config should pass a resolved hard-case weighting spec path."""
+    config_path = tmp_path / "predictive_weighting.yaml"
+    weighting_spec = tmp_path / "configs" / "crossing_conflict_weighting.yaml"
+    weighting_spec.parent.mkdir(parents=True)
+    weighting_spec.write_text(
+        yaml.safe_dump(
+            {
+                "profile_id": "crossing_conflict_hardcase_repeat_test",
+                "weighting": {
+                    "rule": "repeat_hardcase_rows",
+                    "hardcase_family": "crossing_conflict",
+                    "hardcase_repeat": 3,
+                    "shuffle_seed": 3214,
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_root = _pipeline_test_output_root(tmp_path)
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "experiment": {"run_id": "predictive_weighting_smoke"},
+                "output": {"root": output_root},
+                "scenarios": {
+                    "scenario_matrix": "scenarios.yaml",
+                    "hard_seed_manifest": "hard.yaml",
+                    "planner_grid": "grid.yaml",
+                },
+                "base_collection": {"seeds_per_scenario": 1, "ego_conditioning": True},
+                "hardcase_collection": {"ego_conditioning": True},
+                "mixing": {"weighting_spec": "configs/crossing_conflict_weighting.yaml"},
+                "training": {},
+                "wandb": {"enabled": False},
+                "evaluation": {},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    (tmp_path / "scenarios.yaml").write_text("[]\n", encoding="utf-8")
+    (tmp_path / "hard.yaml").write_text("{}\n", encoding="utf-8")
+    (tmp_path / "grid.yaml").write_text("{}\n", encoding="utf-8")
+
+    monkeypatch.setattr(pipeline, "_sha1_file", lambda _path: "cfghash")
+    monkeypatch.setattr(pipeline, "_git_hash", lambda: "deadbeef")
+    monkeypatch.setattr(
+        pipeline,
+        "_build_random_seed_manifest",
+        lambda **kwargs: _write_seed_manifest(Path(kwargs["output_path"])),
+    )
+    invoked: list[list[str]] = []
+    monkeypatch.setattr(pipeline, "_run", _make_ego_pipeline_run_stub(invoked))
+    monkeypatch.setattr(
+        pipeline,
+        "_run_capture_json",
+        lambda _cmd, **_kwargs: {"status": "ok", "return_code": 0},
+    )
+    monkeypatch.setattr(
+        pipeline,
+        "_parse_args",
+        lambda: pipeline.argparse.Namespace(
+            config=config_path,
+            run_id="predictive_weighting_smoke",
+            log_level="INFO",
+        ),
+    )
+
+    assert pipeline.main() == 0
+    mixed_builder_cmd = next(
+        cmd for cmd in invoked if any("build_predictive_mixed_dataset.py" in part for part in cmd)
+    )
+    assert mixed_builder_cmd[mixed_builder_cmd.index("--weighting-spec") + 1] == str(
+        weighting_spec.resolve()
+    )
+    assert "--hardcase-repeat" not in mixed_builder_cmd
+    assert "--shuffle-seed" not in mixed_builder_cmd
+
+
 def test_pipeline_passes_obstacle_model_family_to_collectors_and_training(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary
Adds a bounded launch/config/tooling slice for #3214: a crossing-conflict hard-case weighting spec, `--weighting-spec` support in the predictive mixed-dataset builder, pipeline plumbing, and fixture tests for deterministic/schema-safe behavior.

This PR does not train a model, publish a checkpoint, or claim predictive model improvement.

## Linked Issues
- Relates to `#3214`
- Follow-up evidence run: `#3254`

## Stack / Dependency
- Base dependency: `origin/main` including merged PR #3253
- Required prior PRs: none
- Stack follow-up issues: `#3254`
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `configs/training/predictive/predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml` with explicit launch/config/tooling-only claim boundary.
- Added `--weighting-spec` to `scripts/training/build_predictive_mixed_dataset.py`.
- Emitted deterministic mixed-dataset metadata: `base_count`, `hard_case_count`, `output_count`, `weighting_profile`, `weighting_rule`, `shuffle_seed`, and `feature_compatibility`.
- Updated `scripts/training/run_predictive_training_pipeline.py` so `mixing.weighting_spec` is resolved and passed to the builder.
- Added fixture tests for deterministic hard-case weighting, schema compatibility metadata, and fail-closed schema mismatch behavior.

## Why It Matters
- Added value: makes the #3214 crossing-conflict retraining bet reproducible before consuming SLURM time.
- Expected impact: later training runs can cite an explicit weighting profile and summary metadata instead of ad hoc oversampling flags.
- Why this is worth merging now: it closes the tooling gap while preserving the evidence boundary for the actual retraining run.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: prepare the dataset-mixing mechanism for testing whether crossing-conflict-weighted predictive retraining improves hard-seed closed-loop success.
- Comparator or baseline, if applicable: current `predictive_proxy_selected_v1` lineage; actual comparison deferred to #3254.
- Evidence tier: launch packet / tooling.
- Result classification: diagnostic-only / launch-config-only.
- Decision or stop rule, if applicable: do not adopt or claim improvement until #3254 produces checkpoint + hard-seed evaluation evidence.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3214 and follow-up #3254.
- New research/benchmark/metric/paper-facing analysis tool, if any: support helper for deterministic predictive dataset mixing; representative use is covered by fixture tests and YAML parse/profile assertions.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA; no training run launched.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA; this is the launch/config/tooling prerequisite.
- Result route: continue through #3254.
- Follow-up question or issue for weak, negative, or non-transfer results: #3254.

## Next Empirical Action
- Rerun needed: yes, in #3254.
- Extractor or analysis tool needed: no additional extractor known; dataset summary metadata now exists.
- Artifact missing or unavailable: retrained checkpoint and hard-seed benchmark evidence are not produced by this PR.
- Stop / revise / continue decision: continue to #3254 for the evidence-producing run.
- Proposed child issue or existing follow-up: #3254.

## Validation / Proof
- Commands run:
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run pytest -q tests/training/test_build_predictive_mixed_dataset.py tests/training/test_run_predictive_training_pipeline.py` -> 25 passed.
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/training/build_predictive_mixed_dataset.py scripts/training/run_predictive_training_pipeline.py tests/training/test_build_predictive_mixed_dataset.py tests/training/test_run_predictive_training_pipeline.py` -> passed.
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/training/build_predictive_mixed_dataset.py scripts/training/run_predictive_training_pipeline.py tests/training/test_build_predictive_mixed_dataset.py tests/training/test_run_predictive_training_pipeline.py` -> passed.
  - `rtk git diff --check` -> passed.
  - YAML parse/profile assertions for `predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml` -> passed.
- Evidence that the change works here: fixture tests prove deterministic weighted output, schema metadata propagation, and fail-closed mismatch handling.
- Benchmarks or smoke tests, if applicable: no benchmark run; #3254 owns the evidence-producing SLURM/evaluation run.

## Risks / Rollout
- Compatibility risks: low; legacy CLI defaults remain available when no weighting spec is passed.
- Failure modes: configs must intentionally reference the weighting spec; this PR does not retarget existing training configs automatically.
- Rollback or fallback plan: remove the weighting-spec config and CLI plumbing; existing `--hardcase-repeat` path remains straightforward.

## Docs / Provenance
- Updated docs: no context note added; the config itself carries the claim boundary.
- Relevant design or provenance notes: #3254 records the evidence-producing successor contract.
- Any assumptions that need to be preserved: this is launch/config/tooling only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via linked PR and follow-up #3254.
- Claim map / benchmark report updated (yes/no/NA): NA, no evidence result.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA; this is a directly referenced training config/spec.
- Context index / memory note updated (yes/no/NA): NA, no durable result.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, #3254.
- Not applicable because: no model checkpoint or benchmark claim is produced here.

## Follow-Up Issues
- Deferred work: actual weighted retraining, checkpoint provenance, and hard-seed evaluation.
- Issues opened for follow-up: #3254.

## Reviewer Notes
- Verify closely: `--weighting-spec` precedence with explicit `hardcase_repeat` / `shuffle_seed` overrides, and schema mismatch fail-closed behavior.
- Known limitations: no SLURM run, no checkpoint, no model-improvement evidence.
