### PR TITLE
feat: proxy-vs-ADE checkpoint-selection analyzer (#3204)

### DIFF
--- a/scripts/research/analyze_predictive_checkpoint_proxy.py
+++ b/scripts/research/analyze_predictive_checkpoint_proxy.py
@@ -1,0 +1,159 @@
+"""Proxy-vs-ADE checkpoint-selection analysis for the predictive planner (#3204).
+
+`train_predictive_planner.py` can evaluate a hard-seed proxy every N epochs and records, per
+proxy epoch, the trajectory-error metric (`val_ade`) and the proxy benchmark success
+(`success_rate`). This tool consumes that training summary and answers the #3204 question:
+
+    Does selecting a checkpoint by a rollout-derived proxy pick a higher hard-case benchmark
+    success than selecting by trajectory error (val_ade)?
+
+It reports, across the proxy-evaluated epochs:
+- the val_ade-selected epoch (min val_ade) and its proxy hard-success;
+- the proxy-selected epoch (max proxy success) and its proxy hard-success;
+- the Spearman rank correlation between val_ade and proxy success (no scipy dependency);
+- a verdict: whether proxy selection beats ADE selection on hard-case success.
+
+It is honest about insufficient evidence: if there are too few proxy epochs or no spread in
+proxy success, it returns an `inconclusive` verdict rather than a misleading correlation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+_MIN_EPOCHS_FOR_CORRELATION = 4
+
+
+def _rank(values: list[float]) -> list[float]:
+    """Return average ranks (1-based) of ``values``, ties share the mean rank."""
+    order = sorted(range(len(values)), key=lambda i: values[i])
+    ranks = [0.0] * len(values)
+    i = 0
+    while i < len(order):
+        j = i
+        while j + 1 < len(order) and values[order[j + 1]] == values[order[i]]:
+            j += 1
+        avg = (i + j) / 2.0 + 1.0
+        for k in range(i, j + 1):
+            ranks[order[k]] = avg
+        i = j + 1
+    return ranks
+
+
+def _pearson(xs: list[float], ys: list[float]) -> float | None:
+    """Return the Pearson correlation of two equal-length sequences, or None if undefined."""
+    n = len(xs)
+    if n < 2:
+        return None
+    mx = sum(xs) / n
+    my = sum(ys) / n
+    cov = sum((x - mx) * (y - my) for x, y in zip(xs, ys, strict=True))
+    vx = sum((x - mx) ** 2 for x in xs)
+    vy = sum((y - my) ** 2 for y in ys)
+    if vx == 0 or vy == 0:
+        return None
+    return cov / (vx**0.5 * vy**0.5)
+
+
+def spearman(xs: list[float], ys: list[float]) -> float | None:
+    """Return the Spearman rank correlation (Pearson on ranks), or None if undefined."""
+    if len(xs) != len(ys) or len(xs) < 2:
+        return None
+    return _pearson(_rank(xs), _rank(ys))
+
+
+def analyze_proxy_history(
+    history: list[dict[str, Any]], *, success_margin: float = 1e-9
+) -> dict[str, Any]:
+    """Analyze proxy-vs-ADE selection from a list of per-epoch proxy records."""
+    usable = [
+        h for h in history if h.get("val_ade") is not None and h.get("success_rate") is not None
+    ]
+    if len(usable) < 2:
+        return {
+            "verdict": "inconclusive",
+            "reason": "fewer than 2 usable proxy epochs",
+            "n": len(usable),
+        }
+
+    ades = [float(h["val_ade"]) for h in usable]
+    succ = [float(h["success_rate"]) for h in usable]
+
+    ade_sel = min(usable, key=lambda h: float(h["val_ade"]))
+    proxy_sel = max(usable, key=lambda h: float(h["success_rate"]))
+
+    rho = spearman(ades, succ)
+    success_spread = max(succ) - min(succ)
+    beats = float(proxy_sel["success_rate"]) > float(ade_sel["success_rate"]) + success_margin
+
+    if success_spread <= success_margin:
+        verdict = "inconclusive"
+        reason = "no spread in proxy hard-success across epochs; cannot distinguish selectors"
+    elif len(usable) < _MIN_EPOCHS_FOR_CORRELATION:
+        verdict = "proxy_better_low_confidence" if beats else "ade_adequate_low_confidence"
+        reason = f"only {len(usable)} proxy epochs; correlation not robust"
+    elif beats:
+        verdict = "proxy_better"
+        reason = "proxy-selected epoch has higher hard-success than the val_ade-selected epoch"
+    else:
+        verdict = "ade_adequate"
+        reason = "val_ade-selected epoch already matches or beats proxy selection on hard-success"
+
+    return {
+        "verdict": verdict,
+        "reason": reason,
+        "n_proxy_epochs": len(usable),
+        "spearman_val_ade_vs_success": rho,
+        "success_spread": success_spread,
+        "ade_selected": {
+            "epoch": ade_sel.get("epoch"),
+            "val_ade": ade_sel.get("val_ade"),
+            "success_rate": ade_sel.get("success_rate"),
+        },
+        "proxy_selected": {
+            "epoch": proxy_sel.get("epoch"),
+            "val_ade": proxy_sel.get("val_ade"),
+            "success_rate": proxy_sel.get("success_rate"),
+        },
+        "proxy_minus_ade_success": float(proxy_sel["success_rate"])
+        - float(ade_sel["success_rate"]),
+    }
+
+
+def analyze_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    """Analyze a training summary's proxy history and return the #3204 report."""
+    proxy = summary.get("proxy", {})
+    history = proxy.get("history", []) if isinstance(proxy, dict) else []
+    report = analyze_proxy_history(history)
+    report["model_id"] = summary.get("model_id")
+    report["proxy_enabled"] = bool(proxy.get("enabled")) if isinstance(proxy, dict) else False
+    report["schema_version"] = "predictive-checkpoint-proxy-report.v1"
+    report["claim_boundary"] = (
+        "Compares proxy-based vs val_ade-based checkpoint selection on the recorded hard-seed proxy. "
+        "Not a paper-grade benchmark claim; the proxy is a hard-seed subset, not the full matrix."
+    )
+    return report
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the #3204 analysis CLI over a training summary JSON and return a POSIX exit code."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--training-summary", type=Path, required=True)
+    parser.add_argument("--out", type=Path, default=None)
+    args = parser.parse_args(argv)
+
+    summary = json.loads(args.training_summary.read_text())
+    report = analyze_summary(summary)
+    rendered = json.dumps(report, indent=2)
+    if args.out is not None:
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(rendered + "\n")
+    print(rendered)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/test_analyze_predictive_checkpoint_proxy.py
+++ b/tests/research/test_analyze_predictive_checkpoint_proxy.py
@@ -1,0 +1,71 @@
+"""Tests for the #3204 proxy-vs-ADE checkpoint-selection analyzer."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_TOOL = _REPO_ROOT / "scripts" / "research" / "analyze_predictive_checkpoint_proxy.py"
+_spec = importlib.util.spec_from_file_location("analyze_predictive_checkpoint_proxy", _TOOL)
+assert _spec and _spec.loader
+mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(mod)
+
+
+def _hist(pairs):
+    return [
+        {"epoch": float(i + 1), "val_ade": a, "success_rate": s} for i, (a, s) in enumerate(pairs)
+    ]
+
+
+def test_spearman_monotonic():
+    """Spearman is 1.0 for a strictly increasing relation."""
+    assert abs(mod.spearman([1, 2, 3, 4], [10, 20, 30, 40]) - 1.0) < 1e-9
+
+
+def test_proxy_better_when_ade_min_has_low_success():
+    """If the lowest-val_ade epoch has poor hard-success but another epoch is better, proxy wins."""
+    # epoch 4 has the best (lowest) val_ade but low success; epoch 2 has higher success.
+    hist = _hist([(1.0, 0.10), (0.9, 0.30), (0.8, 0.10), (0.7, 0.10)])
+    rep = mod.analyze_proxy_history(hist)
+    assert rep["verdict"] == "proxy_better"
+    assert rep["proxy_selected"]["epoch"] == 2.0
+    assert rep["ade_selected"]["epoch"] == 4.0
+    assert rep["proxy_minus_ade_success"] > 0
+
+
+def test_ade_adequate_when_it_picks_best_success():
+    """If the lowest-val_ade epoch also has the highest success, ADE selection is adequate."""
+    hist = _hist([(1.0, 0.10), (0.9, 0.20), (0.7, 0.40), (0.8, 0.30)])
+    rep = mod.analyze_proxy_history(hist)
+    assert rep["verdict"] == "ade_adequate"
+
+
+def test_inconclusive_without_success_spread():
+    """No spread in proxy success -> inconclusive (cannot distinguish selectors), fail-closed honesty."""
+    hist = _hist([(1.0, 0.1), (0.9, 0.1), (0.8, 0.1), (0.7, 0.1)])
+    rep = mod.analyze_proxy_history(hist)
+    assert rep["verdict"] == "inconclusive"
+
+
+def test_low_confidence_with_few_epochs():
+    """Fewer than the correlation threshold of usable epochs is flagged low-confidence."""
+    hist = _hist([(0.9, 0.30), (0.7, 0.10)])
+    rep = mod.analyze_proxy_history(hist)
+    assert rep["verdict"].endswith("low_confidence")
+
+
+def test_analyze_summary_wraps_history():
+    """analyze_summary reads proxy.history and adds report metadata."""
+    summary = {
+        "model_id": "m",
+        "proxy": {
+            "enabled": True,
+            "history": _hist([(1.0, 0.1), (0.8, 0.3), (0.7, 0.1), (0.6, 0.1)]),
+        },
+    }
+    rep = mod.analyze_summary(summary)
+    assert rep["model_id"] == "m"
+    assert rep["proxy_enabled"] is True
+    assert rep["verdict"] == "proxy_better"


### PR DESCRIPTION
## Summary

Implements the **selection bet** of the hard-case portfolio (#3215, child #3204): a tool that answers
whether **proxy-based checkpoint selection beats val_ade-based selection** on hard-case benchmark
success.

`train_predictive_planner.py` already evaluates a hard-seed proxy every N epochs and records, per
epoch, `val_ade` + proxy `success_rate`. This analyzer
(`scripts/research/analyze_predictive_checkpoint_proxy.py`) consumes that training summary and reports:
- the val_ade-selected epoch (min val_ade) and its proxy hard-success;
- the proxy-selected epoch (max proxy success) and its proxy hard-success;
- Spearman rank correlation between val_ade and proxy success (stdlib, no scipy);
- a verdict: `proxy_better` / `ade_adequate` / `inconclusive` (fail-closed when there is no
  hard-success spread or too few proxy epochs).

## Validation

- `uv run pytest tests/research/test_analyze_predictive_checkpoint_proxy.py` → **6 passed**.
- `ruff check` / `ruff format` → clean. Stdlib-only.

## How it gets applied (data in flight)

A unified training run is in progress on LiCCA (`9832497`, CPU) with
`--proxy-scenario-matrix predictive_hardcase_portfolio_v1 --proxy-seed-manifest predictive_hard_seeds_v1
--proxy-every-epochs 5`, which produces the per-epoch proxy history this tool needs. When it
completes I will run the analyzer on its `training_summary.json` and post the real verdict to #3215.

## Research Result Guidance

- **Target hypothesis:** a rollout proxy on hard seeds selects a higher-hard-success checkpoint than
  trajectory error (val_ade) — i.e. val_ade is the wrong selection criterion for hard cases.
- **Comparator:** val_ade-based selection (the current default).
- **Result classification:** tool only in this PR (`smoke`); real verdict follows from run `9832497`.
- **Decision/stop rule:** adopt proxy selection only if `proxy_better` with real success spread;
  otherwise record `ade_adequate`/`inconclusive`.
- **Synthesis surface:** #3215 (portfolio epic).

## Downstream Propagation

- Parent: #3215; sibling bets #3213 (authority, PR #3306), #3214 (model retraining — same training run).
- Follow-up: apply to `9832497` summary; if proxy spread is insufficient, that itself corroborates the
  authority-bet finding that current hard-seed signal is too sparse and motivates richer hard-case data.
