### PR TITLE
refactor: relocate _build_adapter_policy to map_runner_policy_common (#3403)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`tests/common/test_json_pointer.py`). Also fixed `_copy_figures` in `research/imitation_report.py`
   to actually `return` its `dict[str, Path]` mapping (it previously fell through to `None` despite the
   annotation), with a regression test (#3386).
+* Relocated the shared `_build_adapter_policy` helper out of `robot_sf/benchmark/map_runner.py` into a
+  neutral `robot_sf/benchmark/map_runner_policy_common.py` (`build_adapter_policy`), re-exported under
+  the old private name so all ~17 in-module call sites are unchanged (#3403, prerequisite for the
+  #3384 adapter-family decomposition). Behavior-preserving — the helper is a verbatim move and the
+  `map_runner` regression suite passes. This lets future `map_runner_policies/` builder modules reuse
+  the helper without an import cycle back into `map_runner`.
 * Cut pull-request CI wall-clock by parallelizing the `fast-feedback` test phase. Pull requests now
   split the suite into 4 `pytest-split` shards (a matrix on the existing job, so the CI topology is
   unchanged) while `main`/`workflow_dispatch` keep a single full pass so the advisory coverage

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -116,6 +116,9 @@ from robot_sf.benchmark.map_runner_observations import (
     obs_to_external_mpc_format as _obs_to_external_mpc_format,
 )
 from robot_sf.benchmark.map_runner_observations import obs_to_ppo_format as _obs_to_ppo_format
+from robot_sf.benchmark.map_runner_policy_common import (
+    build_adapter_policy as _build_adapter_policy,
+)
 from robot_sf.benchmark.map_runner_policy_metadata import (
     apply_direct_world_velocity_metadata as _apply_direct_world_velocity_metadata,
 )
@@ -344,86 +347,6 @@ _validate_planner_contract = planner_commands.validate_planner_contract
 
 _load_synthetic_actuation_profile = _load_synthetic_actuation_profile_impl
 _load_latency_stress_profile = _load_latency_profile
-
-
-def _build_adapter_policy(
-    *,
-    algo_key: str,
-    algo_config: dict[str, Any],
-    meta: dict[str, Any],
-    adapter: Any,
-    adapter_name: str,
-    robot_kinematics: str | None,
-    normalized_robot_command_mode: str | None,
-    limitations: str | None = None,
-) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
-    """Construct a projected adapter policy with standard metadata wiring.
-
-    Returns:
-        tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
-            Projected policy callable and populated benchmark metadata.
-    """
-    meta.update(
-        {
-            "status": "ok",
-            "config": algo_config,
-            "config_hash": _config_hash(algo_config),
-        }
-    )
-    meta = enrich_algorithm_metadata(
-        algo=algo_key,
-        metadata=meta,
-        execution_mode="adapter",
-        adapter_name=adapter_name,
-        robot_kinematics=robot_kinematics,
-    )
-    _init_feasibility_metadata(meta)
-    planner_meta = meta.get("planner_kinematics")
-    if isinstance(planner_meta, dict):
-        planner_meta["planner_command_space"] = _default_robot_command_space(
-            robot_kinematics,
-            algo_config,
-            robot_command_mode=normalized_robot_command_mode,
-        )
-        if limitations is not None:
-            planner_meta["limitations"] = limitations
-    adapter_kinematics_model = resolve_benchmark_kinematics_model(
-        robot_kinematics=robot_kinematics,
-        command_limits=algo_config,
-    )
-
-    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
-        """Run an adapter-backed planner and project command feasibility.
-
-        Returns:
-            tuple[float, float]: Projected linear and angular command.
-        """
-        linear, angular = adapter.plan(obs)
-        return _project_with_feasibility(
-            model=adapter_kinematics_model,
-            command=(float(linear), float(angular)),
-            meta=meta,
-        )
-
-    _attach_planner_reset(_policy, adapter)
-    _policy._planner_adapter = adapter
-    if hasattr(adapter, "bind_env"):
-        _policy._planner_bind_env = adapter.bind_env
-    if hasattr(adapter, "close"):
-        _policy._planner_close = adapter.close
-    if hasattr(adapter, "diagnostics"):
-
-        def _planner_stats() -> dict[str, Any]:
-            """Expose adapter diagnostics for episode metadata.
-
-            Returns:
-                dict[str, Any]: Adapter diagnostic payload.
-            """
-            return adapter.diagnostics()
-
-        _policy._planner_stats = _planner_stats
-
-    return _policy, meta
 
 
 class _ExternalMPCAdapter:

--- a/robot_sf/benchmark/map_runner_policy_common.py
+++ b/robot_sf/benchmark/map_runner_policy_common.py
@@ -1,0 +1,109 @@
+"""Shared policy-construction helpers for the map-runner benchmark.
+
+These helpers were previously defined inside ``robot_sf.benchmark.map_runner`` and
+called from ~20 of ``_build_policy``'s adapter branches. Hosting them in a neutral
+module lets the per-algorithm builder modules in ``map_runner_policies/`` reuse them
+without an import cycle back into ``map_runner`` (see #3403, follow-up to #3400/#3384).
+
+No behavior change: ``build_adapter_policy`` is a verbatim move of the former
+``map_runner._build_policy`` helper ``_build_adapter_policy``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark import planner_command_contract as _planner_commands
+from robot_sf.benchmark.algorithm_metadata import enrich_algorithm_metadata
+from robot_sf.benchmark.map_runner_policy_metadata import (
+    attach_planner_reset as _attach_planner_reset,
+)
+from robot_sf.benchmark.utils import _config_hash
+from robot_sf.planner.kinematics_model import resolve_benchmark_kinematics_model
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+_default_robot_command_space = _planner_commands.default_robot_command_space
+_init_feasibility_metadata = _planner_commands.init_feasibility_metadata
+_project_with_feasibility = _planner_commands.project_with_feasibility
+
+
+def build_adapter_policy(
+    *,
+    algo_key: str,
+    algo_config: dict[str, Any],
+    meta: dict[str, Any],
+    adapter: Any,
+    adapter_name: str,
+    robot_kinematics: str | None,
+    normalized_robot_command_mode: str | None,
+    limitations: str | None = None,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Construct a projected adapter policy with standard metadata wiring.
+
+    Returns:
+        tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+            Projected policy callable and populated benchmark metadata.
+    """
+    meta.update(
+        {
+            "status": "ok",
+            "config": algo_config,
+            "config_hash": _config_hash(algo_config),
+        }
+    )
+    meta = enrich_algorithm_metadata(
+        algo=algo_key,
+        metadata=meta,
+        execution_mode="adapter",
+        adapter_name=adapter_name,
+        robot_kinematics=robot_kinematics,
+    )
+    _init_feasibility_metadata(meta)
+    planner_meta = meta.get("planner_kinematics")
+    if isinstance(planner_meta, dict):
+        planner_meta["planner_command_space"] = _default_robot_command_space(
+            robot_kinematics,
+            algo_config,
+            robot_command_mode=normalized_robot_command_mode,
+        )
+        if limitations is not None:
+            planner_meta["limitations"] = limitations
+    adapter_kinematics_model = resolve_benchmark_kinematics_model(
+        robot_kinematics=robot_kinematics,
+        command_limits=algo_config,
+    )
+
+    def _policy(obs: dict[str, Any]) -> tuple[float, float]:
+        """Run an adapter-backed planner and project command feasibility.
+
+        Returns:
+            tuple[float, float]: Projected linear and angular command.
+        """
+        linear, angular = adapter.plan(obs)
+        return _project_with_feasibility(
+            model=adapter_kinematics_model,
+            command=(float(linear), float(angular)),
+            meta=meta,
+        )
+
+    _attach_planner_reset(_policy, adapter)
+    _policy._planner_adapter = adapter
+    if hasattr(adapter, "bind_env"):
+        _policy._planner_bind_env = adapter.bind_env
+    if hasattr(adapter, "close"):
+        _policy._planner_close = adapter.close
+    if hasattr(adapter, "diagnostics"):
+
+        def _planner_stats() -> dict[str, Any]:
+            """Expose adapter diagnostics for episode metadata.
+
+            Returns:
+                dict[str, Any]: Adapter diagnostic payload.
+            """
+            return adapter.diagnostics()
+
+        _policy._planner_stats = _planner_stats
+
+    return _policy, meta


### PR DESCRIPTION
## Summary

Closes #3403 — prerequisite refactor that unblocks migrating `_build_policy`'s adapter families (follow-up to #3400/#3402, both children of #3384). **No behavior change.**

## Problem

`_build_adapter_policy` is the shared helper that ~17 of `_build_policy`'s branches funnel through (`risk_surface_dwa`, `lidar_social_force`, `trivial_reference`, the `*_orca`/`hrvo`/external-adapter families, …), but it was defined **inside `map_runner.py`**. Migrating those branches into `map_runner_policies/` builder modules the way #3400 did for `goal` would force each module to import `_build_adapter_policy` back from `map_runner` — an import cycle.

## Changes

- **New `robot_sf/benchmark/map_runner_policy_common.py`** — hosts `build_adapter_policy(...)`, a **verbatim move** of the former `map_runner._build_adapter_policy`. Its dependencies are imported from their canonical modules (`planner_command_contract`, `algorithm_metadata`, `utils`, `map_runner_policy_metadata`, `planner.kinematics_model`) — none of which import `map_runner`, so the new module is acyclic.
- **`map_runner.py`** re-exports it under the old private name (`from ...map_runner_policy_common import build_adapter_policy as _build_adapter_policy`), so all ~17 call sites are unchanged, and the local def is removed (−80 lines).

## Validation

```
uv run pytest tests/benchmark/test_map_runner_utils.py tests/test_map_runner_ppo.py \
  tests/test_map_runner_sac.py tests/benchmark/test_lidar_planner_compatibility.py \
  tests/planner/test_policy_stack_v1.py tests/planner/test_crowdnav_height.py \
  tests/integration/test_social_force_map_runner.py \
  tests/benchmark/test_map_runner_preflight_profiles.py -q
# all pass (176 + 27)

scripts/dev/ruff_fix_format.sh                          # All checks passed
uv run python scripts/tools/sync_ai_config.py --check   # 7 symlinks validated
# import sanity: map_runner._build_adapter_policy is map_runner_policy_common.build_adapter_policy -> True (no cycle)
```

Monkeypatch safety: the three `resolve_benchmark_kinematics_model` patches in `test_map_runner_utils.py` target `_ppo_action_to_unicycle` and the goal path — **not** `_build_adapter_policy` — so they are unaffected by the relocation (verified + passing).

## Follow-up

With the helper now neutral, the adapter families can be migrated into `map_runner_policies/` modules without lazy imports — the next child(ren) of #3384.

## Evidence grade

Tier 1 (benchmark-package structural refactor, behavior-preserving verbatim move). Confidence **High** — proof current for branch head (`eb2c09bc`), rebased on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
