### PR TITLE
ci: require domain-aware approval for evidence PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -38,6 +38,24 @@ to `NA` and state why.
   instrumentation, seed-sufficiency analysis, and why-report generation. For support helpers that
   do not interpret research evidence, state `NA - support helper` with the reason:
 
+## Domain-Aware Approval
+Required when `Evidence tier` is not `NA`/`docs-only`, or `Result classification` is not `NA`.
+Use this for PRs that change evidence classification, experimental comparison methodology, figure
+eligibility, benchmark interpretation, or paper-facing claim surfaces. This approval concerns
+experimental validity and claim boundaries; normal implementation integrity still comes from code
+review, tests, and CI.
+
+- Required for this PR: yes / no - reason
+- Domains reviewed: evidence classification / experimental comparison / figure eligibility / benchmark interpretation / paper-facing claims / NA
+- Status: approved / waived / pending / blocked / not required
+- Approver/review source or waiver:
+- Validity checklist:
+  - Target claim/hypothesis:
+  - Comparator or split/evidence validity:
+  - Fallback/degraded exclusions:
+  - Claim boundary:
+  - Implementation integrity vs experimental validity:
+
 ## Falsification / Non-Transfer Check
 Required for research-result PRs when the expected mechanism did not improve the measured outcome,
 only helped a local slice, or produced diagnostic-only evidence. For support/tooling/docs-only PRs

--- a/docs/code_review.md
+++ b/docs/code_review.md
@@ -47,6 +47,32 @@ follow-up issue names:
 Do not use generic backlog notes as substitutes for blockers or for follow-up issues with a clear
 acceptance condition.
 
+## Domain-Aware Approval Gate
+
+Passing CI, automated review, and implementation-integrity checks is not sufficient for PRs that
+change evidence classification, experimental comparison methodology, figure eligibility, benchmark
+interpretation, or paper-facing claim surfaces. Those PRs need an explicit `Domain-Aware Approval`
+section in the PR body before they can be treated as merge-ready.
+
+The gate is intentionally narrow. Ordinary implementation, docs, and test-only PRs can mark the
+domain approval requirement as not applicable when they do not alter evidence validity, comparison
+methodology, figure eligibility, or claim boundaries.
+
+For PRs where the gate applies, reviewers should verify that the PR body names:
+
+- target claim or hypothesis;
+- comparator and split/evidence-validity policy;
+- fallback/degraded exclusions;
+- claim boundary and evidence tier;
+- whether the change proves implementation integrity only, or also supports experimental validity.
+
+PR #3276 is the motivating comparison-methodology example: automated review accepted the linked
+issue framing even though the comparison remained circular and lacked the held-out scenario-family
+design required by the issue. PR #3273 is the motivating evidence-classification example:
+machine-readable classifications and conservative prose diverged. Future PRs in those categories
+should be held until a domain-aware approval note is present, or should state a blocker instead of
+being presented as merge-ready.
+
 ## Benchmark-Credibility Review
 
 For benchmark-facing changes, explicitly verify:

--- a/docs/maintainer_values.md
+++ b/docs/maintainer_values.md
@@ -69,6 +69,9 @@ Use validation proportional to risk.
   and verify changed links or referenced paths where practical.
 - Runtime, benchmark, metric, schema, model-provenance, and paper-facing changes need executable
   proof appropriate to the claim.
+- PRs that alter evidence classification, experimental comparison methodology, figure eligibility,
+  benchmark interpretation, or paper-facing claim surfaces need explicit domain-aware approval or a
+  stated blocker before they are treated as merge-ready.
 - Low-value tests may be removed without maintainer approval when the reason is unambiguous and
   documented, provided repository coverage expectations still hold or the remaining gap is tracked.
   Do not assume flaky tests are common; classify each failure before broad policy changes.

--- a/scripts/dev/check_pr_followups.py
+++ b/scripts/dev/check_pr_followups.py
@@ -237,10 +237,15 @@ def _domain_value_not_required(text: str) -> bool:
         return False
     if value in DOMAIN_APPROVAL_NOT_REQUIRED or value in EMPTY_OR_PLACEHOLDER:
         return True
