### PR TITLE
test: split core readiness from optional extras (#3301)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -64,6 +64,8 @@ Use `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` for the dependency-mini
 readiness lane. If a change touches predictive or other optional-extra paths and you need the
 optional proof lane directly, run `ROBOT_SF_TEST_LANE=optional scripts/dev/run_tests_parallel.sh
 --lane optional`.
+This lane split was introduced for issue #3301 and PR #3314; the executable source of truth is
+`scripts/dev/pr_ready_check.sh` dispatching to `scripts/dev/run_tests_parallel.sh`.
 
 ### Claim-map validation
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -60,6 +60,11 @@ Escalate to `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` when the change
 schemas, generated indexes, routing behavior, automation, runtime behavior, benchmark/metric/schema
 semantics, model provenance, or paper-facing claims.
 
+Use `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` for the dependency-minimal core
+readiness lane. If a change touches predictive or other optional-extra paths and you need the
+optional proof lane directly, run `ROBOT_SF_TEST_LANE=optional scripts/dev/run_tests_parallel.sh
+--lane optional`.
+
 ### Claim-map validation
 
 The fast-results claim map is an executable issue queue, not only a context note. Before changing

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -88,6 +88,51 @@ print_compact_worktree_status() {
   fi
 }
 
+is_optional_readiness_path() {
+  case "$1" in
+    robot_sf/benchmark/*|\
+    robot_sf/baselines/drl_vo.py|\
+    robot_sf/feature_extractor.py|\
+    robot_sf/feature_extractors/*|\
+    robot_sf/planner/*|\
+    robot_sf/training/*|\
+    robot_sf_carla_bridge/*|\
+    scripts/multi_extractor_training.py|\
+    scripts/tools/benchmark_feature_extractors.py|\
+    scripts/tools/probe_social_navigation_pyenvs_socialforce_runtime.py|\
+    scripts/tools/probe_sonic_model_inference.py|\
+    scripts/training/*|\
+    tests/benchmark/*|\
+    tests/benchmark_full/*|\
+    tests/carla_bridge/*|\
+    tests/integration/*|\
+    tests/planner/*|\
+    tests/render/*|\
+    tests/training/*|\
+    tests/visuals/*|\
+    tests/sb3_test.py|\
+    tests/tools/test_probe_sonic_model_inference.py|\
+    tests/test_baseline_ppo_smoke.py|\
+    tests/test_benchmark_visualization_integration.py|\
+    tests/test_feature_extractors.py|\
+    tests/test_grid_socnav_extractor.py|\
+    tests/test_map_runner_ppo.py|\
+    tests/test_map_runner_sac.py|\
+    tests/test_output_root_migration.py|\
+    tests/test_ppo_diagnostics.py|\
+    tests/test_predictive_model.py|\
+    tests/unit/test_cli_logging_flags.py|\
+    tests/unit/test_figure_orchestrator_requirements.py|\
+    tests/unit/test_runner_helper_coverage.py|\
+    tests/unit/test_runner_video.py)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
 pr_ready_mode_lower=$(printf '%s' "$PR_READY_MODE" | tr '[:upper:]' '[:lower:]')
 case "$pr_ready_mode_lower" in
   "")
@@ -120,6 +165,32 @@ if [[ "$pr_ready_final" == "1" ]]; then
   preflight_check_test_deps
 fi
 
+changed_files=()
+core_changed_files=()
+optional_changed_files=()
+while IFS= read -r changed_file; do
+  [[ -z "$changed_file" ]] && continue
+  changed_files+=("$changed_file")
+  if is_optional_readiness_path "$changed_file"; then
+    optional_changed_files+=("$changed_file")
+  else
+    core_changed_files+=("$changed_file")
+  fi
+done < <(git diff --name-only --diff-filter=ACMRT "$BASE_REF...HEAD")
+
+if [[ ${#changed_files[@]} -gt 0 ]]; then
+  printf 'Changed files vs %s:\n' "$BASE_REF" >&2
+  printf '%s\n' "${changed_files[@]}" >&2
+fi
+if [[ ${#core_changed_files[@]} -gt 0 ]]; then
+  printf 'Core-ready changed files:\n' >&2
+  printf '%s\n' "${core_changed_files[@]}" >&2
+fi
+if [[ ${#optional_changed_files[@]} -gt 0 ]]; then
+  printf 'Optional-extra changed files requiring the predictive lane:\n' >&2
+  printf '%s\n' "${optional_changed_files[@]}" >&2
+fi
+
 followup_args=()
 if [[ "$pr_ready_final" == "1" ]]; then
   followup_args+=(--require-body)
@@ -127,7 +198,14 @@ fi
 uv run python "$SCRIPT_DIR/check_pr_followups.py" "${followup_args[@]}"
 uv run python "$SCRIPT_DIR/check_fast_results_claim_map.py"
 "$SCRIPT_DIR/ruff_fix_format.sh"
-ROBOT_SF_PYTEST_COVERAGE=1 "$SCRIPT_DIR/run_tests_parallel.sh"
+printf 'Running core readiness lane.\n' >&2
+ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=core "$SCRIPT_DIR/run_tests_parallel.sh" --lane core
+if [[ ${#optional_changed_files[@]} -gt 0 ]]; then
+  printf 'Running optional-extra lane for predictive/optional changed files.\n' >&2
+  ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional
+else
+  printf 'No changed files require the optional-extra lane.\n' >&2
+fi
 "$SCRIPT_DIR/check_changed_coverage.sh"
 "$SCRIPT_DIR/check_docstring_todos_diff.sh"
 "$SCRIPT_DIR/check_docstring_todos_ratchet.sh"

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -13,11 +13,16 @@ Wrapper options:
   --failed-first   Run previously failed tests first [default]
   --new-first      Run tests from new files first
   --no-ordering    Disable ordering hints
+  --lane core|optional|all
+                   Select the pytest collection lane. Core defaults to a
+                   dependency-minimal path set; optional defaults to
+                   optional-extra paths; all preserves the existing behavior.
   -h, --help       Show this help message
 
 Environment overrides:
   ROBOT_SF_PYTEST_COVERAGE=1
     Explicit opt-in for coverage output when running this wrapper.
+  ROBOT_SF_TEST_LANE=core|optional|all
   COVERAGE_FILE=<path>
   PYTEST_FAST_FAIL=1|0
   PYTEST_XDIST_DIST=load|worksteal|loadscope|loadfile|loadgroup
@@ -45,6 +50,91 @@ fast_fail="${PYTEST_FAST_FAIL:-1}"
 dist_mode="${PYTEST_XDIST_DIST:-load}"
 order_mode="${PYTEST_ORDER_MODE:-failed-first}"
 worker_override="${PYTEST_NUM_WORKERS:-}"
+lane_mode="${ROBOT_SF_TEST_LANE:-all}"
+core_test_paths=(
+  tests/common
+  tests/contract
+  tests/factories
+  tests/guard
+  tests/sensor
+  tests/sim
+  tests/unit
+  tests/dev
+  tests/test_action_adapters.py
+  tests/test_config_validation.py
+  tests/test_environment_factory_signatures.py
+  tests/test_error_policy.py
+  tests/test_planner.py
+  tests/test_range_sensor.py
+  tests/test_seed_utils.py
+  tests/test_types.py
+  tests/test_ci_script_contract.py
+  tests/map_test.py
+  tests/navigation_test.py
+  tests/ped_grouping_test.py
+  tests/sim_config_test.py
+  tests/unicycle_drive_test.py
+  tests/zone_sampling_test.py
+)
+optional_test_paths=(
+  tests/benchmark
+  tests/benchmark_full
+  tests/carla_bridge
+  tests/integration
+  tests/planner
+  tests/render
+  tests/training
+  tests/visuals
+  tests/tools/test_probe_sonic_model_inference.py
+  tests/sb3_test.py
+  tests/test_baseline_ppo_smoke.py
+  tests/test_benchmark_visualization_integration.py
+  tests/test_feature_extractors.py
+  tests/test_grid_socnav_extractor.py
+  tests/test_map_runner_ppo.py
+  tests/test_map_runner_sac.py
+  tests/test_output_root_migration.py
+  tests/test_ppo_diagnostics.py
+  tests/test_predictive_model.py
+  tests/unit/test_cli_logging_flags.py
+  tests/unit/test_figure_orchestrator_requirements.py
+  tests/unit/test_runner_helper_coverage.py
+  tests/unit/test_runner_video.py
+)
+
+is_optional_test_path() {
+  local path="${1#./}"
+  case "$path" in
+    tests/benchmark|tests/benchmark/*|\
+    tests/benchmark_full|tests/benchmark_full/*|\
+    tests/carla_bridge|tests/carla_bridge/*|\
+    tests/integration|tests/integration/*|\
+    tests/planner|tests/planner/*|\
+    tests/render|tests/render/*|\
+    tests/training|tests/training/*|\
+    tests/visuals|tests/visuals/*|\
+    tests/tools/test_probe_sonic_model_inference.py|\
+    tests/sb3_test.py|\
+    tests/test_baseline_ppo_smoke.py|\
+    tests/test_benchmark_visualization_integration.py|\
+    tests/test_feature_extractors.py|\
+    tests/test_grid_socnav_extractor.py|\
+    tests/test_map_runner_ppo.py|\
+    tests/test_map_runner_sac.py|\
+    tests/test_output_root_migration.py|\
+    tests/test_ppo_diagnostics.py|\
+    tests/test_predictive_model.py|\
+    tests/unit/test_cli_logging_flags.py|\
+    tests/unit/test_figure_orchestrator_requirements.py|\
+    tests/unit/test_runner_helper_coverage.py|\
+    tests/unit/test_runner_video.py)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
 
 pytest_args=()
 while [[ $# -gt 0 ]]; do
@@ -69,6 +159,14 @@ while [[ $# -gt 0 ]]; do
       order_mode="none"
       shift
       ;;
+    --lane)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        echo "--lane requires a non-empty value." >&2
+        exit 2
+      fi
+      lane_mode="$2"
+      shift 2
+      ;;
     -h|--help)
       show_help
       exit 0
@@ -89,7 +187,17 @@ case "$dist_mode" in
     ;;
 esac
 
+case "$lane_mode" in
+  all|core|optional)
+    ;;
+  *)
+    echo "Invalid ROBOT_SF_TEST_LANE value '$lane_mode' (expected all|core|optional)." >&2
+    exit 2
+    ;;
+esac
+
 echo "Resolved pytest-xdist distribution mode: $dist_mode" >&2
+echo "Resolved pytest lane: $lane_mode" >&2
 
 requested_args=()
 if [[ -n "$worker_override" ]]; then
@@ -115,6 +223,47 @@ if [[ "${CI:-}" == "true" ]] || [[ "$coverage_requested" == "1" ]] || \
   [[ "$coverage_requested" == [Yy][Ee][Ss] ]] || \
   [[ "$coverage_requested" == [Oo][Nn] ]]; then
   cmd+=("--cov=robot_sf" "--cov-report=html" "--cov-report=json")
+fi
+
+if [[ "$lane_mode" != "all" ]]; then
+  export ROBOT_SF_TEST_LANE="$lane_mode"
+fi
+
+explicit_test_targets=()
+for pytest_arg in "${pytest_args[@]}"; do
+  [[ "$pytest_arg" == -* ]] && continue
+  if [[ -e "$pytest_arg" || "$pytest_arg" == tests* ]]; then
+    explicit_test_targets+=("$pytest_arg")
+  fi
+done
+
+if [[ "$lane_mode" == "core" ]]; then
+  for pytest_arg in "${explicit_test_targets[@]}"; do
+    if is_optional_test_path "$pytest_arg"; then
+      echo "Core pytest lane cannot run optional-extra path '$pytest_arg'." >&2
+      echo "Use scripts/dev/run_tests_parallel.sh --lane optional for torch/rvo2/CARLA/predictive tests." >&2
+      exit 2
+    fi
+  done
+  if [[ ${#explicit_test_targets[@]} -eq 0 ]]; then
+    for core_test_path in "${core_test_paths[@]}"; do
+      if [[ -e "$core_test_path" ]]; then
+        pytest_args+=("$core_test_path")
+      fi
+    done
+  else
+    for optional_test_path in "${optional_test_paths[@]}"; do
+      if [[ -e "$optional_test_path" ]]; then
+        cmd+=("--ignore=$optional_test_path")
+      fi
+    done
+  fi
+elif [[ "$lane_mode" == "optional" && ${#explicit_test_targets[@]} -eq 0 ]]; then
+  for optional_test_path in "${optional_test_paths[@]}"; do
+    if [[ -e "$optional_test_path" ]]; then
+      pytest_args+=("$optional_test_path")
+    fi
+  done
 fi
 
 if [[ "$fast_fail" == "1" ]]; then

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -102,8 +102,15 @@ optional_test_paths=(
   tests/unit/test_runner_video.py
 )
 
-is_optional_test_path() {
+normalize_pytest_target_path() {
   local path="${1#./}"
+  path="${path%%::*}"
+  printf '%s\n' "$path"
+}
+
+is_optional_test_path() {
+  local path
+  path="$(normalize_pytest_target_path "$1")"
   case "$path" in
     tests/benchmark|tests/benchmark/*|\
     tests/benchmark_full|tests/benchmark_full/*|\
@@ -232,7 +239,8 @@ fi
 explicit_test_targets=()
 for pytest_arg in "${pytest_args[@]}"; do
   [[ "$pytest_arg" == -* ]] && continue
-  if [[ -e "$pytest_arg" || "$pytest_arg" == tests* ]]; then
+  normalized_pytest_arg="$(normalize_pytest_target_path "$pytest_arg")"
+  if [[ -e "$normalized_pytest_arg" || "$normalized_pytest_arg" == tests* ]]; then
     explicit_test_targets+=("$pytest_arg")
   fi
 done

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -270,6 +270,37 @@ _SLOW_FILE_OVERRIDES = {
     "test_edge_cases_recording.py",
     "test_runner_video.py",
 }
+_TEST_LANE_ENV = "ROBOT_SF_TEST_LANE"
+_TEST_LANE_ALL = "all"
+_TEST_LANE_CORE = "core"
+_TEST_LANE_OPTIONAL = "optional"
+_OPTIONAL_TEST_PATH_FRAGMENTS = (
+    "tests/benchmark/",
+    "tests/benchmark_full/",
+    "tests/carla_bridge/",
+    "tests/integration/",
+    "tests/planner/",
+    "tests/render/",
+    "tests/training/",
+    "tests/visuals/",
+)
+_OPTIONAL_TEST_FILES = {
+    "tests/sb3_test.py",
+    "tests/tools/test_probe_sonic_model_inference.py",
+    "tests/test_baseline_ppo_smoke.py",
+    "tests/test_benchmark_visualization_integration.py",
+    "tests/test_feature_extractors.py",
+    "tests/test_grid_socnav_extractor.py",
+    "tests/test_map_runner_ppo.py",
+    "tests/test_map_runner_sac.py",
+    "tests/test_output_root_migration.py",
+    "tests/test_ppo_diagnostics.py",
+    "tests/test_predictive_model.py",
+    "tests/unit/test_cli_logging_flags.py",
+    "tests/unit/test_figure_orchestrator_requirements.py",
+    "tests/unit/test_runner_helper_coverage.py",
+    "tests/unit/test_runner_video.py",
+}
 
 
 @pytest.fixture
@@ -342,6 +373,49 @@ def _should_auto_mark_slow(path_str: str) -> bool:
     if any(filename.startswith(prefix) for prefix in _FAST_FILE_PREFIXES):
         return False
     return True
+
+
+def _configured_test_lane() -> str:
+    """Return the active pytest collection lane."""
+    lane = os.environ.get(_TEST_LANE_ENV, _TEST_LANE_ALL).strip().lower()
+    if lane in {_TEST_LANE_ALL, _TEST_LANE_CORE, _TEST_LANE_OPTIONAL}:
+        return lane
+    return _TEST_LANE_ALL
+
+
+def _is_optional_readiness_test_path(path_str: str) -> bool:
+    """Return whether a test path needs optional-extra readiness dependencies."""
+    normalized = path_str.replace("\\", "/")
+    repo_relative = normalized.split("/tests/", maxsplit=1)
+    if len(repo_relative) == 2:
+        normalized = f"tests/{repo_relative[1]}"
+    return normalized in _OPTIONAL_TEST_FILES or any(
+        fragment in normalized for fragment in _OPTIONAL_TEST_PATH_FRAGMENTS
+    )
+
+
+def _should_collect_in_lane(path_str: str, lane: str) -> bool:
+    """Return whether a path belongs in the requested pytest lane."""
+    is_optional = _is_optional_readiness_test_path(path_str)
+    if lane == _TEST_LANE_CORE:
+        return not is_optional
+    if lane == _TEST_LANE_OPTIONAL:
+        return is_optional
+    return True
+
+
+def pytest_ignore_collect(collection_path, path=None, config=None):  # type: ignore[missing-type-doc]
+    """Skip fast or slow files before import when a lane is explicitly selected."""
+    del path
+    del config
+    lane = _configured_test_lane()
+    if lane == _TEST_LANE_ALL:
+        return False
+
+    path_obj = Path(str(collection_path))
+    if path_obj.is_dir():
+        return False
+    return not _should_collect_in_lane(path_obj.as_posix(), lane)
 
 
 def pytest_collection_modifyitems(config, items):  # type: ignore[missing-type-doc]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -385,8 +385,8 @@ def _configured_test_lane() -> str:
 
 def _is_optional_readiness_test_path(path_str: str) -> bool:
     """Return whether a test path needs optional-extra readiness dependencies."""
-    normalized = path_str.replace("\\", "/")
-    repo_relative = normalized.split("/tests/", maxsplit=1)
+    normalized = path_str.replace("\\", "/").split("::", maxsplit=1)[0]
+    repo_relative = normalized.rsplit("/tests/", maxsplit=1)
     if len(repo_relative) == 2:
         normalized = f"tests/{repo_relative[1]}"
     return normalized in _OPTIONAL_TEST_FILES or any(

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -14,6 +14,7 @@ SCRIPTS_DEV = REPO_ROOT / "scripts" / "dev"
 
 _POST_PREFLIGHT_SCRIPTS = [
     "check_pr_followups.py",
+    "check_fast_results_claim_map.py",
     "ruff_fix_format.sh",
     "run_tests_parallel.sh",
     "check_changed_coverage.sh",
@@ -95,6 +96,19 @@ def _make_fake_scripts(repo: Path) -> None:
             stub.chmod(0o755)
 
 
+def _write_lane_logging_stub(repo: Path) -> Path:
+    """Replace the test wrapper with a logger that records each lane invocation."""
+    stub = repo / "scripts" / "dev" / "run_tests_parallel.sh"
+    stub.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf "%s %s\\n" "${ROBOT_SF_TEST_LANE:-unset}" "$*" >> "$PWD/lane.log"\n'
+        "exit 0\n",
+        encoding="utf-8",
+    )
+    stub.chmod(0o755)
+    return repo / "lane.log"
+
+
 @pytest.fixture()
 def preflight_repo(tmp_path: Path) -> Path:
     """Return a committed git repo with the preflight and stub scripts."""
@@ -172,6 +186,95 @@ def test_interim_mode_keeps_existing_non_preflight_path(preflight_repo: Path) ->
     result = _run_pr_ready(preflight_repo, help_flag=False)
     assert result.returncode == 0, f"Script failed: {result.stderr}"
     assert "Final PR readiness requires analytics dependencies" not in result.stderr
+
+
+def test_pr_ready_check_escalates_optional_changed_files_to_the_optional_lane(
+    preflight_repo: Path,
+) -> None:
+    """Predictive or optional-path changes should trigger the optional lane."""
+    lane_log = _write_lane_logging_stub(preflight_repo)
+
+    changed_file = preflight_repo / "tests" / "planner" / "test_sonic_crowdnav.py"
+    changed_file.parent.mkdir(parents=True, exist_ok=True)
+    changed_file.write_text("print('optional lane')\n", encoding="utf-8")
+    _git(preflight_repo, "add", "-A")
+    _git(preflight_repo, "commit", "-q", "-m", "optional lane change")
+
+    result = _run_pr_ready(
+        preflight_repo,
+        help_flag=False,
+        env_overrides={
+            "BASE_REF": "HEAD~1",
+            "PR_READY_MODE": "interim",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    lane_lines = lane_log.read_text(encoding="utf-8").splitlines()
+    assert lane_lines == [
+        "core --lane core",
+        "optional --lane optional",
+    ]
+    assert "Optional-extra changed files requiring the predictive lane" in result.stderr
+
+
+def test_pr_ready_check_keeps_core_only_changes_on_the_core_lane(preflight_repo: Path) -> None:
+    """Core-only changes should not schedule the optional lane."""
+    lane_log = _write_lane_logging_stub(preflight_repo)
+
+    changed_file = preflight_repo / "tests" / "unit" / "test_core_lane.py"
+    changed_file.parent.mkdir(parents=True, exist_ok=True)
+    changed_file.write_text("print('core lane')\n", encoding="utf-8")
+    _git(preflight_repo, "add", "-A")
+    _git(preflight_repo, "commit", "-q", "-m", "core lane change")
+
+    result = _run_pr_ready(
+        preflight_repo,
+        help_flag=False,
+        env_overrides={
+            "BASE_REF": "HEAD~1",
+            "PR_READY_MODE": "interim",
+        },
+    )
+
+    assert result.returncode == 0, result.stderr
+    lane_lines = lane_log.read_text(encoding="utf-8").splitlines()
+    assert lane_lines == ["core --lane core"]
+    assert "No changed files require the optional-extra lane." in result.stderr
+
+
+def test_core_lane_collection_hook_skips_optional_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The pytest collection hook should keep optional files out of the core lane."""
+    import tests.conftest as test_conftest
+
+    monkeypatch.setenv("ROBOT_SF_TEST_LANE", "core")
+    assert (
+        test_conftest.pytest_ignore_collect(Path("tests/planner/test_sonic_crowdnav.py"), None)
+        is True
+    )
+    assert (
+        test_conftest.pytest_ignore_collect(Path("tests/unit/test_config_validation.py"), None)
+        is False
+    )
+    assert (
+        test_conftest.pytest_ignore_collect(Path("tests/dev/test_pr_ready_preflight.py"), None)
+        is False
+    )
+
+
+def test_optional_lane_collection_hook_skips_core_paths(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The optional lane should collect only optional-extra test paths."""
+    import tests.conftest as test_conftest
+
+    monkeypatch.setenv("ROBOT_SF_TEST_LANE", "optional")
+    assert (
+        test_conftest.pytest_ignore_collect(Path("tests/planner/test_sonic_crowdnav.py"), None)
+        is False
+    )
+    assert (
+        test_conftest.pytest_ignore_collect(Path("tests/dev/test_pr_ready_preflight.py"), None)
+        is True
+    )
 
 
 def test_preflight_passes_when_modules_available(preflight_repo: Path) -> None:

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -260,6 +260,12 @@ def test_core_lane_collection_hook_skips_optional_paths(monkeypatch: pytest.Monk
         test_conftest.pytest_ignore_collect(Path("tests/dev/test_pr_ready_preflight.py"), None)
         is False
     )
+    assert (
+        test_conftest._is_optional_readiness_test_path(
+            "/tmp/tests-parent/repo/tests/planner/test_sonic_crowdnav.py::test_case"
+        )
+        is True
+    )
 
 
 def test_optional_lane_collection_hook_skips_core_paths(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -85,7 +85,7 @@ def test_run_tests_parallel_exposes_xdist_distribution_mode() -> None:
     assert "ROBOT_SF_TEST_LANE=core|optional|all" in script_text
     assert "Resolved pytest lane:" in script_text
     assert "normalize_pytest_target_path()" in script_text
-    assert '${path%%::*}' in script_text
+    assert "${path%%::*}" in script_text
     assert "core_test_paths=(" in script_text
     assert "explicit_test_targets=(" in script_text
     assert 'cmd+=("--ignore=$optional_test_path")' in script_text
@@ -107,7 +107,10 @@ def test_pytest_coverage_is_explicit_opt_in() -> None:
     assert "ROBOT_SF_PYTEST_COVERAGE" in script_text
     assert "${coverage_requested,,}" not in script_text
     assert 'cmd+=("--cov=robot_sf" "--cov-report=html" "--cov-report=json")' in script_text
-    assert 'ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=core "$SCRIPT_DIR/run_tests_parallel.sh" --lane core' in pr_ready_text
+    assert (
+        'ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=core "$SCRIPT_DIR/run_tests_parallel.sh" --lane core'
+        in pr_ready_text
+    )
 
 
 def test_run_tests_parallel_validates_dist_mode_before_resolving_workers() -> None:
@@ -262,8 +265,14 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
     ]
     for gate in expected_gates:
         assert gate in script_text
-    assert 'ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=core "$SCRIPT_DIR/run_tests_parallel.sh" --lane core' in script_text
-    assert 'ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional' in script_text
+    assert (
+        'ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=core "$SCRIPT_DIR/run_tests_parallel.sh" --lane core'
+        in script_text
+    )
+    assert (
+        'ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional'
+        in script_text
+    )
     assert "Optional-extra changed files requiring the predictive lane" in script_text
     assert "No changed files require the optional-extra lane." in script_text
 

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -81,6 +81,15 @@ def test_run_tests_parallel_exposes_xdist_distribution_mode() -> None:
     assert "Invalid PYTEST_XDIST_DIST value" in script_text
     assert 'cmd=(uv run pytest -n "$worker_spec" --dist "$dist_mode")' in script_text
     assert "PYTEST_XDIST_DIST=load|worksteal|loadscope|loadfile|loadgroup" in script_text
+    assert "--lane core|optional|all" in script_text
+    assert "ROBOT_SF_TEST_LANE=core|optional|all" in script_text
+    assert "Resolved pytest lane:" in script_text
+    assert "core_test_paths=(" in script_text
+    assert "explicit_test_targets=(" in script_text
+    assert 'cmd+=("--ignore=$optional_test_path")' in script_text
+    assert 'pytest_args+=("$optional_test_path")' in script_text
+    assert 'pytest_args+=("$core_test_path")' in script_text
+    assert "Core pytest lane cannot run optional-extra path" in script_text
 
 
 def test_pytest_coverage_is_explicit_opt_in() -> None:
@@ -96,7 +105,7 @@ def test_pytest_coverage_is_explicit_opt_in() -> None:
     assert "ROBOT_SF_PYTEST_COVERAGE" in script_text
     assert "${coverage_requested,,}" not in script_text
     assert 'cmd+=("--cov=robot_sf" "--cov-report=html" "--cov-report=json")' in script_text
-    assert 'ROBOT_SF_PYTEST_COVERAGE=1 "$SCRIPT_DIR/run_tests_parallel.sh"' in pr_ready_text
+    assert 'ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=core "$SCRIPT_DIR/run_tests_parallel.sh" --lane core' in pr_ready_text
 
 
 def test_run_tests_parallel_validates_dist_mode_before_resolving_workers() -> None:
@@ -251,6 +260,10 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
     ]
     for gate in expected_gates:
         assert gate in script_text
+    assert 'ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=core "$SCRIPT_DIR/run_tests_parallel.sh" --lane core' in script_text
+    assert 'ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional' in script_text
+    assert "Optional-extra changed files requiring the predictive lane" in script_text
+    assert "No changed files require the optional-extra lane." in script_text
 
     freshness_call = 'uv run python "$SCRIPT_DIR/pr_ready_freshness.py" "${freshness_args[@]}"'
     assert 'freshness_args=(write --base-ref "$BASE_REF")' in script_text

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -84,6 +84,8 @@ def test_run_tests_parallel_exposes_xdist_distribution_mode() -> None:
     assert "--lane core|optional|all" in script_text
     assert "ROBOT_SF_TEST_LANE=core|optional|all" in script_text
     assert "Resolved pytest lane:" in script_text
+    assert "normalize_pytest_target_path()" in script_text
+    assert '${path%%::*}' in script_text
     assert "core_test_paths=(" in script_text
     assert "explicit_test_targets=(" in script_text
     assert 'cmd+=("--ignore=$optional_test_path")' in script_text

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -270,7 +270,7 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
         in script_text
     )
     assert (
-        'ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional'
+        'ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional'
         in script_text
     )
     assert "Optional-extra changed files requiring the predictive lane" in script_text


### PR DESCRIPTION
## Summary
Split local readiness into a dependency-minimal core pytest lane and an explicit optional-extra lane
for predictive, CARLA, planner, and other optional dependency paths.

## Linked Issues
- Closes `#3301`
- Relates to `#3313` (merged)

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none; `#3313` was opened, fixed, and merged.
- Safe to review independently: yes
- Review dependency reason, if any: none; final full-core readiness now passes after `#3313`.

## What Changed
- Added `--lane core|optional|all` to `scripts/dev/run_tests_parallel.sh`.
- Made the core lane default to dependency-minimal test paths and fail closed when explicitly asked
  to run optional-extra paths.
- Made the optional lane default to optional-extra paths and surface missing optional dependencies
  in that lane.
- Updated `scripts/dev/pr_ready_check.sh` to always run the core lane and require the optional lane
  when changed files touch optional/predictive paths.
- Added pytest collection guards and focused regression tests for lane routing.
- Documented core and optional local commands in `docs/dev_guide.md`.

## Why It Matters
- Added value: local readiness no longer fails broad collection on missing `torch` for unrelated
  core/tooling changes.
- Expected impact: optional dependency failures become actionable and lane-specific instead of
  routine noise in unrelated PRs.
- Why this is worth merging now: recent PR validation repeatedly hit missing-`torch` collection
  failures that masked whether the changed scope was actually ready.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow/support change; no research
  result claim.
- Comparator or baseline, if applicable: Existing single broad local pytest lane.
- Evidence tier: final readiness plus targeted smoke.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: core lane must avoid optional imports; optional paths must
  fail in an explicit optional lane when extras are missing.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#3301`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; does not
  interpret research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support workflow change.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this PR; final readiness passed after `#3313` merged.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no.
- Stop / revise / continue decision: continue to merge review once CI passes on the refreshed head.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `bash -n scripts/dev/pr_ready_check.sh && bash -n scripts/dev/run_tests_parallel.sh`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check tests/conftest.py tests/dev/test_pr_ready_preflight.py tests/test_ci_script_contract.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/dev/test_pr_ready_preflight.py tests/test_ci_script_contract.py -q`
  - `PYTEST_NUM_WORKERS=1 scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/run_tests_parallel.sh --lane core --collect-only -q`
  - `PYTEST_NUM_WORKERS=1 scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/run_tests_parallel.sh --lane core --collect-only -q './tests/planner/test_sonic_crowdnav.py::test_imports_without_something'`
  - `PYTEST_NUM_WORKERS=1 scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/run_tests_parallel.sh --lane optional --collect-only -q tests/planner/test_sonic_crowdnav.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/contract/test_forecast_batch_schema.py::test_forecast_batch_schema_entity_rejects_non_datetime_timestamp -q`
  - `uv sync --all-extras`
  - `uv run python scripts/dev/run_compact_validation.py --timeout-seconds 7200 -- env BASE_REF=origin/main PR_READY_MODE=final PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3301/pr-3314-body.md bash scripts/dev/pr_ready_check.sh`
- Evidence that the change works here:
  - Focused lane/contract tests passed: `62 passed`.
  - Core default collect-only passed before the final merge: `1087 tests collected`; no
    missing-`torch` collection error.
  - Core explicit optional path exits `2` before pytest import with a clear message naming the
    optional lane.
  - Optional explicit planner path fails in the optional lane with `ModuleNotFoundError: No module
    named 'torch'`, which is the expected local missing-extra state.
  - Final readiness passed on refreshed `origin/main` at head
    `3544d794ee3f0b1b21a6de019a9f0ec14efe1ed2`: `1088 passed in 66.01s`.
  - Compact final-readiness artifacts:
    `.git/codex-agent-runs/active/compact-validation/validation-20260621T084450Z-399880.log`
    and
    `.git/codex-agent-runs/active/compact-validation/validation-20260621T084450Z-399880.summary.json`.
- Benchmarks or smoke tests, if applicable: NA - workflow/test routing change.

## Risks / Rollout
- Compatibility risks: the default core lane intentionally runs a dependency-minimal path set, not
  the entire historical broad test tree.
- Failure modes: new optional dependency surfaces must be added to the optional path lists.
- Rollback or fallback plan: use `--lane all` to preserve the historical broad collection behavior.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`.
- Relevant design or provenance notes: active run ledger under `.git/codex-agent-runs/active/`.
- Any assumptions that need to be preserved: missing optional extras should be treated as relevant
  failures only when optional/predictive paths changed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR links `#3301`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, `#3313` was opened and merged.
- Not applicable because: this is workflow/test routing, not benchmark evidence or artifact
  publication.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: `#3313` was opened and merged.

## Reviewer Notes
- The PR is ready for merge review after CI finishes on the refreshed head.
- Please review the optional path lists closely; they are conservative and should be updated when
  new optional dependency test surfaces are added.
