### PR TITLE
feat: add occluded-emergence live replay matrix

### DIFF
--- a/configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml
+++ b/configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml
@@ -1,0 +1,22 @@
+schema_version: robot_sf.scenario_matrix.v1
+includes:
+  - ../single/issue_2756_occluded_emergence_live.yaml
+select_scenarios:
+  - issue_2756_occluded_emergence
+scenario_overrides_by_name:
+  issue_2756_occluded_emergence:
+    seeds:
+      - 111
+    metadata:
+      source_issue: 2756
+      replay_issue: 2777
+      matrix_issue: 3320
+      fixture_contract:
+        first_visible_step: 5
+        delay_steps: 2
+        delay_only_expected_first_observed_step: 7
+      claim_boundary: >
+        Live matrix for issue #2777 observation perturbation replay that
+        preserves the issue #2756 occluded-emergence first-visible/delay
+        boundary. Treat outputs as diagnostic stress evidence unless
+        separately promoted with sufficient seeds and comparators.

--- a/configs/scenarios/single/issue_2756_occluded_emergence_live.yaml
+++ b/configs/scenarios/single/issue_2756_occluded_emergence_live.yaml
@@ -1,0 +1,36 @@
+scenarios:
+- name: issue_2756_occluded_emergence
+  scenario_family: occluded_emergence
+  map_file: ../../../maps/svg_maps/francis2023/francis2023_blind_corner.svg
+  simulation_config:
+    max_episode_steps: 160
+    ped_density: 0.0
+  observation_visibility:
+    enabled: true
+    fov_degrees: 120.0
+    max_range_m: 8.0
+    static_occlusion: true
+  single_pedestrians:
+  - id: h1
+    goal_poi: poi_h1_goal
+    metadata:
+      role: emerging_ped
+      source_issue: 2756
+  robot_config: {}
+  metadata:
+    source_issue: 2756
+    source_fixture: tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json
+    source_fixture_meta: tests/fixtures/analysis_workbench/simulation_trace_export_v1/sources/issue_2756_occluded_emergence_fixture_111_ep0000.meta.json
+    family: occluded_emergence
+    label: deterministic_occluded_emergence
+    fixture_contract:
+      first_visible_step: 5
+      delay_steps: 2
+      delay_only_expected_first_observed_step: 7
+    claim_boundary: >
+      Live diagnostics stress slice preserving the issue #2756
+      occluded-emergence fixture boundary for issue #2777 observation
+      perturbation replay. Diagnostic/stress evidence only; not paper-facing
+      benchmark evidence by itself.
+  seeds:
+  - 111

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -174,6 +174,11 @@ Policy caveats:
   perception-limited observation-noise step diagnostics for `hybrid_rule_v0_minimal` on a
   pedestrian-present stress-slice scenario; perturbation plumbing activated, but the distant
   pedestrian produced no measurable planner degradation.
+- `issue_2777_live_observation_noise_replay/`: diagnostic stress-slice live replay for all seven
+  #2755 perturbation families on the #2756 occluded-emergence boundary added by #3320. The wrapper
+  ran `risk_surface_dwa_v0` on `issue_2756_occluded_emergence` seed 111, preserved no-op first
+  visibility at step 5 and delay-only first observation at step 7, but remained
+  `scenario_too_weak` because commands and progress/risk summaries did not change.
 - `issue_3201_observation_noise_live_smoke/`: diagnostic-only same-seed clean vs perturbed
   step-diagnostics replay on the `dense_pedestrian_stress` live matrix candidate. Perturbation
   changed planner-input pedestrian observations, but commands and progress/risk summaries stayed

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/README.md
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/README.md
@@ -2,37 +2,40 @@
 
 ## Status
 
-- Status: `fail_closed`
-- Classification: `blocked`
-- Rationale: No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix.
-
-## Claim Boundary
-
-No benchmark-facing robustness claim. The command failed closed before live replay because the #2755/#2756 occluded-emergence fixture boundary could not be preserved.
+- Status: `live_replay`
+- Classification: `scenario_too_weak`
+- Rationale: All seven perturbation-family live replays completed.
 
 ## Fixture Contract
 
-- `required_scenario`: `issue_2756_occluded_emergence`
-- `required_family`: `occluded_emergence/deterministic_occluded_emergence`
-- `first_visible_step`: `5`
-- `delay_steps`: `2`
-- `delay_only_expected_first_observed_step`: `7`
-- `scenario_matrix`: `configs/scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml`
-- `satisfied`: `False`
-- `blocker`: `No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix.`
+- Scenario: `issue_2756_occluded_emergence`
+- Seed: `111`
+- Matrix: `configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml`
+- No-op first observed step: `5`
+- Delay-only first observed step: `7`
+- Satisfied: `True`
+
+## Claim Boundary
+
+Stress-slice live planner/environment replay for one scenario, one seed, and seven #2755 perturbation families. Treat as benchmark-facing only when fixture_contract.satisfied is true; otherwise diagnostic-only.
+
+Raw trace JSON and per-condition reports were generated locally to build this summary but are not committed.
 
 ## Conditions
 
-| Condition | Status | Classification | Caveat |
-|---|---|---|---|
-| `noop` | `blocked` | `blocked` | No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix. |
-| `low_noise` | `blocked` | `blocked` | No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix. |
-| `medium_noise` | `blocked` | `blocked` | No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix. |
-| `missed_detection_only` | `blocked` | `blocked` | No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix. |
-| `occlusion_only` | `blocked` | `blocked` | No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix. |
-| `delay_only` | `blocked` | `blocked` | No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix. |
-| `combined` | `blocked` | `blocked` | No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix. |
+| Condition | Status | First observed | Hidden observations | Command changed | Classification |
+|---|---|---:|---:|---|---|
+| `noop` | `live_replay` | `5` | `5` | `n/a` | `baseline` |
+| `low_noise` | `live_replay` | `5` | `5` | `False` | `scenario_too_weak` |
+| `medium_noise` | `live_replay` | `5` | `5` | `False` | `scenario_too_weak` |
+| `missed_detection_only` | `live_replay` | `None` | `5` | `False` | `scenario_too_weak` |
+| `occlusion_only` | `live_replay` | `5` | `5` | `False` | `scenario_too_weak` |
+| `delay_only` | `live_replay` | `7` | `5` | `False` | `scenario_too_weak` |
+| `combined` | `live_replay` | `5` | `5` | `False` | `scenario_too_weak` |
 
-## Blockers
+## Interpretation
 
