### PR TITLE
feat: add cross-benchmark metric wrappers

### DIFF
--- a/configs/benchmarks/cross_benchmark_metric_mapping_v1.yaml
+++ b/configs/benchmarks/cross_benchmark_metric_mapping_v1.yaml
@@ -1,0 +1,89 @@
+schema_version: cross-benchmark-metric-mapping.v1
+issue: 3286
+claim_boundary: trace-derived wrapper smoke evidence; not simulator parity or paper-grade evidence
+status_vocabulary:
+  mapping_class:
+    - exact
+    - approximate
+    - unavailable
+  value_status:
+    - available
+    - approximate
+    - unavailable
+rows:
+  - metric_id: socnavbench.path_length_ratio
+    benchmark: SocNavBench
+    external_metric: path_length_ratio
+    robot_sf_source: socnavbench_path_length_ratio
+    units: ratio
+    denominator: straight_line_start_to_goal_distance_m
+    mapping_class: exact
+    evidence_tier: trace-derived
+    semantic_notes: >-
+      Uses the vendored SocNavBench-style path length ratio helper over the Robot SF episode
+      trajectory and goal displacement.
+  - metric_id: common.traversal_time_s
+    benchmark: Common social-navigation
+    external_metric: traversal_time
+    robot_sf_source: time_to_goal
+    units: seconds
+    denominator: episode
+    mapping_class: approximate
+    evidence_tier: trace-derived
+    semantic_notes: >-
+      Robot SF reports first goal-reaching time. External benchmark timeout and episode-stop
+      semantics may differ, so this is an approximate correspondence.
+  - metric_id: common.time_to_collision_min_s
+    benchmark: Common social-navigation
+    external_metric: time_to_collision_min
+    robot_sf_source: time_to_collision_min
+    units: seconds
+    denominator: minimum_approaching_robot_pedestrian_pair
+    mapping_class: approximate
+    evidence_tier: trace-derived
+    semantic_notes: >-
+      Computed from Robot SF robot and pedestrian trace velocities with a constant-velocity
+      approaching-pair assumption.
+  - metric_id: common.closest_pedestrian_distance_m
+    benchmark: Common social-navigation
+    external_metric: distance_to_closest_pedestrian
+    robot_sf_source: distance_to_human_min
+    units: meters
+    denominator: minimum_over_episode
+    mapping_class: exact
+    evidence_tier: trace-derived
+    semantic_notes: >-
+      Uses Robot SF center-to-center robot-pedestrian distance. Surface clearance metrics remain
+      separate because footprint conventions differ across benchmarks.
+  - metric_id: robot_sf.success_trace_predicate
+    benchmark: Robot SF
+    external_metric: success_trace_predicate
+    robot_sf_source: success
+    units: binary
+    denominator: episode
+    mapping_class: exact
+    evidence_tier: trace-derived
+    semantic_notes: >-
+      Robot SF success requires reaching the goal before the horizon and no wall, agent, or human
+      collision under Robot SF collision semantics.
+  - metric_id: socnavbench.personal_space_objective
+    benchmark: SocNavBench
+    external_metric: personal_space_objective
+    robot_sf_source: null
+    units: external_objective_units
+    denominator: external_cost_field
+    mapping_class: unavailable
+    evidence_tier: not_available
+    semantic_notes: >-
+      Robot SF traces expose distance and clearance proxies, but not the external SocNavBench
+      objective field needed for a faithful scalar wrapper.
+  - metric_id: hunavsim.human_behavior_cost
+    benchmark: HuNavSim
+    external_metric: human_behavior_cost
+    robot_sf_source: null
+    units: external_cost_units
+    denominator: external_behavior_model
+    mapping_class: unavailable
+    evidence_tier: not_available
+    semantic_notes: >-
+      Requires HuNavSim behavior-model state that is not present in Robot SF trace exports.

