### PR TITLE
docs: add token-efficient thread profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,20 @@ Treat the following files as the repository-native context stack for Agent-style
 
 Read only the surfaces relevant to the task. Prefer these repo-local files over ad-hoc summaries in issue comments, and avoid loading broad context-note indexes unless the task actually needs them.
 
+## Token-Efficient Active Thread Profile
+
+For long autonomous goals, delegated batches, or explicitly token-saving work, start or resume with
+the copyable profile in `docs/templates/token_efficient_thread_profile.md`. The header records the
+goal, `task_class`, `validation_tier`, scope, out-of-scope work, worktree, context budget,
+delegation artifacts, output budget, stop guard, validation plan, and handoff target.
+
+Use `task_class` to name the dominant risk surface and `validation_tier` to point back to the
+proportional readiness matrix above; do not redefine evidence rules inside the active thread. Use
+compact snapshots and validation wrappers before broad reads, and keep raw logs in common Git-dir
+agent-run artifacts with only artifact paths and short excerpts in the parent thread. Delegated
+worker outputs are route evidence only: parent Codex still reviews the diff, checks the artifact
+bundle, and runs the selected validation before accepting, rerouting, or rejecting the work.
+
 ## Shared Knowledge Graph
 
 This repository tracks an Understand-Anything graph under `.understand-anything/` as a shared

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -47,6 +47,11 @@ Use a detached checkout at latest `origin/main` only for read-only discovery, du
 issue creation or update work. Create or switch to a branch/worktree before editing docs or code,
 running validation for a PR, pushing, or publishing.
 
+For long autonomous goals, delegated batches, and token-saving threads, seed the active prompt or
+resume summary with `docs/templates/token_efficient_thread_profile.md`. The profile keeps
+`task_class`, `validation_tier`, context budget, delegation artifact requirements, and output budget
+explicit without duplicating the maintainer hierarchy or readiness matrix.
+
 Docs-only and instruction-only changes normally use the cheap validation path: inspect the diff,
 verify changed links or paths where practical, and run available lightweight checks. Skill or AI
 workflow edits should also run the relevant skill and sync checks, for example:

--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -1,0 +1,63 @@
+# Token-Efficient Active Thread Profile
+
+Use this header when starting or resuming a long autonomous thread, delegated
+batch, or explicitly token-saving workflow. Keep each value short, point to
+artifacts instead of pasting raw logs, and update the profile when scope or proof
+changes.
+
+```markdown
+## Active Profile
+
+- goal: <one sentence objective>
+- task_class: <docs | workflow | runtime-code | benchmark | metric | schema | model-provenance | paper-facing | mixed>
+- validation_tier: <cheap-docs | skill-sync | focused-tests | full-readiness | benchmark-proof>
+- scope: <files, issues, PRs, or batch included>
+- out_of_scope: <nearby work deliberately deferred>
+- worktree: <absolute or repo-relative worktree path and branch>
+- context_budget: <compact snapshots first; raw logs only by artifact path>
+- delegation_artifacts: <RESULT.md, changed files, diffstat, validation, blockers, mutations>
+- output_budget: <parent-thread summary length and exact artifact paths to return>
+- stop_guard: <usage threshold, wall-clock limit, or external blocker>
+- validation_plan: <commands or checks that prove this task class>
+- handoff_target: <PR, issue comment, context note, or final handoff>
+```
+
+## Field Rules
+
+- `task_class` names the dominant risk surface. Use `mixed` only when one
+  thread intentionally combines more than one class, then name the strongest
+  validation tier that applies.
+- `validation_tier` follows the proportional readiness matrix in
+  `AGENTS.md` and `docs/maintainer_values.md`. Use
+  `docs/context/issue_1512_issue_archetypes.md` for issue archetype language
+  instead of redefining classes here.
+- `context_budget` defaults to compact helpers before broad reads:
+  `scripts/dev/autopilot_state_snapshot.py --include-worktrees`,
+  `scripts/dev/snapshot_issue_batch.py --json`,
+  `scripts/dev/snapshot_pr_queue.py --json`, and
+  `uv run python scripts/dev/run_compact_validation.py -- <command>`.
+- `delegation_artifacts` are route evidence, not task acceptance. Codex still
+  inspects the diff, verifies changed files, and runs the selected validation.
+- `output_budget` should return the result, changed files, validation status,
+  artifact paths, accepted/rejected/rerouted delegates, risks, follow-ups, and
+  current usage. Raw logs stay in the common Git-dir agent-run artifacts unless
+  the failure itself needs a short excerpt.
+- `stop_guard` is binding for autonomous loops. When a usage threshold fires,
+  record the pause in the common Git dir and avoid starting a fresh batch.
+
+## Delegated Worker Artifact Contract
+
+Each delegated implementation or review worker should return a compact artifact
+set, preferably in a `RESULT.md` or equivalent final bundle:
+
+- files inspected and files changed;
+- diffstat or summary of edits by file;
+- validation commands run, exit status, and artifact paths;
+- blockers, uncertainty, and deferred follow-ups;
+- remote-visible mutations performed, or `none`;
+- recommendation: `accept`, `reject`, or `reroute`.
+
+Workers should not create labels, comments, PRs, merges, or other GitHub
+mutations unless the parent explicitly delegates that mutation. Parent Codex
+acceptance requires local diff review plus the validation tier named in the
+active profile.

