### PR TITLE
refactor: migrate risk_surface_dwa + lidar_social_force adapter builders (#3384)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -71,6 +71,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Continued the `_build_policy` decomposition (#3384) by migrating the `risk_surface_dwa` and
+  `lidar_social_force` adapter families from the inline dispatcher into
+  `robot_sf/benchmark/map_runner_policies/adapters.py`, registered in `_POLICY_BUILDERS`. The builders
+  reuse the neutral `map_runner_policy_common.build_adapter_policy` (#3403) and import their adapter
+  classes from `robot_sf.planner.*`, so no import cycle is introduced. Behavior-preserving (the
+  `map_runner` regression suite passes; one test monkeypatch repoints to the new builder namespace).
+  Adapter families that still depend on `map_runner`-local helpers (e.g. `trivial_reference` via
+  `_build_socnav_config`) are deferred to a later slice.
 * Consolidated the RFC6901 JSON-pointer renderer that was copy-pasted in eight modules into a single
   shared helper `robot_sf.common.json_pointer.json_pointer` (#3386). The eight schema-validation call
   sites (`benchmark/{scenario_schema,odd_contract,hazard_traceability,scenario_contract,odd_hazard_coverage_matrix,artifact_catalog}.py`

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -116,6 +116,7 @@ from robot_sf.benchmark.map_runner_observations import (
     obs_to_external_mpc_format as _obs_to_external_mpc_format,
 )
 from robot_sf.benchmark.map_runner_observations import obs_to_ppo_format as _obs_to_ppo_format
+from robot_sf.benchmark.map_runner_policies import adapters as _adapter_policy_builders
 from robot_sf.benchmark.map_runner_policies import goal as _goal_policy_builder
 from robot_sf.benchmark.map_runner_policy_common import (
     build_adapter_policy as _build_adapter_policy,
@@ -210,16 +211,11 @@ from robot_sf.planner.kinematics_model import (
     KinematicsModel,
     resolve_benchmark_kinematics_model,
 )
-from robot_sf.planner.learned_risk_surface import (
-    RiskSurfacePlannerAdapter,
-    build_local_risk_surface_spec,
-)
 from robot_sf.planner.lidar_occupancy import (
     LidarOccupancyPlannerAdapter,
     build_lidar_occupancy_config,
 )
 from robot_sf.planner.lidar_occupancy_grid import build_lidar_grid_route_adapter
-from robot_sf.planner.lidar_tracked_agents import build_lidar_tracked_social_force_adapter
 from robot_sf.planner.mppi_social import (
     MPPISocialPlannerAdapter,
     build_mppi_social_config,
@@ -236,7 +232,7 @@ from robot_sf.planner.predictive_mppi import (
     PredictiveMPPIAdapter,
     build_predictive_mppi_config,
 )
-from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter, build_risk_dwa_config
+from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter
 from robot_sf.planner.safety_barrier import (
     SafetyBarrierPlannerAdapter,
     build_safety_barrier_config,
@@ -878,7 +874,17 @@ def _update_adapter_impact_metrics(
 # Registry of migrated per-algorithm policy builders (#3384). Consulted before the
 # inline dispatch in _build_policy; families not yet migrated fall through to the
 # existing if/elif chain.
-_POLICY_BUILDERS = dict.fromkeys(_goal_policy_builder.GOAL_ALGO_KEYS, _goal_policy_builder.build)
+_POLICY_BUILDERS = {
+    **dict.fromkeys(_goal_policy_builder.GOAL_ALGO_KEYS, _goal_policy_builder.build),
+    **dict.fromkeys(
+        _adapter_policy_builders.RISK_SURFACE_DWA_KEYS,
+        _adapter_policy_builders.build_risk_surface_dwa,
+    ),
+    **dict.fromkeys(
+        _adapter_policy_builders.LIDAR_SOCIAL_FORCE_KEYS,
+        _adapter_policy_builders.build_lidar_social_force,
+    ),
+}
 
 
 def _build_policy(  # noqa: C901, PLR0912, PLR0915
@@ -928,50 +934,6 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             robot_kinematics=robot_kinematics,
             normalized_robot_command_mode=normalized_robot_command_mode,
             limitations=registered_adapter_spec.limitations,
-        )
-
-    if algo_key in {"risk_surface_dwa", "risk_surface_dwa_v0"}:
-        risk_surface_cfg = (
-            algo_config.get("risk_surface")
-            if isinstance(algo_config.get("risk_surface"), dict)
-            else {}
-        )
-        risk_dwa_cfg = (
-            algo_config.get("risk_dwa") if isinstance(algo_config.get("risk_dwa"), dict) else {}
-        )
-        adapter = RiskSurfacePlannerAdapter(
-            spec=build_local_risk_surface_spec(risk_surface_cfg),
-            planner=RiskDWAPlannerAdapter(config=build_risk_dwa_config(risk_dwa_cfg)),
-        )
-        meta["risk_surface_planner"] = {
-            "status": "enabled",
-            "producer": "deterministic_pedestrian_risk_surface",
-            "wrapped_planner": "risk_dwa",
-            "benchmark_strength": False,
-            "claim_boundary": "exploratory_smoke_only",
-        }
-        return _build_adapter_policy(
-            algo_key="risk_surface_dwa",
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="RiskSurfacePlannerAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations="deterministic_risk_surface_fixture_not_benchmark_evidence",
-        )
-
-    if algo_key in {"lidar_social_force", "lidar_tracked_social_force"}:
-        adapter = build_lidar_tracked_social_force_adapter(algo_config)
-        return _build_adapter_policy(
-            algo_key="lidar_social_force",
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="LidarTrackedSocialForceAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations="lidar_endpoint_tracked_social_force_testing_only",
         )
 
     if algo_key in {"trivial_reference", "reference_adapter"}:

--- a/robot_sf/benchmark/map_runner_policies/adapters.py
+++ b/robot_sf/benchmark/map_runner_policies/adapters.py
@@ -1,0 +1,107 @@
+"""Builders for adapter-backed map-runner policy families.
+
+Continuation of the ``_build_policy`` decomposition (#3384), building on the package
+registry (#3400) and the neutral ``build_adapter_policy`` helper (#3403). Each builder
+is a faithful move of the corresponding ``if algo_key in {...}`` branch from
+``robot_sf.benchmark.map_runner`` — no semantic change.
+
+This module migrates the two adapter families whose dependencies all resolve from
+lower-level ``robot_sf.planner`` modules (no ``map_runner``-local helpers), so the
+import graph stays acyclic. Families that still depend on ``map_runner``-local
+helpers (e.g. ``trivial_reference`` via ``_build_socnav_config``) are deferred to a
+later slice.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.map_runner_policy_common import build_adapter_policy
+from robot_sf.planner.learned_risk_surface import (
+    RiskSurfacePlannerAdapter,
+    build_local_risk_surface_spec,
+)
+from robot_sf.planner.lidar_tracked_agents import build_lidar_tracked_social_force_adapter
+from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter, build_risk_dwa_config
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+#: Algorithm keys handled by the risk-surface DWA builder.
+RISK_SURFACE_DWA_KEYS = frozenset({"risk_surface_dwa", "risk_surface_dwa_v0"})
+#: Algorithm keys handled by the lidar tracked social-force builder.
+LIDAR_SOCIAL_FORCE_KEYS = frozenset({"lidar_social_force", "lidar_tracked_social_force"})
+
+
+def build_risk_surface_dwa(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build the deterministic risk-surface DWA adapter policy.
+
+    Returns:
+        Policy callable and enriched metadata dictionary.
+    """
+    normalized_robot_command_mode = (
+        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
+    )
+    risk_surface_cfg = (
+        algo_config.get("risk_surface") if isinstance(algo_config.get("risk_surface"), dict) else {}
+    )
+    risk_dwa_cfg = (
+        algo_config.get("risk_dwa") if isinstance(algo_config.get("risk_dwa"), dict) else {}
+    )
+    adapter = RiskSurfacePlannerAdapter(
+        spec=build_local_risk_surface_spec(risk_surface_cfg),
+        planner=RiskDWAPlannerAdapter(config=build_risk_dwa_config(risk_dwa_cfg)),
+    )
+    meta: dict[str, Any] = {"algorithm": algo_key}
+    meta["risk_surface_planner"] = {
+        "status": "enabled",
+        "producer": "deterministic_pedestrian_risk_surface",
+        "wrapped_planner": "risk_dwa",
+        "benchmark_strength": False,
+        "claim_boundary": "exploratory_smoke_only",
+    }
+    return build_adapter_policy(
+        algo_key="risk_surface_dwa",
+        algo_config=algo_config,
+        meta=meta,
+        adapter=adapter,
+        adapter_name="RiskSurfacePlannerAdapter",
+        robot_kinematics=robot_kinematics,
+        normalized_robot_command_mode=normalized_robot_command_mode,
+        limitations="deterministic_risk_surface_fixture_not_benchmark_evidence",
+    )
+
+
+def build_lidar_social_force(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build the lidar endpoint-tracked social-force adapter policy.
+
+    Returns:
+        Policy callable and enriched metadata dictionary.
+    """
+    normalized_robot_command_mode = (
+        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
+    )
+    adapter = build_lidar_tracked_social_force_adapter(algo_config)
+    meta: dict[str, Any] = {"algorithm": algo_key}
+    return build_adapter_policy(
+        algo_key="lidar_social_force",
+        algo_config=algo_config,
+        meta=meta,
+        adapter=adapter,
+        adapter_name="LidarTrackedSocialForceAdapter",
+        robot_kinematics=robot_kinematics,
+        normalized_robot_command_mode=normalized_robot_command_mode,
+        limitations="lidar_endpoint_tracked_social_force_testing_only",
+    )

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -725,7 +725,12 @@ def test_build_policy_risk_surface_dwa_wires_surface_adapter(
             """Return diagnostics preserving the prototype claim boundary."""
             return {"benchmark_strength": False, "status": "ok"}
 
-    monkeypatch.setattr("robot_sf.benchmark.map_runner.RiskSurfacePlannerAdapter", _DummyAdapter)
+    # The risk_surface_dwa family was extracted to map_runner_policies.adapters (#3384),
+    # which constructs the adapter in its own namespace; patch it there.
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner_policies.adapters.RiskSurfacePlannerAdapter",
+        _DummyAdapter,
+    )
     policy, meta = _build_policy(
         "risk_surface_dwa_v0",
         {


### PR DESCRIPTION
## Summary

Continues the `_build_policy` decomposition (#3384), now that both foundations are merged: the package registry (#3400 / PR #3402) and the neutral `build_adapter_policy` helper (#3403 / PR #3404). **No behavior change.**

Migrates the two adapter families whose dependencies all resolve from lower-level `robot_sf.planner.*` modules (no `map_runner`-local helpers), so the import graph stays acyclic.

## Changes

- **New `robot_sf/benchmark/map_runner_policies/adapters.py`** with `build_risk_surface_dwa` and `build_lidar_social_force` — faithful moves of the inline `if algo_key in {...}` branches. They import their adapter classes from `robot_sf.planner.{learned_risk_surface,risk_dwa,lidar_tracked_agents}` and `build_adapter_policy` from `map_runner_policy_common` — none of which import `map_runner`.
- **`map_runner.py`**: registered both families in `_POLICY_BUILDERS`; removed the two inline branches and the now-unused adapter imports (−52 lines).
- **Test**: repointed one monkeypatch (`RiskSurfacePlannerAdapter`) to the new builder namespace (standard for a refactor that relocates the symbol).

### Deferred (noted)

`trivial_reference` depends on `_build_socnav_config`, which is **duplicated** in `map_runner.py` and `map_runner_policy_resolution.py` and the two definitions **differ** — folding it in would risk a behavior change, so it stays inline for a dedicated slice that first reconciles that helper.

## Validation

```
uv run pytest tests/benchmark/test_map_runner_utils.py tests/test_map_runner_ppo.py \
  tests/test_map_runner_sac.py tests/benchmark/test_lidar_planner_compatibility.py \
  tests/planner/test_policy_stack_v1.py tests/integration/test_social_force_map_runner.py \
  tests/benchmark/test_map_runner_preflight_profiles.py -q
# 192 passed

scripts/dev/ruff_fix_format.sh                          # All checks passed
uv run python scripts/tools/sync_ai_config.py --check   # 7 symlinks validated
# e2e: _build_policy("risk_surface_dwa"|"risk_surface_dwa_v0"|"lidar_social_force") -> status "ok"
```

## Evidence grade

Tier 1 (benchmark-package structural refactor, behavior-preserving faithful move). Confidence **High** — proof current for branch head, branched from current `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
