### PR TITLE
ci: shard PR test suite and trim CI runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,13 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   pull_request:
+    paths-ignore:
+      - "**/*.md"
+      - "docs/**"
   workflow_dispatch:
 
 permissions:
@@ -18,11 +24,24 @@ env:
   SDL_VIDEODRIVER: dummy
   MPLBACKEND: Agg
   PYGAME_HIDE_SUPPORT_PROMPT: "1"
+  # Use CPython 3.12+ sys.monitoring backend for coverage: dramatically lower
+  # instrumentation overhead than the default trace-based core.
+  COVERAGE_CORE: sysmon
 
 jobs:
   fast-feedback:
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    # On pull requests, split the suite into parallel shards (pytest-split) for
+    # fast feedback. On main/workflow_dispatch run a single full pass so the
+    # advisory coverage baseline stays accurate without cross-shard combining.
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: ${{ github.event_name == 'pull_request' && fromJSON('[1, 2, 3, 4]') || fromJSON('[1]') }}
+    env:
+      PYTEST_SHARD_COUNT: ${{ github.event_name == 'pull_request' && '4' || '1' }}
+      PYTEST_SHARD_INDEX: ${{ matrix.shard }}
     steps:
       - name: Checkout
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
@@ -38,16 +57,21 @@ jobs:
           restore-keys: |
             pytest-${{ runner.os }}-
 
+      # Lint and typecheck are shard-independent; run them once (shard 1 only)
+      # to avoid quadruplicated annotations on pull-request shard matrices.
       - name: Lint
+        if: ${{ matrix.shard == 1 }}
         run: scripts/dev/ci_driver.sh lint
 
       - name: Type check
+        if: ${{ matrix.shard == 1 }}
         run: scripts/dev/ci_driver.sh typecheck
 
       - name: Unit tests
         run: scripts/dev/ci_driver.sh test
 
       - name: Restore coverage baseline
+        if: ${{ github.event_name != 'pull_request' }}
         uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: output/coverage/.coverage-baseline.json
@@ -56,6 +80,7 @@ jobs:
             coverage-baseline-main
 
       - name: Compare coverage with baseline
+        if: ${{ github.event_name != 'pull_request' }}
         continue-on-error: true
         run: |
           if [ -f output/coverage/.coverage-baseline.json ]; then
@@ -84,7 +109,7 @@ jobs:
           key: coverage-baseline-${{ github.ref_name }}-${{ github.sha }}
 
       - name: Upload coverage reports