-    return any(
-        value.startswith(f"{prefix} - ") or value.startswith(f"{prefix}: ")
-        for prefix in DOMAIN_APPROVAL_NOT_REQUIRED
-    )
+    return any(_has_value_prefix(value, prefix) for prefix in DOMAIN_APPROVAL_NOT_REQUIRED)
+
+
+def _has_value_prefix(value: str, prefix: str) -> bool:
+    """Return whether *value* starts with *prefix* as a standalone token."""
+    if not value.startswith(prefix):
+        return False
+    rest = value[len(prefix) :]
+    return not rest or rest[0] in " -:,()"
 
 
 def _domain_approval_triggers(body: str) -> tuple[str, ...]:
@@ -261,7 +266,13 @@ def _domain_checklist_errors(section: str) -> tuple[str, ...]:
     errors: list[str] = []
     for label in DOMAIN_VALIDITY_LABELS:
         value = _value_after_label(section, label)
-        if _is_empty_or_option_placeholder(value):
+        cleaned = _clean_value(value)
+        if (
+            not cleaned
+            or cleaned == "-"
+            or cleaned.startswith("#<")
+            or _is_option_placeholder(value)
+        ):
             errors.append(label)
     return tuple(errors)
 
@@ -430,8 +441,9 @@ def analyze_domain_approval(body: str, *, source: str) -> DomainApprovalReport:
     status_value = _clean_value(approval_status).lower()
     note_value = _clean_value(approval_note)
 
-    if _is_empty_or_option_placeholder(required) or required_value.startswith(
-        ("no", "n/a", "na", "not applicable")
+    if _is_empty_or_option_placeholder(required) or any(
+        _has_value_prefix(required_value, prefix)
+        for prefix in ("no", "n/a", "na", "not applicable")
     ):
         return DomainApprovalReport(
             status="domain_approval_required",

--- a/scripts/dev/check_pr_followups.py
+++ b/scripts/dev/check_pr_followups.py
@@ -44,6 +44,20 @@ EMPTY_OR_PLACEHOLDER = {
     "#<id>",
     "<id>",
 }
+DOMAIN_APPROVAL_NOT_REQUIRED = {
+    "docs-only",
+    "docs only",
+    "n/a",
+    "na",
+    "not applicable",
+}
+DOMAIN_VALIDITY_LABELS = (
+    "Target claim/hypothesis",
+    "Comparator or split/evidence validity",
+    "Fallback/degraded exclusions",
+    "Claim boundary",
+    "Implementation integrity vs experimental validity",
+)
 
 
 @dataclass(frozen=True)
@@ -56,6 +70,20 @@ class FollowupReport:
     linked_issues: tuple[str, ...]
     explicit_no_issue_reason: str
     issue_state_errors: tuple[str, ...]
+    message: str
+
+
+@dataclass(frozen=True)
+class DomainApprovalReport:
+    """Compact domain-aware approval report for evidence-validity-sensitive PRs."""
+
+    status: str
+    source: str
+    sensitive_terms: tuple[str, ...]
+    required: str
+    approval_status: str
+    approval_note: str
+    checklist_errors: tuple[str, ...]
     message: str
 
 
@@ -74,6 +102,15 @@ def _clean_value(text: str) -> str:
 def _is_empty_or_placeholder(text: str) -> bool:
     value = _clean_value(text).lower()
     return value in EMPTY_OR_PLACEHOLDER or value.startswith("#<")
+
+
+def _is_option_placeholder(text: str) -> bool:
+    """Return whether a PR template option list was left unselected."""
+    return " / " in _clean_value(text).lower()
+
+
+def _is_empty_or_option_placeholder(text: str) -> bool:
+    return _is_empty_or_placeholder(text) or _is_option_placeholder(text)
 
 
 def _is_no_issue_reason(text: str) -> bool:
@@ -153,6 +190,13 @@ def _value_after_label(section: str, label: str) -> str:
         "issues opened for follow up",
         "issues opened for followup",
         "follow up issues",
+        "required for this pr",
+        "domains reviewed",
+        "status",
+        "approver review source or waiver",
+        "approval or blocker note",
+        "validity checklist",
+        *(_normalize_label(label) for label in DOMAIN_VALIDITY_LABELS),
     }
     for index, line in enumerate(lines):
         item = _strip_bullet_prefix(line)
@@ -184,6 +228,42 @@ def _value_after_label(section: str, label: str) -> str:
 
 def _linked_issues(text: str) -> tuple[str, ...]:
     return tuple(f"#{match}" for match in sorted(set(ISSUE_RE.findall(text)), key=int))
+
+
+def _domain_value_not_required(text: str) -> bool:
+    """Return whether a domain-approval trigger field explicitly opts out."""
+    value = _clean_value(text).lower()
+    if _is_option_placeholder(text):
+        return False
+    if value in DOMAIN_APPROVAL_NOT_REQUIRED or value in EMPTY_OR_PLACEHOLDER:
+        return True
+    return any(
+        value.startswith(f"{prefix} - ") or value.startswith(f"{prefix}: ")
+        for prefix in DOMAIN_APPROVAL_NOT_REQUIRED
+    )
+
+
+def _domain_approval_triggers(body: str) -> tuple[str, ...]:
+    """Return template-field triggers that require domain-aware approval."""
+    section = _extract_section(body, "Research Result Guidance")
+    if not section:
+        return ()
+    triggers: list[str] = []
+    for label in ("Evidence tier", "Result classification"):
+        value = _value_after_label(section, label)
+        if value and not _domain_value_not_required(value):
+            triggers.append(f"{label}: {value}")
+    return tuple(triggers)
+
+
+def _domain_checklist_errors(section: str) -> tuple[str, ...]:
+    """Return missing or placeholder validity-checklist fields."""
+    errors: list[str] = []
+    for label in DOMAIN_VALIDITY_LABELS:
+        value = _value_after_label(section, label)
+        if _is_empty_or_option_placeholder(value):
+            errors.append(label)
+    return tuple(errors)
 
 
 def _verify_open_issues(issues: tuple[str, ...]) -> tuple[str, ...]:
@@ -308,6 +388,139 @@ def analyze_body(body: str, *, source: str, require_open_issues: bool = False) -
     )
 
 
