### PR TITLE
feat: package trace failure predicate contract

### DIFF
--- a/robot_sf/analysis_workbench/__init__.py
+++ b/robot_sf/analysis_workbench/__init__.py
@@ -17,7 +17,9 @@ from robot_sf.analysis_workbench.trace_annotation import (
 from robot_sf.analysis_workbench.trace_failure_predicates import (
     TRACE_FAILURE_PREDICATE_SCHEMA_VERSION,
     TraceFailurePredicate,
+    TraceFailurePredicateDefinition,
     aggregate_trace_failure_predicate_tables,
+    build_trace_failure_predicate_definitions,
     extract_trace_failure_predicates,
     render_trace_failure_predicate_markdown,
 )
@@ -31,7 +33,9 @@ __all__ = [
     "TraceAnnotationSet",
     "TraceAnnotationSetValidationError",
     "TraceFailurePredicate",
+    "TraceFailurePredicateDefinition",
     "aggregate_trace_failure_predicate_tables",
+    "build_trace_failure_predicate_definitions",
     "extract_trace_failure_predicates",
     "load_simulation_trace_export",
     "load_trace_annotation_set",

--- a/robot_sf/analysis_workbench/schemas/simulation_trace_export.v1.json
+++ b/robot_sf/analysis_workbench/schemas/simulation_trace_export.v1.json
@@ -67,7 +67,8 @@
             "properties": {
               "position": {"$ref": "#/$defs/vector2"},
               "heading": {"type": "number"},
-              "velocity": {"$ref": "#/$defs/vector2"}
+              "velocity": {"$ref": "#/$defs/vector2"},
+              "radius": {"type": "number", "minimum": 0}
             }
           },
           "pedestrians": {
@@ -79,7 +80,8 @@
               "properties": {
                 "id": {"type": "string", "minLength": 1},
                 "position": {"$ref": "#/$defs/vector2"},
-                "velocity": {"$ref": "#/$defs/vector2"}
+                "velocity": {"$ref": "#/$defs/vector2"},
+                "radius": {"type": "number", "minimum": 0}
               }
             }
           },

--- a/robot_sf/analysis_workbench/schemas/trace_failure_predicates.v1.json
+++ b/robot_sf/analysis_workbench/schemas/trace_failure_predicates.v1.json
@@ -1,0 +1,202 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://robot-sf.local/schemas/trace_failure_predicates.v1.json",
+  "title": "Robot SF Trace Failure Predicates v1",
+  "type": "object",
+  "additionalProperties": true,
+  "required": [
+    "schema_version",
+    "matrix_metadata",
+    "predicate_definitions",
+    "denominator_status",
+    "summary",
+    "caveats"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "trace_failure_predicates.v1"
+    },
+    "predicate_source": {
+      "type": "string",
+      "minLength": 1
+    },
+    "table_kind": {
+      "type": "string",
+      "minLength": 1
+    },
+    "trace_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "source": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["scenario_id", "seed", "planner_id", "episode_id"],
+      "properties": {
+        "scenario_id": {"type": "string", "minLength": 1},
+        "seed": {"type": "integer"},
+        "planner_id": {"type": "string", "minLength": 1},
+        "episode_id": {"type": "string", "minLength": 1}
+      }
+    },
+    "matrix_metadata": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": ["status", "rate_interpretation", "included_trace_count"],
+      "properties": {
+        "status": {"type": "string", "minLength": 1},
+        "rate_interpretation": {"type": "string", "minLength": 1},
+        "included_trace_count": {"type": "integer", "minimum": 0}
+      }
+    },
+    "predicate_definitions": {
+      "type": "array",
+      "minItems": 1,
+      "items": {"$ref": "#/$defs/predicate_definition"}
+    },
+    "denominator_status": {
+      "enum": ["valid", "not_available", "no_predicate_observed", "pipeline_failure"]
+    },
+    "predicates": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/predicate_record"}
+    },
+    "rows": {
+      "type": "array",
+      "items": {"$ref": "#/$defs/aggregate_row"}
+    },
+    "zero_predicate_groups": {
+      "type": "array",
+      "items": {"type": "object", "additionalProperties": true}
+    },
+    "predicate_denominator_health": {
+      "type": "object",
+      "additionalProperties": {
+        "type": "object",
+        "additionalProperties": {"type": "integer", "minimum": 0}
+      }
+    },
+    "summary": {
+      "type": "object",
+      "additionalProperties": true
+    },
+    "caveats": {
+      "type": "array",
+      "items": {"type": "string"}
+    }
+  },
+  "anyOf": [
+    {
+      "required": ["predicate_source", "trace_id", "source", "predicates"]
+    },
+    {
+      "required": ["table_kind", "rows", "zero_predicate_groups", "predicate_denominator_health"]
+    }
+  ],
+  "$defs": {
+    "predicate_definition": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "predicate_id",
+        "description",
+        "inputs",
+        "units",
+        "thresholds",
+        "denominator_semantics",
+        "emitted_statuses"
+      ],
+      "properties": {
+        "predicate_id": {"type": "string", "minLength": 1},
+        "description": {"type": "string", "minLength": 1},
+        "inputs": {
+          "type": "array",
+          "items": {"type": "string", "minLength": 1}
+        },
+        "units": {
+          "type": "object",
+          "additionalProperties": {"type": "string"}
+        },
+        "thresholds": {
+          "type": "object",
+          "additionalProperties": true
+        },
+        "denominator_semantics": {"type": "string", "minLength": 1},
+        "emitted_statuses": {
+          "type": "array",
+          "minItems": 1,
+          "items": {"enum": ["valid", "not_available", "no_predicate_observed", "pipeline_failure"]}
+        }
+      }
+    },
+    "predicate_record": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "predicate_id",
+        "time_interval_s",
+        "steps",
+        "involved_actors",
+        "scenario_family",
+        "planner_id",
+        "evidence_fields",
+        "severity",
+        "validity_status"
+      ],
+      "properties": {
+        "predicate_id": {"type": "string", "minLength": 1},
+        "time_interval_s": {
+          "type": "array",
+          "prefixItems": [{"type": ["number", "null"]}, {"type": ["number", "null"]}],
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "steps": {
+          "type": "array",
+          "prefixItems": [{"type": ["integer", "null"]}, {"type": ["integer", "null"]}],
+          "minItems": 2,
+          "maxItems": 2
+        },
+        "involved_actors": {
+          "type": "array",
+          "items": {"type": "string"}
+        },
+        "scenario_family": {"type": "string", "minLength": 1},
+        "planner_id": {"type": "string", "minLength": 1},
+        "evidence_fields": {"type": "object", "additionalProperties": true},
+        "severity": {"type": "string", "minLength": 1},
+        "validity_status": {
+          "enum": ["valid", "not_available", "no_predicate_observed", "pipeline_failure"]
+        }
+      }
+    },
+    "aggregate_row": {
+      "type": "object",
+      "additionalProperties": true,
+      "required": [
+        "scenario_family",
+        "planner_id",
+        "seed",
+        "predicate_id",
+        "validity_status",
+        "severity",
+        "predicate_count",
+        "trace_denominator",
+        "predicate_rate_per_trace"
+      ],
+      "properties": {
+        "scenario_family": {"type": "string", "minLength": 1},
+        "planner_id": {"type": "string", "minLength": 1},
+        "seed": {"type": "integer"},
+        "predicate_id": {"type": "string", "minLength": 1},
+        "validity_status": {
+          "enum": ["valid", "not_available", "no_predicate_observed", "pipeline_failure"]
+        },
+        "severity": {"type": "string", "minLength": 1},
+        "predicate_count": {"type": "integer", "minimum": 0},
+        "trace_denominator": {"type": "integer", "minimum": 0},
+        "predicate_rate_per_trace": {"type": "number", "minimum": 0}
+      }
+    }
+  }
+}

