### PR TITLE
fix: suppress compact-validation false failure nodes

### DIFF
--- a/scripts/dev/run_compact_validation.py
+++ b/scripts/dev/run_compact_validation.py
@@ -153,6 +153,7 @@ def run_compact_validation(
     elapsed = time.monotonic() - started
     combined = log_path.read_text(encoding="utf-8", errors="replace")
     excerpt, truncated = _failure_lines(combined, limit=excerpt_lines, width=excerpt_width)
+    failing_node_ids = _pytest_node_ids(combined) if returncode != 0 else []
     summary: dict[str, Any] = {
         "schema": SCHEMA_VERSION,
         "command": command,
@@ -168,7 +169,7 @@ def run_compact_validation(
         "summary_path": str(summary_path),
         "excerpt_line_count": len(excerpt),
         "excerpt_truncated": truncated,
-        "failing_node_ids": _pytest_node_ids(combined),
+        "failing_node_ids": failing_node_ids,
         "failure_excerpt": excerpt,
     }
     summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")

--- a/tests/dev/test_run_compact_validation.py
+++ b/tests/dev/test_run_compact_validation.py
@@ -72,6 +72,51 @@ def test_run_compact_validation_json_summary_for_success(tmp_path: Path, capsys)
     assert Path(payload["summary_path"]).exists()
 
 
+def test_run_compact_validation_suppresses_node_ids_on_success(tmp_path: Path) -> None:
+    """Passing pytest-like logs should not look like failed test summaries."""
+    artifact_dir = tmp_path / "artifacts"
+    command = [
+        sys.executable,
+        "-c",
+        "\n".join(
+            [
+                "print('tests/planner/test_policy_stack_v1.py::test_policy_stack_runs_atomic_topology_smoke_through_map_runner')",
+                "print('tests/examples/test_examples_run.py::test_example_runs_without_error[quickstart/01_basic_robot.py]')",
+                "print('============================= slowest 10 durations =============================')",
+                "print('18.15s call     tests/planner/test_policy_stack_v1.py::test_policy_stack_runs_atomic_topology_smoke_through_map_runner')",
+                "print('=========== 7588 passed, 12 skipped, 9 warnings in 328.89s ===========')",
+            ]
+        ),
+    ]
+
+    summary = run_compact_validation(command, artifact_dir=artifact_dir)
+
+    assert summary["exit_code"] == 0
+    assert summary["failing_node_ids"] == []
+    assert "test_policy_stack_runs_atomic_topology_smoke" in "\n".join(summary["failure_excerpt"])
+
+
+def test_run_compact_validation_keeps_node_ids_on_failure(tmp_path: Path) -> None:
+    """Nonzero pytest-like output should still report failing node ids."""
+    artifact_dir = tmp_path / "artifacts"
+    command = [
+        sys.executable,
+        "-c",
+        "\n".join(
+            [
+                "import sys",
+                "print('FAILED tests/dev/test_compact.py::test_real_failure - AssertionError')",
+                "sys.exit(1)",
+            ]
+        ),
+    ]
+
+    summary = run_compact_validation(command, artifact_dir=artifact_dir)
+
+    assert summary["exit_code"] == 1
+    assert summary["failing_node_ids"] == ["tests/dev/test_compact.py::test_real_failure"]
+
+
 def test_run_compact_validation_marks_truncated_plain_output(tmp_path: Path) -> None:
     """Large output without failure keywords should still report truncation."""
     artifact_dir = tmp_path / "artifacts"


### PR DESCRIPTION
## Summary
Fixes compact validation summaries so successful commands do not report pytest-like warning or slow-duration node ids as `failing_node_ids`.

## Linked Issues
- Closes `#3316`
- Relates to `#3315`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- `scripts/dev/run_compact_validation.py` now populates `failing_node_ids` only when the wrapped command exits nonzero.
- Added focused regression coverage for passing logs that contain pytest-style node IDs and failing logs that should still report a real node ID.

## Why It Matters
- Added value: successful validation runs no longer look partially failed in agent handoffs.
- Expected impact: less unnecessary rerunning or investigation after successful `run_compact_validation.py` runs.
- Why this is worth merging now: #3315 produced exactly this false-positive summary during final readiness.

## Research Result Guidance
Required for research-labelled, benchmark-labelled, metric-facing, paper-facing, or other
evidence-producing PRs. For support/tooling/docs-only PRs that make no research claim, set fields
to `NA` and state why.

- Target claim / hypothesis / blocker this should affect: NA - workflow reporting bugfix, no research claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: docs-only
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #3316
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; this reports validation command summaries and does not interpret research evidence.

## Domain-Aware Approval
Required when `Evidence tier` is not `NA`/`docs-only`, or `Result classification` is not `NA`.
Use this for PRs that change evidence classification, experimental comparison methodology, figure
eligibility, benchmark interpretation, or paper-facing claim surfaces. This approval concerns
experimental validity and claim boundaries; normal implementation integrity still comes from code
review, tests, and CI.

- Required for this PR: no - workflow reporting bugfix only.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: NA - no evidence-validity claim.
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: NA
  - Fallback/degraded exclusions: NA
  - Claim boundary: no research-result claim.
  - Implementation integrity vs experimental validity: targeted tests prove reporting behavior only.

## Falsification / Non-Transfer Check
Required for research-result PRs when the expected mechanism did not improve the measured outcome,
only helped a local slice, or produced diagnostic-only evidence. For support/tooling/docs-only PRs
that make no research claim, set fields to `NA` and state why.

- Did the mechanism activate? NA - workflow reporting bugfix only.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
Required when evidence is missing, blocked, diagnostic-only, or negative. For docs-only, support,
or already-complete evidence PRs, set fields to `NA` and state why.

- Rerun needed: NA
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `uv run ruff format scripts/dev/run_compact_validation.py tests/dev/test_run_compact_validation.py`
  - `uv run ruff check scripts/dev/run_compact_validation.py tests/dev/test_run_compact_validation.py`
  - `uv run pytest tests/dev/test_run_compact_validation.py -q`
  - `uv run python scripts/dev/run_compact_validation.py --artifact-dir output/tmp/issue-3316-smoke --json -- python -c "...pytest-like passing node output..."`
  - `PYTEST_NUM_WORKERS=4 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3316-pr-body.md uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused tests cover both success suppression and failure retention; smoke summary returned exit 0 with `failing_node_ids: []`.
- Final readiness proof: reduced-worker final gate passed with `7585 passed, 12 skipped`; the compact summary JSON had `exit_code: 0` and `failing_node_ids: []` while preserving warning/slow-test excerpt context. Earlier `PYTEST_NUM_WORKERS=auto` attempts hit unrelated timeout/performance failures; the failed nodes passed when rerun directly.
- New/updated artifacts: ignored `output/tmp/issue-3316-smoke/*` smoke artifacts only; disposable local proof, not promoted.

## Risks / Rollout
- Risk: consumers that expected `failing_node_ids` on successful warning-heavy runs will now see an empty list.
- Rollout / rollback plan: revert this two-line behavior change if a real consumer needs success-run node IDs, though the field name is failure-specific.

## Docs / Provenance
- Docs updated: NA
- Provenance notes: issue #3316 was opened from PR #3315 final-readiness evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - PR closes #3316.
- Claim map / benchmark report / leaderboard update needed (yes/no/NA): NA - no research result claim.
- Registry / config index update needed (yes/no/NA): NA
- Context index or memory note update needed (yes/no/NA): NA

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none
