### PR TITLE
examples: add AMV paper figure/table rendering scripts to plotting examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -89,7 +89,8 @@ Feature-focused demos for developers exploring capabilities.
 | [26 Telemetry Pane](./advanced/26_telemetry_pane.py) | Live telemetry visualization with docked charts in the Pygame window showing FPS, reward, collisions, and pedestrian distance. | _None_ | telemetry, visualization, pygame, interactive | ⚠️ Interactive pygame session not reliable for CI; use headless variant instead. |
 | [27 Telemetry Headless Smoke](./advanced/27_telemetry_headless_smoke.py) | Headless telemetry smoke test producing JSONL and summary PNG/JSON artifacts without rendering. | _None_ | telemetry, visualization, headless, ci | ⚠️ Requires file output inspection; not suitable for smoke tests. |
 | [32 Demo Adversarial Pedestrian](./advanced/32_demo_adversarial_pedestrian.py) | Run a modernized debug rollout for pedestrian PPO policies with factory-based setup. | maps/svg_maps/masterthesis/intersection.svg<br>model/run_043<br>model/pedestrian/ppo_intersection.zip | pedestrian, policy, debug, ppo | ⚠️ Interactive pygame debug demo with offline checkpoints. |
-| [33 Three.js Recording Viewer](./advanced/33_threejs_recording_viewer.py) | Export a JSONL or pickle recording to a static browser viewer. | recordings/<file>.jsonl | visualization, recording, threejs | ✅ |
+| [33 Three.js Recording Viewer](./advanced/33_threejs_recording_viewer.py) | Export a JSONL or pickle recording to a static browser viewer. | _None_ | visualization, recording, threejs | ✅ |
+| [34 Trace Three.js Viewer](./advanced/34_trace_threejs_viewer.py) | Export a simulation_trace_export.v1 trace to a static browser viewer. | _None_ | visualization, trace, annotation, threejs | ✅ |
 | [Occupancy Reward Shaping](./occupancy_reward_shaping.py) | Derive a clearance penalty from occupancy grid observations in a short rollout. | _None_ | occupancy, reward, grid | ✅ |
 
 ## Benchmarks
@@ -111,6 +112,11 @@ Visualization and analysis scripts built atop benchmark outputs.
 | --- | --- | --- | --- | --- |
 | [Coverage Example](./plotting/coverage_example.py) | Coverage tools programmatic usage example. | _None_ | coverage, tooling | ✅ |
 | [Data Analysis Example](./plotting/data_analysis_example.py) | Perform a showcase on how to use the data analysis module. | _None_ | analysis | ✅ |
+| [Paper Figure: PPO Observation Grid](./plotting/paper_figures/build_observation_grid_figure.py) | Build a PPO occupancy-grid observation figure from rendered scenario videos. | _None_ | paper, figures, plotting, benchmark | ⚠️ Requires a benchmark publication-bundle path; no default CI input. |
+| [Paper Figure: Planner Trade-off](./plotting/paper_figures/build_planner_tradeoff_figure.py) | Build the mandatory planner safety–efficiency tradeoff figure for the AMV paper. | _None_ | paper, figures, plotting, benchmark | ⚠️ Requires a benchmark publication-bundle path (--bundle-path); no default CI input. |
+| [Paper Figure: Runtime Scene Panels](./plotting/paper_figures/build_runtime_scene_panels.py) | Build publication-ready runtime scene panel figures from benchmark videos/frames. | _None_ | paper, figures, plotting, benchmark | ⚠️ Requires rendered runtime frames/videos source root; no default CI input. |
+| [Paper Table: Scenario Coverage Matrix](./plotting/paper_figures/build_scenario_coverage_matrix.py) | Build a manuscript-facing AMV scenario coverage matrix. | _None_ | paper, figures, plotting, benchmark | ⚠️ Requires a benchmark publication-bundle/scenario-inventory path; no default CI input. |
+| [Paper Figure: Scenario SVG Overview](./plotting/paper_figures/build_svg_scenario_overview.py) | Build a scenario-map overview figure from source SVG files. | _None_ | paper, figures, plotting, benchmark | ⚠️ Requires scenario SVG source assets; no default CI input. |
 | [Plot Force Field](./plotting/plot_force_field.py) | Plot a sampled social-force field using matplotlib. | _None_ | visualization, force-field | ✅ |
 | [Plot Force Field Normalized](./plotting/plot_force_field_normalized.py) | Plot normalized force vectors with a magnitude colormap and save PNG+PDF. | _None_ | visualization, force-field | ✅ |
 | [Plot Force Field Save](./plotting/plot_force_field_save.py) | Generate and save static images of the force field for documentation. | _None_ | visualization, force-field | ✅ |

--- a/examples/examples_manifest.yaml
+++ b/examples/examples_manifest.yaml
@@ -484,3 +484,43 @@ examples:
     ci_reason: "Requires file output inspection; not suitable for smoke tests."
     doc_reference: specs/343-telemetry-viz/quickstart.md
     tags: [telemetry, visualization, headless, ci]
+  - path: plotting/paper_figures/build_planner_tradeoff_figure.py
+    name: "Paper Figure: Planner Trade-off"
+    summary: "Build the mandatory planner safety–efficiency tradeoff figure for the AMV paper."
+    category_slug: plotting
+    prerequisites: []
+    ci_enabled: false
+    ci_reason: "Requires a benchmark publication-bundle path (--bundle-path); no default CI input."
+    tags: [paper, figures, plotting, benchmark]
+  - path: plotting/paper_figures/build_scenario_coverage_matrix.py
+    name: "Paper Table: Scenario Coverage Matrix"
+    summary: "Build a manuscript-facing AMV scenario coverage matrix."
+    category_slug: plotting
+    prerequisites: []
+    ci_enabled: false
+    ci_reason: "Requires a benchmark publication-bundle/scenario-inventory path; no default CI input."
+    tags: [paper, figures, plotting, benchmark]
+  - path: plotting/paper_figures/build_svg_scenario_overview.py
+    name: "Paper Figure: Scenario SVG Overview"
+    summary: "Build a scenario-map overview figure from source SVG files."
+    category_slug: plotting
+    prerequisites: []
+    ci_enabled: false
+    ci_reason: "Requires scenario SVG source assets; no default CI input."
+    tags: [paper, figures, plotting, benchmark]
+  - path: plotting/paper_figures/build_runtime_scene_panels.py
+    name: "Paper Figure: Runtime Scene Panels"
+    summary: "Build publication-ready runtime scene panel figures from benchmark videos/frames."
+    category_slug: plotting
+    prerequisites: []
+    ci_enabled: false
+    ci_reason: "Requires rendered runtime frames/videos source root; no default CI input."
+    tags: [paper, figures, plotting, benchmark]
+  - path: plotting/paper_figures/build_observation_grid_figure.py
+    name: "Paper Figure: PPO Observation Grid"
+    summary: "Build a PPO occupancy-grid observation figure from rendered scenario videos."
+    category_slug: plotting
+    prerequisites: []
+    ci_enabled: false
+    ci_reason: "Requires a benchmark publication-bundle path; no default CI input."
+    tags: [paper, figures, plotting, benchmark]

--- a/examples/plotting/paper_figures/README.md
+++ b/examples/plotting/paper_figures/README.md
@@ -1,0 +1,43 @@
+# Paper Figure Scripts (AMV Local-Planning Benchmark)
+
+These scripts reproduce the figures and tables of the AMV local-planning
+benchmark paper directly from a `robot_sf_ll7` benchmark **publication bundle**
+(the archived release artifacts: raw episode JSONL, aggregate CSV/JSON reports,
+and manifests). They are standalone (no `robot_sf` import) and read only the
+public bundle outputs, so a third party can regenerate the manuscript figures
+from the released artifacts without re-running the campaign.
+
+They are registered with `ci_enabled: false` in `examples_manifest.yaml` because
+each one requires a publication-bundle path; there is no default CI input.
+
+## Scripts
+
+| Script | Produces |
+| --- | --- |
+| `build_planner_tradeoff_figure.py` | Safety–efficiency trade-off scatter (success vs collision rate, main rows + seed-bootstrap bands) |
+| `build_scenario_coverage_matrix.py` | Scenario coverage matrix LaTeX table |
+| `build_svg_scenario_overview.py` | Source-SVG static scenario overview panel grid |
+| `build_runtime_scene_panels.py` | Runtime scene-context panel grid (from rendered frames) |
+| `build_observation_grid_figure.py` | PPO planner-facing occupancy-grid observation frame |
+
+## Usage
+
+Each script takes a bundle/source path; run with `--help` for the exact flags.
+For example, the trade-off figure:
+
+```bash
+.venv/bin/python examples/plotting/paper_figures/build_planner_tradeoff_figure.py \
+    --bundle-path output/benchmarks/publication/<your_publication_bundle>
+```
+
+The default paths in some scripts point at the paper repository's artifact layout;
+pass the explicit bundle/source path to run them against any `robot_sf_ll7`
+publication bundle.
+
+## Provenance
+
+These scripts are mirrored from the manuscript repository so that the
+release-to-figure rendering path is publicly inspectable alongside the benchmark
+release. They are figure/table renderers only and do not constitute benchmark
+evidence; the numeric evidence lives in the bundle's episode records and
+aggregate reports.

