### PR TITLE
benchmark: evaluate near-field turn budget

### DIFF
--- a/configs/benchmarks/predictive_hard_seeds_s20_v1.yaml
+++ b/configs/benchmarks/predictive_hard_seeds_s20_v1.yaml
@@ -1,0 +1,6 @@
+# Predictive planner larger hard-case sample S20 for issue #3342.
+# Twenty total episodes across the four #3215 crossing-conflict hard families.
+classic_cross_trap_high: [200, 201, 202, 203, 204]
+classic_cross_trap_medium: [200, 201, 202, 203, 204]
+classic_cross_trap_low: [200, 201, 202, 203, 204]
+classic_group_crossing_high: [200, 201, 202, 203, 204]

--- a/configs/benchmarks/predictive_hard_seeds_s30_v1.yaml
+++ b/configs/benchmarks/predictive_hard_seeds_s30_v1.yaml
@@ -1,0 +1,6 @@
+# Predictive planner larger hard-case sample S30 for issue #3342.
+# Thirty total episodes across the four #3215 crossing-conflict hard families.
+classic_cross_trap_high: [200, 201, 202, 203, 204, 205, 206, 207]
+classic_cross_trap_medium: [200, 201, 202, 203, 204, 205, 206, 207]
+classic_cross_trap_low: [200, 201, 202, 203, 204, 205, 206]
+classic_group_crossing_high: [200, 201, 202, 203, 204, 205, 206]

