### PR TITLE
feat: add external repo staging assistant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -74,5 +74,8 @@ third_party/socnavbench/surreal/code/human_textures/
 # External MPC repos cloned for planner-zoo research (full git repos, not vendored)
 third_party/external_mpc_repos/
 
+# External repos staged by scripts/tools/manage_external_repos.py (pinned local-only clones)
+third_party/external_repos/
+
 # Cmake
 third_party/python-rvo2/.*

--- a/docs/external_repo_setup.md
+++ b/docs/external_repo_setup.md
@@ -1,0 +1,50 @@
+# External Repository Setup Assistant
+
+Robot SF does not silently vendor optional research/reference repositories. Use the local setup
+assistant to discover supported external repos, clone a pinned commit under a gitignored staging
+path, and write compact provenance manifests without committing upstream code.
+
+```bash
+uv run python scripts/tools/manage_external_repos.py list
+uv run python scripts/tools/manage_external_repos.py explain <name>
+uv run python scripts/tools/manage_external_repos.py check <name>
+uv run python scripts/tools/manage_external_repos.py stage <name>
+```
+
+Staged clones live under `third_party/external_repos/<name>/`, which is gitignored. Generated
+manifests default to `output/external_repos/manifests/`, which is local-only through the canonical
+`output/` ignore rule. A manifest records upstream URL, optional fork URL, pinned SHA, staged
+commit, license and compatibility decisions, redistribution decision, intended Robot SF use,
+validation command, file count, size, aggregate tree checksum, and sample file hashes.
+
+The first registered external repository is `sicnav`, the MIT-licensed Safe Interactive Crowd
+Navigation reference implementation used by the existing SICNav wrapper. The registry pins an
+explicit upstream commit and stages from upstream until an `ll7` fork is created. DR-MPC and any
+other ad-hoc clones under `third_party/external_mpc_repos/` remain follow-up work because each
+candidate still needs a reviewed upstream URL, pinned SHA, license decision, and smoke command.
+
+## License-Gated Fork Procedure
+
+Use a fork only when the license decision allows redistribution through a public `ll7` fork.
+Permissive and common copyleft licenses such as MIT, BSD, Apache, and GPL may be fork candidates
+after the license text is verified. Research-only, private, no-redistribution, unclear, or
+credential-gated repositories must not be publicly forked; pin the upstream commit directly or use a
+private mirror approved for the license.
+
+Before adding a `RepoSpec`:
+
+1. Record the upstream URL, observed license, license URL or file, and access date in
+   `docs/templates/external_repo_audit.md`.
+2. Decide the inclusion model: core runtime dependencies belong in vendor/subtree workflows;
+   optional research or reference repos belong in this gitignored pinned-clone pipeline.
+3. If a public fork is allowed, fork to `https://github.com/ll7/<name>` for durability. The pinned
+   SHA is still mandatory and must refer to the exact commit staged for Robot SF work.
+4. If a public fork is not allowed, leave `fork_url` unset or point to an approved private mirror.
+   Do not publish restricted code as part of the staging process.
+5. Add the `RepoSpec` with license compatibility, redistribution decision, intended use, and a
+   validation command that proves the clone works for its Robot SF use case.
+6. Run `stage <name>`, then run the validation command from the staged checkout or the
+   repo-specific smoke test. Treat missing clones as skip-gated in tests, not as fallback success.
+
+The assistant fails closed when the staging destination is not gitignored or when the pinned SHA
+cannot be fetched from the declared source.

