### PR TITLE
benchmark: add observation-quality smoke evidence

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -166,6 +166,11 @@ Policy caveats:
   changed planner-input pedestrian observations, but commands and progress/risk summaries stayed
   identical because the live scenario remained outside the intended 2 m near-field target. Not
   benchmark or sensor-realism evidence.
+- `issue_2927_observation_quality_live_smoke/`: smoke/diagnostic observation-quality wrapper over
+  the committed near-field live step-diagnostics summary. It attaches validated
+  `observation_quality.v1` metadata, reports false-negative safety effects, and explicitly excludes
+  false-positive actor rows as not available; not planner-superiority or hardware-calibrated sensor
+  evidence.
 - `issue_3206_pedestrian_archetype_reporting_2026-06-20/`: composition-report-only packet for
   the shipped pedestrian speed-archetype MVP. Records deterministic counts, speed factors, and
   no-result boundaries for later homogeneous-vs-heterogeneous smoke runs.

--- a/docs/context/evidence/issue_2927_observation_quality_live_smoke/README.md
+++ b/docs/context/evidence/issue_2927_observation_quality_live_smoke/README.md
@@ -1,0 +1,40 @@
+# Issue #2927 Observation-Quality Live Smoke
+
+## Claim Boundary
+
+Smoke/diagnostic live step-diagnostics evidence only. The report attaches bounded simulator observation-quality metadata to an existing same-seed near-field live replay summary and reports safety effects from that smoke. It is not paper-grade, benchmark-strength planner superiority evidence, or hardware-calibrated sensor realism.
+
+## Source
+
+- Source summary: `docs/context/evidence/issue_3233_near_field_observation_noise/summary.json`
+- Source issue: `#3201`
+- Source classification: `non_null_behavior_delta`
+
+## Execution Boundary
+
+- Evidence status: `smoke evidence`
+- Near-field satisfied: `True`
+- Clean closest robot-pedestrian distance: `1.4515750296008105` m
+- Fallback/degraded rows: none in the source summary.
+- Not-available rows: false-positive actor injection is explicitly excluded.
+
+## Observation Quality
+
+- Schema: `observation_quality.v1`
+- Perturbed false-negative rate: `0.5`
+- Perturbed false-positive rate: `0.0`
+- Perturbed angular noise std: `0.0`
+- Perturbed range limit: `None`
+
+## Safety Effects
+
+- False-negative effect: `non_null_behavior_delta_with_false_negative_perturbation`
+- False-negative rationale: The perturbed live row removed or occluded pedestrian observations. Behavior/progress fields changed in the same-seed comparison.
+- False-positive effect: `not_available_excluded`
+- False-positive rationale: The source live smoke did not inject false-positive actors. False-positive safety effects are explicitly excluded rather than treated as successful evidence.
+
+## Caveats
+
+- One scenario, one seed, one live step-diagnostics summary.
+- Uses non-calibrated simulator observation perturbations only.
+- This report does not claim planner superiority or paper-grade evidence.

