### PR TITLE
feat: derive scenario priors from trace clusters

### DIFF
--- a/docs/context/evidence/issue_2726_scenario_prior_trace_clusters/README.md
+++ b/docs/context/evidence/issue_2726_scenario_prior_trace_clusters/README.md
@@ -1,0 +1,27 @@
+# Issue #2726 Scenario Priors Calibration Report
+
+## Scope
+
+This directory contains evidence and report artifacts for calibrating scenario priors from trace clusters.
+It processes simulation trace exports from the repository, extracts features, groups them deterministically,
+and generates scenario prior candidate cards.
+
+## Evidence Status
+
+- `schema`: `scenario-prior-card-registry.v1`
+- `claim_boundary`: `repository_trace_grounded_not_real_world_calibrated: this report and generated prior cards are derived entirely from deterministic simulation trace clusters. They do not claim real-world validity, representativeness, or generalizability to real-world pedestrian behavior. Refer to issues #3161 and #2918 for real-world staging and calibration requirements.`
+- `validation_reference`: Refer to #3161 and #2918.
+
+## Files
+
+- [scenario_prior_cards_issue_2726.yaml](scenario_prior_cards_issue_2726.yaml): Generated prior cards
+- [report.md](report.md): Human-readable Markdown summary report
+- [report.json](report.json): Fully detailed cluster statistics and traces mapping JSON
+
+## Reproducible Command
+
+```bash
+uv run python scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py \
+    --trace-dir tests/fixtures/analysis_workbench/simulation_trace_export_v1 \
+    --output-dir docs/context/evidence/issue_2726_scenario_prior_trace_clusters
+```

