### PR TITLE
fix: enforce forecast batch timestamp format (#3313)

### DIFF
--- a/robot_sf/benchmark/schemas/forecast_batch_schema.py
+++ b/robot_sf/benchmark/schemas/forecast_batch_schema.py
@@ -20,10 +20,11 @@ FORMAT_CHECKER = jsonschema.FormatChecker()
 @FORMAT_CHECKER.checks("date-time")
 def _is_datetime(instance: object) -> bool:
     """Return True when a string is a timezone-qualified ISO 8601 datetime."""
-    if not isinstance(instance, str) or "T" not in instance:
+    if not isinstance(instance, str) or "t" not in instance.lower():
         return False
+    normalized = f"{instance[:-1]}+00:00" if instance.lower().endswith("z") else instance
     try:
-        parsed = datetime.fromisoformat(instance.replace("Z", "+00:00"))
+        parsed = datetime.fromisoformat(normalized)
     except ValueError:
         return False
     return parsed.tzinfo is not None and parsed.utcoffset() is not None

--- a/robot_sf/benchmark/schemas/forecast_batch_schema.py
+++ b/robot_sf/benchmark/schemas/forecast_batch_schema.py
@@ -8,11 +8,25 @@ interface for schema validation and metadata extraction.
 
 import json
 import re
+from datetime import datetime
 from pathlib import Path
 from typing import Any
 
 import jsonschema
-from jsonschema import Draft202012Validator
+
+FORMAT_CHECKER = jsonschema.FormatChecker()
+
+
+@FORMAT_CHECKER.checks("date-time")
+def _is_datetime(instance: object) -> bool:
+    """Return True when a string is a timezone-qualified ISO 8601 datetime."""
+    if not isinstance(instance, str) or "T" not in instance:
+        return False
+    try:
+        parsed = datetime.fromisoformat(instance.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return parsed.tzinfo is not None and parsed.utcoffset() is not None
 
 
 class ForecastBatchSchema:
@@ -156,7 +170,7 @@ class ForecastBatchSchema:
             jsonschema.validate(
                 instance=batch_data,
                 schema=self._schema_data,
-                format_checker=Draft202012Validator.FORMAT_CHECKER,
+                format_checker=FORMAT_CHECKER,
             )
         except jsonschema.ValidationError as e:
             path = "/".join(str(part) for part in e.absolute_path) if e.absolute_path else "root"

--- a/tests/contract/test_forecast_batch_schema.py
+++ b/tests/contract/test_forecast_batch_schema.py
@@ -245,6 +245,15 @@ def test_forecast_batch_schema_entity_rejects_non_datetime_timestamp() -> None:
         schema.validate_forecast_batch_data(batch)
 
 
+def test_forecast_batch_schema_entity_accepts_lowercase_utc_datetime() -> None:
+    """The structural schema validator should allow RFC3339 lowercase t/z forms."""
+    schema = ForecastBatchSchema(SCHEMA_PATH)
+    batch = _valid_batch_dict()
+    batch["provenance"]["timestamp"] = "2026-06-15t12:00:00z"
+
+    schema.validate_forecast_batch_data(batch)
+
+
 @pytest.mark.parametrize(
     "timestamp",
     [


### PR DESCRIPTION
## Summary
Restores forecast batch JSON Schema `date-time` enforcement for provenance timestamps by registering
a local format checker used by `ForecastBatchSchema.validate_forecast_batch_data`.

## Linked Issues
- Closes `#3313`
- Relates to `#3314`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added a local JSON Schema `date-time` format checker that accepts ISO datetimes with timezone
  information and rejects malformed or timezone-naive timestamps.
- Wired forecast batch structural validation through that checker.

## Why It Matters
- Added value: restores the existing contract test that malformed forecast batch provenance
  timestamps fail closed.
- Expected impact: removes the unrelated validation blocker that prevented #3314 from proving full
  core readiness.
- Why this is worth merging now: #3314 intentionally exposed this failing contract as a readiness
  blocker.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: forecast batch schema validation should
  reject malformed `provenance.timestamp` values.
- Comparator or baseline, if applicable: current `origin/main` accepts `"not-a-date-time"` through
  the structural schema wrapper.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: failing node from #3313 passes and full forecast batch
  schema contract file passes.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#3313`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - schema validation fix, no
  new analysis tool.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes.
- Did the intervention change command source, selected command, trajectory, or route progress? no.
- Did the scenario actually contain the targeted failure mode? yes, `not-a-date-time` now raises.
- Result route: stop.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for #3313; #3314 should rerun full readiness after this lands.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: stop for #3313.
- Proposed child issue or existing follow-up: NA.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/contract/test_forecast_batch_schema.py::test_forecast_batch_schema_entity_rejects_non_datetime_timestamp -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/contract/test_forecast_batch_schema.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/schemas/forecast_batch_schema.py`
  - `git diff --check`
- Evidence that the change works here: the #3313 failing node now passes; the full forecast batch
  schema contract file passes (`39 passed`).
- Benchmarks or smoke tests, if applicable: NA.

## Risks / Rollout
- Compatibility risks: the local checker intentionally requires timezone-qualified ISO datetimes,
  matching the existing typed validator tests.
- Failure modes: if the schema contract later accepts a broader timestamp grammar, this checker
  should be updated with that contract.
- Rollback or fallback plan: revert this PR to return to the previous jsonschema default behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: found while validating #3314.
- Any assumptions that need to be preserved: forecast batch provenance timestamps are expected to be
  timezone-qualified.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes `#3313`.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a focused schema validation fix with no benchmark-result
  propagation.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Please verify the local `date-time` checker preserves the typed validator's timezone requirement.