--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -17,6 +17,18 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+  - path: docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/checksums.sha256
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: configs/benchmarks/issue_2452_mechanism_aware_local_nav_suites_v0.yaml
     status: proposal
     freshness: maintained

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -98,6 +98,12 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_3342_nearfield_turn_budget_2026-06-21/`: diagnostic-local S20 follow-up
+  for the Issue #3215 near-field turn-budget signal. It compares `baseline`,
+  `nearfield_turn`, and `nf_speedcap_only` across clean and observation-noise
+  slices with explicit success, collision, min-distance, and uncertainty fields.
+  The local S20 result does not support adopting the near-field signal; S30 is
+  configured but not run. Not benchmark-strength or paper-facing evidence.
 - `issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/`: diagnostic-only
   native live replay over the #3323 near-field #2756 fixture with a predeclared 2x3 medium/high
   bounded-Gaussian perturbation grid. The grid is `medium_amplitude_sensitive`: seed 3328 is

--- a/docs/context/evidence/issue_3215_hardcase_portfolio_synthesis_2026-06-21/README.md
+++ b/docs/context/evidence/issue_3215_hardcase_portfolio_synthesis_2026-06-21/README.md
@@ -57,7 +57,8 @@ compact table. Nothing was running at synthesis time.
 
 ## Suggested next step
 
-If the near-field-turn signal is worth chasing: a larger hard-seed sample (S20/S30) with the
-`nearfield_turn` / `nf_speedcap_only` configs, collision-metric emission, and an observation-noise
-slice — to decide whether it is a real (if small) effect or sampling noise. Otherwise record the
-negative result in the forecast-lane limitation text (#2835) and route effort elsewhere.
+Issue #3342 added the missing collision-rate and uncertainty fields, configured S20/S30 hard-seed
+manifests, and ran a local S20 diagnostic slice for `baseline`, `nearfield_turn`, and
+`nf_speedcap_only` across clean/noisy observation slices. That S20 result did not reproduce the
+near-field-turn signal and remains diagnostic-local, not benchmark or paper evidence. See
+`docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/`.

--- a/docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/README.md
+++ b/docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/README.md
@@ -1,0 +1,65 @@
+# Issue #3342 Near-Field Turn Budget S20 Diagnostic
+
+**Date:** 2026-06-21 · **Evidence tier:** `diagnostic-local` · **Decision:** S20 does not support adopting the near-field turn-budget signal
+
+## Source
+
+This bundle preserves a compact local S20 follow-up for Issue #3342 after the predictive evaluation
+summary path was extended to emit aggregate collision rate and uncertainty fields. The local run used
+`predictive_proxy_selected_v2_full` from the model registry cache, the
+`predictive_hardcase_portfolio_v1` scenario set, and the new
+`configs/benchmarks/predictive_hard_seeds_s20_v1.yaml` seed manifest.
+
+The six rows in `summary.json` cover:
+
+- variants: `baseline`, `nearfield_turn`, `nf_speedcap_only`;
+- slices: clean and `robustness_smoke_v1` observation noise;
+- metrics: success rate, collision rate, mean minimum distance, and confidence intervals.
+
+Raw episode JSONL remains in ignored local run output and is not mirrored here.
+
+## Result
+
+| Slice | Variant | Episodes | Success | Collision | Mean min distance |
+|---|---:|---:|---:|---:|---:|
+| clean | baseline | 20 | 0.200 | 0.800 | 3.277 |
+| clean | nearfield_turn | 20 | 0.150 | 0.850 | 3.223 |
+| clean | nf_speedcap_only | 20 | 0.150 | 0.850 | 3.223 |
+| noisy | baseline | 20 | 0.200 | 0.800 | 3.276 |
+| noisy | nearfield_turn | 20 | 0.150 | 0.850 | 3.224 |
+| noisy | nf_speedcap_only | 20 | 0.150 | 0.850 | 3.224 |
+
+The local S20 slice does **not** reproduce the Issue #3215 near-field-turn signal. Baseline was
+0.20 success / 0.80 collision in both clean and noisy slices; both near-field variants were
+0.15 success / 0.85 collision. Intervals are wide and overlapping, so this is a diagnostic negative,
+not a benchmark-strength rejection or paper-facing claim.
+
+## Claim Boundary
+
+- Diagnostic-local evidence only; not benchmark-strength, paper-grade, or release evidence.
+- No fallback or degraded rows are promoted as success.
+- Collision metric availability is now explicit in the evaluation summary path, but high collision
+  rates remain an interpretation result, not a quality-gate failure in this diagnostic run.
+- S30 is configured by `configs/benchmarks/predictive_hard_seeds_s30_v1.yaml` but was not run in
+  this bundle.
+- Use `summary.json` for compact review. Recreate raw local output from the tracked configs and
+  command rather than depending on worktree-local generated contents.
+
+## Reproduction
+
+The worker ran the equivalent of the following local campaign loop for each slice and variant:
+
+```bash
+uv run python scripts/validation/evaluate_predictive_planner.py \
+  --checkpoint <local predictive_proxy_selected_v2_full model-cache path> \
+  --scenario-matrix configs/scenarios/sets/predictive_hardcase_portfolio_v1.yaml \
+  --seed-manifest configs/benchmarks/predictive_hard_seeds_s20_v1.yaml \
+  --algo-config configs/algos/hardcase_authority/prediction_planner_authority_<variant>.yaml \
+  --output-dir <local generated run directory> \
+  --tag <variant> \
+  --min-success-rate 0.0 \
+  --workers 4 \
+  --observation-noise configs/observation_noise/robustness_smoke_v1.yaml
+```
+
+For the clean slice, omit `--observation-noise`.

--- a/docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/checksums.sha256
+++ b/docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/checksums.sha256
@@ -1,0 +1,2 @@
+ddd9b508e895b9fc226bff918ce3ad2e86c9840a3e576ccaeb8f7948dfbd6e11  docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/README.md
+870ef4a857d9e446aed4734a2e23ad7fe601fe9c219a2e53b2e146b6336f4844  docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/summary.json

--- a/docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/summary.json
+++ b/docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/summary.json
@@ -1,0 +1,154 @@
+{
+  "status": "diagnostic_local_s20_complete",
+  "evidence_tier": "diagnostic-local, not benchmark/paper-grade",
+  "claim_boundary": "S20 local hard-seed slice only; no final adopt/safety-tradeoff decision",
+  "checkpoint": {
+    "path": "omitted_local_model_cache_path",
+    "sha256": "a28aed6d6ad7e1ebf597277ade1cf908efa6da038d0a9fcfdf80c7c31d8d1be1",
+    "registry_id": "predictive_proxy_selected_v2_full",
+    "registry_release": "model/registry.yaml github_release artifact/models-2026-05-registry-v1"
+  },
+  "scenario_matrix": "configs/scenarios/sets/predictive_hardcase_portfolio_v1.yaml",
+  "seed_manifest": "configs/benchmarks/predictive_hard_seeds_s20_v1.yaml",
+  "rows": [
+    {
+      "slice": "clean",
+      "variant": "baseline",
+      "episodes": 20,
+      "success_rate": 0.2,
+      "success_rate_ci": [
+        0.08065766257979806,
+        0.41601743225189364
+      ],
+      "collision_rate": 0.8,
+      "collision_rate_ci": [
+        0.5839825677481064,
+        0.919342337420202
+      ],
+      "mean_min_distance": 3.2770142625020293,
+      "mean_min_distance_ci": [
+        2.173527174865298,
+        4.7528900634027895
+      ],
+      "collision_metric_status": "available",
+      "quality_pass_all": true,
+      "observation_noise_profile": "none"
+    },
+    {
+      "slice": "clean",
+      "variant": "nearfield_turn",
+      "episodes": 20,
+      "success_rate": 0.15,
+      "success_rate_ci": [
+        0.052368745896216595,
+        0.36041886474075696
+      ],
+      "collision_rate": 0.85,
+      "collision_rate_ci": [
+        0.6395811352592431,
+        0.9476312541037835
+      ],
+      "mean_min_distance": 3.223022387653896,
+      "mean_min_distance_ci": [
+        2.113746974840233,
+        4.716030284378409
+      ],
+      "collision_metric_status": "available",
+      "quality_pass_all": true,
+      "observation_noise_profile": "none"
+    },
+    {
+      "slice": "clean",
+      "variant": "nf_speedcap_only",
+      "episodes": 20,
+      "success_rate": 0.15,
+      "success_rate_ci": [
+        0.052368745896216595,
+        0.36041886474075696
+      ],
+      "collision_rate": 0.85,
+      "collision_rate_ci": [
+        0.6395811352592431,
+        0.9476312541037835
+      ],
+      "mean_min_distance": 3.223022387653896,
+      "mean_min_distance_ci": [
+        2.113746974840233,
+        4.716030284378409
+      ],
+      "collision_metric_status": "available",
+      "quality_pass_all": true,
+      "observation_noise_profile": "none"
+    },
+    {
+      "slice": "noisy",
+      "variant": "baseline",
+      "episodes": 20,
+      "success_rate": 0.2,
+      "success_rate_ci": [
+        0.08065766257979806,
+        0.41601743225189364
+      ],
+      "collision_rate": 0.8,
+      "collision_rate_ci": [
+        0.5839825677481064,
+        0.919342337420202
+      ],
+      "mean_min_distance": 3.276468385156705,
+      "mean_min_distance_ci": [
+        2.172626339107638,
+        4.7534622153241415
+      ],
+      "collision_metric_status": "available",
+      "quality_pass_all": true,
+      "observation_noise_profile": "robustness_smoke_v1"
+    },
+    {
+      "slice": "noisy",
+      "variant": "nearfield_turn",
+      "episodes": 20,
+      "success_rate": 0.15,
+      "success_rate_ci": [
+        0.052368745896216595,
+        0.36041886474075696
+      ],
+      "collision_rate": 0.85,
+      "collision_rate_ci": [
+        0.6395811352592431,
+        0.9476312541037835
+      ],
+      "mean_min_distance": 3.2239643411785353,
+      "mean_min_distance_ci": [
+        2.113389560557123,
+        4.718437631564268
+      ],
+      "collision_metric_status": "available",
+      "quality_pass_all": true,
+      "observation_noise_profile": "robustness_smoke_v1"
+    },
+    {
+      "slice": "noisy",
+      "variant": "nf_speedcap_only",
+      "episodes": 20,
+      "success_rate": 0.15,
+      "success_rate_ci": [
+        0.052368745896216595,
+        0.36041886474075696
+      ],
+      "collision_rate": 0.85,
+      "collision_rate_ci": [
+        0.6395811352592431,
+        0.9476312541037835
+      ],
+      "mean_min_distance": 3.2239643411785353,
+      "mean_min_distance_ci": [
+        2.113389560557123,
+        4.718437631564268
+      ],
+      "collision_metric_status": "available",
+      "quality_pass_all": true,
+      "observation_noise_profile": "robustness_smoke_v1"
+    }
+  ],
+  "interpretation": "Observed S20 local slice does not support the #3215 near-field turn signal: baseline success 0.20 vs nearfield_turn/nf_speedcap_only 0.15 in both clean and noisy slices; collision rate is 0.80 baseline vs 0.85 for both variants. Intervals are wide and overlap; treat as diagnostic negative, not final benchmark claim."
+}

--- a/docs/context/negative_result_register.md
+++ b/docs/context/negative_result_register.md
@@ -132,6 +132,24 @@ Each entry records:
 | `claim_boundary` | Diagnostic-only, not benchmark or paper evidence. Small attributable speed-cap effect; classification `diagnostic_only`, not promote. |
 | `created_at` | 2026-06-20 |
 
+### NR-005: Near-Field Turn Budget S20 Follow-Up
+
+| Field | Value |
+|---|---|
+| `id` | `issue-3342-nearfield-turn-budget-s20` |
+| `hypothesis` | The near-field turn-budget improvement observed in the Issue #3215 n=7 hard slice is a real small effect that survives a larger hard-seed sample. |
+| `tested_artifact` | Predictive planner authority variants `baseline`, `nearfield_turn`, and `nf_speedcap_only` using `predictive_proxy_selected_v2_full`. |
+| `scenario` | `predictive_hardcase_portfolio_v1`, S20 hard-seed manifest, clean and `robustness_smoke_v1` observation-noise slices. |
+| `comparator` | Baseline predictive planner authority config on the same S20 seed schedule. |
+| `result_classification` | `diagnostic_only` |
+| `failure_mode` | `evidence_diagnostic_only` |
+| `why_failed_or_inconclusive` | The local S20 diagnostic slice did not reproduce the near-field signal: baseline was 0.20 success / 0.80 collision in both clean and noisy slices, while `nearfield_turn` and `nf_speedcap_only` were 0.15 success / 0.85 collision. Intervals are wide and overlapping, so the result is a diagnostic negative rather than a benchmark-strength rejection. |
+| `evidence_pointer` | `docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/README.md`, `docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/summary.json` |
+| `recommended_next_action` | Do not adopt the near-field turn-budget signal from S20. Run the configured S30 slice only if the remaining uncertainty is worth the local compute; otherwise route forecast-lane effort to model/data-side blockers. |
+| `linked_issues` | [#3342](https://github.com/ll7/robot_sf_ll7/issues/3342), [#3215](https://github.com/ll7/robot_sf_ll7/issues/3215), [#2835](https://github.com/ll7/robot_sf_ll7/issues/2835) |
+| `claim_boundary` | Diagnostic-local, not benchmark-strength, paper-facing, or release evidence. S30 is configured but not run. |
+| `created_at` | 2026-06-21 |
+
 ## Research Planning Implications
 
 This register is a planning aid. When scoping new experiments:

--- a/scripts/validation/evaluate_predictive_planner.py
+++ b/scripts/validation/evaluate_predictive_planner.py
@@ -9,6 +9,7 @@ import math
 import sys
 from collections import Counter
 from pathlib import Path
+from statistics import NormalDist
 
 import numpy as np
 import yaml
@@ -114,12 +115,10 @@ def _failure_taxonomy(rows: list[dict]) -> dict:
 
 
 def _normal_z(confidence: float) -> float:
-    """Return a normal critical value for common confidence levels."""
-    if math.isclose(confidence, 0.90):
-        return 1.6448536269514722
-    if math.isclose(confidence, 0.99):
-        return 2.5758293035489004
-    return 1.959963984540054
+    """Return the two-sided normal critical value for a confidence level."""
+    if not 0.0 < confidence < 1.0:
+        raise ValueError(f"confidence must be between 0 and 1, got {confidence}")
+    return float(NormalDist().inv_cdf(0.5 + confidence / 2.0))
 
 
 def _wilson_interval(successes: int, total: int, confidence: float) -> list[float | None]:
@@ -142,9 +141,10 @@ def _bootstrap_mean_interval(
     seed: int,
 ) -> list[float | None]:
     """Return deterministic bootstrap CI for a finite-value mean."""
-    if not values or samples <= 0:
+    finite_values = [float(value) for value in values if math.isfinite(float(value))]
+    if not finite_values or samples <= 0:
         return [None, None]
-    arr = np.asarray(values, dtype=float)
+    arr = np.asarray(finite_values, dtype=float)
     rng = np.random.default_rng(seed)
     indices = rng.integers(0, len(arr), size=(int(samples), len(arr)))
     means = np.mean(arr[indices], axis=1)

--- a/scripts/validation/evaluate_predictive_planner.py
+++ b/scripts/validation/evaluate_predictive_planner.py
@@ -15,6 +15,7 @@ import yaml
 from loguru import logger
 
 from robot_sf.benchmark.map_runner import run_map_batch
+from robot_sf.benchmark.observation_noise import load_observation_noise_spec
 from robot_sf.benchmark.predictive_planner_config import build_predictive_planner_algo_config
 from scripts.validation.predictive_eval_common import load_seed_manifest, make_subset_scenarios
 
@@ -65,6 +66,15 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Optional baseline JSONL to compute per-scenario deltas vs a reference run.",
     )
+    parser.add_argument(
+        "--observation-noise",
+        type=Path,
+        default=None,
+        help="Optional observation-noise YAML profile passed through to map-runner evaluation.",
+    )
+    parser.add_argument("--bootstrap-samples", type=int, default=1000)
+    parser.add_argument("--bootstrap-seed", type=int, default=123)
+    parser.add_argument("--confidence", type=float, default=0.95)
     return parser.parse_args()
 
 
@@ -100,6 +110,91 @@ def _failure_taxonomy(rows: list[dict]) -> dict:
         "status_counts": dict(by_status),
         "termination_reason_counts": dict(by_reason),
         "scenario_counts": dict(by_scenario),
+    }
+
+
+def _normal_z(confidence: float) -> float:
+    """Return a normal critical value for common confidence levels."""
+    if math.isclose(confidence, 0.90):
+        return 1.6448536269514722
+    if math.isclose(confidence, 0.99):
+        return 2.5758293035489004
+    return 1.959963984540054
+
+
+def _wilson_interval(successes: int, total: int, confidence: float) -> list[float | None]:
+    """Return Wilson score interval for a Bernoulli rate."""
+    if total <= 0:
+        return [None, None]
+    z = _normal_z(confidence)
+    p = float(successes) / float(total)
+    denom = 1.0 + z * z / total
+    center = (p + z * z / (2.0 * total)) / denom
+    half = z * math.sqrt((p * (1.0 - p) / total) + (z * z / (4.0 * total * total))) / denom
+    return [float(max(0.0, center - half)), float(min(1.0, center + half))]
+
+
+def _bootstrap_mean_interval(
+    values: list[float],
+    *,
+    samples: int,
+    confidence: float,
+    seed: int,
+) -> list[float | None]:
+    """Return deterministic bootstrap CI for a finite-value mean."""
+    if not values or samples <= 0:
+        return [None, None]
+    arr = np.asarray(values, dtype=float)
+    rng = np.random.default_rng(seed)
+    indices = rng.integers(0, len(arr), size=(int(samples), len(arr)))
+    means = np.mean(arr[indices], axis=1)
+    alpha = (1.0 - float(confidence)) / 2.0
+    return [
+        float(np.quantile(means, max(0.0, alpha))),
+        float(np.quantile(means, min(1.0, 1.0 - alpha))),
+    ]
+
+
+def _collision_metric_value(row: dict) -> float | None:
+    """Return the explicit episode collision metric, or None when unavailable."""
+    metrics = row.get("metrics")
+    if not isinstance(metrics, dict):
+        return None
+    for key in ("total_collision_count", "collisions"):
+        value = metrics.get(key)
+        if value is None or value == "":
+            continue
+        try:
+            number = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(number):
+            return number
+    return None
+
+
+def _collision_metric_status(rows: list[dict]) -> dict[str, object]:
+    """Summarize whether every episode has an explicit collision metric."""
+    available = sum(1 for row in rows if _collision_metric_value(row) is not None)
+    total = len(rows)
+    if total == 0:
+        status = "not_available"
+        reason = "no episode rows"
+    elif available == total:
+        status = "available"
+        reason = None
+    elif available == 0:
+        status = "not_available"
+        reason = "no episode rows had metrics.total_collision_count or metrics.collisions"
+    else:
+        status = "partial"
+        reason = "some episode rows lacked metrics.total_collision_count or metrics.collisions"
+    return {
+        "status": status,
+        "reason": reason,
+        "denominator": total,
+        "available": available,
+        "required_fields": ["metrics.total_collision_count", "metrics.collisions"],
     }
 
 
@@ -204,6 +299,11 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         workers=int(args.workers),
         resume=False,
         benchmark_profile="experimental",
+        observation_noise=(
+            load_observation_noise_spec(args.observation_noise)
+            if args.observation_noise is not None
+            else None
+        ),
     )
 
     rows = [
@@ -220,11 +320,43 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         for row in rows
         if row.get("metrics", {}).get("min_distance") is not None
     ]
+    collision_metric_values = [_collision_metric_value(row) for row in rows]
+    collision_vals = [
+        1.0 if float(value) > 0.0 else 0.0 for value in collision_metric_values if value is not None
+    ]
     avg_speed_vals = [float(row.get("metrics", {}).get("avg_speed", 0.0)) for row in rows]
 
     success_rate = _mean(success_vals)
+    collision_rate = _mean(collision_vals) if collision_vals else float("nan")
     mean_min_distance = _mean(min_dist_vals) if min_dist_vals else float("nan")
     mean_speed = _mean(avg_speed_vals)
+    collision_status = _collision_metric_status(rows)
+    success_count = int(sum(success_vals))
+    collision_count = int(sum(collision_vals))
+    uncertainty = {
+        "confidence": float(args.confidence),
+        "bootstrap_samples": int(args.bootstrap_samples),
+        "bootstrap_seed": int(args.bootstrap_seed),
+        "success_rate_ci": _wilson_interval(
+            success_count, len(success_vals), float(args.confidence)
+        ),
+        "collision_rate_ci": _wilson_interval(
+            collision_count,
+            len(collision_vals),
+            float(args.confidence),
+        ),
+        "mean_min_distance_ci": _bootstrap_mean_interval(
+            min_dist_vals,
+            samples=int(args.bootstrap_samples),
+            confidence=float(args.confidence),
+            seed=int(args.bootstrap_seed),
+        ),
+        "methods": {
+            "success_rate": "wilson_score",
+            "collision_rate": "wilson_score",
+            "mean_min_distance": "bootstrap_episode_mean",
+        },
+    }
     per_scenario: dict[str, dict] = {}
     for row in rows:
         scenario_id = str(row.get("scenario_id", "unknown"))
@@ -329,12 +461,18 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         "min_success_rate": float(args.min_success_rate),
         "min_distance": float(args.min_distance),
         "min_distance_available": min_distance_available,
+        "collision_metric_status": collision_status,
+        "collision_metric_available": collision_status["status"] == "available",
         "pass_success_rate": bool(success_rate >= float(args.min_success_rate)),
         "pass_min_distance": bool(
             mean_min_distance >= float(args.min_distance) if min_distance_available else True
         ),
     }
-    gates["pass_all"] = bool(gates["pass_success_rate"] and gates["pass_min_distance"])
+    gates["pass_all"] = bool(
+        gates["pass_success_rate"]
+        and gates["pass_min_distance"]
+        and gates["collision_metric_available"]
+    )
     integrity = _integrity_summary(rows)
 
     result = {
@@ -349,9 +487,12 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         "run_summary": summary,
         "metrics": {
             "success_rate": success_rate,
+            "collision_rate": collision_rate,
             "mean_min_distance": mean_min_distance,
             "mean_avg_speed": mean_speed,
         },
+        "uncertainty": uncertainty,
+        "collision_metric_status": collision_status,
         "per_scenario_delta": per_scenario_summary,
         "failure_taxonomy": _failure_taxonomy(rows),
         "integrity": integrity,

--- a/tests/validation/test_evaluate_predictive_planner_smoke.py
+++ b/tests/validation/test_evaluate_predictive_planner_smoke.py
@@ -134,6 +134,28 @@ def test_evaluate_predictive_planner_fails_closed_without_collision_metric(
     assert payload["quality_gates"]["pass_all"] is False
 
 
+def test_uncertainty_helpers_validate_confidence_and_filter_non_finite() -> None:
+    """Uncertainty helpers should avoid silent confidence fallback and non-finite samples."""
+    assert 1.28 < mod._normal_z(0.80) < 1.29
+
+    try:
+        mod._normal_z(1.0)
+    except ValueError as exc:
+        assert "confidence" in str(exc)
+    else:  # pragma: no cover - explicit failure branch
+        raise AssertionError("expected invalid confidence to fail")
+
+    interval = mod._bootstrap_mean_interval(
+        [1.0, float("nan"), 3.0, float("inf")],
+        samples=20,
+        confidence=0.95,
+        seed=123,
+    )
+    assert interval[0] is not None
+    assert interval[1] is not None
+    assert 1.0 <= interval[0] <= interval[1] <= 3.0
+
+
 def test_integrity_summary_groups_multiple_reasons_per_episode() -> None:
     """Integrity summary should emit one contradiction entry per episode id."""
     rows = [

--- a/tests/validation/test_evaluate_predictive_planner_smoke.py
+++ b/tests/validation/test_evaluate_predictive_planner_smoke.py
@@ -53,6 +53,10 @@ def test_evaluate_predictive_planner_smoke(monkeypatch, tmp_path: Path) -> None:
             algo_config=None,
             seed_manifest=None,
             comparison_jsonl=None,
+            observation_noise=None,
+            bootstrap_samples=20,
+            bootstrap_seed=123,
+            confidence=0.95,
         ),
     )
 
@@ -64,6 +68,70 @@ def test_evaluate_predictive_planner_smoke(monkeypatch, tmp_path: Path) -> None:
     payload = json.loads(summary_path.read_text(encoding="utf-8"))
     assert payload["contract_version"] == "benchmark-reset-v2"
     assert payload["integrity"]["pass"] is True
+    assert payload["collision_metric_status"]["status"] == "available"
+    assert payload["uncertainty"]["success_rate_ci"][1] == 1.0
+
+
+def test_evaluate_predictive_planner_fails_closed_without_collision_metric(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Evaluation quality gates should reject rows without explicit collision metrics."""
+    checkpoint = tmp_path / "predictive_model.pt"
+    checkpoint.write_text("stub", encoding="utf-8")
+    scenario_matrix = tmp_path / "scenarios.yaml"
+    scenario_matrix.write_text("scenarios: []\n", encoding="utf-8")
+    output_dir = tmp_path / "eval_out"
+
+    def _fake_run_map_batch(*args, **kwargs):
+        jsonl_path = Path(args[1])
+        row = {
+            "episode_id": "episode_001",
+            "scenario_id": "scenario_a",
+            "seed": 7,
+            "status": "ok",
+            "termination_reason": "goal_reached",
+            "metrics": {
+                "success_rate": 1.0,
+                "min_distance": 0.9,
+                "avg_speed": 0.4,
+            },
+        }
+        jsonl_path.write_text(json.dumps(row) + "\n", encoding="utf-8")
+        return {"ok": True}
+
+    monkeypatch.setattr(mod, "run_map_batch", _fake_run_map_batch)
+    monkeypatch.setattr(
+        mod,
+        "parse_args",
+        lambda: mod.argparse.Namespace(
+            checkpoint=checkpoint,
+            scenario_matrix=scenario_matrix,
+            schema_path=Path("robot_sf/benchmark/schemas/episode.schema.v1.json"),
+            horizon=10,
+            dt=0.1,
+            workers=1,
+            min_success_rate=0.3,
+            min_distance=0.25,
+            output_dir=output_dir,
+            tag="smoke",
+            algo_config=None,
+            seed_manifest=None,
+            comparison_jsonl=None,
+            observation_noise=None,
+            bootstrap_samples=20,
+            bootstrap_seed=123,
+            confidence=0.95,
+        ),
+    )
+
+    code = mod.main()
+
+    assert code == 2
+    payload = json.loads((output_dir / "smoke_summary.json").read_text(encoding="utf-8"))
+    assert payload["collision_metric_status"]["status"] == "not_available"
+    assert payload["quality_gates"]["collision_metric_available"] is False
+    assert payload["quality_gates"]["pass_all"] is False
 
 
 def test_integrity_summary_groups_multiple_reasons_per_episode() -> None:


### PR DESCRIPTION
## Summary
Adds the Issue #3342 S20/S30 hard-seed manifests, extends the predictive evaluation summary with collision-rate and uncertainty fields, and preserves a compact S20 diagnostic evidence bundle. The local S20 result does not support adopting the near-field turn-budget signal.

## Linked Issues
- Closes `#3342`
- Relates to `#3215`
- Relates to `#2835`

