### PR TITLE
feat: summarize observation-noise cross-fixture grid

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1566,6 +1566,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_3202_ammv_anticipatory_conflict/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -181,8 +181,8 @@ Policy caveats:
   pedestrian-present stress-slice scenario; perturbation plumbing activated, but the distant
   pedestrian produced no measurable planner degradation.
 - `issue_2777_live_observation_noise_replay/`: diagnostic stress-slice live replay for all seven
-  #2755 perturbation families on the #2756 occluded-emergence boundary added by #3320 and moved
-  into near-field geometry by #3323. The wrapper ran `risk_surface_dwa_v0` on
+  Issue #2755 perturbation families on the Issue #2756 occluded-emergence boundary added by
+  Issue #3320 and moved into near-field geometry by Issue #3323. The wrapper ran `risk_surface_dwa_v0` on
   `issue_2756_occluded_emergence` seed 111, preserved no-op first visibility at step 5 and
   delay-only first observation at step 7, reached a 1.6552 m closest robot-pedestrian distance,
   and classified the seven-family run as `policy_insensitive` because perturbations changed
@@ -220,6 +220,12 @@ Policy caveats:
   1.45 m closest robot-pedestrian distance and selected low-speed commands under dynamic-collision
   pressure; the perturbed run changed command sequence/progress and ended with a pedestrian
   collision. Not benchmark or sensor-realism evidence.
+- `issue_3335_observation_noise_cross_fixture_2026-06-21/`: diagnostic-only cross-fixture
+  synthesis of tracked native live observation-noise grid summaries. It records the committed #3330
+  near-field seed/amplitude grid as behavior-sensitive, then preserves a #3335 second-matrix attempt
+  that failed closed because `issue_3320_occluded_emergence_live_replay` was not near-field
+  (`closest_robot_ped_distance=21.80 m`). This is useful negative external-validity evidence, not
+  benchmark, robustness, planner-superiority, or hardware-calibrated sensor-realism evidence.
 - `issue_3202_ammv_anticipatory_conflict/`: diagnostic-only default-vs-AMMV Social Force
   comparison on a waiting-then-crossing fixture plus a direct AMMV mechanism probe. Adapter rows
   stayed identical and lacked AMMV metadata; the direct probe activated AMMV force and produced

--- a/docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/README.md
+++ b/docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/README.md
@@ -1,0 +1,30 @@
+# Issue #3335 Observation-Noise Cross-Fixture Live Grid
+
+## Claim Boundary
+
+Diagnostic-only cross-fixture synthesis of tracked native live step-diagnostics summaries. This checks whether observation-noise behavior sensitivity appears across more than one fixture surface, but it is not benchmark-strength, paper-grade, planner-superiority, robustness, or hardware-calibrated sensor-realism evidence.
+
+## Reproducibility
+
+- Command: `uv run python scripts/benchmark/summarize_observation_noise_live_grid.py --source-summary docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json --source-summary docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid/summary.json --output-json docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/summary.json --output-md docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/README.md`
+- Source summaries: `2`
+- Usable native live sources: `1`
+- Failed-closed sources: `1`
+
+## Classification
+
+- Label: `fixture_candidate_failed_closed_after_sensitive_grid`
+- Rationale: The committed #3330 near-field grid is behavior-sensitive, but the attempted second matrix failed closed under the near-field guardrail. Treat this as a useful negative external-validity check, not robustness evidence.
+
+## Source Rows
+
+| Source | Scenario | Seed | Near-field | Status | Command changed | Closest delta |
+|---|---|---:|---|---|---|---:|
+| `docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json` | `issue_2756_occluded_emergence` | `111` | `True` | `behavior_sensitive_grid` | `True` | `0.008230813627037481` |
+| `docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid/summary.json` | `issue_2756_occluded_emergence` | `111` | `False` | `failed_closed` | `False` | `0.0` |
+
+## Caveats
+
+- This is a synthesis of tracked compact native live summaries, not a new full benchmark.
+- Fallback, degraded, unavailable, or malformed sources fail closed.
+- Fixture/profile-specific results remain diagnostic-only and do not support sensor-realism claims.

--- a/docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid/README.md
+++ b/docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid/README.md
@@ -1,0 +1,49 @@
+# Issue #2777 Live Observation-Noise Replay
+
+## Status
+
+- Status: `fail_closed`
+- Classification: `blocked`
+- Rationale: Issue #3330 seed/amplitude grid requires no-op closest_robot_ped_distance <= 2.0 m; observed 21.803818559278636.
+
+## Claim Boundary
+
+Stress-slice live planner/environment replay for one scenario fixture seed and the selected perturbation condition set. Treat behavior-sensitive differences as diagnostic-only from this fixture; do not infer robustness, sensor realism, planner superiority, or scenario-general behavior.
+
+## Fixture Contract
+
+- `required_scenario`: `issue_2756_occluded_emergence`
+- `required_family`: `occluded_emergence/deterministic_occluded_emergence`
+- `first_visible_step`: `5`
+- `delay_steps`: `2`
+- `delay_only_expected_first_observed_step`: `7`
+- `scenario_matrix`: `configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml`
+- `satisfied`: `True`
+- `blocker`: `None`
+
+## Grid Interpretation
+
+- Evidence status: `diagnostic-only`
+- Label: `unavailable_fail_closed`
+- Summary: Grid interpretation is unavailable/fail-closed because at least one required live replay condition did not complete under the fixture guardrails.
+- Sensitive conditions: `none`
+- Medium-amplitude sensitive conditions: `none`
+- High-noise sensitive conditions: `none`
+- Limitation: Diagnostic-only; no robustness claim is available.
+
+## Conditions
+
+| Condition | Status | Classification | Command changed | Progress/risk changed | Min distance changed | Collision/near-miss changed | Stop/yield proxy changed | Caveat |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| `noop` | `live_replay` | `baseline` | `n/a` | `n/a` | `n/a` | `n/a` | `n/a` |  |
+| `delay_only` | `live_replay` | `scenario_too_weak` | `False` | `False` | `False` | `False` | `False` | The live condition did not expose a near-field behavior difference against the no-op trace. |
+| `medium_noise_2755` | `live_replay` | `scenario_too_weak` | `False` | `False` | `False` | `False` | `False` | The live condition did not expose a near-field behavior difference against the no-op trace. |
+| `medium_noise_3328` | `live_replay` | `scenario_too_weak` | `False` | `False` | `False` | `False` | `False` | The live condition did not expose a near-field behavior difference against the no-op trace. |
+| `medium_noise_3330` | `live_replay` | `scenario_too_weak` | `False` | `False` | `False` | `False` | `False` | The live condition did not expose a near-field behavior difference against the no-op trace. |
+| `high_noise_2755` | `live_replay` | `scenario_too_weak` | `False` | `False` | `False` | `False` | `False` | The live condition did not expose a near-field behavior difference against the no-op trace. |
+| `high_noise_3328` | `live_replay` | `scenario_too_weak` | `False` | `False` | `False` | `False` | `False` | The live condition did not expose a near-field behavior difference against the no-op trace. |
+| `high_noise_3330` | `live_replay` | `scenario_too_weak` | `False` | `False` | `False` | `False` | `False` | The live condition did not expose a near-field behavior difference against the no-op trace. |
+
+## Blockers
+
+- Issue #3330 seed/amplitude grid requires no-op closest_robot_ped_distance <= 2.0 m; observed 21.803818559278636.

