### PR TITLE
benchmark: expose social mini-game controls

### DIFF
--- a/configs/scenarios/sets/issue_3279_social_mini_game_families_v0.yaml
+++ b/configs/scenarios/sets/issue_3279_social_mini_game_families_v0.yaml
@@ -19,10 +19,12 @@
 #   blind_corner     -> blind_corner_occlusion_exposure   (obstacle=maze,       flow=uni)
 #   crowded_traffic  -> crowded_traffic_merge_negotiation  (obstacle=open,      flow=merge, density=high)
 #
-# Not yet exposed as first-class generator parameters (tracked follow-up, #3279):
-#   width_m, occlusion_geometry, start_timing_s, yielding_pressure. The current
-#   generator vocabulary (density/flow/obstacle/groups/speed_var/goal_topology/
-#   robot_context) is mapped to the closest mechanism trigger per family above.
+# Issue #3423 control exposure:
+#   Each family declares metadata.social_mini_game_controls for width_m,
+#   occlusion_geometry, start_timing_s, and yielding_pressure. The current
+#   generated-scenario schema still consumes density/flow/obstacle/groups/
+#   speed_var/goal_topology/robot_context; the control block records the
+#   documented equivalent used for mechanism traceability.
 #
 # Canonical diagnostic smoke command (one baseline-safe planner, one row per family):
 #   python scripts/demo/run_robot_sf_smoke.py \
@@ -45,12 +47,29 @@
     mechanism_aware_suite_id: doorway_bottleneck_negotiation
     target_mechanism: local_bottleneck_or_doorway_coordination
     issue: 3279
+    control_exposure_issue: 3423
     evidence_tier: diagnostic_smoke
     claim_boundary: >
       Proposal-tier Social Mini-Game scenario family; diagnostic smoke input only,
       not planner-ranking or benchmark-strength mechanism evidence.
     generator_param_mapping: "obstacle=bottleneck (doorway), flow=bi (converging streams)"
-    unexposed_parameters: [width_m, occlusion_geometry, start_timing_s, yielding_pressure]
+    social_mini_game_controls:
+      width_m:
+        value_m: 1.4
+        support: documented_equivalent
+        equivalent: "narrow passage implied by obstacle=bottleneck"
+      occlusion_geometry:
+        value: doorway_bottleneck
+        support: documented_equivalent
+        equivalent: "bottleneck obstacle geometry constrains visibility and passing width"
+      start_timing_s:
+        value_s: 0.0
+        support: fixed_seed_equivalent
+        equivalent: "seeded generated initial state; no delayed actor spawn"
+      yielding_pressure:
+        level: medium
+        support: documented_equivalent
+        equivalent: "bidirectional flow through a narrow bottleneck"
 
 - id: smg_hallway_v0
   density: med
@@ -67,12 +86,29 @@
     mechanism_aware_suite_id: hallway_bidirectional_passing
     target_mechanism: bidirectional_corridor_passing
     issue: 3279
+    control_exposure_issue: 3423
     evidence_tier: diagnostic_smoke
     claim_boundary: >
       Proposal-tier Social Mini-Game scenario family; diagnostic smoke input only,
       not planner-ranking or benchmark-strength mechanism evidence.
     generator_param_mapping: "obstacle=open, flow=bi (opposing corridor streams)"
-    unexposed_parameters: [width_m, occlusion_geometry, start_timing_s, yielding_pressure]
+    social_mini_game_controls:
+      width_m:
+        value_m: 2.4
+        support: documented_equivalent
+        equivalent: "open corridor width represented by obstacle=open"
+      occlusion_geometry:
+        value: none
+        support: documented_equivalent
+        equivalent: "open sightline hallway; no static occluder"
+      start_timing_s:
+        value_s: 0.0
+        support: fixed_seed_equivalent
+        equivalent: "seeded generated initial state; simultaneous opposing flow"
+      yielding_pressure:
+        level: medium
+        support: documented_equivalent
+        equivalent: "bidirectional passing pressure from flow=bi"
 
 - id: smg_intersection_v0
   density: med
@@ -89,12 +125,29 @@
     mechanism_aware_suite_id: intersection_crossing_negotiation
     target_mechanism: crossing_flow_right_of_way
     issue: 3279
