### PR TITLE
feat: add AMV actuation variability sampling (#3284)

### DIFF
--- a/configs/benchmarks/issue_2011_amv_actuation_sensitivity_sweep_v0.yaml
+++ b/configs/benchmarks/issue_2011_amv_actuation_sensitivity_sweep_v0.yaml
@@ -17,6 +17,76 @@ pilot:
   workers: 1
   bootstrap_samples: 80
   output_root: output/benchmarks/issue_2011_amv_actuation_sensitivity_pilot
+variability_sampling:
+  default_mode: fixed-variants
+  sample_count: 3
+  seed: 3284
+  source_context: docs/context/issue_2011_amv_actuation_sensitivity_sweep.md
+  caveat: synthetic/provisional variability samples are diagnostic-only and not hardware-calibrated AMV evidence
+variability_distribution:
+  schema_version: synthetic-actuation-variability-distribution.v1
+  mode: synthetic-provisional
+  claim_boundary: diagnostic-only
+  source_context: docs/context/issue_2011_amv_actuation_sensitivity_sweep.md
+  parameters:
+    max_linear_accel_m_s2:
+      distribution: uniform
+      low: 2.425
+      high: 4.625
+      provenance:
+        units: m/s^2
+        source_status: accepted_platform_class_proxy_source
+        source_context: docs/context/issue_2001_amv_actuation_proxy_source_analysis.md
+        caveat: e-scooter platform-class proxy only; not hardware-calibrated AMV evidence
+    max_linear_decel_m_s2:
+      distribution: uniform
+      low: 3.210
+      high: 3.842
+      provenance:
+        units: m/s^2
+        source_status: accepted_platform_class_proxy_source
+        source_context: docs/context/issue_2001_amv_actuation_proxy_source_analysis.md
+        caveat: e-scooter braking proxy only; not hardware-calibrated AMV evidence
+    max_yaw_rate_rad_s:
+      distribution: uniform
+      low: 0.8
+      high: 1.6
+      provenance:
+        units: rad/s
+        source_status: synthetic_stress_factor
+        source_context: docs/context/issue_2011_amv_actuation_sensitivity_sweep.md
+        caveat: synthetic yaw-rate stress range unsupported by the longitudinal proxy source
+    max_angular_accel_rad_s2:
+      distribution: uniform
+      low: 2.0
+      high: 6.0
+      provenance:
+        units: rad/s^2
+        source_status: synthetic_stress_factor
+        source_context: docs/context/issue_2011_amv_actuation_sensitivity_sweep.md
+        caveat: synthetic angular-acceleration stress range unsupported by the longitudinal proxy source
+    latency_mode:
+      distribution: choice
+      choices:
+        - zero-step-delay
+        - one-step-delay
+        - two-step-delay
+      provenance:
+        units: profile-label
+        source_status: synthetic_stress_factor
+        source_context: docs/context/issue_2011_amv_actuation_sensitivity_sweep.md
+        caveat: latency is unsupported by the longitudinal proxy source
+    update_mode:
+      distribution: choice
+      choices:
+        - 2.5hz-hold
+        - 5hz-hold
+        - 10hz-matched
+      provenance:
+        units: profile-label
+        source_status: synthetic_stress_factor
+        source_context: docs/context/issue_2011_amv_actuation_sensitivity_sweep.md
+        caveat: update rate is unsupported by the longitudinal proxy source
 baseline_profile:
   max_linear_accel_m_s2: 2.819
   max_linear_decel_m_s2: 3.429

--- a/docs/context/issue_2011_amv_actuation_sensitivity_sweep.md
+++ b/docs/context/issue_2011_amv_actuation_sensitivity_sweep.md
@@ -35,6 +35,22 @@ planner, and scenario family. The pilot uses two scenarios, one seed, and two pl
 `classic_cross_trap_high`, `francis2023_intersection_wait`, seed `111`, planners `goal` and
 `social_force`.
 
+Issue #3284 extends the same manifest with an opt-in seeded variability-sweep mode:
+
+```bash
+uv run python scripts/tools/run_amv_actuation_sensitivity_sweep.py \
+  --manifest configs/benchmarks/issue_2011_amv_actuation_sensitivity_sweep_v0.yaml \
+  --output output/issue_3284_amv_actuation_variability_samples \
+  --sampling-mode variability-sweep \
+  --sampling-seed 3284
+```
+
+The default remains the 12 fixed low/nominal/high variants. `variability-sweep` materializes
+synthetic/provisional samples from the manifest's `variability_distribution` block and writes
+`reports/sampled_parameter_summary.{json,csv,md}` beside the generated configs. These samples are
+diagnostic-only, preserve the issue #2001 platform-proxy boundary, and are not hardware-calibrated
+AMV evidence.
+
 The implementation also adds the missing `latency_stress_profile` pass-through from
 `robot_sf.benchmark.runner.run_batch` to map-runner execution, and extends synthetic update-rate
 stress with `2.5hz-hold` so the update-rate group has distinct low/nominal/high levels.

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -437,6 +437,19 @@ def _normalized_kinematics_matrix(kinematics: tuple[str, ...]) -> tuple[str, ...
     )
 
 
+def _optional_synthetic_actuation_profile_mapping(
+    payload: Mapping[str, Any],
+    key: str,
+) -> Mapping[str, Any] | None:
+    """Return optional synthetic-actuation profile metadata with fail-closed typing."""
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise TypeError(f"synthetic_actuation_profile.{key} must be a mapping when provided")
+    return value
+
+
 def _sanitize_name(name: str) -> str:
     """Normalize names for stable directory identifiers.
 
@@ -1715,6 +1728,14 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
                 ),
                 update_mode=(
                     str(synthetic_actuation_raw.get("update_mode", "10hz-matched")).strip().lower()
+                ),
+                variability_distribution=_optional_synthetic_actuation_profile_mapping(
+                    synthetic_actuation_raw,
+                    "variability_distribution",
+                ),
+                variability_sample=_optional_synthetic_actuation_profile_mapping(
+                    synthetic_actuation_raw,
+                    "variability_sample",
                 ),
             )
             if synthetic_actuation_raw is not None

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -442,9 +442,9 @@ def _optional_synthetic_actuation_profile_mapping(
     key: str,
 ) -> Mapping[str, Any] | None:
     """Return optional synthetic-actuation profile metadata with fail-closed typing."""
-    value = payload.get(key)
-    if value is None:
+    if key not in payload:
         return None
+    value = payload[key]
     if not isinstance(value, Mapping):
         raise TypeError(f"synthetic_actuation_profile.{key} must be a mapping when provided")
     return value

--- a/robot_sf/benchmark/map_runner_profile_metadata.py
+++ b/robot_sf/benchmark/map_runner_profile_metadata.py
@@ -15,9 +15,9 @@ from robot_sf.benchmark.synthetic_actuation import (
 
 def _optional_profile_mapping(payload: dict[str, Any], key: str) -> Mapping[str, Any] | None:
     """Return an optional nested profile metadata mapping, rejecting malformed values."""
-    value = payload.get(key)
-    if value is None:
+    if key not in payload:
         return None
+    value = payload[key]
     if not isinstance(value, Mapping):
         raise TypeError(f"synthetic_actuation_profile.{key} must be a mapping when provided")
     return value

--- a/robot_sf/benchmark/map_runner_profile_metadata.py
+++ b/robot_sf/benchmark/map_runner_profile_metadata.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from robot_sf.benchmark.latency_stress import LatencyStressProfile, load_latency_stress_profile
@@ -10,6 +11,16 @@ from robot_sf.benchmark.synthetic_actuation import (
     validate_actuation_profile_claim_boundary,
     validate_synthetic_actuation_profile,
 )
+
+
+def _optional_profile_mapping(payload: dict[str, Any], key: str) -> Mapping[str, Any] | None:
+    """Return an optional nested profile metadata mapping, rejecting malformed values."""
+    value = payload.get(key)
+    if value is None:
+        return None
+    if not isinstance(value, Mapping):
+        raise TypeError(f"synthetic_actuation_profile.{key} must be a mapping when provided")
+    return value
 
 
 def load_synthetic_actuation_profile(payload: Any) -> SyntheticActuationProfile | None:
@@ -40,6 +51,8 @@ def load_synthetic_actuation_profile(payload: Any) -> SyntheticActuationProfile 
         max_angular_accel_rad_s2=float(payload.get("max_angular_accel_rad_s2")),
         latency_mode=str(payload.get("latency_mode", "")),
         update_mode=str(payload.get("update_mode", "")),
+        variability_distribution=_optional_profile_mapping(payload, "variability_distribution"),
+        variability_sample=_optional_profile_mapping(payload, "variability_sample"),
     )
     validate_synthetic_actuation_profile(profile)
     return profile

--- a/robot_sf/benchmark/synthetic_actuation.py
+++ b/robot_sf/benchmark/synthetic_actuation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+import random
 import re
 from collections import deque
 from collections.abc import Mapping
@@ -11,6 +12,8 @@ from typing import Any
 
 SYNTHETIC_ACTUATION_CLAIM_SCOPE = "synthetic-only"
 SYNTHETIC_ACTUATION_CLAIM_BOUNDARY = "diagnostic-only"
+SYNTHETIC_ACTUATION_VARIABILITY_SCHEMA_VERSION = "synthetic-actuation-variability-distribution.v1"
+SYNTHETIC_ACTUATION_VARIABILITY_SAMPLE_SCHEMA_VERSION = "synthetic-actuation-variability-sample.v1"
 CALIBRATED_ACTUATION_REQUIRED_PROVENANCE_FIELDS = (
     "source_id",
     "source_uri",
@@ -33,6 +36,22 @@ _UPDATE_MODE_TO_STEPS = {
     "2.5hz-hold": 4,
 }
 _SATURATION_TOL = 1e-9
+_NUMERIC_VARIABILITY_FIELDS = (
+    "max_linear_accel_m_s2",
+    "max_linear_decel_m_s2",
+    "max_yaw_rate_rad_s",
+    "max_angular_accel_rad_s2",
+)
+_CATEGORICAL_VARIABILITY_FIELDS = ("latency_mode", "update_mode")
+_VARIABILITY_FIELDS = _NUMERIC_VARIABILITY_FIELDS + _CATEGORICAL_VARIABILITY_FIELDS
+_VARIABILITY_FIELD_UNITS = {
+    "max_linear_accel_m_s2": "m/s^2",
+    "max_linear_decel_m_s2": "m/s^2",
+    "max_yaw_rate_rad_s": "rad/s",
+    "max_angular_accel_rad_s2": "rad/s^2",
+    "latency_mode": "profile-label",
+    "update_mode": "profile-label",
+}
 
 
 @dataclass(frozen=True)
@@ -49,10 +68,12 @@ class SyntheticActuationProfile:
     profile_version: str = "v0"
     claim_scope: str = SYNTHETIC_ACTUATION_CLAIM_SCOPE
     claim_boundary: str = SYNTHETIC_ACTUATION_CLAIM_BOUNDARY
+    variability_distribution: Mapping[str, Any] | None = None
+    variability_sample: Mapping[str, Any] | None = None
 
     def to_metadata(self) -> dict[str, Any]:
         """Return a JSON-safe metadata payload."""
-        return {
+        payload = {
             "name": self.name,
             "profile_version": self.profile_version,
             "claim_scope": self.claim_scope,
@@ -64,6 +85,11 @@ class SyntheticActuationProfile:
             "latency_mode": self.latency_mode,
             "update_mode": self.update_mode,
         }
+        if self.variability_distribution is not None:
+            payload["variability_distribution"] = _json_safe_mapping(self.variability_distribution)
+        if self.variability_sample is not None:
+            payload["variability_sample"] = _json_safe_mapping(self.variability_sample)
+        return payload
 
 
 def known_latency_modes() -> tuple[str, ...]:
@@ -74,6 +100,29 @@ def known_latency_modes() -> tuple[str, ...]:
 def known_update_modes() -> tuple[str, ...]:
     """Return supported synthetic update-mode labels."""
     return tuple(_UPDATE_MODE_TO_STEPS)
+
+
+def actuation_variability_fields() -> tuple[str, ...]:
+    """Return profile fields that may be sampled by synthetic variability distributions."""
+    return _VARIABILITY_FIELDS
+
+
+def _json_safe_mapping(payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Return a JSON-safe copy of one metadata mapping."""
+    return {
+        str(key): _json_safe_value(value) for key, value in payload.items() if value is not None
+    }
+
+
+def _json_safe_value(value: Any) -> Any:
+    """Return a JSON-safe copy of nested metadata values."""
+    if isinstance(value, Mapping):
+        return _json_safe_mapping(value)
+    if isinstance(value, tuple):
+        return [_json_safe_value(item) for item in value]
+    if isinstance(value, list):
+        return [_json_safe_value(item) for item in value]
+    return value
 
 
 def _non_empty_string(value: Any) -> bool:
@@ -187,12 +236,265 @@ def _validate_mode(value: str, *, field_name: str, known: tuple[str, ...]) -> No
         )
 
 
