### PR TITLE
fix: relax leaner issue-audit core to 4 sections + recognize more heading variants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,16 +38,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   bodies instead of only the markdown templates. The audit previously matched a single strict
   12-section markdown contract and reported 8–12 false "missing section" gaps on nearly every
   issue filed from the leaner YAML forms. The auditor now (a) maps heading variants such as
-  `Scope and non-goals`, `Acceptance criteria`/`Acceptance / stop rule`, `Estimate metadata`,
-  `Validation commands`, and `Question / Goal`/`Background` to their canonical sections;
-  (b) strips trailing parenthetical qualifiers (e.g. `Acceptance criteria (mirrors body)`);
-  (c) credits `###` contract subheadings carried inside the appended `agent-exec-spec` block;
-  and (d) audits leaner-template issues against a shared agent-ready core
-  (`Goal / Problem`, `Scope`, `Effort Estimation`, `Definition of Done`, `Validation / Testing`)
-  while bare/markdown-style bodies keep the strict full contract. Across the 91 open issues this
-  cut spurious "missing section" reports from ~87 issues (many with 8–12 false gaps) to a small
-  set of genuine gaps. The archetype-metadata audit and `audit_archetype_metadata` API are
-  unchanged.
+  `Scope and non-goals`/`Out of scope`/`Scope / decision needed`, `Acceptance criteria`/
+  `Acceptance / stop rule`/`Accept / revise / reject`, `Estimate`/`Estimate metadata`,
+  `Validation commands`, and `Question / Goal`/`Background`/`Summary`/`What to build` to their
+  canonical sections; (b) strips trailing parenthetical qualifiers (e.g.
+  `Acceptance criteria (mirrors body)`); (c) credits `###` contract subheadings carried inside
+  the appended `agent-exec-spec` block; and (d) audits leaner-template issues against a shared
+  agent-ready core (`Goal / Problem`, `Scope`, `Definition of Done`, `Validation / Testing`)
+  while bare/markdown-style bodies keep the strict full 12-section contract. A standalone effort
+  estimate is intentionally not in the core: leaner/agent issues state effort under
+  `Project Metadata` or defer it on blocked work, and the agent-exec-spec agents execute from
+  carries no estimate. Across the 91 open issues this cut spurious "missing section" findings
+  from 762 (≈87 issues, many with 8–12 false gaps) to ~30 (26 issues, genuinely-absent
+  sections), with 65 issues now fully clean. The archetype-metadata audit and
+  `audit_archetype_metadata` API are unchanged.
 * Expanded the canonical issue-archetype taxonomy in
   `docs/context/issue_1512_issue_archetypes.md` and the validator
   (`scripts/tools/issue_template_audit.py`) to bless the work-type archetypes the issue

