### PR TITLE
fix(benchmark): let aggregate --snqi-weights recompute stored SNQI via --recompute-snqi

### DIFF
--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -463,11 +463,13 @@ def _ensure_snqi(
     rec: dict[str, Any],
     weights: dict[str, float] | None,
     baseline: dict[str, dict[str, float]] | None,
+    *,
+    recompute: bool = False,
 ) -> None:
-    """Compute and attach SNQI when missing and inputs are provided."""
+    """Compute and attach SNQI when missing, or recompute when ``recompute`` is set."""
     if rec.get("metrics") is None:
         return
-    if "snqi" in rec["metrics"]:
+    if "snqi" in rec["metrics"] and not recompute:
         return
     if weights is None:
         return
@@ -538,6 +540,7 @@ def compute_aggregates(
     fallback_group_by: str = "scenario_id",
     snqi_weights: dict[str, float] | None = None,
     snqi_baseline: dict[str, dict[str, float]] | None = None,
+    recompute_snqi: bool = False,
     expected_algorithms: set[str] | None = None,
     observation_track_mode: str = "strict",
     logger_ctx=None,
@@ -548,7 +551,7 @@ def compute_aggregates(
         Nested dict of group -> metric -> summary statistics.
     """
     for rec in records:
-        _ensure_snqi(rec, snqi_weights, snqi_baseline)
+        _ensure_snqi(rec, snqi_weights, snqi_baseline, recompute=recompute_snqi)
     observation_track_meta = ensure_observation_track_policy(
         records,
         observation_track_mode=observation_track_mode,
@@ -904,6 +907,7 @@ def compute_aggregates_with_ci(  # noqa: PLR0913
     fallback_group_by: str = "scenario_id",
     snqi_weights: dict[str, float] | None = None,
     snqi_baseline: dict[str, dict[str, float]] | None = None,
+    recompute_snqi: bool = False,
     return_ci: bool = True,
     bootstrap_samples: int = 1000,
     bootstrap_confidence: float = 0.95,
@@ -928,6 +932,7 @@ def compute_aggregates_with_ci(  # noqa: PLR0913
         fallback_group_by=fallback_group_by,
         snqi_weights=snqi_weights,
         snqi_baseline=snqi_baseline,
+        recompute_snqi=recompute_snqi,
         expected_algorithms=expected_algorithms,
         observation_track_mode=observation_track_mode,
         logger_ctx=logger_ctx,
@@ -938,7 +943,7 @@ def compute_aggregates_with_ci(  # noqa: PLR0913
 
     # Rebuild groups with flattened numeric values to avoid rework
     for rec in records:
-        _ensure_snqi(rec, snqi_weights, snqi_baseline)
+        _ensure_snqi(rec, snqi_weights, snqi_baseline, recompute=recompute_snqi)
     groups = _group_flattened(
         records,
         group_by=group_by,

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -533,7 +533,7 @@ def _numeric_items(d: dict[str, Any]) -> dict[str, float]:
     return out
 
 
-def compute_aggregates(
+def compute_aggregates(  # noqa: PLR0913
     records: list[dict[str, Any]],
     *,
     group_by: str = "scenario_params.algo",

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -493,6 +493,7 @@ def _handle_aggregate(args) -> int:
                 fallback_group_by=args.fallback_group_by,
                 snqi_weights=snqi_weights,
                 snqi_baseline=snqi_baseline,
+                recompute_snqi=bool(getattr(args, "recompute_snqi", False)),
                 bootstrap_samples=int(args.bootstrap_samples),
                 bootstrap_confidence=float(args.bootstrap_confidence),
                 bootstrap_seed=(
@@ -507,6 +508,7 @@ def _handle_aggregate(args) -> int:
                 fallback_group_by=args.fallback_group_by,
                 snqi_weights=snqi_weights,
                 snqi_baseline=snqi_baseline,
+                recompute_snqi=bool(getattr(args, "recompute_snqi", False)),
                 observation_track_mode=str(args.observation_track_mode),
             )
         out_path = Path(args.out)
@@ -1843,13 +1845,20 @@ def _add_aggregate_subparser(
         "--snqi-weights",
         type=str,
         default=None,
-        help="Optional SNQI weights JSON to compute metrics.snqi during aggregation",
+        help="Optional SNQI weights JSON to compute metrics.snqi during aggregation "
+        "(fills missing SNQI only; pass --recompute-snqi to override stored values)",
     )
     p.add_argument(
         "--snqi-baseline",
         type=str,
         default=None,
         help="Optional baseline stats JSON used for SNQI normalization",
+    )
+    p.add_argument(
+        "--recompute-snqi",
+        action="store_true",
+        help="Recompute metrics.snqi from --snqi-weights even when episodes already "
+        "contain a stored SNQI value (default: only fill missing SNQI).",
     )
     p.set_defaults(cmd="aggregate")
 

--- a/tests/benchmark/test_aggregate_snqi_recompute.py
+++ b/tests/benchmark/test_aggregate_snqi_recompute.py
@@ -1,0 +1,92 @@
+"""Regression tests for aggregate SNQI recomputation controls."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from robot_sf.benchmark import aggregate
+from robot_sf.benchmark.aggregate import compute_aggregates
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_compute_aggregates_recomputes_stored_snqi_when_requested(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """SNQI aggregation should preserve stored scores unless recompute is explicit."""
+
+    def _fake_snqi(
+        metrics: dict[str, float],
+        weights: dict[str, float],
+        *,
+        baseline_stats: dict[str, dict[str, float]] | None = None,
+    ) -> float:
+        return float(metrics["score"] * weights["score"])
+
+    monkeypatch.setattr(aggregate, "snqi_fn", _fake_snqi)
+    records = [
+        {
+            "episode_id": "ep-1",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "planner-a",
+            "metrics": {"score": 2.0, "snqi": 0.25},
+        }
+    ]
+
+    summary = compute_aggregates(
+        records,
+        group_by="algo",
+        snqi_weights={"score": 3.0},
+    )
+    assert summary["planner-a"]["snqi"]["mean"] == 0.25
+
+    recomputed = compute_aggregates(
+        records,
+        group_by="algo",
+        snqi_weights={"score": 3.0},
+        recompute_snqi=True,
+    )
+    assert recomputed["planner-a"]["snqi"]["mean"] == 6.0
+
+
+def test_aggregate_cli_passes_recompute_snqi_flag(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The aggregate CLI should wire --recompute-snqi into aggregation."""
+    pytest.importorskip("torch")
+
+    from robot_sf.benchmark import cli
+
+    src = tmp_path / "episodes.jsonl"
+    src.write_text('{"episode_id":"ep-1","metrics":{}}\n', encoding="utf-8")
+    weights_path = tmp_path / "weights.json"
+    weights_path.write_text('{"score": 1.0}\n', encoding="utf-8")
+    captured: dict[str, Any] = {}
+
+    def _fake_compute(records: list[dict[str, Any]], **kwargs: Any) -> dict[str, Any]:
+        captured.update(kwargs)
+        return {"_meta": {"records": len(records)}}
+
+    monkeypatch.setattr(cli, "_agg_compute", _fake_compute)
+
+    exit_code = cli.cli_main(
+        [
+            "aggregate",
+            "--in",
+            str(src),
+            "--out",
+            str(tmp_path / "summary.json"),
+            "--snqi-weights",
+            str(weights_path),
+            "--recompute-snqi",
+        ]
+    )
+
+    assert exit_code == 0
+    assert captured["snqi_weights"] == {"score": 1.0}
+    assert captured["recompute_snqi"] is True


### PR DESCRIPTION
## Problem

`robot_sf_bench aggregate --in episodes.jsonl --snqi-weights W --snqi-baseline B` **silently ignores `W`** when the episodes already contain a stored `metrics.snqi`. Re-scoring an existing campaign with different SNQI weights is therefore a no-op — the summary reports the originally-stored SNQI regardless of the weights passed.

## Root cause

`_ensure_snqi` (`aggregate.py`) returns early when `snqi` is already present:

```python
if "snqi" in rec["metrics"]:
    return
```

Its "compute if missing" contract is correct for the campaign path, but it means an explicit `--snqi-weights` on the `aggregate` CLI cannot override stored values.

## Fix (opt-in, backward compatible)

- `_ensure_snqi(..., recompute=False)` recomputes even if present when `recompute=True`.
- `compute_aggregates` / `compute_aggregates_with_ci` gain `recompute_snqi: bool = False` (default preserves existing behavior; the campaign path is unchanged).
- The `aggregate` CLI gains `--recompute-snqi`; `_handle_aggregate` threads it through; the `--snqi-weights` help text is updated.

## Verification

Re-scoring a frozen 1008-episode campaign whose stored SNQI was computed with v3 weights:

| weights | `--recompute-snqi` | orca SNQI |
|---|---|---|
| v4 | no | `-0.2439` (stored v3, unchanged) |
| v4 | yes | `-3.5104` (recomputed with v4) |
| v3 | yes | `-0.2439` (recompute w/ v3 ≈ stored) |

`A == C` confirms backward compatibility; `B` differing confirms the flag applies the passed weights.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--recompute-snqi` option to benchmark aggregation command to optionally refresh SNQI metric calculations.

* **Tests**
  * Added regression tests for SNQI recomputation behavior and CLI integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->