### PR TITLE
docs: fix dev guide baseline matrix path (#3387)

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -1084,7 +1084,7 @@ open output/coverage/htmlcov/index.html
 ```
 Name                                    Stmts   Miss  Cover   Missing
 ---------------------------------------------------------------------
-robot_sf/gym_env/environment.py           150     15  90.00%  42-45, 89-92
+robot_sf/gym_env/environment_factory.py   150     15  90.00%  42-45, 89-92
 robot_sf/sim/simulator.py                 200     50  75.00%  10-20, 150-180
 ---------------------------------------------------------------------
 TOTAL                                   10605    876  91.73%
@@ -1559,9 +1559,9 @@ Key points
 
 CLI usage
 - Run a batch with parallel workers and default resume behavior:
-  - robot_sf_bench run --matrix configs/baselines/example.yaml --out output/benchmarks/episodes.jsonl --workers 4
+  - robot_sf_bench run --matrix configs/baselines/example_matrix.yaml --out output/benchmarks/episodes.jsonl --workers 4
 - Force recomputation (disable resume):
-  - robot_sf_bench run --matrix configs/baselines/example.yaml --out output/benchmarks/episodes.jsonl --workers 4 --no-resume
+  - robot_sf_bench run --matrix configs/baselines/example_matrix.yaml --out output/benchmarks/episodes.jsonl --workers 4 --no-resume
 - Opt in to schema-backed pedestrian-impact reductions:
   - robot_sf_bench run --matrix configs/scenarios/planner_sanity_matrix_v1.yaml --out output/benchmarks/ped_impact/episodes.jsonl --experimental-ped-impact
 - Baseline computation also accepts the same flags:


### PR DESCRIPTION
## Summary
Fixes stale `docs/dev_guide.md` references to the non-existent `configs/baselines/example.yaml` benchmark matrix.

## Linked Issues
- Closes `#3387`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Updated benchmark commands to use the existing `configs/baselines/example_matrix.yaml`.
- Updated an illustrative coverage-table sample path from non-existent `robot_sf/gym_env/environment.py` to existing `robot_sf/gym_env/environment_factory.py`.

## Why It Matters
- Added value: contributor-facing benchmark commands no longer point at a missing file.
- Expected impact: reduces onboarding friction for developers following the dev guide.
- Why this is worth merging now: one-file docs fix with direct path validation.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - docs-only path correction, no research claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: docs-only
- Result classification: NA
- Decision or stop rule, if applicable: documented paths exist and stale path is gone.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#3387`
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Domain-Aware Approval
- Required for this PR: no - docs-only path correction, no benchmark interpretation or paper-facing claim.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: NA
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: NA
  - Fallback/degraded exclusions: NA
  - Claim boundary: no benchmark or paper claim made.
  - Implementation integrity vs experimental validity: path checks only.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop; docs acceptance criteria are covered.
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `rtk ls configs/baselines/example_matrix.yaml`
  - `rtk rg -n "configs/baselines/example\\.yaml" docs/dev_guide.md` (expected no matches, exit 1)
  - `rtk ls robot_sf/gym_env/environment_factory.py`
  - `rtk git diff --check`
  - `rtk git diff --check HEAD~1 HEAD`
- Evidence that the change works here: replacement paths exist and the stale config filename is absent from `docs/dev_guide.md`.
- Benchmarks or smoke tests, if applicable: NA - docs-only path correction; no benchmark claim.

## Risks / Rollout
- Compatibility risks: none expected.
- Failure modes: typo in docs path, covered by path checks.
- Rollback or fallback plan: revert the docs-only commit.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`
- Relevant design or provenance notes: issue `#3387`
- Any assumptions that need to be preserved: this PR does not assert benchmark results; it only fixes paths in documented commands/sample output.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes `#3387`
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark result, registry, claim-map, model-provenance, or paper-facing surface changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: the new documented paths exist and are the intended examples.
- Any known limitations: full PR readiness was not run; this used the repository's cheap docs-only validation path.
