### PR TITLE
feat: extend observation-noise replay seed grid

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1554,6 +1554,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_3201_observation_noise_live_smoke/summary.json
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -183,7 +183,10 @@ Policy caveats:
   observations but not commands or progress/risk summaries. The nested
   `issue_3328_behavior_probe/` evidence adds an opt-in high-amplitude noise probe that changes
   commands/progress on the same one-seed fixture and is classified
-  `behavior_sensitive_diagnostic_only`. Diagnostic stress evidence only; not a robustness claim.
+  `behavior_sensitive_diagnostic_only`. The nested `issue_3330_seed_amplitude_grid/` evidence adds
+  a two-amplitude, three-perturbation-seed Gaussian grid; behavior sensitivity is mixed across the
+  selected cells, with command/progress/min-distance changes in three cells and policy-insensitive
+  results in four non-baseline cells. Diagnostic stress evidence only; not a robustness claim.
 - `issue_3201_observation_noise_live_smoke/`: diagnostic-only same-seed clean vs perturbed
   step-diagnostics replay on the `dense_pedestrian_stress` live matrix candidate. Perturbation
   changed planner-input pedestrian observations, but commands and progress/risk summaries stayed

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/README.md
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/README.md
@@ -49,3 +49,14 @@ high-amplitude noise condition (`std=1.0`, `bound=2.0`, seed 3328). The probe is
 progress/min-distance summaries on one seed, while medium noise and delay-only remain
 policy-insensitive. It is diagnostic stress evidence only, not a robustness, sensor-realism, or
 planner-superiority claim.
+
+## Issue #3330 Seed/Amplitude Grid
+
+`issue_3330_seed_amplitude_grid/` preserves the same #2756/#3323 near-field fixture boundary and
+adds an opt-in two-amplitude, three-perturbation-seed Gaussian grid. The grid is classified
+`behavior_sensitive_diagnostic_only`: behavior sensitivity is mixed across the selected cells.
+`medium_noise_seed_3328`, `high_noise_seed_3328`, and `high_noise_seed_3330` changed selected
+commands plus progress/min-distance summaries, while `medium_noise_seed_2755`,
+`medium_noise_seed_3330`, `high_noise_seed_2755`, and `delay_only` remained policy-insensitive.
+This is diagnostic stress evidence only, not a robustness, sensor-realism, or planner-superiority
+claim.

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/README.md
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/README.md
@@ -1,0 +1,45 @@
+# Issue #2777 Live Observation-Noise Replay
+
+## Status
+
+- Status: `live_replay`
+- Classification: `behavior_sensitive_diagnostic_only`
+- Rationale: All selected live replays completed. The predeclared seed/amplitude grid is diagnostic-only and does not support a robustness, sensor-realism, or planner-superiority claim.
+
+## Claim Boundary
+
+Stress-slice live planner/environment replay for one scenario, one scenario seed, and a predeclared observation-noise seed/amplitude grid. Treat persistence, disappearance, or mixed behavior sensitivity as diagnostic-only; do not infer robustness, sensor realism, or planner superiority.
+
+## Fixture Contract
+
+- `required_scenario`: `issue_2756_occluded_emergence`
+- `required_family`: `occluded_emergence/deterministic_occluded_emergence`
+- `first_visible_step`: `5`
+- `delay_steps`: `2`
+- `delay_only_expected_first_observed_step`: `7`
+- `scenario_matrix`: `configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml`
+- `satisfied`: `True`
+- `blocker`: `None`
+
+## Behavior Sensitivity Summary
+
+- Interpretation: `behavior_sensitivity_is_seed_or_amplitude_specific_in_selected_grid`
+- Behavior-sensitive conditions: `['medium_noise_seed_3328', 'high_noise_seed_3328', 'high_noise_seed_3330']`
+- Policy-insensitive conditions: `['delay_only', 'medium_noise_seed_2755', 'medium_noise_seed_3330', 'high_noise_seed_2755']`
+- Command-changed conditions: `['medium_noise_seed_3328', 'high_noise_seed_3328', 'high_noise_seed_3330']`
+- Progress/risk-changed conditions: `['medium_noise_seed_3328', 'high_noise_seed_3328', 'high_noise_seed_3330']`
+- Stop/yield proxy-changed conditions: `[]`
+- Boundary: Diagnostic-only persistence summary over completed live replay cells. It is not a benchmark-strength robustness, sensor-realism, or planner-superiority claim.
+
+## Conditions
+
+| Condition | Status | Classification | Command changed | Progress/risk changed | Min distance changed | Collision/near-miss changed | Stop/yield proxy changed | Caveat |
+|---|---|---|---:|---:|---:|---:|---:|---|
+| `noop` | `live_replay` | `baseline` | `n/a` | `n/a` | `n/a` | `n/a` | `n/a` |  |
+| `delay_only` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `medium_noise_seed_2755` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `medium_noise_seed_3328` | `live_replay` | `behavior_sensitive_diagnostic_only` | `True` | `True` | `True` | `False` | `False` | Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but the selected diagnostic slice is not enough for a benchmark-strength robustness claim. |
+| `medium_noise_seed_3330` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `high_noise_seed_2755` | `live_replay` | `policy_insensitive` | `False` | `False` | `False` | `False` | `False` | Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical. |
+| `high_noise_seed_3328` | `live_replay` | `behavior_sensitive_diagnostic_only` | `True` | `True` | `True` | `False` | `False` | Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but the selected diagnostic slice is not enough for a benchmark-strength robustness claim. |
+| `high_noise_seed_3330` | `live_replay` | `behavior_sensitive_diagnostic_only` | `True` | `True` | `True` | `False` | `False` | Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but the selected diagnostic slice is not enough for a benchmark-strength robustness claim. |

