### PR TITLE
test-health: run integration episode tests instead of masking failures (#3382)

### DIFF
--- a/tests/integration/test_single_episode_run.py
+++ b/tests/integration/test_single_episode_run.py
@@ -17,15 +17,14 @@ from robot_sf.benchmark.runner import run_episode
 
 def test_single_episode_produces_jsonl_line():
     """Test that running a single episode produces valid JSONL output."""
-    # Define a minimal scenario
+    # Minimal scenario using keys the generator actually accepts
+    # (see robot_sf/benchmark/scenario_generator.py normalize_generation_parameters):
+    # density ∈ {low, med, high}, flow ∈ {uni, bi, cross, merge}.
     scenario_params = {
         "id": "test_basic",
-        "density": 1.0,
-        "flow_pattern": "straight",
-        "obstacles": "none",
-        "repetitions": 1,
-        "map_id": "basic",
-        "seed_offset": 0,
+        "density": "low",
+        "flow": "uni",
+        "obstacle": "open",
     }
 
     seed = 42
@@ -33,82 +32,72 @@ def test_single_episode_produces_jsonl_line():
     with tempfile.TemporaryDirectory() as tmp_dir:
         output_path = Path(tmp_dir) / "episodes.jsonl"
 
-        try:
-            # Run single episode using the runner function
-            episode_data = run_episode(
-                scenario_params=scenario_params,
-                seed=seed,
-                horizon=50,
-                algo="random",  # Use a simple algorithm
-            )
+        # Run single episode using the runner function
+        episode_data = run_episode(
+            scenario_params=scenario_params,
+            seed=seed,
+            horizon=50,
+            algo="random",  # Use a simple algorithm
+        )
 
-            # Write episode data to JSONL
-            with output_path.open("w") as f:
-                f.write(json.dumps(episode_data) + "\n")
+        # Write episode data to JSONL
+        with output_path.open("w") as f:
+            f.write(json.dumps(episode_data) + "\n")
 
-            # Verify output exists and is valid JSON
-            assert output_path.exists()
+        # Verify output exists and is valid JSON
+        assert output_path.exists()
 
-            with output_path.open("r") as f:
-                lines = f.readlines()
+        with output_path.open("r") as f:
+            lines = f.readlines()
 
-            assert len(lines) == 1
+        assert len(lines) == 1
 
-            # Parse and validate episode data structure
-            episode = json.loads(lines[0])
+        # Parse and validate episode data structure
+        episode = json.loads(lines[0])
 
-            # Check required fields
-            assert "episode_id" in episode
-            assert "scenario_id" in episode
-            assert "seed" in episode
-            assert "metrics" in episode
-            assert "status" in episode
+        # Check required fields
+        assert "episode_id" in episode
+        assert "scenario_id" in episode
+        assert "seed" in episode
+        assert "metrics" in episode
+        assert "status" in episode
 
-            # Verify values match input
-            assert episode["scenario_id"] == scenario_params["id"]
-            assert episode["seed"] == seed
-
-        except Exception as e:
-            pytest.skip(f"Episode runner not fully implemented: {e}")
+        # Verify values match input
+        assert episode["scenario_id"] == scenario_params["id"]
+        assert episode["seed"] == seed
 
 
 def test_single_episode_with_metrics():
     """Test that episode includes computed metrics."""
     scenario_params = {
         "id": "test_metrics",
-        "density": 0.5,
-        "flow_pattern": "straight",
-        "obstacles": "none",
-        "repetitions": 1,
-        "map_id": "basic",
+        "density": "med",
+        "flow": "uni",
+        "obstacle": "open",
     }
 
-    try:
-        episode_data = run_episode(
-            scenario_params=scenario_params,
-            seed=123,
-            horizon=50,
-            algo="random",
-        )
+    episode_data = run_episode(
+        scenario_params=scenario_params,
+        seed=123,
+        horizon=50,
+        algo="random",
+    )
 
-        # Check metrics structure
-        metrics = episode_data["metrics"]
+    # Check metrics structure
+    metrics = episode_data["metrics"]
 
-        # Verify key metrics are present (should be numeric)
-        expected_metrics = [
-            "collisions",
-            "near_misses",
-            "success",
-            "time_to_goal_norm",
-            "path_efficiency",
-        ]
+    # Verify key metrics are present (should be numeric)
+    expected_metrics = [
+        "collisions",
+        "near_misses",
+        "success",
+        "time_to_goal_norm",
+        "path_efficiency",
+    ]
 
-        for metric in expected_metrics:
-            assert metric in metrics
-            assert isinstance(metrics[metric], int | float)
-
-    except Exception as e:
-        pytest.skip(f"Episode runner not fully implemented: {e}")
+    for metric in expected_metrics:
+        assert metric in metrics
+        assert isinstance(metrics[metric], int | float)
 
 
 if __name__ == "__main__":

--- a/tests/test_except_skip_policy.py
+++ b/tests/test_except_skip_policy.py
@@ -1,0 +1,82 @@
+"""Test-health policy: forbid `pytest.skip(...)` inside a broad-except handler.
+
+A `try/except Exception: pytest.skip(...)` (or `except BaseException`, or a bare
+`except:`) converts *any* failure — including a real regression in the code under
+test — into a green skip. The test then asserts nothing and can never fail, which
+is the textbook "skip mask" coverage hole (see issue #3382).
+
+This check generalizes the AST-policy approach already used for visual schema
+dependency guards in
+``tests/visuals/test_schema_validation_dependency_policy.py`` and applies it
+across the whole test tree so new offenders are rejected at CI time.
+
+Legitimate conditional skips should use a *narrow* guard instead:
+``pytest.importorskip(...)``, a specific exception type
+(e.g. ``except ImportError``), or ``pytest.mark.skipif(...)``.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+TESTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = TESTS_DIR.parent
+
+_BROAD_EXCEPTION_NAMES = frozenset({"Exception", "BaseException"})
+
+
+def test_no_pytest_skip_inside_broad_except_handler():
+    """No test may call ``pytest.skip(...)`` from a broad ``except`` handler."""
+    offenders: list[str] = []
+
+    for path in sorted(TESTS_DIR.rglob("test_*.py")):
+        tree = ast.parse(path.read_text(encoding="utf-8"))
+        relative_path = path.relative_to(REPO_ROOT)
+        for node in ast.walk(tree):
+            if not (isinstance(node, ast.ExceptHandler) and _is_broad_handler(node)):
+                continue
+            skip_line = _find_pytest_skip(node.body)
+            if skip_line is not None:
+                offenders.append(
+                    f"{relative_path}:{skip_line}: pytest.skip(...) reached from a broad "
+                    "except handler (use pytest.importorskip / a specific exception / "
+                    "pytest.mark.skipif instead)"
+                )
+
+    assert not offenders, "Found prohibited except -> pytest.skip patterns:\n" + "\n".join(
+        offenders
+    )
+
+
+def _is_broad_handler(handler: ast.ExceptHandler) -> bool:
+    """Return whether the handler catches everything (bare/Exception/BaseException)."""
+    exc_type = handler.type
+    if exc_type is None:  # bare `except:`
+        return True
+    names: list[str] = []
+    if isinstance(exc_type, ast.Name):
+        names = [exc_type.id]
+    elif isinstance(exc_type, ast.Tuple):
+        names = [elt.id for elt in exc_type.elts if isinstance(elt, ast.Name)]
+    return any(name in _BROAD_EXCEPTION_NAMES for name in names)
+
+
+def _find_pytest_skip(body: list[ast.stmt]) -> int | None:
+    """Return the line of the first ``pytest.skip(...)`` call in ``body``, if any."""
+    for stmt in body:
+        for node in ast.walk(stmt):
+            if _is_pytest_skip_call(node):
+                return node.lineno
+    return None
+
+
+def _is_pytest_skip_call(node: ast.AST) -> bool:
+    """Return whether node is a ``pytest.skip(...)`` call."""
+    return (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Attribute)
+        and node.func.attr == "skip"
+        and isinstance(node.func.value, ast.Name)
+        and node.func.value.id == "pytest"
+    )

--- a/tests/visuals/test_insufficient_replay_skip.py
+++ b/tests/visuals/test_insufficient_replay_skip.py
@@ -9,7 +9,6 @@ collection time by a dynamic condition inside the test body.
 
 from __future__ import annotations
 
-import importlib
 from typing import TYPE_CHECKING
 
 import pytest
@@ -35,16 +34,15 @@ class DummyCfg:
 
 
 def test_insufficient_replay_skip(tmp_path: Path):
-    # Skip dynamically if SimulationView truly unavailable
     """TODO docstring. Document this function.
 
     Args:
         tmp_path: TODO docstring.
     """
-    try:
-        importlib.import_module("robot_sf.render.sim_view")
-    except Exception:
-        pytest.skip("SimulationView not importable; skip insufficient replay test")
+    # Skip dynamically only when SimulationView is genuinely unavailable.
+    # Narrow guard (importorskip) instead of a blanket `except Exception` so a
+    # real import-time regression surfaces as a failure rather than a silent skip.
+    pytest.importorskip("robot_sf.render.sim_view")
 
     records = [
         {


### PR DESCRIPTION
## Summary

Fixes #3382. Two integration tests in `tests/integration/test_single_episode_run.py` were green in CI but asserted nothing: they wrapped their whole body in `try/except Exception: pytest.skip(...)` while their fixtures passed invalid scenario params (`density: 1.0`, `flow_pattern`). Every run raised during scenario generation, was converted to a skip, and the tests could never fail — the textbook skip-mask coverage hole.

## Changes

- **`tests/integration/test_single_episode_run.py`** — fix both fixtures to use the keys `normalize_generation_parameters` actually accepts (`density ∈ {low,med,high}`, `flow ∈ {uni,bi,cross,merge}`) and remove the blanket `except Exception: pytest.skip(...)`. The tests now execute `run_episode` end-to-end and assert on the produced JSONL episode / metrics.
- **`tests/visuals/test_insufficient_replay_skip.py`** — narrow the import guard from a broad `except Exception: pytest.skip(...)` to `pytest.importorskip("robot_sf.render.sim_view")` (the only other broad-except skip site), and drop the now-unused `importlib` import.
- **`tests/test_except_skip_policy.py`** (new) — repo-wide AST policy test that rejects `pytest.skip(...)` reachable from a broad `except Exception`/`except BaseException`/bare-`except` handler, generalizing the AST-policy approach in `tests/visuals/test_schema_validation_dependency_policy.py`. An AST scan confirmed exactly the 3 sites above were the only offenders, so the policy passes once they are fixed.

I placed the new policy in a dedicated repo-root test file (rather than literally editing the visuals-scoped file) because the rule is repo-wide; the module docstring cross-references the existing machinery the issue pointed to.

## Validation

```
uv run pytest tests/integration/test_single_episode_run.py \
  tests/visuals/test_insufficient_replay_skip.py \
  tests/test_except_skip_policy.py \
  tests/visuals/test_schema_validation_dependency_policy.py -q
# 5 passed

scripts/dev/ruff_fix_format.sh        # All checks passed
uv run python scripts/tools/sync_ai_config.py --check   # 7 symlinks validated
```

The two integration tests now **run** (previously `2 skipped`). Rebased on current `origin/main` (`cb464ce1`); proof re-run post-rebase.

## Acceptance criteria

- [x] `test_single_episode_run.py` runs (not skips) and asserts on the produced JSONL episode.
- [x] The blanket `except Exception: pytest.skip(...)` blocks are removed/narrowed.
- [x] An AST/lint check rejects new `except → pytest.skip` patterns, with the two known sites brought into compliance.

## Evidence grade

Tier 1 (test/contract change); local validation only, no benchmark/metric semantics touched. Confidence: **High** — proof current for branch head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
