### PR TITLE
analysis: compare scenario prior gaps

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -98,6 +98,11 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_2919_scenario_prior_gap_2026-06-21/`: analysis-only authored-vs-repository-trace-derived
+  scenario-prior gap report from the Issue #2917 card registry. It compares pedestrian density,
+  pedestrian speed, and timing-offset parameter families, emits scenario-family proposals, and
+  explicitly defers dataset-backed SDD/ETH/AMV comparison to #3161. Not planner-ranking,
+  benchmark-superiority, or real-world representativeness evidence.
 - `issue_2924_counterfactual_pair_2026-06-21/`: analysis-only counterfactual pair
   runner evidence for a matched prediction-risk fixture. It records invariant enforcement,
   mechanism-trace activation delta, `min_clearance_m` outcome delta, and diagnostic trace panels.

--- a/docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/parameter_comparisons.csv
+++ b/docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/parameter_comparisons.csv
@@ -1,0 +1,4 @@
+parameter,classification,authored_n,authored_min,authored_median,authored_max,trace_n,trace_min,trace_median,trace_max,ks_distance,wasserstein_like_distance,proposal
+pedestrian_density,too_broad,8,0.02,0.03,0.12,1,0.02,0.02,0.02,0.75,0.040095,Split authored `pedestrian_density` stress variants into a centered trace-aligned family near median 0.02 plus a separately labeled stress/extreme family.
+pedestrian_speed,too_broad,25,-0.25,0.5,2,2,0.8,1.1,1.4,0.64,0.623267,Split authored `pedestrian_speed` stress variants into a centered trace-aligned family near median 1.1 plus a separately labeled stress/extreme family.
+timing_offset_s,too_extreme,28,-0.5,1,1,4,0,1,2,0.5,0.649208,Add a `timing_offset_s_centered_trace_probe` family around trace median 1.0 and keep out-of-support authored variants labeled diagnostic stress only.

--- a/docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/scenario_prior_gap_report.md
+++ b/docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/scenario_prior_gap_report.md
@@ -1,0 +1,35 @@
+# Issue #2919 Scenario Prior Gap Report
+
+- Evidence status: `analysis_only`.
+- Claim boundary: analysis_only_repository_prior_gap; no planner ranking, benchmark superiority, real-world representativeness, or dataset-backed prior claim.
+- Registry input: `configs/research/scenario_prior_cards_issue_2917.yaml`.
+- Dataset-backed SDD/ETH/AMV scenario-prior comparison is explicitly deferred to #3161.
+- No planner ranking, benchmark superiority, or real-world representativeness is inferred.
+
+## Method
+
+The script loads the Issue #2917 prior-card registry, selects cards classified as `authored` or `repository_trace_derived`, and extracts numeric samples only from machine-readable YAML/JSON source traces. Text docs, Python scripts, raw datasets, and external-dataset candidate cards are excluded from this run.
+
+Distances are diagnostic: KS distance uses empirical CDF separation and the Wasserstein-like value averages absolute matched-quantile gaps over a 0-100% grid.
+
+## Parameter Comparisons
+
+| Parameter | Class | Authored range | Trace-derived range | KS | Wasserstein-like | Proposal |
+| --- | --- | ---: | ---: | ---: | ---: | --- |
+| pedestrian_density | `too_broad` | 0.02 to 0.12 (n=8) | 0.02 to 0.02 (n=1) | 0.75 | 0.040095 | Split authored `pedestrian_density` stress variants into a centered trace-aligned family near median 0.02 plus a separately labeled stress/extreme family. |
+| pedestrian_speed | `too_broad` | -0.25 to 2 (n=25) | 0.8 to 1.4 (n=2) | 0.64 | 0.623267 | Split authored `pedestrian_speed` stress variants into a centered trace-aligned family near median 1.1 plus a separately labeled stress/extreme family. |
+| timing_offset_s | `too_extreme` | -0.5 to 1 (n=28) | 0 to 2 (n=4) | 0.5 | 0.649208 | Add a `timing_offset_s_centered_trace_probe` family around trace median 1.0 and keep out-of-support authored variants labeled diagnostic stress only. |
+
+## Classification Notes
+
+- `too_narrow`: authored support is materially inside the trace-derived support.
+- `too_broad`: authored support is materially wider than trace-derived support.
+- `too_extreme`: authored support is shifted outside trace-derived central mass or support.
+- `representative`: authored and trace-derived ranges broadly overlap for this repository-only comparison.
+
+## Limitations
+
+- This is not dataset-backed prior calibration; SDD/ETH/AMV comparison is deferred to #3161.
+- Repository trace-derived values come from existing repo configs and compact summaries, not raw real-world traces.
+- Some canonical groups mix offsets, caps, and realized values; proposals are scenario-family design prompts, not statistical claims.
+- No planner ranking, benchmark superiority, or real-world representativeness is inferred.

--- a/docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/summary.json
+++ b/docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/summary.json
@@ -1,0 +1,182 @@
+{
+  "analysis_base_commit": "145bc244f70a1f33e444508c5f37659f304a00ff",
+  "claim_boundary": "analysis_only_repository_prior_gap; no planner ranking, benchmark superiority, real-world representativeness, or dataset-backed prior claim",
+  "classification_counts": {
+    "representative": 0,
+    "too_broad": 2,
+    "too_extreme": 1,
+    "too_narrow": 0
+  },
+  "comparison_count": 3,
+  "comparisons": [
+    {
+      "authored": {
+        "max": 0.12,
+        "median": 0.03,
+        "min": 0.02,
+        "n": 8,
+        "q05": 0.019999999999999997,
+        "q25": 0.0275,
+        "q75": 0.12,
+        "q95": 0.12,
+        "range": 0.09999999999999999
+      },
+      "authored_source_keys": [
+        "density_delta",
+        "max_abs_density_delta",
+        "max_ped_density",
+        "max_pedestrian_density",
+        "max_pedestrian_density_delta"
+      ],
+      "authored_source_paths": [
+        "configs/scenarios/perturbations/issue_1610_pedestrian_density_offset_pilot_v1.yaml"
+      ],
+      "classification": "too_broad",
+      "classification_rationale": "trace-derived samples are point-like while authored range spans wider",
+      "comparison_caveat": "Repository-authored config values and repository-trace-derived config/summary values may mix offsets, caps, and realized values within a canonical parameter family; use classifications as gap-finding proposals only.",
+      "ks_distance": 0.75,
+      "parameter": "pedestrian_density",
+      "proposal": "Split authored `pedestrian_density` stress variants into a centered trace-aligned family near median 0.02 plus a separately labeled stress/extreme family.",
+      "trace_derived": {
+        "max": 0.02,
+        "median": 0.02,
+        "min": 0.02,
+        "n": 1,
+        "q05": 0.02,
+        "q25": 0.02,
+        "q75": 0.02,
+        "q95": 0.02,
+        "range": 0.0
+      },
+      "trace_source_keys": [
+        "ped_density"
+      ],
+      "trace_source_paths": [
+        "configs/scenarios/templates/crossing_ttc.yaml"
+      ],
+      "wasserstein_like_distance": 0.04009504950495049
+    },
+    {
+      "authored": {
+        "max": 2.0,
+        "median": 0.5,
+        "min": -0.25,
+        "n": 25,
+        "q05": 0.25,
+        "q25": 0.5,
+        "q75": 2.0,
+        "q95": 2.0,
+        "range": 2.25
+      },
+      "authored_source_keys": [
+        "max_abs_speed_delta_m_s",
+        "max_single_pedestrian_speed_delta_m_s",
+        "max_single_pedestrian_speed_m_s",
+        "max_speed_m_s",
+        "speed_delta_m_s"
+      ],
+      "authored_source_paths": [
+        "configs/scenarios/perturbations/issue_1610_intersection_wait_phase_grid_v1.yaml",
+        "configs/scenarios/perturbations/issue_1610_ped_speed_pilot_v1.yaml"
+      ],
+      "classification": "too_broad",
+      "classification_rationale": "authored range is substantially wider than trace-derived support",
+      "comparison_caveat": "Repository-authored config values and repository-trace-derived config/summary values may mix offsets, caps, and realized values within a canonical parameter family; use classifications as gap-finding proposals only.",
+      "ks_distance": 0.64,
+      "parameter": "pedestrian_speed",
+      "proposal": "Split authored `pedestrian_speed` stress variants into a centered trace-aligned family near median 1.1 plus a separately labeled stress/extreme family.",
+      "trace_derived": {
+        "max": 1.4,
+        "median": 1.1,
+        "min": 0.8,
+        "n": 2,
+        "q05": 0.83,
+        "q25": 0.9500000000000001,
+        "q75": 1.2499999999999998,
+        "q95": 1.3699999999999999,
+        "range": 0.5999999999999999
+      },
+      "trace_source_keys": [
+        "pedestrian_speed_mps"
+      ],
+      "trace_source_paths": [
+        "configs/adversarial/crossing_ttc_space.yaml"
+      ],
+      "wasserstein_like_distance": 0.6232673267326733
+    },
+    {
+      "authored": {
+        "max": 1.0,
+        "median": 1.0,
+        "min": -0.5,
+        "n": 28,
+        "q05": -0.1499999999999999,
+        "q25": 0.5,
+        "q75": 1.0,
+        "q95": 1.0,
+        "range": 1.5
+      },
+      "authored_source_keys": [
+        "dt_s",
+        "max_abs_dt_s",
+        "max_abs_wait_delta_s",
+        "max_start_delay_offset_s",
+        "max_wait_duration_offset_s",
+        "wait_delta_s"
+      ],
+      "authored_source_paths": [
+        "configs/scenarios/perturbations/issue_1610_intersection_wait_phase_grid_v1.yaml",
+        "configs/scenarios/perturbations/issue_1610_ped_timing_phase_pilot_v1.yaml",
+        "configs/scenarios/perturbations/issue_1610_ped_wait_duration_pilot_v1.yaml"
+      ],
+      "classification": "too_extreme",
+      "classification_rationale": "authored range extends beyond trace-derived support without broad mismatch",
+      "comparison_caveat": "Repository-authored config values and repository-trace-derived config/summary values may mix offsets, caps, and realized values within a canonical parameter family; use classifications as gap-finding proposals only.",
+      "ks_distance": 0.5,
+      "parameter": "timing_offset_s",
+      "proposal": "Add a `timing_offset_s_centered_trace_probe` family around trace median 1.0 and keep out-of-support authored variants labeled diagnostic stress only.",
+      "trace_derived": {
+        "max": 2.0,
+        "median": 1.0,
+        "min": 0.0,
+        "n": 4,
+        "q05": 0.0,
+        "q25": 0.0,
+        "q75": 2.0,
+        "q95": 2.0,
+        "range": 2.0
+      },
+      "trace_source_keys": [
+        "pedestrian_delay_s",
+        "spawn_time_s"
+      ],
+      "trace_source_paths": [
+        "configs/adversarial/crossing_ttc_space.yaml"
+      ],
+      "wasserstein_like_distance": 0.6492079207920791
+    }
+  ],
+  "dataset_comparison_deferral": "Dataset-backed SDD/ETH/AMV scenario-prior comparison is explicitly deferred to #3161.",
+  "evidence_tier": "analysis_only",
+  "files": {
+    "comparison_csv": "docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/parameter_comparisons.csv",
+    "markdown_report": "docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/scenario_prior_gap_report.md",
+    "summary_json": "docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/summary.json"
+  },
+  "issue": 2919,
+  "no_planner_ranking": "No planner ranking, benchmark superiority, or real-world representativeness is inferred.",
+  "registry_path": "configs/research/scenario_prior_cards_issue_2917.yaml",
+  "sample_count": 123,
+  "schema_version": "scenario_prior_gap_issue_2919.v1",
+  "skipped_non_machine_readable_sources": [
+    "authored_scenario_contract_priors: docs/scenario_contracts.md",
+    "authored_scenario_contract_priors: docs/scenario_perturbation_manifest.md",
+    "adversarial_search_generated_scenario_prior: robot_sf/adversarial/scenario_manifest.py",
+    "adversarial_search_generated_scenario_prior: scripts/tools/generate_adversarial_scenario_manifests.py",
+    "adversarial_search_generated_scenario_prior: tests/adversarial/test_adversarial_search.py",
+    "adversarial_search_generated_scenario_prior: tests/adversarial/test_adversarial_scenario_manifest.py",
+    "counterfactual_scenario_pair_mechanism_prior: scripts/tools/create_counterfactual_scenario_pair.py",
+    "counterfactual_scenario_pair_mechanism_prior: docs/context/issue_2547_counterfactual_mechanism_taxonomy.md",
+    "counterfactual_scenario_pair_mechanism_prior: tests/tools/test_create_counterfactual_scenario_pair.py"
+  ]
+}

--- a/scripts/analysis/compare_scenario_priors_issue_2919.py
+++ b/scripts/analysis/compare_scenario_priors_issue_2919.py
@@ -1,0 +1,848 @@
+"""Compare authored and repository-trace-derived scenario prior ranges for Issue #2919.
+
+The comparison is deliberately analysis-only. It uses the Issue #2917 prior-card registry as the
+source router, extracts compact numeric priors from machine-readable repository files, and emits
+gap proposals without making dataset-realism, planner-ranking, or benchmark-superiority claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import subprocess
+from collections import defaultdict
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+DEFAULT_REGISTRY_PATH = Path("configs/research/scenario_prior_cards_issue_2917.yaml")
+DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21")
+REPORT_NAME = "scenario_prior_gap_report.md"
+SUMMARY_NAME = "summary.json"
+CSV_NAME = "parameter_comparisons.csv"
+
+GROUP_AUTHORED = "authored"
+GROUP_TRACE_DERIVED = "repository_trace_derived"
+COMPARABLE_CLASSIFICATIONS = {GROUP_AUTHORED, GROUP_TRACE_DERIVED}
+
+CLAIM_BOUNDARY = (
+    "analysis_only_repository_prior_gap; no planner ranking, benchmark superiority, "
+    "real-world representativeness, or dataset-backed prior claim"
+)
+DATASET_DEFERRAL = (
+    "Dataset-backed SDD/ETH/AMV scenario-prior comparison is explicitly deferred to #3161."
+)
+NO_RANKING_NOTE = (
+    "No planner ranking, benchmark superiority, or real-world representativeness is inferred."
+)
+
+PARAMETER_GROUPS: dict[str, tuple[str, ...]] = {
+    "pedestrian_density": (
+        "ped_density",
+        "density_delta",
+        "max_abs_density_delta",
+        "max_ped_density",
+        "max_pedestrian_density",
+        "max_pedestrian_density_delta",
+    ),
+    "pedestrian_speed": (
+        "pedestrian_speed",
+        "pedestrian_speed_mps",
+        "speed_delta",
+        "speed_delta_m_s",
+        "max_abs_speed_delta",
+        "max_abs_speed_delta_m_s",
+        "max_speed",
+        "max_speed_m_s",
+        "max_single_pedestrian_speed_delta",
+        "max_single_pedestrian_speed_delta_m_s",
+        "max_single_pedestrian_speed",
+        "max_single_pedestrian_speed_m_s",
+    ),
+    "timing_offset_s": (
+        "dt",
+        "dt_s",
+        "pedestrian_delay",
+        "pedestrian_delay_s",
+        "spawn_time",
+        "spawn_time_s",
+        "wait_delta",
+        "wait_delta_s",
+        "max_abs_dt",
+        "max_abs_dt_s",
+        "max_abs_wait_delta",
+        "max_abs_wait_delta_s",
+        "max_start_delay_offset",
+        "max_start_delay_offset_s",
+        "max_wait_duration_offset",
+        "max_wait_duration_offset_s",
+    ),
+    "spatial_offset_m": (
+        "dx",
+        "dx_m",
+        "dy",
+        "dy_m",
+        "max_magnitude",
+        "max_magnitude_m",
+        "max_route_offset",
+        "max_route_offset_m",
+        "max_single_pedestrian_trajectory_waypoint_offset",
+        "max_single_pedestrian_trajectory_waypoint_offset_m",
+    ),
+    "route_coordinate_m": (
+        "start_x",
+        "start_y",
+        "goal_x",
+        "goal_y",
+    ),
+    "clearance_distance_m": (
+        "min_distance",
+        "mean_distance",
+        "max_distance",
+        "min_start_goal_distance",
+        "min_start_goal_distance_m",
+    ),
+    "episode_horizon_steps": ("max_episode_steps",),
+}
+KEY_TO_GROUP = {key: group for group, keys in PARAMETER_GROUPS.items() for key in keys}
+
+SKIP_KEY_PARTS = (
+    "issue",
+    "seed",
+    "schema_version",
+    "version",
+    "hash",
+    "checksum",
+    "exit_code",
+    "candidate_index",
+    "reference_candidate_index",
+    "jobs",
+    "episodes",
+    "failure",
+    "valid",
+    "written",
+    "count",
+    "rate",
+)
+
+
+class ScenarioPriorComparisonError(RuntimeError):
+    """Raised when the Issue #2919 comparison cannot be completed."""
+
+
+@dataclass(frozen=True)
+class ParameterSample:
+    """One extracted numeric prior sample."""
+
+    parameter: str
+    source_key: str
+    value: float
+    card_id: str
+    classification: str
+    source_path: str
+    yaml_path: str
+
+
+@dataclass
+class GroupedParameterSamples:
+    """Grouped samples and provenance for one canonical parameter."""
+
+    values: list[float] = field(default_factory=list)
+    source_keys: set[str] = field(default_factory=set)
+    source_paths: set[str] = field(default_factory=set)
+
+
+def repository_root() -> Path:
+    """Return the current Git repository root."""
+
+    result = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(result.stdout.strip())
+
+
+def load_yaml_or_json(path: Path) -> Any:
+    """Load a YAML or JSON document from a machine-readable source path."""
+
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise ScenarioPriorComparisonError(f"could not read {path}: {exc}") from exc
+    if path.suffix == ".json":
+        return json.loads(text)
+    return yaml.safe_load(text)
+
+
+def iter_machine_readable_files(path: Path):
+    """Yield YAML/JSON files for a card source trace."""
+
+    if path.is_dir():
+        yield from sorted(
+            child
+            for child in path.rglob("*")
+            if child.is_file() and child.suffix.lower() in {".yaml", ".yml", ".json"}
+        )
+    elif path.is_file() and path.suffix.lower() in {".yaml", ".yml", ".json"}:
+        yield path
+
+
+def _is_numeric(value: Any) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def _path_label(path: tuple[str, ...]) -> str:
+    return ".".join(path)
+
+
+def _should_skip_key(key: str) -> bool:
+    normalized = key.lower()
+    return any(part in normalized for part in SKIP_KEY_PARTS)
+
+
+def _canonical_parameter(key: str) -> str | None:
+    normalized = key.lower()
+    if _should_skip_key(normalized):
+        return None
+    return KEY_TO_GROUP.get(normalized)
+
+
+def _append_sample(
+    samples: list[ParameterSample],
+    *,
+    card_id: str,
+    classification: str,
+    source_path: Path,
+    repo_root: Path,
+    yaml_path: tuple[str, ...],
+    source_key: str,
+    value: float,
+) -> None:
+    parameter = _canonical_parameter(source_key)
+    if parameter is None:
+        return
+    samples.append(
+        ParameterSample(
+            parameter=parameter,
+            source_key=source_key,
+            value=float(value),
+            card_id=card_id,
+            classification=classification,
+            source_path=source_path.relative_to(repo_root).as_posix(),
+            yaml_path=_path_label(yaml_path),
+        )
+    )
+
+
+def _range_values(node: dict[Any, Any]) -> list[float]:
+    """Return min/max range endpoints from a mapping when present."""
+
+    if _is_numeric(node.get("min")) and _is_numeric(node.get("max")):
+        return [float(node["min"]), float(node["max"])]
+    if _is_numeric(node.get("minimum")) and _is_numeric(node.get("maximum")):
+        return [float(node["minimum"]), float(node["maximum"])]
+    return []
+
+
+def _append_range_samples(
+    samples: list[ParameterSample],
+    *,
+    node: dict[Any, Any],
+    path: tuple[str, ...],
+    card_id: str,
+    classification: str,
+    source_path: Path,
+    repo_root: Path,
+) -> None:
+    """Append range endpoints for a recognized range mapping."""
+
+    parent_key = path[-1] if path else ""
+    for value in _range_values(node):
+        _append_sample(
+            samples,
+            card_id=card_id,
+            classification=classification,
+            source_path=source_path,
+            repo_root=repo_root,
+            yaml_path=path,
+            source_key=parent_key,
+            value=value,
+        )
+
+
+def _append_scalar_sample(
+    samples: list[ParameterSample],
+    *,
+    node: Any,
+    path: tuple[str, ...],
+    card_id: str,
+    classification: str,
+    source_path: Path,
+    repo_root: Path,
+) -> None:
+    """Append a scalar numeric sample when its key maps to a parameter group."""
+
+    if not (_is_numeric(node) and path):
+        return
+    _append_sample(
+        samples,
+        card_id=card_id,
+        classification=classification,
+        source_path=source_path,
+        repo_root=repo_root,
+        yaml_path=path,
+        source_key=path[-1],
+        value=float(node),
+    )
+
+
+def extract_parameter_samples(
+    payload: Any,
+    *,
+    card_id: str,
+    classification: str,
+    source_path: Path,
+    repo_root: Path,
+) -> list[ParameterSample]:
+    """Extract compact numeric prior samples from a YAML/JSON payload."""
+
+    samples: list[ParameterSample] = []
+
+    def walk(node: Any, path: tuple[str, ...]) -> None:
+        if isinstance(node, dict):
+            _append_range_samples(
+                samples,
+                node=node,
+                path=path,
+                card_id=card_id,
+                classification=classification,
+                source_path=source_path,
+                repo_root=repo_root,
+            )
+            for key, value in node.items():
+                walk(value, (*path, str(key)))
+            return
+        if isinstance(node, list):
+            for value in node:
+                walk(value, path)
+            return
+        _append_scalar_sample(
+            samples,
+            node=node,
+            path=path,
+            card_id=card_id,
+            classification=classification,
+            source_path=source_path,
+            repo_root=repo_root,
+        )
+
+    walk(payload, ())
+    return samples
+
+
+def load_registry_cards(registry_path: Path) -> list[dict[str, Any]]:
+    """Load the Issue #2917 registry and return selected authored/trace-derived cards."""
+
+    registry = load_yaml_or_json(registry_path)
+    if not isinstance(registry, dict):
+        raise ScenarioPriorComparisonError(f"registry is not a mapping: {registry_path}")
+    cards = registry.get("cards")
+    if not isinstance(cards, list):
+        raise ScenarioPriorComparisonError(f"registry has no cards list: {registry_path}")
+    selected = [
+        card
+        for card in cards
+        if isinstance(card, dict) and card.get("classification") in COMPARABLE_CLASSIFICATIONS
+    ]
+    if not selected:
+        raise ScenarioPriorComparisonError("registry contains no authored or trace-derived cards")
+    return selected
+
+
+def collect_samples(
+    registry_path: Path, repo_root: Path
+) -> tuple[list[ParameterSample], list[str]]:
+    """Collect samples from machine-readable source traces in the prior-card registry."""
+
+    samples: list[ParameterSample] = []
+    skipped_sources: list[str] = []
+    for card in load_registry_cards(registry_path):
+        card_id = str(card.get("card_id", "unknown_card"))
+        classification = str(card["classification"])
+        source_traces = card.get("source_traces") or []
+        if not isinstance(source_traces, list):
+            skipped_sources.append(f"{card_id}: source_traces is not a list")
+            continue
+        for source in source_traces:
+            source_path = (repo_root / str(source)).resolve()
+            readable_files = list(iter_machine_readable_files(source_path))
+            if not readable_files:
+                skipped_sources.append(f"{card_id}: {source}")
+                continue
+            for readable_file in readable_files:
+                payload = load_yaml_or_json(readable_file)
+                samples.extend(
+                    extract_parameter_samples(
+                        payload,
+                        card_id=card_id,
+                        classification=classification,
+                        source_path=readable_file,
+                        repo_root=repo_root,
+                    )
+                )
+    return samples, skipped_sources
+
+
+def quantile(values: list[float], probability: float) -> float | None:
+    """Return a linearly interpolated quantile for non-empty values."""
+
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = probability * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def distribution_summary(values: list[float]) -> dict[str, float | int | None]:
+    """Return range and quantile statistics for one distribution."""
+
+    ordered = sorted(values)
+    return {
+        "n": len(ordered),
+        "min": ordered[0] if ordered else None,
+        "q05": quantile(ordered, 0.05),
+        "q25": quantile(ordered, 0.25),
+        "median": quantile(ordered, 0.50),
+        "q75": quantile(ordered, 0.75),
+        "q95": quantile(ordered, 0.95),
+        "max": ordered[-1] if ordered else None,
+        "range": (ordered[-1] - ordered[0]) if len(ordered) > 1 else 0.0 if ordered else None,
+    }
+
+
+def empirical_cdf(values: list[float], threshold: float) -> float:
+    """Return the empirical CDF value at threshold."""
+
+    return sum(1 for value in values if value <= threshold) / len(values)
+
+
+def ks_distance(left: list[float], right: list[float]) -> float | None:
+    """Return a two-sample KS distance for non-empty samples."""
+
+    if not left or not right:
+        return None
+    points = sorted(set(left + right))
+    return max(abs(empirical_cdf(left, point) - empirical_cdf(right, point)) for point in points)
+
+
+def wasserstein_like_distance(left: list[float], right: list[float]) -> float | None:
+    """Return a simple 1D Wasserstein-like distance over matched quantile grid points."""
+
+    if not left or not right:
+        return None
+    probabilities = [index / 100 for index in range(101)]
+    distances = [
+        abs(quantile(left, probability) - quantile(right, probability))
+        for probability in probabilities
+    ]
+    return sum(distances) / len(distances)
+
+
+def classify_prior_gap(authored: list[float], trace: list[float]) -> tuple[str, str]:
+    """Classify authored samples relative to trace-derived samples."""
+
+    authored_stats = distribution_summary(authored)
+    trace_stats = distribution_summary(trace)
+    authored_min = float(authored_stats["min"])
+    authored_max = float(authored_stats["max"])
+    authored_median = float(authored_stats["median"])
+    trace_min = float(trace_stats["min"])
+    trace_max = float(trace_stats["max"])
+    trace_q25 = float(trace_stats["q25"])
+    trace_q75 = float(trace_stats["q75"])
+    trace_range = float(trace_stats["range"])
+    authored_range = float(authored_stats["range"])
+    tolerance = max(abs(trace_range) * 0.05, 1e-9)
+
+    if trace_range <= tolerance:
+        if authored_range <= tolerance and abs(authored_median - trace_min) <= tolerance:
+            return "representative", "authored samples collapse near the trace-derived point mass"
+        if authored_min <= trace_min <= authored_max:
+            return (
+                "too_broad",
+                "trace-derived samples are point-like while authored range spans wider",
+            )
+        return "too_extreme", "authored samples miss the trace-derived point-like value"
+
+    if authored_max < trace_q25 - tolerance or authored_min > trace_q75 + tolerance:
+        return "too_extreme", "authored range is shifted outside the central trace-derived mass"
+    if authored_min > trace_min + tolerance and authored_max < trace_max - tolerance:
+        return "too_narrow", "authored range sits inside the trace-derived support"
+    if authored_range < trace_range * 0.60:
+        return "too_narrow", "authored range is substantially narrower than trace-derived support"
+    if authored_range > trace_range * 1.60:
+        return "too_broad", "authored range is substantially wider than trace-derived support"
+    if authored_min < trace_min - tolerance or authored_max > trace_max + tolerance:
+        return (
+            "too_extreme",
+            "authored range extends beyond trace-derived support without broad mismatch",
+        )
+    return "representative", "authored and trace-derived ranges broadly overlap"
+
+
+def proposal_for(parameter: str, classification: str, trace_stats: dict[str, Any]) -> str:
+    """Return a concrete scenario-family proposal for a classified parameter gap."""
+
+    trace_low = trace_stats.get("q05")
+    trace_high = trace_stats.get("q95")
+    trace_median = trace_stats.get("median")
+    if classification == "too_narrow":
+        return (
+            f"Add a `{parameter}_trace_span` family that samples the trace-derived q05-q95 "
+            f"interval [{trace_low}, {trace_high}] while preserving certification gates."
+        )
+    if classification == "too_broad":
+        return (
+            f"Split authored `{parameter}` stress variants into a centered trace-aligned family "
+            f"near median {trace_median} plus a separately labeled stress/extreme family."
+        )
+    if classification == "too_extreme":
+        return (
+            f"Add a `{parameter}_centered_trace_probe` family around trace median {trace_median} "
+            "and keep out-of-support authored variants labeled diagnostic stress only."
+        )
+    return (
+        f"Keep `{parameter}` as an audit baseline and add no planner-ranking interpretation; "
+        "future dataset-backed calibration belongs in #3161."
+    )
+
+
+def group_samples(samples: list[ParameterSample]) -> dict[str, dict[str, GroupedParameterSamples]]:
+    """Group samples by parameter and classification."""
+
+    grouped: dict[str, dict[str, GroupedParameterSamples]] = defaultdict(
+        lambda: defaultdict(GroupedParameterSamples)
+    )
+    for sample in samples:
+        bucket = grouped[sample.parameter][sample.classification]
+        bucket.values.append(sample.value)
+        bucket.source_keys.add(sample.source_key)
+        bucket.source_paths.add(sample.source_path)
+    return grouped
+
+
+def build_comparison_rows(samples: list[ParameterSample]) -> list[dict[str, Any]]:
+    """Build per-parameter distribution comparison rows."""
+
+    rows: list[dict[str, Any]] = []
+    for parameter, by_classification in sorted(group_samples(samples).items()):
+        authored = by_classification.get(GROUP_AUTHORED)
+        trace = by_classification.get(GROUP_TRACE_DERIVED)
+        if authored is None or trace is None or not authored.values or not trace.values:
+            continue
+        authored_stats = distribution_summary(authored.values)
+        trace_stats = distribution_summary(trace.values)
+        classification, rationale = classify_prior_gap(authored.values, trace.values)
+        rows.append(
+            {
+                "parameter": parameter,
+                "classification": classification,
+                "classification_rationale": rationale,
+                "proposal": proposal_for(parameter, classification, trace_stats),
+                "authored": authored_stats,
+                "trace_derived": trace_stats,
+                "ks_distance": ks_distance(authored.values, trace.values),
+                "wasserstein_like_distance": wasserstein_like_distance(
+                    authored.values, trace.values
+                ),
+                "authored_source_keys": sorted(authored.source_keys),
+                "trace_source_keys": sorted(trace.source_keys),
+                "authored_source_paths": sorted(authored.source_paths),
+                "trace_source_paths": sorted(trace.source_paths),
+                "comparison_caveat": (
+                    "Repository-authored config values and repository-trace-derived config/summary "
+                    "values may mix offsets, caps, and realized values within a canonical parameter "
+                    "family; use classifications as gap-finding proposals only."
+                ),
+            }
+        )
+    return rows
+
+
+def _format_number(value: Any) -> str:
+    if value is None:
+        return "NA"
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def write_csv(rows: list[dict[str, Any]], path: Path) -> None:
+    """Write a compact CSV table for review."""
+
+    fieldnames = [
+        "parameter",
+        "classification",
+        "authored_n",
+        "authored_min",
+        "authored_median",
+        "authored_max",
+        "trace_n",
+        "trace_min",
+        "trace_median",
+        "trace_max",
+        "ks_distance",
+        "wasserstein_like_distance",
+        "proposal",
+    ]
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames, lineterminator="\n")
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "parameter": row["parameter"],
+                    "classification": row["classification"],
+                    "authored_n": row["authored"]["n"],
+                    "authored_min": _format_number(row["authored"]["min"]),
+                    "authored_median": _format_number(row["authored"]["median"]),
+                    "authored_max": _format_number(row["authored"]["max"]),
+                    "trace_n": row["trace_derived"]["n"],
+                    "trace_min": _format_number(row["trace_derived"]["min"]),
+                    "trace_median": _format_number(row["trace_derived"]["median"]),
+                    "trace_max": _format_number(row["trace_derived"]["max"]),
+                    "ks_distance": _format_number(row["ks_distance"]),
+                    "wasserstein_like_distance": _format_number(row["wasserstein_like_distance"]),
+                    "proposal": row["proposal"],
+                }
+            )
+
+
+def analysis_base_commit(repo_root: Path) -> str:
+    """Return the stable base commit used for repository-source comparison.
+
+    The generated summary is tracked in the same commit as this script. Recording ``HEAD``
+    would make the artifact self-referential and dirty on every post-commit reproduction.
+    The merge base with ``origin/main`` is stable for the branch and identifies the repository
+    inputs this analysis compared.
+    """
+
+    try:
+        result = subprocess.run(
+            ["git", "merge-base", "HEAD", "origin/main"],
+            cwd=repo_root,
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return "unknown"
+    return result.stdout.strip()
+
+
+def write_summary(
+    *,
+    rows: list[dict[str, Any]],
+    samples: list[ParameterSample],
+    skipped_sources: list[str],
+    output_dir: Path,
+    repo_root: Path,
+    registry_path: Path,
+) -> dict[str, Any]:
+    """Write the machine-readable summary and return its payload."""
+
+    payload: dict[str, Any] = {
+        "schema_version": "scenario_prior_gap_issue_2919.v1",
+        "issue": 2919,
+        "registry_path": registry_path.relative_to(repo_root).as_posix(),
+        "analysis_base_commit": analysis_base_commit(repo_root),
+        "evidence_tier": "analysis_only",
+        "claim_boundary": CLAIM_BOUNDARY,
+        "dataset_comparison_deferral": DATASET_DEFERRAL,
+        "no_planner_ranking": NO_RANKING_NOTE,
+        "sample_count": len(samples),
+        "skipped_non_machine_readable_sources": skipped_sources,
+        "comparison_count": len(rows),
+        "classification_counts": {
+            classification: sum(1 for row in rows if row["classification"] == classification)
+            for classification in ("too_narrow", "too_broad", "too_extreme", "representative")
+        },
+        "comparisons": rows,
+        "files": {
+            "markdown_report": (output_dir / REPORT_NAME).relative_to(repo_root).as_posix(),
+            "comparison_csv": (output_dir / CSV_NAME).relative_to(repo_root).as_posix(),
+            "summary_json": (output_dir / SUMMARY_NAME).relative_to(repo_root).as_posix(),
+        },
+    }
+    (output_dir / SUMMARY_NAME).write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return payload
+
+
+def write_markdown_report(
+    *,
+    rows: list[dict[str, Any]],
+    output_dir: Path,
+    repo_root: Path,
+    registry_path: Path,
+) -> None:
+    """Write the human-readable gap report."""
+
+    lines = [
+        "# Issue #2919 Scenario Prior Gap Report",
+        "",
+        "- Evidence status: `analysis_only`.",
+        f"- Claim boundary: {CLAIM_BOUNDARY}.",
+        f"- Registry input: `{registry_path.relative_to(repo_root).as_posix()}`.",
+        f"- {DATASET_DEFERRAL}",
+        f"- {NO_RANKING_NOTE}",
+        "",
+        "## Method",
+        "",
+        "The script loads the Issue #2917 prior-card registry, selects cards classified as "
+        "`authored` or `repository_trace_derived`, and extracts numeric samples only from "
+        "machine-readable YAML/JSON source traces. Text docs, Python scripts, raw datasets, and "
+        "external-dataset candidate cards are excluded from this run.",
+        "",
+        "Distances are diagnostic: KS distance uses empirical CDF separation and the "
+        "Wasserstein-like value averages absolute matched-quantile gaps over a 0-100% grid.",
+        "",
+        "## Parameter Comparisons",
+        "",
+        "| Parameter | Class | Authored range | Trace-derived range | KS | Wasserstein-like | Proposal |",
+        "| --- | --- | ---: | ---: | ---: | ---: | --- |",
+    ]
+    for row in rows:
+        authored = row["authored"]
+        trace = row["trace_derived"]
+        authored_range = (
+            f"{_format_number(authored['min'])} to {_format_number(authored['max'])} "
+            f"(n={authored['n']})"
+        )
+        trace_range = (
+            f"{_format_number(trace['min'])} to {_format_number(trace['max'])} (n={trace['n']})"
+        )
+        lines.append(
+            "| {parameter} | `{classification}` | {authored_range} | {trace_range} | "
+            "{ks} | {wasserstein} | {proposal} |".format(
+                parameter=row["parameter"],
+                classification=row["classification"],
+                authored_range=authored_range,
+                trace_range=trace_range,
+                ks=_format_number(row["ks_distance"]),
+                wasserstein=_format_number(row["wasserstein_like_distance"]),
+                proposal=row["proposal"],
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Classification Notes",
+            "",
+            "- `too_narrow`: authored support is materially inside the trace-derived support.",
+            "- `too_broad`: authored support is materially wider than trace-derived support.",
+            "- `too_extreme`: authored support is shifted outside trace-derived central mass or support.",
+            "- `representative`: authored and trace-derived ranges broadly overlap for this repository-only comparison.",
+            "",
+            "## Limitations",
+            "",
+            "- This is not dataset-backed prior calibration; SDD/ETH/AMV comparison is deferred to #3161.",
+            "- Repository trace-derived values come from existing repo configs and compact summaries, not raw real-world traces.",
+            "- Some canonical groups mix offsets, caps, and realized values; proposals are scenario-family design prompts, not statistical claims.",
+            "- No planner ranking, benchmark superiority, or real-world representativeness is inferred.",
+            "",
+        ]
+    )
+    (output_dir / REPORT_NAME).write_text("\n".join(lines), encoding="utf-8")
+
+
+def run_comparison(
+    *,
+    registry_path: Path = DEFAULT_REGISTRY_PATH,
+    output_dir: Path = DEFAULT_OUTPUT_DIR,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Run the Issue #2919 comparison and write evidence files."""
+
+    repo_root = repo_root or repository_root()
+    registry_path = (repo_root / registry_path).resolve()
+    output_dir = (repo_root / output_dir).resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    samples, skipped_sources = collect_samples(registry_path, repo_root)
+    rows = build_comparison_rows(samples)
+    if not rows:
+        raise ScenarioPriorComparisonError(
+            "no comparable authored and trace-derived parameters found"
+        )
+
+    write_csv(rows, output_dir / CSV_NAME)
+    write_markdown_report(
+        rows=rows,
+        output_dir=output_dir,
+        repo_root=repo_root,
+        registry_path=registry_path,
+    )
+    return write_summary(
+        rows=rows,
+        samples=samples,
+        skipped_sources=skipped_sources,
+        output_dir=output_dir,
+        repo_root=repo_root,
+        registry_path=registry_path,
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Compare authored and repository-trace-derived scenario priors from the Issue #2917 "
+            "prior-card registry. Dataset-backed SDD/ETH/AMV comparison is deferred to #3161."
+        )
+    )
+    parser.add_argument(
+        "--registry",
+        type=Path,
+        default=DEFAULT_REGISTRY_PATH,
+        help=f"Prior-card registry path (default: {DEFAULT_REGISTRY_PATH})",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=DEFAULT_OUTPUT_DIR,
+        help=f"Evidence output directory (default: {DEFAULT_OUTPUT_DIR})",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    """CLI entry point."""
+
+    args = parse_args()
+    summary = run_comparison(registry_path=args.registry, output_dir=args.output_dir)
+    print(f"wrote {summary['files']['markdown_report']}")
+    print(f"wrote {summary['files']['comparison_csv']}")
+    print(f"wrote {summary['files']['summary_json']}")
+    print(DATASET_DEFERRAL)
+    print(NO_RANKING_NOTE)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/analysis/test_compare_scenario_priors_issue_2919.py
+++ b/tests/analysis/test_compare_scenario_priors_issue_2919.py
@@ -1,0 +1,220 @@
+"""Tests for the Issue #2919 scenario-prior gap comparison."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.analysis import compare_scenario_priors_issue_2919 as comparator
+
+
+def _write_yaml(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _write_json(path: Path, payload: object) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    return path
+
+
+def _mini_registry(tmp_path: Path) -> Path:
+    _write_yaml(
+        tmp_path / "authored" / "prior.yaml",
+        {
+            "variants": [
+                {
+                    "family": "single_pedestrian_speed_offset",
+                    "parameters": {
+                        "speed_delta_m_s": 0.25,
+                        "max_abs_speed_delta_m_s": 0.5,
+                    },
+                },
+                {
+                    "family": "pedestrian_density_offset",
+                    "parameters": {
+                        "density_delta": 0.02,
+                        "max_ped_density": 0.12,
+                    },
+                },
+            ]
+        },
+    )
+    _write_yaml(
+        tmp_path / "trace" / "space.yaml",
+        {
+            "variables": {
+                "pedestrian_speed_mps": {"min": 0.8, "max": 1.4},
+            }
+        },
+    )
+    _write_json(
+        tmp_path / "trace" / "summary.json",
+        {"simulation_config": {"ped_density": 0.02}},
+    )
+    return _write_yaml(
+        tmp_path / "configs" / "research" / "scenario_prior_cards_issue_2917.yaml",
+        {
+            "schema_version": "scenario-prior-card-registry.v1",
+            "cards": [
+                {
+                    "card_id": "authored_card",
+                    "classification": "authored",
+                    "source_traces": ["authored"],
+                },
+                {
+                    "card_id": "trace_card",
+                    "classification": "repository_trace_derived",
+                    "source_traces": ["trace"],
+                },
+                {
+                    "card_id": "external_deferred",
+                    "classification": "external_dataset_candidate",
+                    "source_traces": ["external"],
+                },
+            ],
+        },
+    )
+
+
+def test_extract_parameter_samples_groups_ranges_and_scalars(tmp_path: Path) -> None:
+    """Extractor should group supported scalar and range keys under canonical parameters."""
+
+    source_path = _write_yaml(
+        tmp_path / "prior.yaml",
+        {
+            "variables": {"pedestrian_speed_mps": {"min": 0.8, "max": 1.4}},
+            "simulation_config": {"ped_density": 0.02},
+            "metadata": {"issue": 2919, "scenario_seed": 123},
+        },
+    )
+
+    samples = comparator.extract_parameter_samples(
+        yaml.safe_load(source_path.read_text(encoding="utf-8")),
+        card_id="trace_card",
+        classification="repository_trace_derived",
+        source_path=source_path,
+        repo_root=tmp_path,
+    )
+
+    by_parameter = {}
+    for sample in samples:
+        by_parameter.setdefault(sample.parameter, []).append(sample.value)
+
+    assert by_parameter["pedestrian_speed"] == [0.8, 1.4]
+    assert by_parameter["pedestrian_density"] == [0.02]
+    assert "scenario_seed" not in {sample.source_key for sample in samples}
+
+
+def test_build_comparison_rows_classifies_gaps() -> None:
+    """Comparable authored and trace-derived distributions should receive issue labels."""
+
+    samples = [
+        comparator.ParameterSample(
+            parameter="pedestrian_speed",
+            source_key="speed_delta_m_s",
+            value=0.25,
+            card_id="authored",
+            classification="authored",
+            source_path="authored.yaml",
+            yaml_path="variants.parameters.speed_delta_m_s",
+        ),
+        comparator.ParameterSample(
+            parameter="pedestrian_speed",
+            source_key="max_abs_speed_delta_m_s",
+            value=0.5,
+            card_id="authored",
+            classification="authored",
+            source_path="authored.yaml",
+            yaml_path="variants.parameters.max_abs_speed_delta_m_s",
+        ),
+        comparator.ParameterSample(
+            parameter="pedestrian_speed",
+            source_key="pedestrian_speed_mps",
+            value=0.8,
+            card_id="trace",
+            classification="repository_trace_derived",
+            source_path="trace.yaml",
+            yaml_path="variables.pedestrian_speed_mps",
+        ),
+        comparator.ParameterSample(
+            parameter="pedestrian_speed",
+            source_key="pedestrian_speed_mps",
+            value=1.4,
+            card_id="trace",
+            classification="repository_trace_derived",
+            source_path="trace.yaml",
+            yaml_path="variables.pedestrian_speed_mps",
+        ),
+    ]
+
+    rows = comparator.build_comparison_rows(samples)
+
+    assert len(rows) == 1
+    assert rows[0]["parameter"] == "pedestrian_speed"
+    assert rows[0]["classification"] in {"too_narrow", "too_extreme"}
+    assert rows[0]["ks_distance"] is not None
+    assert rows[0]["wasserstein_like_distance"] is not None
+    assert "family" in rows[0]["proposal"]
+
+
+def test_run_comparison_writes_report_csv_and_summary(tmp_path: Path) -> None:
+    """The end-to-end runner should write durable compact evidence files."""
+
+    registry = _mini_registry(tmp_path)
+    output_dir = tmp_path / "docs" / "context" / "evidence" / "issue_2919"
+
+    summary = comparator.run_comparison(
+        registry_path=registry.relative_to(tmp_path),
+        output_dir=output_dir.relative_to(tmp_path),
+        repo_root=tmp_path,
+    )
+
+    report_path = output_dir / comparator.REPORT_NAME
+    csv_path = output_dir / comparator.CSV_NAME
+    summary_path = output_dir / comparator.SUMMARY_NAME
+
+    assert report_path.is_file()
+    assert csv_path.is_file()
+    assert summary_path.is_file()
+    assert summary["evidence_tier"] == "analysis_only"
+    assert summary["comparison_count"] >= 2
+    assert "deferred to #3161" in report_path.read_text(encoding="utf-8")
+    assert "No planner ranking" in report_path.read_text(encoding="utf-8")
+    assert "pedestrian_speed" in csv_path.read_text(encoding="utf-8")
+
+
+def test_run_comparison_fails_when_no_common_parameters(tmp_path: Path) -> None:
+    """The runner should fail clearly when registry sources share no comparable parameters."""
+
+    _write_yaml(tmp_path / "authored" / "prior.yaml", {"parameters": {"dx_m": 0.1}})
+    _write_yaml(tmp_path / "trace" / "prior.yaml", {"variables": {"pedestrian_speed_mps": 1.2}})
+    registry = _write_yaml(
+        tmp_path / "registry.yaml",
+        {
+            "cards": [
+                {
+                    "card_id": "authored",
+                    "classification": "authored",
+                    "source_traces": ["authored"],
+                },
+                {
+                    "card_id": "trace",
+                    "classification": "repository_trace_derived",
+                    "source_traces": ["trace"],
+                },
+            ]
+        },
+    )
+
+    with pytest.raises(comparator.ScenarioPriorComparisonError, match="no comparable"):
+        comparator.run_comparison(
+            registry_path=registry.relative_to(tmp_path),
+            output_dir=Path("out"),
+            repo_root=tmp_path,
+        )


### PR DESCRIPTION
## Summary

Closes #2919.

Adds an analysis-only authored-vs-repository-trace-derived scenario-prior comparison. The script loads the #2917 prior-card registry, extracts comparable numeric parameter families from machine-readable YAML/JSON sources, classifies authored support against repository-trace-derived support, and emits concrete scenario-family gap proposals.

The generated evidence is under `docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/` and explicitly defers dataset-backed SDD/ETH/AMV comparison to #3161. It does not infer planner ranking, benchmark superiority, paper-grade evidence, or real-world representativeness.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/analysis/compare_scenario_priors_issue_2919.py --help`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/analysis/compare_scenario_priors_issue_2919.py`
- `scripts/dev/run_worktree_shared_venv.sh -- python -c "import yaml; yaml.safe_load(open('configs/research/scenario_prior_cards_issue_2917.yaml')); print('cards ok')"`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/analysis/test_compare_scenario_priors_issue_2919.py tests/research/test_issue_2917_scenario_prior_cards.py tests/research/test_scenario_distribution_prior_manifest.py tests/research/test_issue_2523_scenario_prior_smoke.py tests/research/test_external_prior_divergence.py -q` (`26 passed`)
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/analysis/compare_scenario_priors_issue_2919.py tests/analysis/test_compare_scenario_priors_issue_2919.py`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/analysis/compare_scenario_priors_issue_2919.py tests/analysis/test_compare_scenario_priors_issue_2919.py`
- `git diff --check`
- Post-commit rerun of `scripts/dev/run_worktree_shared_venv.sh -- python scripts/analysis/compare_scenario_priors_issue_2919.py` leaves no diff.