## Stack / Dependency
- Base dependency: `origin/main` at `1cc44341d79372c1b13ee6ac30ca2d0d3d8063d0`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `configs/benchmarks/predictive_hard_seeds_s20_v1.yaml` and `configs/benchmarks/predictive_hard_seeds_s30_v1.yaml`.
- Extended `scripts/validation/evaluate_predictive_planner.py` with observation-noise pass-through, explicit collision metric availability, aggregate collision rate, Wilson intervals for success/collision, and bootstrap intervals for mean minimum distance.
- Added fail-closed test coverage for missing collision metrics.
- Promoted compact S20 evidence under `docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/`.
- Updated the #3215 synthesis note, evidence index/catalog, and negative-result register.

## Why It Matters
- Added value: converts the #3215 near-field turn-budget follow-up from a missing-metric proposal into a runnable S20/S30 diagnostic path with a preserved S20 result.
- Expected impact: reviewers can see collision rate and uncertainty directly instead of relying on null collision summaries or local `output/` artifacts.
- Why this is worth merging now: it resolves the prerequisite collision-summary gap for this follow-up and records a diagnostic negative before more effort is spent on the same planner-authority lever.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: whether the #3215 near-field turn-budget signal survives a larger hard-seed sample.
- Comparator or baseline, if applicable: baseline predictive authority config on the same S20 hard-seed schedule.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only negative.
- Decision or stop rule, if applicable: do not adopt the near-field turn-budget signal from S20; run S30 only if the remaining uncertainty is worth local compute.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/evidence/issue_3215_hardcase_portfolio_synthesis_2026-06-21/README.md`, `docs/context/negative_result_register.md`, and `docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/`.
- New research/benchmark/metric/paper-facing analysis tool, if any: `evaluate_predictive_planner.py` now emits collision/uncertainty fields and is used on the tracked S20 manifest with compact evidence promoted in this PR.

## Domain-Aware Approval
- Required for this PR: yes - benchmark/research-facing diagnostic result and metric summary path.
- Domains reviewed: evidence classification / experimental comparison / benchmark interpretation.
- Status: pending reviewer approval.
- Approver/review source or waiver: PR review.
- Validity checklist:
  - Target claim/hypothesis: near-field turn-budget signal survival beyond n=7.
  - Comparator or split/evidence validity: same S20 seed schedule for baseline, `nearfield_turn`, and `nf_speedcap_only`; clean and observation-noise slices.
  - Fallback/degraded exclusions: no fallback/degraded rows promoted; collision metric availability is explicit.
  - Claim boundary: diagnostic-local, not benchmark-strength or paper-facing evidence.
  - Implementation integrity vs experimental validity: tests validate summary/gating behavior; experimental validity remains diagnostic because S30 was not run and intervals overlap.

## Falsification / Non-Transfer Check
- Did the mechanism activate? unknown from summary-level evidence; the authority configs ran.
- Did the intervention change command source, selected command, trajectory, or route progress? not measured in this PR.
- Did the scenario actually contain the targeted failure mode? yes, the same hard-case portfolio families from #3215.
- Result route: stop/narrow.
- Follow-up question or issue for weak, negative, or non-transfer results: run the configured S30 slice only if S20 uncertainty remains decision-relevant.

## Next Empirical Action
- Rerun needed: no for S20; optional for S30.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: raw JSONL remains ignored/local; compact summary is tracked.
- Stop / revise / continue decision: do not adopt the near-field signal from S20; continue only if S30 is explicitly prioritized.
- Proposed child issue or existing follow-up: none opened; #3342 can close with diagnostic-local evidence.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/validation/test_evaluate_predictive_planner_smoke.py -q`
  - `uv run ruff check scripts/validation/evaluate_predictive_planner.py tests/validation/test_evaluate_predictive_planner_smoke.py`
  - `uv run ruff format --check scripts/validation/evaluate_predictive_planner.py tests/validation/test_evaluate_predictive_planner_smoke.py`
  - `uv run python scripts/validation/check_docs_proof_consistency.py`
  - `uv run python scripts/validation/evaluate_predictive_planner.py --help | rg -n "observation-noise|bootstrap-samples|bootstrap-seed|confidence"`
  - S20/S30 manifest expansion check (`20` and `30` expanded episodes)
  - `python3 -m json.tool docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/summary.json`
  - `sha256sum -c docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/checksums.sha256`
  - `git diff --check`
