### PR TITLE
docs: tighten token workflow phase audits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,10 @@ bundle, and runs the selected validation before accepting, rerouting, or rejecti
 At each autonomous phase boundary, run the profile's `Phase Audit` checklist before opening another
 batch: reuse recorded usage and route-cache facts, check issue/PR freshness before editing,
 prefer filtered worktree/status snapshots, bound CI polling output, and hand off instead of starting
-new work when usage is close to the stop guard.
+new work when usage is close to the stop guard. The audit must also identify the largest
+parent-thread outputs since the previous phase, including broad searches, full skill or doc rereads,
+raw validation logs, and verbose delegate notifications. Convert repeated leaks into a compact
+ledger field, route-cache entry, or worker prompt constraint before the next batch.
 
 ## Shared Knowledge Graph
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -522,6 +522,26 @@ Manifest-driven decisions remain dry-run and mutation-free. Complete artifacts c
 artifacts, failed validation text, stale expected heads, risky manifest paths, and draft PRs stay
 reroute/stop signals instead of task acceptance.
 
+For phase-end token audits, record one compact route-efficiency row before
+starting another delegated batch:
+
+- latest Codex usage snapshot and whether it is close to the user-defined stop
+  guard;
+- largest parent-thread outputs since the previous audit, such as broad
+  multi-directory `rg` results, full skill rereads, raw validation output, raw
+  GitHub JSON, or verbose delegate final messages;
+- cache hits and misses for loaded skills, issue or PR snapshots, route quota
+  facts, CI monitor commands, and validation artifacts;
+- accepted, rejected, rerouted, and skipped delegates, with the reason the route
+  was or was not cheaper than direct Codex work;
+- next route change, such as using `rg --files | rg <pattern>` before content
+  search, requiring smaller app-agent final messages, or reusing a recorded
+  quota reset instead of retrying the same blocked route.
+
+Keep the row in the active ledger or a common-Git-dir self-review note. Promote
+it into durable docs only when the same leak repeats, the leak was expensive, or
+the user explicitly asks for workflow improvements.
+
 For historical route audits, add `--dashboard` and pass multiple routed-worker
 manifest files. Dashboard mode emits `route_efficiency_dashboard.v1` JSON or
 Markdown with overall metrics, per-manifest breakdowns, provider trends,

--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -22,6 +22,7 @@ changes.
 - output_budget: [parent-thread summary length and exact artifact paths to return]
 - stop_guard: [usage threshold, wall-clock limit, or external blocker]
 - validation_plan: [commands or checks that prove this task class]
