### PR TITLE
feat: add failure-pack input path provenance (#3308)

### DIFF
--- a/docs/context/evidence/issue_2754_signalized_failure_pack_smoke/README.md
+++ b/docs/context/evidence/issue_2754_signalized_failure_pack_smoke/README.md
@@ -47,4 +47,6 @@ uv run python scripts/analysis/build_signalized_crossing_failure_pack_issue_2754
 
 - `summary.json`: compact `signalized_crossing_failure_pack.v1` smoke output with one
   fixture-backed case. The denominator plumbing remains eligible, but fixture/synthetic/smoke
-  provenance keeps the row diagnostic-only and figure-ineligible.
+  provenance keeps the row diagnostic-only and figure-ineligible. Each emitted case records the
+  repo-relative trace path, repo-relative metric JSONL path, matched metric-row line number, and
+  metric-row claim boundary.

--- a/docs/context/evidence/issue_2754_signalized_failure_pack_smoke/summary.json
+++ b/docs/context/evidence/issue_2754_signalized_failure_pack_smoke/summary.json
@@ -6,6 +6,10 @@
     {
       "episode_id": "issue_2868_signalized_crossing_episode_0000",
       "scenario_id": "issue_2868_signalized_crossing",
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_signalized_crossing_fixture_0000.json",
+      "episodes_jsonl_path": "docs/context/evidence/issue_2754_signalized_failure_pack_smoke/episodes.jsonl",
+      "metric_row_line_number": 1,
+      "metric_row_claim_boundary": "smoke fixture only; validates issue #2754 pack extraction against a tracked signalized trace fixture and synthetic metric row, not benchmark evidence or traffic-light compliance evidence.",
       "trace_row_range": [
         0,
         11

--- a/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
+++ b/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
@@ -181,7 +181,11 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
         for line_number, line in enumerate(fh, start=1):
             line = line.strip()
             if line:
-                record = json.loads(line)
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    msg = f"Invalid JSONL in {input_path} at line {line_number}: {exc.msg}"
+                    raise ValueError(msg) from exc
                 if isinstance(record, dict):
                     record[_METRIC_INPUT_PATH_KEY] = input_path
                     record[_METRIC_INPUT_LINE_KEY] = line_number

--- a/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
+++ b/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
@@ -186,9 +186,11 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
                 except json.JSONDecodeError as exc:
                     msg = f"Invalid JSONL in {input_path} at line {line_number}: {exc.msg}"
                     raise ValueError(msg) from exc
-                if isinstance(record, dict):
-                    record[_METRIC_INPUT_PATH_KEY] = input_path
-                    record[_METRIC_INPUT_LINE_KEY] = line_number
+                if not isinstance(record, dict):
+                    msg = f"Invalid JSONL in {input_path} at line {line_number}: expected object"
+                    raise ValueError(msg)
+                record[_METRIC_INPUT_PATH_KEY] = input_path
+                record[_METRIC_INPUT_LINE_KEY] = line_number
                 records.append(record)
     return records
 

--- a/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
+++ b/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
@@ -66,6 +66,8 @@ _DURABLE_SOURCE_KINDS = {"live_execution", "durable_replay"}
 _FIGURE_EVIDENCE_TIERS = {"benchmark", "nominal_benchmark", "paper_grade"}
 _FIGURE_EXECUTION_MODES = {"native", "durable_replay"}
 _ALLOWED_CLAIM_STATUSES = {"allowed", "claimable"}
+_METRIC_INPUT_PATH_KEY = "_failure_pack_metric_input_path"
+_METRIC_INPUT_LINE_KEY = "_failure_pack_metric_input_line"
 
 
 @dataclass(frozen=True)
@@ -111,6 +113,18 @@ def _expand_timeline(timeline: list[dict[str, Any]], dt: float) -> list[dict[str
         steps = max(1, int(np.ceil(duration / dt))) if duration > 0.0 else 0
         expanded.extend([phase_info] * steps)
     return expanded
+
+
+def _portable_input_path(path: Path, *, repo_root: Path | None = None) -> str:
+    """Return a non-absolute path suitable for tracked provenance output."""
+    root = (repo_root or Path.cwd()).resolve()
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(root).as_posix()
+    except ValueError:
+        if path.is_absolute():
+            return path.name
+        return path.as_posix()
 
 
 def find_failure_step(trace: SimulationTraceExport) -> int:
@@ -162,11 +176,16 @@ def get_signal_phase_at_step(
 def _read_jsonl(path: Path) -> list[dict[str, Any]]:
     """Read lines of JSONL into a list of dictionaries."""
     records: list[dict[str, Any]] = []
+    input_path = _portable_input_path(path)
     with path.open("r", encoding="utf-8") as fh:
-        for line in fh:
+        for line_number, line in enumerate(fh, start=1):
             line = line.strip()
             if line:
-                records.append(json.loads(line))
+                record = json.loads(line)
+                if isinstance(record, dict):
+                    record[_METRIC_INPUT_PATH_KEY] = input_path
+                    record[_METRIC_INPUT_LINE_KEY] = line_number
+                records.append(record)
     return records
 
 
@@ -229,9 +248,11 @@ def build_failure_pack(
     comfort_threshold: float,
     near_miss_threshold: float,
     provenance: FailurePackProvenance,
+    trace_input_paths: dict[str, str] | None = None,
 ) -> dict[str, Any]:
     """Assemble failure cases from paired trace exports and metrics records."""
     cases = []
+    trace_input_paths = trace_input_paths or {}
 
     for trace in traces:
         # Match trace with episodes records by episode_id
@@ -311,6 +332,10 @@ def build_failure_pack(
             {
                 "episode_id": trace.source.episode_id,
                 "scenario_id": trace.source.scenario_id,
+                "trace_path": trace_input_paths.get(trace.source.episode_id),
+                "episodes_jsonl_path": matched_rec.get(_METRIC_INPUT_PATH_KEY),
+                "metric_row_line_number": matched_rec.get(_METRIC_INPUT_LINE_KEY),
+                "metric_row_claim_boundary": matched_rec.get("claim_boundary"),
                 "trace_row_range": (
                     [trace.frames[0].step, trace.frames[-1].step] if trace.frames else None
                 ),
@@ -489,10 +514,13 @@ def main(argv: list[str] | None = None) -> int:
     args = parser.parse_args(argv)
 
     loaded_traces = []
+    trace_input_paths = {}
     if args.traces:
         for p in args.traces:
             if p.is_file():
-                loaded_traces.append(load_trace_with_fallback(p))
+                trace = load_trace_with_fallback(p)
+                loaded_traces.append(trace)
+                trace_input_paths[trace.source.episode_id] = _portable_input_path(p)
 
     loaded_records = []
     if args.episodes_jsonl:
@@ -517,6 +545,7 @@ def main(argv: list[str] | None = None) -> int:
             fallback_or_degraded=args.fallback_or_degraded,
             claim_matrix_status=args.claim_matrix_status,
         ),
+        trace_input_paths=trace_input_paths,
     )
 
     sanitized_pack = _sanitize(pack)

--- a/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
+++ b/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
@@ -68,6 +68,7 @@ _FIGURE_EXECUTION_MODES = {"native", "durable_replay"}
 _ALLOWED_CLAIM_STATUSES = {"allowed", "claimable"}
 _METRIC_INPUT_PATH_KEY = "_failure_pack_metric_input_path"
 _METRIC_INPUT_LINE_KEY = "_failure_pack_metric_input_line"
+_REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
 @dataclass(frozen=True)
@@ -117,7 +118,7 @@ def _expand_timeline(timeline: list[dict[str, Any]], dt: float) -> list[dict[str
 
 def _portable_input_path(path: Path, *, repo_root: Path | None = None) -> str:
     """Return a non-absolute path suitable for tracked provenance output."""
-    root = (repo_root or Path.cwd()).resolve()
+    root = (repo_root or _REPO_ROOT).resolve()
     resolved = path.resolve()
     try:
         return resolved.relative_to(root).as_posix()

--- a/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
+++ b/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
@@ -3,17 +3,16 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, Any
+from pathlib import Path
+from typing import Any
 
 import pytest
 
 from scripts.analysis.build_signalized_crossing_failure_pack_issue_2754 import (
     ALLOWED_CLAIM_WORDING,
+    _portable_input_path,
     main,
 )
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 
 def _make_dummy_trace(episode_id: str, scenario_id: str) -> dict[str, Any]:
@@ -128,6 +127,23 @@ def _eligible_runtime_args() -> list[str]:
         "--claim-matrix-status",
         "allowed",
     ]
+
+
+def test_portable_input_path_is_repo_relative_outside_repo_cwd(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Repo-local absolute paths stay repo-relative even when the process CWD is elsewhere."""
+    repo_root = Path(__file__).resolve().parents[2]
+    source_path = (
+        repo_root / "scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py"
+    )
+
+    monkeypatch.chdir(tmp_path)
+
+    assert (
+        _portable_input_path(source_path)
+        == "scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py"
+    )
 
 
 def test_real_failure_case_output(tmp_path: Path) -> None:

--- a/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
+++ b/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
@@ -288,6 +288,31 @@ def test_metric_row_input_provenance_records_matched_jsonl_line(tmp_path: Path) 
     assert not case["episodes_jsonl_path"].startswith("/")
 
 
+def test_invalid_jsonl_error_reports_input_path_and_line(tmp_path: Path) -> None:
+    """Malformed metric rows fail with the JSONL source path and physical line number."""
+    trace_path = tmp_path / "trace.json"
+    trace_path.write_text(json.dumps(_make_dummy_trace("fail_ep_0", "fail_scen_0")))
+    record_path = tmp_path / "episodes.jsonl"
+    record_path.write_text(json.dumps({"episode_id": "other_ep_0"}) + "\n" + "{oops\n")
+    output_path = tmp_path / "result.json"
+
+    with pytest.raises(ValueError) as exc_info:
+        main(
+            [
+                "--traces",
+                str(trace_path),
+                "--episodes-jsonl",
+                str(record_path),
+                "--output-json",
+                str(output_path),
+            ]
+        )
+
+    message = str(exc_info.value)
+    assert "Invalid JSONL in episodes.jsonl at line 2" in message
+    assert "Expecting property name enclosed in double quotes" in message
+
+
 def test_missing_provenance_defaults_to_diagnostic_only(tmp_path: Path) -> None:
     """Missing provenance fails closed even when denominator evidence is planner-observable."""
     trace_path, record_path = _write_failure_inputs(tmp_path)

--- a/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
+++ b/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
@@ -313,6 +313,29 @@ def test_invalid_jsonl_error_reports_input_path_and_line(tmp_path: Path) -> None
     assert "Expecting property name enclosed in double quotes" in message
 
 
+def test_non_object_jsonl_error_reports_input_path_and_line(tmp_path: Path) -> None:
+    """Metric JSONL rows must be objects before provenance fields are attached."""
+    trace_path = tmp_path / "trace.json"
+    trace_path.write_text(json.dumps(_make_dummy_trace("fail_ep_0", "fail_scen_0")))
+    record_path = tmp_path / "episodes.jsonl"
+    record_path.write_text(json.dumps({"episode_id": "other_ep_0"}) + "\n" + "[]\n")
+    output_path = tmp_path / "result.json"
+
+    with pytest.raises(ValueError) as exc_info:
+        main(
+            [
+                "--traces",
+                str(trace_path),
+                "--episodes-jsonl",
+                str(record_path),
+                "--output-json",
+                str(output_path),
+            ]
+        )
+
+    assert "Invalid JSONL in episodes.jsonl at line 2: expected object" in str(exc_info.value)
+
+
 def test_missing_provenance_defaults_to_diagnostic_only(tmp_path: Path) -> None:
     """Missing provenance fails closed even when denominator evidence is planner-observable."""
     trace_path, record_path = _write_failure_inputs(tmp_path)

--- a/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
+++ b/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
@@ -188,6 +188,10 @@ def test_real_failure_case_output(tmp_path: Path) -> None:
     case = result["cases"][0]
     assert case["episode_id"] == "fail_ep_0"
     assert case["scenario_id"] == "fail_scen_0"
+    assert case["trace_path"] == "trace.json"
+    assert case["episodes_jsonl_path"] == "episodes.jsonl"
+    assert case["metric_row_line_number"] == 1
+    assert case["metric_row_claim_boundary"] is None
     assert case["trace_row_range"] == [0, 1]
     assert case["signal_phase"] == "red"
     assert case["stop_line_geometry"] == [[1.0, 1.0], [1.0, -1.0]]
@@ -206,6 +210,82 @@ def test_real_failure_case_output(tmp_path: Path) -> None:
     assert case["allowed_claim_wording"] == ALLOWED_CLAIM_WORDING
     assert case["diagnostic_only"] is False
     assert case["figure_eligible"] is True
+
+
+def test_metric_row_input_provenance_records_matched_jsonl_line(tmp_path: Path) -> None:
+    """The emitted case points to the matched metric row, not just the JSONL file."""
+    trace_data = _make_dummy_trace("fail_ep_0", "fail_scen_0")
+    trace_path = tmp_path / "trace.json"
+    trace_path.write_text(json.dumps(trace_data))
+
+    unmatched_record = {
+        "episode_id": "other_ep_0",
+        "scenario_id": "other_scen_0",
+        "seed": 456,
+        "metrics": {
+            "collisions": 1.0,
+            "comfort_exposure": 0.0,
+            "near_misses": 0,
+            "signal_metrics_denominator": 1,
+            "signal_metrics_evidence": {
+                "state": "planner_observable",
+                "exclusion_reason": "",
+            },
+        },
+    }
+    matched_record = {
+        "episode_id": "fail_ep_0",
+        "scenario_id": "fail_scen_0",
+        "seed": 123,
+        "metrics": {
+            "collisions": 1.0,
+            "comfort_exposure": 0.0,
+            "near_misses": 0,
+            "signal_metrics_denominator": 1,
+            "signal_metrics_evidence": {
+                "state": "planner_observable",
+                "exclusion_reason": "",
+            },
+        },
+        "scenario_params": {
+            "metadata": {
+                "signal_state": {
+                    "timeline": [{"state": "red", "duration": 5.0}],
+                    "stop_line": [[1.0, 1.0], [1.0, -1.0]],
+                }
+            }
+        },
+        "claim_boundary": "unit-test metric row boundary",
+    }
+    record_path = tmp_path / "episodes.jsonl"
+    record_path.write_text(
+        json.dumps(unmatched_record) + "\n" + json.dumps(matched_record) + "\n",
+        encoding="utf-8",
+    )
+
+    output_path = tmp_path / "result.json"
+
+    exit_code = main(
+        [
+            "--traces",
+            str(trace_path),
+            "--episodes-jsonl",
+            str(record_path),
+            "--output-json",
+            str(output_path),
+            *_eligible_runtime_args(),
+        ]
+    )
+    assert exit_code == 0
+
+    result = json.loads(output_path.read_text(encoding="utf-8"))
+    case = result["cases"][0]
+    assert case["trace_path"] == "trace.json"
+    assert case["episodes_jsonl_path"] == "episodes.jsonl"
+    assert case["metric_row_line_number"] == 2
+    assert case["metric_row_claim_boundary"] == "unit-test metric row boundary"
+    assert not case["trace_path"].startswith("/")
+    assert not case["episodes_jsonl_path"].startswith("/")
 
 
 def test_missing_provenance_defaults_to_diagnostic_only(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds case-level input provenance to the signalized-crossing failure-pack builder so each emitted case records the trace path, metric JSONL path, matched JSONL line number, and metric-row claim boundary.

## Linked Issues
- Closes `#3308`
- Relates to `#3298`
- Relates to `#2754`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added repo-relative `trace_path` and `episodes_jsonl_path` to failure-pack cases.
- Added `metric_row_line_number` and `metric_row_claim_boundary` to point each case back to the matched metric row.
- Kept `metric_row` scoped to the metrics dictionary.
- Added focused tests with two JSONL rows to prove the matched row line is recorded.
- Added malformed-JSONL and non-object row handling that reports the repo-relative input path and physical line number.
- Anchored portable provenance paths to the repository root instead of process CWD.
- Regenerated the tracked #2754 smoke summary and updated its README output note.

## Why It Matters
- Added value: makes failure-pack cases auditable back to concrete trace and metric-row inputs.
- Expected impact: downstream reviews can verify which metric row produced a case without relying on absolute local paths or free-text inference.
- Why this is worth merging now: it closes the bounded provenance gap created as follow-up #3308 from the fail-closed eligibility fix.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: failure-pack evidence should preserve case-level source provenance without upgrading fixture/synthetic smoke rows.
- Comparator or baseline, if applicable: previous cases carried metric values but not trace/JSONL path, JSONL line number, or metric-row claim boundary.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: matched case emits non-absolute path and line provenance while #3298 figure eligibility remains fail-closed.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3308 and `docs/context/evidence/issue_2754_signalized_failure_pack_smoke/`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - this extends an existing evidence helper and regenerates its tracked smoke output.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress? no; this changes evidence provenance metadata only.
- Did the scenario actually contain the targeted failure mode? yes; the tracked #2754 smoke summary still contains one fixture-backed failure case.
- Result route: stop
- Follow-up question or issue for weak, negative, or non-transfer results: NA - no deferred scope for this bounded provenance fix.

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop for #3308.
- Proposed child issue or existing follow-up: NA.

## Validation / Proof
- Commands run:
  - `uv sync --all-extras`
  - `uv run ruff format scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py`
  - `uv run ruff check scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py`
  - `uv run pytest tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py -q`
  - `uv run python scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py --traces tests/fixtures/analysis_workbench/simulation_trace_export_v1/issue_2868_signalized_crossing_fixture_0000.json --episodes-jsonl docs/context/evidence/issue_2754_signalized_failure_pack_smoke/episodes.jsonl --artifact-status current --trace-source-kind fixture --metric-source-kind synthetic --evidence-tier smoke --execution-mode fixture --claim-matrix-status diagnostic_only --allowed-claim-wording <smoke-boundary-text> --output-json docs/context/evidence/issue_2754_signalized_failure_pack_smoke/summary.json`
  - `rg -n "/home/|/tmp/|/Users/|robot_sf_ll7.worktrees" docs/context/evidence/issue_2754_signalized_failure_pack_smoke/summary.json docs/context/evidence/issue_2754_signalized_failure_pack_smoke/README.md || true`
  - `git diff --check`
  - `BASE_REF=origin/main PR_READY_MODE=final PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3308-pr-body.md uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused tests prove row 2 is recorded when it is the matched metric row; malformed JSONL reports `episodes.jsonl` plus line `2`; non-object rows fail before provenance fields are attached; repo-local absolute paths remain repo-relative even when CWD is outside the repo; tracked smoke summary now contains repo-relative paths and line `1` with no absolute local paths.
- Benchmarks or smoke tests, if applicable: #2754 tracked smoke evidence regenerated from committed fixture and JSONL input.

## Risks / Rollout
- Compatibility risks: consumers that assume only the previous case fields should ignore the added provenance keys.
- Failure modes: externally supplied absolute temp paths collapse to basename to avoid tracked local paths.
- Rollback or fallback plan: revert this PR to remove the added provenance fields from future generated packs.

## Docs / Provenance
- Updated docs: `docs/context/evidence/issue_2754_signalized_failure_pack_smoke/README.md`
- Relevant design or provenance notes: `docs/context/evidence/issue_2754_signalized_failure_pack_smoke/summary.json`
- Any assumptions that need to be preserved: metric-row claim boundary is recorded as provenance only; it does not upgrade figure eligibility.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, #3308 was claimed and this PR closes it.
- Claim map / benchmark report updated (yes/no/NA): yes, the tracked #2754 smoke evidence was regenerated.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA; the existing evidence note was updated directly.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: no additional downstream propagation is deferred for this scoped fix.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: check that `metric_row_claim_boundary` is copied for provenance only, invalid JSONL errors identify the offending input row, and figure eligibility remains controlled by explicit provenance fields.
- Any known limitations: this PR does not infer provenance from claim-boundary text and does not rerun planner/simulator execution.