+def _validate_variability_provenance(
+    provenance: Any,
+    *,
+    field_name: str,
+) -> Mapping[str, Any]:
+    """Validate the source-status metadata attached to one variability distribution.
+
+    Returns:
+        The original provenance mapping after validation.
+    """
+    if not isinstance(provenance, Mapping):
+        raise ValueError(
+            f"synthetic_actuation_profile.variability_distribution.parameters."
+            f"{field_name}.provenance must be a mapping"
+        )
+    required = ("source_status", "caveat", "units")
+    missing = [name for name in required if not _non_empty_string(provenance.get(name))]
+    expected_units = _VARIABILITY_FIELD_UNITS[field_name]
+    if _non_empty_string(provenance.get("units")) and str(provenance["units"]) != expected_units:
+        missing.append("units")
+    if missing:
+        raise ValueError(
+            f"synthetic_actuation_profile.variability_distribution.parameters.{field_name}"
+            f".provenance missing fields: {', '.join(sorted(set(missing)))}"
+        )
+    return provenance
+
+
+def _validate_numeric_variability_spec(field_name: str, spec: Mapping[str, Any]) -> None:
+    """Validate one numeric uniform distribution spec."""
+    if str(spec.get("distribution", "")).strip() != "uniform":
+        raise ValueError(
+            "Numeric synthetic actuation variability fields currently support only "
+            f"uniform distributions: {field_name}"
+        )
+    try:
+        low = float(spec.get("low"))
+        high = float(spec.get("high"))
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            "synthetic_actuation_profile.variability_distribution.parameters."
+            f"{field_name} requires numeric low/high bounds"
+        ) from exc
+    if not math.isfinite(low) or not math.isfinite(high) or low <= 0.0 or high < low:
+        raise ValueError(
+            "synthetic_actuation_profile.variability_distribution.parameters."
+            f"{field_name} requires finite 0 < low <= high"
+        )
+
+
+def _validate_categorical_variability_spec(field_name: str, spec: Mapping[str, Any]) -> None:
+    """Validate one categorical choice distribution spec."""
+    if str(spec.get("distribution", "")).strip() != "choice":
+        raise ValueError(
+            "Categorical synthetic actuation variability fields currently support only "
+            f"choice distributions: {field_name}"
+        )
+    choices = spec.get("choices")
+    if not isinstance(choices, list | tuple) or not choices:
+        raise ValueError(
+            "synthetic_actuation_profile.variability_distribution.parameters."
+            f"{field_name}.choices must be a non-empty sequence"
+        )
+    known = known_latency_modes() if field_name == "latency_mode" else known_update_modes()
+    for choice in choices:
+        _validate_mode(str(choice), field_name=field_name, known=known)
+
+
+def validate_synthetic_actuation_variability_distribution(
+    distribution: Mapping[str, Any],
+) -> None:
+    """Validate a synthetic/provisional distribution over actuation profile fields."""
+    if not isinstance(distribution, Mapping):
+        raise ValueError("synthetic_actuation_profile.variability_distribution must be a mapping")
+    if distribution.get("schema_version") != SYNTHETIC_ACTUATION_VARIABILITY_SCHEMA_VERSION:
+        raise ValueError(
+            "synthetic_actuation_profile.variability_distribution.schema_version must be "
+            f"'{SYNTHETIC_ACTUATION_VARIABILITY_SCHEMA_VERSION}'"
+        )
+    mode = str(distribution.get("mode", "")).strip()
+    if mode != "synthetic-provisional":
+        raise ValueError(
+            "synthetic_actuation_profile.variability_distribution.mode must be "
+            "'synthetic-provisional'"
+        )
+    claim_boundary = str(
+        distribution.get("claim_boundary", SYNTHETIC_ACTUATION_CLAIM_BOUNDARY)
+    ).strip()
+    if claim_boundary != SYNTHETIC_ACTUATION_CLAIM_BOUNDARY:
+        raise ValueError(
+            "synthetic_actuation_profile.variability_distribution.claim_boundary must be "
+            f"'{SYNTHETIC_ACTUATION_CLAIM_BOUNDARY}'"
+        )
+    parameters = distribution.get("parameters")
+    if not isinstance(parameters, Mapping) or not parameters:
+        raise ValueError(
+            "synthetic_actuation_profile.variability_distribution.parameters must be a "
+            "non-empty mapping"
+        )
+    for raw_field_name, raw_spec in parameters.items():
+        field_name = str(raw_field_name)
+        if field_name not in _VARIABILITY_FIELDS:
+            known = ", ".join(_VARIABILITY_FIELDS)
+            raise ValueError(
+                "Unsupported synthetic_actuation_profile.variability_distribution "
+                f"field '{field_name}'. Expected one of: {known}"
+            )
+        if not isinstance(raw_spec, Mapping):
+            raise ValueError(
+                "synthetic_actuation_profile.variability_distribution.parameters."
+                f"{field_name} must be a mapping"
+            )
+        _validate_variability_provenance(raw_spec.get("provenance"), field_name=field_name)
+        if field_name in _NUMERIC_VARIABILITY_FIELDS:
+            _validate_numeric_variability_spec(field_name, raw_spec)
+        else:
+            _validate_categorical_variability_spec(field_name, raw_spec)
+
+
+def _profile_field_value(profile: SyntheticActuationProfile, field_name: str) -> Any:
+    """Return one supported field value from a synthetic actuation profile."""
+    return getattr(profile, field_name)
+
+
+def _sample_distribution_value(
+    field_name: str,
+    spec: Mapping[str, Any],
+    *,
+    rng: random.Random,
+) -> Any:
+    """Sample one concrete profile value from a validated field distribution.
+
+    Returns:
+        A sampled numeric or categorical profile value.
+    """
+    if field_name in _NUMERIC_VARIABILITY_FIELDS:
+        return float(rng.uniform(float(spec["low"]), float(spec["high"])))
+    choices = [str(choice) for choice in spec["choices"]]
+    return choices[rng.randrange(len(choices))]
+
+
+def sample_synthetic_actuation_profile(
+    base_profile: SyntheticActuationProfile,
+    distribution: Mapping[str, Any],
+    *,
+    seed: int,
+    sample_index: int,
+    name: str | None = None,
+) -> SyntheticActuationProfile:
+    """Materialize one deterministic synthetic variability sample as scalar profile values.
+
+    Returns:
+        A validated scalar synthetic actuation profile carrying sample metadata.
+    """
+    validate_synthetic_actuation_profile(base_profile)
+    validate_synthetic_actuation_variability_distribution(distribution)
+    if sample_index < 0:
+        raise ValueError("sample_index must be >= 0")
+
+    parameters = distribution["parameters"]
+    rng = random.Random(int(seed) + sample_index * 1_000_003)
+    sampled_values: dict[str, Any] = {}
+    for field_name, raw_spec in sorted(parameters.items()):
+        spec = raw_spec if isinstance(raw_spec, Mapping) else {}
+        sampled_values[str(field_name)] = _sample_distribution_value(str(field_name), spec, rng=rng)
+
+    sample_payload = {
+        "schema_version": SYNTHETIC_ACTUATION_VARIABILITY_SAMPLE_SCHEMA_VERSION,
+        "mode": "variability-sweep",
+        "sample_index": int(sample_index),
+        "sample_id": f"sample-{sample_index:03d}",
+        "sampling_seed": int(seed),
+        "sampled_parameters": _json_safe_mapping(sampled_values),
+        "summary": {
+            field_name: {
+                "value": _json_safe_value(value),
+                "units": _VARIABILITY_FIELD_UNITS[field_name],
+            }
+            for field_name, value in sampled_values.items()
+        },
+    }
+
+    values = {
+        field_name: _profile_field_value(base_profile, field_name)
+        for field_name in _VARIABILITY_FIELDS
+    }
+    values.update(sampled_values)
+    return SyntheticActuationProfile(
+        name=name or f"{base_profile.name}-{sample_payload['sample_id']}",
+        profile_version=base_profile.profile_version,
+        claim_scope=base_profile.claim_scope,
+        claim_boundary=base_profile.claim_boundary,
+        max_linear_accel_m_s2=float(values["max_linear_accel_m_s2"]),
+        max_linear_decel_m_s2=float(values["max_linear_decel_m_s2"]),
+        max_yaw_rate_rad_s=float(values["max_yaw_rate_rad_s"]),
+        max_angular_accel_rad_s2=float(values["max_angular_accel_rad_s2"]),
+        latency_mode=str(values["latency_mode"]),
+        update_mode=str(values["update_mode"]),
+        variability_distribution=distribution,
+        variability_sample=sample_payload,
+    )
+
+
+def summarize_synthetic_actuation_samples(
+    profiles: list[SyntheticActuationProfile],
+) -> dict[str, Any]:
+    """Summarize sampled actuation parameters for materialized variability sweeps.
+
+    Returns:
+        JSON-safe sampled-parameter summary rows.
+    """
+    rows: list[dict[str, Any]] = []
+    for profile in profiles:
+        metadata = profile.to_metadata()
+        sample = metadata.get("variability_sample")
+        if not isinstance(sample, Mapping):
+            continue
+        row = {
+            "profile_name": profile.name,
+            "sample_id": str(sample.get("sample_id", "")),
+            "sample_index": int(sample.get("sample_index", -1)),
+            "sampling_seed": int(sample.get("sampling_seed", 0)),
+            "sampled_parameters": dict(sample.get("sampled_parameters", {})),
+            "summary": dict(sample.get("summary", {})),
+            "claim_boundary": profile.claim_boundary,
+        }
+        rows.append(row)
+    return {
+        "schema_version": "synthetic-actuation-sampled-parameter-summary.v1",
+        "claim_boundary": SYNTHETIC_ACTUATION_CLAIM_BOUNDARY,
+        "row_count": len(rows),
+        "rows": rows,
+    }
+
+
+def _validate_variability_sample(sample: Any) -> None:
+    """Validate optional sampled-parameter metadata on a synthetic profile."""
+    if not isinstance(sample, Mapping):
+        raise ValueError("synthetic_actuation_profile.variability_sample must be a mapping")
+    if sample.get("schema_version") != SYNTHETIC_ACTUATION_VARIABILITY_SAMPLE_SCHEMA_VERSION:
+        raise ValueError(
+            "synthetic_actuation_profile.variability_sample.schema_version must be "
+            f"'{SYNTHETIC_ACTUATION_VARIABILITY_SAMPLE_SCHEMA_VERSION}'"
+        )
+
+
 def validate_synthetic_actuation_profile(profile: SyntheticActuationProfile) -> None:
     """Validate that one synthetic profile is usable for differential-drive diagnostics."""
     if not profile.name.strip():
         raise ValueError("synthetic_actuation_profile.name must be non-empty")
     if not profile.profile_version.strip():
         raise ValueError("synthetic_actuation_profile.profile_version must be non-empty")
