### PR TITLE
fix: carry structured failed trace slices

### DIFF
--- a/robot_sf/analysis_workbench/trace_failure_predicates.py
+++ b/robot_sf/analysis_workbench/trace_failure_predicates.py
@@ -439,6 +439,7 @@ def aggregate_trace_failure_predicate_tables(
     scenario_family: str | None = None,
     matrix: Mapping[str, Any] | None = None,
     failed_trace_ids: Iterable[str] | None = None,
+    failed_trace_slices: Iterable[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build denominator-aware aggregate rows across one or more trace predicates.
 
@@ -448,6 +449,7 @@ def aggregate_trace_failure_predicate_tables(
         matrix: Optional predeclared trace-predicate benchmark matrix. When absent, outputs are
             diagnostic-only and claim-ineligible.
         failed_trace_ids: Trace IDs that failed to load.
+        failed_trace_slices: Optional structured metadata for traces that failed before parsing.
 
     Returns:
         Aggregate rows grouped by scenario family, planner, seed, predicate ID,
@@ -460,8 +462,13 @@ def aggregate_trace_failure_predicate_tables(
     included_trace_count = 0
     predicate_status_counts: dict[str, Counter[str]] = defaultdict(Counter)
     failed_trace_id_list = list(failed_trace_ids or [])
-    if failed_trace_id_list:
-        for _failed_id in failed_trace_id_list:
+    failed_trace_slice_rows = _json_safe_failed_trace_slices(failed_trace_slices)
+    failed_trace_count = _failed_trace_count(
+        failed_trace_ids=failed_trace_id_list,
+        failed_trace_slices=failed_trace_slice_rows,
+    )
+    if failed_trace_count:
+        for _failure_index in range(failed_trace_count):
             for pred_id in TRACE_FAILURE_PREDICATE_IDS:
                 predicate_status_counts[pred_id][VALIDITY_STATUS_PIPELINE_FAILURE] += 1
 
@@ -513,6 +520,7 @@ def aggregate_trace_failure_predicate_tables(
         expected_slices=expected_slices,
         observed_slices=set(trace_denominators),
         failed_trace_ids=failed_trace_id_list,
+        failed_trace_slices=failed_trace_slice_rows,
     )
     absent_expected_slice_count = len(absent_expected_slices)
     _record_absent_expected_slice_statuses(
@@ -604,8 +612,8 @@ def aggregate_trace_failure_predicate_tables(
         "schema_version": TRACE_FAILURE_PREDICATE_SCHEMA_VERSION,
         "table_kind": "aggregate_by_predicate_group",
         "summary": {
-            "input_trace_count": included_trace_count + len(failed_trace_id_list),
-            "failed_trace_count": len(failed_trace_id_list),
+            "input_trace_count": included_trace_count + failed_trace_count,
+            "failed_trace_count": failed_trace_count,
             "expected_matrix_slice_count": len(expected_slices),
             "absent_expected_slice_count": absent_expected_slice_count,
             "scenario_family_filter": scenario_family,
@@ -615,10 +623,11 @@ def aggregate_trace_failure_predicate_tables(
         "predicate_definitions": build_trace_failure_predicate_definitions(),
         "denominator_status": _aggregate_denominator_status(
             included_trace_count=included_trace_count,
-            failed_trace_count=len(failed_trace_id_list),
+            failed_trace_count=failed_trace_count,
             absent_expected_slice_count=absent_expected_slice_count,
         ),
         "rows": rows,
+        "failed_trace_slices": failed_trace_slice_rows,
         "absent_expected_slices": absent_expected_slices,
         "zero_predicate_groups": zero_predicate_groups,
         "predicate_denominator_health": {
@@ -677,11 +686,13 @@ def _absent_expected_slice_rows(
     expected_slices: set[tuple[str, str, int]],
     observed_slices: set[tuple[str, str, int]],
     failed_trace_ids: list[str],
+    failed_trace_slices: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Return matrix slices absent from loaded traces and failed trace IDs."""
     failed_expected_slices = _failed_expected_slices(
         expected_slices=expected_slices,
         failed_trace_ids=failed_trace_ids,
+        failed_trace_slices=failed_trace_slices,
     )
     return [
         {
@@ -700,15 +711,101 @@ def _failed_expected_slices(
     *,
     expected_slices: set[tuple[str, str, int]],
     failed_trace_ids: list[str],
+    failed_trace_slices: list[dict[str, Any]],
 ) -> set[tuple[str, str, int]]:
-    """Return expected slices named by failed trace IDs."""
-    return {
+    """Return expected slices named by failed structured metadata or trace IDs."""
+    failed_slices: set[tuple[str, str, int]] = set()
+    covered_failed_ids: set[str] = set()
+    for row in failed_trace_slices:
+        source_path = row.get("source_path")
+        if source_path is not None:
+            covered_failed_ids.add(_failed_trace_source_key(str(source_path)))
+        failed_slice = _complete_failed_trace_slice_metadata(row)
+        if failed_slice in expected_slices:
+            failed_slices.add(failed_slice)
+    uncovered_failed_trace_ids = [
+        failed_id
+        for failed_id in failed_trace_ids
+        if _failed_trace_source_key(failed_id) not in covered_failed_ids
+    ]
+    failed_slices.update(
         expected
         for expected in expected_slices
         if any(
-            _failed_trace_id_matches_slice(failed_id, expected) for failed_id in failed_trace_ids
+            _failed_trace_id_matches_slice(failed_id, expected)
+            for failed_id in uncovered_failed_trace_ids
         )
-    }
+    )
+    return failed_slices
+
+
+def _failed_trace_count(
+    *,
+    failed_trace_ids: list[str],
+    failed_trace_slices: list[dict[str, Any]],
+) -> int:
+    """Return a de-duplicated failed trace count across IDs and structured rows."""
+    failed_sources = {_failed_trace_source_key(failed_id) for failed_id in failed_trace_ids}
+    unkeyed_slice_count = 0
+    for row in failed_trace_slices:
+        source_path = row.get("source_path")
+        if source_path is None:
+            unkeyed_slice_count += 1
+        else:
+            failed_sources.add(_failed_trace_source_key(str(source_path)))
+    return len(failed_sources) + unkeyed_slice_count
+
+
+def _failed_trace_source_key(source: str) -> str:
+    """Return the stable comparable key for a failed trace ID or source path."""
+    return Path(source).name
+
+
+def _json_safe_failed_trace_slices(
+    failed_trace_slices: Iterable[Mapping[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    """Return a bounded JSON-safe failed trace slice payload."""
+    if failed_trace_slices is None:
+        return []
+    rows: list[dict[str, Any]] = []
+    for raw_slice in failed_trace_slices:
+        if not isinstance(raw_slice, Mapping):
+            continue
+        row: dict[str, Any] = {}
+        for key in ("scenario_family", "scenario_id", "planner_id", "seed", "source_path"):
+            value = raw_slice.get(key)
+            if value is None:
+                continue
+            if key == "seed":
+                try:
+                    row[key] = int(value)
+                except (TypeError, ValueError):
+                    row[key] = str(value)
+            else:
+                row[key] = str(value)
+        if row:
+            rows.append(row)
+    return rows
+
+
+def _complete_failed_trace_slice_metadata(
+    failed_trace_slice: Mapping[str, Any],
+) -> tuple[str, str, int] | None:
+    """Return a matrix slice tuple when structured failed metadata is complete."""
+    raw_family = failed_trace_slice.get("scenario_family")
+    raw_planner = failed_trace_slice.get("planner_id")
+    raw_seed = failed_trace_slice.get("seed")
+    if raw_family is None or raw_planner is None or raw_seed is None:
+        return None
+    scenario_family = str(raw_family)
+    planner_id = str(raw_planner)
+    try:
+        seed = int(raw_seed)
+    except (TypeError, ValueError):
+        return None
+    if not scenario_family or not planner_id:
+        return None
+    return (scenario_family, planner_id, seed)
 
 
 def _matrix_expected_slices(

--- a/scripts/tools/build_trace_failure_predicate_tables.py
+++ b/scripts/tools/build_trace_failure_predicate_tables.py
@@ -27,6 +27,7 @@ def build_trace_failure_predicate_tables(
     traces: list[Path],
     scenario_family: str | None = None,
     matrix: Mapping[str, Any] | None = None,
+    failed_trace_slices: list[Mapping[str, Any]] | None = None,
 ) -> tuple[dict[str, Any], list[str]]:
     """Build aggregate predicate tables from one or more trace paths."""
     loaded_traces: list[SimulationTraceExport] = []
@@ -41,6 +42,7 @@ def build_trace_failure_predicate_tables(
         scenario_family=scenario_family,
         matrix=matrix,
         failed_trace_ids=failed_trace_ids,
+        failed_trace_slices=failed_trace_slices,
     )
     return payload, failed_trace_ids
 
@@ -50,6 +52,7 @@ def write_trace_failure_predicate_tables(
     traces: list[Path],
     scenario_family: str | None = None,
     matrix: Mapping[str, Any] | None = None,
+    failed_trace_slices: list[Mapping[str, Any]] | None = None,
     output_json: Path,
     output_markdown: Path,
     output_denominator_health_json: Path | None = None,
@@ -59,6 +62,7 @@ def write_trace_failure_predicate_tables(
         traces=traces,
         scenario_family=scenario_family,
         matrix=matrix,
+        failed_trace_slices=failed_trace_slices,
     )
     denominator_health_report = tfp.build_trace_predicate_denominator_health_report(payload)
 

--- a/tests/analysis_workbench/test_trace_failure_predicates.py
+++ b/tests/analysis_workbench/test_trace_failure_predicates.py
@@ -19,7 +19,10 @@ from robot_sf.analysis_workbench.trace_failure_predicates import (
     extract_trace_failure_predicates,
     render_trace_failure_predicate_markdown,
 )
-from scripts.tools.build_trace_failure_predicate_tables import write_trace_failure_predicate_tables
+from scripts.tools.build_trace_failure_predicate_tables import (
+    build_trace_failure_predicate_tables,
+    write_trace_failure_predicate_tables,
+)
 
 TRACE_FIXTURE_PATH = (
     Path(__file__).resolve().parents[1]
@@ -719,6 +722,65 @@ def test_pipeline_failure_handling(tmp_path: Path) -> None:
     assert "Traces with Pipeline Failures: 1" in markdown
     assert f"`{VALIDITY_STATUS_PIPELINE_FAILURE}`" in markdown
     assert "claim-ineligible" in markdown
+
+
+def test_table_builder_carries_structured_failed_trace_slices(tmp_path: Path) -> None:
+    """Structured failed-trace metadata should flow through the table builder."""
+    valid_trace = _build_trace(
+        trace_id="open-field-dwa-999",
+        scenario_id="open_field",
+        seed=999,
+        planner_id="dwa",
+        frames=[_frame(0, 0.0)],
+    )
+    valid_trace_path = tmp_path / "valid_trace.json"
+    valid_trace_path.write_text(json.dumps(valid_trace.to_dict()), encoding="utf-8")
+    malformed_trace_path = _build_malformed_trace_file(
+        tmp_path, "misleading-open-field-dwa-1000.json"
+    )
+    matrix = {
+        "schema_version": "trace_predicate_matrix.v1",
+        "name": "structured_failed_trace_matrix",
+        "status": "rate_interpretable",
+        "matrix": {
+            "scenario_families": ["open_field"],
+            "planners": ["dwa"],
+            "seeds": [999, 1000, 1001],
+        },
+    }
+
+    payload, failed_trace_ids = build_trace_failure_predicate_tables(
+        traces=[valid_trace_path, malformed_trace_path],
+        matrix=matrix,
+        failed_trace_slices=[
+            {
+                "scenario_family": "open_field",
+                "scenario_id": "open_field",
+                "planner_id": "dwa",
+                "seed": 1001,
+                "source_path": str(malformed_trace_path),
+            }
+        ],
+    )
+
+    assert failed_trace_ids == ["misleading-open-field-dwa-1000.json"]
+    assert payload["failed_trace_slices"] == [
+        {
+            "scenario_family": "open_field",
+            "scenario_id": "open_field",
+            "planner_id": "dwa",
+            "seed": 1001,
+            "source_path": str(malformed_trace_path),
+        }
+    ]
+    assert payload["absent_expected_slices"] == [
+        {
+            "scenario_family": "open_field",
+            "planner_id": "dwa",
+            "seed": 1000,
+            "status": "absent_expected_slice",
+        }
+    ]
 
 
 def test_predicate_denominator_health_in_payload() -> None:

--- a/tests/validation/test_trace_failure_predicates.py
+++ b/tests/validation/test_trace_failure_predicates.py
@@ -527,6 +527,157 @@ def test_failed_expected_matrix_slice_not_reported_absent() -> None:
         assert report["claim_eligibility"] == MATRIX_CLAIM_INELIGIBLE
 
 
+def test_structured_failed_slice_metadata_preferred_over_filename() -> None:
+    """Structured failed slices should satisfy their slice without loose filename matching."""
+    trace = _clean_trace(
+        planner={"event": "step"},
+        scenario_id="open_field",
+        planner_id="dwa",
+        seed=999,
+    )
+    matrix = _matrix_for_slices(
+        scenario_families=["open_field"],
+        planners=["dwa"],
+        seeds=[999, 1000, 1001],
+    )
+
+    payload = aggregate_trace_failure_predicate_tables(
+        [trace],
+        matrix=matrix,
+        failed_trace_ids=["open_field-dwa-1000.json"],
+        failed_trace_slices=[
+            {
+                "scenario_family": "open_field",
+                "scenario_id": "open_field",
+                "planner_id": "dwa",
+                "seed": 1001,
+                "source_path": "open_field-dwa-1000.json",
+            }
+        ],
+    )
+
+    assert payload["summary"]["absent_expected_slice_count"] == 1
+    assert payload["absent_expected_slices"] == [
+        {
+            "scenario_family": "open_field",
+            "planner_id": "dwa",
+            "seed": 1000,
+            "status": "absent_expected_slice",
+        }
+    ]
+    assert payload["failed_trace_slices"] == [
+        {
+            "scenario_family": "open_field",
+            "scenario_id": "open_field",
+            "planner_id": "dwa",
+            "seed": 1001,
+            "source_path": "open_field-dwa-1000.json",
+        }
+    ]
+
+
+def test_structured_failed_slice_metadata_combines_uncovered_failed_ids() -> None:
+    """Structured metadata should not hide unrelated failed trace IDs."""
+    trace = _clean_trace(
+        planner={"event": "step"},
+        scenario_id="open_field",
+        planner_id="dwa",
+        seed=999,
+    )
+    matrix = _matrix_for_slices(
+        scenario_families=["open_field"],
+        planners=["dwa"],
+        seeds=[999, 1000, 1001],
+    )
+
+    payload = aggregate_trace_failure_predicate_tables(
+        [trace],
+        matrix=matrix,
+        failed_trace_ids=["open_field-dwa-1000.json"],
+        failed_trace_slices=[
+            {
+                "scenario_family": "open_field",
+                "scenario_id": "open_field",
+                "planner_id": "dwa",
+                "seed": 1001,
+                "source_path": "open_field-dwa-1001.json",
+            }
+        ],
+    )
+
+    assert payload["summary"]["failed_trace_count"] == 2
+    assert payload["summary"]["absent_expected_slice_count"] == 0
+    assert payload["absent_expected_slices"] == []
+
+
+def test_structured_failed_slice_metadata_deduplicates_source_path_count() -> None:
+    """The same failed source reported by ID and structured metadata counts once."""
+    matrix = _matrix_for_slices(
+        scenario_families=["open_field"],
+        planners=["dwa"],
+        seeds=[1000],
+    )
+
+    payload = aggregate_trace_failure_predicate_tables(
+        [],
+        matrix=matrix,
+        failed_trace_ids=["open_field-dwa-1000.json"],
+        failed_trace_slices=[
+            {
+                "scenario_family": "open_field",
+                "scenario_id": "open_field",
+                "planner_id": "dwa",
+                "seed": 1000,
+                "source_path": "/tmp/open_field-dwa-1000.json",
+            }
+        ],
+    )
+
+    assert payload["summary"]["failed_trace_count"] == 1
+    assert payload["summary"]["absent_expected_slice_count"] == 0
+
+
+def test_incomplete_structured_failed_slice_metadata_fails_closed() -> None:
+    """Incomplete structured failed slices should not satisfy expected matrix slices."""
+    matrix = _matrix_for_slices(
+        scenario_families=["open_field"],
+        planners=["dwa"],
+        seeds=[1000],
+    )
+
+    payload = aggregate_trace_failure_predicate_tables(
+        [],
+        matrix=matrix,
+        failed_trace_ids=["open_field-dwa-1000.json"],
+        failed_trace_slices=[
+            {
+                "scenario_family": "open_field",
+                "planner_id": "dwa",
+                "source_path": "open_field-dwa-1000.json",
+            }
+        ],
+    )
+
+    assert payload["denominator_status"] == "pipeline_failure"
+    assert payload["summary"]["failed_trace_count"] == 1
+    assert payload["summary"]["absent_expected_slice_count"] == 1
+    assert payload["absent_expected_slices"] == [
+        {
+            "scenario_family": "open_field",
+            "planner_id": "dwa",
+            "seed": 1000,
+            "status": "absent_expected_slice",
+        }
+    ]
+    assert payload["failed_trace_slices"] == [
+        {
+            "scenario_family": "open_field",
+            "planner_id": "dwa",
+            "source_path": "open_field-dwa-1000.json",
+        }
+    ]
+
+
 def test_failed_trace_id_requires_ordered_expected_slice_identifier() -> None:
     """Failed trace IDs should not satisfy expected slices through loose token collisions."""
     trace = _clean_trace(


### PR DESCRIPTION
## Summary
Carries structured failed-trace slice metadata through trace-failure predicate aggregation so malformed traces can satisfy the intended matrix slice without relying on filename parsing.

## Linked Issues
- Closes `#3363`
- Relates to `#3359`

## Stack / Dependency
- Base dependency: `main` after PR #3362
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added optional `failed_trace_slices` input to `aggregate_trace_failure_predicate_tables()` and table-builder helpers.
- Preserved a bounded JSON-safe `failed_trace_slices` payload in aggregate output.
- Preferred complete structured failed-slice metadata over filename matching when deciding which expected matrix slices were pipeline failures.
- Added regression coverage for structured precedence, incomplete metadata fail-closed behavior, and table-builder propagation.

## Why It Matters
- Added value: failed trace slices can now be attributed by explicit `(scenario_family, planner_id, seed)` metadata instead of brittle filename inference.
- Expected impact: denominator health remains fail-closed when metadata is missing or incomplete, while correctly avoiding false absent-slice reports when structured metadata is present.
- Why this is worth merging now: it closes the follow-up created by the trace matrix fail-closed fix and strengthens the predicate-table contract before downstream analysis depends on it.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for trace predicate denominator accounting; not a benchmark result.
- Comparator or baseline, if applicable: prior filename-only failed-trace matching.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: structured complete failed-slice metadata must satisfy the corresponding expected matrix slice; incomplete metadata must fail closed.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #3363.
- New research/benchmark/metric/paper-facing analysis tool, if any: `NA - support helper`; this extends an existing aggregation contract and does not interpret new research evidence.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress? no; analysis-table metadata only.
- Did the scenario actually contain the targeted failure mode? yes; tests cover malformed trace load failures with expected matrix slices.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: continue
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/analysis_workbench/test_trace_failure_predicates.py tests/validation/test_trace_failure_predicates.py -q`
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/analysis_workbench/trace_failure_predicates.py scripts/tools/build_trace_failure_predicate_tables.py tests/analysis_workbench/test_trace_failure_predicates.py tests/validation/test_trace_failure_predicates.py`
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/analysis_workbench/trace_failure_predicates.py scripts/tools/build_trace_failure_predicate_tables.py tests/analysis_workbench/test_trace_failure_predicates.py tests/validation/test_trace_failure_predicates.py`
  - `git diff --check`
- Evidence that the change works here: focused predicate-table tests passed (`49 passed`) and lint/format/diff checks passed in the issue worktree.
- Benchmarks or smoke tests, if applicable: targeted smoke only; no benchmark claims.

## Risks / Rollout
- Compatibility risks: additive API parameter; existing callers continue to use filename fallback when no structured metadata is supplied.
- Failure modes: callers that pass incomplete structured metadata intentionally fail closed and do not fall back to filename matching.
- Rollback or fallback plan: revert this commit to return to the prior filename-only behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: issue #3363 and parent PR #3362.
- Any assumptions that need to be preserved: complete structured failed metadata means `scenario_family`, `planner_id`, and integer-convertible `seed`.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, closes #3363.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is a support/analysis contract fix and does not create benchmark evidence or paper-facing claims.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: structured failed slices intentionally take precedence over filename matching when supplied.
- Any known limitations: the CLI does not yet ingest a separate sidecar manifest; callers can pass structured metadata through the Python table-builder API.