+def analyze_domain_approval(body: str, *, source: str) -> DomainApprovalReport:
+    """Return whether domain-sensitive PR bodies carry explicit approval or blocker status."""
+    sensitive_terms = _domain_approval_triggers(body)
+    if not sensitive_terms:
+        return DomainApprovalReport(
+            status="ok",
+            source=source,
+            sensitive_terms=(),
+            required="",
+            approval_status="",
+            approval_note="",
+            checklist_errors=(),
+            message="No domain-sensitive evidence-validity trigger found.",
+        )
+
+    section = _extract_section(body, "Domain-Aware Approval")
+    if not section:
+        return DomainApprovalReport(
+            status="missing_domain_approval",
+            source=source,
+            sensitive_terms=sensitive_terms,
+            required="",
+            approval_status="",
+            approval_note="",
+            checklist_errors=(),
+            message=(
+                "Domain-sensitive evidence-validity terms are present; add a "
+                "Domain-Aware Approval section with approval, waiver, or blocker details."
+            ),
+        )
+
+    required = _value_after_label(section, "Required for this PR")
+    domains = _value_after_label(section, "Domains reviewed")
+    approval_status = _value_after_label(section, "Status")
+    approval_note = _value_after_label(section, "Approver/review source or waiver")
+    if not approval_note:
+        approval_note = _value_after_label(section, "Approval or blocker note")
+    checklist_errors = _domain_checklist_errors(section)
+    required_value = _clean_value(required).lower()
+    status_value = _clean_value(approval_status).lower()
+    note_value = _clean_value(approval_note)
+
+    if _is_empty_or_option_placeholder(required) or required_value.startswith(
+        ("no", "n/a", "na", "not applicable")
+    ):
+        return DomainApprovalReport(
+            status="domain_approval_required",
+            source=source,
+            sensitive_terms=sensitive_terms,
+            required=required,
+            approval_status=approval_status,
+            approval_note=approval_note,
+            checklist_errors=checklist_errors,
+            message=(
+                "Domain-sensitive evidence-validity terms are present; this PR must state "
+                "that domain-aware approval is required or name the blocker."
+            ),
+        )
+    if (
+        _is_empty_or_option_placeholder(domains)
+        or _is_empty_or_option_placeholder(approval_status)
+        or _is_empty_or_option_placeholder(approval_note)
+    ):
+        return DomainApprovalReport(
+            status="missing_domain_approval_note",
+            source=source,
+            sensitive_terms=sensitive_terms,
+            required=required,
+            approval_status=approval_status,
+            approval_note=approval_note,
+            checklist_errors=checklist_errors,
+            message=(
+                "Domain-aware approval requires reviewed domains, a non-empty status, "
+                "and an approver/review source or waiver reason."
+            ),
+        )
+    if checklist_errors:
+        return DomainApprovalReport(
+            status="incomplete_domain_approval",
+            source=source,
+            sensitive_terms=sensitive_terms,
+            required=required,
+            approval_status=approval_status,
+            approval_note=approval_note,
+            checklist_errors=checklist_errors,
+            message=(
+                "Domain-aware approval requires completed validity-checklist fields: "
+                f"{', '.join(checklist_errors)}."
+            ),
+        )
+    if re.search(r"\b(blocked?|blocker|no|not|pending|awaiting)\b", status_value):
+        return DomainApprovalReport(
+            status=(
+                "pending_domain_approval"
+                if re.search(r"\b(blocked?|blocker|pending|awaiting)\b", status_value)
+                else "invalid_domain_approval_status"
+            ),
+            source=source,
+            sensitive_terms=sensitive_terms,
+            required=required,
+            approval_status=approval_status,
+            approval_note=approval_note,
+            checklist_errors=checklist_errors,
+            message=(
+                "Domain-aware approval status must say approved or waived before final readiness."
+            ),
+        )
+    if not re.search(r"\b(approved?|waived|waiver)\b", status_value):
+        return DomainApprovalReport(
+            status="invalid_domain_approval_status",
+            source=source,
+            sensitive_terms=sensitive_terms,
+            required=required,
+            approval_status=approval_status,
+            approval_note=approval_note,
+            checklist_errors=checklist_errors,
+            message=(
+                "Domain-aware approval status must say approved or waived before final readiness."
+            ),
+        )
+
+    return DomainApprovalReport(
+        status="ok",
+        source=source,
+        sensitive_terms=sensitive_terms,
+        required=required,
+        approval_status=approval_status,
+        approval_note=note_value,
+        checklist_errors=(),
+        message="Domain-aware approval or waiver is explicit.",
+    )
+
+
 def _read_event_body(path: Path) -> str | None:
     payload = json.loads(path.read_text(encoding="utf-8"))
     pull_request = payload.get("pull_request")
