### PR TITLE
Extend observation replay behavior probe grid

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -98,6 +98,12 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/`: diagnostic-only
+  native live replay over the #3323 near-field #2756 fixture with a predeclared 2x3 medium/high
+  bounded-Gaussian perturbation grid. The grid is `medium_amplitude_sensitive`: seed 3328 is
+  behavior-sensitive at medium amplitude, seeds 3328 and 3330 are behavior-sensitive at high
+  amplitude, and seed 2755 remains policy-insensitive. Not robustness, calibrated sensor-realism,
+  planner-superiority, paper-facing benchmark, or scenario-general evidence.
 - `issue_3294_release_claim_matrix/`: reviewable v0.1 release claim matrix assembled from
   existing release artifacts, leaderboard row-claim sidecars, release config metadata, and ODD
   coverage rows. It classifies rows as benchmark evidence, diagnostic evidence, or non-claim

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/README.md
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/README.md
@@ -49,3 +49,15 @@ high-amplitude noise condition (`std=1.0`, `bound=2.0`, seed 3328). The probe is
 progress/min-distance summaries on one seed, while medium noise and delay-only remain
 policy-insensitive. It is diagnostic stress evidence only, not a robustness, sensor-realism, or
 planner-superiority claim.
+
+## Issue #3330 Seed/Amplitude Grid
+
+`issue_3330_seed_amplitude_grid/` preserves the same #3323 near-field route and #2756 fixture
+boundary, then predeclares a 2x3 bounded-Gaussian perturbation grid over medium/high amplitudes and
+perturbation seeds 2755, 3328, and 3330. The compact grid result is
+`behavior_sensitive_diagnostic_only` with grid label `medium_amplitude_sensitive`: `medium_noise_3328`,
+`high_noise_3328`, and `high_noise_3330` changed selected commands plus progress/min-distance
+summaries, while `medium_noise_2755`, `medium_noise_3330`, and `high_noise_2755` stayed
+policy-insensitive. This is fixture-local diagnostic stress evidence only; it does not support
+robustness, calibrated sensor-realism, planner-superiority, paper-facing benchmark, or
+scenario-general claims.

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/README.md
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/README.md
@@ -1,0 +1,45 @@
+# Issue #2777 Live Observation-Noise Replay
+
+## Status
+
+- Status: `live_replay`
+- Classification: `behavior_sensitive_diagnostic_only`
+- Rationale: All selected live replays completed. One scenario fixture seed is diagnostic only and does not support a robustness, sensor-realism, or planner-superiority claim.
+
+## Claim Boundary
+
+Stress-slice live planner/environment replay for one scenario fixture seed and the selected perturbation condition set. Treat behavior-sensitive differences as diagnostic-only from this fixture; do not infer robustness, sensor realism, planner superiority, or scenario-general behavior.
+
+## Fixture Contract
+
+- `required_scenario`: `issue_2756_occluded_emergence`
+- `required_family`: `occluded_emergence/deterministic_occluded_emergence`
+- `first_visible_step`: `5`
+- `delay_steps`: `2`
+- `delay_only_expected_first_observed_step`: `7`
+- `scenario_matrix`: `configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml`
+- `satisfied`: `True`
+- `blocker`: `None`
+
+## Grid Interpretation
+
+- Evidence status: `diagnostic-only`
+- Label: `medium_amplitude_sensitive`
+- Summary: Diagnostic-only grid classification: medium-amplitude-sensitive because at least one std=0.30 m, bound=0.60 m condition changed live behavior.
+- Sensitive conditions: `medium_noise_3328, high_noise_3328, high_noise_3330`
+- Medium-amplitude sensitive conditions: `medium_noise_3328`
+- High-noise sensitive conditions: `high_noise_3328, high_noise_3330`
+- Limitation: One scenario and one fixture seed only; this is diagnostic behavior-probe evidence, not a robustness, sensor-realism, or planner-superiority claim.
+
+## Conditions
+
+| Condition | Status | Classification | Command changed | Progress/risk changed | Min distance changed | Collision/near-miss changed | Stop/yield proxy changed | Caveat |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| `noop` | `live_replay` | `baseline` | `n/a` | `n/a` | `n/a` | `n/a` | `n/a` |  |
+| `delay_only` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `medium_noise_2755` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `medium_noise_3328` | `live_replay` | `behavior_sensitive_diagnostic_only` | `True` | `True` | `True` | `False` | `False` | Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but one seed is not enough for a benchmark-strength robustness claim. |
+| `medium_noise_3330` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `high_noise_2755` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `high_noise_3328` | `live_replay` | `behavior_sensitive_diagnostic_only` | `True` | `True` | `True` | `False` | `False` | Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but one seed is not enough for a benchmark-strength robustness claim. |
+| `high_noise_3330` | `live_replay` | `behavior_sensitive_diagnostic_only` | `True` | `True` | `True` | `False` | `False` | Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but one seed is not enough for a benchmark-strength robustness claim. |

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json
@@ -1,0 +1,1428 @@
+{
+  "schema_version": "issue_2777_observation_noise_live_replay.v1",
+  "artifact_shape": "compact_summary_without_raw_traces",
+  "issue": 2777,
+  "status": "live_replay",
+  "classification": {
+    "label": "behavior_sensitive_diagnostic_only",
+    "rationale": "All selected live replays completed. One scenario fixture seed is diagnostic only and does not support a robustness, sensor-realism, or planner-superiority claim."
+  },
+  "claim_boundary": "Stress-slice live planner/environment replay for one scenario fixture seed and the selected perturbation condition set. Treat behavior-sensitive differences as diagnostic-only from this fixture; do not infer robustness, sensor realism, planner superiority, or scenario-general behavior.",
+  "inputs": {
+    "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+    "raw_trace_json": "worktree-local generated traces summarized here; raw trace.json files are intentionally not committed",
+    "generated_funnel": "worktree-local generated_policy_search_funnel.yaml was intentionally not committed"
+  },
+  "fixture_contract": {
+    "required_source_issue": 2756,
+    "required_scenario": "issue_2756_occluded_emergence",
+    "required_family": "occluded_emergence/deterministic_occluded_emergence",
+    "required_seed": 111,
+    "first_visible_step": 5,
+    "delay_steps": 2,
+    "delay_only_expected_first_observed_step": 7,
+    "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+    "satisfied": true,
+    "blocker": null,
+    "matched_scenario": {
+      "name": "issue_2756_occluded_emergence",
+      "source_issue": 2756,
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "seeds": [
+        111
+      ],
+      "first_visible_step": 5,
+      "delay_steps": 2,
+      "delay_only_expected_first_observed_step": 7
+    }
+  },
+  "fixture_observation_boundary": {
+    "noop_first_observed_step": 5,
+    "delay_only_first_observed_step": 7,
+    "expected_noop_first_observed_step": 5,
+    "expected_delay_only_first_observed_step": 7
+  },
+  "run_config": {
+    "candidate": "risk_surface_dwa_v0",
+    "stage": "smoke",
+    "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+    "scenario_name": null,
+    "scenario_index": 0,
+    "seed": null,
+    "seed_index": 0,
+    "horizon": 50,
+    "output_dir": "docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid",
+    "condition_set": "issue_3330_seed_amplitude_grid",
+    "condition_names": [
+      "noop",
+      "delay_only",
+      "medium_noise_2755",
+      "medium_noise_3328",
+      "medium_noise_3330",
+      "high_noise_2755",
+      "high_noise_3328",
+      "high_noise_3330"
+    ],
+    "allow_non_occluded_live_fixture": false,
+    "dry_run": false
+  },
+  "conditions": [
+    {
+      "name": "noop",
+      "description": "Unperturbed live planner/environment replay.",
+      "status": "live_replay"
+    },
+    {
+      "name": "delay_only",
+      "description": "Two-step delayed pedestrian observation, preserving the #2755 expected lag.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "delayed_observation"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 7
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "medium_noise_2755",
+      "description": "Issue #3330 medium-noise seed/amplitude grid condition, std=0.30 m, bound=0.60 m, seed=2755.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "medium_noise_3328",
+      "description": "Issue #3330 medium-noise seed/amplitude grid condition, std=0.30 m, bound=0.60 m, seed=3328.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": true,
+        "changed_steps": [
+          8
+        ],
+        "changed_step_count": 1,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017799448099487414,
+          "changed": true
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017799448099487414,
+          "changed": true
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.6624126661115424,
+          "changed": true
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": true,
+        "changed_command_steps": [
+          8
+        ],
+        "changed_command_step_count": 1,
+        "progress_or_risk_changed": true,
+        "progress_delta_changed_fields": [
+          "net_goal_progress",
+          "best_goal_progress",
+          "closest_robot_ped_distance"
+        ],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.6624126661115424,
+            "changed": true
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "behavior_sensitive_diagnostic_only",
+        "rationale": "Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but one seed is not enough for a benchmark-strength robustness claim."
+      }
+    },
+    {
+      "name": "medium_noise_3330",
+      "description": "Issue #3330 medium-noise seed/amplitude grid condition, std=0.30 m, bound=0.60 m, seed=3330.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "high_noise_2755",
+      "description": "Issue #3330 high-noise seed/amplitude grid condition, std=1.00 m, bound=2.00 m, seed=2755.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "high_noise_3328",
+      "description": "Issue #3330 high-noise seed/amplitude grid condition, std=1.00 m, bound=2.00 m, seed=3328.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": true,
+        "changed_steps": [
+          6,
+          9
+        ],
+        "changed_step_count": 2,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.6632785410644526,
+          "changed": true
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": true,
+        "changed_command_steps": [
+          6,
+          9
+        ],
+        "changed_command_step_count": 2,
+        "progress_or_risk_changed": true,
+        "progress_delta_changed_fields": [
+          "net_goal_progress",
+          "best_goal_progress",
+          "closest_robot_ped_distance"
+        ],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.6632785410644526,
+            "changed": true
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "behavior_sensitive_diagnostic_only",
+        "rationale": "Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but one seed is not enough for a benchmark-strength robustness claim."
+      }
+    },
+    {
+      "name": "high_noise_3330",
+      "description": "Issue #3330 high-noise seed/amplitude grid condition, std=1.00 m, bound=2.00 m, seed=3330.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": true,
+        "changed_steps": [
+          5,
+          8
+        ],
+        "changed_step_count": 2,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.6634374789381774,
+          "changed": true
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": true,
+        "changed_command_steps": [
+          5,
+          8
+        ],
+        "changed_command_step_count": 2,
+        "progress_or_risk_changed": true,
+        "progress_delta_changed_fields": [
+          "net_goal_progress",
+          "best_goal_progress",
+          "closest_robot_ped_distance"
+        ],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.6634374789381774,
+            "changed": true
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "behavior_sensitive_diagnostic_only",
+        "rationale": "Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but one seed is not enough for a benchmark-strength robustness claim."
+      }
+    }
+  ],
+  "blockers": [],
+  "grid_interpretation": {
+    "label": "medium_amplitude_sensitive",
+    "evidence_status": "diagnostic-only",
+    "summary": "Diagnostic-only grid classification: medium-amplitude-sensitive because at least one std=0.30 m, bound=0.60 m condition changed live behavior.",
+    "sensitive_conditions": [
+      "medium_noise_3328",
+      "high_noise_3328",
+      "high_noise_3330"
+    ],
+    "medium_sensitive_conditions": [
+      "medium_noise_3328"
+    ],
+    "high_sensitive_conditions": [
+      "high_noise_3328",
+      "high_noise_3330"
+    ],
+    "unavailable_conditions": [],
+    "limitation": "One scenario and one fixture seed only; this is diagnostic behavior-probe evidence, not a robustness, sensor-realism, or planner-superiority claim.",
+    "reasons": []
+  }
+}

--- a/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
+++ b/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
@@ -41,11 +41,28 @@ REQUIRED_CONDITIONS = (
 )
 DEFAULT_CONDITION_SET = "issue_2755_default"
 ISSUE_3328_CONDITION_SET = "issue_3328_behavior_probe"
+ISSUE_3330_CONDITION_SET = "issue_3330_seed_amplitude_grid"
 ISSUE_3328_REQUIRED_CONDITIONS = (
     "noop",
     "medium_noise",
     "delay_only",
     "high_noise_3328",
+)
+ISSUE_3330_MEDIUM_CONDITIONS = (
+    "medium_noise_2755",
+    "medium_noise_3328",
+    "medium_noise_3330",
+)
+ISSUE_3330_HIGH_CONDITIONS = (
+    "high_noise_2755",
+    "high_noise_3328",
+    "high_noise_3330",
+)
+ISSUE_3330_REQUIRED_CONDITIONS = (
+    "noop",
+    "delay_only",
+    *ISSUE_3330_MEDIUM_CONDITIONS,
+    *ISSUE_3330_HIGH_CONDITIONS,
 )
 PROGRESS_FIELDS = (
     "net_goal_progress",
@@ -138,6 +155,38 @@ HIGH_NOISE_3328_CONDITION = Condition(
         "3328",
     ),
 )
+
+
+def _noise_condition(name: str, *, std_m: str, bound_m: str, seed: int) -> Condition:
+    """Return a bounded-Gaussian condition with explicit seed/amplitude metadata."""
+    amplitude = "medium" if std_m == "0.30" else "high"
+    return Condition(
+        name,
+        (
+            f"Issue #3330 {amplitude}-noise seed/amplitude grid condition, "
+            f"std={std_m} m, bound={bound_m} m, seed={seed}."
+        ),
+        (
+            "--observation-noise-std-m",
+            std_m,
+            "--observation-noise-bound-m",
+            bound_m,
+            "--observation-perturbation-seed",
+            str(seed),
+        ),
+    )
+
+
+ISSUE_3330_GRID_CONDITIONS = (
+    _CONDITION_BY_NAME["noop"],
+    _CONDITION_BY_NAME["delay_only"],
+    _noise_condition("medium_noise_2755", std_m="0.30", bound_m="0.60", seed=2755),
+    _noise_condition("medium_noise_3328", std_m="0.30", bound_m="0.60", seed=3328),
+    _noise_condition("medium_noise_3330", std_m="0.30", bound_m="0.60", seed=3330),
+    _noise_condition("high_noise_2755", std_m="1.00", bound_m="2.00", seed=2755),
+    _noise_condition("high_noise_3328", std_m="1.00", bound_m="2.00", seed=3328),
+    _noise_condition("high_noise_3330", std_m="1.00", bound_m="2.00", seed=3330),
+)
 CONDITION_SETS = {
     DEFAULT_CONDITION_SET: CONDITIONS,
     ISSUE_3328_CONDITION_SET: (
@@ -146,6 +195,7 @@ CONDITION_SETS = {
         _CONDITION_BY_NAME["delay_only"],
         HIGH_NOISE_3328_CONDITION,
     ),
+    ISSUE_3330_CONDITION_SET: ISSUE_3330_GRID_CONDITIONS,
 }
 
 
@@ -791,7 +841,7 @@ def _fail_closed_report(
     blocker: str,
 ) -> dict[str, Any]:
     """Return a fail-closed report without running live diagnostics."""
-    return {
+    report = {
         "schema_version": SCHEMA_VERSION,
         "issue": 2777,
         "status": "fail_closed",
@@ -817,6 +867,12 @@ def _fail_closed_report(
         ],
         "blockers": [blocker],
     }
+    if args.condition_set == ISSUE_3330_CONDITION_SET:
+        report["grid_interpretation"] = _issue_3330_grid_interpretation(
+            conditions=report["conditions"],
+            blockers=report["blockers"],
+        )
+    return report
 
 
 def _run_config(*, args: argparse.Namespace, output_dir: Path) -> dict[str, Any]:
@@ -880,6 +936,25 @@ def _markdown(report: dict[str, Any]) -> str:
         "blocker",
     ):
         lines.append(f"- `{key}`: `{contract.get(key)}`")
+    if report.get("grid_interpretation"):
+        interpretation = _mapping(report.get("grid_interpretation"))
+        lines.extend(
+            [
+                "",
+                "## Grid Interpretation",
+                "",
+                f"- Evidence status: `{interpretation.get('evidence_status')}`",
+                f"- Label: `{interpretation.get('label')}`",
+                f"- Summary: {interpretation.get('summary')}",
+                "- Sensitive conditions: "
+                f"`{', '.join(interpretation.get('sensitive_conditions') or []) or 'none'}`",
+                "- Medium-amplitude sensitive conditions: "
+                f"`{', '.join(interpretation.get('medium_sensitive_conditions') or []) or 'none'}`",
+                "- High-noise sensitive conditions: "
+                f"`{', '.join(interpretation.get('high_sensitive_conditions') or []) or 'none'}`",
+                f"- Limitation: {interpretation.get('limitation')}",
+            ]
+        )
     lines.extend(
         [
             "",
@@ -1050,31 +1125,35 @@ def _attach_condition_comparisons(
     return blockers
 
 
-def _verify_issue_3328_contract_guardrails(
+def _verify_near_field_probe_contract_guardrails(
     *,
     fixture_contract: Mapping[str, Any],
+    issue_label: str,
 ) -> list[str]:
-    """Verify the static fixture-contract side of the #3328 probe."""
+    """Verify the static fixture-contract side of an opt-in near-field probe."""
     blockers: list[str] = []
     if not fixture_contract.get("satisfied"):
-        blockers.append("Issue #3328 behavior probe requires fixture_contract.satisfied=true.")
+        blockers.append(f"{issue_label} requires fixture_contract.satisfied=true.")
 
     matched = _mapping(fixture_contract.get("matched_scenario"))
     if matched.get("name") != ISSUE_2756_FIXTURE_SCENARIO:
         blockers.append(
-            "Issue #3328 behavior probe requires scenario "
+            f"{issue_label} requires scenario "
             f"{ISSUE_2756_FIXTURE_SCENARIO!r}; got {matched.get('name')!r}."
         )
     if ISSUE_2756_FIXTURE_SEED not in _int_list(matched.get("seeds")):
         blockers.append(
-            f"Issue #3328 behavior probe requires seed {ISSUE_2756_FIXTURE_SEED} "
-            f"in matrix seeds; got {matched.get('seeds')!r}."
+            f"{issue_label} requires seed {ISSUE_2756_FIXTURE_SEED} in matrix seeds; "
+            f"got {matched.get('seeds')!r}."
         )
     return blockers
 
 
-def _verify_issue_3328_trace_identity(label: str, trace: Mapping[str, Any]) -> list[str]:
-    """Verify one #3328 probe trace still names the intended scenario and seed."""
+def _verify_near_field_probe_trace_identity(
+    label: str,
+    trace: Mapping[str, Any],
+) -> list[str]:
+    """Verify one opt-in probe trace still names the intended scenario and seed."""
     blockers: list[str] = []
     if trace.get("scenario_id") != ISSUE_2756_FIXTURE_SCENARIO:
         blockers.append(
@@ -1088,20 +1167,56 @@ def _verify_issue_3328_trace_identity(label: str, trace: Mapping[str, Any]) -> l
     return blockers
 
 
-def _verify_issue_3328_near_field_trace(noop_trace: Mapping[str, Any]) -> list[str]:
-    """Verify the #3328 probe no-op trace has near-field interaction geometry."""
+def _verify_near_field_probe_trace(
+    noop_trace: Mapping[str, Any],
+    *,
+    issue_label: str,
+) -> list[str]:
+    """Verify an opt-in probe no-op trace has near-field interaction geometry."""
     closest = _mapping(noop_trace.get("progress_summary")).get("closest_robot_ped_distance")
     finite_closest = _finite_number(closest)
     if finite_closest is None:
-        return [
-            "Issue #3328 behavior probe requires a finite no-op closest_robot_ped_distance value."
-        ]
+        return [f"{issue_label} requires a finite no-op closest_robot_ped_distance value."]
     if finite_closest > 2.0:
         return [
-            "Issue #3328 behavior probe requires no-op closest_robot_ped_distance <= 2.0 m; "
-            f"observed {closest}."
+            f"{issue_label} requires no-op closest_robot_ped_distance <= 2.0 m; observed {closest}."
         ]
     return []
+
+
+def _verify_near_field_behavior_probe_guardrails(
+    *,
+    output_dir: Path,
+    fixture_contract: Mapping[str, Any],
+    issue_label: str,
+) -> list[str]:
+    """Fail closed unless an opt-in probe remains a near-field #2756 replay."""
+    blockers = _verify_near_field_probe_contract_guardrails(
+        fixture_contract=fixture_contract,
+        issue_label=issue_label,
+    )
+    try:
+        noop_trace = _load_trace(output_dir / "traces" / "noop" / "trace.json")
+        delay_trace = _load_trace(output_dir / "traces" / "delay_only" / "trace.json")
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        return blockers + [f"Could not verify {issue_label} guardrails: {exc}"]
+
+    for label, trace in (("noop", noop_trace), ("delay_only", delay_trace)):
+        blockers.extend(_verify_near_field_probe_trace_identity(label, trace))
+
+    noop_first_observed = _first_observed_step(noop_trace)
+    delay_first_observed = _first_observed_step(delay_trace)
+    if noop_first_observed != 5:
+        blockers.append(
+            f"{issue_label} requires no-op first observed step 5; observed {noop_first_observed}."
+        )
+    if delay_first_observed != 7:
+        blockers.append(
+            f"{issue_label} requires delay-only first observed step 7; observed "
+            f"{delay_first_observed}."
+        )
+    blockers.extend(_verify_near_field_probe_trace(noop_trace, issue_label=issue_label))
+    return blockers
 
 
 def _verify_issue_3328_behavior_probe_guardrails(
@@ -1110,30 +1225,24 @@ def _verify_issue_3328_behavior_probe_guardrails(
     fixture_contract: Mapping[str, Any],
 ) -> list[str]:
     """Fail closed unless the opt-in #3328 probe remains a near-field #2756 replay."""
-    blockers = _verify_issue_3328_contract_guardrails(fixture_contract=fixture_contract)
-    try:
-        noop_trace = _load_trace(output_dir / "traces" / "noop" / "trace.json")
-        delay_trace = _load_trace(output_dir / "traces" / "delay_only" / "trace.json")
-    except (OSError, ValueError, json.JSONDecodeError) as exc:
-        return blockers + [f"Could not verify issue #3328 behavior probe guardrails: {exc}"]
+    return _verify_near_field_behavior_probe_guardrails(
+        output_dir=output_dir,
+        fixture_contract=fixture_contract,
+        issue_label="Issue #3328 behavior probe",
+    )
 
-    for label, trace in (("noop", noop_trace), ("delay_only", delay_trace)):
-        blockers.extend(_verify_issue_3328_trace_identity(label, trace))
 
-    noop_first_observed = _first_observed_step(noop_trace)
-    delay_first_observed = _first_observed_step(delay_trace)
-    if noop_first_observed != 5:
-        blockers.append(
-            "Issue #3328 behavior probe requires no-op first observed step 5; "
-            f"observed {noop_first_observed}."
-        )
-    if delay_first_observed != 7:
-        blockers.append(
-            "Issue #3328 behavior probe requires delay-only first observed step 7; "
-            f"observed {delay_first_observed}."
-        )
-    blockers.extend(_verify_issue_3328_near_field_trace(noop_trace))
-    return blockers
+def _verify_issue_3330_seed_amplitude_grid_guardrails(
+    *,
+    output_dir: Path,
+    fixture_contract: Mapping[str, Any],
+) -> list[str]:
+    """Fail closed unless the opt-in #3330 grid remains a near-field #2756 replay."""
+    return _verify_near_field_behavior_probe_guardrails(
+        output_dir=output_dir,
+        fixture_contract=fixture_contract,
+        issue_label="Issue #3330 seed/amplitude grid",
+    )
 
 
 def _verify_fixture_observation_boundary(
@@ -1197,6 +1306,98 @@ def _compact_live_conditions(conditions: list[dict[str, Any]]) -> list[dict[str,
     return compact_conditions
 
 
+def _condition_classification_label(condition: Mapping[str, Any]) -> str:
+    """Return the compact classification label for a condition row."""
+    return str(_mapping(condition.get("classification")).get("label") or "")
+
+
+def _issue_3330_grid_interpretation(
+    *,
+    conditions: list[dict[str, Any]],
+    blockers: list[str],
+) -> dict[str, Any]:
+    """Classify the #3330 seed/amplitude grid without promoting benchmark claims."""
+    by_name = {str(condition.get("name")): condition for condition in conditions}
+    missing = [name for name in ISSUE_3330_REQUIRED_CONDITIONS if name not in by_name]
+    unavailable = bool(blockers or missing) or any(
+        by_name[name].get("status") != "live_replay"
+        for name in ISSUE_3330_REQUIRED_CONDITIONS
+        if name in by_name
+    )
+    if unavailable:
+        reasons = list(blockers)
+        if missing:
+            reasons.append(f"Missing #3330 condition rows: {', '.join(missing)}.")
+        return {
+            "label": "unavailable_fail_closed",
+            "evidence_status": "diagnostic-only",
+            "summary": (
+                "Grid interpretation is unavailable/fail-closed because at least one "
+                "required live replay condition did not complete under the fixture guardrails."
+            ),
+            "sensitive_conditions": [],
+            "medium_sensitive_conditions": [],
+            "high_sensitive_conditions": [],
+            "unavailable_conditions": [
+                name
+                for name in ISSUE_3330_REQUIRED_CONDITIONS
+                if name not in by_name or by_name[name].get("status") != "live_replay"
+            ],
+            "limitation": "Diagnostic-only; no robustness claim is available.",
+            "reasons": reasons,
+        }
+
+    medium_sensitive = [
+        name
+        for name in ISSUE_3330_MEDIUM_CONDITIONS
+        if _condition_classification_label(by_name[name]) == "behavior_sensitive_diagnostic_only"
+    ]
+    high_sensitive = [
+        name
+        for name in ISSUE_3330_HIGH_CONDITIONS
+        if _condition_classification_label(by_name[name]) == "behavior_sensitive_diagnostic_only"
+    ]
+    sensitive_conditions = [*medium_sensitive, *high_sensitive]
+    if medium_sensitive:
+        label = "medium_amplitude_sensitive"
+        summary = (
+            "Diagnostic-only grid classification: medium-amplitude-sensitive because at "
+            "least one std=0.30 m, bound=0.60 m condition changed live behavior."
+        )
+    elif len(high_sensitive) == len(ISSUE_3330_HIGH_CONDITIONS):
+        label = "high_noise_persistent"
+        summary = (
+            "Diagnostic-only grid classification: high-noise persistent because all "
+            "std=1.00 m, bound=2.00 m seed conditions changed live behavior."
+        )
+    elif high_sensitive:
+        label = "mixed_seed_specific"
+        summary = (
+            "Diagnostic-only grid classification: mixed/seed-specific because behavior "
+            "changed for only a subset of high-noise seeds."
+        )
+    else:
+        label = "not_reproduced"
+        summary = (
+            "Diagnostic-only grid classification: not reproduced because the completed "
+            "seed/amplitude grid did not expose behavior-sensitive condition rows."
+        )
+    return {
+        "label": label,
+        "evidence_status": "diagnostic-only",
+        "summary": summary,
+        "sensitive_conditions": sensitive_conditions,
+        "medium_sensitive_conditions": medium_sensitive,
+        "high_sensitive_conditions": high_sensitive,
+        "unavailable_conditions": [],
+        "limitation": (
+            "One scenario and one fixture seed only; this is diagnostic behavior-probe "
+            "evidence, not a robustness, sensor-realism, or planner-superiority claim."
+        ),
+        "reasons": [],
+    }
+
+
 def _final_classification(
     *,
     blockers: list[str],
@@ -1237,8 +1438,9 @@ def _final_classification(
         {
             "label": label,
             "rationale": (
-                "All selected live replays completed. One seed is diagnostic only and "
-                "does not support a robustness, sensor-realism, or planner-superiority claim."
+                "All selected live replays completed. One scenario fixture seed is diagnostic "
+                "only and does not support a robustness, sensor-realism, or "
+                "planner-superiority claim."
             ),
         },
     )
@@ -1298,23 +1500,31 @@ def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
                 fixture_contract=fixture_contract,
             )
         )
+    if args.condition_set == ISSUE_3330_CONDITION_SET:
+        blockers.extend(
+            _verify_issue_3330_seed_amplitude_grid_guardrails(
+                output_dir=output_dir,
+                fixture_contract=fixture_contract,
+            )
+        )
     status, classification = _final_classification(
         blockers=blockers,
         fixture_contract_satisfied=bool(fixture_contract["satisfied"]),
         conditions=conditions,
     )
 
-    return {
+    compact_conditions = _compact_live_conditions(conditions)
+    report = {
         "schema_version": SCHEMA_VERSION,
         "artifact_shape": "compact_summary_without_raw_traces",
         "issue": 2777,
         "status": status,
         "classification": classification,
         "claim_boundary": (
-            "Stress-slice live planner/environment replay for one scenario, one seed, "
+            "Stress-slice live planner/environment replay for one scenario fixture seed "
             "and the selected perturbation condition set. Treat behavior-sensitive "
-            "differences as diagnostic-only from one seed; do not infer robustness, "
-            "sensor realism, or planner superiority."
+            "differences as diagnostic-only from this fixture; do not infer robustness, "
+            "sensor realism, planner superiority, or scenario-general behavior."
         ),
         "inputs": {
             "scenario_matrix": _durable_ref(scenario_matrix),
@@ -1329,9 +1539,15 @@ def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
         "fixture_contract": fixture_contract,
         "fixture_observation_boundary": _fixture_observation_boundary_summary(output_dir),
         "run_config": _run_config(args=args, output_dir=output_dir),
-        "conditions": _compact_live_conditions(conditions),
+        "conditions": compact_conditions,
         "blockers": blockers,
     }
+    if args.condition_set == ISSUE_3330_CONDITION_SET:
+        report["grid_interpretation"] = _issue_3330_grid_interpretation(
+            conditions=compact_conditions,
+            blockers=blockers,
+        )
+    return report
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -1357,7 +1573,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_CONDITION_SET,
         help=(
             "Perturbation condition set to run. The default preserves the seven #2755 "
-            "families; issue_3328_behavior_probe is an opt-in four-condition probe."
+            "families; issue_3328_behavior_probe and issue_3330_seed_amplitude_grid "
+            "are opt-in behavior probes."
         ),
     )
     parser.add_argument("--timeout-seconds", type=float, default=120.0)
@@ -1381,6 +1598,11 @@ def main(argv: list[str] | None = None) -> int:
         != ISSUE_3328_REQUIRED_CONDITIONS
     ):
         raise RuntimeError("Issue #3328 behavior probe condition set drifted")
+    if (
+        tuple(condition.name for condition in CONDITION_SETS[ISSUE_3330_CONDITION_SET])
+        != ISSUE_3330_REQUIRED_CONDITIONS
+    ):
+        raise RuntimeError("Issue #3330 seed/amplitude grid condition set drifted")
     report = run_live_batch(args)
     _write_outputs(report, args.output_dir)
     print(

--- a/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
+++ b/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
@@ -1199,7 +1199,7 @@ def _verify_near_field_behavior_probe_guardrails(
         noop_trace = _load_trace(output_dir / "traces" / "noop" / "trace.json")
         delay_trace = _load_trace(output_dir / "traces" / "delay_only" / "trace.json")
     except (OSError, ValueError, json.JSONDecodeError) as exc:
-        return blockers + [f"Could not verify {issue_label} guardrails: {exc}"]
+        return [*blockers, f"Could not verify {issue_label} guardrails: {exc}"]
 
     for label, trace in (("noop", noop_trace), ("delay_only", delay_trace)):
         blockers.extend(_verify_near_field_probe_trace_identity(label, trace))

--- a/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
+++ b/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
@@ -712,8 +712,8 @@ def test_issue_3330_seed_amplitude_grid_reuses_near_field_fixture_guardrails(
     )
 
     assert blockers
-    assert "Issue #3330 seed/amplitude grid" in blockers[-1]
-    assert "closest_robot_ped_distance <= 2.0" in blockers[-1]
+    assert any("Issue #3330 seed/amplitude grid" in blocker for blocker in blockers)
+    assert any("closest_robot_ped_distance <= 2.0" in blocker for blocker in blockers)
 
 
 def _grid_condition_row(

--- a/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
+++ b/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
@@ -69,6 +69,48 @@ def test_issue_3328_behavior_probe_condition_set_is_opt_in() -> None:
     assert tuple(condition.name for condition in mod.CONDITIONS) == mod.REQUIRED_CONDITIONS
 
 
+def test_issue_3330_seed_amplitude_grid_condition_set_is_opt_in_and_ordered() -> None:
+    """The #3330 grid should preserve defaults while varying seed and amplitude."""
+    mod = _load_script()
+
+    grid_conditions = mod.CONDITION_SETS[mod.ISSUE_3330_CONDITION_SET]
+
+    assert tuple(condition.name for condition in grid_conditions) == (
+        "noop",
+        "delay_only",
+        "medium_noise_2755",
+        "medium_noise_3328",
+        "medium_noise_3330",
+        "high_noise_2755",
+        "high_noise_3328",
+        "high_noise_3330",
+    )
+    expected_flags = {
+        "medium_noise_2755": ("0.30", "0.60", "2755"),
+        "medium_noise_3328": ("0.30", "0.60", "3328"),
+        "medium_noise_3330": ("0.30", "0.60", "3330"),
+        "high_noise_2755": ("1.00", "2.00", "2755"),
+        "high_noise_3328": ("1.00", "2.00", "3328"),
+        "high_noise_3330": ("1.00", "2.00", "3330"),
+    }
+    for condition in grid_conditions:
+        if condition.name in expected_flags:
+            std, bound, seed = expected_flags[condition.name]
+            assert condition.flags == (
+                "--observation-noise-std-m",
+                std,
+                "--observation-noise-bound-m",
+                bound,
+                "--observation-perturbation-seed",
+                seed,
+            )
+    assert tuple(condition.name for condition in mod.CONDITIONS) == mod.REQUIRED_CONDITIONS
+    assert (
+        tuple(condition.name for condition in mod.CONDITION_SETS[mod.ISSUE_3328_CONDITION_SET])
+        == mod.ISSUE_3328_REQUIRED_CONDITIONS
+    )
+
+
 def test_default_strict_mode_fails_closed_without_occluded_fixture(tmp_path: Path) -> None:
     """A non-occluded matrix should not be promoted as #2777 live replay evidence."""
     mod = _load_script()
@@ -255,6 +297,46 @@ def test_issue_3328_behavior_probe_dry_run_plans_only_probe_conditions(tmp_path:
     assert "3328" in commands["high_noise_3328"]
 
 
+def test_issue_3330_seed_amplitude_grid_dry_run_plans_grid_conditions(
+    tmp_path: Path,
+) -> None:
+    """The opt-in #3330 grid should plan only the seed/amplitude grid."""
+    mod = _load_script()
+    matrix = tmp_path / "matrix.yaml"
+    matrix.write_text(
+        "schema_version: robot_sf.scenario_matrix.v1\n"
+        "select_scenarios: [issue_3233_near_field_observation_noise]\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+    args = mod.parse_args(
+        [
+            "--condition-set",
+            mod.ISSUE_3330_CONDITION_SET,
+            "--scenario-matrix",
+            str(matrix),
+            "--output-dir",
+            str(output_dir),
+            "--allow-non-occluded-live-fixture",
+            "--dry-run",
+        ]
+    )
+
+    report = mod.run_live_batch(args)
+
+    assert report["run_config"]["condition_set"] == mod.ISSUE_3330_CONDITION_SET
+    assert [condition["name"] for condition in report["conditions"]] == list(
+        mod.ISSUE_3330_REQUIRED_CONDITIONS
+    )
+    assert "grid_interpretation" not in report
+    commands = {condition["name"]: condition["command"] for condition in report["conditions"]}
+    assert "2755" in commands["medium_noise_2755"]
+    assert "3328" in commands["medium_noise_3328"]
+    assert "3330" in commands["medium_noise_3330"]
+    assert "1.00" in commands["high_noise_3330"]
+    assert "2.00" in commands["high_noise_3330"]
+
+
 def test_scalar_includes_are_ignored_for_fixture_detection(tmp_path: Path) -> None:
     """Malformed scalar includes should not be iterated character-by-character."""
     mod = _load_script()
@@ -388,6 +470,49 @@ def _write_observed_count_trace(path: Path, counts: list[int], closest: float = 
     path.write_text(json.dumps(payload), encoding="utf-8")
 
 
+def _write_grid_trace(
+    path: Path,
+    *,
+    command: list[float],
+    first_observed_step: int,
+    closest: float = 1.5,
+) -> None:
+    """Write a compact multi-step trace for #3330 live-report tests."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "candidate": "risk_surface_dwa_v0",
+        "stage": "issue_2777_live_replay",
+        "scenario_id": "issue_2756_occluded_emergence",
+        "seed": 111,
+        "algo": "risk_surface_dwa",
+        "progress_summary": {
+            "net_goal_progress": 1.0,
+            "best_goal_progress": 1.2,
+            "closest_robot_ped_distance": closest,
+            "closest_robot_ped_step": 3,
+            "collision_flag_counts": {"pedestrian": 0, "obstacle": 0, "robot": 0},
+            "progress_step_count": 1,
+            "regression_step_count": 0,
+            "stagnant_step_count": 0,
+            "longest_stagnant_run": 0,
+        },
+        "steps": [
+            {
+                "step": step,
+                "policy_command": command,
+                "observation_perturbation": {
+                    "noise_profile": "bounded_gaussian",
+                    "missed_actor_count": 0,
+                    "occluded_actor_count": 0,
+                    "observed_actor_count": 1 if step >= first_observed_step else 0,
+                },
+            }
+            for step in range(8)
+        ],
+    }
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+
 def test_fixture_boundary_verifier_requires_noop_and_delay_first_observed_steps(
     tmp_path: Path,
 ) -> None:
@@ -424,6 +549,65 @@ def test_fixture_boundary_verifier_requires_noop_and_delay_first_observed_steps(
 
     assert blockers
     assert "Delay-only" in blockers[0]
+
+
+def test_issue_3330_live_report_includes_grid_interpretation(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    """A completed #3330 live grid should include compact diagnostic interpretation."""
+    mod = _load_script()
+
+    def _fake_execute_conditions(
+        *,
+        args,
+        output_dir: Path,
+        funnel_config: Path,
+    ) -> tuple[list[dict[str, object]], list[str]]:
+        del args, funnel_config
+        conditions: list[dict[str, object]] = []
+        for name in mod.ISSUE_3330_REQUIRED_CONDITIONS:
+            command = [0.0, 0.0] if name == "medium_noise_3328" else [1.0, 0.0]
+            first_observed_step = 7 if name == "delay_only" else 5
+            trace_path = output_dir / "traces" / name / "trace.json"
+            _write_grid_trace(
+                trace_path,
+                command=command,
+                first_observed_step=first_observed_step,
+            )
+            conditions.append(
+                {
+                    "name": name,
+                    "description": name,
+                    "status": "live_replay",
+                    "trace": str(trace_path),
+                }
+            )
+        return conditions, []
+
+    monkeypatch.setattr(mod, "_execute_conditions", _fake_execute_conditions)
+    args = mod.parse_args(
+        [
+            "--condition-set",
+            mod.ISSUE_3330_CONDITION_SET,
+            "--scenario-matrix",
+            str(
+                mod.REPO_ROOT
+                / "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml"
+            ),
+            "--output-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+
+    report = mod.run_live_batch(args)
+    markdown = mod._markdown(report)
+
+    assert report["status"] == "live_replay"
+    assert report["grid_interpretation"]["label"] == "medium_amplitude_sensitive"
+    assert report["grid_interpretation"]["evidence_status"] == "diagnostic-only"
+    assert "## Grid Interpretation" in markdown
+    assert "medium-amplitude-sensitive" in markdown
 
 
 def test_issue_3328_behavior_probe_guardrails_require_near_field_fixture(
@@ -483,6 +667,150 @@ def test_issue_3328_behavior_probe_guardrails_require_near_field_fixture(
 
     assert blockers
     assert "finite no-op closest_robot_ped_distance" in blockers[-1]
+
+
+def test_issue_3330_seed_amplitude_grid_reuses_near_field_fixture_guardrails(
+    tmp_path: Path,
+) -> None:
+    """The #3330 grid should fail closed on the same near-field fixture contract."""
+    mod = _load_script()
+    output_dir = tmp_path / "out"
+    contract = {
+        "satisfied": True,
+        "matched_scenario": {
+            "name": "issue_2756_occluded_emergence",
+            "seeds": [111],
+        },
+    }
+    _write_observed_count_trace(
+        output_dir / "traces/noop/trace.json",
+        [0, 0, 0, 0, 0, 1],
+        closest=1.9,
+    )
+    _write_observed_count_trace(
+        output_dir / "traces/delay_only/trace.json",
+        [0, 0, 0, 0, 0, 0, 0, 1],
+        closest=1.9,
+    )
+
+    assert (
+        mod._verify_issue_3330_seed_amplitude_grid_guardrails(
+            output_dir=output_dir,
+            fixture_contract=contract,
+        )
+        == []
+    )
+
+    _write_observed_count_trace(
+        output_dir / "traces/noop/trace.json",
+        [0, 0, 0, 0, 0, 1],
+        closest=2.1,
+    )
+    blockers = mod._verify_issue_3330_seed_amplitude_grid_guardrails(
+        output_dir=output_dir,
+        fixture_contract=contract,
+    )
+
+    assert blockers
+    assert "Issue #3330 seed/amplitude grid" in blockers[-1]
+    assert "closest_robot_ped_distance <= 2.0" in blockers[-1]
+
+
+def _grid_condition_row(
+    name: str,
+    label: str,
+    status: str = "live_replay",
+) -> dict[str, object]:
+    """Return a compact condition row for grid interpretation tests."""
+    return {
+        "name": name,
+        "status": status,
+        "classification": {"label": label},
+    }
+
+
+def _grid_rows(
+    *,
+    medium_sensitive: set[str] | None = None,
+    high_sensitive: set[str] | None = None,
+) -> list[dict[str, object]]:
+    """Return complete #3330 rows with selected behavior-sensitive conditions."""
+    medium_sensitive = medium_sensitive or set()
+    high_sensitive = high_sensitive or set()
+    rows = [
+        _grid_condition_row("noop", "baseline"),
+        _grid_condition_row("delay_only", "policy_insensitive"),
+    ]
+    for seed in ("2755", "3328", "3330"):
+        name = f"medium_noise_{seed}"
+        label = (
+            "behavior_sensitive_diagnostic_only"
+            if name in medium_sensitive
+            else "policy_insensitive"
+        )
+        rows.append(_grid_condition_row(name, label))
+    for seed in ("2755", "3328", "3330"):
+        name = f"high_noise_{seed}"
+        label = (
+            "behavior_sensitive_diagnostic_only" if name in high_sensitive else "policy_insensitive"
+        )
+        rows.append(_grid_condition_row(name, label))
+    return rows
+
+
+def test_issue_3330_grid_interpretation_labels_seed_amplitude_patterns() -> None:
+    """The grid-level summary should stay diagnostic-only and compact."""
+    mod = _load_script()
+
+    cases = [
+        (
+            {"medium_noise_3328"},
+            set(),
+            "medium_amplitude_sensitive",
+            "medium-amplitude-sensitive",
+        ),
+        (
+            set(),
+            {"high_noise_2755", "high_noise_3328", "high_noise_3330"},
+            "high_noise_persistent",
+            "high-noise persistent",
+        ),
+        (
+            set(),
+            {"high_noise_2755", "high_noise_3330"},
+            "mixed_seed_specific",
+            "mixed/seed-specific",
+        ),
+        (set(), set(), "not_reproduced", "not reproduced"),
+    ]
+    for medium_sensitive, high_sensitive, label, expected_phrase in cases:
+        interpretation = mod._issue_3330_grid_interpretation(
+            conditions=_grid_rows(
+                medium_sensitive=medium_sensitive,
+                high_sensitive=high_sensitive,
+            ),
+            blockers=[],
+        )
+
+        assert interpretation["label"] == label
+        assert interpretation["evidence_status"] == "diagnostic-only"
+        assert expected_phrase in interpretation["summary"]
+
+
+def test_issue_3330_grid_interpretation_fails_closed_when_unavailable() -> None:
+    """The grid-level summary should not interpret incomplete live evidence."""
+    mod = _load_script()
+    rows = _grid_rows()
+    rows[-1]["status"] = "blocked"
+
+    interpretation = mod._issue_3330_grid_interpretation(
+        conditions=rows,
+        blockers=["high_noise_3330 live replay failed"],
+    )
+
+    assert interpretation["label"] == "unavailable_fail_closed"
+    assert "unavailable/fail-closed" in interpretation["summary"]
+    assert interpretation["sensitive_conditions"] == []
 
 
 def test_trace_comparison_names_scenario_seed_planner_and_policy_insensitive(


### PR DESCRIPTION
## Summary
Adds an opt-in `issue_3330_seed_amplitude_grid` live observation-noise replay condition set and promotes compact evidence for issue #3330.

## Linked Issues
- Closes `#3330`
- Follow-up `#3335`
- Relates to `#2777`, `#3328`