--- a/docs/context/evidence/issue_2927_observation_quality_live_smoke/summary.json
+++ b/docs/context/evidence/issue_2927_observation_quality_live_smoke/summary.json
@@ -1,0 +1,246 @@
+{
+  "schema_version": "issue_2927_observation_quality_live_smoke.v1",
+  "issue": 2927,
+  "claim_boundary": "Smoke/diagnostic live step-diagnostics evidence only. The report attaches bounded simulator observation-quality metadata to an existing same-seed near-field live replay summary and reports safety effects from that smoke. It is not paper-grade, benchmark-strength planner superiority evidence, or hardware-calibrated sensor realism.",
+  "source_live_smoke": {
+    "summary_path": "docs/context/evidence/issue_3233_near_field_observation_noise/summary.json",
+    "schema_version": "issue_3201_observation_noise_live_smoke.v1",
+    "issue": 3201,
+    "classification": {
+      "label": "non_null_behavior_delta",
+      "rationale": "Same-seed clean and perturbed live traces differ in selected commands or progress/risk summary fields."
+    }
+  },
+  "scenario": {
+    "clean": "issue_3233_near_field_observation_noise",
+    "perturbed": "issue_3233_near_field_observation_noise",
+    "same_scenario": true
+  },
+  "seed": {
+    "clean": 3233,
+    "perturbed": 3233,
+    "same_seed": true
+  },
+  "execution_boundary": {
+    "mode": "live_step_diagnostics_summary",
+    "evidence_status": "smoke evidence",
+    "near_field_threshold_m": 2.0,
+    "clean_closest_robot_ped_distance_m": 1.4515750296008105,
+    "near_field_satisfied": true,
+    "fallback_rows": [],
+    "degraded_rows": [],
+    "not_available_rows": [
+      {
+        "row": "false_positive_actor_injection",
+        "reason": "not modeled by the source live-smoke perturbation",
+        "classification": "explicitly_excluded"
+      }
+    ]
+  },
+  "observation_quality": {
+    "clean": {
+      "schema_version": "observation_quality.v1",
+      "fields": {
+        "visibility": [
+          "live_step_diagnostics_simulated_pedestrians"
+        ],
+        "occlusion": [
+          "not_modeled_in_this_smoke"
+        ],
+        "latency_s": 0.0,
+        "dropout_probability": 0.0,
+        "range_limit_m": null,
+        "angular_noise_std_rad": 0.0,
+        "false_negative_rate": 0.0,
+        "false_positive_rate": 0.0,
+        "notes": "clean diagnostic simulator observation-quality metadata only; not hardware-calibrated sensor realism."
+      }
+    },
+    "perturbed": {
+      "schema_version": "observation_quality.v1",
+      "fields": {
+        "visibility": [
+          "live_step_diagnostics_simulated_pedestrians"
+        ],
+        "occlusion": [
+          "not_modeled_in_this_smoke"
+        ],
+        "latency_s": 0.0,
+        "dropout_probability": 0.5,
+        "range_limit_m": null,
+        "angular_noise_std_rad": 0.0,
+        "false_negative_rate": 0.5,
+        "false_positive_rate": 0.0,
+        "notes": "perturbed diagnostic simulator observation-quality metadata only; not hardware-calibrated sensor realism."
+      }
+    }
+  },
+  "observation_summary": {
+    "clean": {
+      "missed_actor_observations_total": 0,
+      "occluded_actor_observations_total": 0,
+      "min_observed_actor_count": 1,
+      "max_observed_actor_count": 1,
+      "noise_profiles": [
+        "none"
+      ],
+      "evidence_classes": [
+        "ideal_state"
+      ]
+    },
+    "perturbed": {
+      "missed_actor_observations_total": 3,
+      "occluded_actor_observations_total": 0,
+      "min_observed_actor_count": 0,
+      "max_observed_actor_count": 1,
+      "noise_profiles": [
+        "bounded_gaussian"
+      ],
+      "evidence_classes": [
+        "perception_limited"
+      ]
+    },
+    "changed": true
+  },
+  "command_summary": {
+    "clean_first": [
+      0.3,
+      0.0
+    ],
+    "perturbed_first": [
+      1.2,
+      0.4431303704642192
+    ],
+    "clean_last": [
+      0.6,
+      0.0
+    ],
+    "perturbed_last": [
+      0.0,
+      0.0
+    ],
+    "sequence_changed": true
+  },
+  "progress_delta": {
+    "steps_observed": {
+      "clean": 50,
+      "perturbed": 6,
+      "delta": -44.0,
+      "changed": true
+    },
+    "initial_goal_distance": {
+      "clean": 2.000001,
+      "perturbed": 2.000001,
+      "delta": 0.0,
+      "changed": false
+    },
+    "final_goal_distance": {
+      "clean": 12.468645089252165,
+      "perturbed": 14.480990556613484,
+      "delta": 2.0123454673613193,
+      "changed": true
+    },
+    "best_goal_distance": {
+      "clean": 2.000001,
+      "perturbed": 2.000001,
+      "delta": 0.0,
+      "changed": false
+    },
+    "net_goal_progress": {
+      "clean": -10.468644089252166,
+      "perturbed": -12.480989556613483,
+      "delta": -2.0123454673613175,
+      "changed": true
+    },
+    "best_goal_progress": {
+      "clean": 0.0,
+      "perturbed": 0.0,
+      "delta": 0.0,
+      "changed": false
+    },
+    "progress_step_count": {
+      "clean": 49,
+      "perturbed": 5,
+      "delta": -44.0,
+      "changed": true
+    },
+    "regression_step_count": {
+      "clean": 1,
+      "perturbed": 1,
+      "delta": 0.0,
+      "changed": false
+    },
+    "stagnant_step_count": {
+      "clean": 0,
+      "perturbed": 0,
+      "delta": 0.0,
+      "changed": false
+    },
+    "longest_stagnant_run": {
+      "clean": 0,
+      "perturbed": 0,
+      "delta": 0.0,
+      "changed": false
+    },
+    "closest_robot_ped_distance": {
+      "clean": 1.4515750296008105,
+      "perturbed": 1.395304852291646,
+      "delta": -0.056270177309164504,
+      "changed": true
+    },
+    "closest_robot_ped_step": {
+      "clean": 25,
+      "perturbed": 5,
+      "delta": -20.0,
+      "changed": true
+    },
+    "collision_flag_counts": {
+      "clean": {
+        "pedestrian": 0,
+        "obstacle": 0,
+        "robot": 0
+      },
+      "perturbed": {
+        "pedestrian": 1,
+        "obstacle": 0,
+        "robot": 0
+      },
+      "delta": null,
+      "changed": true
+    }
+  },
+  "safety_effects": {
+    "false_negative": {
+      "effect": "non_null_behavior_delta_with_false_negative_perturbation",
+      "missed_actor_observations_delta": 3,
+      "occluded_actor_observations_delta": 0,
+      "collision_delta": {
+        "obstacle": {
+          "clean": 0,
+          "perturbed": 0,
+          "delta": 0
+        },
+        "pedestrian": {
+          "clean": 0,
+          "perturbed": 1,
+          "delta": 1
+        },
+        "robot": {
+          "clean": 0,
+          "perturbed": 0,
+          "delta": 0
+        }
+      },
+      "rationale": "The perturbed live row removed or occluded pedestrian observations. Behavior/progress fields changed in the same-seed comparison."
+    },
+    "false_positive": {
+      "effect": "not_available_excluded",
+      "false_positive_actor_rows": 0,
+      "rationale": "The source live smoke did not inject false-positive actors. False-positive safety effects are explicitly excluded rather than treated as successful evidence."
+    }
+  },
+  "classification": {
+    "label": "non_null_behavior_delta",
+    "rationale": "Same-seed clean and perturbed live traces differ in selected commands or progress/risk summary fields."
+  }
+}