--- a/docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid/summary.json
+++ b/docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid/summary.json
@@ -1,0 +1,1395 @@
+{
+  "schema_version": "issue_2777_observation_noise_live_replay.v1",
+  "artifact_shape": "compact_summary_without_raw_traces",
+  "issue": 2777,
+  "status": "fail_closed",
+  "classification": {
+    "label": "blocked",
+    "rationale": "Issue #3330 seed/amplitude grid requires no-op closest_robot_ped_distance <= 2.0 m; observed 21.803818559278636."
+  },
+  "claim_boundary": "Stress-slice live planner/environment replay for one scenario fixture seed and the selected perturbation condition set. Treat behavior-sensitive differences as diagnostic-only from this fixture; do not infer robustness, sensor realism, planner superiority, or scenario-general behavior.",
+  "inputs": {
+    "scenario_matrix": "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml",
+    "raw_trace_json": "worktree-local generated traces summarized here; raw trace.json files are intentionally not committed",
+    "generated_funnel": "worktree-local generated_policy_search_funnel.yaml was intentionally not committed"
+  },
+  "fixture_contract": {
+    "required_source_issue": 2756,
+    "required_scenario": "issue_2756_occluded_emergence",
+    "required_family": "occluded_emergence/deterministic_occluded_emergence",
+    "required_seed": 111,
+    "first_visible_step": 5,
+    "delay_steps": 2,
+    "delay_only_expected_first_observed_step": 7,
+    "scenario_matrix": "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml",
+    "satisfied": true,
+    "blocker": null,
+    "matched_scenario": {
+      "name": "issue_2756_occluded_emergence",
+      "source_issue": 2756,
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "seeds": [
+        111
+      ],
+      "first_visible_step": 5,
+      "delay_steps": 2,
+      "delay_only_expected_first_observed_step": 7
+    }
+  },
+  "fixture_observation_boundary": {
+    "noop_first_observed_step": 5,
+    "delay_only_first_observed_step": 7,
+    "expected_noop_first_observed_step": 5,
+    "expected_delay_only_first_observed_step": 7
+  },
+  "run_config": {
+    "candidate": "risk_surface_dwa_v0",
+    "stage": "smoke",
+    "scenario_matrix": "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml",
+    "scenario_name": null,
+    "scenario_index": 0,
+    "seed": null,
+    "seed_index": 0,
+    "horizon": 50,
+    "output_dir": "docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid",
+    "condition_set": "issue_3330_seed_amplitude_grid",
+    "condition_names": [
+      "noop",
+      "delay_only",
+      "medium_noise_2755",
+      "medium_noise_3328",
+      "medium_noise_3330",
+      "high_noise_2755",
+      "high_noise_3328",
+      "high_noise_3330"
+    ],
+    "allow_non_occluded_live_fixture": false,
+    "dry_run": false
+  },
+  "conditions": [
+    {
+      "name": "noop",
+      "description": "Unperturbed live planner/environment replay.",
+      "status": "live_replay"
+    },
+    {
+      "name": "delay_only",
+      "description": "Two-step delayed pedestrian observation, preserving the #2755 expected lag.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "delayed_observation"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 21.803818559278636,
+            "condition": 21.803818559278636,
+            "changed": false
+          },
+          "step": {
+            "noop": 49,
+            "condition": 49,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 7
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
+    },
+    {
+      "name": "medium_noise_2755",
+      "description": "Issue #3330 medium-noise seed/amplitude grid condition, std=0.30 m, bound=0.60 m, seed=2755.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 21.803818559278636,
+            "condition": 21.803818559278636,
+            "changed": false
+          },
+          "step": {
+            "noop": 49,
+            "condition": 49,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
+    },
+    {
+      "name": "medium_noise_3328",
+      "description": "Issue #3330 medium-noise seed/amplitude grid condition, std=0.30 m, bound=0.60 m, seed=3328.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 21.803818559278636,
+            "condition": 21.803818559278636,
+            "changed": false
+          },
+          "step": {
+            "noop": 49,
+            "condition": 49,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
+    },
+    {
+      "name": "medium_noise_3330",
+      "description": "Issue #3330 medium-noise seed/amplitude grid condition, std=0.30 m, bound=0.60 m, seed=3330.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 21.803818559278636,
+            "condition": 21.803818559278636,
+            "changed": false
+          },
+          "step": {
+            "noop": 49,
+            "condition": 49,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
+    },
+    {
+      "name": "high_noise_2755",
+      "description": "Issue #3330 high-noise seed/amplitude grid condition, std=1.00 m, bound=2.00 m, seed=2755.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 21.803818559278636,
+            "condition": 21.803818559278636,
+            "changed": false
+          },
+          "step": {
+            "noop": 49,
+            "condition": 49,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
+    },
+    {
+      "name": "high_noise_3328",
+      "description": "Issue #3330 high-noise seed/amplitude grid condition, std=1.00 m, bound=2.00 m, seed=3328.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 21.803818559278636,
+            "condition": 21.803818559278636,
+            "changed": false
+          },
+          "step": {
+            "noop": 49,
+            "condition": 49,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
+    },
+    {
+      "name": "high_noise_3330",
+      "description": "Issue #3330 high-noise seed/amplitude grid condition, std=1.00 m, bound=2.00 m, seed=3330.",
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          2.0,
+          0.0
+        ],
+        "condition_last": [
+          2.0,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": -6.406017516898584,
+          "condition": -6.406017516898584,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 1.4428721856717952,
+          "condition": 1.4428721856717952,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 21.803818559278636,
+          "condition": 21.803818559278636,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 49,
+          "condition": 49,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 21.803818559278636,
+            "condition": 21.803818559278636,
+            "changed": false
+          },
+          "step": {
+            "noop": 49,
+            "condition": 49,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "scenario_too_weak",
+        "rationale": "The live condition did not expose a near-field behavior difference against the no-op trace."
+      }
+    }
+  ],
+  "blockers": [
+    "Issue #3330 seed/amplitude grid requires no-op closest_robot_ped_distance <= 2.0 m; observed 21.803818559278636."
+  ],
+  "grid_interpretation": {
+    "label": "unavailable_fail_closed",
+    "evidence_status": "diagnostic-only",
+    "summary": "Grid interpretation is unavailable/fail-closed because at least one required live replay condition did not complete under the fixture guardrails.",
+    "sensitive_conditions": [],
+    "medium_sensitive_conditions": [],
+    "high_sensitive_conditions": [],
+    "unavailable_conditions": [],
+    "limitation": "Diagnostic-only; no robustness claim is available.",
+    "reasons": [
+      "Issue #3330 seed/amplitude grid requires no-op closest_robot_ped_distance <= 2.0 m; observed 21.803818559278636."
+    ]
+  }
+}