Attempted broader selector:

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/ -k "scenario and prior" -q` did not complete collection because of an unrelated missing optional `torch` import in `tests/test_output_root_migration.py`.

## Research Result Guidance

- Target claim/hypothesis/blocker: identify authored scenario-prior gaps relative to repository-trace-derived priors from existing repo artifacts.
- Comparator/baseline: authored prior-card sources vs `repository_trace_derived` prior-card sources from `configs/research/scenario_prior_cards_issue_2917.yaml`.
- Evidence tier: `analysis_only`.
- Result classification: diagnostic gap report: `pedestrian_density` and `pedestrian_speed` classified `too_broad`, `timing_offset_s` classified `too_extreme` for this repository-only comparison.
- Decision/stop rule: emit scenario-family proposals only; do not infer planner ranking or real-world representativeness.
- Synthesis surface/update target: `docs/context/evidence/issue_2919_scenario_prior_gap_2026-06-21/` and `docs/context/evidence/README.md`.

## Downstream Propagation

- Parent issue: #2919 is closed by this PR.
- Claim map / benchmark report / leaderboard: NA; analysis-only prior-gap report, not benchmark evidence.
- Registry / config index: NA; this compares existing registry inputs and emits evidence, no new scenario registry entries.
- Context index / memory note: evidence catalog updated in `docs/context/evidence/README.md`.
- Follow-up issue: dataset-backed SDD/ETH/AMV comparison remains deferred to #3161.