--- a/robot_sf/analysis_workbench/trace_failure_predicates.py
+++ b/robot_sf/analysis_workbench/trace_failure_predicates.py
@@ -22,6 +22,15 @@ TRACE_FAILURE_PREDICATE_SOURCE = "trace_failure_predicates.rule_based.v1"
 TRACE_PREDICATE_DENOMINATOR_HEALTH_SCHEMA_VERSION = "trace_predicate_denominator_health.v1"
 TRACE_PREDICATE_MATRIX_SCHEMA_VERSION = "trace_predicate_matrix.v1"
 
+DEFAULT_CLEARANCE_THRESHOLD_M = 0.4
+DEFAULT_COLLISION_MISSING_RADIUS_NEAR_DISTANCE_M = 0.2
+DEFAULT_NEAR_MISS_THRESHOLD_M = 0.5
+DEFAULT_STATIONARY_DISPLACEMENT_THRESHOLD_M = 0.05
+DEFAULT_LOW_PROGRESS_DISPLACEMENT_THRESHOLD_M = 0.25
+DEFAULT_OSCILLATION_MIN_SIGN_CHANGES = 3
+DEFAULT_EVASIVE_ANGULAR_VELOCITY_THRESHOLD = 1.0
+DEFAULT_EVASIVE_LINEAR_DROP_THRESHOLD_MPS = 0.3
+
 VALIDITY_STATUS_VALID = "valid"
 VALIDITY_STATUS_UNAVAILABLE_DATA = "not_available"
 VALIDITY_STATUS_NO_PREDICATE_OBSERVED = "no_predicate_observed"
@@ -34,11 +43,13 @@ DENOMINATOR_HEALTH_STATUSES = (
 )
 
 TRACE_FAILURE_PREDICATE_IDS = (
+    "collision",
     "late_evasive_reaction",
     "oscillatory_local_control",
     "occlusion_triggered_near_miss",
     "bottleneck_deadlock",
     "zero_motion_timeout_behavior",
+    "low_progress",
     "clearance_critical_interaction",
 )
 