## Stack / Dependency
- Base dependency: `PR #3331`
- Required prior PRs: `#3331`
- Stack follow-up issues: `#3335`
- Safe to review independently: yes
- Review dependency reason, if any: builds on the opt-in #3328 behavior probe merged in #3331.

## What Changed
- Added opt-in condition set `issue_3330_seed_amplitude_grid` without changing the default #2755 set or the #3328 probe set.
- Added medium/high bounded-Gaussian perturbation rows for seeds 2755, 3328, and 3330, plus shared near-field fixture guardrails.
- Added diagnostic-only grid interpretation labels for medium-amplitude sensitivity, high-noise persistence, mixed seed-specific sensitivity, not reproduced, and unavailable/fail-closed.
- Added focused tests for condition ordering/flags, dry-run planning, guardrails, report inclusion, and interpretation categories.
- Promoted compact evidence under `docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/`.

## Why It Matters
- Added value: moves #3328 from one high-amplitude perturbation seed to a predeclared 2x3 seed/amplitude grid.
- Expected impact: shows behavior sensitivity is fixture-local and seed/profile-dependent rather than a one-off single-row artifact.
- Why this is worth merging now: it creates a small, reproducible bridge from one-seed diagnostic evidence to the next external-validity question.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: whether #3328 behavior sensitivity reproduces within the same #3323 near-field #2756 fixture across perturbation seeds/amplitudes.
- Comparator or baseline, if applicable: no-op native live replay on `issue_2756_occluded_emergence` seed 111 with the #3323 near-field route; policy-insensitive rows in the same grid.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: stop after the predeclared 2x3 grid; do not add a second fixture or calibrated profile in this PR.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/evidence/issue_2777_live_observation_noise_replay/`.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use included on tracked matrix `configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml`; follow-up #3335 carries cross-fixture/profile extension.