--- a/docs/templates/external_repo_audit.md
+++ b/docs/templates/external_repo_audit.md
@@ -1,0 +1,81 @@
+# External Repository Audit Template
+
+Use this template before registering an external code repository for Robot SF staging. Keep paths
+repository-relative. Do not commit upstream source code unless the license and a maintainer decision
+explicitly choose a vendored/subtree inclusion model.
+
+## Summary
+
+- Repository name:
+- Upstream URL:
+- Optional fork or private mirror URL:
+- Access date:
+- Pinned commit SHA:
+- Related issue or PR: none / `Issue #<id>` / `PR #<id>`
+- Intended Robot SF use:
+- Inclusion model: vendor/subtree / gitignored pinned clone / reference-only / reject
+
+## License And Redistribution
+
+- Observed license:
+- License URL or file:
+- Citation or notice requirement:
+- Commercial, research-only, or non-redistribution limits:
+- Public `ll7` fork decision: allowed / blocked / unclear
+- License compatibility decision: compatible / blocked / unclear
+- Redistribution decision: public fork allowed / private mirror only / no redistribution / unclear
+- Decision rationale:
+
+## Source Contract
+
+- Canonical upstream files that define the contract:
+- Expected entrypoint, package, or executable:
+- Required runtime or environment:
+- Expected inputs:
+- Expected outputs:
+- Known API, kinematics, checkpoint, or data assumptions:
+- Verdict: integrate next / prototype only / assessment only / reject
+
+## Staging And Manifest
+
+- Staging path: `third_party/external_repos/<name>/`
+- Manifest path: `output/external_repos/manifests/<name>.provenance.json`
+- Checksum algorithm: SHA-256
+- Expected manifest fields:
+  - upstream URL
+  - optional fork URL
+  - pinned SHA
+  - staged commit
+  - license note
+  - license compatibility decision
+  - redistribution decision
+  - intended Robot SF use
+  - validation command
+  - aggregate tree checksum
+- Verification command:
+
+## Smoke Test Convention
+
+- Staged-check command:
+- Robot SF wrapper or adapter smoke command:
+- Skip-if-not-staged behavior:
+- Fail-closed condition for missing dependencies:
+- Difference between source-harness proof and Robot SF wrapper proof:
+
+## Follow-Up
+
+- Required follow-up issue: none / `Issue #<id>`
+- Remaining provenance gaps:
+- Remaining runtime or adapter gaps:
+- Context note, registry, or benchmark report to update:
+
+## Validation Checklist
+
+- [ ] Upstream URL, access date, and pinned commit SHA are recorded.
+- [ ] License, citation, fork, compatibility, and redistribution decisions are recorded.
+- [ ] Inclusion model is explicit and matches the license decision.
+- [ ] Staging path is under `third_party/external_repos/<name>/` and gitignored.
+- [ ] Manifest path is local-only under `output/external_repos/manifests/`.
+- [ ] Pinned SHA is reachable from the declared source.
+- [ ] Validation command or skip-gated smoke test is recorded.
+- [ ] No restricted source code is committed unless a maintainer explicitly chose vendoring.

