### PR TITLE
fix: classify tied fidelity ranks as non-identifiable (#3299)

### DIFF
--- a/docs/context/evidence/issue_3207_fidelity_sensitivity_actual_slice_2026-06-20/README.md
+++ b/docs/context/evidence/issue_3207_fidelity_sensitivity_actual_slice_2026-06-20/README.md
@@ -15,24 +15,27 @@
 - Seeds: `111, 112, 113`
 - Planners: `baseline_social_force, goal_seek`
 - Limitation: local torch/rvo2-independent slice uses two non-learned planners; full config fixed_scope planners remain future work.
-- Result caveats: `ranking_stability_is_on_bounded_two_planner_slice_only, full_fixed_scope_planners_not_run, all_observed_success_rates_zero, all_observed_collision_rates_one`
+- Result caveats: `ranking_stability_is_on_bounded_two_planner_slice_only, full_fixed_scope_planners_not_run, rank_non_identifiable_primary_metric_zero_variance, all_observed_success_rates_zero, all_observed_collision_rates_one`
 
 ## Rank Stability
 
-- Nominal ranking: `baseline_social_force, goal_seek`
-- Rank stable on this slice: `True`
+- Nominal deterministic order: `baseline_social_force, goal_seek`
+- Rank evidence status: `non-identifiable`
+- Rank identifiability reason: `primary_metric_zero_variance`
+- Rank stable on this slice: `not_applicable`
 - Flipping variants: `none`
+- Non-identifiable variants: `integration_timestep__dt_0_05, integration_timestep__dt_0_20, social_force_speed_archetypes__mixed_balanced, social_force_speed_archetypes__rush_hour, observation_noise__pose_heading_low, observation_noise__pedestrian_dropout_low, clearance_radius__radius_0_30, clearance_radius__radius_0_50`
 
-| Variant | Kendall tau | Rank flips | Top-1 changed |
-|---|---:|---:|---|
-| `integration_timestep__dt_0_05` | 1 | 0 | `False` |
-| `integration_timestep__dt_0_20` | 1 | 0 | `False` |
-| `social_force_speed_archetypes__mixed_balanced` | 1 | 0 | `False` |
-| `social_force_speed_archetypes__rush_hour` | 1 | 0 | `False` |
-| `observation_noise__pose_heading_low` | 1 | 0 | `False` |
-| `observation_noise__pedestrian_dropout_low` | 1 | 0 | `False` |
-| `clearance_radius__radius_0_30` | 1 | 0 | `False` |
-| `clearance_radius__radius_0_50` | 1 | 0 | `False` |
+| Variant | Rank evidence | Kendall tau | Rank flips | Top-1 changed |
+|---|---|---:|---:|---|
+| `integration_timestep__dt_0_05` | `non-identifiable: primary_metric_zero_variance` | NA | NA | NA |
+| `integration_timestep__dt_0_20` | `non-identifiable: primary_metric_zero_variance` | NA | NA | NA |
+| `social_force_speed_archetypes__mixed_balanced` | `non-identifiable: primary_metric_zero_variance` | NA | NA | NA |
+| `social_force_speed_archetypes__rush_hour` | `non-identifiable: primary_metric_zero_variance` | NA | NA | NA |
+| `observation_noise__pose_heading_low` | `non-identifiable: primary_metric_zero_variance` | NA | NA | NA |
+| `observation_noise__pedestrian_dropout_low` | `non-identifiable: primary_metric_zero_variance` | NA | NA | NA |
+| `clearance_radius__radius_0_30` | `non-identifiable: primary_metric_zero_variance` | NA | NA | NA |
+| `clearance_radius__radius_0_50` | `non-identifiable: primary_metric_zero_variance` | NA | NA | NA |
 
 This evidence measures internal simulator-fidelity sensitivity for the bounded local slice only.
 It must not be cited as simulator-realism, sim-to-real, full benchmark, or paper-facing ranking evidence.

--- a/docs/context/evidence/issue_3207_fidelity_sensitivity_actual_slice_2026-06-20/summary.json
+++ b/docs/context/evidence/issue_3207_fidelity_sensitivity_actual_slice_2026-06-20/summary.json
@@ -193,7 +193,7 @@
     "axes": [
       {
         "axis": "integration_timestep__dt_0_05",
-        "kendall_tau": 1.0,
+        "kendall_tau": null,
         "metric_drift": {
           "collision_rate": 0.0,
           "comfort_exposure_mean": 0.03812597358533808,
@@ -203,16 +203,18 @@
           "success_rate": 0.0,
           "time_to_goal_norm": 0.06712962962962965
         },
-        "rank_flips": 0,
+        "rank_flips": null,
+        "rank_identifiability_reason": "primary_metric_zero_variance",
+        "rank_identifiable": false,
         "ranking": [
           "baseline_social_force",
           "goal_seek"
         ],
-        "top1_changed": false
+        "top1_changed": null
       },
       {
         "axis": "integration_timestep__dt_0_20",
-        "kendall_tau": 1.0,
+        "kendall_tau": null,
         "metric_drift": {
           "collision_rate": 0.0,
           "comfort_exposure_mean": 0.024598038364609335,
@@ -222,16 +224,18 @@
           "success_rate": 0.0,
           "time_to_goal_norm": 0.0046296296296296224
         },
-        "rank_flips": 0,
+        "rank_flips": null,
+        "rank_identifiability_reason": "primary_metric_zero_variance",
+        "rank_identifiable": false,
         "ranking": [
           "baseline_social_force",
           "goal_seek"
         ],
-        "top1_changed": false
+        "top1_changed": null
       },
       {
         "axis": "social_force_speed_archetypes__mixed_balanced",
-        "kendall_tau": 1.0,
+        "kendall_tau": null,
         "metric_drift": {
           "collision_rate": 0.0,
           "comfort_exposure_mean": 0.00077663624205347,
@@ -241,16 +245,18 @@
           "success_rate": 0.0,
           "time_to_goal_norm": 0.0018518518518518823
         },
-        "rank_flips": 0,
+        "rank_flips": null,
+        "rank_identifiability_reason": "primary_metric_zero_variance",
+        "rank_identifiable": false,
         "ranking": [
           "baseline_social_force",
           "goal_seek"
         ],
-        "top1_changed": false
+        "top1_changed": null
       },
       {
         "axis": "social_force_speed_archetypes__rush_hour",
-        "kendall_tau": 1.0,
+        "kendall_tau": null,
         "metric_drift": {
           "collision_rate": 0.0,
           "comfort_exposure_mean": 0.00077663624205347,
@@ -260,16 +266,18 @@
           "success_rate": 0.0,
           "time_to_goal_norm": 0.0018518518518518823
         },
-        "rank_flips": 0,
+        "rank_flips": null,
+        "rank_identifiability_reason": "primary_metric_zero_variance",
+        "rank_identifiable": false,
         "ranking": [
           "baseline_social_force",
           "goal_seek"
         ],
-        "top1_changed": false
+        "top1_changed": null
       },
       {
         "axis": "observation_noise__pose_heading_low",
-        "kendall_tau": 1.0,
+        "kendall_tau": null,
         "metric_drift": {
           "collision_rate": 0.0,
           "comfort_exposure_mean": 0.004734397428990549,
@@ -279,16 +287,18 @@
           "success_rate": 0.0,
           "time_to_goal_norm": 0.002777777777777851
         },
-        "rank_flips": 0,
+        "rank_flips": null,
+        "rank_identifiability_reason": "primary_metric_zero_variance",
+        "rank_identifiable": false,
         "ranking": [
           "baseline_social_force",
           "goal_seek"
         ],
-        "top1_changed": false
+        "top1_changed": null
       },
       {
         "axis": "observation_noise__pedestrian_dropout_low",
-        "kendall_tau": 1.0,
+        "kendall_tau": null,
         "metric_drift": {
           "collision_rate": 0.0,
           "comfort_exposure_mean": 0.0,
@@ -298,16 +308,18 @@
           "success_rate": 0.0,
           "time_to_goal_norm": 0.0
         },
-        "rank_flips": 0,
+        "rank_flips": null,
+        "rank_identifiability_reason": "primary_metric_zero_variance",
+        "rank_identifiable": false,
         "ranking": [
           "baseline_social_force",
           "goal_seek"
         ],
-        "top1_changed": false
+        "top1_changed": null
       },
       {
         "axis": "clearance_radius__radius_0_30",
-        "kendall_tau": 1.0,
+        "kendall_tau": null,
         "metric_drift": {
           "collision_rate": 0.0,
           "comfort_exposure_mean": 0.023809523809523805,
@@ -317,16 +329,18 @@
           "success_rate": 0.0,
           "time_to_goal_norm": 0.06666666666666671
         },
-        "rank_flips": 0,
+        "rank_flips": null,
+        "rank_identifiability_reason": "primary_metric_zero_variance",
+        "rank_identifiable": false,
         "ranking": [
           "baseline_social_force",
           "goal_seek"
         ],
-        "top1_changed": false
+        "top1_changed": null
       },
       {
         "axis": "clearance_radius__radius_0_50",
-        "kendall_tau": 1.0,
+        "kendall_tau": null,
         "metric_drift": {
           "collision_rate": 0.0,
           "comfort_exposure_mean": 0.0021043771043771017,
@@ -336,12 +350,14 @@
           "success_rate": 0.0,
           "time_to_goal_norm": 0.0009259259259259134
         },
-        "rank_flips": 0,
+        "rank_flips": null,
+        "rank_identifiability_reason": "primary_metric_zero_variance",
+        "rank_identifiable": false,
         "ranking": [
           "baseline_social_force",
           "goal_seek"
         ],
-        "top1_changed": false
+        "top1_changed": null
       }
     ],
     "flipping_axes": [],
@@ -350,15 +366,28 @@
       "baseline_social_force",
       "goal_seek"
     ],
