### PR TITLE
docs: add simulation evidence safety case template (#3291)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -201,6 +201,7 @@ thin: existing Markdown files remain the source of truth, and generated HTML und
 * **[Scenario Zoo Index](./scenario_zoo/index.md)** - Family-oriented scenario catalog with links to source configs, maps, benchmark surfaces, and caveats
 * **[Hazard Traceability](./hazard_traceability.md)** - `hazard_traceability.v1` schema, typed loader, fixture, and coverage summary for scenario-to-hazard evidence caveats
 * **[ODD Contracts](./odd_contracts.md)** - `odd_contract.v1` schema, typed loader, fixture, and boundary for benchmark and falsification evidence assumptions
+* **[Simulation-Evidence Safety Case Template](./simulation_evidence_safety_case.md)** - Public-safe scaffold for mapping Robot SF simulation evidence, provenance, credibility gaps, and outside-simulation evidence requirements without implying certification
 * **[Scenario Contracts](./scenario_contracts.md)** - `scenario_contract.v1` schema, typed loader, fixture, and boundary between authored intent, certification, and benchmark evidence
 * **[Scenario Certification](./scenario_certification.md)** - `scenario_cert.v1` schema, CLI, labels, and fail-closed benchmark eligibility rules
 * **[Scenario Perturbation Manifest](./scenario_perturbation_manifest.md)** - `scenario_perturbation_manifest.v1` schema, no-op and bounded route-offset preflight, and evidence boundary for perturbation pilots
@@ -440,6 +441,7 @@ thin: existing Markdown files remain the source of truth, and generated HTML und
 * [**Scenario Specification Checklist**](./scenario_spec_checklist.md) - Authoring checklist for per-scenario/archetype/manifest files
 * [**Hazard Traceability**](./hazard_traceability.md) - Summarize intended hazard coverage for scenario IDs or families without treating traceability as safety proof
 * [**ODD Contracts**](./odd_contracts.md) - Validate operating-assumption metadata that bounds benchmark and falsification evidence without certifying safety
+* [**Simulation-Evidence Safety Case Template**](./simulation_evidence_safety_case.md) - Map benchmark artifacts to bounded safety-case sections while naming simulation limits and external evidence needs
 * [**Scenario Contracts**](./scenario_contracts.md) - Validate authored scenario-intent contracts before certification or benchmark execution
 * [**Scenario Certification**](./scenario_certification.md) - Generate machine-readable validity, feasibility, stress-only, and hard-but-solvable certificates for scenario manifests
 * [**Issue #1240 Scenario Coverage Entropy**](./context/issue_1240_scenario_coverage_entropy.md) - Config-only entropy and novelty report for diagnostic scenario-set curation; not benchmark-success evidence

--- a/docs/simulation_evidence_safety_case.md
+++ b/docs/simulation_evidence_safety_case.md
@@ -1,0 +1,184 @@
+# Simulation-Evidence Safety Case Template
+
+[Back to Documentation Index](./README.md)
+
+**Status**: Public-safe template for organizing Robot SF simulation evidence.
+
+**Related issue**: [#3291](https://github.com/ll7/robot_sf_ll7/issues/3291)
+
+This template helps reviewers map Robot SF benchmark and falsification evidence into a structured
+safety argument. It is not a safety certificate, legal compliance claim, deployment approval, or
+proof that simulation alone establishes safety.
+
+Use it when a report, release packet, or issue needs to state what simulation evidence supports,
+what it does not support, and what evidence must come from outside the simulator.
+
+## Claim Boundary
+
+A filled template may support a bounded statement such as:
+
+> Under the named ODD, scenario, seed, metric, and artifact contracts, this benchmark campaign gives
+> diagnostic or benchmark evidence for the listed hazards and requirements.
+
+It must not support these statements by itself:
+
+- the robot is safe for real-world deployment,
+- the planner satisfies a regulatory or operational safety case,
+- unmodeled pedestrians, vehicle classes, weather, sensors, or actuation dynamics are covered,
+- fallback, degraded, failed, not-available, or metadata-only rows are success evidence.
+
+Use the repository evidence ladder from
+[Maintainer Values And Hard Contracts](./maintainer_values.md): `diagnostic-only`,
+`smoke evidence`, `nominal benchmark evidence`, and `paper-grade`. When confidence is below about
+95 percent, put the caveat or uncertainty next to the claim.
+
+## Required Links
+
+Every filled safety-case instance should link these surfaces when they exist. If one is missing,
+record `missing` plus the unblock condition instead of leaving the field blank.
+
+| Field | Required reference |
+| --- | --- |
+| ODD scope | [ODD contract](./odd_contracts.md) or explicit `missing` status. |
+| Hazard mapping | [Hazard traceability](./hazard_traceability.md) row or explicit gap. |
+| Scenario intent | [Scenario contract](./scenario_contracts.md) or explicit gap. |
+| Scenario feasibility | [Scenario certification](./scenario_certification.md) or exclusion reason. |
+| Artifact provenance | Campaign root or manifest, command, commit, checksum, and artifact category from the [Artifact Evidence Vocabulary](./context/artifact_evidence_vocabulary.md). |
+| Credibility assessment | Filled credibility checklist, planned assessment, or blocker. |
+| External evidence | Required real-world, operational, hardware, human-factors, or regulatory evidence outside Robot SF. |
+
+## Template
+
+### 1. Header
+
+| Field | Value |
+| --- | --- |
+| Safety-case id | `<stable id>` |
+| Owner / reviewer | `<person or team>` |
+| Date and source commit | `<date>`, `<commit>` |
+| Evidence status | `diagnostic-only` / `smoke evidence` / `nominal benchmark evidence` / `paper-grade` |
+| Intended use | `<analysis, benchmark release, paper appendix, internal gate, other>` |
+| Non-claims | `<deployment readiness, legal compliance, real-world safety certification, etc.>` |
+
+### 2. System And ODD Scope
+
+| Field | Value |
+| --- | --- |
+| Robot or AMV class | `<platform class and modeled kinematics>` |
+| Planner or policy | `<planner id, policy id, adapter mode>` |
+| Operating context | `<public-space context, speed envelope, density envelope>` |
+| ODD contract | `<path and contract id>` |
+| ODD exclusions | `<weather, public-road autonomy, sensor limits, legal claims, etc.>` |
+| Scenario set | `<config or manifest path>` |
+| Seed policy | `<seed count, deterministic policy, excluded seeds>` |
+
+### 3. Hazards And Requirements
+
+| Hazard id | Hazard statement | Requirement or question | Simulation evidence expected | Outside-simulation evidence required |
+| --- | --- | --- | --- | --- |
+| `<hazard_id>` | `<harm or undesired state>` | `<requirement, threshold, or decision>` | `<metrics, scenarios, artifacts>` | `<field data, HIL, hardware, human study, regulator review, etc.>` |
+
+Keep requirements audit-friendly. If a requirement is not measurable in Robot SF, say so and route
+it to an external evidence row.
+
+### 4. Evidence Map
+
+| Evidence id | Artifact category | Source and provenance | Status | Caveats | Supports | Does not support |
+| --- | --- | --- | --- | --- | --- | --- |
+| `<id>` | `<durable evidence copy, benchmark claim, release artifact, etc.>` | `<manifest, command, commit, checksum>` | `<covered, partial, missing, excluded, unavailable>` | `<fallback/degraded rows, schema gaps, missing real-world data>` | `<bounded claim>` | `<claim gap>` |
+
+Rules:
+
+- Link to the durable artifact or manifest, not only a local `output/` path.
+- Name fallback, degraded, failed, and not-available rows as caveats or exclusions.
+- Keep metric/schema versions visible when they affect the claim.
+- Treat metadata-only surfaces as claim boundaries, not execution evidence.
+
+### 5. Credibility And Validation Limits
+
+| Question | Current answer | Evidence or blocker |
+| --- | --- | --- |
+| Numerical implementation checked? | `<yes/no/partial>` | `<tests, fixtures, validators>` |
+| Scenario validity checked? | `<yes/no/partial>` | `<scenario_cert.v1, contract, exclusions>` |
+| Model assumptions reviewed? | `<yes/no/partial>` | `<pedestrian model, kinematics, sensor, actuation assumptions>` |
+| Uncertainty quantified? | `<yes/no/partial>` | `<confidence intervals, seed count, sensitivity report>` |
+| Real-world validation available? | `<yes/no/partial>` | `<external source or missing evidence>` |
+| Known invalid domains named? | `<yes/no/partial>` | `<ODD exclusions, unsupported settings>` |
+
+This section separates verification of repository behavior from validation against real-world
+behavior. A campaign can be reproducible and still not validated for deployment use.
+
+### 6. Residual Risk And Decision
+
+| Residual risk or gap | Owner | Required next evidence | Blocks current claim? |
+| --- | --- | --- | --- |
+| `<gap>` | `<owner>` | `<smallest proof step>` | `yes/no` |
+
+Decision:
+
+- `continue`: evidence is enough for the bounded internal/research claim.
+- `revise`: claim wording, scenario set, metric, or artifact provenance must be narrowed.
+- `block`: required proof for the stated claim is missing.
+- `external`: the next evidence must come from outside Robot SF.
+
+## Toy Example Mapping
+
+This example is intentionally limited. It shows how to fill the template without implying safety or
+deployment readiness.
+
+### Example Header
+
+| Field | Value |
+| --- | --- |
+| Safety-case id | `toy_low_speed_public_space_hazard_coverage` |
+| Evidence status | `diagnostic-only` |
+| Intended use | Demonstrate how hazard/ODD coverage evidence maps into a safety-case scaffold. |
+| Non-claims | No deployment readiness, legal compliance, real-world safety certification, or planner safety claim. |
+
+### Example Scope
+
+| Field | Value |
+| --- | --- |
+| Robot or AMV class | Low-speed public-space AMV/robot class represented by existing benchmark metadata. |
+| Planner or policy | Mixed rows from the source campaign; this example does not compare planner safety. |
+| ODD contract | [`configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml`](../configs/benchmarks/odd_contracts/low_speed_public_space_v1.yaml). |
+| Hazard mapping | [`configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml`](../configs/benchmarks/hazard_traceability/low_speed_public_space_v1.yaml). |
+| Scenario contract | [`configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml`](../configs/scenarios/contracts/station_platform_candidate_pack_issue736_contracts.yaml). |
+| Source campaign root | [`docs/context/evidence/issue_1484_broader_cross_kinematics_2026-05-28`](./context/evidence/issue_1484_broader_cross_kinematics_2026-05-28/README.md). |
+| Evidence artifact | [`docs/context/evidence/issue_2156_research_v1_hazard_odd_2026-06-03`](./context/evidence/issue_2156_research_v1_hazard_odd_2026-06-03/README.md). |
+| Credibility assessment | `missing`: this toy example records the gap; issue #3290 tracks a reusable credibility checklist. |
+
+### Example Hazard And Requirement Rows
+
+| Hazard id | Requirement or question | Simulation evidence expected | Current mapped status | Outside-simulation evidence required |
+| --- | --- | --- | --- | --- |
+| `robot_pedestrian_collision` | Can the campaign support a collision-hazard coverage statement? | Non-caveated executed rows linked to collision-rate evidence for mapped scenarios. | `missing`: metadata exists, but no executed row matched the mapped scenarios in the Issue #2156 rollup. | Real-world incident/hazard analysis, hardware emergency-stop behavior, sensor-performance evidence, and operational safety review. |
+| `near_miss` | Can the campaign support a near-miss coverage statement? | Non-caveated executed rows with `min_ttc` or `pet` evidence for mapped scenarios. | `missing`: no executed row matched the mapped near-miss scenarios. | Real pedestrian interaction data, validated TTC/PET thresholds, and human-factors review. |
+
+### Example Evidence Map
+
+| Evidence id | Artifact category | Source and provenance | Status | Supports | Does not support |
+| --- | --- | --- | --- | --- | --- |
+| `issue_2156_hazard_odd_rollup` | Durable evidence copy | Source campaign root `docs/context/evidence/issue_1484_broader_cross_kinematics_2026-05-28`; rollup files `hazard_odd_coverage_summary.json`, `hazard_coverage_table.csv`, `odd_boundary_table.csv`, and `checksums.sha256` under the Issue #2156 evidence directory. Generated by `scripts/tools/hazard_odd_coverage_rollup.py` at commit `0b5a2efcdd738f5019e75a063218a99c9772d589`. | `diagnostic-only`; hazard statuses are `missing=5`, ODD statuses are `partial=2`, `excluded=8`, scenario-contract statuses are `missing=1`. | A traceability gap: current metadata and executed rows are not yet joined for the listed hazards. | Any claim that the campaign proves collision or near-miss mitigation, benchmark coverage completeness, or deployment safety. |
+
+### Example Decision
+
+Decision: `revise`.
+
+The evidence is useful because it identifies missing joins between hazard metadata and executed
+rows. The next smallest proof step is to add or select scenario contracts and hazard mappings that
+name the executed AMV scenarios, rerun the same rollup, and only then decide whether the result
+supports `smoke evidence` or `nominal benchmark evidence`. Real-world validation remains outside
+the simulator and must be handled by a separate evidence source.
+
+## Review Checklist
+
+- The claim boundary appears before result interpretation.
+- Evidence status is one of the repository ladder values.
+- ODD, hazard, scenario, certification, provenance, and credibility links are present or explicitly
+  marked `missing`.
+- `output/` is not cited as the durable evidence location.
+- Fallback, degraded, failed, and not-available rows are caveats, not success evidence.
+- The template names at least one real-world or operational evidence gap that simulation cannot
+  fill.
+- The decision is `continue`, `revise`, `block`, or `external`, with the next proof step named.


### PR DESCRIPTION
## Summary
Adds a public-safe simulation-evidence safety case template for Robot SF docs, plus documentation index links near the hazard/ODD/scenario contract surfaces.

## Linked Issues
- Closes `#3291`
- Relates to `#3290`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3290`
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `docs/simulation_evidence_safety_case.md` with a claim boundary, required evidence links, fillable safety-case sections, residual-risk decision rows, and a review checklist.
- Added a bounded toy mapping using the existing Issue #2156 hazard/ODD coverage evidence to show diagnostic-only evidence, missing coverage caveats, and outside-simulation evidence needs.
- Linked the new template from `docs/README.md` in the benchmark and simulation documentation indexes.

## Why It Matters
- Added value: gives reviewers a consistent scaffold for mapping simulation evidence without overclaiming safety or deployment readiness.
- Expected impact: makes future benchmark, release, and safety-oriented docs clearer about claim boundaries, provenance, credibility gaps, and external evidence requirements.
- Why this is worth merging now: `#3291` is a docs-tier ready issue and this establishes the template before follow-on credibility checklist work in `#3290`.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: docs scaffold for simulation-evidence safety-case mapping; no benchmark result claim.
- Comparator or baseline, if applicable: existing hazard/ODD/scenario/evidence docs without one fillable safety-case template.
- Evidence tier: docs-only.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: template must avoid simulation-alone safety claims and name external evidence gaps.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#3291`; `docs/README.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - documentation scaffold only, no analysis tool added.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - docs-only scaffold.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: existing `#3290` covers the reusable credibility checklist referenced by the template.

## Next Empirical Action
- Rerun needed: NA - docs-only.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: NA for this PR; the toy example explicitly marks credibility assessment as missing and points to `#3290`.
- Stop / revise / continue decision: continue with docs-only merge if review agrees the claim boundary is conservative.
- Proposed child issue or existing follow-up: existing `#3290`.

## Validation / Proof
- Commands run:
  - `ls docs/odd_contracts.md docs/hazard_odd_coverage_rollup.md docs/context/artifact_evidence_vocabulary.md docs/maintainer_values.md docs/context/evidence/issue_2156_research_v1_hazard_odd_2026-06-03/README.md docs/context/evidence/issue_1484_broader_cross_kinematics_2026-05-28/README.md`
  - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
  - focused local Markdown link check for `docs/simulation_evidence_safety_case.md` and `docs/README.md`
  - `git diff --cached --check`
- Evidence that the change works here: referenced docs/evidence paths resolve; proof-consistency check passed for the two changed files; the new local links resolve.
- Benchmarks or smoke tests, if applicable: NA - docs-only.

## Risks / Rollout
- Compatibility risks: low; Markdown docs only.
- Failure modes: reviewers may want the toy example narrowed further if it reads as benchmark evidence rather than diagnostic-only evidence.
- Rollback or fallback plan: revert the new doc and two README links.

## Docs / Provenance
- Updated docs: `docs/simulation_evidence_safety_case.md`, `docs/README.md`.
- Relevant design or provenance notes: links to `docs/context/artifact_evidence_vocabulary.md`, hazard/ODD/scenario docs, and Issue #2156 evidence pack.
- Any assumptions that need to be preserved: simulation evidence can organize bounded claims but cannot establish deployment safety without external evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes `#3291`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no, existing `#3290` covers the referenced credibility checklist follow-up.
- Not applicable because: docs-only scaffold; no benchmark, registry, artifact, or paper-facing result is promoted.

## Follow-Up Issues
- Deferred work: reusable simulation-model credibility checklist.
- Issues opened for follow-up: none; using existing `#3290`.

## Reviewer Notes
- Anything a reviewer should verify closely: whether the toy example stays clearly diagnostic-only and avoids implying planner safety.
- Any known limitations: the template is human-readable only; no schema or validator is added in this PR.
