### PR TITLE
fix: populate map-runner collision summaries

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -102,6 +102,7 @@ from robot_sf.benchmark.map_runner_metrics import (
 from robot_sf.benchmark.map_runner_metrics import (
     normalize_pedestrian_impact_controls as _normalize_pedestrian_impact_controls,
 )
+from robot_sf.benchmark.map_runner_metrics import summarize_collision_metrics
 from robot_sf.benchmark.map_runner_observations import (
     extract_ppo_dt as _extract_ppo_dt,  # noqa: F401 - compatibility re-export for tests.
 )
@@ -2610,6 +2611,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
             "preflight": preflight,
             "observation_noise": noise_spec,
             "observation_noise_hash": noise_hash,
+            "metrics": summarize_collision_metrics([]),
             "latency_stress_profile": (
                 latency_profile.to_metadata(dt=latency_metadata_dt)
                 if latency_profile is not None
@@ -2750,6 +2752,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         as_completed_fn=as_completed,
     )
     wrote = batch_execution.wrote
+    episode_records = batch_execution.episode_records
     failures = batch_execution.failures
     adapter_native_steps = batch_execution.adapter_native_steps
     adapter_adapted_steps = batch_execution.adapter_adapted_steps
@@ -2775,6 +2778,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         batch_runtime_sec=batch_execution.batch_runtime_sec,
         wrote=wrote,
         failures=failures,
+        episode_records=episode_records,
         preflight_skipped_jobs=preflight_skipped_jobs,
         out_path=out_path,
         readiness=readiness,

--- a/robot_sf/benchmark/map_runner_batch_runner.py
+++ b/robot_sf/benchmark/map_runner_batch_runner.py
@@ -15,6 +15,7 @@ class BatchExecutionResult(NamedTuple):
     """Counters and metadata accumulated while executing map-runner jobs."""
 
     wrote: int
+    episode_records: list[dict[str, Any]]
     failures: list[dict[str, Any]]
     adapter_native_steps: int
     adapter_adapted_steps: int
@@ -76,13 +77,14 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
     apply_worker_metadata_bridge,
     scenario_id,
     feasibility_totals: FeasibilityTotals,
-) -> tuple[int, list[dict[str, Any]], bool, int, int, dict[str, Any] | None]:
+) -> tuple[int, list[dict[str, Any]], list[dict[str, Any]], bool, int, int, dict[str, Any] | None]:
     """Execute map-runner jobs serially and append successful records.
 
     Returns:
         Write count, failures, adapter counters, and runtime algorithm contract.
     """
     wrote = 0
+    episode_records: list[dict[str, Any]] = []
     failures: list[dict[str, Any]] = []
     adapter_native_steps = 0
     adapter_adapted_steps = 0
@@ -109,6 +111,7 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
                 )
                 write_validated_to_handle(handle, schema, rec)
                 wrote += 1
