### PR TITLE
adversarial: add candidate batch certification CLI (#2920)

### DIFF
--- a/robot_sf/adversarial/batch_certification.py
+++ b/robot_sf/adversarial/batch_certification.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import sys
 from collections import Counter
 from dataclasses import dataclass, replace
@@ -67,6 +68,15 @@ class BatchCertificationPolicy:
     reject_statuses: tuple[str, ...] = (REASON_INVALID, REASON_DEGENERATE)
     reject_duplicates: bool = True
     min_batch_validity_rate: float | None = None
+
+    def __post_init__(self) -> None:
+        """Validate policy values that affect emitted certification payloads."""
+        if self.min_batch_validity_rate is None:
+            return
+        if not math.isfinite(self.min_batch_validity_rate):
+            raise ValueError("min_batch_validity_rate must be finite")
+        if not 0.0 <= self.min_batch_validity_rate <= 1.0:
+            raise ValueError("min_batch_validity_rate must be between 0 and 1")
 
     def to_dict(self) -> dict[str, object]:
         """Return JSON-safe policy settings used by a certification run."""

--- a/robot_sf/adversarial/batch_certification.py
+++ b/robot_sf/adversarial/batch_certification.py
@@ -20,10 +20,15 @@ makes no planner benchmark claim.
 
 from __future__ import annotations
 
+import argparse
+import json
+import sys
 from collections import Counter
 from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import TYPE_CHECKING
+
+import yaml
 
 from robot_sf.adversarial.manifest_quality import (
     EVIDENCE_BOUNDARY,
@@ -63,6 +68,14 @@ class BatchCertificationPolicy:
     reject_duplicates: bool = True
     min_batch_validity_rate: float | None = None
 
+    def to_dict(self) -> dict[str, object]:
+        """Return JSON-safe policy settings used by a certification run."""
+        return {
+            "reject_statuses": list(self.reject_statuses),
+            "reject_duplicates": self.reject_duplicates,
+            "min_batch_validity_rate": self.min_batch_validity_rate,
+        }
+
 
 @dataclass(frozen=True)
 class CandidateCertification:
@@ -100,6 +113,7 @@ class BatchCertification:
     rejection_counts: dict[str, int]
     validity_rate: float
     candidates: list[CandidateCertification]
+    policy: BatchCertificationPolicy
     quality_summary: ManifestsQualitySummary | None = None
 
     def to_dict(self) -> dict[str, object]:
@@ -118,6 +132,7 @@ class BatchCertification:
             "rejected_count": self.rejected_count,
             "validity_rate": self.validity_rate,
             "rejection_counts": dict(self.rejection_counts),
+            "policy": self.policy.to_dict(),
             "candidates": [candidate.to_dict() for candidate in self.candidates],
         }
         if self.quality_summary is not None:
@@ -185,6 +200,7 @@ def certify_records(
         rejection_counts=dict(rejection_counts),
         validity_rate=validity_rate,
         candidates=candidates,
+        policy=policy,
     )
 
 
@@ -215,3 +231,84 @@ def certify_candidate_batch(
         reference_manifest=reference_manifest,
     )
     return replace(certification, quality_summary=summary)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """Build a CLI parser for the pre-planner batch-certification gate."""
+    parser = argparse.ArgumentParser(
+        description="Certify adversarial candidate batches before planner execution."
+    )
+    parser.add_argument(
+        "manifests",
+        nargs="+",
+        type=Path,
+        help="Candidate manifest YAML files and/or directories.",
+    )
+    parser.add_argument(
+        "--reference-manifest",
+        type=Path,
+        default=None,
+        help="Optional reference manifest used for perturbation-distance provenance.",
+    )
+    parser.add_argument(
+        "--min-batch-validity-rate",
+        type=float,
+        default=None,
+        help="Optional batch-level minimum validity rate required to accept the batch.",
+    )
+    parser.add_argument(
+        "--allow-duplicates",
+        action="store_true",
+        help="Keep later duplicate control hashes instead of rejecting them.",
+    )
+    parser.add_argument(
+        "--skip-quality-summary",
+        action="store_true",
+        help="Skip embedding the manifest-quality provenance summary in the output payload.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Write JSON output to this path; if omitted, print to stdout.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Exit codes:
+        0: batch accepted.
+        1: input/IO/parse error.
+        2: batch rejected by the certification gate.
+    """
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    policy = BatchCertificationPolicy(
+        reject_duplicates=not args.allow_duplicates,
+        min_batch_validity_rate=args.min_batch_validity_rate,
+    )
+    try:
+        certification = certify_candidate_batch(
+            manifest_inputs=[*args.manifests],
+            policy=policy,
+            reference_manifest=args.reference_manifest,
+            include_quality_summary=not args.skip_quality_summary,
+        )
+        payload = certification.to_dict()
+        text = json.dumps(payload, indent=2, sort_keys=True)
+        output = text
+        if args.output_json is not None:
+            args.output_json.parent.mkdir(parents=True, exist_ok=True)
+            args.output_json.write_text(text + "\n", encoding="utf-8")
+            output = args.output_json.as_posix()
+        sys.stdout.write(f"{output}\n")
+        return 0 if certification.accepted else 2
+    except (OSError, ValueError, json.JSONDecodeError, yaml.YAMLError) as exc:
+        sys.stderr.write(f"Error: {exc}\n")
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/robot_sf/benchmark/schemas/adversarial_candidate_quality.v1.json
+++ b/robot_sf/benchmark/schemas/adversarial_candidate_quality.v1.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://example.com/robot-sf/adversarial_candidate_quality.v1.json",
+  "title": "RobotSF Adversarial Candidate Quality Summary (v1)",
+  "description": "Pre-planner certification summary for adversarial candidate batches. This is a generator-quality gate, not planner benchmark evidence.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "evidence_boundary",
+    "batch_accepted",
+    "total",
+    "accepted_count",
+    "rejected_count",
+    "validity_rate",
+    "rejection_counts",
+    "policy",
+    "candidates"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "adversarial_candidate_quality.v1"
+    },
+    "evidence_boundary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "batch_accepted": {
+      "type": "boolean"
+    },
+    "total": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "accepted_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "rejected_count": {
+      "type": "integer",
+      "minimum": 0
+    },
+    "validity_rate": {
+      "type": "number",
+      "minimum": 0,
+      "maximum": 1
+    },
+    "rejection_counts": {
+      "type": "object",
+      "propertyNames": {
+        "enum": ["invalid", "degenerate", "duplicate"]
+      },
+      "additionalProperties": {
+        "type": "integer",
+        "minimum": 0
+      }
+    },
+    "policy": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["reject_statuses", "reject_duplicates", "min_batch_validity_rate"],
+      "properties": {
+        "reject_statuses": {
+          "type": "array",
+          "items": {
+            "enum": ["invalid", "degenerate", "duplicate"]
+          },
+          "minItems": 1
+        },
+        "reject_duplicates": {
+          "type": "boolean"
+        },
+        "min_batch_validity_rate": {
+          "type": ["number", "null"],
+          "minimum": 0,
+          "maximum": 1
+        }
+      }
+    },
+    "candidates": {
+      "type": "array",
+      "items": {
+        "$ref": "#/$defs/candidate_decision"
+      }
+    },
+    "quality_summary": {
+      "type": "object",
+      "required": ["schema_version"],
+      "properties": {
+        "schema_version": {
+          "const": "adversarial_manifest_quality_summary.v1"
+        }
+      },
+      "additionalProperties": true
+    }
+  },
+  "$defs": {
+    "candidate_decision": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["index", "path", "status", "accepted", "reasons"],
+      "properties": {
+        "index": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "path": {
+          "type": "string",
+          "minLength": 1
+        },
+        "status": {
+          "enum": ["valid", "invalid", "degenerate"]
+        },
+        "accepted": {
+          "type": "boolean"
+        },
+        "reasons": {
+          "type": "array",
+          "items": {
+            "enum": ["invalid", "degenerate", "duplicate"]
+          }
+        }
+      }
+    }
+  }
+}

--- a/scripts/tools/certify_adversarial_candidate_batch.py
+++ b/scripts/tools/certify_adversarial_candidate_batch.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+"""CLI entry point for adversarial candidate-batch certification."""
+
+from __future__ import annotations
+
+import sys
+
+from robot_sf.adversarial.batch_certification import main as certification_main
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run as a script with arguments from ``sys.argv``."""
+    return certification_main(argv)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/adversarial/test_batch_certification.py
+++ b/tests/adversarial/test_batch_certification.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 
+import jsonschema
+import pytest
 import yaml
 
 from robot_sf.adversarial import manifest_quality
@@ -13,9 +16,20 @@ from robot_sf.adversarial.batch_certification import (
     certify_candidate_batch,
     certify_records,
 )
+from robot_sf.adversarial.batch_certification import (
+    main as batch_cli_main,
+)
 from robot_sf.adversarial.config import CandidateSpec, Pose2D
 from robot_sf.adversarial.manifest_quality import ManifestQualityRecord
 from robot_sf.adversarial.scenario_manifest import compute_control_hash
+
+_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "benchmark"
+    / "schemas"
+    / "adversarial_candidate_quality.v1.json"
+)
 
 
 def _record(status: str, *, path: str, control_hash: str | None = None) -> ManifestQualityRecord:
@@ -101,6 +115,26 @@ def test_batch_validity_gate_rejects_low_quality_batch() -> None:
     assert next(c for c in result.candidates if c.path == "a").accepted is True
 
 
+def test_payload_records_non_default_policy() -> None:
+    """Non-default gate policy is part of the emitted provenance payload."""
+    records = [
+        _record("valid", path="a", control_hash="dup"),
+        _record("valid", path="b", control_hash="dup"),
+    ]
+    policy = BatchCertificationPolicy(
+        reject_duplicates=False,
+        min_batch_validity_rate=0.75,
+    )
+
+    payload = certify_records(records, policy).to_dict()
+
+    assert payload["policy"] == {
+        "reject_statuses": ["invalid", "degenerate"],
+        "reject_duplicates": False,
+        "min_batch_validity_rate": 0.75,
+    }
+
+
 def test_empty_batch_is_not_accepted() -> None:
     """An empty batch produces a well-formed, non-accepted result."""
     result = certify_records([])
@@ -115,6 +149,11 @@ def test_to_dict_emits_candidate_quality_v1() -> None:
     payload = result.to_dict()
     assert payload["schema_version"] == ADVERSARIAL_CANDIDATE_QUALITY_SCHEMA
     assert "evidence_boundary" in payload
+    assert payload["policy"] == {
+        "reject_statuses": ["invalid", "degenerate"],
+        "reject_duplicates": True,
+        "min_batch_validity_rate": None,
+    }
     assert payload["total"] == 1
     assert payload["candidates"][0]["path"] == "a"
 
@@ -224,3 +263,63 @@ def test_certify_records_without_quality_summary(tmp_path: Path) -> None:
     result = certify_candidate_batch([tmp_path], include_quality_summary=False)
     assert result.quality_summary is None
     assert "quality_summary" not in result.to_dict()
+
+
+def test_candidate_quality_payload_validates_against_schema(tmp_path: Path) -> None:
+    """The emitted payload should validate against the canonical v1 schema."""
+    _write_manifest(tmp_path / "a.yaml", _controls(0.0), "valid")
+    _write_manifest(tmp_path / "b.yaml", _controls(1.0), "invalid")
+
+    payload = certify_candidate_batch([tmp_path]).to_dict()
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    jsonschema.Draft202012Validator(schema).validate(payload)
+
+
+def test_batch_certification_cli_writes_output_json_and_exits_zero(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """An accepted batch writes the summary JSON and exits successfully."""
+    _write_manifest(tmp_path / "a.yaml", _controls(0.0), "valid")
+    output_json = tmp_path / "candidate_quality.json"
+
+    exit_code = batch_cli_main([str(tmp_path), "--output-json", str(output_json)])
+
+    assert exit_code == 0
+    assert capsys.readouterr().out.strip() == output_json.as_posix()
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == ADVERSARIAL_CANDIDATE_QUALITY_SCHEMA
+    assert payload["batch_accepted"] is True
+
+
+def test_batch_certification_cli_rejects_bad_batch_with_gate_exit_code(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A rejected batch still writes diagnostics but returns a non-zero gate exit code."""
+    _write_manifest(tmp_path / "bad.yaml", _controls(0.0), "degenerate")
+    output_json = tmp_path / "candidate_quality.json"
+
+    exit_code = batch_cli_main([str(tmp_path), "--output-json", str(output_json)])
+
+    assert exit_code == 2
+    assert capsys.readouterr().out.strip() == output_json.as_posix()
+    payload = json.loads(output_json.read_text(encoding="utf-8"))
+    assert payload["batch_accepted"] is False
+    assert payload["rejection_counts"] == {"degenerate": 1}
+
+
+def test_batch_certification_cli_reports_malformed_yaml_without_traceback(
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Malformed YAML should be a bounded input error, not a traceback."""
+    (tmp_path / "bad.yaml").write_text("candidate_controls: [\n", encoding="utf-8")
+
+    exit_code = batch_cli_main([str(tmp_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 1
+    assert captured.out == ""
+    assert captured.err.startswith("Error: ")

--- a/tests/adversarial/test_batch_certification.py
+++ b/tests/adversarial/test_batch_certification.py
@@ -115,6 +115,13 @@ def test_batch_validity_gate_rejects_low_quality_batch() -> None:
     assert next(c for c in result.candidates if c.path == "a").accepted is True
 
 
+@pytest.mark.parametrize("threshold", [-0.1, 1.1, float("nan"), float("inf")])
+def test_policy_rejects_invalid_batch_validity_thresholds(threshold: float) -> None:
+    """Batch-level validity thresholds must stay schema-compatible probabilities."""
+    with pytest.raises(ValueError, match="min_batch_validity_rate"):
+        BatchCertificationPolicy(min_batch_validity_rate=threshold)
+
+
 def test_payload_records_non_default_policy() -> None:
     """Non-default gate policy is part of the emitted provenance payload."""
     records = [


### PR DESCRIPTION
## Summary
Adds a callable pre-planner certification gate for adversarial candidate batches, plus a canonical `adversarial_candidate_quality.v1` schema for the emitted quality payload.

## Linked Issues
- Relates to `#2920`

## Stack / Dependency
- Base dependency: latest `origin/main`
- Required prior PRs: none
- Stack follow-up issues: `#2920` remains open; `#3265` tracks planner-comparison integration and post-execution row classification propagation.
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added a CLI surface to `robot_sf.adversarial.batch_certification` and a thin script entrypoint at `scripts/tools/certify_adversarial_candidate_batch.py`.
- Added `adversarial_candidate_quality.v1` schema for pre-planner candidate-quality payloads.
- Included applied certification policy in the output payload so non-default knobs are reproducible.
- Added focused tests for schema validation, CLI success/rejection exit codes, malformed YAML handling, and policy provenance.

## Why It Matters
- Added value: adversarial candidate batches can be rejected before planner execution instead of wasting benchmark time on invalid, degenerate, or duplicate candidates.
- Expected impact: cleaner planner-comparison inputs and more auditable generator-quality artifacts.
- Why this is worth merging now: it provides the reviewable gate surface without changing benchmark runner behavior yet.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: candidate-batch quality should be certified before planner comparison consumes adversarial search outputs.
- Comparator or baseline, if applicable: prior batch certification existed as library logic only, without a canonical CLI/schema handoff.
- Evidence tier: targeted smoke / contract proof.
- Result classification: blocker-resolution for the callable pre-planner gate; not benchmark evidence.
- Decision or stop rule, if applicable: continue #2920 only after a planner-comparison entrypoint consumes or requires this gate.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2920.
- New research/benchmark/metric/paper-facing analysis tool, if any: support helper only; this PR does not run planner benchmarks or interpret outcomes.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/adversarial/test_batch_certification.py -q`
  - `uv run ruff check robot_sf/adversarial/batch_certification.py scripts/tools/certify_adversarial_candidate_batch.py tests/adversarial/test_batch_certification.py`
  - `uv run ruff format --check robot_sf/adversarial/batch_certification.py scripts/tools/certify_adversarial_candidate_batch.py tests/adversarial/test_batch_certification.py`
  - `python -m json.tool robot_sf/benchmark/schemas/adversarial_candidate_quality.v1.json >/dev/null`
  - `git diff --check`
  - malformed-YAML CLI smoke: script exits `1` without traceback
- Evidence that the change works here: focused tests passed (`16 passed`), schema parses, Ruff passed, and CLI handles accepted, rejected, and malformed inputs.
- Benchmarks or smoke tests, if applicable: CLI smoke only; not benchmark evidence.

## Risks / Rollout
- Compatibility risks: none expected; this adds a new CLI/schema and does not change existing runner behavior.
- Failure modes: users may assume pre-planner quality certification covers simulation failure/fallback/degraded outcomes; PR text and module boundary state that it does not.
- Rollback or fallback plan: remove the CLI/script/schema additions and keep the existing library-only gate.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, pending review/merge.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, #3265.
- Not applicable because: this PR is a smoke-tier pre-execution support surface, not planner benchmark evidence.

## Follow-Up Issues
- Deferred work: wire this certification gate into a planner-comparison or adversarial-campaign entrypoint; continue separating post-execution simulation failure, fallback, degraded rows, and genuine behavioral failures.
- Issues opened for follow-up: #3265.

## Reviewer Notes
- Please focus on CLI exit codes, malformed input behavior, schema reproducibility, and the boundary that this is pre-planner certification only.
