### PR TITLE
refactor: consolidate _json_pointer ×8 into shared helper + fix _copy_figures return (#3386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Consolidated the RFC6901 JSON-pointer renderer that was copy-pasted in eight modules into a single
+  shared helper `robot_sf.common.json_pointer.json_pointer` (#3386). The eight schema-validation call
+  sites (`benchmark/{scenario_schema,odd_contract,hazard_traceability,scenario_contract,odd_hazard_coverage_matrix,artifact_catalog}.py`
+  and `analysis_workbench/{simulation_trace_export,trace_annotation}.py`) now import it, removing the
+  latent hazard of an escaping fix diverging between copies. As part of unifying the two prior copies,
+  the three `analysis_workbench`/`artifact_catalog` sites now render the *root* path (empty error path)
+  as the RFC6901-correct empty string `""` instead of `"/"`; this only affects the rare root-level
+  schema-error message string and is covered by a new unit test
+  (`tests/common/test_json_pointer.py`). Also fixed `_copy_figures` in `research/imitation_report.py`
+  to actually `return` its `dict[str, Path]` mapping (it previously fell through to `None` despite the
+  annotation), with a regression test (#3386).
 * Cut pull-request CI wall-clock by parallelizing the `fast-feedback` test phase. Pull requests now
   split the suite into 4 `pytest-split` shards (a matrix on the existing job, so the CI topology is
   unchanged) while `main`/`workflow_dispatch` keep a single full pass so the advisory coverage

--- a/robot_sf/analysis_workbench/simulation_trace_export.py
+++ b/robot_sf/analysis_workbench/simulation_trace_export.py
@@ -11,6 +11,8 @@ from typing import Any
 
 from jsonschema import Draft202012Validator
 
+from robot_sf.common.json_pointer import json_pointer
+
 SIMULATION_TRACE_EXPORT_SCHEMA_VERSION = "simulation_trace_export.v1"
 SIMULATION_TRACE_EXPORT_SCHEMA_FILE = (
     Path(__file__).with_name("schemas") / "simulation_trace_export.v1.json"
@@ -120,7 +122,7 @@ def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
 
     validator = Draft202012Validator(load_simulation_trace_export_schema())
     return [
-        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        f"{json_pointer(error.absolute_path)}: {error.message}"
         for error in sorted(
             validator.iter_errors(payload),
             key=lambda err: list(err.absolute_path),
@@ -186,14 +188,3 @@ def _export_from_payload(payload: Mapping[str, Any]) -> SimulationTraceExport:
             for frame in payload["frames"]
         ],
     )
-
-
-def _json_pointer(path: Any) -> str:
-    """Render a JSON Schema error path as an RFC6901-style pointer.
-
-    Returns:
-        JSON pointer string for the provided path.
-    """
-
-    parts = [str(part).replace("~", "~0").replace("/", "~1") for part in path]
-    return "/" + "/".join(parts) if parts else "/"

--- a/robot_sf/analysis_workbench/trace_annotation.py
+++ b/robot_sf/analysis_workbench/trace_annotation.py
@@ -17,6 +17,7 @@ from robot_sf.analysis_workbench.simulation_trace_export import (
     SimulationTraceExportValidationError,
     load_simulation_trace_export,
 )
+from robot_sf.common.json_pointer import json_pointer
 
 TRACE_ANNOTATION_SET_SCHEMA_VERSION = "trace_annotation_set.v1"
 TRACE_ANNOTATION_SET_SCHEMA_FILE = (
@@ -160,7 +161,7 @@ def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
 
     validator = Draft202012Validator(load_trace_annotation_set_schema())
     return [
-        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        f"{json_pointer(error.absolute_path)}: {error.message}"
         for error in sorted(
             validator.iter_errors(payload),
             key=lambda err: list(err.absolute_path),
@@ -447,14 +448,3 @@ def _annotation_set_from_payload(payload: Mapping[str, Any]) -> TraceAnnotationS
             for annotation in payload["annotations"]
         ],
     )
-
-
-def _json_pointer(path: Any) -> str:
-    """Render a JSON Schema error path as an RFC6901-style pointer.
-
-    Returns:
-        JSON pointer string for the provided path.
-    """
-
-    parts = [str(part).replace("~", "~0").replace("/", "~1") for part in path]
-    return "/" + "/".join(parts) if parts else "/"

--- a/robot_sf/benchmark/artifact_catalog.py
+++ b/robot_sf/benchmark/artifact_catalog.py
@@ -15,6 +15,8 @@ from typing import Any
 import yaml
 from jsonschema import Draft202012Validator
 
+from robot_sf.common.json_pointer import json_pointer
+
 ARTIFACT_CATALOG_SCHEMA_VERSION = "artifact_catalog.v1"
 ARTIFACT_CATALOG_SCHEMA_FILE = Path(__file__).with_name("schemas") / "artifact_catalog.v1.json"
 _SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
@@ -172,7 +174,7 @@ def _schema_validation_issues(payload: Mapping[str, Any]) -> list[ArtifactCatalo
 
     validator = Draft202012Validator(load_artifact_catalog_schema())
     return [
-        ArtifactCatalogIssue(_json_pointer(error.absolute_path), error.message)
+        ArtifactCatalogIssue(json_pointer(error.absolute_path), error.message)
         for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
     ]
 
@@ -347,13 +349,6 @@ def _as_list(value: Any) -> list[Any]:
     """Return value when it is a list, otherwise an empty list."""
 
     return value if isinstance(value, list) else []
-
-
-def _json_pointer(path: Any) -> str:
-    """Return a JSON pointer for a schema error path."""
-
-    parts = [str(part).replace("~", "~0").replace("/", "~1") for part in path]
-    return "/" + "/".join(parts) if parts else "/"
 
 
 def _catalog_from_payload(payload: Mapping[str, Any]) -> ArtifactCatalog:

--- a/robot_sf/benchmark/hazard_traceability.py
+++ b/robot_sf/benchmark/hazard_traceability.py
@@ -12,6 +12,8 @@ from typing import Any
 import yaml
 from jsonschema import Draft202012Validator
 
+from robot_sf.common.json_pointer import json_pointer
+
 HAZARD_TRACEABILITY_SCHEMA_VERSION = "hazard_traceability.v1"
 HAZARD_COVERAGE_SUMMARY_SCHEMA_VERSION = "hazard-traceability-coverage.v1"
 HAZARD_TRACEABILITY_SCHEMA_FILE = (
@@ -186,7 +188,7 @@ def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
 
     validator = Draft202012Validator(load_hazard_traceability_schema())
     return [
-        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        f"{json_pointer(error.absolute_path)}: {error.message}"
         for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
     ]
 
@@ -283,22 +285,6 @@ def _mapping_from_payload(payload: Mapping[str, Any]) -> HazardTraceability:
         ),
         extensions=dict(payload.get("extensions", {})),
     )
-
-
-def _json_pointer(path_elems: Iterable[Any]) -> str:
-    """Render a validation error path as an RFC6901-style JSON pointer.
-
-    Returns:
-        JSON pointer string, or an empty string for the root path.
-    """
-
-    parts: list[str] = []
-    for part in path_elems:
-        if isinstance(part, int):
-            parts.append(str(part))
-        else:
-            parts.append(str(part).replace("~", "~0").replace("/", "~1"))
-    return "/" + "/".join(parts) if parts else ""
 
 
 __all__ = [

--- a/robot_sf/benchmark/odd_contract.py
+++ b/robot_sf/benchmark/odd_contract.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -13,6 +13,7 @@ import yaml
 from jsonschema import Draft202012Validator
 
 from robot_sf.benchmark.observation_quality import ObservationQuality
+from robot_sf.common.json_pointer import json_pointer
 
 ODD_CONTRACT_SCHEMA_VERSION = "odd_contract.v1"
 ODD_CONTRACT_SCHEMA_FILE = Path(__file__).with_name("schemas") / "odd_contract.v1.json"
@@ -247,7 +248,7 @@ def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
 
     validator = Draft202012Validator(load_odd_contract_schema())
     return [
-        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        f"{json_pointer(error.absolute_path)}: {error.message}"
         for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
     ]
 
@@ -328,22 +329,6 @@ def _contract_from_payload(payload: Mapping[str, Any]) -> OddContract:
         ),
         extensions=dict(payload.get("extensions", {})),
     )
-
-
-def _json_pointer(path_elems: Iterable[Any]) -> str:
-    """Render a validation error path as an RFC6901-style JSON pointer.
-
-    Returns:
-        JSON pointer string, or an empty string for the root path.
-    """
-
-    parts: list[str] = []
-    for part in path_elems:
-        if isinstance(part, int):
-            parts.append(str(part))
-        else:
-            parts.append(str(part).replace("~", "~0").replace("/", "~1"))
-    return "/" + "/".join(parts) if parts else ""
 
 
 __all__ = [

--- a/robot_sf/benchmark/odd_hazard_coverage_matrix.py
+++ b/robot_sf/benchmark/odd_hazard_coverage_matrix.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import json
 import subprocess
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass
 from datetime import UTC, datetime
 from functools import lru_cache
@@ -15,6 +15,8 @@ from typing import Any
 
 import yaml
 from jsonschema import Draft202012Validator
+
+from robot_sf.common.json_pointer import json_pointer
 
 ODD_HAZARD_COVERAGE_SCHEMA_VERSION = "odd_hazard_coverage.v1"
 ODD_HAZARD_COVERAGE_SCHEMA_FILE = (
@@ -473,7 +475,7 @@ def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
 
     validator = Draft202012Validator(load_odd_hazard_coverage_schema())
     return [
-        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        f"{json_pointer(error.absolute_path)}: {error.message}"
         for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
     ]
 
@@ -622,18 +624,6 @@ def _generation_provenance(*, repo_root: Path) -> dict[str, str]:
         "base_commit": _git_commit(repo_root=repo_root),
         "tree_state": _git_tree_state(repo_root=repo_root),
     }
-
-
-def _json_pointer(path_elems: Iterable[Any]) -> str:
-    """Render a validation error path as an RFC6901-style JSON pointer."""
-
-    parts: list[str] = []
-    for part in path_elems:
-        if isinstance(part, int):
-            parts.append(str(part))
-        else:
-            parts.append(str(part).replace("~", "~0").replace("/", "~1"))
-    return "/" + "/".join(parts) if parts else ""
 
 
 __all__ = [

--- a/robot_sf/benchmark/scenario_contract.py
+++ b/robot_sf/benchmark/scenario_contract.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import json
-from collections.abc import Iterable, Mapping
+from collections.abc import Mapping
 from dataclasses import asdict, dataclass, field
 from functools import lru_cache
 from pathlib import Path
@@ -11,6 +11,8 @@ from typing import Any
 
 import yaml
 from jsonschema import Draft202012Validator
+
+from robot_sf.common.json_pointer import json_pointer
 
 CONTRACT_SCHEMA_VERSION = "scenario_contract.v1"
 CERT_SCHEMA_VERSION = "scenario_cert.v1"
@@ -310,7 +312,7 @@ def _schema_validation_errors(payload: Mapping[str, Any]) -> list[str]:
 
     validator = Draft202012Validator(load_scenario_contract_schema())
     return [
-        f"{_json_pointer(error.absolute_path)}: {error.message}"
+        f"{json_pointer(error.absolute_path)}: {error.message}"
         for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
     ]
 
@@ -460,22 +462,6 @@ def _scenario_names_from_payload(raw: Any) -> list[str]:
         if isinstance(name, str):
             names.append(name)
     return names
-
-
-def _json_pointer(path_elems: Iterable[Any]) -> str:
-    """Render a validation error path as an RFC6901-style JSON pointer.
-
-    Returns:
-        JSON pointer string, or an empty string for the root path.
-    """
-
-    parts: list[str] = []
-    for part in path_elems:
-        if isinstance(part, int):
-            parts.append(str(part))
-        else:
-            parts.append(str(part).replace("~", "~0").replace("/", "~1"))
-    return "/" + "/".join(parts) if parts else ""
 
 
 __all__ = [

--- a/robot_sf/benchmark/scenario_schema.py
+++ b/robot_sf/benchmark/scenario_schema.py
@@ -16,10 +16,9 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
-if TYPE_CHECKING:
-    from collections.abc import Iterable
+from robot_sf.common.json_pointer import json_pointer
 
 try:
     from jsonschema import Draft7Validator
@@ -38,24 +37,6 @@ def load_scenario_schema() -> dict[str, Any]:
     """
     with SCHEMA_FILE.open("r", encoding="utf-8") as f:
         return json.load(f)
-
-
-def _json_pointer(path_elems: Iterable[Any]) -> str:
-    """Render an RFC6901-style pointer from a jsonschema error path.
-
-    Args:
-        path_elems: Iterable of keys/indices describing a JSON path.
-
-    Returns:
-        JSON pointer string ("" for root).
-    """
-    parts: list[str] = []
-    for p in path_elems:
-        if isinstance(p, int):
-            parts.append(str(p))
-        else:
-            parts.append(str(p).replace("~", "~0").replace("/", "~1"))
-    return "/" + "/".join(parts) if parts else ""  # RFC6901 pointer-ish
 
 
 def validate_scenario_list(scenarios: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -78,7 +59,7 @@ def validate_scenario_list(scenarios: list[dict[str, Any]]) -> list[dict[str, An
     # Per-item schema validation (keep index alignment for better messages)
     for i, s in enumerate(scenarios):
         for err in validator.iter_errors(s):
-            path = _json_pointer(err.path)
+            path = json_pointer(err.path)
             errors.append(
                 {
                     "index": i,

--- a/robot_sf/common/json_pointer.py
+++ b/robot_sf/common/json_pointer.py
@@ -1,0 +1,33 @@
+"""Shared RFC6901 JSON-pointer rendering for schema-validation error paths.
+
+This helper was previously copy-pasted in eight modules across ``robot_sf``
+(see issue #3386). Centralizing it removes the latent correctness hazard of a
+schema-escaping fix diverging between copies.
+
+The function escapes each path element per RFC6901 (``~`` -> ``~0``,
+``/`` -> ``~1``) and renders the root path (an empty element sequence) as the
+empty string ``""``, which is the RFC6901 representation of "the whole
+document".
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def json_pointer(path_elems: Iterable[Any]) -> str:
+    """Render an RFC6901-style JSON pointer from a jsonschema error path.
+
+    Args:
+        path_elems: Iterable of keys/indices describing a JSON path (for
+            example a :class:`jsonschema.exceptions.ValidationError`'s
+            ``absolute_path``).
+
+    Returns:
+        The JSON pointer string, or ``""`` for the root path.
+    """
+    parts = [str(part).replace("~", "~0").replace("/", "~1") for part in path_elems]
+    return "/" + "/".join(parts) if parts else ""

--- a/robot_sf/research/imitation_report.py
+++ b/robot_sf/research/imitation_report.py
@@ -440,7 +440,11 @@ def _figure_paths(summary_path: Path) -> dict[str, Path]:
 
 
 def _copy_figures(figures: dict[str, Path], destination: Path) -> dict[str, Path]:
-    """Copy figure files into the report figures/ directory and render PDF copies."""
+    """Copy figure files into the report figures/ directory and render PDF copies.
+
+    Returns:
+        Mapping of figure label to the copied PNG path in ``destination``.
+    """
 
     destination.mkdir(parents=True, exist_ok=True)
     copied: dict[str, Path] = {}
@@ -462,6 +466,8 @@ def _copy_figures(figures: dict[str, Path], destination: Path) -> dict[str, Path
         finally:
             if fig:
                 plt.close(fig)
+
+    return copied
 
 
 def _extract_seeds(summary: dict[str, Any]) -> list[int]:

--- a/tests/common/test_json_pointer.py
+++ b/tests/common/test_json_pointer.py
@@ -1,0 +1,45 @@
+"""Tests for the shared RFC6901 JSON-pointer helper (issue #3386)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.common.json_pointer import json_pointer
+
+
+def test_root_path_renders_empty_string():
+    """An empty path is the whole document -> RFC6901 root pointer ``""``."""
+    assert json_pointer([]) == ""
+
+
+def test_single_key():
+    """A single string key renders as ``/key``."""
+    assert json_pointer(["scenarios"]) == "/scenarios"
+
+
+def test_nested_keys_and_indices():
+    """Mixed string keys and integer indices join into a slash-separated pointer."""
+    assert json_pointer(["scenarios", 0, "id"]) == "/scenarios/0/id"
+
+
+def test_integer_only_path():
+    """Integer indices render via ``str`` (no escaping needed)."""
+    assert json_pointer([2]) == "/2"
+
+
+@pytest.mark.parametrize(
+    ("element", "expected"),
+    [
+        ("a/b", "/a~1b"),  # forward slash -> ~1
+        ("m~n", "/m~0n"),  # tilde -> ~0
+        ("~/", "/~0~1"),  # both, escaped in order (~ before /)
+    ],
+)
+def test_rfc6901_escaping(element: str, expected: str):
+    """Tilde and slash are escaped per RFC6901 (``~`` -> ``~0``, ``/`` -> ``~1``)."""
+    assert json_pointer([element]) == expected
+
+
+def test_accepts_any_iterable():
+    """A generator (like jsonschema's ``absolute_path``) works, not just lists."""
+    assert json_pointer(iter(["a", "b"])) == "/a/b"

--- a/tests/research/test_imitation_report.py
+++ b/tests/research/test_imitation_report.py
@@ -13,6 +13,7 @@ if TYPE_CHECKING:
 from robot_sf.research.imitation_report import (
     ImitationReportConfig,
     _ci_from_samples,
+    _copy_figures,
     _fmt_ci,
     generate_imitation_report,
 )
@@ -140,3 +141,26 @@ def test_parse_hparams_handles_valid_and_invalid(monkeypatch):
     assert parsed["epochs"] == "5"
     assert parsed["dataset"] == "1000"
     assert "" not in parsed
+
+
+def test_copy_figures_returns_copied_mapping(tmp_path: Path):
+    """_copy_figures returns the label -> destination mapping it builds (issue #3386).
+
+    Regression guard: the function is annotated ``-> dict[str, Path]`` but used to
+    fall off the end returning ``None``.
+    """
+    src_dir = tmp_path / "src"
+    src_dir.mkdir()
+    fig_png = src_dir / "loss_curve.png"
+    png_bytes = base64.b64decode(
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    )
+    fig_png.write_bytes(png_bytes)
+
+    dest_dir = tmp_path / "report" / "figures"
+    copied = _copy_figures({"loss_curve": fig_png}, dest_dir)
+
+    assert isinstance(copied, dict)
+    assert set(copied) == {"loss_curve"}
+    assert copied["loss_curve"] == dest_dir / "loss_curve.png"
+    assert copied["loss_curve"].exists()


### PR DESCRIPTION
## Summary

Partial fix for #3386 — the two low-risk, fully-autonomous items of the four-part audit.

The RFC6901 JSON-pointer renderer for jsonschema error paths was copy-pasted in **eight** modules (5 long-form + 3 comprehension variants). A schema-escaping fix had to be applied in eight places, and the two variants had **silently diverged** on the root-path return value (`""` vs `"/"`).

## Changes

- **New `robot_sf/common/json_pointer.py`** — a single `json_pointer()` helper (neutral `common` package so `analysis_workbench` doesn't take a new dependency on `benchmark`). Root path → RFC6901-correct `""`.
- **Replaced all 8 local `_json_pointer` defs** with an import of the shared helper:
  - `benchmark/{scenario_schema, odd_contract, hazard_traceability, scenario_contract, odd_hazard_coverage_matrix, artifact_catalog}.py`
  - `analysis_workbench/{simulation_trace_export, trace_annotation}.py`
- **`research/imitation_report.py`** — `_copy_figures` is annotated `-> dict[str, Path]` but fell through to `None`; added `return copied` (the sole caller discarded the value, so no behavior change) + a Returns docstring.
- **Tests** — `tests/common/test_json_pointer.py` (escaping, root, nested keys/indices, generator input) and a `_copy_figures` return regression test.
- **CHANGELOG** updated under `### Changed`.

### Behavior note (disclosed)

The 3 comprehension-variant sites (`artifact_catalog`, `simulation_trace_export`, `trace_annotation`) previously rendered the **root** path (empty error path) as `"/"`; they now use the RFC6901-correct `""`. This only affects the rare *root-level* schema-error **message string**; no test or non-message consumer depended on `"/"` (verified by grep). The int special-case in the long-form variant was a confirmed no-op (`str(int)` has no `~`/`/`), so removing it changes nothing.

## Out of scope (deferred)

The other two items of #3386 are intentionally **not** in this PR — see the issue comment:
- **#2 atomic-write helper consolidation** — straightforward follow-up, kept separate for a focused diff.
- **#3 dead-symbol removal** — the issue itself flags this as needing **maintainer confirmation** that the public-looking symbols aren't intended external API, so it is not eligible for autonomous implementation here.

I left #3386 open as the coordination issue for those two remaining items.

## Validation

```
uv run pytest tests/common/test_json_pointer.py tests/research/test_imitation_report.py \
  tests/test_scenario_schema.py tests/benchmark/test_odd_contract.py \
  tests/benchmark/test_hazard_traceability.py tests/benchmark/test_scenario_contract.py \
  tests/benchmark/test_odd_hazard_coverage_matrix.py tests/benchmark/test_artifact_catalog.py \
  tests/analysis_workbench/test_simulation_trace_export.py \
  tests/analysis_workbench/test_trace_annotation.py \
  tests/tools/test_compile_benchmark_artifacts.py tests/tools/test_release_evidence_snapshot.py -q
# 85 passed

scripts/dev/ruff_fix_format.sh        # All checks passed
uv run python scripts/tools/sync_ai_config.py --check   # 7 symlinks validated
# grep confirms zero remaining `_json_pointer` references
```

## Evidence grade

Tier 1 (shared-utility consolidation; benchmark-adjacent error-message rendering, no metric semantics). Confidence **High** — proof current for branch head (`7c40ea16`), rebased on `origin/main`.

## Acceptance criteria (this PR)

- [x] One shared `_json_pointer` (variant signatures reconciled); the 8 call sites import it.
- [x] `_copy_figures` returns `copied`; a test asserts the returned mapping.
- [ ] Atomic-write helper consolidation — deferred (#2).
- [ ] Dead-symbol removal — deferred, needs maintainer confirmation (#3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