--- a/docs/context/issue_3286_cross_benchmark_metric_wrappers.md
+++ b/docs/context/issue_3286_cross_benchmark_metric_wrappers.md
@@ -1,0 +1,40 @@
+# Issue #3286 Cross-Benchmark Metric Wrappers
+
+Status: smoke evidence for trace-derived wrappers, not simulator parity or paper-grade evidence.
+
+Related:
+- GitHub issue: https://github.com/ll7/robot_sf_ll7/issues/3286
+- Input correspondence note: `docs/context/issue_2928_socnavbench_hunavsim_metric_correspondence.md`
+- Versioned mapping: `configs/benchmarks/cross_benchmark_metric_mapping_v1.yaml`
+- Wrapper module: `robot_sf/benchmark/cross_benchmark_metrics.py`
+
+## Claim Boundary
+
+The new wrapper layer exposes Robot SF trace-derived metrics in an external-style row format. It
+does not show that Robot SF, SocNavBench, or HuNavSim are equivalent simulators. Rows are labeled as
+`available`, `approximate`, or `unavailable`, and unavailable external-only metrics remain in the
+report so consumers cannot silently treat missing simulator state as a zero-valued metric.
+
+## Implemented Wrapper Rows
+
+| Metric ID | Source | Status Boundary |
+| --- | --- | --- |
+| `socnavbench.path_length_ratio` | `socnavbench_path_length_ratio` | available when the Robot SF trajectory and goal displacement are valid |
+| `common.traversal_time_s` | `time_to_goal` | approximate because timeout and episode-stop semantics vary by benchmark |
+| `common.time_to_collision_min_s` | `time_to_collision_min` | approximate because it uses a constant-velocity approaching-pair assumption |
+| `common.closest_pedestrian_distance_m` | `distance_to_human_min` | available as center-to-center distance, not footprint clearance |
+| `robot_sf.success_trace_predicate` | `success` | available when a horizon is supplied |
+| `socnavbench.personal_space_objective` | none | unavailable; external objective field is not present in Robot SF traces |
+| `hunavsim.human_behavior_cost` | none | unavailable; HuNavSim behavior-model state is not present in Robot SF traces |
+
+## Fixture Smoke Result
+
+The focused fixture test builds a three-step Robot SF trace with one static pedestrian and verifies
+that the wrapper report includes:
+
+- available rows for path-length ratio, closest-pedestrian distance, and Robot SF success;
+- approximate rows for traversal time and minimum time-to-collision;
+- unavailable rows for external simulator-only metrics.
+
+This is smoke evidence that the wrapper contract works on a deterministic trace. It is not a
+benchmark result and should not be used as cross-simulator parity evidence.

