### PR TITLE
metrics: add Social Mini-Game diagnostic rows

### DIFF
--- a/configs/benchmarks/social_mini_game_metric_contract_v1.yaml
+++ b/configs/benchmarks/social_mini_game_metric_contract_v1.yaml
@@ -1,0 +1,49 @@
+schema_version: social-mini-game-metric-contract.v1
+issue: 3280
+status: diagnostic_contract
+claim_boundary: >
+  Social Mini-Game metrics are mechanism diagnostics for local social-navigation scenarios. They
+  expose denominators, units, support counts, and unavailable rows, but they do not establish
+  real-world comfort, fairness, safety, or paper-grade benchmark evidence by themselves.
+episode_metrics_namespace: metrics.social_mini_game
+row_schema_version: social-mini-game-metrics.v1
+status_values:
+  - available
+  - unavailable
+  - undefined
+missing_data_policy: >
+  Emit a row for each contract metric. Use status=available only when a value is supported by the
+  episode data. Use status=undefined when the metric is mathematically undefined for the episode
+  outcome. Use status=unavailable when the required signal is absent. Valid zero values must remain
+  numeric values with status=available.
+metric_rows:
+  - id: makespan_ratio
+    units: ratio
+    denominator: successful episodes with finite ideal-time baseline
+    source_metric: time_to_goal_ideal_ratio
+    missing_data_behavior: undefined when the episode did not reach the goal or lacks ideal time
+  - id: path_deviation_ratio
+    units: ratio_over_straight_line
+    denominator: robot trajectory length divided by start-goal displacement
+    source_metric: socnavbench_path_length_ratio - 1
+    missing_data_behavior: undefined when start-goal displacement or trajectory length is unavailable
+  - id: deadlock_frequency
+    units: events_per_episode
+    denominator: one episode
+    source_metric: failure_to_progress
+    missing_data_behavior: undefined when failure-to-progress cannot be computed
+  - id: flow_throughput
+    units: pedestrians_per_second
+    denominator: pedestrian arrivals or exits over elapsed scenario time
+    source_metric: unavailable until episodes carry arrival or exit counts
+    missing_data_behavior: unavailable without pedestrian arrival or exit counts
+  - id: distributional_inconvenience
+    units: diagnostic_cohort_delta
+    denominator: matched robot-present and control pedestrian trajectories by cohort
+    source_metric: distributional_disruption
+    missing_data_behavior: unavailable without paired control trajectory cohort comparison
+  - id: invasiveness
+    units: m*s
+    denominator: proxemic exposure over robot-pedestrian trajectory samples
+    source_metric: human_interaction_proxy.canonical_reductions.human_discomfort_exposure_m_s
+    missing_data_behavior: unavailable when human-interaction proxy metrics are disabled or unsupported

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -426,7 +426,7 @@ def _flatten_human_interaction_proxy_block(
 
 def _flatten_social_mini_game_block(base: dict[str, Any], social_mini_game: Any) -> None:
     """Flatten available Social Mini-Game row values with a stable prefix."""
-    if not isinstance(social_mini_game, dict):
+    if not isinstance(social_mini_game, dict) or not social_mini_game:
         return
     base["social_mini_game_status"] = social_mini_game.get("status")
     base["social_mini_game_mechanism_family"] = social_mini_game.get("mechanism_family")

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -424,6 +424,28 @@ def _flatten_human_interaction_proxy_block(
             base[source_key] = reductions.get(source_key)
 
 
+def _flatten_social_mini_game_block(base: dict[str, Any], social_mini_game: Any) -> None:
+    """Flatten available Social Mini-Game row values with a stable prefix."""
+    if not isinstance(social_mini_game, dict):
+        return
+    base["social_mini_game_status"] = social_mini_game.get("status")
+    base["social_mini_game_mechanism_family"] = social_mini_game.get("mechanism_family")
+    rows = social_mini_game.get("rows") or []
+    if not isinstance(rows, list):
+        return
+    for row in rows:
+        if not isinstance(row, dict):
+            continue
+        metric = row.get("metric")
+        if not isinstance(metric, str) or not metric:
+            continue
+        prefix = f"social_mini_game_{metric}"
+        base[f"{prefix}_status"] = row.get("status")
+        base[f"{prefix}_support_count"] = row.get("support_count")
+        if row.get("status") == "available" and "value" in row:
+            base[prefix] = row.get("value")
+
+
 def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     """Flatten metrics dict into a flat per-episode row.
 
@@ -441,6 +463,7 @@ def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     ped_impact = metrics.pop("pedestrian_impact", {}) or {}
     social_acceptability = metrics.pop("social_acceptability", {}) or {}
     human_interaction_proxy = metrics.pop("human_interaction_proxy", {}) or {}
+    social_mini_game = metrics.pop("social_mini_game", {}) or {}
     inter_robot = metrics.pop("inter_robot", {}) or {}
     # Flatten known force quantiles
     for qk in ("q50", "q90", "q95"):
@@ -451,6 +474,7 @@ def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     _flatten_pedestrian_impact_block(base, ped_impact)
     _flatten_social_acceptability_block(base, social_acceptability)
     _flatten_human_interaction_proxy_block(base, human_interaction_proxy)
+    _flatten_social_mini_game_block(base, social_mini_game)
     if isinstance(inter_robot, dict):
         for key, value in inter_robot.items():
             base[str(key)] = value

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -3047,9 +3047,7 @@ def _attach_social_mini_game_block(metrics: dict[str, Any]) -> None:
         and bool(distributional_block.get("cohort_metrics"))
     )
     distributional_support_counts = (
-        distributional_block.get("support_counts")
-        if isinstance(distributional_block, dict)
-        else {}
+        distributional_block.get("support_counts") if isinstance(distributional_block, dict) else {}
     )
     if not isinstance(distributional_support_counts, dict):
         distributional_support_counts = {}

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -1683,6 +1683,8 @@ def failure_to_progress(
     Section 3.2, Table 1: "Failure to progress (FP)" metric
     """
     T = data.robot_pos.shape[0]
+    if not math.isfinite(data.dt) or data.dt <= 0.0:
+        return float("nan")
     window_steps = int(np.ceil(time_threshold / data.dt))
 
     if T < window_steps:
@@ -1729,6 +1731,8 @@ def stalled_time(data: EpisodeData, *, velocity_threshold: float = 0.05) -> floa
     ---------------
     Section 3.2, Table 1: "Stalled time (ST)" metric
     """
+    if not math.isfinite(data.dt) or data.dt < 0.0:
+        return float("nan")
     speeds = np.linalg.norm(data.robot_vel, axis=1)
     stalled_count = np.count_nonzero(speeds < velocity_threshold)
     return float(stalled_count * data.dt)
@@ -2529,6 +2533,8 @@ METRIC_NAMES: list[str] = [
     "wall_collisions",
     "clearing_distance_min",
     "clearing_distance_avg",
+    "failure_to_progress",
+    "stalled_time",
     "signal_red_phase_violations",
     "signal_stop_line_crossings_under_red",
     "signal_min_distance_to_stop_line_before_crossing_m",
@@ -2607,6 +2613,8 @@ def compute_all_metrics(  # noqa: PLR0913, PLR0915
     )
 
     values: dict[str, Any] = {}
+    if isinstance(data.episode_metadata, dict):
+        values["_episode_metadata"] = dict(data.episode_metadata)
     try:
         values.update(calculate_signal_metrics(data))
     except Exception:
@@ -2684,6 +2692,8 @@ def compute_all_metrics(  # noqa: PLR0913, PLR0915
     values["wall_collisions"] = values["obstacle_collision_count"]
     values["clearing_distance_min"] = clearing_distance_min(data)
     values["clearing_distance_avg"] = clearing_distance_avg(data)
+    values["failure_to_progress"] = failure_to_progress(data)
+    values["stalled_time"] = stalled_time(data)
     if experimental_ped_impact:
         values.update(
             experimental_ped_impact_metrics(
@@ -2783,6 +2793,8 @@ def post_process_metrics(
     _attach_pedestrian_impact_block(metrics)
     _attach_social_acceptability_block(metrics)
     _attach_human_interaction_proxy_block(metrics)
+    _attach_social_mini_game_block(metrics)
+    metrics.pop("_episode_metadata", None)
     return _sanitize_metrics(metrics)
 
 
@@ -2903,6 +2915,200 @@ def _attach_human_interaction_proxy_block(metrics: dict[str, Any]) -> None:
         "interpretation": (
             "Diagnostic simulation-proxy metrics for mechanism reports only; not validated "
             "human comfort, human-subject, safety, or paper-grade social-compliance evidence."
+        ),
+    }
+
+
+def _social_mini_game_metric_row(
+    *,
+    metric: str,
+    status: str,
+    unit: str,
+    denominator: str,
+    value: float | int | bool | None = None,
+    support_count: int = 0,
+    unavailable_reason: str | None = None,
+) -> dict[str, Any]:
+    """Build one Social Mini-Game metric row with explicit availability semantics.
+
+    Returns:
+        Row dictionary ready for the ``social_mini_game`` metric block.
+    """
+    row: dict[str, Any] = {
+        "metric": metric,
+        "status": status,
+        "unit": unit,
+        "denominator": denominator,
+        "support_count": int(support_count),
+    }
+    if value is not None:
+        row["value"] = value
+    if unavailable_reason:
+        row["unavailable_reason"] = unavailable_reason
+    return row
+
+
+def _social_mini_game_mechanism_family(metrics: dict[str, Any]) -> str:
+    """Resolve a mechanism-family label from optional episode metadata.
+
+    Returns:
+        Mechanism-family label, or ``unknown`` when no supported metadata key is present.
+    """
+    metadata = metrics.get("_episode_metadata")
+    if not isinstance(metadata, dict):
+        return "unknown"
+    for key in (
+        "social_mini_game_mechanism_family",
+        "mechanism_family",
+        "mechanism_aware_suite_id",
+        "target_mechanism",
+        "mechanism_id",
+    ):
+        value = metadata.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "unknown"
+
+
+def _attach_social_mini_game_block(metrics: dict[str, Any]) -> None:
+    """Attach Social Mini-Game diagnostic metric rows when source metrics are present."""
+    rows: list[dict[str, Any]] = []
+
+    makespan_ratio = metrics.get("time_to_goal_ideal_ratio")
+    makespan_valid = bool(metrics.get("time_to_goal_ideal_ratio_valid", False))
+    rows.append(
+        _social_mini_game_metric_row(
+            metric="makespan_ratio",
+            status="available" if makespan_valid and makespan_ratio is not None else "undefined",
+            unit="ratio",
+            denominator="successful episodes with finite ideal-time baseline",
+            value=makespan_ratio if makespan_valid and makespan_ratio is not None else None,
+            support_count=1 if makespan_valid and makespan_ratio is not None else 0,
+            unavailable_reason=(
+                None
+                if makespan_valid and makespan_ratio is not None
+                else "episode did not reach the goal with a finite ideal-time baseline"
+            ),
+        )
+    )
+
+    path_ratio = metrics.get("socnavbench_path_length_ratio")
+    path_ratio_available = isinstance(path_ratio, int | float) and math.isfinite(float(path_ratio))
+    rows.append(
+        _social_mini_game_metric_row(
+            metric="path_deviation_ratio",
+            status="available" if path_ratio_available else "undefined",
+            unit="ratio_over_straight_line",
+            denominator="robot trajectory length divided by start-goal displacement",
+            value=float(path_ratio) - 1.0 if path_ratio_available else None,
+            support_count=1 if path_ratio_available else 0,
+            unavailable_reason=(
+                None
+                if path_ratio_available
+                else "start-goal displacement or trajectory length was unavailable"
+            ),
+        )
+    )
+
+    deadlock_value = metrics.get("failure_to_progress")
+    deadlock_available = isinstance(deadlock_value, int | float) and math.isfinite(
+        float(deadlock_value)
+    )
+    rows.append(
+        _social_mini_game_metric_row(
+            metric="deadlock_frequency",
+            status="available" if deadlock_available else "undefined",
+            unit="events_per_episode",
+            denominator="one episode",
+            value=float(deadlock_value) if deadlock_available else None,
+            support_count=1 if deadlock_available else 0,
+            unavailable_reason=(
+                None
+                if deadlock_available
+                else "failure-to-progress metric was unavailable for this episode"
+            ),
+        )
+    )
+
+    rows.append(
+        _social_mini_game_metric_row(
+            metric="flow_throughput",
+            status="unavailable",
+            unit="pedestrians_per_second",
+            denominator="pedestrian arrivals or exits over elapsed scenario time",
+            unavailable_reason="episode data does not carry pedestrian arrival or exit counts",
+        )
+    )
+
+    distributional_block = metrics.get("distributional_disruption")
+    distributional_available = (
+        isinstance(distributional_block, dict)
+        and distributional_block.get("schema_version") == "distributional-disruption.v1"
+        and bool(distributional_block.get("cohort_metrics"))
+    )
+    rows.append(
+        _social_mini_game_metric_row(
+            metric="distributional_inconvenience",
+            status="available" if distributional_available else "unavailable",
+            unit="diagnostic_cohort_delta",
+            denominator="matched robot-present and control pedestrian trajectories by cohort",
+            support_count=(
+                sum(
+                    int(value)
+                    for value in (distributional_block.get("support_counts") or {}).values()
+                    if isinstance(value, int | float)
+                )
+                if distributional_available
+                else 0
+            ),
+            unavailable_reason=(
+                None
+                if distributional_available
+                else "control trajectory cohort comparison was unavailable"
+            ),
+        )
+    )
+
+    human_block = metrics.get("human_interaction_proxy")
+    human_reductions = (
+        human_block.get("canonical_reductions") if isinstance(human_block, dict) else {}
+    )
+    invasiveness_value = (
+        human_reductions.get("human_discomfort_exposure_m_s")
+        if isinstance(human_reductions, dict)
+        else None
+    )
+    invasiveness_available = isinstance(invasiveness_value, int | float) and math.isfinite(
+        float(invasiveness_value)
+    )
+    rows.append(
+        _social_mini_game_metric_row(
+            metric="invasiveness",
+            status="available" if invasiveness_available else "unavailable",
+            unit="m*s",
+            denominator="proxemic exposure over robot-pedestrian trajectory samples",
+            value=float(invasiveness_value) if invasiveness_available else None,
+            support_count=(
+                int((human_block.get("sample_counts") or {}).get("timesteps") or 0)
+                if isinstance(human_block, dict)
+                else 0
+            ),
+            unavailable_reason=(
+                None
+                if invasiveness_available
+                else "human-interaction proxy metrics were not enabled or lacked support"
+            ),
+        )
+    )
+
+    metrics["social_mini_game"] = {
+        "schema_version": "social-mini-game-metrics.v1",
+        "status": "diagnostic",
+        "mechanism_family": _social_mini_game_mechanism_family(metrics),
+        "rows": rows,
+        "interpretation": (
+            "Diagnostic Social Mini-Game mechanism metrics. Rows distinguish valid zero values "
+            "from unavailable or undefined metrics and are not paper-grade evidence by themselves."
         ),
     }
 

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -3046,6 +3046,13 @@ def _attach_social_mini_game_block(metrics: dict[str, Any]) -> None:
         and distributional_block.get("schema_version") == "distributional-disruption.v1"
         and bool(distributional_block.get("cohort_metrics"))
     )
+    distributional_support_counts = (
+        distributional_block.get("support_counts")
+        if isinstance(distributional_block, dict)
+        else {}
+    )
+    if not isinstance(distributional_support_counts, dict):
+        distributional_support_counts = {}
     rows.append(
         _social_mini_game_metric_row(
             metric="distributional_inconvenience",
@@ -3055,7 +3062,7 @@ def _attach_social_mini_game_block(metrics: dict[str, Any]) -> None:
             support_count=(
                 sum(
                     int(value)
-                    for value in (distributional_block.get("support_counts") or {}).values()
+                    for value in distributional_support_counts.values()
                     if isinstance(value, int | float)
                 )
                 if distributional_available

--- a/robot_sf/benchmark/schemas/episode.schema.v1.json
+++ b/robot_sf/benchmark/schemas/episode.schema.v1.json
@@ -833,6 +833,85 @@
                     },
                     "additionalProperties": true
                 },
+                "social_mini_game": {
+                    "type": "object",
+                    "description": "Schema-backed diagnostic Social Mini-Game metric rows with explicit availability semantics.",
+                    "required": [
+                        "schema_version",
+                        "status",
+                        "mechanism_family",
+                        "rows",
+                        "interpretation"
+                    ],
+                    "properties": {
+                        "schema_version": {
+                            "const": "social-mini-game-metrics.v1"
+                        },
+                        "status": {
+                            "const": "diagnostic"
+                        },
+                        "mechanism_family": {
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "rows": {
+                            "type": "array",
+                            "minItems": 1,
+                            "items": {
+                                "type": "object",
+                                "required": [
+                                    "metric",
+                                    "status",
+                                    "unit",
+                                    "denominator",
+                                    "support_count"
+                                ],
+                                "properties": {
+                                    "metric": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "status": {
+                                        "type": "string",
+                                        "enum": [
+                                            "available",
+                                            "unavailable",
+                                            "undefined"
+                                        ]
+                                    },
+                                    "unit": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "denominator": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    },
+                                    "value": {
+                                        "type": [
+                                            "number",
+                                            "integer",
+                                            "boolean"
+                                        ]
+                                    },
+                                    "support_count": {
+                                        "type": "integer",
+                                        "minimum": 0
+                                    },
+                                    "unavailable_reason": {
+                                        "type": "string",
+                                        "minLength": 1
+                                    }
+                                },
+                                "additionalProperties": true
+                            }
+                        },
+                        "interpretation": {
+                            "type": "string"
+                        }
+                    },
+                    "additionalProperties": true
+                },
                 "distributional_disruption": {
                     "type": "object",
                     "description": "Schema-backed distributional disruption metric block for observable cohort comparison.",

--- a/tests/benchmark/test_social_mini_game_metric_contract.py
+++ b/tests/benchmark/test_social_mini_game_metric_contract.py
@@ -1,0 +1,34 @@
+"""Contract tests for Social Mini-Game diagnostic metric documentation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+def test_social_mini_game_metric_contract_documents_expected_rows() -> None:
+    """The Social Mini-Game metric contract should name every emitted diagnostic row."""
+    path = (
+        Path(__file__).resolve().parents[2]
+        / "configs"
+        / "benchmarks"
+        / "social_mini_game_metric_contract_v1.yaml"
+    )
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+
+    assert payload["schema_version"] == "social-mini-game-metric-contract.v1"
+    assert payload["row_schema_version"] == "social-mini-game-metrics.v1"
+    assert payload["status_values"] == ["available", "unavailable", "undefined"]
+    rows = {row["id"]: row for row in payload["metric_rows"]}
+    assert set(rows) == {
+        "makespan_ratio",
+        "path_deviation_ratio",
+        "deadlock_frequency",
+        "flow_throughput",
+        "distributional_inconvenience",
+        "invasiveness",
+    }
+    assert rows["deadlock_frequency"]["denominator"] == "one episode"
+    assert "arrival or exit counts" in rows["flow_throughput"]["missing_data_behavior"]

--- a/tests/contract/test_episode_schema.py
+++ b/tests/contract/test_episode_schema.py
@@ -229,6 +229,62 @@ def test_episode_schema_validates_human_interaction_proxy_block() -> None:
         jsonschema.validate(instance=record, schema=schema)
 
 
+def test_episode_schema_validates_social_mini_game_block() -> None:
+    """The Social Mini-Game metric block should validate row availability contracts."""
+    schema = _load_schema()
+    record = {
+        "episode_id": "e_social_mini_game",
+        "version": "v1",
+        "scenario_id": "sc_social_mini_game",
+        "seed": 123,
+        "metrics": {
+            "collisions": 0,
+            "near_misses": 0,
+            "social_mini_game": {
+                "schema_version": "social-mini-game-metrics.v1",
+                "status": "diagnostic",
+                "mechanism_family": "doorway",
+                "rows": [
+                    {
+                        "metric": "deadlock_frequency",
+                        "status": "available",
+                        "unit": "events_per_episode",
+                        "denominator": "one episode",
+                        "value": 0.0,
+                        "support_count": 1,
+                    },
+                    {
+                        "metric": "flow_throughput",
+                        "status": "unavailable",
+                        "unit": "pedestrians_per_second",
+                        "denominator": "pedestrian arrivals or exits",
+                        "support_count": 0,
+                        "unavailable_reason": "missing arrival or exit counts",
+                    },
+                ],
+                "interpretation": "Diagnostic Social Mini-Game mechanism metrics.",
+            },
+        },
+        "termination_reason": "max_steps",
+        "outcome": {
+            "route_complete": False,
+            "collision_event": False,
+            "timeout_event": True,
+        },
+        "integrity": {"contradictions": []},
+    }
+
+    jsonschema.validate(instance=record, schema=schema)
+    record["metrics"]["social_mini_game"]["schema_version"] = "wrong"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=record, schema=schema)
+
+    record["metrics"]["social_mini_game"]["schema_version"] = "social-mini-game-metrics.v1"
+    record["metrics"]["social_mini_game"]["rows"][0]["support_count"] = -1
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(instance=record, schema=schema)
+
+
 def test_episode_schema_rejects_collision_event_without_collision_metric() -> None:
     """New v1 records should not report collision_event=true with zero collision count."""
     schema = _load_schema()

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -579,6 +579,25 @@ def test_compute_aggregates_flattens_social_mini_game_available_rows() -> None:
     assert "social_mini_game_flow_throughput" not in metrics
 
 
+def test_flatten_metrics_skips_empty_social_mini_game_block() -> None:
+    """Empty Social Mini-Game blocks should not create null diagnostic columns."""
+    record = {
+        "episode_id": "ep-1",
+        "scenario_id": "sc-1",
+        "seed": 1,
+        "metrics": {
+            "success": True,
+            "social_mini_game": {},
+        },
+    }
+
+    flat = flatten_metrics(record)
+
+    assert "social_mini_game" not in flat
+    assert "social_mini_game_status" not in flat
+    assert "social_mini_game_mechanism_family" not in flat
+
+
 def test_flatten_metrics_keeps_distributional_disruption_nested_out_of_scalar_rows() -> None:
     """Distributional disruption is a schema block, not a scalar aggregate metric."""
     record = {

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -503,6 +503,82 @@ def test_compute_aggregates_flattens_human_interaction_proxy_block() -> None:
     assert metrics["pedestrian_path_deviation_proxy_m"]["mean"] == pytest.approx(0.3)
 
 
+def test_compute_aggregates_flattens_social_mini_game_available_rows() -> None:
+    """Available Social Mini-Game row values should aggregate without nested payload leakage."""
+    records = [
+        {
+            "episode_id": "ep-1",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "planner-a",
+            "metrics": {
+                "success": True,
+                "social_mini_game": {
+                    "schema_version": "social-mini-game-metrics.v1",
+                    "status": "diagnostic",
+                    "mechanism_family": "doorway",
+                    "rows": [
+                        {
+                            "metric": "deadlock_frequency",
+                            "status": "available",
+                            "unit": "events_per_episode",
+                            "denominator": "one episode",
+                            "value": 0.0,
+                            "support_count": 1,
+                        },
+                        {
+                            "metric": "flow_throughput",
+                            "status": "unavailable",
+                            "unit": "pedestrians_per_second",
+                            "denominator": "pedestrian arrivals or exits",
+                            "support_count": 0,
+                            "unavailable_reason": "missing arrival or exit counts",
+                        },
+                    ],
+                    "interpretation": "diagnostic only",
+                },
+            },
+        },
+        {
+            "episode_id": "ep-2",
+            "scenario_id": "sc-1",
+            "seed": 2,
+            "algo": "planner-a",
+            "metrics": {
+                "success": True,
+                "social_mini_game": {
+                    "schema_version": "social-mini-game-metrics.v1",
+                    "status": "diagnostic",
+                    "mechanism_family": "doorway",
+                    "rows": [
+                        {
+                            "metric": "deadlock_frequency",
+                            "status": "available",
+                            "unit": "events_per_episode",
+                            "denominator": "one episode",
+                            "value": 2.0,
+                            "support_count": 1,
+                        }
+                    ],
+                    "interpretation": "diagnostic only",
+                },
+            },
+        },
+    ]
+
+    flat = flatten_metrics(records[0])
+    assert "social_mini_game" not in flat
+    assert flat["social_mini_game_deadlock_frequency"] == 0.0
+    assert flat["social_mini_game_flow_throughput_status"] == "unavailable"
+    assert "social_mini_game_flow_throughput" not in flat
+
+    summary = compute_aggregates(records, group_by="algo")
+
+    metrics = summary["planner-a"]
+    assert metrics["social_mini_game_deadlock_frequency"]["mean"] == 1.0
+    assert "social_mini_game_flow_throughput" not in metrics
+
+
 def test_flatten_metrics_keeps_distributional_disruption_nested_out_of_scalar_rows() -> None:
     """Distributional disruption is a schema block, not a scalar aggregate metric."""
     record = {

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -900,6 +900,59 @@ def test_post_process_metrics_adds_human_interaction_proxy_block() -> None:
     assert "group-membership" in block["exclusions"]["group_split_intrusion"]
 
 
+def test_post_process_metrics_adds_social_mini_game_rows() -> None:
+    """Social Mini-Game rows should distinguish valid zero values from unavailable metrics."""
+    metrics = post_process_metrics(
+        {
+            "success": 1.0,
+            "collisions": 0.0,
+            "_episode_metadata": {"mechanism_aware_suite_id": "doorway_yield"},
+            "time_to_goal_ideal_ratio": 1.25,
+            "time_to_goal_ideal_ratio_valid": 1.0,
+            "socnavbench_path_length_ratio": 1.4,
+            "failure_to_progress": 0.0,
+            "distributional_disruption": {
+                "schema_version": "distributional-disruption.v1",
+                "support_counts": {"slow_speed_tier": 2},
+                "cohort_metrics": {"slow_speed_tier": {"displacement_mean_m": 0.2}},
+            },
+            "human_proxy_available": 1.0,
+            "human_proxy_proxemic_radius_m": 1.2,
+            "human_proxy_yield_speed_mps": 0.1,
+            "human_proxy_ped_count": 2.0,
+            "human_proxy_timestep_count": 4.0,
+            "human_discomfort_exposure_m_s": 0.0,
+        },
+        snqi_weights=None,
+        snqi_baseline=None,
+    )
+
+    block = metrics["social_mini_game"]
+    assert block["schema_version"] == "social-mini-game-metrics.v1"
+    assert block["status"] == "diagnostic"
+    assert block["mechanism_family"] == "doorway_yield"
+    assert "_episode_metadata" not in metrics
+    rows = {row["metric"]: row for row in block["rows"]}
+    assert rows["makespan_ratio"]["value"] == 1.25
+    assert rows["path_deviation_ratio"]["value"] == pytest.approx(0.4)
+    assert rows["deadlock_frequency"]["status"] == "available"
+    assert rows["deadlock_frequency"]["value"] == 0.0
+    assert rows["flow_throughput"]["status"] == "unavailable"
+    assert "arrival or exit counts" in rows["flow_throughput"]["unavailable_reason"]
+    assert rows["distributional_inconvenience"]["support_count"] == 2
+    assert rows["invasiveness"]["status"] == "available"
+    assert rows["invasiveness"]["value"] == 0.0
+
+
+def test_compute_all_metrics_emits_deadlock_source_metrics() -> None:
+    """Deadlock source metrics should be available to Social Mini-Game post-processing."""
+    ep = _make_episode(T=8, K=0)
+    vals = compute_all_metrics(ep, horizon=8)
+
+    assert "failure_to_progress" in vals
+    assert "stalled_time" in vals
+
+
 def test_experimental_ped_impact_handles_empty_crowd() -> None:
     """Experimental pedestrian-impact metrics should stay stable when K=0."""
     ep = _make_episode(T=8, K=0)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -944,6 +944,27 @@ def test_post_process_metrics_adds_social_mini_game_rows() -> None:
     assert rows["invasiveness"]["value"] == 0.0
 
 
+def test_post_process_metrics_treats_invalid_distributional_support_counts_as_zero() -> None:
+    """Malformed support-count payloads should not crash or inflate diagnostic support."""
+    metrics = post_process_metrics(
+        {
+            "success": 1.0,
+            "collisions": 0.0,
+            "distributional_disruption": {
+                "schema_version": "distributional-disruption.v1",
+                "support_counts": ["slow_speed_tier"],
+                "cohort_metrics": {"slow_speed_tier": {"displacement_mean_m": 0.2}},
+            },
+        },
+        snqi_weights=None,
+        snqi_baseline=None,
+    )
+
+    rows = {row["metric"]: row for row in metrics["social_mini_game"]["rows"]}
+    assert rows["distributional_inconvenience"]["status"] == "available"
+    assert rows["distributional_inconvenience"]["support_count"] == 0
+
+
 def test_compute_all_metrics_emits_deadlock_source_metrics() -> None:
     """Deadlock source metrics should be available to Social Mini-Game post-processing."""
     ep = _make_episode(T=8, K=0)


### PR DESCRIPTION
## Summary
Adds schema-backed Social Mini-Game diagnostic metric rows with explicit units, denominators, support counts, unavailable/undefined statuses, and aggregate flattening for available scalar values.

## Linked Issues
- Closes `#3280`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `metrics.social_mini_game` post-processing rows for makespan ratio, path deviation ratio, deadlock frequency, flow throughput, distributional inconvenience, and invasiveness.
- Emitted `failure_to_progress` and `stalled_time` from `compute_all_metrics` so deadlock rows have source metrics.
- Added episode schema coverage, aggregate flattening for available row values, and a documented metric contract at `configs/benchmarks/social_mini_game_metric_contract_v1.yaml`.
- Added tests for valid zero values versus unavailable rows.

## Why It Matters
- Added value: mechanism reports can now distinguish supported Social Mini-Game diagnostics from unavailable or undefined metrics.
- Expected impact: aggregate reports remain backward compatible while exposing stable `social_mini_game_*` scalar columns for available rows.
- Why this is worth merging now: it fills the metric surface requested by #3280 without promoting unsupported flow or distributional claims.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: social-navigation mechanism diagnostics need explicit metric denominators and missing-data semantics.
- Comparator or baseline, if applicable: existing aggregate metrics without a Social Mini-Game row block.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only
- Decision or stop rule, if applicable: supported rows are emitted only from existing source signals; unsupported rows remain unavailable/undefined.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3280.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - adds metric schema rows and aggregate flattening, not a new interpretive analysis tool.

## Domain-Aware Approval
- Required for this PR: yes - metric-facing diagnostic schema and benchmark-report surface.
- Domains reviewed: benchmark interpretation
- Status: pending
- Approver/review source or waiver: pending domain-aware review.
- Validity checklist:
  - Target claim/hypothesis: diagnostic Social Mini-Game rows can be emitted with explicit status, unit, denominator, and support count.
  - Comparator or split/evidence validity: no comparator claim; fixture/schema tests validate row semantics.
  - Fallback/degraded exclusions: unsupported flow throughput and missing paired-control data are unavailable, not silently dropped.
  - Claim boundary: diagnostic-only; not real-world comfort, fairness, safety, or paper-grade evidence.
  - Implementation integrity vs experimental validity: implementation covered by tests; experimental validity remains diagnostic.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: none opened.

## Next Empirical Action
- Rerun needed: no for this schema/fixture slice.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: pedestrian arrival/exit counts remain unavailable for flow throughput.
- Stop / revise / continue decision: continue with diagnostic-only row semantics.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_metrics.py tests/test_aggregate.py tests/contract/test_episode_schema.py tests/benchmark/test_social_mini_game_metric_contract.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark -k 'metric or mechanism or compliance' -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/metrics.py robot_sf/benchmark/aggregate.py tests/test_metrics.py tests/test_aggregate.py tests/contract/test_episode_schema.py tests/benchmark/test_social_mini_game_metric_contract.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/metrics.py robot_sf/benchmark/aggregate.py tests/test_metrics.py tests/test_aggregate.py tests/contract/test_episode_schema.py tests/benchmark/test_social_mini_game_metric_contract.py`
  - `git diff --check`
- Evidence that the change works here: focused fixture/schema/aggregate suite passed with `114 passed`; issue benchmark filter passed with `165 passed, 1378 deselected`; Ruff passed.
- Benchmarks or smoke tests, if applicable: diagnostic metric fixture tests only; no benchmark-strength evidence claimed.

## Risks / Rollout
- Compatibility risks: new `failure_to_progress` and `stalled_time` raw metrics appear in `compute_all_metrics`; aggregate reports should remain compatible because nested Social Mini-Game rows flatten only stable scalar values.
- Failure modes: downstream consumers that assume a closed metric set may notice the new raw metrics.
- Rollback or fallback plan: revert this commit to remove the new schema block and raw metric emissions.

## Docs / Provenance
- Updated docs: `configs/benchmarks/social_mini_game_metric_contract_v1.yaml`
- Relevant design or provenance notes: #3280.
- Any assumptions that need to be preserved: `distributional_inconvenience` is used instead of a generated `fairness` metric name; flow throughput remains unavailable without arrival/exit counts.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR links and closes #3280.
- Claim map / benchmark report updated (yes/no/NA): NA - diagnostic schema only.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): yes - metric contract config added.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark or paper-facing claim is established.

## Follow-Up Issues
- Deferred work: true flow throughput requires future episode arrival/exit count signals.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: status choices for `undefined` versus `unavailable`, and the diagnostic-only claim boundary.
- Any known limitations: mechanism family is sourced from episode metadata when available and falls back to `unknown`.
