### PR TITLE
feat: add behavior-sensitive observation replay probe

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -179,8 +179,11 @@ Policy caveats:
   into near-field geometry by #3323. The wrapper ran `risk_surface_dwa_v0` on
   `issue_2756_occluded_emergence` seed 111, preserved no-op first visibility at step 5 and
   delay-only first observation at step 7, reached a 1.6552 m closest robot-pedestrian distance,
-  and classified the run as `policy_insensitive` because perturbations changed observations but
-  not commands or progress/risk summaries. Diagnostic stress evidence only; not a robustness claim.
+  and classified the seven-family run as `policy_insensitive` because perturbations changed
+  observations but not commands or progress/risk summaries. The nested
+  `issue_3328_behavior_probe/` evidence adds an opt-in high-amplitude noise probe that changes
+  commands/progress on the same one-seed fixture and is classified
+  `behavior_sensitive_diagnostic_only`. Diagnostic stress evidence only; not a robustness claim.
 - `issue_3201_observation_noise_live_smoke/`: diagnostic-only same-seed clean vs perturbed
   step-diagnostics replay on the `dense_pedestrian_stress` live matrix candidate. Perturbation
   changed planner-input pedestrian observations, but commands and progress/risk summaries stayed

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/README.md
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/README.md
@@ -40,3 +40,12 @@ Raw trace JSON and per-condition reports were generated locally to build this su
 - The no-op trace first observes the pedestrian at step 5, and the delay-only condition first observes it at step 7.
 - The no-op trace reaches a closest robot-pedestrian distance of 1.6552 m, inside the <=2 m near-field target.
 - Perturbations changed planner-input observations, but selected commands and progress/risk summaries stayed unchanged; this is policy-insensitive diagnostic stress evidence, not a robustness claim.
+
+## Issue #3328 Behavior Probe
+
+`issue_3328_behavior_probe/` preserves this same near-field fixture boundary and adds an opt-in
+high-amplitude noise condition (`std=1.0`, `bound=2.0`, seed 3328). The probe is classified
+`behavior_sensitive_diagnostic_only`: it changes selected commands at steps 6 and 9 plus
+progress/min-distance summaries on one seed, while medium noise and delay-only remain
+policy-insensitive. It is diagnostic stress evidence only, not a robustness, sensor-realism, or
+planner-superiority claim.

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3328_behavior_probe/README.md
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3328_behavior_probe/README.md
@@ -1,0 +1,31 @@
+# Issue #2777 Live Observation-Noise Replay
+
+## Status
+
+- Status: `live_replay`
+- Classification: `behavior_sensitive_diagnostic_only`
+- Rationale: All selected live replays completed. One seed is diagnostic only and does not support a robustness, sensor-realism, or planner-superiority claim.
+
+## Claim Boundary
+
+Stress-slice live planner/environment replay for one scenario, one seed, and the selected perturbation condition set. Treat behavior-sensitive differences as diagnostic-only from one seed; do not infer robustness, sensor realism, or planner superiority.
+
+## Fixture Contract
+
+- `required_scenario`: `issue_2756_occluded_emergence`
+- `required_family`: `occluded_emergence/deterministic_occluded_emergence`
+- `first_visible_step`: `5`
+- `delay_steps`: `2`
+- `delay_only_expected_first_observed_step`: `7`
+- `scenario_matrix`: `configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml`
+- `satisfied`: `True`
+- `blocker`: `None`
+
+## Conditions
+
+| Condition | Status | Classification | Command changed | Progress/risk changed | Min distance changed | Collision/near-miss changed | Stop/yield proxy changed | Caveat |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| `noop` | `live_replay` | `baseline` | `n/a` | `n/a` | `n/a` | `n/a` | `n/a` |  |
+| `medium_noise` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `delay_only` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `high_noise_3328` | `live_replay` | `behavior_sensitive_diagnostic_only` | `True` | `True` | `True` | `False` | `False` | Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but one seed is not enough for a benchmark-strength robustness claim. |

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3328_behavior_probe/summary.json
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3328_behavior_probe/summary.json
@@ -1,0 +1,642 @@
+{
+  "schema_version": "issue_2777_observation_noise_live_replay.v1",
+  "artifact_shape": "compact_summary_without_raw_traces",
+  "issue": 2777,
+  "status": "live_replay",
+  "classification": {
+    "label": "behavior_sensitive_diagnostic_only",
+    "rationale": "All selected live replays completed. One seed is diagnostic only and does not support a robustness, sensor-realism, or planner-superiority claim."
+  },
+  "claim_boundary": "Stress-slice live planner/environment replay for one scenario, one seed, and the selected perturbation condition set. Treat behavior-sensitive differences as diagnostic-only from one seed; do not infer robustness, sensor realism, or planner superiority.",
+  "inputs": {
+    "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+    "raw_trace_json": "worktree-local generated traces summarized here; raw trace.json files are intentionally not committed",
+    "generated_funnel": "worktree-local generated_policy_search_funnel.yaml was intentionally not committed"
+  },
+  "fixture_contract": {
+    "required_source_issue": 2756,
+    "required_scenario": "issue_2756_occluded_emergence",
+    "required_family": "occluded_emergence/deterministic_occluded_emergence",
+    "required_seed": 111,
+    "first_visible_step": 5,
+    "delay_steps": 2,
+    "delay_only_expected_first_observed_step": 7,
+    "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+    "satisfied": true,
+    "blocker": null,
+    "matched_scenario": {
+      "name": "issue_2756_occluded_emergence",
+      "source_issue": 2756,
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "seeds": [
+        111
+      ],
+      "first_visible_step": 5,
+      "delay_steps": 2,
+      "delay_only_expected_first_observed_step": 7
+    }
+  },
+  "fixture_observation_boundary": {
+    "noop_first_observed_step": 5,
+    "delay_only_first_observed_step": 7,
+    "expected_noop_first_observed_step": 5,
+    "expected_delay_only_first_observed_step": 7
+  },
+  "run_config": {
+    "candidate": "risk_surface_dwa_v0",
+    "stage": "smoke",
+    "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+    "scenario_name": null,
+    "scenario_index": 0,
+    "seed": null,
+    "seed_index": 0,
+    "horizon": 50,
+    "output_dir": "docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3328_behavior_probe",
+    "condition_set": "issue_3328_behavior_probe",
+    "condition_names": [
+      "noop",
+      "medium_noise",
+      "delay_only",
+      "high_noise_3328"
+    ],
+    "allow_non_occluded_live_fixture": false,
+    "dry_run": false
+  },
+  "conditions": [
+    {
+      "name": "noop",
+      "description": "Unperturbed live planner/environment replay.",
+      "status": "live_replay"
+    },
+    {
+      "name": "medium_noise",
+      "description": "Bounded Gaussian pedestrian-position perturbation, std=0.30 m, bound=0.60 m.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "delay_only",
+      "description": "Two-step delayed pedestrian observation, preserving the #2755 expected lag.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "delayed_observation"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 7
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "high_noise_3328",
+      "description": "Issue #3328 high-noise behavior probe, std=1.0 m, bound=2.0 m, seed=3328.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": true,
+        "changed_steps": [
+          6,
+          9
+        ],
+        "changed_step_count": 2,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.6632785410644526,
+          "changed": true
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": true,
+        "changed_command_steps": [
+          6,
+          9
+        ],
+        "changed_command_step_count": 2,
+        "progress_or_risk_changed": true,
+        "progress_delta_changed_fields": [
+          "net_goal_progress",
+          "best_goal_progress",
+          "closest_robot_ped_distance"
+        ],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.6632785410644526,
+            "changed": true
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "behavior_sensitive_diagnostic_only",
+        "rationale": "Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but one seed is not enough for a benchmark-strength robustness claim."
+      }
+    }
+  ],
+  "blockers": []
+}

