### PR TITLE
fix: type UnicycleDriveState.velocity as scalar float (#3381)

### DIFF
--- a/robot_sf/ped_ego/unicycle_drive.py
+++ b/robot_sf/ped_ego/unicycle_drive.py
@@ -39,7 +39,7 @@ class UnicycleDriveState:
     """A class that represents the state of a unicycle drive pedestrian."""
 
     pose: PedPose = field(default_factory=lambda: ((0.0, 0.0), 0.0))
-    velocity: PolarVec2D = field(default_factory=lambda: (0.0, 0.0))
+    velocity: float = 0.0
 
     @property
     def pos(self) -> Vec2D:

--- a/tests/unicycle_drive_test.py
+++ b/tests/unicycle_drive_test.py
@@ -132,3 +132,25 @@ def test_unicycle_over_limit_negative_steering_clipped():
     motion.move(state, (0.0, -100.0), 1.0)
     pos_after, _ = state.pose
     assert pos_after[0] > 0.0
+
+
+def test_default_unicycle_state_can_move():
+    """A default-constructed UnicycleDriveState steps without raising and reports a well-formed speed.
+
+    Covers the previously untested default path where ``velocity`` is not passed explicitly.
+    Regression for the tuple-vs-scalar default bug.
+    """
+    state = UnicycleDriveState()
+    assert state.velocity == 0.0
+    speed, orient = state.current_speed
+    assert speed == 0.0
+    assert orient == 0.0
+
+    motion = UnicycleMotion(UnicycleDriveSettings())
+    motion.move(state, (1.0, 0.0), 0.1)
+
+    assert isinstance(state.velocity, float)
+    assert state.velocity > 0.0
+    speed_after, orient_after = state.current_speed
+    assert speed_after == state.velocity
+    assert orient_after == 0.0


### PR DESCRIPTION
## Summary
Fix `UnicycleDriveState.velocity` field annotation/default: it was typed as `PolarVec2D` and defaulted to a tuple `(0.0, 0.0)`, but every code path treats it as a scalar `float` forward speed. A default-constructed state crashed on first `move()`.

## Linked Issues
- Closes `#3381`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes

## What Changed
- `robot_sf/ped_ego/unicycle_drive.py`: changed `velocity` field from `PolarVec2D = field(default_factory=lambda: (0.0, 0.0))` to `float = 0.0`, matching the actual scalar contract used by `move`, `reset_state`, and `current_speed`.
- `tests/unicycle_drive_test.py`: added `test_default_unicycle_state_can_move` regression test that constructs a default `UnicycleDriveState`, verifies `current_speed` is well-formed, steps once, and confirms velocity is a positive float.

## Why It Matters
- Added value: fixes a correctness bug where default-constructed `UnicycleDriveState` raised `TypeError` on first `move()` and `current_speed` returned a malformed nested tuple `((0.0, 0.0), 0.0)`.
- Expected impact: the incorrect `PolarVec2D` annotation no longer misleads type-checkers or new callers. The bug was masked in production because the simulator always calls `reset_state(...)` (which writes scalar `0`) before stepping.
- Why this is worth merging now: removes a latent crash and a misleading type annotation on a core kinematics dataclass.

## Research Result Guidance
NA - support bugfix: this is a kinematics correctness fix with no research, benchmark, metric, or paper-facing claim.

- Target claim / hypothesis / blocker this should affect: NA
- Comparator or baseline, if applicable: NA
- Evidence tier: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper

## Domain-Aware Approval
- Required for this PR: no - reason: no evidence classification, experimental comparison, or paper-facing claim changed
- Domains reviewed: NA
- Status: not required

## Falsification / Non-Transfer Check
NA - support bugfix with no research claim.

- Did the mechanism activate? NA
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
NA - evidence is complete for this bugfix.

- Rerun needed: no / NA
- Extractor or analysis tool needed: no / NA
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `uv run python -c "from robot_sf.ped_ego.unicycle_drive import UnicycleDriveState, UnicycleMotion, UnicycleDriveSettings; s = UnicycleDriveState(); print(s.velocity, s.current_speed); UnicycleMotion(UnicycleDriveSettings()).move(s, (1.0, 0.1), 0.1); print(s.velocity, s.current_speed)"` (reproduction from issue, now passes)
  - `uv run pytest tests/unicycle_drive_test.py -v` (8 passed, including new regression test)
  - `uv run pytest tests/sim/ -q` (24 passed)
  - `uv run ruff check robot_sf/ped_ego/unicycle_drive.py tests/unicycle_drive_test.py` (passed)
  - `uv run ruff format robot_sf/ped_ego/unicycle_drive.py tests/unicycle_drive_test.py` (unchanged)
- Evidence that the change works here: the reproduction command from the issue body no longer raises `TypeError`; `current_speed` returns `(0.0, 0.0)` before move and `(0.1, 0.001...)` after; all existing unicycle and simulator tests still pass.

## Risks / Rollback
- Compatibility risks: very low. All production code already treats `velocity` as scalar via `reset_state`; no caller depended on the tuple default.
- Failure modes: none expected; the change makes the default match the runtime contract.
- Rollback or fallback plan: revert the one-line field change.

## Docs / Provenance
- Updated docs: none needed.
- Relevant design or provenance notes: none.
- Any assumptions that need to be preserved: `current_speed` still returns `(speed, orient)` as `PolarVec2D`; only the `velocity` field itself is now scalar.

## Downstream Propagation
- Parent issue updated (no): NA
- Claim map / benchmark report updated (NA): no benchmark claim
- Leaderboard / artifact catalog updated (NA): NA
- Registry or config index updated (NA): NA
- Context index / memory note updated (no): NA
- Follow-up issue opened for deferred propagation (no): NA
- Not applicable because: this is a bounded kinematics bugfix with no benchmark, registry, claim-map, or paper-facing surface.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: confirm `current_speed`'s `PolarVec2D` return annotation is still appropriate (it returns `(speed, orient)` which is a valid polar representation).
- Any known limitations: the `PolarVec2D` import is retained because `current_speed` still uses it as a return type.
