### PR TITLE
prediction: add forecast-risk eligibility fixtures (#2904)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added durable issue-2904 forecast-risk eligibility fixtures
+  (`tests/fixtures/benchmark/forecast_risk_eligibility/`) and the regenerated
+  `ForecastCalibrationReport.v1` evidence bundle under
+  `docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/`. The pedestrian
+  (`deployable_tracked`) and bicycle (`deployable_observation`) fixtures yield calibrated,
+  risk-scoring-eligible reliability rows so the forecast-risk calibration filter's
+  `calibration_filtered`, `actor_class_aware`, and `observation_tier_aware` modes are no longer
+  blocked for lack of eligible rows: the calibration report recommendation flips from
+  `wait`/blocked to `continue`/analysis-only and the filter's overall recommendation flips from
+  `wait` to `diagnostic_only`. Fixtures and evidence are diagnostic/analysis-only and do not change
+  `_risk_scoring_eligibility`, calibration thresholds, or planner risk coupling (#2904).
+
+### Fixed
+
+* Fixed `scripts/validation/validate_forecast_risk_calibration_filter.py` so its
+  `_any_eligible_for_risk_scoring` gate recognizes the canonical `eligible_analysis_only` token
+  emitted by `build_forecast_calibration_report`. The gate previously matched only the legacy
+  `{"eligible", "calibrated"}` strings, which the report never emits, leaving the
+  `calibration_filtered` mode permanently blocked for every real calibration report regardless of
+  eligible rows. Legacy tokens are retained for backward compatibility (#2904).
+
 ### Changed
 
 * Removed redundant Black/autopep8 formatter configuration and the unused Black optional

--- a/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/README.md
+++ b/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/README.md
@@ -1,0 +1,84 @@
+# Issue #2904 — Forecast-Risk Eligibility Fixtures
+
+## Scope
+
+Durable fixtures + regenerated evidence that unblock the forecast-risk calibration filter. Before
+this change the canonical calibration report (Issue #2865) contained only
+`actor_class=unavailable` rows on a single observation tier (`deployable_tracked`), so the filter
+returned `wait`/blocked for lack of risk-scoring-eligible rows. These fixtures add calibrated rows
+with explicit actor classes across two observation tiers so the calibration filter becomes
+meaningful.
+
+This is diagnostic / analysis-only evidence. It does **not** claim forecast-variant superiority,
+planner safety, navigation benefit, or benchmark/paper-grade quality.
+
+## Source fixtures (`ForecastMetrics.v1`)
+
+- [`metric_pedestrian_deployable_tracked.json`](../../../../tests/fixtures/benchmark/forecast_risk_eligibility/metric_pedestrian_deployable_tracked.json)
+  — `actor_class=pedestrian`, `observation_tier=deployable_tracked`, coverage `0.91`, denominator `12`.
+- [`metric_bicycle_deployable_observation.json`](../../../../tests/fixtures/benchmark/forecast_risk_eligibility/metric_bicycle_deployable_observation.json)
+  — `actor_class=bicycle`, `observation_tier=deployable_observation`, coverage `0.88`, denominator `8`.
+
+Both rows are calibrated within tolerance (coverage in `[0.85, 0.95]` around target `0.90`),
+carry `semantic_metadata_present="present"`, and therefore resolve to
+`risk_scoring_eligibility=eligible_analysis_only`.
+
+## Artifacts in this bundle
+
+- [`calibration_report.json`](calibration_report.json) / [`calibration_report.md`](calibration_report.md)
+  — `ForecastCalibrationReport.v1`; `recommendation.decision=continue` (`claim_status=analysis-only`),
+  2 reliability rows, 0 limitation rows.
+- [`report.json`](report.json) / [`report.md`](report.md) / [`summary.json`](summary.json)
+  — `forecast_risk_calibration_filter.diagnostic_comparison.v1`; all five modes `available`,
+  overall `recommendation=diagnostic_only`.
+
+## Coverage achieved (Definition of Done)
+
+| Requirement | Result |
+| --- | --- |
+| Pedestrian row exposes `actor_class` | `pedestrian` (denominator 12) |
+| Bicycle/dynamic-agent row exposes `actor_class` | `bicycle` (denominator 8) |
+| ≥2 observation tiers | `deployable_tracked`, `deployable_observation` |
+| Risk-scoring-eligible rows | 2 × `eligible_analysis_only` |
+| Calibration-filtered mode not blocked | `available`; overall `diagnostic_only` (was `wait`) |
+
+## Reproducible commands
+
+```bash
+# 1. Build the calibration report from the durable fixtures.
+uv run python scripts/benchmark/build_forecast_calibration_report.py \
+  tests/fixtures/benchmark/forecast_risk_eligibility/metric_pedestrian_deployable_tracked.json \
+  tests/fixtures/benchmark/forecast_risk_eligibility/metric_bicycle_deployable_observation.json \
+  --report-id issue_2904_forecast_risk_eligibility_2026-06-20 \
+  --generated-at-utc 2026-06-20T00:00:00+00:00 \
+  --out-json docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/calibration_report.json \
+  --out-md docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/calibration_report.md
+
+# 2. Run the forecast-risk calibration filter against the regenerated report.
+uv run python scripts/validation/validate_forecast_risk_calibration_filter.py \
+  --calibration-report docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/calibration_report.json \
+  --out-dir docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20
+```
+
+## Note on the filter gate
+
+`scripts/validation/validate_forecast_risk_calibration_filter.py::_any_eligible_for_risk_scoring`
+previously matched only the legacy tokens `{"eligible", "calibrated"}`, which the canonical
+calibration report never emits — it emits `eligible_analysis_only`. The gate now also recognizes
+`eligible_analysis_only`, so eligible rows actually unblock the `calibration_filtered` mode. The
+legacy tokens are retained for backward compatibility. This is an eligibility repair only; it does
+not change `_risk_scoring_eligibility`, calibration thresholds, or planner risk coupling
+(`calibration_filtered` still runs with `forecast_risk_weight=0.0`).
+
+## Validation
+
+```bash
+uv run pytest tests/benchmark/test_forecast_risk_eligibility_fixtures.py
+uv run pytest tests/validation/test_forecast_risk_calibration_filter.py
+```
+
+## Claim boundary
+
+Diagnostic-only. Forecast-risk scoring remains opt-in with `forecast_risk_weight=0.0` by default.
+This bundle does not establish safety, navigation benefit, human realism, benchmark-strength
+predictor quality, or paper/dissertation claims.

--- a/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/calibration_report.json
+++ b/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/calibration_report.json
@@ -1,0 +1,59 @@
+{
+  "calibration_parameters": {
+    "coverage_target": 0.9,
+    "coverage_tolerance": 0.05
+  },
+  "claim_boundary": "Calibration summaries are analysis-only evidence. They do not prove planner safety or navigation benefit, and unavailable uncertainty denominators remain limitations.",
+  "generated_at_utc": "2026-06-20T00:00:00+00:00",
+  "limitation_rows": [],
+  "recommendation": {
+    "claim_status": "analysis-only",
+    "decision": "continue",
+    "reason": "all rows have available uncertainty metrics within coverage tolerance"
+  },
+  "reliability_rows": [
+    {
+      "actor_class": "pedestrian",
+      "calibration_status": "calibrated_within_tolerance",
+      "coverage_gap": 0.010000000000000009,
+      "coverage_target": 0.9,
+      "denominator": 12,
+      "empirical_coverage": 0.91,
+      "failure_taxonomy": "none_observed",
+      "horizon_s": 1.0,
+      "likelihood": -1.2,
+      "miss_rate": null,
+      "observation_tier": "deployable_tracked",
+      "predictor_family": "probabilistic_cv",
+      "recommendation": "continue",
+      "risk_scoring_eligibility": "eligible_analysis_only",
+      "scenario_family": "classic_crossing",
+      "semantic_metadata_present": "present",
+      "sharpness_proxy": 0.24,
+      "unavailable_metrics": []
+    },
+    {
+      "actor_class": "bicycle",
+      "calibration_status": "calibrated_within_tolerance",
+      "coverage_gap": -0.020000000000000018,
+      "coverage_target": 0.9,
+      "denominator": 8,
+      "empirical_coverage": 0.88,
+      "failure_taxonomy": "none_observed",
+      "horizon_s": 1.0,
+      "likelihood": -1.5,
+      "miss_rate": null,
+      "observation_tier": "deployable_observation",
+      "predictor_family": "probabilistic_cv",
+      "recommendation": "continue",
+      "risk_scoring_eligibility": "eligible_analysis_only",
+      "scenario_family": "motion_rich_bicycle",
+      "semantic_metadata_present": "present",
+      "sharpness_proxy": 0.31,
+      "unavailable_metrics": []
+    }
+  ],
+  "report_id": "issue_2904_forecast_risk_eligibility_2026-06-20",
+  "schema_version": "ForecastCalibrationReport.v1",
+  "source_schema_version": "ForecastMetrics.v1"
+}

--- a/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/calibration_report.md
+++ b/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/calibration_report.md
@@ -1,0 +1,14 @@
+# Forecast Calibration Report
+
+- Report id: issue_2904_forecast_risk_eligibility_2026-06-20
+- Decision: continue
+- Claim status: analysis-only
+- Reliability rows: 2
+- Limitation rows: 0
+
+| scenario_family | horizon_s | observation_tier | predictor_family | actor_class | semantic_metadata | coverage | miss_rate | status | sharpness | failure_taxonomy | eligibility |
+| --- | ---: | --- | --- | --- | --- | ---: | ---: | --- | ---: | --- | --- |
+| classic_crossing | 1 | deployable_tracked | probabilistic_cv | pedestrian | present | 0.91 | NA | calibrated_within_tolerance | 0.24 | none_observed | eligible_analysis_only |
+| motion_rich_bicycle | 1 | deployable_observation | probabilistic_cv | bicycle | present | 0.88 | NA | calibrated_within_tolerance | 0.31 | none_observed | eligible_analysis_only |
+
+Calibration summaries are analysis-only evidence. They do not prove planner safety or navigation benefit, and unavailable uncertainty denominators remain limitations.

--- a/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/report.json
+++ b/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/report.json
@@ -1,0 +1,121 @@
+{
+  "calibration_report": "docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/calibration_report.json",
+  "claim_boundary": "diagnostic_only_not_benchmark_evidence",
+  "diagnostic_weight": 5.0,
+  "issue": 2869,
+  "modes": [
+    {
+      "false_positive": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "forecast_risk_weight": 0.0,
+      "high_risk": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "mode": "no_risk",
+      "reason": "baseline forecast_risk_weight=0",
+      "status": "available",
+      "uses_calibration_filter": false
+    },
+    {
+      "false_positive": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "forecast_risk_weight": 5.0,
+      "high_risk": {
+        "forecast_penalty": 5.0,
+        "progress_proxy": 0.2,
+        "selected_proposal": "risk_dwa",
+        "shield_stop_count": 0,
+        "speed": 0.2
+      },
+      "mode": "raw_risk",
+      "reason": "diagnostic unfiltered forecast risk",
+      "status": "available",
+      "uses_calibration_filter": false
+    },
+    {
+      "false_positive": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "forecast_risk_weight": 5.0,
+      "high_risk": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "mode": "calibration_filtered",
+      "reason": "calibration report contains risk-scoring-eligible rows",
+      "status": "available",
+      "uses_calibration_filter": true
+    },
+    {
+      "false_positive": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "forecast_risk_weight": 5.0,
+      "high_risk": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "mode": "actor_class_aware",
+      "reason": "per-actor-class calibration rows available",
+      "status": "available",
+      "uses_calibration_filter": true
+    },
+    {
+      "false_positive": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "forecast_risk_weight": 5.0,
+      "high_risk": {
+        "forecast_penalty": 0.0,
+        "progress_proxy": 1.0,
+        "selected_proposal": "goal",
+        "shield_stop_count": 0,
+        "speed": 1.0
+      },
+      "mode": "observation_tier_aware",
+      "reason": "cross-tier calibration rows available: ['deployable_observation', 'deployable_tracked']",
+      "status": "available",
+      "uses_calibration_filter": true
+    }
+  ],
+  "recommendation": "diagnostic_only",
+  "recommendation_rationale": "Calibration-filtered rows are available in the input report, but this tool remains a deterministic diagnostic comparison rather than benchmark evidence. Use it only to decide whether a same-seed benchmark comparison is now warranted.",
+  "schema_version": "forecast_risk_calibration_filter.diagnostic_comparison.v1",
+  "tradeoffs": {
+    "false_positive_stopping_avoided": true,
+    "false_positive_unnecessary_slowdown_count": 0,
+    "route_progress_tradeoff": 0.8
+  }
+}

--- a/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/report.md
+++ b/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/report.md
@@ -1,0 +1,40 @@
+# Issue #2869 Forecast Risk Calibration Filter Diagnostic
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/2869>
+
+## Boundary
+
+- **schema_version**: `forecast_risk_calibration_filter.diagnostic_comparison.v1`
+- **claim_boundary**: `diagnostic_only_not_benchmark_evidence`
+- **calibration_report**: `docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/calibration_report.json`
+- **diagnostic_weight**: 5.0
+- **recommendation**: `diagnostic_only`
+
+## Risk Mode Comparison
+
+| mode | status | forecast_risk_weight | high_risk selected | high_risk speed | high_risk penalty | false_positive selected | false_positive speed | false_positive penalty |
+|---|---:|---:|---|---:|---:|---|---:|---:|
+| no_risk | available | 0.0 | goal | 1.000000 | 0.000000 | goal | 1.000000 | 0.000000 |
+| raw_risk | available | 5.0 | risk_dwa | 0.200000 | 5.000000 | goal | 1.000000 | 0.000000 |
+| calibration_filtered | available | 5.0 | goal | 1.000000 | 0.000000 | goal | 1.000000 | 0.000000 |
+| actor_class_aware | available | 5.0 | goal | 1.000000 | 0.000000 | goal | 1.000000 | 0.000000 |
+| observation_tier_aware | available | 5.0 | goal | 1.000000 | 0.000000 | goal | 1.000000 | 0.000000 |
+
+### Blocked mode reasons
+
+
+## Tradeoffs
+
+| tradeoff | value |
+|---|---|
+| route_progress_tradeoff (no_risk - raw_risk) | 0.800000 |
+| false_positive_stopping_avoided | True |
+| false_positive_unnecessary_slowdown_count | 0 |
+
+## Recommendation
+
+**DIAGNOSTIC_ONLY**
+
+Calibration-filtered rows are available in the input report, but this tool remains a deterministic diagnostic comparison rather than benchmark evidence. Use it only to decide whether a same-seed benchmark comparison is now warranted.
+
+> This report is diagnostic-only. It does not establish safety, navigation benefit, human realism, benchmark-strength predictor quality, or paper/dissertation claims.

--- a/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/summary.json
+++ b/docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/summary.json
@@ -1,0 +1,11 @@
+{
+  "blocked_mode_count": 0,
+  "claim_boundary": "diagnostic_only_not_benchmark_evidence",
+  "false_positive_stopping_avoided": true,
+  "false_positive_unnecessary_slowdown_count": 0,
+  "issue": 2869,
+  "mode_count": 5,
+  "recommendation": "diagnostic_only",
+  "route_progress_tradeoff": 0.8,
+  "schema_version": "forecast_risk_calibration_filter.diagnostic_comparison.v1"
+}

--- a/scripts/validation/validate_forecast_risk_calibration_filter.py
+++ b/scripts/validation/validate_forecast_risk_calibration_filter.py
@@ -114,8 +114,14 @@ def _load_calibration_report(path: Path) -> dict[str, Any]:
 
 
 def _any_eligible_for_risk_scoring(rows: list[dict[str, Any]]) -> bool:
-    """Return True if at least one row is eligible for forecast-risk scoring."""
-    eligible = {"eligible", "calibrated"}
+    """Return True if at least one row is eligible for forecast-risk scoring.
+
+    Recognizes the eligibility vocabulary emitted by
+    :func:`robot_sf.benchmark.forecast_calibration_report._risk_scoring_eligibility`
+    (canonical token ``eligible_analysis_only``) as well as the legacy ``eligible`` /
+    ``calibrated`` tokens kept for backward compatibility.
+    """
+    eligible = {"eligible", "calibrated", "eligible_analysis_only"}
     return any(str(row.get("risk_scoring_eligibility", "")) in eligible for row in rows)
 
 

--- a/tests/benchmark/test_forecast_risk_eligibility_fixtures.py
+++ b/tests/benchmark/test_forecast_risk_eligibility_fixtures.py
@@ -1,0 +1,93 @@
+"""Tests for the Issue #2904 forecast-risk eligibility fixtures.
+
+These durable fixtures exist so the forecast-risk calibration filter produces
+risk-scoring-eligible rows instead of returning ``wait``-for-lack-of-rows. The
+tests assert eligibility, actor-class coverage, observation-tier coverage, and
+that the calibration report recommendation is a real decision (not ``wait``).
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.forecast_calibration_report import (
+    build_forecast_calibration_report,
+)
+from scripts.validation import validate_forecast_risk_calibration_filter as filter_validator
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+_FIXTURE_DIR = REPO_ROOT / "tests/fixtures/benchmark/forecast_risk_eligibility"
+_PEDESTRIAN_FIXTURE = _FIXTURE_DIR / "metric_pedestrian_deployable_tracked.json"
+_BICYCLE_FIXTURE = _FIXTURE_DIR / "metric_bicycle_deployable_observation.json"
+_DURABLE_CALIBRATION_REPORT = (
+    REPO_ROOT
+    / "docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20"
+    / "calibration_report.json"
+)
+
+
+def _load_fixtures() -> list[dict[str, object]]:
+    return [
+        json.loads(_PEDESTRIAN_FIXTURE.read_text(encoding="utf-8")),
+        json.loads(_BICYCLE_FIXTURE.read_text(encoding="utf-8")),
+    ]
+
+
+def _build_report() -> dict[str, object]:
+    return build_forecast_calibration_report(
+        _load_fixtures(),
+        report_id="issue_2904_forecast_risk_eligibility_2026-06-20",
+        coverage_target=0.9,
+        coverage_tolerance=0.05,
+        generated_at_utc="2026-06-20T00:00:00+00:00",
+    )
+
+
+def test_fixtures_produce_risk_scoring_eligible_rows() -> None:
+    """At least one reliability row must be eligible for forecast-risk scoring."""
+    report = _build_report()
+    eligible = [
+        row
+        for row in report["reliability_rows"]
+        if row["risk_scoring_eligibility"] == "eligible_analysis_only"
+    ]
+    assert len(eligible) >= 1
+    assert report["limitation_rows"] == []
+
+
+def test_fixtures_cover_pedestrian_and_dynamic_actor_classes() -> None:
+    """The fixtures must contribute a pedestrian and a bicycle actor class."""
+    report = _build_report()
+    actor_classes = {row["actor_class"] for row in report["reliability_rows"]}
+    assert "pedestrian" in actor_classes
+    assert "bicycle" in actor_classes
+    assert "unavailable" not in actor_classes
+
+
+def test_fixtures_span_at_least_two_observation_tiers() -> None:
+    """The fixtures must span at least two distinct observation tiers."""
+    report = _build_report()
+    tiers = {row["observation_tier"] for row in report["reliability_rows"]}
+    assert tiers == {"deployable_tracked", "deployable_observation"}
+    assert len(tiers) >= 2
+
+
+def test_fixtures_yield_real_recommendation_not_wait() -> None:
+    """The calibration recommendation must be a real decision, not ``wait``."""
+    report = _build_report()
+    decision = report["recommendation"]["decision"]
+    assert decision in {"continue", "revise"}
+    assert decision != "wait"
+
+
+def test_durable_report_unblocks_filter_calibration_filtered_mode() -> None:
+    """End-to-end: the durable report unblocks the filter's calibration_filtered mode (#2904)."""
+    assert _DURABLE_CALIBRATION_REPORT.exists()
+    diagnostic = filter_validator.build_report(calibration_path=_DURABLE_CALIBRATION_REPORT)
+    by_mode = {row["mode"]: row["status"] for row in diagnostic["modes"]}
+    assert by_mode["calibration_filtered"] == "available"
+    assert by_mode["actor_class_aware"] == "available"
+    assert by_mode["observation_tier_aware"] == "available"
+    # Overall recommendation must be a real bounded decision, not wait-for-lack-of-rows.
+    assert diagnostic["recommendation"] != "wait"

--- a/tests/fixtures/benchmark/forecast_risk_eligibility/metric_bicycle_deployable_observation.json
+++ b/tests/fixtures/benchmark/forecast_risk_eligibility/metric_bicycle_deployable_observation.json
@@ -1,0 +1,71 @@
+{
+  "aggregate_rows": [
+    {
+      "actor_class": "bicycle",
+      "denominator": 8,
+      "dt_s": 0.5,
+      "horizon_s": 1.0,
+      "metric": "mean_coverage",
+      "observation_tier": "deployable_observation",
+      "scenario_id": "motion_rich_bicycle_low",
+      "semantic_metadata_present": "present",
+      "status": "ok",
+      "value": 0.88
+    },
+    {
+      "actor_class": "bicycle",
+      "denominator": 8,
+      "dt_s": 0.5,
+      "horizon_s": 1.0,
+      "metric": "mean_likelihood",
+      "observation_tier": "deployable_observation",
+      "scenario_id": "motion_rich_bicycle_low",
+      "semantic_metadata_present": "present",
+      "status": "ok",
+      "value": -1.5
+    },
+    {
+      "actor_class": "bicycle",
+      "denominator": 8,
+      "dt_s": 0.5,
+      "horizon_s": 1.0,
+      "metric": "mean_expected_ade",
+      "observation_tier": "deployable_observation",
+      "scenario_id": "motion_rich_bicycle_low",
+      "semantic_metadata_present": "present",
+      "status": "ok",
+      "value": 0.31
+    },
+    {
+      "actor_class": "bicycle",
+      "denominator": 0,
+      "dt_s": 0.5,
+      "horizon_s": 1.0,
+      "metric": "mean_minade@k",
+      "observation_tier": "deployable_observation",
+      "scenario_id": "motion_rich_bicycle_low",
+      "semantic_metadata_present": "present",
+      "status": "unavailable",
+      "value": null
+    }
+  ],
+  "artifact_input": {
+    "command": "durable bicycle metric fixture for issue #2904 forecast-risk eligibility",
+    "generated_at_utc": "2026-06-20T00:00:00+00:00",
+    "issue": 2904,
+    "source": "tests/fixtures/benchmark/forecast_risk_eligibility/metric_bicycle_deployable_observation.json"
+  },
+  "provenance": {
+    "dt_s": 0.5,
+    "horizons_s": [
+      1.0
+    ],
+    "observation_tier": "deployable_observation",
+    "predictor_family": "probabilistic_cv",
+    "predictor_id": "probabilistic-baseline-bicycle-observation-fixture",
+    "scenario_family": "motion_rich_bicycle",
+    "scenario_id": "motion_rich_bicycle_low",
+    "semantic_metadata_present": "present"
+  },
+  "schema_version": "ForecastMetrics.v1"
+}

--- a/tests/fixtures/benchmark/forecast_risk_eligibility/metric_pedestrian_deployable_tracked.json
+++ b/tests/fixtures/benchmark/forecast_risk_eligibility/metric_pedestrian_deployable_tracked.json
@@ -1,0 +1,71 @@
+{
+  "aggregate_rows": [
+    {
+      "actor_class": "pedestrian",
+      "denominator": 12,
+      "dt_s": 0.5,
+      "horizon_s": 1.0,
+      "metric": "mean_coverage",
+      "observation_tier": "deployable_tracked",
+      "scenario_id": "classic_crossing_low",
+      "semantic_metadata_present": "present",
+      "status": "ok",
+      "value": 0.91
+    },
+    {
+      "actor_class": "pedestrian",
+      "denominator": 12,
+      "dt_s": 0.5,
+      "horizon_s": 1.0,
+      "metric": "mean_likelihood",
+      "observation_tier": "deployable_tracked",
+      "scenario_id": "classic_crossing_low",
+      "semantic_metadata_present": "present",
+      "status": "ok",
+      "value": -1.2
+    },
+    {
+      "actor_class": "pedestrian",
+      "denominator": 12,
+      "dt_s": 0.5,
+      "horizon_s": 1.0,
+      "metric": "mean_expected_ade",
+      "observation_tier": "deployable_tracked",
+      "scenario_id": "classic_crossing_low",
+      "semantic_metadata_present": "present",
+      "status": "ok",
+      "value": 0.24
+    },
+    {
+      "actor_class": "pedestrian",
+      "denominator": 0,
+      "dt_s": 0.5,
+      "horizon_s": 1.0,
+      "metric": "mean_minade@k",
+      "observation_tier": "deployable_tracked",
+      "scenario_id": "classic_crossing_low",
+      "semantic_metadata_present": "present",
+      "status": "unavailable",
+      "value": null
+    }
+  ],
+  "artifact_input": {
+    "command": "durable pedestrian metric fixture for issue #2904 forecast-risk eligibility",
+    "generated_at_utc": "2026-06-20T00:00:00+00:00",
+    "issue": 2904,
+    "source": "tests/fixtures/benchmark/forecast_risk_eligibility/metric_pedestrian_deployable_tracked.json"
+  },
+  "provenance": {
+    "dt_s": 0.5,
+    "horizons_s": [
+      1.0
+    ],
+    "observation_tier": "deployable_tracked",
+    "predictor_family": "probabilistic_cv",
+    "predictor_id": "probabilistic-baseline-pedestrian-tracked-fixture",
+    "scenario_family": "classic_crossing",
+    "scenario_id": "classic_crossing_low",
+    "semantic_metadata_present": "present"
+  },
+  "schema_version": "ForecastMetrics.v1"
+}

--- a/tests/validation/test_forecast_risk_calibration_filter.py
+++ b/tests/validation/test_forecast_risk_calibration_filter.py
@@ -81,6 +81,18 @@ class TestModeAvailability:
         assert status == "available"
         assert "eligible" in reason
 
+    def test_calibration_filtered_available_with_canonical_eligibility_token(self) -> None:
+        """The gate recognizes the canonical ``eligible_analysis_only`` token (issue #2904).
+
+        ``build_forecast_calibration_report`` only ever emits ``eligible_analysis_only`` for
+        eligible rows; the legacy ``{"eligible", "calibrated"}`` set never matched it, leaving
+        the ``calibration_filtered`` mode permanently blocked for real reports.
+        """
+        rows = [{"risk_scoring_eligibility": "eligible_analysis_only"}]
+        status, reason = validator._mode_availability("calibration_filtered", rows)
+        assert status == "available"
+        assert "risk-scoring-eligible rows" in reason
+
     def test_actor_class_aware_blocked_when_unavailable(self) -> None:
         """actor_class_aware is blocked when all rows have actor_class unavailable."""
         rows = [{"actor_class": "unavailable"}]


### PR DESCRIPTION
## Summary

Closes #2904. Authors durable `ForecastMetrics.v1` fixtures and regenerated evidence that unblock the forecast-risk calibration filter, then fixes the stale eligibility gate so the `calibration_filtered` mode is actually reachable.

**Before:** the canonical Issue #2865 calibration report contained only `actor_class=unavailable` rows on a single observation tier (`deployable_tracked`), so the filter returned `wait`/blocked for lack of risk-scoring-eligible rows.

**After:** the calibration report recommendation is `continue`/analysis-only and the filter's overall recommendation is `diagnostic_only` (not `wait`), with all five modes `available`.

## Changes

- **Fixtures** (`tests/fixtures/benchmark/forecast_risk_eligibility/`):
  - `metric_pedestrian_deployable_tracked.json` — pedestrian, `deployable_tracked`, coverage 0.91, denom 12.
  - `metric_bicycle_deployable_observation.json` — bicycle, `deployable_observation`, coverage 0.88, denom 8.
  - Both calibrated within tolerance → `risk_scoring_eligibility=eligible_analysis_only`.
- **Evidence** (`docs/context/evidence/issue_2904_forecast_risk_eligibility_2026-06-20/`): regenerated `ForecastCalibrationReport.v1` (`calibration_report.json`/`.md`), filter diagnostic (`report.json`/`.md`, `summary.json`), and a `README.md` with reproducible commands, denominator/actor/tier counts, and claim boundary.
- **Gate fix** (`scripts/validation/validate_forecast_risk_calibration_filter.py`): `_any_eligible_for_risk_scoring` now recognizes the canonical `eligible_analysis_only` token emitted by `build_forecast_calibration_report`. The gate previously matched only legacy `{"eligible","calibrated"}` strings the report never emits, leaving `calibration_filtered` permanently blocked for every real report. Legacy tokens retained for backward compatibility.
- **Tests**: `tests/benchmark/test_forecast_risk_eligibility_fixtures.py` (calibration-report eligibility + end-to-end filter unblock) and one gate-token unit test in `tests/validation/test_forecast_risk_calibration_filter.py`.
- **CHANGELOG**: `Added` + `Fixed` entries.

## Definition of Done (issue #2904)

- [x] ≥1 pedestrian row and ≥1 bicycle/dynamic-agent row expose `actor_class`.
- [x] ≥2 observation tiers (`deployable_tracked`, `deployable_observation`).
- [x] Report contains risk-scoring-eligible rows (2 × `eligible_analysis_only`).
- [x] Calibration-filtered mode returns a real decision, not blocked (`continue` / overall `diagnostic_only`).

## Claim boundary

Diagnostic / analysis-only. Does **not** change `_risk_scoring_eligibility`, calibration thresholds, or planner risk coupling (`calibration_filtered` still runs with `forecast_risk_weight=0.0`). No benchmark/paper-grade claim.

## Validation

```
uv run ruff format --check <changed py>          # clean
uv run ruff check <changed py>                    # clean
uv run pytest tests/ -k "forecast and (calibration or eligib or risk)" \
  tests/validation/test_forecast_risk_calibration_filter.py            # 87 passed
uv run pytest tests/validation/test_forecast_risk_calibration_filter.py \
  tests/benchmark/test_forecast_risk_eligibility_fixtures.py \
  tests/benchmark/test_forecast_calibration_report.py                  # 45 passed
```

The pre-existing `test_current_evidence_blocks_three_modes` still passes, confirming the default Issue #2865 evidence remains blocked (no behavior change for reports without eligible rows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)