+    control_exposure_issue: 3423
     evidence_tier: diagnostic_smoke
     claim_boundary: >
       Proposal-tier Social Mini-Game scenario family; diagnostic smoke input only,
       not planner-ranking or benchmark-strength mechanism evidence.
     generator_param_mapping: "obstacle=open, flow=cross (perpendicular crossing streams)"
-    unexposed_parameters: [width_m, occlusion_geometry, start_timing_s, yielding_pressure]
+    social_mini_game_controls:
+      width_m:
+        value_m: 2.8
+        support: documented_equivalent
+        equivalent: "open crossing area represented by obstacle=open"
+      occlusion_geometry:
+        value: none
+        support: documented_equivalent
+        equivalent: "open intersection; no static occluder"
+      start_timing_s:
+        value_s: 0.0
+        support: fixed_seed_equivalent
+        equivalent: "seeded generated initial state; crossing flow starts together"
+      yielding_pressure:
+        level: high
+        support: documented_equivalent
+        equivalent: "perpendicular right-of-way pressure from flow=cross"
 
 - id: smg_blind_corner_v0
   density: low
@@ -111,12 +164,29 @@
     mechanism_aware_suite_id: blind_corner_occlusion_exposure
     target_mechanism: occluded_emergence_exposure
     issue: 3279
+    control_exposure_issue: 3423
     evidence_tier: diagnostic_smoke
     claim_boundary: >
       Proposal-tier Social Mini-Game scenario family; diagnostic smoke input only,
       not planner-ranking or benchmark-strength mechanism evidence.
-    generator_param_mapping: "obstacle=maze (L-corner occlusion proxy), flow=uni"
-    unexposed_parameters: [width_m, occlusion_geometry, start_timing_s, yielding_pressure]
+    generator_param_mapping: "obstacle=maze (generated L-corner / blind-corner equivalent), flow=uni"
+    social_mini_game_controls:
+      width_m:
+        value_m: 1.6
+        support: documented_equivalent
+        equivalent: "narrow L-corner corridor represented by obstacle=maze"
+      occlusion_geometry:
+        value: l_corner_blind_corner
+        support: documented_equivalent
+        equivalent: "generated maze obstacle documented as the L-corner / blind-corner equivalent"
+      start_timing_s:
+        value_s: 0.0
+        support: fixed_seed_equivalent
+        equivalent: "seeded generated initial state; emerging actor timing is geometric, not delayed spawn"
+      yielding_pressure:
+        level: medium
+        support: documented_equivalent
+        equivalent: "single-direction blind-corner exposure with robot_context=ahead"
 
 - id: smg_crowded_traffic_v0
   density: high
@@ -133,9 +203,26 @@
     mechanism_aware_suite_id: crowded_traffic_merge_negotiation
     target_mechanism: dense_merge_negotiation
     issue: 3279
+    control_exposure_issue: 3423
     evidence_tier: diagnostic_smoke
     claim_boundary: >
       Proposal-tier Social Mini-Game scenario family; diagnostic smoke input only,
       not planner-ranking or benchmark-strength mechanism evidence.
     generator_param_mapping: "density=high, flow=merge (converging crowd), groups=0.2"
-    unexposed_parameters: [width_m, occlusion_geometry, start_timing_s, yielding_pressure]
+    social_mini_game_controls:
+      width_m:
+        value_m: 3.0
+        support: documented_equivalent
+        equivalent: "open merge area represented by obstacle=open"
+      occlusion_geometry:
+        value: none
+        support: documented_equivalent
+        equivalent: "crowd pressure scenario without static occluder"
+      start_timing_s:
+        value_s: 0.0
+        support: fixed_seed_equivalent
+        equivalent: "seeded generated initial state; merge pressure begins at episode start"
+      yielding_pressure:
+        level: high
+        support: documented_equivalent
+        equivalent: "density=high, flow=merge, groups=0.2"

--- a/docs/context/issue_3279_social_mini_game_families.md
+++ b/docs/context/issue_3279_social_mini_game_families.md
@@ -13,30 +13,45 @@ the research report, implemented as *parameterized generated* scenarios on the e
 
 Each family entry is a deterministic fixture (fixed `id` + `seeds: [3279]`) **and** a
 parameterized generator path (consumed by `generate_scenario`); the manifest records a