+- phase_audit_record: [latest compact token-spend review, route changes, and reusable lesson path]
 - handoff_target: [PR, issue comment, context note, or final handoff]
 ```
 
@@ -58,6 +59,10 @@ changes.
   the failure itself needs a short excerpt.
 - `stop_guard` is binding for autonomous loops. When a usage threshold fires,
   record the pause in the common Git dir and avoid starting a fresh batch.
+- `phase_audit_record` keeps the token-spend review outside the parent thread.
+  Record the latest usage snapshot, reused context cache, skipped broad reads,
+  accepted or rejected delegates, and any candidate lesson note. Link the
+  common-Git-dir artifact instead of pasting raw route logs.
 
 ## Phase Audit
 
@@ -65,10 +70,17 @@ At each phase boundary, review the active thread for token leaks before starting
 new work. Keep the audit to one compact paragraph or checklist, and patch the
 workflow only when the savings are reusable.
 
+- Start from the current `resume_checkpoint`, `loaded_context_cache`, and
+  `phase_audit_record`. Reread long skills, issue bodies, PR snapshots, or
+  context notes only when their recorded freshness key changed.
 - Run one usage check per phase, record the reset window, and reuse it until a
   cooldown, direct user request, or new phase makes it stale.
 - Refresh the issue or PR head SHA before implementation and before review
   repair so closed, merged, or superseded work is detected before editing.
+- Treat parent-thread search output as a budgeted surface. Prefer file-name
+  discovery (`rg --files | rg <focused-pattern>`), `rg -l`, and bounded
+  `sed -n` ranges; redirect broad `rg -n` or multi-directory searches to a
+  private artifact and report only paths plus the decision-relevant excerpt.
 - Use filtered status helpers for local state:
   `uv run python scripts/dev/worktree_hygiene_snapshot.py --repo-status --filter <branch> --json`
   for branch cleanup, and raw `git worktree list --porcelain` only when the
@@ -82,8 +94,32 @@ workflow only when the savings are reusable.
 - Require delegated workers to return only files inspected, files changed,
   validation, blockers, and recommendation. Ask for raw logs only after the
   parent identifies a specific uncertainty.
+- Reject or reroute worker output that lacks compact artifacts before reading
+  full logs. Accept sparse or app-agent-only output only after parent-owned diff
+  review and validation prove the result independently.
+- After every accepted, rejected, or rerouted delegate, append a one-paragraph
+  self-review note when the route created reusable evidence about output size,
+  artifact quality, quota pressure, or validation cost.
 - When usage is close to the stop guard, finish the active PR or blocker record,
   then hand off instead of opening a fresh batch.
+
+## Token-Spend Review
+
+Use this compact review before creating workflow-improvement PRs or continuing a
+long goal near a usage guard:
+
+- `usage`: latest primary and secondary remaining percentages, reset times, and
+  whether the stop guard is close.
+- `largest_parent_outputs`: broad commands, full skill reads, raw logs, or
+  verbose delegate messages that entered the parent thread.
+- `delegation_economics`: delegates accepted, rejected, rerouted, or skipped,
+  plus whether reviewing them was cheaper than direct Codex work.
+- `cache_hits`: skills, docs, snapshots, issue state, route facts, and usage
+  readings reused instead of reread.
+- `cache_misses`: repeated reads or rediscovery that should become ledger
+  fields, route-cache entries, or worker prompt constraints.
+- `next_savings`: three to ten concrete changes, each phrased as a rule that
+  prevents a repeated token leak and names the evidence that triggered it.
 
 ## Delegated Worker Artifact Contract
 


### PR DESCRIPTION
## Summary

- Review this thread's Codex token spend and convert the reusable lessons into phase-audit guidance.
- Add `phase_audit_record` and a compact `Token-Spend Review` checklist to the token-efficient active-thread profile.
- Require future autonomous phase audits to identify the largest parent-thread outputs and convert repeated leaks into ledger fields, route-cache entries, or worker prompt constraints.

## Token-Spend Review

Observed in this thread:

- Good: work stayed in a dedicated worktree, used `rtk`, used usage snapshots, and kept the change docs-only.
- Good: the final patch is small and validation used compact commands.
- Needs improvement: full skill rereads and broad parent-thread searches still consumed avoidable context.
- Needs improvement: a broad `rg` over docs/scripts and an ad hoc line-length probe both produced large parent output.
- Needs improvement: phase-end self-review needed a more explicit destination and checklist.

Promoted improvements:

1. Reuse `resume_checkpoint`, `loaded_context_cache`, and `phase_audit_record` before rereading long skills or snapshots.
2. Treat parent-thread search output as a budgeted surface and prefer file-name discovery, `rg -l`, and bounded excerpts.
3. Record largest parent outputs at every autonomous phase boundary.
4. Record cache hits and misses for skills, issue/PR snapshots, route facts, CI commands, and validation artifacts.
5. Record accepted, rejected, rerouted, and skipped delegates with a delegation-economics note.
6. Reject or reroute worker output without compact artifacts before reading full logs.
7. Append one-paragraph self-review notes when delegation produces reusable route-quality evidence.
8. Finish active PR/blocker work and hand off instead of opening new batches near the usage guard.

## Validation

- `git diff --check HEAD^ HEAD` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_active_doc_examples.py` exited 0.
  - Existing diagnostics remain in `docs/dev_guide.md:341` and `examples/plotting/paper_figures/README.md:29`; this PR does not touch those lines.

## Downstream Propagation

- Updated `AGENTS.md`, `docs/dev_guide.md`, and `docs/templates/token_efficient_thread_profile.md`.
- Private self-review note recorded under the common Git dir: `.git/codex-agent-runs/notes/inbox/2026-06-22-token-workflow-savings.md`.

## Research Result Guidance

NA - workflow/documentation-only token-efficiency guidance; no benchmark, metric, model-provenance, or paper-facing claim is introduced.
