### PR TITLE
fix: log benchmark metric coercion failures (#3383)

### DIFF
--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -489,6 +489,7 @@ def _ensure_snqi(
     baseline: dict[str, dict[str, float]] | None,
     *,
     recompute: bool = False,
+    strict: bool = False,
 ) -> None:
     """Compute and attach SNQI when missing, or recompute when ``recompute`` is set."""
     if rec.get("metrics") is None:
@@ -499,9 +500,18 @@ def _ensure_snqi(
         return
     try:
         rec["metrics"]["snqi"] = float(snqi_fn(rec["metrics"], weights, baseline_stats=baseline))
-    except Exception:
-        # Leave untouched if computation fails
-        pass
+    except (ArithmeticError, KeyError, TypeError, ValueError):
+        logger.bind(
+            event="aggregation_snqi_compute_failed",
+            episode_id=rec.get("episode_id"),
+            scenario_id=rec.get("scenario_id"),
+            seed=rec.get("seed"),
+            algo=rec.get("algo") or _get_nested(rec, "scenario_params.algo"),
+            recompute_snqi=recompute,
+            strict=strict,
+        ).exception("Failed to compute SNQI for episode record.")
+        if strict:
+            raise
 
 
 def write_episode_csv(
@@ -575,7 +585,13 @@ def compute_aggregates(  # noqa: PLR0913
         Nested dict of group -> metric -> summary statistics.
     """
     for rec in records:
-        _ensure_snqi(rec, snqi_weights, snqi_baseline, recompute=recompute_snqi)
+        _ensure_snqi(
+            rec,
+            snqi_weights,
+            snqi_baseline,
+            recompute=recompute_snqi,
+            strict=_normalize_observation_track_mode(observation_track_mode) == "strict",
+        )
     observation_track_meta = ensure_observation_track_policy(
         records,
         observation_track_mode=observation_track_mode,
@@ -967,7 +983,13 @@ def compute_aggregates_with_ci(  # noqa: PLR0913
 
     # Rebuild groups with flattened numeric values to avoid rework
     for rec in records:
-        _ensure_snqi(rec, snqi_weights, snqi_baseline, recompute=recompute_snqi)
+        _ensure_snqi(
+            rec,
+            snqi_weights,
+            snqi_baseline,
+            recompute=recompute_snqi,
+            strict=_normalize_observation_track_mode(observation_track_mode) == "strict",
+        )
     groups = _group_flattened(
         records,
         group_by=group_by,

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -500,13 +500,15 @@ def _ensure_snqi(
         return
     try:
         rec["metrics"]["snqi"] = float(snqi_fn(rec["metrics"], weights, baseline_stats=baseline))
-    except (ArithmeticError, KeyError, TypeError, ValueError):
+    except Exception:
         logger.bind(
             event="aggregation_snqi_compute_failed",
             episode_id=rec.get("episode_id"),
             scenario_id=rec.get("scenario_id"),
             seed=rec.get("seed"),
-            algo=rec.get("algo") or _get_nested(rec, "scenario_params.algo"),
+            algo=rec.get("algo")
+            if rec.get("algo") is not None
+            else _get_nested(rec, "scenario_params.algo"),
             recompute_snqi=recompute,
             strict=strict,
         ).exception("Failed to compute SNQI for episode record.")

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -2776,8 +2776,13 @@ def post_process_metrics(
         if count_key in metrics and metrics[count_key] is not None:
             try:
                 metrics[count_key] = int(metrics[count_key])
-            except Exception:  # pragma: no cover
-                pass
+            except (OverflowError, TypeError, ValueError):
+                invalid_value = metrics.pop(count_key, None)
+                logger.bind(
+                    event="metrics_count_coercion_failed",
+                    metric_key=count_key,
+                    metric_value=repr(invalid_value),
+                ).warning("Dropping metric count value that could not be coerced to int.")
     for valid_key in (
         "time_to_goal_success_only_valid",
         "time_to_goal_ideal_ratio_valid",
@@ -2788,8 +2793,13 @@ def post_process_metrics(
         if valid_key in metrics and metrics[valid_key] is not None:
             try:
                 metrics[valid_key] = bool(int(metrics[valid_key]))
-            except Exception:  # pragma: no cover
-                pass
+            except (OverflowError, TypeError, ValueError):
+                invalid_value = metrics.pop(valid_key, None)
+                logger.bind(
+                    event="metrics_flag_coercion_failed",
+                    metric_key=valid_key,
+                    metric_value=repr(invalid_value),
+                ).warning("Dropping metric flag value that could not be coerced to bool.")
     _attach_pedestrian_impact_block(metrics)
     _attach_social_acceptability_block(metrics)
     _attach_human_interaction_proxy_block(metrics)

--- a/robot_sf/benchmark/snqi/cli.py
+++ b/robot_sf/benchmark/snqi/cli.py
@@ -73,7 +73,7 @@ def cmd_recompute_weights(args: argparse.Namespace) -> int:
 
         return 0
 
-    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+    except Exception:
         logger.bind(event="snqi_cli_failed", stage="recompute_weights").exception(
             "SNQI CLI failed while recomputing weights."
         )
@@ -235,7 +235,7 @@ def cmd_ablation_analysis(args: argparse.Namespace) -> int:
             impacts.get(comp, 0.0)
 
         return 0
-    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+    except Exception:
         logger.bind(event="snqi_cli_failed", stage="ablation_analysis").exception(
             "SNQI CLI failed while computing ablation analysis."
         )

--- a/robot_sf/benchmark/snqi/cli.py
+++ b/robot_sf/benchmark/snqi/cli.py
@@ -13,12 +13,19 @@ import sys
 from collections.abc import Iterable
 from pathlib import Path
 
+from loguru import logger
+
 from robot_sf.benchmark.snqi.compute import (
     WEIGHT_NAMES,
     compute_snqi_ablation,
     recompute_snqi_weights,
 )
 from robot_sf.benchmark.snqi.types import SNQIWeights
+
+
+def _log_cli_failure(stage: str, message: str, **context: object) -> None:
+    """Log a structured SNQI CLI failure before returning a non-zero status."""
+    logger.bind(event="snqi_cli_failed", stage=stage, **context).error(message)
 
 
 def cmd_recompute_weights(args: argparse.Namespace) -> int:
@@ -31,6 +38,11 @@ def cmd_recompute_weights(args: argparse.Namespace) -> int:
         # Load baseline statistics
         baseline_stats_path = Path(args.baseline_stats)
         if not baseline_stats_path.exists():
+            _log_cli_failure(
+                "load_baseline_stats",
+                "SNQI CLI baseline statistics file is missing.",
+                path=str(baseline_stats_path),
+            )
             return 1
 
         with baseline_stats_path.open("r", encoding="utf-8") as f:
@@ -39,6 +51,7 @@ def cmd_recompute_weights(args: argparse.Namespace) -> int:
         method = args.method
 
         if method not in {"canonical", "balanced", "optimized"}:
+            _log_cli_failure("validate_method", "SNQI CLI recompute method is unsupported.")
             return 2
 
         # Recompute SNQI weights using baseline statistics
@@ -60,7 +73,10 @@ def cmd_recompute_weights(args: argparse.Namespace) -> int:
 
         return 0
 
-    except Exception:
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        logger.bind(event="snqi_cli_failed", stage="recompute_weights").exception(
+            "SNQI CLI failed while recomputing weights."
+        )
         return 1
 
 
@@ -146,10 +162,20 @@ def cmd_ablation_analysis(args: argparse.Namespace) -> int:
     try:
         episodes_path = Path(args.episodes)
         if not episodes_path.exists():
+            _log_cli_failure(
+                "load_episodes",
+                "SNQI CLI episodes file is missing.",
+                path=str(episodes_path),
+            )
             return 1
 
         episodes = _load_episodes_jsonl(episodes_path)
         if not episodes:
+            _log_cli_failure(
+                "load_episodes",
+                "SNQI CLI episodes file produced no valid records.",
+                path=str(episodes_path),
+            )
             return 1
 
         # Determine weights
@@ -157,6 +183,11 @@ def cmd_ablation_analysis(args: argparse.Namespace) -> int:
         if args.weights:
             weights_path = Path(args.weights)
             if not weights_path.exists():
+                _log_cli_failure(
+                    "load_weights",
+                    "SNQI CLI weights file is missing.",
+                    path=str(weights_path),
+                )
                 return 1
             weight_obj = SNQIWeights.load(weights_path)
             weight_map = dict(weight_obj.weights)
@@ -204,7 +235,10 @@ def cmd_ablation_analysis(args: argparse.Namespace) -> int:
             impacts.get(comp, 0.0)
 
         return 0
-    except Exception:
+    except (OSError, json.JSONDecodeError, KeyError, TypeError, ValueError):
+        logger.bind(event="snqi_cli_failed", stage="ablation_analysis").exception(
+            "SNQI CLI failed while computing ablation analysis."
+        )
         return 1
 
 

--- a/scripts/coverage/check_changed_files_coverage.py
+++ b/scripts/coverage/check_changed_files_coverage.py
@@ -281,6 +281,8 @@ def _changed_line_numbers(base: str, path: Path, repo_root: Path) -> set[int]:
             new_line += 1
         elif line.startswith("-") and not line.startswith("---"):
             continue
+        elif line.startswith("\\"):
+            continue
         else:
             new_line += 1
     return changed

--- a/tests/benchmark/test_aggregate_snqi_recompute.py
+++ b/tests/benchmark/test_aggregate_snqi_recompute.py
@@ -181,6 +181,53 @@ def test_compute_aggregates_logs_key_error_snqi_failure_in_diagnostic_mode(
     )
 
 
+def test_compute_aggregates_logs_unexpected_snqi_failure_in_diagnostic_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Diagnostic aggregation should log unexpected SNQI failures and continue."""
+
+    def _unexpected_snqi(
+        metrics: dict[str, float],
+        weights: dict[str, float],
+        *,
+        baseline_stats: dict[str, dict[str, float]] | None = None,
+    ) -> float:
+        raise AttributeError("unexpected snqi shape")
+
+    monkeypatch.setattr(aggregate, "snqi_fn", _unexpected_snqi)
+    records = [
+        {
+            "episode_id": "ep-attr-error",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "",
+            "scenario_params": {"algo": "nested-planner"},
+            "observation_track": "features",
+            "metrics": {"score": 2.0},
+        }
+    ]
+    captured: list = []
+    handle = logger.add(captured.append, level="ERROR")
+    try:
+        result = compute_aggregates(
+            records,
+            group_by="scenario_params.algo",
+            snqi_weights={"score": 3.0},
+            observation_track_mode="diagnostic-cross-track",
+        )
+    finally:
+        logger.remove(handle)
+
+    score_summary = next(group["score"] for group in result.values() if "score" in group)
+    assert score_summary["mean"] == 2.0
+    assert "snqi" not in records[0]["metrics"]
+    assert any(
+        msg.record["extra"].get("event") == "aggregation_snqi_compute_failed"
+        and msg.record["extra"].get("algo") == ""
+        for msg in captured
+    )
+
+
 def test_aggregate_cli_passes_recompute_snqi_flag(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/benchmark/test_aggregate_snqi_recompute.py
+++ b/tests/benchmark/test_aggregate_snqi_recompute.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 import pytest
+from loguru import logger
 
 from robot_sf.benchmark import aggregate
 from robot_sf.benchmark.aggregate import compute_aggregates
@@ -51,6 +52,90 @@ def test_compute_aggregates_recomputes_stored_snqi_when_requested(
         recompute_snqi=True,
     )
     assert recomputed["planner-a"]["snqi"]["mean"] == 6.0
+
+
+def test_compute_aggregates_logs_record_id_and_reraises_snqi_failure_in_strict_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Strict aggregation should fail closed with record context when SNQI recompute fails."""
+
+    def _failing_snqi(
+        metrics: dict[str, float],
+        weights: dict[str, float],
+        *,
+        baseline_stats: dict[str, dict[str, float]] | None = None,
+    ) -> float:
+        raise ValueError("bad snqi input")
+
+    monkeypatch.setattr(aggregate, "snqi_fn", _failing_snqi)
+    records = [
+        {
+            "episode_id": "ep-snqi-fail",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "planner-a",
+            "metrics": {"score": 2.0},
+        }
+    ]
+    captured: list = []
+    handle = logger.add(captured.append, level="ERROR")
+    try:
+        with pytest.raises(ValueError, match="bad snqi input"):
+            compute_aggregates(records, group_by="algo", snqi_weights={"score": 3.0})
+    finally:
+        logger.remove(handle)
+
+    assert any(
+        msg.record["extra"].get("event") == "aggregation_snqi_compute_failed"
+        and msg.record["extra"].get("episode_id") == "ep-snqi-fail"
+        for msg in captured
+    )
+
+
+def test_compute_aggregates_logs_key_error_snqi_failure_in_diagnostic_mode(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Diagnostic aggregation should log missing SNQI inputs without serializing SNQI."""
+
+    def _missing_metric_snqi(
+        metrics: dict[str, float],
+        weights: dict[str, float],
+        *,
+        baseline_stats: dict[str, dict[str, float]] | None = None,
+    ) -> float:
+        raise KeyError("renamed_metric")
+
+    monkeypatch.setattr(aggregate, "snqi_fn", _missing_metric_snqi)
+    records = [
+        {
+            "episode_id": "ep-missing-key",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "planner-a",
+            "observation_track": "features",
+            "metrics": {"score": 2.0},
+        }
+    ]
+    captured: list = []
+    handle = logger.add(captured.append, level="ERROR")
+    try:
+        result = compute_aggregates(
+            records,
+            group_by="algo",
+            snqi_weights={"score": 3.0},
+            observation_track_mode="diagnostic-cross-track",
+        )
+    finally:
+        logger.remove(handle)
+
+    assert "snqi" not in records[0]["metrics"]
+    score_summary = next(group["score"] for group in result.values() if "score" in group)
+    assert score_summary["mean"] == 2.0
+    assert any(
+        msg.record["extra"].get("event") == "aggregation_snqi_compute_failed"
+        and msg.record["extra"].get("episode_id") == "ep-missing-key"
+        for msg in captured
+    )
 
 
 def test_aggregate_cli_passes_recompute_snqi_flag(

--- a/tests/benchmark/test_snqi_cli_failure_logging.py
+++ b/tests/benchmark/test_snqi_cli_failure_logging.py
@@ -92,6 +92,36 @@ def test_cmd_recompute_weights_logs_expected_failure_stages(
     _assert_logged_stage(captured, "recompute_weights")
 
 
+def test_cmd_recompute_weights_logs_unexpected_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Top-level recompute command should log unexpected exceptions before returning."""
+    baseline_path = tmp_path / "baseline.json"
+    output_path = tmp_path / "weights.json"
+    baseline_path.write_text(json.dumps(_baseline_stats()), encoding="utf-8")
+
+    def _fail_recompute(**kwargs: object) -> SNQIWeights:
+        raise AttributeError("unexpected recompute state")
+
+    monkeypatch.setattr(snqi_cli, "recompute_snqi_weights", _fail_recompute)
+    captured, handle = _capture_errors()
+    try:
+        exit_code = snqi_cli.cmd_recompute_weights(
+            argparse.Namespace(
+                baseline_stats=str(baseline_path),
+                out=str(output_path),
+                method="balanced",
+                seed=7,
+            ),
+        )
+    finally:
+        logger.remove(handle)
+
+    assert exit_code == 1
+    _assert_logged_stage(captured, "recompute_weights")
+
+
 def test_cmd_ablation_analysis_logs_expected_failure_stages(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
@@ -170,4 +200,37 @@ def test_cmd_ablation_analysis_logs_expected_failure_stages(
     ]
     assert len(load_episode_logs) >= 2
     _assert_logged_stage(captured, "load_weights")
+    _assert_logged_stage(captured, "ablation_analysis")
+
+
+def test_cmd_ablation_analysis_logs_unexpected_exception(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Top-level ablation command should log unexpected exceptions before returning."""
+    episodes_path = tmp_path / "episodes.jsonl"
+    episodes_path.write_text(
+        json.dumps({"metrics": {"collisions": 0, "near_misses": 1, "jerk_mean": 0.1}}) + "\n",
+        encoding="utf-8",
+    )
+
+    def _fail_ablation(**kwargs: object) -> dict[str, float]:
+        raise AttributeError("unexpected ablation state")
+
+    monkeypatch.setattr(snqi_cli, "compute_snqi_ablation", _fail_ablation)
+    captured, handle = _capture_errors()
+    try:
+        exit_code = snqi_cli.cmd_ablation_analysis(
+            argparse.Namespace(
+                episodes=str(episodes_path),
+                summary_out=str(tmp_path / "failed-out.json"),
+                weights=None,
+                components=None,
+                seed=11,
+            )
+        )
+    finally:
+        logger.remove(handle)
+
+    assert exit_code == 1
     _assert_logged_stage(captured, "ablation_analysis")

--- a/tests/coverage/test_check_changed_files_coverage.py
+++ b/tests/coverage/test_check_changed_files_coverage.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
 from scripts.coverage.check_changed_files_coverage import (
+    _changed_line_numbers,
     _coverage_for_changed_lines,
     _is_doc_or_comment_only_python_change,
 )
@@ -54,3 +60,27 @@ def test_changed_line_coverage_treats_non_executable_edits_as_covered() -> None:
 
     assert coverage == 100.0
     assert scope == "changed executable lines 0/0"
+
+
+def test_changed_line_parser_ignores_no_newline_marker(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unified diff metadata lines should not advance the new-file line counter."""
+
+    def fake_run(*args, **kwargs):
+        del args, kwargs
+        return SimpleNamespace(
+            returncode=0,
+            stdout="\n".join(
+                [
+                    "@@ -1 +1,2 @@",
+                    "+first",
+                    "\\ No newline at end of file",
+                    "+second",
+                ]
+            ),
+        )
+
+    monkeypatch.setattr("scripts.coverage.check_changed_files_coverage.subprocess.run", fake_run)
+
+    assert _changed_line_numbers("origin/main", Path("demo.py"), Path(".")) == {1, 2}

--- a/tests/test_snqi_cli_method_aliases.py
+++ b/tests/test_snqi_cli_method_aliases.py
@@ -8,6 +8,7 @@ import sys
 from typing import TYPE_CHECKING
 
 import pytest
+from loguru import logger
 
 from robot_sf.benchmark.snqi import cli as snqi_cli
 from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES
@@ -162,6 +163,41 @@ def test_cmd_recompute_weights_rejects_missing_or_unknown_inputs(tmp_path: Path)
         ),
     )
     assert unknown_method == 2
+
+
+def test_cmd_recompute_weights_logs_failing_stage(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unexpected SNQI recompute failures should log the stage before returning non-zero."""
+    baseline_path = tmp_path / "baseline.json"
+    output_path = tmp_path / "weights.json"
+    baseline_path.write_text(json.dumps(_baseline_stats()), encoding="utf-8")
+
+    def _fail_recompute(**kwargs: object) -> SNQIWeights:
+        raise ValueError("cannot recompute")
+
+    monkeypatch.setattr(snqi_cli, "recompute_snqi_weights", _fail_recompute)
+    captured: list = []
+    handle = logger.add(captured.append, level="ERROR")
+    try:
+        exit_code = snqi_cli.cmd_recompute_weights(
+            argparse.Namespace(
+                baseline_stats=str(baseline_path),
+                out=str(output_path),
+                method="balanced",
+                seed=7,
+            ),
+        )
+    finally:
+        logger.remove(handle)
+
+    assert exit_code == 1
+    assert any(
+        msg.record["extra"].get("event") == "snqi_cli_failed"
+        and msg.record["extra"].get("stage") == "recompute_weights"
+        for msg in captured
+    )
 
 
 def test_episode_loading_and_baseline_stats_helpers(tmp_path: Path) -> None:

--- a/tests/unit/benchmark/test_metrics_post_process.py
+++ b/tests/unit/benchmark/test_metrics_post_process.py
@@ -1,5 +1,7 @@
 """Tests for post-processing helpers in benchmark metrics."""
 
+from loguru import logger
+
 from robot_sf.benchmark.metrics import post_process_metrics
 
 
@@ -34,3 +36,28 @@ def test_post_process_metrics_drops_non_finite_values():
 
     assert "mean_distance" not in metrics
     assert metrics["near_misses"] == 0
+
+
+def test_post_process_metrics_logs_and_drops_invalid_count_and_flag_values():
+    """Invalid count/flag payloads should not survive into serialized metric output."""
+    captured: list = []
+    handle = logger.add(captured.append, level="WARNING")
+    try:
+        metrics = post_process_metrics(
+            {
+                "success": 0.0,
+                "collisions": "not-a-count",
+                "near_misses": 2.0,
+                "social_proxemic_available": "not-a-flag",
+            },
+            snqi_weights=None,
+            snqi_baseline=None,
+        )
+    finally:
+        logger.remove(handle)
+
+    assert "collisions" not in metrics
+    assert "social_proxemic_available" not in metrics
+    assert metrics["near_misses"] == 2
+    logged_keys = {msg.record["extra"].get("metric_key") for msg in captured}
+    assert {"collisions", "social_proxemic_available"} <= logged_keys


### PR DESCRIPTION
## Summary
Hardens benchmark result-path error handling so SNQI and count/flag coercion failures are logged instead of silently disappearing or leaking malformed values.

## Linked Issues
- Closes `#3383`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Added contextual SNQI aggregation logging with record identifiers and strict-mode re-raise behavior for expected compute failures.
- Added structured SNQI CLI stage logging before non-zero returns on expected load/recompute/ablation failures.
- Updated benchmark metric post-processing so invalid count/flag coercions are logged and dropped instead of serialized unchanged.
- Updated the changed-file coverage gate to measure changed executable statements, avoiding inherited whole-file coverage debt on large legacy modules while keeping edited lines covered.
- Added focused regression tests for strict SNQI failure, diagnostic-mode KeyError logging, SNQI CLI stage logging, and invalid count/flag drop behavior.

## Why It Matters
- Added value: benchmark result-producing paths now fail louder when headline metric inputs are malformed.
- Expected impact: easier diagnosis of missing SNQI values and malformed safety/count metrics without changing metric formulas.
- Why this is worth merging now: the issue describes silent data-integrity failure modes in benchmark outputs; this PR replaces them with explicit logs and focused tests.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: benchmark result-path robustness and observability; no benchmark performance/result claim.
- Comparator or baseline, if applicable: previous behavior silently swallowed/logged nothing or serialized uncoerced values.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: targeted tests prove logging/drop/re-raise paths for the reported silent-failure classes.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue `#3383`
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Domain-Aware Approval
- Required for this PR: yes - metric-facing benchmark result-path error handling.
- Domains reviewed: evidence classification, benchmark interpretation, paper-facing claims
- Status: approved
- Approver/review source or waiver: Codex parent semantic review against #3383 scope after GPT-5.5 xhigh simplification; no formula/schema/threshold/paper-claim change found.
- Validity checklist:
  - Target claim/hypothesis: result-path failures should become observable and fail closed under strict aggregation.
  - Comparator or split/evidence validity: targeted tests compare prior silent/drop-through behavior to logged/drop/re-raise behavior.
  - Fallback/degraded exclusions: no fallback or degraded benchmark execution is presented as evidence.
  - Claim boundary: targeted robustness proof only; no benchmark outcome or planner-quality claim.
  - Implementation integrity vs experimental validity: implementation integrity covered by focused tests and PR readiness; experimental validity limited to error-path observability.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes - tests exercise SNQI aggregation failures, SNQI CLI failure stages, and invalid metric coercion.
- Did the intervention change command source, selected command, trajectory, or route progress? no
- Did the scenario actually contain the targeted failure mode? yes - synthetic focused tests inject malformed/missing SNQI inputs and invalid count/flag values.
- Result route: stop
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop; issue acceptance criteria are covered by focused tests.
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `rtk uv run pytest tests/benchmark/test_aggregate_snqi_recompute.py tests/test_snqi_cli_method_aliases.py tests/unit/benchmark/test_metrics_post_process.py -q`
  - `rtk uv run ruff check robot_sf/benchmark/aggregate.py robot_sf/benchmark/snqi/cli.py robot_sf/benchmark/metrics.py tests/benchmark/test_aggregate_snqi_recompute.py tests/test_snqi_cli_method_aliases.py tests/unit/benchmark/test_metrics_post_process.py`
  - `rtk uv run ruff format --check robot_sf/benchmark/aggregate.py robot_sf/benchmark/snqi/cli.py robot_sf/benchmark/metrics.py tests/benchmark/test_aggregate_snqi_recompute.py tests/test_snqi_cli_method_aliases.py tests/unit/benchmark/test_metrics_post_process.py`
  - after syncing latest `origin/main`: `rtk uv run pytest tests/benchmark/test_aggregate_snqi_recompute.py tests/test_snqi_cli_method_aliases.py tests/unit/benchmark/test_metrics_post_process.py tests/tools/test_sync_ai_config.py -q`
  - after syncing latest `origin/main`: `rtk uv run ruff check robot_sf/benchmark/aggregate.py robot_sf/benchmark/snqi/cli.py robot_sf/benchmark/metrics.py tests/benchmark/test_aggregate_snqi_recompute.py tests/test_snqi_cli_method_aliases.py tests/unit/benchmark/test_metrics_post_process.py tests/tools/test_sync_ai_config.py`
  - after changed-line coverage repair: `rtk uv run pytest --cov=robot_sf --cov=scripts.coverage.check_changed_files_coverage --cov-report=json tests/coverage/test_check_changed_files_coverage.py tests/benchmark/test_snqi_cli_failure_logging.py tests/benchmark/test_aggregate_snqi_recompute.py tests/unit/benchmark/test_metrics_post_process.py -q && rtk uv run python scripts/coverage/check_changed_files_coverage.py --base origin/main`
  - `rtk git diff --check`
- Evidence that the change works here: focused tests pass for the previously silent error paths; changed executable lines are covered at 100% for the modified benchmark modules; final PR readiness is run with this body before publication.
- Benchmarks or smoke tests, if applicable: targeted smoke only; no benchmark run or benchmark outcome claim.

## Risks / Rollout
- Compatibility risks: low-to-medium; invalid count/flag values are now dropped instead of serialized unchanged, strict SNQI aggregation re-raises expected compute failures, and changed-file coverage now measures changed executable statements instead of full-file inherited coverage.
- Failure modes: downstream workflows that depended on malformed serialized values may notice fields missing instead.
- Rollback or fallback plan: revert the commit if a downstream compatibility issue appears; the previous permissive behavior is isolated to these catch paths.

## Docs / Provenance
- Updated docs: none
- Relevant design or provenance notes: issue `#3383`; active ledger `.git/codex-agent-runs/active/issue-3383-delegation-ledger.md`
- Any assumptions that need to be preserved: this PR intentionally changes observability/error policy only, not metric formulas, thresholds, schemas, or paper-facing claims.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes `#3383`
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark outcome, leaderboard, registry, model-provenance, or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: error-policy boundary only; no formulas, thresholds, schemas, or public benchmark claims should have changed.
- Any known limitations: targeted tests cover synthetic failure paths rather than a full benchmark campaign.
