### PR TITLE
fix: stop silent error swallowing on benchmark SNQI and count-metric paths (#3383)

### DIFF
--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -489,8 +489,14 @@ def _ensure_snqi(
     baseline: dict[str, dict[str, float]] | None,
     *,
     recompute: bool = False,
+    strict: bool = False,
 ) -> None:
-    """Compute and attach SNQI when missing, or recompute when ``recompute`` is set."""
+    """Compute and attach SNQI when missing, or recompute when ``recompute`` is set.
+
+    When ``strict`` is True, computation failures re-raise instead of being
+    logged-and-skipped, so paper/release runs fail closed rather than silently
+    emitting records without an SNQI value.
+    """
     if rec.get("metrics") is None:
         return
     if "snqi" in rec["metrics"] and not recompute:
@@ -499,9 +505,11 @@ def _ensure_snqi(
         return
     try:
         rec["metrics"]["snqi"] = float(snqi_fn(rec["metrics"], weights, baseline_stats=baseline))
-    except Exception:
-        # Leave untouched if computation fails
-        pass
+    except (KeyError, ValueError, TypeError):
+        rec_id = rec.get("episode_id", rec.get("scenario_id", "unknown"))
+        logger.exception("SNQI computation failed for record {}; snqi left unset", rec_id)
+        if strict:
+            raise
 
 
 def write_episode_csv(
@@ -510,15 +518,19 @@ def write_episode_csv(
     *,
     snqi_weights: dict[str, float] | None = None,
     snqi_baseline: dict[str, dict[str, float]] | None = None,
+    strict: bool = False,
 ) -> str:
     # Optionally compute SNQI per record if missing
     """Write per-episode metrics to CSV.
+
+    When ``strict`` is True, SNQI computation failures abort the write instead
+    of silently emitting records without an SNQI value.
 
     Returns:
         Path string to the written CSV file.
     """
     for rec in records:
-        _ensure_snqi(rec, snqi_weights, snqi_baseline)
+        _ensure_snqi(rec, snqi_weights, snqi_baseline, strict=strict)
 
     # Determine all metric keys across records for CSV header
     flat_rows = [flatten_metrics(r) for r in records]
@@ -568,6 +580,7 @@ def compute_aggregates(  # noqa: PLR0913
     expected_algorithms: set[str] | None = None,
     observation_track_mode: str = "strict",
     logger_ctx=None,
+    strict: bool = False,
 ) -> dict[str, dict[str, dict[str, float]]]:
     """Aggregate metrics by group and compute summary statistics.
 
@@ -575,7 +588,7 @@ def compute_aggregates(  # noqa: PLR0913
         Nested dict of group -> metric -> summary statistics.
     """
     for rec in records:
-        _ensure_snqi(rec, snqi_weights, snqi_baseline, recompute=recompute_snqi)
+        _ensure_snqi(rec, snqi_weights, snqi_baseline, recompute=recompute_snqi, strict=strict)
     observation_track_meta = ensure_observation_track_policy(
         records,
         observation_track_mode=observation_track_mode,
@@ -939,6 +952,7 @@ def compute_aggregates_with_ci(  # noqa: PLR0913
     expected_algorithms: set[str] | None = None,
     observation_track_mode: str = "strict",
     logger_ctx=None,
+    strict: bool = False,
 ) -> dict[str, dict[str, dict[str, Any]]]:
     """Compute grouped aggregates and optional bootstrap CIs.
 
@@ -960,6 +974,7 @@ def compute_aggregates_with_ci(  # noqa: PLR0913
         expected_algorithms=expected_algorithms,
         observation_track_mode=observation_track_mode,
         logger_ctx=logger_ctx,
+        strict=strict,
     )
     if not return_ci or bootstrap_samples <= 0:
         # Upcast type to Any container for compatibility, but keep content unchanged
@@ -967,7 +982,7 @@ def compute_aggregates_with_ci(  # noqa: PLR0913
 
     # Rebuild groups with flattened numeric values to avoid rework
     for rec in records:
-        _ensure_snqi(rec, snqi_weights, snqi_baseline, recompute=recompute_snqi)
+        _ensure_snqi(rec, snqi_weights, snqi_baseline, recompute=recompute_snqi, strict=strict)
     groups = _group_flattened(
         records,
         group_by=group_by,

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -2776,8 +2776,13 @@ def post_process_metrics(
         if count_key in metrics and metrics[count_key] is not None:
             try:
                 metrics[count_key] = int(metrics[count_key])
-            except Exception:  # pragma: no cover
-                pass
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Count metric {!r} could not be coerced to int (value={!r}); dropping",
+                    count_key,
+                    metrics[count_key],
+                )
+                metrics[count_key] = None
     for valid_key in (
         "time_to_goal_success_only_valid",
         "time_to_goal_ideal_ratio_valid",
@@ -2788,8 +2793,13 @@ def post_process_metrics(
         if valid_key in metrics and metrics[valid_key] is not None:
             try:
                 metrics[valid_key] = bool(int(metrics[valid_key]))
-            except Exception:  # pragma: no cover
-                pass
+            except (TypeError, ValueError):
+                logger.warning(
+                    "Validity flag {!r} could not be coerced to bool (value={!r}); dropping",
+                    valid_key,
+                    metrics[valid_key],
+                )
+                metrics[valid_key] = None
     _attach_pedestrian_impact_block(metrics)
     _attach_social_acceptability_block(metrics)
     _attach_human_interaction_proxy_block(metrics)

--- a/robot_sf/benchmark/snqi/cli.py
+++ b/robot_sf/benchmark/snqi/cli.py
@@ -13,6 +13,8 @@ import sys
 from collections.abc import Iterable
 from pathlib import Path
 
+from loguru import logger
+
 from robot_sf.benchmark.snqi.compute import (
     WEIGHT_NAMES,
     compute_snqi_ablation,
@@ -61,6 +63,7 @@ def cmd_recompute_weights(args: argparse.Namespace) -> int:
         return 0
 
     except Exception:
+        logger.exception("SNQI recompute-weights command failed")
         return 1
 
 
@@ -205,6 +208,7 @@ def cmd_ablation_analysis(args: argparse.Namespace) -> int:
 
         return 0
     except Exception:
+        logger.exception("SNQI ablation-analysis command failed")
         return 1
 
 

--- a/tests/benchmark/test_aggregate_snqi_recompute.py
+++ b/tests/benchmark/test_aggregate_snqi_recompute.py
@@ -90,3 +90,41 @@ def test_aggregate_cli_passes_recompute_snqi_flag(
     assert exit_code == 0
     assert captured["snqi_weights"] == {"score": 1.0}
     assert captured["recompute_snqi"] is True
+
+
+def test_ensure_snqi_strict_re_raises_on_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    """In strict mode, SNQI computation failures should re-raise, not silently pass."""
+
+    def _broken_snqi(metrics, weights, *, baseline_stats=None):
+        raise KeyError("missing metric key")
+
+    monkeypatch.setattr(aggregate, "snqi_fn", _broken_snqi)
+    rec: dict[str, Any] = {
+        "episode_id": "ep-strict",
+        "metrics": {"score": 1.0},
+    }
+
+    with pytest.raises(KeyError, match="missing metric key"):
+        aggregate._ensure_snqi(rec, {"score": 1.0}, None, strict=True)
+
+    # snqi should remain unset because the exception propagated before assignment
+    assert "snqi" not in rec["metrics"]
+
+
+def test_ensure_snqi_non_strict_logs_and_continues(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without strict mode, SNQI failures should be logged and snqi left unset, not raised."""
+
+    def _broken_snqi(metrics, weights, *, baseline_stats=None):
+        raise ValueError("bad value")
+
+    monkeypatch.setattr(aggregate, "snqi_fn", _broken_snqi)
+    rec: dict[str, Any] = {
+        "episode_id": "ep-lenient",
+        "metrics": {"score": 1.0},
+    }
+
+    # Should not raise
+    aggregate._ensure_snqi(rec, {"score": 1.0}, None, strict=False)
+
+    # snqi should remain unset
+    assert "snqi" not in rec["metrics"]

--- a/tests/unit/benchmark/test_metrics_post_process.py
+++ b/tests/unit/benchmark/test_metrics_post_process.py
@@ -34,3 +34,27 @@ def test_post_process_metrics_drops_non_finite_values():
 
     assert "mean_distance" not in metrics
     assert metrics["near_misses"] == 0
+
+
+def test_post_process_metrics_drops_non_coercible_count():
+    """A non-coercible safety count should be set to None, not silently left as a bad value."""
+    metrics_raw = {
+        "success": 1.0,
+        "collisions": "not-a-number",
+    }
+
+    metrics = post_process_metrics(metrics_raw, snqi_weights=None, snqi_baseline=None)
+
+    assert metrics["collisions"] is None
+
+
+def test_post_process_metrics_drops_non_coercible_valid_flag():
+    """A non-coercible validity flag should be set to None, not silently left as a bad value."""
+    metrics_raw = {
+        "success": 1.0,
+        "social_proxemic_available": "bad",
+    }
+
+    metrics = post_process_metrics(metrics_raw, snqi_weights=None, snqi_baseline=None)
+
+    assert metrics["social_proxemic_available"] is None


### PR DESCRIPTION
## Summary
Stop silent `except Exception: pass` / `return 1` error swallowing on benchmark result-producing paths (SNQI computation, SNQI CLI, count/flag normalization). Failures are now logged with context, catches are narrowed to expected exception types, and a `strict` mode lets paper/release runs fail closed.

## Linked Issues
- Closes `#3383`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes

## What Changed
- **`robot_sf/benchmark/aggregate.py`**: `_ensure_snqi` gains a `strict: bool = False` kwarg. Catches narrowed from `except Exception` to `(KeyError, ValueError, TypeError)` so an `AttributeError` (e.g. typo) surfaces as a crash. On failure, `logger.exception` logs the record id. `write_episode_csv`, `compute_aggregates`, and `compute_aggregates_with_ci` propagate `strict`.
- **`robot_sf/benchmark/snqi/cli.py`**: `cmd_recompute_weights` and `cmd_ablation_analysis` now `logger.exception("...")` before `return 1`, so the failing stage is visible in stderr/logs instead of a bare exit code.
- **`robot_sf/benchmark/metrics.py`**: `post_process_metrics` count/flag coercion catches narrowed from `except Exception` to `(TypeError, ValueError)`. On failure, `logger.warning` logs the key and value, and the metric is set to `None` instead of silently serializing an un-coerced value.
- **Tests**: 4 new regression tests — strict re-raise, non-strict log-and-continue, non-coercible count drop, non-coercible valid-flag drop.

## Why It Matters
- Added value: silent error swallowing on SNQI and safety-count serialization paths could drop or corrupt headline metrics with no signal. This fix makes failures visible (logged) and optionally fatal (strict mode), aligning with the repo's fail-loud, paper-grade reproducibility values.
- Expected impact: benchmark runs that previously silently emitted records without SNQI or with malformed safety counts will now log the failure. Paper/release runs using `strict=True` will fail closed.
- Why this is worth merging now: the current behavior undermines reproducibility — results look complete but are quietly missing/wrong.

## Research Result Guidance
NA - reliability/observability fix: this changes error handling on benchmark result paths, not the metric computations themselves. No new benchmark claim is made.

- Target claim / hypothesis / blocker this should affect: NA
- Comparator or baseline, if applicable: NA
- Evidence tier: targeted smoke (unit tests prove the new error-handling behavior)
- Result classification: NA - support fix
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper

## Domain-Aware Approval
- Required for this PR: no - reason: no evidence classification, experimental comparison methodology, or paper-facing claim changed. The metric computation logic is unchanged; only error handling around it is tightened.
- Domains reviewed: NA
- Status: not required

## Falsification / Non-Transfer Check
NA - support fix with no research claim.

## Next Empirical Action
NA - evidence is complete for this fix.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_aggregate_snqi_recompute.py tests/unit/benchmark/test_metrics_post_process.py tests/test_snqi_cli_recompute.py tests/test_metrics.py tests/test_snqi_malformed_skip_cli.py tests/test_snqi_cli_method_aliases.py -q` (103 passed, 1 skipped)
  - `uv run ruff check robot_sf/benchmark/aggregate.py robot_sf/benchmark/snqi/cli.py robot_sf/benchmark/metrics.py tests/benchmark/test_aggregate_snqi_recompute.py tests/unit/benchmark/test_metrics_post_process.py` (passed)
  - `uv run ruff format ...` (unchanged)
- Evidence that the change works here: new tests prove strict re-raise, non-strict log-and-continue, and count/flag drop-to-None behavior. Existing aggregate, SNQI CLI, and metrics tests all still pass.

## Risks / Rollback
- Compatibility risks: low. The `strict` parameter defaults to `False`, preserving existing behavior. The narrowed catches mean an unexpected `AttributeError` or similar will now crash instead of being silently swallowed — this is intentional (it surfaces bugs).
- Failure modes: if a caller relied on the silent swallowing to handle an expected error, that error will now be logged. The metric is still left unset (non-strict) or raised (strict).
- Rollback or fallback plan: revert the commit.

## Docs / Provenance
- Updated docs: none needed (internal error-handling change).
- Relevant design or provenance notes: the good-pattern reference is `runner.py:1503` which already uses `logger.exception`.
- Any assumptions that need to be preserved: `strict` defaults to `False` for backward compatibility.

## Downstream Propagation
- Parent issue updated (no): NA
- Claim map / benchmark report updated (NA): no benchmark claim changed
- Leaderboard / artifact catalog updated (NA): NA
- Registry or config index updated (NA): NA
- Context index / memory note updated (no): NA
- Follow-up issue opened for deferred propagation (no): NA
- Not applicable because: this is a bounded error-handling reliability fix with no benchmark, registry, claim-map, or paper-facing surface.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: confirm the narrowed catch types `(KeyError, ValueError, TypeError)` for `_ensure_snqi` and `(TypeError, ValueError)` for metrics coercion cover the expected failure modes without being too broad.
- Any known limitations: `compute_aggregates` already has `# noqa: PLR0913` (too many args); adding `strict` increases the count by one but preserves the existing suppression.