--- a/docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
+++ b/docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
@@ -1,0 +1,811 @@
+{
+  "claim_boundary": "repository_trace_grounded_not_real_world_calibrated: this report and generated prior cards are derived entirely from deterministic simulation trace clusters. They do not claim real-world validity, representativeness, or generalizability to real-world pedestrian behavior. Refer to issues #3161 and #2918 for real-world staging and calibration requirements.",
+  "cluster_count": 9,
+  "clusters": {
+    "bottleneck_sparse_unsignalized_nominal": {
+      "traces": [
+        {
+          "episode_id": "issue_2937_bottleneck_motion_rich_ep0000",
+          "features": {
+            "bottleneck_width": 1.5,
+            "has_signal": false,
+            "min_distance_m": 1.118033988749895,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "medium",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/bottleneck_motion_rich_fixture.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2937_bottleneck_motion_rich"
+        },
+        {
+          "episode_id": "fixture_episode_001",
+          "features": {
+            "bottleneck_width": 1.5,
+            "has_signal": false,
+            "min_distance_m": 1.1090987332063813,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "medium",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.01,
+            "robot_total_distance_m": 0.01,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "fixture_trace_001"
+        }
+      ],
+      "traces_count": 2
+    },
+    "crossing_sparse_signalized_nominal": {
+      "traces": [
+        {
+          "episode_id": "issue_2868_goal_directed_crossing_episode_0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": true,
+            "min_distance_m": 1.6720047846821493,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 1.0,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_goal_directed_crossing_fixture_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2868_goal_directed_crossing_0000"
+        },
+        {
+          "episode_id": "issue_2868_signalized_crossing_episode_0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": true,
+            "min_distance_m": 1.0,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 0.6666666666666666,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_signalized_crossing_fixture_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2868_signalized_crossing_0000"
+        },
+        {
+          "episode_id": "issue_2868_goal_directed_crossing_episode_0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": true,
+            "min_distance_m": 1.0031948963187562,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 1.0,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_goal_directed_crossing_fixture_extended.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2868_goal_directed_crossing_0000_issue_2937_extended"
+        },
+        {
+          "episode_id": "issue_2868_signalized_crossing_episode_0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": true,
+            "min_distance_m": 1.0,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 0.8787878787878788,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_signalized_crossing_fixture_extended.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2868_signalized_crossing_0000_issue_2937_extended"
+        }
+      ],
+      "traces_count": 4
+    },
+    "crossing_sparse_unsignalized_collision": {
+      "traces": [
+        {
+          "episode_id": "issue_2937_crossing_proxy_motion_rich_ep0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.25,
+            "outcome": "collision",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/crossing_proxy_motion_rich_fixture.json",
+          "planner_id": "orca",
+          "trace_id": "issue_2937_crossing_proxy_motion_rich"
+        }
+      ],
+      "traces_count": 1
+    },
+    "general_dense_unsignalized_collision": {
+      "traces": [
+        {
+          "episode_id": "dense_pedestrian_stress_ep0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.15620499351813316,
+            "outcome": "collision",
+            "pedestrian_count": 3,
+            "pedestrian_density": "dense",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 1.9,
+            "robot_total_distance_m": 1.9,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/dense_pedestrian_stress_episode_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2765_dense_pedestrian_stress_seed2765_ep0000"
+        }
+      ],
+      "traces_count": 1
+    },
+    "general_sparse_signalized_nominal": {
+      "traces": [
+        {
+          "episode_id": "issue_2868_waiting_intent_change_episode_0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": true,
+            "min_distance_m": 1.972308292331602,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 3,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 0.75,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_waiting_intent_change_fixture_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2868_waiting_intent_change_0000"
+        },
+        {
+          "episode_id": "issue_2868_waiting_intent_change_episode_0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": true,
+            "min_distance_m": 1.972308292331602,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 3,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 0.9090909090909091,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_waiting_intent_change_fixture_extended.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2868_waiting_intent_change_0000_issue_2937_extended"
+        }
+      ],
+      "traces_count": 2
+    },
+    "general_sparse_unsignalized_near-miss": {
+      "traces": [
+        {
+          "episode_id": "issue_2868_route_conflict_goal_episode_0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.46647615158762407,
+            "outcome": "near-miss",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_route_conflict_goal_fixture_extended.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2868_route_conflict_goal_0000_issue_2937_extended"
+        }
+      ],
+      "traces_count": 1
+    },
+    "general_sparse_unsignalized_nominal": {
+      "traces": [
+        {
+          "episode_id": "issue_2868_route_conflict_goal_episode_0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 1.4611296999240007,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.0,
+            "robot_total_distance_m": 0.0,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 1.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_route_conflict_goal_fixture_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2868_route_conflict_goal_0000"
+        },
+        {
+          "episode_id": "0",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": null,
+            "outcome": "nominal",
+            "pedestrian_count": 0,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.38365064317548836,
+            "robot_total_distance_m": 0.38371487836849727,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.3333333333333333,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/planner_sanity_open_episode_0000.json",
+          "planner_id": "trace_fixture_gen",
+          "trace_id": "planner_sanity_open-ep0-seed7-source-aae87cf6"
+        }
+      ],
+      "traces_count": 2
+    },
+    "occluded_sparse_unsignalized_near-miss": {
+      "traces": [
+        {
+          "episode_id": "issue_2756_occluded_emergence_ep0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.5,
+            "outcome": "near-miss",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 2,
+            "robot_displacement_m": 1.84,
+            "robot_total_distance_m": 1.84,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.09090909090909091,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/occluded_emergence_episode_extended.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2756_occluded_emergence_seed111_ep0000_issue_2937_extended"
+        },
+        {
+          "episode_id": "issue_2756_occluded_emergence_ep0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.5,
+            "outcome": "near-miss",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 2,
+            "robot_displacement_m": 0.82,
+            "robot_total_distance_m": 0.82,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.1875,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2756_occluded_emergence_seed111_ep0000"
+        },
+        {
+          "episode_id": "issue_2780_occluded_emergence_fast_pedestrian_ep0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.7241657268885349,
+            "outcome": "near-miss",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 2,
+            "robot_displacement_m": 1.08,
+            "robot_total_distance_m": 1.08,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2780_occluded_emergence_fast_pedestrian_seed111_ep0000"
+        },
+        {
+          "episode_id": "issue_2780_occluded_emergence_late_visibility_ep0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.61773780845922,
+            "outcome": "near-miss",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 4,
+            "robot_displacement_m": 0.9,
+            "robot_total_distance_m": 0.9,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2780_occluded_emergence_late_visibility_seed111_ep0000"
+        },
+        {
+          "episode_id": "issue_2780_occluded_emergence_left_close_ep0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.36055512754639896,
+            "outcome": "near-miss",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 4,
+            "robot_displacement_m": 0.9,
+            "robot_total_distance_m": 0.9,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2780_occluded_emergence_left_close_seed111_ep0000"
+        },
+        {
+          "episode_id": "issue_2780_occluded_emergence_slow_pedestrian_ep0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.48,
+            "outcome": "near-miss",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 0,
+            "robot_displacement_m": 0.72,
+            "robot_total_distance_m": 0.72,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_slow_pedestrian_episode_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2780_occluded_emergence_slow_pedestrian_seed111_ep0000"
+        }
+      ],
+      "traces_count": 6
+    },
+    "occluded_sparse_unsignalized_nominal": {
+      "traces": [
+        {
+          "episode_id": "issue_2780_occluded_emergence_right_close_ep0000",
+          "features": {
+            "bottleneck_width": null,
+            "has_signal": false,
+            "min_distance_m": 0.9838699100999075,
+            "outcome": "nominal",
+            "pedestrian_count": 1,
+            "pedestrian_density": "sparse",
+            "planner_stop_events": 4,
+            "robot_displacement_m": 0.9,
+            "robot_total_distance_m": 0.9,
+            "signal_green_fraction": 0.0,
+            "stop_fraction": 0.0,
+            "topology_switches": 0
+          },
+          "file_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json",
+          "planner_id": "hybrid_rule_v0_minimal",
+          "trace_id": "issue_2780_occluded_emergence_right_close_seed111_ep0000"
+        }
+      ],
+      "traces_count": 1
+    }
+  },
+  "clusters_count": 9,
+  "evidence_status": "repository_trace_derived_proposal",
+  "follow_up_data_requirements": [
+    "Stage real-world trajectory data under issue #3161 before making representativeness claims.",
+    "Use issue #2918 calibration context before promoting these proposal cards into calibrated priors."
+  ],
+  "limitations": [
+    "Repository trace fixtures are synthetic or simulator-derived and are not real-world calibrated.",
+    "Rule-based clustering is deterministic and reviewable, but not a statistical clustering claim.",
+    "Candidate cards are proposal surfaces only and do not establish benchmark usefulness or planner performance improvement."
+  ],
+  "scenario_prior_candidates": [
+    {
+      "card_id": "trace_cluster_bottleneck_sparse_unsignalized_nominal",
+      "classification": "repository_trace_derived",
+      "dataset_license_status": "not_applicable_generated_synthetic",
+      "excluded_populations": [
+        "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+        "hardware-calibrated environments (refer to #2918 for calibration context)"
+      ],
+      "feature_extraction_method": "Deterministic rule-based feature extraction and cluster assignment of repository simulation trace exports. No heavy clustering or machine learning applied.",
+      "odd_conditions": [
+        "repository-trace-grounded only; does not represent real-world statistics",
+        "diagnostic-only cluster prior family"
+      ],
+      "parameter_bounds": {
+        "enforcement": "rule_based_clustering",
+        "min_distance_range_m": "[1.11, 1.12]",
+        "representation": "scenario_prior.v1",
+        "trace_count": 2,
+        "units": "position=m, velocity=m/s, time=s"
+      },
+      "prior_family": "Repository trace cluster for bottleneck scenarios with sparse pedestrian density (unsignalized, nominal)",
+      "related_surfaces": [
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json"
+      ],
+      "source_traces": [
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/bottleneck_motion_rich_fixture.json (trace_id: issue_2937_bottleneck_motion_rich, episode_id: issue_2937_bottleneck_motion_rich_ep0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json (trace_id: fixture_trace_001, episode_id: fixture_episode_001)"
+      ],
+      "source_type": "repository_trace_derived",
+      "unsupported_claims": [
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data"
+      ]
+    },
+    {
+      "card_id": "trace_cluster_crossing_sparse_signalized_nominal",
+      "classification": "repository_trace_derived",
+      "dataset_license_status": "not_applicable_generated_synthetic",
+      "excluded_populations": [
+        "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+        "hardware-calibrated environments (refer to #2918 for calibration context)"
+      ],
+      "feature_extraction_method": "Deterministic rule-based feature extraction and cluster assignment of repository simulation trace exports. No heavy clustering or machine learning applied.",
+      "odd_conditions": [
+        "repository-trace-grounded only; does not represent real-world statistics",
+        "diagnostic-only cluster prior family"
+      ],
+      "parameter_bounds": {
+        "enforcement": "rule_based_clustering",
+        "min_distance_range_m": "[1.00, 1.67]",
+        "representation": "scenario_prior.v1",
+        "trace_count": 4,
+        "units": "position=m, velocity=m/s, time=s"
+      },
+      "prior_family": "Repository trace cluster for crossing scenarios with sparse pedestrian density (signalized, nominal)",
+      "related_surfaces": [
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json"
+      ],
+      "source_traces": [
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_goal_directed_crossing_fixture_0000.json (trace_id: issue_2868_goal_directed_crossing_0000, episode_id: issue_2868_goal_directed_crossing_episode_0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_signalized_crossing_fixture_0000.json (trace_id: issue_2868_signalized_crossing_0000, episode_id: issue_2868_signalized_crossing_episode_0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_goal_directed_crossing_fixture_extended.json (trace_id: issue_2868_goal_directed_crossing_0000_issue_2937_extended, episode_id: issue_2868_goal_directed_crossing_episode_0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_signalized_crossing_fixture_extended.json (trace_id: issue_2868_signalized_crossing_0000_issue_2937_extended, episode_id: issue_2868_signalized_crossing_episode_0000)"
+      ],
+      "source_type": "repository_trace_derived",
+      "unsupported_claims": [
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data"
+      ]
+    },
+    {
+      "card_id": "trace_cluster_crossing_sparse_unsignalized_collision",
+      "classification": "repository_trace_derived",
+      "dataset_license_status": "not_applicable_generated_synthetic",
+      "excluded_populations": [
+        "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+        "hardware-calibrated environments (refer to #2918 for calibration context)"
+      ],
+      "feature_extraction_method": "Deterministic rule-based feature extraction and cluster assignment of repository simulation trace exports. No heavy clustering or machine learning applied.",
+      "odd_conditions": [
+        "repository-trace-grounded only; does not represent real-world statistics",
+        "diagnostic-only cluster prior family"
+      ],
+      "parameter_bounds": {
+        "enforcement": "rule_based_clustering",
+        "min_distance_range_m": "[0.25, 0.25]",
+        "representation": "scenario_prior.v1",
+        "trace_count": 1,
+        "units": "position=m, velocity=m/s, time=s"
+      },
+      "prior_family": "Repository trace cluster for crossing scenarios with sparse pedestrian density (unsignalized, collision)",
+      "related_surfaces": [
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json"
+      ],
+      "source_traces": [
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/crossing_proxy_motion_rich_fixture.json (trace_id: issue_2937_crossing_proxy_motion_rich, episode_id: issue_2937_crossing_proxy_motion_rich_ep0000)"
+      ],
+      "source_type": "repository_trace_derived",
+      "unsupported_claims": [
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data"
+      ]
+    },
+    {
+      "card_id": "trace_cluster_general_dense_unsignalized_collision",
+      "classification": "repository_trace_derived",
+      "dataset_license_status": "not_applicable_generated_synthetic",
+      "excluded_populations": [
+        "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+        "hardware-calibrated environments (refer to #2918 for calibration context)"
+      ],
+      "feature_extraction_method": "Deterministic rule-based feature extraction and cluster assignment of repository simulation trace exports. No heavy clustering or machine learning applied.",
+      "odd_conditions": [
+        "repository-trace-grounded only; does not represent real-world statistics",
+        "diagnostic-only cluster prior family"
+      ],
+      "parameter_bounds": {
+        "enforcement": "rule_based_clustering",
+        "min_distance_range_m": "[0.16, 0.16]",
+        "representation": "scenario_prior.v1",
+        "trace_count": 1,
+        "units": "position=m, velocity=m/s, time=s"
+      },
+      "prior_family": "Repository trace cluster for general scenarios with dense pedestrian density (unsignalized, collision)",
+      "related_surfaces": [
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json"
+      ],
+      "source_traces": [
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/dense_pedestrian_stress_episode_0000.json (trace_id: issue_2765_dense_pedestrian_stress_seed2765_ep0000, episode_id: dense_pedestrian_stress_ep0000)"
+      ],
+      "source_type": "repository_trace_derived",
+      "unsupported_claims": [
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data"
+      ]
+    },
+    {
+      "card_id": "trace_cluster_general_sparse_signalized_nominal",
+      "classification": "repository_trace_derived",
+      "dataset_license_status": "not_applicable_generated_synthetic",
+      "excluded_populations": [
+        "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+        "hardware-calibrated environments (refer to #2918 for calibration context)"
+      ],
+      "feature_extraction_method": "Deterministic rule-based feature extraction and cluster assignment of repository simulation trace exports. No heavy clustering or machine learning applied.",
+      "odd_conditions": [
+        "repository-trace-grounded only; does not represent real-world statistics",
+        "diagnostic-only cluster prior family"
+      ],
+      "parameter_bounds": {
+        "enforcement": "rule_based_clustering",
+        "min_distance_range_m": "[1.97, 1.97]",
+        "representation": "scenario_prior.v1",
+        "trace_count": 2,
+        "units": "position=m, velocity=m/s, time=s"
+      },
+      "prior_family": "Repository trace cluster for general scenarios with sparse pedestrian density (signalized, nominal)",
+      "related_surfaces": [
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json"
+      ],
+      "source_traces": [
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_waiting_intent_change_fixture_0000.json (trace_id: issue_2868_waiting_intent_change_0000, episode_id: issue_2868_waiting_intent_change_episode_0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_waiting_intent_change_fixture_extended.json (trace_id: issue_2868_waiting_intent_change_0000_issue_2937_extended, episode_id: issue_2868_waiting_intent_change_episode_0000)"
+      ],
+      "source_type": "repository_trace_derived",
+      "unsupported_claims": [
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data"
+      ]
+    },
+    {
+      "card_id": "trace_cluster_general_sparse_unsignalized_near-miss",
+      "classification": "repository_trace_derived",
+      "dataset_license_status": "not_applicable_generated_synthetic",
+      "excluded_populations": [
+        "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+        "hardware-calibrated environments (refer to #2918 for calibration context)"
+      ],
+      "feature_extraction_method": "Deterministic rule-based feature extraction and cluster assignment of repository simulation trace exports. No heavy clustering or machine learning applied.",
+      "odd_conditions": [
+        "repository-trace-grounded only; does not represent real-world statistics",
+        "diagnostic-only cluster prior family"
+      ],
+      "parameter_bounds": {
+        "enforcement": "rule_based_clustering",
+        "min_distance_range_m": "[0.47, 0.47]",
+        "representation": "scenario_prior.v1",
+        "trace_count": 1,
+        "units": "position=m, velocity=m/s, time=s"
+      },
+      "prior_family": "Repository trace cluster for general scenarios with sparse pedestrian density (unsignalized, near-miss)",
+      "related_surfaces": [
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json"
+      ],
+      "source_traces": [
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_route_conflict_goal_fixture_extended.json (trace_id: issue_2868_route_conflict_goal_0000_issue_2937_extended, episode_id: issue_2868_route_conflict_goal_episode_0000)"
+      ],
+      "source_type": "repository_trace_derived",
+      "unsupported_claims": [
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data"
+      ]
+    },
+    {
+      "card_id": "trace_cluster_general_sparse_unsignalized_nominal",
+      "classification": "repository_trace_derived",
+      "dataset_license_status": "not_applicable_generated_synthetic",
+      "excluded_populations": [
+        "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+        "hardware-calibrated environments (refer to #2918 for calibration context)"
+      ],
+      "feature_extraction_method": "Deterministic rule-based feature extraction and cluster assignment of repository simulation trace exports. No heavy clustering or machine learning applied.",
+      "odd_conditions": [
+        "repository-trace-grounded only; does not represent real-world statistics",
+        "diagnostic-only cluster prior family"
+      ],
+      "parameter_bounds": {
+        "enforcement": "rule_based_clustering",
+        "min_distance_range_m": "[1.46, 1.46]",
+        "representation": "scenario_prior.v1",
+        "trace_count": 2,
+        "units": "position=m, velocity=m/s, time=s"
+      },
+      "prior_family": "Repository trace cluster for general scenarios with sparse pedestrian density (unsignalized, nominal)",
+      "related_surfaces": [
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json"
+      ],
+      "source_traces": [
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_route_conflict_goal_fixture_0000.json (trace_id: issue_2868_route_conflict_goal_0000, episode_id: issue_2868_route_conflict_goal_episode_0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/planner_sanity_open_episode_0000.json (trace_id: planner_sanity_open-ep0-seed7-source-aae87cf6, episode_id: 0)"
+      ],
+      "source_type": "repository_trace_derived",
+      "unsupported_claims": [
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data"
+      ]
+    },
+    {
+      "card_id": "trace_cluster_occluded_sparse_unsignalized_near-miss",
+      "classification": "repository_trace_derived",
+      "dataset_license_status": "not_applicable_generated_synthetic",
+      "excluded_populations": [
+        "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+        "hardware-calibrated environments (refer to #2918 for calibration context)"
+      ],
+      "feature_extraction_method": "Deterministic rule-based feature extraction and cluster assignment of repository simulation trace exports. No heavy clustering or machine learning applied.",
+      "odd_conditions": [
+        "repository-trace-grounded only; does not represent real-world statistics",
+        "diagnostic-only cluster prior family"
+      ],
+      "parameter_bounds": {
+        "enforcement": "rule_based_clustering",
+        "min_distance_range_m": "[0.36, 0.72]",
+        "representation": "scenario_prior.v1",
+        "trace_count": 6,
+        "units": "position=m, velocity=m/s, time=s"
+      },
+      "prior_family": "Repository trace cluster for occluded scenarios with sparse pedestrian density (unsignalized, near-miss)",
+      "related_surfaces": [
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json"
+      ],
+      "source_traces": [
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/occluded_emergence_episode_extended.json (trace_id: issue_2756_occluded_emergence_seed111_ep0000_issue_2937_extended, episode_id: issue_2756_occluded_emergence_ep0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json (trace_id: issue_2756_occluded_emergence_seed111_ep0000, episode_id: issue_2756_occluded_emergence_ep0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json (trace_id: issue_2780_occluded_emergence_fast_pedestrian_seed111_ep0000, episode_id: issue_2780_occluded_emergence_fast_pedestrian_ep0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json (trace_id: issue_2780_occluded_emergence_late_visibility_seed111_ep0000, episode_id: issue_2780_occluded_emergence_late_visibility_ep0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json (trace_id: issue_2780_occluded_emergence_left_close_seed111_ep0000, episode_id: issue_2780_occluded_emergence_left_close_ep0000)",
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_slow_pedestrian_episode_0000.json (trace_id: issue_2780_occluded_emergence_slow_pedestrian_seed111_ep0000, episode_id: issue_2780_occluded_emergence_slow_pedestrian_ep0000)"
+      ],
+      "source_type": "repository_trace_derived",
+      "unsupported_claims": [
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data"
+      ]
+    },
+    {
+      "card_id": "trace_cluster_occluded_sparse_unsignalized_nominal",
+      "classification": "repository_trace_derived",
+      "dataset_license_status": "not_applicable_generated_synthetic",
+      "excluded_populations": [
+        "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+        "hardware-calibrated environments (refer to #2918 for calibration context)"
+      ],
+      "feature_extraction_method": "Deterministic rule-based feature extraction and cluster assignment of repository simulation trace exports. No heavy clustering or machine learning applied.",
+      "odd_conditions": [
+        "repository-trace-grounded only; does not represent real-world statistics",
+        "diagnostic-only cluster prior family"
+      ],
+      "parameter_bounds": {
+        "enforcement": "rule_based_clustering",
+        "min_distance_range_m": "[0.98, 0.98]",
+        "representation": "scenario_prior.v1",
+        "trace_count": 1,
+        "units": "position=m, velocity=m/s, time=s"
+      },
+      "prior_family": "Repository trace cluster for occluded scenarios with sparse pedestrian density (unsignalized, nominal)",
+      "related_surfaces": [
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+        "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json"
+      ],
+      "source_traces": [
+        "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json (trace_id: issue_2780_occluded_emergence_right_close_seed111_ep0000, episode_id: issue_2780_occluded_emergence_right_close_ep0000)"
+      ],
+      "source_type": "repository_trace_derived",
+      "unsupported_claims": [
+        "learned_prior_realism",
+        "benchmark_usefulness",
+        "cross_dataset_generalization",
+        "planner_performance_improvement",
+        "license_safe_redistribution_of_raw_data"
+      ]
+    }
+  ],
+  "schema_version": "scenario-prior-calibration-report.v1",
+  "total_processed": 20,
+  "trace_count": 20
+}

--- a/docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+++ b/docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
@@ -1,0 +1,107 @@
+# Calibrate Scenario Priors from Simulation Trace Clusters
+
+## Claim Boundary & Evidence Status
+
+- **Claim Boundary**: `repository_trace_grounded_not_real_world_calibrated: this report and generated prior cards are derived entirely from deterministic simulation trace clusters. They do not claim real-world validity, representativeness, or generalizability to real-world pedestrian behavior. Refer to issues #3161 and #2918 for real-world staging and calibration requirements.`
+- **Status**: `repository_trace_derived_proposal`
+- **Context References**: Refer to issue #3161 for real-world staging contracts and #2918 for calibration context.
+- **Axioms**: This analysis runs strictly on repository trace fixtures. No external dataset or real-world representativeness is claimed.
+
+## Summary
+
+- **Total simulation traces processed**: 20
+- **Total unique clusters identified**: 9
+
+## Cluster Table
+
+| Cluster ID | Scenarios | Density | Signal | Outcome | Traces | Mean Min Dist (m) | Mean Stop Frac |
+| --- | --- | --- | --- | --- | ---: | ---: | ---: |
+| `bottleneck_sparse_unsignalized_nominal` | bottleneck | sparse | unsignalized | nominal | 2 | 1.11 | 0.50 |
+| `crossing_sparse_signalized_nominal` | crossing | sparse | signalized | nominal | 4 | 1.17 | 1.00 |
+| `crossing_sparse_unsignalized_collision` | crossing | sparse | unsignalized | collision | 1 | 0.25 | 1.00 |
+| `general_dense_unsignalized_collision` | general | dense | unsignalized | collision | 1 | 0.16 | 0.00 |
+| `general_sparse_signalized_nominal` | general | sparse | signalized | nominal | 2 | 1.97 | 1.00 |
+| `general_sparse_unsignalized_near-miss` | general | sparse | unsignalized | near-miss | 1 | 0.47 | 1.00 |
+| `general_sparse_unsignalized_nominal` | general | sparse | unsignalized | nominal | 2 | 1.46 | 0.67 |
+| `occluded_sparse_unsignalized_near-miss` | occluded | sparse | unsignalized | near-miss | 6 | 0.53 | 0.05 |
+| `occluded_sparse_unsignalized_nominal` | occluded | sparse | unsignalized | nominal | 1 | 0.98 | 0.00 |
+
+## Cluster Lineage Details
+
+For each cluster, the lineage pointers to source trace file paths, trace IDs, and episode IDs are detailed below.
+
+### Cluster: `bottleneck_sparse_unsignalized_nominal`
+
+- **Traces count**: 2
+- **Source Trace Pointers**:
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/bottleneck_motion_rich_fixture.json` (trace_id: `issue_2937_bottleneck_motion_rich`, episode_id: `issue_2937_bottleneck_motion_rich_ep0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json` (trace_id: `fixture_trace_001`, episode_id: `fixture_episode_001`)
+
+### Cluster: `crossing_sparse_signalized_nominal`
+
+- **Traces count**: 4
+- **Source Trace Pointers**:
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_goal_directed_crossing_fixture_0000.json` (trace_id: `issue_2868_goal_directed_crossing_0000`, episode_id: `issue_2868_goal_directed_crossing_episode_0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_signalized_crossing_fixture_0000.json` (trace_id: `issue_2868_signalized_crossing_0000`, episode_id: `issue_2868_signalized_crossing_episode_0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_goal_directed_crossing_fixture_extended.json` (trace_id: `issue_2868_goal_directed_crossing_0000_issue_2937_extended`, episode_id: `issue_2868_goal_directed_crossing_episode_0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_signalized_crossing_fixture_extended.json` (trace_id: `issue_2868_signalized_crossing_0000_issue_2937_extended`, episode_id: `issue_2868_signalized_crossing_episode_0000`)
+
+### Cluster: `crossing_sparse_unsignalized_collision`
+
+- **Traces count**: 1
+- **Source Trace Pointers**:
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/crossing_proxy_motion_rich_fixture.json` (trace_id: `issue_2937_crossing_proxy_motion_rich`, episode_id: `issue_2937_crossing_proxy_motion_rich_ep0000`)
+
+### Cluster: `general_dense_unsignalized_collision`
+
+- **Traces count**: 1
+- **Source Trace Pointers**:
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/dense_pedestrian_stress_episode_0000.json` (trace_id: `issue_2765_dense_pedestrian_stress_seed2765_ep0000`, episode_id: `dense_pedestrian_stress_ep0000`)
+
+### Cluster: `general_sparse_signalized_nominal`
+
+- **Traces count**: 2
+- **Source Trace Pointers**:
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_waiting_intent_change_fixture_0000.json` (trace_id: `issue_2868_waiting_intent_change_0000`, episode_id: `issue_2868_waiting_intent_change_episode_0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_waiting_intent_change_fixture_extended.json` (trace_id: `issue_2868_waiting_intent_change_0000_issue_2937_extended`, episode_id: `issue_2868_waiting_intent_change_episode_0000`)
+
+### Cluster: `general_sparse_unsignalized_near-miss`
+
+- **Traces count**: 1
+- **Source Trace Pointers**:
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_route_conflict_goal_fixture_extended.json` (trace_id: `issue_2868_route_conflict_goal_0000_issue_2937_extended`, episode_id: `issue_2868_route_conflict_goal_episode_0000`)
+
+### Cluster: `general_sparse_unsignalized_nominal`
+
+- **Traces count**: 2
+- **Source Trace Pointers**:
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_route_conflict_goal_fixture_0000.json` (trace_id: `issue_2868_route_conflict_goal_0000`, episode_id: `issue_2868_route_conflict_goal_episode_0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/planner_sanity_open_episode_0000.json` (trace_id: `planner_sanity_open-ep0-seed7-source-aae87cf6`, episode_id: `0`)
+
+### Cluster: `occluded_sparse_unsignalized_near-miss`
+
+- **Traces count**: 6
+- **Source Trace Pointers**:
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/occluded_emergence_episode_extended.json` (trace_id: `issue_2756_occluded_emergence_seed111_ep0000_issue_2937_extended`, episode_id: `issue_2756_occluded_emergence_ep0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json` (trace_id: `issue_2756_occluded_emergence_seed111_ep0000`, episode_id: `issue_2756_occluded_emergence_ep0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json` (trace_id: `issue_2780_occluded_emergence_fast_pedestrian_seed111_ep0000`, episode_id: `issue_2780_occluded_emergence_fast_pedestrian_ep0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json` (trace_id: `issue_2780_occluded_emergence_late_visibility_seed111_ep0000`, episode_id: `issue_2780_occluded_emergence_late_visibility_ep0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json` (trace_id: `issue_2780_occluded_emergence_left_close_seed111_ep0000`, episode_id: `issue_2780_occluded_emergence_left_close_ep0000`)
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_slow_pedestrian_episode_0000.json` (trace_id: `issue_2780_occluded_emergence_slow_pedestrian_seed111_ep0000`, episode_id: `issue_2780_occluded_emergence_slow_pedestrian_ep0000`)
+
+### Cluster: `occluded_sparse_unsignalized_nominal`
+
+- **Traces count**: 1
+- **Source Trace Pointers**:
+  - `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json` (trace_id: `issue_2780_occluded_emergence_right_close_seed111_ep0000`, episode_id: `issue_2780_occluded_emergence_right_close_ep0000`)
+
+## Limitations
+
+- These priors are repository-trace-grounded proposals, not real-world calibrated priors.
+- The input set is limited to committed simulation trace fixtures and may overrepresent synthetic edge cases.
+- Cluster assignment is deterministic and rule-based; it is intended for provenance and reviewability rather than statistical optimality.
+
+## Follow-Up Data Requirements
+
+- Stage real-world trajectory data under issue #3161 before making representativeness claims.
+- Use issue #2918 calibration context before promoting these proposal cards into calibrated priors.

--- a/docs/context/evidence/issue_2726_scenario_prior_trace_clusters/scenario_prior_cards_issue_2726.yaml
+++ b/docs/context/evidence/issue_2726_scenario_prior_trace_clusters/scenario_prior_cards_issue_2726.yaml
@@ -1,0 +1,340 @@
+schema_version: scenario-prior-card-registry.v1
+name: calibrate_scenario_priors_from_traces_issue_2726
+issue: 2726
+status: partial_initial_registry
+benchmark_evidence: false
+claim_boundary: 'repository_trace_grounded_not_real_world_calibrated: this report
+  and generated prior cards are derived entirely from deterministic simulation trace
+  clusters. They do not claim real-world validity, representativeness, or generalizability
+  to real-world pedestrian behavior. Refer to issues #3161 and #2918 for real-world
+  staging and calibration requirements.'
+cards:
+- card_id: trace_cluster_bottleneck_sparse_unsignalized_nominal
+  prior_family: Repository trace cluster for bottleneck scenarios with sparse pedestrian
+    density (unsignalized, nominal)
+  classification: repository_trace_derived
+  source_type: repository_trace_derived
+  dataset_license_status: not_applicable_generated_synthetic
+  source_traces:
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/bottleneck_motion_rich_fixture.json
+    (trace_id: issue_2937_bottleneck_motion_rich, episode_id: issue_2937_bottleneck_motion_rich_ep0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json
+    (trace_id: fixture_trace_001, episode_id: fixture_episode_001)'
+  feature_extraction_method: Deterministic rule-based feature extraction and cluster
+    assignment of repository simulation trace exports. No heavy clustering or machine
+    learning applied.
+  parameter_bounds:
+    representation: scenario_prior.v1
+    units: position=m, velocity=m/s, time=s
+    enforcement: rule_based_clustering
+    min_distance_range_m: '[1.11, 1.12]'
+    trace_count: 2
+  excluded_populations:
+  - 'real-world datasets not staged in-repo (refer to #3161 for staging contracts)'
+  - 'hardware-calibrated environments (refer to #2918 for calibration context)'
+  unsupported_claims:
+  - learned_prior_realism
+  - benchmark_usefulness
+  - cross_dataset_generalization
+  - planner_performance_improvement
+  - license_safe_redistribution_of_raw_data
+  odd_conditions:
+  - repository-trace-grounded only; does not represent real-world statistics
+  - diagnostic-only cluster prior family
+  related_surfaces:
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
+- card_id: trace_cluster_crossing_sparse_signalized_nominal
+  prior_family: Repository trace cluster for crossing scenarios with sparse pedestrian
+    density (signalized, nominal)
+  classification: repository_trace_derived
+  source_type: repository_trace_derived
+  dataset_license_status: not_applicable_generated_synthetic
+  source_traces:
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_goal_directed_crossing_fixture_0000.json
+    (trace_id: issue_2868_goal_directed_crossing_0000, episode_id: issue_2868_goal_directed_crossing_episode_0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_signalized_crossing_fixture_0000.json
+    (trace_id: issue_2868_signalized_crossing_0000, episode_id: issue_2868_signalized_crossing_episode_0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_goal_directed_crossing_fixture_extended.json
+    (trace_id: issue_2868_goal_directed_crossing_0000_issue_2937_extended, episode_id:
+    issue_2868_goal_directed_crossing_episode_0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_signalized_crossing_fixture_extended.json
+    (trace_id: issue_2868_signalized_crossing_0000_issue_2937_extended, episode_id:
+    issue_2868_signalized_crossing_episode_0000)'
+  feature_extraction_method: Deterministic rule-based feature extraction and cluster
+    assignment of repository simulation trace exports. No heavy clustering or machine
+    learning applied.
+  parameter_bounds:
+    representation: scenario_prior.v1
+    units: position=m, velocity=m/s, time=s
+    enforcement: rule_based_clustering
+    min_distance_range_m: '[1.00, 1.67]'
+    trace_count: 4
+  excluded_populations:
+  - 'real-world datasets not staged in-repo (refer to #3161 for staging contracts)'
+  - 'hardware-calibrated environments (refer to #2918 for calibration context)'
+  unsupported_claims:
+  - learned_prior_realism
+  - benchmark_usefulness
+  - cross_dataset_generalization
+  - planner_performance_improvement
+  - license_safe_redistribution_of_raw_data
+  odd_conditions:
+  - repository-trace-grounded only; does not represent real-world statistics
+  - diagnostic-only cluster prior family
+  related_surfaces:
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
+- card_id: trace_cluster_crossing_sparse_unsignalized_collision
+  prior_family: Repository trace cluster for crossing scenarios with sparse pedestrian
+    density (unsignalized, collision)
+  classification: repository_trace_derived
+  source_type: repository_trace_derived
+  dataset_license_status: not_applicable_generated_synthetic
+  source_traces:
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/crossing_proxy_motion_rich_fixture.json
+    (trace_id: issue_2937_crossing_proxy_motion_rich, episode_id: issue_2937_crossing_proxy_motion_rich_ep0000)'
+  feature_extraction_method: Deterministic rule-based feature extraction and cluster
+    assignment of repository simulation trace exports. No heavy clustering or machine
+    learning applied.
+  parameter_bounds:
+    representation: scenario_prior.v1
+    units: position=m, velocity=m/s, time=s
+    enforcement: rule_based_clustering
+    min_distance_range_m: '[0.25, 0.25]'
+    trace_count: 1
+  excluded_populations:
+  - 'real-world datasets not staged in-repo (refer to #3161 for staging contracts)'
+  - 'hardware-calibrated environments (refer to #2918 for calibration context)'
+  unsupported_claims:
+  - learned_prior_realism
+  - benchmark_usefulness
+  - cross_dataset_generalization
+  - planner_performance_improvement
+  - license_safe_redistribution_of_raw_data
+  odd_conditions:
+  - repository-trace-grounded only; does not represent real-world statistics
+  - diagnostic-only cluster prior family
+  related_surfaces:
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
+- card_id: trace_cluster_general_dense_unsignalized_collision
+  prior_family: Repository trace cluster for general scenarios with dense pedestrian
+    density (unsignalized, collision)
+  classification: repository_trace_derived
+  source_type: repository_trace_derived
+  dataset_license_status: not_applicable_generated_synthetic
+  source_traces:
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/dense_pedestrian_stress_episode_0000.json
+    (trace_id: issue_2765_dense_pedestrian_stress_seed2765_ep0000, episode_id: dense_pedestrian_stress_ep0000)'
+  feature_extraction_method: Deterministic rule-based feature extraction and cluster
+    assignment of repository simulation trace exports. No heavy clustering or machine
+    learning applied.
+  parameter_bounds:
+    representation: scenario_prior.v1
+    units: position=m, velocity=m/s, time=s
+    enforcement: rule_based_clustering
+    min_distance_range_m: '[0.16, 0.16]'
+    trace_count: 1
+  excluded_populations:
+  - 'real-world datasets not staged in-repo (refer to #3161 for staging contracts)'
+  - 'hardware-calibrated environments (refer to #2918 for calibration context)'
+  unsupported_claims:
+  - learned_prior_realism
+  - benchmark_usefulness
+  - cross_dataset_generalization
+  - planner_performance_improvement
+  - license_safe_redistribution_of_raw_data
+  odd_conditions:
+  - repository-trace-grounded only; does not represent real-world statistics
+  - diagnostic-only cluster prior family
+  related_surfaces:
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
+- card_id: trace_cluster_general_sparse_signalized_nominal
+  prior_family: Repository trace cluster for general scenarios with sparse pedestrian
+    density (signalized, nominal)
+  classification: repository_trace_derived
+  source_type: repository_trace_derived
+  dataset_license_status: not_applicable_generated_synthetic
+  source_traces:
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_waiting_intent_change_fixture_0000.json
+    (trace_id: issue_2868_waiting_intent_change_0000, episode_id: issue_2868_waiting_intent_change_episode_0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_waiting_intent_change_fixture_extended.json
+    (trace_id: issue_2868_waiting_intent_change_0000_issue_2937_extended, episode_id:
+    issue_2868_waiting_intent_change_episode_0000)'
+  feature_extraction_method: Deterministic rule-based feature extraction and cluster
+    assignment of repository simulation trace exports. No heavy clustering or machine
+    learning applied.
+  parameter_bounds:
+    representation: scenario_prior.v1
+    units: position=m, velocity=m/s, time=s
+    enforcement: rule_based_clustering
+    min_distance_range_m: '[1.97, 1.97]'
+    trace_count: 2
+  excluded_populations:
+  - 'real-world datasets not staged in-repo (refer to #3161 for staging contracts)'
+  - 'hardware-calibrated environments (refer to #2918 for calibration context)'
+  unsupported_claims:
+  - learned_prior_realism
+  - benchmark_usefulness
+  - cross_dataset_generalization
+  - planner_performance_improvement
+  - license_safe_redistribution_of_raw_data
+  odd_conditions:
+  - repository-trace-grounded only; does not represent real-world statistics
+  - diagnostic-only cluster prior family
+  related_surfaces:
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
+- card_id: trace_cluster_general_sparse_unsignalized_near-miss
+  prior_family: Repository trace cluster for general scenarios with sparse pedestrian
+    density (unsignalized, near-miss)
+  classification: repository_trace_derived
+  source_type: repository_trace_derived
+  dataset_license_status: not_applicable_generated_synthetic
+  source_traces:
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/issue_2868_route_conflict_goal_fixture_extended.json
+    (trace_id: issue_2868_route_conflict_goal_0000_issue_2937_extended, episode_id:
+    issue_2868_route_conflict_goal_episode_0000)'
+  feature_extraction_method: Deterministic rule-based feature extraction and cluster
+    assignment of repository simulation trace exports. No heavy clustering or machine
+    learning applied.
+  parameter_bounds:
+    representation: scenario_prior.v1
+    units: position=m, velocity=m/s, time=s
+    enforcement: rule_based_clustering
+    min_distance_range_m: '[0.47, 0.47]'
+    trace_count: 1
+  excluded_populations:
+  - 'real-world datasets not staged in-repo (refer to #3161 for staging contracts)'
+  - 'hardware-calibrated environments (refer to #2918 for calibration context)'
+  unsupported_claims:
+  - learned_prior_realism
+  - benchmark_usefulness
+  - cross_dataset_generalization
+  - planner_performance_improvement
+  - license_safe_redistribution_of_raw_data
+  odd_conditions:
+  - repository-trace-grounded only; does not represent real-world statistics
+  - diagnostic-only cluster prior family
+  related_surfaces:
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
+- card_id: trace_cluster_general_sparse_unsignalized_nominal
+  prior_family: Repository trace cluster for general scenarios with sparse pedestrian
+    density (unsignalized, nominal)
+  classification: repository_trace_derived
+  source_type: repository_trace_derived
+  dataset_license_status: not_applicable_generated_synthetic
+  source_traces:
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_route_conflict_goal_fixture_0000.json
+    (trace_id: issue_2868_route_conflict_goal_0000, episode_id: issue_2868_route_conflict_goal_episode_0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/planner_sanity_open_episode_0000.json
+    (trace_id: planner_sanity_open-ep0-seed7-source-aae87cf6, episode_id: 0)'
+  feature_extraction_method: Deterministic rule-based feature extraction and cluster
+    assignment of repository simulation trace exports. No heavy clustering or machine
+    learning applied.
+  parameter_bounds:
+    representation: scenario_prior.v1
+    units: position=m, velocity=m/s, time=s
+    enforcement: rule_based_clustering
+    min_distance_range_m: '[1.46, 1.46]'
+    trace_count: 2
+  excluded_populations:
+  - 'real-world datasets not staged in-repo (refer to #3161 for staging contracts)'
+  - 'hardware-calibrated environments (refer to #2918 for calibration context)'
+  unsupported_claims:
+  - learned_prior_realism
+  - benchmark_usefulness
+  - cross_dataset_generalization
+  - planner_performance_improvement
+  - license_safe_redistribution_of_raw_data
+  odd_conditions:
+  - repository-trace-grounded only; does not represent real-world statistics
+  - diagnostic-only cluster prior family
+  related_surfaces:
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
+- card_id: trace_cluster_occluded_sparse_unsignalized_near-miss
+  prior_family: Repository trace cluster for occluded scenarios with sparse pedestrian
+    density (unsignalized, near-miss)
+  classification: repository_trace_derived
+  source_type: repository_trace_derived
+  dataset_license_status: not_applicable_generated_synthetic
+  source_traces:
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2937/occluded_emergence_episode_extended.json
+    (trace_id: issue_2756_occluded_emergence_seed111_ep0000_issue_2937_extended, episode_id:
+    issue_2756_occluded_emergence_ep0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json
+    (trace_id: issue_2756_occluded_emergence_seed111_ep0000, episode_id: issue_2756_occluded_emergence_ep0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_fast_pedestrian_episode_0000.json
+    (trace_id: issue_2780_occluded_emergence_fast_pedestrian_seed111_ep0000, episode_id:
+    issue_2780_occluded_emergence_fast_pedestrian_ep0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_late_visibility_episode_0000.json
+    (trace_id: issue_2780_occluded_emergence_late_visibility_seed111_ep0000, episode_id:
+    issue_2780_occluded_emergence_late_visibility_ep0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_left_close_episode_0000.json
+    (trace_id: issue_2780_occluded_emergence_left_close_seed111_ep0000, episode_id:
+    issue_2780_occluded_emergence_left_close_ep0000)'
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_slow_pedestrian_episode_0000.json
+    (trace_id: issue_2780_occluded_emergence_slow_pedestrian_seed111_ep0000, episode_id:
+    issue_2780_occluded_emergence_slow_pedestrian_ep0000)'
+  feature_extraction_method: Deterministic rule-based feature extraction and cluster
+    assignment of repository simulation trace exports. No heavy clustering or machine
+    learning applied.
+  parameter_bounds:
+    representation: scenario_prior.v1
+    units: position=m, velocity=m/s, time=s
+    enforcement: rule_based_clustering
+    min_distance_range_m: '[0.36, 0.72]'
+    trace_count: 6
+  excluded_populations:
+  - 'real-world datasets not staged in-repo (refer to #3161 for staging contracts)'
+  - 'hardware-calibrated environments (refer to #2918 for calibration context)'
+  unsupported_claims:
+  - learned_prior_realism
+  - benchmark_usefulness
+  - cross_dataset_generalization
+  - planner_performance_improvement
+  - license_safe_redistribution_of_raw_data
+  odd_conditions:
+  - repository-trace-grounded only; does not represent real-world statistics
+  - diagnostic-only cluster prior family
+  related_surfaces:
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json
+- card_id: trace_cluster_occluded_sparse_unsignalized_nominal
+  prior_family: Repository trace cluster for occluded scenarios with sparse pedestrian
+    density (unsignalized, nominal)
+  classification: repository_trace_derived
+  source_type: repository_trace_derived
+  dataset_license_status: not_applicable_generated_synthetic
+  source_traces:
+  - 'tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_right_close_episode_0000.json
+    (trace_id: issue_2780_occluded_emergence_right_close_seed111_ep0000, episode_id:
+    issue_2780_occluded_emergence_right_close_ep0000)'
+  feature_extraction_method: Deterministic rule-based feature extraction and cluster
+    assignment of repository simulation trace exports. No heavy clustering or machine
+    learning applied.
+  parameter_bounds:
+    representation: scenario_prior.v1
+    units: position=m, velocity=m/s, time=s
+    enforcement: rule_based_clustering
+    min_distance_range_m: '[0.98, 0.98]'
+    trace_count: 1
+  excluded_populations:
+  - 'real-world datasets not staged in-repo (refer to #3161 for staging contracts)'
+  - 'hardware-calibrated environments (refer to #2918 for calibration context)'
+  unsupported_claims:
+  - learned_prior_realism
+  - benchmark_usefulness
+  - cross_dataset_generalization
+  - planner_performance_improvement
+  - license_safe_redistribution_of_raw_data
+  odd_conditions:
+  - repository-trace-grounded only; does not represent real-world statistics
+  - diagnostic-only cluster prior family
+  related_surfaces:
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md
+  - docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json

--- a/scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py
+++ b/scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Calibrate scenario priors from simulation trace clusters.
+
+Loads simulation trace exports, derives simple cluster features, clusters
+traces deterministically, and emits a compact report plus scenario_prior.v1
+candidate cards with lineage pointers.
+
+Usage::
+
+    uv run python scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py \\
+        --trace-dir tests/fixtures/analysis_workbench/simulation_trace_export_v1 \\
+        --output-dir docs/context/evidence/issue_2726_scenario_prior_trace_clusters
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+from typing import Any
+
+import numpy as np
+import yaml
+
+# parent 1 is scripts/analysis, parent 2 is scripts, parent 3 is the repo root.
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+CLAIM_BOUNDARY = (
+    "repository_trace_grounded_not_real_world_calibrated: this report and generated prior "
+    "cards are derived entirely from deterministic simulation trace clusters. They do not "
+    "claim real-world validity, representativeness, or generalizability to real-world pedestrian "
+    "behavior. Refer to issues #3161 and #2918 for real-world staging and calibration requirements."
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--trace-dir",
+        type=pathlib.Path,
+        default=REPO_ROOT / "tests/fixtures/analysis_workbench/simulation_trace_export_v1",
+        help="Directory to recursively search for trace JSON exports.",
+    )
+    parser.add_argument(
+        "--trace-paths",
+        type=pathlib.Path,
+        nargs="*",
+        default=None,
+        help="Explicit list of trace paths to parse, overriding --trace-dir.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        default=REPO_ROOT / "docs/context/evidence/issue_2726_scenario_prior_trace_clusters",
+        help="Directory to write report and YAML registry.",
+    )
+    return parser.parse_args(argv)
+
+
+def extract_features(  # noqa: C901, PLR0912, PLR0915
+    trace_data: dict[str, Any], file_path: pathlib.Path
+) -> dict[str, Any]:
+    """Extract cluster features from a single simulation trace export."""
+    source = trace_data.get("source") or {}
+    scenario_id = source.get("scenario_id") or "unknown"
+    episode_id = source.get("episode_id") or "unknown"
+    planner_id = source.get("planner_id") or "unknown"
+    trace_id = trace_data.get("trace_id") or "unknown"
+    seed = source.get("seed")
+
+    frames = trace_data.get("frames") or []
+    if not frames:
+        frames = trace_data.get("steps") or []
+
+    # 1. Bottleneck width heuristic
+    bottleneck_width = None
+    if "bottleneck" in scenario_id:
+        if "narrow" in scenario_id:
+            bottleneck_width = 0.8
+        elif "wide" in scenario_id:
+            bottleneck_width = 2.5
+        else:
+            bottleneck_width = 1.5  # medium/default bottleneck width
+
+    # 2. Pedestrian count
+    ped_ids = set()
+    for frame in frames:
+        for ped in frame.get("pedestrians", []):
+            ped_id = ped.get("id")
+            if ped_id is not None:
+                ped_ids.add(ped_id)
+    pedestrian_count = len(ped_ids)
+
+    # 3. Pedestrian density classification
+    ped_density = None
+    for key in ["dense_stress_metadata", "metadata", "simulation_config"]:
+        meta = trace_data.get(key)
+        if isinstance(meta, dict):
+            ped_density = (
+                meta.get("ped_density") or meta.get("pedestrian_density") or meta.get("density")
+            )
+            if ped_density is not None:
+                break
+
+    if ped_density is not None:
+        try:
+            ped_density_val = float(ped_density)
+            if ped_density_val <= 0.025:
+                density_label = "sparse"
+            elif ped_density_val <= 0.075:
+                density_label = "medium"
+            else:
+                density_label = "dense"
+        except (ValueError, TypeError):
+            density_label = str(ped_density)
+    elif "dense" in scenario_id or pedestrian_count >= 3:
+        density_label = "dense"
+    elif "medium" in scenario_id or pedestrian_count == 2:
+        density_label = "medium"
+    else:
+        density_label = "sparse"
+
+    # 4. Signal/crossing metadata
+    has_signal = False
+    signal_states = set()
+    green_steps = 0
+    red_steps = 0
+    signal_frames = 0
+
+    for frame in frames:
+        for ped in frame.get("pedestrians", []):
+            sig = ped.get("signal_state")
+            if sig and sig.get("available"):
+                has_signal = True
+                lbl = sig.get("label")
+                if lbl:
+                    signal_states.add(lbl)
+                    signal_frames += 1
+                    if lbl.lower() == "green":
+                        green_steps += 1
+                    elif lbl.lower() == "red":
+                        red_steps += 1
+
+    green_fraction = green_steps / signal_frames if signal_frames > 0 else 0.0
+
+    # 5. Robot route progress
+    robot_positions = []
+    for frame in frames:
+        r = frame.get("robot")
+        if r and "position" in r:
+            robot_positions.append(r["position"])
+
+    displacement = 0.0
+    total_distance = 0.0
+    if len(robot_positions) >= 2:
+        r_array = np.array(robot_positions)
+        displacement = float(np.linalg.norm(r_array[-1] - r_array[0]))
+        total_distance = float(
+            sum(np.linalg.norm(r_array[i] - r_array[i - 1]) for i in range(1, len(r_array)))
+        )
+
+    # 6. Stop/yield events
+    stop_steps = 0
+    for frame in frames:
+        r = frame.get("robot") or {}
+        vel = r.get("velocity", [0.0, 0.0])
+        speed = float(np.linalg.norm(vel))
+        if speed < 0.05:
+            stop_steps += 1
+
+    stop_fraction = stop_steps / len(frames) if frames else 0.0
+    planner_stop_events = sum(
+        1
+        for frame in frames
+        if frame.get("planner", {}).get("event") in ("waiting_red", "stop", "yield", "waiting")
+    )
+
+    # 7. Topology-switch events
+    topology_switches = 0
+    prev_sig = None
+    for frame in frames:
+        planner = frame.get("planner") or {}
+        sig = (
+            planner.get("active_hypothesis")
+            or planner.get("route_id")
+            or planner.get("topology_signature")
+        )
+        if sig is not None:
+            if isinstance(sig, (list, dict)):
+                sig_key = str(sorted(sig) if isinstance(sig, list) else sorted(sig.items()))
+            else:
+                sig_key = str(sig)
+
+            if prev_sig is not None and sig_key != prev_sig:
+                topology_switches += 1
+            prev_sig = sig_key
+
+    event_switches = sum(
+        1 for frame in frames if frame.get("planner", {}).get("event") == "topology-switch"
+    )
+    topology_switches = max(topology_switches, event_switches)
+
+    # 8. Collision/near-miss outcome
+    min_dist = float("inf")
+    for frame in frames:
+        r = frame.get("robot")
+        if not r or "position" not in r:
+            continue
+        r_pos = np.array(r["position"])
+        for ped in frame.get("pedestrians", []):
+            if "position" not in ped:
+                continue
+            p_pos = np.array(ped["position"])
+            dist = float(np.linalg.norm(r_pos - p_pos))
+            min_dist = min(min_dist, dist)
+
+    if min_dist < 0.35:
+        outcome = "collision"
+    elif min_dist < 0.8:
+        outcome = "near-miss"
+    else:
+        outcome = "nominal"
+
+    try:
+        rel_path = file_path.relative_to(REPO_ROOT)
+    except ValueError:
+        rel_path = file_path
+
+    return {
+        "file_path": str(rel_path),
+        "trace_id": trace_id,
+        "scenario_id": scenario_id,
+        "episode_id": episode_id,
+        "planner_id": planner_id,
+        "seed": seed,
+        "features": {
+            "bottleneck_width": bottleneck_width,
+            "pedestrian_count": pedestrian_count,
+            "pedestrian_density": density_label,
+            "has_signal": has_signal,
+            "signal_green_fraction": green_fraction,
+            "robot_displacement_m": displacement,
+            "robot_total_distance_m": total_distance,
+            "stop_fraction": stop_fraction,
+            "planner_stop_events": planner_stop_events,
+            "topology_switches": topology_switches,
+            "min_distance_m": min_dist if min_dist != float("inf") else None,
+            "outcome": outcome,
+        },
+    }
+
+
+def assign_to_cluster(features: dict[str, Any], scenario_id: str) -> str:
+    """Map the extracted trace features to a deterministic cluster ID."""
+    # 1. Scenario type
+    if "bottleneck" in scenario_id:
+        scenario_type = "bottleneck"
+    elif "crossing" in scenario_id:
+        scenario_type = "crossing"
+    elif "occluded" in scenario_id:
+        scenario_type = "occluded"
+    else:
+        scenario_type = "general"
+
+    # 2. Density
+    ped_count = features["pedestrian_count"]
+    if ped_count >= 3:
+        density = "dense"
+    elif ped_count == 2:
+        density = "medium"
+    else:
+        density = "sparse"
+
+    # 3. Signal presence
+    signal = "signalized" if features["has_signal"] else "unsignalized"
+
+    # 4. Outcome
+    outcome = features["outcome"]
+
+    return f"{scenario_type}_{density}_{signal}_{outcome}"
+
+
+def build_markdown_report(
+    clusters: dict[str, list[dict[str, Any]]],
+    total_processed: int,
+) -> str:
+    """Construct a Markdown report summarizing cluster stats and trace lineage."""
+    lines = [
+        "# Calibrate Scenario Priors from Simulation Trace Clusters",
+        "",
+        "## Claim Boundary & Evidence Status",
+        "",
+        f"- **Claim Boundary**: `{CLAIM_BOUNDARY}`",
+        "- **Status**: `repository_trace_derived_proposal`",
+        "- **Context References**: Refer to issue #3161 for real-world staging contracts and #2918 for calibration context.",
+        "- **Axioms**: This analysis runs strictly on repository trace fixtures. No external dataset or real-world representativeness is claimed.",
+        "",
+        "## Summary",
+        "",
+        f"- **Total simulation traces processed**: {total_processed}",
+        f"- **Total unique clusters identified**: {len(clusters)}",
+        "",
+        "## Cluster Table",
+        "",
+        "| Cluster ID | Scenarios | Density | Signal | Outcome | Traces | Mean Min Dist (m) | Mean Stop Frac |",
+        "| --- | --- | --- | --- | --- | ---: | ---: | ---: |",
+    ]
+
+    for cluster_id, traces in sorted(clusters.items()):
+        parts = cluster_id.split("_")
+        scen_type, density, signal, outcome = parts[0], parts[1], parts[2], parts[3]
+
+        min_dists = [
+            t["features"]["min_distance_m"]
+            for t in traces
+            if t["features"]["min_distance_m"] is not None
+        ]
+        mean_dist = f"{np.mean(min_dists):.2f}" if min_dists else "N/A"
+
+        stop_fracs = [t["features"]["stop_fraction"] for t in traces]
+        mean_stop = f"{np.mean(stop_fracs):.2f}" if stop_fracs else "N/A"
+
+        lines.append(
+            f"| `{cluster_id}` | {scen_type} | {density} | {signal} | {outcome} | {len(traces)} | {mean_dist} | {mean_stop} |"
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Cluster Lineage Details",
+            "",
+            "For each cluster, the lineage pointers to source trace file paths, trace IDs, and episode IDs are detailed below.",
+            "",
+        ]
+    )
+
+    for cluster_id, traces in sorted(clusters.items()):
+        lines.extend(
+            [
+                f"### Cluster: `{cluster_id}`",
+                "",
+                "- **Traces count**: " + str(len(traces)),
+                "- **Source Trace Pointers**:",
+            ]
+        )
+        for t in traces:
+            lines.append(
+                f"  - `{t['file_path']}` (trace_id: `{t['trace_id']}`, episode_id: `{t['episode_id']}`)"
+            )
+        lines.append("")
+
+    lines.extend(
+        [
+            "## Limitations",
+            "",
+            "- These priors are repository-trace-grounded proposals, not real-world calibrated priors.",
+            "- The input set is limited to committed simulation trace fixtures and may overrepresent synthetic edge cases.",
+            "- Cluster assignment is deterministic and rule-based; it is intended for provenance and reviewability rather than statistical optimality.",
+            "",
+            "## Follow-Up Data Requirements",
+            "",
+            "- Stage real-world trajectory data under issue #3161 before making representativeness claims.",
+            "- Use issue #2918 calibration context before promoting these proposal cards into calibrated priors.",
+        ]
+    )
+
+    return "\n".join(lines) + "\n"
+
+
+def generate_prior_cards(clusters: dict[str, list[dict[str, Any]]]) -> dict[str, Any]:
+    """Generate scenario prior registry cards based on parsed clusters."""
+    cards = []
+    for cluster_id, traces in sorted(clusters.items()):
+        parts = cluster_id.split("_")
+        scenario_type = parts[0]
+        density = parts[1]
+        signal = parts[2]
+        outcome = parts[3]
+
+        source_traces_pointers = []
+        for t in traces:
+            trace_info = (
+                f"{t['file_path']} (trace_id: {t['trace_id']}, episode_id: {t['episode_id']})"
+            )
+            source_traces_pointers.append(trace_info)
+
+        min_dists = [
+            t["features"]["min_distance_m"]
+            for t in traces
+            if t["features"]["min_distance_m"] is not None
+        ]
+        min_dist_range = (
+            f"[{min(min_dists):.2f}, {max(min_dists):.2f}]" if min_dists else "not_applicable"
+        )
+
+        card = {
+            "card_id": f"trace_cluster_{cluster_id}",
+            "prior_family": f"Repository trace cluster for {scenario_type} scenarios with {density} pedestrian density ({signal}, {outcome})",
+            "classification": "repository_trace_derived",
+            "source_type": "repository_trace_derived",
+            "dataset_license_status": "not_applicable_generated_synthetic",
+            "source_traces": source_traces_pointers,
+            "feature_extraction_method": (
+                "Deterministic rule-based feature extraction and cluster assignment of "
+                "repository simulation trace exports. No heavy clustering or machine learning applied."
+            ),
+            "parameter_bounds": {
+                "representation": "scenario_prior.v1",
+                "units": "position=m, velocity=m/s, time=s",
+                "enforcement": "rule_based_clustering",
+                "min_distance_range_m": min_dist_range,
+                "trace_count": len(traces),
+            },
+            "excluded_populations": [
+                "real-world datasets not staged in-repo (refer to #3161 for staging contracts)",
+                "hardware-calibrated environments (refer to #2918 for calibration context)",
+            ],
+            "unsupported_claims": [
+                "learned_prior_realism",
+                "benchmark_usefulness",
+                "cross_dataset_generalization",
+                "planner_performance_improvement",
+                "license_safe_redistribution_of_raw_data",
+            ],
+            "odd_conditions": [
+                "repository-trace-grounded only; does not represent real-world statistics",
+                "diagnostic-only cluster prior family",
+            ],
+            "related_surfaces": [
+                "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.md",
+                "docs/context/evidence/issue_2726_scenario_prior_trace_clusters/report.json",
+            ],
+        }
+        cards.append(card)
+
+    registry = {
+        "schema_version": "scenario-prior-card-registry.v1",
+        "name": "calibrate_scenario_priors_from_traces_issue_2726",
+        "issue": 2726,
+        "status": "partial_initial_registry",
+        "benchmark_evidence": False,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "cards": cards,
+    }
+    return registry
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run CLI tool to parse, cluster, and output scenario prior evidence."""
+    args = parse_args(argv)
+
+    # 1. Resolve paths to process
+    trace_files: list[pathlib.Path] = []
+    if args.trace_paths:
+        trace_files = [pathlib.Path(p) for p in args.trace_paths]
+    # Recursively search trace-dir for json files
+    elif args.trace_dir.exists():
+        trace_files = sorted(args.trace_dir.glob("**/*.json"))
+
+    print(f"Found {len(trace_files)} JSON candidate files to analyze.")
+
+    # 2. Extract features
+    results = []
+    for tf in trace_files:
+        try:
+            with open(tf, encoding="utf-8") as f:
+                data = json.load(f)
+            # Basic validation
+            if not isinstance(data, dict):
+                continue
+            if "schema_version" not in data or "frames" not in data:
+                # Skip files that don't match the simulation_trace_export schema
+                continue
+
+            features = extract_features(data, tf)
+            results.append(features)
+        except Exception as e:
+            print(f"Skipping {tf} due to parsing error: {e}")
+
+    # 3. Deterministic Clustering
+    clusters: dict[str, list[dict[str, Any]]] = {}
+    for r in results:
+        cluster_id = assign_to_cluster(r["features"], r["scenario_id"])
+        clusters.setdefault(cluster_id, []).append(r)
+
+    print(f"Traces grouped into {len(clusters)} clusters.")
+
+    # 4. Generate YAML registry cards
+    registry = generate_prior_cards(clusters)
+
+    # 5. Build reports
+    md_report = build_markdown_report(clusters, len(results))
+
+    # 6. Ensure output directory exists and write artifacts
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    yaml_path = args.output_dir / "scenario_prior_cards_issue_2726.yaml"
+    with open(yaml_path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(registry, fh, default_flow_style=False, sort_keys=False)
+
+    md_path = args.output_dir / "report.md"
+    with open(md_path, "w", encoding="utf-8") as fh:
+        fh.write(md_report)
+
+    json_path = args.output_dir / "report.json"
+    report_json_data = {
+        "schema_version": "scenario-prior-calibration-report.v1",
+        "claim_boundary": CLAIM_BOUNDARY,
+        "evidence_status": "repository_trace_derived_proposal",
+        "trace_count": len(results),
+        "cluster_count": len(clusters),
+        "total_processed": len(results),
+        "clusters_count": len(clusters),
+        "limitations": [
+            "Repository trace fixtures are synthetic or simulator-derived and are not real-world calibrated.",
+            "Rule-based clustering is deterministic and reviewable, but not a statistical clustering claim.",
+            "Candidate cards are proposal surfaces only and do not establish benchmark usefulness or planner performance improvement.",
+        ],
+        "follow_up_data_requirements": [
+            "Stage real-world trajectory data under issue #3161 before making representativeness claims.",
+            "Use issue #2918 calibration context before promoting these proposal cards into calibrated priors.",
+        ],
+        "scenario_prior_candidates": registry["cards"],
+        "clusters": {
+            cid: {
+                "traces_count": len(traces),
+                "traces": [
+                    {
+                        "file_path": t["file_path"],
+                        "trace_id": t["trace_id"],
+                        "episode_id": t["episode_id"],
+                        "planner_id": t["planner_id"],
+                        "features": t["features"],
+                    }
+                    for t in traces
+                ],
+            }
+            for cid, traces in clusters.items()
+        },
+    }
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(report_json_data, fh, indent=2, sort_keys=True)
+
+    # Write README.md in output dir
+    readme_path = args.output_dir / "README.md"
+    readme_content = f"""# Issue #2726 Scenario Priors Calibration Report
+
+## Scope
+
+This directory contains evidence and report artifacts for calibrating scenario priors from trace clusters.
+It processes simulation trace exports from the repository, extracts features, groups them deterministically,
+and generates scenario prior candidate cards.
+
+## Evidence Status
+
+- `schema`: `scenario-prior-card-registry.v1`
+- `claim_boundary`: `{CLAIM_BOUNDARY}`
+- `validation_reference`: Refer to #3161 and #2918.
+
+## Files
+
+- [scenario_prior_cards_issue_2726.yaml](scenario_prior_cards_issue_2726.yaml): Generated prior cards
+- [report.md](report.md): Human-readable Markdown summary report
+- [report.json](report.json): Fully detailed cluster statistics and traces mapping JSON
+
+## Reproducible Command
+
+```bash
+uv run python scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py \\
+    --trace-dir tests/fixtures/analysis_workbench/simulation_trace_export_v1 \\
+    --output-dir docs/context/evidence/issue_2726_scenario_prior_trace_clusters
+```
+"""
+    with open(readme_path, "w", encoding="utf-8") as fh:
+        fh.write(readme_content)
+
+    print(f"Report and YAML cards successfully written to: {args.output_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    import sys
+
+    sys.exit(main())

--- a/tests/analysis/test_calibrate_scenario_priors_from_traces_issue_2726.py
+++ b/tests/analysis/test_calibrate_scenario_priors_from_traces_issue_2726.py
@@ -1,0 +1,198 @@
+"""Tests for calibrate_scenario_priors_from_traces_issue_2726.py."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import tempfile
+
+import yaml
+
+from scripts.analysis.calibrate_scenario_priors_from_traces_issue_2726 import (
+    assign_to_cluster,
+    extract_features,
+    generate_prior_cards,
+    main,
+)
+
+
+def test_extract_features_minimal():
+    """Verify feature extraction with a minimal mock trace data."""
+    trace_data = {
+        "schema_version": "simulation_trace_export.v1",
+        "trace_id": "test_trace_1",
+        "source": {
+            "scenario_id": "classic_bottleneck_medium",
+            "seed": 111,
+            "planner_id": "hybrid_rule_v0_minimal",
+            "episode_id": "test_episode_1",
+        },
+        "frames": [
+            {
+                "step": 0,
+                "time_s": 0.0,
+                "robot": {"position": [0.0, 0.0], "velocity": [1.0, 0.0]},
+                "pedestrians": [
+                    {
+                        "id": 1,
+                        "position": [1.0, 0.0],
+                        "signal_state": {"available": True, "label": "red"},
+                    }
+                ],
+                "planner": {"active_hypothesis": "hyp_1"},
+            },
+            {
+                "step": 1,
+                "time_s": 0.1,
+                "robot": {"position": [0.1, 0.0], "velocity": [0.0, 0.0]},
+                "pedestrians": [
+                    {
+                        "id": 1,
+                        "position": [1.0, 0.0],
+                        "signal_state": {"available": True, "label": "green"},
+                    }
+                ],
+                "planner": {"active_hypothesis": "hyp_2"},
+            },
+        ],
+    }
+
+    file_path = pathlib.Path("/tmp/mock_trace.json")
+    result = extract_features(trace_data, file_path)
+
+    assert result["trace_id"] == "test_trace_1"
+    assert result["scenario_id"] == "classic_bottleneck_medium"
+    assert result["episode_id"] == "test_episode_1"
+    assert result["planner_id"] == "hybrid_rule_v0_minimal"
+    assert result["seed"] == 111
+
+    features = result["features"]
+    assert features["bottleneck_width"] == 1.5
+    assert features["pedestrian_count"] == 1
+    assert features["pedestrian_density"] == "medium"
+    assert features["has_signal"] is True
+    assert features["signal_green_fraction"] == 0.5
+    assert features["robot_displacement_m"] == 0.1
+    assert features["robot_total_distance_m"] == 0.1
+    # First frame speed = 1.0 >= 0.05, second speed = 0.0 < 0.05. stop fraction = 0.5
+    assert features["stop_fraction"] == 0.5
+    # topology switches: active_hypothesis transitioned hyp_1 -> hyp_2
+    assert features["topology_switches"] == 1
+    # min distance robot-ped is at step 1: dist([0.1, 0.0], [1.0, 0.0]) = 0.9.
+    assert features["min_distance_m"] == 0.9
+    assert features["outcome"] == "nominal"
+
+
+def test_assign_to_cluster():
+    """Verify cluster assignment returns deterministic names."""
+    features = {
+        "pedestrian_count": 3,
+        "has_signal": True,
+        "outcome": "near-miss",
+    }
+    cluster = assign_to_cluster(features, "issue_2868_signalized_crossing")
+    assert cluster == "crossing_dense_signalized_near-miss"
+
+
+def test_generate_prior_cards():
+    """Verify prior registry cards structure matches sdd_scenario_distribution_candidate formatting."""
+    clusters = {
+        "crossing_sparse_signalized_nominal": [
+            {
+                "file_path": "tests/fixtures/mock.json",
+                "trace_id": "t1",
+                "episode_id": "ep1",
+                "features": {
+                    "min_distance_m": 0.9,
+                    "stop_fraction": 0.0,
+                },
+            },
+            {
+                "file_path": "tests/fixtures/mock_2.json",
+                "trace_id": "t2",
+                "episode_id": "ep2",
+                "features": {
+                    "min_distance_m": 0.7,
+                    "stop_fraction": 0.5,
+                },
+            },
+        ]
+    }
+    registry = generate_prior_cards(clusters)
+
+    assert registry["schema_version"] == "scenario-prior-card-registry.v1"
+    assert len(registry["cards"]) == 1
+    card = registry["cards"][0]
+    assert card["card_id"] == "trace_cluster_crossing_sparse_signalized_nominal"
+    assert card["classification"] == "repository_trace_derived"
+    assert card["source_traces"] == [
+        "tests/fixtures/mock.json (trace_id: t1, episode_id: ep1)",
+        "tests/fixtures/mock_2.json (trace_id: t2, episode_id: ep2)",
+    ]
+    assert "repository-trace-grounded" in card["odd_conditions"][0]
+
+
+def test_main_cli_execution():
+    """Verify main function parses arguments, processes inputs, and writes reports correctly."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp_path = pathlib.Path(tmpdir)
+        trace_dir = tmp_path / "traces"
+        trace_dir.mkdir()
+
+        # Write mock trace file
+        trace_file = trace_dir / "mock_trace.json"
+        mock_data = {
+            "schema_version": "simulation_trace_export.v1",
+            "trace_id": "mock_1",
+            "source": {
+                "scenario_id": "classic_bottleneck_medium",
+                "seed": 111,
+                "planner_id": "hybrid_rule_v0_minimal",
+                "episode_id": "ep_1",
+            },
+            "frames": [
+                {
+                    "step": 0,
+                    "time_s": 0.0,
+                    "robot": {"position": [0.0, 0.0], "velocity": [0.0, 0.0]},
+                    "pedestrians": [],
+                    "planner": {},
+                }
+            ],
+        }
+        with open(trace_file, "w", encoding="utf-8") as f:
+            json.dump(mock_data, f)
+
+        output_dir = tmp_path / "output"
+
+        exit_code = main(
+            [
+                "--trace-dir",
+                str(trace_dir),
+                "--output-dir",
+                str(output_dir),
+            ]
+        )
+
+        assert exit_code == 0
+        assert (output_dir / "report.md").exists()
+        assert (output_dir / "report.json").exists()
+        assert (output_dir / "scenario_prior_cards_issue_2726.yaml").exists()
+        assert (output_dir / "README.md").exists()
+
+        # Load and verify content of report.json
+        with open(output_dir / "report.json", encoding="utf-8") as f:
+            report_data = json.load(f)
+            assert report_data["total_processed"] == 1
+            assert report_data["trace_count"] == 1
+            assert report_data["cluster_count"] == 1
+            assert "bottleneck_sparse_unsignalized_nominal" in report_data["clusters"]
+            assert report_data["limitations"]
+            assert report_data["follow_up_data_requirements"]
+            assert report_data["scenario_prior_candidates"][0]["source_traces"]
+
+        # Load and verify content of cards yaml
+        with open(output_dir / "scenario_prior_cards_issue_2726.yaml", encoding="utf-8") as f:
+            yaml_data = yaml.safe_load(f)
+            assert yaml_data["issue"] == 2726
+            assert len(yaml_data["cards"]) == 1


### PR DESCRIPTION
## Summary
Adds a deterministic scenario-prior calibration script for issue #2726, plus focused tests and a first-use evidence pack generated from committed simulation trace fixtures.

## Linked Issues
- Closes `#2726`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py`.
- Added focused tests for feature extraction, deterministic cluster assignment, multi-source lineage retention, candidate card shape, and CLI output.
- Added generated evidence under `docs/context/evidence/issue_2726_scenario_prior_trace_clusters/`.

## Why It Matters
- Added value: scenario-prior proposals now have trace-cluster lineage instead of only hand-authored context.
- Expected impact: future AMV/matching and scenario-prior work can inspect deterministic repository-trace clusters with explicit caveats.
- Why this is worth merging now: it turns #2726 into a reproducible analysis surface with no external-data requirement.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: repository trace fixtures can ground candidate `scenario_prior.v1` cards with explicit source lineage and limitations.
- Comparator or baseline, if applicable: previous state lacked a #2726-specific trace-cluster calibration script/evidence pack.
- Evidence tier: analysis-only / targeted smoke.
- Result classification: diagnostic-only / proposal.
- Decision or stop rule, if applicable: generated cards must retain source trace path, trace id, and episode id lineage and must not claim real-world calibration.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #2726.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use on committed trace fixtures is tracked in `docs/context/evidence/issue_2726_scenario_prior_trace_clusters/`.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes; 20 committed trace fixtures grouped into 9 deterministic clusters.
- Did the intervention change command source, selected command, trajectory, or route progress? NA; analysis tool only.
- Did the scenario actually contain the targeted failure mode? mixed fixture set; this PR produces diagnostic proposal cards, not a benchmark/failure claim.
- Result route: continue as repository-trace-grounded proposal only.
- Follow-up question or issue for weak, negative, or non-transfer results: real-world staging remains #3161; calibration context remains #2918.

## Next Empirical Action
- Rerun needed: no for the committed smoke evidence; yes before any calibrated-prior or representativeness claim.
- Extractor or analysis tool needed: no for this scoped issue.
- Artifact missing or unavailable: no external real-world dataset is included or required here.
- Stop / revise / continue decision: continue as diagnostic proposal.
- Proposed child issue or existing follow-up: #3161 and #2918.

## Validation / Proof
- Commands run:
  - `uv run python scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py --trace-dir tests/fixtures/analysis_workbench/simulation_trace_export_v1 --output-dir docs/context/evidence/issue_2726_scenario_prior_trace_clusters`
  - `uv run pytest tests/analysis/test_calibrate_scenario_priors_from_traces_issue_2726.py -q`
  - `uv run ruff check scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py tests/analysis/test_calibrate_scenario_priors_from_traces_issue_2726.py`
  - `uv run ruff format --check scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py tests/analysis/test_calibrate_scenario_priors_from_traces_issue_2726.py`
  - `git diff --check -- scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py tests/analysis/test_calibrate_scenario_priors_from_traces_issue_2726.py docs/context/evidence/issue_2726_scenario_prior_trace_clusters`
  - `jq`/YAML checks confirmed `trace_count=20`, `cluster_count=9`, `candidate_count=9`, first card source count `2`, and `benchmark_evidence=false`.
- Evidence that the change works here: generated `report.json`, `report.md`, and `scenario_prior_cards_issue_2726.yaml` from committed fixtures with complete lineage.
- Benchmarks or smoke tests, if applicable: analysis-only smoke evidence.

Full readiness caveat:
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` was run through `scripts/dev/run_compact_validation.py` and failed because unrelated test collection imports `torch`, which is absent in this local worktree environment. The same run also reports no PR body source because it was executed before PR creation.

## Risks / Rollout
- Compatibility risks: input fixture schema variants may require future adapters.
- Failure modes: deterministic bucketing is not statistical clustering; it is intended for reviewable proposal generation.
- Rollback or fallback plan: remove the standalone script and evidence directory.

## Docs / Provenance
- Updated docs: `docs/context/evidence/issue_2726_scenario_prior_trace_clusters/README.md`.
- Relevant design or provenance notes: evidence is generated from committed fixtures only; no external data.
- Any assumptions that need to be preserved: generated candidate cards are repository-trace-grounded proposals, not real-world calibrated priors.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via PR link and close keyword.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA; generated proposal cards are evidence-local and not promoted.
- Context index / memory note updated (yes/no/NA): NA; evidence is colocated under `docs/context/evidence/`.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA; existing issues #3161/#2918 carry the real-data/calibration requirements.
- Not applicable because: this is an analysis-only proposal surface, not a benchmark or calibrated prior registry update.

## Follow-Up Issues
- Deferred work: stage real-world trajectory data before representativeness claims; calibrate before promotion.
- Issues opened for follow-up: none; uses #3161 and #2918.

## Reviewer Notes
- Anything a reviewer should verify closely: source lineage retention in multi-trace candidate cards and the no-real-world-calibration wording.
- Any known limitations: fixtures are synthetic/simulator-derived and candidate cards are proposals only.