@@ -346,6 +559,21 @@ def _format_report(report: FollowupReport) -> str:
         f"status={report.status}; source={report.source}; deferred={deferred!r}; "
         f"linked_issues={issue_text}; no_issue_reason={no_issue!r}; "
         f"issue_state_errors={state_errors!r}; {report.message}"
+    )
+
+
+def _format_domain_report(report: DomainApprovalReport) -> str:
+    terms = ", ".join(report.sensitive_terms) if report.sensitive_terms else "none"
+    required = report.required if report.required else "none"
+    approval_status = report.approval_status if report.approval_status else "none"
+    approval_note = report.approval_note if report.approval_note else "none"
+    checklist_errors = ", ".join(report.checklist_errors) if report.checklist_errors else "none"
+    return (
+        "PR domain-approval check: "
+        f"status={report.status}; source={report.source}; sensitive_terms={terms}; "
+        f"required={required!r}; approval_status={approval_status!r}; "
+        f"approval_note={approval_note!r}; checklist_errors={checklist_errors!r}; "
+        f"{report.message}"
     )
 
 
@@ -398,26 +626,41 @@ def main(argv: list[str] | None = None) -> int:
         "PR_READY_REQUIRE_OPEN_FOLLOWUP_ISSUES", ""
     ).lower() in {"1", "true", "yes", "on"}
     report = analyze_body(body, source=source, require_open_issues=require_open)
+    domain_report = analyze_domain_approval(body, source=source)
+    failing_statuses = {
+        "missing_followup",
+        "missing_section",
+        "issue_state_error",
+        "residual_scope_without_followup",
+    }
+    domain_failing_statuses = {
+        "missing_domain_approval",
+        "domain_approval_required",
+        "missing_domain_approval_note",
+        "incomplete_domain_approval",
+        "pending_domain_approval",
+        "invalid_domain_approval_status",
+    }
     if args.json:
-        print(json.dumps(report.__dict__, sort_keys=True))
+        print(
+            json.dumps(
+                {
+                    "followups": report.__dict__,
+                    "domain_approval": domain_report.__dict__,
+                },
+                sort_keys=True,
+            )
+        )
     else:
