### PR TITLE
fix: default unicycle velocity to scalar (#3381)

### DIFF
--- a/robot_sf/ped_ego/unicycle_drive.py
+++ b/robot_sf/ped_ego/unicycle_drive.py
@@ -39,7 +39,7 @@ class UnicycleDriveState:
     """A class that represents the state of a unicycle drive pedestrian."""
 
     pose: PedPose = field(default_factory=lambda: ((0.0, 0.0), 0.0))
-    velocity: PolarVec2D = field(default_factory=lambda: (0.0, 0.0))
+    velocity: float = 0.0
 
     @property
     def pos(self) -> Vec2D:

--- a/tests/unicycle_drive_test.py
+++ b/tests/unicycle_drive_test.py
@@ -99,6 +99,19 @@ def test_unicycle_acceleration():
     assert speed == 0  # assert not moving backwards
 
 
+def test_unicycle_default_state_moves_with_scalar_current_speed():
+    """Default state uses scalar velocity compatible with motion integration."""
+    motion = UnicycleMotion(UnicycleDriveSettings())
+    state = UnicycleDriveState()
+
+    motion.move(state, (1.0, 0.0), 1.0)
+
+    current_speed = state.current_speed
+    assert isinstance(state.velocity, float)
+    assert isinstance(current_speed[0], float)
+    assert current_speed == (1.0, state.orient)
+
+
 def test_unicycle_over_limit_acceleration_clipped():
     """Acceleration beyond max_accel is clipped."""
     motion = UnicycleMotion(UnicycleDriveSettings(max_accel=1.0))


### PR DESCRIPTION
## Summary
Fixes the default `UnicycleDriveState.velocity` contract so a default-constructed unicycle state starts with a scalar speed instead of a tuple.

## Linked Issues
- Closes `#3381`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Changed `UnicycleDriveState.velocity` from a `PolarVec2D` tuple default to a scalar `float` default.
- Added a regression test that default-constructs `UnicycleDriveState`, runs one `UnicycleMotion.move(...)`, and verifies scalar `current_speed`.

## Why It Matters
- Added value: fixes a direct crash path for default-constructed unicycle drive state.
- Expected impact: aligns the dataclass type/default with the existing scalar integration logic.
- Why this is worth merging now: the issue is small, isolated, and prevents future callers from inheriting a misleading type contract.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - localized runtime correctness bugfix, no research claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: NA - localized runtime bugfix, no research evidence claim.
- Result classification: NA - localized runtime bugfix, no research result.
- Decision or stop rule, if applicable: NA for research; runtime acceptance is default state moving once without raising and exposing scalar current speed.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#3381`
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Domain-Aware Approval
- Required for this PR: no - localized kinematics state type/default fix, no benchmark interpretation or paper-facing claim boundary.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: maintainer policy permits proportional validation for localized runtime fixes.
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: NA
  - Fallback/degraded exclusions: NA
  - Claim boundary: no benchmark or paper claim made.
  - Implementation integrity vs experimental validity: implementation integrity covered by focused test and PR readiness.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop; issue acceptance criteria are covered.
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- pytest tests/unicycle_drive_test.py -q`
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/ped_ego/unicycle_drive.py tests/unicycle_drive_test.py`
  - `rtk scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/ped_ego/unicycle_drive.py tests/unicycle_drive_test.py`
  - `rtk uv sync --all-extras`
  - `rtk uv run python scripts/dev/run_compact_validation.py -- bash -lc 'PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3381-pr-body.md scripts/dev/pr_ready_check.sh'`
- Evidence that the change works here: focused test covers the default construction crash path and final PR readiness passes for committed branch head.
- Benchmarks or smoke tests, if applicable: targeted unit smoke only; no benchmark claim.

## Risks / Rollout
- Compatibility risks: low; existing callers already treat `velocity` as scalar and write floats.
- Failure modes: external code expecting the incorrect tuple default would need to adapt, but that tuple contradicted the motion contract.
- Rollback or fallback plan: revert the single commit if unexpected downstream type assumptions appear.

## Docs / Provenance
- Updated docs: none
- Relevant design or provenance notes: issue `#3381` documents the reproduced crash and scalar contract.
- Any assumptions that need to be preserved: `current_speed` remains a `(speed, orient)` polar tuple while `state.velocity` is scalar.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes `#3381`
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark, registry, claim-map, model-provenance, or paper-facing surface changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: confirm the scalar `velocity` field matches all existing writes in `UnicycleMotion.move` and reset paths.
- Any known limitations: broader suite coverage left to normal CI; local readiness and focused tests passed.
