### PR TITLE
fix(benchmark): auto-select SocNav structured observation for dict-obs PPO checkpoints

### DIFF
--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -12,6 +12,7 @@ import numpy as np
 from loguru import logger
 
 from robot_sf.benchmark.algorithm_metadata import (
+    canonical_algorithm_name,
     enrich_algorithm_metadata,
     infer_execution_mode_from_counts,
     resolve_observation_mode,
@@ -211,9 +212,23 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         scenario=scenario,
         seed=int(seed),
     )
+    requested_observation_mode = observation_mode
+    if (
+        requested_observation_mode is None
+        and observation_level is None
+        and canonical_algorithm_name(algo) == "ppo"
+        and str(policy_cfg.get("obs_mode", "")).strip().lower()
+        in {"dict", "native_dict", "multi_input"}
+    ):
+        # Grid/dict PPO checkpoints require the SocNav structured
+        # (occupancy-grid) observation they were trained with. The PPO spec
+        # default (sensor_fusion_state) disables the occupancy grid, so a
+        # dict-obs checkpoint would otherwise fail with "Missing required dict
+        # observation keys". Select the structured stack when none was requested.
+        requested_observation_mode = "socnav_state"
     active_observation_mode = resolve_observation_mode(
         algo,
-        observation_mode,
+        requested_observation_mode,
         observation_level=observation_level,
     )
     _apply_active_observation_mode_to_env_config(


### PR DESCRIPTION
## Problem

Benchmark runs of grid-trained PPO checkpoints (e.g. `ppo_15m_grid_socnav`, `obs_mode: dict`) fail at the first PPO inference step:

```
ValueError: Missing required dict observation keys: goal_current, goal_next,
map_size, occupancy_grid, occupancy_grid_meta_center_on_robot,
occupancy_grid_meta_channel_indices
  (robot_sf/baselines/ppo.py:_align_model_obs_dict)
```

## Root cause

The PPO observation spec defaults to `sensor_fusion_state` (lidar-based). When a planner row does not explicitly request an observation mode, `resolve_observation_mode` returns that default, and `apply_active_observation_mode_to_env_config` then **disables the occupancy grid** (`observation_mode=DEFAULT_GYM`, `use_occupancy_grid=False`) for `sensor_fusion_state`. But a dict/grid checkpoint requires the SocNav structured (occupancy-grid) observation it was trained with, so its required keys are absent and inference fails.

This is latent in ~26 benchmark configs that pair `ppo_15m_grid_socnav` with the default mode (the paper matrices, `camera_ready_*`, `issue_*`, etc.) — i.e. any config that does not set `observation_mode: socnav_state` on the PPO row.

## Fix

In `map_runner_episode`, when no observation mode/level is explicitly requested **and** the planner is a PPO checkpoint declaring `obs_mode` in {`dict`, `native_dict`, `multi_input`}, auto-select `socnav_state` (already a supported PPO mode) so the env keeps the occupancy grid the checkpoint needs. Explicit `observation_mode` requests are untouched.

This fixes affected dict/grid PPO configs at the routing layer and prevents recurrence (configs no longer need to remember `observation_mode: socnav_state` for grid checkpoints).

## Verification

Reviewed proof for head `388321f3d5cd4ddcac144d982e3066633e6af475`:

- CI green: `fast-feedback`, `promoted-planner-smoke`, `smoke-artifacts`, `wheel-smoke-install`, `examples-smoke`, aggregate `ci`, and CodeRabbit all succeeded.
- Focused detached-worktree probe ran `run_map_episode` on `configs/scenarios/single/pr_promoted_planner_smoke.yaml` with `algo="ppo"`, `algo_config={"obs_mode": "dict", "fallback_to_goal": False}`, and no explicit `observation_mode`/`observation_level`. It asserted:
  - episode metadata `observation_mode=socnav_state`
  - episode metadata `observation_level=tracked_agents_no_noise`
  - PPO observation spec `active_mode=socnav_state`, `default_mode=sensor_fusion_state`
  - first policy observation includes `occupancy_grid`, `robot_position`, `robot_heading`, and `goal_next`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/map_runner_episode.py` passed.
- `git diff --check origin/main...HEAD` passed.
- CI artifacts inspected:
  - `pr-promoted-planner-smoke` artifact covers `goal`, `social_force`, and `orca`; it is green but does not exercise PPO.
  - `benchmark-artifacts` includes generic `ci_smoke`/`simple_policy` evidence; it is green but does not exercise the dict-PPO regression path.

Author-reported, not independently inspected in this review: PPO-only smoke with `benchmark_success=true`/`fallback_or_degraded_rows=0`, and full 7-planner camera-ready campaign with 1008 episodes. Treat the reviewed proof above as the merge evidence for this narrow routing fix.

## Follow-up (out of scope)

A more thorough design would have the checkpoint metadata declare its required observation contract directly (so the benchmark derives it without an algo-specific branch). Tracked in #3305. This PR is the minimal routing fix.