--- a/scripts/tools/manage_external_repos.py
+++ b/scripts/tools/manage_external_repos.py
@@ -1,0 +1,501 @@
+#!/usr/bin/env python3
+"""License-aware assistant for staging pinned external git repositories.
+
+The helper deliberately stages external code as local-only git clones rather than vendoring it into
+Robot SF. Each registered repository must declare an explicit pinned commit, license decision,
+redistribution decision, intended use, and validation command before it can be staged.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_STAGE_ROOT = REPO_ROOT / "third_party" / "external_repos"
+DEFAULT_MANIFEST_DIR = REPO_ROOT / "output" / "external_repos" / "manifests"
+
+
+class ExternalRepoError(RuntimeError):
+    """Raised when an external repository cannot be safely staged or validated."""
+
+
+@dataclass(frozen=True)
+class RepoSpec:
+    """Static registry entry for one supported external repository."""
+
+    name: str
+    title: str
+    upstream_url: str
+    fork_url: str | None
+    pinned_sha: str
+    stage_path: Path
+    source_access_date: str
+    license_note: str
+    license_compatibility_decision: str
+    redistribution_decision: str
+    intended_use: str
+    validation_command: str
+    related_issues: tuple[int, ...] = ()
+
+
+REPOS: tuple[RepoSpec, ...] = (
+    RepoSpec(
+        name="sicnav",
+        title="Safe Interactive Crowd Navigation reference implementation",
+        upstream_url="https://github.com/sepsamavi/safe-interactive-crowdnav",
+        fork_url=None,
+        pinned_sha="c702fb8ac9ba6439ca61da7dde68b8524bbc6a1f",
+        stage_path=DEFAULT_STAGE_ROOT / "sicnav",
+        source_access_date="2026-06-21",
+        license_note="MIT License, as reported by GitHub repository license metadata.",
+        license_compatibility_decision="compatible for local research/reference staging",
+        redistribution_decision=(
+            "public fork allowed by MIT after maintainer review; this registry stages from "
+            "upstream until an ll7 fork is created"
+        ),
+        intended_use=(
+            "Reference checkout for SICNav wrapper/provenance work; wrapper smoke and benchmark "
+            "eligibility remain separate gates."
+        ),
+        validation_command=(
+            "uv run pytest tests/baselines/test_external_mpc_wrappers.py "
+            "-k sicnav_skip_without_external_repo -q"
+        ),
+        related_issues=(3347, 3366),
+    ),
+)
+
+
+def list_repos() -> tuple[RepoSpec, ...]:
+    """Return the supported external repository registry."""
+    return REPOS
+
+
+def _get_repo(name: str) -> RepoSpec:
+    """Resolve a repository name or raise a user-facing error."""
+    for repo in REPOS:
+        if repo.name == name:
+            return repo
+    supported = ", ".join(repo.name for repo in REPOS) or "none registered yet"
+    raise ExternalRepoError(f"Unknown repository '{name}'. Supported repositories: {supported}")
+
+
+def _run_git(
+    args: list[str],
+    *,
+    cwd: Path,
+    check: bool = True,
+) -> subprocess.CompletedProcess[str]:
+    """Run a git command and return captured text output."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=check,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _relative_to_repo(path: Path, repo_root: Path) -> Path | None:
+    """Return a repo-relative path when path is inside repo_root."""
+    try:
+        return path.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+
+
+def _git_check_ignored(path: Path, repo_root: Path) -> bool:
+    """Return whether git ignore rules cover a repo-local path."""
+    rel = _relative_to_repo(path, repo_root)
+    if rel is None:
+        return True
+    result = subprocess.run(
+        ["git", "check-ignore", "-q", "--", rel.as_posix()],
+        cwd=repo_root,
+        check=False,
+    )
+    return result.returncode == 0
+
+
+def _ensure_stage_path_ignored(stage_path: Path, repo_root: Path) -> None:
+    """Fail closed if the clone destination is repo-local and not gitignored."""
+    if _relative_to_repo(stage_path, repo_root) is None:
+        return
+    if not _git_check_ignored(stage_path, repo_root):
+        rel = _relative_to_repo(stage_path, repo_root)
+        raise ExternalRepoError(
+            "External repository destination is not covered by gitignore: "
+            f"{rel}. Add an explicit ignore rule before staging."
+        )
+
+
+def _assert_license_decisions_recorded(spec: RepoSpec) -> None:
+    """Fail closed when the registry entry does not record license decisions."""
+    missing: list[str] = []
+    if not spec.source_access_date:
+        missing.append("source_access_date")
+    if not spec.license_note:
+        missing.append("license_note")
+    if not spec.license_compatibility_decision:
+        missing.append("license_compatibility_decision")
+    if not spec.redistribution_decision:
+        missing.append("redistribution_decision")
+    if not spec.intended_use:
+        missing.append("intended_use")
+    if not spec.validation_command:
+        missing.append("validation_command")
+    if missing:
+        raise ExternalRepoError(
+            f"{spec.name} is missing required registry fields: {', '.join(missing)}"
+        )
+
+
+def _assert_pinned_sha_reachable(spec: RepoSpec) -> None:
+    """Fail closed unless git can fetch the pinned commit from the declared source."""
+    with tempfile.TemporaryDirectory(prefix="robot-sf-external-repo-") as temp_dir:
+        probe = Path(temp_dir)
+        _run_git(["init"], cwd=probe)
+        _run_git(["remote", "add", "origin", spec.fork_url or spec.upstream_url], cwd=probe)
+        result = _run_git(
+            ["fetch", "--depth=1", "origin", spec.pinned_sha],
+            cwd=probe,
+            check=False,
+        )
+        if result.returncode != 0:
+            detail = (result.stderr or result.stdout).strip()
+            raise ExternalRepoError(
+                f"Pinned SHA is unreachable for {spec.name}: {spec.pinned_sha}. {detail}"
+            )
+
+
+def _checkout_pinned_clone(spec: RepoSpec, stage_path: Path) -> None:
+    """Clone or update stage_path and detach it at the pinned commit."""
+    source_url = spec.fork_url or spec.upstream_url
+    if stage_path.exists():
+        if not (stage_path / ".git").exists():
+            raise ExternalRepoError(
+                f"Destination already exists and is not a git clone: {stage_path}"
+            )
+    else:
+        stage_path.parent.mkdir(parents=True, exist_ok=True)
+        _run_git(["clone", "--no-checkout", source_url, str(stage_path)], cwd=stage_path.parent)
+    _run_git(["fetch", "--depth=1", "origin", spec.pinned_sha], cwd=stage_path)
+    _run_git(["checkout", "--detach", spec.pinned_sha], cwd=stage_path)
+    staged_commit = _run_git(["rev-parse", "HEAD"], cwd=stage_path).stdout.strip()
+    if staged_commit != spec.pinned_sha:
+        raise ExternalRepoError(
+            f"Staged commit mismatch for {spec.name}: expected {spec.pinned_sha}, got "
+            f"{staged_commit}"
+        )
+
+
+def _git_tracked_files(stage_path: Path) -> list[Path]:
+    """Return tracked files in deterministic order for the staged commit."""
+    result = _run_git(["ls-tree", "-r", "--name-only", "HEAD"], cwd=stage_path)
+    return [stage_path / line for line in result.stdout.splitlines() if line]
+
+
+def _tree_checksum(stage_path: Path) -> dict[str, Any]:
+    """Compute an aggregate checksum over tracked files in the staged repository."""
+    digest = hashlib.sha256()
+    sample_files: list[dict[str, Any]] = []
+    total_size = 0
+    files = _git_tracked_files(stage_path)
+    for file_path in files:
+        file_digest = hashlib.sha256()
+        with file_path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                file_digest.update(chunk)
+        size = file_path.stat().st_size
+        total_size += size
+        rel = file_path.relative_to(stage_path).as_posix()
+        file_sha = file_digest.hexdigest()
+        digest.update(rel.encode("utf-8"))
+        digest.update(b"\0")
+        digest.update(str(size).encode("ascii"))
+        digest.update(b"\0")
+        digest.update(file_sha.encode("ascii"))
+        digest.update(b"\0")
+        if len(sample_files) < 20:
+            sample_files.append({"path": rel, "size_bytes": size, "sha256": file_sha})
+    return {
+        "file_count": len(files),
+        "total_size_bytes": total_size,
+        "tree_sha256": digest.hexdigest(),
+        "sample_files": sample_files,
+    }
+
+
+def check_repo(
+    name: str | None = None,
+    *,
+    spec: RepoSpec | None = None,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    """Validate local staging status for one external repository."""
+    repo = spec or _get_repo(name or "")
+    stage_path = repo.stage_path.expanduser().resolve()
+    report: dict[str, Any] = {
+        "name": repo.name,
+        "title": repo.title,
+        "upstream_url": repo.upstream_url,
+        "fork_url": repo.fork_url,
+        "pinned_sha": repo.pinned_sha,
+        "stage_path": str(stage_path),
+        "source_access_date": repo.source_access_date,
+        "license_note": repo.license_note,
+        "license_compatibility_decision": repo.license_compatibility_decision,
+        "redistribution_decision": repo.redistribution_decision,
+        "intended_use": repo.intended_use,
+        "validation_command": repo.validation_command,
+        "related_issues": list(repo.related_issues),
+        "ok": False,
+        "status": "missing",
+    }
+    if not stage_path.exists():
+        report["action"] = (
+            "Missing local clone. Run "
+            f"`uv run python scripts/tools/manage_external_repos.py stage {repo.name}`."
+        )
+        return report
+    if not (stage_path / ".git").exists():
+        report["status"] = "invalid"
+        report["action"] = "Staging path exists but is not a git clone."
+        return report
+    staged_commit = _run_git(["rev-parse", "HEAD"], cwd=stage_path).stdout.strip()
+    report["staged_commit"] = staged_commit
+    if staged_commit != repo.pinned_sha:
+        report["status"] = "wrong-sha"
+        report["action"] = (
+            f"Clone is at {staged_commit}; restage or checkout pinned SHA {repo.pinned_sha}."
+        )
+        return report
+    if not _git_check_ignored(stage_path, repo_root):
+        report["status"] = "not-gitignored"
+        report["action"] = "Staging path is not covered by gitignore; add an ignore rule."
+        return report
+    report["ok"] = True
+    report["status"] = "available"
+    report["action"] = "Pinned clone satisfies the declared local staging contract."
+    return report
+
+
+def check_all(*, repo_root: Path = REPO_ROOT) -> list[dict[str, Any]]:
+    """Validate every registered external repository."""
+    return [check_repo(spec=repo, repo_root=repo_root) for repo in REPOS]
+
+
+def stage_repo(
+    name: str | None = None,
+    *,
+    spec: RepoSpec | None = None,
+    manifest_out: Path | None = None,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    """Clone the pinned repository and write a compact provenance manifest."""
+    repo = spec or _get_repo(name or "")
+    _assert_license_decisions_recorded(repo)
+    stage_path = repo.stage_path.expanduser().resolve()
+    _ensure_stage_path_ignored(stage_path, repo_root)
+    _assert_pinned_sha_reachable(repo)
+    try:
+        _checkout_pinned_clone(repo, stage_path)
+        checksum = _tree_checksum(stage_path)
+    except Exception:
+        if stage_path.exists() and not any(stage_path.iterdir()):
+            shutil.rmtree(stage_path)
+        raise
+    staged_commit = _run_git(["rev-parse", "HEAD"], cwd=stage_path).stdout.strip()
+    manifest = {
+        "schema": "robot_sf_external_repo_manifest.v1",
+        "name": repo.name,
+        "title": repo.title,
+        "upstream_url": repo.upstream_url,
+        "fork_url": repo.fork_url,
+        "pinned_sha": repo.pinned_sha,
+        "staged_commit": staged_commit,
+        "stage_path": str(stage_path),
+        "source_access_date": repo.source_access_date,
+        "license_note": repo.license_note,
+        "license_compatibility_decision": repo.license_compatibility_decision,
+        "redistribution_decision": repo.redistribution_decision,
+        "intended_use": repo.intended_use,
+        "validation_command": repo.validation_command,
+        "file_count": checksum["file_count"],
+        "total_size_bytes": checksum["total_size_bytes"],
+        "tree_sha256": checksum["tree_sha256"],
+        "checksum_policy": (
+            "aggregate_tree_sha256 over tracked relative path, size, and sha256 at the pinned "
+            "commit; sample file hashes are included for review while the clone remains local."
+        ),
+        "sample_files": checksum["sample_files"],
+        "related_issues": list(repo.related_issues),
+        "created_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat(),
+    }
+    output_path = manifest_out or DEFAULT_MANIFEST_DIR / f"{repo.name}.provenance.json"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(json.dumps(manifest, indent=2, sort_keys=True), encoding="utf-8")
+    return manifest
+
+
+def _print_json(payload: Any) -> None:
+    """Print a stable JSON payload."""
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _repo_summary(repo: RepoSpec, *, include_status: bool) -> dict[str, Any]:
+    """Return one list/explain payload."""
+    payload: dict[str, Any] = {
+        "name": repo.name,
+        "title": repo.title,
+        "upstream_url": repo.upstream_url,
+        "fork_url": repo.fork_url,
+        "pinned_sha": repo.pinned_sha,
+        "stage_path": str(repo.stage_path),
+        "source_access_date": repo.source_access_date,
+        "license_note": repo.license_note,
+        "license_compatibility_decision": repo.license_compatibility_decision,
+        "redistribution_decision": repo.redistribution_decision,
+        "intended_use": repo.intended_use,
+        "validation_command": repo.validation_command,
+        "related_issues": list(repo.related_issues),
+    }
+    if include_status:
+        status = check_repo(spec=repo)
+        payload["status"] = status["status"]
+        payload["ok"] = status["ok"]
+        payload["action"] = status["action"]
+    return payload
+
+
+def _print_repo_summary(payload: dict[str, Any]) -> None:
+    """Print a concise human-readable repository summary."""
+    print(f"{payload['name']}: {payload['title']}")
+    if "status" in payload:
+        print(f"  status: {payload['status']}")
+        print(f"  action: {payload['action']}")
+    print(f"  stage path: {payload['stage_path']}")
+    print(f"  upstream: {payload['upstream_url']}")
+    print(f"  fork: {payload['fork_url'] or 'none'}")
+    print(f"  pinned sha: {payload['pinned_sha']}")
+    print(f"  access date: {payload['source_access_date']}")
+    print(f"  license: {payload['license_note']}")
+    print(f"  compatibility: {payload['license_compatibility_decision']}")
+    print(f"  redistribution: {payload['redistribution_decision']}")
+    print(f"  intended use: {payload['intended_use']}")
+    print(f"  validation: {payload['validation_command']}")
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="Print machine-readable JSON output.")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    subparsers.add_parser("list", help="List supported repositories and local status.")
+
+    explain_parser = subparsers.add_parser("explain", help="Explain one repository contract.")
+    explain_parser.add_argument("name")
+
+    check_parser = subparsers.add_parser("check", help="Check one staged repository.")
+    check_parser.add_argument("name", nargs="?", default="all")
+
+    stage_parser = subparsers.add_parser("stage", help="Clone a pinned repo and write manifest.")
+    stage_parser.add_argument("name")
+    stage_parser.add_argument("--manifest-out", type=Path)
+
+    return parser.parse_args()
+
+
+def _emit_repo_entries(payload: list[dict[str, Any]], *, as_json: bool) -> None:
+    """Print list/check payload entries."""
+    if as_json:
+        _print_json(payload)
+        return
+    if not payload:
+        print("No external repositories are registered yet.")
+        return
+    for index, entry in enumerate(payload):
+        if index:
+            print("")
+        _print_repo_summary(entry)
+
+
+def _handle_list(args: argparse.Namespace) -> int:
+    """Handle the list subcommand."""
+    payload = [_repo_summary(repo, include_status=True) for repo in REPOS]
+    _emit_repo_entries(payload, as_json=args.json)
+    return 0
+
+
+def _handle_explain(args: argparse.Namespace) -> int:
+    """Handle the explain subcommand."""
+    repo = _get_repo(args.name)
+    payload = _repo_summary(repo, include_status=False)
+    if args.json:
+        _print_json(payload)
+        return 0
+    _print_repo_summary(payload)
+    return 0
+
+
+def _handle_check(args: argparse.Namespace) -> int:
+    """Handle the check subcommand."""
+    if args.name == "all":
+        payload = check_all()
+        _emit_repo_entries(payload, as_json=args.json)
+        return 0 if all(entry["ok"] for entry in payload) else 2
+    payload = check_repo(args.name)
+    if args.json:
+        _print_json(payload)
+    else:
+        _print_repo_summary(payload)
+    return 0 if payload["ok"] else 2
+
+
+def _handle_stage(args: argparse.Namespace) -> int:
+    """Handle the stage subcommand."""
+    payload = stage_repo(args.name, manifest_out=args.manifest_out)
+    if args.json:
+        _print_json(payload)
+        return 0
+    output_path = args.manifest_out or DEFAULT_MANIFEST_DIR / (payload["name"] + ".provenance.json")
+    print(f"wrote manifest for {payload['name']}: {output_path}")
+    return 0
+
+
+def _handle_error(exc: ExternalRepoError, *, as_json: bool) -> int:
+    """Print one user-facing CLI error."""
+    if as_json:
+        _print_json({"ok": False, "error": str(exc)})
+    else:
+        print(f"error: {exc}")
+    return 2
+
+
+def main() -> int:
+    """Run the external-repository assistant."""
+    args = parse_args()
+    handlers = {
+        "list": _handle_list,
+        "explain": _handle_explain,
+        "check": _handle_check,
+        "stage": _handle_stage,
+    }
+    try:
+        return handlers[args.command](args)
+    except ExternalRepoError as exc:
+        return _handle_error(exc, as_json=args.json)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_manage_external_repos.py
+++ b/tests/tools/test_manage_external_repos.py
@@ -1,0 +1,200 @@
+"""Tests for the external repository staging assistant."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.tools import manage_external_repos
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _run_git(args: list[str], *, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a git command for local staging fixtures."""
+    return subprocess.run(
+        ["git", *args],
+        cwd=cwd,
+        check=True,
+        text=True,
+        capture_output=True,
+    )
+
+
+def _init_git_repo(path: Path, *, gitignore: str = "") -> None:
+    """Create a small git repo for git-ignore staging checks."""
+    _run_git(["init"], cwd=path)
+    _run_git(["config", "user.email", "tests@example.invalid"], cwd=path)
+    _run_git(["config", "user.name", "Robot SF Tests"], cwd=path)
+    if gitignore:
+        (path / ".gitignore").write_text(gitignore, encoding="utf-8")
+        _run_git(["add", ".gitignore"], cwd=path)
+        _run_git(["commit", "-m", "add ignore rules"], cwd=path)
+
+
+def _init_upstream_repo(path: Path) -> str:
+    """Create an upstream fixture repository and return its pinned commit."""
+    _init_git_repo(path)
+    (path / "README.md").write_text("# fixture repo\n", encoding="utf-8")
+    (path / "planner.py").write_text("print('planner fixture')\n", encoding="utf-8")
+    _run_git(["add", "README.md", "planner.py"], cwd=path)
+    _run_git(["commit", "-m", "initial fixture"], cwd=path)
+    return _run_git(["rev-parse", "HEAD"], cwd=path).stdout.strip()
+
+
+def _repo_spec(
+    *,
+    upstream: Path,
+    pinned_sha: str,
+    stage_path: Path,
+    validation_command: str = "python planner.py",
+) -> manage_external_repos.RepoSpec:
+    """Build a local fixture RepoSpec."""
+    return manage_external_repos.RepoSpec(
+        name="fixture-planner",
+        title="Fixture planner",
+        upstream_url=str(upstream),
+        fork_url=None,
+        pinned_sha=pinned_sha,
+        stage_path=stage_path,
+        source_access_date="2026-06-21",
+        license_note="MIT fixture license.",
+        license_compatibility_decision="compatible for local test staging",
+        redistribution_decision="do not redistribute fixture clone",
+        intended_use="exercise external repository staging",
+        validation_command=validation_command,
+        related_issues=(3347,),
+    )
+
+
+def test_registry_covers_first_external_repo_entry() -> None:
+    """The first production slice should include at least one real stageable repo."""
+    repo_names = {repo.name for repo in manage_external_repos.list_repos()}
+
+    assert "sicnav" in repo_names
+
+
+def test_check_all_reports_missing_unstaged_registered_repos(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Registered repos should be visible even before their local clones are staged."""
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    pinned_sha = _init_upstream_repo(upstream)
+    spec = _repo_spec(
+        upstream=upstream,
+        pinned_sha=pinned_sha,
+        stage_path=tmp_path / "third_party" / "external_repos" / "fixture-planner",
+    )
+    monkeypatch.setattr(manage_external_repos, "REPOS", (spec,))
+
+    reports = manage_external_repos.check_all(repo_root=tmp_path)
+
+    assert reports
+    assert {report["name"] for report in reports} == {"fixture-planner"}
+    assert all(report["status"] == "missing" for report in reports)
+
+
+def test_check_reports_missing_unstaged_repo(tmp_path: Path) -> None:
+    """Registered repos should fail closed until the pinned clone is staged."""
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    pinned_sha = _init_upstream_repo(upstream)
+    spec = _repo_spec(
+        upstream=upstream,
+        pinned_sha=pinned_sha,
+        stage_path=tmp_path / "third_party" / "external_repos" / "fixture-planner",
+    )
+
+    report = manage_external_repos.check_repo(spec=spec, repo_root=tmp_path)
+
+    assert report["ok"] is False
+    assert report["status"] == "missing"
+    assert report["pinned_sha"] == pinned_sha
+    assert "stage fixture-planner" in report["action"]
+
+
+def test_stage_rejects_destination_not_covered_by_gitignore(tmp_path: Path) -> None:
+    """Repo-local external clones must be gitignored before staging."""
+    _init_git_repo(tmp_path)
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    pinned_sha = _init_upstream_repo(upstream)
+    spec = _repo_spec(
+        upstream=upstream,
+        pinned_sha=pinned_sha,
+        stage_path=tmp_path / "third_party" / "external_repos" / "fixture-planner",
+    )
+
+    with pytest.raises(manage_external_repos.ExternalRepoError, match="not covered by gitignore"):
+        manage_external_repos.stage_repo(
+            spec=spec,
+            manifest_out=tmp_path / "manifest.json",
+            repo_root=tmp_path,
+        )
+
+
+def test_stage_clones_pinned_sha_and_writes_manifest(tmp_path: Path) -> None:
+    """Staging should clone, pin, checksum, and write compact provenance."""
+    _init_git_repo(tmp_path, gitignore="third_party/external_repos/\n")
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    pinned_sha = _init_upstream_repo(upstream)
+    stage_path = tmp_path / "third_party" / "external_repos" / "fixture-planner"
+    manifest_path = tmp_path / "manifests" / "fixture-planner.provenance.json"
+    spec = _repo_spec(upstream=upstream, pinned_sha=pinned_sha, stage_path=stage_path)
+
+    manifest = manage_external_repos.stage_repo(
+        spec=spec,
+        manifest_out=manifest_path,
+        repo_root=tmp_path,
+    )
+
+    assert manifest_path.is_file()
+    payload = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert payload == manifest
+    assert payload["schema"] == "robot_sf_external_repo_manifest.v1"
+    assert payload["name"] == "fixture-planner"
+    assert payload["upstream_url"] == str(upstream)
+    assert payload["fork_url"] is None
+    assert payload["pinned_sha"] == pinned_sha
+    assert payload["staged_commit"] == pinned_sha
+    assert payload["source_access_date"] == "2026-06-21"
+    assert payload["license_compatibility_decision"] == "compatible for local test staging"
+    assert payload["redistribution_decision"] == "do not redistribute fixture clone"
+    assert payload["intended_use"] == "exercise external repository staging"
+    assert payload["validation_command"] == "python planner.py"
+    assert payload["tree_sha256"]
+    assert payload["file_count"] >= 2
+    assert payload["sample_files"][0]["path"] in {"README.md", "planner.py"}
+    assert (stage_path / ".git").exists()
+    assert _run_git(["rev-parse", "HEAD"], cwd=stage_path).stdout.strip() == pinned_sha
+
+
+def test_stage_rejects_unreachable_pinned_sha(tmp_path: Path) -> None:
+    """Staging must fail before writing a manifest when the pinned SHA cannot be fetched."""
+    _init_git_repo(tmp_path, gitignore="third_party/external_repos/\n")
+    upstream = tmp_path / "upstream"
+    upstream.mkdir()
+    _init_upstream_repo(upstream)
+    unreachable_sha = "f" * 40
+    spec = _repo_spec(
+        upstream=upstream,
+        pinned_sha=unreachable_sha,
+        stage_path=tmp_path / "third_party" / "external_repos" / "fixture-planner",
+    )
+    manifest_path = tmp_path / "manifest.json"
+
+    with pytest.raises(manage_external_repos.ExternalRepoError, match="Pinned SHA is unreachable"):
+        manage_external_repos.stage_repo(
+            spec=spec,
+            manifest_out=manifest_path,
+            repo_root=tmp_path,
+        )
+
+    assert not manifest_path.exists()
+    assert not spec.stage_path.exists()


### PR DESCRIPTION
## Summary
Adds a license-aware external repository staging assistant for pinned, gitignored sub-clones, plus docs, an audit template, and focused tests. The first concrete registry entry is `sicnav`, pinned to an explicit upstream commit with an MIT license decision.

## Linked Issues
- Closes `#3347`
- Follow-up: `#3366`

## Stack / Dependency
- Base dependency: `main`
- Required prior PRs: none
- Stack follow-up issues: `#3366`
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added `scripts/tools/manage_external_repos.py` with `list`, `explain`, `check`, and `stage` verbs.
- Added a static `RepoSpec` registry with `sicnav` pinned to `c702fb8ac9ba6439ca61da7dde68b8524bbc6a1f`.
- Enforced gitignored clone destinations under `third_party/external_repos/` before staging.
- Wrote local-only provenance manifests under `output/external_repos/manifests/` with source, license, redistribution, intended-use, checksum, and validation metadata.
- Added docs and a repo-intake audit template.
- Added tests for registry exposure, missing staged repos, gitignore fail-closed behavior, local pinned clone staging, manifest fields, and unreachable SHA rejection.

## Why It Matters
- Added value: external code repos can now be staged reproducibly without vendoring upstream code into the Robot SF tree.
- Expected impact: planner/reference repo intake gets the same fail-closed provenance posture as external data staging.
- Why this is worth merging now: it replaces ad-hoc clone handling with a testable tool and creates a concrete path to migrate the remaining `third_party/external_mpc_repos/` usage.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: workflow blocker for reproducible external repository intake; no benchmark result.
- Comparator or baseline, if applicable: ad-hoc ignored clones under `third_party/external_mpc_repos/` with no pinning manifest.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: `stage sicnav` must clone the pinned SHA into a gitignored path and write a manifest; unreachable SHA and unignored destinations must fail closed.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #3347; follow-up #3366 for remaining ad-hoc clone migration.
- New research/benchmark/metric/paper-facing analysis tool, if any: `NA - support helper`; this manages provenance and staging, not evidence interpretation.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress? no; workflow/tooling only.
- Did the scenario actually contain the targeted failure mode? yes; tests cover missing clones, unignored destinations, and unreachable SHAs.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: #3366 handles remaining external MPC clone migration/rejection decisions.

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none for this support slice
- Stop / revise / continue decision: continue via #3366
- Proposed child issue or existing follow-up: #3366

## Validation / Proof
- Commands run:
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_manage_external_repos.py -q`
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/manage_external_repos.py tests/tools/test_manage_external_repos.py`
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/tools/manage_external_repos.py tests/tools/test_manage_external_repos.py`
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/manage_external_repos.py --json list`
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/manage_external_repos.py --json stage sicnav --manifest-out output/external_repos/manifests/sicnav.provenance.json`
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/manage_external_repos.py --json check sicnav`
  - `git status --ignored --short -uall third_party/external_repos output/external_repos`
  - `git diff --check`
- Evidence that the change works here: tests passed (`6 passed`); `stage sicnav` cloned the pinned commit, wrote a local-only manifest, and `check sicnav` reported `available`; generated clone and manifest were ignored and then removed before commit.
- Benchmarks or smoke tests, if applicable: targeted workflow smoke only; no benchmark claims.

## Risks / Rollout
- Compatibility risks: none to runtime paths; existing wrappers still point at `third_party/external_mpc_repos/` until #3366 migrates them.
- Failure modes: staging a large upstream repo may consume local disk; this is local-only and gitignored.
- Rollback or fallback plan: revert this PR to remove the assistant and ignore rule.

## Docs / Provenance
- Updated docs: `docs/external_repo_setup.md`, `docs/templates/external_repo_audit.md`.
- Relevant design or provenance notes: modeled on `scripts/tools/manage_external_data.py` and `docs/context/external_planner_reuse_checklist.md`.
- Any assumptions that need to be preserved: GitHub metadata reported SICNav as MIT licensed on 2026-06-21; DR-MPC was not registered because GitHub reported no license metadata.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, closes #3347.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): yes, new static repo registry in `manage_external_repos.py`.
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, #3366.
- Not applicable because: this is workflow/tooling support and does not change benchmark evidence.

## Follow-Up Issues
- Deferred work: migrate or explicitly reject existing `third_party/external_mpc_repos/` clone usage.
- Issues opened for follow-up: #3366

## Reviewer Notes
- Anything a reviewer should verify closely: license/provenance wording for `sicnav`, and that the assistant remains local-only for cloned upstream source.
- Any known limitations: no public `ll7` fork is created in this PR; DR-MPC is intentionally left out until its license/reuse decision is reviewed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an external repository setup assistant tool with commands to list, check, and stage external repositories.
  * Automatic provenance manifest generation with license and redistribution tracking.

* **Documentation**
  * Added comprehensive guide for external repository setup workflow.
  * Added audit template for registering external code repositories.

* **Tests**
  * Added test coverage for external repository management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->