--- a/scripts/tools/issue_template_audit.py
+++ b/scripts/tools/issue_template_audit.py
@@ -45,11 +45,16 @@ SECTION_ALIASES: dict[str, str] = {
     "question / goal": "Goal / Problem",
     "goal / question": "Goal / Problem",
     "background": "Goal / Problem",
+    "summary": "Goal / Problem",
+    "what to build": "Goal / Problem",
+    "what to build once unblocked": "Goal / Problem",
     "scope": "Scope",
     # YAML issue forms (epic/execution-run/test-debt/blocked-external-artifact) name this
     # "Scope and non-goals"; treat it as the canonical Scope section.
     "scope and non-goals": "Scope",
     "scope / out of scope": "Scope",
+    "out of scope": "Scope",
+    "scope / decision needed": "Scope",
     "added value estimation": "Added Value Estimation",
     "value estimation": "Added Value Estimation",
     "effort estimation": "Effort Estimation",
@@ -65,9 +70,10 @@ SECTION_ALIASES: dict[str, str] = {
     "definition of done": "Definition of Done",
     # YAML forms and agent-authored bodies use "Acceptance criteria" for the same contract.
     "acceptance criteria": "Definition of Done",
-    # Research/epic bodies fold the acceptance contract into a stop-rule heading.
+    # Research/epic bodies fold the acceptance contract into a stop-rule or decision heading.
     "acceptance / stop rule": "Definition of Done",
     "accept / revise / reject criteria": "Definition of Done",
+    "accept / revise / reject": "Definition of Done",
     "success metrics": "Success Metrics",
     "validation / testing": "Validation / Testing",
     "validation": "Validation / Testing",
@@ -93,6 +99,7 @@ LEANER_TEMPLATE_SIGNATURES: frozenset[str] = frozenset(
         "acceptance criteria",
         "acceptance / stop rule",
         "accept / revise / reject criteria",
+        "accept / revise / reject",
         "estimate",
         "estimate metadata",
         "validation command",
@@ -101,13 +108,15 @@ LEANER_TEMPLATE_SIGNATURES: frozenset[str] = frozenset(
     }
 )
 
-# Shared agent-ready core required of every issue regardless of template family. The full
-# markdown contract (``SECTION_ORDER``) is a superset of this and stays the default so bare
-# or markdown-style bodies keep the stricter requirement.
+# Shared agent-ready core required of every issue regardless of template family: what the
+# problem is, what is in/out of scope, when it is done, and how to validate. The full markdown
+# contract (``SECTION_ORDER``) is a superset of this and stays the default so bare or
+# markdown-style bodies keep the stricter requirement. A standalone effort estimate is not in
+# the core: leaner/agent issues state effort under ``Project Metadata`` (or defer it on blocked
+# work), and the agent-exec-spec that agents execute from carries no estimate.
 CORE_SECTION_ORDER: tuple[str, ...] = (
     "Goal / Problem",
     "Scope",
-    "Effort Estimation",
     "Definition of Done",
     "Validation / Testing",
 )


### PR DESCRIPTION
## Summary

Follow-up to #3388 (which aligned `issue_template_audit.py` with the repo's YAML/agent issue vocabularies). While applying the audit across all 91 open issues, two refinements remained:

1. **Drop the standalone effort estimate from the leaner agent-ready core.** The core is now `Goal / Problem`, `Scope`, `Definition of Done`, `Validation / Testing`. Leaner/agent issues state effort under `Project Metadata` or defer it on blocked work, and the `agent-exec-spec` agents actually execute from carries no estimate — so a separate `Effort Estimation` heading isn't essential to agent-readiness. **Bare and markdown-style bodies still require the full 12-section contract** (unchanged).
2. **Recognize more genuine heading synonyms** the automation emits: `Summary` / `What to build` → Goal/Problem; `Out of scope` / `Scope / decision needed` → Scope; `Accept / revise / reject` → Definition of Done.

## Impact (across the 91 open issues)
- Fully-clean issues: **65 / 91** (was ~2 before #3388).
- Remaining ~30 findings on 26 issues are **genuinely-absent** sections (e.g. research issues using `## Implementation Plan` / `## Required Work` with no `## Scope`; decision issues using `## Decision Needed`). No content was fabricated to make them pass.

## Tests
- `tests/tools/test_issue_template_audit.py` (existing coverage exercises the leaner core + variants).
- `uv run python -m pytest tests/tools/test_issue_template_audit.py tests/tools/test_issue_archetype_sync.py tests/test_issue_templates.py -q` → **45 passed**.
- `ruff format` + `ruff check` clean.

## Note
This branch is the clean rebase of a follow-up commit that landed on the #3388 branch *after* that PR was squash-merged. Diff is limited to `scripts/tools/issue_template_audit.py` + `CHANGELOG.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Issue template validation now recognizes additional heading format variants for improved section detection across templates.
  * Relaxed core template requirements—Effort Estimation is no longer mandatory for certain issue types.
  * Enhanced support for diverse issue template families with better heading compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->