### PR TITLE
refactor: extract camera_ready_campaign config dataclasses into config module (#3405)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`tests/common/test_json_pointer.py`). Also fixed `_copy_figures` in `research/imitation_report.py`
   to actually `return` its `dict[str, Path]` mapping (it previously fell through to `None` despite the
   annotation), with a regression test (#3386).
+* Began decomposing the ~4967-line `robot_sf/benchmark/camera_ready_campaign.py` (the largest module in
+  `robot_sf/`) by extracting its 6 config dataclasses (`AmvProfileConfig`, `SeedPolicy`,
+  `ScenarioCandidateSelection`, `PlannerSpec`, `SnqiContractConfig`, `CampaignConfig`) plus the
+  `_AMV_DIMENSIONS` / `DEFAULT_SEED_SETS_PATH` constants into a new
+  `robot_sf/benchmark/camera_ready_campaign_config.py` (#3405, first slice of #3385). The names are
+  re-exported from `camera_ready_campaign`, so existing imports (e.g. in `release_protocol.py`,
+  `orca_preflight.py`, and tests) are unchanged. Behavior-preserving verbatim move; the
+  camera-ready/release regression suites pass.
 * Cut pull-request CI wall-clock by parallelizing the `fast-feedback` test phase. Pull requests now
   split the suite into 4 `pytest-split` shards (a matrix on the existing job, so the CI topology is
   unchanged) while `main`/`workflow_dispatch` keep a single full pass so the advisory coverage

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -17,7 +17,7 @@ import time
 from collections import defaultdict
 from collections.abc import Mapping
 from copy import deepcopy
-from dataclasses import asdict, dataclass, field
+from dataclasses import asdict
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -29,6 +29,16 @@ from shapely.geometry import LineString, Polygon
 
 from robot_sf.benchmark.aggregate import compute_aggregates_with_ci, read_jsonl
 from robot_sf.benchmark.artifact_publication import export_publication_bundle
+from robot_sf.benchmark.camera_ready_campaign_config import (  # re-exported for back-compat
+    _AMV_DIMENSIONS,
+    DEFAULT_SEED_SETS_PATH,
+    AmvProfileConfig,
+    CampaignConfig,
+    PlannerSpec,
+    ScenarioCandidateSelection,
+    SeedPolicy,
+    SnqiContractConfig,
+)
 from robot_sf.benchmark.fallback_policy import (
     availability_payload,
     classify_planner_row_status,
@@ -98,7 +108,6 @@ if TYPE_CHECKING:
 
 CAMPAIGN_SCHEMA_VERSION = "benchmark-camera-ready-campaign.v1"
 DEFAULT_EPISODE_SCHEMA_PATH = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
-DEFAULT_SEED_SETS_PATH = Path("configs/benchmarks/seed_sets_v1.yaml")
 
 _REPORT_METRICS: tuple[str, ...] = (
     "success",
@@ -126,7 +135,6 @@ _PAPER_KINEMATICS_BY_PROFILE = {
     "paper-matrix-v1": ("differential_drive",),
     "paper-cross-kinematics-v1": ("differential_drive", "bicycle_drive", "holonomic"),
 }
-_AMV_DIMENSIONS = ("use_case", "context", "speed_regime", "maneuver_type")
 _AMV_COVERAGE_ENFORCEMENT = {"warn", "error"}
 _SNQI_CONTRACT_ENFORCEMENT = {"warn", "error"}
 _ROUTE_CLEARANCE_WARN_THRESHOLD_M = 0.5
@@ -225,119 +233,6 @@ def _normalize_kinematics_matrix(raw: Any) -> tuple[str, ...]:
         if text:
             normalized.append(text)
     return tuple(normalized)
-
-
-@dataclass(frozen=True)
-class AmvProfileConfig:
-    """AMV paper-profile scope contract settings."""
-
-    name: str = "amv-paper-v1"
-    contract_version: str = "1"
-    coverage_enforcement: str = "warn"
-    required_dimensions: dict[str, tuple[str, ...]] = field(
-        default_factory=lambda: dict.fromkeys(_AMV_DIMENSIONS, ())
-    )
-
-
-@dataclass(frozen=True)
-class SeedPolicy:
-    """Seed selection policy for campaign scenarios."""
-
-    mode: str = "scenario-default"
-    seed_set: str | None = None
-    seeds: tuple[int, ...] = ()
-    seed_sets_path: Path = DEFAULT_SEED_SETS_PATH
-
-
-@dataclass(frozen=True)
-class ScenarioCandidateSelection:
-    """Optional named scenario subset for compact benchmark slices."""
-
-    names: tuple[str, ...] = ()
-    selection_name: str | None = None
-
-
-@dataclass(frozen=True)
-class PlannerSpec:
-    """One planner entry in a benchmark campaign matrix."""
-
-    key: str
-    algo: str
-    human_model_variant: str | None = None
-    human_model_source: str | None = None
-    benchmark_profile: str = "baseline-safe"
-    algo_config_path: Path | None = None
-    socnav_missing_prereq_policy: str = "fail-fast"
-    adapter_impact_eval: bool = False
-    observation_mode: str | None = None
-    workers_override: int | None = None
-    horizon_override: int | None = None
-    dt_override: float | None = None
-    enabled: bool = True
-    planner_group: str = "experimental"
-    planner_group_explicit: bool = False
-
-
-@dataclass(frozen=True)
-class SnqiContractConfig:
-    """SNQI paper-facing behavior contract configuration."""
-
-    enabled: bool = True
-    enforcement: str = "warn"
-    rank_alignment_warn_threshold: float = 0.5
-    rank_alignment_fail_threshold: float = 0.3
-    outcome_separation_warn_threshold: float = 0.05
-    outcome_separation_fail_threshold: float = 0.0
-    max_component_dominance_warn_threshold: float = 0.24
-    max_component_dominance_fail_threshold: float = 0.27
-    calibration_seed: int = 123
-    calibration_trials: int = 3000
-
-
-@dataclass(frozen=True)
-class CampaignConfig:
-    """Top-level camera-ready benchmark campaign config."""
-
-    name: str
-    scenario_matrix_path: Path
-    planners: tuple[PlannerSpec, ...]
-    scenario_candidates: ScenarioCandidateSelection = field(
-        default_factory=ScenarioCandidateSelection
-    )
-    scenario_amv_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
-    seed_policy: SeedPolicy = SeedPolicy()
-    scenario_horizons_path: Path | None = None
-    workers: int = 1
-    horizon: int | None = None
-    dt: float | None = None
-    record_forces: bool = True
-    resume: bool = True
-    bootstrap_samples: int = 400
-    bootstrap_confidence: float = 0.95
-    bootstrap_seed: int = 123
-    snqi_weights_path: Path | None = None
-    snqi_baseline_path: Path | None = None
-    stop_on_failure: bool = False
-    export_publication_bundle: bool = True
-    include_videos_in_publication: bool = False
-    overwrite_publication_bundle: bool = True
-    repository_url: str = "https://github.com/ll7/robot_sf_ll7"
-    release_tag: str = "{release_tag}"
-    doi: str = "10.5281/zenodo.<record-id>"
-    paper_interpretation_profile: str = "baseline-ready-core"
-    preview_scenario_limit: int = 100
-    kinematics_matrix: tuple[str, ...] = ("differential_drive",)
-    holonomic_command_mode: str = "vx_vy"
-    observation_mode: str | None = None
-    paper_facing: bool = False
-    paper_profile_version: str | None = None
-    amv_profile: AmvProfileConfig = field(default_factory=AmvProfileConfig)
-    synthetic_actuation_profile: SyntheticActuationProfile | None = None
-    latency_stress_profile: LatencyStressProfile | None = None
-    comparability_mapping_path: Path | None = None
-    snqi_contract: SnqiContractConfig = field(default_factory=SnqiContractConfig)
-    route_clearance_certifications_path: Path | None = None
-    observation_noise: dict[str, Any] | None = None
 
 
 def _repo_relative(path: Path) -> str:

--- a/robot_sf/benchmark/camera_ready_campaign_config.py
+++ b/robot_sf/benchmark/camera_ready_campaign_config.py
@@ -1,0 +1,135 @@
+"""Config dataclasses for the camera-ready benchmark campaign.
+
+Extracted verbatim from ``robot_sf.benchmark.camera_ready_campaign`` (#3405, first
+slice of the #3385 decomposition). These are pure frozen configuration dataclasses
+plus the two constants their field defaults reference; ``camera_ready_campaign``
+re-exports them so existing import paths keep working.
+
+No behavior change: definitions are a verbatim move.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from robot_sf.benchmark.latency_stress import LatencyStressProfile
+    from robot_sf.benchmark.synthetic_actuation import SyntheticActuationProfile
+
+DEFAULT_SEED_SETS_PATH = Path("configs/benchmarks/seed_sets_v1.yaml")
+_AMV_DIMENSIONS = ("use_case", "context", "speed_regime", "maneuver_type")
+
+
+@dataclass(frozen=True)
+class AmvProfileConfig:
+    """AMV paper-profile scope contract settings."""
+
+    name: str = "amv-paper-v1"
+    contract_version: str = "1"
+    coverage_enforcement: str = "warn"
+    required_dimensions: dict[str, tuple[str, ...]] = field(
+        default_factory=lambda: dict.fromkeys(_AMV_DIMENSIONS, ())
+    )
+
+
+@dataclass(frozen=True)
+class SeedPolicy:
+    """Seed selection policy for campaign scenarios."""
+
+    mode: str = "scenario-default"
+    seed_set: str | None = None
+    seeds: tuple[int, ...] = ()
+    seed_sets_path: Path = DEFAULT_SEED_SETS_PATH
+
+
+@dataclass(frozen=True)
+class ScenarioCandidateSelection:
+    """Optional named scenario subset for compact benchmark slices."""
+
+    names: tuple[str, ...] = ()
+    selection_name: str | None = None
+
+
+@dataclass(frozen=True)
+class PlannerSpec:
+    """One planner entry in a benchmark campaign matrix."""
+
+    key: str
+    algo: str
+    human_model_variant: str | None = None
+    human_model_source: str | None = None
+    benchmark_profile: str = "baseline-safe"
+    algo_config_path: Path | None = None
+    socnav_missing_prereq_policy: str = "fail-fast"
+    adapter_impact_eval: bool = False
+    observation_mode: str | None = None
+    workers_override: int | None = None
+    horizon_override: int | None = None
+    dt_override: float | None = None
+    enabled: bool = True
+    planner_group: str = "experimental"
+    planner_group_explicit: bool = False
+
+
+@dataclass(frozen=True)
+class SnqiContractConfig:
+    """SNQI paper-facing behavior contract configuration."""
+
+    enabled: bool = True
+    enforcement: str = "warn"
+    rank_alignment_warn_threshold: float = 0.5
+    rank_alignment_fail_threshold: float = 0.3
+    outcome_separation_warn_threshold: float = 0.05
+    outcome_separation_fail_threshold: float = 0.0
+    max_component_dominance_warn_threshold: float = 0.24
+    max_component_dominance_fail_threshold: float = 0.27
+    calibration_seed: int = 123
+    calibration_trials: int = 3000
+
+
+@dataclass(frozen=True)
+class CampaignConfig:
+    """Top-level camera-ready benchmark campaign config."""
+
+    name: str
+    scenario_matrix_path: Path
+    planners: tuple[PlannerSpec, ...]
+    scenario_candidates: ScenarioCandidateSelection = field(
+        default_factory=ScenarioCandidateSelection
+    )
+    scenario_amv_overrides: dict[str, dict[str, str]] = field(default_factory=dict)
+    seed_policy: SeedPolicy = SeedPolicy()
+    scenario_horizons_path: Path | None = None
+    workers: int = 1
+    horizon: int | None = None
+    dt: float | None = None
+    record_forces: bool = True
+    resume: bool = True
+    bootstrap_samples: int = 400
+    bootstrap_confidence: float = 0.95
+    bootstrap_seed: int = 123
+    snqi_weights_path: Path | None = None
+    snqi_baseline_path: Path | None = None
+    stop_on_failure: bool = False
+    export_publication_bundle: bool = True
+    include_videos_in_publication: bool = False
+    overwrite_publication_bundle: bool = True
+    repository_url: str = "https://github.com/ll7/robot_sf_ll7"
+    release_tag: str = "{release_tag}"
+    doi: str = "10.5281/zenodo.<record-id>"
+    paper_interpretation_profile: str = "baseline-ready-core"
+    preview_scenario_limit: int = 100
+    kinematics_matrix: tuple[str, ...] = ("differential_drive",)
+    holonomic_command_mode: str = "vx_vy"
+    observation_mode: str | None = None
+    paper_facing: bool = False
+    paper_profile_version: str | None = None
+    amv_profile: AmvProfileConfig = field(default_factory=AmvProfileConfig)
+    synthetic_actuation_profile: SyntheticActuationProfile | None = None
+    latency_stress_profile: LatencyStressProfile | None = None
+    comparability_mapping_path: Path | None = None
+    snqi_contract: SnqiContractConfig = field(default_factory=SnqiContractConfig)
+    route_clearance_certifications_path: Path | None = None
+    observation_noise: dict[str, Any] | None = None


### PR DESCRIPTION
## Summary

Closes #3405 — first implementable slice of #3385 (decompose the ~4967-line `camera_ready_campaign.py`, the largest module in `robot_sf/`). **No behavior change** — a verbatim move of the config dataclass cluster.

## Changes

- **New `robot_sf/benchmark/camera_ready_campaign_config.py`** — hosts the 6 frozen config dataclasses (`AmvProfileConfig`, `SeedPolicy`, `ScenarioCandidateSelection`, `PlannerSpec`, `SnqiContractConfig`, `CampaignConfig`) plus the two constants their field defaults reference (`_AMV_DIMENSIONS`, `DEFAULT_SEED_SETS_PATH`).
- **`camera_ready_campaign.py`** re-exports all of them (and re-imports the two constants, which it uses in 12+ other places), so existing import paths are unchanged. Net −116 lines from the monolith.

### Cycle / contract handling

- `camera_ready_campaign_config.py` imports **nothing** from `camera_ready_campaign` → acyclic. The two cross-types (`SyntheticActuationProfile`, `LatencyStressProfile`) appear only in `CampaignConfig` annotations, so they're imported under `TYPE_CHECKING` from their canonical modules (`synthetic_actuation`, `latency_stress`).
- Re-export preserves the existing external imports: `release_protocol.py`, `orca_preflight.py`, `tests/tools/test_run_benchmark_release.py`, `tests/benchmark/test_orca_preflight.py` (`from robot_sf.benchmark.camera_ready_campaign import CampaignConfig, PlannerSpec, SeedPolicy`). Verified: the re-exported objects are identical (`is`), and both external importer modules load.

## Validation

```
uv run pytest tests/benchmark/test_camera_ready_campaign.py tests/tools/test_run_benchmark_release.py \
  tests/benchmark/test_orca_preflight.py tests/tools/test_analyze_camera_ready_campaign.py \
  tests/tools/test_compare_camera_ready_campaigns.py tests/benchmark/test_issue_2155_research_v1_matrix.py -q
# all pass (157 + 25)

scripts/dev/ruff_fix_format.sh                          # All checks passed
uv run python scripts/tools/sync_ai_config.py --check   # 7 symlinks validated
```

## Scope / follow-ups (later children of #3385)

`load_campaign_config` / `_validate_campaign_config`; the `_write_*` artifact-IO, `_build_*` summary, route-clearance, and reporting clusters.

## Evidence grade

Tier 1 (benchmark-package structural refactor, behavior-preserving verbatim move). This module is paper-/release-critical; the change is a pure data-definition relocation with re-export and a strong regression net. Confidence **High** — proof current for branch head (`18802669`), rebased on `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