--- a/docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/summary.json
+++ b/docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/summary.json
@@ -1,0 +1,130 @@
+{
+  "schema_version": "issue_3335_observation_noise_live_grid.v1",
+  "issue": 3335,
+  "claim_boundary": "Diagnostic-only cross-fixture synthesis of tracked native live step-diagnostics summaries. This checks whether observation-noise behavior sensitivity appears across more than one fixture surface, but it is not benchmark-strength, paper-grade, planner-superiority, robustness, or hardware-calibrated sensor-realism evidence.",
+  "reproducibility": {
+    "command": "uv run python scripts/benchmark/summarize_observation_noise_live_grid.py --source-summary docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json --source-summary docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid/summary.json --output-json docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/summary.json --output-md docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/README.md",
+    "source_summaries": [
+      "docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json",
+      "docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid/summary.json"
+    ]
+  },
+  "source_count": 2,
+  "usable_native_live_source_count": 1,
+  "failed_closed_source_count": 1,
+  "sources": [
+    {
+      "path": "docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json",
+      "schema_version": "issue_2777_observation_noise_live_replay.v1",
+      "source_issue": 2777,
+      "scenario": "issue_2756_occluded_emergence",
+      "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+      "condition_set": "issue_3330_seed_amplitude_grid",
+      "same_scenario": true,
+      "seed": 111,
+      "same_seed": true,
+      "status": "behavior_sensitive_grid",
+      "usable": true,
+      "status_rationale": "Diagnostic-only grid classification: medium-amplitude-sensitive because at least one std=0.30 m, bound=0.60 m condition changed live behavior.",
+      "classification": {
+        "label": "behavior_sensitive_diagnostic_only",
+        "rationale": "All selected live replays completed. One scenario fixture seed is diagnostic only and does not support a robustness, sensor-realism, or planner-superiority claim."
+      },
+      "grid_interpretation": {
+        "label": "medium_amplitude_sensitive",
+        "evidence_status": "diagnostic-only",
+        "summary": "Diagnostic-only grid classification: medium-amplitude-sensitive because at least one std=0.30 m, bound=0.60 m condition changed live behavior.",
+        "sensitive_conditions": [
+          "medium_noise_3328",
+          "high_noise_3328",
+          "high_noise_3330"
+        ],
+        "medium_sensitive_conditions": [
+          "medium_noise_3328"
+        ],
+        "high_sensitive_conditions": [
+          "high_noise_3328",
+          "high_noise_3330"
+        ],
+        "unavailable_conditions": [],
+        "limitation": "One scenario and one fixture seed only; this is diagnostic behavior-probe evidence, not a robustness, sensor-realism, or planner-superiority claim.",
+        "reasons": []
+      },
+      "near_field": {
+        "threshold_m": 2.0,
+        "clean_closest_robot_ped_distance_m": 1.65520666531114,
+        "satisfied": true
+      },
+      "command_sequence_changed": true,
+      "closest_distance_delta_m": 0.008230813627037481,
+      "collision_counts": {
+        "clean": {
+          "pedestrian": 0,
+          "obstacle": 0,
+          "robot": 0
+        },
+        "perturbed": {
+          "pedestrian": 0,
+          "obstacle": 0,
+          "robot": 0
+        }
+      },
+      "observation_summary_changed": null
+    },
+    {
+      "path": "docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid/summary.json",
+      "schema_version": "issue_2777_observation_noise_live_replay.v1",
+      "source_issue": 2777,
+      "scenario": "issue_2756_occluded_emergence",
+      "scenario_matrix": "configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml",
+      "condition_set": "issue_3330_seed_amplitude_grid",
+      "same_scenario": true,
+      "seed": 111,
+      "same_seed": true,
+      "status": "failed_closed",
+      "usable": false,
+      "status_rationale": "Issue #3330 seed/amplitude grid requires no-op closest_robot_ped_distance <= 2.0 m; observed 21.803818559278636.",
+      "classification": {
+        "label": "blocked",
+        "rationale": "Issue #3330 seed/amplitude grid requires no-op closest_robot_ped_distance <= 2.0 m; observed 21.803818559278636."
+      },
+      "grid_interpretation": {
+        "label": "unavailable_fail_closed",
+        "evidence_status": "diagnostic-only",
+        "summary": "Grid interpretation is unavailable/fail-closed because at least one required live replay condition did not complete under the fixture guardrails.",
+        "sensitive_conditions": [],
+        "medium_sensitive_conditions": [],
+        "high_sensitive_conditions": [],
+        "unavailable_conditions": [],
+        "limitation": "Diagnostic-only; no robustness claim is available.",
+        "reasons": [
+          "Issue #3330 seed/amplitude grid requires no-op closest_robot_ped_distance <= 2.0 m; observed 21.803818559278636."
+        ]
+      },
+      "near_field": {
+        "threshold_m": 2.0,
+        "clean_closest_robot_ped_distance_m": 21.803818559278636,
+        "satisfied": false
+      },
+      "command_sequence_changed": false,
+      "closest_distance_delta_m": 0.0,
+      "collision_counts": {
+        "clean": {
+          "pedestrian": 0,
+          "obstacle": 0,
+          "robot": 0
+        },
+        "perturbed": {
+          "pedestrian": 0,
+          "obstacle": 0,
+          "robot": 0
+        }
+      },
+      "observation_summary_changed": null
+    }
+  ],
+  "classification": {
+    "label": "fixture_candidate_failed_closed_after_sensitive_grid",
+    "rationale": "The committed #3330 near-field grid is behavior-sensitive, but the attempted second matrix failed closed under the near-field guardrail. Treat this as a useful negative external-validity check, not robustness evidence."
+  }
+}

--- a/scripts/benchmark/summarize_observation_noise_live_grid.py
+++ b/scripts/benchmark/summarize_observation_noise_live_grid.py
@@ -53,6 +53,25 @@ def _mapping(value: Any) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+def _conditions(summary: dict[str, Any]) -> list[Any]:
+    """Return summary conditions when they have the expected list shape."""
+
+    value = summary.get("conditions")
+    return value if isinstance(value, list) else []
+
+
+def _has_condition_list(summary: dict[str, Any]) -> bool:
+    """Return whether summary conditions have the expected list shape."""
+
+    return isinstance(summary.get("conditions"), list)
+
+
+def _first_item(value: Any) -> Any | None:
+    """Return the first item from a sequence-like summary field."""
+
+    return value[0] if isinstance(value, (list, tuple)) and value else None
+
+
 def _number(value: Any) -> float | None:
     """Normalize finite scalar values for report calculations."""
 
