### PR TITLE
refactor: route teb through policy builder registry

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -271,10 +271,6 @@ from robot_sf.planner.sonic_crowdnav import (
     build_sonic_crowdnav_config,
 )
 from robot_sf.planner.stream_gap import StreamGapPlannerAdapter, build_stream_gap_config
-from robot_sf.planner.teb_commitment import (
-    TEBCommitmentPlannerAdapter,
-    build_teb_commitment_config,
-)
 from robot_sf.planner.topology_guided_local_policy import (
     TopologyGuidedHybridRulePlannerAdapter,
     build_topology_guided_local_policy_config,
@@ -2037,8 +2033,6 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
     elif algo_key in {"socnav_bench"}:
         allow_fallback = bool(algo_config.get("allow_fallback", False))
         adapter = SocNavBenchSamplingAdapter(config=socnav_cfg, allow_fallback=allow_fallback)
-    elif algo_key == "teb":
-        adapter = TEBCommitmentPlannerAdapter(config=build_teb_commitment_config(algo_config))
     elif algo_key in {"nmpc_social", "nmpc"}:
         adapter = NMPCSocialPlannerAdapter(config=build_nmpc_social_config(algo_config))
     elif algo_key in {"rvo", "dwa"}:

--- a/robot_sf/benchmark/policy_builders.py
+++ b/robot_sf/benchmark/policy_builders.py
@@ -6,6 +6,10 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter, build_risk_dwa_config
+from robot_sf.planner.teb_commitment import (
+    TEBCommitmentPlannerAdapter,
+    build_teb_commitment_config,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -37,8 +41,24 @@ def _build_risk_dwa_policy_spec(algo_config: dict[str, Any]) -> AdapterPolicySpe
     )
 
 
+def _build_teb_policy_spec(algo_config: dict[str, Any]) -> AdapterPolicySpec:
+    """Build the TEB commitment adapter spec without applying map-runner metadata.
+
+    Returns:
+        AdapterPolicySpec: Adapter construction payload for the map runner.
+    """
+
+    return AdapterPolicySpec(
+        algo_key="teb",
+        algo_config=algo_config,
+        adapter=TEBCommitmentPlannerAdapter(config=build_teb_commitment_config(algo_config)),
+        adapter_name="TEBCommitmentPlannerAdapter",
+    )
+
+
 _ADAPTER_POLICY_BUILDERS: dict[str, Callable[[dict[str, Any]], AdapterPolicySpec]] = {
     "risk_dwa": _build_risk_dwa_policy_spec,
+    "teb": _build_teb_policy_spec,
 }
 
 

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -623,7 +623,10 @@ def test_build_policy_teb_wires_teb_adapter(
             """Return a deterministic planner command for the wiring test."""
             return (0.4, 0.2)
 
-    monkeypatch.setattr("robot_sf.benchmark.map_runner.TEBCommitmentPlannerAdapter", _DummyAdapter)
+    monkeypatch.setattr(
+        "robot_sf.benchmark.policy_builders.TEBCommitmentPlannerAdapter",
+        _DummyAdapter,
+    )
     policy, meta = _build_policy("teb", {"commit_gain": 0.8})
     linear, angular = policy(
         {"robot": {"position": [0.0, 0.0], "heading": [0.0]}, "goal": {"current": [1.0, 0.0]}}
@@ -632,6 +635,8 @@ def test_build_policy_teb_wires_teb_adapter(
     assert meta["status"] == "ok"
     assert meta["policy_semantics"] == "corridor_commitment_local_planner"
     assert meta["planner_kinematics"]["execution_mode"] == "adapter"
+    assert meta["planner_kinematics"]["adapter_name"] == "TEBCommitmentPlannerAdapter"
+    assert hasattr(policy, "_planner_adapter")
 
 
 def test_build_policy_nmpc_social_wires_nmpc_adapter(


### PR DESCRIPTION
## Summary
- move `teb` adapter construction into `robot_sf.benchmark.policy_builders`
- route `_build_policy("teb", ...)` through the registered adapter builder path established for `risk_dwa`
- keep the map-runner adapter metadata and existing TEB wiring behavior intact

Partial progress on #3355. This does not close #3355 because `run_campaign` and additional `_build_policy` branches remain.

## Validation
- `uv sync --all-extras`
- `uv run pytest tests/benchmark/test_map_runner_utils.py::test_build_policy_teb_wires_teb_adapter tests/benchmark/test_map_runner_utils.py::test_build_policy_risk_dwa_routes_through_registered_adapter_builder -q` (`2 passed`)
- `uv run python scripts/dev/run_compact_validation.py -- uv run pytest tests/benchmark/test_planner_command_contract.py tests/benchmark/test_map_runner_utils.py -q` (`exit 0`; summary under `.git/codex-agent-runs/active/compact-validation/validation-20260621T205910Z-1136847.summary.json`)
- `uv run ruff check robot_sf/benchmark/policy_builders.py robot_sf/benchmark/map_runner.py tests/benchmark/test_map_runner_utils.py`
- `uv run ruff format --check robot_sf/benchmark/policy_builders.py robot_sf/benchmark/map_runner.py tests/benchmark/test_map_runner_utils.py`
- `git diff --check`

## Research Result Guidance
- NA - architecture hygiene only. This PR changes planner construction ownership, not benchmark semantics or planner quality claims.

## Downstream Propagation
- Issue #3355 remains open for the remaining `_build_policy` branches and `run_campaign` decomposition.
- No benchmark reports, leaderboards, registry entries, or artifact catalogs are updated.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal reorganization of planner configuration modules for improved code structure and maintainability.

* **Tests**
  * Updated test coverage to align with restructured planner support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->