--- a/scripts/benchmark/build_observation_quality_live_smoke_issue_2927.py
+++ b/scripts/benchmark/build_observation_quality_live_smoke_issue_2927.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Build issue #2927 observation-quality live-smoke evidence.
+
+This report wraps an existing same-seed live step-diagnostics summary and adds
+bounded ``observation_quality.v1`` metadata plus explicit false-negative and
+false-positive safety-effect interpretation.  It is diagnostic smoke evidence,
+not benchmark-strength or hardware-calibrated sensor evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.observation_quality import ObservationQuality
+
+SCHEMA_VERSION = "issue_2927_observation_quality_live_smoke.v1"
+OBSERVATION_QUALITY_SCHEMA_VERSION = "observation_quality.v1"
+DEFAULT_SOURCE_SUMMARY = Path(
+    "docs/context/evidence/issue_3233_near_field_observation_noise/summary.json"
+)
+DEFAULT_OUTPUT_JSON = Path(
+    "docs/context/evidence/issue_2927_observation_quality_live_smoke/summary.json"
+)
+DEFAULT_OUTPUT_MD = Path(
+    "docs/context/evidence/issue_2927_observation_quality_live_smoke/README.md"
+)
+CLAIM_BOUNDARY = (
+    "Smoke/diagnostic live step-diagnostics evidence only. The report attaches "
+    "bounded simulator observation-quality metadata to an existing same-seed "
+    "near-field live replay summary and reports safety effects from that smoke. "
+    "It is not paper-grade, benchmark-strength planner superiority evidence, "
+    "or hardware-calibrated sensor realism."
+)
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    """Return a mapping or an empty mapping for null/malformed values."""
+
+    return value if isinstance(value, dict) else {}
+
+
+def _number(value: Any) -> float | None:
+    """Return a finite float for scalar values when available."""
+
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _quality_from_config(config: dict[str, Any], *, role: str) -> dict[str, Any]:
+    """Convert live perturbation config into the observation-quality field group."""
+
+    missed_probability = float(config.get("missed_detection_probability", 0.0) or 0.0)
+    delay_steps = int(config.get("delay_steps", 0) or 0)
+    quality = ObservationQuality(
+        visibility=["live_step_diagnostics_simulated_pedestrians"],
+        occlusion=(
+            ["distance_occlusion_proxy"]
+            if config.get("occlusion_distance_m") is not None
+            else ["not_modeled_in_this_smoke"]
+        ),
+        latency_s=0.0 if delay_steps <= 0 else float(delay_steps) * 0.1,
+        dropout_probability=missed_probability,
+        range_limit_m=None,
+        angular_noise_std_rad=0.0,
+        false_negative_rate=missed_probability,
+        false_positive_rate=0.0,
+        notes=(
+            f"{role} diagnostic simulator observation-quality metadata only; "
+            "not hardware-calibrated sensor realism."
+        ),
+    )
+    return {
+        "schema_version": OBSERVATION_QUALITY_SCHEMA_VERSION,
+        "fields": quality.to_dict(),
+    }
+
+
+def _behavior_changed(source: dict[str, Any]) -> bool:
+    """Return whether the source live smoke observed planner-behavior differences."""
+
+    if _mapping(source.get("command_summary")).get("sequence_changed") is True:
+        return True
+    return any(
+        _mapping(delta).get("changed") is True
+        for delta in _mapping(source.get("progress_delta")).values()
+    )
+
+
+def _collision_delta(source: dict[str, Any]) -> dict[str, Any]:
+    """Return compact collision-count changes from the source progress delta."""
+
+    collision = _mapping(_mapping(source.get("progress_delta")).get("collision_flag_counts"))
+    clean = _mapping(collision.get("clean"))
+    perturbed = _mapping(collision.get("perturbed"))
+    keys = sorted(set(clean) | set(perturbed))
+    return {
+        key: {
+            "clean": clean.get(key, 0),
+            "perturbed": perturbed.get(key, 0),
+            "delta": int(perturbed.get(key, 0) or 0) - int(clean.get(key, 0) or 0),
+        }
+        for key in keys
+    }
+
+
+def _safety_effects(source: dict[str, Any]) -> dict[str, Any]:
+    """Summarize false-negative and false-positive effects without overclaiming."""
+
+    observation = _mapping(source.get("observation_summary"))
+    clean = _mapping(observation.get("clean"))
+    perturbed = _mapping(observation.get("perturbed"))
+    missed_delta = int(perturbed.get("missed_actor_observations_total", 0) or 0) - int(
+        clean.get("missed_actor_observations_total", 0) or 0
+    )
+    occluded_delta = int(perturbed.get("occluded_actor_observations_total", 0) or 0) - int(
+        clean.get("occluded_actor_observations_total", 0) or 0
+    )
+    behavior_changed = _behavior_changed(source)
+    if missed_delta > 0 or occluded_delta > 0:
+        false_negative_effect = (
+            "non_null_behavior_delta_with_false_negative_perturbation"
+            if behavior_changed
+            else "observation_only_false_negative_perturbation"
+        )
+        false_negative_rationale = (
+            "The perturbed live row removed or occluded pedestrian observations. "
+            "Behavior/progress fields changed in the same-seed comparison."
+            if behavior_changed
+            else "The perturbed live row changed pedestrian observations, but compared "
+            "behavior/progress fields stayed unchanged."
+        )
+    else:
+        false_negative_effect = "none_observed"
+        false_negative_rationale = (
+            "No added missed or occluded pedestrian observations were recorded."
+        )
+
+    return {
+        "false_negative": {
+            "effect": false_negative_effect,
+            "missed_actor_observations_delta": missed_delta,
+            "occluded_actor_observations_delta": occluded_delta,
+            "collision_delta": _collision_delta(source),
+            "rationale": false_negative_rationale,
+        },
+        "false_positive": {
+            "effect": "not_available_excluded",
+            "false_positive_actor_rows": 0,
+            "rationale": (
+                "The source live smoke did not inject false-positive actors. "
+                "False-positive safety effects are explicitly excluded rather than "
+                "treated as successful evidence."
+            ),
+        },
+    }
+
+
+def _require_bool(name: str, value: Any) -> bool:
+    """Return a boolean evidence flag without truthiness coercion."""
+
+    if not isinstance(value, bool):
+        raise ValueError(f"{name} must be a boolean")
+    return value
+
+
+def build_report(source: dict[str, Any]) -> dict[str, Any]:
+    """Build the issue #2927 report from a live-smoke source summary."""
+
+    configs = _mapping(source.get("observation_perturbation_config"))
+    clean_config = _mapping(configs.get("clean"))
+    perturbed_config = _mapping(configs.get("perturbed"))
+    near_field = _mapping(source.get("near_field_target"))
+    closest = _number(near_field.get("clean_closest_robot_ped_distance_m"))
+    near_field_satisfied = _require_bool(
+        "near_field_target.satisfied",
+        near_field.get("satisfied", False),
+    )
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 2927,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "source_live_smoke": {
+            "summary_path": DEFAULT_SOURCE_SUMMARY.as_posix(),
+            "schema_version": source.get("schema_version"),
+            "issue": source.get("issue"),
+            "classification": source.get("classification"),
+        },
+        "scenario": source.get("scenario"),
+        "seed": source.get("seed"),
+        "execution_boundary": {
+            "mode": "live_step_diagnostics_summary",
+            "evidence_status": "smoke evidence",
+            "near_field_threshold_m": near_field.get("threshold_m", 2.0),
+            "clean_closest_robot_ped_distance_m": closest,
+            "near_field_satisfied": near_field_satisfied,
+            "fallback_rows": [],
+            "degraded_rows": [],
+            "not_available_rows": [
+                {
+                    "row": "false_positive_actor_injection",
+                    "reason": "not modeled by the source live-smoke perturbation",
+                    "classification": "explicitly_excluded",
+                }
+            ],
+        },
+        "observation_quality": {
+            "clean": _quality_from_config(clean_config, role="clean"),
+            "perturbed": _quality_from_config(perturbed_config, role="perturbed"),
+        },
+        "observation_summary": source.get("observation_summary"),
+        "command_summary": source.get("command_summary"),
+        "progress_delta": source.get("progress_delta"),
+        "safety_effects": _safety_effects(source),
+        "classification": source.get("classification"),
+    }
+
+
+def _markdown(report: dict[str, Any]) -> str:
+    """Render a compact Markdown report."""
+
+    classification = _mapping(report.get("classification"))
+    boundary = _mapping(report.get("execution_boundary"))
+    effects = _mapping(report.get("safety_effects"))
+    false_negative = _mapping(effects.get("false_negative"))
+    false_positive = _mapping(effects.get("false_positive"))
+    quality = _mapping(report.get("observation_quality"))
+    perturbed_quality = _mapping(_mapping(quality.get("perturbed")).get("fields"))
+    lines = [
+        "# Issue #2927 Observation-Quality Live Smoke",
+        "",
+        "## Claim Boundary",
+        "",
+        report["claim_boundary"],
+        "",
+        "## Source",
+        "",
+        f"- Source summary: `{report['source_live_smoke']['summary_path']}`",
+        f"- Source issue: `#{report['source_live_smoke']['issue']}`",
+        f"- Source classification: `{classification.get('label')}`",
+        "",
+        "## Execution Boundary",
+        "",
+        f"- Evidence status: `{boundary.get('evidence_status')}`",
+        f"- Near-field satisfied: `{boundary.get('near_field_satisfied')}`",
+        f"- Clean closest robot-pedestrian distance: "
+        f"`{boundary.get('clean_closest_robot_ped_distance_m')}` m",
+        "- Fallback/degraded rows: none in the source summary.",
+        "- Not-available rows: false-positive actor injection is explicitly excluded.",
+        "",
+        "## Observation Quality",
+        "",
+        f"- Schema: `{_mapping(quality.get('perturbed')).get('schema_version')}`",
+        f"- Perturbed false-negative rate: `{perturbed_quality.get('false_negative_rate')}`",
+        f"- Perturbed false-positive rate: `{perturbed_quality.get('false_positive_rate')}`",
+        f"- Perturbed angular noise std: `{perturbed_quality.get('angular_noise_std_rad')}`",
+        f"- Perturbed range limit: `{perturbed_quality.get('range_limit_m')}`",
+        "",
+        "## Safety Effects",
+        "",
+        f"- False-negative effect: `{false_negative.get('effect')}`",
+        f"- False-negative rationale: {false_negative.get('rationale')}",
+        f"- False-positive effect: `{false_positive.get('effect')}`",
+        f"- False-positive rationale: {false_positive.get('rationale')}",
+        "",
+        "## Caveats",
+        "",
+        "- One scenario, one seed, one live step-diagnostics summary.",
+        "- Uses non-calibrated simulator observation perturbations only.",
+        "- This report does not claim planner superiority or paper-grade evidence.",
+    ]
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source-summary-json", type=Path, default=DEFAULT_SOURCE_SUMMARY)
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_OUTPUT_JSON)
+    parser.add_argument("--output-md", type=Path, default=DEFAULT_OUTPUT_MD)
+    args = parser.parse_args(argv)
+
+    source = json.loads(args.source_summary_json.read_text(encoding="utf-8"))
+    report = build_report(source)
+    report["source_live_smoke"]["summary_path"] = args.source_summary_json.as_posix()
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    args.output_md.parent.mkdir(parents=True, exist_ok=True)
+    args.output_md.write_text(_markdown(report), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "schema_version": report["schema_version"],
+                "issue": report["issue"],
+                "classification": report["classification"],
+                "output_json": args.output_json.as_posix(),
+                "output_md": args.output_md.as_posix(),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/run_observation_noise_envelope.py
+++ b/scripts/benchmark/run_observation_noise_envelope.py
@@ -27,12 +27,15 @@ from robot_sf.benchmark.observation_perturbation import (
     ObservationPerturbationState,
     perturb_ground_truth,
 )
+from robot_sf.benchmark.observation_quality import ObservationQuality
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 FIXTURE_PATH = (
     REPO_ROOT / "tests/fixtures/analysis_workbench/simulation_trace_export_v1/"
     "occluded_emergence_episode_0000.json"
 )
+OBSERVATION_QUALITY_SCHEMA_VERSION = "observation_quality.v1"
+TRACE_DT_S = 0.1
 
 CONDITIONS: dict[str, dict[str, Any]] = {
     "noop": {"description": "No perturbation applied (baseline)."},
@@ -286,6 +289,34 @@ def _spec_summary(spec: ObservationPerturbationSpec) -> dict[str, Any]:
         "delay_steps": spec.delay_steps,
         "noise_profile": spec.noise_profile,
         "is_noop": spec.is_noop,
+        "observation_quality": _observation_quality_group(spec),
+    }
+
+
+def _observation_quality_group(spec: ObservationPerturbationSpec) -> dict[str, Any]:
+    """Return the bounded observation-quality field group for one perturbation spec."""
+
+    quality = ObservationQuality(
+        visibility=["trace_fixture_observed_pedestrians"],
+        occlusion=(
+            ["explicit_occlusion_mask"]
+            if spec.occlusion_mask is not None
+            else ["fixture_declared_visibility_boundary"]
+        ),
+        latency_s=float(spec.delay_steps) * TRACE_DT_S,
+        dropout_probability=float(spec.missed_detection_probability),
+        range_limit_m=None,
+        angular_noise_std_rad=0.0,
+        false_negative_rate=float(spec.missed_detection_probability),
+        false_positive_rate=0.0,
+        notes=(
+            "Diagnostic simulator observation-quality metadata only; "
+            "not hardware-calibrated sensor realism."
+        ),
+    )
+    return {
+        "schema_version": OBSERVATION_QUALITY_SCHEMA_VERSION,
+        "fields": quality.to_dict(),
     }
 
 

--- a/tests/benchmark/test_observation_noise_envelope.py
+++ b/tests/benchmark/test_observation_noise_envelope.py
@@ -318,6 +318,31 @@ def test_spec_summary_fields() -> None:
     assert summary["position_noise_std_m"] == 0.5
 
 
+def test_spec_summary_includes_observation_quality_group() -> None:
+    """Condition specs should carry the bounded observation-quality.v1 metadata group."""
+    mod = _load_script()
+    from robot_sf.benchmark.observation_perturbation import ObservationPerturbationSpec
+    from robot_sf.benchmark.observation_quality import ObservationQuality
+
+    spec = ObservationPerturbationSpec(
+        position_noise_std_m=0.3,
+        position_noise_bound_m=0.6,
+        missed_detection_probability=0.5,
+        delay_steps=2,
+        seed=2927,
+    )
+
+    group = mod._spec_summary(spec)["observation_quality"]
+    quality = ObservationQuality.from_dict(group["fields"])
+
+    assert group["schema_version"] == "observation_quality.v1"
+    assert quality.false_negative_rate == 0.5
+    assert quality.dropout_probability == 0.5
+    assert quality.false_positive_rate == 0.0
+    assert quality.latency_s == 0.2
+    assert "hardware-calibrated" in quality.notes
+
+
 def test_script_is_importable() -> None:
     """The script can be loaded as a module without errors."""
     mod = _load_script()

--- a/tests/benchmark/test_observation_quality_live_smoke_issue_2927.py
+++ b/tests/benchmark/test_observation_quality_live_smoke_issue_2927.py
@@ -1,0 +1,136 @@
+"""Tests for issue #2927 observation-quality live-smoke evidence."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.observation_quality import ObservationQuality
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/build_observation_quality_live_smoke_issue_2927.py"
+SOURCE_SUMMARY_PATH = (
+    REPO_ROOT / "docs/context/evidence/issue_3233_near_field_observation_noise/summary.json"
+)
+_LOADED_MOD = None
+
+
+def _load_script():
+    """Load the issue #2927 evidence builder as a module."""
+
+    global _LOADED_MOD
+    if _LOADED_MOD is not None:
+        return _LOADED_MOD
+    spec = importlib.util.spec_from_file_location(
+        "build_observation_quality_live_smoke_issue_2927", SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["build_observation_quality_live_smoke_issue_2927"] = mod
+    spec.loader.exec_module(mod)
+    _LOADED_MOD = mod
+    return _LOADED_MOD
+
+
+def _source_summary() -> dict:
+    """Load the committed near-field live-smoke summary used as source evidence."""
+
+    return json.loads(SOURCE_SUMMARY_PATH.read_text(encoding="utf-8"))
+
+
+def test_report_attaches_valid_observation_quality_metadata() -> None:
+    """The issue #2927 report should expose validated observation_quality.v1 groups."""
+
+    report = _load_script().build_report(_source_summary())
+
+    clean = report["observation_quality"]["clean"]
+    perturbed = report["observation_quality"]["perturbed"]
+    clean_quality = ObservationQuality.from_dict(clean["fields"])
+    perturbed_quality = ObservationQuality.from_dict(perturbed["fields"])
+
+    assert report["schema_version"] == "issue_2927_observation_quality_live_smoke.v1"
+    assert clean["schema_version"] == "observation_quality.v1"
+    assert perturbed["schema_version"] == "observation_quality.v1"
+    assert clean_quality.false_negative_rate == 0.0
+    assert perturbed_quality.false_negative_rate == 0.5
+    assert perturbed_quality.false_positive_rate == 0.0
+    assert perturbed_quality.range_limit_m is None
+    assert "hardware-calibrated" in perturbed_quality.notes
+
+
+def test_report_keeps_live_smoke_claim_boundary_and_exclusions() -> None:
+    """Live-smoke evidence should stay diagnostic and fail closed on unavailable rows."""
+
+    report = _load_script().build_report(_source_summary())
+
+    assert report["issue"] == 2927
+    assert report["execution_boundary"]["evidence_status"] == "smoke evidence"
+    assert report["execution_boundary"]["near_field_satisfied"] is True
+    assert report["execution_boundary"]["fallback_rows"] == []
+    assert report["execution_boundary"]["degraded_rows"] == []
+    assert report["execution_boundary"]["not_available_rows"] == [
+        {
+            "row": "false_positive_actor_injection",
+            "reason": "not modeled by the source live-smoke perturbation",
+            "classification": "explicitly_excluded",
+        }
+    ]
+    assert "planner superiority" in report["claim_boundary"]
+    assert "hardware-calibrated" in report["claim_boundary"]
+
+
+def test_report_rejects_non_boolean_near_field_satisfied() -> None:
+    """Near-field evidence flags should not be accepted through truthiness coercion."""
+
+    source = _source_summary()
+    source["near_field_target"]["satisfied"] = "false"
+
+    with pytest.raises(ValueError, match="near_field_target.satisfied must be a boolean"):
+        _load_script().build_report(source)
+
+
+def test_report_summarizes_false_negative_and_false_positive_safety_effects() -> None:
+    """The safety summary should name both false-negative and false-positive outcomes."""
+
+    report = _load_script().build_report(_source_summary())
+    effects = report["safety_effects"]
+
+    assert effects["false_negative"]["effect"] == (
+        "non_null_behavior_delta_with_false_negative_perturbation"
+    )
+    assert effects["false_negative"]["missed_actor_observations_delta"] == 3
+    assert effects["false_negative"]["collision_delta"]["pedestrian"]["delta"] == 1
+    assert effects["false_positive"]["effect"] == "not_available_excluded"
+    assert effects["false_positive"]["false_positive_actor_rows"] == 0
+    assert "explicitly excluded" in effects["false_positive"]["rationale"]
+
+
+def test_cli_writes_compact_evidence_bundle(tmp_path: Path) -> None:
+    """The CLI should write JSON and Markdown evidence artifacts."""
+
+    output_json = tmp_path / "summary.json"
+    output_md = tmp_path / "README.md"
+
+    assert (
+        _load_script().main(
+            [
+                "--source-summary-json",
+                str(SOURCE_SUMMARY_PATH),
+                "--output-json",
+                str(output_json),
+                "--output-md",
+                str(output_md),
+            ]
+        )
+        == 0
+    )
+
+    report = json.loads(output_json.read_text(encoding="utf-8"))
+    markdown = output_md.read_text(encoding="utf-8")
+    assert report["issue"] == 2927
+    assert "Issue #2927 Observation-Quality Live Smoke" in markdown
+    assert "False-positive effect" in markdown
+    assert "planner superiority" in markdown


### PR DESCRIPTION
## Summary

Closes #2927.

Completes the remaining observation-quality smoke evidence on top of the ODD/ForecastBatch contract metadata that already landed in #3262 (`313993739`). This PR adds `observation_quality.v1` metadata to the observation-noise envelope condition summaries and promotes a compact #2927 live-smoke report that records false-negative safety effects while explicitly excluding unavailable false-positive actor-injection evidence.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/benchmark/run_observation_noise_envelope.py --help`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/benchmark/build_observation_quality_live_smoke_issue_2927.py`
- `scripts/dev/run_worktree_shared_venv.sh -- python -c "import json; json.load(open('robot_sf/benchmark/schemas/odd_contract.v1.json')); json.load(open('robot_sf/benchmark/schemas/forecast_batch.schema.v1.json')); json.load(open('docs/context/evidence/issue_2927_observation_quality_live_smoke/summary.json')); print('schemas ok')"`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_odd_contract.py tests/benchmark/test_forecast_batch.py tests/benchmark/test_observation_perturbation.py tests/benchmark/test_observation_noise_envelope.py tests/benchmark/test_observation_quality_live_smoke_issue_2927.py -q` (`100 passed`)
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/benchmark/run_observation_noise_envelope.py scripts/benchmark/build_observation_quality_live_smoke_issue_2927.py tests/benchmark/test_observation_noise_envelope.py tests/benchmark/test_observation_quality_live_smoke_issue_2927.py`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/benchmark/run_observation_noise_envelope.py scripts/benchmark/build_observation_quality_live_smoke_issue_2927.py tests/benchmark/test_observation_noise_envelope.py tests/benchmark/test_observation_quality_live_smoke_issue_2927.py`
- `git diff --check origin/main..HEAD`

## Research Result Guidance

- Target claim/hypothesis/blocker: observation-quality assumptions can be carried through the existing ODD/ForecastBatch contract layer and tied to one local smoke evidence bundle.
- Comparator/baseline: same-seed clean vs perturbed near-field live observation summary from the existing #3201/#3233 evidence source.
- Evidence tier: smoke/diagnostic.
- Result classification: diagnostic non-null behavior delta with false-negative perturbation; false-positive actor injection is explicitly `not_available_excluded`.
- Decision/stop rule: report stays diagnostic and does not upgrade to benchmark-strength, paper-grade, planner-superiority, or hardware-calibrated sensor evidence.
- Synthesis surface/update target: `docs/context/evidence/issue_2927_observation_quality_live_smoke/` and `docs/context/evidence/README.md`.

## Downstream Propagation

- Parent issue: #2927 is closed by this PR; ODD/ForecastBatch schema attachment was already delivered by #3262.
- Claim map / benchmark report / leaderboard: NA; this is smoke/diagnostic evidence only.
- Registry / config index: NA; no new benchmark config contract is introduced.
- Context index / memory note: evidence catalog updated in `docs/context/evidence/README.md`.
- Follow-up issue: NA for this scoped closeout. Hardware-calibrated sensor claims remain out of scope without accepted source provenance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive documentation for new observation quality evidence bundle, including perturbation parameters, safety effects, and diagnostic boundaries.

* **New Features**
  * Introduced observation quality evidence report with metadata for assessing false-negative and false-positive detection effects in sensor observations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->