### PR TITLE
feat: add occluder timing perturbations

### DIFF
--- a/configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml
+++ b/configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml
@@ -1,0 +1,44 @@
+schema_version: scenario_perturbation_manifest.v1
+manifest_id: issue_3369_occluder_timing_pilot_v1
+description: >
+  Diagnostic-only occluder-timing perturbation pilot for issue #3369. This manifest shifts the
+  emerging pedestrian release time in the tracked issue #2756 occluded-emergence live fixture while
+  keeping the source scenario, seed, map, and route geometry fixed. Preflight eligibility is input
+  validation only; it is not benchmark evidence.
+scenario_config: configs/scenarios/single/issue_2756_occluded_emergence_live.yaml
+seed_controls:
+  baseline_seeds:
+  - 111
+  replay_seed_policy: explicit
+  source: issue_2756_occluded_emergence_fixture
+validity:
+  require_scenario_certification: true
+  max_route_offset_m: 0.5
+  max_occluder_timing_offset_s: 0.5
+  invalid_variant_evidence_policy: exclude_from_success_evidence
+  notes: >
+    Occluder timing variants require observation_visibility.static_occlusion=true,
+    metadata.fixture_contract timing fields, and selected single_pedestrians metadata.role=emerging_ped.
+variants:
+- variant_id: issue_2756_occluded_emergence_noop
+  scenario_id: issue_2756_occluded_emergence
+  family: noop
+  seeds:
+  - 111
+- variant_id: issue_2756_occluded_emergence_occluder_timing_h1_p050
+  scenario_id: issue_2756_occluded_emergence
+  family: occluder_timing_offset
+  seeds:
+  - 111
+  rationale: >
+    Delay the emerging pedestrian by 0.5 s to generate a diagnostic counterfactual input for
+    occlusion-exposure sensitivity. This does not assert any benchmark outcome.
+  parameters:
+    dt_s: 0.5
+    max_abs_dt_s: 0.5
+    pedestrian_id: h1
+pilot_matrix_note:
+  parent_issue: "#3369"
+  next_step: >
+    Use materialized pilot inputs only as diagnostic counterfactual candidates after preflight.
+  evidence_boundary: local_pilot_input_not_benchmark_evidence

--- a/docs/context/issue_2547_counterfactual_mechanism_taxonomy.md
+++ b/docs/context/issue_2547_counterfactual_mechanism_taxonomy.md
@@ -26,9 +26,15 @@ The manifest now includes:
 - `pair_report.artifact_manifest_ref`;
 - `pair_report.expected_vs_observed_metric_change`.
 