+    if profile.variability_distribution is not None and not isinstance(
+        profile.variability_distribution, Mapping
+    ):
+        raise ValueError("synthetic_actuation_profile.variability_distribution must be a mapping")
+    sample = profile.variability_sample
+    if sample is not None and not isinstance(sample, Mapping):
+        raise ValueError("synthetic_actuation_profile.variability_sample must be a mapping")
     profile_metadata = profile.to_metadata()
     if _looks_calibrated_actuation_profile(profile_metadata):
         _validate_calibrated_actuation_provenance(
@@ -219,6 +521,10 @@ def validate_synthetic_actuation_profile(profile: SyntheticActuationProfile) -> 
         field_name="update_mode",
         known=known_update_modes(),
     )
+    if profile.variability_distribution is not None:
+        validate_synthetic_actuation_variability_distribution(profile.variability_distribution)
+    if sample is not None:
+        _validate_variability_sample(sample)
 
 
 @dataclass(frozen=True)

--- a/scripts/tools/run_amv_actuation_sensitivity_sweep.py
+++ b/scripts/tools/run_amv_actuation_sensitivity_sweep.py
@@ -31,9 +31,19 @@ from robot_sf.benchmark.camera_ready_campaign import (
     prepare_campaign_preflight,
     run_campaign,
 )
-from robot_sf.benchmark.synthetic_actuation import known_latency_modes, known_update_modes
+from robot_sf.benchmark.synthetic_actuation import (
+    SYNTHETIC_ACTUATION_CLAIM_BOUNDARY,
+    SyntheticActuationProfile,
+    known_latency_modes,
+    known_update_modes,
+    sample_synthetic_actuation_profile,
+    summarize_synthetic_actuation_samples,
+    validate_synthetic_actuation_profile,
+    validate_synthetic_actuation_variability_distribution,
+)
 
 _SCHEMA_VERSION = "robot-sf-amv-actuation-sensitivity-results.v1"