-mechanism label and the parameter values in `metadata`.
+mechanism label, the generator parameters, and the Issue #3423
+`metadata.social_mini_game_controls` block in `metadata`.
 
 ## Covered mechanisms (this cut)
 
-| Family | mechanism_aware_suite_id | Generator mapping |
-| --- | --- | --- |
-| doorway | `doorway_bottleneck_negotiation` | `obstacle=bottleneck`, `flow=bi` |
-| hallway | `hallway_bidirectional_passing` | `obstacle=open`, `flow=bi` |
-| intersection | `intersection_crossing_negotiation` | `obstacle=open`, `flow=cross` |
-| blind_corner | `blind_corner_occlusion_exposure` | `obstacle=maze`, `flow=uni` |
-| crowded_traffic | `crowded_traffic_merge_negotiation` | `density=high`, `flow=merge`, `groups=0.2` |
+| Family | mechanism_aware_suite_id | Generator mapping | Issue #3423 controls |
+| --- | --- | --- | --- |
+| doorway | `doorway_bottleneck_negotiation` | `obstacle=bottleneck`, `flow=bi` | narrow `width_m`, doorway-bottleneck `occlusion_geometry`, fixed-seed `start_timing_s`, medium `yielding_pressure` |
+| hallway | `hallway_bidirectional_passing` | `obstacle=open`, `flow=bi` | open-corridor `width_m`, no static `occlusion_geometry`, fixed-seed `start_timing_s`, medium `yielding_pressure` |
+| intersection | `intersection_crossing_negotiation` | `obstacle=open`, `flow=cross` | open-crossing `width_m`, no static `occlusion_geometry`, fixed-seed `start_timing_s`, high `yielding_pressure` |
+| blind_corner | `blind_corner_occlusion_exposure` | `obstacle=maze`, `flow=uni` | narrow L-corner `width_m`, documented `l_corner_blind_corner` `occlusion_geometry`, fixed-seed `start_timing_s`, medium `yielding_pressure` |
+| crowded_traffic | `crowded_traffic_merge_negotiation` | `density=high`, `flow=merge`, `groups=0.2` | open-merge `width_m`, no static `occlusion_geometry`, fixed-seed `start_timing_s`, high `yielding_pressure` |
 
-## Not yet covered (follow-up under #3279)
+## Issue #3423 Control Exposure
 
-- **First-class parameter exposure** for `width_m`, `occlusion_geometry`, `start_timing_s`,
-  and `yielding_pressure`. The current generator vocabulary
-  (`density`/`flow`/`obstacle`/`groups`/`speed_var`/`goal_topology`/`robot_context`) only
-  *approximates* these triggers; extending the generator schema is deferred.
+The manifest now exposes `width_m`, `occlusion_geometry`, `start_timing_s`, and
+`yielding_pressure` as first-class Social Mini-Game metadata under
+`metadata.social_mini_game_controls`. These controls are documented equivalents
+for the existing generated-scenario vocabulary
+(`density`/`flow`/`obstacle`/`groups`/`speed_var`/`goal_topology`/`robot_context`),
+not a new generator engine or behavioral certification layer.
+
+`blind_corner` no longer relies on an unnamed coarse proxy: its control metadata
+declares `occlusion_geometry: l_corner_blind_corner`, and the test suite checks
+that the generated `maze` obstacle path contains both vertical and horizontal
+occluder segments suitable for the documented L-corner / blind-corner
+equivalent.
+
+## Still Not Covered
+
+- **Parameterized generator semantics.** The Issue #3423 controls are manifest-level documented
+  equivalents. The lower-level generator still consumes the existing vocabulary, so changing
+  `width_m`, delayed actor starts, or continuous yielding-pressure dynamics remains future work.
 - **Planner smoke scope.** The v0 family set now has an executable diagnostic smoke against the
   baseline-safe `simple_policy` planner. This proves the benchmark runner can emit one episode
   record per family; it is still not planner-ranking or benchmark-strength mechanism evidence.
   Broader planner comparisons remain out of scope for this note.
-- **L-corner geometry fidelity.** `blind_corner` uses the coarse `maze` obstacle layout as an
-  occlusion proxy; a dedicated L-corner geometry is a follow-up.
+- **Geometry fidelity.** The blind-corner row is an explicit generated L-corner equivalent, not a
+  calibrated reproduction of a real built environment or the Francis 2023 map.
 
 ## Claim boundary
 