--- a/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
+++ b/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
@@ -38,6 +38,14 @@ REQUIRED_CONDITIONS = (
     "delay_only",
     "combined",
 )
+DEFAULT_CONDITION_SET = "issue_2755_default"
+ISSUE_3328_CONDITION_SET = "issue_3328_behavior_probe"
+ISSUE_3328_REQUIRED_CONDITIONS = (
+    "noop",
+    "medium_noise",
+    "delay_only",
+    "high_noise_3328",
+)
 PROGRESS_FIELDS = (
     "net_goal_progress",
     "best_goal_progress",
@@ -116,6 +124,28 @@ CONDITIONS = (
         ),
     ),
 )
+_CONDITION_BY_NAME = {condition.name: condition for condition in CONDITIONS}
+HIGH_NOISE_3328_CONDITION = Condition(
+    "high_noise_3328",
+    "Issue #3328 high-noise behavior probe, std=1.0 m, bound=2.0 m, seed=3328.",
+    (
+        "--observation-noise-std-m",
+        "1.0",
+        "--observation-noise-bound-m",
+        "2.0",
+        "--observation-perturbation-seed",
+        "3328",
+    ),
+)
+CONDITION_SETS = {
+    DEFAULT_CONDITION_SET: CONDITIONS,
+    ISSUE_3328_CONDITION_SET: (
+        _CONDITION_BY_NAME["noop"],
+        _CONDITION_BY_NAME["medium_noise"],
+        _CONDITION_BY_NAME["delay_only"],
+        HIGH_NOISE_3328_CONDITION,
+    ),
+}
 
 
 def _repo_path(path: Path) -> Path:
@@ -355,6 +385,11 @@ def _condition_command(
     return command
 
 
+def _selected_conditions(args: argparse.Namespace) -> tuple[Condition, ...]:
+    """Return the conditions selected by the requested condition set."""
+    return CONDITION_SETS[str(args.condition_set)]
+
+
 def _durable_ref(path: Path) -> str:
     """Return a report-safe path reference."""
     try:
@@ -423,6 +458,192 @@ def _progress_delta(noop: dict[str, Any], condition: dict[str, Any]) -> dict[str
     }
 
 
+def _near_miss_total(trace: dict[str, Any]) -> tuple[float | None, bool]:
+    """Return the summed near-miss metadata and whether the field was reported."""
+    total = 0.0
+    available = False
+    for row in trace.get("steps", []):
+        meta = _mapping(_mapping(row).get("meta"))
+        if "near_misses" not in meta:
+            continue
+        available = True
+        try:
+            total += float(meta.get("near_misses", 0) or 0)
+        except (TypeError, ValueError):
+            continue
+    return (total if available else None), available
+
+
+def _near_miss_summary(
+    noop_trace: dict[str, Any], condition_trace: dict[str, Any]
+) -> dict[str, Any]:
+    """Compare near-miss counts when diagnostics traces expose that field."""
+    noop_total, noop_available = _near_miss_total(noop_trace)
+    condition_total, condition_available = _near_miss_total(condition_trace)
+    if not noop_available and not condition_available:
+        return {
+            "status": "unavailable",
+            "noop": None,
+            "condition": None,
+            "changed": False,
+            "limitation": "Diagnostics trace rows did not expose meta.near_misses.",
+        }
+    status = "available" if noop_available and condition_available else "partial"
+    return {
+        "status": status,
+        "noop": noop_total,
+        "condition": condition_total,
+        "changed": (
+            noop_total != condition_total if noop_available and condition_available else False
+        ),
+    }
+
+
+def _collision_summary(
+    noop_trace: dict[str, Any], condition_trace: dict[str, Any]
+) -> dict[str, Any]:
+    """Compare progress-summary collision counts."""
+    noop_counts = _mapping(noop_trace.get("progress_summary")).get("collision_flag_counts")
+    condition_counts = _mapping(condition_trace.get("progress_summary")).get(
+        "collision_flag_counts"
+    )
+    if noop_counts is None and condition_counts is None:
+        return {
+            "status": "unavailable",
+            "noop": None,
+            "condition": None,
+            "changed": False,
+            "limitation": "Diagnostics progress summaries did not expose collision_flag_counts.",
+        }
+    status = "available" if noop_counts is not None and condition_counts is not None else "partial"
+    return {
+        "status": status,
+        "noop": noop_counts,
+        "condition": condition_counts,
+        "changed": noop_counts != condition_counts if status == "available" else False,
+    }
+
+
+def _command_speed(command: Any) -> float | None:
+    """Return the linear-speed component from a policy command when present."""
+    if not isinstance(command, list | tuple) or not command:
+        return None
+    value = command[0]
+    if isinstance(value, bool):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _first_command_stop_step(trace: dict[str, Any]) -> int | None:
+    """Return the first step whose selected command has zero linear speed."""
+    for fallback_step, row in enumerate(trace.get("steps", [])):
+        row = _mapping(row)
+        speed = _command_speed(row.get("policy_command"))
+        if speed is not None and abs(speed) <= 1e-9:
+            return _optional_int(row.get("step")) or fallback_step
+    return None
+
+
+def _has_command_speed(trace: dict[str, Any]) -> bool:
+    """Return whether any trace row has a parseable selected linear-speed command."""
+    return any(
+        _command_speed(_mapping(row).get("policy_command")) is not None
+        for row in trace.get("steps", [])
+    )
+
+
+def _changed_command_steps(
+    noop_trace: dict[str, Any], condition_trace: dict[str, Any]
+) -> list[int]:
+    """Return trace steps where the selected policy command differs from no-op."""
+    noop_steps = [_mapping(row) for row in noop_trace.get("steps", [])]
+    condition_steps = [_mapping(row) for row in condition_trace.get("steps", [])]
+    changed: list[int] = []
+    for index in range(max(len(noop_steps), len(condition_steps))):
+        noop_row = noop_steps[index] if index < len(noop_steps) else {}
+        condition_row = condition_steps[index] if index < len(condition_steps) else {}
+        if noop_row.get("policy_command") == condition_row.get("policy_command"):
+            continue
+        step = _optional_int(condition_row.get("step"))
+        if step is None:
+            step = _optional_int(noop_row.get("step"))
+        changed.append(index if step is None else step)
+    return changed
+
+
+def _stop_yield_timing_proxy(
+    noop_trace: dict[str, Any],
+    condition_trace: dict[str, Any],
+) -> dict[str, Any]:
+    """Report the available stop/yield proxy without inventing direct event timing."""
+    noop_available = _has_command_speed(noop_trace)
+    condition_available = _has_command_speed(condition_trace)
+    noop_stop = _first_command_stop_step(noop_trace)
+    condition_stop = _first_command_stop_step(condition_trace)
+    status = "available" if noop_available and condition_available else "unavailable"
+    return {
+        "status": status,
+        "definition": (
+            "First diagnostics trace step where the selected policy_command linear "
+            "speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield "
+            "event timing is not available in these traces."
+        ),
+        "direct_event_available": False,
+        "noop_first_stop_step": noop_stop if noop_available else None,
+        "condition_first_stop_step": condition_stop if condition_available else None,
+        "changed": noop_stop != condition_stop if status == "available" else False,
+    }
+
+
+def _behavior_change_summary(
+    noop_trace: dict[str, Any],
+    condition_trace: dict[str, Any],
+) -> dict[str, Any]:
+    """Name behavior-change dimensions used for #2777/#3328 interpretation."""
+    progress_delta = _progress_delta(noop_trace, condition_trace)
+    changed_steps = _changed_command_steps(noop_trace, condition_trace)
+    near_miss = _near_miss_summary(noop_trace, condition_trace)
+    collision = _collision_summary(noop_trace, condition_trace)
+    stop_proxy = _stop_yield_timing_proxy(noop_trace, condition_trace)
+    changed_progress_fields = [
+        field for field, payload in progress_delta.items() if payload["changed"]
+    ]
+    return {
+        "command_sequence_changed": bool(changed_steps),
+        "changed_command_steps": changed_steps,
+        "changed_command_step_count": len(changed_steps),
+        "progress_or_risk_changed": bool(changed_progress_fields),
+        "progress_delta_changed_fields": changed_progress_fields,
+        "closest_robot_ped": {
+            "distance": progress_delta["closest_robot_ped_distance"],
+            "step": progress_delta["closest_robot_ped_step"],
+        },
+        "min_distance_changed": progress_delta["closest_robot_ped_distance"]["changed"],
+        "collision_or_near_miss_changed": (
+            bool(collision["changed"]) or bool(near_miss["changed"])
+        ),
+        "collision_summary": collision,
+        "near_miss_summary": near_miss,
+        "stop_yield_timing_proxy": stop_proxy,
+        "stop_yield_timing": {
+            "direct_event_available": False,
+            "limitation": (
+                "Direct stop/yield event timing is not available in diagnostics traces; "
+                "only a zero-linear-speed command proxy is reported."
+            ),
+            "command_stop_proxy": {
+                "definition": stop_proxy["definition"],
+                "noop_first_stop_step": stop_proxy["noop_first_stop_step"],
+                "condition_first_stop_step": stop_proxy["condition_first_stop_step"],
+                "changed": stop_proxy["changed"],
+            },
+        },
+    }
+
+
 def _first_observed_step(trace: dict[str, Any]) -> int | None:
     """Return the first trace step with at least one planner-visible actor."""
     for row in trace.get("steps", []):
@@ -439,9 +660,7 @@ def _classification(
     fixture_contract_satisfied: bool,
 ) -> dict[str, str]:
     """Classify one live condition against the no-op trace."""
-    progress_delta = _progress_delta(noop_trace, condition_trace)
-    command_changed = _commands(noop_trace) != _commands(condition_trace)
-    progress_changed = any(item["changed"] for item in progress_delta.values())
+    behavior = _behavior_change_summary(noop_trace, condition_trace)
     observation_changed = _observation_totals(noop_trace) != _observation_totals(condition_trace)
     closest = _mapping(noop_trace.get("progress_summary")).get("closest_robot_ped_distance")
     near_field = isinstance(closest, (int, float)) and closest <= 2.0
@@ -453,9 +672,14 @@ def _classification(
                 "occluded-emergence fixture boundary."
             ),
         }
