### PR TITLE
refactor: migrate sicnav external staging path

### DIFF
--- a/configs/algos/sicnav_camera_ready.yaml
+++ b/configs/algos/sicnav_camera_ready.yaml
@@ -2,7 +2,7 @@
 allow_testing_algorithms: true
 include_in_paper: false
 
-repo_root: third_party/external_mpc_repos/sicnav
+repo_root: third_party/external_repos/sicnav
 checkpoint_path: sicnav_diffusion/JMID/MID/checkpoints/jrdb_bev_0_25_multi_class_epoch16.pt
 solver: ipopt
 device: cpu

--- a/docs/context/issue_3366_external_mpc_staging_audit.md
+++ b/docs/context/issue_3366_external_mpc_staging_audit.md
@@ -1,0 +1,162 @@
+# Issue 3366 External MPC Staging Audit
+
+Date: 2026-06-22
+
+Related:
+
+- Issue #3366: migrate `third_party/external_mpc_repos` clones to pinned external repo staging.
+- Issue #3347 / PR #3367: first production external repo staging assistant.
+- `docs/templates/external_repo_audit.md`
+- `docs/context/issue_771_drmpscnav_assessment.md`
+
+## Inventory
+
+The current checkout and main checkout do not contain a local
+`third_party/external_mpc_repos/` directory. The remaining migration work is therefore tracked
+path and provenance cleanup, not preservation of a machine-local clone.
+
+Tracked legacy references found on 2026-06-22:
+
+- `robot_sf/baselines/sicnav.py`
+- `configs/algos/sicnav_camera_ready.yaml`
+- `robot_sf/benchmark/algorithm_metadata.py`
+- `robot_sf/baselines/dr_mpc.py`
+- `configs/algos/dr_mpc_exploratory.yaml`
+- DR-MPC wrapper and map-runner tests that pass explicit legacy paths.
+
+## SICNav Audit
+
+- Repository name: `sicnav`
+- Upstream URL: `https://github.com/sepsamavi/safe-interactive-crowdnav`
+- Optional fork or private mirror URL: none
+- Access date: 2026-06-21 for the pinned registry entry; GitHub metadata rechecked 2026-06-22.
+- Pinned commit SHA: `c702fb8ac9ba6439ca61da7dde68b8524bbc6a1f`
+- Related issue or PR: Issue #3366, Issue #3347, PR #3367
+- Intended Robot SF use: reference checkout for SICNav wrapper and provenance work.
+- Inclusion model: gitignored pinned clone
+
+License and redistribution:
+
+- Observed license: MIT License in GitHub repository metadata.
+- License URL or file: upstream repository license metadata.
+- Citation or notice requirement: preserve upstream license/notice in any future redistributed fork.
+- Commercial, research-only, or non-redistribution limits: none identified from GitHub metadata.
+- Public `ll7` fork decision: allowed by license after maintainer review; not required for this
+  staging slice.
+- License compatibility decision: compatible for local research/reference staging.
+- Redistribution decision: public fork allowed by MIT after maintainer review; this registry stages
+  from upstream until an `ll7` fork is created.
+- Decision rationale: upstream license metadata is permissive and the clone remains local-only
+  under `third_party/external_repos/sicnav`.
+
+Source contract:
+
+- Canonical upstream files that define the contract: `sicnav_diffusion/` package and checkpoint
+  paths referenced by the Robot SF wrapper.
+- Expected entrypoint, package, or executable: `sicnav_diffusion` or `sicnav` import surface with
+  a supported policy constructor.
+- Required runtime or environment: upstream solver/dependency stack; not installed by the staging
+  helper.
+- Expected inputs: Robot SF wrapper maps structured robot/human state into the upstream policy
+  contract.
+- Expected outputs: velocity or unicycle command projected into Robot SF `unicycle_vw` semantics.
+- Known API, kinematics, checkpoint, or data assumptions: upstream checkpoint availability remains
+  separate from clone staging.
+- Verdict: integrate next as a pinned local reference only; benchmark eligibility still requires a
+  dependency-backed wrapper smoke.
+
+Staging and manifest:
+
+- Staging path: `third_party/external_repos/sicnav/`
+- Manifest path: `output/external_repos/manifests/sicnav.provenance.json`
+- Checksum algorithm: aggregate SHA-256 over tracked file path, size, and file hash.
+- Verification command:
+  `uv run python scripts/tools/manage_external_repos.py --json stage sicnav --manifest-out output/external_repos/manifests/sicnav.provenance.json`
+
+Smoke test convention:
+
+- Staged-check command:
+  `uv run pytest tests/baselines/test_external_mpc_wrappers.py -k sicnav_skip_without_external_repo -q`
+- Robot SF wrapper or adapter smoke command:
+  same skip-gated test for source checkout presence; dependency-backed wrapper execution remains a
+  future proof gate.
+- Skip-if-not-staged behavior: skip when `third_party/external_repos/sicnav` is absent.
+- Fail-closed condition for missing dependencies: missing upstream package or unsupported policy
+  surface is not benchmark evidence.
+- Difference between source-harness proof and Robot SF wrapper proof: staging proves a pinned source
+  checkout and import surface only; it does not prove the full Robot SF adapter or benchmark path.
+
+## DR-MPC Audit
+
+- Repository name: `dr_mpc`
+- Upstream URL: `https://github.com/James-R-Han/DR-MPC`
+- Optional fork or private mirror URL: none
+- Access date: GitHub metadata rechecked 2026-06-22.
+- Pinned commit SHA: none registered.
+- Related issue or PR: Issue #3366, Issue #771
+- Intended Robot SF use: source-side assessment anchor for residual MPC wrapper work.
+- Inclusion model: reject / reference-only
+
+License and redistribution:
+
+- Observed license: no license metadata reported by GitHub.
+- License URL or file: none verified.
+- Citation or notice requirement: unknown.
+- Commercial, research-only, or non-redistribution limits: unknown.
+- Public `ll7` fork decision: blocked until an explicit license or maintainer approval exists.
+- License compatibility decision: blocked for registered staging and redistribution.
+- Redistribution decision: no redistribution.
+- Decision rationale: absent license metadata is enough to reject public fork/staging in the
+  license-gated pipeline.
+
+Source contract:
+
+- Canonical upstream files that define the contract: `scripts/online_continuous_task.py`,
+  `scripts/configs`, and environment-specific dependency files from the prior #771 assessment.
+- Expected entrypoint, package, or executable: source-side reproduction first; no registered Robot
+  SF staging command.
+- Required runtime or environment: Python/torch stack plus RVO2/pysteam-style dependencies.
+- Expected inputs: robot pose/velocity/goal and human trajectory state stacks.
+- Expected outputs: residual MPC command projected into Robot SF unicycle semantics.
+- Known API, kinematics, checkpoint, or data assumptions: residual policy and dependency/runtime
+  requirements remain unproven in this repository.
+- Verdict: reject from pinned external staging for now; keep DR-MPC as reference-only until license
+  and source-side reproduction are resolved.
+
+Staging and manifest:
+
+- Staging path: none.
+- Manifest path: none.
+- Verification command: none; no staging entry should be added while license metadata is absent.
+
+Smoke test convention:
+
+- Staged-check command: none.
+- Robot SF wrapper or adapter smoke command: existing wrapper tests with fake modules remain
+  source-independent contract tests only.
+- Skip-if-not-staged behavior: not applicable until a staging entry is accepted.
+- Fail-closed condition for missing dependencies: missing DR-MPC runtime remains an unavailable
+  dependency, not fallback success.
+- Difference between source-harness proof and Robot SF wrapper proof: DR-MPC still lacks a
+  source-harness proof, so Robot SF wrapper proof is out of scope for this staging slice.
+
+## Follow-Up
+
+- Required follow-up issue: create one only if maintainers decide to pursue DR-MPC license
+  clarification or source-side reproduction.
+- Remaining provenance gaps: DR-MPC license and pinned commit.
+- Remaining runtime or adapter gaps: SICNav dependency-backed wrapper smoke; DR-MPC source-side
+  reproduction.
+- Context note, registry, or benchmark report to update: this note and `docs/external_repo_setup.md`.
+
+## Validation Checklist
+
+- [x] Upstream URL, access date, and pinned commit SHA are recorded for SICNav.
+- [x] License, fork, compatibility, and redistribution decisions are recorded for SICNav.
+- [x] Inclusion model is explicit and matches the license decision.
+- [x] Staging path is under `third_party/external_repos/sicnav/` and gitignored.
+- [x] Manifest path is local-only under `output/external_repos/manifests/`.
+- [x] Pinned SHA is reachable from the declared source when `stage sicnav` succeeds.
+- [x] Validation command or skip-gated smoke test is recorded.
+- [x] No restricted source code is committed.
+- [x] DR-MPC is explicitly rejected from staging until license and reproduction gaps are resolved.