+    "non_identifiable_axes": [
+      "integration_timestep__dt_0_05",
+      "integration_timestep__dt_0_20",
+      "social_force_speed_archetypes__mixed_balanced",
+      "social_force_speed_archetypes__rush_hour",
+      "observation_noise__pose_heading_low",
+      "observation_noise__pedestrian_dropout_low",
+      "clearance_radius__radius_0_30",
+      "clearance_radius__radius_0_50"
+    ],
     "primary_metric": "success_rate",
-    "rank_stable": true,
-    "schema_version": "fidelity_rank_stability.v1"
+    "rank_identifiability_reason": "primary_metric_zero_variance",
+    "rank_identifiable": false,
+    "rank_stable": null,
+    "schema_version": "fidelity_rank_stability.v2"
   },
   "raw_output_policy": "raw JSONL remains ignored under output/",
   "raw_rows_path": "output/fidelity_sensitivity/issue_3207_actual_slice_2026-06-20/episode_rows.jsonl",
   "result_caveats": [
     "ranking_stability_is_on_bounded_two_planner_slice_only",
     "full_fixed_scope_planners_not_run",
+    "rank_non_identifiable_primary_metric_zero_variance",
     "all_observed_success_rates_zero",
     "all_observed_collision_rates_one"
   ],

--- a/robot_sf/benchmark/fidelity_rank_stability.py
+++ b/robot_sf/benchmark/fidelity_rank_stability.py
@@ -2,11 +2,11 @@
 
 Given planner metric tables measured under a *nominal* simulation fidelity plus
 one table per *fidelity-perturbation axis* (the sweep output), this module reports
