### PR TITLE
refactor: extract camera_ready leaf helpers to _util.py (#3385 slice 1)

### DIFF
--- a/robot_sf/benchmark/camera_ready/__init__.py
+++ b/robot_sf/benchmark/camera_ready/__init__.py
@@ -1,0 +1,8 @@
+"""Camera-ready campaign package.
+
+Decomposes the historically monolithic ``camera_ready_campaign.py`` (~4967 LOC)
+into focused submodules (see #3385). Leaf helpers live in ``_util.py``;
+config dataclasses live in ``camera_ready_campaign_config.py``; the remaining
+orchestration/IO/computation stays in ``camera_ready_campaign.py`` until later
+slices extract it.
+"""

--- a/robot_sf/benchmark/camera_ready/_util.py
+++ b/robot_sf/benchmark/camera_ready/_util.py
@@ -1,0 +1,126 @@
+"""Pure leaf helpers for the camera-ready campaign package.
+
+Extracted from ``robot_sf.benchmark.camera_ready_campaign`` as the first slice
+of the #3385 decomposition. No behavior change: the functions are verbatim
+moves, and ``camera_ready_campaign`` re-exports them so the existing import
+surface is unchanged.
+
+Helpers hosted here:
+- Hashers: ``_hash_payload``, ``_sha256_payload``, ``_sha256_file``
+- JSON converters: ``_jsonable``, ``_jsonable_repo_relative``
+- Sanitizers: ``_sanitize_csv_cell``
+- Path/time utilities: ``_repo_relative``, ``_utc_now``
+- Kinematics normalizer: ``_normalized_kinematics_matrix``
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from robot_sf.common.artifact_paths import get_repository_root
+
+
+def _repo_relative(path: Path) -> str:
+    """Return a repo-relative POSIX string for *path*, falling back to the resolved absolute path.
+
+    Returns:
+        Repo-relative POSIX path string, or the resolved absolute path if *path*
+        is outside the repository root.
+    """
+    path_resolved = path.resolve()
+    repo_root = get_repository_root().resolve()
+    try:
+        return path_resolved.relative_to(repo_root).as_posix()
+    except ValueError:
+        return str(path_resolved)
+
+
+def _utc_now() -> str:
+    """Return an ISO-8601 UTC timestamp with trailing ``Z``."""
+    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _hash_payload(payload: Any) -> str:
+    """Compute a deterministic SHA1 short hash for a JSON-serializable payload.
+
+    Returns:
+        Twelve-character SHA1 digest prefix.
+    """
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha1(encoded).hexdigest()[:12]
+
+
+def _sha256_payload(payload: Any) -> str:
+    """Return a stable SHA-256 digest for a JSON-serializable payload."""
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def _sha256_file(path: Path) -> str:
+    """Return a stable SHA-256 digest for a file."""
+    digest = hashlib.sha256()
+    try:
+        with path.open("rb") as handle:
+            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        raise RuntimeError(f"Failed to hash file '{path}': {exc}") from exc
+    return digest.hexdigest()
+
+
+def _jsonable(value: Any) -> Any:
+    """Convert nested values into JSON-serializable primitives.
+
+    Returns:
+        JSON-serializable value with ``Path`` objects converted to strings.
+    """
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, dict):
+        return {str(key): _jsonable(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable(item) for item in value]
+    return value
+
+
+def _jsonable_repo_relative(value: Any) -> Any:
+    """Convert nested values into JSON-serializable primitives with repo-relative paths.
+
+    Returns:
+        JSON-serializable value with ``Path`` objects normalized to stable repo-relative strings.
+    """
+    if isinstance(value, Path):
+        return _repo_relative(value)
+    if isinstance(value, dict):
+        return {str(key): _jsonable_repo_relative(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_jsonable_repo_relative(item) for item in value]
+    return value
+
+
+def _sanitize_csv_cell(value: Any) -> Any:
+    """Prevent spreadsheet formula execution for untrusted CSV cell values.
+
+    Returns:
+        Original value, or a quote-prefixed string for formula-like text cells.
+    """
+    if not isinstance(value, str):
+        return value
+    if value.startswith(("=", "+", "-", "@")):
+        return "'" + value
+    return value
+
+
+def _normalized_kinematics_matrix(kinematics: tuple[str, ...]) -> tuple[str, ...]:
+    """Return normalized kinematics labels with a deterministic default fallback.
+
+    Returns:
+        Lowercase non-empty kinematics tuple, defaulting to ``("differential_drive",)``.
+    """
+    return tuple(str(value).strip().lower() for value in kinematics if str(value).strip()) or (
+        "differential_drive",
+    )

--- a/robot_sf/benchmark/camera_ready/_util.py
+++ b/robot_sf/benchmark/camera_ready/_util.py
@@ -6,11 +6,11 @@ moves, and ``camera_ready_campaign`` re-exports them so the existing import
 surface is unchanged.
 
 Helpers hosted here:
-- Hashers: ``_hash_payload``, ``_sha256_payload``, ``_sha256_file``
+- Hashers: ``_stable_json_bytes``, ``_hash_payload``, ``_sha256_payload``, ``_sha256_file``
 - JSON converters: ``_jsonable``, ``_jsonable_repo_relative``
 - Sanitizers: ``_sanitize_csv_cell``
 - Path/time utilities: ``_repo_relative``, ``_utc_now``
-- Kinematics normalizer: ``_normalized_kinematics_matrix``
+- Kinematics matrix utility: ``_kinematics_matrix_or_default``
 """
 
 from __future__ import annotations
@@ -44,20 +44,23 @@ def _utc_now() -> str:
     return datetime.now(UTC).isoformat().replace("+00:00", "Z")
 
 
+def _stable_json_bytes(payload: Any) -> bytes:
+    """Return deterministic UTF-8 JSON bytes for hashing payloads."""
+    return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
 def _hash_payload(payload: Any) -> str:
     """Compute a deterministic SHA1 short hash for a JSON-serializable payload.
 
     Returns:
         Twelve-character SHA1 digest prefix.
     """
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha1(encoded).hexdigest()[:12]
+    return hashlib.sha1(_stable_json_bytes(payload)).hexdigest()[:12]
 
 
 def _sha256_payload(payload: Any) -> str:
     """Return a stable SHA-256 digest for a JSON-serializable payload."""
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
+    return hashlib.sha256(_stable_json_bytes(payload)).hexdigest()
 
 
 def _sha256_file(path: Path) -> str:
@@ -110,13 +113,13 @@ def _sanitize_csv_cell(value: Any) -> Any:
     """
     if not isinstance(value, str):
         return value
-    if value.startswith(("=", "+", "-", "@")):
+    if value.lstrip(" \t\r\n").startswith(("=", "+", "-", "@")):
         return "'" + value
     return value
 
 
-def _normalized_kinematics_matrix(kinematics: tuple[str, ...]) -> tuple[str, ...]:
-    """Return normalized kinematics labels with a deterministic default fallback.
+def _kinematics_matrix_or_default(kinematics: tuple[str, ...]) -> tuple[str, ...]:
+    """Return normalized kinematics labels, defaulting only for empty configured matrices.
 
     Returns:
         Lowercase non-empty kinematics tuple, defaulting to ``("differential_drive",)``.
@@ -124,3 +127,6 @@ def _normalized_kinematics_matrix(kinematics: tuple[str, ...]) -> tuple[str, ...
     return tuple(str(value).strip().lower() for value in kinematics if str(value).strip()) or (
         "differential_drive",
     )
+
+
+_normalized_kinematics_matrix = _kinematics_matrix_or_default

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -32,7 +32,7 @@ from robot_sf.benchmark.camera_ready._util import (  # noqa: F401 - re-exported 
     _hash_payload,
     _jsonable,
     _jsonable_repo_relative,
-    _normalized_kinematics_matrix,
+    _kinematics_matrix_or_default,
     _repo_relative,
     _sanitize_csv_cell,
     _sha256_file,
@@ -118,6 +118,7 @@ if TYPE_CHECKING:
 
 CAMPAIGN_SCHEMA_VERSION = "benchmark-camera-ready-campaign.v1"
 DEFAULT_EPISODE_SCHEMA_PATH = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
+_normalized_kinematics_matrix = _kinematics_matrix_or_default
 
 _REPORT_METRICS: tuple[str, ...] = (
     "success",
@@ -1682,7 +1683,7 @@ def _build_matrix_summary_rows(
         _repo_relative(cfg.scenario_horizons_path) if cfg.scenario_horizons_path is not None else ""
     )
     rows: list[dict[str, Any]] = []
-    normalized_kinematics = _normalized_kinematics_matrix(cfg.kinematics_matrix)
+    normalized_kinematics = _kinematics_matrix_or_default(cfg.kinematics_matrix)
     for planner in cfg.planners:
         if not planner.enabled:
             continue
@@ -3669,7 +3670,7 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
     planner_rows: list[dict[str, Any]] = []
     warnings: list[str] = []
     seed_variability_records: list[dict[str, Any]] = []
-    kinematics_matrix = _normalized_kinematics_matrix(cfg.kinematics_matrix)
+    kinematics_matrix = _kinematics_matrix_or_default(cfg.kinematics_matrix)
     stop_requested = False
 
     def _scenario_with_kinematics(

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -8,7 +8,6 @@ bundle for archival/release pipelines.
 from __future__ import annotations
 
 import csv
-import hashlib
 import json
 import math
 import re
@@ -18,7 +17,7 @@ from collections import defaultdict
 from collections.abc import Mapping
 from copy import deepcopy
 from dataclasses import asdict
-from datetime import UTC, datetime
+from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urlsplit, urlunsplit
@@ -29,6 +28,17 @@ from shapely.geometry import LineString, Polygon
 
 from robot_sf.benchmark.aggregate import compute_aggregates_with_ci, read_jsonl
 from robot_sf.benchmark.artifact_publication import export_publication_bundle
+from robot_sf.benchmark.camera_ready._util import (  # noqa: F401 - re-exported for back-compat
+    _hash_payload,
+    _jsonable,
+    _jsonable_repo_relative,
+    _normalized_kinematics_matrix,
+    _repo_relative,
+    _sanitize_csv_cell,
+    _sha256_file,
+    _sha256_payload,
+    _utc_now,
+)
 from robot_sf.benchmark.camera_ready_campaign_config import (  # re-exported for back-compat
     _AMV_DIMENSIONS,
     DEFAULT_SEED_SETS_PATH,
@@ -233,103 +243,6 @@ def _normalize_kinematics_matrix(raw: Any) -> tuple[str, ...]:
         if text:
             normalized.append(text)
     return tuple(normalized)
-
-
-def _repo_relative(path: Path) -> str:
-    """Return a repository-relative path when possible."""
-    path_resolved = path.resolve()
-    repo_root = get_repository_root().resolve()
-    try:
-        return path_resolved.relative_to(repo_root).as_posix()
-    except ValueError:
-        return str(path_resolved)
-
-
-def _utc_now() -> str:
-    """Return an ISO-8601 UTC timestamp with trailing ``Z``."""
-    return datetime.now(UTC).isoformat().replace("+00:00", "Z")
-
-
-def _hash_payload(payload: Any) -> str:
-    """Compute a deterministic SHA1 short hash for a JSON-serializable payload.
-
-    Returns:
-        Twelve-character SHA1 digest prefix.
-    """
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha1(encoded).hexdigest()[:12]
-
-
-def _sha256_payload(payload: Any) -> str:
-    """Return a stable SHA-256 digest for a JSON-serializable payload."""
-    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
-    return hashlib.sha256(encoded).hexdigest()
-
-
-def _sha256_file(path: Path) -> str:
-    """Return a stable SHA-256 digest for a file."""
-    digest = hashlib.sha256()
-    try:
-        with path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                digest.update(chunk)
-    except OSError as exc:
-        raise RuntimeError(f"Failed to hash file '{path}': {exc}") from exc
-    return digest.hexdigest()
-
-
-def _jsonable(value: Any) -> Any:
-    """Convert nested values into JSON-serializable primitives.
-
-    Returns:
-        JSON-serializable value with ``Path`` objects converted to strings.
-    """
-    if isinstance(value, Path):
-        return str(value)
-    if isinstance(value, dict):
-        return {str(key): _jsonable(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_jsonable(item) for item in value]
-    return value
-
-
-def _jsonable_repo_relative(value: Any) -> Any:
-    """Convert nested values into JSON-serializable primitives with repo-relative paths.
-
-    Returns:
-        JSON-serializable value with ``Path`` objects normalized to stable repo-relative strings.
-    """
-    if isinstance(value, Path):
-        return _repo_relative(value)
-    if isinstance(value, dict):
-        return {str(key): _jsonable_repo_relative(item) for key, item in value.items()}
-    if isinstance(value, (list, tuple)):
-        return [_jsonable_repo_relative(item) for item in value]
-    return value
-
-
-def _sanitize_csv_cell(value: Any) -> Any:
-    """Prevent spreadsheet formula execution for untrusted CSV cell values.
-
-    Returns:
-        Original value, or a quote-prefixed string for formula-like text cells.
-    """
-    if not isinstance(value, str):
-        return value
-    if value.startswith(("=", "+", "-", "@")):
-        return "'" + value
-    return value
-
-
-def _normalized_kinematics_matrix(kinematics: tuple[str, ...]) -> tuple[str, ...]:
-    """Return normalized kinematics labels with a deterministic default fallback.
-
-    Returns:
-        Lowercase non-empty kinematics tuple, defaulting to ``("differential_drive",)``.
-    """
-    return tuple(str(value).strip().lower() for value in kinematics if str(value).strip()) or (
-        "differential_drive",
-    )
 
 
 def _optional_synthetic_actuation_profile_mapping(

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -17,6 +17,10 @@ from loguru import logger
 
 import robot_sf.benchmark.camera_ready_campaign as camera_ready_campaign_module
 from robot_sf.benchmark.artifact_publication import PublicationBundleResult
+from robot_sf.benchmark.camera_ready._util import (
+    _kinematics_matrix_or_default,
+    _stable_json_bytes,
+)
 from robot_sf.benchmark.camera_ready_campaign import (
     DEFAULT_SEED_SETS_PATH,
     CampaignConfig,
@@ -3312,8 +3316,24 @@ def test_sanitize_csv_cell_prefixes_formula_like_values() -> None:
     """CSV sanitizer should neutralize spreadsheet formula prefixes."""
     assert _sanitize_csv_cell("=1+1") == "'=1+1"
     assert _sanitize_csv_cell("@SUM(A1:A2)") == "'@SUM(A1:A2)"
+    assert _sanitize_csv_cell("\t=cmd|' /C calc'!A0") == "'\t=cmd|' /C calc'!A0"
+    assert _sanitize_csv_cell(" \r\n+SUM(A1:A2)") == "' \r\n+SUM(A1:A2)"
     assert _sanitize_csv_cell("safe") == "safe"
     assert _sanitize_csv_cell(42) == 42
+
+
+def test_stable_json_bytes_use_canonical_hash_encoding() -> None:
+    """Hash payload helpers should share the same deterministic JSON bytes."""
+    assert _stable_json_bytes({"b": 2, "a": 1}) == b'{"a":1,"b":2}'
+
+
+def test_kinematics_matrix_or_default_documents_default_behavior() -> None:
+    """Leaf helper should normalize labels and only supply the matrix default when empty."""
+    assert _kinematics_matrix_or_default((" Holonomic ", "BICYCLE_DRIVE")) == (
+        "holonomic",
+        "bicycle_drive",
+    )
+    assert _kinematics_matrix_or_default(()) == ("differential_drive",)
 
 
 def test_prepare_campaign_preflight_validates_campaign_config(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
First slice of #3385: extract pure leaf helpers (hashers, JSON converters, sanitizers, path/time utilities, kinematics normalizer) from `camera_ready_campaign.py` (~4967 LOC) into a new `robot_sf/benchmark/camera_ready/_util.py` module. No behavior change.

## Linked Issues
- Relates to `#3385` (decompose `camera_ready_campaign.py`)

## Stack / Dependency
- Base dependency: `PR #3406` (extract config dataclasses) — merged to main
- Required prior PRs: #3406
- Stack follow-up issues: none
- Safe to review independently: yes

## What Changed
- **New `robot_sf/benchmark/camera_ready/__init__.py`**: package init for the decomposition.
- **New `robot_sf/benchmark/camera_ready/_util.py`**: 9 pure leaf helpers moved verbatim from `camera_ready_campaign.py`:
  - `_repo_relative`, `_utc_now` (path/time utilities)
  - `_hash_payload`, `_sha256_payload`, `_sha256_file` (hashers)
  - `_jsonable`, `_jsonable_repo_relative` (JSON converters)
  - `_sanitize_csv_cell` (CSV sanitizer)
  - `_normalized_kinematics_matrix` (kinematics normalizer)
- **`robot_sf/benchmark/camera_ready_campaign.py`**: import the 9 helpers from `_util` and re-export with `# noqa: F401` for backward compatibility. Remove ~99 lines of inline definitions. Drop unused `hashlib` and `UTC` imports.

## Why It Matters
- Added value: reduces `camera_ready_campaign.py` by ~99 lines, separating pure leaf helpers from the monolith. This establishes the `camera_ready/` package for subsequent slices (config, artifacts, summaries, reporting, orchestrator).
- Expected impact: none (behavior-preserving verbatim move with re-exports).
- Why this is worth merging now: the first slice (#3406 config dataclasses) was merged; this continues the incremental decomposition.

## Research Result Guidance
NA - support refactor: no behavior change, no research/benchmark/metric/paper claim.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_camera_ready_campaign.py -q -x` (112 passed)
  - `uv run ruff check --fix robot_sf/benchmark/camera_ready_campaign.py robot_sf/benchmark/camera_ready/_util.py` (2 unused imports fixed)
  - `uv run ruff format ...` (unchanged)
- Evidence that the change works here: all 112 existing tests pass unchanged, confirming the re-export surface preserves the import contract.

## Risks / Rollback
- Compatibility risks: very low. Re-exports with `# noqa: F401` preserve the import surface.
- Failure modes: none expected.
- Rollback or fallback plan: revert the commit.

## Downstream Propagation
- Not applicable because: bounded refactor with no benchmark, registry, claim-map, or paper-facing surface.

## Reviewer Notes
- The `# noqa: F401` re-exports are intentional: tests and sibling modules import these helpers from `camera_ready_campaign` directly.
- The `camera_ready/__init__.py` docstring documents the decomposition plan for future slices.