+                episode_records.append(rec)
             except Exception as exc:  # pragma: no cover - error path
                 logger.exception(
                     "Map batch worker failed in serial execution: scenario={} seed={}",
@@ -124,6 +127,7 @@ def _serial_execute_map_jobs(  # noqa: PLR0913
                 )
     return (
         wrote,
+        episode_records,
         failures,
         adapter_samples_seen,
         adapter_native_steps,
@@ -146,13 +150,14 @@ def _parallel_execute_map_jobs(  # noqa: PLR0913
     workers: int,
     executor_cls,
     as_completed_fn,
-) -> tuple[int, list[dict[str, Any]], bool, int, int, dict[str, Any] | None]:
+) -> tuple[int, list[dict[str, Any]], list[dict[str, Any]], bool, int, int, dict[str, Any] | None]:
     """Execute map-runner jobs in parallel and append records in job order.
 
     Returns:
         Write count, failures, adapter counters, and runtime algorithm contract.
     """
     wrote = 0
+    episode_records: list[dict[str, Any]] = []
     failures: list[dict[str, Any]] = []
     adapter_native_steps = 0
     adapter_adapted_steps = 0
@@ -202,6 +207,7 @@ def _parallel_execute_map_jobs(  # noqa: PLR0913
             try:
                 write_validated_to_handle(handle, schema, results_by_idx[idx])
                 wrote += 1
+                episode_records.append(results_by_idx[idx])
             except Exception as exc:  # pragma: no cover - write/validate path
                 rec = results_by_idx[idx]
                 logger.exception(
@@ -222,6 +228,7 @@ def _parallel_execute_map_jobs(  # noqa: PLR0913
                 )
     return (
         wrote,
+        episode_records,
         failures,
         adapter_samples_seen,
         adapter_native_steps,
@@ -255,6 +262,7 @@ def execute_map_jobs(  # noqa: PLR0913
     if workers <= 1:
         (
             wrote,
+            episode_records,
             failures,
             adapter_samples_seen,
             adapter_native_steps,
@@ -274,6 +282,7 @@ def execute_map_jobs(  # noqa: PLR0913
     else:
         (
             wrote,
+            episode_records,
             failures,
             adapter_samples_seen,
             adapter_native_steps,
@@ -295,6 +304,7 @@ def execute_map_jobs(  # noqa: PLR0913
         )
     return BatchExecutionResult(
         wrote=wrote,
+        episode_records=episode_records,
         failures=failures,
         adapter_native_steps=adapter_native_steps,
         adapter_adapted_steps=adapter_adapted_steps,

--- a/robot_sf/benchmark/map_runner_batch_summary.py
+++ b/robot_sf/benchmark/map_runner_batch_summary.py
@@ -10,6 +10,7 @@ from robot_sf.benchmark.algorithm_metadata import (
 )
 from robot_sf.benchmark.fallback_policy import availability_payload
 from robot_sf.benchmark.latency_stress import not_available_latency_metrics
+from robot_sf.benchmark.map_runner_metrics import summarize_collision_metrics
 from robot_sf.benchmark.map_runner_provenance import map_result_provenance
 from robot_sf.benchmark.utils import attach_track_metadata
 
@@ -194,6 +195,7 @@ def build_completed_batch_summary(  # noqa: PLR0913
     batch_runtime_sec: float,
     wrote: int,
     failures: list[dict[str, Any]],
+    episode_records: list[dict[str, Any]],
     preflight_skipped_jobs: int,
     out_path: Path,
     readiness: Any,
@@ -315,6 +317,7 @@ def build_completed_batch_summary(  # noqa: PLR0913
         "observation_noise": noise_spec,
         "observation_noise_hash": noise_hash,
         "observation_level": active_observation_level,
+        "metrics": summarize_collision_metrics(episode_records),
         "synthetic_actuation_profile": actuation_profile_metadata,
         "latency_stress_profile": latency_profile_metadata,
         "latency_stress_metrics": (

--- a/robot_sf/benchmark/map_runner_metrics.py
+++ b/robot_sf/benchmark/map_runner_metrics.py
@@ -45,6 +45,97 @@ def collision_metric_value(metrics: dict[str, Any], key: str) -> float:
     return value if math.isfinite(value) else 0.0
 
 
+def _finite_float(value: Any) -> float | None:
+    """Return a finite float value, or ``None`` when the input is unavailable."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _episode_collision_value(record: dict[str, Any]) -> tuple[float | None, str | None]:
+    """Return one episode's collision value and source path when available."""
+    metrics = record.get("metrics")
+    if isinstance(metrics, dict):
+        for key in ("collisions", "total_collision_count", "collision_count"):
+            if key in metrics:
+                value = _finite_float(metrics.get(key))
+                if value is not None:
+                    return value, f"episode.metrics.{key}"
+
+    outcome = record.get("outcome")
+    if isinstance(outcome, dict) and "collision_event" in outcome:
+        return 1.0 if bool(outcome.get("collision_event")) else 0.0, (
+            "episode.outcome.collision_event"
+        )
+    return None, None
+
+
+def summarize_collision_metrics(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Build a batch-level collision summary from successful episode records.
+
+    Returns:
+        Backward-compatible scalar aliases plus explicit availability metadata.
+    """
+    denominator = len(records)
+    if denominator <= 0:
+        return {
+            "collision": "not_available",
+            "collision_count": "not_available",
+            "collision_rate": "not_available",
+            "collision_status": {
+                "status": "not_available",
+                "reason": "no successful episode records were available for aggregation",
+                "denominator": 0,
+                "source": None,
+            },
+        }
+
+    collision_count = 0.0
+    collided_episodes = 0
+    available = 0
+    sources: set[str] = set()
+    for record in records:
+        value, source = _episode_collision_value(record)
+        if value is None:
+            continue
+        if source is not None:
+            sources.add(source)
+        available += 1
+        collision_count += value
+        if value > 0.0:
+            collided_episodes += 1
+
+    if available <= 0:
+        return {
+            "collision": "not_available",
+            "collision_count": "not_available",
+            "collision_rate": "not_available",
+            "collision_status": {
+                "status": "not_available",
+                "reason": "successful episode records did not emit collision metrics",
+                "denominator": denominator,
+                "source": None,
+            },
+        }
+
+    status = "available" if available == denominator else "partial"
+    reason = None if status == "available" else "some successful records lacked collision metrics"
+    source = ",".join(sorted(sources))
+    return {
+        "collision": float(collision_count),
+        "collision_count": float(collision_count),
+        "collision_rate": float(collided_episodes / denominator),
+        "collision_status": {
+            "status": status,
+            "reason": reason,
+            "denominator": denominator,
+            "source": source,
+        },
+    }
+
+
 def floor_collision_metrics_from_flags(
     metrics: dict[str, Any],
     *,

--- a/robot_sf/benchmark/map_runner_metrics.py
+++ b/robot_sf/benchmark/map_runner_metrics.py
@@ -66,9 +66,10 @@ def _episode_collision_value(record: dict[str, Any]) -> tuple[float | None, str 
 
     outcome = record.get("outcome")
     if isinstance(outcome, dict) and "collision_event" in outcome:
-        return 1.0 if bool(outcome.get("collision_event")) else 0.0, (
-            "episode.outcome.collision_event"
-        )
+        event = outcome.get("collision_event")
+        if event is None:
+            return None, None
+        return 1.0 if bool(event) else 0.0, "episode.outcome.collision_event"
     return None, None
 
 
@@ -126,7 +127,7 @@ def summarize_collision_metrics(records: list[dict[str, Any]]) -> dict[str, Any]
     return {
         "collision": float(collision_count),
         "collision_count": float(collision_count),
-        "collision_rate": float(collided_episodes / denominator),
+        "collision_rate": float(collided_episodes / available),
         "collision_status": {
             "status": status,
             "reason": reason,

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -3583,6 +3583,62 @@ def test_run_map_batch_serial_and_resume(tmp_path: Path, monkeypatch: pytest.Mon
     assert result["written"] == 0
 
 
+def test_run_map_batch_summary_populates_collision_metric(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Completed map batches should expose aggregate collision status instead of null."""
+    scenarios = [
+        {"name": "clear", "metadata": {"supported": True}},
+        {"name": "collision", "metadata": {"supported": True}},
+    ]
+    out_path = tmp_path / "episodes.jsonl"
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.validate_scenario_list", lambda scenarios: []
+    )
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.load_schema", lambda path: {})
+
+    def _fake_run_map_job_worker(job):
+        """Emit one clear and one colliding episode record."""
+        scenario, seed, _params = job
+        collision_count = 1.0 if scenario["name"] == "collision" else 0.0
+        return {
+            "episode_id": f"{scenario['name']}-{seed}",
+            "scenario_id": scenario["name"],
+            "seed": seed,
+            "metrics": {"collisions": collision_count},
+            "outcome": {"collision_event": collision_count > 0.0},
+            "algorithm_metadata": {},
+        }
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._run_map_job_worker",
+        _fake_run_map_job_worker,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._write_validated_to_handle",
+        lambda *args, **kwargs: None,
+    )
+
+    result = run_map_batch(
+        scenarios,
+        out_path,
+        schema_path=tmp_path / "schema.json",
+        workers=1,
+        resume=False,
+    )
+
+    assert result["written"] == 2
+    assert result["metrics"]["collision"] == pytest.approx(1.0)
+    assert result["metrics"]["collision_count"] == pytest.approx(1.0)
+    assert result["metrics"]["collision_rate"] == pytest.approx(0.5)
+    assert result["metrics"]["collision_status"] == {
+        "status": "available",
+        "reason": None,
+        "denominator": 2,
+        "source": "episode.metrics.collisions",
+    }
+
+
 def test_run_map_batch_rejects_unsupported_observation_override(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -56,6 +56,7 @@ from robot_sf.benchmark.map_runner_batch_plan import (
     build_worker_fixed_params,
     resolve_batch_kinematics_tag,
 )
+from robot_sf.benchmark.map_runner_metrics import summarize_collision_metrics
 from robot_sf.common.types import Rect
 from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition
@@ -3636,6 +3637,27 @@ def test_run_map_batch_summary_populates_collision_metric(
         "reason": None,
         "denominator": 2,
         "source": "episode.metrics.collisions",
+    }
+
+
+def test_summarize_collision_metrics_preserves_missing_collision_events() -> None:
+    """Missing collision-event data should stay unavailable instead of coercing to no collision."""
+    summary = summarize_collision_metrics(
+        [
+            {"outcome": {"collision_event": None}},
+            {"outcome": {"collision_event": True}},
+            {"outcome": {"collision_event": False}},
+        ]
+    )
+
+    assert summary["collision"] == pytest.approx(1.0)
+    assert summary["collision_count"] == pytest.approx(1.0)
+    assert summary["collision_rate"] == pytest.approx(0.5)
+    assert summary["collision_status"] == {
+        "status": "partial",
+        "reason": "some successful records lacked collision metrics",
+        "denominator": 3,
+        "source": "episode.outcome.collision_event",
     }
 
 


### PR DESCRIPTION
## Summary

- identifies the `metrics.collision` gap as a summary assembly issue: episode JSONL records already carried collision metrics, but successful records were discarded before batch summary construction
- threads validated successful episode records through map-runner batch execution and emits summary `metrics.collision`, `metrics.collision_count`, `metrics.collision_rate`, and `metrics.collision_status`
- uses explicit `not_available` collision metrics when no successful records, or no successful records with collision data, are available
- adds a regression test for a completed map batch with one clear episode and one colliding episode

Closes #3341.

## Validation

- `uv run python -m pytest tests/benchmark/test_map_runner_utils.py -q` — 119 passed
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_runner.py robot_sf/benchmark/map_runner_batch_summary.py robot_sf/benchmark/map_runner_metrics.py tests/benchmark/test_map_runner_utils.py` — passed
- `git diff --check` — passed

## Research Result Guidance

- Target claim / blocker: predictive hard-case portfolio summaries should expose a collision safety metric or an explicit unavailable status instead of silent null/missing data.
- Comparator / baseline: prior map-runner batch summaries omitted `metrics`, while per-episode records already emitted `metrics.collisions`.
- Evidence tier: targeted regression and focused map-runner utility suite.
- Result classification: implementation evidence for summary emission; not a new benchmark result.
- Decision / stop rule: this PR fixes the summary contract when successful episode records are present; downstream hard-case synthesis can rerun or reinterpret summaries using the populated field.
- Synthesis surface / update target: #3341 and the #3215 hard-case portfolio synthesis follow-up.

## Downstream Propagation

- Parent issue: #3341 should be closed by this PR.
- Claim map / benchmark report: no benchmark result is changed in this PR; any #3215 synthesis update should use regenerated or validated summaries after merge.
- Registry / config index: not applicable.
- Context / memory: no durable context update needed until downstream hard-case evidence is refreshed.

## Residual Risk

`metrics.collision_rate` is an episode-incidence rate over successful written records. `metrics.collision_count` preserves the summed episode collision metric for consumers that need the count rather than the incidence denominator.
