### PR TITLE
benchmark: add fidelity sweep dry-run manifest (#3207)

### DIFF
--- a/robot_sf/benchmark/fidelity_sweep_manifest.py
+++ b/robot_sf/benchmark/fidelity_sweep_manifest.py
@@ -1,0 +1,173 @@
+"""Dry-run fidelity sweep manifest builder for issue #3207.
+
+This module only enumerates the planned fidelity sensitivity matrix. It does
+not bind config patches to runtime objects, run benchmark episodes, or promote
+benchmark evidence.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.fidelity_sensitivity import validate_fidelity_sensitivity_config
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+FIDELITY_SWEEP_MANIFEST_SCHEMA = "fidelity-sweep-manifest.v1"
+UNRESOLVED_RUNTIME_BINDING = "unresolved_runtime_binding"
+DRY_RUN_CLAIM_BOUNDARY = (
+    "dry-run manifest only: enumerates the fixed issue #3207 fidelity sensitivity scope; "
+    "not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, "
+    "and not paper-facing evidence."
+)
+SURFACE_RELATIONSHIP = (
+    "axes is canonical for this dry-run manifest; fidelity_axes is retained as a "
+    "secondary analysis-contract surface and is not used to enumerate variants."
+)
+
+
+@dataclass(frozen=True)
+class ManifestOptions:
+    """Stable metadata for a dry-run manifest build."""
+
+    config_path: str
+    git_head: str = "unknown"
+    dry_run: bool = True
+
+
+def build_fidelity_sweep_manifest(
+    config: Mapping[str, Any],
+    *,
+    options: ManifestOptions,
+) -> dict[str, Any]:
+    """Build a deterministic dry-run manifest from the canonical `axes` surface.
+
+    Returns:
+        JSON-serializable manifest payload.
+    """
+    if not options.dry_run:
+        raise ValueError("fidelity sweep manifest builder only supports dry-run manifests")
+
+    validated = validate_fidelity_sensitivity_config(config)
+    fixed_scope = validated["fixed_scope"]
+    axes = [_axis_manifest(axis) for axis in validated["axes"]]
+    return {
+        "schema_version": FIDELITY_SWEEP_MANIFEST_SCHEMA,
+        "issue": int(validated.get("issue", 3207)),
+        "study_id": str(validated["study_id"]),
+        "status": "manifest_dry_run_only",
+        "dry_run": True,
+        "evidence_status": "not_benchmark_evidence",
+        "claim_boundary": DRY_RUN_CLAIM_BOUNDARY,
+        "config_path": options.config_path,
+        "git_head": options.git_head,
+        "fixed_scope": copy.deepcopy(fixed_scope),
+        "seeds": copy.deepcopy(fixed_scope["seeds"]),
+        "planner_groups": copy.deepcopy(fixed_scope["planner_groups"]),
+        "baseline": copy.deepcopy(validated.get("baseline")),
+        "ranking": copy.deepcopy(validated["ranking"]),
+        "metrics": copy.deepcopy(validated["metrics"]),
+        "result_contract": copy.deepcopy(validated.get("result_contract")),
+        "axis_count": len(axes),
+        "axes": axes,
+        "config_surface_relationship": _surface_relationship(validated),
+    }
+
+
+def write_fidelity_sweep_manifest(manifest: Mapping[str, Any], output_dir: str | Path) -> Path:
+    """Write a deterministic JSON dry-run manifest.
+
+    Returns:
+        Path to the written JSON manifest.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    manifest_path = out / "fidelity_sweep_manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+def _axis_manifest(axis: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize one canonical axis while preserving source variant order.
+
+    Returns:
+        JSON-serializable axis manifest.
+    """
+    variants = [_variant_manifest(variant) for variant in axis["variants"]]
+    baseline_variants = [variant["key"] for variant in variants if variant["baseline"]]
+    if len(baseline_variants) != 1:
+        raise ValueError(f"axis {axis.get('key')!r} must mark exactly one baseline variant")
+    return {
+        "key": str(axis["key"]),
+        "rationale": str(axis.get("rationale", "")),
+        "variant_count": len(variants),
+        "baseline_variant": baseline_variants[0],
+        "variants": variants,
+    }
+
+
+def _variant_manifest(variant: Mapping[str, Any]) -> dict[str, Any]:
+    """Preserve patch/noise payloads without claiming runtime executability.
+
+    Returns:
+        JSON-serializable variant manifest.
+    """
+    patch = copy.deepcopy(variant.get("patch")) if "patch" in variant else None
+    observation_noise = (
+        copy.deepcopy(variant.get("observation_noise")) if "observation_noise" in variant else None
+    )
+    return {
+        "key": str(variant["key"]),
+        "baseline": bool(variant.get("baseline", False)),
+        "patch": patch,
+        "observation_noise": observation_noise,
+        "payload_kind": _payload_kind(patch=patch, observation_noise=observation_noise),
+        "runtime_binding_status": UNRESOLVED_RUNTIME_BINDING,
+        "runtime_binding_note": (
+            "Payload copied from config for manifest review only; no runtime patch binding or "
+            "benchmark execution was performed."
+        ),
+    }
+
+
+def _payload_kind(*, patch: Any, observation_noise: Any) -> str:
+    if patch is not None and observation_noise is not None:
+        return "patch_and_observation_noise"
+    if patch is not None:
+        return "patch"
+    if observation_noise is not None:
+        return "observation_noise"
+    return "none"
+
+
+def _surface_relationship(config: Mapping[str, Any]) -> dict[str, Any]:
+    fidelity_axes = config.get("fidelity_axes")
+    secondary_axis_keys = (
+        sorted(str(key) for key in fidelity_axes) if isinstance(fidelity_axes, dict) else []
+    )
+    return {
+        "canonical_surface": "axes",
+        "secondary_surface": "fidelity_axes" if isinstance(fidelity_axes, dict) else None,
+        "manifest_source": "axes",
+        "canonical_axis_keys": [str(axis["key"]) for axis in config["axes"]],
+        "secondary_axis_keys": secondary_axis_keys,
+        "relationship": SURFACE_RELATIONSHIP,
+    }
+
+
+__all__ = [
+    "DRY_RUN_CLAIM_BOUNDARY",
+    "FIDELITY_SWEEP_MANIFEST_SCHEMA",
+    "UNRESOLVED_RUNTIME_BINDING",
+    "ManifestOptions",
+    "build_fidelity_sweep_manifest",
+    "write_fidelity_sweep_manifest",
+]

--- a/scripts/benchmark/build_fidelity_sweep_manifest.py
+++ b/scripts/benchmark/build_fidelity_sweep_manifest.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Build an issue #3207 dry-run fidelity sweep manifest."""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from robot_sf.benchmark.fidelity_sensitivity import load_fidelity_sensitivity_config
+from robot_sf.benchmark.fidelity_sweep_manifest import (
+    ManifestOptions,
+    build_fidelity_sweep_manifest,
+    write_fidelity_sweep_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _git_head() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return "unknown"
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default="configs/research/fidelity_sensitivity_v1.yaml",
+        help="Tracked fidelity-sensitivity config path.",
+    )
+    parser.add_argument(
+        "--out",
+        default="output/fidelity_sensitivity_manifest",
+        help="Output directory for fidelity_sweep_manifest.json.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        required=True,
+        help="Required acknowledgement that this only builds a manifest and runs no sweep.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entry point."""
+    args = parse_args()
+    config = load_fidelity_sensitivity_config(REPO_ROOT / args.config)
+    manifest = build_fidelity_sweep_manifest(
+        config,
+        options=ManifestOptions(
+            config_path=args.config,
+            git_head=_git_head(),
+            dry_run=args.dry_run,
+        ),
+    )
+    manifest_path = write_fidelity_sweep_manifest(manifest, REPO_ROOT / args.out)
+    print(f"wrote dry-run fidelity sweep manifest: {manifest_path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_fidelity_sweep_manifest.py
+++ b/tests/benchmark/test_fidelity_sweep_manifest.py
@@ -1,0 +1,133 @@
+"""Tests for dry-run fidelity sweep manifests for issue #3207."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.fidelity_sensitivity import load_fidelity_sensitivity_config
+from robot_sf.benchmark.fidelity_sweep_manifest import (
+    FIDELITY_SWEEP_MANIFEST_SCHEMA,
+    ManifestOptions,
+    build_fidelity_sweep_manifest,
+    write_fidelity_sweep_manifest,
+)
+
+_CONFIG_PATH = "configs/research/fidelity_sensitivity_v1.yaml"
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _repo_config() -> dict[str, object]:
+    return load_fidelity_sensitivity_config(_CONFIG_PATH)
+
+
+def test_manifest_uses_axes_surface_and_preserves_payloads() -> None:
+    """The manifest contract is sourced from canonical `axes`, not `fidelity_axes`."""
+    config = _repo_config()
+
+    manifest = build_fidelity_sweep_manifest(
+        config,
+        options=ManifestOptions(config_path=_CONFIG_PATH, git_head="abc1234"),
+    )
+
+    assert manifest["schema_version"] == FIDELITY_SWEEP_MANIFEST_SCHEMA
+    assert manifest["status"] == "manifest_dry_run_only"
+    assert manifest["evidence_status"] == "not_benchmark_evidence"
+    assert manifest["fixed_scope"] == config["fixed_scope"]
+    assert manifest["seeds"] == [111, 112, 113]
+    assert manifest["planner_groups"] == ["orca", "default_social_force", "hybrid_rule_v0_minimal"]
+    assert manifest["config_surface_relationship"]["canonical_surface"] == "axes"
+    assert manifest["config_surface_relationship"]["secondary_surface"] == "fidelity_axes"
+    assert manifest["config_surface_relationship"]["manifest_source"] == "axes"
+    assert [axis["key"] for axis in manifest["axes"]] == [axis["key"] for axis in config["axes"]]
+
+    timestep_axis = manifest["axes"][0]
+    assert timestep_axis["baseline_variant"] == "dt_0_10_nominal"
+    assert timestep_axis["variants"][0]["patch"] == {"dt": 0.05}
+    assert timestep_axis["variants"][0]["observation_noise"] is None
+    assert timestep_axis["variants"][0]["runtime_binding_status"] == ("unresolved_runtime_binding")
+
+    noise_axis = next(axis for axis in manifest["axes"] if axis["key"] == "observation_noise")
+    assert noise_axis["baseline_variant"] == "none_nominal"
+    assert noise_axis["variants"][1]["patch"] is None
+    assert noise_axis["variants"][1]["observation_noise"]["profile"] == "pose_heading_low"
+    assert noise_axis["variants"][1]["runtime_binding_status"] == ("unresolved_runtime_binding")
+
+
+def test_manifest_rejects_axes_without_exactly_one_baseline() -> None:
+    """Each canonical axis must mark exactly one baseline variant."""
+    config = _repo_config()
+    config["axes"][0]["variants"][0]["baseline"] = True
+
+    with pytest.raises(ValueError, match="exactly one baseline variant"):
+        build_fidelity_sweep_manifest(
+            config,
+            options=ManifestOptions(config_path=_CONFIG_PATH, git_head="abc1234"),
+        )
+
+
+def test_manifest_claim_boundary_prevents_benchmark_or_paper_claims() -> None:
+    """The dry-run manifest must not be worded as evidence."""
+    manifest = build_fidelity_sweep_manifest(
+        _repo_config(),
+        options=ManifestOptions(config_path=_CONFIG_PATH, git_head="abc1234"),
+    )
+
+    claim_boundary = manifest["claim_boundary"]
+    assert "dry-run manifest only" in claim_boundary
+    assert "not benchmark evidence" in claim_boundary
+    assert "not simulator-realism evidence" in claim_boundary
+    assert "not sim-to-real evidence" in claim_boundary
+    assert "not paper-facing evidence" in claim_boundary
+    assert manifest["dry_run"] is True
+
+
+def test_manifest_json_output_is_deterministic(tmp_path: Path) -> None:
+    """Repeated builds and writes with the same inputs should produce byte-identical JSON."""
+    config = _repo_config()
+    options = ManifestOptions(config_path=_CONFIG_PATH, git_head="abc1234")
+
+    first = build_fidelity_sweep_manifest(config, options=options)
+    second = build_fidelity_sweep_manifest(config, options=options)
+
+    assert first == second
+    assert json.dumps(first, indent=2, sort_keys=True) == json.dumps(
+        second, indent=2, sort_keys=True
+    )
+
+    first_path = write_fidelity_sweep_manifest(first, tmp_path / "first")
+    second_path = write_fidelity_sweep_manifest(second, tmp_path / "second")
+
+    assert first_path.read_text(encoding="utf-8") == second_path.read_text(encoding="utf-8")
+
+
+def test_manifest_reports_fidelity_axes_as_secondary_risk_not_source() -> None:
+    """Conflicting `fidelity_axes` names must not change the manifest axis source."""
+    config = _repo_config()
+    config["fidelity_axes"] = {
+        "unrelated_runtime_surface": {
+            "description": "must not drive the dry-run manifest",
+            "nominal": 1.0,
+            "values": [1.0, 2.0],
+        }
+    }
+
+    manifest = build_fidelity_sweep_manifest(
+        config,
+        options=ManifestOptions(config_path=_CONFIG_PATH, git_head="abc1234"),
+    )
+
+    assert "unrelated_runtime_surface" not in {axis["key"] for axis in manifest["axes"]}
+    assert manifest["config_surface_relationship"]["manifest_source"] == "axes"
+    assert manifest["config_surface_relationship"]["secondary_axis_keys"] == [
+        "unrelated_runtime_surface"
+    ]
+    assert (
+        manifest["config_surface_relationship"]["relationship"]
+        == "axes is canonical for this dry-run manifest; fidelity_axes is retained as a "
+        "secondary analysis-contract surface and is not used to enumerate variants."
+    )


### PR DESCRIPTION
## Summary

- add a dry-run fidelity sweep manifest builder for #3207
- add a CLI that writes `output/fidelity_sensitivity_manifest/fidelity_sweep_manifest.json`
- add tests for manifest shape, baseline validation, claim boundary, deterministic output, and the `axes` vs `fidelity_axes` surface relationship

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_fidelity_sweep_manifest.py --config configs/research/fidelity_sensitivity_v1.yaml --out output/fidelity_sensitivity_manifest --dry-run`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_fidelity_sweep_manifest.py tests/benchmark/test_fidelity_sensitivity.py tests/benchmark/test_fidelity_rank_stability.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/fidelity_sweep_manifest.py scripts/benchmark/build_fidelity_sweep_manifest.py tests/benchmark/test_fidelity_sweep_manifest.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/fidelity_sweep_manifest.py scripts/benchmark/build_fidelity_sweep_manifest.py tests/benchmark/test_fidelity_sweep_manifest.py`
- `git diff --check origin/main..HEAD`

## Downstream Propagation

- Parent issue: #3207.
- This PR does not run the fidelity sweep, submit jobs, or produce benchmark evidence.
- Generated `output/fidelity_sensitivity_manifest/fidelity_sweep_manifest.json` is a local ignored dry-run artifact only.
- The manifest declares `status: manifest_dry_run_only`, `evidence_status: not_benchmark_evidence`, and unresolved runtime bindings for variant payloads.

## Research Result Guidance

- Target claim: whether planner rankings remain stable under deliberate simulation-fidelity perturbations.
- Evidence tier in this PR: manifest/dry-run tooling only.
- Result classification: not evidence; launch/manifest preparation only.
- Stop rule for future work: only classify validity-boundary evidence after a real sweep is run and promoted through a compact evidence bundle.