--- a/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json
+++ b/docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/summary.json
@@ -1,0 +1,1593 @@
+{
+  "schema_version": "issue_2777_observation_noise_live_replay.v1",
+  "artifact_shape": "compact_summary_without_raw_traces",
+  "issue": 2777,
+  "status": "live_replay",
+  "classification": {
+    "label": "behavior_sensitive_diagnostic_only",
+    "rationale": "All selected live replays completed. The predeclared seed/amplitude grid is diagnostic-only and does not support a robustness, sensor-realism, or planner-superiority claim."
+  },
+  "claim_boundary": "Stress-slice live planner/environment replay for one scenario, one scenario seed, and a predeclared observation-noise seed/amplitude grid. Treat persistence, disappearance, or mixed behavior sensitivity as diagnostic-only; do not infer robustness, sensor realism, or planner superiority.",
+  "inputs": {
+    "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+    "raw_trace_json": "worktree-local generated traces summarized here; raw trace.json files are intentionally not committed",
+    "generated_funnel": "worktree-local generated_policy_search_funnel.yaml was intentionally not committed"
+  },
+  "fixture_contract": {
+    "required_source_issue": 2756,
+    "required_scenario": "issue_2756_occluded_emergence",
+    "required_family": "occluded_emergence/deterministic_occluded_emergence",
+    "required_seed": 111,
+    "first_visible_step": 5,
+    "delay_steps": 2,
+    "delay_only_expected_first_observed_step": 7,
+    "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+    "satisfied": true,
+    "blocker": null,
+    "matched_scenario": {
+      "name": "issue_2756_occluded_emergence",
+      "source_issue": 2756,
+      "family": "occluded_emergence",
+      "label": "deterministic_occluded_emergence",
+      "seeds": [
+        111
+      ],
+      "first_visible_step": 5,
+      "delay_steps": 2,
+      "delay_only_expected_first_observed_step": 7
+    }
+  },
+  "fixture_observation_boundary": {
+    "noop_first_observed_step": 5,
+    "delay_only_first_observed_step": 7,
+    "expected_noop_first_observed_step": 5,
+    "expected_delay_only_first_observed_step": 7
+  },
+  "run_config": {
+    "candidate": "risk_surface_dwa_v0",
+    "stage": "smoke",
+    "scenario_matrix": "configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml",
+    "scenario_name": null,
+    "scenario_index": 0,
+    "seed": null,
+    "seed_index": 0,
+    "horizon": 50,
+    "output_dir": "docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid",
+    "condition_set": "issue_3330_seed_amplitude_grid",
+    "condition_names": [
+      "noop",
+      "delay_only",
+      "medium_noise_seed_2755",
+      "medium_noise_seed_3328",
+      "medium_noise_seed_3330",
+      "high_noise_seed_2755",
+      "high_noise_seed_3328",
+      "high_noise_seed_3330"
+    ],
+    "allow_non_occluded_live_fixture": false,
+    "dry_run": false
+  },
+  "behavior_sensitivity_summary": {
+    "live_condition_count": 7,
+    "behavior_sensitive_condition_count": 3,
+    "policy_insensitive_condition_count": 4,
+    "behavior_sensitive_conditions": [
+      "medium_noise_seed_3328",
+      "high_noise_seed_3328",
+      "high_noise_seed_3330"
+    ],
+    "policy_insensitive_conditions": [
+      "delay_only",
+      "medium_noise_seed_2755",
+      "medium_noise_seed_3330",
+      "high_noise_seed_2755"
+    ],
+    "command_changed_conditions": [
+      "medium_noise_seed_3328",
+      "high_noise_seed_3328",
+      "high_noise_seed_3330"
+    ],
+    "progress_or_risk_changed_conditions": [
+      "medium_noise_seed_3328",
+      "high_noise_seed_3328",
+      "high_noise_seed_3330"
+    ],
+    "min_distance_changed_conditions": [
+      "medium_noise_seed_3328",
+      "high_noise_seed_3328",
+      "high_noise_seed_3330"
+    ],
+    "collision_or_near_miss_changed_conditions": [],
+    "stop_yield_proxy_changed_conditions": [],
+    "seed_amplitude_cells": [
+      {
+        "condition": "delay_only",
+        "position_noise_std_m": null,
+        "position_noise_bound_m": null,
+        "observation_perturbation_seed": null,
+        "classification": "policy_insensitive",
+        "command_sequence_changed": false,
+        "progress_or_risk_changed": false,
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "stop_yield_proxy_changed": false
+      },
+      {
+        "condition": "medium_noise_seed_2755",
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "observation_perturbation_seed": 2755,
+        "classification": "policy_insensitive",
+        "command_sequence_changed": false,
+        "progress_or_risk_changed": false,
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "stop_yield_proxy_changed": false
+      },
+      {
+        "condition": "medium_noise_seed_3328",
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "observation_perturbation_seed": 3328,
+        "classification": "behavior_sensitive_diagnostic_only",
+        "command_sequence_changed": true,
+        "progress_or_risk_changed": true,
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "stop_yield_proxy_changed": false
+      },
+      {
+        "condition": "medium_noise_seed_3330",
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "observation_perturbation_seed": 3330,
+        "classification": "policy_insensitive",
+        "command_sequence_changed": false,
+        "progress_or_risk_changed": false,
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "stop_yield_proxy_changed": false
+      },
+      {
+        "condition": "high_noise_seed_2755",
+        "position_noise_std_m": 1.0,
+        "position_noise_bound_m": 2.0,
+        "observation_perturbation_seed": 2755,
+        "classification": "policy_insensitive",
+        "command_sequence_changed": false,
+        "progress_or_risk_changed": false,
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "stop_yield_proxy_changed": false
+      },
+      {
+        "condition": "high_noise_seed_3328",
+        "position_noise_std_m": 1.0,
+        "position_noise_bound_m": 2.0,
+        "observation_perturbation_seed": 3328,
+        "classification": "behavior_sensitive_diagnostic_only",
+        "command_sequence_changed": true,
+        "progress_or_risk_changed": true,
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "stop_yield_proxy_changed": false
+      },
+      {
+        "condition": "high_noise_seed_3330",
+        "position_noise_std_m": 1.0,
+        "position_noise_bound_m": 2.0,
+        "observation_perturbation_seed": 3330,
+        "classification": "behavior_sensitive_diagnostic_only",
+        "command_sequence_changed": true,
+        "progress_or_risk_changed": true,
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "stop_yield_proxy_changed": false
+      }
+    ],
+    "interpretation": "behavior_sensitivity_is_seed_or_amplitude_specific_in_selected_grid",
+    "claim_boundary": "Diagnostic-only persistence summary over completed live replay cells. It is not a benchmark-strength robustness, sensor-realism, or planner-superiority claim."
+  },
+  "conditions": [
+    {
+      "name": "noop",
+      "description": "Unperturbed live planner/environment replay.",
+      "perturbation": {
+        "position_noise_std_m": null,
+        "position_noise_bound_m": null,
+        "observation_perturbation_seed": null,
+        "observation_delay_steps": null,
+        "missed_detection_probability": null,
+        "occlusion_distance_m": null
+      },
+      "status": "live_replay"
+    },
+    {
+      "name": "delay_only",
+      "description": "Two-step delayed pedestrian observation, preserving the #2755 expected lag.",
+      "perturbation": {
+        "position_noise_std_m": null,
+        "position_noise_bound_m": null,
+        "observation_perturbation_seed": null,
+        "observation_delay_steps": 2,
+        "missed_detection_probability": null,
+        "occlusion_distance_m": null
+      },
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "delayed_observation"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 7
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "medium_noise_seed_2755",
+      "description": "Issue #3330 medium-amplitude Gaussian grid cell, std=0.30 m, bound=0.60 m, seed=2755.",
+      "perturbation": {
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "observation_perturbation_seed": 2755,
+        "observation_delay_steps": null,
+        "missed_detection_probability": null,
+        "occlusion_distance_m": null
+      },
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "medium_noise_seed_3328",
+      "description": "Issue #3330 medium-amplitude Gaussian grid cell, std=0.30 m, bound=0.60 m, seed=3328.",
+      "perturbation": {
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "observation_perturbation_seed": 3328,
+        "observation_delay_steps": null,
+        "missed_detection_probability": null,
+        "occlusion_distance_m": null
+      },
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": true,
+        "changed_steps": [
+          8
+        ],
+        "changed_step_count": 1,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017799448099487414,
+          "changed": true
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017799448099487414,
+          "changed": true
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.6624126661115424,
+          "changed": true
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": true,
+        "changed_command_steps": [
+          8
+        ],
+        "changed_command_step_count": 1,
+        "progress_or_risk_changed": true,
+        "progress_delta_changed_fields": [
+          "net_goal_progress",
+          "best_goal_progress",
+          "closest_robot_ped_distance"
+        ],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.6624126661115424,
+            "changed": true
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "behavior_sensitive_diagnostic_only",
+        "rationale": "Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but the selected diagnostic slice is not enough for a benchmark-strength robustness claim."
+      }
+    },
+    {
+      "name": "medium_noise_seed_3330",
+      "description": "Issue #3330 medium-amplitude Gaussian grid cell, std=0.30 m, bound=0.60 m, seed=3330.",
+      "perturbation": {
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "observation_perturbation_seed": 3330,
+        "observation_delay_steps": null,
+        "missed_detection_probability": null,
+        "occlusion_distance_m": null
+      },
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "high_noise_seed_2755",
+      "description": "Issue #3330 high-amplitude Gaussian grid cell, std=1.0 m, bound=2.0 m, seed=2755.",
+      "perturbation": {
+        "position_noise_std_m": 1.0,
+        "position_noise_bound_m": 2.0,
+        "observation_perturbation_seed": 2755,
+        "observation_delay_steps": null,
+        "missed_detection_probability": null,
+        "occlusion_distance_m": null
+      },
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": false,
+        "changed_steps": [],
+        "changed_step_count": 0,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.017716584144122027,
+          "changed": false
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.65520666531114,
+          "changed": false
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": false,
+        "changed_command_steps": [],
+        "changed_command_step_count": 0,
+        "progress_or_risk_changed": false,
+        "progress_delta_changed_fields": [],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.65520666531114,
+            "changed": false
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": false,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "policy_insensitive",
+        "rationale": "Perturbation changed planner-input observations in a near-field trace, but selected commands and progress/risk summaries were identical."
+      }
+    },
+    {
+      "name": "high_noise_seed_3328",
+      "description": "Issue #3330 high-amplitude Gaussian grid cell, std=1.0 m, bound=2.0 m, seed=3328.",
+      "perturbation": {
+        "position_noise_std_m": 1.0,
+        "position_noise_bound_m": 2.0,
+        "observation_perturbation_seed": 3328,
+        "observation_delay_steps": null,
+        "missed_detection_probability": null,
+        "occlusion_distance_m": null
+      },
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": true,
+        "changed_steps": [
+          6,
+          9
+        ],
+        "changed_step_count": 2,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.6632785410644526,
+          "changed": true
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": true,
+        "changed_command_steps": [
+          6,
+          9
+        ],
+        "changed_command_step_count": 2,
+        "progress_or_risk_changed": true,
+        "progress_delta_changed_fields": [
+          "net_goal_progress",
+          "best_goal_progress",
+          "closest_robot_ped_distance"
+        ],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.6632785410644526,
+            "changed": true
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "behavior_sensitive_diagnostic_only",
+        "rationale": "Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but the selected diagnostic slice is not enough for a benchmark-strength robustness claim."
+      }
+    },
+    {
+      "name": "high_noise_seed_3330",
+      "description": "Issue #3330 high-amplitude Gaussian grid cell, std=1.0 m, bound=2.0 m, seed=3330.",
+      "perturbation": {
+        "position_noise_std_m": 1.0,
+        "position_noise_bound_m": 2.0,
+        "observation_perturbation_seed": 3330,
+        "observation_delay_steps": null,
+        "missed_detection_probability": null,
+        "occlusion_distance_m": null
+      },
+      "status": "live_replay",
+      "scenario": {
+        "noop": "issue_2756_occluded_emergence",
+        "condition": "issue_2756_occluded_emergence",
+        "same": true
+      },
+      "seed": {
+        "noop": 111,
+        "condition": 111,
+        "same": true
+      },
+      "planner_mode": {
+        "candidate": "risk_surface_dwa_v0",
+        "algo": "risk_surface_dwa",
+        "stage": "smoke"
+      },
+      "observation_summary": {
+        "noop": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "fixture_visibility",
+            "none"
+          ]
+        },
+        "condition": {
+          "missed_actor_observations_total": 0,
+          "occluded_actor_observations_total": 0,
+          "visibility_hidden_actor_observations_total": 5,
+          "min_observed_actor_count": 0,
+          "max_observed_actor_count": 1,
+          "noise_profiles": [
+            "bounded_gaussian"
+          ]
+        }
+      },
+      "command_summary": {
+        "sequence_changed": true,
+        "changed_steps": [
+          5,
+          8
+        ],
+        "changed_step_count": 2,
+        "noop_first": [
+          2.0,
+          0.0
+        ],
+        "condition_first": [
+          2.0,
+          0.0
+        ],
+        "noop_last": [
+          1.2,
+          0.0
+        ],
+        "condition_last": [
+          1.2,
+          0.0
+        ]
+      },
+      "progress_delta": {
+        "net_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "best_goal_progress": {
+          "noop": 0.017716584144122027,
+          "condition": 0.0077209567744040974,
+          "changed": true
+        },
+        "closest_robot_ped_distance": {
+          "noop": 1.65520666531114,
+          "condition": 1.6634374789381774,
+          "changed": true
+        },
+        "closest_robot_ped_step": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "collision_flag_counts": {
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "progress_step_count": {
+          "noop": 14,
+          "condition": 14,
+          "changed": false
+        },
+        "regression_step_count": {
+          "noop": 1,
+          "condition": 1,
+          "changed": false
+        },
+        "stagnant_step_count": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        },
+        "longest_stagnant_run": {
+          "noop": 0,
+          "condition": 0,
+          "changed": false
+        }
+      },
+      "behavior_change_summary": {
+        "command_sequence_changed": true,
+        "changed_command_steps": [
+          5,
+          8
+        ],
+        "changed_command_step_count": 2,
+        "progress_or_risk_changed": true,
+        "progress_delta_changed_fields": [
+          "net_goal_progress",
+          "best_goal_progress",
+          "closest_robot_ped_distance"
+        ],
+        "closest_robot_ped": {
+          "distance": {
+            "noop": 1.65520666531114,
+            "condition": 1.6634374789381774,
+            "changed": true
+          },
+          "step": {
+            "noop": 14,
+            "condition": 14,
+            "changed": false
+          }
+        },
+        "min_distance_changed": true,
+        "collision_or_near_miss_changed": false,
+        "collision_summary": {
+          "status": "available",
+          "noop": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "condition": {
+            "pedestrian": 0,
+            "obstacle": 0,
+            "robot": 0
+          },
+          "changed": false
+        },
+        "near_miss_summary": {
+          "status": "available",
+          "noop": 0.0,
+          "condition": 0.0,
+          "changed": false
+        },
+        "stop_yield_timing_proxy": {
+          "status": "available",
+          "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+          "direct_event_available": false,
+          "noop_first_stop_step": null,
+          "condition_first_stop_step": null,
+          "changed": false
+        },
+        "stop_yield_timing": {
+          "direct_event_available": false,
+          "limitation": "Direct stop/yield event timing is not available in diagnostics traces; only a zero-linear-speed command proxy is reported.",
+          "command_stop_proxy": {
+            "definition": "First diagnostics trace step where the selected policy_command linear speed component is present and abs(speed_mps) <= 1e-9. Direct stop/yield event timing is not available in these traces.",
+            "noop_first_stop_step": null,
+            "condition_first_stop_step": null,
+            "changed": false
+          }
+        }
+      },
+      "fixture_visibility": {
+        "noop_first_observed_step": 5,
+        "condition_first_observed_step": 5
+      },
+      "classification": {
+        "label": "behavior_sensitive_diagnostic_only",
+        "rationale": "Perturbation changed selected commands or progress/risk fields. This is live behavior evidence, but the selected diagnostic slice is not enough for a benchmark-strength robustness claim."
+      }
+    }
+  ],
+  "blockers": []
+}