-The first supported feature remains `robot_route_offset`, mapped to the `clearance_pressure`
-mechanism label. Because the pair generator does not execute a smoke run, the expected-vs-observed
-section is deliberately `not_available` with the reason
+Supported features currently include:
+
+- `robot_route_offset`, mapped to the `clearance_pressure` mechanism label.
+- `occluder_timing_offset` (Issue #3369), mapped to the `occlusion_exposure` mechanism label after
+  preflight proves the source scenario is an occluded-emergence fixture with static occlusion,
+  fixture timing metadata, and an explicit `emerging_ped` target.
+
+Because the pair generator does not execute a smoke run, the expected-vs-observed section is
+deliberately `not_available` with the reason
 `no smoke-run metrics were supplied to this pair manifest`.
 
 ## Evidence
@@ -47,6 +53,9 @@ expected-vs-observed status.
 rtk uv run pytest tests/tools/test_create_counterfactual_scenario_pair.py -q
 rtk uv run ruff check scripts/tools/create_counterfactual_scenario_pair.py tests/tools/test_create_counterfactual_scenario_pair.py
 ```
+
+Issue #3369 additionally validates the occluder-timing manifest and preflight/materialization
+surface through `tests/scenario_certification/test_scenario_perturbation_preflight.py`.
 
 Expected result: targeted generator tests pass and Ruff reports no issues.
 

--- a/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
+++ b/robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://example.com/robot-sf/scenario_perturbation_manifest.v1.json",
   "title": "RobotSF Scenario Perturbation Manifest (v1)",
-  "description": "Minimal manifest for no-op baselines plus bounded route, pedestrian timing, single-pedestrian speed/wait/trajectory, and pedestrian-density perturbation preflight. Validity preflight is not benchmark execution evidence.",
+  "description": "Minimal manifest for no-op baselines plus bounded route, pedestrian timing, occluder timing, single-pedestrian speed/wait/trajectory, and pedestrian-density perturbation preflight. Validity preflight is not benchmark execution evidence.",
   "type": "object",
   "additionalProperties": false,
   "required": [
@@ -72,6 +72,10 @@
           "exclusiveMinimum": 0
         },
         "max_start_delay_offset_s": {
+          "type": "number",
+          "exclusiveMinimum": 0
+        },
+        "max_occluder_timing_offset_s": {
           "type": "number",
           "exclusiveMinimum": 0
         },
@@ -157,6 +161,37 @@
           "validity": {
             "required": [
               "max_start_delay_offset_s"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "if": {
+        "properties": {
+          "variants": {
+            "contains": {
+              "type": "object",
+              "properties": {
+                "family": {
+                  "const": "occluder_timing_offset"
+                }
+              },
+              "required": [
+                "family"
+              ]
+            }
+          }
+        },
+        "required": [
+          "variants"
+        ]
+      },
+      "then": {
+        "properties": {
+          "validity": {
+            "required": [
+              "max_occluder_timing_offset_s"
             ]
           }
         }
@@ -313,6 +348,7 @@
             "robot_route_offset",
             "pedestrian_route_offset",
             "single_pedestrian_start_delay_offset",
+            "occluder_timing_offset",
             "single_pedestrian_speed_offset",
             "single_pedestrian_wait_duration_offset",
             "single_pedestrian_trajectory_waypoint_offset",
@@ -574,6 +610,50 @@
                 "required": [
                   "dt_s",
                   "max_abs_dt_s"
+                ],
+                "properties": {
+                  "dt_s": {
+                    "type": "number"
+                  },
+                  "max_abs_dt_s": {
+                    "type": "number",
+                    "exclusiveMinimum": 0
+                  },
+                  "pedestrian_id": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "pedestrian_selector": {
+                    "const": "all"
+                  }
+                }
+              }
+            }
+          }
+        },
+        {
+          "if": {
+            "properties": {
+              "family": {
+                "const": "occluder_timing_offset"
+              }
+            },
+            "required": [
+              "family"
+            ]
+          },
+          "then": {
+            "required": [
+              "parameters"
+            ],
+            "properties": {
+              "parameters": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": [
+                  "dt_s",
+                  "max_abs_dt_s",
+                  "pedestrian_id"
                 ],
                 "properties": {
                   "dt_s": {

--- a/robot_sf/scenario_certification/perturbation_family_registry.py
+++ b/robot_sf/scenario_certification/perturbation_family_registry.py
@@ -92,6 +92,35 @@ _PERTURBATION_FAMILIES: tuple[PerturbationFamily, ...] = (
         optional_parameters=("pedestrian_id", "pedestrian_selector"),
     ),
     PerturbationFamily(
+        name="occluder_timing_offset",
+        description=(
+            "Bounded timing offset for the explicit emerging pedestrian in an occluded-emergence "
+            "scenario"
+        ),
+        target_surface="occluded_emergence_single_pedestrian_start_delay_s",
+        semantic_boundary=(
+            "|dt_s| ≤ min(variant_max_abs_dt_s, manifest_max_occluder_timing_offset_s); "
+            "scenario must declare static occlusion, fixture timing metadata, and an emerging "
+            "pedestrian"
+        ),
+        validity_constraints=(
+            "max_occluder_timing_offset_s",
+            "static_occlusion_required",
+            "fixture_contract_required",
+            "emerging_pedestrian_role_required",
+            "pedestrian_id_required",
+        ),
+        fail_closed_rules=(
+            "abs_dt_s > bound excludes variant",
+            "scenario without observation_visibility.static_occlusion excludes variant",
+            "scenario without metadata.fixture_contract excludes variant",
+            "selected pedestrian without metadata.role=emerging_ped excludes variant",
+            "updated start_delay_s < 0 excludes variant",
+        ),
+        required_parameters=("dt_s", "max_abs_dt_s", "pedestrian_id"),
+        optional_parameters=("pedestrian_selector",),
+    ),
+    PerturbationFamily(
         name="single_pedestrian_speed_offset",
         description="Bounded speed offset for explicit single_pedestrians",
         target_surface="single_pedestrian_speed_m_s",

--- a/robot_sf/scenario_certification/perturbation_preflight.py
+++ b/robot_sf/scenario_certification/perturbation_preflight.py
@@ -418,6 +418,7 @@ def _normalize_variant(variant: Any) -> Mapping[str, Any]:
         "robot_route_offset",
         "pedestrian_route_offset",
         "single_pedestrian_start_delay_offset",
+        "occluder_timing_offset",
         "single_pedestrian_speed_offset",
         "single_pedestrian_wait_duration_offset",
         "pedestrian_density_offset",
@@ -459,6 +460,8 @@ def _validate_perturbation_bounds(
         raise ValueError(f"{family} variants require a parameters mapping")
     if family == "single_pedestrian_start_delay_offset":
         return _validate_start_delay_offset_bounds(variant, manifest=manifest)
+    if family == "occluder_timing_offset":
+        return _validate_occluder_timing_offset_bounds(variant, manifest=manifest)
     if family == "single_pedestrian_speed_offset":
         return _validate_single_pedestrian_speed_offset_bounds(variant, manifest=manifest)
     if family == "single_pedestrian_wait_duration_offset":
@@ -617,6 +620,13 @@ def _resolve_scenario_dependent_perturbation_summary(
     Returns:
         dict[str, Any]: Scenario-independent or enriched perturbation summary.
     """
+    if variant["family"] == "occluder_timing_offset":
+        return _occluder_timing_summary_for_scenario(
+            variant,
+            perturbation_summary=perturbation_summary,
+            scenario_config=scenario_config,
+            scenarios=scenarios,
+        )
     if variant["family"] != "pedestrian_density_offset":
         return dict(perturbation_summary)
     return _pedestrian_density_summary_for_scenario(
@@ -657,6 +667,149 @@ def _pedestrian_density_summary_for_scenario(
     return summary
 
 
+def _occluder_timing_fixture_context(
+    scenario: Mapping[str, Any],
+    *,
+    scenario_config: Path,
+) -> tuple[dict[str, Any], Path, Mapping[str, Any]]:
+    """Return fixture metadata required by occluder-timing perturbations."""
+    observation_visibility = scenario.get("observation_visibility")
+    if not isinstance(observation_visibility, Mapping) or (
+        observation_visibility.get("static_occlusion") is not True
+    ):
+        raise ValueError("occluder_timing_offset requires observation_visibility.static_occlusion")
+    if not bool(observation_visibility.get("enabled", False)):
+        raise ValueError("occluder_timing_offset requires observation_visibility.enabled")
+    metadata = scenario.get("metadata")
+    if not isinstance(metadata, Mapping):
+        raise ValueError("occluder_timing_offset requires scenario metadata")
+    scenario_family = str(scenario.get("scenario_family") or metadata.get("family") or "").strip()
+    if scenario_family != "occluded_emergence":
+        raise ValueError("occluder_timing_offset requires scenario_family='occluded_emergence'")
+    fixture_contract = metadata.get("fixture_contract")
+    if not isinstance(fixture_contract, Mapping):
+        raise ValueError("occluder_timing_offset requires metadata.fixture_contract")
+    for required_key in ("first_visible_step", "delay_steps"):
+        if required_key not in fixture_contract:
+            raise ValueError(
+                f"occluder_timing_offset requires metadata.fixture_contract.{required_key}"
+            )
+    source_fixture = _resolve_path(
+        metadata.get("source_fixture"),
+        base_dir=scenario_config.parent,
+        field_name="metadata.source_fixture",
+    )
+    trace_occlusion = _trace_fixture_occlusion(source_fixture)
+    if trace_occlusion.get("first_visible_step") != fixture_contract.get("first_visible_step"):
+        raise ValueError(
+            "occluder_timing_offset requires source fixture first_visible_step to match "
+            "metadata.fixture_contract.first_visible_step"
+        )
+    return dict(fixture_contract), source_fixture, trace_occlusion
+
+
+def _selected_occluder_timing_pedestrian(
+    scenario: Mapping[str, Any],
+    *,
+    scenario_config: Path,
+    parameters: Any,
+) -> tuple[Any, dict[str, Any]]:
+    """Return the explicitly selected emerging pedestrian for an occluder-timing variant."""
+    pedestrian_id = str(parameters.get("pedestrian_id", "")).strip()
+    pedestrian_metadata = _single_pedestrian_metadata(scenario, pedestrian_id)
+    if pedestrian_metadata.get("role") != "emerging_ped":
+        raise ValueError(
+            "occluder_timing_offset requires selected pedestrian metadata.role='emerging_ped'"
+        )
+    config = build_robot_config_from_scenario(scenario, scenario_path=scenario_config)
+    if not config.map_pool.map_defs:
+        raise ValueError("scenario map pool is empty")
+    _map_name, map_def = next(iter(config.map_pool.map_defs.items()))
+    selected = _select_single_pedestrians(
+        list(map_def.single_pedestrians),
+        parameters,
+        family="occluder_timing_offset",
+    )
+    if len(selected) != 1:
+        raise ValueError("occluder_timing_offset requires exactly one selected pedestrian")
+    return selected[0], pedestrian_metadata
+
+
+def _occluder_timing_summary_for_scenario(
+    variant: Mapping[str, Any],
+    *,
+    perturbation_summary: Mapping[str, Any],
+    scenario_config: Path,
+    scenarios: list[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Return occlusion-specific timing facts for one occluder-timing variant."""
+    scenario = dict(select_scenario(scenarios, str(variant["scenario_id"])))
+    fixture_contract, source_fixture, trace_occlusion = _occluder_timing_fixture_context(
+        scenario,
+        scenario_config=scenario_config,
+    )
+    pedestrian, pedestrian_metadata = _selected_occluder_timing_pedestrian(
+        scenario,
+        scenario_config=scenario_config,
+        parameters=variant.get("parameters", {}),
+    )
+    baseline_start_delay_s = float(pedestrian.start_delay_s)
+    updated_start_delay_s = baseline_start_delay_s + float(perturbation_summary["dt_s"])
+    if updated_start_delay_s < 0.0:
+        raise ValueError(
+            f"occluder_timing_offset would make pedestrian {pedestrian.id!r} start_delay_s negative"
+        )
+    summary = dict(perturbation_summary)
+    summary["baseline_start_delay_s"] = baseline_start_delay_s
+    summary["updated_start_delay_s"] = updated_start_delay_s
+    summary["occlusion"] = {
+        "static_occlusion": True,
+        "source_fixture": source_fixture.as_posix(),
+        "source_fixture_occluder_id": trace_occlusion.get("occluder_id"),
+        "fixture_contract": dict(fixture_contract),
+        "selected_pedestrian_role": pedestrian_metadata.get("role"),
+    }
+    return summary
+
+
+def _trace_fixture_occlusion(source_fixture: Path) -> Mapping[str, Any]:
+    """Return the occlusion payload from a trace fixture, failing closed when incomplete."""
+    try:
+        trace_payload = json.loads(source_fixture.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(
+            f"occluder_timing_offset cannot read source fixture: {source_fixture}"
+        ) from exc
+    if not isinstance(trace_payload, Mapping):
+        raise ValueError("occluder_timing_offset source fixture must contain a mapping")
+    occlusion = trace_payload.get("occlusion")
+    if not isinstance(occlusion, Mapping):
+        raise ValueError("occluder_timing_offset requires source fixture occlusion metadata")
+    for required_key in ("first_visible_step", "occluder_id", "occluder_bounds"):
+        if required_key not in occlusion:
+            raise ValueError(
+                f"occluder_timing_offset requires source fixture occlusion.{required_key}"
+            )
+    if not isinstance(occlusion.get("occluder_bounds"), Mapping):
+        raise ValueError("occluder_timing_offset requires source fixture occluder_bounds mapping")
+    return occlusion
+
+
+def _single_pedestrian_metadata(scenario: Mapping[str, Any], pedestrian_id: str) -> dict[str, Any]:
+    """Return raw metadata for one scenario-level single pedestrian."""
+    raw_pedestrians = scenario.get("single_pedestrians")
+    if not isinstance(raw_pedestrians, list):
+        raise ValueError("occluder_timing_offset selected no single pedestrians")
+    for item in raw_pedestrians:
+        if not isinstance(item, Mapping):
+            continue
+        if str(item.get("id")) != pedestrian_id:
+            continue
+        metadata = item.get("metadata")
+        return dict(metadata) if isinstance(metadata, Mapping) else {}
+    raise ValueError(f"occluder_timing_offset selected no pedestrian {pedestrian_id!r}")
+
+
 def _validate_start_delay_offset_bounds(
     variant: Mapping[str, Any],
     *,
@@ -690,6 +843,51 @@ def _validate_start_delay_offset_bounds(
         "max_abs_dt_s": bound,
         "target": {
             "pedestrian_id": parameters.get("pedestrian_id"),
+            "selector": parameters.get("pedestrian_selector", "all"),
+        },
+    }
+    if abs_dt_s > bound:
+        return [
+            f"{family} abs_dt_s {abs_dt_s:.6f} s exceeds variant max_abs_dt_s {bound:.6f} s"
+        ], summary
+    return [], summary
+
+
+def _validate_occluder_timing_offset_bounds(
+    variant: Mapping[str, Any],
+    *,
+    manifest: Mapping[str, Any],
+) -> tuple[list[str], dict[str, Any]]:
+    """Validate bounded occluded-emergence timing perturbations.
+
+    Returns:
+        tuple[list[str], dict[str, Any]]: Fail-closed reasons and perturbation summary.
+    """
+    family = str(variant["family"])
+    parameters = variant.get("parameters")
+    if not isinstance(parameters, Mapping):
+        raise ValueError(f"{family} variants require a parameters mapping")
+    dt_s = _finite_float(parameters.get("dt_s"), field_name="parameters.dt_s")
+    variant_max = _positive_float(
+        parameters.get("max_abs_dt_s"),
+        field_name="parameters.max_abs_dt_s",
+    )
+    manifest_max = _positive_float(
+        manifest["validity"].get("max_occluder_timing_offset_s"),
+        field_name="validity.max_occluder_timing_offset_s",
+    )
+    pedestrian_id = parameters.get("pedestrian_id")
+    if not isinstance(pedestrian_id, str) or not pedestrian_id.strip():
+        raise ValueError(f"{family} requires parameters.pedestrian_id")
+    bound = min(variant_max, manifest_max)
+    abs_dt_s = abs(dt_s)
+    summary = {
+        "family": family,
+        "dt_s": dt_s,
+        "abs_dt_s": abs_dt_s,
+        "max_abs_dt_s": bound,
+        "target": {
+            "pedestrian_id": pedestrian_id,
             "selector": parameters.get("pedestrian_selector", "all"),
         },
     }
@@ -834,11 +1032,12 @@ def _certify_variant(
         raise ValueError("scenario map pool is empty")
     _map_name, map_def = next(iter(config.map_pool.map_defs.items()))
     perturbed_map = deepcopy(map_def)
-    if variant["family"] == "single_pedestrian_start_delay_offset":
+    if variant["family"] in {"single_pedestrian_start_delay_offset", "occluder_timing_offset"}:
         _apply_start_delay_offset(
             perturbed_map.single_pedestrians,
             dt_s=float(perturbation_summary["dt_s"]),
             parameters=variant.get("parameters", {}),
+            family=str(variant["family"]),
         )
     elif variant["family"] == "single_pedestrian_speed_offset":
         _apply_single_pedestrian_speed_offset(
@@ -927,7 +1126,7 @@ def _materialize_variant_scenario(
             route_path=route_path,
         )
         scenario["route_overrides_file"] = route_path.relative_to(matrix_path.parent).as_posix()
-    elif variant["family"] == "single_pedestrian_start_delay_offset":
+    elif variant["family"] in {"single_pedestrian_start_delay_offset", "occluder_timing_offset"}:
         scenario["single_pedestrians"] = _single_pedestrian_overrides_for_start_delay(
             variant,
             scenario=scenario,
@@ -1094,16 +1293,14 @@ def _apply_start_delay_offset(
     *,
     dt_s: float,
     parameters: Any,
+    family: str = "single_pedestrian_start_delay_offset",
 ) -> None:
     """Offset selected single-pedestrian start delays in place."""
-    selected = _select_single_pedestrians(pedestrians, parameters)
+    selected = _select_single_pedestrians(pedestrians, parameters, family=family)
     for ped in selected:
         updated = float(ped.start_delay_s) + float(dt_s)
         if updated < 0.0:
-            raise ValueError(
-                "single_pedestrian_start_delay_offset would make "
-                f"pedestrian {ped.id!r} start_delay_s negative"
-            )
+            raise ValueError(f"{family} would make pedestrian {ped.id!r} start_delay_s negative")
         ped.start_delay_s = updated
 
 
@@ -1321,19 +1518,18 @@ def _single_pedestrian_overrides_for_start_delay(
     if not config.map_pool.map_defs:
         raise ValueError("scenario map pool is empty")
     _map_name, map_def = next(iter(config.map_pool.map_defs.items()))
+    family = str(variant["family"])
     selected = _select_single_pedestrians(
         list(map_def.single_pedestrians),
         variant.get("parameters", {}),
+        family=family,
     )
     selected_ids = {str(ped.id) for ped in selected}
     delays = {}
     for ped in selected:
         updated = float(ped.start_delay_s) + float(perturbation_summary["dt_s"])
         if updated < 0.0:
-            raise ValueError(
-                "single_pedestrian_start_delay_offset would make "
-                f"pedestrian {ped.id!r} start_delay_s negative"
-            )
+            raise ValueError(f"{family} would make pedestrian {ped.id!r} start_delay_s negative")
         delays[str(ped.id)] = updated
 
     raw_overrides = scenario.get("single_pedestrians")

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -202,7 +202,11 @@ printf 'Running core readiness lane.\n' >&2
 ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=core "$SCRIPT_DIR/run_tests_parallel.sh" --lane core
 if [[ ${#optional_changed_files[@]} -gt 0 ]]; then
   printf 'Running optional-extra lane for predictive/optional changed files.\n' >&2
-  ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional
+  optional_pytest_addopts="${PYTEST_ADDOPTS:-}"
+  if [[ " $optional_pytest_addopts " != *" --cov-append "* ]]; then
+    optional_pytest_addopts="${optional_pytest_addopts:+$optional_pytest_addopts }--cov-append"
+  fi
+  PYTEST_ADDOPTS="$optional_pytest_addopts" ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional
 else
   printf 'No changed files require the optional-extra lane.\n' >&2
 fi

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -57,6 +57,7 @@ core_test_paths=(
   tests/contract
   tests/factories
   tests/guard
+  tests/scenario_certification
   tests/sensor
   tests/sim
   tests/unit

--- a/scripts/tools/create_counterfactual_scenario_pair.py
+++ b/scripts/tools/create_counterfactual_scenario_pair.py
@@ -31,7 +31,10 @@ EVIDENCE_TIER = "diagnostic-only"
 DENOMINATOR_POLICY = "counterfactual_pairs_not_benchmark_denominator"
 GENERATOR_ID = "create_counterfactual_scenario_pair"
 _SUCCESS_EVIDENCE_CANDIDATE = "eligible_success_evidence_candidate"
-_SUPPORTED_FEATURES = frozenset({"robot_route_offset"})
+_SUPPORTED_FEATURES = frozenset({"robot_route_offset", "occluder_timing_offset"})
+_FEATURE_ALIASES = {
+    "occluder_timing": "occluder_timing_offset",
+}
 MECHANISM_TAXONOMY_LABELS = (
     "clearance_pressure",
     "bottleneck_negotiation",
@@ -58,7 +61,26 @@ _MECHANISM_TAXONOMY_BY_FEATURE = {
             "seed and source scenario must remain unchanged",
             "single pair is a mechanism hypothesis input, not causal evidence",
         ],
-    }
+    },
+    "occluder_timing_offset": {
+        "label": "occlusion_exposure",
+        "label_source": MECHANISM_TAXONOMY_SCHEMA_VERSION,
+        "mechanism_hypothesis": (
+            "A bounded release-time offset for the emerging pedestrian changes occlusion exposure "
+            "while holding the source scenario, seed, and map geometry fixed."
+        ),
+        "expected_metric_direction": {
+            "first_visible_step": "changes_with_release_timing",
+            "collision_or_near_miss_risk": "may_increase_when_visibility_window_shrinks",
+            "success": "no_directional_claim_from_pair_manifest",
+        },
+        "validity_constraints": [
+            "baseline and intervention must both pass perturbation preflight",
+            "source scenario must declare static occlusion and fixture timing metadata",
+            "selected pedestrian must be the emerging pedestrian",
+            "single pair is a diagnostic input, not benchmark or causal evidence",
+        ],
+    },
 }
 
 if TYPE_CHECKING:
@@ -76,13 +98,22 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--feature",
         required=True,
-        help="Perturbation family to vary. This narrow slice supports robot_route_offset.",
+        help=(
+            "Perturbation family to vary. Supported: robot_route_offset, occluder_timing_offset."
+        ),
     )
     parser.add_argument(
         "--magnitude",
         type=float,
         required=True,
-        help="Feature magnitude. For robot_route_offset this is dx_m in meters.",
+        help=(
+            "Feature magnitude. For robot_route_offset this is dx_m in meters; "
+            "for occluder_timing_offset this is dt_s in seconds."
+        ),
+    )
+    parser.add_argument(
+        "--pedestrian-id",
+        help="Selected emerging pedestrian id for occluder_timing_offset.",
     )
     parser.add_argument("--seed", type=int, required=True, help="Replay seed held fixed.")
     parser.add_argument(
@@ -107,6 +138,7 @@ def create_pair_manifest(
     magnitude: float,
     seed: int,
     scenario_config: Path,
+    pedestrian_id: str | None = None,
 ) -> dict[str, Any]:
     """Create a preflight-validated counterfactual pair payload.
 
@@ -116,7 +148,11 @@ def create_pair_manifest(
     if seed < 0:
         raise CounterfactualPairError("seed must be non-negative")
     family = _supported_family(feature)
-    parameters = _intervention_parameters(feature=family.name, magnitude=magnitude)
+    parameters = _intervention_parameters(
+        feature=family.name,
+        magnitude=magnitude,
+        pedestrian_id=pedestrian_id,
+    )
     parameter_reasons, family_entry = validate_perturbation_family_parameters(
         family.name,
         parameters,
@@ -155,6 +191,7 @@ def create_pair_manifest(
             },
         ],
     }
+    perturbation_manifest["validity"].update(_validity_bounds_for_feature(family.name, magnitude))
     preflight_payload = _preflight_embedded_manifest(perturbation_manifest)
     _require_pair_preflight_success(preflight_payload)
 
@@ -213,8 +250,9 @@ def create_pair_manifest(
 
 def _supported_family(feature: str):
     """Return the registered family entry for a supported counterfactual feature."""
+    normalized = _FEATURE_ALIASES.get(feature, feature)
     try:
-        family = perturbation_family(feature)
+        family = perturbation_family(normalized)
     except ValueError as exc:
         raise CounterfactualPairError(f"unsupported counterfactual feature: {feature}") from exc
     if family.name not in _SUPPORTED_FEATURES:
@@ -225,20 +263,41 @@ def _supported_family(feature: str):
     return family
 
 
-def _intervention_parameters(*, feature: str, magnitude: float) -> dict[str, float]:
+def _intervention_parameters(
+    *,
+    feature: str,
+    magnitude: float,
+    pedestrian_id: str | None,
+) -> dict[str, Any]:
     """Map the CLI feature magnitude onto registered perturbation-family parameters."""
-    if feature != "robot_route_offset":
-        raise CounterfactualPairError(f"unsupported counterfactual feature: {feature}")
     if not math.isfinite(magnitude):
         raise CounterfactualPairError("magnitude must be finite")
     if magnitude == 0.0:
         raise CounterfactualPairError("magnitude must be non-zero for a counterfactual pair")
-    max_magnitude = abs(magnitude)
-    return {
-        "dx_m": magnitude,
-        "dy_m": 0.0,
-        "max_magnitude_m": max_magnitude,
-    }
+    if feature == "robot_route_offset":
+        max_magnitude = abs(magnitude)
+        return {
+            "dx_m": magnitude,
+            "dy_m": 0.0,
+            "max_magnitude_m": max_magnitude,
+        }
+    if feature == "occluder_timing_offset":
+        if not isinstance(pedestrian_id, str) or not pedestrian_id.strip():
+            raise CounterfactualPairError("occluder_timing_offset requires --pedestrian-id")
+        max_abs_dt_s = abs(magnitude)
+        return {
+            "dt_s": magnitude,
+            "max_abs_dt_s": max_abs_dt_s,
+            "pedestrian_id": pedestrian_id.strip(),
+        }
+    raise CounterfactualPairError(f"unsupported counterfactual feature: {feature}")
+
+
+def _validity_bounds_for_feature(feature: str, magnitude: float) -> dict[str, float]:
+    """Return feature-specific manifest validity bounds."""
+    if feature == "occluder_timing_offset":
+        return {"max_occluder_timing_offset_s": abs(magnitude)}
+    return {}
 
 
 def _mechanism_taxonomy_for_feature(feature: str) -> dict[str, Any]:
@@ -370,6 +429,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             magnitude=args.magnitude,
             seed=args.seed,
             scenario_config=args.scenario_config,
+            pedestrian_id=args.pedestrian_id,
         )
     except CounterfactualPairError as exc:
         print(f"error: {exc}", file=sys.stderr)

--- a/tests/scenario_certification/test_perturbation_family_registry.py
+++ b/tests/scenario_certification/test_perturbation_family_registry.py
@@ -24,6 +24,7 @@ def test_supported_families_covers_manifest_enum() -> None:
         "robot_route_offset",
         "pedestrian_route_offset",
         "single_pedestrian_start_delay_offset",
+        "occluder_timing_offset",
         "single_pedestrian_speed_offset",
         "single_pedestrian_wait_duration_offset",
         "single_pedestrian_trajectory_waypoint_offset",
@@ -35,7 +36,7 @@ def test_supported_families_covers_manifest_enum() -> None:
 def test_perturbation_families_iterable_is_ordered() -> None:
     """The families tuple should return the same order each call."""
     families = perturbation_families()
-    assert len(families) == 8
+    assert len(families) == 9
     names = [f.name for f in families]
     assert names[0] == "noop"
     assert names[-1] == "pedestrian_density_offset"
@@ -156,3 +157,14 @@ def test_density_family_optional_max_ped_density() -> None:
     assert "max_ped_density" in family.optional_parameters
     assert "density_delta" in family.required_parameters
     assert "max_abs_density_delta" in family.required_parameters
+
+
+def test_occluder_timing_family_requires_explicit_emerging_pedestrian() -> None:
+    """Occluder timing must be stricter than generic pedestrian start-delay offsets."""
+    family = perturbation_family("occluder_timing_offset")
+
+    assert "max_occluder_timing_offset_s" in family.validity_constraints
+    assert "pedestrian_id" in family.required_parameters
+    assert "dt_s" in family.required_parameters
+    assert "max_abs_dt_s" in family.required_parameters
+    assert "static_occlusion_required" in family.validity_constraints

--- a/tests/scenario_certification/test_scenario_perturbation_preflight.py
+++ b/tests/scenario_certification/test_scenario_perturbation_preflight.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import jsonschema
 import pytest
@@ -20,6 +21,9 @@ from robot_sf.training.scenario_loader import (
     load_scenarios,
     select_scenario,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _write_manifest(path: Path, *, max_route_offset_m: float = 0.5) -> Path:
@@ -143,6 +147,71 @@ def _write_start_delay_manifest(
             },
         ],
     }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _write_occluder_timing_manifest(
+    path: Path,
+    *,
+    scenario_config: str = "configs/scenarios/single/issue_2756_occluded_emergence_live.yaml",
+    scenario_id: str = "issue_2756_occluded_emergence",
+    dt_s: float = 0.5,
+    max_abs_dt_s: float = 0.5,
+    pedestrian_id: str = "h1",
+) -> Path:
+    """Write a perturbation manifest that offsets occluded-emergence timing."""
+    payload = {
+        "schema_version": PERTURBATION_MANIFEST_SCHEMA_VERSION,
+        "manifest_id": "test_occluder_timing_perturbation_manifest",
+        "scenario_config": scenario_config,
+        "seed_controls": {
+            "baseline_seeds": [111],
+            "replay_seed_policy": "explicit",
+        },
+        "validity": {
+            "require_scenario_certification": True,
+            "max_route_offset_m": 0.5,
+            "max_occluder_timing_offset_s": 0.5,
+            "invalid_variant_evidence_policy": "exclude_from_success_evidence",
+        },
+        "variants": [
+            {
+                "variant_id": f"{scenario_id}_noop",
+                "scenario_id": scenario_id,
+                "family": "noop",
+                "seeds": [111],
+            },
+            {
+                "variant_id": f"{scenario_id}_occluder_timing_offset",
+                "scenario_id": scenario_id,
+                "family": "occluder_timing_offset",
+                "seeds": [111],
+                "parameters": {
+                    "dt_s": dt_s,
+                    "max_abs_dt_s": max_abs_dt_s,
+                    "pedestrian_id": pedestrian_id,
+                },
+            },
+        ],
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _write_occluder_timing_scenario_config(
+    path: Path,
+    *,
+    mutate: Callable[[dict], None],
+) -> Path:
+    """Write a temporary occluded-emergence scenario config with one targeted mutation."""
+    source_path = Path("configs/scenarios/single/issue_2756_occluded_emergence_live.yaml")
+    payload = yaml.safe_load(source_path.read_text(encoding="utf-8"))
+    scenario = payload["scenarios"][0]
+    scenario["map_file"] = (
+        Path("maps/svg_maps/francis2023/francis2023_blind_corner.svg").resolve().as_posix()
+    )
+    mutate(scenario)
     path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
     return path
 
@@ -412,6 +481,38 @@ def test_manifest_schema_requires_manifest_timing_cap_for_start_delay_offset(
         jsonschema.validate(manifest, schema)
 
 
+def test_manifest_schema_accepts_bounded_occluder_timing_offset(
+    tmp_path: Path,
+) -> None:
+    """The public schema should expose the occlusion-gated timing family."""
+    manifest_path = _write_occluder_timing_manifest(tmp_path / "perturbations.yaml")
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    jsonschema.validate(manifest, schema)
+
+
+def test_manifest_schema_requires_manifest_timing_cap_for_occluder_timing_offset(
+    tmp_path: Path,
+) -> None:
+    """Occluder-timing manifests should carry variant-local and policy-level bounds."""
+    manifest_path = _write_occluder_timing_manifest(tmp_path / "perturbations.yaml")
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    del manifest["validity"]["max_occluder_timing_offset_s"]
+    schema = json.loads(
+        Path("robot_sf/benchmark/schemas/scenario_perturbation_manifest.v1.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    with pytest.raises(jsonschema.ValidationError, match="max_occluder_timing_offset_s"):
+        jsonschema.validate(manifest, schema)
+
+
 def test_manifest_schema_accepts_bounded_single_pedestrian_speed_offset(
     tmp_path: Path,
 ) -> None:
@@ -589,6 +690,16 @@ def test_manifest_schema_rejects_cross_family_parameters(tmp_path: Path) -> None
     timing_manifest["variants"][1]["parameters"]["dx_m"] = 0.0
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(timing_manifest, schema)
+
+    occluder_timing_manifest_path = _write_occluder_timing_manifest(
+        tmp_path / "occluder_timing_perturbations.yaml"
+    )
+    occluder_timing_manifest = yaml.safe_load(
+        occluder_timing_manifest_path.read_text(encoding="utf-8")
+    )
+    occluder_timing_manifest["variants"][1]["parameters"]["dx_m"] = 0.0
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(occluder_timing_manifest, schema)
 
     speed_manifest_path = _write_speed_manifest(
         tmp_path / "speed_perturbations.yaml",
@@ -776,6 +887,198 @@ def test_preflight_excludes_negative_start_delay_result(tmp_path: Path) -> None:
     assert excluded.reasons == [
         "preflight_error: single_pedestrian_start_delay_offset would make pedestrian 'h3' start_delay_s negative"
     ]
+
+
+def test_preflight_certifies_bounded_occluder_timing_offset(
+    tmp_path: Path,
+) -> None:
+    """Occluder timing should certify only with explicit occlusion fixture metadata."""
+    manifest_path = _write_occluder_timing_manifest(tmp_path / "perturbations.yaml")
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    assert [result.variant_id for result in report.results] == [
+        "issue_2756_occluded_emergence_noop",
+        "issue_2756_occluded_emergence_occluder_timing_offset",
+    ]
+    assert {result.validity_status for result in report.results} == {"valid"}
+    result = report.results[1]
+    assert result.family == "occluder_timing_offset"
+    assert result.perturbation_summary["dt_s"] == pytest.approx(0.5)
+    assert result.perturbation_summary["target"]["pedestrian_id"] == "h1"
+    assert result.perturbation_summary["baseline_start_delay_s"] == pytest.approx(0.0)
+    assert result.perturbation_summary["updated_start_delay_s"] == pytest.approx(0.5)
+    occlusion = result.perturbation_summary["occlusion"]
+    assert occlusion["static_occlusion"] is True
+    assert occlusion["source_fixture_occluder_id"] == "static_wall_behind_corner"
+    assert occlusion["fixture_contract"]["first_visible_step"] == 5
+    assert occlusion["fixture_contract"]["delay_steps"] == 2
+    assert occlusion["selected_pedestrian_role"] == "emerging_ped"
+
+
+def test_preflight_excludes_occluder_timing_for_non_emergence_scenario(
+    tmp_path: Path,
+) -> None:
+    """Occluder timing must not silently degrade into a generic start-delay offset."""
+    manifest_path = _write_occluder_timing_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_config="configs/scenarios/single/observation_visibility_blind_corner_smoke.yaml",
+        scenario_id="observation_visibility_blind_corner_smoke",
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.family == "occluder_timing_offset"
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: occluder_timing_offset requires scenario_family='occluded_emergence'"
+    ]
+
+
+def test_preflight_excludes_occluder_timing_without_fixture_contract(
+    tmp_path: Path,
+) -> None:
+    """Occluder timing must fail closed without fixture timing metadata."""
+    scenario_config = _write_occluder_timing_scenario_config(
+        tmp_path / "occluded_emergence.yaml",
+        mutate=lambda scenario: scenario["metadata"].pop("fixture_contract"),
+    )
+    manifest_path = _write_occluder_timing_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_config=scenario_config.as_posix(),
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: occluder_timing_offset requires metadata.fixture_contract"
+    ]
+
+
+def test_preflight_excludes_occluder_timing_with_unreadable_source_fixture(
+    tmp_path: Path,
+) -> None:
+    """Occluder timing must fail closed when the source trace fixture is missing."""
+
+    def _break_source_fixture(scenario: dict) -> None:
+        scenario["metadata"]["source_fixture"] = "tests/fixtures/missing_occlusion_trace.json"
+
+    scenario_config = _write_occluder_timing_scenario_config(
+        tmp_path / "occluded_emergence.yaml",
+        mutate=_break_source_fixture,
+    )
+    manifest_path = _write_occluder_timing_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_config=scenario_config.as_posix(),
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons[0].startswith(
+        "preflight_error: occluder_timing_offset cannot read source fixture:"
+    )
+
+
+def test_preflight_excludes_occluder_timing_with_fixture_step_mismatch(
+    tmp_path: Path,
+) -> None:
+    """Occluder timing must fail closed when trace and scenario fixture metadata diverge."""
+
+    def _shift_fixture_contract(scenario: dict) -> None:
+        scenario["metadata"]["fixture_contract"]["first_visible_step"] = 6
+
+    scenario_config = _write_occluder_timing_scenario_config(
+        tmp_path / "occluded_emergence.yaml",
+        mutate=_shift_fixture_contract,
+    )
+    manifest_path = _write_occluder_timing_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_config=scenario_config.as_posix(),
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: occluder_timing_offset requires source fixture first_visible_step "
+        "to match metadata.fixture_contract.first_visible_step"
+    ]
+
+
+def test_preflight_excludes_occluder_timing_without_emerging_pedestrian_role(
+    tmp_path: Path,
+) -> None:
+    """Occluder timing requires the selected pedestrian to be the emerging pedestrian."""
+
+    def _remove_emerging_role(scenario: dict) -> None:
+        scenario["single_pedestrians"][0]["metadata"]["role"] = "bystander"
+
+    scenario_config = _write_occluder_timing_scenario_config(
+        tmp_path / "occluded_emergence.yaml",
+        mutate=_remove_emerging_role,
+    )
+    manifest_path = _write_occluder_timing_manifest(
+        tmp_path / "perturbations.yaml",
+        scenario_config=scenario_config.as_posix(),
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: occluder_timing_offset requires selected pedestrian "
+        "metadata.role='emerging_ped'"
+    ]
+
+
+def test_preflight_excludes_negative_occluder_timing_result(tmp_path: Path) -> None:
+    """Occluder timing cannot make the emerging pedestrian start before time zero."""
+    manifest_path = _write_occluder_timing_manifest(
+        tmp_path / "perturbations.yaml",
+        dt_s=-0.5,
+        max_abs_dt_s=0.5,
+    )
+
+    report = preflight_perturbation_manifest(manifest_path)
+
+    excluded = report.results[1]
+    assert excluded.validity_status == "invalid"
+    assert excluded.benchmark_evidence_status == "excluded_from_success_evidence"
+    assert excluded.certificate is None
+    assert excluded.reasons == [
+        "preflight_error: occluder_timing_offset would make pedestrian 'h1' start_delay_s negative"
+    ]
+
+
+def test_tracked_occluder_timing_manifest_preflights() -> None:
+    """The checked-in #3369 pilot manifest should remain schema-valid and preflight-clean."""
+    report = preflight_perturbation_manifest(
+        "configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml"
+    )
+
+    assert [result.variant_id for result in report.results] == [
+        "issue_2756_occluded_emergence_noop",
+        "issue_2756_occluded_emergence_occluder_timing_h1_p050",
+    ]
+    assert {result.validity_status for result in report.results} == {"valid"}
+    assert report.results[1].perturbation_summary["updated_start_delay_s"] == pytest.approx(0.5)
 
 
 def test_preflight_certifies_bounded_single_pedestrian_speed_offset(
@@ -1303,6 +1606,41 @@ def test_materialize_pilot_matrix_writes_start_delay_overrides(tmp_path: Path) -
     _map_name, offset_map = next(iter(offset_config.map_pool.map_defs.items()))
     delays = {ped.id: ped.start_delay_s for ped in offset_map.single_pedestrians}
     assert delays["h3"] == pytest.approx(0.5)
+
+
+def test_materialize_pilot_matrix_writes_occluder_timing_overrides(tmp_path: Path) -> None:
+    """Occluder-timing variants should update only the emerging pedestrian delay."""
+    manifest_path = _write_occluder_timing_manifest(tmp_path / "perturbations.yaml")
+
+    materialized = materialize_perturbation_pilot_matrix(
+        manifest_path,
+        output_dir=tmp_path / "pilot",
+        seed_limit=1,
+    )
+
+    assert materialized.included_variants == (
+        "issue_2756_occluded_emergence_noop",
+        "issue_2756_occluded_emergence_occluder_timing_offset",
+    )
+    matrix_path = Path(materialized.scenario_matrix_path)
+    generated_scenarios = load_scenarios(matrix_path)
+    offset_scenario = generated_scenarios[1]
+    overrides = {entry["id"]: entry for entry in offset_scenario["single_pedestrians"]}
+    assert overrides["h1"]["metadata"]["role"] == "emerging_ped"
+    assert overrides["h1"]["start_delay_s"] == pytest.approx(0.5)
+    metadata = offset_scenario["metadata"]["scenario_perturbation"]
+    assert metadata["family"] == "occluder_timing_offset"
+    assert metadata["perturbation_summary"]["occlusion"]["selected_pedestrian_role"] == (
+        "emerging_ped"
+    )
+
+    offset_config = build_robot_config_from_scenario(
+        offset_scenario,
+        scenario_path=matrix_path,
+    )
+    _map_name, offset_map = next(iter(offset_config.map_pool.map_defs.items()))
+    delays = {ped.id: ped.start_delay_s for ped in offset_map.single_pedestrians}
+    assert delays["h1"] == pytest.approx(0.5)
 
 
 def test_materialize_pilot_matrix_start_delay_selector_all(tmp_path: Path) -> None:

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -88,6 +88,7 @@ def test_run_tests_parallel_exposes_xdist_distribution_mode() -> None:
     assert "${path%%::*}" in script_text
     assert "core_test_paths=(" in script_text
     assert "tests/analysis_workbench" in script_text
+    assert "tests/scenario_certification" in script_text
     assert "explicit_test_targets=(" in script_text
     assert 'cmd+=("--ignore=$optional_test_path")' in script_text
     assert 'pytest_args+=("$optional_test_path")' in script_text
@@ -112,6 +113,8 @@ def test_pytest_coverage_is_explicit_opt_in() -> None:
         'ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=core "$SCRIPT_DIR/run_tests_parallel.sh" --lane core'
         in pr_ready_text
     )
+    assert 'optional_pytest_addopts="${PYTEST_ADDOPTS:-}"' in pr_ready_text
+    assert "--cov-append" in pr_ready_text
 
 
 def test_run_tests_parallel_validates_dist_mode_before_resolving_workers() -> None:
@@ -271,7 +274,7 @@ def test_pr_ready_check_records_freshness_after_successful_gates() -> None:
         in script_text
     )
     assert (
-        'ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional'
+        'PYTEST_ADDOPTS="$optional_pytest_addopts" ROBOT_SF_PYTEST_COVERAGE=1 ROBOT_SF_TEST_LANE=optional "$SCRIPT_DIR/run_tests_parallel.sh" --lane optional'
         in script_text
     )
     assert "Optional-extra changed files requiring the predictive lane" in script_text

--- a/tests/tools/test_create_counterfactual_scenario_pair.py
+++ b/tests/tools/test_create_counterfactual_scenario_pair.py
@@ -129,6 +129,83 @@ def test_create_supported_robot_route_offset_pair(tmp_path: Path) -> None:
     assert "*id" not in output_text
 
 
+def test_create_supported_occluder_timing_pair(tmp_path: Path) -> None:
+    """The CLI should write a preflight-validated occluder-timing pair."""
+    output_path = tmp_path / "pair.yaml"
+
+    result = create_counterfactual_scenario_pair.main(
+        [
+            "--source",
+            "issue_2756_occluded_emergence",
+            "--feature",
+            "occluder_timing",
+            "--magnitude",
+            "0.5",
+            "--pedestrian-id",
+            "h1",
+            "--seed",
+            "111",
+            "--scenario-config",
+            "configs/scenarios/single/issue_2756_occluded_emergence_live.yaml",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    assert result == 0
+    output_text = output_path.read_text(encoding="utf-8")
+    payload = yaml.safe_load(output_text)
+    assert payload["changed_feature"] == "occluder_timing_offset"
+    assert payload["evidence_tier"] == "diagnostic-only"
+    assert validate_lineage_contract(payload) == []
+    assert payload["mechanism_taxonomy"]["label"] == "occlusion_exposure"
+    assert payload["intervention"]["parameters"] == {
+        "dt_s": 0.5,
+        "max_abs_dt_s": 0.5,
+        "pedestrian_id": "h1",
+    }
+    validity = payload["perturbation_manifest"]["validity"]
+    assert validity["max_occluder_timing_offset_s"] == 0.5
+    assert payload["perturbation_manifest"]["variants"][1]["family"] == ("occluder_timing_offset")
+    assert [row["benchmark_evidence_status"] for row in payload["preflight"]["results"]] == [
+        "eligible_success_evidence_candidate",
+        "eligible_success_evidence_candidate",
+    ]
+    summary = payload["preflight"]["results"][1]["perturbation_summary"]
+    assert summary["target"]["pedestrian_id"] == "h1"
+    assert summary["updated_start_delay_s"] == 0.5
+    assert summary["occlusion"]["source_fixture_occluder_id"] == "static_wall_behind_corner"
+    assert "&id" not in output_text
+    assert "*id" not in output_text
+
+
+def test_occluder_timing_requires_pedestrian_id_without_output(tmp_path: Path, capsys) -> None:
+    """Occluder timing should fail closed when no emerging pedestrian is selected."""
+    output_path = tmp_path / "pair.yaml"
+
+    result = create_counterfactual_scenario_pair.main(
+        [
+            "--source",
+            "issue_2756_occluded_emergence",
+            "--feature",
+            "occluder_timing_offset",
+            "--magnitude",
+            "0.5",
+            "--seed",
+            "111",
+            "--scenario-config",
+            "configs/scenarios/single/issue_2756_occluded_emergence_live.yaml",
+            "--output",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert result == 2
+    assert "occluder_timing_offset requires --pedestrian-id" in captured.err
+    assert not output_path.exists()
+
+
 def test_unsupported_feature_fails_closed_without_output(tmp_path: Path, capsys) -> None:
     """Unsupported features should not emit candidate inputs."""
     output_path = tmp_path / "pair.yaml"


### PR DESCRIPTION
## Summary
Adds a bounded `occluder_timing_offset` perturbation family for occluded-emergence counterfactual inputs, plus schema/preflight/materialization support, a tracked diagnostic pilot manifest, and CLI support in `create_counterfactual_scenario_pair.py`.

## Linked Issues
- Closes `#3369`
- Follow-up diagnostic pilot: `#3372`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3372`
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added the `occluder_timing_offset` perturbation family to the registry and manifest schema with a required `max_occluder_timing_offset_s` validity cap.
- Added fail-closed preflight checks for static occlusion, occluded-emergence scenario metadata, fixture timing/source trace metadata, explicit `emerging_ped` selection, and nonnegative shifted start delay.
- Reused start-delay materialization only after occluder-specific preflight has proven the row eligible.
- Extended `scripts/tools/create_counterfactual_scenario_pair.py` with `occluder_timing_offset` and the user-facing alias `occluder_timing`, mapped to the `occlusion_exposure` mechanism label.
- Added tracked diagnostic manifest `configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml`.
- Fixed PR readiness routing so scenario-certification tests run in the core lane and optional coverage appends instead of overwriting core coverage.
- Updated tests and the counterfactual mechanism taxonomy note.

## Why It Matters
- Added value: gives the counterfactual workflow a bounded, fixture-aware way to generate occlusion-exposure timing candidates.
- Expected impact: future diagnostic pilots can perturb emerging-pedestrian release timing without silently degrading into generic start-delay edits.
- Why this is worth merging now: it closes the input-generation gap while preserving the benchmark-evidence boundary.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: unblock diagnostic occlusion-exposure sensitivity inputs for occluded-emergence scenarios.
- Comparator or baseline, if applicable: noop row for the same scenario/seed in the tracked manifest.
- Evidence tier: diagnostic probe input generation and preflight proof.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: do not claim sensitivity, causal, benchmark, or paper-facing results until follow-up #3372 runs and classifies the paired pilot.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3369; `docs/context/issue_2547_counterfactual_mechanism_taxonomy.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: support extension to the existing counterfactual pair generator; representative use is covered by the tracked #3369 manifest and preflight tests. Follow-up #3372 will run the empirical pilot and record diagnostic result status.

## Domain-Aware Approval
- Required for this PR: yes - it adds a diagnostic evidence-input surface and must preserve claim boundaries.
- Domains reviewed: evidence classification, benchmark interpretation
- Status: waived
- Approver/review source or waiver: waiver - implementation-only input generation reviewed by self-review plus delegated read-only verifier; this PR makes no benchmark or paper claim.
- Validity checklist:
  - Target claim/hypothesis: occluder timing can be generated as a diagnostic input, not that it changes outcomes.
  - Comparator or split/evidence validity: noop and intervention rows share scenario, seed, map, and route geometry.
  - Fallback/degraded exclusions: preflight excludes missing occlusion/fixture/emerging-ped contracts and negative shifted delays.
  - Claim boundary: diagnostic counterfactual input generation only.
  - Implementation integrity vs experimental validity: tests prove schema/preflight/materialization contracts; #3372 covers empirical execution.

## Falsification / Non-Transfer Check
- Did the mechanism activate? unknown - this PR does not execute the pilot.
- Did the intervention change command source, selected command, trajectory, or route progress? unknown - execution deferred to #3372.
- Did the scenario actually contain the targeted failure mode? preflight verifies the occluded-emergence fixture contract and source trace metadata.
- Result route: continue
- Follow-up question or issue for weak, negative, or non-transfer results: #3372

## Next Empirical Action
- Rerun needed: yes - run the paired diagnostic pilot in #3372.
- Extractor or analysis tool needed: no new extractor known; use existing trace/metric surfaces first.
- Artifact missing or unavailable: no durable result artifact yet.
- Stop / revise / continue decision: continue to #3372.
- Proposed child issue or existing follow-up: #3372

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/scenario_certification/perturbation_family_registry.py robot_sf/scenario_certification/perturbation_preflight.py scripts/tools/create_counterfactual_scenario_pair.py tests/scenario_certification/test_perturbation_family_registry.py tests/scenario_certification/test_scenario_perturbation_preflight.py tests/tools/test_create_counterfactual_scenario_pair.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/scenario_certification/test_perturbation_family_registry.py tests/scenario_certification/test_scenario_perturbation_preflight.py tests/tools/test_create_counterfactual_scenario_pair.py tests/benchmark/test_occluded_emergence_fixture.py tests/benchmark/test_occluded_emergence_variants.py -q` (`113 passed`)
  - `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/preflight_scenario_perturbations.py configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml --fail-on-excluded`
  - `git diff --check`
  - `PYTEST_NUM_WORKERS=4 PR_READY_MODE=interim BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`1176 passed`, interim dirty-tree proof before commit)
  - `PYTEST_NUM_WORKERS=4 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3369-pr-body.md scripts/dev/pr_ready_check.sh` (`1308 passed` core; `2771 passed, 9 skipped` optional; changed-file coverage `100.0%` registry and `90.1%` preflight warning-only; final freshness clean)
