### PR TITLE
refactor: seed benchmark policy builder registry

### DIFF
--- a/docs/205-complexity-refactoring/README.md
+++ b/docs/205-complexity-refactoring/README.md
@@ -88,12 +88,17 @@ All refactored modules were thoroughly tested:
 ## Future Considerations
 
 ### Remaining High-Complexity Functions
-The following functions still have complexity > 10 but are candidates for future refactoring:
-1. `robot_sf/nav/map_config.py:serialize_map()` (complexity 13)
-2. `robot_sf/render/interactive_playback.py:_handle_playback_key()` (complexity 11)
-3. `robot_sf/render/interactive_playbook.py:_rebuild_trajectories_up_to_frame()` (complexity 11)
-4. `robot_sf/gym_env/multi_robot_env.py:step()` (complexity 11)
-5. `robot_sf/data_analysis/extract_json_from_pickle.py:convert_to_serializable()` (complexity 11)
+The following functions still have complexity suppressions or complexity > 10 and are candidates
+for future refactoring:
+1. `robot_sf/benchmark/map_runner.py:_build_policy()` (C901/PLR0912/PLR0915 suppressed) - policy
+   construction registry migration in progress.
+2. `robot_sf/benchmark/camera_ready_campaign.py:run_campaign()` (C901/PLR0912/PLR0915 suppressed)
+   - campaign-stage decomposition still pending.
+3. `robot_sf/nav/map_config.py:serialize_map()` (complexity 13)
+4. `robot_sf/render/interactive_playback.py:_handle_playback_key()` (complexity 11)
+5. `robot_sf/render/interactive_playbook.py:_rebuild_trajectories_up_to_frame()` (complexity 11)
+6. `robot_sf/gym_env/multi_robot_env.py:step()` (complexity 11)
+7. `robot_sf/data_analysis/extract_json_from_pickle.py:convert_to_serializable()` (complexity 11)
 
 ### Recommended Next Steps
 1. **Incremental Refactoring**: Address remaining complex functions in future iterations

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -160,6 +160,7 @@ from robot_sf.benchmark.observation_noise import (
 )
 from robot_sf.benchmark.obstacle_sampling import sample_obstacle_points
 from robot_sf.benchmark.path_utils import compute_shortest_path_length
+from robot_sf.benchmark.policy_builders import build_registered_adapter_policy_spec
 from robot_sf.benchmark.scenario_schema import validate_scenario_list
 from robot_sf.benchmark.schema_validator import load_schema
 from robot_sf.benchmark.utils import (
@@ -1024,16 +1025,17 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
 
         return _policy, meta
 
-    if algo_key == "risk_dwa":
-        adapter = RiskDWAPlannerAdapter(config=build_risk_dwa_config(algo_config))
+    registered_adapter_spec = build_registered_adapter_policy_spec(algo_key, algo_config)
+    if registered_adapter_spec is not None:
         return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=algo_config,
+            algo_key=registered_adapter_spec.algo_key,
+            algo_config=registered_adapter_spec.algo_config,
             meta=meta,
-            adapter=adapter,
-            adapter_name="RiskDWAPlannerAdapter",
+            adapter=registered_adapter_spec.adapter,
+            adapter_name=registered_adapter_spec.adapter_name,
             robot_kinematics=robot_kinematics,
             normalized_robot_command_mode=normalized_robot_command_mode,
+            limitations=registered_adapter_spec.limitations,
         )
 
     if algo_key in {"risk_surface_dwa", "risk_surface_dwa_v0"}:

--- a/robot_sf/benchmark/policy_builders.py
+++ b/robot_sf/benchmark/policy_builders.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter, build_risk_dwa_config
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 @dataclass(frozen=True)
@@ -34,7 +37,7 @@ def _build_risk_dwa_policy_spec(algo_config: dict[str, Any]) -> AdapterPolicySpe
     )
 
 