+_SAMPLING_MODES = ("fixed-variants", "variability-sweep", "all")
 _METRICS = (
     "success",
     "collisions",
@@ -75,6 +85,21 @@ def _build_parser() -> argparse.ArgumentParser:
         choices=("materialize", "preflight", "pilot", "aggregate"),
         default="materialize",
         help="Materialize configs, run preflight, run the pilot matrix, or aggregate existing runs.",
+    )
+    parser.add_argument(
+        "--sampling-mode",
+        choices=_SAMPLING_MODES,
+        default=None,
+        help=(
+            "Actuation profile materialization mode. Defaults to the manifest "
+            "variability_sampling.default_mode, which remains fixed-variants."
+        ),
+    )
+    parser.add_argument(
+        "--sampling-seed",
+        type=int,
+        default=None,
+        help="Override the manifest seed for deterministic variability-sweep sampling.",
     )
     parser.add_argument(
         "--campaign-root",
@@ -144,12 +169,93 @@ def _write_yaml(path: Path, payload: Mapping[str, Any]) -> None:
     path.write_text(yaml.safe_dump(dict(payload), sort_keys=False), encoding="utf-8")
 
 
+def _sampling_settings(manifest: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return optional variability sampling settings from the manifest."""
+    settings = manifest.get("variability_sampling")
+    if settings is None:
+        return {}
+    if not isinstance(settings, Mapping):
+        raise TypeError("variability_sampling must be a mapping when provided")
+    return settings
+
+
+def _resolve_sampling_mode(
+    manifest: Mapping[str, Any],
+    sampling_mode: str | None,
+) -> str:
+    """Resolve the requested actuation materialization mode."""
+    settings = _sampling_settings(manifest)
+    mode = str(sampling_mode or settings.get("default_mode", "fixed-variants")).strip()
+    if mode not in _SAMPLING_MODES:
+        raise ValueError(
+            f"Unsupported sampling mode '{mode}'. Expected one of: {', '.join(_SAMPLING_MODES)}"
+        )
+    return mode
+
+
+def _resolve_sampling_seed(
+    manifest: Mapping[str, Any],
+    sampling_seed: int | None,
+) -> int:
+    """Resolve the deterministic variability sampling seed."""
+    if sampling_seed is not None:
+        return int(sampling_seed)
+    settings = _sampling_settings(manifest)
+    return int(settings.get("seed", 3284))
+
+
+def _resolve_sample_count(manifest: Mapping[str, Any]) -> int:
+    """Resolve the number of variability samples to materialize."""
+    settings = _sampling_settings(manifest)
+    sample_count = int(settings.get("sample_count", 3))
+    if sample_count <= 0:
+        raise ValueError("variability_sampling.sample_count must be > 0")
+    return sample_count
+
+
+def _variability_distribution(manifest: Mapping[str, Any]) -> Mapping[str, Any] | None:
+    """Return validated variability distribution metadata when the manifest declares it."""
+    distribution = manifest.get("variability_distribution")
+    if distribution is None:
+        return None
+    if not isinstance(distribution, Mapping):
+        raise TypeError("variability_distribution must be a mapping when provided")
+    validate_synthetic_actuation_variability_distribution(distribution)
+    return distribution
+
+
+def _base_synthetic_profile(manifest: Mapping[str, Any]) -> SyntheticActuationProfile:
+    """Return the manifest baseline profile as a validated typed profile."""
+    baseline = manifest.get("baseline_profile")
+    if not isinstance(baseline, Mapping):
+        raise ValueError("Sweep manifest baseline_profile must be a mapping")
+    profile = SyntheticActuationProfile(
+        name=f"{manifest['name']}_baseline",
+        profile_version="v0",
+        claim_scope="synthetic-only",
+        claim_boundary=SYNTHETIC_ACTUATION_CLAIM_BOUNDARY,
+        max_linear_accel_m_s2=float(baseline["max_linear_accel_m_s2"]),
+        max_linear_decel_m_s2=float(baseline["max_linear_decel_m_s2"]),
+        max_yaw_rate_rad_s=float(baseline["max_yaw_rate_rad_s"]),
+        max_angular_accel_rad_s2=float(baseline["max_angular_accel_rad_s2"]),
+        latency_mode=str(baseline["latency_mode"]),
+        update_mode=str(baseline["update_mode"]),
+    )
+    validate_synthetic_actuation_profile(profile)
+    return profile
+
+
 def _validate_manifest(manifest: Mapping[str, Any]) -> None:  # noqa: C901
     """Validate the sweep manifest before materializing configs."""
     if manifest.get("schema_version") != "robot-sf-amv-actuation-sensitivity-sweep.v1":
         raise ValueError("Unsupported sweep manifest schema_version")
     if str(manifest.get("claim_boundary", "")).strip() != "diagnostic-only":
         raise ValueError("Sweep claim_boundary must stay diagnostic-only")
+    _base_synthetic_profile(manifest)
+    _resolve_sampling_mode(manifest, None)
+    _resolve_sample_count(manifest)
+    _resolve_sampling_seed(manifest, None)
+    _variability_distribution(manifest)
     variants = manifest.get("variants")
     if not isinstance(variants, list) or not variants:
         raise ValueError("Sweep manifest must define non-empty variants")
@@ -205,6 +311,9 @@ def _materialize_variant_config(  # noqa: C901
     if not isinstance(profile_patch, dict):
         raise TypeError("Sweep variant profile must be a mapping")
     baseline.update(profile_patch)
+    distribution = _variability_distribution(manifest)
+    if distribution is not None and "variability_distribution" not in baseline:
+        baseline["variability_distribution"] = deepcopy(dict(distribution))
 
     update_mode = str(baseline.get("update_mode", "")).strip()
     latency_mode = str(baseline.get("latency_mode", "")).strip()
@@ -235,6 +344,11 @@ def _materialize_variant_config(  # noqa: C901
         "latency_mode": latency_mode,
         "update_mode": update_mode,
     }
+    for metadata_key in ("variability_distribution", "variability_sample"):
+        if isinstance(baseline.get(metadata_key), Mapping):
+            payload["synthetic_actuation_profile"][metadata_key] = deepcopy(
+                dict(baseline[metadata_key])
+            )
 
     latency_steps = _LATENCY_MODE_TO_STEPS[latency_mode]
     update_mode_label, update_period = _UPDATE_MODE_TO_PERIOD[update_mode]
@@ -294,24 +408,231 @@ def _materialize_variant_config(  # noqa: C901
         "supported_fields": list(variant.get("supported_fields") or []),
         "source_context": str(variant.get("source_context", "")),
         "caveat": str(variant.get("caveat", "")),
+        "sampling_mode": str(variant.get("sampling_mode", "fixed-variants")),
     }
+    for metadata_key in ("sample_id", "sample_index", "sampling_seed", "sampled_parameters"):
+        if metadata_key in variant:
+            payload["issue_2011_sweep_variant"][metadata_key] = deepcopy(variant[metadata_key])
     return payload
+
+
+def _entry_from_variant(
+    *,
+    variant: Mapping[str, Any],
+    config_path: Path,
+    root: Path,
+) -> dict[str, Any]:
+    """Return one resolved manifest entry for a materialized config."""
+    entry = {
+        "variant_name": str(variant["name"]),
+        "field_group": str(variant["field_group"]),
+        "level": str(variant["level"]),
+        "source_status": str(variant["source_status"]),
+        "config_path": _repo_relative(config_path, root=root),
+        "config_sha256": _sha256_file(config_path),
+        "supported_fields": list(variant.get("supported_fields") or []),
+        "source_context": str(variant.get("source_context", "")),
+        "caveat": str(variant.get("caveat", "")),
+        "sampling_mode": str(variant.get("sampling_mode", "fixed-variants")),
+    }
+    for key in ("sample_id", "sample_index", "sampling_seed", "sampled_parameters"):
+        if key in variant:
+            entry[key] = deepcopy(variant[key])
+    return entry
+
+
+def _sample_variants(
+    *,
+    manifest: Mapping[str, Any],
+    seed: int,
+) -> tuple[list[dict[str, Any]], list[SyntheticActuationProfile]]:
+    """Return deterministic sampled-variability pseudo-variants and profiles."""
+    distribution = _variability_distribution(manifest)
+    if distribution is None:
+        raise ValueError("variability-sweep mode requires manifest variability_distribution")
+    sample_count = _resolve_sample_count(manifest)
+    base_profile = _base_synthetic_profile(manifest)
+    settings = _sampling_settings(manifest)
+    source_context = str(
+        distribution.get("source_context")
+        or settings.get("source_context")
+        or "configs/benchmarks/issue_2011_amv_actuation_sensitivity_sweep_v0.yaml"
+    )
+    caveat = str(
+        settings.get("caveat")
+        or "Synthetic/provisional variability samples are diagnostic-only and not "
+        "hardware-calibrated AMV evidence."
+    )
+    parameters = distribution.get("parameters")
+    if not isinstance(parameters, Mapping):
+        raise ValueError("variability_distribution.parameters must be a mapping")
+
+    variants: list[dict[str, Any]] = []
+    profiles: list[SyntheticActuationProfile] = []
+    for sample_index in range(sample_count):
+        variant_name = f"variability_sample_{sample_index:03d}"
+        profile = sample_synthetic_actuation_profile(
+            base_profile,
+            distribution,
+            seed=seed,
+            sample_index=sample_index,
+            name=variant_name,
+        )
+        metadata = profile.to_metadata()
+        sample = metadata.get("variability_sample")
+        sampled_parameters = (
+            dict(sample.get("sampled_parameters", {})) if isinstance(sample, Mapping) else {}
+        )
+        variants.append(
+            {
+                "name": variant_name,
+                "field_group": "variability_sample",
+                "level": f"sample-{sample_index:03d}",
+                "source_status": "synthetic_provisional_distribution",
+                "supported_fields": list(parameters),
+                "source_context": source_context,
+                "caveat": caveat,
+                "profile": metadata,
+                "sampling_mode": "variability-sweep",
+                "sample_id": f"sample-{sample_index:03d}",
+                "sample_index": sample_index,
+                "sampling_seed": seed,
+                "sampled_parameters": sampled_parameters,
+            }
+        )
+        profiles.append(profile)
+    return variants, profiles
+
+
+def _sample_summary_from_entries(entries: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Return a compact sampled-parameter summary from resolved manifest entries."""
+    rows = []
+    for entry in entries:
+        if str(entry.get("sampling_mode", "")) != "variability-sweep":
+            continue
+        rows.append(
+            {
+                "profile_name": str(entry.get("variant_name", "")),
+                "sample_id": str(entry.get("sample_id", "")),
+                "sample_index": int(entry.get("sample_index", -1)),
+                "sampling_seed": int(entry.get("sampling_seed", 0)),
+                "sampled_parameters": dict(entry.get("sampled_parameters", {})),
+                "claim_boundary": SYNTHETIC_ACTUATION_CLAIM_BOUNDARY,
+            }
+        )
+    return {
+        "schema_version": "synthetic-actuation-sampled-parameter-summary.v1",
+        "claim_boundary": SYNTHETIC_ACTUATION_CLAIM_BOUNDARY,
+        "row_count": len(rows),
+        "rows": rows,
+    }
+
+
+def _write_sampled_parameter_summary(
+    output_dir: Path,
+    summary: Mapping[str, Any],
+) -> None:
+    """Write JSON, CSV, and Markdown summaries for sampled variability parameters."""
+    rows = summary.get("rows")
+    if not isinstance(rows, list) or not rows:
+        return
+    reports_dir = output_dir / "reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    _write_json(reports_dir / "sampled_parameter_summary.json", summary)
+
+    field_names = sorted(
+        {
+            str(field_name)
+            for row in rows
+            if isinstance(row, Mapping)
+            for field_name in dict(row.get("sampled_parameters", {}))
+        }
+    )
+    csv_path = reports_dir / "sampled_parameter_summary.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "profile_name",
+                "sample_id",
+                "sample_index",
+                "sampling_seed",
+                "claim_boundary",
+                *field_names,
+            ],
+            lineterminator="\n",
+        )
+        writer.writeheader()
+        for row in rows:
+            if not isinstance(row, Mapping):
+                continue
+            sampled = dict(row.get("sampled_parameters", {}))
+            writer.writerow(
+                {
+                    "profile_name": str(row.get("profile_name", "")),
+                    "sample_id": str(row.get("sample_id", "")),
+                    "sample_index": int(row.get("sample_index", -1)),
+                    "sampling_seed": int(row.get("sampling_seed", 0)),
+                    "claim_boundary": str(row.get("claim_boundary", "")),
+                    **{field_name: sampled.get(field_name, "") for field_name in field_names},
+                }
+            )
+
+    lines = [
+        "# Issue #3284 Sampled Actuation Parameters",
+        "",
+        "diagnostic-only synthetic/provisional variability samples. These rows are not "
+        "hardware-calibrated AMV evidence.",
+        "",
+        "| Profile | Sample | Seed | Claim boundary | Sampled parameters |",
+        "| --- | --- | ---: | --- | --- |",
+    ]
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        sampled = json.dumps(dict(row.get("sampled_parameters", {})), sort_keys=True)
+        lines.append(
+            "| "
+            f"{row.get('profile_name')} | {row.get('sample_id')} | "
+            f"{row.get('sampling_seed')} | {row.get('claim_boundary')} | "
+            f"`{sampled}` |"
+        )
+    (reports_dir / "sampled_parameter_summary.md").write_text(
+        "\n".join(lines) + "\n",
+        encoding="utf-8",
+    )
 
 
 def materialize_configs(
     *,
     manifest_path: Path,
     output_dir: Path,
+    sampling_mode: str | None = None,
+    sampling_seed: int | None = None,
 ) -> tuple[dict[str, Any], list[dict[str, Any]]]:
     """Write generated camera-ready configs and return the resolved manifest/index."""
     root = _repo_root()
     manifest = _load_yaml(manifest_path)
     _validate_manifest(manifest)