-        if: failure() || github.ref == 'refs/heads/main'
+        if: ${{ github.event_name != 'pull_request' && (failure() || github.ref == 'refs/heads/main') }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: coverage-reports

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Cut pull-request CI wall-clock by parallelizing the `fast-feedback` test phase. Pull requests now
+  split the suite into 4 `pytest-split` shards (a matrix on the existing job, so the CI topology is
+  unchanged) while `main`/`workflow_dispatch` keep a single full pass so the advisory coverage
+  baseline stays accurate without cross-shard combining. The shared `run_tests_parallel.sh` wrapper
+  gained `PYTEST_SHARD_COUNT`/`PYTEST_SHARD_INDEX` env hooks (`--splits`/`--group`); coverage is
+  skipped while sharding. Also enabled the CPython 3.12+ `COVERAGE_CORE=sysmon` backend to lower
+  coverage instrumentation overhead, and added a docs-only `paths-ignore` filter so Markdown/`docs/`
+  changes no longer trigger the full CI workflow. Adds `pytest-split` to the `dev` dependency group.
 * Removed redundant Black/autopep8 formatter configuration and the unused Black optional
   development dependency; Ruff format remains the canonical formatter.
 * Extended the issue-1515 hybrid-evidence matrix validator with an opt-in git-history proof path:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -477,6 +477,7 @@ dev = [
     "setuptools>=70.0.0",
     "pylint>=3.3.4",
     "pytest-xdist>=3.6.1",
+    "pytest-split>=0.9.0",
 ]
 docs = [
     "myst-parser>=4.0.0",

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -28,6 +28,12 @@ Environment overrides:
   PYTEST_XDIST_DIST=load|worksteal|loadscope|loadfile|loadgroup
   PYTEST_ORDER_MODE=failed-first|new-first|none
   PYTEST_NUM_WORKERS=<int>|auto
+  PYTEST_SHARD_COUNT=<int>
+    pytest-split shard count (default 1). When >1, runs a disjoint subset via
+    `--splits N --group G` and disables coverage (partial shard data cannot be
+    combined in the single-job CI topology).
+  PYTEST_SHARD_INDEX=<int>
+    pytest-split shard index in 1..PYTEST_SHARD_COUNT (default 1).
 
 Examples:
   scripts/dev/run_tests_parallel.sh
@@ -227,11 +233,29 @@ echo "Resolved pytest-xdist workers: $worker_spec" >&2
 
 cmd=(uv run pytest -n "$worker_spec" --dist "$dist_mode")
 
+# pytest-split sharding: when CI provisions multiple shards, run a disjoint
+# subset per shard so the suite parallelizes across runners. Coverage is skipped
+# while sharding because partial per-shard data cannot be combined in this
+# single-job topology; the full coverage pass runs unsharded on
+# main/workflow_dispatch (PYTEST_SHARD_COUNT=1).
+shard_count="${PYTEST_SHARD_COUNT:-1}"
+shard_index="${PYTEST_SHARD_INDEX:-1}"
+sharding_active="0"
+if [[ "$shard_count" =~ ^[0-9]+$ ]] && [[ "$shard_count" -gt 1 ]]; then
+  if ! [[ "$shard_index" =~ ^[0-9]+$ ]] || [[ "$shard_index" -lt 1 ]] || [[ "$shard_index" -gt "$shard_count" ]]; then
+    echo "PYTEST_SHARD_INDEX must be an integer in 1..$shard_count when PYTEST_SHARD_COUNT>1 (got '$shard_index')." >&2
+    exit 2
+  fi
+  sharding_active="1"
+  cmd+=("--splits" "$shard_count" "--group" "$shard_index")
+  echo "Resolved pytest-split shard: group $shard_index of $shard_count" >&2
+fi
+
 coverage_requested="${ROBOT_SF_PYTEST_COVERAGE:-}"
-if [[ "${CI:-}" == "true" ]] || [[ "$coverage_requested" == "1" ]] || \
+if [[ "$sharding_active" != "1" ]] && { [[ "${CI:-}" == "true" ]] || [[ "$coverage_requested" == "1" ]] || \
   [[ "$coverage_requested" == [Tt][Rr][Uu][Ee] ]] || \
   [[ "$coverage_requested" == [Yy][Ee][Ss] ]] || \
-  [[ "$coverage_requested" == [Oo][Nn] ]]; then
+  [[ "$coverage_requested" == [Oo][Nn] ]]; }; then
   cmd+=("--cov=robot_sf" "--cov-report=html" "--cov-report=json")
 fi
 

--- a/uv.lock
+++ b/uv.lock
@@ -4525,6 +4525,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -5001,6 +5013,7 @@ dev = [
     { name = "pylint" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-split" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "scalene" },
@@ -5080,6 +5093,7 @@ dev = [
     { name = "pylint", specifier = ">=3.3.4" },
     { name = "pytest", specifier = ">=8.3.3" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
+    { name = "pytest-split", specifier = ">=0.9.0" },
     { name = "pytest-xdist", specifier = ">=3.6.1" },
     { name = "ruff", specifier = "==0.15.12" },
     { name = "scalene", specifier = ">=1.5.48" },


### PR DESCRIPTION
## Problem

CI wall-clock on PRs is ~20 min and is bounded almost entirely by the `fast-feedback` job. Measured on a recent run:

| Job | Time |
| --- | --- |
| **fast-feedback** | **20.5 min** (the whole gate) |
| examples-smoke | 9.5 min |
| wheel-smoke-install | 7.2 min |
| smoke-artifacts | 5.5 min |

Inside `fast-feedback`: setup ~2.5 min, lint 1s, typecheck 6s, and **the pytest phase = 17 min 8s** (`7740 passed … in 1028.94s`) on a single 4-core runner with coverage instrumentation. Dependency install is already cached (~56s) and is not the bottleneck.

## Changes

- **Shard the suite on PRs.** `fast-feedback` gains a `strategy.matrix` that splits tests into 4 `pytest-split` shards on `pull_request`. This is a matrix on the *existing* job, so the job topology the CI contract tests pin (`tests/test_ci_driver_contract.py`) is unchanged. With 4 shards × 4 cores that's effectively ~16-way parallelism instead of 4.
- **Keep coverage honest without combining.** `main`/`workflow_dispatch` run a single full (unsharded) pass, so the advisory coverage baseline stays accurate — no cross-shard coverage combine needed. The coverage steps are gated to non-PR events; coverage is suppressed while sharding.
- **`COVERAGE_CORE=sysmon`** — CPython 3.12+ `sys.monitoring` coverage backend, much lower instrumentation overhead, applied to the full pass.
- **Docs-only skip** — `paths-ignore: ['**/*.md', 'docs/**']` so Markdown/docs changes don't trigger the workflow. Safe here because `main` is not a protected branch (no required status checks), so a skipped workflow never blocks a merge.
- **Wrapper hooks** — `run_tests_parallel.sh` learns `PYTEST_SHARD_COUNT`/`PYTEST_SHARD_INDEX` (→ `--splits`/`--group`), validates the index range, and skips coverage while sharding. Adds `pytest-split` to the `dev` dependency group (lock regenerated).

## Expected impact

PR `fast-feedback` test phase drops from ~17 min toward ~4–5 min, bringing PR wall-clock from ~20 min toward the next pole (`examples-smoke`, ~9.5 min). Splits are count-based for now; dropping a `.test_durations` file later would balance shard runtimes further. `main` CI is intentionally unchanged (full pass + coverage).

## Validation

- `tests/test_ci_driver_contract.py` + `tests/test_ci_script_contract.py`: **68 passed** — job set, phase assignments, timeouts, and action pinning all still satisfied.
- pytest-split smoke on `tests/common`: groups 4+4+4+3 = 15 (full collection, disjoint); coverage flags correctly absent while sharding.
- Wrapper rejects out-of-range shard index (exit 2); `bash -n` clean; workflow YAML parses with the expected structure.
- **Smoke evidence only** — full multi-shard timing and the dynamic-matrix expansion are exercised by this PR's own CI run, which can't be reproduced locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Implemented test parallelization via sharding (4 shards on pull requests) for faster feedback.
  * Skipped coverage instrumentation during sharded test runs to reduce overhead.

* **Chores**
  * Updated CI workflow to ignore documentation-only changes, preventing unnecessary pipeline runs.
  * Added test sharding dependency to development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->