### PR TITLE
docs: occluder-timing counterfactual pilot diagnostic evidence (#3372)

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -17,6 +17,18 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+  - path: docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/checksums.sha256
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_3342_nearfield_turn_budget_2026-06-21/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/README.md
+++ b/docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/README.md
@@ -1,0 +1,56 @@
+# Issue #3372 Occluder-Timing Counterfactual Pilot
+
+**Date:** 2026-06-22 · **Evidence tier:** `diagnostic-only` · **Parent:** #3369
+
+## Source
+
+This bundle records a compact local run of the Issue #3369 occluder-timing perturbation pilot on
+durable, tracked inputs, synthesized as diagnostic counterfactual sensitivity. The run pairs the
+`noop` baseline against a single `occluder_timing_offset` variant that delays the emerging
+pedestrian release by `+0.5 s` while holding the source scenario, seed, map, and route geometry
+fixed.
+
+- Manifest: `configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml`
+- Scenario fixture: `configs/scenarios/single/issue_2756_occluded_emergence_live.yaml`
+- Baseline commit: `877b603831309af9ddb93df49093096521209db4`
+- Planner: `goal` · Seed: `111` · Horizon: `80` · dt: `0.1`
+
+Preflight reported both variants `valid` (no exclusions); the perturbed variant carried the
+`dynamic_interaction_present` eligibility reason. Materialized scenario matrix and route overrides
+remain ignored local `output/` artifacts that are reproducible from the tracked manifest and the
+commands in `summary.json`. Raw `trace_response.json` / `.md` are likewise ignored local outputs;
+`summary.json` is the compact tracked representation.
+
+## Result
+
+Both rows are valid diagnostic results (fail-closed classification: `valid_diagnostic_result`).
+Each variant ran the full horizon (`termination_reason: max_steps`); the pair completed.
+
+| Row | Variant | Closest-approach step | Clearance (m) | Center distance (m) |
+|---|---|---:|---:|---:|
+| noop baseline | `..._noop` | 79 | 20.918 | 22.318 |
+| occluder +0.5 s | `..._occluder_timing_h1_p050` | 79 | 25.518 | 26.918 |
+
+Mean closest-approach deltas (perturbed − noop), `goal` planner, 1 pair completed:
+
+- `clearance_m`: `+4.600`
+- `center_distance_m`: `+4.600`
+- `time_s`: `0.000`
+- `goal_distance_m`: `0.000`
+- `progress_m`: `0.000`
+
+A `+0.5 s` occluder release delay increased the robot's closest-approach clearance to the emerging
+pedestrian by ~`4.60 m`, with the closest approach still occurring at step 79 (positive clearance
+delta = perturbed run was farther from the closest pedestrian at its closest approach). This is
+consistent with the pedestrian emerging later, so the robot clears the conflict zone with more
+margin under this single seed and planner.
+
+## Claim Boundary
+
+- Diagnostic-only counterfactual sensitivity input/result; **not** benchmark-strength, causal, or
+  paper-facing evidence.
+- Single seed (`111`), single planner (`goal`), single perturbation magnitude (`+0.5 s`): the
+  reported delta is a per-pair diagnostic observation, not a distribution or a directional claim.
+- No fallback or degraded rows are promoted as success; preflight eligibility is input validation
+  only.
+- Reproduce raw local output from the tracked manifest and the commands recorded in `summary.json`.

--- a/docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/checksums.sha256
+++ b/docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/checksums.sha256
@@ -1,0 +1,2 @@
+e3a603417a8fe90bdcf72d3d66e236de2a22bbffa9d4d11960e5ce58d565e675  docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/README.md
+8542b11b022955a94a0531d0fd1e1829d469f5cf701e1656adc40c57988e3390  docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/summary.json

--- a/docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/summary.json
+++ b/docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/summary.json
@@ -1,0 +1,84 @@
+{
+  "status": "diagnostic_local_pilot_complete",
+  "evidence_tier": "diagnostic-only, not benchmark/causal/paper-grade",
+  "claim_boundary": "diagnostic counterfactual sensitivity input/result for the occluder-timing family; not benchmark-strength, causal, or paper-facing evidence",
+  "issue": "#3372",
+  "parent_issue": "#3369",
+  "provenance": {
+    "base_commit": "877b603831309af9ddb93df49093096521209db4",
+    "manifest": "configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml",
+    "scenario_fixture": "configs/scenarios/single/issue_2756_occluded_emergence_live.yaml",
+    "planner": "goal",
+    "seed": 111,
+    "seed_limit": 1,
+    "horizon": 80,
+    "dt": 0.1,
+    "preflight_schema_version": "scenario_perturbation_preflight.v1",
+    "materialization_schema_version": "scenario_perturbation_pilot_matrix.v1",
+    "trace_response_schema_version": "scenario_perturbation_trace_response.v1"
+  },
+  "local_output_note": "<run-dir> is any git-ignored local directory (the run used a path under the ignored output/ tree). The materialized matrix and raw trace_response.json/.md are reproducible from the tracked manifest and these commands and are not mirrored here.",
+  "commands": [
+    "uv run python scripts/tools/preflight_scenario_perturbations.py configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml --output <run-dir>/preflight.json",
+    "uv run python scripts/tools/materialize_scenario_perturbation_pilot.py configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml --output-dir <run-dir>/matrix",
+    "uv run --extra training python scripts/validation/run_scenario_perturbation_trace_response.py configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml --materialized-output-dir <run-dir>/matrix --output <run-dir>/trace_response.json --markdown-output <run-dir>/trace_response.md --source-scenario-id issue_2756_occluded_emergence --perturbed-family occluder_timing_offset --perturbed-variant-id issue_2756_occluded_emergence_occluder_timing_h1_p050 --planner goal --seed-limit 1 --horizon 80"
+  ],
+  "preflight": {
+    "included_variants": [
+      "issue_2756_occluded_emergence_noop",
+      "issue_2756_occluded_emergence_occluder_timing_h1_p050"
+    ],
+    "excluded_variants": [],
+    "noop_validity_status": "valid",
+    "perturbed_validity_status": "valid",
+    "perturbed_reasons": ["dynamic_interaction_present"]
+  },
+  "rows": [
+    {
+      "row": "noop_baseline",
+      "variant_id": "issue_2756_occluded_emergence_noop",
+      "family": "noop",
+      "planner": "goal",
+      "seed": 111,
+      "row_status": "valid_diagnostic_result",
+      "pair_status": "completed",
+      "termination_reason": "max_steps",
+      "closest_approach": {
+        "step": 79,
+        "time_s": 8.0,
+        "clearance_m": 20.917907,
+        "center_distance_m": 22.317907
+      }
+    },
+    {
+      "row": "occluder_timing_offset_h1_p050",
+      "variant_id": "issue_2756_occluded_emergence_occluder_timing_h1_p050",
+      "family": "occluder_timing_offset",
+      "parameters": {"dt_s": 0.5, "max_abs_dt_s": 0.5, "pedestrian_id": "h1"},
+      "planner": "goal",
+      "seed": 111,
+      "row_status": "valid_diagnostic_result",
+      "pair_status": "completed",
+      "termination_reason": "max_steps",
+      "closest_approach": {
+        "step": 79,
+        "time_s": 8.0,
+        "clearance_m": 25.517635,
+        "center_distance_m": 26.917635
+      }
+    }
+  ],
+  "pair_delta": {
+    "planner": "goal",
+    "pairs": 1,
+    "status_counts": {"completed": 1},
+    "closest_approach_delta": {
+      "clearance_m": 4.599728,
+      "center_distance_m": 4.599728,
+      "time_s": 0.0,
+      "goal_distance_m": 0.0,
+      "progress_m": 0.0
+    },
+    "interpretation": "A +0.5 s occluder release delay increased the robot closest-approach clearance to the emerging pedestrian by ~4.60 m under the goal planner at seed 111, with closest-approach timing unchanged (step 79). Single seed and single planner; diagnostic-only sensitivity input, not a causal or benchmark claim."
+  }
+}


### PR DESCRIPTION
## Summary
Runs the Issue #3369 occluder-timing perturbation pilot on durable, tracked inputs and synthesizes the paired diagnostic sensitivity result for #3372, without treating it as benchmark evidence.

- Input manifest: `configs/scenarios/perturbations/issue_3369_occluder_timing_pilot_v1.yaml`
- Scenario fixture: `configs/scenarios/single/issue_2756_occluded_emergence_live.yaml`
- Baseline commit: `877b603831309af9ddb93df49093096521209db4`

## What changed
- New evidence bundle `docs/context/evidence/issue_3372_occluder_timing_pilot_2026-06-22/` (`README.md`, `summary.json`, `checksums.sha256`).
- Registered the three bundle files in `docs/context/catalog.yaml` as `status: evidence`.

## Result (diagnostic-only)
Both variants preflight-valid (no exclusions) and completed (`termination_reason: max_steps`); each row is classified fail-closed as `valid_diagnostic_result`. Under the `goal` planner at seed `111`:

| Row | Closest-approach step | Clearance (m) | Center distance (m) |
|---|---:|---:|---:|
| noop baseline | 79 | 20.918 | 22.318 |
| occluder +0.5 s | 79 | 25.518 | 26.918 |

Mean closest-approach delta (perturbed − noop): `clearance_m +4.600`, `time_s 0.000`, `progress_m 0.000`. A +0.5 s occluder release delay increased the robot's closest-approach clearance to the emerging pedestrian by ~4.60 m, with the closest approach still at step 79.

## Claim boundary / evidence status
Diagnostic counterfactual sensitivity input/result only — **not** benchmark-strength, causal, or paper-facing. Single seed, single planner, single magnitude; no directional or distributional claim. No fallback/degraded rows are promoted as success. Raw materialized matrix and trace outputs remain in ignored `output/` and are reproducible from the tracked manifest and the commands recorded in `summary.json`.

## Validation
- `scripts/tools/preflight_scenario_perturbations.py` → both variants `valid`, 0 excluded.
- `scripts/tools/materialize_scenario_perturbation_pilot.py` → 2 variants materialized.
- `scripts/validation/run_scenario_perturbation_trace_response.py` (`--extra training`) → 1 pair completed.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` → passed (4 changed files).
- `pre-commit run --files <changed>` → clean.

## Acceptance criteria (#3372)
- [x] Preflight and materialization commands recorded with commit/config provenance.
- [x] Both rows classified fail-closed (valid diagnostic result).
- [x] Report states explicitly this is diagnostic, not benchmark/causal/paper-facing.
- [x] Large `output/` artifacts are disposable; the bundle is the small tracked representation.

Closes #3372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - PR closes #3372 and links parent #3369.
- Claim map / benchmark report updated (yes/no/NA): NA - diagnostic-only pilot evidence, explicitly not benchmark-strength.
- Leaderboard / artifact catalog updated (yes/no/NA): yes - compact evidence bundle is registered in `docs/context/catalog.yaml`; no leaderboard update applies.
- Registry or config index updated (yes/no/NA): NA - uses existing tracked perturbation manifest and scenario fixture.
- Context index / memory note updated (yes/no/NA): yes - evidence bundle is discoverable through `docs/context/catalog.yaml`.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - the PR is scoped to the #3372 diagnostic pilot; broader follow-up remains under #3369.
- Not applicable because: benchmark, leaderboard, and paper-facing propagation do not apply to this single-seed diagnostic pilot.

## Follow-Up Issues
- Deferred work: broader occluder-timing conclusions require additional seeds/planners/magnitudes before any benchmark or paper-facing claim.
- Issues opened for follow-up: NA; parent #3369 remains the broader follow-up surface.

## Reviewer Notes
- Verify the bundle never promotes fallback/degraded rows as success and keeps the diagnostic-only claim boundary ahead of the result interpretation.
- Raw `output/` artifacts are intentionally excluded; `summary.json`, `README.md`, and checksums are the durable tracked representation.