--- a/robot_sf/benchmark/cross_benchmark_metrics.py
+++ b/robot_sf/benchmark/cross_benchmark_metrics.py
@@ -1,0 +1,344 @@
+"""Cross-benchmark metric wrappers for Robot SF trace-derived metrics.
+
+The wrappers in this module expose a small, explicit correspondence layer for
+social-navigation benchmark concepts that can be computed from ``EpisodeData``.
+They are not simulator-parity proof: approximate and unavailable rows are
+preserved in the output so reports cannot silently treat proxy metrics as
+equivalent external benchmark scores.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable, Mapping
+from dataclasses import asdict, dataclass
+from typing import Any
+
+from robot_sf.benchmark.metrics import (
+    EpisodeData,
+    distance_to_human_min,
+    socnavbench_path_length_ratio,
+    success,
+    time_to_collision_min,
+    time_to_goal,
+)
+
+CROSS_BENCHMARK_METRIC_MAPPING_VERSION = "cross-benchmark-metric-mapping.v1"
+CROSS_BENCHMARK_METRIC_REPORT_SCHEMA_VERSION = "cross-benchmark-metric-report.v1"
+CROSS_BENCHMARK_CLAIM_BOUNDARY = (
+    "trace-derived wrapper smoke evidence; not simulator parity or paper-grade evidence"
+)
+
+MAPPING_CLASSES = {"exact", "approximate", "unavailable"}
+VALUE_STATUSES = {"available", "approximate", "unavailable"}
+
+
+@dataclass(frozen=True)
+class CrossBenchmarkMetricMapping:
+    """One metric correspondence row."""
+
+    metric_id: str
+    benchmark: str
+    external_metric: str
+    robot_sf_source: str | None
+    units: str
+    denominator: str
+    mapping_class: str
+    evidence_tier: str
+    semantic_notes: str
+
+    def __post_init__(self) -> None:
+        """Validate vocabulary used by the checked-in mapping table."""
+        if self.mapping_class not in MAPPING_CLASSES:
+            raise ValueError(f"Unsupported mapping_class: {self.mapping_class}")
+
+
+@dataclass(frozen=True)
+class CrossBenchmarkMetricRow:
+    """Computed external-style metric row with explicit availability status."""
+
+    metric_id: str
+    benchmark: str
+    external_metric: str
+    status: str
+    mapping_class: str
+    value: float | None
+    units: str
+    denominator: str
+    robot_sf_source: str | None
+    evidence_tier: str
+    semantic_notes: str
+    unavailable_reason: str | None = None
+
+    def __post_init__(self) -> None:
+        """Validate status vocabulary used in reports."""
+        if self.status not in VALUE_STATUSES:
+            raise ValueError(f"Unsupported status: {self.status}")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON/YAML-safe row dictionary."""
+        payload = asdict(self)
+        if self.value is not None:
+            payload["value"] = float(self.value)
+        return payload
+
+
+def cross_benchmark_metric_mappings() -> tuple[CrossBenchmarkMetricMapping, ...]:
+    """Return the versioned Robot SF cross-benchmark correspondence table."""
+    return (
+        CrossBenchmarkMetricMapping(
+            metric_id="socnavbench.path_length_ratio",
+            benchmark="SocNavBench",
+            external_metric="path_length_ratio",
+            robot_sf_source="socnavbench_path_length_ratio",
+            units="ratio",
+            denominator="straight_line_start_to_goal_distance_m",
+            mapping_class="exact",
+            evidence_tier="trace-derived",
+            semantic_notes=(
+                "Uses the vendored SocNavBench-style path length ratio helper over the Robot SF "
+                "episode trajectory and goal displacement."
+            ),
+        ),
+        CrossBenchmarkMetricMapping(
+            metric_id="common.traversal_time_s",
+            benchmark="Common social-navigation",
+            external_metric="traversal_time",
+            robot_sf_source="time_to_goal",
+            units="seconds",
+            denominator="episode",
+            mapping_class="approximate",
+            evidence_tier="trace-derived",
+            semantic_notes=(
+                "Robot SF reports first goal-reaching time. External benchmark timeouts and "
+                "episode-stop semantics may differ, so this is an approximate correspondence."
+            ),
+        ),
+        CrossBenchmarkMetricMapping(
+            metric_id="common.time_to_collision_min_s",
+            benchmark="Common social-navigation",
+            external_metric="time_to_collision_min",
+            robot_sf_source="time_to_collision_min",
+            units="seconds",
+            denominator="minimum_approaching_robot_pedestrian_pair",
+            mapping_class="approximate",
+            evidence_tier="trace-derived",
+            semantic_notes=(
+                "Computed from Robot SF robot and pedestrian trace velocities with a "
+                "constant-velocity approaching-pair assumption."
+            ),
+        ),
+        CrossBenchmarkMetricMapping(
+            metric_id="common.closest_pedestrian_distance_m",
+            benchmark="Common social-navigation",
+            external_metric="distance_to_closest_pedestrian",
+            robot_sf_source="distance_to_human_min",
+            units="meters",
+            denominator="minimum_over_episode",
+            mapping_class="exact",
+            evidence_tier="trace-derived",
+            semantic_notes=(
+                "Uses Robot SF center-to-center robot-pedestrian distance. Surface clearance "
+                "metrics remain separate because footprint conventions differ across benchmarks."
+            ),
+        ),
+        CrossBenchmarkMetricMapping(
+            metric_id="robot_sf.success_trace_predicate",
+            benchmark="Robot SF",
+            external_metric="success_trace_predicate",
+            robot_sf_source="success",
+            units="binary",
+            denominator="episode",
+            mapping_class="exact",
+            evidence_tier="trace-derived",
+            semantic_notes=(
+                "Robot SF success requires reaching the goal before the horizon and no wall, "
+                "agent, or human collision under Robot SF collision semantics."
+            ),
+        ),
+        CrossBenchmarkMetricMapping(
+            metric_id="socnavbench.personal_space_objective",
+            benchmark="SocNavBench",
+            external_metric="personal_space_objective",
+            robot_sf_source=None,
+            units="external_objective_units",
+            denominator="external_cost_field",
+            mapping_class="unavailable",
+            evidence_tier="not_available",
+            semantic_notes=(
+                "Robot SF traces expose distance and clearance proxies, but not the external "
+                "SocNavBench objective field needed for a faithful scalar wrapper."
+            ),
+        ),
+        CrossBenchmarkMetricMapping(
+            metric_id="hunavsim.human_behavior_cost",
+            benchmark="HuNavSim",
+            external_metric="human_behavior_cost",
+            robot_sf_source=None,
+            units="external_cost_units",
+            denominator="external_behavior_model",
+            mapping_class="unavailable",
+            evidence_tier="not_available",
+            semantic_notes=(
+                "Requires HuNavSim behavior-model state that is not present in Robot SF trace "
+                "exports."
+            ),
+        ),
+    )
+
+
+def mapping_table_as_dicts() -> list[dict[str, Any]]:
+    """Return the mapping table as serializable dictionaries."""
+    return [asdict(row) for row in cross_benchmark_metric_mappings()]
+
+
+def compute_cross_benchmark_metric_rows(
+    data: EpisodeData,
+    *,
+    horizon: int | None = None,
+) -> list[CrossBenchmarkMetricRow]:
+    """Compute external-style metric rows from one Robot SF episode trace.
+
+    Args:
+        data: Episode trace container.
+        horizon: Optional episode horizon. Required for the Robot SF success predicate row.
+
+    Returns:
+        List of metric rows with explicit availability and approximation status.
+    """
+    compute_by_metric_id: dict[str, tuple[Callable[[], float], str]] = {
+        "socnavbench.path_length_ratio": (
+            lambda: socnavbench_path_length_ratio(data),
+            "invalid_or_empty_trajectory",
+        ),
+        "common.traversal_time_s": (lambda: time_to_goal(data), "goal_not_reached"),
+        "common.time_to_collision_min_s": (
+            lambda: time_to_collision_min(data),
+            "no_approaching_pair_or_pedestrians",
+        ),
+        "common.closest_pedestrian_distance_m": (
+            lambda: distance_to_human_min(data),
+            "no_pedestrians",
+        ),
+    }
+    if horizon is not None:
+        compute_by_metric_id["robot_sf.success_trace_predicate"] = (
+            lambda: success(data, horizon=horizon),
+            "invalid_horizon_or_trace",
+        )
+
+    rows: list[CrossBenchmarkMetricRow] = []
+    for mapping in cross_benchmark_metric_mappings():
+        if mapping.mapping_class == "unavailable":
+            rows.append(_unavailable_row(mapping, reason="external_metric_not_trace_derivable"))
+            continue
+        if mapping.metric_id not in compute_by_metric_id:
+            rows.append(_unavailable_row(mapping, reason="required_context_missing"))
+            continue
+        compute, unavailable_reason = compute_by_metric_id[mapping.metric_id]
+        value = compute()
+        rows.append(_row_from_value(mapping, value=value, unavailable_reason=unavailable_reason))
+    return rows
+
+
+def build_cross_benchmark_metric_report(
+    data: EpisodeData,
+    *,
+    horizon: int | None = None,
+) -> dict[str, Any]:
+    """Build a compact report payload for one fixture trace.
+
+    Returns:
+        JSON-safe report with schema, mapping version, claim boundary, and rows.
+    """
+    rows = compute_cross_benchmark_metric_rows(data, horizon=horizon)
+    return {
+        "schema_version": CROSS_BENCHMARK_METRIC_REPORT_SCHEMA_VERSION,
+        "mapping_version": CROSS_BENCHMARK_METRIC_MAPPING_VERSION,
+        "claim_boundary": CROSS_BENCHMARK_CLAIM_BOUNDARY,
+        "rows": [row.to_dict() for row in rows],
+    }
+
+
+def summarize_status_counts(rows: list[CrossBenchmarkMetricRow]) -> dict[str, int]:
+    """Count wrapper row statuses for compact report checks.
+
+    Returns:
+        Mapping from each known row status to its count.
+    """
+    counts = dict.fromkeys(sorted(VALUE_STATUSES), 0)
+    for row in rows:
+        counts[row.status] += 1
+    return counts
+
+
+def _row_from_value(
+    mapping: CrossBenchmarkMetricMapping,
+    *,
+    value: float,
+    unavailable_reason: str,
+) -> CrossBenchmarkMetricRow:
+    """Convert one computed scalar into a status-preserving report row.
+
+    Returns:
+        Available or approximate row when the value is finite, otherwise unavailable.
+    """
+    if not math.isfinite(value):
+        return _unavailable_row(mapping, reason=unavailable_reason)
+    status = "approximate" if mapping.mapping_class == "approximate" else "available"
+    return CrossBenchmarkMetricRow(
+        metric_id=mapping.metric_id,
+        benchmark=mapping.benchmark,
+        external_metric=mapping.external_metric,
+        status=status,
+        mapping_class=mapping.mapping_class,
+        value=float(value),
+        units=mapping.units,
+        denominator=mapping.denominator,
+        robot_sf_source=mapping.robot_sf_source,
+        evidence_tier=mapping.evidence_tier,
+        semantic_notes=mapping.semantic_notes,
+    )
+
+
+def _unavailable_row(
+    mapping: CrossBenchmarkMetricMapping,
+    *,
+    reason: str,
+) -> CrossBenchmarkMetricRow:
+    """Return an unavailable row while preserving the mapping rationale."""
+    return CrossBenchmarkMetricRow(
+        metric_id=mapping.metric_id,
+        benchmark=mapping.benchmark,
+        external_metric=mapping.external_metric,
+        status="unavailable",
+        mapping_class=mapping.mapping_class,
+        value=None,
+        units=mapping.units,
+        denominator=mapping.denominator,
+        robot_sf_source=mapping.robot_sf_source,
+        evidence_tier=mapping.evidence_tier,
+        semantic_notes=mapping.semantic_notes,
+        unavailable_reason=reason,
+    )
+
+
+def mapping_ids(rows: Mapping[str, Any] | list[Mapping[str, Any]]) -> set[str]:
+    """Return metric IDs from serialized mapping rows."""
+    iterable = rows.values() if isinstance(rows, Mapping) else rows
+    return {str(row["metric_id"]) for row in iterable}
+
+
+__all__ = [
+    "CROSS_BENCHMARK_CLAIM_BOUNDARY",
+    "CROSS_BENCHMARK_METRIC_MAPPING_VERSION",
+    "CROSS_BENCHMARK_METRIC_REPORT_SCHEMA_VERSION",
+    "CrossBenchmarkMetricMapping",
+    "CrossBenchmarkMetricRow",
+    "build_cross_benchmark_metric_report",
+    "compute_cross_benchmark_metric_rows",
+    "cross_benchmark_metric_mappings",
+    "mapping_ids",
+    "mapping_table_as_dicts",
+    "summarize_status_counts",
+]