@@ -88,7 +99,7 @@ def matrix_required_fields_for_predicate(matrix: Mapping[str, Any], predicate_id
     return list(fields) if isinstance(fields, list | tuple) else []
 
 
-def _trace_has_field(trace: SimulationTraceExport, field_path: str) -> bool:
+def _trace_has_field(trace: SimulationTraceExport, field_path: str) -> bool:  # noqa: C901
     """Check whether at least one frame provides a dotted trace field.
 
     Supports paths such as ``robot.position``, ``pedestrians.position``,
@@ -98,6 +109,8 @@ def _trace_has_field(trace: SimulationTraceExport, field_path: str) -> bool:
     Returns:
         True when at least one frame contains the field, False otherwise.
     """
+    if field_path == "planner.occlusion_or_visibility":
+        return any(_occlusion_value(frame.planner) is not None for frame in trace.frames)
     parts = field_path.split(".")
     if not parts:
         return False
@@ -168,17 +181,197 @@ class TraceFailurePredicate:
         return asdict(self)
 
 
+@dataclass(frozen=True, slots=True)
+class TraceFailurePredicateDefinition:
+    """Stable documentation for one reusable trace failure predicate."""
+
+    predicate_id: str
+    description: str
+    inputs: list[str]
+    units: dict[str, str]
+    thresholds: dict[str, Any]
+    denominator_semantics: str
+    emitted_statuses: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert the predicate definition to JSON-safe primitives.
+
+        Returns:
+            Dictionary representation of the definition record.
+        """
+        return asdict(self)
+
+
+def build_trace_failure_predicate_definitions(
+    *,
+    clearance_threshold_m: float = DEFAULT_CLEARANCE_THRESHOLD_M,
+    collision_missing_radius_near_distance_m: float = (
+        DEFAULT_COLLISION_MISSING_RADIUS_NEAR_DISTANCE_M
+    ),
+    near_miss_threshold_m: float = DEFAULT_NEAR_MISS_THRESHOLD_M,
+    stationary_displacement_threshold_m: float = DEFAULT_STATIONARY_DISPLACEMENT_THRESHOLD_M,
+    low_progress_displacement_threshold_m: float = DEFAULT_LOW_PROGRESS_DISPLACEMENT_THRESHOLD_M,
+    oscillation_min_sign_changes: int = DEFAULT_OSCILLATION_MIN_SIGN_CHANGES,
+    evasive_angular_velocity_threshold: float = DEFAULT_EVASIVE_ANGULAR_VELOCITY_THRESHOLD,
+    evasive_linear_drop_threshold_mps: float = DEFAULT_EVASIVE_LINEAR_DROP_THRESHOLD_MPS,
+) -> list[dict[str, Any]]:
+    """Return machine-readable predicate definitions and denominator semantics.
+
+    Returns:
+        JSON-safe definition rows ordered by ``TRACE_FAILURE_PREDICATE_IDS``.
+    """
+    definitions = (
+        TraceFailurePredicateDefinition(
+            predicate_id="collision",
+            description=(
+                "Robot-pedestrian center distance is at or below the sum of robot and pedestrian "
+                "radii."
+            ),
+            inputs=[
+                "robot.position",
+                "robot.radius",
+                "pedestrians.id",
+                "pedestrians.position",
+                "pedestrians.radius",
+            ],
+            units={"distance": "m", "radius": "m"},
+            thresholds={"missing_radius_near_distance_m": collision_missing_radius_near_distance_m},
+            denominator_semantics=(
+                "The denominator requires robot and pedestrian radii. Near-contact geometry "
+                "without radii emits not_available instead of a benchmark-collision claim."
+            ),
+            emitted_statuses=[VALIDITY_STATUS_VALID, VALIDITY_STATUS_UNAVAILABLE_DATA],
+        ),
+        TraceFailurePredicateDefinition(
+            predicate_id="late_evasive_reaction",
+            description=(
+                "Robot first enters near-miss pressure and only later issues a strong angular "
+                "command or linear-speed drop."
+            ),
+            inputs=[
+                "robot.position",
+                "pedestrians.id",
+                "pedestrians.position",
+                "planner.selected_action.linear_velocity",
+                "planner.selected_action.angular_velocity",
+            ],
+            units={"distance": "m", "linear_velocity": "m/s", "angular_velocity": "rad/s"},
+            thresholds={
+                "near_miss_threshold_m": near_miss_threshold_m,
+                "evasive_angular_velocity_threshold": evasive_angular_velocity_threshold,
+                "evasive_linear_drop_threshold_mps": evasive_linear_drop_threshold_mps,
+            },
+            denominator_semantics=(
+                "No emitted row means no late evasive pattern was observed for that trace, unless "
+                "matrix-required fields mark the predicate not_available."
+            ),
+            emitted_statuses=[VALIDITY_STATUS_VALID, VALIDITY_STATUS_UNAVAILABLE_DATA],
+        ),
+        TraceFailurePredicateDefinition(
+            predicate_id="oscillatory_local_control",
+            description="Selected angular velocity changes sign at least the configured count.",
+            inputs=["planner.selected_action.angular_velocity"],
+            units={"angular_velocity": "rad/s"},
+            thresholds={"oscillation_min_sign_changes": oscillation_min_sign_changes},
+            denominator_semantics=(
+                "No emitted row means the angular-command sign-change threshold was not met, unless "
+                "matrix-required fields mark the predicate not_available."
+            ),
+            emitted_statuses=[VALIDITY_STATUS_VALID, VALIDITY_STATUS_UNAVAILABLE_DATA],
+        ),
+        TraceFailurePredicateDefinition(
+            predicate_id="occlusion_triggered_near_miss",
+            description="A near miss occurs on a frame with explicit occlusion or blocked visibility.",
+            inputs=[
+                "robot.position",
+                "pedestrians.id",
+                "pedestrians.position",
+                "planner.occlusion_or_visibility",
+            ],
+            units={"distance": "m"},
+            thresholds={"near_miss_threshold_m": near_miss_threshold_m},
+            denominator_semantics=(
+                "Near-miss geometry without occlusion/visibility evidence emits not_available "
+                "instead of being treated as false."
+            ),
+            emitted_statuses=[VALIDITY_STATUS_VALID, VALIDITY_STATUS_UNAVAILABLE_DATA],
+        ),
+        TraceFailurePredicateDefinition(
+            predicate_id="bottleneck_deadlock",
+            description="Planner metadata reports an explicit bottleneck_deadlock event.",
+            inputs=["planner.event"],
+            units={},
+            thresholds={"event": "bottleneck_deadlock"},
+            denominator_semantics=(
+                "No emitted row means no bottleneck_deadlock event was observed, unless "
+                "matrix-required fields mark the predicate not_available."
+            ),
+            emitted_statuses=[VALIDITY_STATUS_VALID, VALIDITY_STATUS_UNAVAILABLE_DATA],
+        ),
+        TraceFailurePredicateDefinition(
+            predicate_id="zero_motion_timeout_behavior",
+            description="Timeout or truncation occurs while total robot displacement stays near zero.",
+            inputs=["robot.position", "planner.event"],
+            units={"displacement": "m"},
+            thresholds={
+                "stationary_displacement_threshold_m": stationary_displacement_threshold_m,
+                "timeout_events": ["timeout", "time_limit", "max_steps", "truncated"],
+            },
+            denominator_semantics=(
+                "No emitted row means either no timeout/truncation event was observed or the robot "
+                "moved beyond the stationary threshold."
+            ),
+            emitted_statuses=[VALIDITY_STATUS_VALID, VALIDITY_STATUS_UNAVAILABLE_DATA],
+        ),
+        TraceFailurePredicateDefinition(
+            predicate_id="low_progress",
+            description=(
+                "Timeout or truncation occurs while total robot displacement remains below the "
+                "low-progress threshold."
+            ),
+            inputs=["robot.position", "planner.event"],
+            units={"displacement": "m"},
+            thresholds={
+                "low_progress_displacement_threshold_m": low_progress_displacement_threshold_m,
+                "timeout_events": ["timeout", "time_limit", "max_steps", "truncated"],
+            },
+            denominator_semantics=(
+                "No emitted row means either no timeout/truncation event was observed or the robot "
+                "moved beyond the low-progress threshold."
+            ),
+            emitted_statuses=[VALIDITY_STATUS_VALID, VALIDITY_STATUS_UNAVAILABLE_DATA],
+        ),
+        TraceFailurePredicateDefinition(
+            predicate_id="clearance_critical_interaction",
+            description="Robot-pedestrian center distance is at or below the clearance threshold.",
+            inputs=["robot.position", "pedestrians.id", "pedestrians.position"],
+            units={"distance": "m"},
+            thresholds={"clearance_threshold_m": clearance_threshold_m},
+            denominator_semantics=(
+                "Every loaded trace contributes one denominator count. Missing positions prevent "
+                "emission and are tracked through denominator health when declared in a matrix."
+            ),
+            emitted_statuses=[VALIDITY_STATUS_VALID, VALIDITY_STATUS_UNAVAILABLE_DATA],
+        ),
+    )
+    return [definition.to_dict() for definition in definitions]
+
+
 def extract_trace_failure_predicates(  # noqa: PLR0913
     trace: SimulationTraceExport,
     *,
     scenario_family: str | None = None,
     matrix: Mapping[str, Any] | None = None,
-    clearance_threshold_m: float = 0.4,
-    near_miss_threshold_m: float = 0.5,
-    stationary_displacement_threshold_m: float = 0.05,
-    oscillation_min_sign_changes: int = 3,
-    evasive_angular_velocity_threshold: float = 1.0,
-    evasive_linear_drop_threshold_mps: float = 0.3,
+    clearance_threshold_m: float = DEFAULT_CLEARANCE_THRESHOLD_M,
+    collision_missing_radius_near_distance_m: float = (
+        DEFAULT_COLLISION_MISSING_RADIUS_NEAR_DISTANCE_M
+    ),
+    near_miss_threshold_m: float = DEFAULT_NEAR_MISS_THRESHOLD_M,
+    stationary_displacement_threshold_m: float = DEFAULT_STATIONARY_DISPLACEMENT_THRESHOLD_M,
+    low_progress_displacement_threshold_m: float = DEFAULT_LOW_PROGRESS_DISPLACEMENT_THRESHOLD_M,
+    oscillation_min_sign_changes: int = DEFAULT_OSCILLATION_MIN_SIGN_CHANGES,
+    evasive_angular_velocity_threshold: float = DEFAULT_EVASIVE_ANGULAR_VELOCITY_THRESHOLD,
+    evasive_linear_drop_threshold_mps: float = DEFAULT_EVASIVE_LINEAR_DROP_THRESHOLD_MPS,
 ) -> dict[str, Any]:
     """Extract dissertation-relevant trace failure predicates.
 
@@ -192,8 +385,12 @@ def extract_trace_failure_predicates(  # noqa: PLR0913
         matrix: Optional predeclared trace-predicate benchmark matrix. When provided, missing
             matrix-required trace fields cause ``not_available`` predicate rows.
         clearance_threshold_m: Distance threshold for clearance-critical interactions.
+        collision_missing_radius_near_distance_m: Near-contact distance that emits
+            ``not_available`` when collision radii are missing.
         near_miss_threshold_m: Distance threshold for near-miss and evasive predicates.
         stationary_displacement_threshold_m: Displacement threshold for zero-motion detection.
+        low_progress_displacement_threshold_m: Displacement threshold for timeout low-progress
+            detection.
         oscillation_min_sign_changes: Minimum angular sign changes for oscillation.
         evasive_angular_velocity_threshold: Angular velocity threshold for evasive reactions.
         evasive_linear_drop_threshold_mps: Linear velocity drop threshold for evasive reactions.
@@ -206,13 +403,29 @@ def extract_trace_failure_predicates(  # noqa: PLR0913
         scenario_family=scenario_family,
         matrix=matrix,
         clearance_threshold_m=clearance_threshold_m,
+        collision_missing_radius_near_distance_m=collision_missing_radius_near_distance_m,
         near_miss_threshold_m=near_miss_threshold_m,
         stationary_displacement_threshold_m=stationary_displacement_threshold_m,
+        low_progress_displacement_threshold_m=low_progress_displacement_threshold_m,
         oscillation_min_sign_changes=oscillation_min_sign_changes,
         evasive_angular_velocity_threshold=evasive_angular_velocity_threshold,
         evasive_linear_drop_threshold_mps=evasive_linear_drop_threshold_mps,
     )
-    return _predicates_payload(trace=trace, predicates=predicates, matrix=matrix)
+    return _predicates_payload(
+        trace=trace,
+        predicates=predicates,
+        matrix=matrix,
+        predicate_definitions=build_trace_failure_predicate_definitions(
+            clearance_threshold_m=clearance_threshold_m,
+            collision_missing_radius_near_distance_m=collision_missing_radius_near_distance_m,
+            near_miss_threshold_m=near_miss_threshold_m,
+            stationary_displacement_threshold_m=stationary_displacement_threshold_m,
+            low_progress_displacement_threshold_m=low_progress_displacement_threshold_m,
+            oscillation_min_sign_changes=oscillation_min_sign_changes,
+            evasive_angular_velocity_threshold=evasive_angular_velocity_threshold,
+            evasive_linear_drop_threshold_mps=evasive_linear_drop_threshold_mps,
+        ),
+    )
 
 
 def aggregate_trace_failure_predicate_tables(
@@ -260,12 +473,16 @@ def aggregate_trace_failure_predicate_tables(
             trace,
             scenario_family=group_family,
             matrix=matrix,
-            clearance_threshold_m=0.4,
-            near_miss_threshold_m=0.5,
-            stationary_displacement_threshold_m=0.05,
-            oscillation_min_sign_changes=3,
-            evasive_angular_velocity_threshold=1.0,
-            evasive_linear_drop_threshold_mps=0.3,
+            clearance_threshold_m=DEFAULT_CLEARANCE_THRESHOLD_M,
+            collision_missing_radius_near_distance_m=(
+                DEFAULT_COLLISION_MISSING_RADIUS_NEAR_DISTANCE_M
+            ),
+            near_miss_threshold_m=DEFAULT_NEAR_MISS_THRESHOLD_M,
+            stationary_displacement_threshold_m=DEFAULT_STATIONARY_DISPLACEMENT_THRESHOLD_M,
+            low_progress_displacement_threshold_m=DEFAULT_LOW_PROGRESS_DISPLACEMENT_THRESHOLD_M,
+            oscillation_min_sign_changes=DEFAULT_OSCILLATION_MIN_SIGN_CHANGES,
+            evasive_angular_velocity_threshold=DEFAULT_EVASIVE_ANGULAR_VELOCITY_THRESHOLD,
+            evasive_linear_drop_threshold_mps=DEFAULT_EVASIVE_LINEAR_DROP_THRESHOLD_MPS,
         )
         predicate_statuses_in_trace: dict[str, set[str]] = defaultdict(set)
         for predicate in extracted_predicates:
@@ -377,6 +594,11 @@ def aggregate_trace_failure_predicate_tables(
             "row_count": len(rows),
         },
         "matrix_metadata": matrix_metadata,
+        "predicate_definitions": build_trace_failure_predicate_definitions(),
+        "denominator_status": _aggregate_denominator_status(
+            included_trace_count=included_trace_count,
+            failed_trace_count=len(failed_trace_id_list),
+        ),
         "rows": rows,
         "zero_predicate_groups": zero_predicate_groups,
         "predicate_denominator_health": {
@@ -413,6 +635,19 @@ def _record_predicate_denominator_statuses(
                 predicate_status_counts[pred_id][status] += 1
         else:
             predicate_status_counts[pred_id][VALIDITY_STATUS_NO_PREDICATE_OBSERVED] += 1
+
+
+def _aggregate_denominator_status(*, included_trace_count: int, failed_trace_count: int) -> str:
+    """Classify aggregate denominator availability for machine-readable consumers.
+
+    Returns:
+        Denominator status string.
+    """
+    if failed_trace_count > 0:
+        return VALIDITY_STATUS_PIPELINE_FAILURE
+    if included_trace_count > 0:
+        return VALIDITY_STATUS_VALID
+    return VALIDITY_STATUS_UNAVAILABLE_DATA
 
 
 def render_trace_failure_predicate_markdown(
@@ -617,6 +852,10 @@ def build_trace_predicate_denominator_health_report(
             "total_traces_processed": input_trace_count,
             "failed_trace_count": failed_trace_count,
             "predicate_family_count": len(TRACE_FAILURE_PREDICATE_IDS),
+            "denominator_status": _aggregate_denominator_status(
+                included_trace_count=max(input_trace_count - failed_trace_count, 0),
+                failed_trace_count=failed_trace_count,
+            ),
         },
         "predicates": predicate_reports,
         "caveats": caveats,
@@ -734,6 +973,7 @@ def _predicates_payload(
     trace: SimulationTraceExport,
     predicates: list[TraceFailurePredicate],
     matrix: Mapping[str, Any] | None,
+    predicate_definitions: list[dict[str, Any]],
 ) -> dict[str, Any]:
     """Build the trace predicate payload schema.
 
@@ -761,6 +1001,8 @@ def _predicates_payload(
             "episode_id": trace.source.episode_id,
         },
         "matrix_metadata": matrix_metadata,
+        "predicate_definitions": predicate_definitions,
+        "denominator_status": VALIDITY_STATUS_VALID,
         "predicates": [predicate.to_dict() for predicate in predicates],
         "summary": _summary(predicates),
         "caveats": caveats,
@@ -865,8 +1107,10 @@ def _extract_trace_failure_predicate_records(  # noqa: C901, PLR0913
     scenario_family: str | None,
     matrix: Mapping[str, Any] | None,
     clearance_threshold_m: float,
+    collision_missing_radius_near_distance_m: float,
     near_miss_threshold_m: float,
     stationary_displacement_threshold_m: float,
+    low_progress_displacement_threshold_m: float,
     oscillation_min_sign_changes: int,
     evasive_angular_velocity_threshold: float,
     evasive_linear_drop_threshold_mps: float,
@@ -890,6 +1134,14 @@ def _extract_trace_failure_predicate_records(  # noqa: C901, PLR0913
     # skip per-frame extraction to avoid duplicate not_available rows.
     occlusion_guarded = "occlusion_triggered_near_miss" in unavailable
 
+    if "collision" not in unavailable:
+        predicates.extend(
+            _collision_events(
+                trace,
+                scenario_family=family,
+                collision_missing_radius_near_distance_m=(collision_missing_radius_near_distance_m),
+            )
+        )
     if "clearance_critical_interaction" not in unavailable:
         predicates.extend(
             _clearance_critical_interactions(
@@ -924,6 +1176,14 @@ def _extract_trace_failure_predicate_records(  # noqa: C901, PLR0913
         )
         if zero_motion is not None:
             predicates.append(zero_motion)
+    if "low_progress" not in unavailable:
+        low_progress = _low_progress(
+            trace,
+            scenario_family=family,
+            low_progress_displacement_threshold_m=low_progress_displacement_threshold_m,
+        )
+        if low_progress is not None:
+            predicates.append(low_progress)
     if "bottleneck_deadlock" not in unavailable:
         predicates.extend(_bottleneck_deadlocks(trace, scenario_family=family))
     if not occlusion_guarded:
@@ -964,6 +1224,74 @@ def _clearance_critical_interactions(
                         "clearance_threshold_m": clearance_threshold_m,
                     },
                     severity="high" if distance_m <= clearance_threshold_m * 0.75 else "medium",
+                    validity_status=VALIDITY_STATUS_VALID,
+                )
+            )
+    return predicates
+
+
+def _collision_events(
+    trace: SimulationTraceExport,
+    *,
+    scenario_family: str,
+    collision_missing_radius_near_distance_m: float,
+) -> list[TraceFailurePredicate]:
+    """Return collision predicates for radius-overlap contact-distance frames."""
+    predicates: list[TraceFailurePredicate] = []
+    for frame in trace.frames:
+        nearest = _nearest_pedestrian(frame)
+        if nearest is None:
+            continue
+        pedestrian_id, distance_m = nearest
+        pedestrian = _pedestrian_by_id(frame, pedestrian_id)
+        robot_radius_m = _number_or_none(frame.robot.get("radius"))
+        pedestrian_radius_m = (
+            _number_or_none(pedestrian.get("radius")) if pedestrian is not None else None
+        )
+        if robot_radius_m is None or pedestrian_radius_m is None:
+            if distance_m <= collision_missing_radius_near_distance_m:
+                missing_fields = []
+                if robot_radius_m is None:
+                    missing_fields.append("robot.radius")
+                if pedestrian_radius_m is None:
+                    missing_fields.append("pedestrians.radius")
+                predicates.append(
+                    _predicate(
+                        "collision",
+                        frame,
+                        frame,
+                        scenario_family=scenario_family,
+                        planner_id=trace.source.planner_id,
+                        involved_actors=["robot", pedestrian_id],
+                        evidence_fields={
+                            "distance_m": distance_m,
+                            "missing_fields": missing_fields,
+                            "missing_radius_near_distance_m": (
+                                collision_missing_radius_near_distance_m
+                            ),
+                        },
+                        severity=VALIDITY_STATUS_UNAVAILABLE_DATA,
+                        validity_status=VALIDITY_STATUS_UNAVAILABLE_DATA,
+                    )
+                )
+            continue
+        collision_distance_m = robot_radius_m + pedestrian_radius_m
+        if distance_m <= collision_distance_m:
+            predicates.append(
+                _predicate(
+                    "collision",
+                    frame,
+                    frame,
+                    scenario_family=scenario_family,
+                    planner_id=trace.source.planner_id,
+                    involved_actors=["robot", pedestrian_id],
+                    evidence_fields={
+                        "distance_m": distance_m,
+                        "robot_radius_m": robot_radius_m,
+                        "pedestrian_radius_m": pedestrian_radius_m,
+                        "collision_distance_m": collision_distance_m,
+                    },
+                    severity="critical",
                     validity_status=VALIDITY_STATUS_VALID,
                 )
             )
@@ -1077,12 +1405,7 @@ def _zero_motion_timeout_behavior(
     start = trace.frames[0]
     end = trace.frames[-1]
     displacement_m = _distance(start.robot.get("position"), end.robot.get("position"))
-    timeout_frames = [
-        frame
-        for frame in trace.frames
-        if str(frame.planner.get("event", "")).strip().lower()
-        in {"timeout", "time_limit", "max_steps", "truncated"}
-    ]
+    timeout_frames = _timeout_frames(trace)
     if not timeout_frames or displacement_m is None:
         return None
     if displacement_m > stationary_displacement_threshold_m:
@@ -1100,6 +1423,50 @@ def _zero_motion_timeout_behavior(
             "timeout_events": [frame.planner.get("event") for frame in timeout_frames],
         },
         severity="high",
+        validity_status=VALIDITY_STATUS_VALID,
+    )
+
+
+def _timeout_frames(trace: SimulationTraceExport) -> list[SimulationTraceFrame]:
+    """Return frames with timeout or truncation planner events."""
+    timeout_events = {"timeout", "time_limit", "max_steps", "truncated"}
+    return [
+        frame
+        for frame in trace.frames
+        if str(frame.planner.get("event", "")).strip().lower() in timeout_events
+    ]
+
+
+def _low_progress(
+    trace: SimulationTraceExport,
+    *,
+    scenario_family: str,
+    low_progress_displacement_threshold_m: float,
+) -> TraceFailurePredicate | None:
+    """Return a low-progress predicate when timeout evidence accompanies small movement."""
+    if not trace.frames:
+        return None
+    start = trace.frames[0]
+    end = trace.frames[-1]
+    displacement_m = _distance(start.robot.get("position"), end.robot.get("position"))
+    timeout_frames = _timeout_frames(trace)
+    if not timeout_frames or displacement_m is None:
+        return None
+    if displacement_m > low_progress_displacement_threshold_m:
+        return None
+    return _predicate(
+        "low_progress",
+        start,
+        end,
+        scenario_family=scenario_family,
+        planner_id=trace.source.planner_id,
+        involved_actors=["robot"],
+        evidence_fields={
+            "episode_displacement_m": displacement_m,
+            "low_progress_displacement_threshold_m": low_progress_displacement_threshold_m,
+            "timeout_events": [frame.planner.get("event") for frame in timeout_frames],
+        },
+        severity="medium",
         validity_status=VALIDITY_STATUS_VALID,
     )
 
@@ -1255,6 +1622,14 @@ def _nearest_pedestrian(frame: SimulationTraceFrame) -> tuple[str, float] | None
     return nearest
 
 
+def _pedestrian_by_id(frame: SimulationTraceFrame, pedestrian_id: str) -> Mapping[str, Any] | None:
+    """Return pedestrian metadata for an emitted actor id."""
+    for pedestrian in frame.pedestrians:
+        if str(pedestrian.get("id", "unknown")) == pedestrian_id:
+            return pedestrian
+    return None
+
+
 def _selected_action(frame: SimulationTraceFrame) -> dict[str, Any]:
     """Return planner selected-action metadata.
 
@@ -1378,7 +1753,9 @@ __all__ = [
     "VALIDITY_STATUS_UNAVAILABLE_DATA",
     "VALIDITY_STATUS_VALID",
     "TraceFailurePredicate",
+    "TraceFailurePredicateDefinition",
     "aggregate_trace_failure_predicate_tables",
+    "build_trace_failure_predicate_definitions",
     "build_trace_predicate_denominator_health_report",
     "extract_trace_failure_predicates",
     "load_trace_predicate_matrix",

--- a/robot_sf/analysis_workbench/trace_failure_predicates.py
+++ b/robot_sf/analysis_workbench/trace_failure_predicates.py
@@ -354,7 +354,10 @@ def build_trace_failure_predicate_definitions(
             emitted_statuses=[VALIDITY_STATUS_VALID, VALIDITY_STATUS_UNAVAILABLE_DATA],
         ),
     )
-    return [definition.to_dict() for definition in definitions]
+    definitions_by_id = {definition.predicate_id: definition for definition in definitions}
+    return [
+        definitions_by_id[predicate_id].to_dict() for predicate_id in TRACE_FAILURE_PREDICATE_IDS
+    ]
 
 
 def extract_trace_failure_predicates(  # noqa: PLR0913
@@ -1239,22 +1242,42 @@ def _collision_events(
     """Return collision predicates for radius-overlap contact-distance frames."""
     predicates: list[TraceFailurePredicate] = []
     for frame in trace.frames:
-        nearest = _nearest_pedestrian(frame)
-        if nearest is None:
-            continue
-        pedestrian_id, distance_m = nearest
-        pedestrian = _pedestrian_by_id(frame, pedestrian_id)
-        robot_radius_m = _number_or_none(frame.robot.get("radius"))
-        pedestrian_radius_m = (
-            _number_or_none(pedestrian.get("radius")) if pedestrian is not None else None
-        )
-        if robot_radius_m is None or pedestrian_radius_m is None:
-            if distance_m <= collision_missing_radius_near_distance_m:
-                missing_fields = []
-                if robot_radius_m is None:
-                    missing_fields.append("robot.radius")
-                if pedestrian_radius_m is None:
-                    missing_fields.append("pedestrians.radius")
+        for pedestrian in frame.pedestrians:
+            distance_m = _distance(frame.robot.get("position"), pedestrian.get("position"))
+            if distance_m is None:
+                continue
+            pedestrian_id = str(pedestrian.get("id", "unknown"))
+            robot_radius_m = _number_or_none(frame.robot.get("radius"))
+            pedestrian_radius_m = _number_or_none(pedestrian.get("radius"))
+            if robot_radius_m is None or pedestrian_radius_m is None:
+                if distance_m <= collision_missing_radius_near_distance_m:
+                    missing_fields = []
+                    if robot_radius_m is None:
+                        missing_fields.append("robot.radius")
+                    if pedestrian_radius_m is None:
+                        missing_fields.append("pedestrians.radius")
+                    predicates.append(
+                        _predicate(
+                            "collision",
+                            frame,
+                            frame,
+                            scenario_family=scenario_family,
+                            planner_id=trace.source.planner_id,
+                            involved_actors=["robot", pedestrian_id],
+                            evidence_fields={
+                                "distance_m": distance_m,
+                                "missing_fields": missing_fields,
+                                "missing_radius_near_distance_m": (
+                                    collision_missing_radius_near_distance_m
+                                ),
+                            },
+                            severity=VALIDITY_STATUS_UNAVAILABLE_DATA,
+                            validity_status=VALIDITY_STATUS_UNAVAILABLE_DATA,
+                        )
+                    )
+                continue
+            collision_distance_m = robot_radius_m + pedestrian_radius_m
+            if distance_m <= collision_distance_m:
                 predicates.append(
                     _predicate(
                         "collision",
@@ -1265,36 +1288,14 @@ def _collision_events(
                         involved_actors=["robot", pedestrian_id],
                         evidence_fields={
                             "distance_m": distance_m,
-                            "missing_fields": missing_fields,
-                            "missing_radius_near_distance_m": (
-                                collision_missing_radius_near_distance_m
-                            ),
+                            "robot_radius_m": robot_radius_m,
+                            "pedestrian_radius_m": pedestrian_radius_m,
+                            "collision_distance_m": collision_distance_m,
                         },
-                        severity=VALIDITY_STATUS_UNAVAILABLE_DATA,
-                        validity_status=VALIDITY_STATUS_UNAVAILABLE_DATA,
+                        severity="critical",
+                        validity_status=VALIDITY_STATUS_VALID,
                     )
                 )
-            continue
-        collision_distance_m = robot_radius_m + pedestrian_radius_m
-        if distance_m <= collision_distance_m:
-            predicates.append(
-                _predicate(
-                    "collision",
-                    frame,
-                    frame,
-                    scenario_family=scenario_family,
-                    planner_id=trace.source.planner_id,
-                    involved_actors=["robot", pedestrian_id],
-                    evidence_fields={
-                        "distance_m": distance_m,
-                        "robot_radius_m": robot_radius_m,
-                        "pedestrian_radius_m": pedestrian_radius_m,
-                        "collision_distance_m": collision_distance_m,
-                    },
-                    severity="critical",
-                    validity_status=VALIDITY_STATUS_VALID,
-                )
-            )
     return predicates
 
 
@@ -1620,14 +1621,6 @@ def _nearest_pedestrian(frame: SimulationTraceFrame) -> tuple[str, float] | None
         if nearest is None or distance_m < nearest[1]:
             nearest = (pedestrian_id, distance_m)
     return nearest
-
-
-def _pedestrian_by_id(frame: SimulationTraceFrame, pedestrian_id: str) -> Mapping[str, Any] | None:
-    """Return pedestrian metadata for an emitted actor id."""
-    for pedestrian in frame.pedestrians:
-        if str(pedestrian.get("id", "unknown")) == pedestrian_id:
-            return pedestrian
-    return None
 
 
 def _selected_action(frame: SimulationTraceFrame) -> dict[str, Any]:

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -52,6 +52,7 @@ order_mode="${PYTEST_ORDER_MODE:-failed-first}"
 worker_override="${PYTEST_NUM_WORKERS:-}"
 lane_mode="${ROBOT_SF_TEST_LANE:-all}"
 core_test_paths=(
+  tests/analysis_workbench
   tests/common
   tests/contract
   tests/factories

--- a/tests/analysis_workbench/test_trace_failure_predicates.py
+++ b/tests/analysis_workbench/test_trace_failure_predicates.py
@@ -5,12 +5,16 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+from jsonschema import Draft202012Validator
+
 from robot_sf.analysis_workbench.simulation_trace_export import (
     load_simulation_trace_export,
     simulation_trace_export_from_dict,
 )
 from robot_sf.analysis_workbench.trace_failure_predicates import (
     aggregate_trace_failure_predicate_tables,
+    build_trace_failure_predicate_definitions,
     build_trace_predicate_denominator_health_report,
     extract_trace_failure_predicates,
     render_trace_failure_predicate_markdown,
@@ -23,6 +27,13 @@ TRACE_FIXTURE_PATH = (
     / "analysis_workbench"
     / "simulation_trace_export_v1"
     / "minimal_trace.json"
+)
+TRACE_PREDICATE_SCHEMA_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "robot_sf"
+    / "analysis_workbench"
+    / "schemas"
+    / "trace_failure_predicates.v1.json"
 )
 
 
@@ -87,6 +98,16 @@ def _find_row(
     predicate_id: str,
 ) -> dict[str, object] | None:
     return next((row for row in rows if row.get("predicate_id") == predicate_id), None)
+
+
+def _assert_predicate_schema_valid(payload: dict[str, object]) -> None:
+    """Assert that a trace-predicate payload validates against its public schema."""
+    schema = json.loads(TRACE_PREDICATE_SCHEMA_PATH.read_text(encoding="utf-8"))
+    errors = sorted(
+        Draft202012Validator(schema).iter_errors(payload),
+        key=lambda error: list(error.absolute_path),
+    )
+    assert not errors, [error.message for error in errors]
 
 
 def test_aggregate_preserves_occlusion_not_available_row() -> None:
@@ -226,6 +247,242 @@ def test_aggregate_includes_clearance_critical_interaction_predicate() -> None:
     assert row is not None
     assert row["validity_status"] == "valid"
     assert row["severity"] == "high"
+
+
+def test_aggregate_includes_collision_and_low_progress_predicates() -> None:
+    """Collision and low-progress rows should be reusable predicate-table records."""
+    collision_trace = _build_trace(
+        trace_id="trace-collision",
+        scenario_id="scenario-collision",
+        seed=21,
+        planner_id="planner-k",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                robot={
+                    "position": [0.0, 0.0],
+                    "heading": 0.0,
+                    "velocity": [0.0, 0.0],
+                    "radius": 0.18,
+                },
+                pedestrians=[
+                    {
+                        "id": "ped_1",
+                        "position": [0.3, 0.0],
+                        "velocity": [0.0, 0.0],
+                        "radius": 0.14,
+                    }
+                ],
+            )
+        ],
+    )
+    low_progress_trace = _build_trace(
+        trace_id="trace-low-progress",
+        scenario_id="scenario-low-progress",
+        seed=22,
+        planner_id="planner-l",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                robot={"position": [0.0, 0.0], "heading": 0.0, "velocity": [0.0, 0.0]},
+                action=(0.1, 0.0),
+            ),
+            _frame(
+                1,
+                1.0,
+                robot={"position": [0.12, 0.0], "heading": 0.0, "velocity": [0.0, 0.0]},
+                action=(0.0, 0.0),
+                planner_extra={"event": "timeout"},
+            ),
+        ],
+    )
+
+    collision_row = _find_row(
+        _aggregate_rows(aggregate_trace_failure_predicate_tables([collision_trace])),
+        predicate_id="collision",
+    )
+    low_progress_row = _find_row(
+        _aggregate_rows(aggregate_trace_failure_predicate_tables([low_progress_trace])),
+        predicate_id="low_progress",
+    )
+
+    assert collision_row is not None
+    assert collision_row["validity_status"] == "valid"
+    assert collision_row["severity"] == "critical"
+    assert low_progress_row is not None
+    assert low_progress_row["validity_status"] == "valid"
+    assert low_progress_row["severity"] == "medium"
+
+
+def test_predicate_definitions_document_inputs_thresholds_and_denominators() -> None:
+    """Reusable predicate definitions should be machine-readable and complete."""
+    definitions = {
+        definition["predicate_id"]: definition
+        for definition in build_trace_failure_predicate_definitions()
+    }
+
+    assert "collision" in definitions
+    assert definitions["collision"]["units"]["distance"] == "m"
+    assert definitions["collision"]["thresholds"]["missing_radius_near_distance_m"] == 0.2
+    assert "denominator" in definitions["collision"]["denominator_semantics"]
+    assert "low_progress" in definitions
+    assert (
+        definitions["low_progress"]["thresholds"]["low_progress_displacement_threshold_m"] == 0.25
+    )
+
+
+def test_collision_uses_radius_overlap_not_fixed_center_distance() -> None:
+    """Collision should follow benchmark footprint-overlap semantics."""
+    trace = _build_trace(
+        trace_id="trace-radius-collision",
+        scenario_id="scenario-radius-collision",
+        seed=25,
+        planner_id="planner-radius",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                robot={
+                    "position": [0.0, 0.0],
+                    "heading": 0.0,
+                    "velocity": [0.0, 0.0],
+                    "radius": 0.18,
+                },
+                pedestrians=[
+                    {
+                        "id": "ped_1",
+                        "position": [0.3, 0.0],
+                        "velocity": [0.0, 0.0],
+                        "radius": 0.14,
+                    }
+                ],
+            )
+        ],
+    )
+
+    predicates = extract_trace_failure_predicates(trace)["predicates"]
+    collision = next(row for row in predicates if row["predicate_id"] == "collision")
+
+    assert collision["validity_status"] == "valid"
+    assert collision["evidence_fields"]["distance_m"] == 0.3
+    assert collision["evidence_fields"]["collision_distance_m"] == pytest.approx(0.32)
+
+
+def test_collision_near_contact_without_radii_is_not_available() -> None:
+    """Near-contact geometry without radii should not become a collision claim."""
+    trace = _build_trace(
+        trace_id="trace-missing-radius-collision",
+        scenario_id="scenario-missing-radius-collision",
+        seed=26,
+        planner_id="planner-radius",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [0.1, 0.0], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+
+    predicates = extract_trace_failure_predicates(trace)["predicates"]
+    collision = next(row for row in predicates if row["predicate_id"] == "collision")
+
+    assert collision["validity_status"] == "not_available"
+    assert collision["severity"] == "not_available"
+    assert collision["evidence_fields"]["missing_fields"] == [
+        "robot.radius",
+        "pedestrians.radius",
+    ]
+
+
+def test_mixed_valid_and_failed_traces_report_pipeline_failure_denominator() -> None:
+    """Mixed valid and failed trace bundles should fail closed at the aggregate denominator."""
+    valid_trace = _build_trace(
+        trace_id="trace-valid-with-failed-peer",
+        scenario_id="scenario-mixed-denominator",
+        seed=27,
+        planner_id="planner-mixed",
+        frames=[_frame(0, 0.0)],
+    )
+
+    payload = aggregate_trace_failure_predicate_tables(
+        [valid_trace], failed_trace_ids=["bad-trace.json"]
+    )
+    health = build_trace_predicate_denominator_health_report(payload)
+
+    assert payload["denominator_status"] == "pipeline_failure"
+    assert health["summary"]["denominator_status"] == "pipeline_failure"
+
+
+def test_zero_trace_bundle_reports_unavailable_denominator() -> None:
+    """Zero valid input traces should be explicit, not a silent zero denominator."""
+    payload = aggregate_trace_failure_predicate_tables([])
+    health = build_trace_predicate_denominator_health_report(payload)
+
+    assert payload["denominator_status"] == "not_available"
+    assert payload["summary"]["input_trace_count"] == 0
+    assert payload["rows"] == []
+    assert health["summary"]["denominator_status"] == "not_available"
+    assert all(report["total_denominator_count"] == 0 for report in health["predicates"].values())
+
+
+def test_matrix_occlusion_logical_field_accepts_visibility_alias() -> None:
+    """Matrix-required logical occlusion evidence should accept supported trace aliases."""
+    trace = _build_trace(
+        trace_id="trace-occlusion-alias",
+        scenario_id="scenario-occlusion-alias",
+        seed=24,
+        planner_id="planner-n",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [0.2, 0.0], "velocity": [0.0, 0.0]}],
+                planner_extra={"visibility": {"line_of_sight": False}},
+            )
+        ],
+    )
+    matrix = {
+        "schema_version": "trace_predicate_matrix.v1",
+        "name": "occlusion_alias_matrix",
+        "status": "proposed",
+        "matrix": {
+            "required_trace_fields_by_predicate": {
+                "occlusion_triggered_near_miss": ["planner.occlusion_or_visibility"]
+            }
+        },
+    }
+
+    payload = aggregate_trace_failure_predicate_tables([trace], matrix=matrix)
+    occlusion_row = _find_row(
+        _aggregate_rows(payload),
+        predicate_id="occlusion_triggered_near_miss",
+    )
+
+    assert occlusion_row is not None
+    assert occlusion_row["validity_status"] == "valid"
+
+
+def test_trace_failure_predicate_payloads_validate_public_schema() -> None:
+    """Single-trace and aggregate predicate outputs should validate against the public schema."""
+    trace = _build_trace(
+        trace_id="trace-schema",
+        scenario_id="scenario-schema",
+        seed=23,
+        planner_id="planner-m",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                pedestrians=[{"id": "ped_1", "position": [0.1, 0.0], "velocity": [0.0, 0.0]}],
+            )
+        ],
+    )
+
+    _assert_predicate_schema_valid(extract_trace_failure_predicates(trace))
+    _assert_predicate_schema_valid(aggregate_trace_failure_predicate_tables([trace]))
 
 
 def test_denominator_and_markdown_render_include_rate_fields() -> None:
