### PR TITLE
feat: capture benchmark run provenance sidecars

### DIFF
--- a/robot_sf/benchmark/manifest.py
+++ b/robot_sf/benchmark/manifest.py
@@ -102,11 +102,32 @@ def _sha256_jsonable(payload: object) -> str:
     return hashlib.sha256(encoded).hexdigest()
 
 
-def _artifact_entry(path: Path) -> dict[str, object]:
+def _artifact_entry(path: Path, *, required: bool = False) -> dict[str, object]:
     """Return the minimum machine-readable artifact identity for a path."""
+    if not path.exists():
+        if required:
+            raise ValueError(f"Required provenance artifact does not exist: {path}")
+        return {
+            "path": str(path),
+            "artifact_status": "missing",
+            "sha256": None,
+            "size": None,
+            "mtime_ns": None,
+        }
+    if not path.is_file():
+        if required:
+            raise ValueError(f"Required provenance artifact is not a file: {path}")
+        return {
+            "path": str(path),
+            "artifact_status": "not_file",
+            "sha256": None,
+            "size": None,
+            "mtime_ns": None,
+        }
     stat = _stat_of(path)
     return {
         "path": str(path),
+        "artifact_status": "available",
         "sha256": _sha256_file(path),
         "size": stat.size,
         "mtime_ns": stat.mtime_ns,
@@ -138,7 +159,7 @@ def _build_simulation_run_provenance(
         "schema_version": SIMULATION_RUN_PROVENANCE_SCHEMA_VERSION,
         "bundle_status": "complete",
         "inputs": _artifact_entries(input_paths),
-        "outputs": [_artifact_entry(out_path)],
+        "outputs": [_artifact_entry(out_path, required=True)],
         "generated_reports": _artifact_entries(report_paths),
         "stable_identifiers": {
             "episode_ids_sha256": _sha256_jsonable(sorted(set(episode_ids))),
@@ -149,6 +170,21 @@ def _build_simulation_run_provenance(
     }
     _validate_simulation_run_provenance(bundle)
     return bundle
+
+
+def _validate_provenance_artifact_entry(collection_name: str, artifact: object) -> None:
+    """Validate one provenance artifact entry."""
+    if not isinstance(artifact, dict) or not artifact.get("path"):
+        raise ValueError(f"Simulation-run provenance {collection_name} entries require path")
+    status = artifact.get("artifact_status", "available")
+    if status == "available" and not artifact.get("sha256"):
+        raise ValueError(
+            f"Simulation-run provenance {collection_name} available entries require sha256"
+        )
+    if status not in {"available", "missing", "not_file"}:
+        raise ValueError(
+            f"Simulation-run provenance {collection_name} artifact_status is invalid"
+        )
 
 
 def _validate_simulation_run_provenance(bundle: dict[str, object]) -> None:
@@ -174,14 +210,7 @@ def _validate_simulation_run_provenance(bundle: dict[str, object]) -> None:
         if not isinstance(collection, list):
             raise ValueError(f"Simulation-run provenance {collection_name} must be a list")
         for artifact in collection:
-            if (
-                not isinstance(artifact, dict)
-                or not artifact.get("path")
-                or not artifact.get("sha256")
-            ):
-                raise ValueError(
-                    f"Simulation-run provenance {collection_name} entries require path and sha256"
-                )
+            _validate_provenance_artifact_entry(collection_name, artifact)
 
 
 def manifest_path_for(out_path: Path) -> Path:

--- a/robot_sf/benchmark/manifest.py
+++ b/robot_sf/benchmark/manifest.py
@@ -161,7 +161,9 @@ def _validate_simulation_run_provenance(bundle: dict[str, object]) -> None:
     optional_fields = bundle.get("optional_fields")
     if not isinstance(optional_fields, dict):
         raise ValueError("Simulation-run provenance optional_fields must be a mapping")
-    missing_optionals = [field for field in _EXPLICIT_OPTIONAL_FIELDS if field not in optional_fields]
+    missing_optionals = [
+        field for field in _EXPLICIT_OPTIONAL_FIELDS if field not in optional_fields
+    ]
     if missing_optionals:
         raise ValueError(
             "Simulation-run provenance optional_fields missing explicit fields: "
@@ -172,7 +174,11 @@ def _validate_simulation_run_provenance(bundle: dict[str, object]) -> None:
         if not isinstance(collection, list):
             raise ValueError(f"Simulation-run provenance {collection_name} must be a list")
         for artifact in collection:
-            if not isinstance(artifact, dict) or not artifact.get("path") or not artifact.get("sha256"):
+            if (
+                not isinstance(artifact, dict)
+                or not artifact.get("path")
+                or not artifact.get("sha256")
+            ):
                 raise ValueError(
                     f"Simulation-run provenance {collection_name} entries require path and sha256"
                 )

--- a/robot_sf/benchmark/manifest.py
+++ b/robot_sf/benchmark/manifest.py
@@ -182,9 +182,7 @@ def _validate_provenance_artifact_entry(collection_name: str, artifact: object) 
             f"Simulation-run provenance {collection_name} available entries require sha256"
         )
     if status not in {"available", "missing", "not_file"}:
-        raise ValueError(
-            f"Simulation-run provenance {collection_name} artifact_status is invalid"
-        )
+        raise ValueError(f"Simulation-run provenance {collection_name} artifact_status is invalid")
 
 
 def _validate_simulation_run_provenance(bundle: dict[str, object]) -> None:

--- a/robot_sf/benchmark/manifest.py
+++ b/robot_sf/benchmark/manifest.py
@@ -46,15 +46,31 @@ Notes
 
 from __future__ import annotations
 
+import hashlib
 import json
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 from robot_sf.benchmark.constants import EPISODE_SCHEMA_VERSION
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
-    from pathlib import Path
+
+
+SIMULATION_RUN_PROVENANCE_SCHEMA_VERSION = "simulation_run_provenance.v1"
+_REQUIRED_PROVENANCE_FIELDS = frozenset(
+    {
+        "schema_version",
+        "bundle_status",
+        "inputs",
+        "outputs",
+        "generated_reports",
+        "stable_identifiers",
+        "optional_fields",
+    }
+)
+_EXPLICIT_OPTIONAL_FIELDS = ("run_id", "invocation", "config_path", "scenario_path")
 
 
 @dataclass(frozen=True)
@@ -69,6 +85,97 @@ def _stat_of(path: Path) -> _Stat:
     """Return size and mtime_ns for a path."""
     st = path.stat()
     return _Stat(size=int(st.st_size), mtime_ns=int(st.st_mtime_ns))
+
+
+def _sha256_file(path: Path) -> str:
+    """Return a SHA256 checksum for a provenance artifact."""
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _sha256_jsonable(payload: object) -> str:
+    """Return a stable SHA256 digest for JSON-serializable provenance identity."""
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _artifact_entry(path: Path) -> dict[str, object]:
+    """Return the minimum machine-readable artifact identity for a path."""
+    stat = _stat_of(path)
+    return {
+        "path": str(path),
+        "sha256": _sha256_file(path),
+        "size": stat.size,
+        "mtime_ns": stat.mtime_ns,
+    }
+
+
+def _artifact_entries(paths: Iterable[Path] | None) -> list[dict[str, object]]:
+    """Return artifact entries for provided paths, preserving explicit absence as an empty list."""
+    if paths is None:
+        return []
+    return [_artifact_entry(Path(path)) for path in paths]
+
+
+def _build_simulation_run_provenance(
+    *,
+    out_path: Path,
+    episode_ids: list[str],
+    identity_hash: str | None,
+    schema_version: str,
+    input_paths: Iterable[Path] | None,
+    report_paths: Iterable[Path] | None,
+) -> dict[str, object]:
+    """Build and validate the minimum simulation-run provenance bundle.
+
+    Returns:
+        Machine-readable provenance bundle for the simulation output sidecar.
+    """
+    bundle: dict[str, object] = {
+        "schema_version": SIMULATION_RUN_PROVENANCE_SCHEMA_VERSION,
+        "bundle_status": "complete",
+        "inputs": _artifact_entries(input_paths),
+        "outputs": [_artifact_entry(out_path)],
+        "generated_reports": _artifact_entries(report_paths),
+        "stable_identifiers": {
+            "episode_ids_sha256": _sha256_jsonable(sorted(set(episode_ids))),
+            "identity_hash": identity_hash,
+            "schema_version": schema_version,
+        },
+        "optional_fields": dict.fromkeys(_EXPLICIT_OPTIONAL_FIELDS),
+    }
+    _validate_simulation_run_provenance(bundle)
+    return bundle
+
+
+def _validate_simulation_run_provenance(bundle: dict[str, object]) -> None:
+    """Fail closed when the required provenance bundle contract is incomplete."""
+    missing = sorted(_REQUIRED_PROVENANCE_FIELDS - bundle.keys())
+    if missing:
+        raise ValueError(f"Simulation-run provenance missing required fields: {missing}")
+    if bundle.get("schema_version") != SIMULATION_RUN_PROVENANCE_SCHEMA_VERSION:
+        raise ValueError("Simulation-run provenance schema_version is invalid")
+    optional_fields = bundle.get("optional_fields")
+    if not isinstance(optional_fields, dict):
+        raise ValueError("Simulation-run provenance optional_fields must be a mapping")
+    missing_optionals = [field for field in _EXPLICIT_OPTIONAL_FIELDS if field not in optional_fields]
+    if missing_optionals:
+        raise ValueError(
+            "Simulation-run provenance optional_fields missing explicit fields: "
+            f"{missing_optionals}"
+        )
+    for collection_name in ("inputs", "outputs", "generated_reports"):
+        collection = bundle.get(collection_name)
+        if not isinstance(collection, list):
+            raise ValueError(f"Simulation-run provenance {collection_name} must be a list")
+        for artifact in collection:
+            if not isinstance(artifact, dict) or not artifact.get("path") or not artifact.get("sha256"):
+                raise ValueError(
+                    f"Simulation-run provenance {collection_name} entries require path and sha256"
+                )
 
 
 def manifest_path_for(out_path: Path) -> Path:
@@ -152,6 +259,9 @@ def save_manifest(
     episode_ids: Iterable[str],
     identity_hash: str | None = None,
     schema_version: str = EPISODE_SCHEMA_VERSION,
+    *,
+    input_paths: Iterable[Path] | None = None,
+    report_paths: Iterable[Path] | None = None,
 ) -> None:
     """Write or update the manifest to reflect the current on-disk state.
 
@@ -160,10 +270,14 @@ def save_manifest(
         episode_ids: All episode ids currently present in the JSONL file.
         identity_hash: Optional content hash written for tamper detection.
         schema_version: Episode schema version recorded in the manifest.
+        input_paths: Optional simulation inputs to checksum into the provenance bundle.
+        report_paths: Optional generated reports to checksum into the provenance bundle.
 
     Notes:
         - If the JSONL file does not exist, the function returns without writing.
         - The sidecar captures the target file's stat for change detection.
+        - ``simulation_run_provenance`` records explicit ``None`` values for optional
+          run metadata that this entry point cannot infer.
     """
     if not out_path.exists():
         return
@@ -178,6 +292,14 @@ def save_manifest(
         "episode_ids": ids_sorted,
         "episodes_count": len(ids_sorted),
         "schema_version": schema_version,
+        "simulation_run_provenance": _build_simulation_run_provenance(
+            out_path=out_path,
+            episode_ids=ids_sorted,
+            identity_hash=identity_hash,
+            schema_version=schema_version,
+            input_paths=input_paths,
+            report_paths=report_paths,
+        ),
     }
     if identity_hash is not None:
         rec["identity_hash"] = identity_hash

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -1740,6 +1740,7 @@ def _finalize_batch(
     out_path: Path,
     wrote: int,
     resume: bool,
+    provenance_input_paths: list[Path] | None = None,
 ) -> dict[str, Any]:
     """Finalize batch processing: save manifest and optional performance snapshot.
 
@@ -1754,6 +1755,7 @@ def _finalize_batch(
             index_existing(out_path),
             identity_hash=_episode_identity_hash(),
             schema_version=EPISODE_SCHEMA_VERSION,
+            input_paths=provenance_input_paths,
         )
 
     # Optional: write a small performance snapshot for video encoding if requested
@@ -1957,7 +1959,15 @@ def run_batch(  # noqa: PLR0913
     )
 
     # Finalize and return summary
-    summary = _finalize_batch(out_path, wrote, resume)
+    provenance_input_paths = [Path(schema_path)]
+    if isinstance(scenarios_or_path, str | Path):
+        provenance_input_paths.append(Path(scenarios_or_path))
+    summary = _finalize_batch(
+        out_path,
+        wrote,
+        resume,
+        provenance_input_paths=provenance_input_paths,
+    )
     summary["total_jobs"] = len(jobs)
     summary["failures"] = failures
     if benchmark_track is not None:

--- a/tests/benchmark/test_map_runner_result_provenance.py
+++ b/tests/benchmark/test_map_runner_result_provenance.py
@@ -134,6 +134,43 @@ def test_save_manifest_emits_simulation_run_provenance_bundle(tmp_path: Path) ->
     assert stable_identifiers["schema_version"] == "v1"
 
 
+def test_save_manifest_records_unavailable_optional_artifacts(tmp_path: Path) -> None:
+    """Optional provenance inputs should be explicit when missing or not file artifacts."""
+    out_path = tmp_path / "episodes.jsonl"
+    out_path.write_text('{"episode_id":"scenario-a--7"}\n', encoding="utf-8")
+    missing_path = tmp_path / "missing.yaml"
+    directory_path = tmp_path / "report_dir"
+    directory_path.mkdir()
+
+    save_manifest(
+        out_path,
+        ["scenario-a--7"],
+        identity_hash="identity-v1",
+        input_paths=[missing_path],
+        report_paths=[directory_path],
+    )
+
+    payload = json.loads(manifest_path_for(out_path).read_text(encoding="utf-8"))
+    provenance = payload["simulation_run_provenance"]
+
+    assert provenance["inputs"][0] == {
+        "path": str(missing_path),
+        "artifact_status": "missing",
+        "sha256": None,
+        "size": None,
+        "mtime_ns": None,
+    }
+    assert provenance["generated_reports"][0] == {
+        "path": str(directory_path),
+        "artifact_status": "not_file",
+        "sha256": None,
+        "size": None,
+        "mtime_ns": None,
+    }
+    assert provenance["outputs"][0]["artifact_status"] == "available"
+    assert provenance["outputs"][0]["sha256"]
+
+
 def test_finalize_batch_threads_inputs_into_resume_manifest_provenance(tmp_path: Path) -> None:
     """Batch finalization should preserve schema/scenario inputs in resume sidecar provenance."""
     out_path = tmp_path / "episodes.jsonl"

--- a/tests/benchmark/test_map_runner_result_provenance.py
+++ b/tests/benchmark/test_map_runner_result_provenance.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
 import shlex
 import sys
 from pathlib import Path
 
 import pytest
 
+from robot_sf.benchmark.manifest import manifest_path_for, save_manifest
 from robot_sf.benchmark.map_runner import _map_result_provenance, run_map_batch
+from robot_sf.benchmark.runner import _finalize_batch
 
 
 def test_run_map_batch_empty_summary_has_result_provenance(
@@ -89,3 +92,70 @@ def test_map_result_provenance_can_mark_existing_jsonl_available() -> None:
     assert provenance["seed_identity"]["total_jobs"] == 1
     assert provenance["seed_identity"]["written"] == 0
     assert provenance["artifact_pointer_status"] == "local_jsonl_present"
+
+
+def test_save_manifest_emits_simulation_run_provenance_bundle(tmp_path: Path) -> None:
+    """Resume sidecars should link inputs, outputs, reports, and explicit missing optionals."""
+    out_path = tmp_path / "episodes.jsonl"
+    out_path.write_text('{"episode_id":"scenario-a--7"}\n', encoding="utf-8")
+    scenario_path = tmp_path / "scenario.yaml"
+    scenario_path.write_text("scenario: a\n", encoding="utf-8")
+    summary_path = tmp_path / "summary.json"
+    summary_path.write_text('{"status":"diagnostic"}\n', encoding="utf-8")
+
+    save_manifest(
+        out_path,
+        ["scenario-a--7"],
+        identity_hash="identity-v1",
+        input_paths=[scenario_path],
+        report_paths=[summary_path],
+    )
+
+    payload = json.loads(manifest_path_for(out_path).read_text(encoding="utf-8"))
+    provenance = payload["simulation_run_provenance"]
+
+    assert provenance["schema_version"] == "simulation_run_provenance.v1"
+    assert provenance["bundle_status"] == "complete"
+    assert provenance["optional_fields"] == {
+        "run_id": None,
+        "invocation": None,
+        "config_path": None,
+        "scenario_path": None,
+    }
+    assert provenance["inputs"][0]["path"] == str(scenario_path)
+    assert len(provenance["inputs"][0]["sha256"]) == 64
+    assert provenance["outputs"][0]["path"] == str(out_path)
+    assert provenance["outputs"][0]["sha256"]
+    assert provenance["generated_reports"][0]["path"] == str(summary_path)
+    assert provenance["generated_reports"][0]["sha256"]
+    stable_identifiers = provenance["stable_identifiers"]
+    assert len(stable_identifiers["episode_ids_sha256"]) == 64
+    assert stable_identifiers["identity_hash"] == "identity-v1"
+    assert stable_identifiers["schema_version"] == "v1"
+
+
+def test_finalize_batch_threads_inputs_into_resume_manifest_provenance(tmp_path: Path) -> None:
+    """Batch finalization should preserve schema/scenario inputs in resume sidecar provenance."""
+    out_path = tmp_path / "episodes.jsonl"
+    out_path.write_text('{"episode_id":"scenario-a--7"}\n', encoding="utf-8")
+    schema_path = tmp_path / "episode.schema.json"
+    schema_path.write_text('{"schema_version":"v1"}\n', encoding="utf-8")
+    scenario_path = tmp_path / "scenario.yaml"
+    scenario_path.write_text("scenario: a\n", encoding="utf-8")
+
+    _finalize_batch(
+        out_path,
+        wrote=1,
+        resume=True,
+        provenance_input_paths=[schema_path, scenario_path],
+    )
+
+    payload = json.loads(manifest_path_for(out_path).read_text(encoding="utf-8"))
+    provenance = payload["simulation_run_provenance"]
+
+    assert [entry["path"] for entry in provenance["inputs"]] == [
+        str(schema_path),
+        str(scenario_path),
+    ]
+    assert all(entry["sha256"] for entry in provenance["inputs"])
+    assert provenance["outputs"][0]["path"] == str(out_path)


### PR DESCRIPTION
## Summary
- Add `simulation_run_provenance.v1` to benchmark resume sidecar manifests written by `save_manifest`.
- Record checksummed input/output/report artifact identities, stable episode/schema identifiers, and explicit `None` values for optional run metadata not inferable at the sidecar layer.
- Thread schema/scenario input paths from `run_batch` finalization into the emitted sidecar provenance bundle.

Closes #3289.

## Validation
- `uv run python -m pytest tests/benchmark/test_map_runner_result_provenance.py -q`
- `uv run ruff check robot_sf/benchmark/manifest.py robot_sf/benchmark/runner.py tests/benchmark/test_map_runner_result_provenance.py`
- `uv run python scripts/dev/run_compact_validation.py -- uv run python -m pytest tests/telemetry tests/benchmark -k 'manifest or provenance' -q`
- `uv run python -m pytest tests/unit/test_resume_manifest.py -q`

## Research Result Guidance
- Target claim/hypothesis/blocker: workflow support for automatic simulation-run provenance capture.
- Comparator/baseline: previous resume sidecar only tracked output stat, episode ids, schema version, and identity hash.
- Evidence tier: implementation + focused tests; no benchmark campaign evidence claimed.
- Result classification: workflow/tooling improvement.
- Decision/stop rule: accepted if sidecar manifests emit a complete minimum provenance bundle and existing resume invalidation remains compatible.
- Synthesis surface/update target: issue #3289.

## Downstream Propagation
- Parent issue: #3289 should close after merge.
- Claim map / benchmark report / leaderboard: NA - no benchmark result claim.
- Registry/config index: NA - no new benchmark config.
- Context index or memory note: NA for this narrow code/test change.
- Follow-up issue: not required for this slice; richer entry-point-specific metadata can be added later if a campaign needs it.

## Delegation
- Implementation was delegated to a bounded worker in the linked worktree.
- Parent reviewed compact artifacts, inspected diffs, repaired runner call-site plumbing, reran validation, and accepted the branch head.