-    if command_changed or progress_changed:
+    if (
+        behavior["command_sequence_changed"]
+        or behavior["progress_or_risk_changed"]
+        or behavior["collision_or_near_miss_changed"]
+        or behavior["stop_yield_timing_proxy"]["changed"]
+    ):
         return {
-            "label": "diagnostic_only",
+            "label": "behavior_sensitive_diagnostic_only",
             "rationale": (
                 "Perturbation changed selected commands or progress/risk fields. "
                 "This is live behavior evidence, but one seed is not enough for "
@@ -488,6 +712,7 @@ def _compare_condition(
     """Compare one condition trace against the no-op trace."""
     noop_trace = _load_trace(noop_trace_path)
     condition_trace = _load_trace(condition_trace_path)
+    behavior = _behavior_change_summary(noop_trace, condition_trace)
     return {
         "trace": _durable_ref(condition_trace_path),
         "scenario": {
@@ -510,7 +735,9 @@ def _compare_condition(
             "condition": _observation_totals(condition_trace),
         },
         "command_summary": {
-            "sequence_changed": _commands(noop_trace) != _commands(condition_trace),
+            "sequence_changed": behavior["command_sequence_changed"],
+            "changed_steps": behavior["changed_command_steps"],
+            "changed_step_count": behavior["changed_command_step_count"],
             "noop_first": _commands(noop_trace)[0] if _commands(noop_trace) else None,
             "condition_first": _commands(condition_trace)[0]
             if _commands(condition_trace)
@@ -521,6 +748,7 @@ def _compare_condition(
             else None,
         },
         "progress_delta": _progress_delta(noop_trace, condition_trace),
+        "behavior_change_summary": behavior,
         "fixture_visibility": {
             "noop_first_observed_step": _first_observed_step(noop_trace),
             "condition_first_observed_step": _first_observed_step(condition_trace),
@@ -563,7 +791,7 @@ def _fail_closed_report(
                 "status": "blocked",
                 "blocker": blocker,
             }
-            for condition in CONDITIONS
+            for condition in _selected_conditions(args)
         ],
         "blockers": [blocker],
     }
@@ -581,6 +809,8 @@ def _run_config(*, args: argparse.Namespace, output_dir: Path) -> dict[str, Any]
         "seed_index": args.seed_index,
         "horizon": args.horizon,
         "output_dir": _durable_ref(output_dir),
+        "condition_set": args.condition_set,
+        "condition_names": [condition.name for condition in _selected_conditions(args)],
         "allow_non_occluded_live_fixture": bool(args.allow_non_occluded_live_fixture),
         "dry_run": bool(args.dry_run),
     }
@@ -591,6 +821,11 @@ def _write_outputs(report: dict[str, Any], output_dir: Path) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
     (output_dir / "summary.json").write_text(json.dumps(report, indent=2), encoding="utf-8")
     (output_dir / "README.md").write_text(_markdown(report), encoding="utf-8")
+
+
+def _markdown_value(value: Any) -> str:
+    """Return a compact table value for optional report fields."""
+    return "n/a" if value is None else str(value)
 
 
 def _markdown(report: dict[str, Any]) -> str:
@@ -628,16 +863,26 @@ def _markdown(report: dict[str, Any]) -> str:
             "",
             "## Conditions",
             "",
-            "| Condition | Status | Classification | Caveat |",
-            "|---|---|---|---|",
+            "| Condition | Status | Classification | Command changed | Progress/risk changed | "
+            "Min distance changed | Collision/near-miss changed | Stop/yield proxy changed | Caveat |",
+            "|---|---|---|---:|---:|---:|---:|---:|---|",
         ]
     )
     for condition in report["conditions"]:
         classification = _mapping(condition.get("classification"))
-        label = classification.get("label") or condition.get("status", "")
+        label = classification.get("label") or (
+            "baseline" if condition["name"] == "noop" else condition.get("status", "")
+        )
+        behavior = _mapping(condition.get("behavior_change_summary"))
+        stop_proxy = _mapping(behavior.get("stop_yield_timing_proxy"))
         lines.append(
             f"| `{condition['name']}` | `{condition['status']}` | "
             f"`{label}` | "
+            f"`{_markdown_value(behavior.get('command_sequence_changed'))}` | "
+            f"`{_markdown_value(behavior.get('progress_or_risk_changed'))}` | "
+            f"`{_markdown_value(behavior.get('min_distance_changed'))}` | "
+            f"`{_markdown_value(behavior.get('collision_or_near_miss_changed'))}` | "
+            f"`{_markdown_value(stop_proxy.get('changed'))}` | "
             f"{condition.get('blocker') or classification.get('rationale', '')} |"
         )
     if report.get("blockers"):
@@ -680,7 +925,7 @@ def _planned_report(
                     args=args,
                 ),
             }
-            for condition in CONDITIONS
+            for condition in _selected_conditions(args)
         ],
         "blockers": [] if fixture_contract["satisfied"] else [fixture_contract["blocker"]],
     }
