### PR TITLE
fix(plotting): place micro-scene robot goal in free space

### DIFF
--- a/examples/plotting/plot_micro_pedestrian_scene.py
+++ b/examples/plotting/plot_micro_pedestrian_scene.py
@@ -142,8 +142,10 @@ def main() -> None:
     velocities = np.asarray(sim.peds.vel())
 
     # --- Schematic ego robot + goal (overlaid; not part of pysocialforce) -----
+    # Goal placed in free space (clear of every pedestrian disc at this frame)
+    # so the green goal ring does not overlap a red pedestrian.
     robot_pos = np.array([5.4, 2.3])
-    robot_goal = np.array([8.8, 7.2])
+    robot_goal = np.array([8.0, 7.8])
     robot_heading = robot_goal - robot_pos
     robot_heading_norm = np.linalg.norm(robot_heading)
     if robot_heading_norm > 0:


### PR DESCRIPTION
## What

`examples/plotting/plot_micro_pedestrian_scene.py` produces the vector micro-scene snapshot embedded as a figure in the dissertation. With the schematic goal at `(8.8, 7.2)`, the green goal ring overlapped a red pedestrian disc at the rendered frame, so the goal looked like it coincided with a pedestrian.

This moves `robot_goal` to `(8.0, 7.8)`, which sits in free space clear of every pedestrian at this frame.

## Why it's safe

The robot and its goal are **schematic overlays** drawn on top of the scene — they are not part of the pysocialforce simulation. So the pedestrian positions and velocities (the real simulator output) are unchanged; only the overlaid goal marker moves.

## Regenerate

```
uv run python examples/plotting/plot_micro_pedestrian_scene.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example pedestrian scene visualization with adjusted robot goal positioning to better demonstrate proper placement in free space.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->