- Evidence that the change works here: focused tests cover schema acceptance/rejection, fail-closed occlusion metadata gates, materialized start-delay override, tracked pilot preflight, and CLI pair generation.
- Benchmarks or smoke tests, if applicable: tracked manifest preflight returned both rows valid/eligible; this is input validation only, not benchmark execution.

## Risks / Rollout
- Compatibility risks: new schema enum/cap is additive but manifests using `occluder_timing_offset` must include the new cap and explicit pedestrian id.
- Failure modes: non-occluded scenarios, missing fixture metadata, wrong pedestrian role, unreadable source trace, mismatched fixture timing, and negative shifted delay fail closed.
- Rollback or fallback plan: revert the family/schema/CLI addition; existing perturbation families remain independent.

## Docs / Provenance
- Updated docs: `docs/context/issue_2547_counterfactual_mechanism_taxonomy.md`.
- Relevant design or provenance notes: tracked #3369 pilot manifest documents diagnostic-only boundary.
- Any assumptions that need to be preserved: positive fixture baseline has `start_delay_s=0.0`; negative offsets are invalid unless a future source fixture has positive baseline delay.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR will close #3369.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark or claim result.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no benchmark artifact.
- Registry or config index updated (yes/no/NA): registry/schema updated; no separate index exists for this small manifest.
- Context index / memory note updated (yes/no/NA): context note updated; index already links the taxonomy note.
- Follow-up issue opened for deferred propagation (yes/no/NA): yes, #3372.
- Not applicable because: result propagation is deferred until the diagnostic pilot actually runs.

## Follow-Up Issues
- Deferred work: run and synthesize the paired occluder-timing diagnostic pilot.
- Issues opened for follow-up: #3372

## Reviewer Notes
- Anything a reviewer should verify closely: the occluder-specific preflight gates run before certification/materialization, preventing generic start-delay fallback.
- Any known limitations: this PR produces diagnostic inputs only; it does not run or interpret an empirical sensitivity result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for occluder timing offset perturbations in counterfactual scenario pairs, enabling timing delay variations for occluded pedestrians.
  * Extended CLI tool to accept pedestrian selection for occluder timing scenarios.

* **Documentation**
  * Updated counterfactual mechanism taxonomy to document occluder timing perturbation feature and validation requirements.

* **Tests**
  * Added comprehensive test coverage for occluder timing perturbation validation, certification, and scenario generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->