-_ADAPTER_POLICY_BUILDERS = {
+_ADAPTER_POLICY_BUILDERS: dict[str, Callable[[dict[str, Any]], AdapterPolicySpec]] = {
     "risk_dwa": _build_risk_dwa_policy_spec,
 }
 

--- a/robot_sf/benchmark/policy_builders.py
+++ b/robot_sf/benchmark/policy_builders.py
@@ -1,0 +1,55 @@
+"""Policy-builder registry helpers for benchmark map-runner planners."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter, build_risk_dwa_config
+
+
+@dataclass(frozen=True)
+class AdapterPolicySpec:
+    """Planner adapter payload for map-runner policy wrapping."""
+
+    algo_key: str
+    algo_config: dict[str, Any]
+    adapter: Any
+    adapter_name: str
+    limitations: str | None = None
+
+
+def _build_risk_dwa_policy_spec(algo_config: dict[str, Any]) -> AdapterPolicySpec:
+    """Build the Risk-DWA adapter spec without applying map-runner metadata.
+
+    Returns:
+        AdapterPolicySpec: Adapter construction payload for the map runner.
+    """
+
+    return AdapterPolicySpec(
+        algo_key="risk_dwa",
+        algo_config=algo_config,
+        adapter=RiskDWAPlannerAdapter(config=build_risk_dwa_config(algo_config)),
+        adapter_name="RiskDWAPlannerAdapter",
+    )
+
+
+_ADAPTER_POLICY_BUILDERS = {
+    "risk_dwa": _build_risk_dwa_policy_spec,
+}
+
+
+def build_registered_adapter_policy_spec(
+    algo_key: str,
+    algo_config: dict[str, Any],
+) -> AdapterPolicySpec | None:
+    """Return a registered adapter policy spec for ``algo_key`` when migrated.
+
+    Returns:
+        AdapterPolicySpec | None: Registered adapter payload, or ``None`` for unmigrated keys.
+    """
+
+    builder = _ADAPTER_POLICY_BUILDERS.get(algo_key)
+    if builder is None:
+        return None
+    return builder(algo_config)

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -57,6 +57,7 @@ from robot_sf.benchmark.map_runner_batch_plan import (
     resolve_batch_kinematics_tag,
 )
 from robot_sf.benchmark.map_runner_metrics import summarize_collision_metrics
+from robot_sf.benchmark.policy_builders import build_registered_adapter_policy_spec
 from robot_sf.common.types import Rect
 from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition
@@ -657,6 +658,39 @@ def test_build_policy_nmpc_social_wires_nmpc_adapter(
     assert meta["status"] == "ok"
     assert meta["policy_semantics"] == "nonlinear_model_predictive_local_planner"
     assert meta["planner_kinematics"]["execution_mode"] == "adapter"
+
+
+def test_build_policy_risk_dwa_routes_through_registered_adapter_builder(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first policy-builder registry slice should preserve Risk-DWA metadata."""
+
+    class _DummyAdapter:
+        """Planner adapter test double for policy-builder registry wiring."""
+
+        def __init__(self, config) -> None:
+            self.config = config
+
+        def plan(self, _obs):
+            """Return a deterministic planner command for the wiring test."""
+            return (0.2, -0.05)
+
+    monkeypatch.setattr(
+        "robot_sf.benchmark.policy_builders.RiskDWAPlannerAdapter",
+        _DummyAdapter,
+    )
+
+    policy, meta = _build_policy("risk_dwa", {"max_linear_speed": 0.7})
+    linear, angular = policy(
+        {"robot": {"position": [0.0, 0.0], "heading": [0.0]}, "goal": {"current": [1.0, 0.0]}}
+    )
+
+    assert (linear, angular) == (0.2, -0.05)
+    assert build_registered_adapter_policy_spec("goal", {}) is None
+    assert meta["status"] == "ok"
+    assert meta["planner_kinematics"]["execution_mode"] == "adapter"
+    assert meta["planner_kinematics"]["adapter_name"] == "RiskDWAPlannerAdapter"
+    assert hasattr(policy, "_planner_adapter")
 
 
 def test_build_policy_risk_surface_dwa_wires_surface_adapter(


### PR DESCRIPTION
## Summary
- Add `robot_sf/benchmark/policy_builders.py` as the first policy-builder registry slice.
- Route only `risk_dwa` through the new registered adapter spec while keeping `_build_adapter_policy` in `map_runner.py` so existing metadata enrichment, feasibility projection, reset/bind/diagnostics hooks, and adapter semantics stay centralized.
- Refresh `docs/205-complexity-refactoring/README.md` so the two suppressed benchmark hotspots from #3355 are visible in the remaining-debt list.

Refs #3355. This is intentionally a partial first slice and does not close the issue; `run_campaign` decomposition and broader `_build_policy` migration remain pending.

## Validation
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/policy_builders.py tests/benchmark/test_map_runner_utils.py`
- `uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/policy_builders.py tests/benchmark/test_map_runner_utils.py`
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/205-complexity-refactoring/README.md`
- `uv run pytest tests/benchmark/test_map_runner_utils.py::test_build_policy_risk_dwa_routes_through_registered_adapter_builder -q`
- `uv run pytest tests/benchmark/test_planner_command_contract.py tests/benchmark/test_map_runner_utils.py -q`
- `uv run python scripts/dev/complexity_runtime_baseline.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/policy_builders.py --top 5`

## Downstream Propagation
- Complexity debt docs updated directly.
- No benchmark result, leaderboard, artifact registry, or schema changed.
- Follow-up remains #3355: migrate additional policy-builder families and decompose `camera_ready_campaign.py::run_campaign`.

## Research Result Guidance
- Target claim/hypothesis/blocker: architecture hygiene for the benchmark policy-builder hotspot.
- Comparator/baseline: previous inline `risk_dwa` branch in `_build_policy`.
- Evidence tier: focused command-contract and map-runner policy-construction tests.
- Result classification: partial implementation / architecture-seam progress, not benchmark evidence.
- Decision/stop rule: stopped before SocNav tail, learned-policy branches, fallback/degraded semantics, or `run_campaign` changes.
- Synthesis surface/update target: #3355 remains open for the remaining migration/decomposition.

## Delegation
- Accepted route evidence: read-only scout `Descartes` recommended `risk_dwa` as the first safe slice and warned against SocNav, learned-policy, fallback/degraded, and `run_campaign` edits.
- Parent adjustment: kept `_build_adapter_policy` in `map_runner.py` for this slice to reduce metadata-drift risk.
