### PR TITLE
fix: expose ego pedestrian next-goal signal

### DIFF
--- a/docs/dev/observation_contract.md
+++ b/docs/dev/observation_contract.md
@@ -16,6 +16,16 @@ and downstream tooling.
 | `drive_state` | `(timesteps, 5)` | `[speed_x, speed_rot, target_distance, target_angle, next_target_angle]` |
 | `rays` | `(timesteps, num_rays)` | LiDAR ranges stacked over time |
 
+### Target Semantics
+
+- Robot environments set `target_distance` and `target_angle` from the robot pose to the current
+  route waypoint, and `next_target_angle` from that waypoint toward the following route waypoint
+  when `SimulationSettings.use_next_goal` is enabled.
+- Pedestrian environments set the ego-pedestrian target to the robot position. When
+  `use_next_goal` is enabled, `next_target_angle` points from that robot target toward the robot's
+  current route waypoint. This preserves the ego-pedestrian "track the robot" goal contract while
+  exposing the route direction of the moving target.
+
 ### Stacking Rules
 
 - `timesteps` equals `observation_stack.stack_steps` on the environment config.

--- a/robot_sf/gym_env/env_util.py
+++ b/robot_sf/gym_env/env_util.py
@@ -578,11 +578,12 @@ def init_ped_collision_and_sensors(
         Returns:
             np.ndarray: Target sensor observation (goal direction and distances).
         """
+        next_goal_pos = sim.ego_ped_next_goal_pos if sim_config.use_next_goal else None
         return target_sensor_obs(
             sim.ego_ped.pose,
             sim.ego_ped_goal_pos,
-            None,
-        )  # TODO: What next goal to choose?
+            next_goal_pos,
+        )
 
     def speed_sensor_ego_ped():
         """Capture current speed for the ego pedestrian.
@@ -598,9 +599,9 @@ def init_ped_collision_and_sensors(
             speed_sensor_ego_ped,
             target_sensor_ego_ped,
             orig_obs_space[1],
-            False,
+            sim_config.use_next_goal,
         ),
-    )  # Ego pedestrian does not have a next goal
+    )
 
     # Format: [robot, ego_pedestrian]
     return occupancies, sensor_fusions

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -531,6 +531,16 @@ class PedSimulator(Simulator):
         """
         return self.robots[0].pos
 
+    @property
+    def ego_ped_next_goal_pos(self) -> Vec2D | None:
+        """Return the route target after the ego pedestrian's current target.
+
+        The ego pedestrian's current target is the robot position. The following point is therefore
+        the robot's current route goal, which lets the target sensor expose the robot's route
+        direction without changing the existing robot-chasing goal contract.
+        """
+        return self.goal_pos[0] if self.goal_pos else None
+
     def _sync_ego_ped_social_force_state(self) -> None:
         """Synchronize the appended ego-pedestrian row in the PySF state array."""
         pysf_states = self.pysf_state.pysf_states()

--- a/tests/sensor/test_env_util_additional_coverage.py
+++ b/tests/sensor/test_env_util_additional_coverage.py
@@ -22,6 +22,7 @@ from robot_sf.gym_env.env_util import (
 from robot_sf.gym_env.unified_config import RobotSimulationConfig
 from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition
+from robot_sf.sensor.goal_sensor import target_sensor_obs
 
 
 def _minimal_map_def() -> MapDefinition:
@@ -128,6 +129,11 @@ class _FakePedSim:
         return self._goal_pos
 
     @property
+    def ego_ped_next_goal_pos(self) -> tuple[float, float]:
+        """Following point for the ego pedestrian target sensor."""
+        return (3.2, 2.3)
+
+    @property
     def next_goal_pos(self) -> list[None]:
         """Current robot next-goal placeholders."""
         return [None]
@@ -212,6 +218,40 @@ def test_init_ped_spaces_and_collision_sensor_initialization() -> None:
     assert "rays" in robot_obs
     assert "drive_state" in ego_obs
     assert "rays" in ego_obs
+
+
+def test_init_ped_collision_sensor_exposes_ego_ped_next_goal() -> None:
+    """Ego-pedestrian target observations should honor the next-goal channel."""
+    map_def = _minimal_map_def()
+    cfg = PedEnvSettings()
+    cfg.sim_config.use_next_goal = True
+    _action_spaces, _obs_spaces, orig_obs_spaces = init_ped_spaces(cfg, map_def)
+    sim = _FakePedSim(map_def)
+
+    _occupancies, sensors = init_ped_collision_and_sensors(sim, cfg, orig_obs_spaces)
+
+    assert sensors[1].use_next_goal is True
+    expected = target_sensor_obs(
+        sim.ego_ped.pose,
+        sim.ego_ped_goal_pos,
+        sim.ego_ped_next_goal_pos,
+    )
+    assert sensors[1].target_sensor() == pytest.approx(expected)
+    assert sensors[1].target_sensor()[2] != pytest.approx(0.0)
+
+
+def test_init_ped_collision_sensor_respects_disabled_ego_ped_next_goal() -> None:
+    """Disabling next-goal observations should zero the ego-pedestrian turn channel."""
+    map_def = _minimal_map_def()
+    cfg = PedEnvSettings()
+    cfg.sim_config.use_next_goal = False
+    _action_spaces, _obs_spaces, orig_obs_spaces = init_ped_spaces(cfg, map_def)
+    sim = _FakePedSim(map_def)
+
+    _occupancies, sensors = init_ped_collision_and_sensors(sim, cfg, orig_obs_spaces)
+
+    assert sensors[1].use_next_goal is False
+    assert sensors[1].target_sensor()[2] == pytest.approx(0.0)
 
 
 def test_pedestrian_coords_with_ego_preserves_order_and_shape() -> None:

--- a/tests/sim/test_simulator_action_count.py
+++ b/tests/sim/test_simulator_action_count.py
@@ -11,6 +11,7 @@ from robot_sf.common.types import Line2D, Rect
 from robot_sf.gym_env.unified_config import PedestrianSimulationConfig, RobotSimulationConfig
 from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition, MapDefinitionPool
+from robot_sf.nav.navigation import RouteNavigator
 from robot_sf.sim.sim_config import SimulationSettings
 from robot_sf.sim.simulator import PedSimulator, init_ped_simulators, init_simulators
 
@@ -168,3 +169,16 @@ def test_ped_simulator_ped_and_ego_pos_returns_pysf_position_view() -> None:
     simulator.pysf_state = SimpleNamespace(ped_positions=positions)
 
     assert simulator.ped_and_ego_pos is positions
+
+
+def test_ped_simulator_ego_ped_next_goal_tracks_robot_current_waypoint() -> None:
+    """Ego-pedestrian next-goal target should follow robot route progress."""
+    simulator = PedSimulator.__new__(PedSimulator)
+    navigator = RouteNavigator(waypoints=[(2.0, 1.0), (4.0, 3.0)])
+    simulator.robot_navs = [navigator]
+
+    assert simulator.ego_ped_next_goal_pos == (2.0, 1.0)
+
+    navigator.waypoint_id = 1
+
+    assert simulator.ego_ped_next_goal_pos == (4.0, 3.0)


### PR DESCRIPTION
## Summary

Closes #3348.

- add `PedSimulator.ego_ped_next_goal_pos` so the ego-pedestrian target sensor can describe the robot target's route direction
- wire the ego-pedestrian `SensorFusion` through `SimulationSettings.use_next_goal` instead of permanently zeroing the next-target channel
- document the pedestrian target semantics and move env-util sensor coverage into the core readiness lane

## Semantics

The ego pedestrian still targets the robot position. When `use_next_goal` is enabled, `next_target_angle` now points from that robot target toward the robot's current route waypoint. This mirrors the robot target-sensor contract without inventing a separate ego-pedestrian route model.

## Validation

- `uv run python scripts/dev/run_compact_validation.py -- uv run pytest -q tests/sensor/test_env_util_additional_coverage.py tests/sim/test_simulator_action_count.py tests/test_goal_sensor.py tests/test_sensor_fusion_stack.py` -> passed
- `uv run ruff check robot_sf/gym_env/env_util.py robot_sf/sim/simulator.py tests/sensor/test_env_util_additional_coverage.py tests/sim/test_simulator_action_count.py` -> passed
- `uv run ruff format --check robot_sf/gym_env/env_util.py robot_sf/sim/simulator.py tests/sensor/test_env_util_additional_coverage.py tests/sim/test_simulator_action_count.py` -> passed
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/dev/observation_contract.md` -> passed
- `git diff --check HEAD~1 HEAD` -> passed
- `BASE_REF=origin/main uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh` -> passed; core lane `1105 passed`, no optional-extra lane required

## Downstream Propagation

- Parent issue: #3348 should close with this observation-contract fix.
- Docs: updated `docs/dev/observation_contract.md`.
- Artifact policy: readiness generated ignored `output/coverage/` files only; no durable artifacts required.

## Research Result Guidance

NA - engineering-correctness fix for an observation-contract asymmetry. This PR makes no benchmark, policy-quality, safety, or paper-facing claim.

## Follow-Up Issues

- Deferred work: none.
- Issues opened for follow-up: NA.