### PR TITLE
training: prepare crossing-conflict predictive retraining (#3254)

### DIFF
--- a/configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
+++ b/configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
@@ -1,0 +1,83 @@
+# Issue #3254 crossing-conflict weighted predictive retraining config.
+#
+# This is a prepare-only launch/config surface. It intentionally references the
+# #3214 weighting spec, but it does not publish a retrained checkpoint, benchmark
+# result, or predictive model-improvement claim.
+
+experiment:
+  run_id: predictive_crossing_conflict_weighted_issue_3254
+
+claim_boundary: >
+  Prepare-only predictive retraining config for issue #3254. No retrained
+  checkpoint, hard-seed benchmark result, or model-improvement claim exists until
+  a SLURM/GPU run records checkpoint provenance and closed-loop evaluation
+  evidence against the current predictive baseline.
+
+output:
+  root: output/tmp/predictive_planner/pipeline
+
+scenarios:
+  scenario_matrix: ../../scenarios/classic_interactions.yaml
+  hard_seed_manifest: ../../benchmarks/predictive_hard_seeds_v1.yaml
+  planner_grid: ../../benchmarks/predictive_sweep_planner_grid_v1.yaml
+
+base_collection:
+  # Based on the current XL ego-conditioned full predictive profile.
+  seeds_per_scenario: 24
+  random_seed_base: 41000
+  max_steps: 260
+  max_agents: 24
+  horizon_steps: 12
+  max_speed: 1.2
+  ego_conditioning: true
+
+hardcase_collection:
+  # Keep the hard-suite feature layout aligned with the base collection.
+  max_steps: 300
+  max_agents: 24
+  horizon_steps: 12
+  max_speed: 1.2
+  ego_conditioning: true
+
+mixing:
+  weighting_spec: predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml
+
+training:
+  model_id: predictive_crossing_conflict_weighted_issue_3254_xl_ego
+  epochs: 400
+  batch_size: 128
+  lr: 0.0002
+  weight_decay: 0.00001
+  val_split: 0.2
+  seed: 42
+  hidden_dim: 256
+  message_passing_steps: 4
+  max_val_ade: 1.0
+  max_val_fde: 1.8
+  proxy_every_epochs: 20
+  proxy_horizon: 120
+  proxy_dt: 0.1
+  proxy_workers: 1
+
+wandb:
+  enabled: true
+  project: robot_sf
+  entity: ll7
+  group: predictive-crossing-conflict-issue-3254
+  job_type: train
+  name: predictive_crossing_conflict_weighted_issue_3254
+  mode: online
+  tags:
+    - predictive
+    - crossing-conflict
+    - hardcase-weighting
+    - issue-3254
+    - xl
+    - ego-conditioned
+    - prepare-only
+
+evaluation:
+  workers: 1
+  campaign_workers: 2
+  horizon: 120
+  dt: 0.1

--- a/experiments/submission_queue.yaml
+++ b/experiments/submission_queue.yaml
@@ -5,6 +5,46 @@ description: >
   state ledger. Entries become runnable only after they are marked ready_to_submit and pass
   scripts/dev/submit_training_jobs.py gates.
 entries:
+  - id: issue-3254-crossing-conflict-predictive
+    status: planned
+    issue: 3254
+    objective: >
+      Prepare the crossing-conflict weighted predictive retraining run using the
+      #3214 hard-case weighting spec, without claiming a checkpoint or benchmark
+      result until the SLURM run and evaluation evidence exist.
+    config: configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
+    launcher: SLURM/Auxme/predictive_training_pipeline.sl
+    target:
+      cluster: auxme
+      host: licca
+      launcher_note: >
+        Public launcher is a private-operations-overlay stub in this checkout;
+        keep this queue entry planned until the private launcher path is
+        available on a SLURM-capable host.
+    resources:
+      gpus: 1
+      cpus: 8
+      memory: 32G
+      walltime: 1-12:00:00
+    seeds:
+      - 42
+    output_root: output/slurm/issue3254-crossing-conflict-predictive
+    log_path: output/slurm/%j-issue3254-crossing-conflict-predictive.out
+    priority_reason: >
+      Issue #3254 is the evidence-producing follow-up for #3214; this row is a
+      launch packet placeholder for the full predictive pipeline config that
+      references the crossing-conflict weighting spec. Claim boundary:
+      prepare-only, no retrained checkpoint, benchmark result, or model-improvement
+      claim.
+    auto_submit: false
+    job_name: gse-3254-crossing-conflict-predictive
+    wrapper: scripts/dev/sbatch_use_max_time.sh
+    wrapper_args:
+      - --time
+      - 1-12:00:00
+    sbatch_args:
+      - --output=output/slurm/%j-issue3254-crossing-conflict-predictive.out
+
   - id: issue-1977-bc-warm-start-ppo
     status: planned
     issue: 1977

--- a/tests/dev/test_submit_training_jobs.py
+++ b/tests/dev/test_submit_training_jobs.py
@@ -3,15 +3,13 @@
 from __future__ import annotations
 
 import subprocess
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 
 import pytest
 import yaml
 
 from scripts.dev import submit_training_jobs
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _write_minimal_repo(tmp_path: Path, *, allow_slurm: bool = False) -> Path:
@@ -58,6 +56,28 @@ def _write_queue(repo: Path, payload: dict[str, Any]) -> Path:
     queue_path.parent.mkdir(parents=True, exist_ok=True)
     queue_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
     return queue_path
+
+
+def test_real_issue_3254_queue_entry_is_prepare_only() -> None:
+    """The real #3254 queue packet should validate but remain non-submittable."""
+    repo = Path(__file__).resolve().parents[2]
+
+    entries = submit_training_jobs.load_queue(
+        repo / "experiments" / "submission_queue.yaml",
+        repo_root=repo,
+    )
+    entry = next(
+        item for item in entries if item.queue_id == "issue-3254-crossing-conflict-predictive"
+    )
+
+    assert entry.status == "planned"
+    assert entry.auto_submit is False
+    assert entry.config == (
+        "configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml"
+    )
+    assert entry.launcher == "SLURM/Auxme/predictive_training_pipeline.sl"
+    assert entry.job_name == "gse-3254-crossing-conflict-predictive"
+    assert "prepare-only" in entry.priority_reason
 
 
 def test_load_queue_rejects_missing_required_field(tmp_path: Path) -> None:

--- a/tests/training/test_run_predictive_training_pipeline.py
+++ b/tests/training/test_run_predictive_training_pipeline.py
@@ -435,6 +435,31 @@ def test_pipeline_passes_resolved_weighting_spec_to_mixed_builder(
     assert "--shuffle-seed" not in mixed_builder_cmd
 
 
+def test_issue_3254_config_targets_crossing_conflict_weighting_spec() -> None:
+    """The real #3254 config should use the #3214 spec without CLI-style overrides."""
+    repo = Path(__file__).resolve().parents[2]
+    config_path = (
+        repo
+        / "configs"
+        / "training"
+        / "predictive"
+        / "predictive_crossing_conflict_weighted_issue_3254.yaml"
+    )
+
+    cfg = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    mixing = cfg["mixing"]
+    weighting_spec = config_path.parent / mixing["weighting_spec"]
+
+    assert weighting_spec.name == "predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml"
+    assert weighting_spec.is_file()
+    assert "hardcase_repeat" not in mixing
+    assert "shuffle_seed" not in mixing
+    assert cfg["base_collection"]["ego_conditioning"] is True
+    assert cfg["hardcase_collection"]["ego_conditioning"] is True
+    assert cfg["training"]["model_id"] == "predictive_crossing_conflict_weighted_issue_3254_xl_ego"
+    assert "prepare-only" in cfg["claim_boundary"].lower()
+
+
 def test_pipeline_passes_obstacle_model_family_to_collectors_and_training(
     monkeypatch,
     tmp_path: Path,


### PR DESCRIPTION
## Summary

- add a prepare-only #3254 predictive training config that wraps the #3214 crossing-conflict weighting spec
- add a planned, non-auto-submitting queue entry for the private-ops SLURM launch surface
- add focused tests that keep the queue entry non-submittable and verify the config points at the #3214 weighting spec

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/submit_training_jobs.py --dry-run`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_submit_training_jobs.py tests/training/test_run_predictive_training_pipeline.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/dev/test_submit_training_jobs.py tests/training/test_run_predictive_training_pipeline.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/dev/test_submit_training_jobs.py tests/training/test_run_predictive_training_pipeline.py`
- `git diff --check HEAD~1..HEAD`

## Downstream Propagation

- Parent issue: #3254.
- This PR intentionally does not submit a job, publish a checkpoint, or claim model improvement.
- The queue entry remains `planned` and `auto_submit: false` because this host is not SLURM-capable and the public predictive launcher is a private-ops stub.
- Next step is a SLURM-capable/private-ops launch worker that verifies the launcher can consume the #3254 config, then promotes the queue entry to `ready_to_submit` only after duplicate and scheduler gates pass.

## Research Result Guidance

- Target claim: whether crossing-conflict weighted retraining improves closed-loop hard-seed success.
- Evidence tier in this PR: launch/config preparation only.
- Result classification: not evidence; prepare-only.
- Stop rule for the future run: adopt/escalate only if hard-seed success improves without regressing broader success; if ADE/FDE improves without closed-loop success, record non-transfer from trajectory proxy to benchmark success.