- Evidence that the change works here: `docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/summary.json` records six S20 rows with success, collision, min-distance, and intervals.
- Benchmarks or smoke tests, if applicable: local S20 diagnostic campaign over clean/noisy slices for `baseline`, `nearfield_turn`, and `nf_speedcap_only`.

## Risks / Rollout
- Compatibility risks: `evaluate_predictive_planner.py` now fails closed when collision metrics are absent; callers with old row schemas will need explicit collision metrics.
- Failure modes: S20 evidence is diagnostic-only; `pass_all` gates collision metric availability, not a safety threshold on collision rate.
- Rollback or fallback plan: revert the commit to restore prior summary schema; S20/S30 manifests and evidence bundle are independent data/docs additions.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`, `docs/context/evidence/issue_3215_hardcase_portfolio_synthesis_2026-06-21/README.md`, `docs/context/negative_result_register.md`.
- Relevant design or provenance notes: `docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/README.md`.
- Any assumptions that need to be preserved: local S20 result is diagnostic-local and not a benchmark-strength or paper-facing claim; S30 is configured but not run.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR closes #3342.
- Claim map / benchmark report updated (yes/no/NA): yes, #3215 synthesis note updated.
- Leaderboard / artifact catalog updated (yes/no/NA): artifact catalog updated.
- Registry or config index updated (yes/no/NA): config manifests added; no model registry change.
- Context index / memory note updated (yes/no/NA): evidence index and negative-result register updated; memory note NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: no paper-facing or leaderboard claim is promoted.

## Follow-Up Issues
- Deferred work: optional S30 run if the remaining uncertainty is worth local compute.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify closely that the promoted evidence does not overstate S20: it is diagnostic-local and negative/inconclusive, not benchmark-grade.
- The collision quality gate checks metric availability, not acceptable collision rate; interpretation lives in the evidence note/register.
- Ignored raw local outputs were inspected but intentionally not tracked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added observation-noise support to evaluation workflows.
  * Introduced confidence-interval and uncertainty quantification for evaluation metrics.
  * Added collision-rate computation with dedicated metric extraction.

* **Documentation**
  * Added diagnostic evidence bundle and negative result register entry documenting near-field signal evaluation findings.

* **Tests**
  * Added test coverage for collision metric validation and uncertainty computation.

* **Chores**
  * Added new benchmark hard-seed configurations for diagnostic sampling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->