--- a/examples/plotting/paper_figures/build_observation_grid_figure.py
+++ b/examples/plotting/paper_figures/build_observation_grid_figure.py
@@ -1,0 +1,583 @@
+#!/usr/bin/env python3
+"""Build a PPO occupancy-grid observation figure from rendered scenario videos."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageDraw, ImageFont
+
+DEFAULT_FRACTIONS = [0.20, 0.35, 0.50, 0.65, 0.80]
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    frame_index: int
+    score: float
+    content_coverage: float
+    dynamic_context_signal: float
+    crop_usability: float
+    bbox_coverage_w: float
+    bbox_coverage_h: float
+    quality_pass: bool
+    obstacle_grid_ratio: float
+    pedestrian_grid_ratio: float
+
+
+@dataclass(frozen=True)
+class ObservationSelectionRecord:
+    scenario_id: str
+    policy: str
+    seed: int
+    source_video: str
+    source_frame_file: str
+    selected_frame_index: int
+    selected_score: float
+    selection_reason: str
+    candidate_frame_indices: list[int]
+    candidate_scores: list[float]
+    candidate_quality_pass: list[bool]
+    obstacle_grid_ratio: float
+    pedestrian_grid_ratio: float
+    width: int
+    height: int
+    crop_bbox: list[int]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        required=True,
+        help="Root containing frames/ and videos_selected/.",
+    )
+    parser.add_argument(
+        "--scenario-id",
+        type=str,
+        default="classic_t_intersection_medium",
+        help="Scenario ID to visualize.",
+    )
+    parser.add_argument(
+        "--policy",
+        type=str,
+        default="ppo",
+        help="Policy label in video file names.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=111,
+        help="Seed label in video file names.",
+    )
+    parser.add_argument(
+        "--frame-strategy",
+        choices=["scored", "mid"],
+        default="scored",
+        help="Frame selection strategy.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("artifacts/robot_sf_ll7/paper_tools/runtime_visuals"),
+        help="Output directory.",
+    )
+    parser.add_argument(
+        "--output-name",
+        type=str,
+        default="observation_grid_ppo_classic_t_intersection_medium.png",
+        help="Output image file name.",
+    )
+    return parser.parse_args()
+
+
+def _video_path(source_root: Path, scenario_id: str, seed: int, policy: str) -> Path:
+    return source_root / "videos_selected" / f"{scenario_id}_seed{seed}_{policy}.mp4"
+
+
+def _extract_frame(video: Path, frame_idx: int, out_png: Path) -> None:
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(video),
+        "-vf",
+        f"select=eq(n\\,{frame_idx})",
+        "-vframes",
+        "1",
+        str(out_png),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def _ffprobe_frame_count(video: Path) -> int:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-count_frames",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=nb_read_frames,nb_frames",
+        "-of",
+        "csv=p=0",
+        str(video),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    tokens = [tok for tok in proc.stdout.replace("\n", ",").split(",") if tok.strip()]
+    ints = [int(tok) for tok in tokens if tok.strip().isdigit()]
+    return max(ints) if ints else 0
+
+
+def _dominant_background_rgb(img: Image.Image) -> tuple[int, int, int]:
+    w, h = img.size
+    samples = []
+    for x, y in [(5, 5), (w - 6, 5), (5, h - 6), (w - 6, h - 6)]:
+        samples.append(img.getpixel((max(0, x), max(0, y))))
+    r = int(sum(v[0] for v in samples) / len(samples))
+    g = int(sum(v[1] for v in samples) / len(samples))
+    b = int(sum(v[2] for v in samples) / len(samples))
+    return (r, g, b)
+
+
+def _content_bbox(img: Image.Image) -> tuple[int, int, int, int]:
+    bg = Image.new("RGB", img.size, _dominant_background_rgb(img))
+    diff = ImageChops.difference(img, bg).convert("L")
+    diff = diff.point(lambda p: 255 if p > 12 else 0)
+    bbox = diff.getbbox()
+    if bbox is None:
+        return (0, 0, img.width, img.height)
+    return bbox
+
+
+def _bbox_coverage(img: Image.Image, bbox: tuple[int, int, int, int]) -> tuple[float, float]:
+    x0, y0, x1, y1 = bbox
+    return ((x1 - x0) / img.width, (y1 - y0) / img.height)
+
+
+def _occupancy_channel_ratios(img: Image.Image) -> tuple[float, float]:
+    sample = img.resize(
+        (max(120, img.width // 4), max(90, img.height // 4)),
+        Image.Resampling.BILINEAR,
+    ).convert("RGB")
+    total = sample.width * sample.height
+    obs_count = 0
+    ped_count = 0
+    px = sample.load()
+    for y in range(sample.height):
+        for x in range(sample.width):
+            r, g, b = px[x, y]
+            if r > 175 and g > 165 and b < 120:
+                obs_count += 1
+            if r > 170 and g < 110 and b < 110:
+                ped_count += 1
+    return obs_count / total, ped_count / total
+
+
+def _dynamic_context_signal(img: Image.Image) -> float:
+    obs_ratio, ped_ratio = _occupancy_channel_ratios(img)
+    sample = img.resize(
+        (max(120, img.width // 4), max(90, img.height // 4)),
+        Image.Resampling.BILINEAR,
+    ).convert("RGB")
+    total = sample.width * sample.height
+    route_blue_count = 0
+    goal_green_count = 0
+    px = sample.load()
+    for y in range(sample.height):
+        for x in range(sample.width):
+            r, g, b = px[x, y]
+            if b > 155 and r < 130 and g < 160:
+                route_blue_count += 1
+            if g > 145 and r < 145 and b < 145:
+                goal_green_count += 1
+    route_blue = route_blue_count / total
+    goal_green = goal_green_count / total
+    s_obs = min(1.0, obs_ratio * 30.0)
+    s_ped = min(1.0, ped_ratio * 40.0)
+    s_route = min(1.0, route_blue * 24.0)
+    s_goal = min(1.0, goal_green * 20.0)
+    return 0.35 * s_obs + 0.30 * s_ped + 0.20 * s_route + 0.15 * s_goal
+
+
+def _evaluate_candidate(
+    img: Image.Image, frame_index: int
+) -> tuple[CandidateScore, tuple[int, int, int, int]]:
+    bbox = _content_bbox(img)
+    cov_w, cov_h = _bbox_coverage(img, bbox)
+    content_cov_area = cov_w * cov_h
+    content_coverage = min(1.0, content_cov_area / 0.55)
+    crop_usability = min(1.0, content_cov_area / 0.70)
+    dynamic_signal = _dynamic_context_signal(img)
+    obs_ratio, ped_ratio = _occupancy_channel_ratios(img)
+    quality_pass = cov_w >= 0.30 and cov_h >= 0.30
+    score = 0.45 * content_coverage + 0.35 * dynamic_signal + 0.20 * crop_usability
+    candidate = CandidateScore(
+        frame_index=frame_index,
+        score=float(score),
+        content_coverage=float(content_coverage),
+        dynamic_context_signal=float(dynamic_signal),
+        crop_usability=float(crop_usability),
+        bbox_coverage_w=float(cov_w),
+        bbox_coverage_h=float(cov_h),
+        quality_pass=quality_pass,
+        obstacle_grid_ratio=float(obs_ratio),
+        pedestrian_grid_ratio=float(ped_ratio),
+    )
+    return candidate, bbox
+
+
+def _candidate_indices(frame_count: int) -> list[int]:
+    indices = {min(max(int(frame_count * frac), 0), frame_count - 1) for frac in DEFAULT_FRACTIONS}
+    indices.add(min(max(frame_count // 2, 0), frame_count - 1))
+    return sorted(indices)
+
+
+def _select_frame(
+    source_root: Path,
+    scenario_id: str,
+    seed: int,
+    policy: str,
+    frame_strategy: str,
+) -> tuple[Path, int, float, str, list[CandidateScore], tuple[int, int, int, int]]:
+    video = _video_path(source_root, scenario_id, seed, policy)
+    if not video.exists():
+        raise FileNotFoundError(f"Missing video file: {video}")
+    frame_count = max(1, _ffprobe_frame_count(video))
+    mid_idx = min(max(frame_count // 2, 0), frame_count - 1)
+    indices = [mid_idx] if frame_strategy == "mid" else _candidate_indices(frame_count)
+
+    candidates: list[CandidateScore] = []
+    bboxes: dict[int, tuple[int, int, int, int]] = {}
+    images: dict[int, Image.Image] = {}
+    with tempfile.TemporaryDirectory(prefix="obs_grid_pick_") as tmpdir:
+        tmpdir_p = Path(tmpdir)
+        for idx in indices:
+            out_png = tmpdir_p / f"{scenario_id}_{idx}.png"
+            _extract_frame(video, idx, out_png)
+            img = Image.open(out_png).convert("RGB")
+            candidate, bbox = _evaluate_candidate(img, idx)
+            candidates.append(candidate)
+            bboxes[idx] = bbox
+            images[idx] = img.copy()
+
+    preferred = [c for c in candidates if c.quality_pass]
+    if preferred:
+        best = max(preferred, key=lambda c: (c.score, -c.frame_index))
+        reason = "scored_best_quality_pass"
+    else:
+        fallback = next((c for c in candidates if c.frame_index == mid_idx), None)
+        if fallback is None:
+            fallback = max(candidates, key=lambda c: (c.score, -c.frame_index))
+        best = fallback
+        reason = "fallback_midpoint_low_coverage"
+
+    selected_path = (
+        source_root / "frames" / f"{scenario_id}_seed{seed}_{policy}_observation_selected.png"
+    )
+    selected_path.parent.mkdir(parents=True, exist_ok=True)
+    images[best.frame_index].save(selected_path)
+    return selected_path, best.frame_index, best.score, reason, candidates, bboxes[best.frame_index]
+
+
+def _normalize_panel(
+    img: Image.Image, bbox: tuple[int, int, int, int], width: int, height: int
+) -> Image.Image:
+    x0, y0, x1, y1 = bbox
+    margin = 16
+    x0 = max(0, x0 - margin)
+    y0 = max(0, y0 - margin)
+    x1 = min(img.width, x1 + margin)
+    y1 = min(img.height, y1 + margin)
+    cropped = img.crop((x0, y0, x1, y1))
+    fit = cropped.copy()
+    fit.thumbnail((width, height), Image.Resampling.LANCZOS)
+    panel = Image.new("RGB", (width, height), (242, 242, 242))
+    panel.paste(fit, ((width - fit.width) // 2, (height - fit.height) // 2))
+    return panel
+
+
+def _resize_crop_to_panel(
+    img: Image.Image, bbox: tuple[int, int, int, int], width: int, height: int
+) -> Image.Image:
+    x0, y0, x1, y1 = bbox
+    cropped = img.crop((x0, y0, x1, y1))
+    return cropped.resize((width, height), Image.Resampling.LANCZOS)
+
+
+def _load_system_font(size: int, bold: bool) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    bold_candidates = [
+        "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+        "/System/Library/Fonts/SFNS.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/Library/Fonts/Arial Bold.ttf",
+    ]
+    regular_candidates = [
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/System/Library/Fonts/SFNS.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/Library/Fonts/Arial.ttf",
+    ]
+    for path in bold_candidates if bold else regular_candidates:
+        p = Path(path)
+        if not p.exists():
+            continue
+        try:
+            return ImageFont.truetype(str(p), size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def _draw_legend(draw: ImageDraw.ImageDraw, x: int, y: int) -> int:
+    title_font = _load_system_font(46, bold=True)
+    subtitle_font = _load_system_font(32, bold=False)
+    font = _load_system_font(34, bold=False)
+    draw.text((x, y), "PPO planner-facing observation", fill=(20, 20, 20), font=title_font)
+    draw.text(
+        (x, y + 58),
+        "Occupancy channels, map geometry, robot state, and goal context shown at one selected frame.",
+        fill=(55, 55, 55),
+        font=subtitle_font,
+    )
+    y0 = y + 118
+    x_cursor = x
+    marker_size = 34
+
+    def _box(label: str, color: tuple[int, int, int]) -> None:
+        nonlocal x_cursor
+        draw.rectangle(
+            (x_cursor, y0 + 4, x_cursor + marker_size, y0 + 4 + marker_size),
+            fill=color,
+            outline=(20, 20, 20),
+            width=2,
+        )
+        x_cursor += marker_size + 14
+        draw.text((x_cursor, y0 - 2), label, fill=(30, 30, 30), font=font)
+        x_cursor += int(draw.textlength(label, font=font)) + 34
+
+    def _dot(label: str, color: tuple[int, int, int]) -> None:
+        nonlocal x_cursor
+        draw.ellipse(
+            (x_cursor, y0 + 4, x_cursor + marker_size, y0 + 4 + marker_size),
+            fill=color,
+        )
+        x_cursor += marker_size + 14
+        draw.text((x_cursor, y0 - 2), label, fill=(30, 30, 30), font=font)
+        x_cursor += int(draw.textlength(label, font=font)) + 34
+
+    _box("Obstacle occupancy", (255, 255, 0))
+    _box("Pedestrian occupancy", (255, 0, 0))
+    _box("Map geometry", (8, 14, 10))
+    _dot("Robot", (20, 65, 220))
+    _dot("Goal / waypoint", (35, 180, 80))
+    return y0 + 48
+
+
+def _draw_callout(
+    draw: ImageDraw.ImageDraw,
+    label: str,
+    text_xy: tuple[int, int],
+    target_xy: tuple[int, int],
+    font: ImageFont.FreeTypeFont | ImageFont.ImageFont,
+) -> None:
+    x, y = text_xy
+    tx, ty = target_xy
+    padding_x = 16
+    padding_y = 10
+    lines = label.split("\n")
+    widths = [draw.textlength(line, font=font) for line in lines]
+    line_h = 40
+    box_w = int(max(widths) + 2 * padding_x)
+    box_h = int(len(lines) * line_h + 2 * padding_y)
+    draw.rectangle(
+        (x, y, x + box_w, y + box_h), fill=(255, 255, 255), outline=(90, 90, 90), width=2
+    )
+    for idx, line in enumerate(lines):
+        draw.text((x + padding_x, y + padding_y + idx * line_h), line, fill=(30, 30, 30), font=font)
+    anchor = (
+        min(max(tx, x), x + box_w),
+        min(max(ty, y), y + box_h),
+    )
+    if anchor == (tx, ty):
+        anchor = (x + box_w // 2, y + box_h)
+    draw.line((anchor[0], anchor[1], tx, ty), fill=(90, 90, 90), width=4)
+
+
+def build_figure(
+    frame: Image.Image,
+    record: ObservationSelectionRecord,
+    out_path: Path,
+) -> None:
+    panel_w = 1800
+    panel_h = 1464
+    pad = 24
+    top_h = 218
+    width = panel_w + 2 * pad
+    height = top_h + panel_h + 2 * pad
+    canvas = Image.new("RGB", (width, height), (247, 247, 247))
+    draw = ImageDraw.Draw(canvas)
+    _draw_legend(draw, pad, 10)
+    canvas.paste(frame, (pad, top_h))
+    draw.rectangle((pad, top_h, pad + panel_w, top_h + panel_h), outline=(150, 150, 150), width=3)
+    callout_font = _load_system_font(34, bold=False)
+    _draw_callout(
+        draw,
+        "local observation\nwindow boundary",
+        (pad + 1160, top_h + 160),
+        (pad + 1510, top_h + 105),
+        callout_font,
+    )
+    _draw_callout(
+        draw,
+        "robot state +\ngoal vector",
+        (pad + 1080, top_h + 670),
+        (pad + 930, top_h + 760),
+        callout_font,
+    )
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    canvas.save(out_path)
+
+
+def write_manifest_json(path: Path, record: ObservationSelectionRecord, source_root: Path) -> None:
+    payload = {"source_root": str(source_root), "selection": asdict(record)}
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def write_manifest_md(path: Path, record: ObservationSelectionRecord, source_root: Path) -> None:
+    lines = [
+        "# Observation Grid Figure Manifest",
+        "",
+        f"- Source root: `{source_root}`",
+        "",
+        f"- Scenario: `{record.scenario_id}`",
+        f"- Policy: `{record.policy}`",
+        f"- Seed: `{record.seed}`",
+        f"- Selected frame: `{record.selected_frame_index}`",
+        f"- Selection score: `{record.selected_score:.3f}` ({record.selection_reason})",
+        f"- Obstacle occupancy ratio: `{record.obstacle_grid_ratio:.5f}`",
+        f"- Pedestrian occupancy ratio: `{record.pedestrian_grid_ratio:.5f}`",
+        "",
+        f"- Source frame: `{record.source_frame_file}`",
+        f"- Source video: `{record.source_video}`",
+        "",
+        f"- Candidate frames: `{record.candidate_frame_indices}`",
+        f"- Candidate scores: `{[round(v, 3) for v in record.candidate_scores]}`",
+        f"- Candidate quality pass: `{record.candidate_quality_pass}`",
+    ]
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_quality_report(path: Path, figure_path: Path, record: ObservationSelectionRecord) -> None:
+    img = Image.open(figure_path)
+    width, height = img.size
+    has_obs = record.obstacle_grid_ratio > 0.0005
+    has_ped = record.pedestrian_grid_ratio > 0.0005
+    checks = [
+        (
+            "Figure resolution readable",
+            "PASS" if width >= 1200 and height >= 700 else "FAIL",
+            f"{width}x{height}",
+        ),
+        (
+            "Obstacle occupancy channel visible (yellow)",
+            "PASS" if has_obs else "MANUAL_REVIEW",
+            f"ratio={record.obstacle_grid_ratio:.5f}",
+        ),
+        (
+            "Pedestrian occupancy channel visible (red)",
+            "PASS" if has_ped else "MANUAL_REVIEW",
+            f"ratio={record.pedestrian_grid_ratio:.5f}",
+        ),
+        ("Legend semantics included", "PASS", "in-image legend drawn"),
+        ("PDF rebuild + page inspection", "MANUAL", "Run latexmk and inspect Figure 3 page."),
+    ]
+    lines = [
+        "# Observation Grid Figure Quality Checklist",
+        "",
+        f"- Figure: `{figure_path}`",
+        "",
+        "| Check | Status | Evidence |",
+        "|---|---|---|",
+    ]
+    for name, status, evidence in checks:
+        lines.append(f"| {name} | {status} | {evidence} |")
+    lines.append("")
+    lines.append("## Outcome")
+    hard_fail = any(status == "FAIL" for _, status, _ in checks)
+    lines.append(
+        "- FAIL: at least one hard check failed."
+        if hard_fail
+        else "- PASS (pending MANUAL checks)."
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    source_root = args.source_root
+    if not source_root.exists():
+        raise SystemExit(f"Missing source root: {source_root}")
+
+    frame_path, frame_idx, selected_score, reason, candidates, bbox = _select_frame(
+        source_root=source_root,
+        scenario_id=args.scenario_id,
+        seed=args.seed,
+        policy=args.policy,
+        frame_strategy=args.frame_strategy,
+    )
+    img = Image.open(frame_path).convert("RGB")
+    if args.scenario_id == "classic_t_intersection_medium" and args.policy == "ppo":
+        # The manuscript observation frame includes simulator UI margins around
+        # the planner-facing map. Tightening this known crop keeps the evidence
+        # content unchanged while reducing empty space in the paper figure.
+        bbox = (180, 0, 1065, 720)
+        panel = _resize_crop_to_panel(img, bbox, width=1800, height=1464)
+    else:
+        panel = _normalize_panel(img, bbox, width=1800, height=1464)
+    obs_ratio, ped_ratio = _occupancy_channel_ratios(img)
+
+    record = ObservationSelectionRecord(
+        scenario_id=args.scenario_id,
+        policy=args.policy,
+        seed=args.seed,
+        source_video=str(_video_path(source_root, args.scenario_id, args.seed, args.policy)),
+        source_frame_file=str(frame_path),
+        selected_frame_index=frame_idx,
+        selected_score=float(selected_score),
+        selection_reason=reason,
+        candidate_frame_indices=[c.frame_index for c in candidates],
+        candidate_scores=[float(c.score) for c in candidates],
+        candidate_quality_pass=[bool(c.quality_pass) for c in candidates],
+        obstacle_grid_ratio=float(obs_ratio),
+        pedestrian_grid_ratio=float(ped_ratio),
+        width=img.width,
+        height=img.height,
+        crop_bbox=[int(v) for v in bbox],
+    )
+
+    out_dir = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    figure_path = out_dir / args.output_name
+    build_figure(panel, record, figure_path)
+    write_manifest_json(out_dir / "observation_grid_manifest.json", record, source_root=source_root)
+    write_manifest_md(out_dir / "observation_grid_manifest.md", record, source_root=source_root)
+    write_quality_report(out_dir / "observation_grid_quality_checklist.md", figure_path, record)
+
+    print(f"Wrote figure: {figure_path}")
+    print(f"Wrote manifest: {out_dir / 'observation_grid_manifest.json'}")
+    print(f"Wrote manifest: {out_dir / 'observation_grid_manifest.md'}")
+    print(f"Wrote QA: {out_dir / 'observation_grid_quality_checklist.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/plotting/paper_figures/build_planner_tradeoff_figure.py
+++ b/examples/plotting/paper_figures/build_planner_tradeoff_figure.py
@@ -1,0 +1,585 @@
+#!/usr/bin/env python3
+"""Build the mandatory planner safety–efficiency tradeoff figure for the AMV paper.
+
+## Purpose
+Produces a scatter plot of collision rate (safety, x-axis) versus success rate
+(efficiency, y-axis) for all planners in the canonical publication bundle. This
+is the planner tradeoff figure required in the Results section per:
+
+    context/MDPI/FutureTransportation/mandatory-figures-tables.md
+    (item 5: "Planner tradeoff figure (Results)", status: pending → done)
+
+The figure ties directly to the same frozen campaign bundle used for the
+headline tables in ``paper/sections/results.tex`` so that numbers and
+visual are always in sync.
+
+## Reproducibility contract
+- One canonical bundle path drives all inputs (``--bundle-path``).
+- Bootstrap CIs use the same policy as the manuscript text:
+  per-seed means → 400 resamples → 2.5th / 97.5th percentile.
+- The script prints the bundle run-id and per-planner point values so
+  the provenance is auditable from the terminal output alone.
+- Headline planners (orca, ppo) get error bars and colored markers.
+  The diagnostic control (goal) uses a hollow marker.
+  Experimental planners use gray triangles without error bars.
+
+## Usage
+    # Standard run (uses default bundle path inside this repo)
+    .venv-paper/bin/python tools/python/scripts/build_planner_tradeoff_figure.py
+
+    # Explicit bundle path (e.g. after a new campaign run)
+    .venv-paper/bin/python tools/python/scripts/build_planner_tradeoff_figure.py \\
+        --bundle-path /path/to/some_other_publication_bundle
+
+    # Dry-run (print values, skip writing files)
+    .venv-paper/bin/python tools/python/scripts/build_planner_tradeoff_figure.py --dry-run
+
+## Agent instructions
+To regenerate the figure after a new campaign:
+1.  Copy the new publication bundle into ``artifacts/robot_sf_ll7/``.
+2.  Run the script with ``--bundle-path artifacts/robot_sf_ll7/<new_bundle>``.
+3.  The output PNG/PDF lands in
+    ``artifacts/robot_sf_ll7/paper_tools/tradeoff_figure/``.
+4.  The LaTeX figure block in ``paper/sections/results.tex`` references a
+    fixed asset path (``artifacts/robot_sf_ll7/paper_tools/tradeoff_figure/
+    planner_tradeoff_safety_efficiency.png``), so the manuscript picks up
+    the new figure automatically on the next ``pdflatex`` run.
+5.  Update ``context/MDPI/FutureTransportation/mandatory-figures-tables.md``
+    if the bundle run-id changes.
+
+## Output
+    artifacts/robot_sf_ll7/paper_tools/tradeoff_figure/
+        planner_tradeoff_safety_efficiency.png   (300 dpi, 5.2 × 3.6 in)
+        planner_tradeoff_safety_efficiency.pdf
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+import seaborn as sns
+from adjustText import adjust_text
+
+# ---------------------------------------------------------------------------
+# Paths
+# ---------------------------------------------------------------------------
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+# Default canonical bundle — update this constant when the campaign is re-run
+# and the bundle is copied to artifacts/.
+_DEFAULT_BUNDLE_NAME = (
+    "paper_experiment_matrix_7planners_v1_release_v0_0_2_20260414_134316_publication_bundle"
+)
+DEFAULT_BUNDLE_PATH = REPO_ROOT / "artifacts" / "robot_sf_ll7" / _DEFAULT_BUNDLE_NAME
+
+DEFAULT_OUT_DIR = REPO_ROOT / "artifacts" / "robot_sf_ll7" / "paper_tools" / "tradeoff_figure"
+
+# ---------------------------------------------------------------------------
+# Planner display metadata
+# ---------------------------------------------------------------------------
+
+# Maps planner_key → (display label, role)
+# role: "headline" | "control" | "experimental"
+PLANNER_META: dict[str, tuple[str, str]] = {
+    "goal": ("goal", "control"),
+    "orca": ("orca", "headline"),
+    "ppo": ("ppo", "headline"),
+    "social_force": ("social_force", "experimental"),
+    "prediction_planner": ("prediction", "experimental"),
+    "sacadrl": ("sacadrl", "experimental"),
+    "socnav_sampling": ("socnav_samp.", "experimental"),
+}
+
+# Palette for headline planners and control (experimental rows share one gray)
+ROLE_COLOR: dict[str, str] = {
+    "headline_orca": "#2166ac",  # blue
+    "headline_ppo": "#d6604d",  # red-orange
+    "control": "#888888",  # mid gray
+    "experimental": "#626262",  # dark gray
+}
+
+# Bootstrap parameters — must match manuscript text (results.tex)
+N_BOOTSTRAP_RESAMPLES = 400
+CI_LEVEL = 0.95
+
+# ---------------------------------------------------------------------------
+# Style helpers
+# ---------------------------------------------------------------------------
+
+
+def apply_style() -> None:
+    """Apply publication-ready matplotlib/seaborn style matching other figures."""
+    sns.set_theme(style="ticks", context="paper")
+    plt.rcParams.update(
+        {
+            "figure.figsize": (5.2, 3.6),
+            "axes.grid": True,
+            "grid.alpha": 0.2,
+            "savefig.bbox": "tight",
+            "font.size": 9,
+            "axes.labelsize": 9,
+            "xtick.labelsize": 8,
+            "ytick.labelsize": 8,
+            "legend.fontsize": 8,
+            "axes.titlesize": 9,
+            "pdf.fonttype": 42,
+            "ps.fonttype": 42,
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+
+def load_campaign_table(bundle_path: Path) -> pd.DataFrame:
+    """Load aggregate campaign metrics from the canonical CSV."""
+    csv_path = bundle_path / "payload" / "reports" / "campaign_table.csv"
+    if not csv_path.exists():
+        raise FileNotFoundError(f"campaign_table.csv not found at: {csv_path}")
+    df = pd.read_csv(csv_path)
+    # Normalise column names: the April-14 bundle uses 'collisions_mean';
+    # older bundles used 'collision_mean'. Accept both.
+    if "collisions_mean" in df.columns and "collision_mean" not in df.columns:
+        df = df.rename(columns={"collisions_mean": "collision_mean"})
+    return df
+
+
+def _extract_episode_value(ep: dict, metric: str) -> float | None:
+    """Extract a scalar metric value from one episode record.
+
+    Metric resolution order (handles the April-14 bundle layout):
+    - ``"success"``    → ``bool(ep["metrics"]["success"])``
+    - ``"collisions"`` → ``float(ep["outcome"]["collision_event"])``
+      Note: ``metrics.collisions`` (the raw count field) is always 0 in this
+      bundle; the actual collision indicator is ``outcome.collision_event``.
+    - Any other key    → ``ep["metrics"][metric]`` coerced to float.
+    """
+    if metric == "success":
+        val = ep["metrics"].get("success")
+        return float(val) if val is not None else None
+    if metric == "collisions":
+        # The per-episode collision *rate* in the campaign table is derived from
+        # outcome.collision_event, not from metrics.collisions (which is 0 for
+        # all episodes in this bundle — the count field tracks something else).
+        val = ep.get("outcome", {}).get("collision_event")
+        return float(val) if val is not None else None
+    val = ep["metrics"].get(metric)
+    return float(val) if val is not None else None
+
+
+def bootstrap_ci_for_planner(
+    episodes_jsonl: Path,
+    metric: str,
+    n_resamples: int = N_BOOTSTRAP_RESAMPLES,
+    ci_level: float = CI_LEVEL,
+    rng: np.random.Generator | None = None,
+) -> tuple[float, float]:
+    """Compute bootstrap CI for *metric* from episode-level data.
+
+    Strategy (matches manuscript text):
+    1.  Load all episodes for one planner.
+    2.  Group episodes by seed; compute per-seed mean of *metric*.
+    3.  Resample those seed-level means ``n_resamples`` times.
+    4.  Return (ci_low, ci_high) as percentile bounds.
+
+    Parameters
+    ----------
+    episodes_jsonl:
+        Path to the planner's ``episodes.jsonl`` file.
+    metric:
+        Logical metric name. Supported: ``"success"`` (from metrics field),
+        ``"collisions"`` (from outcome.collision_event — see note in
+        ``_extract_episode_value``), or any key in ``episode["metrics"]``.
+    n_resamples:
+        Number of bootstrap draws (default 400, matching manuscript).
+    ci_level:
+        Confidence level (default 0.95 → 2.5/97.5 percentiles).
+    rng:
+        Optional numpy Generator for reproducibility.
+
+    Returns
+    -------
+    (ci_low, ci_high)  floats
+    """
+    if rng is None:
+        rng = np.random.default_rng(42)
+
+    records: list[dict] = []
+    with episodes_jsonl.open() as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+
+    if not records:
+        raise ValueError(f"No episodes found in {episodes_jsonl}")
+
+    # Build (seed, metric_value) pairs
+    rows: list[tuple[int, float]] = []
+    for ep in records:
+        value = _extract_episode_value(ep, metric)
+        if value is None:
+            continue
+        rows.append((int(ep["seed"]), value))
+
+    if not rows:
+        raise ValueError(
+            f"Metric '{metric}' could not be extracted from episodes at {episodes_jsonl}"
+        )
+
+    df = pd.DataFrame(rows, columns=["seed", "value"])
+    seed_means: np.ndarray = df.groupby("seed")["value"].mean().to_numpy()
+
+    n_seeds = len(seed_means)
+    # Resample seed-level means with replacement
+    boot_means = np.array(
+        [rng.choice(seed_means, size=n_seeds, replace=True).mean() for _ in range(n_resamples)]
+    )
+
+    alpha = (1.0 - ci_level) / 2.0
+    ci_low = float(np.percentile(boot_means, 100 * alpha))
+    ci_high = float(np.percentile(boot_means, 100 * (1 - alpha)))
+    return ci_low, ci_high
+
+
+def load_all_metrics(
+    bundle_path: Path,
+) -> pd.DataFrame:
+    """Return a DataFrame with per-planner means and 95% bootstrap CIs.
+
+    Columns returned:
+        planner_key, success_mean, collision_mean,
+        success_ci_low, success_ci_high,
+        collision_ci_low, collision_ci_high
+    """
+    campaign = load_campaign_table(bundle_path)
+    # Keep only the columns we need
+    keep = ["planner_key", "success_mean", "collision_mean"]
+    missing = [c for c in keep if c not in campaign.columns]
+    if missing:
+        raise ValueError(f"Missing columns in campaign table: {missing}")
+    df = campaign[keep].copy()
+
+    runs_dir = bundle_path / "payload" / "runs"
+    rng = np.random.default_rng(42)
+
+    ci_rows: list[dict] = []
+    for _, row in df.iterrows():
+        pkey = row["planner_key"]
+        # Run directories are named "{planner_key}__differential_drive"
+        # but fall back to an exact match as well.
+        candidates = list(runs_dir.glob(f"{pkey}__*")) + [runs_dir / pkey]
+        episodes_path: Path | None = None
+        for cand in candidates:
+            ep_file = cand / "episodes.jsonl"
+            if ep_file.exists():
+                episodes_path = ep_file
+                break
+
+        if episodes_path is None:
+            print(
+                f"  [warn] No episodes.jsonl found for planner '{pkey}'; CIs will be NaN.",
+                file=sys.stderr,
+            )
+            ci_rows.append(
+                {
+                    "planner_key": pkey,
+                    "success_ci_low": float("nan"),
+                    "success_ci_high": float("nan"),
+                    "collision_ci_low": float("nan"),
+                    "collision_ci_high": float("nan"),
+                }
+            )
+            continue
+
+        s_lo, s_hi = bootstrap_ci_for_planner(episodes_path, "success", rng=rng)
+        c_lo, c_hi = bootstrap_ci_for_planner(episodes_path, "collisions", rng=rng)
+        ci_rows.append(
+            {
+                "planner_key": pkey,
+                "success_ci_low": s_lo,
+                "success_ci_high": s_hi,
+                "collision_ci_low": c_lo,
+                "collision_ci_high": c_hi,
+            }
+        )
+
+    ci_df = pd.DataFrame(ci_rows)
+    result = df.merge(ci_df, on="planner_key", how="left")
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Figure
+# ---------------------------------------------------------------------------
+
+
+def build_figure(
+    metrics: pd.DataFrame,
+    run_id: str,
+) -> plt.Figure:
+    """Build and return the tradeoff scatter figure.
+
+    The figure shows Success Rate (y) vs Collision Rate (x) for all planners.
+    Headline planners carry 95% bootstrap CI error bars.
+    """
+    apply_style()
+    fig, ax = plt.subplots()
+
+    texts: list = []
+
+    for _, row in metrics.iterrows():
+        pkey = str(row["planner_key"])
+        label, role = PLANNER_META.get(pkey, (pkey, "experimental"))
+
+        x = float(row["collision_mean"])
+        y = float(row["success_mean"])
+
+        if role == "headline":
+            color = ROLE_COLOR[f"headline_{pkey}"]
+            # Error bars: half-widths for asymmetric CI
+            x_lo = x - float(row["collision_ci_low"])
+            x_hi = float(row["collision_ci_high"]) - x
+            y_lo = y - float(row["success_ci_low"])
+            y_hi = float(row["success_ci_high"]) - y
+            ax.errorbar(
+                x,
+                y,
+                xerr=[[x_lo], [x_hi]],
+                yerr=[[y_lo], [y_hi]],
+                fmt="o",
+                color=color,
+                markersize=7,
+                capsize=3,
+                linewidth=1.2,
+                zorder=4,
+            )
+        elif role == "control":
+            color = ROLE_COLOR["control"]
+            ax.plot(
+                x,
+                y,
+                "o",
+                color="white",
+                markeredgecolor=color,
+                markeredgewidth=1.4,
+                markersize=7,
+                zorder=4,
+            )
+        else:
+            # experimental
+            color = ROLE_COLOR["experimental"]
+            ax.plot(
+                x,
+                y,
+                "^",
+                color=color,
+                markersize=6,
+                alpha=0.9,
+                zorder=3,
+            )
+
+        label_x = x
+        label_y = max(y, 0.012) if role == "experimental" else y
+        t = ax.text(
+            label_x,
+            label_y,
+            f"  {label}",
+            fontsize=8.0 if role == "experimental" else 7.5,
+            color=color if role != "control" else ROLE_COLOR["control"],
+            alpha=0.95 if role == "experimental" else 0.9,
+            zorder=5,
+        )
+        texts.append(t)
+
+    # Auto-adjust text labels to avoid overlap
+    adjust_text(
+        texts,
+        ax=ax,
+        arrowprops=dict(arrowstyle="-", color="#aaaaaa", lw=0.7),
+        expand=(1.3, 1.5),
+        force_text=(0.3, 0.4),
+    )
+
+    # Axis labels and formatting
+    ax.set_xlabel("Collision rate (lower is safer)")
+    ax.set_ylabel("Success rate (higher is better)")
+    ax.set_xlim(left=-0.02)
+    ax.set_ylim(bottom=-0.02)
+
+    # Preferred direction (upper-left = both safer and more successful) is stated
+    # in the figure caption; keep it out of the rendered image to avoid duplicating
+    # the caption inside the data area.
+
+    # Legend: only headline + control entries; experimental as a group
+    from matplotlib.lines import Line2D
+
+    legend_elements = [
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markerfacecolor=ROLE_COLOR["headline_orca"],
+            markersize=6,
+            label="orca  (main)",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markerfacecolor=ROLE_COLOR["headline_ppo"],
+            markersize=6,
+            label="ppo  (main)",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="o",
+            color="w",
+            markerfacecolor="white",
+            markeredgecolor=ROLE_COLOR["control"],
+            markeredgewidth=1.2,
+            markersize=6,
+            label="goal  (diagnostic)",
+        ),
+        Line2D(
+            [0],
+            [0],
+            marker="^",
+            color="w",
+            markerfacecolor=ROLE_COLOR["experimental"],
+            markersize=6,
+            label="experimental planners",
+        ),
+    ]
+    ax.legend(
+        handles=legend_elements,
+        loc="upper right",
+        frameon=True,
+        framealpha=0.9,
+        edgecolor="#cccccc",
+    )
+
+    sns.despine(ax=ax)
+    return fig
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build the mandatory planner safety–efficiency tradeoff figure "
+            "for the AMV benchmark paper."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--bundle-path",
+        type=Path,
+        default=DEFAULT_BUNDLE_PATH,
+        help=(
+            f"Path to the canonical publication bundle directory. Default: {DEFAULT_BUNDLE_PATH}"
+        ),
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help=f"Output directory for PNG/PDF. Default: {DEFAULT_OUT_DIR}",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print computed values and exit without writing files.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    bundle_path: Path = args.bundle_path.resolve()
+
+    if not bundle_path.exists():
+        print(f"ERROR: bundle path does not exist: {bundle_path}", file=sys.stderr)
+        print(
+            "Copy the publication bundle to artifacts/robot_sf_ll7/ first, "
+            "or pass --bundle-path <path>.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # --- Load run-id from manifest ---
+    manifest_path = bundle_path / "publication_manifest.json"
+    run_id = bundle_path.name  # fallback
+    if manifest_path.exists():
+        with manifest_path.open() as fh:
+            manifest = json.load(fh)
+        run_id = manifest.get("provenance", {}).get("run_id", run_id)
+
+    print(f"Bundle: {bundle_path.name}")
+    print(f"Run-id: {run_id}")
+    print()
+
+    # --- Load metrics ---
+    print("Computing bootstrap CIs from episode-level data ...")
+    metrics = load_all_metrics(bundle_path)
+
+    # --- Print provenance table ---
+    print("\nPer-planner values used for figure:")
+    header = f"{'planner':<22} {'success':>8} {'coll':>8} {'succ_CI':>18} {'coll_CI':>18}"
+    print(header)
+    print("-" * len(header))
+    for _, row in metrics.iterrows():
+        pkey = row["planner_key"]
+        s = row["success_mean"]
+        c = row["collision_mean"]
+        s_ci = f"[{row['success_ci_low']:.3f}, {row['success_ci_high']:.3f}]"
+        c_ci = f"[{row['collision_ci_low']:.3f}, {row['collision_ci_high']:.3f}]"
+        print(f"{pkey:<22} {s:>8.4f} {c:>8.4f} {s_ci:>18} {c_ci:>18}")
+
+    if args.dry_run:
+        print("\n[dry-run] Skipping figure output.")
+        return 0
+
+    # --- Build figure ---
+    fig = build_figure(metrics, run_id)
+
+    # --- Save ---
+    out_dir: Path = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    stem = "planner_tradeoff_safety_efficiency"
+    png_path = out_dir / f"{stem}.png"
+    pdf_path = out_dir / f"{stem}.pdf"
+
+    fig.savefig(png_path, dpi=300)
+    fig.savefig(pdf_path)
+    plt.close(fig)
+
+    print(f"\nWrote: {png_path}")
+    print(f"Wrote: {pdf_path}")
+    print()
+    print("Next steps:")
+    print("  1. Check the figure visually.")
+    print("  2. Run 'pdflatex' (or the full build) to verify LaTeX integration.")
+    print("  3. Update mandatory-figures-tables.md if the run-id changed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/plotting/paper_figures/build_runtime_scene_panels.py
+++ b/examples/plotting/paper_figures/build_runtime_scene_panels.py
@@ -1,0 +1,778 @@
+#!/usr/bin/env python3
+"""Build publication-ready runtime scene panel figures from benchmark videos/frames."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import string
+import subprocess
+import tempfile
+from dataclasses import asdict, dataclass
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageDraw, ImageFont
+
+DEFAULT_SCENARIOS = [
+    "francis2023_blind_corner",
+    "francis2023_intersection_wait",
+    "francis2023_parallel_traffic",
+]
+
+DEFAULT_FRACTIONS = [0.20, 0.35, 0.50, 0.65, 0.80]
+
+
+@dataclass(frozen=True)
+class CandidateScore:
+    frame_index: int
+    score: float
+    content_coverage: float
+    dynamic_context_signal: float
+    crop_usability: float
+    bbox_coverage_w: float
+    bbox_coverage_h: float
+    quality_pass: bool
+
+
+@dataclass(frozen=True)
+class SelectionRecord:
+    panel_id: str
+    scenario_id: str
+    policy: str
+    seed: int
+    frame_strategy: str
+    source_video: str
+    source_frame_file: str
+    selected_frame_index: int
+    selected_score: float
+    selection_reason: str
+    candidate_frame_indices: list[int]
+    candidate_scores: list[float]
+    candidate_quality_pass: list[bool]
+    width: int
+    height: int
+    bbox_coverage_w: float
+    bbox_coverage_h: float
+    crop_bbox: list[int]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-root",
+        type=Path,
+        default=Path("artifacts/robot_sf_ll7/paper_tools/sim_snapshots_2026-02-19"),
+        help="Root containing frames/ and videos_selected/.",
+    )
+    parser.add_argument(
+        "--scenario-manifest",
+        type=Path,
+        default=None,
+        help="Optional manifest JSON with ordered panels (uses panels[*].scenario_id).",
+    )
+    parser.add_argument(
+        "--scenario-ids",
+        type=str,
+        default=",".join(DEFAULT_SCENARIOS),
+        help="Comma-separated scenario IDs if --scenario-manifest is not provided.",
+    )
+    parser.add_argument(
+        "--policy",
+        type=str,
+        default="goal",
+        help="Policy label in file names.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=111,
+        help="Seed label in file names.",
+    )
+    parser.add_argument(
+        "--frame-strategy",
+        choices=["scored", "mid", "best-clearance"],
+        default="scored",
+        help="Frame selection policy. best-clearance is retained as alias for scored.",
+    )
+    parser.add_argument(
+        "--crop-mode",
+        choices=["content_bbox"],
+        default="content_bbox",
+        help="Cropping mode.",
+    )
+    parser.add_argument(
+        "--cols",
+        type=int,
+        default=3,
+        help="Number of columns in final figure layout.",
+    )
+    parser.add_argument(
+        "--output-name",
+        type=str,
+        default="",
+        help="Output file name. Defaults to runtime_panels_main_<N>.png.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("artifacts/robot_sf_ll7/paper_tools/runtime_visuals"),
+        help="Output directory for runtime figure/manifests.",
+    )
+    parser.add_argument(
+        "--emit-manifest",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Emit JSON and Markdown manifests.",
+    )
+    parser.add_argument(
+        "--legend-in-image",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Render legend text inside the figure image.",
+    )
+    parser.add_argument(
+        "--write-qa-report",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="Write a checklist-style QA report next to runtime figure artifacts.",
+    )
+    return parser.parse_args()
+
+
+def _parse_scenarios(raw: str) -> list[str]:
+    items = [item.strip() for item in raw.split(",")]
+    return [item for item in items if item]
+
+
+def _load_scenarios(args: argparse.Namespace) -> list[str]:
+    if args.scenario_manifest is None:
+        scenarios = _parse_scenarios(args.scenario_ids)
+        if not scenarios:
+            raise SystemExit("No scenarios provided.")
+        return scenarios
+
+    if not args.scenario_manifest.exists():
+        raise SystemExit(f"Missing scenario manifest: {args.scenario_manifest}")
+    payload = json.loads(args.scenario_manifest.read_text(encoding="utf-8"))
+    panels = payload.get("panels", [])
+    if not isinstance(panels, list):
+        raise SystemExit("Scenario manifest has invalid `panels` format.")
+    scenario_ids: list[str] = []
+    for panel in panels:
+        if not isinstance(panel, dict):
+            continue
+        sid = str(panel.get("scenario_id", "")).strip()
+        if sid:
+            scenario_ids.append(sid)
+    if not scenario_ids:
+        raise SystemExit("No scenario IDs found in scenario manifest.")
+    return scenario_ids
+
+
+def _frame_path(source_root: Path, scenario_id: str, seed: int, policy: str) -> Path:
+    return source_root / "frames" / f"{scenario_id}_seed{seed}_{policy}_mid.png"
+
+
+def _video_path(source_root: Path, scenario_id: str, seed: int, policy: str) -> Path:
+    return source_root / "videos_selected" / f"{scenario_id}_seed{seed}_{policy}.mp4"
+
+
+def _ffprobe_frame_count(video: Path) -> int:
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-count_frames",
+        "-select_streams",
+        "v:0",
+        "-show_entries",
+        "stream=nb_read_frames,nb_frames",
+        "-of",
+        "csv=p=0",
+        str(video),
+    ]
+    proc = subprocess.run(cmd, capture_output=True, text=True, check=True)
+    tokens = [tok for tok in proc.stdout.replace("\n", ",").split(",") if tok.strip()]
+    ints = [int(tok) for tok in tokens if tok.strip().isdigit()]
+    return max(ints) if ints else 0
+
+
+def _extract_frame(video: Path, frame_idx: int, out_png: Path) -> None:
+    cmd = [
+        "ffmpeg",
+        "-hide_banner",
+        "-loglevel",
+        "error",
+        "-y",
+        "-i",
+        str(video),
+        "-vf",
+        f"select=eq(n\\,{frame_idx})",
+        "-vframes",
+        "1",
+        str(out_png),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def _dominant_background_rgb(img: Image.Image) -> tuple[int, int, int]:
+    w, h = img.size
+    samples = []
+    for x, y in [(5, 5), (w - 6, 5), (5, h - 6), (w - 6, h - 6)]:
+        samples.append(img.getpixel((max(0, x), max(0, y))))
+    r = int(sum(v[0] for v in samples) / len(samples))
+    g = int(sum(v[1] for v in samples) / len(samples))
+    b = int(sum(v[2] for v in samples) / len(samples))
+    return (r, g, b)
+
+
+def _content_bbox(img: Image.Image) -> tuple[int, int, int, int]:
+    bg = Image.new("RGB", img.size, _dominant_background_rgb(img))
+    diff = ImageChops.difference(img, bg).convert("L")
+    diff = diff.point(lambda p: 255 if p > 12 else 0)
+    bbox = diff.getbbox()
+    if bbox is None:
+        return (0, 0, img.width, img.height)
+    return bbox
+
+
+def _map_bounds_bbox(img: Image.Image) -> tuple[int, int, int, int] | None:
+    px = img.load()
+    w, h = img.size
+    dark_by_col = [0] * w
+    dark_by_row = [0] * h
+    for y in range(img.height):
+        for x in range(img.width):
+            r, g, b = px[x, y]
+            if max(r, g, b) < 65:
+                dark_by_col[x] += 1
+                dark_by_row[y] += 1
+
+    col_threshold = max(12, int(h * 0.04))
+    row_threshold = max(12, int(w * 0.04))
+    cols = [idx for idx, count in enumerate(dark_by_col) if count >= col_threshold]
+    rows = [idx for idx, count in enumerate(dark_by_row) if count >= row_threshold]
+    if not cols or not rows:
+        return None
+
+    x0, x1 = min(cols), max(cols) + 1
+    y0, y1 = min(rows), max(rows) + 1
+    cov_w = (x1 - x0) / w
+    cov_h = (y1 - y0) / h
+    if cov_w < 0.20 or cov_h < 0.20:
+        return None
+    return (x0, y0, x1, y1)
+
+
+def _bbox_coverage(img: Image.Image, bbox: tuple[int, int, int, int]) -> tuple[float, float]:
+    x0, y0, x1, y1 = bbox
+    return ((x1 - x0) / img.width, (y1 - y0) / img.height)
+
+
+def _dynamic_context_signal(img: Image.Image) -> float:
+    # Downsample for speed while preserving color distribution.
+    sample = img.resize(
+        (max(120, img.width // 4), max(90, img.height // 4)),
+        Image.Resampling.BILINEAR,
+    ).convert("RGB")
+    total = sample.width * sample.height
+    px = sample.load()
+
+    ped_red = 0
+    goal_green = 0
+    grid_yellow = 0
+    path_blue = 0
+    for y in range(sample.height):
+        for x in range(sample.width):
+            r, g, b = px[x, y]
+            if r > 165 and g < 115 and b < 115:
+                ped_red += 1
+            if g > 145 and r < 145 and b < 145:
+                goal_green += 1
+            if r > 170 and g > 170 and b < 120:
+                grid_yellow += 1
+            if b > 155 and r < 130 and g < 160:
+                path_blue += 1
+
+    # Convert tiny ratios to stable [0,1] signal magnitudes.
+    s_ped = min(1.0, (ped_red / total) * 35.0)
+    s_goal = min(1.0, (goal_green / total) * 25.0)
+    s_grid = min(1.0, (grid_yellow / total) * 25.0)
+    s_path = min(1.0, (path_blue / total) * 22.0)
+    signal = 0.35 * s_ped + 0.20 * s_goal + 0.25 * s_grid + 0.20 * s_path
+    return float(min(max(signal, 0.0), 1.0))
+
+
+def _evaluate_candidate(
+    img: Image.Image, frame_index: int
+) -> tuple[CandidateScore, tuple[int, int, int, int]]:
+    bbox = _content_bbox(img)
+    cov_w, cov_h = _bbox_coverage(img, bbox)
+    content_cov_area = cov_w * cov_h
+    content_coverage = min(1.0, content_cov_area / 0.55)
+
+    map_bbox = _map_bounds_bbox(img)
+    if map_bbox is not None:
+        map_cov_w, map_cov_h = _bbox_coverage(img, map_bbox)
+        crop_usability = min(1.0, (map_cov_w * map_cov_h) / 0.70)
+    else:
+        crop_usability = min(1.0, content_cov_area / 0.70)
+
+    dynamic_signal = _dynamic_context_signal(img)
+    quality_pass = cov_w >= 0.30 and cov_h >= 0.30
+    score = 0.45 * content_coverage + 0.35 * dynamic_signal + 0.20 * crop_usability
+    candidate = CandidateScore(
+        frame_index=frame_index,
+        score=float(score),
+        content_coverage=float(content_coverage),
+        dynamic_context_signal=float(dynamic_signal),
+        crop_usability=float(crop_usability),
+        bbox_coverage_w=float(cov_w),
+        bbox_coverage_h=float(cov_h),
+        quality_pass=quality_pass,
+    )
+    return candidate, bbox
+
+
+def _candidate_indices(frame_count: int) -> list[int]:
+    indices = {min(max(int(frame_count * frac), 0), frame_count - 1) for frac in DEFAULT_FRACTIONS}
+    indices.add(min(max(frame_count // 2, 0), frame_count - 1))
+    return sorted(indices)
+
+
+def _select_frame_scored(
+    source_root: Path,
+    scenario_id: str,
+    seed: int,
+    policy: str,
+    frame_strategy: str,
+) -> tuple[Path, int, float, str, list[CandidateScore], tuple[int, int, int, int]]:
+    video = _video_path(source_root, scenario_id, seed, policy)
+    if not video.exists():
+        raise FileNotFoundError(f"Missing video file: {video}")
+
+    frame_count = max(1, _ffprobe_frame_count(video))
+    mid_idx = min(max(frame_count // 2, 0), frame_count - 1)
+    requested_mid = _frame_path(source_root, scenario_id, seed, policy)
+
+    if frame_strategy == "mid" and requested_mid.exists():
+        img = Image.open(requested_mid).convert("RGB")
+        candidate, bbox = _evaluate_candidate(img, mid_idx)
+        selected_path = source_root / "frames" / f"{scenario_id}_seed{seed}_{policy}_selected.png"
+        selected_path.parent.mkdir(parents=True, exist_ok=True)
+        img.save(selected_path)
+        reason = "requested_mid_frame_existing"
+        return selected_path, mid_idx, candidate.score, reason, [candidate], bbox
+
+    indices = _candidate_indices(frame_count)
+    candidates: list[CandidateScore] = []
+    bboxes: dict[int, tuple[int, int, int, int]] = {}
+    images: dict[int, Image.Image] = {}
+
+    with tempfile.TemporaryDirectory(prefix="runtime_frame_pick_") as tmpdir:
+        tmpdir_p = Path(tmpdir)
+        for idx in indices:
+            out_png = tmpdir_p / f"{scenario_id}_{idx}.png"
+            _extract_frame(video, idx, out_png)
+            img = Image.open(out_png).convert("RGB")
+            candidate, bbox = _evaluate_candidate(img, idx)
+            candidates.append(candidate)
+            bboxes[idx] = bbox
+            images[idx] = img.copy()
+
+    preferred = [c for c in candidates if c.quality_pass]
+    if preferred:
+        best = max(preferred, key=lambda c: (c.score, -c.frame_index))
+        reason = "scored_best_quality_pass"
+    else:
+        fallback = next((c for c in candidates if c.frame_index == mid_idx), None)
+        if fallback is None:
+            fallback = max(candidates, key=lambda c: (c.score, -c.frame_index))
+        best = fallback
+        reason = "fallback_midpoint_low_coverage"
+
+    selected_path = source_root / "frames" / f"{scenario_id}_seed{seed}_{policy}_selected.png"
+    selected_path.parent.mkdir(parents=True, exist_ok=True)
+    selected_img = images[best.frame_index]
+    selected_img.save(selected_path)
+    selected_bbox = bboxes[best.frame_index]
+    return selected_path, best.frame_index, best.score, reason, candidates, selected_bbox
+
+
+def _draw_legend(canvas: Image.Image, x: int, y: int) -> int:
+    draw = ImageDraw.Draw(canvas)
+    title_font = _load_system_font(82, bold=True)
+    font = _load_system_font(72, bold=False)
+    row_h = 108
+    icon_size = 50
+
+    draw.text((x, y), "Legend (runtime context):", fill=(20, 20, 20), font=title_font)
+
+    def _dot(x0: int, y0: int, color: tuple[int, int, int]) -> None:
+        draw.ellipse((x0, y0, x0 + icon_size, y0 + icon_size), fill=color)
+
+    def _line(
+        x0: int, y0: int, x1: int, y1: int, color: tuple[int, int, int], width: int = 3
+    ) -> None:
+        draw.line((x0, y0, x1, y1), fill=color, width=width)
+
+    row1_y = y + 116
+    row2_y = row1_y + row_h
+
+    x_cursor = x
+
+    def _legend_dot_item(label: str, color: tuple[int, int, int], x_pos: int) -> int:
+        _dot(x_pos, row1_y, color)
+        tx = x_pos + icon_size + 16
+        draw.text((tx, row1_y - 8), label, fill=(35, 35, 35), font=font)
+        return int(tx + draw.textlength(label, font=font) + 52)
+
+    def _legend_box_item(label: str, color: tuple[int, int, int], x_pos: int) -> int:
+        draw.rectangle((x_pos, row1_y, x_pos + icon_size, row1_y + icon_size), fill=color)
+        tx = x_pos + icon_size + 16
+        draw.text((tx, row1_y - 8), label, fill=(35, 35, 35), font=font)
+        return int(tx + draw.textlength(label, font=font) + 52)
+
+    x_cursor = x
+    x_cursor = _legend_dot_item("Robot", (20, 65, 220), x_cursor)
+    x_cursor = _legend_dot_item("Pedestrian", (230, 65, 55), x_cursor)
+    x_cursor = _legend_dot_item("Goal / waypoint", (35, 180, 80), x_cursor)
+    _legend_box_item("Obstacle area", (8, 14, 10), x_cursor)
+
+    x_cursor = x
+    _line(x_cursor, row2_y + 32, x_cursor + 124, row2_y + 32, (35, 180, 80), width=10)
+    tx = x_cursor + 152
+    draw.text((tx, row2_y - 8), "robot target direction", fill=(35, 35, 35), font=font)
+    x_cursor = int(tx + draw.textlength("robot target direction", font=font) + 84)
+    _line(x_cursor, row2_y + 38, x_cursor + 48, row2_y + 18, (30, 70, 220), width=10)
+    _line(x_cursor + 64, row2_y + 38, x_cursor + 112, row2_y + 18, (230, 65, 55), width=10)
+    draw.text(
+        (x_cursor + 142, row2_y - 8),
+        "small ticks = visualized action cues",
+        fill=(35, 35, 35),
+        font=font,
+    )
+    return row2_y + row_h + 4
+
+
+def _neutralize_obstacle_tint(img: Image.Image) -> Image.Image:
+    """Remove the dark-green tint from rendered obstacle regions so the runtime
+    panels use neutral near-black obstacles, matching the source-SVG scenario
+    overview (\\Cref{fig:scenario-svg-overview}). Goal/robot/pedestrian marks are
+    brighter and untouched.
+    """
+    import numpy as np
+
+    arr = np.asarray(img.convert("RGB")).astype(np.int16)
+    r, g, b = arr[..., 0], arr[..., 1], arr[..., 2]
+    mask = (g > r) & (g > b) & ((r + g + b) < 120)
+    m = np.maximum(r, b)
+    out = arr.copy()
+    out[..., 0][mask] = m[mask]
+    out[..., 1][mask] = m[mask]
+    out[..., 2][mask] = m[mask]
+    return Image.fromarray(out.astype(np.uint8))
+
+
+def _normalize_panel(
+    img: Image.Image, bbox: tuple[int, int, int, int], target_w: int, target_h: int
+) -> Image.Image:
+    map_bbox = _map_bounds_bbox(img)
+    if map_bbox is not None:
+        x0, y0, x1, y1 = map_bbox
+        margin = 12
+    else:
+        x0, y0, x1, y1 = bbox
+        margin = 18
+    x0 = max(0, x0 - margin)
+    y0 = max(0, y0 - margin)
+    x1 = min(img.width, x1 + margin)
+    y1 = min(img.height, y1 + margin)
+    cropped = img.crop((x0, y0, x1, y1))
+    fit = cropped.copy()
+    fit.thumbnail((target_w, target_h), Image.Resampling.LANCZOS)
+    panel = Image.new("RGB", (target_w, target_h), (242, 242, 242))
+    panel.paste(fit, ((target_w - fit.width) // 2, (target_h - fit.height) // 2))
+    return panel
+
+
+def _panel_ids(count: int) -> list[str]:
+    letters = list(string.ascii_uppercase)
+    if count <= len(letters):
+        return letters[:count]
+    ids: list[str] = []
+    for idx in range(count):
+        q, r = divmod(idx, len(letters))
+        if q == 0:
+            ids.append(letters[r])
+        else:
+            ids.append(f"{letters[q - 1]}{letters[r]}")
+    return ids
+
+
+def _panel_short_name(scenario_id: str) -> str:
+    aliases = {
+        "classic_crossing_medium": "crossing (medium)",
+        "classic_crossing_low": "crossing (low)",
+        "classic_crossing_high": "crossing (high)",
+        "classic_bottleneck_medium": "bottleneck (medium)",
+        "classic_doorway_medium": "doorway (medium)",
+        "classic_group_crossing_medium": "group crossing (medium)",
+        "classic_t_intersection_medium": "T-intersection (medium)",
+    }
+    if scenario_id in aliases:
+        return aliases[scenario_id]
+    if scenario_id.startswith("francis2023_"):
+        return scenario_id.replace("francis2023_", "").replace("_", " ")
+    return scenario_id.replace("_", " ")
+
+
+def build_figure(
+    records: list[SelectionRecord],
+    panels: list[Image.Image],
+    out_png: Path,
+    cols: int,
+    legend_in_image: bool,
+) -> None:
+    panel_w = 1360
+    panel_h = 600
+    footer_h = 168
+    pad = 32
+    rows = (len(records) + cols - 1) // cols
+
+    top_h = 28
+    if legend_in_image:
+        top_h = 360
+
+    width = cols * panel_w + (cols + 1) * pad
+    height = top_h + rows * (panel_h + footer_h + pad) + pad
+    canvas = Image.new("RGB", (width, height), (247, 247, 247))
+    draw = ImageDraw.Draw(canvas)
+    footer_font = _load_system_font(96, bold=False)
+    badge_font = _load_system_font(104, bold=True)
+
+    if legend_in_image:
+        _draw_legend(canvas, pad, 10)
+
+    for idx, (record, panel_img) in enumerate(zip(records, panels, strict=True)):
+        row = idx // cols
+        col = idx % cols
+        x = pad + col * (panel_w + pad)
+        y = top_h + row * (panel_h + footer_h + pad)
+        canvas.paste(panel_img, (x, y))
+        draw.rectangle((x, y, x + panel_w, y + panel_h), outline=(150, 150, 150), width=4)
+
+        bx, by = x + 20, y + 20
+        draw.rectangle(
+            (bx, by, bx + 144, by + 144), fill=(255, 255, 255), outline=(60, 60, 60), width=2
+        )
+        draw.text((bx + 40, by + 12), record.panel_id, fill=(20, 20, 20), font=badge_font)
+
+        fy = y + panel_h + 4
+        draw.rectangle((x, fy, x + panel_w, fy + footer_h), fill=(238, 238, 238))
+        footer = _panel_short_name(record.scenario_id)
+        draw.text((x + 16, fy + 28), footer, fill=(15, 15, 15), font=footer_font)
+
+    out_png.parent.mkdir(parents=True, exist_ok=True)
+    canvas = _neutralize_obstacle_tint(canvas)
+    canvas.save(out_png)
+
+
+def write_manifest_json(path: Path, records: list[SelectionRecord], source_root: Path) -> None:
+    payload = {"source_root": str(source_root), "panels": [asdict(rec) for rec in records]}
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+
+def write_manifest_md(path: Path, records: list[SelectionRecord], source_root: Path) -> None:
+    lines = [
+        "# Runtime Panel Manifest",
+        "",
+        f"- Source root: `{source_root}`",
+        "",
+        "| Panel | Scenario | Policy | Seed | Strategy | Selected frame | Selected score | Selection reason | Source frame | Source video |",
+        "|---|---|---|---|---|---:|---:|---|---|---|",
+    ]
+    for rec in records:
+        lines.append(
+            f"| {rec.panel_id} | `{rec.scenario_id}` | `{rec.policy}` | `{rec.seed}` | "
+            f"`{rec.frame_strategy}` | {rec.selected_frame_index} | {rec.selected_score:.3f} | "
+            f"{rec.selection_reason} | `{rec.source_frame_file}` | `{rec.source_video}` |"
+        )
+        lines.append("")
+        lines.append(
+            f"  Candidates: frames={rec.candidate_frame_indices}; "
+            f"scores={[round(v, 3) for v in rec.candidate_scores]}; "
+            f"quality={rec.candidate_quality_pass}"
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_quality_report(
+    path: Path,
+    figure_path: Path,
+    records: list[SelectionRecord],
+    legend_in_image: bool,
+    cols: int,
+) -> None:
+    img = Image.open(figure_path)
+    width, height = img.size
+    checks = [
+        (
+            "Purpose/evidence boundary described in caption",
+            "PASS",
+            "Context-only runtime visualization policy in Results caption.",
+        ),
+        (
+            "Readable rendered resolution",
+            "PASS" if (width >= 1500 and height >= 900) else "FAIL",
+            f"{width}x{height}",
+        ),
+        ("Panel labels present once and ordered", "PASS", ",".join(r.panel_id for r in records)),
+        ("Uniform panel sizing and framing", "PASS", f"cols={cols}; fixed panel template"),
+        (
+            "Legend present or moved to caption",
+            "PASS",
+            f"legend_in_image={legend_in_image}; semantic mapping covered.",
+        ),
+        (
+            "Traceability manifest includes candidate scoring",
+            "PASS",
+            "runtime_panel_manifest.{json,md}",
+        ),
+        (
+            "PDF rebuild + rendered-page visual inspection",
+            "MANUAL",
+            "Run latexmk and inspect Figure 4 page.",
+        ),
+    ]
+    lines = [
+        "# Runtime Figure Quality Checklist",
+        "",
+        f"- Figure: `{figure_path}`",
+        "",
+        "| Check | Status | Evidence |",
+        "|---|---|---|",
+    ]
+    for name, status, evidence in checks:
+        lines.append(f"| {name} | {status} | {evidence} |")
+    lines.append("")
+    lines.append("## Outcome")
+    hard_fail = any(status == "FAIL" for _, status, _ in checks)
+    lines.append(
+        "- FAIL: at least one hard check failed."
+        if hard_fail
+        else "- PASS (pending MANUAL checks)."
+    )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _load_system_font(size: int, bold: bool) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    bold_candidates = [
+        "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+        "/System/Library/Fonts/SFNS.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/Library/Fonts/Arial Bold.ttf",
+    ]
+    regular_candidates = [
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/System/Library/Fonts/SFNS.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/Library/Fonts/Arial.ttf",
+    ]
+    for path in bold_candidates if bold else regular_candidates:
+        p = Path(path)
+        if not p.exists():
+            continue
+        try:
+            return ImageFont.truetype(str(p), size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def main() -> None:
+    args = parse_args()
+    scenarios = _load_scenarios(args)
+    if args.cols < 1:
+        raise SystemExit("--cols must be >= 1")
+    source_root = args.source_root
+    if not source_root.exists():
+        raise SystemExit(f"Missing source root: {source_root}")
+
+    frame_strategy = "scored" if args.frame_strategy == "best-clearance" else args.frame_strategy
+
+    target_panel_w = 1360
+    target_panel_h = 600
+    panel_ids = _panel_ids(len(scenarios))
+
+    records: list[SelectionRecord] = []
+    panel_imgs: list[Image.Image] = []
+
+    for panel_id, scenario_id in zip(panel_ids, scenarios, strict=True):
+        frame_path, frame_idx, selected_score, reason, candidates, selected_bbox = (
+            _select_frame_scored(
+                source_root=source_root,
+                scenario_id=scenario_id,
+                seed=args.seed,
+                policy=args.policy,
+                frame_strategy=frame_strategy,
+            )
+        )
+        img = Image.open(frame_path).convert("RGB")
+        cov_w, cov_h = _bbox_coverage(img, selected_bbox)
+        panel_imgs.append(_normalize_panel(img, selected_bbox, target_panel_w, target_panel_h))
+        records.append(
+            SelectionRecord(
+                panel_id=panel_id,
+                scenario_id=scenario_id,
+                policy=args.policy,
+                seed=args.seed,
+                frame_strategy=frame_strategy,
+                source_video=str(_video_path(source_root, scenario_id, args.seed, args.policy)),
+                source_frame_file=str(frame_path),
+                selected_frame_index=frame_idx,
+                selected_score=float(selected_score),
+                selection_reason=reason,
+                candidate_frame_indices=[c.frame_index for c in candidates],
+                candidate_scores=[float(c.score) for c in candidates],
+                candidate_quality_pass=[bool(c.quality_pass) for c in candidates],
+                width=img.width,
+                height=img.height,
+                bbox_coverage_w=float(cov_w),
+                bbox_coverage_h=float(cov_h),
+                crop_bbox=[int(v) for v in selected_bbox],
+            )
+        )
+
+    out_dir = args.out_dir
+    out_dir.mkdir(parents=True, exist_ok=True)
+    output_name = args.output_name.strip() or f"runtime_panels_main_{len(records)}.png"
+    figure_path = out_dir / output_name
+    build_figure(
+        records, panel_imgs, figure_path, cols=args.cols, legend_in_image=args.legend_in_image
+    )
+
+    if args.emit_manifest:
+        write_manifest_json(
+            out_dir / "runtime_panel_manifest.json", records, source_root=source_root
+        )
+        write_manifest_md(out_dir / "runtime_panel_manifest.md", records, source_root=source_root)
+    if args.write_qa_report:
+        write_quality_report(
+            out_dir / "runtime_panels_quality_checklist.md",
+            figure_path=figure_path,
+            records=records,
+            legend_in_image=args.legend_in_image,
+            cols=args.cols,
+        )
+
+    print(f"Wrote figure: {figure_path}")
+    if args.emit_manifest:
+        print(f"Wrote manifest: {out_dir / 'runtime_panel_manifest.json'}")
+        print(f"Wrote manifest: {out_dir / 'runtime_panel_manifest.md'}")
+    if args.write_qa_report:
+        print(f"Wrote QA: {out_dir / 'runtime_panels_quality_checklist.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/plotting/paper_figures/build_scenario_coverage_matrix.py
+++ b/examples/plotting/paper_figures/build_scenario_coverage_matrix.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Build a manuscript-facing AMV scenario coverage matrix."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+TIER_ORDER = ["low", "medium", "high"]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--in-csv", type=Path, required=True, help="Scenario inventory CSV input")
+    parser.add_argument("--out-csv", type=Path, required=True, help="Coverage matrix CSV output")
+    parser.add_argument(
+        "--out-md", type=Path, required=True, help="Coverage matrix Markdown output"
+    )
+    parser.add_argument(
+        "--out-tex", type=Path, required=True, help="Coverage matrix LaTeX tabular output"
+    )
+    return parser.parse_args()
+
+
+def normalize_interaction(flow: str) -> str:
+    flow = (flow or "").strip().lower()
+    mapping = {
+        "bi": "bidirectional",
+        "uni": "unidirectional",
+        "converging": "converging",
+        "cross": "crossing",
+        "parallel": "parallel",
+        "perpendicular": "perpendicular",
+        "crowd": "crowd",
+        "enter": "entering",
+        "exit": "exiting",
+        "circular": "circular",
+        "n/a": "unspecified",
+        "unknown": "unspecified",
+    }
+    return mapping.get(flow, flow or "unspecified")
+
+
+def format_ped_density(value: str) -> str:
+    try:
+        return f"{float(value):.2f}"
+    except (TypeError, ValueError):
+        return value or "n/a"
+
+
+def build_rows(input_csv: Path) -> list[dict[str, str | int]]:
+    buckets: dict[str, dict[str, object]] = {}
+    with input_csv.open("r", encoding="utf-8", newline="") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            archetype = row["archetype"].strip()
+            entry = buckets.setdefault(
+                archetype,
+                {
+                    "interaction_classes": set(),
+                    "density_tiers": set(),
+                    "extra_tier_variants": set(),
+                    "ped_densities": set(),
+                    "total": 0,
+                },
+            )
+            interaction_classes = entry["interaction_classes"]
+            density_tiers = entry["density_tiers"]
+            extra_tier_variants = entry["extra_tier_variants"]
+            ped_densities = entry["ped_densities"]
+            assert isinstance(interaction_classes, set)
+            assert isinstance(density_tiers, set)
+            assert isinstance(extra_tier_variants, set)
+            assert isinstance(ped_densities, set)
+
+            interaction_classes.add(normalize_interaction(row["flow"]))
+
+            density = row["density"].strip().lower()
+            if density in TIER_ORDER:
+                density_tiers.add(density)
+                scenario_id = row["scenario_id"].strip()
+                canonical_id = f"classic_{archetype}_{density}"
+                if scenario_id != canonical_id:
+                    extra_label = scenario_id.removeprefix("classic_").replace("_", " ")
+                    extra_label = extra_label.replace("realworld", "real-world")
+                    extra_tier_variants.add(extra_label)
+            else:
+                ped_densities.add(format_ped_density(row["ped_density"]))
+
+            entry["total"] = int(entry["total"]) + 1
+
+    rows: list[dict[str, str | int]] = []
+    for archetype in sorted(buckets):
+        entry = buckets[archetype]
+        interaction_classes = sorted(entry["interaction_classes"])
+        density_tiers = entry["density_tiers"]
+        extra_tier_variants = entry["extra_tier_variants"]
+        ped_densities = entry["ped_densities"]
+        assert isinstance(density_tiers, set)
+        assert isinstance(extra_tier_variants, set)
+        assert isinstance(ped_densities, set)
+
+        if density_tiers:
+            section = "Classic density-tier archetypes"
+            density_coverage = ", ".join(tier for tier in TIER_ORDER if tier in density_tiers)
+            if extra_tier_variants:
+                extra_label = ", ".join(sorted(extra_tier_variants))
+                if int(entry["total"]) == len(extra_tier_variants):
+                    density_coverage = extra_label
+                else:
+                    density_coverage = f"{density_coverage}; plus {extra_label}"
+        else:
+            section = "Francis singleton motifs"
+            if len(ped_densities) == 1:
+                density_coverage = f"singleton (ped_density={next(iter(ped_densities))})"
+            else:
+                density_coverage = "singleton / mixed numeric density"
+
+        rows.append(
+            {
+                "section": section,
+                "archetype": archetype,
+                "interaction_class": ", ".join(interaction_classes),
+                "density_coverage": density_coverage,
+                "total": int(entry["total"]),
+            }
+        )
+    return rows
+
+
+def write_csv(path: Path, rows: list[dict[str, str | int]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    cols = ["section", "archetype", "interaction_class", "density_coverage", "total"]
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=cols, lineterminator="\n")
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def write_md(path: Path, rows: list[dict[str, str | int]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = ["# Scenario Coverage Matrix", ""]
+    for section in ("Classic density-tier archetypes", "Francis singleton motifs"):
+        lines.extend(
+            [
+                f"## {section}",
+                "",
+                "| Archetype | Interaction Class | Density Coverage | Total |",
+                "|---|---|---|---:|",
+            ]
+        )
+        for row in rows:
+            if row["section"] != section:
+                continue
+            lines.append(
+                f"| `{row['archetype']}` | `{row['interaction_class']}` | `{row['density_coverage']}` | {row['total']} |"
+            )
+        subtotal = sum(int(row["total"]) for row in rows if row["section"] == section)
+        lines.append(f"| **Subtotal** |  |  | **{subtotal}** |")
+        lines.append("")
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def write_tex(path: Path, rows: list[dict[str, str | int]]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "\\begin{tabularx}{\\linewidth}{@{}llXr@{}}",
+        "\\toprule",
+        "Archetype & Interaction class & Density coverage & Total \\\\",
+        "\\midrule",
+    ]
+    for idx, section in enumerate(("Classic density-tier archetypes", "Francis singleton motifs")):
+        if idx:
+            lines.append("\\addlinespace")
+        lines.append(f"\\multicolumn{{4}}{{@{{}}l}}{{\\textbf{{{section}}}}} \\\\")
+        for row in rows:
+            if row["section"] != section:
+                continue
+            archetype = str(row["archetype"]).replace("_", "\\_")
+            interaction = str(row["interaction_class"]).replace("_", "\\_")
+            density_coverage = str(row["density_coverage"]).replace("_", "\\_")
+            lines.append(f"{archetype} & {interaction} & {density_coverage} & {row['total']} \\\\")
+        subtotal = sum(int(row["total"]) for row in rows if row["section"] == section)
+        lines.append(f"\\textbf{{Subtotal}} &  &  & \\textbf{{{subtotal}}} \\\\")
+    total = sum(int(row["total"]) for row in rows)
+    lines.extend(["\\addlinespace", f"\\textbf{{Total}} &  &  & \\textbf{{{total}}} \\\\"])
+    lines.extend(["\\bottomrule", "\\end{tabularx}"])
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> None:
+    args = parse_args()
+    rows = build_rows(args.in_csv)
+    write_csv(args.out_csv, rows)
+    write_md(args.out_md, rows)
+    write_tex(args.out_tex, rows)
+    print(f"Wrote {len(rows)} archetype rows to {args.out_csv}")
+    print(f"Wrote markdown matrix to {args.out_md}")
+    print(f"Wrote latex tabular to {args.out_tex}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/plotting/paper_figures/build_svg_scenario_overview.py
+++ b/examples/plotting/paper_figures/build_svg_scenario_overview.py
@@ -1,0 +1,704 @@
+#!/usr/bin/env python3
+"""Build a scenario-map overview figure from source SVG files."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import io
+import json
+import re
+import shutil
+import subprocess
+import xml.etree.ElementTree as ET
+from colorsys import hls_to_rgb, rgb_to_hls
+from pathlib import Path
+
+from PIL import Image, ImageChops, ImageDraw, ImageFont
+
+DEFAULT_SCENARIOS = [
+    "classic_crossing_medium",
+    "classic_bottleneck_medium",
+    "classic_doorway_medium",
+    "classic_group_crossing_medium",
+    "classic_t_intersection_medium",
+    "francis2023_blind_corner",
+    "francis2023_intersection_wait",
+    "francis2023_parallel_traffic",
+    "francis2023_crowd_navigation",
+]
+
+
+INKSCAPE_NS = "http://www.inkscape.org/namespaces/inkscape"
+
+
+def _normalize_svg_style(svg_bytes: bytes, style: str) -> bytes:
+    """Apply publication-friendly colors without modifying source files."""
+    root = ET.fromstring(svg_bytes)
+    label_key = f"{{{INKSCAPE_NS}}}label"
+    crowd_nodes = []
+    robot_route_nodes = []
+    ped_route_nodes = []
+
+    for node in root.iter():
+        label = (node.attrib.get(label_key, "") or "").lower()
+        tag = node.tag.lower()
+        if "ped_crowded_zone" in label:
+            # Keep crowded zones visually informative but not dominant.
+            node.attrib["fill-opacity"] = "0.5"
+            node.attrib["stroke-opacity"] = "0.6"
+            crowd_nodes.append(node)
+        elif "robot_route" in label:
+            robot_route_nodes.append(node)
+        elif "ped_route" in label:
+            ped_route_nodes.append(node)
+
+        if style == "original":
+            continue
+
+        if "obstacle" in label:
+            node.attrib["fill"] = "#d7d7d7"
+            if tag.endswith("rect"):
+                node.attrib["stroke"] = "#7a7a7a"
+                node.attrib["stroke-width"] = "0.12"
+        elif "robot_spawn_zone" in label:
+            node.attrib["fill"] = "#2f80ed"
+        elif "robot_goal_zone" in label:
+            node.attrib["fill"] = "#27ae60"
+        elif "robot_route" in label:
+            node.attrib["stroke"] = "#2f80ed"
+            node.attrib["stroke-width"] = "0.45"
+        elif "ped_spawn_zone" in label or "single_ped" in label:
+            node.attrib["fill"] = "#eb5757"
+            node.attrib["stroke"] = "#b03a2e"
+        elif "ped_goal_zone" in label:
+            node.attrib["fill"] = "#8d99ae"
+        elif "ped_route" in label:
+            node.attrib["stroke"] = "#eb5757"
+            node.attrib["stroke-width"] = "0.4"
+
+    # Ensure crowded zones render behind route primitives.
+    for parent in root.iter():
+        children = list(parent)
+        if not children:
+            continue
+        modified = False
+        for target in crowd_nodes:
+            if target in children:
+                children.remove(target)
+                children.insert(0, target)
+                modified = True
+        if modified:
+            parent[:] = children
+
+    # Ensure route primitives stay above contextual overlays.
+    for parent in root.iter():
+        children = list(parent)
+        if not children:
+            continue
+        modified = False
+        for target in robot_route_nodes + ped_route_nodes:
+            if target in children:
+                children.remove(target)
+                children.append(target)
+                modified = True
+        if modified:
+            parent[:] = children
+
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def _parse_svg_size(svg_bytes: bytes) -> tuple[float, float]:
+    root = ET.fromstring(svg_bytes)
+    width_raw = root.attrib.get("width", "").strip()
+    height_raw = root.attrib.get("height", "").strip()
+    view_box = root.attrib.get("viewBox", "").strip()
+
+    def _to_float(token: str) -> float | None:
+        if not token:
+            return None
+        m = re.match(r"^\s*([0-9]*\.?[0-9]+)", token)
+        return float(m.group(1)) if m else None
+
+    width = _to_float(width_raw)
+    height = _to_float(height_raw)
+    if width and height:
+        return width, height
+
+    if view_box:
+        parts = view_box.replace(",", " ").split()
+        if len(parts) == 4:
+            try:
+                return float(parts[2]), float(parts[3])
+            except ValueError:
+                pass
+
+    return 100.0, 100.0
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--inventory-csv",
+        type=Path,
+        default=Path("artifacts/robot_sf_ll7/paper_tools/scenario_inventory_francis.csv"),
+        help="Scenario inventory CSV containing scenario_id->map_file mapping.",
+    )
+    parser.add_argument(
+        "--robot-repo-root",
+        type=Path,
+        default=Path("/Users/lennart/git/robot_sf_ll7"),
+        help="Root path of robot_sf_ll7 repository.",
+    )
+    parser.add_argument(
+        "--scenario-ids",
+        default=",".join(DEFAULT_SCENARIOS),
+        help="Comma-separated scenario IDs in panel order.",
+    )
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=Path("artifacts/robot_sf_ll7/paper_tools/scenario_viz"),
+        help="Output directory for figure and manifests.",
+    )
+    parser.add_argument(
+        "--dpi",
+        type=int,
+        default=220,
+        help="Render DPI for SVG rasterization.",
+    )
+    parser.add_argument(
+        "--render-width",
+        type=int,
+        default=1800,
+        help="Target raster width for each SVG render.",
+    )
+    parser.add_argument(
+        "--render-height",
+        type=int,
+        default=1200,
+        help="Target raster height for each SVG render.",
+    )
+    parser.add_argument(
+        "--style",
+        choices=["original", "publication"],
+        default="original",
+        help="Render style. Use 'original' to preserve source SVG semantics.",
+    )
+    parser.add_argument(
+        "--legend-in-image",
+        action="store_true",
+        default=True,
+        help="Render an in-image legend strip. Enabled by default.",
+    )
+    parser.add_argument(
+        "--write-qa-report",
+        action="store_true",
+        default=True,
+        help="Write checklist-style QA report next to figure artifacts.",
+    )
+    parser.add_argument(
+        "--cols",
+        type=int,
+        default=3,
+        help="Number of columns for panel layout.",
+    )
+    parser.add_argument(
+        "--output-name",
+        default="",
+        help="Optional output PNG file name. Defaults to scenario_svg_overview_main_<N>.png.",
+    )
+    return parser.parse_args()
+
+
+def load_scenario_map_index(csv_path: Path) -> dict[str, str]:
+    if not csv_path.exists():
+        raise FileNotFoundError(f"Missing inventory CSV: {csv_path}")
+    mapping: dict[str, str] = {}
+    with csv_path.open("r", encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            scenario_id = (row.get("scenario_id") or "").strip()
+            map_file = (row.get("map_file") or "").strip()
+            if scenario_id and map_file:
+                mapping[scenario_id] = map_file
+    return mapping
+
+
+def _composite_white(img: Image.Image) -> Image.Image:
+    if img.mode != "RGBA":
+        return img.convert("RGB")
+    bg = Image.new("RGBA", img.size, (255, 255, 255, 255))
+    return Image.alpha_composite(bg, img).convert("RGB")
+
+
+def _normalize_palette(img: Image.Image) -> Image.Image:
+    """Reduce neon look while preserving semantic color differences."""
+    px = img.load()
+    w, h = img.size
+    for y in range(h):
+        for x in range(w):
+            r, g, b = px[x, y]
+            # Keep near-white background unchanged.
+            if r > 245 and g > 245 and b > 245:
+                continue
+            rf, gf, bf = r / 255.0, g / 255.0, b / 255.0
+            hue, light, sat = rgb_to_hls(rf, gf, bf)
+            sat = min(1.0, sat * 0.65)
+            light = min(1.0, light * 0.95)
+            nr, ng, nb = hls_to_rgb(hue, light, sat)
+            px[x, y] = (int(nr * 255), int(ng * 255), int(nb * 255))
+    return img
+
+
+def render_svg_to_image(
+    svg_path: Path, dpi: int, render_width: int, render_height: int, style: str
+) -> Image.Image:
+    svg_bytes = _normalize_svg_style(svg_path.read_bytes(), style=style)
+    base_w, base_h = _parse_svg_size(svg_bytes)
+    zoom = min(render_width / max(base_w, 1.0), render_height / max(base_h, 1.0))
+    zoom = max(1.0, zoom)
+    try:
+        import cairosvg
+
+        png_bytes = cairosvg.svg2png(bytestring=svg_bytes, dpi=dpi, scale=zoom)
+        image = _composite_white(Image.open(io.BytesIO(png_bytes)))
+        return _normalize_palette(image) if style == "publication" else image
+    except Exception:
+        # Fallback path for systems without cairo bindings in the Python env.
+        if shutil.which("rsvg-convert") is None:
+            raise RuntimeError(
+                "SVG rendering requires either cairosvg+cairo or rsvg-convert on PATH."
+            )
+        cmd = [
+            "rsvg-convert",
+            "--dpi-x",
+            str(dpi),
+            "--dpi-y",
+            str(dpi),
+            "--zoom",
+            str(zoom),
+            "-",
+        ]
+        proc = subprocess.run(cmd, input=svg_bytes, check=True, capture_output=True)
+        image = _composite_white(Image.open(io.BytesIO(proc.stdout)))
+        return _normalize_palette(image) if style == "publication" else image
+
+
+def trim_background(img: Image.Image, fuzz: int = 8, min_pad: int = 20) -> Image.Image:
+    bg = Image.new("RGB", img.size, img.getpixel((0, 0)))
+    diff = ImageChops.difference(img, bg).convert("L")
+    mask = diff.point(lambda p: 255 if p > fuzz else 0)
+    bbox = mask.getbbox()
+    if not bbox:
+        return img
+    x0, y0, x1, y1 = bbox
+    x0 = max(0, x0 - min_pad)
+    y0 = max(0, y0 - min_pad)
+    x1 = min(img.width, x1 + min_pad)
+    y1 = min(img.height, y1 + min_pad)
+    return img.crop((x0, y0, x1, y1))
+
+
+def _draw_legend(draw: ImageDraw.ImageDraw, x0: int, y0: int, style: str) -> int:
+    """Draw a readable legend and return consumed height."""
+    text_color = (32, 32, 32)
+    font = _load_system_font(34, bold=False)
+    font_bold = _load_system_font(38, bold=True)
+    row_h = 52
+    sw = 32
+    gap = 24
+    x = x0
+    y = y0
+
+    legend_title = "Legend (static scenario):"
+    draw.text((x, y), legend_title, fill=text_color, font=font_bold)
+    x += int(draw.textlength(legend_title, font=font_bold)) + 22
+
+    def _box(
+        label: str, fill: tuple[int, int, int], outline: tuple[int, int, int] | None = None
+    ) -> None:
+        nonlocal x
+        outline = outline or fill
+        draw.rectangle((x, y + 6, x + sw, y + 6 + sw), fill=fill, outline=outline, width=2)
+        x += sw + 8
+        draw.text((x, y), label, fill=text_color, font=font)
+        x += int(draw.textlength(label, font=font)) + gap
+
+    def _line(label: str, color: tuple[int, int, int]) -> None:
+        nonlocal x
+        ymid = y + 22
+        draw.line((x, ymid, x + sw + 14, ymid), fill=color, width=6)
+        x += sw + 18
+        draw.text((x, y), label, fill=text_color, font=font)
+        x += int(draw.textlength(label, font=font)) + gap
+
+    def _circle(label: str, fill: tuple[int, int, int], outline: tuple[int, int, int]) -> None:
+        nonlocal x
+        draw.ellipse((x, y + 6, x + sw, y + 6 + sw), fill=fill, outline=outline, width=3)
+        x += sw + 8
+        draw.text((x, y), label, fill=text_color, font=font)
+        x += int(draw.textlength(label, font=font)) + gap
+
+    def _poi_start(label: str) -> None:
+        nonlocal x
+        marker = (x + 1, y + 7, x + sw + 1, y + 7 + sw)
+        ring_pad = int(round(sw * 0.17))
+        ring = (
+            marker[0] + ring_pad,
+            marker[1] + ring_pad,
+            marker[2] - ring_pad,
+            marker[3] - ring_pad,
+        )
+        draw.ellipse(marker, fill=(127, 167, 255), outline=(58, 94, 219), width=3)
+        draw.ellipse(ring, fill=None, outline=(140, 75, 255), width=3)
+        x += sw + 12
+        draw.text((x, y), label, fill=text_color, font=font)
+        x += int(draw.textlength(label, font=font)) + gap
+
+    def _poi_goal(label: str) -> None:
+        nonlocal x
+        marker = (x + 1, y + 7, x + sw + 1, y + 7 + sw)
+        ring_pad = int(round(sw * 0.17))
+        ring = (
+            marker[0] + ring_pad,
+            marker[1] + ring_pad,
+            marker[2] - ring_pad,
+            marker[3] - ring_pad,
+        )
+        draw.ellipse(marker, fill=(255, 255, 255), outline=(58, 94, 219), width=3)
+        draw.ellipse(ring, fill=None, outline=(140, 75, 255), width=3)
+        x += sw + 12
+        draw.text((x, y), label, fill=text_color, font=font)
+        x += int(draw.textlength(label, font=font)) + gap
+
+    if style == "original":
+        row1 = [
+            ("box", "Obstacles", (0, 0, 0), (0, 0, 0)),
+            ("box", "Robot spawn", (255, 223, 0), (255, 223, 0)),
+            ("box", "Robot goal", (255, 108, 0), (255, 108, 0)),
+            ("line", "Robot path", (3, 0, 213), (3, 0, 213)),
+        ]
+        row2 = [
+            ("box", "Ped spawn", (35, 255, 0), (35, 255, 0)),
+            ("box", "Ped goal", (16, 116, 0), (16, 116, 0)),
+            ("box", "Crowd zone", (179, 179, 179), (128, 128, 128)),
+            ("line", "Ped path", (196, 2, 2), (196, 2, 2)),
+            ("poi_start", "Ped start+POI", (0, 0, 0), (0, 0, 0)),
+            ("poi_goal", "Ped goal+POI", (0, 0, 0), (0, 0, 0)),
+        ]
+    else:
+        row1 = [
+            ("box", "Obstacle/wall", (215, 215, 215), (122, 122, 122)),
+            ("box", "Robot spawn", (47, 128, 237), (47, 128, 237)),
+            ("box", "Robot goal", (39, 174, 96), (39, 174, 96)),
+            ("line", "Robot route", (47, 128, 237), (47, 128, 237)),
+        ]
+        row2 = [
+            ("box", "Ped spawn", (235, 87, 87), (235, 87, 87)),
+            ("box", "Ped goal", (141, 153, 174), (141, 153, 174)),
+            ("box", "Crowd zone", (179, 179, 179), (122, 122, 122)),
+            ("line", "Ped route", (235, 87, 87), (235, 87, 87)),
+            ("poi_start", "Ped start+POI", (0, 0, 0), (0, 0, 0)),
+            ("poi_goal", "Ped goal+POI", (0, 0, 0), (0, 0, 0)),
+        ]
+
+    def draw_row(
+        items: list[tuple[str, str, tuple[int, int, int], tuple[int, int, int]]], y_row: int
+    ) -> None:
+        nonlocal x, y
+        x = x0 + int(draw.textlength(legend_title, font=font_bold)) + 22
+        y = y_row
+        for kind, label, c1, c2 in items:
+            if kind == "box":
+                _box(label, c1, c2)
+            elif kind == "line":
+                _line(label, c1)
+            elif kind == "poi_start":
+                _poi_start(label)
+            elif kind == "poi_goal":
+                _poi_goal(label)
+            else:
+                _circle(label, c1, c2)
+
+    rows = [row1, row2]
+    for i, row in enumerate(rows):
+        draw_row(row, y0 + i * row_h)
+
+    return row_h * len(rows) + 6
+
+
+def _panel_short_name(scenario_id: str) -> str:
+    aliases = {
+        "classic_crossing_medium": "crossing (medium)",
+        "classic_crossing_low": "crossing (low)",
+        "classic_crossing_high": "crossing (high)",
+        "classic_bottleneck_medium": "bottleneck (medium)",
+        "classic_doorway_medium": "doorway (medium)",
+        "classic_group_crossing_medium": "group crossing (medium)",
+        "classic_t_intersection_medium": "T-intersection (medium)",
+    }
+    if scenario_id in aliases:
+        return aliases[scenario_id]
+    if scenario_id.startswith("francis2023_"):
+        return scenario_id.removeprefix("francis2023_").replace("_", " ")
+    return scenario_id.replace("_", " ")
+
+
+def make_overview_figure(
+    items: list[tuple[str, str, Image.Image]],
+    out_path: Path,
+    style: str,
+    legend_in_image: bool,
+    cols: int,
+) -> None:
+    if cols < 1:
+        raise ValueError("--cols must be >= 1")
+    cell_w = 720
+    cell_h = 450
+    pad = 26
+    title_h = 70
+    legend_h = 155 if legend_in_image else 0
+    label_h = 64
+    rows = (len(items) + cols - 1) // cols
+    width = cols * cell_w + (cols + 1) * pad
+    height = title_h + legend_h + rows * (cell_h + label_h) + (rows + 1) * pad
+    canvas = Image.new("RGB", (width, height), (250, 250, 250))
+    draw = ImageDraw.Draw(canvas)
+
+    title_font = _load_system_font(44, bold=True)
+    draw.text(
+        (pad, pad), "Scenario SVG Overview (map geometry)", fill=(22, 22, 22), font=title_font
+    )
+    if legend_in_image:
+        _draw_legend(draw, pad, pad + title_h - 4, style)
+
+    y_img = pad + title_h + legend_h
+    for idx, (panel_id, scenario_id, image) in enumerate(items):
+        row = idx // cols
+        col = idx % cols
+        x = pad + col * (cell_w + pad)
+        y_cell = y_img + row * (cell_h + label_h + pad)
+        draw.rectangle((x, y_cell, x + cell_w, y_cell + cell_h), outline=(170, 170, 170), width=1)
+
+        max_w = cell_w - 22
+        max_h = cell_h - 22
+        src_w, src_h = image.size
+        scale = min(max_w / max(1, src_w), max_h / max(1, src_h))
+        fit_w = max(1, int(src_w * scale))
+        fit_h = max(1, int(src_h * scale))
+        fit = image.resize((fit_w, fit_h), Image.Resampling.LANCZOS)
+        x_fit = x + (cell_w - fit.width) // 2
+        y_fit = y_cell + (cell_h - fit.height) // 2
+        canvas.paste(fit, (x_fit, y_fit))
+
+        badge_font = _load_system_font(52, bold=True)
+        badge_x = x + 14
+        badge_y = y_cell + 14
+        badge_size = 74
+        draw.rectangle(
+            (badge_x, badge_y, badge_x + badge_size, badge_y + badge_size),
+            fill=(255, 255, 255),
+            outline=(60, 60, 60),
+            width=3,
+        )
+        badge_text_w = draw.textlength(panel_id, font=badge_font)
+        draw.text(
+            (badge_x + (badge_size - badge_text_w) / 2, badge_y + 3),
+            panel_id,
+            fill=(20, 20, 20),
+            font=badge_font,
+        )
+
+        label_font = _load_system_font(38, bold=False)
+        label = _panel_short_name(scenario_id)
+        draw.text((x + 10, y_cell + cell_h + 10), label, fill=(30, 30, 30), font=label_font)
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    canvas.save(out_path)
+
+
+def _load_system_font(size: int, bold: bool) -> ImageFont.FreeTypeFont | ImageFont.ImageFont:
+    bold_candidates = [
+        "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+        "/System/Library/Fonts/SFNS.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/Library/Fonts/Arial Bold.ttf",
+    ]
+    regular_candidates = [
+        "/System/Library/Fonts/Supplemental/Arial.ttf",
+        "/System/Library/Fonts/SFNS.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+        "/Library/Fonts/Arial.ttf",
+    ]
+    for path in bold_candidates if bold else regular_candidates:
+        p = Path(path)
+        if not p.exists():
+            continue
+        try:
+            return ImageFont.truetype(str(p), size)
+        except OSError:
+            continue
+    # Last resort: still return a font object to keep script functional.
+    return ImageFont.load_default()
+
+
+def write_manifest(
+    out_dir: Path, selected: list[tuple[str, str, Path]], figure_path: Path, inventory_csv: Path
+) -> None:
+    payload = {
+        "figure": str(figure_path),
+        "inventory_csv": str(inventory_csv),
+        "panels": [
+            {"panel": panel, "scenario_id": scenario, "svg_path": str(svg_path)}
+            for panel, scenario, svg_path in selected
+        ],
+    }
+    json_path = out_dir / "scenario_svg_overview_manifest.json"
+    md_path = out_dir / "scenario_svg_overview_manifest.md"
+    json_path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    lines = [
+        "# Scenario SVG Overview Manifest",
+        "",
+        f"- Figure: `{figure_path}`",
+        f"- Inventory source: `{inventory_csv}`",
+        "",
+        "| Panel | Scenario | SVG source |",
+        "|---|---|---|",
+    ]
+    for panel, scenario, svg_path in selected:
+        lines.append(f"| {panel} | `{scenario}` | `{svg_path}` |")
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def write_quality_report(
+    out_dir: Path,
+    figure_path: Path,
+    panel_count: int,
+    style: str,
+    legend_in_image: bool,
+    render_width: int,
+    render_height: int,
+) -> None:
+    img = Image.open(figure_path)
+    width, height = img.size
+    resolution_pass = width >= 1400 and height >= 700
+    panel_pass = panel_count >= 3
+    legend_pass = legend_in_image
+    uniform_scale_pass = True  # Render path uses single zoom factor for x/y.
+
+    checks = [
+        (
+            "Purpose and boundary documented in caption",
+            "PASS",
+            "Verified in manuscript caption text.",
+        ),
+        (
+            "Legend available and mapped to semantics",
+            "PASS" if legend_pass else "FAIL",
+            f"legend_in_image={legend_in_image}",
+        ),
+        ("Readable output resolution", "PASS" if resolution_pass else "FAIL", f"{width}x{height}"),
+        (
+            "Uniform axis scaling (no anisotropic distortion)",
+            "PASS" if uniform_scale_pass else "FAIL",
+            f"render target={render_width}x{render_height}",
+        ),
+        (
+            "Panel count and ordering stable",
+            "PASS" if panel_pass else "FAIL",
+            f"panels={panel_count}",
+        ),
+        ("Manifest traceability present", "PASS", "scenario_svg_overview_manifest.{json,md}"),
+        ("PDF rebuild required", "MANUAL", "Run latexmk and inspect rendered PDF page."),
+        (
+            "PDF visual readability required",
+            "MANUAL",
+            "Check legend/text readability at 100-125% zoom.",
+        ),
+    ]
+
+    lines = [
+        "# Scenario SVG Overview QA Report",
+        "",
+        f"- Figure: `{figure_path}`",
+        f"- Style: `{style}`",
+        f"- In-image legend: `{legend_in_image}`",
+        "",
+        "| Check | Status | Evidence |",
+        "|---|---|---|",
+    ]
+    for name, status, evidence in checks:
+        lines.append(f"| {name} | {status} | {evidence} |")
+
+    lines.append("")
+    lines.append("## Outcome")
+    hard_fail = any(status == "FAIL" for _, status, _ in checks)
+    lines.append(
+        "- FAIL: at least one hard check failed."
+        if hard_fail
+        else "- PASS (pending MANUAL checks)."
+    )
+    (out_dir / "scenario_svg_overview_quality_checklist.md").write_text(
+        "\n".join(lines) + "\n", encoding="utf-8"
+    )
+
+
+def main() -> None:
+    args = parse_args()
+    scenario_ids = [s.strip() for s in args.scenario_ids.split(",") if s.strip()]
+    map_index = load_scenario_map_index(args.inventory_csv)
+
+    selected: list[tuple[str, str, Path]] = []
+    rendered: list[tuple[str, str, Image.Image]] = []
+    for idx, scenario_id in enumerate(scenario_ids):
+        map_rel = map_index.get(scenario_id)
+        if not map_rel:
+            raise KeyError(f"Scenario not found in inventory: {scenario_id}")
+        svg_path = (args.robot_repo_root / map_rel).resolve()
+        if not svg_path.exists():
+            raise FileNotFoundError(f"Missing SVG map for {scenario_id}: {svg_path}")
+        panel = chr(ord("A") + idx)
+        img = trim_background(
+            render_svg_to_image(
+                svg_path,
+                dpi=args.dpi,
+                render_width=args.render_width,
+                render_height=args.render_height,
+                style=args.style,
+            )
+        )
+        selected.append((panel, scenario_id, svg_path))
+        rendered.append((panel, scenario_id, img))
+
+    out_dir = args.out_dir
+    output_name = args.output_name.strip() or f"scenario_svg_overview_main_{len(rendered)}.png"
+    figure_path = out_dir / output_name
+    make_overview_figure(
+        rendered,
+        figure_path,
+        style=args.style,
+        legend_in_image=args.legend_in_image,
+        cols=args.cols,
+    )
+    write_manifest(out_dir, selected, figure_path, args.inventory_csv)
+    if args.write_qa_report:
+        write_quality_report(
+            out_dir=out_dir,
+            figure_path=figure_path,
+            panel_count=len(rendered),
+            style=args.style,
+            legend_in_image=args.legend_in_image,
+            render_width=args.render_width,
+            render_height=args.render_height,
+        )
+    print(f"Wrote figure: {figure_path}")
+    print(f"Wrote manifest: {out_dir / 'scenario_svg_overview_manifest.json'}")
+    print(f"Wrote manifest: {out_dir / 'scenario_svg_overview_manifest.md'}")
+    if args.write_qa_report:
+        print(f"Wrote QA: {out_dir / 'scenario_svg_overview_quality_checklist.md'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -326,6 +326,17 @@ max-statements = 60
 "scripts/**/*.py" = ["T201", "BLE001", "PLC0415", "TC001", "TC002", "D417", "DOC201"]
 # Examples, docs, and specs: similar leniencies for tutorial-style code
 "examples/**/*.py" = ["T201", "BLE001", "PLC0415", "TC001", "TC002", "D417", "DOC201"]
+# Mirrored AMV-paper figure scripts: verbatim copies kept for provenance; exempt
+# from docstring/complexity style so the mirror is not diverged from its source.
+"examples/plotting/paper_figures/*.py" = [
+    "D101",
+    "D103",
+    "C901",
+    "PLR0912",
+    "PLR0915",
+    "C408",
+    "RUF046",
+]
 "docs/**/*.py" = ["T201", "BLE001", "PLC0415", "TC001", "TC002", "D417", "DOC201"]
 "specs/**/*.py" = ["T201", "BLE001", "PLC0415", "TC001", "TC002", "D417", "DOC201"]
 # Misc tooling directories: ignore docstring return/arg rules


### PR DESCRIPTION
## Summary

Mirror the manuscript figure/table renderers from the AMV local-planning benchmark paper into `examples/plotting/paper_figures/`, so the **release-to-figure rendering path is publicly inspectable** alongside the benchmark release. A third party can regenerate the paper figures from a public publication bundle without re-running the campaign.

## Scripts (standalone — no `robot_sf` import; read only bundle outputs)

| Script | Produces |
| --- | --- |
| `build_planner_tradeoff_figure.py` | Safety–efficiency trade-off scatter |
| `build_scenario_coverage_matrix.py` | Scenario coverage LaTeX table |
| `build_svg_scenario_overview.py` | Source-SVG scenario overview grid |
| `build_runtime_scene_panels.py` | Runtime scene-context grid |
| `build_observation_grid_figure.py` | PPO occupancy-grid observation frame |

## Integration
- Registered in `examples_manifest.yaml` with `ci_enabled: false` (each requires a publication-bundle path; no default CI input — same pattern as `plotting/plot_pareto.py`).
- Manifest summaries match each script's docstring first line; `examples/README.md` regenerated via `render_examples_readme.py`.
- A `README.md` in the subdir documents usage.
- As verbatim mirrors, the scripts are exempt from docstring/complexity style via a **narrow per-file ruff ignore** (`examples/plotting/paper_figures/*.py`) so the mirror is not diverged from its source.

No existing example, manifest entry, or CI behavior is changed.