-whether the planner **ranking** is stable across fidelity assumptions and which
-axes flip it. That is the evidence behind a defensible benchmark validity
-boundary: a ranking that survives a bounded fidelity sweep is benchmark-
-strengthening; an axis that flips the ranking is a required reporting caveat and a
-calibration candidate.
+whether the planner **ranking** is identifiable and, when it is, stable across
+fidelity assumptions. That is the evidence behind a defensible benchmark validity
+boundary: an identifiable ranking that survives a bounded fidelity sweep is
+benchmark-strengthening; a non-identifiable ranking or an axis that flips the
+ranking is a required reporting caveat and a calibration candidate.
 
 Pure and deterministic: it operates on already-measured metric tables and runs no
 simulation. It is analysis tooling and makes no benchmark or sim-to-real claim;
@@ -25,7 +25,10 @@ from robot_sf.benchmark.rank_metrics import kendall_tau as _shared_kendall_tau
 if TYPE_CHECKING:
     from collections.abc import Iterable, Mapping
 
-FIDELITY_RANK_STABILITY_SCHEMA = "fidelity_rank_stability.v1"
+FIDELITY_RANK_STABILITY_SCHEMA = "fidelity_rank_stability.v2"
+PRIMARY_METRIC_ZERO_VARIANCE_REASON = "primary_metric_zero_variance"
+PRIMARY_METRIC_INSUFFICIENT_REASON = "primary_metric_insufficient_finite_values"
+AXIS_PRIMARY_METRIC_NON_IDENTIFIABLE_REASON = "axis_primary_metric_non_identifiable"
 
 
 def rank_planners(
@@ -64,6 +67,24 @@ def _finite_metric_value(metrics: Mapping[str, object], metric: str) -> float | 
     if not math.isfinite(value):
         return None
     return value
+
+
+def _primary_metric_identifiability(
+    table: Mapping[str, Mapping[str, object]],
+    metric: str,
+) -> tuple[bool, str | None]:
+    """Return whether planner ranks are identifiable from ``metric`` values."""
+    values = [
+        value
+        for planner in sorted(table)
+        if (value := _finite_metric_value(table[planner], metric)) is not None
+    ]
+    if len(values) < 2:
+        return False, PRIMARY_METRIC_INSUFFICIENT_REASON
+    first = values[0]
+    if all(value == first for value in values[1:]):
+        return False, PRIMARY_METRIC_ZERO_VARIANCE_REASON
+    return True, None
 
 
 def kendall_tau(order_a: list[str], order_b: list[str]) -> float:
@@ -133,20 +154,25 @@ class AxisRankStability:
 
     axis: str
     ranking: list[str]
-    kendall_tau: float
-    rank_flips: int
-    top1_changed: bool
+    rank_identifiable: bool
+    rank_identifiability_reason: str | None
+    kendall_tau: float | None
+    rank_flips: int | None
+    top1_changed: bool | None
     metric_drift: dict[str, float]
 
     def to_dict(self) -> dict[str, object]:
         """Return JSON-safe representation.
 
         Returns:
-            Mapping with the axis ranking, tau, rank flips, top-1 change, and drift.
+            Mapping with the axis order, identifiability, tau, rank flips, top-1
+            change, and drift.
         """
         return {
             "axis": self.axis,
             "ranking": list(self.ranking),
+            "rank_identifiable": self.rank_identifiable,
+            "rank_identifiability_reason": self.rank_identifiability_reason,
             "kendall_tau": self.kendall_tau,
             "rank_flips": self.rank_flips,
             "top1_changed": self.top1_changed,
@@ -163,22 +189,28 @@ class FidelitySensitivityReport:
     nominal_ranking: list[str]
     axes: list[AxisRankStability]
     flipping_axes: list[str]
-    rank_stable: bool
+    non_identifiable_axes: list[str]
+    rank_identifiable: bool
+    rank_identifiability_reason: str | None
+    rank_stable: bool | None
 
     def to_dict(self) -> dict[str, object]:
-        """Return the ``fidelity_rank_stability.v1`` JSON-safe payload.
+        """Return the ``fidelity_rank_stability.v2`` JSON-safe payload.
 
         Returns:
-            Mapping with the schema version, nominal ranking, per-axis results,
-            flipping axes, and the validity-boundary verdict.
+            Mapping with the schema version, nominal order, per-axis results,
+            identifiable/non-identifiable axes, and the validity-boundary verdict.
         """
         return {
             "schema_version": FIDELITY_RANK_STABILITY_SCHEMA,
             "primary_metric": self.primary_metric,
             "higher_is_better": self.higher_is_better,
             "nominal_ranking": list(self.nominal_ranking),
+            "rank_identifiable": self.rank_identifiable,
+            "rank_identifiability_reason": self.rank_identifiability_reason,
             "rank_stable": self.rank_stable,
             "flipping_axes": list(self.flipping_axes),
+            "non_identifiable_axes": list(self.non_identifiable_axes),
             "axes": [axis.to_dict() for axis in self.axes],
         }
 
@@ -194,9 +226,12 @@ def analyze_fidelity_sensitivity(
     """Analyze planner-ranking stability across fidelity-perturbation axes.
 
     Each axis table must contain the same planner set as ``nominal_table``. The
-    nominal ranking (by ``primary_metric``) is the reference; each axis reports
+    nominal order (by ``primary_metric``) is the reference. When the nominal and
+    axis primary metrics contain an identifiable ordering, each axis reports
     Kendall tau, rank-flip count, top-1 change, and per-metric drift relative to
-    nominal. An axis with any rank flip is flagged as ranking-sensitive.
+    nominal. All-tied or otherwise insufficient primary metrics preserve
+    deterministic order only for serialization and return null rank-evidence
+    fields with a non-identifiable reason.
 
     Returns:
         A :class:`FidelitySensitivityReport` with per-axis results and the
@@ -212,9 +247,13 @@ def analyze_fidelity_sensitivity(
     nominal_ranking = rank_planners(
         nominal_table, primary_metric, higher_is_better=higher_is_better
     )
+    nominal_identifiable, nominal_non_identifiable_reason = _primary_metric_identifiability(
+        nominal_table, primary_metric
+    )
 
     axes: list[AxisRankStability] = []
     flipping_axes: list[str] = []
+    non_identifiable_axes: list[str] = []
     for axis_name, table in axis_tables.items():
         if set(table) != nominal_planners:
             raise ValueError(
@@ -222,19 +261,49 @@ def analyze_fidelity_sensitivity(
                 f"({sorted(table)} vs {sorted(nominal_planners)})"
             )
         ranking = rank_planners(table, primary_metric, higher_is_better=higher_is_better)
-        flips = count_rank_flips(nominal_ranking, ranking)
+        axis_identifiable, axis_non_identifiable_reason = _primary_metric_identifiability(
+            table, primary_metric
+        )
+        rank_identifiable = nominal_identifiable and axis_identifiable
+        rank_identifiability_reason = (
+            nominal_non_identifiable_reason
+            if not nominal_identifiable
+            else axis_non_identifiable_reason
+        )
+        flips: int | None = None
+        tau: float | None = None
+        top1_changed: bool | None = None
+        if rank_identifiable:
+            flips = count_rank_flips(nominal_ranking, ranking)
+            tau = kendall_tau(nominal_ranking, ranking)
+            top1_changed = bool(nominal_ranking and ranking and nominal_ranking[0] != ranking[0])
+        else:
+            non_identifiable_axes.append(axis_name)
         axes.append(
             AxisRankStability(
                 axis=axis_name,
                 ranking=ranking,
-                kendall_tau=kendall_tau(nominal_ranking, ranking),
+                rank_identifiable=rank_identifiable,
+                rank_identifiability_reason=rank_identifiability_reason,
+                kendall_tau=tau,
                 rank_flips=flips,
-                top1_changed=bool(nominal_ranking and ranking and nominal_ranking[0] != ranking[0]),
+                top1_changed=top1_changed,
                 metric_drift=metric_drift(nominal_table, table, metrics),
             )
         )
-        if flips > 0:
+        if flips is not None and flips > 0:
             flipping_axes.append(axis_name)
+
+    rank_identifiable = nominal_identifiable and not non_identifiable_axes
+    rank_identifiability_reason = nominal_non_identifiable_reason
+    if rank_identifiability_reason is None and non_identifiable_axes:
+        rank_identifiability_reason = AXIS_PRIMARY_METRIC_NON_IDENTIFIABLE_REASON
+    if flipping_axes:
+        rank_stable: bool | None = False
+    elif rank_identifiable:
+        rank_stable = True
+    else:
+        rank_stable = None
 
     return FidelitySensitivityReport(
         primary_metric=primary_metric,
@@ -242,5 +311,8 @@ def analyze_fidelity_sensitivity(
         nominal_ranking=nominal_ranking,
         axes=axes,
         flipping_axes=flipping_axes,
-        rank_stable=not flipping_axes,
+        non_identifiable_axes=non_identifiable_axes,
+        rank_identifiable=rank_identifiable,
+        rank_identifiability_reason=rank_identifiability_reason,
+        rank_stable=rank_stable,
     )

--- a/scripts/benchmark/run_fidelity_sensitivity_campaign.py
+++ b/scripts/benchmark/run_fidelity_sensitivity_campaign.py
@@ -500,6 +500,9 @@ def build_report(
         "ranking_stability_is_on_bounded_two_planner_slice_only",
         "full_fixed_scope_planners_not_run",
     ]
+    if not rank_report.get("rank_identifiable", True):
+        reason = str(rank_report.get("rank_identifiability_reason") or "unknown")
+        result_caveats.append(f"rank_non_identifiable_{reason}")
     if all_success_rates and max(all_success_rates) <= 0.0:
         result_caveats.append("all_observed_success_rates_zero")
     if all_collision_rates and min(all_collision_rates) >= 1.0:
@@ -549,6 +552,12 @@ def build_report(
 
 def format_markdown(report: Mapping[str, Any]) -> str:
     """Render compact evidence Markdown."""
+    rank_stability = report["rank_stability"]
+    rank_identifiable = bool(rank_stability.get("rank_identifiable", True))
+    rank_reason = str(rank_stability.get("rank_identifiability_reason") or "none")
+    rank_stable = rank_stability.get("rank_stable")
+    rank_stable_text = "not_applicable" if rank_stable is None else str(rank_stable)
+    rank_status = "identifiable" if rank_identifiable else "non-identifiable"
     lines = [
         f"# Issue #3207 Fidelity Sensitivity Actual Slice {report['date']}",
         "",
@@ -571,17 +580,28 @@ def format_markdown(report: Mapping[str, Any]) -> str:
         "",
         "## Rank Stability",
         "",
-        f"- Nominal ranking: `{', '.join(report['rank_stability']['nominal_ranking'])}`",
-        f"- Rank stable on this slice: `{report['rank_stability']['rank_stable']}`",
-        f"- Flipping variants: `{', '.join(report['rank_stability']['flipping_axes']) or 'none'}`",
+        f"- Nominal deterministic order: `{', '.join(rank_stability['nominal_ranking'])}`",
+        f"- Rank evidence status: `{rank_status}`",
+        f"- Rank identifiability reason: `{rank_reason}`",
+        f"- Rank stable on this slice: `{rank_stable_text}`",
+        f"- Flipping variants: `{', '.join(rank_stability['flipping_axes']) or 'none'}`",
+        f"- Non-identifiable variants: `{', '.join(rank_stability.get('non_identifiable_axes', [])) or 'none'}`",
         "",
-        "| Variant | Kendall tau | Rank flips | Top-1 changed |",
-        "|---|---:|---:|---|",
+        "| Variant | Rank evidence | Kendall tau | Rank flips | Top-1 changed |",
+        "|---|---|---:|---:|---|",
     ]
-    for axis in report["rank_stability"]["axes"]:
+    for axis in rank_stability["axes"]:
+        axis_identifiable = bool(axis.get("rank_identifiable", True))
+        axis_reason = str(axis.get("rank_identifiability_reason") or "none")
+        axis_status = "identifiable" if axis_identifiable else f"non-identifiable: {axis_reason}"
+        tau = axis.get("kendall_tau")
+        flips = axis.get("rank_flips")
+        top1_changed = axis.get("top1_changed")
+        tau_text = "NA" if tau is None else f"{float(tau):.6g}"
+        flips_text = "NA" if flips is None else str(int(flips))
+        top1_text = "NA" if top1_changed is None else f"`{top1_changed}`"
         lines.append(
-            f"| `{axis['axis']}` | {float(axis['kendall_tau']):.6g} | "
-            f"{int(axis['rank_flips'])} | `{axis['top1_changed']}` |"
+            f"| `{axis['axis']}` | `{axis_status}` | {tau_text} | {flips_text} | {top1_text} |"
         )
     lines.extend(
         [

--- a/tests/benchmark/test_fidelity_rank_stability.py
+++ b/tests/benchmark/test_fidelity_rank_stability.py
@@ -8,7 +8,9 @@ import pytest
 import yaml
 
 from robot_sf.benchmark.fidelity_rank_stability import (
+    AXIS_PRIMARY_METRIC_NON_IDENTIFIABLE_REASON,
     FIDELITY_RANK_STABILITY_SCHEMA,
+    PRIMARY_METRIC_ZERO_VARIANCE_REASON,
     analyze_fidelity_sensitivity,
     count_rank_flips,
     kendall_tau,
@@ -158,6 +160,65 @@ def test_analyze_flags_ranking_flipping_axis() -> None:
     assert axis.kendall_tau < 1.0
 
 
+def test_analyze_marks_all_tie_nominal_rank_non_identifiable() -> None:
+    """All-tied nominal primary metrics preserve order only for serialization."""
+    nominal = {
+        "planner_b": {"success_rate": 0.0, "collision_rate": 1.0},
+        "planner_a": {"success_rate": 0.0, "collision_rate": 1.0},
+    }
+    axis_tables = {
+        "timestep": {
+            "planner_b": {"success_rate": 0.0, "collision_rate": 1.0},
+            "planner_a": {"success_rate": 0.0, "collision_rate": 1.0},
+        }
+    }
+
+    report = analyze_fidelity_sensitivity(
+        nominal, axis_tables, primary_metric="success_rate", drift_metrics=["success_rate"]
+    )
+
+    assert report.nominal_ranking == ["planner_a", "planner_b"]
+    assert report.rank_identifiable is False
+    assert report.rank_identifiability_reason == PRIMARY_METRIC_ZERO_VARIANCE_REASON
+    assert report.rank_stable is None
+    assert report.flipping_axes == []
+    assert report.non_identifiable_axes == ["timestep"]
+    axis = report.axes[0]
+    assert axis.ranking == ["planner_a", "planner_b"]
+    assert axis.rank_identifiable is False
+    assert axis.rank_identifiability_reason == PRIMARY_METRIC_ZERO_VARIANCE_REASON
+    assert axis.kendall_tau is None
+    assert axis.rank_flips is None
+    assert axis.top1_changed is None
+
+
+def test_analyze_marks_axis_all_tie_rank_non_identifiable() -> None:
+    """A tied axis cannot support tau/flip evidence even when nominal ranks exist."""
+    axis_tables = {
+        "observation_noise": {
+            "planner_x": {"success_rate": 0.0, "collision_rate": 1.0},
+            "planner_y": {"success_rate": 0.0, "collision_rate": 1.0},
+            "planner_z": {"success_rate": 0.0, "collision_rate": 1.0},
+        },
+    }
+
+    report = analyze_fidelity_sensitivity(
+        _NOMINAL, axis_tables, primary_metric="success_rate", drift_metrics=["success_rate"]
+    )
+
+    assert report.rank_identifiable is False
+    assert report.rank_identifiability_reason == AXIS_PRIMARY_METRIC_NON_IDENTIFIABLE_REASON
+    assert report.rank_stable is None
+    assert report.flipping_axes == []
+    assert report.non_identifiable_axes == ["observation_noise"]
+    axis = report.axes[0]
+    assert axis.rank_identifiable is False
+    assert axis.rank_identifiability_reason == PRIMARY_METRIC_ZERO_VARIANCE_REASON
+    assert axis.kendall_tau is None
+    assert axis.rank_flips is None
+    assert axis.top1_changed is None
+
+
 def test_analyze_rejects_planner_set_mismatch() -> None:
     """An axis missing a nominal planner is rejected."""
     axis_tables = {"bad": {"planner_x": {"success_rate": 0.9}}}
@@ -173,7 +234,10 @@ def test_report_to_dict_uses_schema() -> None:
     payload = report.to_dict()
     assert payload["schema_version"] == FIDELITY_RANK_STABILITY_SCHEMA
     assert payload["nominal_ranking"] == ["planner_x", "planner_y", "planner_z"]
+    assert payload["rank_identifiable"] is True
+    assert payload["rank_identifiability_reason"] is None
     assert payload["rank_stable"] is True
+    assert payload["non_identifiable_axes"] == []
 
 
 # --- shipped config -------------------------------------------------------

--- a/tests/benchmark/test_fidelity_sensitivity_campaign.py
+++ b/tests/benchmark/test_fidelity_sensitivity_campaign.py
@@ -355,3 +355,61 @@ def test_report_classifies_actual_slice_without_paper_or_sim_to_real_claim(tmp_p
     assert "not simulator-realism" in report["claim_boundary"]
     assert "sim-to-real" in report["claim_boundary"]
     assert report["rank_stability"]["rank_stable"] is True
+
+
+def test_build_report_marks_zero_success_slice_rank_non_identifiable(tmp_path: Path) -> None:
+    """All-zero success rates are metric drift evidence, not rank-stability evidence."""
+    config = yaml.safe_load(CONFIG_PATH.read_text(encoding="utf-8"))
+    variants = campaign_runner.load_variant_specs(config, include_all_variants=False)
+    rows = []
+    for variant in variants:
+        for planner in ("goal_seek", "baseline_social_force"):
+            rows.append(
+                {
+                    "variant": variant.key,
+                    "planner": planner,
+                    "scenario_id": "classic_cross_trap_low",
+                    "seed": 111,
+                    "metrics": {
+                        "success_rate": 0.0,
+                        "collision_rate": 1.0,
+                        "min_clearance": 0.0,
+                        "mean_clearance": 0.0,
+                        "near_miss_rate": 1.0,
+                        "comfort_exposure_mean": 1.0,
+                        "time_to_goal_norm": 1.0,
+                    },
+                }
+            )
+
+    report = campaign_runner.build_report(
+        config=config,
+        rows=rows,
+        variants=variants,
+        scenario_set="configs/scenarios/sets/paper_cross_kinematics_v1.yaml",
+        horizon=12,
+        raw_rows_path=tmp_path / "episode_rows.jsonl",
+        git_provenance={
+            "git_head": "abc1234",
+            "git_worktree_dirty": True,
+            "git_status_short_at_generation": [" M example.py"],
+        },
+        date="2026-06-20",
+    )
+
+    rank_stability = report["rank_stability"]
+    assert rank_stability["rank_identifiable"] is False
+    assert rank_stability["rank_identifiability_reason"] == "primary_metric_zero_variance"
+    assert rank_stability["rank_stable"] is None
+    assert rank_stability["flipping_axes"] == []
+    assert rank_stability["non_identifiable_axes"]
+    assert "rank_non_identifiable_primary_metric_zero_variance" in report["result_caveats"]
+
+    markdown = campaign_runner.format_markdown(report)
+    first_axis = rank_stability["non_identifiable_axes"][0]
+    assert "Rank evidence status: `non-identifiable`" in markdown
+    assert (
+        f"| `{first_axis}` | `non-identifiable: primary_metric_zero_variance` | NA | NA | NA |"
+        in markdown
+    )
+    assert "primary_metric_zero_variance" in markdown

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -198,6 +198,7 @@ def test_analyze_body_collects_multiline_deferred_work() -> None:
 def test_cli_reads_github_pull_request_event(tmp_path: Path, monkeypatch) -> None:
     """The CLI can read pull_request.body from a GitHub event payload."""
     monkeypatch.delenv("PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES", raising=False)
+    monkeypatch.delenv("PR_READY_PR_BODY_FILE", raising=False)
     event_path = tmp_path / "event.json"
     event_path.write_text(
         json.dumps(

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -199,7 +199,6 @@ def test_cli_reads_github_pull_request_event(tmp_path: Path, monkeypatch) -> Non
     """The CLI can read pull_request.body from a GitHub event payload."""
     monkeypatch.delenv("PR_READY_PR_BODY_FILE", raising=False)
     monkeypatch.delenv("PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES", raising=False)
-    monkeypatch.delenv("PR_READY_PR_BODY_FILE", raising=False)
     event_path = tmp_path / "event.json"
     event_path.write_text(
         json.dumps(


### PR DESCRIPTION
## Summary
Classifies zero-variance/all-tied fidelity rank comparisons as non-identifiable instead of rank-stable evidence, while preserving deterministic planner order only for serialization.

## Linked Issues
- Closes `#3299`
- Relates to `#3207`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Bumped the shared fidelity rank-stability payload to `fidelity_rank_stability.v2`.
- Added report-level and axis-level `rank_identifiable`, `rank_identifiability_reason`, and `non_identifiable_axes` fields.
- Returns `null` for Kendall tau, rank flips, top-1 changed, and overall `rank_stable` when the primary metric cannot identify a ranking.
- Updated the fidelity sensitivity campaign report and Markdown renderer to emit non-identifiable caveats.
- Amended the tracked #3207 actual-slice evidence so its all-zero `success_rate` comparison is no longer presented as rank-stable evidence.
- Added focused regression tests for all-tied nominal and axis primary metrics.

## Why It Matters
- Added value: prevents deterministic tie ordering from being mistaken for empirical rank stability.
- Expected impact: #3207-style fidelity evidence remains usable for metric drift and wiring checks without overclaiming planner-ranking evidence when the primary metric has zero variance.
- Why this is worth merging now: the tracked #3207 actual-slice summary currently has all observed `success_rate` values tied at zero and should fail closed as non-identifiable rank evidence.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: benchmark rank-stability evidence must distinguish identifiable primary-metric rankings from deterministic serialization order.
- Comparator or baseline, if applicable: previous `fidelity_rank_stability.v1` reported `rank_stable: true`, `kendall_tau: 1.0`, and zero flips on all-tied success-rate data.
- Evidence tier: targeted smoke plus tracked evidence amendment.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: all-tied or insufficient primary-metric values now produce non-identifiable rank evidence with nullable tau/flips/top-1 fields.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3299 and `docs/context/evidence/issue_3207_fidelity_sensitivity_actual_slice_2026-06-20/`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - this updates an existing analysis contract and uses it on the tracked #3207 evidence summary.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress? no; this changes post-run rank evidence classification only.
- Did the scenario actually contain the targeted failure mode? yes; the amended #3207 actual-slice summary has all observed `success_rate` values tied at `0.0`.
- Result route: stop
- Follow-up question or issue for weak, negative, or non-transfer results: NA - no deferred scope for this fix.

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none for this scoped contract fix.
- Stop / revise / continue decision: stop for #3299.
- Proposed child issue or existing follow-up: NA.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run ruff format robot_sf/benchmark/fidelity_rank_stability.py scripts/benchmark/run_fidelity_sensitivity_campaign.py tests/benchmark/test_fidelity_rank_stability.py tests/benchmark/test_fidelity_sensitivity_campaign.py`
  - `uv run ruff check robot_sf/benchmark/fidelity_rank_stability.py scripts/benchmark/run_fidelity_sensitivity_campaign.py tests/benchmark/test_fidelity_rank_stability.py tests/benchmark/test_fidelity_sensitivity_campaign.py`
  - `uv run pytest tests/benchmark/test_fidelity_rank_stability.py tests/benchmark/test_fidelity_sensitivity_campaign.py -q`
  - `git diff --check`
  - `BASE_REF=origin/main PR_READY_MODE=final PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3299-pr-body.md uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused tests cover all-tied nominal and axis primary metrics; tracked #3207 evidence now emits `rank_identifiable: false`, `rank_stable: null`, and `rank_non_identifiable_primary_metric_zero_variance`.
- Benchmarks or smoke tests, if applicable: no new simulation run; evidence was amended from tracked aggregate metrics in the existing #3207 slice.

## Risks / Rollout
- Compatibility risks: `fidelity_rank_stability.v2` intentionally makes rank-evidence fields nullable for non-identifiable comparisons; consumers expecting only floats/bools should read the schema version and identifiability fields.
- Failure modes: if downstream code ignores `rank_identifiable`, it may still treat deterministic `nominal_ranking` as empirical evidence.
- Rollback or fallback plan: revert this PR to restore the v1 payload semantics, but that also restores the overclaim on all-tied primary metrics.

## Docs / Provenance
- Updated docs: `docs/context/evidence/issue_3207_fidelity_sensitivity_actual_slice_2026-06-20/README.md`
- Relevant design or provenance notes: `docs/context/evidence/issue_3207_fidelity_sensitivity_actual_slice_2026-06-20/summary.json`
- Any assumptions that need to be preserved: deterministic ranking order remains a serialization order only when `rank_identifiable` is false.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, #3299 was claimed and this PR closes it.
- Claim map / benchmark report updated (yes/no/NA): yes, the tracked #3207 evidence report was amended.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA; this updates the existing evidence note directly.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: no additional downstream propagation is deferred for this scoped fix.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: check that `nominal_ranking` remains deterministic output but is no longer treated as evidence when `rank_identifiable` is false.
- Any known limitations: this PR does not rerun the #3207 simulation slice; it reclassifies rank evidence from the tracked aggregate metrics.