### PR TITLE
refactor: consolidate atomic-JSON-write helper into shared common.atomic_io (#3386)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Consolidated the duplicated durable atomic-JSON-write helper into a single shared
+  `robot_sf.common.atomic_io.atomic_write_json` (#3386). The `mkstemp -> fsync -> os.replace` helper
+  previously copy-pasted in `benchmark/imitation_manifest.py` and `benchmark/full_classic/io_utils.py`
+  now imports the shared version; behavior is preserved (the helper resolves the path and creates the
+  parent directory, a safe superset of the prior two). `benchmark/forecast_dataset_recorder.py` keeps
+  its own writer for now because it has a different output contract (trailing newline, no `fsync`).
+  Covered by `tests/common/test_atomic_io.py`.
 * Cut pull-request CI wall-clock by parallelizing the `fast-feedback` test phase. Pull requests now
   split the suite into 4 `pytest-split` shards (a matrix on the existing job, so the CI topology is
   unchanged) while `main`/`workflow_dispatch` keep a single full pass so the advisory coverage

--- a/robot_sf/benchmark/full_classic/io_utils.py
+++ b/robot_sf/benchmark/full_classic/io_utils.py
@@ -6,12 +6,12 @@ Implemented in tasks T025 (append, write_manifest integration) and updated later
 from __future__ import annotations
 
 import json
-import os
-import tempfile
 from pathlib import Path
 from typing import Any
 
 from loguru import logger
+
+from robot_sf.common.atomic_io import atomic_write_json
 
 
 def _ensure_parent(path: Path) -> None:
@@ -44,23 +44,6 @@ def _serialize_obj(obj: Any):  # separated to keep write_manifest simple
     return str(obj)
 
 
-def _atomic_write_json(path: Path, data: dict) -> None:
-    """Write JSON atomically via a temporary file and replace."""
-    tmp_fd, tmp_path = tempfile.mkstemp(prefix=path.name, dir=str(path.parent))
-    try:
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as tmp_f:
-            json.dump(data, tmp_f, indent=2, sort_keys=True)
-            tmp_f.flush()
-            os.fsync(tmp_f.fileno())
-        os.replace(tmp_path, path)
-    finally:  # cleanup tmp if failure prior to replace
-        if os.path.exists(tmp_path):
-            try:
-                os.unlink(tmp_path)
-            except OSError:  # pragma: no cover
-                pass
-
-
 def append_episode_record(path, record):  # T025
     """Append a single episode record as JSON line.
 
@@ -86,5 +69,5 @@ def write_manifest(manifest, path):  # T025
     for key in ("git_hash", "scenario_matrix_hash", "config"):
         if key not in data:
             raise ValueError(f"Manifest missing required key: {key}")
-    _atomic_write_json(p, data)
+    atomic_write_json(p, data)
     logger.debug("Manifest written: {}", p)

--- a/robot_sf/benchmark/imitation_manifest.py
+++ b/robot_sf/benchmark/imitation_manifest.py
@@ -7,9 +7,6 @@ where possible so artefacts remain portable across machines and CI runners.
 
 from __future__ import annotations
 
-import json
-import os
-import tempfile
 from datetime import datetime
 from enum import Enum
 from pathlib import Path
@@ -24,6 +21,7 @@ from robot_sf.common.artifact_paths import (
     get_repository_root,
     get_trajectory_dataset_dir,
 )
+from robot_sf.common.atomic_io import atomic_write_json
 
 if TYPE_CHECKING:  # pragma: no cover - import surface for type checkers only
     from collections.abc import Mapping
@@ -116,25 +114,6 @@ def _serialize_metrics_map(metrics: Mapping[str, MetricAggregate]) -> dict[str, 
         Mapping of metric names to serialized metric dicts.
     """
     return {name: _serialize_metric(metric) for name, metric in sorted(metrics.items())}
-
-
-def _atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
-    """Atomically write a JSON payload to disk."""
-    path = path.resolve(strict=False)
-    path.parent.mkdir(parents=True, exist_ok=True)
-    tmp_fd, tmp_name = tempfile.mkstemp(prefix=f"{path.name}.", dir=str(path.parent))
-    try:
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
-            json.dump(payload, handle, indent=2, sort_keys=True)
-            handle.flush()
-            os.fsync(handle.fileno())
-        os.replace(tmp_name, path)
-    finally:
-        if os.path.exists(tmp_name):
-            try:
-                os.unlink(tmp_name)
-            except OSError:  # pragma: no cover - defensive cleanup
-                pass
 
 
 def serialize_expert_policy(artifact: ExpertPolicyArtifact) -> dict[str, Any]:
@@ -240,7 +219,7 @@ def write_expert_policy_manifest(
         if manifest_path is not None
         else get_expert_policy_manifest_path(artifact.policy_id)
     )
-    _atomic_write_json(target, payload)
+    atomic_write_json(target, payload)
     logger.debug("Expert policy manifest written to {}", target)
     return target
 
@@ -262,7 +241,7 @@ def write_trajectory_dataset_manifest(
         target = base / f"{artifact.dataset_id}.json"
     else:
         target = Path(manifest_path)
-    _atomic_write_json(target, payload)
+    atomic_write_json(target, payload)
     logger.debug("Trajectory dataset manifest written to {}", target)
     return target
 
@@ -296,7 +275,7 @@ def write_training_run_manifest(
         if manifest_path is not None
         else get_training_run_manifest_path(artifact.run_id)
     )
-    _atomic_write_json(target, payload)
+    atomic_write_json(target, payload)
     logger.debug("Training run manifest written to {}", target)
     return target
 

--- a/robot_sf/common/atomic_io.py
+++ b/robot_sf/common/atomic_io.py
@@ -1,0 +1,49 @@
+"""Durable atomic JSON writes shared across the benchmark package.
+
+Previously this ``mkstemp -> fsync -> os.replace`` helper was copy-pasted in
+``benchmark/imitation_manifest.py`` and ``benchmark/full_classic/io_utils.py``
+(see issue #3386). Centralizing it keeps the durable-write contract in one place.
+
+The write is atomic: data is fully written and fsync'd to a temporary file in the
+destination directory, then ``os.replace`` swaps it into place in a single
+filesystem operation, so a reader never observes a partially written file.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+    from pathlib import Path
+
+
+def atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
+    """Atomically write ``payload`` as pretty-printed, key-sorted JSON to ``path``.
+
+    The parent directory is created if needed. The payload is flushed and fsync'd
+    to a temporary file in the same directory before an atomic ``os.replace``, and
+    the temporary file is cleaned up if anything fails before the replace.
+
+    Args:
+        path: Destination file path.
+        payload: JSON-serializable mapping to write.
+    """
+    path = path.resolve(strict=False)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_fd, tmp_name = tempfile.mkstemp(prefix=f"{path.name}.", dir=str(path.parent))
+    try:
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_name, path)
+    finally:
+        if os.path.exists(tmp_name):
+            try:
+                os.unlink(tmp_name)
+            except OSError:  # pragma: no cover - defensive cleanup
+                pass

--- a/robot_sf/common/atomic_io.py
+++ b/robot_sf/common/atomic_io.py
@@ -36,7 +36,15 @@ def atomic_write_json(path: Path, payload: Mapping[str, Any]) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     tmp_fd, tmp_name = tempfile.mkstemp(prefix=f"{path.name}.", dir=str(path.parent))
     try:
-        with os.fdopen(tmp_fd, "w", encoding="utf-8") as handle:
+        try:
+            handle = os.fdopen(tmp_fd, "w", encoding="utf-8")
+        except Exception:
+            try:
+                os.close(tmp_fd)
+            except OSError:  # pragma: no cover - defensive cleanup
+                pass
+            raise
+        with handle:
             json.dump(payload, handle, indent=2, sort_keys=True)
             handle.flush()
             os.fsync(handle.fileno())

--- a/tests/common/test_atomic_io.py
+++ b/tests/common/test_atomic_io.py
@@ -1,0 +1,44 @@
+"""Tests for the shared atomic JSON-write helper (issue #3386)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from robot_sf.common.atomic_io import atomic_write_json
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def test_writes_pretty_sorted_json(tmp_path: Path):
+    """Payload is written as indented, key-sorted JSON readable back as a dict."""
+    target = tmp_path / "manifest.json"
+    atomic_write_json(target, {"b": 1, "a": {"d": 2, "c": 3}})
+
+    text = target.read_text(encoding="utf-8")
+    # Keys are sorted at every level and the output is indented.
+    assert text.index('"a"') < text.index('"b"')
+    assert text.index('"c"') < text.index('"d"')
+    assert "\n" in text  # indent=2 produces multi-line output
+    assert json.loads(text) == {"a": {"c": 3, "d": 2}, "b": 1}
+
+
+def test_creates_missing_parent_directories(tmp_path: Path):
+    """The destination's parent directory is created when absent."""
+    target = tmp_path / "nested" / "deeper" / "out.json"
+    atomic_write_json(target, {"x": 1})
+
+    assert target.exists()
+    assert json.loads(target.read_text(encoding="utf-8")) == {"x": 1}
+
+
+def test_overwrites_existing_file_atomically(tmp_path: Path):
+    """A second write replaces the prior content and leaves no temp files behind."""
+    target = tmp_path / "data.json"
+    atomic_write_json(target, {"v": 1})
+    atomic_write_json(target, {"v": 2})
+
+    assert json.loads(target.read_text(encoding="utf-8")) == {"v": 2}
+    # Only the final file remains in the directory (temp file was cleaned up).
+    assert [p.name for p in tmp_path.iterdir()] == ["data.json"]

--- a/tests/common/test_atomic_io.py
+++ b/tests/common/test_atomic_io.py
@@ -3,7 +3,10 @@
 from __future__ import annotations
 
 import json
+import os
 from typing import TYPE_CHECKING
+
+import pytest
 
 from robot_sf.common.atomic_io import atomic_write_json
 
@@ -42,3 +45,25 @@ def test_overwrites_existing_file_atomically(tmp_path: Path):
     assert json.loads(target.read_text(encoding="utf-8")) == {"v": 2}
     # Only the final file remains in the directory (temp file was cleaned up).
     assert [p.name for p in tmp_path.iterdir()] == ["data.json"]
+
+
+def test_closes_temp_fd_when_fdopen_fails(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    """The raw mkstemp fd is closed if os.fdopen fails before owning it."""
+    target = tmp_path / "data.json"
+    captured_fd: int | None = None
+
+    def fail_fdopen(fd: int, *args: object, **kwargs: object):
+        nonlocal captured_fd
+        captured_fd = fd
+        raise OSError("fdopen failed")
+
+    monkeypatch.setattr(os, "fdopen", fail_fdopen)
+
+    with pytest.raises(OSError, match="fdopen failed"):
+        atomic_write_json(target, {"v": 1})
+
+    assert captured_fd is not None
+    with pytest.raises(OSError):
+        os.fstat(captured_fd)
+    assert not target.exists()
+    assert list(tmp_path.iterdir()) == []


### PR DESCRIPTION
## Summary

Second slice of #3386 — completes **acceptance item #2** (atomic-write helper consolidation). Stacks alongside the already-open #1+#4 PR; non-overlapping files.

The durable `mkstemp → fsync → os.replace` atomic-JSON-write helper was duplicated as a private `_atomic_write_json` in two modules. A durability/edge-case fix had to be made in both places.

## Changes

- **New `robot_sf/common/atomic_io.py`** — single `atomic_write_json(path, payload)` helper. Its body is the **robust superset** of the two prior copies: `path.resolve(strict=False)` + `parent.mkdir(parents=True, exist_ok=True)` prelude (harmless/idempotent for both callers) followed by the shared `fsync` + `os.replace` core. Accepts `Mapping[str, Any]`.
- **`benchmark/imitation_manifest.py`** (3 call sites) and **`benchmark/full_classic/io_utils.py`** (1 call site) now import and use it; removed both local defs and the now-unused `json`/`os`/`tempfile` imports.
- **Tests** — `tests/common/test_atomic_io.py` (sorted+indented output, parent-dir creation, atomic overwrite + temp-file cleanup).
- **CHANGELOG** updated under `### Changed`.

### Behavior preservation

- `imitation_manifest` copy was already identical to the shared body → no change.
- `io_utils` copy gains the `resolve`+`mkdir` prelude (its caller `write_manifest` already does `_ensure_parent`, so `mkdir` is a no-op) and a trailing-dot temp-file prefix (invisible to output). Serialized output is byte-identical.

### Out of scope (noted for follow-up)

`benchmark/forecast_dataset_recorder.py` also defines an `_atomic_write_json`, but it's a **different implementation** — fixed `path.with_suffix(".tmp")` name, no `fsync`, and it appends a trailing newline. Folding it into the robust helper would change its serialized output (checksum-sensitive), so it is intentionally left as-is. The issue listed only the two `mkstemp+fsync` copies.

## Validation

```
uv run pytest tests/common/test_atomic_io.py tests/test_benchmark_imitation_manifest.py \
  tests/benchmark_full/ -q
# 47 passed

scripts/dev/ruff_fix_format.sh                          # All checks passed
uv run python scripts/tools/sync_ai_config.py --check   # 7 symlinks validated
# grep confirms zero remaining `_atomic_write_json` in the two modified files
```

## Evidence grade

Tier 1 (shared durable-write utility consolidation; behavior-preserving). Confidence **High** — proof current for branch head (`3618db7e`), rebased on `origin/main`.

## Acceptance criteria (#3386)

- [x] One shared atomic-JSON-write helper used by both `imitation_manifest.py` and `full_classic/io_utils.py`.
- [ ] `_json_pointer` consolidation + `_copy_figures` — covered by the companion PR.
- [ ] Dead-symbol removal — deferred, needs maintainer confirmation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
