### PR TITLE
fix: align issue-template audit with repo's own templates + expand archetype taxonomy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed `scripts/tools/issue_template_audit.py` so it recognizes the repo's own YAML issue
+  forms (`epic`/`execution-run`/`test-debt`/`blocked-external-artifact`) and agent-authored
+  bodies instead of only the markdown templates. The audit previously matched a single strict
+  12-section markdown contract and reported 8–12 false "missing section" gaps on nearly every
+  issue filed from the leaner YAML forms. The auditor now (a) maps heading variants such as
+  `Scope and non-goals`, `Acceptance criteria`/`Acceptance / stop rule`, `Estimate metadata`,
+  `Validation commands`, and `Question / Goal`/`Background` to their canonical sections;
+  (b) strips trailing parenthetical qualifiers (e.g. `Acceptance criteria (mirrors body)`);
+  (c) credits `###` contract subheadings carried inside the appended `agent-exec-spec` block;
+  and (d) audits leaner-template issues against a shared agent-ready core
+  (`Goal / Problem`, `Scope`, `Effort Estimation`, `Definition of Done`, `Validation / Testing`)
+  while bare/markdown-style bodies keep the strict full contract. Across the 91 open issues this
+  cut spurious "missing section" reports from ~87 issues (many with 8–12 false gaps) to a small
+  set of genuine gaps. The archetype-metadata audit and `audit_archetype_metadata` API are
+  unchanged.
+* Expanded the canonical issue-archetype taxonomy in
+  `docs/context/issue_1512_issue_archetypes.md` and the validator
+  (`scripts/tools/issue_template_audit.py`) to bless the work-type archetypes the issue
+  automation already emits — `implementation`, `test`, `refactor`, `data` — and to accept the
+  deprecated spellings `agent_task` (→ `implementation`) and the evidence tier `proposal`
+  (→ `idea`) on read without rewriting issue bodies. This clears the validator's
+  invalid-metadata findings on the four affected open issues (#2000, #3069, #3071, #3206)
+  without per-issue edits, and wires `implementation`/`data` into
+  `issue_archetype_sync.py`'s `SAFE_ARCHETYPE_LABEL_MAP` (`type:implementation`/`type:data`,
+  both existing labels).
 * Fixed `scripts/validation/validate_forecast_risk_calibration_filter.py` so its
   `_any_eligible_for_risk_scoring` gate recognizes the canonical `eligible_analysis_only` token
   emitted by `build_forecast_calibration_report`. The gate previously matched only the legacy

--- a/docs/context/issue_1512_issue_archetypes.md
+++ b/docs/context/issue_1512_issue_archetypes.md
@@ -25,6 +25,19 @@ Every issue should declare exactly one `archetype` from this set:
 | `docs` | Documentation-only contract or guidance updates |
 | `benchmark-campaign` | A benchmark campaign intended to produce benchmark evidence |
 | `training-campaign` | A training campaign intended to produce model or training evidence |
+| `implementation` | Building or changing simulator/benchmark/runtime code to add a capability or runnable path (not primarily a campaign, analysis, or docs change) |
+| `test` | Adding, repairing, or de-flaking test coverage or test infrastructure |
+| `refactor` | Restructuring existing code without changing intended behavior |
+| `data` | Acquiring, staging, ingesting, or making reproducible a dataset/trace/artifact input (often paired with `blocked` evidence when the source is external) |
+
+### Deprecated archetype spellings
+
+These are accepted on read and treated as their canonical value; prefer the canonical form for new
+issues:
+
+| Deprecated | Canonical | Note |
+|---|---|---|
+| `agent_task` | `implementation` | Generic agent placeholder; declare the specific archetype (e.g. `docs`, `analysis`) when it is clear |
 
 ## Canonical Evidence-Tier Values
 
@@ -43,6 +56,14 @@ Every issue should declare exactly one `evidence_tier` from this set:
 | `synthesis` | Evidence is a synthesis of prior durable inputs rather than a new run |
 | `paper_grade` | Paper-facing, benchmark-success, or release-grade evidence |
 | `blocked` | The requested evidence could not be produced because a prerequisite is missing or invalid |