--- a/tests/benchmark/test_cross_benchmark_metrics.py
+++ b/tests/benchmark/test_cross_benchmark_metrics.py
@@ -1,0 +1,179 @@
+"""Tests for trace-derived cross-benchmark metric wrappers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+import pytest
+import yaml
+
+from robot_sf.benchmark.cross_benchmark_metrics import (
+    CROSS_BENCHMARK_CLAIM_BOUNDARY,
+    CROSS_BENCHMARK_METRIC_MAPPING_VERSION,
+    CROSS_BENCHMARK_METRIC_REPORT_SCHEMA_VERSION,
+    CrossBenchmarkMetricRow,
+    build_cross_benchmark_metric_report,
+    compute_cross_benchmark_metric_rows,
+    cross_benchmark_metric_mappings,
+    mapping_ids,
+    mapping_table_as_dicts,
+    summarize_status_counts,
+)
+from robot_sf.benchmark.metrics import EpisodeData
+
+REPO_ROOT = Path(__file__).parents[2]
+MAPPING_PATH = REPO_ROOT / "configs/benchmarks/cross_benchmark_metric_mapping_v1.yaml"
+DOC_PATH = REPO_ROOT / "docs/context/issue_3286_cross_benchmark_metric_wrappers.md"
+
+
+def _fixture_episode() -> EpisodeData:
+    """Return a tiny trace with one approaching robot/pedestrian pair."""
+    robot_pos = np.asarray(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [2.0, 0.0],
+        ],
+        dtype=float,
+    )
+    robot_vel = np.asarray(
+        [
+            [1.0, 0.0],
+            [1.0, 0.0],
+            [1.0, 0.0],
+        ],
+        dtype=float,
+    )
+    peds_pos = np.asarray(
+        [
+            [[4.0, 0.0]],
+            [[4.0, 0.0]],
+            [[4.0, 0.0]],
+        ],
+        dtype=float,
+    )
+    return EpisodeData(
+        robot_pos=robot_pos,
+        robot_vel=robot_vel,
+        robot_acc=np.zeros_like(robot_pos),
+        peds_pos=peds_pos,
+        ped_forces=np.ones_like(peds_pos),
+        goal=np.asarray([2.0, 0.0], dtype=float),
+        dt=1.0,
+        reached_goal_step=2,
+    )
+
+
+def _rows_by_id() -> dict[str, CrossBenchmarkMetricRow]:
+    """Compute fixture rows keyed by metric ID."""
+    rows = compute_cross_benchmark_metric_rows(_fixture_episode(), horizon=5)
+    return {row.metric_id: row for row in rows}
+
+
+def test_mapping_config_matches_runtime_mapping_table() -> None:
+    """The checked-in YAML mapping should stay aligned with the runtime table."""
+    payload = yaml.safe_load(MAPPING_PATH.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == CROSS_BENCHMARK_METRIC_MAPPING_VERSION
+    assert payload["issue"] == 3286
+    assert payload["claim_boundary"] == CROSS_BENCHMARK_CLAIM_BOUNDARY
+
+    config_rows = payload["rows"]
+    runtime_rows = mapping_table_as_dicts()
+    assert mapping_ids(config_rows) == mapping_ids(runtime_rows)
+    assert mapping_ids(config_rows) == {row.metric_id for row in cross_benchmark_metric_mappings()}
+
+    for row in config_rows:
+        assert {
+            "metric_id",
+            "benchmark",
+            "external_metric",
+            "robot_sf_source",
+            "units",
+            "denominator",
+            "mapping_class",
+            "evidence_tier",
+            "semantic_notes",
+        } <= set(row)
+        assert row["mapping_class"] in payload["status_vocabulary"]["mapping_class"]
+
+
+def test_fixture_report_labels_available_approximate_and_unavailable_rows() -> None:
+    """Wrapper reports should preserve status instead of collapsing unavailable rows."""
+    rows = compute_cross_benchmark_metric_rows(_fixture_episode(), horizon=5)
+    counts = summarize_status_counts(rows)
+
+    assert counts["available"] >= 3
+    assert counts["approximate"] >= 2
+    assert counts["unavailable"] >= 2
+
+    report = build_cross_benchmark_metric_report(_fixture_episode(), horizon=5)
+    assert report["schema_version"] == CROSS_BENCHMARK_METRIC_REPORT_SCHEMA_VERSION
+    assert report["mapping_version"] == CROSS_BENCHMARK_METRIC_MAPPING_VERSION
+    assert report["claim_boundary"] == CROSS_BENCHMARK_CLAIM_BOUNDARY
+    assert {row["status"] for row in report["rows"]} == {
+        "available",
+        "approximate",
+        "unavailable",
+    }
+
+
+def test_fixture_computes_trace_derivable_external_style_metrics() -> None:
+    """Deterministic fixture values should match the underlying Robot SF trace helpers."""
+    rows = _rows_by_id()
+
+    path_ratio = rows["socnavbench.path_length_ratio"]
+    assert path_ratio.status == "available"
+    assert path_ratio.value == pytest.approx(1.000005)
+    assert path_ratio.units == "ratio"
+
+    traversal_time = rows["common.traversal_time_s"]
+    assert traversal_time.status == "approximate"
+    assert traversal_time.value == pytest.approx(2.0)
+    assert "timeout" in traversal_time.semantic_notes
+
+    ttc = rows["common.time_to_collision_min_s"]
+    assert ttc.status == "approximate"
+    assert ttc.value == pytest.approx(2.0)
+    assert ttc.denominator == "minimum_approaching_robot_pedestrian_pair"
+
+    closest = rows["common.closest_pedestrian_distance_m"]
+    assert closest.status == "available"
+    assert closest.value == pytest.approx(2.0)
+    assert "center-to-center" in closest.semantic_notes
+
+    success = rows["robot_sf.success_trace_predicate"]
+    assert success.status == "available"
+    assert success.value == pytest.approx(1.0)
+
+
+def test_unavailable_external_only_metrics_keep_reasons() -> None:
+    """External simulator-only rows should be explicit unavailable rows, not zeros."""
+    rows = _rows_by_id()
+
+    for metric_id in (
+        "socnavbench.personal_space_objective",
+        "hunavsim.human_behavior_cost",
+    ):
+        row = rows[metric_id]
+        assert row.status == "unavailable"
+        assert row.value is None
+        assert row.robot_sf_source is None
+        assert row.unavailable_reason == "external_metric_not_trace_derivable"
+
+
+def test_success_predicate_is_unavailable_without_horizon() -> None:
+    """Rows that need extra context should fail closed as unavailable."""
+    rows = {row.metric_id: row for row in compute_cross_benchmark_metric_rows(_fixture_episode())}
+
+    success = rows["robot_sf.success_trace_predicate"]
+    assert success.status == "unavailable"
+    assert success.unavailable_reason == "required_context_missing"
+
+
+def test_context_note_links_mapping_and_wrapper_surfaces() -> None:
+    """The compact context note should make the wrapper discoverable."""
+    note = DOC_PATH.read_text(encoding="utf-8")
+    assert "configs/benchmarks/cross_benchmark_metric_mapping_v1.yaml" in note
+    assert "robot_sf/benchmark/cross_benchmark_metrics.py" in note
+    assert "not simulator parity or paper-grade evidence" in note


### PR DESCRIPTION
## Summary
Adds an additive cross-benchmark metric wrapper layer for Robot SF trace-derived social-navigation metrics, with explicit available/approximate/unavailable row status. This is smoke evidence for wrapper correctness, not simulator parity or paper-grade evidence.

## Linked Issues
- Closes `#3286`
- Relates to `#2928`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `robot_sf/benchmark/cross_benchmark_metrics.py` with versioned mapping rows and report helpers.
- Added `configs/benchmarks/cross_benchmark_metric_mapping_v1.yaml` with units, denominators, mapping class, and semantic notes.
- Added fixture tests for path-length ratio, traversal time, time-to-collision, closest-pedestrian distance, success predicate, and external-only unavailable metrics.
- Added `docs/context/issue_3286_cross_benchmark_metric_wrappers.md` to record the claim boundary and fixture smoke result.

## Why It Matters
- Added value: downstream reports can present external-style metric rows without hiding approximation or unavailable simulator state.
- Expected impact: improves benchmark interoperability hygiene while keeping existing Robot SF metric/report defaults unchanged.
- Why this is worth merging now: it turns the #2928 correspondence analysis into a tested, versioned wrapper surface for local trace-derived metrics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Robot SF can expose a bounded set of cross-benchmark metric correspondences from existing traces while fail-closing unavailable external-only metrics.
- Comparator or baseline, if applicable: existing native `robot_sf.benchmark.metrics` helpers and #2928 correspondence note.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: positive, diagnostic-only.
- Decision or stop rule, if applicable: stop at trace-computable wrappers; do not claim simulator parity or external benchmark equivalence.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3286 and `docs/context/issue_3286_cross_benchmark_metric_wrappers.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use is the committed deterministic fixture test in `tests/benchmark/test_cross_benchmark_metrics.py`; output remains diagnostic-only.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, wrapper rows compute available/approximate metrics and preserve unavailable rows on the fixture.
- Did the intervention change command source, selected command, trajectory, or route progress? no; this is an additive reporting/wrapper layer.
- Did the scenario actually contain the targeted failure mode? yes, tests cover external-only metrics that must remain unavailable rather than zero-valued.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: none for this PR.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none for the fixture smoke contract.
- Stop / revise / continue decision: continue with review/CI; do not promote to benchmark parity evidence.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run ruff check robot_sf/benchmark/cross_benchmark_metrics.py tests/benchmark/test_cross_benchmark_metrics.py`
  - `uv run ruff format --check robot_sf/benchmark/cross_benchmark_metrics.py tests/benchmark/test_cross_benchmark_metrics.py`
  - `uv run python -m pytest tests/benchmark/test_cross_benchmark_metrics.py -q`
  - `uv run python -m pytest tests/benchmark -k "metric or wrapper" -q`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused tests passed (`6 passed`), metric-wrapper selection passed (`124 passed, 1375 deselected`), and full readiness passed (`7536 passed, 12 skipped`).
- Benchmarks or smoke tests, if applicable: deterministic fixture smoke only; no benchmark result claimed.

## Risks / Rollout
- Compatibility risks: low; no existing metric defaults or report outputs are changed.
- Failure modes: downstream consumers could overread approximate rows unless they inspect `status` and `mapping_class`; docs and tests assert those fields stay visible.
- Rollback or fallback plan: remove the additive module/config/doc/test if the wrapper surface is not desired.

## Docs / Provenance
- Updated docs: `docs/context/issue_3286_cross_benchmark_metric_wrappers.md`.
- Relevant design or provenance notes: `docs/context/issue_2928_socnavbench_hunavsim_metric_correspondence.md` remains the input analysis.
- Any assumptions that need to be preserved: wrapper output is trace-derived diagnostic smoke evidence, not simulator parity.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, claim/comment state updated before PR.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark result or release claim changed.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes, versioned config added under `configs/benchmarks/`.
- Context index / memory note updated (yes/no/NA): context note added; index update not required for this narrow issue note.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this PR adds wrapper infrastructure and fixture smoke proof only; it does not promote benchmark evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the claim-boundary language and unavailable/approximate row semantics.
- Any known limitations: HuNavSim and SocNavBench external-only metrics remain unavailable unless a future adapter provides those simulator fields.