## Domain-Aware Approval
- Required for this PR: yes - benchmark-facing diagnostic evidence classification.
- Domains reviewed: evidence classification, benchmark interpretation
- Status: approved
- Approver/review source or waiver: Parent agent review with GPT-5.5 xhigh simplifier Wegener and native live replay evidence
- Validity checklist:
  - Target claim/hypothesis: fixture-local behavior sensitivity across perturbation seeds/amplitudes.
  - Comparator or split/evidence validity: no-op baseline plus predeclared medium/high seed grid on one tracked fixture.
  - Fallback/degraded exclusions: native live replay only; fallback/degraded execution is not success evidence.
  - Claim boundary: diagnostic-only, one scenario fixture seed, no robustness/sensor-realism/planner-superiority/paper-facing/scenario-general claim.
  - Implementation integrity vs experimental validity: tests cover wrapper/report contracts; live replay establishes only the stated diagnostic boundary.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes.
- Did the intervention change command source, selected command, trajectory, or route progress? yes - `medium_noise_3328`, `high_noise_3328`, and `high_noise_3330` changed selected commands and progress/min-distance summaries.
- Did the scenario actually contain the targeted failure mode? yes - the no-op trace preserves the #2756 visibility boundary and reaches 1.6552 m closest robot-pedestrian distance.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #3335 extends beyond one fixture or toward calibrated profiles.