+
+### Deprecated evidence-tier spellings
+
+Accepted on read and treated as their canonical value; prefer the canonical form for new issues:
+
+| Deprecated | Canonical | Note |
+|---|---|---|
+| `proposal` | `idea` | Early proposal/scoping work with no execution evidence yet |
 
 ## Short Metadata Block
 

--- a/scripts/tools/issue_archetype_sync.py
+++ b/scripts/tools/issue_archetype_sync.py
@@ -33,6 +33,8 @@ SAFE_ARCHETYPE_LABEL_MAP: dict[str, str] = {
     "benchmark-campaign": "type:benchmark",
     "analysis": "type:analysis",
     "training-campaign": "type:training",
+    "implementation": "type:implementation",
+    "data": "type:data",
 }
 
 TYPED_LABEL_PREFIX = "type:"

--- a/scripts/tools/issue_template_audit.py
+++ b/scripts/tools/issue_template_audit.py
@@ -37,26 +37,80 @@ SECTION_ORDER: tuple[str, ...] = (
 SECTION_ALIASES: dict[str, str] = {
     "goal / problem": "Goal / Problem",
     "goal/problem": "Goal / Problem",
+    "goal": "Goal / Problem",
     "problem": "Goal / Problem",
     "objective": "Goal / Problem",
     "problem description": "Goal / Problem",
+    # Agent-authored bodies open with these instead of "Goal / Problem".
+    "question / goal": "Goal / Problem",
+    "goal / question": "Goal / Problem",
+    "background": "Goal / Problem",
     "scope": "Scope",
+    # YAML issue forms (epic/execution-run/test-debt/blocked-external-artifact) name this
+    # "Scope and non-goals"; treat it as the canonical Scope section.
+    "scope and non-goals": "Scope",
+    "scope / out of scope": "Scope",
     "added value estimation": "Added Value Estimation",
     "value estimation": "Added Value Estimation",
     "effort estimation": "Effort Estimation",
+    # YAML forms collapse the granular estimate sections into one "Estimate metadata"
+    # block; agent-authored bodies use a bare "Estimate". Map both to the effort section
+    # so the leaner core (below) is satisfied without inventing the markdown-only sub-sections.
+    "estimate": "Effort Estimation",
+    "estimate metadata": "Effort Estimation",
     "complexity estimation": "Complexity Estimation",
     "risk assessment": "Risk Assessment",
     "affected files": "Affected Files",
     "files and components": "Affected Files",
     "definition of done": "Definition of Done",
+    # YAML forms and agent-authored bodies use "Acceptance criteria" for the same contract.
+    "acceptance criteria": "Definition of Done",
+    # Research/epic bodies fold the acceptance contract into a stop-rule heading.
+    "acceptance / stop rule": "Definition of Done",
+    "accept / revise / reject criteria": "Definition of Done",
     "success metrics": "Success Metrics",
     "validation / testing": "Validation / Testing",
     "validation": "Validation / Testing",
     "testing": "Validation / Testing",
+    # YAML-form validation heading variants.
+    "validation command": "Validation / Testing",
+    # Agent-exec-spec blocks use the plural "Validation commands".
+    "validation commands": "Validation / Testing",
+    "targeted validation": "Validation / Testing",
     "estimate discussion": "Estimate Discussion",
     "estimate rationale": "Estimate Discussion",
     "project metadata": "Project Metadata",
 }
+
+# Headings emitted by the YAML issue forms and agent-authored bodies but never by the
+# markdown templates. Their presence positively identifies a leaner-template issue, which
+# is audited against ``CORE_SECTION_ORDER`` instead of the full markdown contract.
+LEANER_TEMPLATE_SIGNATURES: frozenset[str] = frozenset(
+    {
+        "scope and non-goals",
+        "scope / out of scope",
+        "non-goals",
+        "acceptance criteria",
+        "acceptance / stop rule",
+        "accept / revise / reject criteria",
+        "estimate",
+        "estimate metadata",
+        "validation command",
+        "targeted validation",
+        "implementation plan",
+    }
+)
+
+# Shared agent-ready core required of every issue regardless of template family. The full
+# markdown contract (``SECTION_ORDER``) is a superset of this and stays the default so bare
+# or markdown-style bodies keep the stricter requirement.
+CORE_SECTION_ORDER: tuple[str, ...] = (
+    "Goal / Problem",
+    "Scope",
+    "Effort Estimation",
+    "Definition of Done",
+    "Validation / Testing",
+)
 
 SECTION_PLACEHOLDERS: dict[str, str] = {
     "Goal / Problem": "<!-- Describe the problem or goal here. -->",
@@ -73,7 +127,11 @@ SECTION_PLACEHOLDERS: dict[str, str] = {
     "Project Metadata": "- Priority:\n- Effort (h):\n- Reviewed:",
 }
 
-HEADING_RE = re.compile(r"^##\s+(?P<title>.+?)\s*$", re.MULTILINE)
+# Match level-2 and level-3 ATX headings. Agent-authored bodies carry their
+# contract content (acceptance/validation/steps) as ``###`` subheadings inside the
+# appended ``<!-- agent-exec-spec:v1 -->`` block, so crediting ``###`` lets the audit
+# see content that genuinely exists instead of reporting it as missing.
+HEADING_RE = re.compile(r"^#{2,3}\s+(?P<title>.+?)\s*$", re.MULTILINE)
 METADATA_SECTION_TITLE = "Archetype Metadata"
 METADATA_YAML_RE = re.compile(
     r"^[ \t]*```ya?ml\s*\r?\n(?P<block>.*?)(?:\r?\n)?^[ \t]*```",
@@ -94,7 +152,19 @@ VALID_ARCHETYPES: tuple[str, ...] = (
     "docs",
     "benchmark-campaign",
     "training-campaign",
+    # Work-type archetypes the issue automation emits; canonical per the 2026-06-22
+    # taxonomy expansion (see docs/context/issue_1512_issue_archetypes.md).
+    "implementation",
+    "test",
+    "refactor",
+    "data",
 )
+# Deprecated archetype spellings accepted on read and treated as their canonical value.
+# The auditor does not rewrite issue bodies; aliases only prevent false "invalid value"
+# findings for values the automation still emits.
+ARCHETYPE_ALIASES: dict[str, str] = {
+    "agent_task": "implementation",
+}
 VALID_EVIDENCE_TIERS: tuple[str, ...] = (
     "idea",
     "launch_packet",
@@ -108,6 +178,10 @@ VALID_EVIDENCE_TIERS: tuple[str, ...] = (
     "paper_grade",
     "blocked",
 )
+# Deprecated evidence-tier spellings accepted on read and treated as their canonical value.
+EVIDENCE_TIER_ALIASES: dict[str, str] = {
+    "proposal": "idea",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -151,16 +225,43 @@ class ArchetypeMetadataAuditResult:
         return tuple(result)
 
 
-def normalize_section_title(raw_title: str) -> str:
-    """Map a markdown heading to a canonical template section name."""
+def _clean_heading(raw_title: str) -> str:
+    """Strip decoration/punctuation from a heading without alias mapping."""
 
     cleaned = raw_title.strip()
     cleaned = re.sub(r"^[^\w]+", "", cleaned)
+    # Drop a trailing parenthetical qualifier, e.g. "Acceptance criteria (mirrors body)"
+    # or "Entry points (verified)", so qualified agent-exec-spec headings still normalize.
+    cleaned = re.sub(r"\s*\([^()]*\)\s*$", "", cleaned)
     cleaned = re.sub(r"\s*/\s*", " / ", cleaned)
     cleaned = re.sub(r"\s+", " ", cleaned)
     cleaned = re.sub(r"[:：]+$", "", cleaned)
-    normalized = cleaned.lower()
-    return SECTION_ALIASES.get(normalized, cleaned)
+    return cleaned
+
+
+def normalize_section_title(raw_title: str) -> str:
+    """Map a markdown heading to a canonical template section name."""
+
+    cleaned = _clean_heading(raw_title)
+    return SECTION_ALIASES.get(cleaned.lower(), cleaned)
+
+
+def select_required_sections(body: str) -> tuple[str, ...]:
+    """Pick the required-section contract matching the issue's template family.
+
+    The markdown issue templates emit the full granular contract
+    (``SECTION_ORDER``). The YAML issue forms and agent-authored bodies use a
+    leaner vocabulary (e.g. ``Acceptance criteria``, ``Estimate metadata``) and
+    deliberately omit the markdown-only sub-sections. When a body positively
+    signals the leaner family we audit it against the shared agent-ready core so
+    it is not flagged for sections its template never produced. Bare or
+    markdown-style bodies keep the stricter full contract by default.
+    """
+
+    for match in HEADING_RE.finditer(body):
+        if _clean_heading(match.group("title")).lower() in LEANER_TEMPLATE_SIGNATURES:
+            return CORE_SECTION_ORDER
+    return SECTION_ORDER
 
 
 def extract_present_sections(body: str) -> tuple[str, ...]:
@@ -190,11 +291,20 @@ def _extract_named_section(body: str, expected_title: str) -> str | None:
 
 
 def _validate_canonical_value(
-    key: str, value: object, allowed_values: tuple[str, ...]
+    key: str,
+    value: object,
+    allowed_values: tuple[str, ...],
+    aliases: dict[str, str] | None = None,
 ) -> str | None:
-    """Return a finding when a metadata value is absent from the canonical set."""
+    """Return a finding when a metadata value is absent from the canonical set.
 
-    if not isinstance(value, str) or value not in allowed_values:
+    Deprecated spellings listed in ``aliases`` are accepted (the auditor never
+    rewrites issue bodies), so values the automation still emits do not surface as
+    invalid.
+    """
+
+    accepted = isinstance(value, str) and (value in allowed_values or value in (aliases or {}))
+    if not accepted:
         return f"Invalid {key!r} value {value!r}; expected one of: " + ", ".join(allowed_values)
     return None
 
@@ -252,14 +362,17 @@ def audit_archetype_metadata(body: str) -> ArchetypeMetadataAuditResult:
 
     if "archetype" in parsed:
         archetype_finding = _validate_canonical_value(
-            "archetype", parsed.get("archetype"), VALID_ARCHETYPES
+            "archetype", parsed.get("archetype"), VALID_ARCHETYPES, ARCHETYPE_ALIASES
         )
         if archetype_finding is not None:
             invalid_values["archetype"] = parsed.get("archetype")
 
     if "evidence_tier" in parsed:
         evidence_tier_finding = _validate_canonical_value(
-            "evidence_tier", parsed.get("evidence_tier"), VALID_EVIDENCE_TIERS
+            "evidence_tier",
+            parsed.get("evidence_tier"),
+            VALID_EVIDENCE_TIERS,
+            EVIDENCE_TIER_ALIASES,
         )
         if evidence_tier_finding is not None:
             invalid_values["evidence_tier"] = parsed.get("evidence_tier")
@@ -298,7 +411,7 @@ def audit_issue_body(body: str) -> IssueAuditResult:
     """Audit an issue body against the repo's template contract."""
 
     present = extract_present_sections(body)
-    missing = missing_sections(body)
+    missing = missing_sections(body, select_required_sections(body))
     repaired = build_repaired_body(body, missing)
     return IssueAuditResult(
         present_sections=present,

--- a/tests/tools/test_issue_template_audit.py
+++ b/tests/tools/test_issue_template_audit.py
@@ -5,13 +5,126 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from scripts.tools.issue_template_audit import (
+    CORE_SECTION_ORDER,
+    SECTION_ORDER,
     audit_issue_body,
     main,
     normalize_section_title,
+    select_required_sections,
 )
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+def test_yaml_form_issue_audits_against_leaner_core() -> None:
+    """Verify YAML-form issues are audited against the shared core, not the full markdown set.
+
+    This matters because the repo ships YAML issue forms (epic/execution-run/...) whose
+    headings (``Scope and non-goals``, ``Acceptance criteria``, ``Estimate metadata``)
+    deliberately omit the markdown-only sub-sections; auditing them against the full
+    markdown contract produced false "missing section" reports.
+    """
+
+    body = """## Goal / Problem
+
+Ship the thing.
+
+## Scope and non-goals
+
+- In scope: the thing.
+- Out of scope: everything else.
+
+## Acceptance criteria
+
+- [ ] The thing works.
+
+## Validation / Testing
+
+- [ ] Run the gate.
+
+## Estimate metadata
+
+- Effort: 4h.
+"""
+
+    assert select_required_sections(body) == CORE_SECTION_ORDER
+    result = audit_issue_body(body)
+    assert result.missing_sections == ()
+
+
+def test_agent_exec_spec_h3_content_counts_as_present() -> None:
+    """Verify contract content carried as ``###`` headings in the agent-exec-spec is credited.
+
+    This matters because agent-authored bodies place acceptance/validation content as
+    ``###`` subheadings (often with parenthetical qualifiers) inside the appended
+    ``agent-exec-spec`` block; the audit must see that real content instead of flagging it.
+    """
+
+    body = """## Goal / Problem
+
+Do the work.
+
+## Scope
+
+- In scope: x.
+
+## Estimate
+
+- 6h.
+
+<!-- agent-exec-spec:v1 -->
+## 🤖 Agent execution spec (codex gpt5.5 medium)
+
+### Acceptance criteria (mirrors body)
+
+- [ ] Done.
+
+### Validation commands
+
+```bash
+uv run pytest -q
+```
+"""
+
+    assert select_required_sections(body) == CORE_SECTION_ORDER
+    result = audit_issue_body(body)
+    assert "Definition of Done" not in result.missing_sections
+    assert "Validation / Testing" not in result.missing_sections
+    assert "Effort Estimation" not in result.missing_sections
+    assert result.missing_sections == ()
+
+
+def test_bare_body_still_uses_full_markdown_contract() -> None:
+    """Verify a bare body with no leaner signals keeps the strict full contract.
+
+    This matters because the leaner core must only apply when a body positively signals
+    the YAML-form/agent family; otherwise incomplete markdown issues would stop being flagged.
+    """
+
+    body = """## Goal / Problem
+
+Bare body.
+
+## Scope
+
+- In scope:
+"""
+
+    assert select_required_sections(body) == SECTION_ORDER
+    result = audit_issue_body(body)
+    assert "Added Value Estimation" in result.missing_sections
+    assert "Project Metadata" in result.missing_sections
+
+
+def test_normalize_section_title_handles_variants() -> None:
+    """Verify new heading aliases and parenthetical stripping map to canonical sections."""
+
+    assert normalize_section_title("Scope and non-goals") == "Scope"
+    assert normalize_section_title("Acceptance criteria (mirrors body)") == "Definition of Done"
+    assert normalize_section_title("Validation commands") == "Validation / Testing"
+    assert normalize_section_title("Estimate metadata") == "Effort Estimation"
+    assert normalize_section_title("Question / Goal") == "Goal / Problem"
 
 
 def test_issue_template_audit_repairs_missing_sections() -> None:
@@ -374,6 +487,62 @@ linked_policy: [docs/context/issue_1512_issue_archetypes.md
 
     assert result.metadata.parse_error is not None
     assert result.metadata.findings[0].startswith("Malformed archetype metadata YAML:")
+
+
+def test_issue_template_audit_accepts_expanded_archetypes() -> None:
+    """Verify the 2026-06-22 work-type archetypes validate without findings.
+
+    This matters because the issue automation emits implementation/test/refactor/data and the
+    maintainer chose to bless them as canonical instead of remapping every issue.
+    """
+
+    for archetype in ("implementation", "test", "refactor", "data"):
+        body = f"""## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: {archetype}
+evidence_tier: smoke
+linked_policy:
+  - docs/context/issue_1512_issue_archetypes.md
+```
+"""
+        result = audit_issue_body(body)
+        assert result.metadata.invalid_values == {}, archetype
+        assert result.metadata.findings == (), archetype
+
+
+def test_issue_template_audit_accepts_deprecated_metadata_aliases() -> None:
+    """Verify deprecated archetype/evidence-tier spellings are accepted on read.
+
+    This matters because ``agent_task`` and ``proposal`` are still emitted by older automation,
+    and the auditor should not flag them as invalid (it never rewrites issue bodies).
+    """
+
+    body = """## Goal / Problem
+
+Context.
+
+## Archetype Metadata
+
+```yaml
+archetype: agent_task
+evidence_tier: proposal
+linked_policy:
+  - docs/context/issue_1512_issue_archetypes.md
+```
+"""
+
+    result = audit_issue_body(body)
+    assert result.metadata.invalid_values == {}
+    assert result.metadata.findings == ()
+    # The body is preserved verbatim; aliases are accepted, not rewritten.
+    assert result.metadata.parsed_metadata is not None
+    assert result.metadata.parsed_metadata["archetype"] == "agent_task"
+    assert result.metadata.parsed_metadata["evidence_tier"] == "proposal"
 
 
 def test_issue_template_audit_cli_repairs_body(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary

While auditing all open issues, the repo's own `issue_template_audit.py` reported that ~87 of 91 open issues were missing template sections — but inspection showed those issues are well-specified. The auditor only recognized the **markdown** issue templates and enforced a strict 12-section contract, so every issue filed from the repo's **YAML forms** (`epic`/`execution-run`/`test-debt`/`blocked-external-artifact`) or authored by agents was flagged with 8–12 false gaps.

This fixes the measurement (and clears the few real metadata defects via a taxonomy expansion the maintainer chose).

**Impact across the 91 open issues:** false "missing section" findings dropped **762 → 112 (−85%)**; the remainder are genuine gaps (e.g. 35 issues that truly lack a standalone effort estimate). Invalid archetype/evidence-tier findings: **4 → 0**.

## Audit accuracy (`scripts/tools/issue_template_audit.py`)

- Maps heading variants to canonical sections: `Scope and non-goals`, `Acceptance criteria` / `Acceptance / stop rule`, `Estimate` / `Estimate metadata`, `Validation command(s)` / `Targeted validation`, `Question / Goal` / `Background`.
- Strips trailing parenthetical qualifiers (e.g. `Acceptance criteria (mirrors body)`).
- Credits `###` contract subheadings carried inside the appended `<!-- agent-exec-spec:v1 -->` block (content that genuinely exists).
- Audits leaner-template issues (positively detected by signature headings) against a shared agent-ready core — `Goal / Problem`, `Scope`, `Effort Estimation`, `Definition of Done`, `Validation / Testing`. **Bare and markdown-style bodies keep the strict full contract** (existing behavior preserved).

## Archetype taxonomy expansion (per maintainer decision)

The automation emits archetype values the validator rejected. Rather than editing individual issue bodies, the canonical set is expanded:

- Bless `implementation`, `test`, `refactor`, `data` as canonical archetypes.
- Accept deprecated spellings on read (no body rewrites): `agent_task` → `implementation`, evidence tier `proposal` → `idea`.
- Wire `implementation`/`data` into `issue_archetype_sync.py`'s `SAFE_ARCHETYPE_LABEL_MAP` (`type:implementation`/`type:data`, both existing labels).
- Documented in `docs/context/issue_1512_issue_archetypes.md` with the new rows + deprecated-alias notes.

This clears the validator's invalid-metadata findings on #2000, #3069, #3071, #3206 **without per-issue edits**.

## Not changed
- `audit_archetype_metadata` API and the archetype-metadata block audit are unchanged (so `issue_archetype_sync.py`'s validation path is unaffected).
- No issue bodies were edited; no genuine gaps were "scaffolded" away.

## Tests
- `tests/tools/test_issue_template_audit.py`: +6 tests (YAML-form core, agent-exec-spec `###` recognition, bare-body strictness preserved, heading-variant normalization, expanded archetypes, deprecated aliases).
- `uv run python -m pytest tests/tools/test_issue_template_audit.py tests/tools/test_issue_archetype_sync.py tests/test_issue_templates.py -q` → **45 passed**.
- `ruff format` + `ruff check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA - PR fixes issue-audit tooling behavior and taxonomy docs directly; no linked parent issue is declared.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark or research result claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no benchmark artifact or leaderboard row.
- Registry or config index updated (yes/no/NA): NA - issue archetype taxonomy docs and sync label map were updated in this PR.
- Context index / memory note updated (yes/no/NA): yes - `docs/context/issue_1512_issue_archetypes.md` carries the taxonomy update.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - no deferred propagation required for the scoped audit/taxonomy fix.
- Not applicable because: this PR is workflow/tooling correctness plus taxonomy documentation; it makes no benchmark, metric, model-provenance, or paper-facing claim.

## Follow-Up Issues
- Deferred work: none identified for this PR scope.
- Issues opened for follow-up: NA.

## Reviewer Notes
- Verify leaner-template detection does not weaken bare markdown issue audits; `test_bare_body_still_uses_full_markdown_contract` covers that guard.
- Verify aliases are accepted on read only and issue bodies are not rewritten.
