### PR TITLE
benchmark: derive checkpoint observation contracts from metadata

### DIFF
--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -11,9 +11,11 @@ from typing import Any
 from robot_sf.baselines.interface import ActionContract, ObservationContract, PlannerMetadata
 from robot_sf.benchmark.algorithm_readiness import get_algorithm_readiness
 from robot_sf.benchmark.observation_levels import (
+    OBSERVATION_LEVEL_KEYS,
     observation_level_for_mode,
     resolve_observation_level_contract,
 )
+from robot_sf.models.registry import get_registry_entry
 
 _BASELINE_CATEGORY_BY_CANONICAL: dict[str, str] = {
     "goal": "classical",
@@ -136,6 +138,8 @@ _DEFAULT_OBSERVATION_SPEC: dict[str, Any] = {
         "and pedestrian state when present."
     ),
 }
+
+_DICT_STYLE_PLANNER_OBSERVATION_MODES = {"dict", "native_dict", "multi_input"}
 
 _OBSERVATION_SPEC_BY_CANONICAL: dict[str, dict[str, Any]] = {
     "goal": {
@@ -1085,6 +1089,293 @@ def resolve_observation_mode(
     return active_mode
 
 
+def _normalize_optional_string(value: Any) -> str | None:
+    """Return a stripped string or ``None`` for blank/missing values."""
+    if value is None:
+        return None
+    normalized = str(value).strip()
+    return normalized or None
+
+
+def _planner_observation_modes_compatible(left: str | None, right: str | None) -> bool:
+    """Return whether two planner-side observation mode labels describe the same family."""
+    left_mode = _normalize_optional_string(left)
+    right_mode = _normalize_optional_string(right)
+    if left_mode is None or right_mode is None:
+        return True
+    left_key = left_mode.lower()
+    right_key = right_mode.lower()
+    if left_key == right_key:
+        return True
+    return (
+        left_key in _DICT_STYLE_PLANNER_OBSERVATION_MODES
+        and right_key in _DICT_STYLE_PLANNER_OBSERVATION_MODES
+    )
+
+
+def _dict_style_checkpoint_metadata_required(canonical: str, planner_mode: str | None) -> bool:
+    """Return whether a dict-style checkpoint would otherwise use the wrong default producer."""
+    normalized = _normalize_optional_string(planner_mode)
+    if normalized is None or normalized.lower() not in _DICT_STYLE_PLANNER_OBSERVATION_MODES:
+        return False
+    return resolve_observation_mode(canonical) != "socnav_state"
+
+
+def _observation_contract_from_transfer_metadata(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return transfer-metadata observation contract when present."""
+    transfer = payload.get("transfer_benchmark")
+    if not isinstance(transfer, dict):
+        algorithm_metadata = payload.get("algorithm_metadata")
+        if isinstance(algorithm_metadata, dict):
+            transfer = algorithm_metadata.get("transfer_benchmark")
+    if not isinstance(transfer, dict):
+        return None, None
+    contract = transfer.get("observation_contract")
+    if not isinstance(contract, dict):
+        raise ValueError(
+            "malformed learned checkpoint observation metadata: "
+            "transfer_benchmark.observation_contract must be a mapping"
+        )
+    return contract, "algo_config.transfer_benchmark.observation_contract"
+
+
+def _observation_contract_from_registry(
+    payload: dict[str, Any],
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return model-registry benchmark-promotion metadata when a model_id is configured."""
+    model_id = _normalize_optional_string(payload.get("model_id"))
+    if model_id is None:
+        return None, None
+    try:
+        registry_entry = get_registry_entry(model_id)
+    except (FileNotFoundError, KeyError, TypeError, ValueError) as exc:
+        raise ValueError(
+            "requires learned checkpoint observation metadata but model registry lookup failed "
+            f"for model_id={model_id!r}: {exc}"
+        ) from exc
+    promotion = registry_entry.get("benchmark_promotion")
+    if not isinstance(promotion, dict):
+        return None, None
+    return promotion, "model_registry.benchmark_promotion"
+
+
+def _learned_checkpoint_observation_metadata(
+    algo_config: dict[str, Any],
+) -> tuple[dict[str, Any] | None, str | None]:
+    """Return the first supported learned-checkpoint observation metadata block."""
+    transfer_contract, transfer_source = _observation_contract_from_transfer_metadata(algo_config)
+    if transfer_contract is not None:
+        return transfer_contract, transfer_source
+
+    direct_contract = algo_config.get("observation_contract")
+    if isinstance(direct_contract, dict):
+        return direct_contract, "algo_config.observation_contract"
+    if direct_contract is not None:
+        raise ValueError(
+            "malformed learned checkpoint observation metadata: "
+            "observation_contract must be a mapping"
+        )
+
+    direct_promotion = algo_config.get("benchmark_promotion")
+    if isinstance(direct_promotion, dict):
+        return direct_promotion, "algo_config.benchmark_promotion"
+    if direct_promotion is not None:
+        raise ValueError(
+            "malformed learned checkpoint observation metadata: "
+            "benchmark_promotion must be a mapping"
+        )
+
+    return _observation_contract_from_registry(algo_config)
+
+
+def _planner_observation_mode_from_metadata(metadata: dict[str, Any]) -> str | None:
+    """Return the metadata-declared planner-side observation mode, if any."""
+    for key in ("planner_observation_mode", "observation_mode", "obs_mode"):
+        value = _normalize_optional_string(metadata.get(key))
+        if value is not None:
+            return value
+    return None
+
+
+def _metadata_declares_observation_contract(metadata: dict[str, Any]) -> bool:
+    """Return whether metadata contains fields that can resolve an observation producer."""
+    for key in (
+        "observation_level",
+        "active_observation_mode",
+        "runtime_observation_mode",
+        "runner_observation_mode",
+        "observation_producer_mode",
+        "planner_observation_mode",
+        "observation_mode",
+        "obs_mode",
+    ):
+        if _normalize_optional_string(metadata.get(key)) is not None:
+            return True
+    return False
+
+
+def _active_observation_mode_from_checkpoint_metadata(
+    canonical: str,
+    metadata: dict[str, Any],
+) -> tuple[str, str | None]:
+    """Resolve the runtime observation producer declared by checkpoint metadata.
+
+    Returns:
+        Active observation mode and the raw metadata observation-level label, when present.
+    """
+    runtime_mode = None
+    for key in (
+        "active_observation_mode",
+        "runtime_observation_mode",
+        "runner_observation_mode",
+        "observation_producer_mode",
+    ):
+        runtime_mode = _normalize_optional_string(metadata.get(key))
+        if runtime_mode is not None:
+            break
+    observation_level = _normalize_optional_string(metadata.get("observation_level"))
+
+    try:
+        if runtime_mode is not None:
+            level = (
+                observation_level
+                if observation_level is not None and observation_level in OBSERVATION_LEVEL_KEYS
+                else None
+            )
+            return resolve_observation_mode(
+                canonical,
+                runtime_mode,
+                observation_level=level,
+            ), observation_level
+        if observation_level is not None and observation_level in OBSERVATION_LEVEL_KEYS:
+            return (
+                resolve_observation_mode(canonical, observation_level=observation_level),
+                observation_level,
+            )
+        if observation_level is not None:
+            return resolve_observation_mode(canonical, observation_level), observation_level
+    except ValueError as exc:
+        raise ValueError(
+            "incompatible learned checkpoint observation metadata for "
+            f"algorithm '{canonical}': {exc}"
+        ) from exc
+
+    raise ValueError(
+        "malformed learned checkpoint observation metadata: expected observation_level "
+        "or active_observation_mode"
+    )
+
+
+def resolve_learned_checkpoint_observation_contract(
+    algo: str,
+    algo_config: dict[str, Any] | None = None,
+    *,
+    observation_mode: str | None = None,
+    observation_level: str | None = None,
+) -> dict[str, Any]:
+    """Resolve the active observation producer for learned-checkpoint benchmark execution.
+
+    Explicit runner overrides win. Without overrides, dict-family checkpoint configs whose
+    algorithm default is not SocNav state must provide metadata that declares the required
+    observation contract; this prevents running those checkpoints with the wrong producer.
+
+    Returns:
+        A classification payload containing the active observation mode and metadata source.
+    """
+    canonical = canonical_algorithm_name(algo)
+    config = dict(algo_config or {})
+    config_planner_mode = _normalize_optional_string(config.get("obs_mode"))
+
+    explicit_mode = _normalize_optional_string(observation_mode)
+    explicit_level = _normalize_optional_string(observation_level)
+    if explicit_mode is not None or explicit_level is not None:
+        active_mode = resolve_observation_mode(
+            canonical,
+            explicit_mode,
+            observation_level=explicit_level,
+        )
+        if explicit_mode is not None and explicit_level is not None:
+            source = "explicit_observation_mode_and_level"
+        elif explicit_mode is not None:
+            source = "explicit_observation_mode"
+        else:
+            source = "explicit_observation_level"
+        return {
+            "status": "explicit_override",
+            "metadata_source": source,
+            "active_observation_mode": active_mode,
+            "observation_level": explicit_level,
+            "observation_level_key": (
+                explicit_level if explicit_level in OBSERVATION_LEVEL_KEYS else None
+            ),
+            "planner_observation_mode": config_planner_mode,
+        }
+
+    metadata_required = _dict_style_checkpoint_metadata_required(canonical, config_planner_mode)
+    metadata, metadata_source = _learned_checkpoint_observation_metadata(config)
+
+    if metadata is None:
+        if metadata_required:
+            raise ValueError(
+                f"Algorithm '{canonical}' with obs_mode={config_planner_mode!r} requires "
+                "learned checkpoint observation metadata; provide model registry "
+                "benchmark_promotion, transfer_benchmark.observation_contract, or an explicit "
+                "observation_mode/observation_level override."
+            )
+        active_mode = resolve_observation_mode(canonical)
+        return {
+            "status": "not_applicable",
+            "metadata_source": "algorithm_default",
+            "active_observation_mode": active_mode,
+            "observation_level": observation_level_for_mode(active_mode).key,
+            "observation_level_key": observation_level_for_mode(active_mode).key,
+            "planner_observation_mode": config_planner_mode,
+        }
+    if not _metadata_declares_observation_contract(metadata):
+        if metadata_required:
+            raise ValueError(
+                f"Algorithm '{canonical}' with obs_mode={config_planner_mode!r} requires "
+                "learned checkpoint observation metadata, but the resolved metadata source "
+                f"{metadata_source!r} does not declare observation_level or active_observation_mode."
+            )
+        active_mode = resolve_observation_mode(canonical)
+        return {
+            "status": "not_applicable",
+            "metadata_source": "algorithm_default",
+            "active_observation_mode": active_mode,
+            "observation_level": observation_level_for_mode(active_mode).key,
+            "observation_level_key": observation_level_for_mode(active_mode).key,
+            "planner_observation_mode": config_planner_mode,
+        }
+
+    metadata_planner_mode = _planner_observation_mode_from_metadata(metadata)
+    planner_mode = config_planner_mode or metadata_planner_mode
+    if not _planner_observation_modes_compatible(config_planner_mode, metadata_planner_mode):
+        raise ValueError(
+            "incompatible learned checkpoint observation metadata for "
+            f"algorithm '{canonical}': config obs_mode={config_planner_mode!r} conflicts with "
+            f"metadata planner_observation_mode={metadata_planner_mode!r}"
+        )
+
+    active_mode, metadata_level = _active_observation_mode_from_checkpoint_metadata(
+        canonical,
+        metadata,
+    )
+    return {
+        "status": "metadata_resolved",
+        "metadata_source": metadata_source,
+        "active_observation_mode": active_mode,
+        "observation_level": metadata_level or observation_level_for_mode(active_mode).key,
+        "observation_level_key": (
+            metadata_level if metadata_level in OBSERVATION_LEVEL_KEYS else None
+        )
+        or observation_level_for_mode(active_mode).key,
+        "planner_observation_mode": planner_mode,
+    }
+
+
 def _resolve_observation_metadata(
     canonical: str,
     *,
@@ -1386,5 +1677,6 @@ __all__ = [
     "infer_execution_mode_from_counts",
     "observation_spec_for_algorithm",
     "planner_contract_for_algorithm",
+    "resolve_learned_checkpoint_observation_contract",
     "resolve_observation_mode",
 ]

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -22,7 +22,7 @@ from robot_sf.benchmark import map_runner_policy_resolution as _policy_resolutio
 from robot_sf.benchmark import planner_command_contract as planner_commands
 from robot_sf.benchmark.algorithm_metadata import (
     enrich_algorithm_metadata,
-    resolve_observation_mode,
+    resolve_learned_checkpoint_observation_contract,
 )
 from robot_sf.benchmark.algorithm_readiness import (
     BenchmarkProfile,
@@ -2436,15 +2436,32 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
 
     kinematics_tag, scenario_kinematics = _resolve_batch_kinematics_tag(filtered)
     batch_observation_mode = str(observation_mode).strip() if observation_mode is not None else None
+    raw_policy_cfg = _parse_algo_config(algo_config_path)
+    _, policy_cfg = _resolve_policy_search_candidate_runtime(
+        default_algo=algo,
+        algo_config_path=algo_config_path,
+        algo_config=raw_policy_cfg,
+        scenario={},
+    )
+    learned_observation_contract = resolve_learned_checkpoint_observation_contract(
+        algo,
+        policy_cfg,
+        observation_mode=batch_observation_mode,
+        observation_level=observation_level,
+    )
+    active_observation_mode = str(learned_observation_contract["active_observation_mode"])
+    resolved_observation_level = observation_level
+    if resolved_observation_level is None:
+        resolved_observation_level = learned_observation_contract.get("observation_level_key")
     algo_contract = enrich_algorithm_metadata(
         algo=algo,
         metadata={},
         robot_kinematics=kinematics_tag,
         adapter_impact_requested=adapter_impact_eval,
-        observation_mode=batch_observation_mode,
-        observation_level=observation_level,
+        observation_mode=active_observation_mode,
+        observation_level=resolved_observation_level,
     )
-    active_observation_mode = str(algo_contract["observation_spec"]["active_mode"])
+    algo_contract["learned_checkpoint_observation_contract"] = learned_observation_contract
     active_observation_level = str(algo_contract["observation_level"]["key"])
     attach_track_metadata(
         algo_contract,
@@ -2462,13 +2479,6 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     out_path = Path(out_path)
     out_path.parent.mkdir(parents=True, exist_ok=True)
     schema = load_schema(schema_path)
-    raw_policy_cfg = _parse_algo_config(algo_config_path)
-    _, policy_cfg = _resolve_policy_search_candidate_runtime(
-        default_algo=algo,
-        algo_config_path=algo_config_path,
-        algo_config=raw_policy_cfg,
-        scenario={},
-    )
     robot_command_mode: str | None = None
     for scenario in filtered:
         robot_cfg = scenario.get("robot_config")
@@ -2510,10 +2520,14 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 algo_config=raw_policy_cfg,
                 scenario=scenario,
             )
-            validation_observation_mode = resolve_observation_mode(
+            validation_observation_contract = resolve_learned_checkpoint_observation_contract(
                 validation_algo,
-                batch_observation_mode,
+                validation_cfg,
+                observation_mode=batch_observation_mode,
                 observation_level=observation_level,
+            )
+            validation_observation_mode = str(
+                validation_observation_contract["active_observation_mode"]
             )
             compatible_contract = _validate_planner_contract(
                 algo=validation_algo,
@@ -2641,16 +2655,25 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     scenario=sc,
                     seed=int(seed),
                 )
-                identity_observation_mode = resolve_observation_mode(
+                identity_observation_contract = resolve_learned_checkpoint_observation_contract(
                     identity_algo,
-                    batch_observation_mode,
+                    identity_cfg,
+                    observation_mode=batch_observation_mode,
                     observation_level=observation_level,
                 )
+                identity_observation_mode = str(
+                    identity_observation_contract["active_observation_mode"]
+                )
+                identity_observation_level = observation_level
+                if identity_observation_level is None:
+                    identity_observation_level = identity_observation_contract.get(
+                        "observation_level_key"
+                    )
                 identity_contract = enrich_algorithm_metadata(
                     algo=identity_algo,
                     metadata={},
                     observation_mode=identity_observation_mode,
-                    observation_level=observation_level,
+                    observation_level=identity_observation_level,
                 )
                 identity_observation_level = str(identity_contract["observation_level"]["key"])
                 identity_payload = _scenario_identity_payload(

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -12,10 +12,9 @@ import numpy as np
 from loguru import logger
 
 from robot_sf.benchmark.algorithm_metadata import (
-    canonical_algorithm_name,
     enrich_algorithm_metadata,
     infer_execution_mode_from_counts,
-    resolve_observation_mode,
+    resolve_learned_checkpoint_observation_contract,
 )
 from robot_sf.benchmark.latency_stress import not_available_latency_metrics
 from robot_sf.benchmark.map_runner_actions import DEFAULT_KINEMATICS as _DEFAULT_KINEMATICS
@@ -212,25 +211,16 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         scenario=scenario,
         seed=int(seed),
     )
-    requested_observation_mode = observation_mode
-    if (
-        requested_observation_mode is None
-        and observation_level is None
-        and canonical_algorithm_name(algo) == "ppo"
-        and str(policy_cfg.get("obs_mode", "")).strip().lower()
-        in {"dict", "native_dict", "multi_input"}
-    ):
-        # Grid/dict PPO checkpoints require the SocNav structured
-        # (occupancy-grid) observation they were trained with. The PPO spec
-        # default (sensor_fusion_state) disables the occupancy grid, so a
-        # dict-obs checkpoint would otherwise fail with "Missing required dict
-        # observation keys". Select the structured stack when none was requested.
-        requested_observation_mode = "socnav_state"
-    active_observation_mode = resolve_observation_mode(
+    learned_observation_contract = resolve_learned_checkpoint_observation_contract(
         algo,
-        requested_observation_mode,
+        policy_cfg,
+        observation_mode=observation_mode,
         observation_level=observation_level,
     )
+    active_observation_mode = str(learned_observation_contract["active_observation_mode"])
+    resolved_observation_level = observation_level
+    if resolved_observation_level is None:
+        resolved_observation_level = learned_observation_contract.get("observation_level_key")
     _apply_active_observation_mode_to_env_config(
         config,
         active_observation_mode=active_observation_mode,
@@ -260,8 +250,9 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         metadata=algo_meta,
         robot_kinematics=robot_kinematics,
         observation_mode=active_observation_mode,
-        observation_level=observation_level,
+        observation_level=resolved_observation_level,
     )
+    algo_meta["learned_checkpoint_observation_contract"] = learned_observation_contract
     active_observation_level = str(algo_meta["observation_level"]["key"])
     attach_track_metadata(
         algo_meta,

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from robot_sf.benchmark import algorithm_metadata
 from robot_sf.benchmark.algorithm_metadata import (
     canonical_algorithm_name,
     enrich_algorithm_metadata,
@@ -39,6 +40,127 @@ def test_observation_spec_declares_supported_modes_and_rejects_invalid_override(
         excinfo.value
     )
     assert "socnav_state" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("obs_mode", ["dict", "native_dict", "multi_input"])
+def test_learned_checkpoint_contract_derives_ppo_dict_family_from_registry_metadata(
+    obs_mode: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Dict-family PPO checkpoints should derive the active producer from checkpoint metadata."""
+
+    def _registry_entry(_model_id: str) -> dict[str, object]:
+        return {
+            "benchmark_promotion": {
+                "observation_level": "tracked_agents_no_noise",
+                "observation_mode": "dict",
+            }
+        }
+
+    monkeypatch.setattr(algorithm_metadata, "get_registry_entry", _registry_entry, raising=False)
+
+    contract = algorithm_metadata.resolve_learned_checkpoint_observation_contract(
+        "ppo",
+        {"model_id": "ppo-grid", "obs_mode": obs_mode},
+    )
+
+    assert contract["active_observation_mode"] == "socnav_state"
+    assert contract["status"] == "metadata_resolved"
+    assert contract["metadata_source"] == "model_registry.benchmark_promotion"
+    assert contract["planner_observation_mode"] == obs_mode
+
+
+def test_learned_checkpoint_contract_explicit_observation_mode_override_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit observation-mode overrides should not require checkpoint metadata."""
+
+    def _unexpected_registry_lookup(_model_id: str) -> dict[str, object]:
+        raise AssertionError("explicit observation overrides must bypass metadata lookup")
+
+    monkeypatch.setattr(
+        algorithm_metadata,
+        "get_registry_entry",
+        _unexpected_registry_lookup,
+        raising=False,
+    )
+
+    contract = algorithm_metadata.resolve_learned_checkpoint_observation_contract(
+        "ppo",
+        {"model_id": "metadata-not-needed", "obs_mode": "dict"},
+        observation_mode="sensor_fusion_state",
+    )
+
+    assert contract["active_observation_mode"] == "sensor_fusion_state"
+    assert contract["status"] == "explicit_override"
+    assert contract["metadata_source"] == "explicit_observation_mode"
+
+
+def test_learned_checkpoint_contract_explicit_observation_level_override_wins(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Explicit observation-level overrides should select their compatible producer."""
+
+    def _unexpected_registry_lookup(_model_id: str) -> dict[str, object]:
+        raise AssertionError("explicit observation overrides must bypass metadata lookup")
+
+    monkeypatch.setattr(
+        algorithm_metadata,
+        "get_registry_entry",
+        _unexpected_registry_lookup,
+        raising=False,
+    )
+
+    contract = algorithm_metadata.resolve_learned_checkpoint_observation_contract(
+        "ppo",
+        {"model_id": "metadata-not-needed", "obs_mode": "dict"},
+        observation_level="lidar_2d",
+    )
+
+    assert contract["active_observation_mode"] == "sensor_fusion_state"
+    assert contract["status"] == "explicit_override"
+    assert contract["metadata_source"] == "explicit_observation_level"
+
+
+def test_learned_checkpoint_contract_rejects_missing_dict_family_metadata() -> None:
+    """Dict-family learned checkpoints should fail closed when metadata is absent."""
+    with pytest.raises(ValueError, match="requires learned checkpoint observation metadata"):
+        algorithm_metadata.resolve_learned_checkpoint_observation_contract(
+            "ppo",
+            {"obs_mode": "dict"},
+        )
+
+
+def test_learned_checkpoint_contract_rejects_malformed_metadata() -> None:
+    """Malformed checkpoint observation metadata should fail with a classified error."""
+    with pytest.raises(ValueError, match="malformed learned checkpoint observation metadata"):
+        algorithm_metadata.resolve_learned_checkpoint_observation_contract(
+            "ppo",
+            {"obs_mode": "dict", "observation_contract": "not-a-mapping"},
+        )
+
+
+def test_learned_checkpoint_contract_rejects_incompatible_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Metadata that resolves to an unsupported producer should fail before execution."""
+
+    def _registry_entry(_model_id: str) -> dict[str, object]:
+        return {
+            "benchmark_promotion": {
+                "observation_level": "tracked_agents_no_noise",
+                "active_observation_mode": "goal_state",
+                "observation_mode": "dict",
+            }
+        }
+
+    monkeypatch.setattr(algorithm_metadata, "get_registry_entry", _registry_entry, raising=False)
+
+    with pytest.raises(ValueError, match="incompatible learned checkpoint observation metadata"):
+        algorithm_metadata.resolve_learned_checkpoint_observation_contract(
+            "ppo",
+            {"model_id": "ppo-bad", "obs_mode": "dict"},
+        )
 
 
 def test_enriched_metadata_embeds_typed_planner_contract_payload() -> None:

--- a/tests/benchmark/test_map_runner_preflight_profiles.py
+++ b/tests/benchmark/test_map_runner_preflight_profiles.py
@@ -2,10 +2,27 @@
 
 from __future__ import annotations
 
+import sys
+import types
 from typing import TYPE_CHECKING
 
 import pytest
 import yaml
+
+# This module tests map-runner preflight plumbing with all policy execution stubbed. The shared
+# lightweight validation venv does not include torch, but map_runner imports the experimental
+# CrowdNav_HEIGHT adapter at module import time. Provide only the marker SciPy probes during import;
+# tests that execute torch-dependent adapter code should still fail instead of silently passing.
+try:  # pragma: no cover - exercised only in optional-dependency environments
+    import torch as _torch  # noqa: F401
+except ModuleNotFoundError:  # pragma: no cover - local lightweight validation path
+    _torch_stub = types.ModuleType("torch")
+
+    class _TorchTensor:
+        """Marker class for SciPy optional torch-array detection."""
+
+    _torch_stub.Tensor = _TorchTensor
+    sys.modules["torch"] = _torch_stub
 
 from robot_sf.benchmark import map_runner
 
@@ -446,6 +463,11 @@ def test_adapter_impact_summary_finalizes_from_worker_records(
     monkeypatch.setattr(map_runner, "validate_scenario_list", lambda _scenarios: [])
     monkeypatch.setattr(map_runner, "load_schema", lambda _path: {})
     monkeypatch.setattr(map_runner, "_write_validated", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        map_runner,
+        "_build_policy",
+        lambda _algo, _cfg: (lambda _obs: (0.0, 0.0), {"status": "ok"}),
+    )
     monkeypatch.setattr(
         map_runner,
         "_run_map_job_worker",

--- a/tests/benchmark/test_map_runner_preflight_profiles.py
+++ b/tests/benchmark/test_map_runner_preflight_profiles.py
@@ -119,6 +119,50 @@ def test_paper_baseline_allows_ppo_when_gate_is_met(tmp_path: Path, monkeypatch)
     assert summary["algorithm_metadata_contract"]["baseline_category"] == "learning"
 
 
+def test_run_map_batch_derives_ppo_observation_mode_from_registry_metadata(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """Batch metadata should use checkpoint metadata for PPO dict-observation producers."""
+    _patch_lightweight_batch(monkeypatch)
+    monkeypatch.setattr(
+        map_runner,
+        "_build_policy",
+        lambda _algo, _cfg: (lambda _obs: (0.0, 0.0), {"status": "ok"}),
+    )
+    algo_cfg_path = tmp_path / "ppo_grid.yaml"
+    algo_cfg_path.write_text(
+        yaml.safe_dump(
+            {
+                "model_id": (
+                    "ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417"
+                ),
+                "obs_mode": "dict",
+                "action_space": "unicycle",
+                "fallback_to_goal": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    summary = map_runner.run_map_batch(
+        [_scenario()],
+        tmp_path / "episodes.jsonl",
+        schema_path=SCHEMA_PATH,
+        algo="ppo",
+        benchmark_profile="experimental",
+        algo_config_path=str(algo_cfg_path),
+        resume=False,
+    )
+
+    assert summary["algorithm_metadata_contract"]["observation_spec"]["active_mode"] == (
+        "socnav_state"
+    )
+    assert summary["algorithm_metadata_contract"]["observation_level"]["key"] == (
+        "tracked_agents_no_noise"
+    )
+
+
 def test_socnav_fail_fast_policy_raises(tmp_path: Path, monkeypatch) -> None:
     """SocNav preflight policy `fail-fast` should propagate prereq failures."""
     _patch_lightweight_batch(monkeypatch)


### PR DESCRIPTION
## Summary
Derives learned-checkpoint observation contracts from metadata instead of a PPO-specific dict-observation branch. The runner now resolves promoted PPO registry metadata to the SocNav structured observation producer while preserving explicit observation overrides and failing closed on missing or incompatible metadata.

## Linked Issues
- Closes #3305
- Relates to #3303

## Stack / Dependency
- Base dependency: current `origin/main`
- Required prior PRs: #3303
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: #3303 introduced the narrow compatibility branch that this PR generalizes.

## What Changed
- Added `resolve_learned_checkpoint_observation_contract()` in `robot_sf/benchmark/algorithm_metadata.py`.
- Wired `map_runner.py` and `map_runner_episode.py` to resolve active observation mode/level from transfer, direct config, or model-registry metadata.
- Preserved explicit `observation_mode` / `observation_level` overrides.
- Added fail-closed tests for missing, malformed, and incompatible checkpoint observation metadata.
- Made map-runner preflight tests locally executable in the lightweight shared venv by stubbing only the unrelated optional `torch` import path.

## Why It Matters
- Added value: removes a hard-coded PPO dict-observation special case from episode execution.
- Expected impact: promoted dict-observation PPO checkpoints get `socnav_state` / `tracked_agents_no_noise` from registry metadata rather than runner-specific assumptions.
- Why this is worth merging now: it closes the follow-up left by #3303 and makes future learned-checkpoint contracts explicit and reviewable.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: benchmark runner should not silently execute learned checkpoints with the wrong observation producer.
- Comparator or baseline, if applicable: #3303 PPO-specific `obs_mode in {dict,native_dict,multi_input}` branch.
- Evidence tier: targeted smoke plus focused contract tests.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: metadata-derived contract must resolve the promoted PPO registry row and fail closed for absent or invalid metadata.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3305 closes when this PR merges.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support/contract plumbing; no new analysis tool or benchmark interpretation.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, the focused runner test resolves the promoted PPO registry row to `socnav_state`.
- Did the intervention change command source, selected command, trajectory, or route progress? no direct benchmark execution; this changes pre-execution observation contract resolution.
- Did the scenario actually contain the targeted failure mode? targeted metadata smoke uses the promoted dict-observation PPO checkpoint configuration that motivated #3303.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: no for this contract change; CI remains the broad gate.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no benchmark artifact expected.
- Stop / revise / continue decision: continue.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_preflight_profiles.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_algorithm_metadata_contract.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/algorithm_metadata.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_map_runner_preflight_profiles.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/algorithm_metadata.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_map_runner_preflight_profiles.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m py_compile robot_sf/benchmark/algorithm_metadata.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_map_runner_preflight_profiles.py`
  - `git diff --check origin/main..HEAD && git diff --check`
- Evidence that the change works here: 16 map-runner preflight tests and 37 algorithm metadata contract tests pass locally; the new runner test proves the promoted PPO registry metadata resolves to `socnav_state` and `tracked_agents_no_noise`.
- Benchmarks or smoke tests, if applicable: targeted metadata smoke only; no benchmark performance claim.

## Risks / Rollout
- Compatibility risks: config rows with dict-style learned checkpoints and no metadata now fail closed instead of silently selecting a producer.
- Failure modes: malformed metadata raises a classified `ValueError`; explicit overrides still bypass metadata.
- Rollback or fallback plan: use explicit `observation_mode` / `observation_level` overrides or revert to #3303 behavior if unexpected metadata rows surface.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: registry `benchmark_promotion` metadata is the source for the promoted PPO row.
- Any assumptions that need to be preserved: non-PPO learned-policy registry rows do not currently provide a benchmark observation contract, so the optional non-PPO test condition is not applicable in this PR.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, closes #3305 through this PR.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA, uses existing registry metadata.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is benchmark execution contract plumbing and does not add benchmark evidence or a new artifact.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify the fail-closed behavior for dict-family checkpoint configs without metadata.
- The test-only torch marker is intentionally minimal; tests that execute the CrowdNav_HEIGHT adapter should still fail without the real optional dependency.
