### PR TITLE
workflow: gate adversarial smoke with candidate certification (#3265)

### DIFF
--- a/docs/context/issue_2562_adversarial_manifest_smoke.md
+++ b/docs/context/issue_2562_adversarial_manifest_smoke.md
@@ -15,12 +15,13 @@ Related surfaces:
 
 ## Current Command Surface
 
-Issue #3265 adds an opt-in pre-planner certification gate to the smoke runner:
-`--require-candidate-certification`. When enabled, the runner writes an
-`adversarial_candidate_quality.v1` payload before materialization, records the payload path and
-applied policy in `candidate_certification`, and blocks rejected batches before planner execution.
-`--allow-rejected-candidates-diagnostic` is the explicit diagnostic-only override; certification
-status stays separate from `planner_runs` and post-execution smoke classification.
+Issue [`#3265`](https://github.com/ll7/robot_sf_ll7/issues/3265) adds an opt-in
+pre-planner certification gate to the smoke runner: `--require-candidate-certification`. When
+enabled, the runner writes an `adversarial_candidate_quality.v1` payload before materialization,
+records the payload path and applied policy in `candidate_certification`, and blocks rejected
+batches before planner execution. `--allow-rejected-candidates-diagnostic` is the explicit
+diagnostic-only override; certification status stays separate from `planner_runs` and
+post-execution smoke classification.
 
 ## Result
 

--- a/docs/context/issue_2562_adversarial_manifest_smoke.md
+++ b/docs/context/issue_2562_adversarial_manifest_smoke.md
@@ -13,6 +13,15 @@ Related surfaces:
 - Smoke runner: `scripts/tools/run_adversarial_manifest_smoke.py`
 - Evidence: `docs/context/evidence/issue_2562_adversarial_manifest_smoke/summary.json`
 
+## Current Command Surface
+
+Issue #3265 adds an opt-in pre-planner certification gate to the smoke runner:
+`--require-candidate-certification`. When enabled, the runner writes an
+`adversarial_candidate_quality.v1` payload before materialization, records the payload path and
+applied policy in `candidate_certification`, and blocks rejected batches before planner execution.
+`--allow-rejected-candidates-diagnostic` is the explicit diagnostic-only override; certification
+status stays separate from `planner_runs` and post-execution smoke classification.
+
 ## Result
 
 Issue #2562 adds the first planner-facing smoke for `adversarial_scenario_manifest.v1`. The runner
@@ -87,7 +96,8 @@ tests passed with 2 tests, and Ruff check passed.
 
 ## Follow-Up Direction
 
-The next useful step is a certification or replay-determinism gate for selected manifest candidates
-before treating any generated case as more than development stress input. If the adapter-mode
-`social_force` collision signal looks interesting, rerun with a native/comparable planner pair or a
-larger certified candidate packet before making any planner interpretation.
+The certification gate now exists for generated candidate batches. The next useful step is a
+replay-determinism or larger certified-packet run before treating any generated case as more than
+development stress input. If the adapter-mode `social_force` collision signal looks interesting,
+rerun with a native/comparable planner pair or a larger certified candidate packet before making any
+planner interpretation.

--- a/scripts/tools/run_adversarial_manifest_smoke.py
+++ b/scripts/tools/run_adversarial_manifest_smoke.py
@@ -15,6 +15,11 @@ from typing import Any
 
 import yaml
 
+from robot_sf.adversarial.batch_certification import (
+    ADVERSARIAL_CANDIDATE_QUALITY_SCHEMA,
+    BatchCertificationPolicy,
+    certify_candidate_batch,
+)
 from robot_sf.adversarial.config import SearchSpaceConfig
 from robot_sf.adversarial.materialize import (
     materialize_manifest_route_overrides,
@@ -40,6 +45,7 @@ EVIDENCE_BOUNDARY = (
     "smoke-only: generated cases are uncategorized development stress tests; this run does not "
     "establish adversarial coverage, planner weakness, leaderboard standing, or paper-facing claims."
 )
+DEFAULT_CANDIDATE_CERTIFICATION_JSON = "candidate_certification.json"
 
 
 def _load_yaml_mapping(path: Path) -> dict[str, Any]:
@@ -139,6 +145,66 @@ def _valid_manifests(
         for manifest in manifests
         if manifest.validation is not None and manifest.validation.status is ManifestCategory.VALID
     ]
+
+
+def _candidate_certification_policy(args: argparse.Namespace) -> BatchCertificationPolicy:
+    """Build the pre-planner candidate-certification policy from CLI arguments."""
+
+    return BatchCertificationPolicy(
+        reject_duplicates=not bool(getattr(args, "allow_duplicate_candidates", False)),
+        min_batch_validity_rate=getattr(args, "min_batch_validity_rate", None),
+    )
+
+
+def _candidate_certification_output_path(args: argparse.Namespace, output_dir: Path) -> Path:
+    """Resolve where the certification payload should be written."""
+
+    configured = getattr(args, "candidate_certification_json", None)
+    if configured is None:
+        return output_dir / DEFAULT_CANDIDATE_CERTIFICATION_JSON
+    return Path(configured)
+
+
+def _run_candidate_certification(
+    args: argparse.Namespace,
+    *,
+    manifest_dir: Path,
+    output_dir: Path,
+) -> dict[str, Any]:
+    """Certify generated candidates and write the pre-planner gate artifact."""
+
+    output_path = _candidate_certification_output_path(args, output_dir)
+    policy = _candidate_certification_policy(args)
+    reference_manifest = getattr(args, "candidate_certification_reference_manifest", None)
+    certification = certify_candidate_batch(
+        [manifest_dir],
+        policy=policy,
+        reference_manifest=reference_manifest,
+    )
+    payload = certification.to_dict()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    diagnostic_override = bool(getattr(args, "allow_rejected_candidates_diagnostic", False))
+    return {
+        "schema_version": ADVERSARIAL_CANDIDATE_QUALITY_SCHEMA,
+        "payload_path": output_path.as_posix(),
+        "status": "accepted"
+        if certification.accepted
+        else "diagnostic_override"
+        if diagnostic_override
+        else "rejected",
+        "batch_accepted": certification.accepted,
+        "diagnostic_override": diagnostic_override and not certification.accepted,
+        "applied_policy": policy.to_dict(),
+        "total": certification.total,
+        "accepted_count": certification.accepted_count,
+        "rejected_count": certification.rejected_count,
+        "accepted_candidate_paths": [
+            candidate.path for candidate in certification.candidates if candidate.accepted
+        ],
+        "validity_rate": certification.validity_rate,
+        "rejection_counts": dict(certification.rejection_counts),
+    }
 
 
 def _materialize_matrix(
@@ -430,12 +496,37 @@ def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
         encoding="utf-8",
     )
     manifest_rows = _write_manifest_batch(manifests, output_dir=output_dir)
-    selected = _valid_manifests(manifests)[: args.max_valid]
+    candidate_certification: dict[str, Any] = {
+        "status": "not_required",
+        "batch_accepted": None,
+        "diagnostic_override": False,
+    }
+    if bool(getattr(args, "require_candidate_certification", False)):
+        candidate_certification = _run_candidate_certification(
+            args,
+            manifest_dir=output_dir / "manifests",
+            output_dir=output_dir,
+        )
+    certification_blocks_planners = (
+        candidate_certification["status"] == "rejected"
+        and not candidate_certification["diagnostic_override"]
+    )
+    if bool(getattr(args, "require_candidate_certification", False)):
+        accepted_paths = set(candidate_certification.get("accepted_candidate_paths", []))
+        selected = [
+            manifest
+            for manifest, row in zip(manifests, manifest_rows, strict=True)
+            if row["path"] in accepted_paths
+            and manifest.validation is not None
+            and manifest.validation.status is ManifestCategory.VALID
+        ][: args.max_valid]
+    else:
+        selected = _valid_manifests(manifests)[: args.max_valid]
 
     planner_runs: list[dict[str, Any]] = []
     matrix_path: Path | None = None
     materialized_rows: list[dict[str, Any]] = []
-    if selected:
+    if selected and not certification_blocks_planners:
         matrix_path, materialized_rows = _materialize_matrix(
             selected,
             scenario_template=scenario_template,
@@ -454,7 +545,11 @@ def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
                 )
             )
 
-    result_classification = _classify_smoke_result(generation, selected, planner_runs)
+    result_classification = (
+        "candidate_certification_rejected"
+        if certification_blocks_planners
+        else _classify_smoke_result(generation, selected, planner_runs)
+    )
     payload = {
         "schema_version": SUMMARY_SCHEMA_VERSION,
         "evidence_classification": EVIDENCE_CLASSIFICATION,
@@ -466,6 +561,7 @@ def run_smoke(args: argparse.Namespace) -> dict[str, Any]:
         },
         "source": source.to_dict(),
         "generation": generation,
+        "candidate_certification": candidate_certification,
         "manifests": manifest_rows,
         "materialized": {
             "matrix_path": matrix_path.as_posix() if matrix_path is not None else None,
@@ -525,6 +621,42 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--horizon", type=int, default=60)
     parser.add_argument("--dt", type=float, default=0.1)
     parser.add_argument("--workers", type=int, default=1)
+    parser.add_argument(
+        "--require-candidate-certification",
+        action="store_true",
+        help="Certify generated candidate manifests before materialization or planner execution.",
+    )
+    parser.add_argument(
+        "--candidate-certification-json",
+        type=Path,
+        default=None,
+        help=(
+            "Path for the adversarial_candidate_quality.v1 payload. Defaults to "
+            f"<output-dir>/{DEFAULT_CANDIDATE_CERTIFICATION_JSON}."
+        ),
+    )
+    parser.add_argument(
+        "--candidate-certification-reference-manifest",
+        type=Path,
+        default=None,
+        help="Optional reference manifest used for certification perturbation provenance.",
+    )
+    parser.add_argument(
+        "--min-batch-validity-rate",
+        type=float,
+        default=None,
+        help="Optional candidate-batch validity rate required before planner execution.",
+    )
+    parser.add_argument(
+        "--allow-duplicate-candidates",
+        action="store_true",
+        help="Do not reject repeated normalized control hashes during candidate certification.",
+    )
+    parser.add_argument(
+        "--allow-rejected-candidates-diagnostic",
+        action="store_true",
+        help="Continue the smoke run after a rejected certification and mark it diagnostic-only.",
+    )
     return parser
 
 

--- a/scripts/tools/run_adversarial_manifest_smoke.py
+++ b/scripts/tools/run_adversarial_manifest_smoke.py
@@ -156,6 +156,18 @@ def _candidate_certification_policy(args: argparse.Namespace) -> BatchCertificat
     )
 
 
+def _bounded_unit_interval(value: str) -> float:
+    """Parse a finite float constrained to the unit interval."""
+
+    try:
+        parsed = float(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError("must be a finite float between 0 and 1") from exc
+    if not math.isfinite(parsed) or not 0.0 <= parsed <= 1.0:
+        raise argparse.ArgumentTypeError("must be a finite float between 0 and 1")
+    return parsed
+
+
 def _candidate_certification_output_path(args: argparse.Namespace, output_dir: Path) -> Path:
     """Resolve where the certification payload should be written."""
 
@@ -643,7 +655,7 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--min-batch-validity-rate",
-        type=float,
+        type=_bounded_unit_interval,
         default=None,
         help="Optional candidate-batch validity rate required before planner execution.",
     )

--- a/tests/tools/test_run_adversarial_manifest_smoke.py
+++ b/tests/tools/test_run_adversarial_manifest_smoke.py
@@ -309,3 +309,285 @@ def test_run_smoke_only_materializes_valid_manifests(
     assert payload["result_classification"] == "smoke_passed"
     assert payload["materialized"]["selected_valid_candidates"] == [{"scenario_seed": 7}]
     assert run_batch_calls == [str(output_dir / "materialized_matrix.yaml")]
+
+
+def _base_smoke_args(
+    tmp_path: Path,
+    *,
+    template: Path,
+    space: Path,
+    output_dir: Path,
+    require_candidate_certification: bool = True,
+    allow_rejected_candidates_diagnostic: bool = False,
+    min_batch_validity_rate: float | None = None,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        search_space=space,
+        scenario_template=template,
+        count=1,
+        seed=42,
+        max_valid=2,
+        output_dir=output_dir,
+        summary_json=tmp_path / "summary.json",
+        schema=_SCHEMA,
+        generator_family="random",
+        planner=["goal"],
+        horizon=12,
+        dt=0.1,
+        workers=1,
+        require_candidate_certification=require_candidate_certification,
+        candidate_certification_json=None,
+        candidate_certification_reference_manifest=None,
+        min_batch_validity_rate=min_batch_validity_rate,
+        allow_duplicate_candidates=False,
+        allow_rejected_candidates_diagnostic=allow_rejected_candidates_diagnostic,
+    )
+
+
+def _generated_counts(
+    *,
+    total: int,
+    valid: int,
+    invalid: int = 0,
+    degenerate: int = 0,
+) -> dict[str, Any]:
+    return {
+        "total_candidates": total,
+        "valid": valid,
+        "invalid": invalid,
+        "degenerate": degenerate,
+        "rejection_reasons": {},
+    }
+
+
+def test_run_smoke_records_accepted_candidate_certification(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Accepted certification writes its payload and records policy provenance."""
+    template = tmp_path / "template.yaml"
+    space = tmp_path / "space.yaml"
+    output_dir = tmp_path / "output"
+    _write_template(template)
+    _write_space(space)
+    run_batch_calls: list[str] = []
+
+    monkeypatch.setattr(
+        smoke,
+        "generate_manifests",
+        lambda *_args, **_kwargs: (
+            [build_manifest(_smoke_candidate())],
+            _generated_counts(total=1, valid=1),
+        ),
+    )
+    monkeypatch.setattr(
+        smoke,
+        "_materialize_matrix",
+        lambda *_args, **_kwargs: (
+            output_dir / "materialized_matrix.yaml",
+            [{"scenario_seed": 7}],
+        ),
+    )
+
+    def fake_run_batch(**kwargs: Any) -> dict[str, Any]:
+        run_batch_calls.append(str(kwargs.get("scenarios_or_path")))
+        Path(kwargs["out_path"]).write_text("", encoding="utf-8")
+        return {"status": "success", "total_jobs": 1, "written": 1, "failed_jobs": 0}
+
+    monkeypatch.setattr(smoke, "run_batch", fake_run_batch)
+    args = _base_smoke_args(
+        tmp_path,
+        template=template,
+        space=space,
+        output_dir=output_dir,
+        min_batch_validity_rate=1.0,
+    )
+
+    payload = smoke.run_smoke(args)
+
+    certification = payload["candidate_certification"]
+    assert certification["status"] == "accepted"
+    assert certification["schema_version"] == "adversarial_candidate_quality.v1"
+    assert certification["applied_policy"]["min_batch_validity_rate"] == 1.0
+    assert certification["diagnostic_override"] is False
+    assert run_batch_calls == [str(output_dir / "materialized_matrix.yaml")]
+    certification_payload = json.loads(
+        Path(certification["payload_path"]).read_text(encoding="utf-8")
+    )
+    assert certification_payload["schema_version"] == "adversarial_candidate_quality.v1"
+    assert certification_payload["batch_accepted"] is True
+
+
+def test_run_smoke_fail_closes_rejected_candidate_certification(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Rejected certification blocks materialization and planner execution."""
+    template = tmp_path / "template.yaml"
+    space = tmp_path / "space.yaml"
+    output_dir = tmp_path / "output"
+    _write_template(template)
+    _write_space(space)
+    valid_manifest = build_manifest(_smoke_candidate())
+    invalid_manifest = AdversarialScenarioManifest(
+        validation=ValidationRecord(status=ManifestCategory.INVALID),
+    )
+
+    monkeypatch.setattr(
+        smoke,
+        "generate_manifests",
+        lambda *_args, **_kwargs: (
+            [valid_manifest, invalid_manifest],
+            _generated_counts(total=2, valid=1, invalid=1),
+        ),
+    )
+    monkeypatch.setattr(
+        smoke,
+        "_materialize_matrix",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("materialization should be blocked")
+        ),
+    )
+    monkeypatch.setattr(
+        smoke,
+        "run_batch",
+        lambda **_kwargs: (_ for _ in ()).throw(AssertionError("planner should be blocked")),
+    )
+    args = _base_smoke_args(
+        tmp_path,
+        template=template,
+        space=space,
+        output_dir=output_dir,
+        min_batch_validity_rate=1.0,
+    )
+
+    payload = smoke.run_smoke(args)
+
+    assert payload["result_classification"] == "candidate_certification_rejected"
+    assert payload["planner_runs"] == []
+    assert payload["materialized"]["matrix_path"] is None
+    certification = payload["candidate_certification"]
+    assert certification["status"] == "rejected"
+    assert certification["batch_accepted"] is False
+    assert certification["accepted_count"] == 1
+    assert certification["rejected_count"] == 1
+
+
+def test_run_smoke_diagnostic_override_allows_rejected_certification(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Explicit diagnostic override keeps pre-planner status separate from planner status."""
+    template = tmp_path / "template.yaml"
+    space = tmp_path / "space.yaml"
+    output_dir = tmp_path / "output"
+    _write_template(template)
+    _write_space(space)
+    valid_manifest = build_manifest(_smoke_candidate())
+    invalid_manifest = AdversarialScenarioManifest(
+        validation=ValidationRecord(status=ManifestCategory.INVALID),
+    )
+    materialized_inputs: list[list[AdversarialScenarioManifest]] = []
+    run_batch_calls: list[str] = []
+
+    monkeypatch.setattr(
+        smoke,
+        "generate_manifests",
+        lambda *_args, **_kwargs: (
+            [valid_manifest, invalid_manifest],
+            _generated_counts(total=2, valid=1, invalid=1),
+        ),
+    )
+
+    def fake_materialize_matrix(
+        materialized: list[AdversarialScenarioManifest],
+        **_kwargs: Any,
+    ) -> tuple[Path, list[dict[str, Any]]]:
+        materialized_inputs.append(materialized)
+        matrix_path = output_dir / "materialized_matrix.yaml"
+        matrix_path.write_text("scenarios: []\n", encoding="utf-8")
+        return matrix_path, [{"scenario_seed": 7}]
+
+    def fake_run_batch(**kwargs: Any) -> dict[str, Any]:
+        run_batch_calls.append(str(kwargs.get("scenarios_or_path")))
+        Path(kwargs["out_path"]).write_text("", encoding="utf-8")
+        return {"status": "success", "total_jobs": 1, "written": 1, "failed_jobs": 0}
+
+    monkeypatch.setattr(smoke, "_materialize_matrix", fake_materialize_matrix)
+    monkeypatch.setattr(smoke, "run_batch", fake_run_batch)
+    args = _base_smoke_args(
+        tmp_path,
+        template=template,
+        space=space,
+        output_dir=output_dir,
+        allow_rejected_candidates_diagnostic=True,
+        min_batch_validity_rate=1.0,
+    )
+
+    payload = smoke.run_smoke(args)
+
+    assert payload["candidate_certification"]["status"] == "diagnostic_override"
+    assert payload["candidate_certification"]["diagnostic_override"] is True
+    assert payload["result_classification"] == "smoke_passed"
+    assert payload["planner_runs"][0]["exit_code"] == 0
+    assert materialized_inputs == [[valid_manifest]]
+    assert run_batch_calls == [str(output_dir / "materialized_matrix.yaml")]
+
+
+def test_run_smoke_does_not_materialize_duplicate_valid_candidates(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Certification decisions filter duplicate-valid candidates before materialization."""
+    template = tmp_path / "template.yaml"
+    space = tmp_path / "space.yaml"
+    output_dir = tmp_path / "output"
+    _write_template(template)
+    _write_space(space)
+    first_manifest = build_manifest(_smoke_candidate())
+    duplicate_manifest = build_manifest(_smoke_candidate())
+    materialized_inputs: list[list[AdversarialScenarioManifest]] = []
+
+    monkeypatch.setattr(
+        smoke,
+        "generate_manifests",
+        lambda *_args, **_kwargs: (
+            [first_manifest, duplicate_manifest],
+            _generated_counts(total=2, valid=2),
+        ),
+    )
+
+    def fake_materialize_matrix(
+        materialized: list[AdversarialScenarioManifest],
+        **_kwargs: Any,
+    ) -> tuple[Path, list[dict[str, Any]]]:
+        materialized_inputs.append(materialized)
+        matrix_path = output_dir / "materialized_matrix.yaml"
+        matrix_path.write_text("scenarios: []\n", encoding="utf-8")
+        return matrix_path, [{"scenario_seed": 7}]
+
+    monkeypatch.setattr(smoke, "_materialize_matrix", fake_materialize_matrix)
+    monkeypatch.setattr(
+        smoke,
+        "run_batch",
+        lambda **kwargs: {
+            "status": "success",
+            "total_jobs": 1,
+            "written": 1,
+            "failed_jobs": 0,
+            "out_path": str(kwargs["out_path"]),
+        },
+    )
+    args = _base_smoke_args(
+        tmp_path,
+        template=template,
+        space=space,
+        output_dir=output_dir,
+    )
+
+    payload = smoke.run_smoke(args)
+
+    assert payload["candidate_certification"]["status"] == "accepted"
+    assert payload["candidate_certification"]["rejection_counts"] == {"duplicate": 1}
+    assert payload["candidate_certification"]["accepted_count"] == 1
+    assert materialized_inputs == [[first_manifest]]

--- a/tests/tools/test_run_adversarial_manifest_smoke.py
+++ b/tests/tools/test_run_adversarial_manifest_smoke.py
@@ -7,6 +7,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import pytest
 import yaml
 
 from robot_sf.adversarial.config import CandidateSpec, Pose2D
@@ -591,3 +592,25 @@ def test_run_smoke_does_not_materialize_duplicate_valid_candidates(
     assert payload["candidate_certification"]["rejection_counts"] == {"duplicate": 1}
     assert payload["candidate_certification"]["accepted_count"] == 1
     assert materialized_inputs == [[first_manifest]]
+
+
+@pytest.mark.parametrize("threshold", ["nan", "-0.1", "1.1", "inf"])
+def test_parser_rejects_invalid_batch_validity_thresholds(threshold: str) -> None:
+    """The smoke CLI should reject invalid certification thresholds at parse time."""
+    parser = smoke.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(
+            [
+                "--search-space",
+                "space.yaml",
+                "--scenario-template",
+                "template.yaml",
+                "--output-dir",
+                "output",
+                "--summary-json",
+                "summary.json",
+                "--min-batch-validity-rate",
+                threshold,
+            ]
+        )


### PR DESCRIPTION
## Summary
Adds an opt-in pre-planner certification gate to the adversarial manifest smoke runner so generated candidate batches can be certified before materialization or planner execution.

## Linked Issues
- Closes #3265
- Relates to `#2920`

## Stack / Dependency
- Base dependency: merged PR `#3264`
- Required prior PRs: `#3264`
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: depends on the `adversarial_candidate_quality.v1` certification API that landed in `#3264`.

## What Changed
- Added `--require-candidate-certification` to `scripts/tools/run_adversarial_manifest_smoke.py`.
- Writes an `adversarial_candidate_quality.v1` payload before materialization when the gate is enabled.
- Records the certification payload path, applied policy, accepted/rejected counts, validity rate, and override status in the smoke summary.
- Fails closed for rejected candidate batches unless `--allow-rejected-candidates-diagnostic` is explicitly set.
- Filters materialized candidates by certification-accepted paths, so duplicate-valid candidates rejected by the gate do not reach planner runs.
- Updated the adversarial manifest smoke context note to mark the certification gate as implemented.

## Why It Matters
- Added value: adversarial candidate generation can now be guarded before planner execution.
- Expected impact: rejected/low-quality candidate batches stop before materialization and planner runs, while diagnostic override remains explicit and traceable.
- Why this is worth merging now: it connects the newly added certification artifact to the existing canonical adversarial smoke command without running long benchmarks.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: unblock pre-planner candidate-quality gating for adversarial campaign smoke workflows.
- Comparator or baseline, if applicable: previous smoke runner filtered only by manifest validation status and did not record candidate certification provenance.
- Evidence tier: targeted smoke via focused tests.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: accepted, rejected, diagnostic override, and duplicate-filter paths are all covered by focused tests.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2562_adversarial_manifest_smoke.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support workflow gate; it does not interpret planner performance or produce benchmark claims.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, in focused tests.
- Did the intervention change command source, selected command, trajectory, or route progress? no planner behavior claim; it changes pre-planner gating only.
- Did the scenario actually contain the targeted failure mode? tests cover rejected batches, duplicates, and diagnostic override.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: NA for this support gate.

## Next Empirical Action
- Rerun needed: no for this support change.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue with future larger certified-packet or replay-determinism evidence when needed.
- Proposed child issue or existing follow-up: none opened for this PR.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/adversarial/test_batch_certification.py tests/tools/test_run_adversarial_manifest_smoke.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/run_adversarial_manifest_smoke.py tests/tools/test_run_adversarial_manifest_smoke.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/tools/run_adversarial_manifest_smoke.py tests/tools/test_run_adversarial_manifest_smoke.py`
  - `git diff --check`
- Evidence that the change works here: focused suite passed with 27 tests covering the certification API and smoke command integration.
- Benchmarks or smoke tests, if applicable: focused smoke-runner tests only; no long benchmark run.

## Risks / Rollout
- Compatibility risks: default behavior is unchanged unless `--require-candidate-certification` is set.
- Failure modes: a rejected batch now blocks planner execution when the new flag is enabled; diagnostic continuation requires the explicit override flag.
- Rollback or fallback plan: omit `--require-candidate-certification` to use the previous validation-only smoke behavior, or revert this branch.

## Docs / Provenance
- Updated docs: `docs/context/issue_2562_adversarial_manifest_smoke.md`.
- Relevant design or provenance notes: the certification payload remains a separate artifact; post-execution planner statuses stay in `planner_runs`.
- Any assumptions that need to be preserved: candidate certification is generator-quality/pre-planner evidence, not planner benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR link; issue closes on merge.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): no; existing context note was updated in place and remains discoverable.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a support workflow gate with no planner-performance, benchmark, metric, or paper-facing claim.

## Follow-Up Issues
- Deferred work: none required for #3265 acceptance.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that rejected certification blocks before `_materialize_matrix()` and `run_batch()`.
- Verify duplicate-valid candidates are filtered by certification accepted paths, not just by manifest validation status.
- Known limitation: this does not run or claim any long adversarial planner benchmark.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added candidate certification gating that validates batches before materialization
  * Rejected candidates now block planner execution unless diagnostic override is enabled
  * New deduplication filtering for valid candidate batches
  * Certification status and policies tracked in results

* **Documentation**
  * Updated documentation on certification gate behavior and application

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