--- a/docs/external_repo_setup.md
+++ b/docs/external_repo_setup.md
@@ -19,9 +19,15 @@ validation command, file count, size, aggregate tree checksum, and sample file h
 
 The first registered external repository is `sicnav`, the MIT-licensed Safe Interactive Crowd
 Navigation reference implementation used by the existing SICNav wrapper. The registry pins an
-explicit upstream commit and stages from upstream until an `ll7` fork is created. DR-MPC and any
-other ad-hoc clones under `third_party/external_mpc_repos/` remain follow-up work because each
-candidate still needs a reviewed upstream URL, pinned SHA, license decision, and smoke command.
+explicit upstream commit and stages from upstream until an `ll7` fork is created. The tracked
+SICNav defaults use `third_party/external_repos/sicnav`, not the legacy
+`third_party/external_mpc_repos/sicnav` path.
+
+DR-MPC is intentionally not registered in this pipeline. GitHub metadata reported no license for
+`https://github.com/James-R-Han/DR-MPC` on 2026-06-22, so public fork, redistribution, and pinned
+local staging remain blocked. Keep DR-MPC as reference-only/source-side-first until an explicit
+license decision and source-harness proof exist. The issue #3366 audit is tracked in
+`docs/context/issue_3366_external_mpc_staging_audit.md`.
 
 ## License-Gated Fork Procedure
 

