### PR TITLE
feat: add multi-robot research smoke foothold (#3069)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a diagnostic-only multi-robot research smoke foothold (#3069): a small
+  runnable scenario config (`configs/multi_robot/issue_3069_smoke.yaml`), a smoke
+  runner (`scripts/validation/run_multi_robot_smoke_issue_3069.py`) that rolls out
+  the multi-robot environment via `make_multi_robot_env` and reports per-agent
+  inter-robot collision and goal-progress telemetry from the environment's native
+  `info["agents"]` metadata, and a guard test
+  (`tests/gym_env/test_multi_robot_smoke_issue_3069.py`). The report carries an
+  explicit `claim_boundary: diagnostic_only` / `evidence_tier: smoke` and
+  `multi_robot_benchmark_claim: false`; it proves only that the multi-robot path
+  runs end-to-end and is not a fleet-scale, MAPPO, or paper-facing claim (#3069).
 * Added durable issue-2904 forecast-risk eligibility fixtures
   (`tests/fixtures/benchmark/forecast_risk_eligibility/`) and the regenerated
   `ForecastCalibrationReport.v1` evidence bundle under

--- a/configs/multi_robot/issue_3069_smoke.yaml
+++ b/configs/multi_robot/issue_3069_smoke.yaml
@@ -1,0 +1,23 @@
+# Multi-robot research smoke foothold (issue #3069).
+#
+# Diagnostic-only / smoke evidence tier. This is NOT a benchmark suite and makes
+# no fleet-scale, MAPPO, or paper-facing multi-robot claim. It defines the
+# smallest runnable multi-robot rollout so the research lane has a foothold that
+# is guarded against silent rot.
+#
+# Consumed by scripts/validation/run_multi_robot_smoke_issue_3069.py, which maps
+# these fields onto MultiRobotConfig and rolls out a fixed number of steps,
+# reporting per-agent collision and progress telemetry from the environment's
+# native info["agents"] meta dicts.
+schema_version: multi_robot_smoke.v1
+issue: 3069
+evidence_tier: smoke
+claim_boundary: diagnostic_only
+num_robots: 2
+steps: 40
+seed: 0
+# Disable stochastic lidar noise so the smoke rollout is reproducible.
+deterministic_lidar: true
+# Simple unicycle goal-seeking controller; falls back to hold-position when an
+# agent has no resolvable goal. No learned policy is involved.
+policy: goal_seeking

--- a/scripts/validation/run_multi_robot_smoke_issue_3069.py
+++ b/scripts/validation/run_multi_robot_smoke_issue_3069.py
@@ -1,0 +1,292 @@
+#!/usr/bin/env python3
+"""Run a minimal multi-robot research smoke and report per-agent telemetry (issue #3069).
+
+This is a **diagnostic-only / smoke** foothold for the multi-robot research lane
+(parent #3057). It builds the smallest runnable multi-robot environment via
+``robot_sf.gym_env.environment_factory.make_multi_robot_env``, rolls out a fixed
+number of steps with a simple goal-seeking controller, and reports per-agent
+collision and progress fields straight from the environment's native
+``info["agents"]`` metadata.
+
+Claim boundary: this proves only that the multi-robot environment steps
+end-to-end and surfaces inter-robot collision/progress telemetry. It is **not** a
+benchmark and makes no fleet-scale, MAPPO, or paper-facing multi-robot claim.
+
+Usage::
+
+    uv run python scripts/validation/run_multi_robot_smoke_issue_3069.py --help
+    uv run python scripts/validation/run_multi_robot_smoke_issue_3069.py \\
+        --json-output output/multi_robot_smoke_issue_3069.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import time
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+from robot_sf.gym_env.environment_factory import make_multi_robot_env
+from robot_sf.gym_env.unified_config import MultiRobotConfig
+from robot_sf.sensor.range_sensor import LidarScannerSettings
+
+SCHEMA_VERSION = "multi_robot_smoke.v1"
+ISSUE = 3069
+DEFAULT_CONFIG = Path("configs/multi_robot/issue_3069_smoke.yaml")
+
+# Per-agent flags surfaced verbatim from RobotState.meta_dict().
+_COLLISION_FLAGS = (
+    "is_robot_collision",
+    "is_pedestrian_collision",
+    "is_obstacle_collision",
+)
+_PROGRESS_FLAGS = (
+    "is_route_complete",
+    "is_waypoint_complete",
+    "is_timesteps_exceeded",
+)
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    """Load the smoke config mapping (empty dict when absent)."""
+    if not path.is_file():
+        return {}
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else {}
+
+
+def _goal_seeking_actions(env: Any) -> np.ndarray:
+    """Return simple unicycle goal-seeking actions for every robot.
+
+    Falls back to a hold-position (zero) action for any robot without a
+    resolvable goal so the smoke never crashes on incomplete scenarios.
+    """
+    actions: list[list[float]] = []
+    for sim in env.simulators:
+        goals = list(getattr(sim, "goal_pos", []) or [])
+        for index, robot in enumerate(sim.robots):
+            goal = goals[index] if index < len(goals) else None
+            if goal is None:
+                actions.append([0.0, 0.0])
+                continue
+            pos = np.asarray(robot.pose[0], dtype=float)
+            heading = float(robot.pose[1])
+            goal_xy = np.asarray(goal, dtype=float)
+            delta = goal_xy - pos
+            distance = float(np.linalg.norm(delta))
+            target_heading = float(np.arctan2(delta[1], delta[0])) if distance > 1e-9 else heading
+            heading_error = ((target_heading - heading + np.pi) % (2.0 * np.pi)) - np.pi
+            linear = min(0.6, distance)
+            angular = float(np.clip(2.0 * heading_error, -1.0, 1.0))
+            actions.append([linear, angular])
+    return np.asarray(actions, dtype=np.float32)
+
+
+def _actions(env: Any, policy: str) -> np.ndarray:
+    """Return the action array for the requested smoke policy."""
+    if policy == "zero":
+        return np.zeros(env.action_space.shape, dtype=env.action_space.dtype)
+    return _goal_seeking_actions(env)
+
+
+def _summarize_agent(index: int, first: dict[str, Any], last: dict[str, Any]) -> dict[str, Any]:
+    """Summarize one agent's collision and progress telemetry."""
+    initial = first.get("prev_distance_to_goal", first.get("distance_to_goal"))
+    final = last.get("distance_to_goal")
+    initial_f = float(initial) if isinstance(initial, (int, float)) else None
+    final_f = float(final) if isinstance(final, (int, float)) else None
+    progress: float | None = None
+    if initial_f is not None and final_f is not None and math.isfinite(initial_f - final_f):
+        progress = initial_f - final_f
+    summary: dict[str, Any] = {
+        "agent_index": index,
+        "step_of_episode": int(last.get("step_of_episode", 0)),
+        "initial_distance_to_goal": initial_f,
+        "final_distance_to_goal": final_f,
+        "distance_progress": progress,
+    }
+    for flag in (*_COLLISION_FLAGS, *_PROGRESS_FLAGS):
+        summary[flag] = bool(last.get(flag, False))
+    return summary
+
+
+def run_smoke(
+    *,
+    num_robots: int = 2,
+    steps: int = 40,
+    seed: int = 0,
+    deterministic_lidar: bool = True,
+    policy: str = "goal_seeking",
+) -> dict[str, Any]:
+    """Roll out a small multi-robot episode and return a diagnostic smoke report."""
+    if num_robots < 1:
+        raise ValueError("num_robots must be >= 1")
+    if steps < 1:
+        raise ValueError("steps must be >= 1")
+
+    config_kwargs: dict[str, Any] = {"num_robots": num_robots}
+    if deterministic_lidar:
+        config_kwargs["lidar_config"] = LidarScannerSettings(scan_noise=[0.0, 0.0])
+    config = MultiRobotConfig(**config_kwargs)
+
+    env = make_multi_robot_env(config=config, seed=seed)
+    started = time.time()
+    steps_executed = 0
+    total_reward = 0.0
+    terminated = False
+    truncated = False
+    first_metas: list[dict[str, Any]] | None = None
+    last_metas: list[dict[str, Any]] | None = None
+    try:
+        env.reset(seed=seed)
+        for _ in range(steps):
+            _obs, reward, terminated, truncated, info = env.step(_actions(env, policy))
+            steps_executed += 1
+            total_reward += float(reward)
+            metas = [dict(agent["meta"]) for agent in info["agents"]]
+            if first_metas is None:
+                first_metas = metas
+            last_metas = metas
+            if terminated or truncated:
+                break
+    finally:
+        env.close()
+    wall_time_sec = max(1e-9, time.time() - started)
+
+    agents: list[dict[str, Any]] = []
+    if first_metas is not None and last_metas is not None:
+        for index, last in enumerate(last_metas):
+            first = first_metas[index] if index < len(first_metas) else last
+            agents.append(_summarize_agent(index, first, last))
+
+    robot_collisions = [a for a in agents if a["is_robot_collision"]]
+    inter_robot = {
+        "any_robot_collision": bool(robot_collisions),
+        "robot_collision_count": len(robot_collisions),
+        "robot_collision_agents": [a["agent_index"] for a in robot_collisions],
+    }
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": ISSUE,
+        "evidence_tier": "smoke",
+        "claim_boundary": "diagnostic_only",
+        "multi_robot_benchmark_claim": False,
+        "config": {
+            "num_robots": num_robots,
+            "steps": steps,
+            "seed": seed,
+            "deterministic_lidar": deterministic_lidar,
+            "policy": policy,
+        },
+        "rollout": {
+            "steps_executed": steps_executed,
+            "terminated": bool(terminated),
+            "truncated": bool(truncated),
+            "total_reward": total_reward,
+            "wall_time_sec": wall_time_sec,
+        },
+        "agents": agents,
+        "inter_robot": inter_robot,
+        "notes": (
+            "Diagnostic-only multi-robot foothold (issue #3069). Proves the "
+            "multi-robot environment steps end-to-end and surfaces per-agent "
+            "collision/progress telemetry. Not a benchmark; no fleet-scale, "
+            "MAPPO, or paper-facing claim."
+        ),
+    }
+
+
+def _format_report(report: dict[str, Any]) -> str:
+    """Render a compact human-readable summary."""
+    cfg = report["config"]
+    rollout = report["rollout"]
+    lines = [
+        "multi-robot research smoke (issue #3069) — diagnostic_only",
+        f"  num_robots={cfg['num_robots']} steps_executed={rollout['steps_executed']} "
+        f"seed={cfg['seed']} policy={cfg['policy']}",
+        f"  terminated={rollout['terminated']} total_reward={rollout['total_reward']:.4f} "
+        f"wall_time_sec={rollout['wall_time_sec']:.3f}",
+        f"  inter_robot_collision={report['inter_robot']['any_robot_collision']} "
+        f"(count={report['inter_robot']['robot_collision_count']})",
+    ]
+    for agent in report["agents"]:
+        progress = agent["distance_progress"]
+        progress_str = f"{progress:.3f}" if isinstance(progress, float) else "n/a"
+        lines.append(
+            f"  agent[{agent['agent_index']}] progress={progress_str} "
+            f"route_complete={agent['is_route_complete']} "
+            f"robot_collision={agent['is_robot_collision']} "
+            f"timeout={agent['is_timesteps_exceeded']}"
+        )
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Run a diagnostic-only multi-robot research smoke (issue #3069).",
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG,
+        help=f"Smoke config providing defaults (default: {DEFAULT_CONFIG}).",
+    )
+    parser.add_argument("--num-robots", type=int, default=None, help="Override robot count.")
+    parser.add_argument("--steps", type=int, default=None, help="Override rollout step count.")
+    parser.add_argument("--seed", type=int, default=None, help="Override RNG seed.")
+    parser.add_argument(
+        "--policy",
+        choices=("goal_seeking", "zero"),
+        default=None,
+        help="Override smoke control policy.",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        default=None,
+        help="Write the full smoke report as JSON to this path.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the multi-robot smoke CLI. Returns the process exit code."""
+    args = _parse_args(argv)
+    config = _load_config(args.config)
+
+    num_robots = (
+        args.num_robots if args.num_robots is not None else int(config.get("num_robots", 2))
+    )
+    steps = args.steps if args.steps is not None else int(config.get("steps", 40))
+    seed = args.seed if args.seed is not None else int(config.get("seed", 0))
+    policy = args.policy if args.policy is not None else str(config.get("policy", "goal_seeking"))
+    deterministic_lidar = bool(config.get("deterministic_lidar", True))
+
+    report = run_smoke(
+        num_robots=num_robots,
+        steps=steps,
+        seed=seed,
+        deterministic_lidar=deterministic_lidar,
+        policy=policy,
+    )
+
+    print(_format_report(report))
+
+    if args.json_output is not None:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gym_env/test_multi_robot_smoke_issue_3069.py
+++ b/tests/gym_env/test_multi_robot_smoke_issue_3069.py
@@ -1,0 +1,77 @@
+"""Smoke guard for the multi-robot research foothold (issue #3069).
+
+Diagnostic-only: asserts the multi-robot smoke path runs end-to-end and reports
+per-agent collision/progress telemetry with an explicit diagnostic-only claim
+boundary. It is not a benchmark and asserts no multi-robot performance claim.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from scripts.validation.run_multi_robot_smoke_issue_3069 import main, run_smoke
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+_PER_AGENT_KEYS = {
+    "agent_index",
+    "step_of_episode",
+    "initial_distance_to_goal",
+    "final_distance_to_goal",
+    "distance_progress",
+    "is_robot_collision",
+    "is_pedestrian_collision",
+    "is_obstacle_collision",
+    "is_route_complete",
+    "is_waypoint_complete",
+    "is_timesteps_exceeded",
+}
+
+
+def test_run_smoke_reports_per_agent_telemetry() -> None:
+    """The smoke rollout runs and surfaces per-agent collision/progress fields."""
+    report = run_smoke(num_robots=2, steps=3, seed=0)
+
+    # Diagnostic-only claim boundary is explicit and conservative.
+    assert report["schema_version"] == "multi_robot_smoke.v1"
+    assert report["issue"] == 3069
+    assert report["evidence_tier"] == "smoke"
+    assert report["claim_boundary"] == "diagnostic_only"
+    assert report["multi_robot_benchmark_claim"] is False
+
+    # The path executed at least one step against the requested robot count.
+    assert report["config"]["num_robots"] == 2
+    assert report["rollout"]["steps_executed"] >= 1
+    assert isinstance(report["rollout"]["total_reward"], float)
+
+    # Per-agent telemetry is reported for every robot.
+    assert len(report["agents"]) == 2
+    for index, agent in enumerate(report["agents"]):
+        assert agent["agent_index"] == index
+        assert _PER_AGENT_KEYS <= set(agent)
+        for flag in ("is_robot_collision", "is_route_complete", "is_timesteps_exceeded"):
+            assert isinstance(agent[flag], bool)
+
+    # Inter-robot collision fields are reported (not deferred).
+    inter_robot = report["inter_robot"]
+    assert isinstance(inter_robot["any_robot_collision"], bool)
+    assert inter_robot["robot_collision_count"] == sum(
+        1 for agent in report["agents"] if agent["is_robot_collision"]
+    )
+
+
+def test_main_writes_json_report(tmp_path: Path) -> None:
+    """The CLI runs and writes a JSON smoke report with the claim boundary."""
+    out_path = tmp_path / "multi_robot_smoke.json"
+    exit_code = main(
+        ["--num-robots", "2", "--steps", "2", "--seed", "0", "--json-output", str(out_path)]
+    )
+
+    assert exit_code == 0
+    assert out_path.is_file()
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["claim_boundary"] == "diagnostic_only"
+    assert payload["multi_robot_benchmark_claim"] is False
+    assert len(payload["agents"]) == 2


### PR DESCRIPTION
## Summary

Implements the agent-executable slice of #3069: the smallest runnable
**multi-robot research smoke path** so the fleet/crowd-interaction lane (parent
#3057) has a foothold guarded against silent rot — without pretending v0 is a
full multi-agent benchmark.

Blocker #3062 (research campaign manifest/artifact flow) is now closed, so this
issue is unblocked.

## Changes

- **`configs/multi_robot/issue_3069_smoke.yaml`** — small smoke scenario config
  (2 robots, deterministic lidar, goal-seeking policy), tagged `evidence_tier:
  smoke` / `claim_boundary: diagnostic_only`.
- **`scripts/validation/run_multi_robot_smoke_issue_3069.py`** — builds the
  multi-robot env via `make_multi_robot_env(MultiRobotConfig(...))`, rolls out a
  fixed number of steps with a simple unicycle goal-seeking controller (falls
  back to hold-position when a goal is unresolvable), and reports **per-agent
  inter-robot collision and goal-progress telemetry** straight from the
  environment's native `info["agents"]` meta dicts. Emits JSON with an explicit
  claim boundary.
- **`tests/gym_env/test_multi_robot_smoke_issue_3069.py`** — guards the path runs
  end-to-end and surfaces per-agent collision/progress fields.

## Claim boundary

This is **diagnostic-only / smoke** evidence. The report carries
`claim_boundary: diagnostic_only`, `evidence_tier: smoke`, and
`multi_robot_benchmark_claim: false`. It proves only that the multi-robot
environment steps end-to-end and surfaces inter-robot collision/progress
telemetry. It is **not** a benchmark and makes no fleet-scale, MAPPO, or
paper-facing multi-robot claim.

## Validation

```
# 1. CLI help
uv run python scripts/validation/run_multi_robot_smoke_issue_3069.py --help        # ok

# 2. Real smoke rollout (default config: 2 robots, 40 steps, seed 0)
uv run python scripts/validation/run_multi_robot_smoke_issue_3069.py \
    --json-output output/multi_robot_smoke_issue_3069.json                          # exit 0
#   -> steps_executed=40, terminated=False, inter_robot_collision=False
#   -> agent[0] distance_progress=+7.11, agent[1] distance_progress=-6.25
#      (naive controller; honest diagnostic telemetry, not a performance claim)

# 3. Focused + spec test slice
uv run python -m pytest tests/gym_env/ -k "multi_robot" -q                          # 4 passed
uv run ruff check / ruff format --check (new files)                                # clean
```

The JSON report is written to git-ignored `output/`; the compact summary above is
the promoted smoke evidence (no tracked evidence bundle, so no evidence-PR
approval gate is triggered).

## Definition of Done (#3069)

- [x] A small multi-robot scenario/report path runs locally and produces a report.
- [x] Smoke test guards the path against silent rot.
- [x] Inter-robot collision/progress fields are reported (not deferred).
- [x] No broad multi-robot benchmark claim is made from smoke evidence alone.

## Known limitations / out of scope

- The goal-seeking controller is intentionally naive (no learned policy); agent
  progress can be negative. This is a foothold, not a planner evaluation.
- No MAPPO, fleet-scale optimization, or paper-facing multi-robot claim.
- The first env-construction call dominates runtime (numba/JIT warmup); the test
  itself is well under the slow-test threshold once warm.

Closes #3069

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - PR closes #3069 and names parent #3057.
- Claim map / benchmark report updated (yes/no/NA): NA - diagnostic-only smoke foothold, not benchmark evidence.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no benchmark or artifact catalog result.
- Registry or config index updated (yes/no/NA): NA - smoke config is issue-local and not a benchmark registry entry.
- Context index / memory note updated (yes/no/NA): NA - compact PR body carries the smoke evidence and limitations.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - current scope is the #3069 foothold only; broader multi-robot research remains under parent #3057.
- Not applicable because: this PR establishes a diagnostic smoke path with explicit non-benchmark claim boundaries and does not produce leaderboard, paper-facing, or benchmark interpretation evidence.

## Follow-Up Issues
- Deferred work: broader fleet-scale, MAPPO, and benchmark-quality multi-robot work remains outside this smoke foothold.
- Issues opened for follow-up: NA; parent #3057 tracks the broader research lane.

## Reviewer Notes
- Verify the diagnostic-only boundary remains explicit in the config, runner output, tests, and changelog entry.
- The smoke JSON written under `output/` is disposable local output; no durable generated artifact is required for this PR.