@@ -45,6 +60,12 @@ behavior; nothing here is planner-ranking, transfer, or benchmark-strength mecha
 
 ## Validation runs (2026-06-22)
 
-- `uv run pytest tests/benchmark/test_social_mini_game_families_issue_3279.py -q` → 5 passed
+- `uv run pytest tests/benchmark/test_social_mini_game_families_issue_3279.py -q` → 8 passed
 - `uv run python -c "import robot_sf.benchmark.scenario_generator"` → import OK
 - `python scripts/demo/run_robot_sf_smoke.py --matrix configs/scenarios/sets/issue_3279_social_mini_game_families_v0.yaml --planners simple_policy --horizon 30 --workers 1 --output-root output/benchmarks/issue_3279_social_mini_game_smoke` → passed, 5 episode records
+
+## Validation runs (2026-06-22, Issue #3423 update)
+
+- `uv run pytest tests/benchmark/test_social_mini_game_families_issue_3279.py -q`
+  validates the control metadata, blind-corner L-corner equivalent, deterministic generation, and
+  one-episode-per-family `simple_policy` smoke.

--- a/docs/context/issue_3279_social_mini_game_families.md
+++ b/docs/context/issue_3279_social_mini_game_families.md
@@ -64,7 +64,7 @@ behavior; nothing here is planner-ranking, transfer, or benchmark-strength mecha
 - `uv run python -c "import robot_sf.benchmark.scenario_generator"` → import OK
 - `python scripts/demo/run_robot_sf_smoke.py --matrix configs/scenarios/sets/issue_3279_social_mini_game_families_v0.yaml --planners simple_policy --horizon 30 --workers 1 --output-root output/benchmarks/issue_3279_social_mini_game_smoke` → passed, 5 episode records
 
-## Validation runs (2026-06-22, Issue #3423 update)
+## Validation Runs (2026-06-22, Issue #3423 Update)
 
 - `uv run pytest tests/benchmark/test_social_mini_game_families_issue_3279.py -q`
   validates the control metadata, blind-corner L-corner equivalent, deterministic generation, and

--- a/tests/benchmark/test_social_mini_game_families_issue_3279.py
+++ b/tests/benchmark/test_social_mini_game_families_issue_3279.py
@@ -120,10 +120,10 @@ def test_blind_corner_declares_l_corner_equivalent_and_generates_obstacles() -> 
 
     generated = generate_scenario(blind, blind["seeds"][0])
     vertical_segments = [
-        obstacle for obstacle in generated.obstacles if obstacle[0] == obstacle[2]
+        obstacle for obstacle in generated.obstacles if np.isclose(obstacle[0], obstacle[2])
     ]
     horizontal_segments = [
-        obstacle for obstacle in generated.obstacles if obstacle[1] == obstacle[3]
+        obstacle for obstacle in generated.obstacles if np.isclose(obstacle[1], obstacle[3])
     ]
     assert vertical_segments, "blind-corner equivalent should include vertical occluder geometry"
     assert horizontal_segments, "blind-corner equivalent should include horizontal occluder geometry"

--- a/tests/benchmark/test_social_mini_game_families_issue_3279.py
+++ b/tests/benchmark/test_social_mini_game_families_issue_3279.py
@@ -31,6 +31,12 @@ _EXPECTED_FAMILIES = {
     "blind_corner",
     "crowded_traffic",
 }
+_EXPECTED_CONTROL_KEYS = {
+    "width_m",
+    "occlusion_geometry",
+    "start_timing_s",
+    "yielding_pressure",
+}
 
 
 def _load_families() -> list[dict]:
@@ -64,6 +70,63 @@ def test_each_family_uses_distinct_generator_parameters() -> None:
     scenarios = _load_families()
     combos = [(s["flow"], s["obstacle"], s["density"]) for s in scenarios]
     assert len(combos) == len(set(combos)), f"families must use distinct param combos: {combos}"