--- a/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
+++ b/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
@@ -47,6 +47,23 @@ ISSUE_3328_REQUIRED_CONDITIONS = (
     "delay_only",
     "high_noise_3328",
 )
+ISSUE_3330_CONDITION_SET = "issue_3330_seed_amplitude_grid"
+ISSUE_3330_NOISE_SEEDS = (2755, 3328, 3330)
+ISSUE_3330_AMPLITUDE_PROFILES = (
+    ("medium", "0.30", "0.60"),
+    ("high", "1.0", "2.0"),
+)
+ISSUE_3330_REQUIRED_CONDITIONS = (
+    "noop",
+    "delay_only",
+    "medium_noise_seed_2755",
+    "medium_noise_seed_3328",
+    "medium_noise_seed_3330",
+    "high_noise_seed_2755",
+    "high_noise_seed_3328",
+    "high_noise_seed_3330",
+)
+BEHAVIOR_PROBE_CONDITION_SETS = {ISSUE_3328_CONDITION_SET, ISSUE_3330_CONDITION_SET}
 PROGRESS_FIELDS = (
     "net_goal_progress",
     "best_goal_progress",
@@ -67,6 +84,31 @@ class Condition:
     name: str
     description: str
     flags: tuple[str, ...] = ()
+
+
+def _gaussian_condition(
+    *,
+    profile: str,
+    std_m: str,
+    bound_m: str,
+    seed: int,
+) -> Condition:
+    """Return a seeded Gaussian observation-noise grid condition."""
+    return Condition(
+        f"{profile}_noise_seed_{seed}",
+        (
+            f"Issue #3330 {profile}-amplitude Gaussian grid cell, "
+            f"std={std_m} m, bound={bound_m} m, seed={seed}."
+        ),
+        (
+            "--observation-noise-std-m",
+            std_m,
+            "--observation-noise-bound-m",
+            bound_m,
+            "--observation-perturbation-seed",
+            str(seed),
+        ),
+    )
 
 
 CONDITIONS = (
@@ -146,6 +188,20 @@ CONDITION_SETS = {
         _CONDITION_BY_NAME["delay_only"],
         HIGH_NOISE_3328_CONDITION,
     ),
+    ISSUE_3330_CONDITION_SET: (
+        _CONDITION_BY_NAME["noop"],
+        _CONDITION_BY_NAME["delay_only"],
+        *(
+            _gaussian_condition(
+                profile=profile,
+                std_m=std_m,
+                bound_m=bound_m,
+                seed=seed,
+            )
+            for profile, std_m, bound_m in ISSUE_3330_AMPLITUDE_PROFILES
+            for seed in ISSUE_3330_NOISE_SEEDS
+        ),
+    ),
 }
 
 
@@ -202,6 +258,17 @@ def _optional_int(value: Any) -> int | None:
         return int(value)
     except (TypeError, ValueError):
         return None
+
+
+def _optional_float(value: Any) -> float | None:
+    """Return a finite non-boolean float when coercion is possible."""
+    if isinstance(value, bool) or value is None:
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
 
 
 def _int_list(value: Any) -> list[int]:
@@ -397,6 +464,40 @@ def _durable_ref(path: Path) -> str:
         return path.relative_to(REPO_ROOT).as_posix()
     except ValueError:
         return path.as_posix()
+
+
+def _condition_flag_value(condition: Condition, flag: str) -> str | None:
+    """Return a condition flag value when the flag is present."""
+    try:
+        index = condition.flags.index(flag)
+    except ValueError:
+        return None
+    value_index = index + 1
+    return condition.flags[value_index] if value_index < len(condition.flags) else None
+
+
+def _condition_perturbation(condition: Condition) -> dict[str, Any]:
+    """Return machine-readable perturbation parameters for one condition."""
+    return {
+        "position_noise_std_m": _optional_float(
+            _condition_flag_value(condition, "--observation-noise-std-m")
+        ),
+        "position_noise_bound_m": _optional_float(
+            _condition_flag_value(condition, "--observation-noise-bound-m")
+        ),
+        "observation_perturbation_seed": _optional_int(
+            _condition_flag_value(condition, "--observation-perturbation-seed")
+        ),
+        "observation_delay_steps": _optional_int(
+            _condition_flag_value(condition, "--observation-delay-steps")
+        ),
+        "missed_detection_probability": _optional_float(
+            _condition_flag_value(condition, "--missed-detection-probability")
+        ),
+        "occlusion_distance_m": _optional_float(
+            _condition_flag_value(condition, "--occlusion-distance-m")
+        ),
+    }
 
 
 def _load_trace(path: Path) -> dict[str, Any]:
@@ -704,8 +805,8 @@ def _classification(
             "label": "behavior_sensitive_diagnostic_only",
             "rationale": (
                 "Perturbation changed selected commands or progress/risk fields. "
-                "This is live behavior evidence, but one seed is not enough for "
-                "a benchmark-strength robustness claim."
+                "This is live behavior evidence, but the selected diagnostic slice is not "
+                "enough for a benchmark-strength robustness claim."
             ),
         }
     if observation_changed and near_field:
@@ -810,6 +911,7 @@ def _fail_closed_report(
             {
                 "name": condition.name,
                 "description": condition.description,
+                "perturbation": _condition_perturbation(condition),
                 "status": "blocked",
                 "blocker": blocker,
             }
@@ -880,6 +982,37 @@ def _markdown(report: dict[str, Any]) -> str:
         "blocker",
     ):
         lines.append(f"- `{key}`: `{contract.get(key)}`")
+    behavior_summary = _mapping(report.get("behavior_sensitivity_summary"))
+    if behavior_summary:
+        lines.extend(
+            [
+                "",
+                "## Behavior Sensitivity Summary",
+                "",
+                f"- Interpretation: `{behavior_summary.get('interpretation')}`",
+                (
+                    f"- Behavior-sensitive conditions: "
+                    f"`{behavior_summary.get('behavior_sensitive_conditions')}`"
+                ),
+                (
+                    f"- Policy-insensitive conditions: "
+                    f"`{behavior_summary.get('policy_insensitive_conditions')}`"
+                ),
+                (
+                    f"- Command-changed conditions: "
+                    f"`{behavior_summary.get('command_changed_conditions')}`"
+                ),
+                (
+                    f"- Progress/risk-changed conditions: "
+                    f"`{behavior_summary.get('progress_or_risk_changed_conditions')}`"
+                ),
+                (
+                    f"- Stop/yield proxy-changed conditions: "
+                    f"`{behavior_summary.get('stop_yield_proxy_changed_conditions')}`"
+                ),
+                f"- Boundary: {behavior_summary.get('claim_boundary')}",
+            ]
+        )
     lines.extend(
         [
             "",
@@ -939,6 +1072,7 @@ def _planned_report(
             {
                 "name": condition.name,
                 "description": condition.description,
+                "perturbation": _condition_perturbation(condition),
                 "status": "planned",
                 "command": _condition_command(
                     condition=condition,
@@ -988,6 +1122,7 @@ def _execute_conditions(
                 {
                     "name": condition.name,
                     "description": condition.description,
+                    "perturbation": _condition_perturbation(condition),
                     "status": "blocked",
                     "command": command,
                     "blocker": blocker,
@@ -1006,6 +1141,7 @@ def _execute_conditions(
                 {
                     "name": condition.name,
                     "description": condition.description,
+                    "perturbation": _condition_perturbation(condition),
                     "status": "blocked",
                     "command": command,
                     "blocker": blocker,
@@ -1016,6 +1152,7 @@ def _execute_conditions(
             {
                 "name": condition.name,
                 "description": condition.description,
+                "perturbation": _condition_perturbation(condition),
                 "status": "live_replay",
                 "command": command,
                 "trace": _durable_ref(trace_path),
@@ -1054,27 +1191,29 @@ def _verify_issue_3328_contract_guardrails(
     *,
     fixture_contract: Mapping[str, Any],
 ) -> list[str]:
-    """Verify the static fixture-contract side of the #3328 probe."""
+    """Verify the static fixture-contract side of behavior-sensitive probes."""
     blockers: list[str] = []
     if not fixture_contract.get("satisfied"):
-        blockers.append("Issue #3328 behavior probe requires fixture_contract.satisfied=true.")
+        blockers.append(
+            "Behavior-sensitive observation-noise probe requires fixture_contract.satisfied=true."
+        )
 
     matched = _mapping(fixture_contract.get("matched_scenario"))
     if matched.get("name") != ISSUE_2756_FIXTURE_SCENARIO:
         blockers.append(
-            "Issue #3328 behavior probe requires scenario "
+            "Behavior-sensitive observation-noise probe requires scenario "
             f"{ISSUE_2756_FIXTURE_SCENARIO!r}; got {matched.get('name')!r}."
         )
     if ISSUE_2756_FIXTURE_SEED not in _int_list(matched.get("seeds")):
         blockers.append(
-            f"Issue #3328 behavior probe requires seed {ISSUE_2756_FIXTURE_SEED} "
+            f"Behavior-sensitive observation-noise probe requires seed {ISSUE_2756_FIXTURE_SEED} "
             f"in matrix seeds; got {matched.get('seeds')!r}."
         )
     return blockers
 
 
 def _verify_issue_3328_trace_identity(label: str, trace: Mapping[str, Any]) -> list[str]:
-    """Verify one #3328 probe trace still names the intended scenario and seed."""
+    """Verify one behavior-sensitive probe trace still names the intended scenario and seed."""
     blockers: list[str] = []
     if trace.get("scenario_id") != ISSUE_2756_FIXTURE_SCENARIO:
         blockers.append(
@@ -1089,16 +1228,18 @@ def _verify_issue_3328_trace_identity(label: str, trace: Mapping[str, Any]) -> l
 
 
 def _verify_issue_3328_near_field_trace(noop_trace: Mapping[str, Any]) -> list[str]:
-    """Verify the #3328 probe no-op trace has near-field interaction geometry."""
+    """Verify the behavior-sensitive probe no-op trace has near-field interaction geometry."""
     closest = _mapping(noop_trace.get("progress_summary")).get("closest_robot_ped_distance")
     finite_closest = _finite_number(closest)
     if finite_closest is None:
         return [
-            "Issue #3328 behavior probe requires a finite no-op closest_robot_ped_distance value."
+            "Behavior-sensitive observation-noise probe requires a finite no-op "
+            "closest_robot_ped_distance value."
         ]
     if finite_closest > 2.0:
         return [
-            "Issue #3328 behavior probe requires no-op closest_robot_ped_distance <= 2.0 m; "
+            "Behavior-sensitive observation-noise probe requires no-op "
+            "closest_robot_ped_distance <= 2.0 m; "
             f"observed {closest}."
         ]
     return []
@@ -1109,7 +1250,7 @@ def _verify_issue_3328_behavior_probe_guardrails(
     output_dir: Path,
     fixture_contract: Mapping[str, Any],
 ) -> list[str]:
-    """Fail closed unless the opt-in #3328 probe remains a near-field #2756 replay."""
+    """Fail closed unless opt-in behavior probes remain near-field #2756 replays."""
     blockers = _verify_issue_3328_contract_guardrails(fixture_contract=fixture_contract)
     try:
         noop_trace = _load_trace(output_dir / "traces" / "noop" / "trace.json")
@@ -1124,12 +1265,12 @@ def _verify_issue_3328_behavior_probe_guardrails(
     delay_first_observed = _first_observed_step(delay_trace)
     if noop_first_observed != 5:
         blockers.append(
-            "Issue #3328 behavior probe requires no-op first observed step 5; "
+            "Behavior-sensitive observation-noise probe requires no-op first observed step 5; "
             f"observed {noop_first_observed}."
         )
     if delay_first_observed != 7:
         blockers.append(
-            "Issue #3328 behavior probe requires delay-only first observed step 7; "
+            "Behavior-sensitive observation-noise probe requires delay-only first observed step 7; "
             f"observed {delay_first_observed}."
         )
     blockers.extend(_verify_issue_3328_near_field_trace(noop_trace))
@@ -1197,11 +1338,162 @@ def _compact_live_conditions(conditions: list[dict[str, Any]]) -> list[dict[str,
     return compact_conditions
 
 
+def _live_condition_rows(conditions: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return completed non-baseline condition rows."""
+    return [
+        item
+        for item in conditions
+        if item.get("name") != "noop" and item.get("status") == "live_replay"
+    ]
+
+
+def _behavior_bool(item: Mapping[str, Any], key: str) -> bool:
+    """Return a boolean behavior-change field from a condition row."""
+    behavior = _mapping(item.get("behavior_change_summary"))
+    return bool(behavior.get(key))
+
+
+def _conditions_where(conditions: list[dict[str, Any]], key: str) -> list[str]:
+    """Return live condition names where a behavior-change flag is true."""
+    return [
+        str(item["name"]) for item in _live_condition_rows(conditions) if _behavior_bool(item, key)
+    ]
+
+
+def _condition_grid_cell(item: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a compact seed/amplitude row for the behavior-sensitivity summary."""
+    behavior = _mapping(item.get("behavior_change_summary"))
+    perturbation = _mapping(item.get("perturbation"))
+    classification = _mapping(item.get("classification"))
+    return {
+        "condition": item.get("name"),
+        "position_noise_std_m": perturbation.get("position_noise_std_m"),
+        "position_noise_bound_m": perturbation.get("position_noise_bound_m"),
+        "observation_perturbation_seed": perturbation.get("observation_perturbation_seed"),
+        "classification": classification.get("label"),
+        "command_sequence_changed": bool(behavior.get("command_sequence_changed")),
+        "progress_or_risk_changed": bool(behavior.get("progress_or_risk_changed")),
+        "min_distance_changed": bool(behavior.get("min_distance_changed")),
+        "collision_or_near_miss_changed": bool(behavior.get("collision_or_near_miss_changed")),
+        "stop_yield_proxy_changed": bool(
+            _mapping(behavior.get("stop_yield_timing_proxy")).get("changed")
+        ),
+    }
+
+
+def _behavior_sensitivity_interpretation(
+    *,
+    live_condition_count: int,
+    behavior_sensitive_count: int,
+) -> str:
+    """Classify persistence across the selected condition grid."""
+    if live_condition_count == 0:
+        return "no_live_conditions"
+    if behavior_sensitive_count == 0:
+        return "behavior_sensitivity_disappeared_in_selected_grid"
+    if behavior_sensitive_count == live_condition_count:
+        return "behavior_sensitivity_persisted_across_selected_grid"
+    return "behavior_sensitivity_is_seed_or_amplitude_specific_in_selected_grid"
+
+
+def _behavior_sensitivity_summary(conditions: list[dict[str, Any]]) -> dict[str, Any]:
+    """Summarize behavior sensitivity across completed non-baseline conditions."""
+    live_conditions = _live_condition_rows(conditions)
+    behavior_sensitive_conditions = [
+        str(item["name"])
+        for item in live_conditions
+        if _mapping(item.get("classification")).get("label") == "behavior_sensitive_diagnostic_only"
+    ]
+    policy_insensitive_conditions = [
+        str(item["name"])
+        for item in live_conditions
+        if _mapping(item.get("classification")).get("label") == "policy_insensitive"
+    ]
+    return {
+        "live_condition_count": len(live_conditions),
+        "behavior_sensitive_condition_count": len(behavior_sensitive_conditions),
+        "policy_insensitive_condition_count": len(policy_insensitive_conditions),
+        "behavior_sensitive_conditions": behavior_sensitive_conditions,
+        "policy_insensitive_conditions": policy_insensitive_conditions,
+        "command_changed_conditions": _conditions_where(conditions, "command_sequence_changed"),
+        "progress_or_risk_changed_conditions": _conditions_where(
+            conditions, "progress_or_risk_changed"
+        ),
+        "min_distance_changed_conditions": _conditions_where(conditions, "min_distance_changed"),
+        "collision_or_near_miss_changed_conditions": _conditions_where(
+            conditions,
+            "collision_or_near_miss_changed",
+        ),
+        "stop_yield_proxy_changed_conditions": [
+            str(item["name"])
+            for item in live_conditions
+            if bool(
+                _mapping(
+                    _mapping(item.get("behavior_change_summary")).get("stop_yield_timing_proxy")
+                ).get("changed")
+            )
+        ],
+        "seed_amplitude_cells": [_condition_grid_cell(item) for item in live_conditions],
+        "interpretation": _behavior_sensitivity_interpretation(
+            live_condition_count=len(live_conditions),
+            behavior_sensitive_count=len(behavior_sensitive_conditions),
+        ),
+        "claim_boundary": (
+            "Diagnostic-only persistence summary over completed live replay cells. "
+            "It is not a benchmark-strength robustness, sensor-realism, or "
+            "planner-superiority claim."
+        ),
+    }
+
+
+def _classification_rationale(condition_set: str) -> str:
+    """Return top-level classification rationale text for a condition set."""
+    if condition_set == ISSUE_3330_CONDITION_SET:
+        return (
+            "All selected live replays completed. The predeclared seed/amplitude grid is "
+            "diagnostic-only and does not support a robustness, sensor-realism, or "
+            "planner-superiority claim."
+        )
+    if condition_set == ISSUE_3328_CONDITION_SET:
+        return (
+            "All selected live replays completed. One behavior-probe seed is diagnostic only and "
+            "does not support a robustness, sensor-realism, or planner-superiority claim."
+        )
+    return (
+        "All selected live replays completed. The selected stress slice is diagnostic only and "
+        "does not support a robustness, sensor-realism, or planner-superiority claim."
+    )
+
+
+def _claim_boundary(args: argparse.Namespace) -> str:
+    """Return conservative claim-boundary text for the selected condition set."""
+    if args.condition_set == ISSUE_3330_CONDITION_SET:
+        return (
+            "Stress-slice live planner/environment replay for one scenario, one scenario seed, "
+            "and a predeclared observation-noise seed/amplitude grid. Treat persistence, "
+            "disappearance, or mixed behavior sensitivity as diagnostic-only; do not infer "
+            "robustness, sensor realism, or planner superiority."
+        )
+    if args.condition_set == ISSUE_3328_CONDITION_SET:
+        return (
+            "Stress-slice live planner/environment replay for one scenario, one seed, and the "
+            "selected perturbation condition set. Treat behavior-sensitive differences as "
+            "diagnostic-only from one perturbation seed; do not infer robustness, sensor realism, "
+            "or planner superiority."
+        )
+    return (
+        "Stress-slice live planner/environment replay for one scenario, one seed, and the selected "
+        "perturbation condition set. Treat as benchmark-facing only when fixture_contract.satisfied "
+        "is true; otherwise diagnostic-only."
+    )
+
+
 def _final_classification(
     *,
     blockers: list[str],
     fixture_contract_satisfied: bool,
     conditions: list[dict[str, Any]],
+    condition_set: str,
 ) -> tuple[str, dict[str, str]]:
     """Resolve the top-level status/classification for the issue report."""
     if blockers:
@@ -1236,16 +1528,13 @@ def _final_classification(
         "live_replay",
         {
             "label": label,
-            "rationale": (
-                "All selected live replays completed. One seed is diagnostic only and "
-                "does not support a robustness, sensor-realism, or planner-superiority claim."
-            ),
+            "rationale": _classification_rationale(condition_set),
         },
     )
 
 
 def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
-    """Run the seven live diagnostics conditions and return the summary report."""
+    """Run the selected live diagnostics conditions and return the summary report."""
     output_dir = args.output_dir
     output_dir = _repo_path(output_dir)
     output_dir.mkdir(parents=True, exist_ok=True)
@@ -1291,7 +1580,7 @@ def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
             fixture_contract=fixture_contract,
         )
     )
-    if args.condition_set == ISSUE_3328_CONDITION_SET:
+    if args.condition_set in BEHAVIOR_PROBE_CONDITION_SETS:
         blockers.extend(
             _verify_issue_3328_behavior_probe_guardrails(
                 output_dir=output_dir,
@@ -1302,7 +1591,9 @@ def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
         blockers=blockers,
         fixture_contract_satisfied=bool(fixture_contract["satisfied"]),
         conditions=conditions,
+        condition_set=args.condition_set,
     )
+    compact_conditions = _compact_live_conditions(conditions)
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -1310,12 +1601,7 @@ def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
         "issue": 2777,
         "status": status,
         "classification": classification,
-        "claim_boundary": (
-            "Stress-slice live planner/environment replay for one scenario, one seed, "
-            "and the selected perturbation condition set. Treat behavior-sensitive "
-            "differences as diagnostic-only from one seed; do not infer robustness, "
-            "sensor realism, or planner superiority."
-        ),
+        "claim_boundary": _claim_boundary(args),
         "inputs": {
             "scenario_matrix": _durable_ref(scenario_matrix),
             "raw_trace_json": (
@@ -1329,7 +1615,8 @@ def run_live_batch(args: argparse.Namespace) -> dict[str, Any]:
         "fixture_contract": fixture_contract,
         "fixture_observation_boundary": _fixture_observation_boundary_summary(output_dir),
         "run_config": _run_config(args=args, output_dir=output_dir),
-        "conditions": _compact_live_conditions(conditions),
+        "behavior_sensitivity_summary": _behavior_sensitivity_summary(compact_conditions),
+        "conditions": compact_conditions,
         "blockers": blockers,
     }
 
@@ -1357,7 +1644,8 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=DEFAULT_CONDITION_SET,
         help=(
             "Perturbation condition set to run. The default preserves the seven #2755 "
-            "families; issue_3328_behavior_probe is an opt-in four-condition probe."
+            "families; issue_3328_behavior_probe is an opt-in four-condition probe; "
+            "issue_3330_seed_amplitude_grid is an opt-in diagnostic seed/amplitude grid."
         ),
     )
     parser.add_argument("--timeout-seconds", type=float, default=120.0)
@@ -1381,6 +1669,11 @@ def main(argv: list[str] | None = None) -> int:
         != ISSUE_3328_REQUIRED_CONDITIONS
     ):
         raise RuntimeError("Issue #3328 behavior probe condition set drifted")
+    if (
+        tuple(condition.name for condition in CONDITION_SETS[ISSUE_3330_CONDITION_SET])
+        != ISSUE_3330_REQUIRED_CONDITIONS
+    ):
+        raise RuntimeError("Issue #3330 seed/amplitude grid condition set drifted")
     report = run_live_batch(args)
     _write_outputs(report, args.output_dir)
     print(

--- a/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
+++ b/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
@@ -69,6 +69,90 @@ def test_issue_3328_behavior_probe_condition_set_is_opt_in() -> None:
     assert tuple(condition.name for condition in mod.CONDITIONS) == mod.REQUIRED_CONDITIONS
 
 
+def test_issue_3330_seed_amplitude_grid_condition_set_is_opt_in() -> None:
+    """The #3330 grid should predeclare two amplitudes across three perturbation seeds."""
+    mod = _load_script()
+
+    grid_conditions = mod.CONDITION_SETS[mod.ISSUE_3330_CONDITION_SET]
+
+    assert (
+        tuple(condition.name for condition in grid_conditions) == mod.ISSUE_3330_REQUIRED_CONDITIONS
+    )
+    perturbations = {
+        condition.name: mod._condition_perturbation(condition)
+        for condition in grid_conditions
+        if "noise_seed" in condition.name
+    }
+    assert {payload["observation_perturbation_seed"] for payload in perturbations.values()} == {
+        2755,
+        3328,
+        3330,
+    }
+    assert {
+        (
+            payload["position_noise_std_m"],
+            payload["position_noise_bound_m"],
+        )
+        for payload in perturbations.values()
+    } == {(0.3, 0.6), (1.0, 2.0)}
+    assert tuple(condition.name for condition in mod.CONDITIONS) == mod.REQUIRED_CONDITIONS
+
+
+def test_behavior_sensitivity_summary_classifies_mixed_grid() -> None:
+    """Grid summaries should distinguish persistent sensitivity from seed-specific sensitivity."""
+    mod = _load_script()
+    conditions = [
+        {"name": "noop", "status": "live_replay"},
+        {
+            "name": "medium_noise_seed_2755",
+            "status": "live_replay",
+            "classification": {"label": "policy_insensitive"},
+            "perturbation": {
+                "position_noise_std_m": 0.3,
+                "position_noise_bound_m": 0.6,
+                "observation_perturbation_seed": 2755,
+            },
+            "behavior_change_summary": {
+                "command_sequence_changed": False,
+                "progress_or_risk_changed": False,
+                "min_distance_changed": False,
+                "collision_or_near_miss_changed": False,
+                "stop_yield_timing_proxy": {"changed": False},
+            },
+        },
+        {
+            "name": "high_noise_seed_3330",
+            "status": "live_replay",
+            "classification": {"label": "behavior_sensitive_diagnostic_only"},
+            "perturbation": {
+                "position_noise_std_m": 1.0,
+                "position_noise_bound_m": 2.0,
+                "observation_perturbation_seed": 3330,
+            },
+            "behavior_change_summary": {
+                "command_sequence_changed": True,
+                "progress_or_risk_changed": True,
+                "min_distance_changed": True,
+                "collision_or_near_miss_changed": False,
+                "stop_yield_timing_proxy": {"changed": False},
+            },
+        },
+    ]
+
+    summary = mod._behavior_sensitivity_summary(conditions)
+
+    assert (
+        summary["interpretation"]
+        == "behavior_sensitivity_is_seed_or_amplitude_specific_in_selected_grid"
+    )
+    assert summary["behavior_sensitive_conditions"] == ["high_noise_seed_3330"]
+    assert summary["policy_insensitive_conditions"] == ["medium_noise_seed_2755"]
+    assert summary["command_changed_conditions"] == ["high_noise_seed_3330"]
+    assert summary["progress_or_risk_changed_conditions"] == ["high_noise_seed_3330"]
+    assert summary["seed_amplitude_cells"][1]["position_noise_bound_m"] == 2.0
+    assert "Diagnostic-only" in summary["claim_boundary"]
+
+
 def test_default_strict_mode_fails_closed_without_occluded_fixture(tmp_path: Path) -> None:
     """A non-occluded matrix should not be promoted as #2777 live replay evidence."""
     mod = _load_script()
@@ -253,6 +337,44 @@ def test_issue_3328_behavior_probe_dry_run_plans_only_probe_conditions(tmp_path:
     assert "2.0" in commands["high_noise_3328"]
     assert "--observation-perturbation-seed" in commands["high_noise_3328"]
     assert "3328" in commands["high_noise_3328"]
+
+
+def test_issue_3330_grid_dry_run_plans_seed_amplitude_cells(tmp_path: Path) -> None:
+    """The opt-in #3330 grid should expose explicit seed/amplitude cells."""
+    mod = _load_script()
+    matrix = tmp_path / "matrix.yaml"
+    matrix.write_text(
+        "schema_version: robot_sf.scenario_matrix.v1\n"
+        "select_scenarios: [issue_3233_near_field_observation_noise]\n",
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+    args = mod.parse_args(
+        [
+            "--condition-set",
+            mod.ISSUE_3330_CONDITION_SET,
+            "--scenario-matrix",
+            str(matrix),
+            "--output-dir",
+            str(output_dir),
+            "--allow-non-occluded-live-fixture",
+            "--dry-run",
+        ]
+    )
+
+    report = mod.run_live_batch(args)
+
+    assert report["run_config"]["condition_set"] == mod.ISSUE_3330_CONDITION_SET
+    assert [condition["name"] for condition in report["conditions"]] == list(
+        mod.ISSUE_3330_REQUIRED_CONDITIONS
+    )
+    cells = {condition["name"]: condition["perturbation"] for condition in report["conditions"]}
+    assert cells["medium_noise_seed_3330"]["position_noise_std_m"] == 0.3
+    assert cells["medium_noise_seed_3330"]["position_noise_bound_m"] == 0.6
+    assert cells["medium_noise_seed_3330"]["observation_perturbation_seed"] == 3330
+    assert cells["high_noise_seed_3330"]["position_noise_std_m"] == 1.0
+    assert cells["high_noise_seed_3330"]["position_noise_bound_m"] == 2.0
+    assert cells["high_noise_seed_3330"]["observation_perturbation_seed"] == 3330
 
 
 def test_scalar_includes_are_ignored_for_fixture_detection(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Closes #3330.

- add the `issue_3330_seed_amplitude_grid` live replay condition set with delay-only plus 3 seeds x 2 observation-noise amplitudes
- emit machine-readable perturbation metadata and a top-level behavior-sensitivity summary
- promote compact diagnostic evidence and update the evidence/catalog indexes

## Result

The run is diagnostic-only. The selected grid preserves the no-op/delay fixture contract and shows behavior sensitivity in 3 of 7 perturbed cells: `medium_noise_seed_3328`, `high_noise_seed_3328`, and `high_noise_seed_3330`. It does not establish robustness, sensor-realism, or planner-superiority claims.

## Validation

- `uv run ruff check scripts/benchmark/run_observation_noise_live_replay_issue_2777.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py`
- `uv run pytest tests/benchmark/test_issue_2777_observation_noise_live_replay.py -q` -> 23 passed
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
- `uv run python scripts/benchmark/run_observation_noise_live_replay_issue_2777.py --help`
- `uv run python scripts/benchmark/run_observation_noise_live_replay_issue_2777.py --condition-set issue_3330_seed_amplitude_grid --scenario-matrix configs/scenarios/sets/issue_3323_occluded_emergence_near_field_live_replay.yaml --output-dir docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid`
- `git diff --check HEAD~1 HEAD`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> core lane passed (`1103 passed`); optional lane failed with xdist worker crashes plus one timing anomaly. Direct rerun of the four reported nodes passed (`4 passed in 11.42s`). Follow-up anomaly note added to #3334.

## Downstream Propagation

- Parent issue: #3330 should use this PR and the committed compact evidence as the diagnostic result.
- Evidence/catalog: updated `docs/context/evidence/issue_2777_live_observation_noise_replay/README.md`, `docs/context/evidence/README.md`, and `docs/context/catalog.yaml`.
- Artifact policy: raw traces/funnel files were not committed; only compact README/summary evidence is tracked. Local `output/` contents are disposable validation scratch.

## Research Result Guidance

- Target claim/hypothesis/blocker: behavior-sensitive observation-noise replay should be extended beyond one perturbation seed before using it as a prioritization signal.
- Comparator/baseline: no-op and delay-only rows in the same occluded-emergence live replay fixture.
- Evidence tier: diagnostic live replay stress probe.
- Result classification: `behavior_sensitive_diagnostic_only`; sensitivity is seed/amplitude specific in this selected grid.
- Decision/stop rule: #3330 is satisfied as a broader diagnostic probe, but stronger benchmark or robustness claims remain out of scope.
- Synthesis surface/update target: committed evidence README/summary under `docs/context/evidence/issue_2777_live_observation_noise_replay/issue_3330_seed_amplitude_grid/`.