@@ -631,7 +888,7 @@ def test_writer_persists_denominator_health_json_when_requested(tmp_path: Path) 
     assert paths == (json_output, markdown_output, health_output)
     health = json.loads(health_output.read_text(encoding="utf-8"))
     assert health["schema_version"] == "trace_predicate_denominator_health.v1"
-    assert health["summary"]["predicate_family_count"] == 6
+    assert health["summary"]["predicate_family_count"] == 8
 
 
 def test_markdown_report_with_denominator_health(tmp_path: Path) -> None:

--- a/tests/analysis_workbench/test_trace_failure_predicates.py
+++ b/tests/analysis_workbench/test_trace_failure_predicates.py
@@ -370,6 +370,51 @@ def test_collision_uses_radius_overlap_not_fixed_center_distance() -> None:
     assert collision["evidence_fields"]["collision_distance_m"] == pytest.approx(0.32)
 
 
+def test_collision_checks_all_pedestrians_not_only_nearest_center() -> None:
+    """A larger non-nearest pedestrian can overlap even when the nearest does not."""
+    trace = _build_trace(
+        trace_id="trace-non-nearest-radius-collision",
+        scenario_id="scenario-radius-collision",
+        seed=28,
+        planner_id="planner-radius",
+        frames=[
+            _frame(
+                0,
+                0.0,
+                robot={
+                    "position": [0.0, 0.0],
+                    "heading": 0.0,
+                    "velocity": [0.0, 0.0],
+                    "radius": 0.1,
+                },
+                pedestrians=[
+                    {
+                        "id": "ped_small_nearest",
+                        "position": [0.22, 0.0],
+                        "velocity": [0.0, 0.0],
+                        "radius": 0.05,
+                    },
+                    {
+                        "id": "ped_large_farther",
+                        "position": [0.3, 0.0],
+                        "velocity": [0.0, 0.0],
+                        "radius": 0.22,
+                    },
+                ],
+            )
+        ],
+    )
+
+    collisions = [
+        row
+        for row in extract_trace_failure_predicates(trace)["predicates"]
+        if row["predicate_id"] == "collision" and row["validity_status"] == "valid"
+    ]
+
+    assert [row["involved_actors"][1] for row in collisions] == ["ped_large_farther"]
+    assert collisions[0]["evidence_fields"]["collision_distance_m"] == pytest.approx(0.32)
+
+
 def test_collision_near_contact_without_radii_is_not_available() -> None:
     """Near-contact geometry without radii should not become a collision claim."""
     trace = _build_trace(

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -87,6 +87,7 @@ def test_run_tests_parallel_exposes_xdist_distribution_mode() -> None:
     assert "normalize_pytest_target_path()" in script_text
     assert "${path%%::*}" in script_text
     assert "core_test_paths=(" in script_text
+    assert "tests/analysis_workbench" in script_text
     assert "explicit_test_targets=(" in script_text
     assert 'cmd+=("--ignore=$optional_test_path")' in script_text
     assert 'pytest_args+=("$optional_test_path")' in script_text


### PR DESCRIPTION
## Summary
Packages trace-level failure predicates as a reusable analysis-workbench contract, including predicate definitions, a public JSON schema, denominator health, and CLI-compatible aggregate payloads.

## Linked Issues
- Closes `#3277`
- Follow-up `#3359`

## Stack / Dependency
- Base dependency: `origin/main` after PR #3358
- Required prior PRs: none
- Stack follow-up issues: `#3359`
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added machine-readable predicate definitions with inputs, units, thresholds, emitted statuses, and denominator semantics.
- Added `collision` and `low_progress` predicate families; collision now uses radius-overlap semantics and emits `not_available` for near-contact traces missing radii.
- Added `trace_failure_predicates.v1` schema and optional `radius` fields to `simulation_trace_export.v1`.
- Made aggregate denominator status fail closed on any failed trace.
- Added analysis-workbench tests to the core readiness lane so changed-file coverage includes this surface.

## Why It Matters
- Added value: AMV trace predicates can now be reused consistently by library callers, CLI table generation, and downstream reports.
- Expected impact: safer diagnostic tables with explicit missingness instead of silent false negatives or center-distance collision shortcuts.
- Why this is worth merging now: it closes a reusable validation contract needed before future AMV predicate matrices and synthesis work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: unblock trace-level AMV validation checks; no benchmark safety claim is made here.
- Comparator or baseline, if applicable: existing trace predicate table helper without public predicate definitions, collision/low-progress coverage, or public schema.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: blocker-resolution / diagnostic-only.
- Decision or stop rule, if applicable: merge when focused predicate tests, committed-fixture CLI smoke, and full PR readiness pass.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3277; #3359 covers deferred matrix-slice completeness.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use on committed fixture `tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json` via `scripts/tools/build_trace_failure_predicate_tables.py`; absent predeclared matrix-slice enforcement deferred to #3359.

## Domain-Aware Approval
- Required for this PR: yes - analysis-tool semantics and denominator claim boundaries changed.
- Domains reviewed: evidence classification / benchmark interpretation / paper-facing claims.
- Status: waived for merge by implementation proof; no benchmark or paper claim is made.
- Approver/review source or waiver: autonomous review kept outputs diagnostic-only and opened #3359 for remaining matrix completeness.
- Validity checklist:
  - Target claim/hypothesis: reusable diagnostic predicate extraction, not safety improvement.
  - Comparator or split/evidence validity: committed minimal trace fixture and synthetic predicate fixtures.
  - Fallback/degraded exclusions: collision requires radii for valid collision rows; missing radii emit `not_available`.
  - Claim boundary: diagnostic-only unless a compliant predeclared matrix supports rate wording.
  - Implementation integrity vs experimental validity: tests validate implementation; downstream empirical interpretation remains deferred.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, predicate rows and denominator health are emitted by focused tests and CLI smoke.
- Did the intervention change command source, selected command, trajectory, or route progress? no, analysis-only.
- Did the scenario actually contain the targeted failure mode? synthetic fixtures cover collision, low progress, occlusion missingness, zero denominator, and pipeline failure.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #3359.

## Next Empirical Action
- Rerun needed: no for this implementation PR.
- Extractor or analysis tool needed: yes, #3359 should extend matrix completeness checks.
- Artifact missing or unavailable: none for this PR; local `output/coverage/*` is disposable validation output.
- Stop / revise / continue decision: continue with matrix-slice completeness follow-up.
- Proposed child issue or existing follow-up: #3359.

## Validation / Proof
- Commands run:
  - `uv run python -m pytest tests/analysis_workbench/test_trace_failure_predicates.py tests/validation/test_trace_failure_predicates.py -q`
  - `uv run ruff check robot_sf/analysis_workbench scripts/tools/build_trace_failure_predicate_tables.py tests/analysis_workbench/test_trace_failure_predicates.py tests/validation/test_trace_failure_predicates.py`
  - `uv run ruff format --check robot_sf/analysis_workbench scripts/tools/build_trace_failure_predicate_tables.py tests/analysis_workbench/test_trace_failure_predicates.py tests/validation/test_trace_failure_predicates.py`
  - `uv run python -m pytest tests/analysis_workbench -q`
  - `uv run python scripts/tools/build_trace_failure_predicate_tables.py --trace tests/fixtures/analysis_workbench/simulation_trace_export_v1/minimal_trace.json --json-output "$tmpdir/tables.json" --markdown-output "$tmpdir/tables.md" --denominator-health-json-output "$tmpdir/health.json"`
  - `uv run python -m pytest tests/benchmark/test_map_runner_utils.py::test_run_map_episode_records_synthetic_actuation_metrics tests/analysis_workbench/test_simulation_trace_export.py::test_build_trace_export_uses_aggregate_simulation_step_trace -q`
  - `uv run python -m pytest tests/test_ci_script_contract.py::test_run_tests_parallel_exposes_xdist_distribution_mode -q`
  - `BASE_REF=origin/main uv run python scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: focused suites passed 38 tests; full analysis-workbench suite passed 59 tests; final compact readiness exited 0 with summary `/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/compact-validation/validation-20260621T193436Z-319933.summary.json`.
- Benchmarks or smoke tests, if applicable: CLI smoke on committed minimal trace fixture wrote valid JSON, denominator-health JSON, and Markdown.

## Risks / Rollout
- Compatibility risks: optional radius fields are additive; old trace exports remain schema-valid.
- Failure modes: matrix denominator health still does not classify absent expected scenario/planner/seed slices; tracked in #3359.
- Rollback or fallback plan: revert this PR to restore prior diagnostic-only predicate behavior.

## Docs / Provenance
- Updated docs: none; public contract lives in `robot_sf/analysis_workbench/schemas/trace_failure_predicates.v1.json` and predicate definitions.
- Relevant design or provenance notes: #3277 issue contract and #3359 follow-up.
- Any assumptions that need to be preserved: collision validity requires robot and pedestrian radii; near-contact without radii is `not_available`.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #3277.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA, contract captured in schema/tests.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, #3359.
- Not applicable because: this is diagnostic analysis tooling, not empirical result publication.

## Follow-Up Issues
- Deferred work: enforce absent predeclared trace-predicate matrix slices as claim-blocking denominator health.
- Issues opened for follow-up: #3359.

## Reviewer Notes
- Verify closely: radius-overlap collision semantics, `not_available` missing-radii behavior, and aggregate `pipeline_failure` denominator status.
- Known limitations: no absent expected matrix-slice status until #3359.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added collision and low-progress predicates to trace failure analysis with configurable thresholds
  * Simulation traces now capture radius information for robots and pedestrians

* **Tests**
  * Added comprehensive schema validation and test coverage for trace failure predicate outputs
  * Expanded testing for predicate definitions, denominator diagnostics, and end-to-end validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->