--- a/robot_sf/baselines/sicnav.py
+++ b/robot_sf/baselines/sicnav.py
@@ -38,7 +38,7 @@ class SICNavPlannerConfig:
     """Configuration for the SICNav baseline wrapper."""
 
     checkpoint_path: str | None = None
-    repo_root: str = "third_party/external_mpc_repos/sicnav"
+    repo_root: str = "third_party/external_repos/sicnav"
     upstream_repo_url: str = "https://github.com/sepsamavi/safe-interactive-crowdnav"
     solver: str = "ipopt"
     device: str = "cpu"

--- a/robot_sf/benchmark/algorithm_metadata.py
+++ b/robot_sf/benchmark/algorithm_metadata.py
@@ -501,8 +501,8 @@ _UPSTREAM_REFERENCE_BY_CANONICAL: dict[str, dict[str, Any]] = {
     },
     "sicnav": {
         "repo_url": "https://github.com/sepsamavi/safe-interactive-crowdnav",
-        "commit": "local_vendor_reference",
-        "checkout_path": "third_party/external_mpc_repos/sicnav",
+        "commit": "c702fb8ac9ba6439ca61da7dde68b8524bbc6a1f",
+        "checkout_path": "third_party/external_repos/sicnav",
         "upstream_policy": "sicnav_diffusion.policy.sicnav_acados.SICNavAcados",
         "default_checkpoint": (
             "sicnav_diffusion/JMID/MID/checkpoints/jrdb_bev_0_25_multi_class_epoch16.pt"

--- a/tests/baselines/test_external_mpc_wrappers.py
+++ b/tests/baselines/test_external_mpc_wrappers.py
@@ -3,6 +3,7 @@
 import os
 import sys
 import types
+from importlib.util import find_spec
 from pathlib import Path
 
 import pytest
@@ -13,6 +14,9 @@ from robot_sf.baselines.dr_mpc import Observation as DRMPCObservation
 from robot_sf.baselines.interface import Observation as InterfaceObservation
 from robot_sf.baselines.sicnav import Observation as SICNavObservation
 from robot_sf.baselines.sicnav import SICNavPlanner, build_sicnav_config
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SICNAV_STAGE_PATH = REPO_ROOT / "third_party" / "external_repos" / "sicnav"
 
 
 def _make_robot_observation() -> dict[str, object]:
@@ -57,6 +61,28 @@ def test_sicnav_step_raises_when_dependency_missing(
     )
     with pytest.raises(RuntimeError, match="SICNav dependency"):
         planner.step(_make_robot_observation())
+
+
+def test_sicnav_config_builder_uses_external_repos_default() -> None:
+    """SICNav config defaults should point at the license-staged external repo path."""
+    cfg = build_sicnav_config({})
+    assert cfg.repo_root == "third_party/external_repos/sicnav"
+
+
+def test_sicnav_skip_without_external_repo() -> None:
+    """Smoke-check the staged SICNav checkout when it is present locally."""
+    if not SICNAV_STAGE_PATH.exists():
+        pytest.skip(f"SICNav external repo is not staged at {SICNAV_STAGE_PATH}")
+
+    cfg = build_sicnav_config({})
+    planner = SICNavPlanner(cfg, seed=1)
+    assert planner._resolve_repo_root(cfg.repo_root) == SICNAV_STAGE_PATH.resolve()
+
+    with planner._upstream_import_context():
+        package_names = {"sicnav_diffusion", "sicnav"}
+        package_paths = [SICNAV_STAGE_PATH / name for name in package_names]
+        assert any(path.exists() for path in package_paths)
+        assert any(find_spec(name) is not None for name in package_names)
 
 
 def test_dr_mpc_step_raises_when_dependency_missing() -> None:

--- a/tests/benchmark/test_algorithm_metadata_contract.py
+++ b/tests/benchmark/test_algorithm_metadata_contract.py
@@ -397,6 +397,21 @@ def test_drl_vo_metadata_exposes_reference_contract() -> None:
     assert upstream["commit"] == "6d734b6e0df77fd4c4faa4649ca0fcb3e69cf835"
 
 
+def test_sicnav_metadata_exposes_pinned_external_repo_contract() -> None:
+    """SICNav metadata should point at the pinned external-repo staging contract."""
+    meta = enrich_algorithm_metadata(
+        algo="sicnav",
+        metadata={"status": "ok"},
+        execution_mode="adapter",
+        robot_kinematics="differential_drive",
+    )
+
+    upstream = meta["upstream_reference"]
+    assert upstream["repo_url"] == "https://github.com/sepsamavi/safe-interactive-crowdnav"
+    assert upstream["commit"] == "c702fb8ac9ba6439ca61da7dde68b8524bbc6a1f"
+    assert upstream["checkout_path"] == "third_party/external_repos/sicnav"
+
+
 def test_social_navigation_pyenvs_orca_metadata_exposes_upstream_wrapper_contract() -> None:
     """Prototype external ORCA metadata should expose upstream repo and projection boundary."""
     meta = enrich_algorithm_metadata(

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -1522,7 +1522,7 @@ def test_build_policy_sicnav_wires_external_mpc_adapter(
     monkeypatch.setattr("robot_sf.benchmark.map_runner.SICNavPlanner", _DummyPlanner)
     policy, meta = _build_policy(
         "sicnav",
-        {"repo_root": "third_party/external_mpc_repos/sicnav"},
+        {"repo_root": "third_party/external_repos/sicnav"},
         robot_kinematics="differential_drive",
     )
     linear, angular = policy(


### PR DESCRIPTION
## Summary

- migrate SICNav defaults, config, metadata, and tests from legacy `third_party/external_mpc_repos/sicnav` to the pinned external-repo staging path `third_party/external_repos/sicnav`
- record the #3366 audit: SICNav is MIT and stageable; DR-MPC remains reference-only/rejected for staging because GitHub reports no license metadata
- add a skip-gated SICNav staged-check smoke and metadata contract coverage for the pinned checkout

## Validation

- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/manage_external_repos.py --json stage sicnav --manifest-out output/external_repos/manifests/sicnav.provenance.json`
- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/baselines/test_external_mpc_wrappers.py -k sicnav_skip_without_external_repo -q` -> 1 passed with the staged checkout present
- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/baselines/test_external_mpc_wrappers.py tests/tools/test_manage_external_repos.py tests/benchmark/test_algorithm_metadata_contract.py -q` -> 55 passed, 1 skipped after removing the local-only staged checkout
- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/baselines/sicnav.py robot_sf/benchmark/algorithm_metadata.py tests/baselines/test_external_mpc_wrappers.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_map_runner_utils.py scripts/tools/manage_external_repos.py`
- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/baselines/sicnav.py robot_sf/benchmark/algorithm_metadata.py tests/baselines/test_external_mpc_wrappers.py tests/benchmark/test_algorithm_metadata_contract.py tests/benchmark/test_map_runner_utils.py scripts/tools/manage_external_repos.py`
- `git diff --check`

Validation limitation: targeted collection of `tests/benchmark/test_map_runner_utils.py::test_build_policy_sicnav_wires_external_mpc_adapter` could not run in the shared local venv because importing the module requires `torch`, which is not installed in that route. The changed line there is a SICNav path literal; CI should cover the full environment.

## Downstream Propagation

- Issue #3366 audit added at `docs/context/issue_3366_external_mpc_staging_audit.md`.
- No restricted upstream code is committed. The staged SICNav clone and manifest were generated for proof, confirmed ignored, and removed before commit.

## Research Result Guidance

NA - workflow/provenance cleanup for external repository staging; no benchmark or paper-facing result is claimed.