@@ -695,7 +940,7 @@ def _execute_conditions(
     """Run all condition subprocesses and collect raw condition statuses."""
     conditions: list[dict[str, Any]] = []
     blockers: list[str] = []
-    for condition in CONDITIONS:
+    for condition in _selected_conditions(args):
         command = _condition_command(
             condition=condition,
             output_dir=output_dir,
@@ -783,6 +1028,89 @@ def _attach_condition_comparisons(
     return blockers
 
 
+def _verify_issue_3328_contract_guardrails(
+    *,
+    fixture_contract: Mapping[str, Any],
+) -> list[str]:
+    """Verify the static fixture-contract side of the #3328 probe."""
+    blockers: list[str] = []
+    if not fixture_contract.get("satisfied"):
+        blockers.append("Issue #3328 behavior probe requires fixture_contract.satisfied=true.")
+
+    matched = _mapping(fixture_contract.get("matched_scenario"))
+    if matched.get("name") != ISSUE_2756_FIXTURE_SCENARIO:
+        blockers.append(
+            "Issue #3328 behavior probe requires scenario "
+            f"{ISSUE_2756_FIXTURE_SCENARIO!r}; got {matched.get('name')!r}."
+        )
+    if ISSUE_2756_FIXTURE_SEED not in _int_list(matched.get("seeds")):
+        blockers.append(
+            f"Issue #3328 behavior probe requires seed {ISSUE_2756_FIXTURE_SEED} "
+            f"in matrix seeds; got {matched.get('seeds')!r}."
+        )
+    return blockers
+
+
+def _verify_issue_3328_trace_identity(label: str, trace: Mapping[str, Any]) -> list[str]:
+    """Verify one #3328 probe trace still names the intended scenario and seed."""
+    blockers: list[str] = []
+    if trace.get("scenario_id") != ISSUE_2756_FIXTURE_SCENARIO:
+        blockers.append(
+            f"{label} trace scenario is {trace.get('scenario_id')!r}, "
+            f"expected {ISSUE_2756_FIXTURE_SCENARIO!r}."
+        )
+    if _optional_int(trace.get("seed")) != ISSUE_2756_FIXTURE_SEED:
+        blockers.append(
+            f"{label} trace seed is {trace.get('seed')!r}, expected {ISSUE_2756_FIXTURE_SEED!r}."
+        )
+    return blockers
+
+
+def _verify_issue_3328_near_field_trace(noop_trace: Mapping[str, Any]) -> list[str]:
+    """Verify the #3328 probe no-op trace has near-field interaction geometry."""
+    closest = _mapping(noop_trace.get("progress_summary")).get("closest_robot_ped_distance")
+    if not isinstance(closest, int | float):
+        return ["Issue #3328 behavior probe requires a no-op closest_robot_ped_distance value."]
+    if float(closest) > 2.0:
+        return [
+            "Issue #3328 behavior probe requires no-op closest_robot_ped_distance <= 2.0 m; "
+            f"observed {closest}."
+        ]
+    return []
+
+
+def _verify_issue_3328_behavior_probe_guardrails(
+    *,
+    output_dir: Path,
+    fixture_contract: Mapping[str, Any],
+) -> list[str]:
+    """Fail closed unless the opt-in #3328 probe remains a near-field #2756 replay."""
+    blockers = _verify_issue_3328_contract_guardrails(fixture_contract=fixture_contract)
+    try:
+        noop_trace = _load_trace(output_dir / "traces" / "noop" / "trace.json")
+        delay_trace = _load_trace(output_dir / "traces" / "delay_only" / "trace.json")
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return blockers + [f"Could not verify issue #3328 behavior probe guardrails: {exc}"]
+
+    for label, trace in (("noop", noop_trace), ("delay_only", delay_trace)):
+        blockers.extend(_verify_issue_3328_trace_identity(label, trace))
+
+    noop_first_observed = _first_observed_step(noop_trace)
+    delay_first_observed = _first_observed_step(delay_trace)
+    if noop_first_observed != 5:
+        blockers.append(
+            "Issue #3328 behavior probe requires no-op first observed step 5; "
+            f"observed {noop_first_observed}."
+        )
+    if delay_first_observed != 7:
+        blockers.append(
+            "Issue #3328 behavior probe requires delay-only first observed step 7; "
+            f"observed {delay_first_observed}."
+        )
+    blockers.extend(_verify_issue_3328_near_field_trace(noop_trace))
+    return blockers
+
+
 def _verify_fixture_observation_boundary(
     *,
     output_dir: Path,
@@ -815,6 +1143,35 @@ def _verify_fixture_observation_boundary(
     return blockers
 
 
+def _fixture_observation_boundary_summary(output_dir: Path) -> dict[str, int | None]:
+    """Return the observed no-op and delay-only fixture timing summary."""
+    summary = {
+        "noop_first_observed_step": None,
+        "delay_only_first_observed_step": None,
+        "expected_noop_first_observed_step": 5,
+        "expected_delay_only_first_observed_step": 7,
+    }
+    try:
+        noop_trace = _load_trace(output_dir / "traces" / "noop" / "trace.json")
+        delay_trace = _load_trace(output_dir / "traces" / "delay_only" / "trace.json")
+    except (OSError, ValueError, json.JSONDecodeError):
+        return summary
+    summary["noop_first_observed_step"] = _first_observed_step(noop_trace)
+    summary["delay_only_first_observed_step"] = _first_observed_step(delay_trace)
+    return summary
+
+
+def _compact_live_conditions(conditions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Drop worktree-local command and raw trace paths from durable report rows."""
+    compact_conditions: list[dict[str, Any]] = []
+    for condition in conditions:
+        compact = dict(condition)
+        for key in ("command", "trace", "report"):
+            compact.pop(key, None)
+        compact_conditions.append(compact)
+    return compact_conditions
+
+
 def _final_classification(
     *,
     blockers: list[str],
@@ -840,19 +1197,24 @@ def _final_classification(
         for item in conditions
         if item["name"] != "noop"
     }
-    if "diagnostic_only" in labels:
+    if "behavior_sensitive_diagnostic_only" in labels:
+        label = "behavior_sensitive_diagnostic_only"
+    elif "diagnostic_only" in labels:
         label = "diagnostic_only"
     elif "policy_insensitive" in labels:
         label = "policy_insensitive"
     elif "scenario_too_weak" in labels:
         label = "scenario_too_weak"
     else:
-        label = "robustness_evidence"
+        label = "diagnostic_only"
     return (
         "live_replay",
         {
             "label": label,
-            "rationale": "All seven perturbation-family live replays completed.",
+            "rationale": (
+                "All selected live replays completed. One seed is diagnostic only and "
+                "does not support a robustness, sensor-realism, or planner-superiority claim."
+            ),
         },
     )
 
@@ -904,6 +1266,13 @@ def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
             fixture_contract=fixture_contract,
         )
     )
+    if args.condition_set == ISSUE_3328_CONDITION_SET:
+        blockers.extend(
+            _verify_issue_3328_behavior_probe_guardrails(
+                output_dir=output_dir,
+                fixture_contract=fixture_contract,
+            )
+        )
     status, classification = _final_classification(
         blockers=blockers,
         fixture_contract_satisfied=bool(fixture_contract["satisfied"]),
@@ -912,17 +1281,30 @@ def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
 
     return {
         "schema_version": SCHEMA_VERSION,
+        "artifact_shape": "compact_summary_without_raw_traces",
         "issue": 2777,
         "status": status,
         "classification": classification,
         "claim_boundary": (
             "Stress-slice live planner/environment replay for one scenario, one seed, "
-            "and seven #2755 perturbation families. Treat as benchmark-facing only "
-            "when fixture_contract.satisfied is true; otherwise diagnostic-only."
+            "and the selected perturbation condition set. Treat behavior-sensitive "
+            "differences as diagnostic-only from one seed; do not infer robustness, "
+            "sensor realism, or planner superiority."
         ),
+        "inputs": {
+            "scenario_matrix": _durable_ref(scenario_matrix),
+            "raw_trace_json": (
+                "worktree-local generated traces summarized here; raw trace.json files "
+                "are intentionally not committed"
+            ),
+            "generated_funnel": (
+                "worktree-local generated_policy_search_funnel.yaml was intentionally not committed"
+            ),
+        },
         "fixture_contract": fixture_contract,
+        "fixture_observation_boundary": _fixture_observation_boundary_summary(output_dir),
         "run_config": _run_config(args=args, output_dir=output_dir),
-        "conditions": conditions,
+        "conditions": _compact_live_conditions(conditions),
         "blockers": blockers,
     }
 
@@ -944,6 +1326,15 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--seed", type=int, default=None)
     parser.add_argument("--seed-index", type=int, default=0)
     parser.add_argument("--horizon", type=int, default=50)
+    parser.add_argument(
+        "--condition-set",
+        choices=sorted(CONDITION_SETS),
+        default=DEFAULT_CONDITION_SET,
+        help=(
+            "Perturbation condition set to run. The default preserves the seven #2755 "
+            "families; issue_3328_behavior_probe is an opt-in four-condition probe."
+        ),
+    )
     parser.add_argument("--timeout-seconds", type=float, default=120.0)
     parser.add_argument(
         "--allow-non-occluded-live-fixture",
@@ -960,6 +1351,11 @@ def main(argv: list[str] | None = None) -> int:
     args.output_dir = _repo_path(args.output_dir)
     if tuple(condition.name for condition in CONDITIONS) != REQUIRED_CONDITIONS:
         raise RuntimeError("Issue #2777 condition set drifted from the required seven families")
+    if (
+        tuple(condition.name for condition in CONDITION_SETS[ISSUE_3328_CONDITION_SET])
+        != ISSUE_3328_REQUIRED_CONDITIONS
+    ):
+        raise RuntimeError("Issue #3328 behavior probe condition set drifted")
     report = run_live_batch(args)
     _write_outputs(report, args.output_dir)
     print(

--- a/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
+++ b/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import subprocess
 import sys
 from collections.abc import Mapping
@@ -411,6 +412,24 @@ def _mapping(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _finite_number(value: Any) -> float | None:
+    """Return a finite non-boolean number, otherwise ``None``."""
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        return None
+    number = float(value)
+    return number if math.isfinite(number) else None
+
+
+def _values_differ(left: Any, right: Any) -> bool:
+    """Compare report values while treating paired NaN values as unchanged."""
+    if isinstance(left, int | float) and isinstance(right, int | float):
+        left_float = float(left)
+        right_float = float(right)
+        if math.isnan(left_float) and math.isnan(right_float):
+            return False
+    return left != right
+
+
 def _commands(trace: dict[str, Any]) -> list[Any]:
     """Return selected policy commands from a diagnostics trace."""
     return [_mapping(row).get("policy_command") for row in trace.get("steps", [])]
@@ -452,7 +471,7 @@ def _progress_delta(noop: dict[str, Any], condition: dict[str, Any]) -> dict[str
         field: {
             "noop": noop_summary.get(field),
             "condition": condition_summary.get(field),
-            "changed": noop_summary.get(field) != condition_summary.get(field),
+            "changed": _values_differ(noop_summary.get(field), condition_summary.get(field)),
         }
         for field in PROGRESS_FIELDS
     }
@@ -468,9 +487,11 @@ def _near_miss_total(trace: dict[str, Any]) -> tuple[float | None, bool]:
             continue
         available = True
         try:
-            total += float(meta.get("near_misses", 0) or 0)
+            value = float(meta.get("near_misses", 0) or 0)
         except (TypeError, ValueError):
             continue
+        if math.isfinite(value):
+            total += value
     return (total if available else None), available
 
 
@@ -663,7 +684,8 @@ def _classification(
     behavior = _behavior_change_summary(noop_trace, condition_trace)
     observation_changed = _observation_totals(noop_trace) != _observation_totals(condition_trace)
     closest = _mapping(noop_trace.get("progress_summary")).get("closest_robot_ped_distance")
-    near_field = isinstance(closest, (int, float)) and closest <= 2.0
+    finite_closest = _finite_number(closest)
+    near_field = finite_closest is not None and finite_closest <= 2.0
     if not fixture_contract_satisfied:
         return {
             "label": "diagnostic_only",
@@ -1069,9 +1091,12 @@ def _verify_issue_3328_trace_identity(label: str, trace: Mapping[str, Any]) -> l
 def _verify_issue_3328_near_field_trace(noop_trace: Mapping[str, Any]) -> list[str]:
     """Verify the #3328 probe no-op trace has near-field interaction geometry."""
     closest = _mapping(noop_trace.get("progress_summary")).get("closest_robot_ped_distance")
-    if not isinstance(closest, int | float):
-        return ["Issue #3328 behavior probe requires a no-op closest_robot_ped_distance value."]
-    if float(closest) > 2.0:
+    finite_closest = _finite_number(closest)
+    if finite_closest is None:
+        return [
+            "Issue #3328 behavior probe requires a finite no-op closest_robot_ped_distance value."
+        ]
+    if finite_closest > 2.0:
         return [
             "Issue #3328 behavior probe requires no-op closest_robot_ped_distance <= 2.0 m; "
             f"observed {closest}."

--- a/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
+++ b/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
@@ -37,9 +37,36 @@ def test_condition_set_matches_issue_2755_contract() -> None:
     mod = _load_script()
 
     assert tuple(condition.name for condition in mod.CONDITIONS) == mod.REQUIRED_CONDITIONS
+    assert mod.CONDITION_SETS[mod.DEFAULT_CONDITION_SET] == mod.CONDITIONS
     delay = next(condition for condition in mod.CONDITIONS if condition.name == "delay_only")
     assert "--observation-delay-steps" in delay.flags
     assert "2" in delay.flags
+
+
+def test_issue_3328_behavior_probe_condition_set_is_opt_in() -> None:
+    """The #3328 probe should not mutate the default seven-condition run."""
+    mod = _load_script()
+
+    probe_conditions = mod.CONDITION_SETS[mod.ISSUE_3328_CONDITION_SET]
+
+    assert tuple(condition.name for condition in probe_conditions) == (
+        "noop",
+        "medium_noise",
+        "delay_only",
+        "high_noise_3328",
+    )
+    high_noise = next(
+        condition for condition in probe_conditions if condition.name == "high_noise_3328"
+    )
+    assert high_noise.flags == (
+        "--observation-noise-std-m",
+        "1.0",
+        "--observation-noise-bound-m",
+        "2.0",
+        "--observation-perturbation-seed",
+        "3328",
+    )
+    assert tuple(condition.name for condition in mod.CONDITIONS) == mod.REQUIRED_CONDITIONS
 
 
 def test_default_strict_mode_fails_closed_without_occluded_fixture(tmp_path: Path) -> None:
@@ -190,6 +217,44 @@ def test_dry_run_plans_all_live_diagnostics_commands(tmp_path: Path) -> None:
     assert (output_dir / "generated_policy_search_funnel.yaml").exists()
 
 
+def test_issue_3328_behavior_probe_dry_run_plans_only_probe_conditions(tmp_path: Path) -> None:
+    """The opt-in #3328 condition set should plan only the probe conditions."""
+    mod = _load_script()
+    matrix = tmp_path / "matrix.yaml"
+    matrix.write_text(
+        "schema_version: robot_sf.scenario_matrix.v1\n"
+        "select_scenarios: [issue_3233_near_field_observation_noise]\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+    args = mod.parse_args(
+        [
+            "--condition-set",
+            mod.ISSUE_3328_CONDITION_SET,
+            "--scenario-matrix",
+            str(matrix),
+            "--output-dir",
+            str(output_dir),
+            "--allow-non-occluded-live-fixture",
+            "--dry-run",
+        ]
+    )
+
+    report = mod.run_live_batch(args)
+
+    assert report["run_config"]["condition_set"] == mod.ISSUE_3328_CONDITION_SET
+    assert [condition["name"] for condition in report["conditions"]] == list(
+        mod.ISSUE_3328_REQUIRED_CONDITIONS
+    )
+    commands = {condition["name"]: condition["command"] for condition in report["conditions"]}
+    assert "--observation-noise-std-m" in commands["high_noise_3328"]
+    assert "1.0" in commands["high_noise_3328"]
+    assert "--observation-noise-bound-m" in commands["high_noise_3328"]
+    assert "2.0" in commands["high_noise_3328"]
+    assert "--observation-perturbation-seed" in commands["high_noise_3328"]
+    assert "3328" in commands["high_noise_3328"]
+
+
 def test_scalar_includes_are_ignored_for_fixture_detection(tmp_path: Path) -> None:
     """Malformed scalar includes should not be iterated character-by-character."""
     mod = _load_script()
@@ -261,12 +326,19 @@ def test_live_condition_timeout_becomes_fail_closed_blocker(
     assert "timed out" in blockers[0]
 
 
-def _write_trace(path: Path, *, command: list[float], observed_count: int, closest: float) -> None:
+def _write_trace(
+    path: Path,
+    *,
+    command: list[float],
+    observed_count: int,
+    closest: float,
+    seed: int = 111,
+) -> None:
     payload = {
         "candidate": "risk_surface_dwa_v0",
         "stage": "issue_2777_live_replay",
         "scenario_id": "issue_2756_occluded_emergence",
-        "seed": 2756,
+        "seed": seed,
         "algo": "risk_surface_dwa",
         "progress_summary": {
             "net_goal_progress": 1.0,
@@ -294,12 +366,15 @@ def _write_trace(path: Path, *, command: list[float], observed_count: int, close
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
-def _write_observed_count_trace(path: Path, counts: list[int]) -> None:
+def _write_observed_count_trace(path: Path, counts: list[int], closest: float = 1.5) -> None:
     """Write a tiny diagnostics trace with configurable observed actor counts."""
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "scenario_id": "issue_2756_occluded_emergence",
         "seed": 111,
+        "progress_summary": {
+            "closest_robot_ped_distance": closest,
+        },
         "steps": [
             {
                 "step": step,
@@ -351,6 +426,52 @@ def test_fixture_boundary_verifier_requires_noop_and_delay_first_observed_steps(
     assert "Delay-only" in blockers[0]
 
 
+def test_issue_3328_behavior_probe_guardrails_require_near_field_fixture(
+    tmp_path: Path,
+) -> None:
+    """The opt-in probe should fail closed if the no-op trace is not near-field."""
+    mod = _load_script()
+    output_dir = tmp_path / "out"
+    contract = {
+        "satisfied": True,
+        "matched_scenario": {
+            "name": "issue_2756_occluded_emergence",
+            "seeds": [111],
+        },
+    }
+    _write_observed_count_trace(
+        output_dir / "traces/noop/trace.json",
+        [0, 0, 0, 0, 0, 1],
+        closest=1.9,
+    )
+    _write_observed_count_trace(
+        output_dir / "traces/delay_only/trace.json",
+        [0, 0, 0, 0, 0, 0, 0, 1],
+        closest=1.9,
+    )
+
+    assert (
+        mod._verify_issue_3328_behavior_probe_guardrails(
+            output_dir=output_dir,
+            fixture_contract=contract,
+        )
+        == []
+    )
+
+    _write_observed_count_trace(
+        output_dir / "traces/noop/trace.json",
+        [0, 0, 0, 0, 0, 1],
+        closest=2.1,
+    )
+    blockers = mod._verify_issue_3328_behavior_probe_guardrails(
+        output_dir=output_dir,
+        fixture_contract=contract,
+    )
+
+    assert blockers
+    assert "closest_robot_ped_distance <= 2.0" in blockers[-1]
+
+
 def test_trace_comparison_names_scenario_seed_planner_and_policy_insensitive(
     tmp_path: Path,
 ) -> None:
@@ -371,6 +492,56 @@ def test_trace_comparison_names_scenario_seed_planner_and_policy_insensitive(
     assert comparison["seed"]["same"] is True
     assert comparison["planner_mode"]["candidate"] == "risk_surface_dwa_v0"
     assert comparison["classification"]["label"] == "policy_insensitive"
+
+
+def test_trace_comparison_reports_behavior_change_dimensions(tmp_path: Path) -> None:
+    """Comparison payload should name command, risk, min-distance, collision, and stop proxies."""
+    mod = _load_script()
+    noop = tmp_path / "noop.json"
+    condition = tmp_path / "condition.json"
+    _write_trace(noop, command=[0.0, 0.0], observed_count=1, closest=1.5)
+    _write_trace(condition, command=[1.0, 0.0], observed_count=0, closest=0.8)
+    noop_payload = json.loads(noop.read_text(encoding="utf-8"))
+    condition_payload = json.loads(condition.read_text(encoding="utf-8"))
+    noop_payload["progress_summary"]["collision_flag_counts"]["pedestrian"] = 0
+    condition_payload["progress_summary"]["collision_flag_counts"]["pedestrian"] = 1
+    noop_payload["steps"][0]["step"] = 3
+    condition_payload["steps"][0]["step"] = 3
+    noop_payload["steps"][0]["meta"] = {"near_misses": 0}
+    condition_payload["steps"][0]["meta"] = {"near_misses": 1}
+    noop.write_text(json.dumps(noop_payload), encoding="utf-8")
+    condition.write_text(json.dumps(condition_payload), encoding="utf-8")
+
+    comparison = mod._compare_condition(
+        noop_trace_path=noop,
+        condition_trace_path=condition,
+        fixture_contract_satisfied=True,
+    )
+
+    behavior = comparison["behavior_change_summary"]
+    assert behavior["command_sequence_changed"] is True
+    assert behavior["changed_command_steps"] == [3]
+    assert comparison["command_summary"]["changed_steps"] == [3]
+    assert behavior["progress_or_risk_changed"] is True
+    assert "collision_flag_counts" in behavior["progress_delta_changed_fields"]
+    assert behavior["min_distance_changed"] is True
+    assert behavior["closest_robot_ped"]["distance"]["condition"] == 0.8
+    assert behavior["collision_or_near_miss_changed"] is True
+    assert behavior["collision_summary"]["changed"] is True
+    assert behavior["near_miss_summary"]["status"] == "available"
+    assert behavior["near_miss_summary"]["changed"] is True
+    assert behavior["stop_yield_timing_proxy"]["status"] == "available"
+    assert behavior["stop_yield_timing_proxy"]["direct_event_available"] is False
+    assert "policy_command linear speed" in behavior["stop_yield_timing_proxy"]["definition"]
+    assert behavior["stop_yield_timing_proxy"]["changed"] is True
+    assert behavior["stop_yield_timing_proxy"]["noop_first_stop_step"] == 3
+    assert behavior["stop_yield_timing_proxy"]["condition_first_stop_step"] is None
+    assert behavior["stop_yield_timing"]["direct_event_available"] is False
+    assert "not available" in behavior["stop_yield_timing"]["limitation"]
+    assert behavior["stop_yield_timing"]["command_stop_proxy"]["changed"] is True
+    assert behavior["stop_yield_timing"]["command_stop_proxy"]["noop_first_stop_step"] == 3
+    assert behavior["stop_yield_timing"]["command_stop_proxy"]["condition_first_stop_step"] is None
+    assert comparison["classification"]["label"] == "behavior_sensitive_diagnostic_only"
 
 
 def test_observation_totals_ignore_missing_noise_profile(tmp_path: Path) -> None:

--- a/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
+++ b/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
@@ -471,6 +471,19 @@ def test_issue_3328_behavior_probe_guardrails_require_near_field_fixture(
     assert blockers
     assert "closest_robot_ped_distance <= 2.0" in blockers[-1]
 
+    _write_observed_count_trace(
+        output_dir / "traces/noop/trace.json",
+        [0, 0, 0, 0, 0, 1],
+        closest=float("nan"),
+    )
+    blockers = mod._verify_issue_3328_behavior_probe_guardrails(
+        output_dir=output_dir,
+        fixture_contract=contract,
+    )
+
+    assert blockers
+    assert "finite no-op closest_robot_ped_distance" in blockers[-1]
+
 
 def test_trace_comparison_names_scenario_seed_planner_and_policy_insensitive(
     tmp_path: Path,
@@ -542,6 +555,41 @@ def test_trace_comparison_reports_behavior_change_dimensions(tmp_path: Path) -> 
     assert behavior["stop_yield_timing"]["command_stop_proxy"]["noop_first_stop_step"] == 3
     assert behavior["stop_yield_timing"]["command_stop_proxy"]["condition_first_stop_step"] is None
     assert comparison["classification"]["label"] == "behavior_sensitive_diagnostic_only"
+
+
+def test_progress_delta_treats_paired_nan_values_as_unchanged() -> None:
+    """Paired NaN summary fields should not create false behavior sensitivity."""
+    mod = _load_script()
+    noop = {"progress_summary": {"net_goal_progress": float("nan")}}
+    condition = {"progress_summary": {"net_goal_progress": float("nan")}}
+
+    delta = mod._progress_delta(noop, condition)
+
+    assert delta["net_goal_progress"]["changed"] is False
+
+
+def test_near_miss_summary_ignores_non_finite_counts() -> None:
+    """Non-finite near-miss metadata should not poison the summed comparison."""
+    mod = _load_script()
+    noop = {
+        "steps": [
+            {"meta": {"near_misses": 1}},
+            {"meta": {"near_misses": float("nan")}},
+        ]
+    }
+    condition = {
+        "steps": [
+            {"meta": {"near_misses": 1}},
+            {"meta": {"near_misses": float("inf")}},
+        ]
+    }
+
+    summary = mod._near_miss_summary(noop, condition)
+
+    assert summary["status"] == "available"
+    assert summary["noop"] == 1
+    assert summary["condition"] == 1
+    assert summary["changed"] is False
 
 
 def test_observation_totals_ignore_missing_noise_profile(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds an opt-in `issue_3328_behavior_probe` condition set to the #2777 live
observation-noise replay wrapper and promotes compact evidence for a one-seed behavior-sensitive
near-field probe. The default seven #2755 perturbation-family run remains unchanged.

## Linked Issues
- Closes `#3328`
- Relates to `#3323`
- Follow-up `#3330`

## Stack / Dependency
- Base dependency: merged `PR #3329`
- Required prior PRs: `#3329`
- Stack follow-up issues: `#3330`
- Safe to review independently: yes
- Review dependency reason, if any: this branch starts from `origin/main` after #3329 and only adds
  an opt-in probe plus evidence derived from the #3323 matrix.

## What Changed
- Added `--condition-set issue_3328_behavior_probe` with `noop`, `medium_noise`, `delay_only`, and
  `high_noise_3328` (`std=1.0`, `bound=2.0`, perturbation seed 3328).
- Extended the live replay summary to report changed command steps, progress/risk deltas, closest
  distance deltas, collision/near-miss status, and a zero-speed stop/yield proxy.
- Added fail-closed guardrails for the opt-in probe: #2756 fixture match, seed 111, no-op first
  observed step 5, delay-only first observed step 7, and no-op closest distance <= 2.0 m.
- Promoted compact evidence under
  `docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3328_behavior_probe/`.

## Why It Matters
- Added value: shows the near-field #2777 replay can produce behavior-sensitive evidence under a
  deliberately high-amplitude observation perturbation.
- Expected impact: converts the prior `policy_insensitive` stress result into a sharper diagnostic
  boundary without changing the default #2755 replay contract.
- Why this is worth merging now: it gives the next research loop a concrete positive mechanism
  probe and a compact evidence surface, while #3330 carries broader seed/profile validation.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: whether near-field #2777 live
  observation perturbations can change selected commands or progress/risk summaries.
- Comparator or baseline, if applicable: no-op replay on
  `configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml`.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: stop this slice once the fixture boundary is preserved and
  a one-seed high-amplitude probe is classified without robustness language.
- Parent issue, claim map, registry, context note, or synthesis surface to update:
  `docs/context/evidence/issue_2777_live_observation_noise_replay/` and `#3328`.
- New research/benchmark/metric/paper-facing analysis tool, if any: the opt-in condition set was
  used on durable tracked input in this PR; follow-up #3330 covers broader validation.

## Domain-Aware Approval
- Required for this PR: yes - it changes evidence classification/reporting for a benchmark-facing
  diagnostic wrapper.
- Domains reviewed: evidence classification and benchmark interpretation.
- Status: approved
- Approver/review source or waiver: parent agent review with GPT-5.5 xhigh simplifier route and fail-closed acceptance checks; no paper-facing claim.
- Validity checklist:
  - Target claim/hypothesis: behavior sensitivity can occur on the near-field #2777 replay.
  - Comparator or split/evidence validity: same scenario, seed, planner, horizon, and #3323 matrix
    against no-op condition.
  - Fallback/degraded exclusions: fallback/degraded execution is not accepted as success evidence;
    the run is native live replay.
  - Claim boundary: one scenario, one seed, high-amplitude diagnostic probe only.
  - Implementation integrity vs experimental validity: tests/PR readiness cover implementation;
    claim remains diagnostic-only pending #3330.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes.
- Did the intervention change command source, selected command, trajectory, or route progress? yes,
  `high_noise_3328` changed selected commands at steps 6 and 9 and changed net/best progress plus
  closest distance.
- Did the scenario actually contain the targeted failure mode? yes, it preserved the #2756
  first-visible/delay boundary and no-op closest distance was 1.6552 m.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #3330 tests whether the
  behavior sensitivity persists beyond one seed and one deliberately high-amplitude perturbation.

## Next Empirical Action
- Rerun needed: yes, in follow-up #3330.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: broader seed/amplitude/calibrated-profile evidence is not yet
  available.
- Stop / revise / continue decision: continue with bounded broader validation.
- Proposed child issue or existing follow-up: #3330.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_issue_2777_observation_noise_live_replay.py tests/validation/test_run_policy_search_step_diagnostics.py -q`
  - `uv run ruff check scripts/benchmark/run_observation_noise_live_replay_issue_2777.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py`
  - `uv run ruff format --check scripts/benchmark/run_observation_noise_live_replay_issue_2777.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py`
  - `uv run robot_sf_bench validate-config --matrix configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml`
  - `uv run python scripts/benchmark/run_observation_noise_live_replay_issue_2777.py --condition-set issue_3328_behavior_probe --scenario-matrix configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml --output-dir docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3328_behavior_probe`
  - compact assertion over
    `docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3328_behavior_probe/summary.json`
  - `git diff --check`
  - `BASE_REF=origin/main uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: compact summary reports `live_replay` /
  `behavior_sensitive_diagnostic_only`, no blockers, no-op first observed step 5, delay-only first
  observed step 7, and `high_noise_3328` changed command steps `[6, 9]`.
- Benchmarks or smoke tests, if applicable: diagnostic live replay only; not benchmark-strength or
  paper-facing evidence.

## Risks / Rollout
- Compatibility risks: default #2755 condition set is unchanged; risk is limited to the opt-in
  condition-set path and richer summary payload.
- Failure modes: future raw traces missing collision/near-miss or direct stop/yield fields are
  reported as unavailable/proxy-only rather than inferred.
- Rollback or fallback plan: use default `issue_2755_default` condition set or revert the opt-in
  condition-set addition.

## Docs / Provenance
- Updated docs:
  - `docs/context/evidence/README.md`
  - `docs/context/evidence/issue_2777_live_observation_noise_replay/README.md`
  - `docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3328_behavior_probe/`
- Relevant design or provenance notes: raw traces and generated funnel were worktree-local and not
  committed; summary records this explicitly.
- Any assumptions that need to be preserved: `std=1.0`/`bound=2.0` is a deliberately
  high-amplitude diagnostic probe, not a calibrated sensor-realism claim.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes #3328.
- Claim map / benchmark report updated (yes/no/NA): NA, diagnostic-only evidence not promoted to a
  stronger claim map.
- Leaderboard / artifact catalog updated (yes/no/NA): NA, no planner-ranking claim.
- Registry or config index updated (yes/no/NA): NA, no new scenario/config registry entry.
- Context index / memory note updated (yes/no/NA): yes, evidence README/index updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, #3330.
- Not applicable because: no robustness, sensor-realism, planner-superiority, paper-facing, or
  leaderboard claim is made.

## Follow-Up Issues
- Deferred work: broader seed/amplitude/calibrated-profile validation.
- Issues opened for follow-up: #3330.

## Reviewer Notes
- Verify that default seven-condition behavior remains unchanged.
- Verify that the `behavior_sensitive_diagnostic_only` label is not interpreted as robustness
  evidence; it is one scenario, one seed, and one high-amplitude perturbation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified live observation-noise replay test classifications and expected outcomes for various condition sets

* **New Features**
  * Added optional high-amplitude noise diagnostic probe for behavior sensitivity analysis
  * Introduced configurable condition set selection for noise replay experiments via new CLI option
  * Enhanced behavior detection to include command sequences, progress metrics, timing, and collision analysis

* **Tests**
  * Added coverage for new diagnostic behavior probe and condition set selection

<!-- end of auto-generated comment: release notes by coderabbit.ai -->