--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -8,18 +8,18 @@ changes.
 ```markdown
 ## Active Profile
 
-- goal: <one sentence objective>
-- task_class: <docs | workflow | runtime-code | benchmark | metric | schema | model-provenance | paper-facing | mixed>
-- validation_tier: <cheap-docs | skill-sync | focused-tests | full-readiness | benchmark-proof>
-- scope: <files, issues, PRs, or batch included>
-- out_of_scope: <nearby work deliberately deferred>
-- worktree: <absolute or repo-relative worktree path and branch>
-- context_budget: <compact snapshots first; raw logs only by artifact path>
-- delegation_artifacts: <RESULT.md, changed files, diffstat, validation, blockers, mutations>
-- output_budget: <parent-thread summary length and exact artifact paths to return>
-- stop_guard: <usage threshold, wall-clock limit, or external blocker>
-- validation_plan: <commands or checks that prove this task class>
-- handoff_target: <PR, issue comment, context note, or final handoff>
+- goal: [one sentence objective]
+- task_class: [docs | workflow | runtime-code | benchmark | metric | schema | model-provenance | paper-facing | mixed]
+- validation_tier: [cheap-docs | skill-sync | focused-tests | full-readiness | benchmark-proof]
+- scope: [files, issues, PRs, or batch included]
+- out_of_scope: [nearby work deliberately deferred]
+- worktree: [absolute or repo-relative worktree path and branch]
+- context_budget: [compact snapshots first; raw logs only by artifact path]
+- delegation_artifacts: [RESULT.md, changed files, diffstat, validation, blockers, mutations]
+- output_budget: [parent-thread summary length and exact artifact paths to return]
+- stop_guard: [usage threshold, wall-clock limit, or external blocker]
+- validation_plan: [commands or checks that prove this task class]
+- handoff_target: [PR, issue comment, context note, or final handoff]
 ```
 
 ## Field Rules
@@ -32,9 +32,9 @@ changes.
   `docs/context/issue_1512_issue_archetypes.md` for issue archetype language
   instead of redefining classes here.
 - `context_budget` defaults to compact helpers before broad reads:
-  `scripts/dev/autopilot_state_snapshot.py --include-worktrees`,
-  `scripts/dev/snapshot_issue_batch.py --json`,
-  `scripts/dev/snapshot_pr_queue.py --json`, and
+  `uv run python scripts/dev/autopilot_state_snapshot.py --include-worktrees`,
+  `uv run python scripts/dev/snapshot_issue_batch.py --json`,
+  `uv run python scripts/dev/snapshot_pr_queue.py --json`, and
   `uv run python scripts/dev/run_compact_validation.py -- <command>`.
 - `delegation_artifacts` are route evidence, not task acceptance. Codex still
   inspects the diff, verifies changed files, and runs the selected validation.


### PR DESCRIPTION
## Summary
- Add `docs/templates/token_efficient_thread_profile.md`, a copyable active-thread header for long autonomous, delegated, and token-saving work.
- Link the profile from `AGENTS.md` and `docs/dev_guide.md` so task class, validation tier, context budget, delegation artifacts, output budget, stop guard, and handoff target are explicit without duplicating the maintainer hierarchy.
- Define the compact delegated-worker artifact contract and keep worker outputs as route evidence until parent Codex validates the diff.

Closes #3350.
Closes #3351.
Closes #3352.
Closes #3353.
Closes #3354.

## Validation
- `uv run python scripts/validation/check_docs_proof_consistency.py --path AGENTS.md --path docs/dev_guide.md --path docs/templates/token_efficient_thread_profile.md`
- `uv run python scripts/tools/sync_ai_config.py --check`
- `for p in docs/templates/token_efficient_thread_profile.md docs/maintainer_values.md docs/context/issue_1512_issue_archetypes.md scripts/dev/autopilot_state_snapshot.py scripts/dev/snapshot_issue_batch.py scripts/dev/snapshot_pr_queue.py scripts/dev/run_compact_validation.py; do [ -e "$p" ] || { echo "missing $p"; exit 1; }; done`
- `git diff --check`

## Downstream Propagation
- Agent entry points updated directly in `AGENTS.md` and `docs/dev_guide.md`.
- No generated indexes, skills, schemas, runtime code, benchmark results, or evidence catalogs changed.
- No follow-up issue needed: the reviewer-requested `schema`/`model-provenance` task-class alignment was fixed in this PR.

## Research Result Guidance
NA - workflow/docs-only guidance. This PR does not add benchmark, metric, schema, model-provenance, or paper-facing evidence claims.

## Delegation
- Accepted: Ampere read-only scout recommended one coherent #3350-#3354 batch and identified the missing repo-local `save-codex-tokens` skill path as out of scope.
- Rerouted then accepted: Aquinas read-only review found the initial template omitted `schema`; the template now includes `schema` and `model-provenance` in `task_class` examples.
