### PR TITLE
docs: tighten autopilot token efficiency

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -57,11 +57,15 @@ In token-efficient mode:
   ledger and compact PR/issue/worktree snapshots first. Reopen full skills,
   docs, raw CI output, or broad GitHub/worktree inventories only when the
   ledger is missing, stale, or lacks a field needed for the next mutation.
+  Record the loaded-context cache in the active profile so repeated resumes do
+  not reread long skill/docs surfaces that are already fresh for the current
+  branch, issue/PR head SHA, and phase.
 - Prefer compact parent-thread snapshots before broad repository, GitHub,
   worktree, CI, or validation output.
 - For routine orientation, start with `scripts/dev/autopilot_state_snapshot.py`
   instead of repeated broad `gh issue list`, `gh pr view`, `git worktree list`,
-  or claim-state calls.
+  or claim-state calls. Read its `controller_checkpoint.token_efficiency`
+  recommendations before deciding whether a broader command is still needed.
 - Require artifact-first compact worker artifacts before reading raw logs.
 - For every delegated implementation/review/queue task, the worker **must** write compact artifacts in
   `<run_artifact_dir>` as: `result.json`, `RESULT.md`, `diffstat.txt`, and `validation.json`.
@@ -78,6 +82,10 @@ In token-efficient mode:
   a context pack, snapshot, or targeted artifact is missing and the broad read is explicitly
   justified. Redirect larger command output to private artifacts and return only a compact summary
   with inspected files, command exit codes, and short evidence excerpts.
+- If a command is expected to exceed that cap, run it through
+  `scripts/dev/run_compact_validation.py`, a purpose-built snapshot helper, or a
+  private common-Git-dir artifact and paste only the path plus the short
+  evidence needed for the next controller decision.
 - A successful worker command exit code, positive wrapper message, or candidate commit is route evidence
   only. The parent phase is not complete until this evidence is reviewed, diff status is verified locally,
   and required commands are rerun from the parent with parent-owned proof.

--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -16,6 +16,7 @@ changes.
 - worktree: [absolute or repo-relative worktree path and branch]
 - context_budget: [compact snapshots first; raw logs only by artifact path]
 - resume_checkpoint: [active ledger path plus loaded skills/docs, current PR/issue/head SHA, and next stale-state trigger]
+- loaded_context_cache: [skills/docs/snapshots already read this phase, plus the condition that requires rereading]
 - route_cache: [unavailable routes and reset times, known-good worker lane, and current CI monitor command]
 - delegation_artifacts: [RESULT.md, changed files, diffstat, validation, blockers, mutations]
 - output_budget: [parent-thread summary length and exact artifact paths to return]
@@ -41,6 +42,11 @@ changes.
 - `resume_checkpoint` should be the first thing refreshed after compaction or
   automatic continuation. If it is fresh, do not reread full skills, broad
   issue queues, or full worktree inventories before the next mutation.
+- `loaded_context_cache` prevents compaction recovery from becoming another
+  broad-read pass. Record each long skill, issue body, PR snapshot, and context
+  note already loaded in the current phase, then reread only when the branch,
+  issue/PR head SHA, skill file modification time, or explicit stale-state
+  trigger changes.
 - `route_cache` keeps quota and invocation facts close to the active work:
   Spark usage-limit resets, failed helper flags, the exact bounded CI monitor
   command, and the current fallback worker. Reuse it before retrying a route.

--- a/scripts/dev/autopilot_state_snapshot.py
+++ b/scripts/dev/autopilot_state_snapshot.py
@@ -34,6 +34,13 @@ GENERATED_STATUS_PATHS = (
     "__pycache__",
 )
 STATUS_LINE_LIMIT = 30
+TOKEN_EFFICIENCY_ACTIONS = (
+    "refresh this snapshot or the active ledger before reopening full skill/docs context",
+    "prefer compact issue/PR/CI helpers before broad gh, git worktree, or rg output",
+    "review delegate artifacts in result -> validation -> diffstat order before raw logs",
+    "store verbose validation, worker, and CI logs outside the parent thread",
+    "record unavailable worker routes and reset times before retrying delegation",
+)
 
 
 @dataclass(frozen=True)
@@ -303,6 +310,11 @@ def controller_checkpoint(
         ],
         "issue_numbers": [issue.get("number") for issue in issues],
         "prs": pr_next_actions,
+        "token_efficiency": {
+            "parent_output_limit_lines": 200,
+            "compact_first": True,
+            "recommended_next_steps": list(TOKEN_EFFICIENCY_ACTIONS),
+        },
         "next_action": next_action,
     }
 

--- a/tests/dev/test_autopilot_state_snapshot.py
+++ b/tests/dev/test_autopilot_state_snapshot.py
@@ -156,6 +156,11 @@ def test_build_snapshot_includes_queue_claim_pr_and_worktree_state(monkeypatch, 
     assert payload["git"]["compact_status"]["full_untracked_inventory_omitted"] is True
     assert payload["controller_checkpoint"]["branch"] == "issue-2671-compact-state-snapshots"
     assert payload["controller_checkpoint"]["next_action"] == "continue_from_snapshot"
+    assert payload["controller_checkpoint"]["token_efficiency"] == {
+        "parent_output_limit_lines": 200,
+        "compact_first": True,
+        "recommended_next_steps": list(snapshot.TOKEN_EFFICIENCY_ACTIONS),
+    }
     assert payload["claims"] == [
         {
             "issue": 2671,


### PR DESCRIPTION
## Summary
- Add token-efficiency recommendations to `autopilot_state_snapshot.py` controller checkpoints.
- Document a loaded-context cache in the token-efficient thread profile.
- Tighten goal-autopilot guidance around compaction resumes, compact snapshots, and private verbose logs.

## Token-spend review behind this PR
- Long skill/docs surfaces were reread after compaction even when the active summary already had the relevant rule.
- Broad command output entered the parent thread during queue and file discovery.
- Worker route failures and reset times were sometimes rediscovered instead of cached in the active profile.
- Delegate review needed a stricter artifact-first order to avoid raw log inspection.
- Noisy validation/CI output needed a clearer default of private artifacts plus short evidence excerpts.

## Validation
- `rtk git diff --check`
- `rtk scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/dev/test_autopilot_state_snapshot.py -q`
- `rtk scripts/dev/run_worktree_shared_venv.sh -- python -m ruff check scripts/dev/autopilot_state_snapshot.py tests/dev/test_autopilot_state_snapshot.py`
- `rtk scripts/dev/run_worktree_shared_venv.sh -- python -m ruff format --check scripts/dev/autopilot_state_snapshot.py tests/dev/test_autopilot_state_snapshot.py`

## Downstream Propagation
NA - workflow guidance and compact snapshot metadata only; no benchmark, model, schema, or artifact contract changed.

## Research Result Guidance
NA - no research claim or benchmark result is introduced.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**: Enhanced guidance for token-efficient AI operations, including best practices for context caching, profile management strategies, and minimizing documentation re-reads.
* **New Features**: Introduced context caching and comprehensive token efficiency tracking with optimization recommendations, output limits, and visibility into system resource usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->