### PR TITLE
feat: disjoint-split + null-test infra for proposal-vs-random (#3275, batch 1)

### DIFF
--- a/robot_sf/adversarial/disjoint_evaluation.py
+++ b/robot_sf/adversarial/disjoint_evaluation.py
@@ -1,0 +1,347 @@
+"""Disjoint fit/evaluation splitting, overlap provenance, and null tests.
+
+These utilities make an adversarial proposal-vs-random comparison non-circular
+(issue #3275). PR #3276 ranked candidates by distance to the failure archive and
+evaluated them using the same distance to the same archive, which is circular.
+
+This module provides the machinery a non-circular, held-out comparison requires:
+
+* split a failure archive into fit/eval sets whose *scenario families* are
+  disjoint, so a model fit on one family is evaluated on held-out families;
+* compute explicit overlap provenance (scenario-family / seed / archive-id) plus
+  archive hashes, so reviewers can verify disjointness;
+* run permutation null tests (shuffled-outcome label test and a ranking
+  permutation test) against an *independent* outcome vector;
+* classify held-out evidence **fail-closed** — it is never ``eligible`` unless a
+  disjoint split, independent (non-archive-nearness) outcomes, candidate
+  certification, and a rejected null are all present.
+
+None of these functions assert held-out yield on their own; they provide the
+inputs a later evaluation step needs before any survived/falsified verdict.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import random
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# Permutation-test float comparison tolerance.
+_EPS = 1e-12
+
+
+def scenario_family_key(entry: dict[str, Any]) -> str:
+    """Return a stable scenario-family key for a failure-archive entry.
+
+    Prefers the archive ``cluster_key`` (the archive's own grouping over policy,
+    scenario template, and failure attribution). Falls back to failure and
+    source-manifest fields, then to ``"unknown_family"``.
+
+    Returns:
+        A deterministic, JSON-comparable family key string.
+    """
+    cluster_key = entry.get("cluster_key")
+    if isinstance(cluster_key, dict) and cluster_key:
+        return json.dumps(cluster_key, sort_keys=True, separators=(",", ":"))
+    if isinstance(cluster_key, str) and cluster_key.strip():
+        return cluster_key
+
+    parts: list[str] = []
+    attribution = entry.get("failure_attribution")
+    if isinstance(attribution, dict):
+        primary = attribution.get("primary_failure")
+        if isinstance(primary, str) and primary:
+            parts.append(f"failure={primary}")
+    source_manifest = entry.get("source_manifest")
+    if isinstance(source_manifest, str) and source_manifest:
+        parts.append(f"manifest={source_manifest}")
+    return "|".join(parts) if parts else "unknown_family"
+
+
+@dataclass(frozen=True)
+class DisjointSplit:
+    """A fit/evaluation split with non-overlapping scenario families."""
+
+    fit_entries: list[dict[str, Any]]
+    eval_entries: list[dict[str, Any]]
+    fit_families: list[str]
+    eval_families: list[str]
+    is_disjoint_split: bool
+
+
+def disjoint_family_split(
+    entries: Sequence[dict[str, Any]],
+    *,
+    eval_fraction: float = 0.5,
+    seed: int = 0,
+) -> DisjointSplit:
+    """Partition ``entries`` into fit/eval sets with disjoint scenario families.
+
+    Each scenario family is assigned wholesale to either the fit or the eval
+    side, so no family appears on both sides. The assignment is deterministic
+    given ``seed``. When fewer than two families are present a disjoint split is
+    impossible, so all entries go to the fit side and ``is_disjoint_split`` is
+    ``False``.
+
+    Args:
+        entries: Failure-archive entries (dicts with optional ``cluster_key``).
+        eval_fraction: Target fraction of *families* (not entries) held out for
+            evaluation, clamped so both sides keep at least one family.
+        seed: Deterministic shuffle seed for family assignment.
+
+    Returns:
+        A :class:`DisjointSplit`.
+    """
+    if not 0.0 < eval_fraction < 1.0:
+        raise ValueError("eval_fraction must be in the open interval (0, 1)")
+
+    families: dict[str, list[dict[str, Any]]] = {}
+    for entry in entries:
+        families.setdefault(scenario_family_key(entry), []).append(entry)
+
+    family_keys = sorted(families)
+    if len(family_keys) < 2:
+        return DisjointSplit(
+            fit_entries=list(entries),
+            eval_entries=[],
+            fit_families=family_keys,
+            eval_families=[],
+            is_disjoint_split=False,
+        )
+
+    shuffled = list(family_keys)
+    random.Random(seed).shuffle(shuffled)
+    n_eval = max(1, min(len(shuffled) - 1, round(eval_fraction * len(shuffled))))
+    eval_families = set(shuffled[:n_eval])
+
+    fit_entries = [e for e in entries if scenario_family_key(e) not in eval_families]
+    eval_entries = [e for e in entries if scenario_family_key(e) in eval_families]
+    return DisjointSplit(
+        fit_entries=fit_entries,
+        eval_entries=eval_entries,
+        fit_families=sorted(set(family_keys) - eval_families),
+        eval_families=sorted(eval_families),
+        is_disjoint_split=bool(fit_entries) and bool(eval_entries),
+    )
+
+
+def archive_sha256(data: Any) -> str:
+    """Return a deterministic SHA-256 digest of JSON-serializable archive data."""
+    encoded = json.dumps(data, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _distinct(entries: Sequence[dict[str, Any]], key: str) -> set[Any]:
+    """Return the set of non-null ``candidate``/top-level values for ``key``."""
+    values: set[Any] = set()
+    for entry in entries:
+        if key == "scenario_seed":
+            candidate = entry.get("candidate", {})
+            value = candidate.get("scenario_seed") if isinstance(candidate, dict) else None
+        else:
+            value = entry.get(key)
+        if value is not None:
+            values.add(value)
+    return values
+
+
+def compute_overlap_provenance(
+    fit_entries: Sequence[dict[str, Any]],
+    eval_entries: Sequence[dict[str, Any]],
+) -> dict[str, Any]:
+    """Compute fit/eval overlap provenance for a disjoint split.
+
+    Reports scenario-family, scenario-seed, and archive-id overlaps between the
+    fit and eval sets. ``disjointness_checks_passed`` is ``True`` only when both
+    sides are non-empty and share no scenario family and no archive id. Seed
+    overlap is recorded for transparency but does not, by itself, fail the
+    disjointness check (the held-out unit is the scenario family).
+
+    Returns:
+        A JSON-safe provenance dict.
+    """
+    fit_families = {scenario_family_key(e) for e in fit_entries}
+    eval_families = {scenario_family_key(e) for e in eval_entries}
+    family_overlap = sorted(fit_families & eval_families)
+
+    seed_overlap = sorted(
+        _distinct(fit_entries, "scenario_seed") & _distinct(eval_entries, "scenario_seed")
+    )
+    id_overlap = sorted(
+        _distinct(fit_entries, "archive_id") & _distinct(eval_entries, "archive_id")
+    )
+
+    disjoint = bool(fit_entries) and bool(eval_entries) and not family_overlap and not id_overlap
+    return {
+        "split_policy": "disjoint_scenario_family",
+        "fit_size": len(fit_entries),
+        "eval_size": len(eval_entries),
+        "fit_families": sorted(fit_families),
+        "eval_families": sorted(eval_families),
+        "scenario_family_overlap": family_overlap,
+        "scenario_family_overlap_count": len(family_overlap),
+        "seed_overlap": seed_overlap,
+        "seed_overlap_count": len(seed_overlap),
+        "archive_id_overlap": id_overlap,
+        "archive_id_overlap_count": len(id_overlap),
+        "disjointness_checks_passed": disjoint,
+    }
+
+
+def _mean(values: Sequence[float]) -> float:
+    """Return the arithmetic mean, or ``0.0`` for an empty sequence."""
+    return sum(values) / len(values) if values else 0.0
+
+
+def permutation_test_mean_difference(
+    group_a: Sequence[float],
+    group_b: Sequence[float],
+    *,
+    n_permutations: int = 1000,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Two-sided permutation test on the difference of group means (a - b).
+
+    Returns the observed difference and a permutation p-value using the
+    add-one estimator ``(count + 1) / (n_permutations + 1)``.
+
+    Returns:
+        A JSON-safe result dict; ``status`` is ``"not_available_empty_group"``
+        when either group is empty.
+    """
+    if n_permutations < 1:
+        raise ValueError("n_permutations must be >= 1")
+    a = [float(x) for x in group_a]
+    b = [float(x) for x in group_b]
+    if not a or not b:
+        return {
+            "observed_difference": 0.0,
+            "p_value": None,
+            "n_permutations": 0,
+            "status": "not_available_empty_group",
+        }
+
+    observed = _mean(a) - _mean(b)
+    pooled = a + b
+    n_a = len(a)
+    rng = random.Random(seed)
+    extreme = 0
+    for _ in range(n_permutations):
+        rng.shuffle(pooled)
+        perm_diff = _mean(pooled[:n_a]) - _mean(pooled[n_a:])
+        if abs(perm_diff) >= abs(observed) - _EPS:
+            extreme += 1
+    return {
+        "observed_difference": round(observed, 6),
+        "p_value": round((extreme + 1) / (n_permutations + 1), 6),
+        "n_permutations": n_permutations,
+        "status": "complete",
+    }
+
+
+def shuffled_outcome_null_test(
+    proposal_outcomes: Sequence[float],
+    random_outcomes: Sequence[float],
+    *,
+    n_permutations: int = 1000,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Null test: are proposal and random *outcomes* exchangeable?
+
+    If the proposal selection carries no real signal, the proposal-minus-random
+    mean-outcome difference should be indistinguishable from permutations of the
+    pooled outcome labels (large p-value).
+
+    Returns:
+        The :func:`permutation_test_mean_difference` result tagged with
+        ``test = "shuffled_outcome_label_permutation"``.
+    """
+    result = permutation_test_mean_difference(
+        proposal_outcomes,
+        random_outcomes,
+        n_permutations=n_permutations,
+        seed=seed,
+    )
+    result["test"] = "shuffled_outcome_label_permutation"
+    return result
+
+
+def ranking_permutation_test(
+    ranked_outcomes: Sequence[float],
+    *,
+    selection_size: int,
+    n_permutations: int = 1000,
+    seed: int = 0,
+) -> dict[str, Any]:
+    """Null test: does the ranking concentrate high outcomes in its top-k?
+
+    Compares the mean outcome of the top ``selection_size`` ranked items against
+    the distribution of top-k means under random orderings of the same outcomes.
+    A real ranking signal yields a small (one-sided) p-value.
+
+    Returns:
+        A JSON-safe result dict; ``status`` flags invalid selection sizes.
+    """
+    if n_permutations < 1:
+        raise ValueError("n_permutations must be >= 1")
+    outcomes = [float(x) for x in ranked_outcomes]
+    n = len(outcomes)
+    if n == 0 or selection_size <= 0 or selection_size > n:
+        return {
+            "test": "ranking_permutation",
+            "p_value": None,
+            "n_permutations": 0,
+            "status": "not_available_invalid_selection",
+        }
+
+    observed_top_mean = _mean(outcomes[:selection_size])
+    indices = list(range(n))
+    rng = random.Random(seed)
+    at_least_as_high = 0
+    for _ in range(n_permutations):
+        rng.shuffle(indices)
+        sampled = [outcomes[i] for i in indices[:selection_size]]
+        if _mean(sampled) >= observed_top_mean - _EPS:
+            at_least_as_high += 1
+    return {
+        "test": "ranking_permutation",
+        "observed_top_mean": round(observed_top_mean, 6),
+        "p_value": round((at_least_as_high + 1) / (n_permutations + 1), 6),
+        "n_permutations": n_permutations,
+        "selection_size": selection_size,
+        "status": "complete",
+    }
+
+
+def classify_held_out_evidence(
+    *,
+    disjointness_checks_passed: bool,
+    independent_outcomes_available: bool,
+    certification_available: bool,
+    null_tests_reject_null: bool,
+) -> str:
+    """Fail-closed classification of held-out proposal-vs-random evidence.
+
+    Returns ``"eligible_held_out_diagnostic"`` only when every precondition
+    holds. Any missing precondition returns a precise ``not_available_*`` reason.
+    This never returns eligible from circular archive-nearness outcomes, because
+    ``independent_outcomes_available`` must be supplied by an evaluation step that
+    does not reuse the ranking objective.
+
+    Returns:
+        An eligibility/``not_available_*`` string.
+    """
+    if not disjointness_checks_passed:
+        return "not_available_no_disjoint_split"
+    if not independent_outcomes_available:
+        return "not_available_requires_independent_planner_outcomes"
+    if not certification_available:
+        return "not_available_requires_candidate_certification"
+    if not null_tests_reject_null:
+        return "not_available_null_tests_not_rejected"
+    return "eligible_held_out_diagnostic"

--- a/scripts/adversarial/run_proposal_vs_random_issue_2921.py
+++ b/scripts/adversarial/run_proposal_vs_random_issue_2921.py
@@ -161,6 +161,63 @@ def load_archive(path: Path | None) -> tuple[str, str, dict[str, Any], bool]:
         )
 
 
+def build_archive_evaluation_provenance(
+    archive_data: dict[str, Any],
+    *,
+    state: str,
+    synthetic_archive: bool,
+    split_seed: int,
+) -> dict[str, Any]:
+    """Build archive-evaluation provenance for the comparison report.
+
+    For the diagnostic/blocked plumbing paths this preserves the historical
+    placeholder provenance (no disjoint split). For an active real-archive run it
+    computes a disjoint scenario-family split, real fit/eval overlap provenance
+    (scenario-family / seed / archive-id), and a fail-closed held-out-evidence
+    classification. The held-out claim stays fail-closed here: independent
+    (non-archive-nearness) planner outcomes are not yet available, so eligibility
+    resolves to a precise ``not_available`` reason.
+
+    Returns:
+        A JSON-safe provenance dict.
+    """
+    provenance: dict[str, Any] = {
+        "archive_sha256": _payload_sha256(archive_data),
+        "evaluation_outcome_sha256": None,
+        "split_policy": "none_plumbing_fixture",
+        "scenario_family_overlap": "not_checked",
+        "seed_overlap": "not_checked",
+        "archive_id_overlap": "not_checked",
+        "disjointness_checks_passed": False,
+        "required_for_held_out_claim": True,
+    }
+    if state != "active" or synthetic_archive:
+        provenance["held_out_evidence_status"] = "not_available_plumbing_fixture"
+        return provenance
+
+    from robot_sf.adversarial.disjoint_evaluation import (
+        archive_sha256,
+        classify_held_out_evidence,
+        compute_overlap_provenance,
+        disjoint_family_split,
+    )
+
+    entries = archive_data.get("entries", [])
+    split = disjoint_family_split(entries, eval_fraction=0.5, seed=split_seed)
+    overlap = compute_overlap_provenance(split.fit_entries, split.eval_entries)
+    provenance.update(overlap)
+    provenance["fit_archive_sha256"] = archive_sha256(split.fit_entries)
+    provenance["eval_archive_sha256"] = archive_sha256(split.eval_entries)
+    provenance["independent_outcome_evaluation"] = "not_available_requires_planner_execution"
+    provenance["held_out_evidence_status"] = classify_held_out_evidence(
+        disjointness_checks_passed=overlap["disjointness_checks_passed"],
+        independent_outcomes_available=False,
+        certification_available=False,
+        null_tests_reject_null=False,
+    )
+    return provenance
+
+
 def compute_metrics(selection: list[Any], evaluate_fn: Any) -> dict[str, Any]:
     """Compute summary metrics for a candidate selection."""
     objs = [evaluate_fn(c) for c in selection]
@@ -273,16 +330,12 @@ def main() -> int:
 
     proposal_metrics["certification_statuses_advisory"] = cert_statuses_advisory
     proposal_metrics["certification_statuses_strict"] = cert_statuses_strict
-    provenance = {
-        "archive_sha256": _payload_sha256(archive_data),
-        "evaluation_outcome_sha256": None,
-        "split_policy": "none_plumbing_fixture",
-        "scenario_family_overlap": "not_checked",
-        "seed_overlap": "not_checked",
-        "archive_id_overlap": "not_checked",
-        "disjointness_checks_passed": False,
-        "required_for_held_out_claim": True,
-    }
+    provenance = build_archive_evaluation_provenance(
+        archive_data,
+        state=state,
+        synthetic_archive=synthetic_archive,
+        split_seed=args.seed,
+    )
 
     report = {
         "schema_version": "adversarial_proposal_comparison.v1",

--- a/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
+++ b/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
@@ -276,3 +276,95 @@ def test_real_archive_without_search_space_fails_closed(tmp_path: Path, monkeypa
     assert report["synthetic_archive"] is False
     assert report["synthetic_search_space"] is True
     assert report["archive_evaluation_provenance"]["disjointness_checks_passed"] is False
+
+
+_SEARCH_SPACE_YAML = """\
+schema_version: adversarial-search-space.v1
+variables:
+  start_x: {min: 1.0, max: 3.0}
+  start_y: {min: 2.0, max: 4.0}
+  goal_x: {min: 7.0, max: 9.0}
+  goal_y: {min: 2.0, max: 4.0}
+  spawn_time_s: {min: 0.0, max: 2.0}
+  pedestrian_speed_mps: {min: 0.8, max: 1.4}
+  pedestrian_delay_s: {min: 0.0, max: 2.0}
+  scenario_seed: {min: 100, max: 999}
+constraints:
+  min_start_goal_distance_m: 2.0
+"""
+
+
+def _two_family_archive() -> dict:
+    """Build a small two-family archive with disjoint families/ids/seeds."""
+    entries = []
+    for family in ("goal_collision", "orca_collision"):
+        for i in range(3):
+            seed = (100 if family == "goal_collision" else 200) + i
+            entries.append(
+                {
+                    "archive_id": f"{family}_{i}",
+                    "cluster_key": family,
+                    "candidate": {
+                        "start": {"x": 2.0, "y": 3.0},
+                        "goal": {"x": 8.0, "y": 3.0},
+                        "spawn_time_s": 1.0,
+                        "pedestrian_speed_mps": 1.0,
+                        "pedestrian_delay_s": 0.5,
+                        "scenario_seed": seed,
+                    },
+                    "failure_attribution": {"primary_failure": "collision"},
+                    "objective_value": 8.0,
+                    "normalized_perturbation": 0.1,
+                }
+            )
+    return {"schema_version": "adversarial_failure_archive.v1", "entries": entries}
+
+
+def test_active_real_archive_computes_disjoint_provenance_but_fails_closed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """An active real-archive run computes a real disjoint split yet stays fail-closed."""
+    from scripts.adversarial.run_proposal_vs_random_issue_2921 import main as script_main
+
+    archive_path = tmp_path / "archive.json"
+    search_space_path = tmp_path / "search_space.yaml"
+    output_json = tmp_path / "report.json"
+    archive_path.write_text(json.dumps(_two_family_archive()), encoding="utf-8")
+    search_space_path.write_text(_SEARCH_SPACE_YAML, encoding="utf-8")
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_proposal_vs_random_issue_2921.py",
+            "--archive",
+            archive_path.as_posix(),
+            "--search-space",
+            search_space_path.as_posix(),
+            "--budget",
+            "3",
+            "--seed",
+            "7",
+            "--output",
+            output_json.as_posix(),
+        ],
+    )
+
+    assert script_main() == 0
+    report = json.loads(output_json.read_text(encoding="utf-8"))
+    assert report["state"] == "active"
+    assert report["synthetic_archive"] is False
+    assert report["synthetic_search_space"] is False
+
+    provenance = report["archive_evaluation_provenance"]
+    assert provenance["split_policy"] == "disjoint_scenario_family"
+    assert provenance["disjointness_checks_passed"] is True
+    assert provenance["scenario_family_overlap"] == []
+    assert provenance["archive_id_overlap"] == []
+    assert provenance["fit_size"] > 0
+    assert provenance["eval_size"] > 0
+
+    # Held-out yield stays fail-closed: independent planner outcomes are not wired yet.
+    assert report["held_out_evidence"] is False
+    assert provenance["held_out_evidence_status"] == (
+        "not_available_requires_independent_planner_outcomes"
+    )

--- a/tests/adversarial/test_disjoint_evaluation.py
+++ b/tests/adversarial/test_disjoint_evaluation.py
@@ -1,0 +1,255 @@
+"""Tests for disjoint fit/evaluation splitting, overlap provenance, and null tests.
+
+These cover the issue #3275 machinery in isolation. The module imports no
+simulation/torch surfaces, so these tests run standalone.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.adversarial.disjoint_evaluation import (
+    DisjointSplit,
+    archive_sha256,
+    classify_held_out_evidence,
+    compute_overlap_provenance,
+    disjoint_family_split,
+    permutation_test_mean_difference,
+    ranking_permutation_test,
+    scenario_family_key,
+    shuffled_outcome_null_test,
+)
+
+
+def _entry(family: str, archive_id: str, seed: int) -> dict:
+    """Build a minimal archive entry with a string cluster_key family."""
+    return {
+        "archive_id": archive_id,
+        "cluster_key": family,
+        "candidate": {"scenario_seed": seed},
+    }
+
+
+def test_scenario_family_key_sources() -> None:
+    """Family key prefers cluster_key, then failure/manifest, then a fallback."""
+    assert scenario_family_key({"cluster_key": "goal_collision"}) == "goal_collision"
+
+    dict_key = scenario_family_key(
+        {"cluster_key": {"policy": "orca", "primary_failure": "collision"}}
+    )
+    # dict cluster keys serialize deterministically (sorted keys).
+    assert dict_key == '{"policy":"orca","primary_failure":"collision"}'
+
+    fallback = scenario_family_key(
+        {"failure_attribution": {"primary_failure": "timeout"}, "source_manifest": "m.json"}
+    )
+    assert fallback == "failure=timeout|manifest=m.json"
+
+    assert scenario_family_key({}) == "unknown_family"
+
+
+def test_disjoint_family_split_partitions_by_family() -> None:
+    """Two families split into non-overlapping fit/eval sides."""
+    entries = [
+        _entry("A", "a0", 1),
+        _entry("A", "a1", 2),
+        _entry("B", "b0", 3),
+        _entry("B", "b1", 4),
+    ]
+    split = disjoint_family_split(entries, eval_fraction=0.5, seed=0)
+    assert isinstance(split, DisjointSplit)
+    assert split.is_disjoint_split is True
+    assert set(split.fit_families).isdisjoint(split.eval_families)
+    assert split.fit_entries and split.eval_entries
+    # Every entry lands on exactly one side.
+    assert len(split.fit_entries) + len(split.eval_entries) == len(entries)
+
+
+def test_disjoint_family_split_is_deterministic() -> None:
+    """Same seed yields the same family assignment."""
+    entries = [_entry("A", "a0", 1), _entry("B", "b0", 2), _entry("C", "c0", 3)]
+    first = disjoint_family_split(entries, seed=7)
+    second = disjoint_family_split(entries, seed=7)
+    assert first.fit_families == second.fit_families
+    assert first.eval_families == second.eval_families
+
+
+def test_disjoint_family_split_single_family_cannot_split() -> None:
+    """A single family cannot form a disjoint split; all entries go to fit."""
+    entries = [_entry("A", "a0", 1), _entry("A", "a1", 2)]
+    split = disjoint_family_split(entries, seed=0)
+    assert split.is_disjoint_split is False
+    assert split.eval_entries == []
+    assert len(split.fit_entries) == 2
+
+
+def test_disjoint_family_split_rejects_degenerate_fraction() -> None:
+    """eval_fraction must be strictly inside (0, 1)."""
+    entries = [_entry("A", "a0", 1), _entry("B", "b0", 2)]
+    for bad in (0.0, 1.0, -0.1, 1.5):
+        with pytest.raises(ValueError, match="eval_fraction"):
+            disjoint_family_split(entries, eval_fraction=bad)
+
+
+def test_overlap_provenance_disjoint() -> None:
+    """Disjoint families with distinct archive ids pass the disjointness check."""
+    fit = [_entry("A", "a0", 1), _entry("A", "a1", 2)]
+    eval_ = [_entry("B", "b0", 3), _entry("B", "b1", 4)]
+    prov = compute_overlap_provenance(fit, eval_)
+    assert prov["disjointness_checks_passed"] is True
+    assert prov["scenario_family_overlap"] == []
+    assert prov["archive_id_overlap"] == []
+    assert prov["split_policy"] == "disjoint_scenario_family"
+    assert prov["fit_size"] == 2
+    assert prov["eval_size"] == 2
+
+
+def test_overlap_provenance_detects_family_and_id_overlap() -> None:
+    """Shared family or archive id fails the disjointness check."""
+    fit = [_entry("A", "a0", 1)]
+    eval_ = [_entry("A", "a1", 2)]  # same family A
+    prov = compute_overlap_provenance(fit, eval_)
+    assert prov["disjointness_checks_passed"] is False
+    assert prov["scenario_family_overlap"] == ["A"]
+
+    shared_id = compute_overlap_provenance([_entry("A", "x", 1)], [_entry("B", "x", 2)])
+    assert shared_id["disjointness_checks_passed"] is False
+    assert shared_id["archive_id_overlap"] == ["x"]
+
+
+def test_overlap_provenance_records_seed_overlap_without_failing() -> None:
+    """Seed overlap is recorded but does not by itself fail disjointness."""
+    fit = [_entry("A", "a0", 5)]
+    eval_ = [_entry("B", "b0", 5)]  # shared seed 5, disjoint family/id
+    prov = compute_overlap_provenance(fit, eval_)
+    assert prov["seed_overlap"] == [5]
+    assert prov["seed_overlap_count"] == 1
+    assert prov["disjointness_checks_passed"] is True
+
+
+def test_overlap_provenance_empty_eval_not_disjoint() -> None:
+    """An empty eval side cannot be a disjoint split."""
+    prov = compute_overlap_provenance([_entry("A", "a0", 1)], [])
+    assert prov["disjointness_checks_passed"] is False
+
+
+def test_archive_sha256_is_deterministic_and_sensitive() -> None:
+    """Hash is stable for equal data and changes when data changes."""
+    a = [_entry("A", "a0", 1)]
+    assert archive_sha256(a) == archive_sha256([_entry("A", "a0", 1)])
+    assert archive_sha256(a) != archive_sha256([_entry("A", "a0", 2)])
+
+
+def test_permutation_test_separates_signal_from_noise() -> None:
+    """Clear group separation yields a small p-value; identical groups ~1.0."""
+    separated = permutation_test_mean_difference(
+        [10.0, 10.0, 10.0], [0.0, 0.0, 0.0], n_permutations=200, seed=1
+    )
+    assert separated["status"] == "complete"
+    assert separated["observed_difference"] == 10.0
+    assert separated["p_value"] < 0.3
+
+    identical = permutation_test_mean_difference(
+        [5.0, 5.0, 5.0], [5.0, 5.0, 5.0], n_permutations=200, seed=1
+    )
+    assert identical["observed_difference"] == 0.0
+    assert identical["p_value"] == 1.0
+
+
+def test_permutation_test_empty_group_fail_closed() -> None:
+    """An empty group returns a not_available status, not a misleading p-value."""
+    result = permutation_test_mean_difference([], [1.0], n_permutations=10, seed=0)
+    assert result["status"] == "not_available_empty_group"
+    assert result["p_value"] is None
+
+
+def test_permutation_test_rejects_zero_permutations() -> None:
+    """n_permutations must be at least one."""
+    with pytest.raises(ValueError, match="n_permutations"):
+        permutation_test_mean_difference([1.0], [2.0], n_permutations=0)
+
+
+def test_shuffled_outcome_null_test_tags_test_name() -> None:
+    """The shuffled-outcome null test delegates and tags the test name."""
+    result = shuffled_outcome_null_test([3.0, 3.0], [0.0, 0.0], n_permutations=100, seed=2)
+    assert result["test"] == "shuffled_outcome_label_permutation"
+    assert result["status"] == "complete"
+
+
+def test_ranking_permutation_test_detects_ranking_signal() -> None:
+    """A descending ranking concentrates high outcomes in its top-k (small p)."""
+    descending = [float(v) for v in range(20, 0, -1)]
+    result = ranking_permutation_test(descending, selection_size=3, n_permutations=500, seed=3)
+    assert result["status"] == "complete"
+    assert result["observed_top_mean"] == 19.0
+    assert result["p_value"] < 0.1
+
+
+def test_ranking_permutation_test_flat_outcomes_no_signal() -> None:
+    """Flat outcomes give the maximum p-value (no ranking signal)."""
+    result = ranking_permutation_test(
+        [5.0, 5.0, 5.0, 5.0], selection_size=2, n_permutations=100, seed=0
+    )
+    assert result["p_value"] == 1.0
+
+
+def test_ranking_permutation_test_invalid_selection() -> None:
+    """Invalid selection sizes fail closed."""
+    assert ranking_permutation_test([1.0, 2.0], selection_size=0)["status"] == (
+        "not_available_invalid_selection"
+    )
+    assert ranking_permutation_test([1.0, 2.0], selection_size=5)["status"] == (
+        "not_available_invalid_selection"
+    )
+    assert ranking_permutation_test([], selection_size=1)["status"] == (
+        "not_available_invalid_selection"
+    )
+
+
+def test_classify_held_out_evidence_fail_closed() -> None:
+    """Held-out evidence is eligible only when every precondition holds."""
+    assert (
+        classify_held_out_evidence(
+            disjointness_checks_passed=False,
+            independent_outcomes_available=True,
+            certification_available=True,
+            null_tests_reject_null=True,
+        )
+        == "not_available_no_disjoint_split"
+    )
+    assert (
+        classify_held_out_evidence(
+            disjointness_checks_passed=True,
+            independent_outcomes_available=False,
+            certification_available=True,
+            null_tests_reject_null=True,
+        )
+        == "not_available_requires_independent_planner_outcomes"
+    )
+    assert (
+        classify_held_out_evidence(
+            disjointness_checks_passed=True,
+            independent_outcomes_available=True,
+            certification_available=False,
+            null_tests_reject_null=True,
+        )
+        == "not_available_requires_candidate_certification"
+    )
+    assert (
+        classify_held_out_evidence(
+            disjointness_checks_passed=True,
+            independent_outcomes_available=True,
+            certification_available=True,
+            null_tests_reject_null=False,
+        )
+        == "not_available_null_tests_not_rejected"
+    )
+    assert (
+        classify_held_out_evidence(
+            disjointness_checks_passed=True,
+            independent_outcomes_available=True,
+            certification_available=True,
+            null_tests_reject_null=True,
+        )
+        == "eligible_held_out_diagnostic"
+    )


### PR DESCRIPTION
## Summary
Batch 1 of #3275. PR #3276 (issue #2921) ranks candidates by distance to the failure archive and evaluates selected candidates using essentially the same distance to the same archive — a circular comparison. This PR adds the machinery a **non-circular, held-out** comparison requires, while keeping the held-out yield claim **fail-closed**.

This is infrastructure only: **no held-out yield, benchmark, causal, or planner-performance claim is made.**

## What changed
- **New `robot_sf/adversarial/disjoint_evaluation.py`** (pure, no simulation deps):
  - `scenario_family_key` + `disjoint_family_split` — partition a failure archive into fit/eval sets whose **scenario families are disjoint** (a family is never split across sides).
  - `compute_overlap_provenance` — scenario-family / scenario-seed / archive-id overlap + archive hashes; `disjointness_checks_passed` is `True` only when both sides are non-empty and share no family and no archive id (seed overlap is recorded, not used to pass/fail).
  - `permutation_test_mean_difference`, `shuffled_outcome_null_test`, `ranking_permutation_test` — permutation null tests over an **independent** outcome vector.
  - `classify_held_out_evidence` — fail-closed; never `eligible` without a disjoint split, independent (non-archive-nearness) outcomes, candidate certification, and a rejected null.
- **`scripts/adversarial/run_proposal_vs_random_issue_2921.py`** — on the active real-archive path, computes real disjoint-split provenance via the new module. `held_out_evidence` stays `False`; `held_out_evidence_status = not_available_requires_independent_planner_outcomes`. The diagnostic/blocked plumbing paths (and their existing assertions) are unchanged.

## Real-data check (diagnostic)
Run against the tracked two-family archive `issue_1502_adversarial_two_family` + `configs/adversarial/crossing_ttc_space.yaml`:

```
state: active · held_out_evidence: False
split_policy: disjoint_scenario_family · disjointness_checks_passed: True
fit_size: 29 (orca/collision)  eval_size: 31 (goal/collision)
scenario_family_overlap: []   archive_id_overlap: []   seed_overlap_count: 25
held_out_evidence_status: not_available_requires_independent_planner_outcomes
```

The `seed_overlap_count: 25` is the point: the two families share 25 scenario seeds, so a naive seed split would leak — the disjoint-family split avoids that and records the overlap transparently.

## Validation
- `tests/adversarial/test_disjoint_evaluation.py` — 18 new unit tests (split correctness/determinism, overlap detection, permutation null tests on signal vs noise, fail-closed classifier).
- `tests/adversarial/test_adversarial_proposal_model_issue_2921.py` — new active-path integration test; all 11 prior tests unchanged and green.
- `uv run --extra training pytest tests/adversarial/` → **173 passed**. `ruff` + `pre-commit` clean.

## Scope / batches
- **This PR (batch 1):** disjoint split + overlap provenance + null-test utilities + fail-closed classifier, wired for provenance only.
- **Batch 2 (follow-up):** evaluate selected candidates through **actual planner executions + certified failure outcomes** on the disjoint eval split, then apply the null tests to those non-circular outcomes and report held-out proposal-vs-random yield.

Relates to #3275 (does not close it; batch 2 completes the held-out evidence path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - PR relates to #3275 and keeps it open for Batch 2 held-out planner outcome execution.
- Claim map / benchmark report updated (yes/no/NA): NA - infrastructure/provenance only; no held-out yield, benchmark, causal, or planner-performance claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no benchmark artifact or leaderboard result.
- Registry or config index updated (yes/no/NA): NA - no registry/config index change.
- Context index / memory note updated (yes/no/NA): NA - the PR body records the fail-closed boundary and Batch 2 follow-up surface.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - #3275 remains open and is explicitly named for Batch 2.
- Not applicable because: this PR adds disjoint-split/null-test infrastructure and active-path provenance only; it deliberately classifies held-out evidence as `not_available_requires_independent_planner_outcomes`.

## Follow-Up Issues
- Deferred work: Batch 2 must run actual planner executions on the disjoint eval split, certify outcomes, and apply the null tests to independent non-circular outcomes before any held-out yield claim.
- Issues opened for follow-up: NA - #3275 remains open for that work.

## Reviewer Notes
- Review should focus on fail-closed evidence classification, split/provenance correctness, and preventing circular archive-nearness outcomes from being reported as held-out yield.
- `seed_overlap` is recorded as provenance but does not fail disjointness; the held-out unit is scenario family plus archive id.