+    resolved_sampling_mode = _resolve_sampling_mode(manifest, sampling_mode)
+    resolved_sampling_seed = _resolve_sampling_seed(manifest, sampling_seed)
     base_config_path = root / str(manifest["base_config"])
     base_payload = _load_yaml(base_config_path)
     configs_dir = output_dir / "generated_configs"
     entries: list[dict[str, Any]] = []
-    for variant in manifest["variants"]:
+
+    materialized_variants: list[dict[str, Any]] = []
+    if resolved_sampling_mode in {"fixed-variants", "all"}:
+        materialized_variants.extend(dict(variant) for variant in manifest["variants"])
+    sampled_profiles: list[SyntheticActuationProfile] = []
+    if resolved_sampling_mode in {"variability-sweep", "all"}:
+        sample_variants, sampled_profiles = _sample_variants(
+            manifest=manifest,
+            seed=resolved_sampling_seed,
+        )
+        materialized_variants.extend(sample_variants)
+
+    for variant in materialized_variants:
         config_payload = _materialize_variant_config(
             manifest=manifest,
             base_payload=base_payload,
@@ -319,19 +640,13 @@ def materialize_configs(
         )
         config_path = configs_dir / f"{variant['name']}.yaml"
         _write_yaml(config_path, config_payload)
-        entries.append(
-            {
-                "variant_name": str(variant["name"]),
-                "field_group": str(variant["field_group"]),
-                "level": str(variant["level"]),
-                "source_status": str(variant["source_status"]),
-                "config_path": _repo_relative(config_path, root=root),
-                "config_sha256": _sha256_file(config_path),
-                "supported_fields": list(variant.get("supported_fields") or []),
-                "source_context": str(variant.get("source_context", "")),
-                "caveat": str(variant.get("caveat", "")),
-            }
-        )
+        entries.append(_entry_from_variant(variant=variant, config_path=config_path, root=root))
+
+    sampled_parameter_summary = summarize_synthetic_actuation_samples(sampled_profiles)
+    if not sampled_parameter_summary["rows"]:
+        sampled_parameter_summary = _sample_summary_from_entries(entries)
+    _write_sampled_parameter_summary(output_dir, sampled_parameter_summary)
+
     resolved = {
         "schema_version": _SCHEMA_VERSION,
         "name": str(manifest["name"]),
@@ -342,6 +657,17 @@ def materialize_configs(
         "claim_boundary": "diagnostic-only",
         "paper_facing": False,
         "pilot": manifest["pilot"],
+        "variability_sampling": {
+            "mode": resolved_sampling_mode,
+            "seed": resolved_sampling_seed,
+            "sample_count": _resolve_sample_count(manifest),
+        },
+        "variability_distribution": (
+            deepcopy(dict(_variability_distribution(manifest)))
+            if _variability_distribution(manifest) is not None
+            else None
+        ),
+        "sampled_parameter_summary": sampled_parameter_summary,
         "variants": entries,
     }
     _write_json(output_dir / "resolved_sweep_manifest.json", resolved)
@@ -516,7 +842,7 @@ def _format_optional_float(value: float | None) -> str:
     return "nan" if value is None else f"{value:.6f}"
 
 
-def aggregate_campaigns(  # noqa: C901, PLR0912
+def aggregate_campaigns(  # noqa: C901, PLR0912, PLR0915
     *,
     output_dir: Path,
     entries: Sequence[Mapping[str, Any]],
@@ -592,6 +918,8 @@ def aggregate_campaigns(  # noqa: C901, PLR0912
             "variant_name": variant_name,
             "level": str(entry["level"]),
             "source_status": str(entry["source_status"]),
+            "sampling_mode": str(entry.get("sampling_mode", "fixed-variants")),
+            "sample_id": str(entry.get("sample_id", "")),
             **campaign_status_by_variant.get(
                 variant_name,
                 {
@@ -605,6 +933,9 @@ def aggregate_campaigns(  # noqa: C901, PLR0912
             "scenario_family": scenario_family,
             "episodes": int(bucket["episodes"]),
         }
+        sampled_parameters = dict(entry.get("sampled_parameters", {}))
+        if sampled_parameters:
+            row["sampled_parameters"] = json.dumps(sampled_parameters, sort_keys=True)
         for metric in _METRICS:
             mean = _mean(bucket[metric])
             base_mean = baseline.get(metric)
@@ -634,6 +965,7 @@ def aggregate_campaigns(  # noqa: C901, PLR0912
         {
             "schema_version": _SCHEMA_VERSION,
             "claim_boundary": "diagnostic-only",
+            "sampled_parameter_summary": _sample_summary_from_entries(entries),
             "rows": rows,
         },
     )
@@ -649,6 +981,8 @@ def _write_effect_markdown(path: Path, rows: Sequence[Mapping[str, Any]]) -> Non
         "",
         "diagnostic-only pilot summary. Longitudinal rows use platform-class proxy values; "
         "yaw, latency, and update-rate rows remain synthetic stress factors.",
+        "Variability-sweep rows, when present, are synthetic/provisional samples and not "
+        "hardware-calibrated AMV evidence.",
         "",
         "| Field group | Level | Campaign status | Benchmark success | Planner | Scenario family | Episodes | Success delta | Collision delta | Near-miss delta |",
         "| --- | --- | --- | --- | --- | --- | ---: | ---: | ---: | ---: |",
@@ -725,7 +1059,12 @@ def main(argv: Sequence[str] | None = None) -> int:
     logger.remove()
     logger.add(sys.stderr, level=args.log_level)
     args.output.mkdir(parents=True, exist_ok=True)
-    manifest, entries = materialize_configs(manifest_path=args.manifest, output_dir=args.output)
+    manifest, entries = materialize_configs(
+        manifest_path=args.manifest,
+        output_dir=args.output,
+        sampling_mode=args.sampling_mode,
+        sampling_seed=args.sampling_seed,
+    )
     source_manifest = _load_yaml(args.manifest)
     if args.mode == "preflight":
         run_preflights(

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -267,53 +267,52 @@ def test_load_campaign_config_preserves_synthetic_actuation_variability_metadata
 ) -> None:
     """Synthetic actuation variability metadata should survive typed config loading."""
     config_path = tmp_path / "campaign.yaml"
-    config_path.write_text(
-        yaml.safe_dump(
-            {
-                "name": "sampled_actuation_profile",
-                "paper_facing": False,
-                "scenario_matrix": "configs/scenarios/single/francis2023_blind_corner.yaml",
-                "kinematics_matrix": ["differential_drive"],
-                "synthetic_actuation_profile": {
-                    "name": "variability_sample_000",
-                    "profile_version": "v0",
-                    "claim_scope": "synthetic-only",
-                    "claim_boundary": "diagnostic-only",
-                    "max_linear_accel_m_s2": 3.0,
-                    "max_linear_decel_m_s2": 3.4,
-                    "max_yaw_rate_rad_s": 1.0,
-                    "max_angular_accel_rad_s2": 3.0,
-                    "latency_mode": "one-step-delay",
-                    "update_mode": "5hz-hold",
-                    "variability_distribution": {
-                        "schema_version": "synthetic-actuation-variability-distribution.v1",
-                        "mode": "synthetic-provisional",
-                        "claim_boundary": "diagnostic-only",
-                        "parameters": {
-                            "max_linear_accel_m_s2": {
-                                "distribution": "uniform",
-                                "low": 2.5,
-                                "high": 4.5,
-                                "provenance": {
-                                    "units": "m/s^2",
-                                    "source_status": "synthetic_stress_factor",
-                                    "caveat": "test-only provisional range",
-                                },
-                            }
+    config_payload = {
+        "name": "sampled_actuation_profile",
+        "paper_facing": False,
+        "scenario_matrix": "configs/scenarios/single/francis2023_blind_corner.yaml",
+        "kinematics_matrix": ["differential_drive"],
+        "synthetic_actuation_profile": {
+            "name": "variability_sample_000",
+            "profile_version": "v0",
+            "claim_scope": "synthetic-only",
+            "claim_boundary": "diagnostic-only",
+            "max_linear_accel_m_s2": 3.0,
+            "max_linear_decel_m_s2": 3.4,
+            "max_yaw_rate_rad_s": 1.0,
+            "max_angular_accel_rad_s2": 3.0,
+            "latency_mode": "one-step-delay",
+            "update_mode": "5hz-hold",
+            "variability_distribution": {
+                "schema_version": "synthetic-actuation-variability-distribution.v1",
+                "mode": "synthetic-provisional",
+                "claim_boundary": "diagnostic-only",
+                "parameters": {
+                    "max_linear_accel_m_s2": {
+                        "distribution": "uniform",
+                        "low": 2.5,
+                        "high": 4.5,
+                        "provenance": {
+                            "units": "m/s^2",
+                            "source_status": "synthetic_stress_factor",
+                            "caveat": "test-only provisional range",
                         },
-                    },
-                    "variability_sample": {
-                        "schema_version": "synthetic-actuation-variability-sample.v1",
-                        "mode": "variability-sweep",
-                        "sample_index": 0,
-                        "sample_id": "sample-000",
-                        "sampling_seed": 17,
-                        "sampled_parameters": {"max_linear_accel_m_s2": 3.0},
-                    },
+                    }
                 },
-                "planners": [{"key": "goal", "algo": "goal"}],
-            }
-        ),
+            },
+            "variability_sample": {
+                "schema_version": "synthetic-actuation-variability-sample.v1",
+                "mode": "variability-sweep",
+                "sample_index": 0,
+                "sample_id": "sample-000",
+                "sampling_seed": 17,
+                "sampled_parameters": {"max_linear_accel_m_s2": 3.0},
+            },
+        },
+        "planners": [{"key": "goal", "algo": "goal"}],
+    }
+    config_path.write_text(
+        yaml.safe_dump(config_payload),
         encoding="utf-8",
     )
 
@@ -323,6 +322,15 @@ def test_load_campaign_config_preserves_synthetic_actuation_variability_metadata
     metadata = cfg.synthetic_actuation_profile.to_metadata()
     assert metadata["variability_distribution"]["parameters"]["max_linear_accel_m_s2"]["low"] == 2.5
     assert metadata["variability_sample"]["sample_id"] == "sample-000"
+
+    bad_config_path = tmp_path / "campaign_null_sample.yaml"
+    bad_config_payload = dict(config_payload)
+    bad_profile_payload = dict(bad_config_payload["synthetic_actuation_profile"])
+    bad_profile_payload["variability_sample"] = None
+    bad_config_payload["synthetic_actuation_profile"] = bad_profile_payload
+    bad_config_path.write_text(yaml.safe_dump(bad_config_payload), encoding="utf-8")
+    with pytest.raises(TypeError, match="variability_sample must be a mapping"):
+        load_campaign_config(bad_config_path)
 
 
 def test_synthetic_actuation_variability_distribution_rejects_missing_provenance() -> None:
@@ -420,7 +428,7 @@ def test_synthetic_actuation_variability_sampling_is_seeded_and_summarized() -> 
 
     with pytest.raises(ValueError, match="sample_index must be >= 0"):
         sample_synthetic_actuation_profile(base_profile, distribution, seed=17, sample_index=-1)
-    with pytest.raises(ValueError, match="variability_sample.schema_version"):
+    with pytest.raises(ValueError, match=r"variability_sample\.schema_version"):
         validate_synthetic_actuation_profile(replace(base_profile, variability_sample={}))
     with pytest.raises(ValueError, match="variability_distribution must be a mapping"):
         validate_synthetic_actuation_profile(
@@ -483,6 +491,8 @@ def test_map_runner_profile_loader_preserves_variability_metadata() -> None:
         load_synthetic_actuation_profile({**payload, "claim_scope": "paper-facing"})
     with pytest.raises(TypeError, match="variability_sample must be a mapping"):
         load_synthetic_actuation_profile({**payload, "variability_sample": []})
+    with pytest.raises(TypeError, match="variability_sample must be a mapping"):
+        load_synthetic_actuation_profile({**payload, "variability_sample": None})
 
 
 def test_load_campaign_config_rejects_malformed_latency_stress_profile(

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -40,12 +40,17 @@ from robot_sf.benchmark.camera_ready_campaign import (
     run_campaign,
     write_campaign_report,
 )
+from robot_sf.benchmark.map_runner_profile_metadata import load_synthetic_actuation_profile
 from robot_sf.benchmark.orca_preflight import OrcaRvo2PreflightError
 from robot_sf.benchmark.synthetic_actuation import (
     CALIBRATED_ACTUATION_REQUIRED_PROVENANCE_FIELDS,
     SyntheticActuationProfile,
+    actuation_variability_fields,
+    sample_synthetic_actuation_profile,
+    summarize_synthetic_actuation_samples,
     validate_actuation_profile_claim_boundary,
     validate_synthetic_actuation_profile,
+    validate_synthetic_actuation_variability_distribution,
 )
 from robot_sf.common.artifact_paths import get_repository_root
 
@@ -255,6 +260,229 @@ def test_load_campaign_config_rejects_malformed_synthetic_actuation_profile(
 
     with pytest.raises(TypeError, match="synthetic_actuation_profile must be a mapping"):
         load_campaign_config(config_path)
+
+
+def test_load_campaign_config_preserves_synthetic_actuation_variability_metadata(
+    tmp_path: Path,
+) -> None:
+    """Synthetic actuation variability metadata should survive typed config loading."""
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "name": "sampled_actuation_profile",
+                "paper_facing": False,
+                "scenario_matrix": "configs/scenarios/single/francis2023_blind_corner.yaml",
+                "kinematics_matrix": ["differential_drive"],
+                "synthetic_actuation_profile": {
+                    "name": "variability_sample_000",
+                    "profile_version": "v0",
+                    "claim_scope": "synthetic-only",
+                    "claim_boundary": "diagnostic-only",
+                    "max_linear_accel_m_s2": 3.0,
+                    "max_linear_decel_m_s2": 3.4,
+                    "max_yaw_rate_rad_s": 1.0,
+                    "max_angular_accel_rad_s2": 3.0,
+                    "latency_mode": "one-step-delay",
+                    "update_mode": "5hz-hold",
+                    "variability_distribution": {
+                        "schema_version": "synthetic-actuation-variability-distribution.v1",
+                        "mode": "synthetic-provisional",
+                        "claim_boundary": "diagnostic-only",
+                        "parameters": {
+                            "max_linear_accel_m_s2": {
+                                "distribution": "uniform",
+                                "low": 2.5,
+                                "high": 4.5,
+                                "provenance": {
+                                    "units": "m/s^2",
+                                    "source_status": "synthetic_stress_factor",
+                                    "caveat": "test-only provisional range",
+                                },
+                            }
+                        },
+                    },
+                    "variability_sample": {
+                        "schema_version": "synthetic-actuation-variability-sample.v1",
+                        "mode": "variability-sweep",
+                        "sample_index": 0,
+                        "sample_id": "sample-000",
+                        "sampling_seed": 17,
+                        "sampled_parameters": {"max_linear_accel_m_s2": 3.0},
+                    },
+                },
+                "planners": [{"key": "goal", "algo": "goal"}],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    cfg = load_campaign_config(config_path)
+
+    assert cfg.synthetic_actuation_profile is not None
+    metadata = cfg.synthetic_actuation_profile.to_metadata()
+    assert metadata["variability_distribution"]["parameters"]["max_linear_accel_m_s2"]["low"] == 2.5
+    assert metadata["variability_sample"]["sample_id"] == "sample-000"
+
+
+def test_synthetic_actuation_variability_distribution_rejects_missing_provenance() -> None:
+    """Synthetic variability distributions should fail closed without source caveats."""
+    with pytest.raises(ValueError, match="provenance missing fields"):
+        validate_synthetic_actuation_variability_distribution(
+            {
+                "schema_version": "synthetic-actuation-variability-distribution.v1",
+                "mode": "synthetic-provisional",
+                "claim_boundary": "diagnostic-only",
+                "parameters": {
+                    "max_linear_accel_m_s2": {
+                        "distribution": "uniform",
+                        "low": 2.5,
+                        "high": 4.5,
+                        "provenance": {"units": "m/s^2"},
+                    }
+                },
+            }
+        )
+
+
+def test_synthetic_actuation_variability_sampling_is_seeded_and_summarized() -> None:
+    """Seeded distribution sampling should materialize reproducible scalar profiles."""
+    base_profile = SyntheticActuationProfile(
+        name="amv-actuation-baseline",
+        profile_version="v0",
+        claim_scope="synthetic-only",
+        claim_boundary="diagnostic-only",
+        max_linear_accel_m_s2=3.0,
+        max_linear_decel_m_s2=3.4,
+        max_yaw_rate_rad_s=1.0,
+        max_angular_accel_rad_s2=3.0,
+        latency_mode="one-step-delay",
+        update_mode="5hz-hold",
+    )
+    distribution = {
+        "schema_version": "synthetic-actuation-variability-distribution.v1",
+        "mode": "synthetic-provisional",
+        "claim_boundary": "diagnostic-only",
+        "parameters": {
+            "max_linear_accel_m_s2": {
+                "distribution": "uniform",
+                "low": 2.5,
+                "high": 4.5,
+                "provenance": {
+                    "units": "m/s^2",
+                    "source_status": "synthetic_stress_factor",
+                    "caveat": "test-only provisional range",
+                },
+            },
+            "update_mode": {
+                "distribution": "choice",
+                "choices": ["2.5hz-hold", "5hz-hold"],
+                "provenance": {
+                    "units": "profile-label",
+                    "source_status": "synthetic_stress_factor",
+                    "caveat": "test-only provisional choices",
+                },
+            },
+        },
+    }
+
+    assert "max_linear_accel_m_s2" in actuation_variability_fields()
+    first = sample_synthetic_actuation_profile(base_profile, distribution, seed=17, sample_index=0)
+    repeated = sample_synthetic_actuation_profile(
+        base_profile,
+        distribution,
+        seed=17,
+        sample_index=0,
+    )
+
+    assert first.to_metadata() == repeated.to_metadata()
+    assert 2.5 <= first.max_linear_accel_m_s2 <= 4.5
+    assert first.update_mode in {"2.5hz-hold", "5hz-hold"}
+    assert first.variability_sample is not None
+    assert first.variability_sample["sample_id"] == "sample-000"
+
+    summary = summarize_synthetic_actuation_samples([base_profile, first])
+    assert summary["row_count"] == 1
+    assert summary["rows"][0]["sampled_parameters"]["max_linear_accel_m_s2"] == pytest.approx(
+        first.max_linear_accel_m_s2
+    )
+
+    tuple_metadata = replace(
+        base_profile,
+        variability_sample={
+            "schema_version": "synthetic-actuation-variability-sample.v1",
+            "tuple_value": ("a", "b"),
+            "list_value": [1, None],
+        },
+    ).to_metadata()
+    assert tuple_metadata["variability_sample"]["tuple_value"] == ["a", "b"]
+    assert tuple_metadata["variability_sample"]["list_value"] == [1, None]
+
+    with pytest.raises(ValueError, match="sample_index must be >= 0"):
+        sample_synthetic_actuation_profile(base_profile, distribution, seed=17, sample_index=-1)
+    with pytest.raises(ValueError, match="variability_sample.schema_version"):
+        validate_synthetic_actuation_profile(replace(base_profile, variability_sample={}))
+    with pytest.raises(ValueError, match="variability_distribution must be a mapping"):
+        validate_synthetic_actuation_profile(
+            replace(base_profile, variability_distribution=["not", "a", "mapping"])
+        )
+
+
+def test_map_runner_profile_loader_preserves_variability_metadata() -> None:
+    """Map-runner profile normalization should preserve sampled-profile metadata."""
+    payload = {
+        "name": "variability_sample_000",
+        "profile_version": "v0",
+        "claim_scope": "synthetic-only",
+        "claim_boundary": "diagnostic-only",
+        "max_linear_accel_m_s2": 3.0,
+        "max_linear_decel_m_s2": 3.4,
+        "max_yaw_rate_rad_s": 1.0,
+        "max_angular_accel_rad_s2": 3.0,
+        "latency_mode": "one-step-delay",
+        "update_mode": "5hz-hold",
+        "variability_distribution": {
+            "schema_version": "synthetic-actuation-variability-distribution.v1",
+            "mode": "synthetic-provisional",
+            "claim_boundary": "diagnostic-only",
+            "parameters": {
+                "max_linear_accel_m_s2": {
+                    "distribution": "uniform",
+                    "low": 2.5,
+                    "high": 4.5,
+                    "provenance": {
+                        "units": "m/s^2",
+                        "source_status": "synthetic_stress_factor",
+                        "caveat": "test-only provisional range",
+                    },
+                }
+            },
+        },
+        "variability_sample": {
+            "schema_version": "synthetic-actuation-variability-sample.v1",
+            "sample_id": "sample-000",
+        },
+    }
+
+    profile = load_synthetic_actuation_profile(payload)
+
+    assert profile is not None
+    assert load_synthetic_actuation_profile(None) is None
+    assert load_synthetic_actuation_profile(profile) is profile
+    assert profile.to_metadata()["variability_sample"]["sample_id"] == "sample-000"
+    assert (
+        profile.to_metadata()["variability_distribution"]["parameters"]["max_linear_accel_m_s2"][
+            "high"
+        ]
+        == 4.5
+    )
+
+    with pytest.raises(TypeError, match="synthetic_actuation_profile must be a mapping"):
+        load_synthetic_actuation_profile([])
+    with pytest.raises(ValueError, match="claim_scope must be 'synthetic-only'"):
+        load_synthetic_actuation_profile({**payload, "claim_scope": "paper-facing"})
+    with pytest.raises(TypeError, match="variability_sample must be a mapping"):
+        load_synthetic_actuation_profile({**payload, "variability_sample": []})
 
 
 def test_load_campaign_config_rejects_malformed_latency_stress_profile(

--- a/tests/tools/test_run_amv_actuation_sensitivity_sweep.py
+++ b/tests/tools/test_run_amv_actuation_sensitivity_sweep.py
@@ -8,6 +8,7 @@ from pathlib import Path
 import pytest
 import yaml
 
+from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
 from scripts.tools import run_amv_actuation_sensitivity_sweep as sweep
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -22,6 +23,8 @@ def test_issue_2011_sweep_manifest_materializes_diagnostic_configs(tmp_path: Pat
     resolved = json.loads((tmp_path / "resolved_sweep_manifest.json").read_text(encoding="utf-8"))
     assert resolved["claim_boundary"] == "diagnostic-only"
     assert len(resolved["variants"]) == 12
+    assert resolved["variability_sampling"]["mode"] == "fixed-variants"
+    assert resolved["sampled_parameter_summary"]["row_count"] == 0
     assert {(entry["field_group"], entry["level"]) for entry in resolved["variants"]} >= {
         ("longitudinal_proxy", "low"),
         ("longitudinal_proxy", "nominal"),
@@ -37,6 +40,11 @@ def test_issue_2011_sweep_manifest_materializes_diagnostic_configs(tmp_path: Pat
         )
     )
     assert low_update["synthetic_actuation_profile"]["update_mode"] == "2.5hz-hold"
+    assert (
+        low_update["synthetic_actuation_profile"]["variability_distribution"]["schema_version"]
+        == "synthetic-actuation-variability-distribution.v1"
+    )
+    assert "variability_sample" not in low_update["synthetic_actuation_profile"]
     assert low_update["latency_stress_profile"]["planner_update_mode"] == "hold-last"
     assert low_update["latency_stress_profile"]["planner_update_period_steps"] == 4
     assert low_update["paper_facing"] is False
@@ -46,6 +54,99 @@ def test_issue_2011_sweep_manifest_materializes_diagnostic_configs(tmp_path: Pat
     ]
     assert low_update["seed_policy"] == {"mode": "fixed-list", "seeds": [111]}
     assert [planner["key"] for planner in low_update["planners"]] == ["goal", "social_force"]
+
+
+def test_issue_3284_sweep_materializes_seeded_variability_samples(tmp_path: Path) -> None:
+    """The opt-in variability sweep should produce deterministic sampled profile configs."""
+    output_a = tmp_path / "sampled_a"
+    output_b = tmp_path / "sampled_b"
+    args = [
+        "--manifest",
+        str(MANIFEST_PATH),
+        "--sampling-mode",
+        "variability-sweep",
+        "--sampling-seed",
+        "17",
+    ]
+
+    assert sweep.main([*args, "--output", str(output_a)]) == 0
+    assert sweep.main([*args, "--output", str(output_b)]) == 0
+
+    resolved = json.loads((output_a / "resolved_sweep_manifest.json").read_text(encoding="utf-8"))
+    assert resolved["variability_sampling"] == {
+        "mode": "variability-sweep",
+        "seed": 17,
+        "sample_count": 3,
+    }
+    assert len(resolved["variants"]) == 3
+    assert resolved["sampled_parameter_summary"]["row_count"] == 3
+
+    first_profile = yaml.safe_load(
+        (output_a / "generated_configs" / "variability_sample_000.yaml").read_text(encoding="utf-8")
+    )["synthetic_actuation_profile"]
+    repeated_profile = yaml.safe_load(
+        (output_b / "generated_configs" / "variability_sample_000.yaml").read_text(encoding="utf-8")
+    )["synthetic_actuation_profile"]
+    assert first_profile == repeated_profile
+    assert first_profile["variability_sample"]["sampling_seed"] == 17
+    assert first_profile["variability_sample"]["sample_id"] == "sample-000"
+    assert 2.425 <= first_profile["max_linear_accel_m_s2"] <= 4.625
+    assert 3.210 <= first_profile["max_linear_decel_m_s2"] <= 3.842
+    assert 0.8 <= first_profile["max_yaw_rate_rad_s"] <= 1.6
+    assert 2.0 <= first_profile["max_angular_accel_rad_s2"] <= 6.0
+
+    cfg = load_campaign_config(output_a / "generated_configs" / "variability_sample_000.yaml")
+    assert cfg.synthetic_actuation_profile is not None
+    assert cfg.synthetic_actuation_profile.variability_sample is not None
+    assert cfg.synthetic_actuation_profile.variability_sample["sample_id"] == "sample-000"
+
+    assert (output_a / "reports" / "sampled_parameter_summary.json").exists()
+    assert (output_a / "reports" / "sampled_parameter_summary.csv").exists()
+    md_text = (output_a / "reports" / "sampled_parameter_summary.md").read_text(encoding="utf-8")
+    assert "diagnostic-only" in md_text
+    assert "hardware-calibrated AMV evidence" in md_text
+
+
+def test_issue_3284_aggregate_carries_sample_metadata(tmp_path: Path) -> None:
+    """Aggregate outputs should preserve sampled-parameter summaries for sampled variants."""
+    materialized_dir = tmp_path / "materialized"
+    sweep.main(
+        [
+            "--manifest",
+            str(MANIFEST_PATH),
+            "--output",
+            str(materialized_dir),
+            "--sampling-mode",
+            "variability-sweep",
+            "--sampling-seed",
+            "17",
+        ]
+    )
+    resolved = json.loads(
+        (materialized_dir / "resolved_sweep_manifest.json").read_text(encoding="utf-8")
+    )
+    entries = resolved["variants"]
+    first_variant = entries[0]["variant_name"]
+    roots = [_write_campaign_fixture(tmp_path, first_variant, 1.0, 0.0)]
+
+    rows = sweep.aggregate_campaigns(
+        output_dir=tmp_path / "aggregated",
+        entries=entries,
+        campaign_roots=roots,
+    )
+
+    assert rows[0]["sampling_mode"] == "variability-sweep"
+    assert rows[0]["sample_id"] == "sample-000"
+    assert "max_linear_accel_m_s2" in rows[0]["sampled_parameters"]
+    summary = json.loads(
+        (tmp_path / "aggregated" / "reports" / "effect_size_summary.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    assert summary["sampled_parameter_summary"]["row_count"] == 3
+    assert "synthetic/provisional" in (
+        tmp_path / "aggregated" / "reports" / "effect_size_summary.md"
+    ).read_text(encoding="utf-8")
 
 
 def test_issue_2011_sweep_aggregates_effect_sizes_from_campaign_roots(tmp_path: Path) -> None:

--- a/tests/tools/test_run_amv_actuation_sensitivity_sweep.py
+++ b/tests/tools/test_run_amv_actuation_sensitivity_sweep.py
@@ -110,17 +110,20 @@ def test_issue_3284_sweep_materializes_seeded_variability_samples(tmp_path: Path
 def test_issue_3284_aggregate_carries_sample_metadata(tmp_path: Path) -> None:
     """Aggregate outputs should preserve sampled-parameter summaries for sampled variants."""
     materialized_dir = tmp_path / "materialized"
-    sweep.main(
-        [
-            "--manifest",
-            str(MANIFEST_PATH),
-            "--output",
-            str(materialized_dir),
-            "--sampling-mode",
-            "variability-sweep",
-            "--sampling-seed",
-            "17",
-        ]
+    assert (
+        sweep.main(
+            [
+                "--manifest",
+                str(MANIFEST_PATH),
+                "--output",
+                str(materialized_dir),
+                "--sampling-mode",
+                "variability-sweep",
+                "--sampling-seed",
+                "17",
+            ]
+        )
+        == 0
     )
     resolved = json.loads(
         (materialized_dir / "resolved_sweep_manifest.json").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Adds diagnostic-only AMV actuation variability distributions and an opt-in seeded `variability-sweep` materialization path for the existing #2011 actuation sensitivity sweep.

## Linked Issues
- Closes `#3284`
- Relates to `#2011`
- Relates to `#2001`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Extended `SyntheticActuationProfile` with optional `variability_distribution` and `variability_sample` metadata plus deterministic profile sampling helpers.
- Preserved variability metadata through camera-ready and map-runner profile loaders.
- Added manifest-level provisional distributions, `--sampling-mode`, `--sampling-seed`, and sampled-parameter reports for `scripts/tools/run_amv_actuation_sensitivity_sweep.py`.
- Updated tests and the #2011 context note with the diagnostic-only sampling boundary.

## Why It Matters
- Added value: #2011 can now materialize fixed low/nominal/high configs or reproducible sampled envelopes from the same tracked manifest.
- Expected impact: follow-up actuation sensitivity probes can report the exact sampled parameters and provenance rather than burying stochastic assumptions.
- Why this is worth merging now: it unblocks distributional diagnostics without changing the default fixed-variant sweep behavior.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: unblock diagnostic AMV actuation-envelope variability sampling with explicit source-proxy and synthetic caveats.
- Comparator or baseline, if applicable: existing 12 fixed #2011 low/nominal/high variants remain the default comparator path.
- Evidence tier: targeted smoke plus full local PR readiness.
- Result classification: diagnostic-only tooling/support.
- Decision or stop rule, if applicable: merge when seeded materialization is deterministic, sampled summaries are emitted, metadata survives config loaders, and benchmark-facing tests pass.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `docs/context/issue_2011_amv_actuation_sensitivity_sweep.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: representative use on tracked manifest was run with `--sampling-mode variability-sweep --sampling-seed 17`; outputs were local disposable validation artifacts and no benchmark result claim is made.

## Domain-Aware Approval
- Required for this PR: yes - reason: this is benchmark-facing diagnostic materialization/report plumbing with explicit evidence-tier and claim-boundary language.
- Domains reviewed: benchmark interpretation, claim boundary
- Status: waived
- Approver/review source or waiver: waived by maintainer value policy for diagnostic-only tooling that makes no benchmark result, figure eligibility, or paper-facing claim; local implementation verification and explicit diagnostic-only caveats cover implementation integrity.
- Validity checklist:
  - Target claim/hypothesis: implementation can emit reproducible sampled actuation configs.
  - Comparator or split/evidence validity: default fixed variants remain unchanged as the default path.
  - Fallback/degraded exclusions: no fallback/degraded benchmark success is claimed.
  - Claim boundary: synthetic/provisional, diagnostic-only, not hardware-calibrated AMV evidence.
  - Implementation integrity vs experimental validity: validates implementation integrity only.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes
- Did the intervention change command source, selected command, trajectory, or route progress? NA - no campaign outcome claim is made.
- Did the scenario actually contain the targeted failure mode? NA - materialization/report plumbing only.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: none for this PR.

## Next Empirical Action
- Rerun needed: no for implementation proof.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none for the implementation scope.
- Stop / revise / continue decision: continue with future diagnostic use of the new mode when a concrete benchmark question is selected.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run ruff check robot_sf/benchmark/synthetic_actuation.py robot_sf/benchmark/map_runner_profile_metadata.py robot_sf/benchmark/camera_ready_campaign.py scripts/tools/run_amv_actuation_sensitivity_sweep.py tests/tools/test_run_amv_actuation_sensitivity_sweep.py tests/benchmark/test_camera_ready_campaign.py`
  - `uv run python scripts/tools/run_amv_actuation_sensitivity_sweep.py --help`
  - `uv run python scripts/tools/run_amv_actuation_sensitivity_sweep.py --manifest configs/benchmarks/issue_2011_amv_actuation_sensitivity_sweep_v0.yaml --output output/validation/issue_3284_variability_sample_smoke --sampling-mode variability-sweep --sampling-seed 17 --log-level WARNING`
  - `uv run python -m pytest tests/tools/test_run_amv_actuation_sensitivity_sweep.py -q`
  - `uv run python -m pytest tests/benchmark/test_camera_ready_campaign.py::test_load_campaign_config_preserves_synthetic_actuation_variability_metadata tests/benchmark/test_camera_ready_campaign.py::test_prepare_campaign_preflight_resolves_synthetic_actuation_slice_metadata -q`
  - `uv run python scripts/dev/run_compact_validation.py -- uv run python -m pytest tests/benchmark -k actuation -q`
  - `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
  - `uv run python scripts/dev/run_compact_validation.py -- uv run python -m pytest tests/benchmark_full/test_integration_reproducibility.py::test_reproducibility_same_seed -q`
  - `PYTEST_NUM_WORKERS=4 PR_READY_MODE=final PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3284-pr-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: seeded materialization emits three deterministic sample configs and `reports/sampled_parameter_summary.{json,csv,md}`; loader tests preserve variability metadata; benchmark actuation tests pass.
- Benchmarks or smoke tests, if applicable: `tests/benchmark -k actuation` passed; no benchmark-performance claim is made.

## Risks / Rollout
- Compatibility risks: generated fixed configs now carry additional optional provenance metadata, but scalar profile values and default fixed-variant materialization remain unchanged.
- Failure modes: malformed distribution provenance fails closed; absent distribution fails if `variability-sweep` is requested.
- Rollback or fallback plan: continue using default `fixed-variants` mode.

## Docs / Provenance
- Updated docs: `docs/context/issue_2011_amv_actuation_sensitivity_sweep.md`.
- Relevant design or provenance notes: #2001 platform-class proxy boundary remains explicit; yaw, latency, angular acceleration, and update rate remain synthetic stress factors.
- Any assumptions that need to be preserved: sampled distributions are synthetic/provisional and diagnostic-only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via this PR closing #3284.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark result claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no durable benchmark artifact.
- Registry or config index updated (yes/no/NA): yes, tracked #2011 manifest updated.
- Context index / memory note updated (yes/no/NA): existing canonical #2011 context note updated; index unchanged because the note already existed.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - no deferred implementation work identified.
- Not applicable because: this PR adds diagnostic tooling/provenance plumbing, not a new benchmark result.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that the default `fixed-variants` materialization still emits 12 configs.
- Verify that `variability-sweep` remains clearly diagnostic-only and preserves sampled parameter provenance.
- Known limitations: this does not run a new benchmark campaign or move any planner-performance claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added `variability-sweep` sampling mode to the AMV actuation sensitivity sweep tool, enabling synthetic parameter sampling via new `--sampling-mode` and `--sampling-seed` CLI options.
  * Generates sampled-parameter summary reports (JSON, CSV, Markdown) for variability sweeps.
  * Materialized configurations now include variability metadata in variant profiles.

* **Documentation**
  * Added documentation for the new variability-sweep sampling mode with CLI usage examples.

* **Tests**
  * Added test coverage for variability sampling and deterministic seed-based generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->