### PR TITLE
refactor: migrate safety_barrier and grid_route policy builders (#3384 slice 2)

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -118,6 +118,7 @@ from robot_sf.benchmark.map_runner_observations import (
 from robot_sf.benchmark.map_runner_observations import obs_to_ppo_format as _obs_to_ppo_format
 from robot_sf.benchmark.map_runner_policies import adapters as _adapter_policy_builders
 from robot_sf.benchmark.map_runner_policies import goal as _goal_policy_builder
+from robot_sf.benchmark.map_runner_policies import safety_barrier as _safety_barrier_builder
 from robot_sf.benchmark.map_runner_policy_common import (
     build_adapter_policy as _build_adapter_policy,
 )
@@ -188,7 +189,10 @@ from robot_sf.planner.gap_prediction import (
     GapAwarePredictionAdapter,
     build_gap_prediction_config,
 )
-from robot_sf.planner.grid_route import GridRoutePlannerAdapter, build_grid_route_config
+from robot_sf.planner.grid_route import (  # noqa: F401
+    GridRoutePlannerAdapter,
+    build_grid_route_config,
+)
 from robot_sf.planner.guarded_ppo import (
     GuardedPPOAdapter,
     build_guarded_ppo_config,
@@ -211,7 +215,7 @@ from robot_sf.planner.kinematics_model import (
     KinematicsModel,
     resolve_benchmark_kinematics_model,
 )
-from robot_sf.planner.lidar_occupancy import (
+from robot_sf.planner.lidar_occupancy import (  # noqa: F401
     LidarOccupancyPlannerAdapter,
     build_lidar_occupancy_config,
 )
@@ -233,7 +237,7 @@ from robot_sf.planner.predictive_mppi import (
     build_predictive_mppi_config,
 )
 from robot_sf.planner.risk_dwa import RiskDWAPlannerAdapter
-from robot_sf.planner.safety_barrier import (
+from robot_sf.planner.safety_barrier import (  # noqa: F401
     SafetyBarrierPlannerAdapter,
     build_safety_barrier_config,
 )
@@ -874,7 +878,7 @@ def _update_adapter_impact_metrics(
 # Registry of migrated per-algorithm policy builders (#3384). Consulted before the
 # inline dispatch in _build_policy; families not yet migrated fall through to the
 # existing if/elif chain.
-_POLICY_BUILDERS = {
+_POLICY_BUILDERS: dict[str, Any] = {
     **dict.fromkeys(_goal_policy_builder.GOAL_ALGO_KEYS, _goal_policy_builder.build),
     **dict.fromkeys(
         _adapter_policy_builders.RISK_SURFACE_DWA_KEYS,
@@ -884,6 +888,7 @@ _POLICY_BUILDERS = {
         _adapter_policy_builders.LIDAR_SOCIAL_FORCE_KEYS,
         _adapter_policy_builders.build_lidar_social_force,
     ),
+    **dict.fromkeys(_safety_barrier_builder.ADAPTER_ALGO_KEYS, _safety_barrier_builder.build),
 }
 
 
@@ -1016,47 +1021,6 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
                 "diagnostic-only selector over fixed proxemic profiles; "
                 "not benchmark or comfort evidence"
             ),
-        )
-
-    if algo_key == "safety_barrier":
-        adapter: Any = SafetyBarrierPlannerAdapter(config=build_safety_barrier_config(algo_config))
-        adapter_name = "SafetyBarrierPlannerAdapter"
-        limitations = "static_obstacle_first_testing_only"
-        if algo_config.get("lidar_occupancy_adapter"):
-            adapter = LidarOccupancyPlannerAdapter(
-                planner=adapter,
-                config=build_lidar_occupancy_config(algo_config),
-            )
-            adapter_name = "LidarOccupancySafetyBarrierAdapter"
-            limitations = "lidar_derived_ego_occupancy_testing_only"
-            meta["lidar_occupancy_adapter"] = {
-                "status": "enabled",
-                "source": "lidar_rays",
-                "output": "ego_occupancy_grid",
-                "planner": "safety_barrier",
-            }
-        return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name=adapter_name,
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations=limitations,
-        )
-
-    if algo_key == "grid_route":
-        adapter = GridRoutePlannerAdapter(config=build_grid_route_config(algo_config))
-        return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="GridRoutePlannerAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations="static_obstacle_first_testing_only",
         )
 
     if algo_key == "topology_guided_hybrid_rule_v0":

--- a/robot_sf/benchmark/map_runner_policies/safety_barrier.py
+++ b/robot_sf/benchmark/map_runner_policies/safety_barrier.py
@@ -1,0 +1,103 @@
+"""Builder for the safety-barrier and grid-route map-runner policy families.
+
+Second slice of the ``_build_policy`` decomposition (#3384). Behavior is a
+faithful move of the original ``if algo_key == "safety_barrier"`` and
+``if algo_key == "grid_route"`` branches from
+``robot_sf.benchmark.map_runner`` — no semantic change.
+
+Both branches construct an adapter and delegate to the shared
+``build_adapter_policy`` helper in ``map_runner_policy_common``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+#: Algorithm keys handled by this builder.
+SAFETY_BARRIER_ALGO_KEYS = frozenset({"safety_barrier"})
+GRID_ROUTE_ALGO_KEYS = frozenset({"grid_route"})
+ADAPTER_ALGO_KEYS = SAFETY_BARRIER_ALGO_KEYS | GRID_ROUTE_ALGO_KEYS
+
+
+def build(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build a safety-barrier or grid-route adapter policy and its metadata.
+
+    Args:
+        algo_key: Normalized algorithm key (one of :data:`ADAPTER_ALGO_KEYS`).
+        algo_config: Algorithm configuration payload.
+        robot_kinematics: Runtime robot kinematics label for metadata enrichment.
+        robot_command_mode: Runtime robot command mode (for holonomic metadata labels).
+
+    Returns:
+        Policy callable and enriched metadata dictionary.
+    """
+    from robot_sf.benchmark.map_runner_policy_common import (  # noqa: PLC0415
+        build_adapter_policy,
+    )
+    from robot_sf.planner.grid_route import (  # noqa: PLC0415
+        GridRoutePlannerAdapter,
+        build_grid_route_config,
+    )
+    from robot_sf.planner.lidar_occupancy import (  # noqa: PLC0415
+        LidarOccupancyPlannerAdapter,
+        build_lidar_occupancy_config,
+    )
+    from robot_sf.planner.safety_barrier import (  # noqa: PLC0415
+        SafetyBarrierPlannerAdapter,
+        build_safety_barrier_config,
+    )
+
+    meta: dict[str, Any] = {"algorithm": algo_key}
+    normalized_robot_command_mode = (
+        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
+    )
+
+    if algo_key in SAFETY_BARRIER_ALGO_KEYS:
+        adapter: Any = SafetyBarrierPlannerAdapter(config=build_safety_barrier_config(algo_config))
+        adapter_name = "SafetyBarrierPlannerAdapter"
+        limitations = "static_obstacle_first_testing_only"
+        if algo_config.get("lidar_occupancy_adapter"):
+            adapter = LidarOccupancyPlannerAdapter(
+                planner=adapter,
+                config=build_lidar_occupancy_config(algo_config),
+            )
+            adapter_name = "LidarOccupancySafetyBarrierAdapter"
+            limitations = "lidar_derived_ego_occupancy_testing_only"
+            meta["lidar_occupancy_adapter"] = {
+                "status": "enabled",
+                "source": "lidar_rays",
+                "output": "ego_occupancy_grid",
+                "planner": "safety_barrier",
+            }
+        return build_adapter_policy(
+            algo_key=algo_key,
+            algo_config=algo_config,
+            meta=meta,
+            adapter=adapter,
+            adapter_name=adapter_name,
+            robot_kinematics=robot_kinematics,
+            normalized_robot_command_mode=normalized_robot_command_mode,
+            limitations=limitations,
+        )
+
+    # grid_route
+    adapter = GridRoutePlannerAdapter(config=build_grid_route_config(algo_config))
+    return build_adapter_policy(
+        algo_key=algo_key,
+        algo_config=algo_config,
+        meta=meta,
+        adapter=adapter,
+        adapter_name="GridRoutePlannerAdapter",
+        robot_kinematics=robot_kinematics,
+        normalized_robot_command_mode=normalized_robot_command_mode,
+        limitations="static_obstacle_first_testing_only",
+    )

--- a/robot_sf/benchmark/map_runner_policies/safety_barrier.py
+++ b/robot_sf/benchmark/map_runner_policies/safety_barrier.py
@@ -40,6 +40,13 @@ def build(
     Returns:
         Policy callable and enriched metadata dictionary.
     """
+    if algo_key not in ADAPTER_ALGO_KEYS:
+        supported = ", ".join(sorted(ADAPTER_ALGO_KEYS))
+        raise ValueError(
+            f"Unsupported safety-barrier/grid-route policy algo_key {algo_key!r}; "
+            f"expected one of: {supported}"
+        )
+
     from robot_sf.benchmark.map_runner_policy_common import (  # noqa: PLC0415
         build_adapter_policy,
     )

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -57,6 +57,7 @@ from robot_sf.benchmark.map_runner_batch_plan import (
     resolve_batch_kinematics_tag,
 )
 from robot_sf.benchmark.map_runner_metrics import summarize_collision_metrics
+from robot_sf.benchmark.map_runner_policies import safety_barrier as safety_barrier_policy_builder
 from robot_sf.benchmark.policy_builders import build_registered_adapter_policy_spec
 from robot_sf.common.types import Rect
 from robot_sf.nav.global_route import GlobalRoute
@@ -703,6 +704,12 @@ def test_build_policy_risk_dwa_routes_through_registered_adapter_builder(
     assert meta["planner_kinematics"]["execution_mode"] == "adapter"
     assert meta["planner_kinematics"]["adapter_name"] == "RiskDWAPlannerAdapter"
     assert hasattr(policy, "_planner_adapter")
+
+
+def test_safety_barrier_policy_builder_rejects_unsupported_algo_key() -> None:
+    """Extracted safety-barrier/grid-route builder should fail closed on bad keys."""
+    with pytest.raises(ValueError, match="unsupported_adapter"):
+        safety_barrier_policy_builder.build("unsupported_adapter", {})
 
 
 def test_build_policy_risk_surface_dwa_wires_surface_adapter(


### PR DESCRIPTION
## Summary
Second slice of #3384: migrate the `safety_barrier` and `grid_route` adapter branches from `map_runner._build_policy` into a new `map_runner_policies/safety_barrier.py` builder module, following the same registry pattern as the goal family migration (#3400). No behavior change.

## Linked Issues
- Relates to `#3384` (decompose `_build_policy`)

## Stack / Dependency
- Base dependency: `PR #3404` (relocate `_build_adapter_policy` to `map_runner_policy_common`) — merged to main
- Required prior PRs: #3400 (goal family scaffold), #3404 (adapter helper relocation)
- Stack follow-up issues: none
- Safe to review independently: yes

## What Changed
- **New `robot_sf/benchmark/map_runner_policies/safety_barrier.py`**: builder module for `safety_barrier` and `grid_route` algo keys. Uses `build_adapter_policy` from `map_runner_policy_common`. Local imports avoid import cycles.
- **`robot_sf/benchmark/map_runner.py`**: 
  - Import new builder module and add its keys to `_POLICY_BUILDERS` registry.
  - Remove inline `safety_barrier` (~25 lines) and `grid_route` (~10 lines) branches from `_build_policy`.
  - Keep `SafetyBarrierPlannerAdapter`, `GridRoutePlannerAdapter`, `LidarOccupancyPlannerAdapter`, and related imports as `# noqa: F401` re-exports because `tests/benchmark/test_map_runner_utils.py` monkeypatches them via the `map_runner` module namespace.

## Why It Matters
- Added value: reduces `_build_policy` by ~35 lines, moving two more adapter families to the registry pattern. Each migrated family makes the remaining monolith easier to review and extend.
- Expected impact: none (behavior-preserving move).
- Why this is worth merging now: continues the incremental decomposition; the prerequisite (`_build_adapter_policy` relocation) was merged in #3404.

## Research Result Guidance
NA - support refactor: no behavior change, no research/benchmark/metric/paper claim.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_map_runner_utils.py -q -x` (121 passed)
  - `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policies/safety_barrier.py` (passed)
  - `uv run ruff format ...` (unchanged)
- Evidence that the change works here: all 121 existing tests pass unchanged, including `test_build_policy_for_portfolio_adapters_tracks_feasibility` which monkeypatches `SafetyBarrierPlannerAdapter` via the `map_runner` module namespace.

## Risks / Rollback
- Compatibility risks: very low. Import surface preserved with `# noqa: F401` re-exports. Registry dispatch is checked before inline branches.
- Failure modes: none expected.
- Rollback or fallback plan: revert the commit.

## Downstream Propagation
- Not applicable because: bounded refactor with no benchmark, registry, claim-map, or paper-facing surface.

## Reviewer Notes
- The `# noqa: F401` re-exports for `SafetyBarrierPlannerAdapter`, `GridRoutePlannerAdapter`, `LidarOccupancyPlannerAdapter`, and `build_lidar_occupancy_config` are intentional: tests monkeypatch these via `map_runner` module namespace.
- The builder uses local imports (inside `build()`) to avoid a `map_runner <-> map_runner_policies` import cycle, matching the pattern in `goal.py`.