## Next Empirical Action
- Rerun needed: yes, in follow-up #3335 for external-validity coverage beyond this one fixture.
- Extractor or analysis tool needed: no for this PR.
- Artifact missing or unavailable: raw traces are intentionally not committed; compact summary/README are promoted.
- Stop / revise / continue decision: continue with #3335.
- Proposed child issue or existing follow-up: #3335.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_issue_2777_observation_noise_live_replay.py -q`
  - `uv run ruff check scripts/benchmark/run_observation_noise_live_replay_issue_2777.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py`
  - `uv run ruff format --check scripts/benchmark/run_observation_noise_live_replay_issue_2777.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py`
  - `uv run robot_sf_bench validate-config --matrix configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml`
  - `uv run python scripts/benchmark/run_observation_noise_live_replay_issue_2777.py --condition-set issue_3330_seed_amplitude_grid --scenario-matrix configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml --output-dir docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid`
  - compact summary assertion over `docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json`
  - `git diff --check`
  - `BASE_REF=origin/main uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: compact PR-ready passed with exit code 0; summary at `.git/codex-agent-runs/active/compact-validation/validation-20260621T150146Z-782033.summary.json`.
- Benchmarks or smoke tests, if applicable: native live replay completed as `live_replay` / `behavior_sensitive_diagnostic_only`; grid label `medium_amplitude_sensitive`.

## Risks / Rollout
- Compatibility risks: low; new condition set is opt-in and default condition sets remain unchanged.
- Failure modes: reviewers could overread fixture-local diagnostic evidence as scenario-general behavior; PR text and evidence docs explicitly caveat this.
- Rollback or fallback plan: revert the commit; existing #2755 default and #3328 probe behavior are preserved separately.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/evidence/issue_2777_live_observation_noise_replay/README.md`, and `docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/README.md`.
- Relevant design or provenance notes: `docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json`.
- Any assumptions that need to be preserved: raw traces are reproducible from tracked config, commit, and command; they remain out of git.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - PR closes #3330.
- Claim map / benchmark report updated (yes/no/NA): NA - diagnostic-only evidence, not promoted to benchmark claim map.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no leaderboard or artifact-catalog row.
- Registry or config index updated (yes/no/NA): NA - no new tracked scenario/config matrix.
- Context index / memory note updated (yes/no/NA): yes - evidence README indexes updated.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes - #3335.
- Not applicable because: stronger cross-fixture/profile propagation is deferred to #3335.

## Follow-Up Issues
- Deferred work: external-validity check beyond the one issue 3323 near-field issue 2756 fixture.
- Issues opened for follow-up: #3335.

## Reviewer Notes
- Verify that `issue_2755_default` and `issue_3328_behavior_probe` remain unchanged.
- The key evidence result is fixture-local: `medium_noise_3328`, `high_noise_3328`, and `high_noise_3330` are behavior-sensitive; seed 2755 remains policy-insensitive at medium and high amplitudes.
- Known limitation: one scenario fixture seed only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added diagnostic documentation for a new observation-noise replay test configuration with seed and amplitude variations.

* **Tests**
  * Added comprehensive test coverage for the new diagnostic grid experiment, including configuration validation, execution, and result interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->