@@ -80,7 +99,7 @@ def _is_native_live_summary(summary: dict[str, Any]) -> bool:
         return (
             str(summary.get("artifact_shape")) == "compact_summary_without_raw_traces"
             and str(run_config.get("condition_set")) == "issue_3330_seed_amplitude_grid"
-            and isinstance(summary.get("conditions"), list)
+            and _has_condition_list(summary)
         )
     inputs = _mapping(summary.get("inputs"))
     has_trace_inputs = "clean_trace_json" in inputs and "perturbed_trace_json" in inputs
@@ -123,11 +142,15 @@ def _source_status(summary: dict[str, Any]) -> dict[str, Any]:
                 "reason": grid.get("summary") or "grid interpretation failed closed",
             }
         if any(
-            _mapping(condition.get("behavior_change_summary")).get("command_sequence_changed")
+            _mapping(_mapping(condition).get("behavior_change_summary")).get(
+                "command_sequence_changed"
+            )
             is True
-            or _mapping(condition.get("behavior_change_summary")).get("progress_or_risk_changed")
+            or _mapping(_mapping(condition).get("behavior_change_summary")).get(
+                "progress_or_risk_changed"
+            )
             is True
-            for condition in summary.get("conditions", [])
+            for condition in _conditions(summary)
         ):
             return {
                 "usable": True,
@@ -160,7 +183,7 @@ def _collision_counts(summary: dict[str, Any]) -> dict[str, Any]:
     """Return compact collision counts from progress deltas."""
 
     if str(summary.get("schema_version")) == "issue_2777_observation_noise_live_replay.v1":
-        for condition in summary.get("conditions", []):
+        for condition in _conditions(summary):
             collision = _mapping(_mapping(condition).get("progress_delta")).get(
                 "collision_flag_counts"
             )
@@ -181,7 +204,7 @@ def _collision_counts(summary: dict[str, Any]) -> dict[str, Any]:
 def _issue_2777_closest_noop(summary: dict[str, Any]) -> float | None:
     """Return the no-op closest distance from an issue #2777 grid summary."""
 
-    conditions = summary.get("conditions", [])
+    conditions = _conditions(summary)
     noop_summary = _mapping(_mapping(conditions[0]).get("progress_summary")) if conditions else {}
     noop_distance = _number(noop_summary.get("closest_robot_ped_distance"))
     if noop_distance is not None:
@@ -202,7 +225,7 @@ def _issue_2777_command_changed(summary: dict[str, Any]) -> bool:
     return any(
         _mapping(_mapping(condition).get("behavior_change_summary")).get("command_sequence_changed")
         is True
-        for condition in summary.get("conditions", [])
+        for condition in _conditions(summary)
     )
 
 
@@ -210,7 +233,7 @@ def _issue_2777_closest_delta(summary: dict[str, Any]) -> float | None:
     """Return the largest finite closest-distance delta across conditions."""
 
     deltas: list[float] = []
-    for condition in summary.get("conditions", []):
+    for condition in _conditions(summary):
         closest = _mapping(_mapping(condition).get("progress_delta")).get(
             "closest_robot_ped_distance"
         )
@@ -242,7 +265,7 @@ def _source_row(path: Path, summary: dict[str, Any]) -> dict[str, Any]:
             or fixture_contract.get("scenario_matrix"),
             "condition_set": run_config.get("condition_set"),
             "same_scenario": True,
-            "seed": _mapping(matched_scenario).get("seeds", [None])[0],
+            "seed": _first_item(matched_scenario.get("seeds")),
             "same_seed": True,
             "status": status["status"],
             "usable": status["usable"],

--- a/scripts/benchmark/summarize_observation_noise_live_grid.py
+++ b/scripts/benchmark/summarize_observation_noise_live_grid.py
@@ -1,0 +1,455 @@
+#!/usr/bin/env python3
+"""Summarize observation-noise live-smoke results across tracked fixtures.
+
+This tool consumes compact summaries produced from native live step-diagnostics
+replays. It does not treat fallback, degraded, unavailable, trace-derived-only,
+or malformed summaries as successful evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "issue_3335_observation_noise_live_grid.v1"
+DEFAULT_SOURCE_SUMMARIES = (
+    Path(
+        "docs/context/evidence/issue_2777_live_observation_noise_replay/"
+        "issue_3330_seed_amplitude_grid/summary.json"
+    ),
+    Path(
+        "docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/"
+        "issue_3320_seed_amplitude_grid/summary.json"
+    ),
+)
+DEFAULT_OUTPUT_JSON = Path(
+    "docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/summary.json"
+)
+DEFAULT_OUTPUT_MD = Path(
+    "docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/README.md"
+)
+CLAIM_BOUNDARY = (
+    "Diagnostic-only cross-fixture synthesis of tracked native live "
+    "step-diagnostics summaries. This checks whether observation-noise "
+    "behavior sensitivity appears across more than one fixture surface, but it "
+    "is not benchmark-strength, paper-grade, planner-superiority, robustness, "
+    "or hardware-calibrated sensor-realism evidence."
+)
+
+BEHAVIOR_LABELS = {"non_null_behavior_delta"}
+OBSERVATION_ONLY_LABELS = {
+    "observation_only_delta",
+    "observation_only_scenario_too_weak",
+    "null_policy_insensitive",
+}
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    """Return ``value`` when it is a mapping, otherwise an empty mapping."""
+
+    return value if isinstance(value, dict) else {}
+
+
+def _number(value: Any) -> float | None:
+    """Normalize finite scalar values for report calculations."""
+
+    if value is None or value == "" or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if math.isfinite(number) else None
+
+
+def _load_summary(path: Path) -> dict[str, Any]:
+    """Load one compact live-smoke summary."""
+
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _is_native_live_summary(summary: dict[str, Any]) -> bool:
+    """Return whether a summary has the expected native live trace shape."""
+
+    schema = str(summary.get("schema_version", ""))
+    if schema == "issue_2777_observation_noise_live_replay.v1":
+        run_config = _mapping(summary.get("run_config"))
+        return (
+            str(summary.get("artifact_shape")) == "compact_summary_without_raw_traces"
+            and str(run_config.get("condition_set")) == "issue_3330_seed_amplitude_grid"
+            and isinstance(summary.get("conditions"), list)
+        )
+    inputs = _mapping(summary.get("inputs"))
+    has_trace_inputs = "clean_trace_json" in inputs and "perturbed_trace_json" in inputs
+    has_progress = isinstance(summary.get("progress_delta"), dict)
+    has_commands = isinstance(summary.get("command_summary"), dict)
+    return schema.endswith("observation_noise_live_smoke.v1") and (
+        has_trace_inputs and has_progress and has_commands
+    )
+
+
+def _source_status(summary: dict[str, Any]) -> dict[str, Any]:
+    """Classify whether one source summary is usable for this synthesis."""
+
+    if not _is_native_live_summary(summary):
+        return {
+            "usable": False,
+            "status": "failed_closed",
+            "reason": "source is not a native live step-diagnostics summary",
+        }
+    if str(summary.get("schema_version")) == "issue_2777_observation_noise_live_replay.v1":
+        classification = _mapping(summary.get("classification"))
+        if str(summary.get("status")) != "live_replay":
+            return {
+                "usable": False,
+                "status": "failed_closed",
+                "reason": classification.get("rationale") or "source did not complete live replay",
+            }
+        fixture_contract = _mapping(summary.get("fixture_contract"))
+        if fixture_contract.get("satisfied") is not True:
+            return {
+                "usable": False,
+                "status": "failed_closed",
+                "reason": fixture_contract.get("blocker") or "fixture contract was not satisfied",
+            }
+        grid = _mapping(summary.get("grid_interpretation"))
+        if str(grid.get("label")) == "unavailable_fail_closed":
+            return {
+                "usable": False,
+                "status": "failed_closed",
+                "reason": grid.get("summary") or "grid interpretation failed closed",
+            }
+        if any(
+            _mapping(condition.get("behavior_change_summary")).get("command_sequence_changed")
+            is True
+            or _mapping(condition.get("behavior_change_summary")).get("progress_or_risk_changed")
+            is True
+            for condition in summary.get("conditions", [])
+        ):
+            return {
+                "usable": True,
+                "status": "behavior_sensitive_grid",
+                "reason": grid.get("summary") or classification.get("rationale"),
+            }
+        return {
+            "usable": True,
+            "status": "policy_insensitive_grid",
+            "reason": grid.get("summary") or classification.get("rationale"),
+        }
+    classification = _mapping(summary.get("classification"))
+    label = str(classification.get("label", ""))
+    if label in BEHAVIOR_LABELS:
+        return {
+            "usable": True,
+            "status": "behavior_sensitive",
+            "reason": classification.get("rationale"),
+        }
+    if label in OBSERVATION_ONLY_LABELS:
+        return {"usable": True, "status": label, "reason": classification.get("rationale")}
+    return {
+        "usable": False,
+        "status": "failed_closed",
+        "reason": f"unsupported classification label: {label or '<missing>'}",
+    }
+
+
+def _collision_counts(summary: dict[str, Any]) -> dict[str, Any]:
+    """Return compact collision counts from progress deltas."""
+
+    if str(summary.get("schema_version")) == "issue_2777_observation_noise_live_replay.v1":
+        for condition in summary.get("conditions", []):
+            collision = _mapping(_mapping(condition).get("progress_delta")).get(
+                "collision_flag_counts"
+            )
+            collision = _mapping(collision)
+            if collision:
+                return {
+                    "clean": _mapping(collision.get("noop")),
+                    "perturbed": _mapping(collision.get("condition")),
+                }
+        return {"clean": {}, "perturbed": {}}
+    collision = _mapping(_mapping(summary.get("progress_delta")).get("collision_flag_counts"))
+    return {
+        "clean": _mapping(collision.get("clean")),
+        "perturbed": _mapping(collision.get("perturbed")),
+    }
+
+
+def _issue_2777_closest_noop(summary: dict[str, Any]) -> float | None:
+    """Return the no-op closest distance from an issue #2777 grid summary."""
+
+    conditions = summary.get("conditions", [])
+    noop_summary = _mapping(_mapping(conditions[0]).get("progress_summary")) if conditions else {}
+    noop_distance = _number(noop_summary.get("closest_robot_ped_distance"))
+    if noop_distance is not None:
+        return noop_distance
+    for condition in conditions:
+        closest = _mapping(_mapping(condition).get("progress_delta")).get(
+            "closest_robot_ped_distance"
+        )
+        noop_distance = _number(_mapping(closest).get("noop"))
+        if noop_distance is not None:
+            return noop_distance
+    return None
+
+
+def _issue_2777_command_changed(summary: dict[str, Any]) -> bool:
+    """Return whether any condition changed selected commands."""
+
+    return any(
+        _mapping(_mapping(condition).get("behavior_change_summary")).get("command_sequence_changed")
+        is True
+        for condition in summary.get("conditions", [])
+    )
+
+
+def _issue_2777_closest_delta(summary: dict[str, Any]) -> float | None:
+    """Return the largest finite closest-distance delta across conditions."""
+
+    deltas: list[float] = []
+    for condition in summary.get("conditions", []):
+        closest = _mapping(_mapping(condition).get("progress_delta")).get(
+            "closest_robot_ped_distance"
+        )
+        closest_map = _mapping(closest)
+        noop = _number(closest_map.get("noop"))
+        condition_value = _number(closest_map.get("condition"))
+        if noop is not None and condition_value is not None:
+            deltas.append(condition_value - noop)
+    if not deltas:
+        return None
+    return max(deltas, key=abs)
+
+
+def _source_row(path: Path, summary: dict[str, Any]) -> dict[str, Any]:
+    """Build one source row for the cross-fixture report."""
+
+    status = _source_status(summary)
+    if str(summary.get("schema_version")) == "issue_2777_observation_noise_live_replay.v1":
+        fixture_contract = _mapping(summary.get("fixture_contract"))
+        matched_scenario = _mapping(fixture_contract.get("matched_scenario"))
+        run_config = _mapping(summary.get("run_config"))
+        closest = _issue_2777_closest_noop(summary)
+        return {
+            "path": path.as_posix(),
+            "schema_version": summary.get("schema_version"),
+            "source_issue": summary.get("issue"),
+            "scenario": matched_scenario.get("name"),
+            "scenario_matrix": run_config.get("scenario_matrix")
+            or fixture_contract.get("scenario_matrix"),
+            "condition_set": run_config.get("condition_set"),
+            "same_scenario": True,
+            "seed": _mapping(matched_scenario).get("seeds", [None])[0],
+            "same_seed": True,
+            "status": status["status"],
+            "usable": status["usable"],
+            "status_rationale": status["reason"],
+            "classification": _mapping(summary.get("classification")),
+            "grid_interpretation": _mapping(summary.get("grid_interpretation")),
+            "near_field": {
+                "threshold_m": 2.0,
+                "clean_closest_robot_ped_distance_m": closest,
+                "satisfied": closest is not None and closest <= 2.0,
+            },
+            "command_sequence_changed": _issue_2777_command_changed(summary),
+            "closest_distance_delta_m": _issue_2777_closest_delta(summary),
+            "collision_counts": _collision_counts(summary),
+            "observation_summary_changed": None,
+        }
+    near_field = _mapping(summary.get("near_field_target"))
+    progress = _mapping(summary.get("progress_delta"))
+    closest_delta = _mapping(progress.get("closest_robot_ped_distance"))
+    return {
+        "path": path.as_posix(),
+        "schema_version": summary.get("schema_version"),
+        "source_issue": summary.get("issue"),
+        "scenario": _mapping(summary.get("scenario")).get("clean"),
+        "same_scenario": _mapping(summary.get("scenario")).get("same_scenario"),
+        "seed": _mapping(summary.get("seed")).get("clean"),
+        "same_seed": _mapping(summary.get("seed")).get("same_seed"),
+        "status": status["status"],
+        "usable": status["usable"],
+        "status_rationale": status["reason"],
+        "classification": _mapping(summary.get("classification")),
+        "near_field": {
+            "threshold_m": near_field.get("threshold_m"),
+            "clean_closest_robot_ped_distance_m": near_field.get(
+                "clean_closest_robot_ped_distance_m"
+            ),
+            "satisfied": near_field.get("satisfied"),
+        },
+        "command_sequence_changed": _mapping(summary.get("command_summary")).get(
+            "sequence_changed"
+        ),
+        "closest_distance_delta_m": closest_delta.get("delta"),
+        "collision_counts": _collision_counts(summary),
+        "observation_summary_changed": _mapping(summary.get("observation_summary")).get("changed"),
+    }
+
+
+def _grid_classification(rows: list[dict[str, Any]]) -> dict[str, str]:
+    """Classify the cross-fixture sensitivity pattern conservatively."""
+
+    usable = [row for row in rows if row["usable"]]
+    failed_closed = [row for row in rows if not row["usable"]]
+    if not usable:
+        return {
+            "label": "failed_closed_no_native_live_evidence",
+            "rationale": "No usable native live step-diagnostics summaries were available.",
+        }
+    sensitive = [
+        row for row in usable if row["status"] in {"behavior_sensitive", "behavior_sensitive_grid"}
+    ]
+    near_field = [row for row in usable if _mapping(row.get("near_field")).get("satisfied") is True]
+    weak = [row for row in usable if row["status"] == "observation_only_scenario_too_weak"]
+    if sensitive and failed_closed:
+        return {
+            "label": "fixture_candidate_failed_closed_after_sensitive_grid",
+            "rationale": (
+                "The committed #3330 near-field grid is behavior-sensitive, but the attempted "
+                "second matrix failed closed under the near-field guardrail. Treat this as a "
+                "useful negative external-validity check, not robustness evidence."
+            ),
+        }
+    if sensitive and len(sensitive) == len(usable):
+        return {
+            "label": "sensitivity_persists_across_sources",
+            "rationale": "All usable native live summaries reported non-null behavior deltas.",
+        }
+    if sensitive and near_field and weak:
+        return {
+            "label": "fixture_specific_near_field_sensitivity",
+            "rationale": (
+                "At least one near-field native live fixture was behavior-sensitive, while "
+                "at least one source changed observations only and was explicitly too weak."
+            ),
+        }
+    if sensitive:
+        return {
+            "label": "mixed_or_profile_specific_sensitivity",
+            "rationale": (
+                "Some, but not all, usable native live summaries reported non-null behavior deltas."
+            ),
+        }
+    return {
+        "label": "no_behavior_sensitivity_observed",
+        "rationale": "Usable native live summaries did not report non-null behavior deltas.",
+    }
+
+
+def build_report(source_paths: list[Path], *, command: str) -> dict[str, Any]:
+    """Build the compact cross-fixture report."""
+
+    rows = [_source_row(path, _load_summary(path)) for path in source_paths]
+    usable = [row for row in rows if row["usable"]]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 3335,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "reproducibility": {
+            "command": command,
+            "source_summaries": [path.as_posix() for path in source_paths],
+        },
+        "source_count": len(rows),
+        "usable_native_live_source_count": len(usable),
+        "failed_closed_source_count": len(rows) - len(usable),
+        "sources": rows,
+        "classification": _grid_classification(rows),
+    }
+
+
+def _markdown(report: dict[str, Any]) -> str:
+    """Render the report as compact Markdown."""
+
+    classification = _mapping(report.get("classification"))
+    lines = [
+        "# Issue #3335 Observation-Noise Cross-Fixture Live Grid",
+        "",
+        "## Claim Boundary",
+        "",
+        str(report["claim_boundary"]),
+        "",
+        "## Reproducibility",
+        "",
+        f"- Command: `{_mapping(report['reproducibility']).get('command')}`",
+        f"- Source summaries: `{report['source_count']}`",
+        f"- Usable native live sources: `{report['usable_native_live_source_count']}`",
+        f"- Failed-closed sources: `{report['failed_closed_source_count']}`",
+        "",
+        "## Classification",
+        "",
+        f"- Label: `{classification.get('label')}`",
+        f"- Rationale: {classification.get('rationale')}",
+        "",
+        "## Source Rows",
+        "",
+        "| Source | Scenario | Seed | Near-field | Status | Command changed | Closest delta |",
+        "|---|---|---:|---|---|---|---:|",
+    ]
+    for row in report["sources"]:
+        near_field = _mapping(row.get("near_field"))
+        lines.append(
+            f"| `{row['path']}` | `{row.get('scenario')}` | `{row.get('seed')}` | "
+            f"`{near_field.get('satisfied')}` | `{row['status']}` | "
+            f"`{row.get('command_sequence_changed')}` | "
+            f"`{row.get('closest_distance_delta_m')}` |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Caveats",
+            "",
+            "- This is a synthesis of tracked compact native live summaries, not a new full benchmark.",
+            "- Fallback, degraded, unavailable, or malformed sources fail closed.",
+            "- Fixture/profile-specific results remain diagnostic-only and do not support sensor-realism claims.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-summary",
+        dest="source_summaries",
+        type=Path,
+        action="append",
+        default=None,
+        help="Tracked compact native live-smoke summary JSON. May be repeated.",
+    )
+    parser.add_argument("--output-json", type=Path, default=DEFAULT_OUTPUT_JSON)
+    parser.add_argument("--output-md", type=Path, default=DEFAULT_OUTPUT_MD)
+    args = parser.parse_args(argv)
+
+    source_paths = list(args.source_summaries or DEFAULT_SOURCE_SUMMARIES)
+    command = (
+        "uv run python scripts/benchmark/summarize_observation_noise_live_grid.py "
+        + " ".join(f"--source-summary {path.as_posix()}" for path in source_paths)
+        + f" --output-json {args.output_json.as_posix()} --output-md {args.output_md.as_posix()}"
+    )
+    report = build_report(source_paths, command=command)
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_md.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(json.dumps(report, indent=2), encoding="utf-8")
+    args.output_md.write_text(_markdown(report), encoding="utf-8")
+    print(
+        json.dumps(
+            {
+                "schema_version": SCHEMA_VERSION,
+                "classification": report["classification"],
+                "output_json": args.output_json.as_posix(),
+                "output_md": args.output_md.as_posix(),
+            },
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_observation_noise_live_grid_summary.py
+++ b/tests/benchmark/test_observation_noise_live_grid_summary.py
@@ -1,0 +1,248 @@
+"""Tests for the issue #3335 observation-noise live-grid summarizer."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = Path("scripts/benchmark/summarize_observation_noise_live_grid.py")
+_LOADED_MOD = None
+
+
+def _load_script():
+    """Load the summarizer script as a module."""
+
+    global _LOADED_MOD
+    if _LOADED_MOD is not None:
+        return _LOADED_MOD
+    spec = importlib.util.spec_from_file_location(
+        "summarize_observation_noise_live_grid", SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["summarize_observation_noise_live_grid"] = mod
+    spec.loader.exec_module(mod)
+    _LOADED_MOD = mod
+    return _LOADED_MOD
+
+
+def _summary(
+    *,
+    scenario: str,
+    label: str,
+    near_field: bool,
+    command_changed: bool,
+    closest_delta: float = 0.0,
+) -> dict:
+    """Build a compact native live summary fixture."""
+
+    return {
+        "schema_version": "issue_3201_observation_noise_live_smoke.v1",
+        "issue": 3201,
+        "inputs": {
+            "clean_trace_json": "worktree-local ignored artifact summarized in this report/a.json",
+            "perturbed_trace_json": "worktree-local ignored artifact summarized in this report/b.json",
+        },
+        "scenario": {"clean": scenario, "perturbed": scenario, "same_scenario": True},
+        "seed": {"clean": 111, "perturbed": 111, "same_seed": True},
+        "near_field_target": {
+            "threshold_m": 2.0,
+            "clean_closest_robot_ped_distance_m": 1.0 if near_field else 7.0,
+            "satisfied": near_field,
+        },
+        "command_summary": {"sequence_changed": command_changed},
+        "observation_summary": {"changed": True},
+        "progress_delta": {
+            "closest_robot_ped_distance": {
+                "clean": 1.0,
+                "perturbed": 1.0 + closest_delta,
+                "delta": closest_delta,
+            },
+            "collision_flag_counts": {
+                "clean": {"pedestrian": 0, "obstacle": 0, "robot": 0},
+                "perturbed": {"pedestrian": 1 if command_changed else 0, "obstacle": 0, "robot": 0},
+            },
+        },
+        "classification": {"label": label, "rationale": "fixture"},
+    }
+
+
+def _write(path: Path, payload: dict) -> Path:
+    """Write one JSON payload and return its path."""
+
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _issue_2777_grid_summary(*, status: str, grid_label: str, closest: float) -> dict:
+    """Build a compact issue #2777 grid summary fixture."""
+
+    behavior_sensitive = grid_label == "medium_amplitude_sensitive"
+    return {
+        "schema_version": "issue_2777_observation_noise_live_replay.v1",
+        "artifact_shape": "compact_summary_without_raw_traces",
+        "issue": 2777,
+        "status": status,
+        "classification": {
+            "label": "behavior_sensitive_diagnostic_only" if behavior_sensitive else "blocked",
+            "rationale": "grid fixture",
+        },
+        "fixture_contract": {
+            "satisfied": True,
+            "matched_scenario": {
+                "name": "issue_2756_occluded_emergence",
+                "seeds": [111],
+            },
+            "scenario_matrix": "configs/scenarios/sets/example.yaml",
+        },
+        "run_config": {
+            "scenario_matrix": "configs/scenarios/sets/example.yaml",
+            "condition_set": "issue_3330_seed_amplitude_grid",
+        },
+        "grid_interpretation": {
+            "label": grid_label,
+            "summary": "grid summary",
+        },
+        "conditions": [
+            {
+                "name": "noop",
+                "progress_summary": {
+                    "closest_robot_ped_distance": closest,
+                    "collision_flag_counts": {"pedestrian": 0},
+                },
+            },
+            {
+                "name": "medium_noise_3328",
+                "behavior_change_summary": {
+                    "command_sequence_changed": behavior_sensitive,
+                    "progress_or_risk_changed": behavior_sensitive,
+                },
+                "progress_delta": {
+                    "closest_robot_ped_distance": {
+                        "noop": closest,
+                        "condition": closest - 0.2,
+                    },
+                    "collision_flag_counts": {
+                        "noop": {"pedestrian": 0},
+                        "condition": {"pedestrian": 0},
+                    },
+                },
+            },
+        ],
+    }
+
+
+def test_issue_2777_grid_sources_classify_failed_second_candidate(tmp_path: Path) -> None:
+    """#3335 should preserve a failed-closed second matrix as negative evidence."""
+
+    sensitive = _write(
+        tmp_path / "sensitive.json",
+        _issue_2777_grid_summary(
+            status="live_replay",
+            grid_label="medium_amplitude_sensitive",
+            closest=1.6,
+        ),
+    )
+    failed = _write(
+        tmp_path / "failed.json",
+        _issue_2777_grid_summary(
+            status="fail_closed",
+            grid_label="unavailable_fail_closed",
+            closest=21.8,
+        ),
+    )
+
+    report = _load_script().build_report([sensitive, failed], command="test")
+
+    assert report["usable_native_live_source_count"] == 1
+    assert report["failed_closed_source_count"] == 1
+    assert (
+        report["classification"]["label"] == "fixture_candidate_failed_closed_after_sensitive_grid"
+    )
+    assert report["sources"][0]["status"] == "behavior_sensitive_grid"
+    assert report["sources"][1]["status"] == "failed_closed"
+
+
+def test_grid_classifies_near_field_sensitivity_as_fixture_specific(tmp_path: Path) -> None:
+    """A sensitive near-field row plus a too-weak row should stay conservative."""
+
+    weak = _write(
+        tmp_path / "weak.json",
+        _summary(
+            scenario="dense_pedestrian_stress",
+            label="observation_only_scenario_too_weak",
+            near_field=False,
+            command_changed=False,
+        ),
+    )
+    sensitive = _write(
+        tmp_path / "near_field.json",
+        _summary(
+            scenario="issue_3233_near_field_observation_noise",
+            label="non_null_behavior_delta",
+            near_field=True,
+            command_changed=True,
+            closest_delta=-0.2,
+        ),
+    )
+
+    report = _load_script().build_report([weak, sensitive], command="test")
+
+    assert report["usable_native_live_source_count"] == 2
+    assert report["failed_closed_source_count"] == 0
+    assert report["classification"]["label"] == "fixture_specific_near_field_sensitivity"
+    assert report["sources"][1]["status"] == "behavior_sensitive"
+
+
+def test_grid_fails_closed_for_trace_derived_summary(tmp_path: Path) -> None:
+    """Trace-derived envelopes should not be accepted as native live replay evidence."""
+
+    trace_derived = _write(
+        tmp_path / "trace_derived.json",
+        {
+            "schema_version": "observation_noise_envelope.v1",
+            "classification": {"label": "diagnostic_only"},
+            "conditions": [],
+        },
+    )
+
+    report = _load_script().build_report([trace_derived], command="test")
+
+    assert report["usable_native_live_source_count"] == 0
+    assert report["failed_closed_source_count"] == 1
+    assert report["classification"]["label"] == "failed_closed_no_native_live_evidence"
+    assert report["sources"][0]["status"] == "failed_closed"
+
+
+def test_cli_writes_summary_and_markdown(tmp_path: Path) -> None:
+    """The CLI writes compact durable artifacts."""
+
+    source = _write(
+        tmp_path / "source.json",
+        _summary(
+            scenario="issue_3233_near_field_observation_noise",
+            label="non_null_behavior_delta",
+            near_field=True,
+            command_changed=True,
+        ),
+    )
+    output_json = tmp_path / "summary.json"
+    output_md = tmp_path / "README.md"
+
+    assert (
+        _load_script().main(
+            [
+                "--source-summary",
+                str(source),
+                "--output-json",
+                str(output_json),
+                "--output-md",
+                str(output_md),
+            ]
+        )
+        == 0
+    )
+
+    assert json.loads(output_json.read_text(encoding="utf-8"))["schema_version"].endswith(".v1")
+    assert "Issue #3335" in output_md.read_text(encoding="utf-8")

--- a/tests/benchmark/test_observation_noise_live_grid_summary.py
+++ b/tests/benchmark/test_observation_noise_live_grid_summary.py
@@ -164,6 +164,63 @@ def test_issue_2777_grid_sources_classify_failed_second_candidate(tmp_path: Path
     assert report["sources"][1]["status"] == "failed_closed"
 
 
+def test_issue_2777_grid_summary_coerces_malformed_conditions(tmp_path: Path) -> None:
+    """Malformed condition fields should fail closed instead of raising during row enrichment."""
+
+    mod = _load_script()
+    for condition_value in (None, {"bad": "shape"}):
+        payload = _issue_2777_grid_summary(
+            status="live_replay",
+            grid_label="medium_amplitude_sensitive",
+            closest=1.6,
+        )
+        payload["conditions"] = condition_value
+        source = _write(tmp_path / f"source_{condition_value is None}.json", payload)
+
+        report = mod.build_report([source], command="test")
+
+        assert report["usable_native_live_source_count"] == 0
+        assert report["sources"][0]["status"] == "failed_closed"
+        assert report["sources"][0]["closest_distance_delta_m"] is None
+        assert report["sources"][0]["collision_counts"] == {"clean": {}, "perturbed": {}}
+
+
+def test_issue_2777_grid_summary_coerces_condition_items_and_seed(tmp_path: Path) -> None:
+    """Non-mapping condition entries and malformed seed lists should not crash summaries."""
+
+    payload = _issue_2777_grid_summary(
+        status="live_replay",
+        grid_label="medium_amplitude_sensitive",
+        closest=1.6,
+    )
+    payload["fixture_contract"]["matched_scenario"]["seeds"] = None
+    payload["conditions"] = [
+        "not-a-condition-map",
+        {
+            "behavior_change_summary": {
+                "command_sequence_changed": True,
+                "progress_or_risk_changed": True,
+            },
+            "progress_delta": {
+                "closest_robot_ped_distance": {"noop": 1.6, "condition": 1.4},
+                "collision_flag_counts": {
+                    "noop": {"pedestrian": 0},
+                    "condition": {"pedestrian": 1},
+                },
+            },
+        },
+    ]
+    source = _write(tmp_path / "source.json", payload)
+
+    report = _load_script().build_report([source], command="test")
+
+    assert report["usable_native_live_source_count"] == 1
+    assert report["sources"][0]["seed"] is None
+    assert report["sources"][0]["status"] == "behavior_sensitive_grid"
+    assert report["sources"][0]["command_sequence_changed"] is True
+    assert abs(report["sources"][0]["closest_distance_delta_m"] - -0.2) < 1e-9
+
+
 def test_grid_classifies_near_field_sensitivity_as_fixture_specific(tmp_path: Path) -> None:
     """A sensitive near-field row plus a too-weak row should stay conservative."""
 


### PR DESCRIPTION
## Summary

- Add `scripts/benchmark/summarize_observation_noise_live_grid.py` to synthesize tracked native live observation-noise grid summaries without accepting fallback/degraded/malformed sources.
- Add #3335 compact evidence under `docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/`.
- Record the #3335 result as diagnostic-only: the committed #3330 near-field grid is behavior-sensitive, but the attempted `issue_3320_occluded_emergence_live_replay` second matrix failed closed because the no-op closest robot-pedestrian distance was 21.80 m, outside the <=2 m near-field guardrail.

Closes #3335.

## Validation

- `uv run pytest tests/benchmark/test_observation_noise_live_grid_summary.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py`
- `uv run ruff check scripts/benchmark/summarize_observation_noise_live_grid.py tests/benchmark/test_observation_noise_live_grid_summary.py`
- `uv run ruff format --check scripts/benchmark/summarize_observation_noise_live_grid.py tests/benchmark/test_observation_noise_live_grid_summary.py`
- `scripts/dev/check_docs_proof_consistency_diff.sh`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/run_observation_noise_live_replay_issue_2777.py --scenario-matrix configs/scenarios/sets/issue_3320_occluded_emergence_live_replay.yaml --condition-set issue_3330_seed_amplitude_grid --output-dir docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/issue_3320_seed_amplitude_grid` (expected fail-closed exit 2; compact summary preserved)
- `PYTEST_NUM_WORKERS=1 BASE_REF=origin/main scripts/dev/pr_ready_check.sh`

Notes:

- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` with default xdist reproduced the known #3334 collection-order anomaly around `tests/test_error_policy.py::TestModelLoadingErrors::test_missing_model_without_fallback_raises`.
- After `uv sync --all-extras`, that node passed directly and the single-worker readiness gate passed: core `1103 passed`; optional `2750 passed, 9 skipped`.

## Downstream Propagation

- Evidence catalog updated via `docs/context/evidence/README.md` and `docs/context/catalog.yaml`.
- Raw trace directories and generated funnel output from the failed-closed live replay were not committed; only compact `README.md` and `summary.json` were preserved.

## Research Result Guidance

- Target claim/hypothesis/blocker: test whether #3330 observation-noise behavior sensitivity generalizes beyond the one near-field fixture seed.
- Comparator/baseline: committed #3330 near-field seed/amplitude grid vs attempted `issue_3320` live matrix replay using the same condition set.
- Evidence tier: diagnostic native live replay summary plus failed-closed candidate evidence.
- Result classification: `fixture_candidate_failed_closed_after_sensitive_grid`.
- Decision/stop rule: stop because the second matrix violates the near-field guardrail (`closest_robot_ped_distance=21.80 m`), so it is not valid external-validity evidence.
- Synthesis surface/update target: `docs/context/evidence/issue_3335_observation_noise_cross_fixture_2026-06-21/`.