-- No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix.
+- The wrapper now executes on the intended issue #2756 occluded-emergence fixture boundary.
+- The no-op trace first observes the pedestrian at step 5, and the delay-only condition first observes it at step 7.
+- Perturbations changed planner-input observations, but selected commands and progress/risk summaries stayed unchanged; this is diagnostic stress evidence, not a robustness claim.
+- The closest robot-pedestrian distance stayed outside the near-field target, so the scenario remains classified as too weak for a behavioral robustness conclusion.

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/summary.json
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/summary.json
@@ -1,27 +1,53 @@
 {
   "schema_version": "issue_2777_observation_noise_live_replay.v1",
+  "artifact_shape": "compact_summary_without_raw_traces",
   "issue": 2777,
-  "status": "fail_closed",
+  "matrix_issue": 3320,
+  "status": "live_replay",
   "classification": {
-    "label": "blocked",
-    "rationale": "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
+    "label": "scenario_too_weak",
+    "rationale": "All seven perturbation-family live replays completed."
   },
-  "claim_boundary": "No benchmark-facing robustness claim. The command failed closed before live replay because the #2755/#2756 occluded-emergence fixture boundary could not be preserved.",
+  "claim_boundary": "Stress-slice live planner/environment replay for one scenario, one seed, and seven #2755 perturbation families. Treat as benchmark-facing only when fixture_contract.satisfied is true; otherwise diagnostic-only.",
+  "inputs": {
+    "scenario_matrix": "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml",
+    "raw_trace_json": "worktree-local generated artifacts summarized here; raw docs/context/evidence/issue_2777_live_observation_noise_replay/traces/*/trace.json files were intentionally not committed",
+    "generated_funnel": "worktree-local generated artifact summarized here; generated_policy_search_funnel.yaml was intentionally not committed"
+  },
   "fixture_contract": {
     "required_source_issue": 2756,
     "required_scenario": "issue_2756_occluded_emergence",
     "required_family": "occluded_emergence/deterministic_occluded_emergence",
+    "required_seed": 111,
     "first_visible_step": 5,
     "delay_steps": 2,
     "delay_only_expected_first_observed_step": 7,
-    "scenario_matrix": "configs/scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml",
-    "satisfied": false,
-    "blocker": "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
+    "scenario_matrix": "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml",
+    "satisfied": true,
+    "blocker": null,
+    "matched_scenario": {
+      "name": "issue_2756_occluded_emergence",
+      "source_issue": 2756,
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "seeds": [
+        111
+      ],
+      "first_visible_step": 5,
+      "delay_steps": 2,
+      "delay_only_expected_first_observed_step": 7
+    }
+  },
+  "fixture_observation_boundary": {
+    "noop_first_observed_step": 5,
+    "delay_only_first_observed_step": 7,
+    "expected_noop_first_observed_step": 5,
+    "expected_delay_only_first_observed_step": 7
   },
   "run_config": {
     "candidate": "risk_surface_dwa_v0",
     "stage": "smoke",
-    "scenario_matrix": "configs/scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml",
+    "scenario_matrix": "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml",
     "scenario_name": null,
     "scenario_index": 0,
     "seed": null,
@@ -34,48 +60,672 @@
   "conditions": [
     {
       "name": "noop",
-      "description": "Unperturbed live planner/environment replay.",
-      "status": "blocked",
-      "blocker": "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
+      "status": "live_replay",
+      "scenario": "issue_2756_occluded_emergence",
+      "seed": 111,
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "fixture_visibility": {
+        "first_observed_step": 5
+      },
+      "observation_summary": {
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 0,
+        "visibility_hidden_actor_observations_total": 5,
+        "min_observed_actor_count": 0,
+        "max_observed_actor_count": 1,
+        "noise_profiles": [
+          "fixture_visibility",
+          "none"
+        ]
+      },
+      "command_summary": {
+        "first": [
+          2.0,
+          0.0
+        ],
+        "last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_summary": {
+        "net_goal_progress": -6.406017516898584,
+        "best_goal_progress": 1.4428721856717952,
+        "closest_robot_ped_distance": 21.803818559278636,
+        "closest_robot_ped_step": 49,
+        "collision_flag_counts": {
+          "pedestrian": 0,
+          "obstacle": 0,
+          "robot": 0
+        },
+        "progress_step_count": 49,
+        "regression_step_count": 1,
+        "stagnant_step_count": 0,
+        "longest_stagnant_run": 0
+      }
     },
     {
       "name": "low_noise",
-      "description": "Bounded Gaussian pedestrian-position perturbation, std=0.10 m, bound=0.20 m.",
-      "status": "blocked",
-      "blocker": "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
+      "status": "live_replay",
+      "scenario": "issue_2756_occluded_emergence",
+      "seed": 111,
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "observation_summary": {
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 0,
+        "visibility_hidden_actor_observations_total": 5,
+        "min_observed_actor_count": 0,
+        "max_observed_actor_count": 1,
+        "noise_profiles": [
+          "bounded_gaussian"
+        ]
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
     },
     {
       "name": "medium_noise",
-      "description": "Bounded Gaussian pedestrian-position perturbation, std=0.30 m, bound=0.60 m.",
-      "status": "blocked",
-      "blocker": "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
+      "status": "live_replay",
+      "scenario": "issue_2756_occluded_emergence",
+      "seed": 111,
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "observation_summary": {
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 0,
+        "visibility_hidden_actor_observations_total": 5,
+        "min_observed_actor_count": 0,
+        "max_observed_actor_count": 1,
+        "noise_profiles": [
+          "bounded_gaussian"
+        ]
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
     },
     {
       "name": "missed_detection_only",
-      "description": "All live pedestrians removed from planner input by missed-detection probability 1.0.",
-      "status": "blocked",
-      "blocker": "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
+      "status": "live_replay",
+      "scenario": "issue_2756_occluded_emergence",
+      "seed": 111,
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": null
+      },
+      "observation_summary": {
+        "missed_actor_observations_total": 50,
+        "occluded_actor_observations_total": 0,
+        "visibility_hidden_actor_observations_total": 5,
+        "min_observed_actor_count": 0,
+        "max_observed_actor_count": 0,
+        "noise_profiles": [
+          "missed_detection"
+        ]
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
     },
     {
       "name": "occlusion_only",
-      "description": "All live pedestrians occluded from planner input with a zero-distance occlusion gate.",
-      "status": "blocked",
-      "blocker": "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
+      "status": "live_replay",
+      "scenario": "issue_2756_occluded_emergence",
+      "seed": 111,
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "observation_summary": {
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 45,
+        "visibility_hidden_actor_observations_total": 5,
+        "min_observed_actor_count": 0,
+        "max_observed_actor_count": 1,
+        "noise_profiles": [
+          "occlusion_mask"
+        ]
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
     },
     {
       "name": "delay_only",
-      "description": "Two-step delayed pedestrian observation, preserving the #2755 expected lag.",
-      "status": "blocked",
-      "blocker": "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
+      "status": "live_replay",
+      "scenario": "issue_2756_occluded_emergence",
+      "seed": 111,
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 7
+      },
+      "observation_summary": {
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 0,
+        "visibility_hidden_actor_observations_total": 5,
+        "min_observed_actor_count": 0,
+        "max_observed_actor_count": 1,
+        "noise_profiles": [
+          "delayed_observation"
+        ]
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
     },
     {
       "name": "combined",
-      "description": "Medium Gaussian perturbation plus full live-pedestrian occlusion.",
-      "status": "blocked",
-      "blocker": "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
+      "status": "live_replay",
+      "scenario": "issue_2756_occluded_emergence",
+      "seed": 111,
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "observation_summary": {
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 45,
+        "visibility_hidden_actor_observations_total": 5,
+        "min_observed_actor_count": 0,
+        "max_observed_actor_count": 1,
+        "noise_profiles": [
+          "bounded_gaussian"
+        ]
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
     }
   ],
-  "blockers": [
-    "No checked-in live scenario matrix preserving the #2755/#2756 occluded-emergence fixture boundary was found in the selected matrix."
-  ]
+  "blockers": []
 }

--- a/robot_sf/benchmark/observation_perturbation.py
+++ b/robot_sf/benchmark/observation_perturbation.py
@@ -13,6 +13,7 @@ carry no sensor-certification semantics.
 from __future__ import annotations
 
 from collections import deque
+from copy import deepcopy
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -107,7 +108,7 @@ class ObservationPerturbationState:
         self._delay_buffer = deque(maxlen=capacity)
         if initial_obs is not None:
             for _ in range(max(1, self.delay_steps)):
-                self._delay_buffer.append(initial_obs)
+                self._delay_buffer.append(deepcopy(initial_obs))
 
 
 def _make_rng(spec: ObservationPerturbationSpec, step: int) -> np.random.Generator | None:

--- a/robot_sf/benchmark/observation_perturbation.py
+++ b/robot_sf/benchmark/observation_perturbation.py
@@ -23,6 +23,7 @@ NOISE_PROFILE_GAUSSIAN = "bounded_gaussian"
 NOISE_PROFILE_MISSED_DETECTION = "missed_detection"
 NOISE_PROFILE_OCCLUSION_MASK = "occlusion_mask"
 NOISE_PROFILE_DELAYED_OBSERVATION = "delayed_observation"
+NOISE_PROFILE_FIXTURE_VISIBILITY = "fixture_visibility"
 EVIDENCE_IDEAL = "ideal_state"
 EVIDENCE_PERCEPTION_LIMITED = "perception_limited"
 
@@ -36,6 +37,7 @@ class ObservationPerturbationSpec:
     missed_detection_probability: float = 0.0
     occlusion_mask: np.ndarray | None = None
     delay_steps: int = 0
+    visibility_mask: np.ndarray | None = None
     seed: int | None = None
 
     def __post_init__(self) -> None:
@@ -57,6 +59,7 @@ class ObservationPerturbationSpec:
             and self.missed_detection_probability <= 0.0
             and self.occlusion_mask is None
             and self.delay_steps <= 0
+            and self.visibility_mask is None
         )
 
     @property
@@ -72,6 +75,8 @@ class ObservationPerturbationSpec:
             return NOISE_PROFILE_OCCLUSION_MASK
         if self.delay_steps > 0:
             return NOISE_PROFILE_DELAYED_OBSERVATION
+        if self.visibility_mask is not None:
+            return NOISE_PROFILE_FIXTURE_VISIBILITY
         return NOISE_PROFILE_NONE
 
 
@@ -97,11 +102,12 @@ class ObservationPerturbationState:
             self._delay_buffer = deque(existing, maxlen=capacity)
 
     def reset(self, initial_obs: dict[str, Any] | None = None) -> None:
-        """Reset the delay buffer, optionally seeding with an initial observation."""
+        """Reset the delay buffer, optionally seeding warmup with an initial observation."""
         capacity = max(1, self.delay_steps + 1)
         self._delay_buffer = deque(maxlen=capacity)
         if initial_obs is not None:
-            self._delay_buffer.append(initial_obs)
+            for _ in range(max(1, self.delay_steps)):
+                self._delay_buffer.append(initial_obs)
 
 
 def _make_rng(spec: ObservationPerturbationSpec, step: int) -> np.random.Generator | None:
@@ -150,6 +156,7 @@ class _DelayedResultContext:
     step: int
     missed_mask: np.ndarray
     occluded_mask: np.ndarray
+    visibility_hidden_mask: np.ndarray
     n_actors: int
     spec: ObservationPerturbationSpec
 
@@ -188,6 +195,7 @@ def _build_delayed_result(ctx: _DelayedResultContext) -> dict[str, Any]:
             "missed_detection_probability": ctx.spec.missed_detection_probability,
             "missed_actor_count": int(ctx.missed_mask.sum()),
             "occluded_actor_count": int(ctx.occluded_mask.sum()),
+            "visibility_hidden_actor_count": int(ctx.visibility_hidden_mask.sum()),
             "delay_steps": ctx.delay,
             "step": ctx.step,
             "actor_count": ctx.n_actors,
@@ -204,14 +212,15 @@ def _compute_observed_state(
     n_actors: int,
     spec: ObservationPerturbationSpec,
     rng: np.random.Generator,
-) -> tuple[np.ndarray, np.ndarray, list[str], np.ndarray, np.ndarray]:
+) -> tuple[np.ndarray, np.ndarray, list[str], np.ndarray, np.ndarray, np.ndarray]:
     """Compute the observed state after missed detections, noise, and occlusion.
 
     Returns:
-        Tuple of (obs_positions, obs_velocities, obs_ids, missed_mask, occluded_mask).
+        Tuple of observed state plus missed, occluded, and fixture-hidden masks.
     """
     missed_mask = np.zeros(n_actors, dtype=bool)
     occluded_mask = np.zeros(n_actors, dtype=bool)
+    visibility_hidden_mask = np.zeros(n_actors, dtype=bool)
 
     # --- missed detections ---
     ids_out = list(actor_ids)
@@ -236,11 +245,20 @@ def _compute_observed_state(
             raise ValueError(f"occlusion_mask length {ext_mask.shape[0]} != actor count {n_actors}")
         occluded_mask = ext_mask & ~missed_mask
 
-    # Build observed array: drop missed, zero occluded positions
-    if missed_mask.any():
-        obs_pos = obs_pos_full[~missed_mask]
-        obs_vel_out = gt_vel[~missed_mask]
-        ids_out = [aid for aid, m in zip(actor_ids, ~missed_mask, strict=True) if m]
+    # --- scenario fixture visibility mask ---
+    if spec.visibility_mask is not None:
+        visible = np.asarray(spec.visibility_mask, dtype=bool).reshape(-1)
+        if visible.shape[0] != n_actors:
+            raise ValueError(f"visibility_mask length {visible.shape[0]} != actor count {n_actors}")
+        visibility_hidden_mask = ~visible
+        occluded_mask = occluded_mask & ~visibility_hidden_mask
+
+    # Build observed array: drop missed/fixture-hidden, zero occluded positions
+    drop_mask = missed_mask | visibility_hidden_mask
+    if drop_mask.any():
+        obs_pos = obs_pos_full[~drop_mask]
+        obs_vel_out = gt_vel[~drop_mask]
+        ids_out = [aid for aid, keep in zip(actor_ids, ~drop_mask, strict=True) if keep]
     else:
         obs_pos = obs_pos_full
         obs_vel_out = gt_vel.copy()
@@ -253,7 +271,7 @@ def _compute_observed_state(
             obs_pos[i] = 0.0
             obs_vel_out[i] = 0.0
 
-    return obs_pos, obs_vel_out, ids_out, missed_mask, occluded_mask
+    return obs_pos, obs_vel_out, ids_out, missed_mask, occluded_mask, visibility_hidden_mask
 
 
 def perturb_ground_truth(
@@ -319,6 +337,7 @@ def perturb_ground_truth(
                 "missed_detection_probability": 0.0,
                 "missed_actor_count": 0,
                 "occluded_actor_count": 0,
+                "visibility_hidden_actor_count": 0,
                 "delay_steps": 0,
                 "step": step,
                 "actor_count": n_actors,
@@ -328,7 +347,14 @@ def perturb_ground_truth(
 
     rng = _make_rng(spec, step)
 
-    obs_pos, obs_vel_out, ids_out, missed_mask, occluded_mask = _compute_observed_state(
+    (
+        obs_pos,
+        obs_vel_out,
+        ids_out,
+        missed_mask,
+        occluded_mask,
+        visibility_hidden_mask,
+    ) = _compute_observed_state(
         gt_pos=gt_pos,
         gt_vel=gt_vel,
         actor_ids=actor_ids,
@@ -358,6 +384,7 @@ def perturb_ground_truth(
                 step=step,
                 missed_mask=missed_mask,
                 occluded_mask=occluded_mask,
+                visibility_hidden_mask=visibility_hidden_mask,
                 n_actors=n_actors,
                 spec=spec,
             )
@@ -376,6 +403,7 @@ def perturb_ground_truth(
             "missed_detection_probability": spec.missed_detection_probability,
             "missed_actor_count": int(missed_mask.sum()),
             "occluded_actor_count": int(occluded_mask.sum()),
+            "visibility_hidden_actor_count": int(visibility_hidden_mask.sum()),
             "delay_steps": 0,
             "step": step,
             "actor_count": n_actors,

--- a/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
+++ b/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
@@ -163,18 +163,25 @@ def _source_issue_matches(value: Any) -> bool:
     return False
 
 
+def _optional_int(value: Any) -> int | None:
+    """Return a non-boolean integer when coercion is exact enough for metadata checks."""
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
 def _int_list(value: Any) -> list[int]:
     """Parse a list of integer-like values while ignoring invalid entries."""
     if not isinstance(value, list):
         return []
     parsed: list[int] = []
     for item in value:
-        if isinstance(item, bool):
-            continue
-        try:
-            parsed.append(int(item))
-        except (TypeError, ValueError):
-            continue
+        parsed_item = _optional_int(item)
+        if parsed_item is not None:
+            parsed.append(parsed_item)
     return parsed
 
 
@@ -188,12 +195,16 @@ def _fixture_candidate(scenario: Mapping[str, Any]) -> dict[str, Any]:
         "family": str(metadata.get("family") or scenario.get("scenario_family") or ""),
         "label": str(metadata.get("label") or fixture.get("label") or ""),
         "seeds": _int_list(scenario.get("seeds")),
-        "first_visible_step": _metadata_field(metadata, fixture, "first_visible_step"),
-        "delay_steps": _metadata_field(metadata, fixture, "delay_steps"),
-        "delay_only_expected_first_observed_step": _metadata_field(
-            metadata,
-            fixture,
-            "delay_only_expected_first_observed_step",
+        "first_visible_step": _optional_int(
+            _metadata_field(metadata, fixture, "first_visible_step")
+        ),
+        "delay_steps": _optional_int(_metadata_field(metadata, fixture, "delay_steps")),
+        "delay_only_expected_first_observed_step": _optional_int(
+            _metadata_field(
+                metadata,
+                fixture,
+                "delay_only_expected_first_observed_step",
+            )
         ),
     }
 
@@ -417,8 +428,7 @@ def _first_observed_step(trace: dict[str, Any]) -> int | None:
     for row in trace.get("steps", []):
         meta = _mapping(_mapping(row).get("observation_perturbation"))
         if int(meta.get("observed_actor_count", 0) or 0) > 0:
-            step = row.get("step")
-            return int(step) if isinstance(step, int) and not isinstance(step, bool) else None
+            return _optional_int(row.get("step"))
     return None
 
 

--- a/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
+++ b/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
@@ -7,21 +7,28 @@ import argparse
 import json
 import subprocess
 import sys
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
 import yaml
 
+from robot_sf.training.scenario_loader import load_scenarios
+
 SCHEMA_VERSION = "issue_2777_observation_noise_live_replay.v1"
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_OUTPUT_DIR = Path("docs/context/evidence/issue_2777_live_observation_noise_replay")
 DEFAULT_SCENARIO_MATRIX = Path(
-    "configs/scenarios/sets/issue_3201_pedestrian_dominated_observation_noise.yaml"
+    "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml"
 )
 DEFAULT_CANDIDATE = "risk_surface_dwa_v0"
 DEFAULT_STAGE = "smoke"
 TRACE_RUNNER = Path("scripts/validation/run_policy_search_step_diagnostics.py")
+ISSUE_2756_FIXTURE_SCENARIO = "issue_2756_occluded_emergence"
+ISSUE_2756_FIXTURE_FAMILY = "occluded_emergence"
+ISSUE_2756_FIXTURE_LABEL = "deterministic_occluded_emergence"
+ISSUE_2756_FIXTURE_SEED = 111
 REQUIRED_CONDITIONS = (
     "noop",
     "low_noise",
@@ -116,60 +123,160 @@ def _repo_path(path: Path) -> Path:
     return path if path.is_absolute() else REPO_ROOT / path
 
 
-def _scenario_matrix_text(matrix_path: Path) -> str:
-    """Return scenario matrix text with includes expanded one level when possible."""
-    raw_text = matrix_path.read_text(encoding="utf-8")
+def _validate_matrix_yaml(matrix_path: Path) -> None:
+    """Raise a stable error when a selected scenario matrix is not valid YAML."""
     try:
-        payload = yaml.safe_load(raw_text) or {}
+        yaml.safe_load(matrix_path.read_text(encoding="utf-8"))
     except yaml.YAMLError as exc:
         raise ValueError(f"{_durable_ref(matrix_path)} is not valid YAML: {exc}") from exc
-    if not isinstance(payload, dict):
-        return raw_text
-    base_payload = dict(payload)
-    base_payload.pop("includes", None)
-    text = yaml.safe_dump(base_payload, sort_keys=False)
-    includes = payload.get("includes", []) or []
-    if not isinstance(includes, list):
-        return text
-    for include in includes:
-        include_path = (matrix_path.parent / str(include)).resolve()
-        if include_path.exists():
-            text += "\n" + include_path.read_text(encoding="utf-8")
-    return text
+
+
+def _scenario_name(scenario: Mapping[str, Any]) -> str:
+    """Return a scenario identifier from common scenario fields."""
+    return str(scenario.get("name") or scenario.get("scenario_id") or scenario.get("id") or "")
+
+
+def _metadata_mapping(scenario: Mapping[str, Any]) -> dict[str, Any]:
+    """Return scenario metadata as a plain mapping."""
+    metadata = scenario.get("metadata")
+    return dict(metadata) if isinstance(metadata, Mapping) else {}
+
+
+def _fixture_mapping(metadata: Mapping[str, Any]) -> dict[str, Any]:
+    """Return the nested fixture contract metadata as a plain mapping."""
+    fixture = metadata.get("fixture_contract")
+    return dict(fixture) if isinstance(fixture, Mapping) else {}
+
+
+def _metadata_field(metadata: Mapping[str, Any], fixture: Mapping[str, Any], key: str) -> Any:
+    """Read fixture metadata, preferring the nested fixture-contract block."""
+    return fixture.get(key, metadata.get(key))
+
+
+def _source_issue_matches(value: Any) -> bool:
+    """Return whether a source-issue metadata value points at issue #2756."""
+    if isinstance(value, int) and not isinstance(value, bool):
+        return value == 2756
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        return normalized == "2756" or normalized.endswith("/issues/2756")
+    return False
+
+
+def _int_list(value: Any) -> list[int]:
+    """Parse a list of integer-like values while ignoring invalid entries."""
+    if not isinstance(value, list):
+        return []
+    parsed: list[int] = []
+    for item in value:
+        if isinstance(item, bool):
+            continue
+        try:
+            parsed.append(int(item))
+        except (TypeError, ValueError):
+            continue
+    return parsed
+
+
+def _fixture_candidate(scenario: Mapping[str, Any]) -> dict[str, Any]:
+    """Extract the #2756 fixture-facing metadata from one loaded scenario."""
+    metadata = _metadata_mapping(scenario)
+    fixture = _fixture_mapping(metadata)
+    return {
+        "name": _scenario_name(scenario),
+        "source_issue": metadata.get("source_issue", fixture.get("source_issue")),
+        "family": str(metadata.get("family") or scenario.get("scenario_family") or ""),
+        "label": str(metadata.get("label") or fixture.get("label") or ""),
+        "seeds": _int_list(scenario.get("seeds")),
+        "first_visible_step": _metadata_field(metadata, fixture, "first_visible_step"),
+        "delay_steps": _metadata_field(metadata, fixture, "delay_steps"),
+        "delay_only_expected_first_observed_step": _metadata_field(
+            metadata,
+            fixture,
+            "delay_only_expected_first_observed_step",
+        ),
+    }
+
+
+def _fixture_candidate_reasons(candidate: Mapping[str, Any]) -> list[str]:
+    """Return fail-closed reasons for a candidate #2756 fixture scenario."""
+    reasons: list[str] = []
+    if candidate["name"] != ISSUE_2756_FIXTURE_SCENARIO:
+        reasons.append(
+            f"scenario name is {candidate['name']!r}, expected {ISSUE_2756_FIXTURE_SCENARIO!r}"
+        )
+    if not _source_issue_matches(candidate["source_issue"]):
+        reasons.append("metadata.source_issue does not point at issue #2756")
+    if candidate["family"] != ISSUE_2756_FIXTURE_FAMILY:
+        reasons.append(
+            f"metadata family is {candidate['family']!r}, expected {ISSUE_2756_FIXTURE_FAMILY!r}"
+        )
+    if candidate["label"] != ISSUE_2756_FIXTURE_LABEL:
+        reasons.append(
+            f"metadata label is {candidate['label']!r}, expected {ISSUE_2756_FIXTURE_LABEL!r}"
+        )
+    if ISSUE_2756_FIXTURE_SEED not in candidate["seeds"]:
+        reasons.append(f"scenario seeds do not include {ISSUE_2756_FIXTURE_SEED}")
+    for key, expected in (
+        ("first_visible_step", 5),
+        ("delay_steps", 2),
+        ("delay_only_expected_first_observed_step", 7),
+    ):
+        if candidate.get(key) != expected:
+            reasons.append(f"{key} is {candidate.get(key)!r}, expected {expected!r}")
+    return reasons
 
 
 def _fixture_contract(matrix_path: Path) -> dict[str, Any]:
-    """Check whether a live matrix appears to preserve the #2755 fixture boundary."""
-    matrix_error = None
-    try:
-        matrix_text = _scenario_matrix_text(matrix_path)
-    except ValueError as exc:
-        matrix_text = ""
-        matrix_error = str(exc)
-    has_occluded_fixture = (
-        "issue_2756_occluded_emergence" in matrix_text
-        or "deterministic_occluded_emergence" in matrix_text
-    )
-    if matrix_error:
-        blocker = matrix_error
-    elif has_occluded_fixture:
-        blocker = None
-    else:
-        blocker = (
-            "No checked-in live scenario matrix preserving the #2755/#2756 "
-            "occluded-emergence fixture boundary was found in the selected matrix."
-        )
-    return {
+    """Check whether a live matrix preserves the #2755/#2756 fixture boundary."""
+    fixture_contract: dict[str, Any] = {
         "required_source_issue": 2756,
-        "required_scenario": "issue_2756_occluded_emergence",
-        "required_family": "occluded_emergence/deterministic_occluded_emergence",
+        "required_scenario": ISSUE_2756_FIXTURE_SCENARIO,
+        "required_family": f"{ISSUE_2756_FIXTURE_FAMILY}/{ISSUE_2756_FIXTURE_LABEL}",
+        "required_seed": ISSUE_2756_FIXTURE_SEED,
         "first_visible_step": 5,
         "delay_steps": 2,
         "delay_only_expected_first_observed_step": 7,
         "scenario_matrix": _durable_ref(matrix_path),
-        "satisfied": has_occluded_fixture,
-        "blocker": blocker,
+        "satisfied": False,
+        "blocker": None,
+        "matched_scenario": None,
     }
+    try:
+        _validate_matrix_yaml(matrix_path)
+        scenarios = load_scenarios(matrix_path)
+    except ValueError as exc:
+        fixture_contract["blocker"] = str(exc)
+        return fixture_contract
+    except Exception as exc:  # pragma: no cover - defensive fail-closed path
+        fixture_contract["blocker"] = (
+            f"{_durable_ref(matrix_path)} could not be loaded as a scenario matrix: {exc}"
+        )
+        return fixture_contract
+
+    candidates = [_fixture_candidate(dict(scenario)) for scenario in scenarios]
+    named_candidates = [
+        candidate for candidate in candidates if candidate["name"] == ISSUE_2756_FIXTURE_SCENARIO
+    ]
+    if not named_candidates:
+        fixture_contract["blocker"] = (
+            "No checked-in live scenario matrix preserving the #2755/#2756 "
+            "occluded-emergence fixture boundary was found in the selected matrix."
+        )
+        return fixture_contract
+
+    candidate = named_candidates[0]
+    reasons = _fixture_candidate_reasons(candidate)
+    fixture_contract["matched_scenario"] = candidate
+    if reasons:
+        fixture_contract["blocker"] = (
+            "Selected matrix contains issue_2756_occluded_emergence, but it does not "
+            f"preserve the required fixture contract: {'; '.join(reasons)}."
+        )
+        return fixture_contract
+
+    fixture_contract["satisfied"] = True
+    return fixture_contract
 
 
 def _write_generated_funnel(
@@ -186,7 +293,7 @@ def _write_generated_funnel(
         "stages": {
             stage: {
                 "scenario_matrix": _repo_path(scenario_matrix).as_posix(),
-                "seed_list": [3233],
+                "seed_list": [ISSUE_2756_FIXTURE_SEED],
                 "benchmark_profile": "experimental",
                 "horizon": int(horizon),
                 "dt": 0.1,
@@ -268,6 +375,7 @@ def _observation_totals(trace: dict[str, Any]) -> dict[str, Any]:
     totals = {
         "missed_actor_observations_total": 0,
         "occluded_actor_observations_total": 0,
+        "visibility_hidden_actor_observations_total": 0,
         "min_observed_actor_count": None,
         "max_observed_actor_count": None,
         "noise_profiles": set(),
@@ -277,6 +385,9 @@ def _observation_totals(trace: dict[str, Any]) -> dict[str, Any]:
         meta = _mapping(row.get("observation_perturbation"))
         totals["missed_actor_observations_total"] += int(meta.get("missed_actor_count", 0) or 0)
         totals["occluded_actor_observations_total"] += int(meta.get("occluded_actor_count", 0) or 0)
+        totals["visibility_hidden_actor_observations_total"] += int(
+            meta.get("visibility_hidden_actor_count", 0) or 0
+        )
         observed_counts.append(int(meta.get("observed_actor_count", 0) or 0))
         profile = meta.get("noise_profile")
         if profile:
@@ -299,6 +410,16 @@ def _progress_delta(noop: dict[str, Any], condition: dict[str, Any]) -> dict[str
         }
         for field in PROGRESS_FIELDS
     }
+
+
+def _first_observed_step(trace: dict[str, Any]) -> int | None:
+    """Return the first trace step with at least one planner-visible actor."""
+    for row in trace.get("steps", []):
+        meta = _mapping(_mapping(row).get("observation_perturbation"))
+        if int(meta.get("observed_actor_count", 0) or 0) > 0:
+            step = row.get("step")
+            return int(step) if isinstance(step, int) and not isinstance(step, bool) else None
+    return None
 
 
 def _classification(
@@ -390,6 +511,10 @@ def _compare_condition(
             else None,
         },
         "progress_delta": _progress_delta(noop_trace, condition_trace),
+        "fixture_visibility": {
+            "noop_first_observed_step": _first_observed_step(noop_trace),
+            "condition_first_observed_step": _first_observed_step(condition_trace),
+        },
         "classification": _classification(
             noop_trace=noop_trace,
             condition_trace=condition_trace,
@@ -648,6 +773,38 @@ def _attach_condition_comparisons(
     return blockers
 
 
+def _verify_fixture_observation_boundary(
+    *,
+    output_dir: Path,
+    fixture_contract: Mapping[str, Any],
+) -> list[str]:
+    """Verify live traces preserve the configured first-visible/delay boundary."""
+    if not fixture_contract.get("satisfied"):
+        return []
+    try:
+        noop_trace = _load_trace(output_dir / "traces" / "noop" / "trace.json")
+        delay_trace = _load_trace(output_dir / "traces" / "delay_only" / "trace.json")
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return [f"Could not verify #2756 live fixture observation boundary: {exc}"]
+
+    expected_first_visible = int(fixture_contract["first_visible_step"])
+    expected_delay_first_observed = int(fixture_contract["delay_only_expected_first_observed_step"])
+    noop_first_observed = _first_observed_step(noop_trace)
+    delay_first_observed = _first_observed_step(delay_trace)
+    blockers: list[str] = []
+    if noop_first_observed != expected_first_visible:
+        blockers.append(
+            "No-op live replay did not preserve the #2756 first-visible boundary: "
+            f"observed {noop_first_observed}, expected {expected_first_visible}."
+        )
+    if delay_first_observed != expected_delay_first_observed:
+        blockers.append(
+            "Delay-only live replay did not preserve the #2756 delayed first-observed boundary: "
+            f"observed {delay_first_observed}, expected {expected_delay_first_observed}."
+        )
+    return blockers
+
+
 def _final_classification(
     *,
     blockers: list[str],
@@ -729,6 +886,12 @@ def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
             output_dir=output_dir,
             conditions=conditions,
             fixture_contract_satisfied=bool(fixture_contract["satisfied"]),
+        )
+    )
+    blockers.extend(
+        _verify_fixture_observation_boundary(
+            output_dir=output_dir,
+            fixture_contract=fixture_contract,
         )
     )
     status, classification = _final_classification(

--- a/scripts/validation/run_policy_search_step_diagnostics.py
+++ b/scripts/validation/run_policy_search_step_diagnostics.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import json
 from collections import Counter
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 
@@ -397,6 +398,45 @@ def _pedestrian_state_from_sim(env: Any) -> tuple[np.ndarray, np.ndarray, list[s
     return ped_pos, ped_vel, actor_ids
 
 
+def _fixture_first_visible_step(scenario: Mapping[str, Any]) -> int | None:
+    """Return a scenario fixture first-visible step when explicitly configured."""
+    metadata = scenario.get("metadata")
+    if not isinstance(metadata, Mapping):
+        return None
+    fixture = metadata.get("fixture_contract")
+    if not isinstance(fixture, Mapping):
+        return None
+    value = fixture.get("first_visible_step")
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None
+
+
+def _empty_observation_snapshot() -> dict[str, Any]:
+    """Return an empty observation snapshot for delay-buffer warmup."""
+    return {
+        "positions": np.zeros((0, 2), dtype=float),
+        "velocities": np.zeros((0, 2), dtype=float),
+        "ids": [],
+    }
+
+
+def _fixture_visibility_mask(
+    *,
+    actor_count: int,
+    step: int,
+    first_visible_step: int | None,
+) -> np.ndarray | None:
+    """Return a mask that hides all actors before a fixture first-visible step."""
+    if first_visible_step is None or step >= first_visible_step:
+        return None
+    return np.zeros(max(0, int(actor_count)), dtype=bool)
+
+
 def _occlusion_mask_by_distance(
     env: Any,
     ped_pos: np.ndarray,
@@ -414,7 +454,10 @@ def _occlusion_mask_by_distance(
 
 
 def _observation_perturbation_spec(
-    args: argparse.Namespace, env: Any
+    args: argparse.Namespace,
+    env: Any,
+    *,
+    visibility_mask: np.ndarray | None = None,
 ) -> ObservationPerturbationSpec:
     """Build a per-step observation perturbation spec from CLI flags."""
     ped_pos, _ped_vel, _actor_ids = _pedestrian_state_from_sim(env)
@@ -428,6 +471,7 @@ def _observation_perturbation_spec(
             occlusion_distance_m=args.occlusion_distance_m,
         ),
         delay_steps=int(args.observation_delay_steps),
+        visibility_mask=visibility_mask,
         seed=args.observation_perturbation_seed,
     )
 
@@ -557,6 +601,9 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         if int(args.observation_delay_steps) > 0
         else None
     )
+    first_visible_step = _fixture_first_visible_step(scenario)
+    if observation_state is not None and first_visible_step is not None:
+        observation_state.reset(initial_obs=_empty_observation_snapshot())
     try:
         obs, _ = env.reset(seed=seed)
         if callable(planner_bind_env):
@@ -573,7 +620,16 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
                 min_robot_ped_dist = _obs_min_robot_ped_distance(obs)
 
             ped_pos, ped_vel, actor_ids = _pedestrian_state_from_sim(env)
-            perturbation_spec = _observation_perturbation_spec(args, env)
+            visibility_mask = _fixture_visibility_mask(
+                actor_count=len(actor_ids),
+                step=step_idx,
+                first_visible_step=first_visible_step,
+            )
+            perturbation_spec = _observation_perturbation_spec(
+                args,
+                env,
+                visibility_mask=visibility_mask,
+            )
             perturbation = perturb_ground_truth(
                 ped_pos,
                 ped_vel,
@@ -667,6 +723,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
             "occlusion_distance_m": args.occlusion_distance_m,
             "delay_steps": int(args.observation_delay_steps),
             "seed": args.observation_perturbation_seed,
+            "fixture_first_visible_step": first_visible_step,
         },
         "planner_summary": _json_ready(planner_summary),
         "progress_summary": _json_ready(progress_summary),

--- a/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
+++ b/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
@@ -59,6 +59,57 @@ def test_default_strict_mode_fails_closed_without_occluded_fixture(tmp_path: Pat
     assert {condition["status"] for condition in report["conditions"]} == {"blocked"}
 
 
+def test_issue_3320_matrix_satisfies_occluded_emergence_contract() -> None:
+    """The tracked issue #3320 matrix preserves the #2756 fixture boundary."""
+    mod = _load_script()
+    matrix = mod.REPO_ROOT / "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml"
+
+    contract = mod._fixture_contract(matrix)
+
+    assert contract["satisfied"] is True
+    assert contract["blocker"] is None
+    assert contract["matched_scenario"]["name"] == "issue_2756_occluded_emergence"
+    assert contract["matched_scenario"]["seeds"] == [111]
+    assert contract["matched_scenario"]["first_visible_step"] == 5
+    assert contract["matched_scenario"]["delay_steps"] == 2
+    assert contract["matched_scenario"]["delay_only_expected_first_observed_step"] == 7
+
+
+def test_mismatched_occluded_emergence_contract_fails_closed(tmp_path: Path) -> None:
+    """A named #2756 scenario must still preserve the exact boundary metadata."""
+    mod = _load_script()
+    scenario = tmp_path / "scenario.yaml"
+    scenario.write_text(
+        "scenarios:\n"
+        "- name: issue_2756_occluded_emergence\n"
+        "  metadata:\n"
+        "    source_issue: 2756\n"
+        "    family: occluded_emergence\n"
+        "    label: deterministic_occluded_emergence\n"
+        "    fixture_contract:\n"
+        "      first_visible_step: 4\n"
+        "      delay_steps: 2\n"
+        "      delay_only_expected_first_observed_step: 6\n"
+        "  seeds: [111]\n",
+        encoding="utf-8",
+    )
+    matrix = tmp_path / "matrix.yaml"
+    matrix.write_text(
+        "schema_version: robot_sf.scenario_matrix.v1\n"
+        "includes:\n"
+        "  - scenario.yaml\n"
+        "select_scenarios:\n"
+        "  - issue_2756_occluded_emergence\n",
+        encoding="utf-8",
+    )
+
+    contract = mod._fixture_contract(matrix)
+
+    assert contract["satisfied"] is False
+    assert "first_visible_step" in contract["blocker"]
+    assert "delay_only_expected_first_observed_step" in contract["blocker"]
+
+
 def test_dry_run_plans_all_live_diagnostics_commands(tmp_path: Path) -> None:
     """Proxy dry-run mode should expose the exact subprocess plan without execution."""
     mod = _load_script()
@@ -195,6 +246,63 @@ def _write_trace(path: Path, *, command: list[float], observed_count: int, close
         ],
     }
     path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def _write_observed_count_trace(path: Path, counts: list[int]) -> None:
+    """Write a tiny diagnostics trace with configurable observed actor counts."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "scenario_id": "issue_2756_occluded_emergence",
+        "seed": 111,
+        "steps": [
+            {
+                "step": step,
+                "observation_perturbation": {
+                    "observed_actor_count": count,
+                },
+            }
+            for step, count in enumerate(counts)
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_fixture_boundary_verifier_requires_noop_and_delay_first_observed_steps(
+    tmp_path: Path,
+) -> None:
+    """The live wrapper should fail closed when trace timing drifts from #2756."""
+    mod = _load_script()
+    output_dir = tmp_path / "out"
+    contract = {
+        "satisfied": True,
+        "first_visible_step": 5,
+        "delay_only_expected_first_observed_step": 7,
+    }
+    _write_observed_count_trace(output_dir / "traces/noop/trace.json", [0, 0, 0, 0, 0, 1])
+    _write_observed_count_trace(
+        output_dir / "traces/delay_only/trace.json",
+        [0, 0, 0, 0, 0, 0, 0, 1],
+    )
+
+    assert (
+        mod._verify_fixture_observation_boundary(
+            output_dir=output_dir,
+            fixture_contract=contract,
+        )
+        == []
+    )
+
+    _write_observed_count_trace(
+        output_dir / "traces/delay_only/trace.json",
+        [0, 0, 0, 0, 0, 0, 1],
+    )
+    blockers = mod._verify_fixture_observation_boundary(
+        output_dir=output_dir,
+        fixture_contract=contract,
+    )
+
+    assert blockers
+    assert "Delay-only" in blockers[0]
 
 
 def test_trace_comparison_names_scenario_seed_planner_and_policy_insensitive(

--- a/tests/benchmark/test_observation_perturbation.py
+++ b/tests/benchmark/test_observation_perturbation.py
@@ -9,6 +9,7 @@ from robot_sf.benchmark.observation_perturbation import (
     EVIDENCE_IDEAL,
     EVIDENCE_PERCEPTION_LIMITED,
     NOISE_PROFILE_DELAYED_OBSERVATION,
+    NOISE_PROFILE_FIXTURE_VISIBILITY,
     NOISE_PROFILE_GAUSSIAN,
     NOISE_PROFILE_MISSED_DETECTION,
     NOISE_PROFILE_NONE,
@@ -83,6 +84,7 @@ class TestNoopSpec:
             "missed_detection_probability",
             "missed_actor_count",
             "occluded_actor_count",
+            "visibility_hidden_actor_count",
             "delay_steps",
             "step",
             "actor_count",
@@ -254,6 +256,52 @@ class TestOcclusionMask:
 
         with pytest.raises(ValueError, match="occlusion_mask length"):
             perturb_ground_truth(pos, vel, ids, spec=spec)
+
+
+class TestFixtureVisibility:
+    """Scenario fixture visibility should hide actors without changing ground truth."""
+
+    def test_visibility_mask_drops_observed_actors_only(self) -> None:
+        """Fixture-hidden actors should be absent from the observed planner input."""
+        pos, vel, ids = _simple_actors()
+        spec = ObservationPerturbationSpec(visibility_mask=np.array([False, True, False]))
+
+        result = perturb_ground_truth(pos, vel, ids, spec=spec, step=0)
+
+        np.testing.assert_array_equal(result["ground_truth"]["positions"], pos)
+        assert result["ground_truth"]["ids"] == ids
+        assert result["observed"]["ids"] == ["ped_B"]
+        np.testing.assert_array_equal(result["observed"]["positions"], pos[1:2])
+        assert result["missing_ids"] == ["ped_A", "ped_C"]
+        assert result["metadata"]["visibility_hidden_actor_count"] == 2
+        assert result["metadata"]["missed_actor_count"] == 0
+        assert result["metadata"]["noise_profile"] == NOISE_PROFILE_FIXTURE_VISIBILITY
+
+    def test_seeded_delay_buffer_preserves_first_observed_boundary(self) -> None:
+        """An empty seeded delay buffer should delay first visibility by two steps."""
+        pos = np.array([[1.0, 2.0]])
+        vel = np.array([[0.1, 0.0]])
+        ids = ["ped_A"]
+        state = ObservationPerturbationState(delay_steps=2)
+        state.reset(
+            initial_obs={
+                "positions": np.zeros((0, 2), dtype=float),
+                "velocities": np.zeros((0, 2), dtype=float),
+                "ids": [],
+            }
+        )
+        observed_counts = []
+        for step in range(8):
+            visibility_mask = np.array([False]) if step < 5 else None
+            spec = ObservationPerturbationSpec(
+                delay_steps=2,
+                visibility_mask=visibility_mask,
+            )
+            result = perturb_ground_truth(pos + step, vel, ids, spec=spec, step=step, state=state)
+            observed_counts.append(result["metadata"]["observed_actor_count"])
+
+        assert observed_counts[:7] == [0, 0, 0, 0, 0, 0, 0]
+        assert observed_counts[7] == 1
 
 
 class TestDelayBehavior:

--- a/tests/benchmark/test_observation_perturbation.py
+++ b/tests/benchmark/test_observation_perturbation.py
@@ -492,3 +492,24 @@ class TestStateReset:
         r = perturb_ground_truth(pos, vel, ids, spec=spec, step=0, state=state)
         # Buffer has initial_obs, delay=1: should return the seeded observation
         np.testing.assert_array_equal(r["observed"]["positions"], pos + 99)
+
+    def test_reset_with_initial_obs_copies_seeded_snapshots(self) -> None:
+        """Seeded delay-buffer warmup should not share mutable snapshot references."""
+        state = ObservationPerturbationState(delay_steps=2)
+        pos, vel, ids = _simple_actors()
+        initial_obs = {
+            "positions": pos.copy(),
+            "velocities": vel.copy(),
+            "ids": list(ids),
+        }
+
+        state.reset(initial_obs=initial_obs)
+        initial_obs["ids"].append("mutated")
+        initial_obs["positions"][0, 0] = 99.0
+
+        first, second = list(state._delay_buffer)
+        assert first is not second
+        assert first["ids"] == ids
+        assert second["ids"] == ids
+        np.testing.assert_array_equal(first["positions"], pos)
+        np.testing.assert_array_equal(second["positions"], pos)

--- a/tests/validation/test_run_policy_search_step_diagnostics.py
+++ b/tests/validation/test_run_policy_search_step_diagnostics.py
@@ -7,6 +7,8 @@ import pytest
 from scripts.validation.run_policy_search_step_diagnostics import (
     _apply_observed_pedestrians_to_policy_obs,
     _diagnostics_stdout_payload,
+    _fixture_first_visible_step,
+    _fixture_visibility_mask,
     _format_planner_summary_lines,
     _occlusion_mask_by_distance,
     _pedestrian_state_from_sim,
@@ -226,6 +228,27 @@ def test_occlusion_mask_by_distance_marks_out_of_range_pedestrians() -> None:
     mask = _occlusion_mask_by_distance(env, positions, occlusion_distance_m=2.0)
 
     assert mask.tolist() == [False, True]
+
+
+def test_fixture_visibility_mask_hides_until_first_visible_step() -> None:
+    """Fixture metadata should become an all-hidden mask before first visibility."""
+    scenario = {"metadata": {"fixture_contract": {"first_visible_step": 5}}}
+
+    first_visible_step = _fixture_first_visible_step(scenario)
+    hidden = _fixture_visibility_mask(
+        actor_count=2,
+        step=4,
+        first_visible_step=first_visible_step,
+    )
+    visible = _fixture_visibility_mask(
+        actor_count=2,
+        step=5,
+        first_visible_step=first_visible_step,
+    )
+
+    assert first_visible_step == 5
+    assert hidden.tolist() == [False, False]
+    assert visible is None
 
 
 def test_policy_obs_uses_observed_pedestrian_payload() -> None:


### PR DESCRIPTION
## Summary

- Add a checked-in issue #3320 live matrix and scenario for `issue_2756_occluded_emergence`
  using seed 111 and the required #2756 first-visible/delay metadata.
- Teach live step diagnostics to honor explicit fixture visibility metadata while preserving
  simulator ground truth, so no-op first observation remains step 5 and two-step delay first
  observation becomes step 7.
- Strengthen the issue #2777 replay wrapper to validate loaded scenario metadata and fail closed if
  produced traces drift from the #2756 no-op/delay observation boundary.
- Promote compact durable evidence for the seven-condition live replay and update the evidence
  index.

Closes #3320.

## Validation

- `rtk uv run pytest tests/benchmark/test_observation_perturbation.py tests/validation/test_run_policy_search_step_diagnostics.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py -q`
  - Passed: 59 tests.
- `rtk uv run ruff check robot_sf/benchmark/observation_perturbation.py scripts/validation/run_policy_search_step_diagnostics.py scripts/benchmark/run_observation_noise_live_replay_issue_2777.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py tests/benchmark/test_observation_perturbation.py tests/validation/test_run_policy_search_step_diagnostics.py`
  - Passed.
- `rtk uv run ruff format --check robot_sf/benchmark/observation_perturbation.py scripts/validation/run_policy_search_step_diagnostics.py scripts/benchmark/run_observation_noise_live_replay_issue_2777.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py tests/benchmark/test_observation_perturbation.py tests/validation/test_run_policy_search_step_diagnostics.py`
  - Passed.
- `rtk uv run python scripts/benchmark/run_observation_noise_live_replay_issue_2777.py --scenario-matrix configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml`
  - Passed: `status=live_replay`, `classification=scenario_too_weak`.
  - Verified #2756 boundary: no-op first observed step `5`, delay-only first observed step `7`.
- `BASE_REF=origin/main uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh`
  - Passed: exit 0, 101.564s.
  - Compact summary: `.git/codex-agent-runs/active/compact-validation/validation-20260621T114201Z-556075.summary.json`.

## Downstream Propagation

- Parent issue: #3320 is closed by this PR.
- Deferred follow-up: #3323 tracks the remaining near-field live geometry needed before any
  stronger behavioral robustness claim.
- Evidence surface updated:
  - `docs/context/evidence/issue_2777_live_observation_noise_replay/README.md`
  - `docs/context/evidence/issue_2777_live_observation_noise_replay/summary.json`
  - `docs/context/evidence/README.md`
- Context catalog: no new catalog path was required because `docs/context/catalog.yaml` already
  indexes the issue #2777 replay README and summary paths.
- Leaderboards, model registries, benchmark release manifests, and config indexes: not updated; this
  is a diagnostic stress-slice matrix/evidence update, not a planner-ranking or release-result
  promotion.

## Research Result Guidance

- Target claim/hypothesis/blocker: resolve the #2777 fail-closed blocker by providing a live matrix
  that preserves the #2756 occluded-emergence observation boundary.
- Comparator/baseline: no-op live replay compared with six #2755 perturbation-family conditions
  (`low_noise`, `medium_noise`, `missed_detection_only`, `occlusion_only`, `delay_only`,
  `combined`) on the same scenario, seed, candidate, and horizon.
- Evidence tier: diagnostic stress-slice evidence, one scenario and one seed. Not paper-facing
  benchmark-strength robustness evidence.
- Result classification: `scenario_too_weak`. The wrapper now executes on the intended fixture
  boundary, perturbations change planner-input observations, and commands/progress/risk summaries
  stay unchanged because the live geometry remains outside the near-field target.
- Decision/stop rule: #3320 succeeds for unblocking #2777 live replay execution without
  `--allow-non-occluded-live-fixture`; no robustness claim is promoted.
- Synthesis/update target: compact replay evidence under
  `docs/context/evidence/issue_2777_live_observation_noise_replay/`.

## Follow-Up Issues

- Deferred work: near-field live geometry remains needed before any stronger behavioral robustness
  claim can be considered.
- Issues opened for follow-up: #3323.

## Domain-Aware Approval

- Required for this PR: yes - evidence-sensitive diagnostic stress classification is updated.
- Domains reviewed: evidence classification, benchmark interpretation.
- Status: waived
- Approver/review source or waiver: agent self-review waiver for merge readiness because the PR
  narrows the claim to diagnostic stress evidence, does not promote benchmark-strength or
  paper-facing claims, and opens #3323 for the remaining near-field validity gap.
- Validity checklist:
  - Target claim/hypothesis: #3320 only unblocks #2777 live replay on the #2756 observation
    boundary; it does not claim robustness.
  - Comparator or split/evidence validity: no-op replay is compared with six #2755 perturbation
    families on the same scenario, seed, candidate, and horizon.
  - Fallback/degraded exclusions: no fallback/degraded execution is counted as evidence; the wrapper
    fails closed when the fixture contract or produced trace timing does not match.
  - Claim boundary: one scenario, one seed, diagnostic stress-slice evidence; stronger behavioral
    interpretation is deferred to #3323.
  - Implementation integrity vs experimental validity: tests and PR readiness cover implementation;
    experimental validity remains limited by `scenario_too_weak` and is not promoted.

## Risks And Limitations

- The live replay is still a one-seed diagnostic stress slice. It should not be used as robustness
  or planner-superiority evidence.
- Raw trace JSON and per-condition reports were generated locally to build the compact summary but
  are intentionally not committed.
- A stronger follow-up would need a near-field live geometry that produces behavioral differences
  under the same #2756 observation boundary.