-        failing_statuses = {
-            "missing_followup",
-            "missing_section",
-            "issue_state_error",
-            "residual_scope_without_followup",
-        }
         stream = sys.stderr if report.status in failing_statuses else sys.stdout
         print(_format_report(report), file=stream)
+        domain_stream = (
+            sys.stderr if domain_report.status in domain_failing_statuses else sys.stdout
+        )
+        print(_format_domain_report(domain_report), file=domain_stream)
     return (
         2
-        if report.status
-        in {
-            "missing_followup",
-            "missing_section",
-            "issue_state_error",
-            "residual_scope_without_followup",
-        }
+        if report.status in failing_statuses or domain_report.status in domain_failing_statuses
         else 0
     )
 

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -11,7 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 from scripts.dev import check_pr_followups
-from scripts.dev.check_pr_followups import analyze_body
+from scripts.dev.check_pr_followups import analyze_body, analyze_domain_approval
 
 SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "check_pr_followups.py"
 
@@ -26,6 +26,35 @@ Example PR.
 """
 
 
+def _domain_body(
+    *,
+    evidence_tier: str = "targeted smoke",
+    result_classification: str = "blocker-resolution",
+    domain_section: str = "",
+) -> str:
+    return f"""## Research Result Guidance
+- Evidence tier: {evidence_tier}
+- Result classification: {result_classification}
+
+{domain_section}
+    """
+
+
+def _approved_domain_section(*, status: str = "approved", note: str = "maintainer review") -> str:
+    return f"""## Domain-Aware Approval
+- Required for this PR: yes - evidence-validity-sensitive result classification
+- Domains reviewed: evidence classification, figure eligibility
+- Status: {status}
+- Approver/review source or waiver: {note}
+- Validity checklist:
+  - Target claim/hypothesis: issue claim boundary stays diagnostic-only
+  - Comparator or split/evidence validity: existing targeted smoke proof only
+  - Fallback/degraded exclusions: fallback/degraded evidence remains excluded
+  - Claim boundary: no paper-facing benchmark claim
+  - Implementation integrity vs experimental validity: tests prove gate behavior, not result validity
+"""
+
+
 def test_analyze_body_passes_when_no_deferred_work_is_declared() -> None:
     """Empty or none deferred-work values are accepted."""
     report = analyze_body(_body(deferred="none"), source="fixture")
@@ -33,6 +62,131 @@ def test_analyze_body_passes_when_no_deferred_work_is_declared() -> None:
     assert report.status == "ok"
     assert report.deferred_work == ""
     assert report.message == "No deferred work declared."
+
+
+def test_domain_approval_not_required_for_na_or_docs_only_research_fields() -> None:
+    """Routine docs/support PRs can opt out without domain-review friction."""
+    report = analyze_domain_approval(
+        _domain_body(evidence_tier="docs-only", result_classification="NA"),
+        source="fixture",
+    )
+
+    assert report.status == "ok"
+    assert report.sensitive_terms == ()
+
+
+def test_domain_approval_required_for_non_na_research_fields() -> None:
+    """Evidence-result PR bodies need the domain approval section."""
+    report = analyze_domain_approval(_domain_body(), source="fixture")
+
+    assert report.status == "missing_domain_approval"
+    assert "Evidence tier: targeted smoke" in report.sensitive_terms
+    assert "Result classification: blocker-resolution" in report.sensitive_terms
+
+
+def test_domain_approval_accepts_approved_review_source() -> None:
+    """Approved domain-review metadata satisfies the evidence-validity gate."""
+    report = analyze_domain_approval(
+        _domain_body(
+            domain_section=_approved_domain_section(
+                note="maintainer review of claim boundary and fallback exclusions"
+            )
+        ),
+        source="fixture",
+    )
+
+    assert report.status == "ok"
+    assert "maintainer review" in report.approval_note
+
+
+def test_domain_approval_accepts_explicit_maintainer_waiver() -> None:
+    """A maintainer waiver is explicit enough to avoid pretending approval happened."""
+    report = analyze_domain_approval(
+        _domain_body(
+            domain_section=_approved_domain_section(
+                status="waived",
+                note="maintainer waiver; diagnostic-only docs update",
+            )
+        ),
+        source="fixture",
+    )
+
+    assert report.status == "ok"
+    assert "waiver" in report.approval_note
+
+
+def test_domain_approval_rejects_pending_or_placeholder_status() -> None:
+    """Pending domain review keeps a sensitive PR out of final readiness."""
+    report = analyze_domain_approval(
+        _domain_body(
+            domain_section="""## Domain-Aware Approval
+- Required for this PR: yes
+- Domains reviewed: experimental comparison
+- Status: pending
+- Approver/review source or waiver: waiting for domain reviewer
+- Validity checklist:
+  - Target claim/hypothesis: issue claim boundary stays diagnostic-only
+  - Comparator or split/evidence validity: existing targeted smoke proof only
+  - Fallback/degraded exclusions: fallback/degraded evidence remains excluded
+  - Claim boundary: no paper-facing benchmark claim
+  - Implementation integrity vs experimental validity: tests prove gate behavior, not result validity
+"""
+        ),
+        source="fixture",
+    )
+
+    assert report.status == "pending_domain_approval"
+
+
+def test_domain_approval_rejects_not_approved_status() -> None:
+    """A negated approval phrase cannot satisfy the final-readiness gate."""
+    report = analyze_domain_approval(
+        _domain_body(domain_section=_approved_domain_section(status="not approved")),
+        source="fixture",
+    )
+
+    assert report.status == "invalid_domain_approval_status"
+
+
+def test_domain_approval_requires_validity_checklist_fields() -> None:
+    """Approval metadata must include the evidence-validity checklist."""
+    report = analyze_domain_approval(
+        _domain_body(
+            domain_section="""## Domain-Aware Approval
+- Required for this PR: yes - evidence-validity-sensitive result classification
+- Domains reviewed: experimental comparison
+- Status: approved
+- Approver/review source or waiver: maintainer review
+- Validity checklist:
+  - Target claim/hypothesis: issue claim boundary stays diagnostic-only
+  - Comparator or split/evidence validity:
+  - Fallback/degraded exclusions: fallback/degraded evidence remains excluded
+  - Claim boundary: no paper-facing benchmark claim
+  - Implementation integrity vs experimental validity: tests prove gate behavior, not result validity
+"""
+        ),
+        source="fixture",
+    )
+
+    assert report.status == "incomplete_domain_approval"
+    assert "Comparator or split/evidence validity" in report.checklist_errors
+
+
+def test_domain_approval_rejects_not_required_for_sensitive_result() -> None:
+    """Non-NA evidence fields cannot be paired with a not-required approval claim."""
+    report = analyze_domain_approval(
+        _domain_body(
+            domain_section="""## Domain-Aware Approval
+- Required for this PR: no - ordinary implementation
+- Domains reviewed: NA
+- Status: not required
+- Approver/review source or waiver: NA
+"""
+        ),
+        source="fixture",
+    )
+
+    assert report.status == "domain_approval_required"
 
 
 def test_analyze_body_requires_issue_when_deferred_work_is_declared() -> None:
@@ -242,6 +396,33 @@ def test_cli_fails_for_deferred_work_without_disposition(tmp_path: Path) -> None
 
     assert result.returncode == 2
     assert "status=missing_followup" in result.stderr
+
+
+def test_cli_fails_for_sensitive_pr_without_domain_approval(tmp_path: Path) -> None:
+    """The CLI blocks evidence-validity PR bodies that omit domain-aware approval."""
+    body_path = tmp_path / "body.md"
+    body_path.write_text(
+        """## Research Result Guidance
+- Evidence tier: targeted smoke
+- Result classification: blocker-resolution
+
+## Follow-Up Issues
+- Deferred work: none
+- Issues opened for follow-up: none
+""",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT), "--body-file", str(body_path)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "status=missing_domain_approval" in result.stderr
 
 
 def test_cli_require_body_fails_closed_without_pr_body_source(monkeypatch) -> None:

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -75,6 +75,27 @@ def test_domain_approval_not_required_for_na_or_docs_only_research_fields() -> N
     assert report.sensitive_terms == ()
 
 
+@pytest.mark.parametrize(
+    ("evidence_tier", "result_classification"),
+    [
+        ("docs-only (support helper)", "NA"),
+        ("na, support-only workflow", "not applicable (workflow bugfix)"),
+    ],
+)
+def test_domain_approval_not_required_allows_punctuated_opt_out_reasons(
+    evidence_tier: str,
+    result_classification: str,
+) -> None:
+    """Docs/NA opt-out fields may include a short reason after punctuation."""
+    report = analyze_domain_approval(
+        _domain_body(evidence_tier=evidence_tier, result_classification=result_classification),
+        source="fixture",
+    )
+
+    assert report.status == "ok"
+    assert report.sensitive_terms == ()
+
+
 def test_domain_approval_required_for_non_na_research_fields() -> None:
     """Evidence-result PR bodies need the domain approval section."""
     report = analyze_domain_approval(_domain_body(), source="fixture")
@@ -97,6 +118,22 @@ def test_domain_approval_accepts_approved_review_source() -> None:
 
     assert report.status == "ok"
     assert "maintainer review" in report.approval_note
+
+
+def test_domain_approval_accepts_none_in_validity_checklist_field() -> None:
+    """A checklist answer can honestly say no exclusion or claim applies."""
+    report = analyze_domain_approval(
+        _domain_body(
+            domain_section=_approved_domain_section().replace(
+                "fallback/degraded evidence remains excluded",
+                "none",
+            )
+        ),
+        source="fixture",
+    )
+
+    assert report.status == "ok"
+    assert report.checklist_errors == ()
 
 
 def test_domain_approval_accepts_explicit_maintainer_waiver() -> None:
@@ -187,6 +224,22 @@ def test_domain_approval_rejects_not_required_for_sensitive_result() -> None:
     )
 
     assert report.status == "domain_approval_required"
+
+
+def test_domain_approval_required_value_does_not_treat_nominal_as_no() -> None:
+    """Required explanations starting with nominal/narrowed stay in the required path."""
+    report = analyze_domain_approval(
+        _domain_body(
+            domain_section=_approved_domain_section().replace(
+                "yes - evidence-validity-sensitive result classification",
+                "nominal benchmark change",
+            )
+        ),
+        source="fixture",
+    )
+
+    assert report.status == "ok"
+    assert report.required == "nominal benchmark change"
 
 
 def test_analyze_body_requires_issue_when_deferred_work_is_declared() -> None:

--- a/tests/test_pull_request_template.py
+++ b/tests/test_pull_request_template.py
@@ -23,6 +23,7 @@ def test_pull_request_template_includes_proof_and_follow_up_sections() -> None:
         "## What Changed",
         "## Why It Matters",
         "## Validation / Proof",
+        "## Domain-Aware Approval",
         "## Risks / Rollout",
         "## Docs / Provenance",
         "## Downstream Propagation",
@@ -33,6 +34,10 @@ def test_pull_request_template_includes_proof_and_follow_up_sections() -> None:
 
     assert "Commands run:" in text
     assert "Evidence that the change works here:" in text
+    assert "Required for this PR:" in text
+    assert "Domains reviewed:" in text
+    assert "Approver/review source or waiver:" in text
+    assert "Implementation integrity vs experimental validity:" in text
     assert "Deferred work:" in text
     assert "Issues opened for follow-up:" in text
     assert "Parent issue updated (yes/no/NA):" in text


### PR DESCRIPTION
## Summary
Adds a PR-body readiness gate for domain-aware approval on evidence-validity-sensitive PRs, and documents the rule in the PR template and review guidance.

## Linked Issues
- Closes `#3302`
- Relates to `#3276`
- Relates to `#3273`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Extended `scripts/dev/check_pr_followups.py` so non-NA research-result fields require a completed `Domain-Aware Approval` section before final readiness.
- Added PR template fields for reviewed domains, approval or waiver source, and validity checklist items.
- Documented the narrow gate in `docs/code_review.md` and `docs/maintainer_values.md`.
- Added focused tests for approved, waived, pending, missing, and incomplete domain-approval cases.

## Why It Matters
- Added value: sensitive evidence-classification, comparison, figure-eligibility, benchmark-interpretation, and paper-facing PRs cannot be presented as merge-ready with only CI or implementation-review proof.
- Expected impact: final readiness now fails closed until the PR body records domain-aware approval or waiver details when the research-result fields indicate evidence-validity-sensitive work.
- Why this is worth merging now: it turns the #3276 and #3273 review lessons into a lightweight repeatable guardrail.

## Research Result Guidance
Required for research-labelled, benchmark-labelled, metric-facing, paper-facing, or other
evidence-producing PRs. For support/tooling/docs-only PRs that make no research claim, set fields
to `NA` and state why.

- Target claim / hypothesis / blocker this should affect: NA - support/tooling workflow gate, no research result claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: docs-only
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #3302
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; the checker enforces PR-body metadata and does not interpret research evidence.

## Domain-Aware Approval
Required when `Evidence tier` is not `NA`/`docs-only`, or `Result classification` is not `NA`.
Use this for PRs that change evidence classification, experimental comparison methodology, figure
eligibility, benchmark interpretation, or paper-facing claim surfaces. This approval concerns
experimental validity and claim boundaries; normal implementation integrity still comes from code
review, tests, and CI.

- Required for this PR: no - this PR adds the workflow guardrail and does not approve or reclassify a concrete research result.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: NA - support/tooling gate only.
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: NA
  - Fallback/degraded exclusions: NA
  - Claim boundary: no research-result claim in this PR.
  - Implementation integrity vs experimental validity: tests prove checker behavior; no experimental validity claim is made.

## Falsification / Non-Transfer Check
Required for research-result PRs when the expected mechanism did not improve the measured outcome,
only helped a local slice, or produced diagnostic-only evidence. For support/tooling/docs-only PRs
that make no research claim, set fields to `NA` and state why.

- Did the mechanism activate? NA - support/tooling gate only.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
Required when evidence is missing, blocked, diagnostic-only, or negative. For docs-only, support,
or already-complete evidence PRs, set fields to `NA` and state why.

- Rerun needed: NA
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `uv run ruff format --check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py`
  - `uv run ruff check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py`
  - `uv run pytest tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py -q`
  - `uv run pytest tests/test_ci_script_contract.py -q`
  - `uv run pytest tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py tests/test_ci_script_contract.py -q`
  - sample `scripts/dev/check_pr_followups.py` CLI pass/fail checks using process-substitution PR bodies.
  - `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3302-pr-body.md uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh`
  - Review-fix validation:
    - `uv run ruff format scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py`
    - `uv run ruff check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py`
    - `uv run pytest tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py tests/test_ci_script_contract.py -q`
    - `PYTEST_NUM_WORKERS=4 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3302-pr-body.md uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused tests cover the domain-approval decision matrix, contract tests confirm the readiness wrapper still invokes the checker, and the final readiness gate runs against this PR body.
- Review-fix proof: addressed Gemini parser-boundary comments; final reduced-worker readiness passed at `04418da560d415cd7dc25ac22d1c401f18e4c8de` with `7592 passed, 12 skipped`.
- Freshness update: merged current `origin/main` after #3314 and #3318, then reran focused validation on the refreshed branch:
  - `uv run ruff check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py tests/test_ci_script_contract.py`
  - `uv run ruff format --check scripts/dev/check_pr_followups.py tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py tests/test_ci_script_contract.py`
  - `uv run pytest tests/dev/test_check_pr_followups.py tests/test_pull_request_template.py tests/test_ci_script_contract.py -q` (`83 passed`)
  - `uv run python scripts/dev/run_compact_validation.py --timeout-seconds 7200 -- env BASE_REF=origin/main PR_READY_MODE=final PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3302-pr-body-current.md bash scripts/dev/pr_ready_check.sh`
    passed at `6c73dbbc7d224b8d37a88e443bfc0b0186a5a3c3` with `1103 passed in 83.19s`
    and `failing_node_ids: []`.
- Freshness artifacts:
  - `.git/codex-agent-runs/active/compact-validation/validation-20260621T092002Z-429097.log`
  - `.git/codex-agent-runs/active/compact-validation/validation-20260621T092002Z-429097.summary.json`
- New/updated artifacts: none.

## Risks / Rollout
- Risk: PR authors need to set `Evidence tier: docs-only` and `Result classification: NA` for support-only PRs, or fill the domain section for sensitive evidence PRs.
- Rollout / rollback plan: revert this checker/template change if the gate proves too noisy; the rule is centralized in `scripts/dev/check_pr_followups.py`.

## Docs / Provenance
- Docs updated: `docs/code_review.md`, `docs/maintainer_values.md`, `.github/PULL_REQUEST_TEMPLATE/pr_default.md`
- Provenance notes: derived from issue #3302 and motivating PRs #3276/#3273.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - PR closes #3302.
- Claim map / benchmark report / leaderboard update needed (yes/no/NA): NA - no research result claim.
- Registry / config index update needed (yes/no/NA): NA
- Context index or memory note update needed (yes/no/NA): NA - workflow rule lives in canonical docs and template.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none; the earlier compact-validation reporting follow-up is complete.