+
+
+def test_each_family_exposes_social_mini_game_controls() -> None:
+    """Issue #3423 controls must be visible as first-class manifest metadata."""
+    scenarios = _load_families()
+    for scenario in scenarios:
+        metadata = scenario["metadata"]
+        assert "unexposed_parameters" not in metadata
+        assert int(metadata["control_exposure_issue"]) == 3423
+
+        controls = metadata["social_mini_game_controls"]
+        assert set(controls) == _EXPECTED_CONTROL_KEYS
+
+        width = controls["width_m"]
+        assert width["support"] == "documented_equivalent"
+        assert width["value_m"] > 0.0
+        assert width["equivalent"]
+
+        occlusion = controls["occlusion_geometry"]
+        assert occlusion["support"] == "documented_equivalent"
+        assert occlusion["value"] in {
+            "doorway_bottleneck",
+            "none",
+            "l_corner_blind_corner",
+        }
+        assert occlusion["equivalent"]
+
+        timing = controls["start_timing_s"]
+        assert timing["support"] == "fixed_seed_equivalent"
+        assert timing["value_s"] >= 0.0
+        assert "seed" in timing["equivalent"].lower()
+
+        yielding = controls["yielding_pressure"]
+        assert yielding["support"] == "documented_equivalent"
+        assert yielding["level"] in {"medium", "high"}
+        assert yielding["equivalent"]
+
+
+def test_blind_corner_declares_l_corner_equivalent_and_generates_obstacles() -> None:
+    """The blind-corner family should no longer be only a vague maze proxy."""
+    scenarios = _load_families()
+    blind = next(scenario for scenario in scenarios if scenario["id"] == "smg_blind_corner_v0")
+
+    controls = blind["metadata"]["social_mini_game_controls"]
+    assert controls["occlusion_geometry"]["value"] == "l_corner_blind_corner"
+    assert "l-corner" in controls["occlusion_geometry"]["equivalent"].lower()
+    assert "L-corner" in blind["metadata"]["generator_param_mapping"]
+
+    generated = generate_scenario(blind, blind["seeds"][0])
+    vertical_segments = [
+        obstacle for obstacle in generated.obstacles if obstacle[0] == obstacle[2]
+    ]
+    horizontal_segments = [
+        obstacle for obstacle in generated.obstacles if obstacle[1] == obstacle[3]
+    ]
+    assert vertical_segments, "blind-corner equivalent should include vertical occluder geometry"
+    assert horizontal_segments, "blind-corner equivalent should include horizontal occluder geometry"
 
 
 def test_each_family_generates_a_deterministic_runnable_scenario() -> None:


### PR DESCRIPTION
## Summary
- Exposes Issue #3423 Social Mini-Game controls in the existing #3279 scenario manifest via `metadata.social_mini_game_controls` for `width_m`, `occlusion_geometry`, `start_timing_s`, and `yielding_pressure`.
- Replaces the old `unexposed_parameters` marker with explicit documented equivalents, including a blind-corner `l_corner_blind_corner` control tied to the generated maze/L-corner obstacle path.
- Extends the Social Mini-Game test suite and context note while preserving the diagnostic-only claim boundary.

## Claim boundary
This is manifest-level control exposure plus tests. It does not add a new generator engine, continuous yielding-pressure dynamics, delayed actor spawning, planner ranking evidence, or benchmark-strength mechanism evidence.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_social_mini_game_families_issue_3279.py -q` -> 8 passed
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- python -c "import robot_sf.benchmark.scenario_generator"`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check tests/benchmark/test_social_mini_game_families_issue_3279.py`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/dev/run_compact_validation.py -- bash scripts/dev/check_docs_proof_consistency_diff.sh`

## Downstream Propagation
- Parent issue/context surface: updates `docs/context/issue_3279_social_mini_game_families.md`.
- Benchmark report/leaderboard: NA; diagnostic scenario inputs only.
- Registry/config index: NA; existing manifest path unchanged.
- Follow-up issue: stronger generator semantics for mutable `width_m`, delayed starts, and continuous yielding pressure remain future work if needed.

## Research Result Guidance
- Target claim/hypothesis/blocker: #3423 control traceability for Social Mini-Game scenario inputs.
- Comparator/baseline: previous #3279 manifest with `unexposed_parameters` and coarse blind-corner proxy wording.
- Evidence tier: proposal / diagnostic-smoke.
- Result classification: control metadata and tests landed; not benchmark evidence.
- Decision/stop rule: accept when schema-valid manifest exposes all four controls, tests cover controls and blind-corner equivalent, and simple_policy smoke still emits one episode per family.
- Synthesis surface/update target: `docs/context/issue_3279_social_mini_game_families.md`.

Closes #3423.
