### PR TITLE
chore: expose .agents/skills to Claude Code via .claude/skills symlink

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/scripts/tools/sync_ai_config.py
+++ b/scripts/tools/sync_ai_config.py
@@ -19,6 +19,7 @@ class LinkSpec:
 
 
 LINK_SPECS = (
+    LinkSpec(".claude/skills", "../.agents/skills"),
     LinkSpec(".codex/skills", "../.agents/skills"),
     LinkSpec(".opencode/skills", "../.agents/skills"),
     LinkSpec(".codex/prompts", "../.agents/prompts/codex"),


### PR DESCRIPTION
## What

Adds a `.claude/skills -> ../.agents/skills` symlink so Claude Code natively discovers the repo's skill set.

## Why

Claude Code loads project skills from `.claude/skills/`, but the canonical skills live in `.agents/skills/` (53 skills, all with Claude-compatible `name:`/`description:` frontmatter). They were already mirrored to `.codex/skills` and `.opencode/skills` via relative symlinks; Claude Code was simply missing its equivalent, so none of the skills showed up.

## How

- Register `.claude/skills` in `LINK_SPECS` in `scripts/tools/sync_ai_config.py`, so the link is created by `--fix`, tracked in git, and drift-validated by `--check` (which runs in `pr_ready_check.sh`) — same treatment as the existing Codex/OpenCode mirrors.
- Commit the resulting symlink (stored as git mode `120000`, relative target, so it resolves correctly per-worktree).

## Validation

- `uv run python scripts/tools/sync_ai_config.py --check` → `AI config links validated: 7 symlinks.`

## Notes

- After merge, run `uv run python scripts/tools/sync_ai_config.py --fix` in the main checkout / other worktrees to materialize the link there.
- A running Claude Code session must be restarted to pick up the newly visible skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal configuration management and file organization for development tooling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->