### PR TITLE
feat: extend explicit VRU prior controls

### DIFF
--- a/docs/context/issue_2524_adversarial_manifests.md
+++ b/docs/context/issue_2524_adversarial_manifests.md
@@ -136,9 +136,11 @@ JSON parsed successfully, and the context catalog consistency check passed.
 - Broad RL, diffusion, or learned-proposal expansion must also pass the Issue #2562 planner-smoke
   path and Issue #2567 quality metrics under the Issue #2568 learned-expansion gate before it is
   treated as ready.
-- `naturalistic_prior` pass/fail is an authored local plausibility screen for generated VRU speed
-  and timing controls. It separates plausible hard cases from stress-only candidates but is not a
-  real-world calibration or benchmark-strength claim.
+- `naturalistic_prior` pass/fail is an authored local plausibility screen for explicit generated
+  VRU controls: scalar speed/timing controls, plus optional explicit acceleration, group-size, and
+  cyclist-profile controls when present. It separates plausible hard cases from stress-only
+  candidates but is not a real-world calibration or benchmark-strength claim, and it does not infer
+  trajectory acceleration, density, or route-shape values from runtime state.
 
 ## Follow-Up Risks
 

--- a/docs/context/issue_3281_naturalistic_vru_priors.md
+++ b/docs/context/issue_3281_naturalistic_vru_priors.md
@@ -14,12 +14,18 @@ Generated `adversarial_scenario_manifest.v1` records now include an additive
 - `profile: urban_vru_default_v1`
 - inclusive interpretable bounds for `pedestrian_speed_mps`, `pedestrian_delay_s`, and
   `spawn_time_s`
+- optional explicit-control bounds for `pedestrian_acceleration_mps2` and `group_size` when those
+  controls are present in the generated manifest
+- cyclist-specific speed and acceleration bounds when `candidate_controls.vru_profile: cyclist`
+  selects the cyclist profile
 - `passed` plus `violation_flags`
 - per-constraint observed value and pass/fail metadata
 
-The v1 prior intentionally uses only fields already present in `CandidateSpec`. Acceleration,
-Social Force, IDM/MOBIL, group-behavior, and cyclist-specific priors are deferred until manifests
-carry those controls explicitly.
+The v1 prior intentionally uses only explicit generated controls in `CandidateSpec` and
+`candidate_controls`. Acceleration, group-size, and cyclist checks are evaluated only when those
+controls are present in the manifest. Social Force, IDM/MOBIL, trajectory-derived acceleration,
+route curvature, and density priors remain deferred because the generated manifest surface does not
+carry those values explicitly.
 
 ## Claim Boundary
 
@@ -29,6 +35,10 @@ local bounds profile only. It is not a paper-facing realism claim.
 `naturalistic_prior.passed: false` separates an intentionally unrealistic or stress-only generated
 candidate from plausible hard cases. It does not automatically make the manifest structurally
 invalid; downstream tooling can filter or report the candidate by naturalness status.
+
+`candidate_controls.vru_profile` is a profile selector, not a numeric naturalistic constraint. The
+generated-candidate schema accepts `pedestrian_acceleration_mps2` and `group_size` as numeric
+constraint fields, while profile selection is represented by the prior `profile` value.
 
 ## Quality Summary
 
@@ -53,4 +63,3 @@ uv run python -m pytest \
   tests/benchmark/test_generated_scenario_candidate_schema.py -q
 uv run python scripts/tools/summarize_adversarial_manifest_quality.py --help
 ```
-

--- a/robot_sf/adversarial/config.py
+++ b/robot_sf/adversarial/config.py
@@ -45,10 +45,13 @@ class CandidateSpec:
     pedestrian_speed_mps: float
     pedestrian_delay_s: float
     scenario_seed: int
+    pedestrian_acceleration_mps2: float | None = None
+    group_size: int | None = None
+    vru_profile: str | None = None
 
     def to_json(self) -> dict[str, Any]:
         """Return a JSON-serializable candidate payload."""
-        return {
+        payload: dict[str, Any] = {
             "start": self.start.to_json(),
             "goal": self.goal.to_json(),
             "spawn_time_s": float(self.spawn_time_s),
@@ -56,6 +59,13 @@ class CandidateSpec:
             "pedestrian_delay_s": float(self.pedestrian_delay_s),
             "scenario_seed": int(self.scenario_seed),
         }
+        if self.pedestrian_acceleration_mps2 is not None:
+            payload["pedestrian_acceleration_mps2"] = float(self.pedestrian_acceleration_mps2)
+        if self.group_size is not None:
+            payload["group_size"] = int(self.group_size)
+        if self.vru_profile is not None:
+            payload["vru_profile"] = str(self.vru_profile)
+        return payload
 
 
 @dataclass(frozen=True)

--- a/robot_sf/adversarial/manifest_quality.py
+++ b/robot_sf/adversarial/manifest_quality.py
@@ -134,6 +134,31 @@ def _same_path(left: Path, right: Path) -> bool:
         return left == right
 
 
+def _optional_candidate_controls_from_mapping(
+    controls: dict[str, Any],
+) -> tuple[float | None, int | None, str | None]:
+    """Parse optional explicit controls from a manifest candidate-controls mapping."""
+    acceleration = None
+    if "pedestrian_acceleration_mps2" in controls:
+        acceleration = _safe_float(controls.get("pedestrian_acceleration_mps2"))
+        if acceleration is None:
+            raise ValueError("candidate_controls.pedestrian_acceleration_mps2 must be finite")
+
+    group_size = None
+    if "group_size" in controls:
+        group_size = _safe_int(controls.get("group_size"))
+        if group_size is None:
+            raise ValueError("candidate_controls.group_size must be an integer")
+
+    vru_profile = None
+    if "vru_profile" in controls:
+        raw_profile = controls.get("vru_profile")
+        if not isinstance(raw_profile, str) or not raw_profile.strip():
+            raise ValueError("candidate_controls.vru_profile must be a non-empty string")
+        vru_profile = raw_profile.strip()
+    return acceleration, group_size, vru_profile
+
+
 def _candidate_from_controls(controls: Any) -> CandidateSpec:
     """Build a deterministic candidate from controls mapping."""
     if not isinstance(controls, dict):
@@ -158,6 +183,7 @@ def _candidate_from_controls(controls: Any) -> CandidateSpec:
             "candidate_controls must include finite spawn_time_s/pedestrian_speed_mps/"
             "pedestrian_delay_s and integer scenario_seed"
         )
+    acceleration, group_size, vru_profile = _optional_candidate_controls_from_mapping(controls)
     return CandidateSpec(
         start=Pose2D(start_x, start_y),
         goal=Pose2D(goal_x, goal_y),
@@ -165,6 +191,9 @@ def _candidate_from_controls(controls: Any) -> CandidateSpec:
         pedestrian_speed_mps=speed,
         pedestrian_delay_s=delay,
         scenario_seed=seed,
+        pedestrian_acceleration_mps2=acceleration,
+        group_size=group_size,
+        vru_profile=vru_profile,
     )
 
 

--- a/robot_sf/adversarial/scenario_manifest.py
+++ b/robot_sf/adversarial/scenario_manifest.py
@@ -22,6 +22,7 @@ EVIDENCE_TIER = "diagnostic-only"
 DENOMINATOR_POLICY = "generated_candidates_not_benchmark_denominator"
 NATURALISTIC_PRIOR_SCHEMA_VERSION = "naturalistic_vru_prior.v1"
 DEFAULT_NATURALISTIC_PRIOR_PROFILE = "urban_vru_default_v1"
+CYCLIST_NATURALISTIC_PRIOR_PROFILE = "urban_cyclist_vru_default_v1"
 
 _DEFAULT_NATURALISTIC_PRIOR_BOUNDS: dict[str, tuple[float, float, str]] = {
     "pedestrian_speed_mps": (
@@ -38,6 +39,30 @@ _DEFAULT_NATURALISTIC_PRIOR_BOUNDS: dict[str, tuple[float, float, str]] = {
         0.0,
         10.0,
         "bounded scenario-entry timing for generated stress candidates",
+    ),
+}
+_OPTIONAL_NATURALISTIC_PRIOR_BOUNDS: dict[str, tuple[float, float, str]] = {
+    "pedestrian_acceleration_mps2": (
+        0.0,
+        3.0,
+        "bounded explicit VRU acceleration control for plausible hard cases",
+    ),
+    "group_size": (
+        1.0,
+        4.0,
+        "bounded explicit VRU group-size control for small-group interaction cases",
+    ),
+}
+_CYCLIST_NATURALISTIC_PRIOR_BOUNDS: dict[str, tuple[float, float, str]] = {
+    "pedestrian_speed_mps": (
+        2.0,
+        8.0,
+        "bounded cyclist-like VRU speed for plausible hard cases",
+    ),
+    "pedestrian_acceleration_mps2": (
+        0.0,
+        4.0,
+        "bounded cyclist-like VRU acceleration control for plausible hard cases",
     ),
 }
 
@@ -275,19 +300,37 @@ def _require_mapping_fields(
 def evaluate_naturalistic_prior(candidate: CandidateSpec) -> NaturalisticPriorRecord:
     """Evaluate the default interpretable VRU naturalness prior for a candidate.
 
-    The v1 adversarial manifest only encodes scalar speed and timing controls, so the default
-    profile intentionally starts there. Trajectory acceleration priors stay out of this function
-    until generated manifests carry time-indexed trajectory controls.
+    Optional acceleration, group, and cyclist-specific checks are evaluated only when those controls
+    are explicitly present in the generated manifest surface. No runtime trajectory state is inferred.
     """
     observed_values = {
         "pedestrian_speed_mps": candidate.pedestrian_speed_mps,
         "pedestrian_delay_s": candidate.pedestrian_delay_s,
         "spawn_time_s": candidate.spawn_time_s,
     }
+    bounds = dict(_DEFAULT_NATURALISTIC_PRIOR_BOUNDS)
+    profile = DEFAULT_NATURALISTIC_PRIOR_PROFILE
+    vru_profile = (
+        str(candidate.vru_profile).strip().lower() if candidate.vru_profile is not None else ""
+    )
+    if vru_profile == "cyclist":
+        bounds.update(_CYCLIST_NATURALISTIC_PRIOR_BOUNDS)
+        profile = CYCLIST_NATURALISTIC_PRIOR_PROFILE
+    if candidate.pedestrian_acceleration_mps2 is not None:
+        observed_values["pedestrian_acceleration_mps2"] = candidate.pedestrian_acceleration_mps2
+        bounds.setdefault(
+            "pedestrian_acceleration_mps2",
+            _OPTIONAL_NATURALISTIC_PRIOR_BOUNDS["pedestrian_acceleration_mps2"],
+        )
+    if candidate.group_size is not None:
+        observed_values["group_size"] = float(candidate.group_size)
+        bounds["group_size"] = _OPTIONAL_NATURALISTIC_PRIOR_BOUNDS["group_size"]
     constraints: list[dict[str, Any]] = []
     violation_flags: list[str] = []
 
-    for field, (min_value, max_value, description) in _DEFAULT_NATURALISTIC_PRIOR_BOUNDS.items():
+    for field, (min_value, max_value, description) in bounds.items():
+        if field not in observed_values:
+            continue
         observed = float(observed_values[field])
         passed = math.isfinite(observed) and min_value <= observed <= max_value
         constraints.append(
@@ -301,9 +344,10 @@ def evaluate_naturalistic_prior(candidate: CandidateSpec) -> NaturalisticPriorRe
             }
         )
         if not passed:
-            violation_flags.append(f"{field}_outside_{DEFAULT_NATURALISTIC_PRIOR_PROFILE}")
+            violation_flags.append(f"{field}_outside_{profile}")
 
     return NaturalisticPriorRecord(
+        profile=profile,
         constraints=tuple(constraints),
         passed=not violation_flags,
         violation_flags=tuple(violation_flags),
@@ -390,12 +434,24 @@ def compute_control_hash(candidate: CandidateSpec, precision: int = 6) -> str:
         round(float(candidate.pedestrian_delay_s), precision) + 0.0,
         int(candidate.scenario_seed),
     )
-    raw = json.dumps(values, sort_keys=True, ensure_ascii=False)
+    optional_values: list[Any] = []
+    if candidate.pedestrian_acceleration_mps2 is not None:
+        optional_values.append(
+            (
+                "pedestrian_acceleration_mps2",
+                round(float(candidate.pedestrian_acceleration_mps2), precision) + 0.0,
+            )
+        )
+    if candidate.group_size is not None:
+        optional_values.append(("group_size", int(candidate.group_size)))
+    if candidate.vru_profile is not None:
+        optional_values.append(("vru_profile", str(candidate.vru_profile).strip().lower()))
+    raw = json.dumps((*values, *optional_values), sort_keys=True, ensure_ascii=False)
     return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
 
 def _candidate_controls_dict(candidate: CandidateSpec) -> dict[str, Any]:
-    return {
+    controls: dict[str, Any] = {
         "start": {"x": float(candidate.start.x), "y": float(candidate.start.y)},
         "goal": {"x": float(candidate.goal.x), "y": float(candidate.goal.y)},
         "spawn_time_s": float(candidate.spawn_time_s),
@@ -403,6 +459,13 @@ def _candidate_controls_dict(candidate: CandidateSpec) -> dict[str, Any]:
         "pedestrian_delay_s": float(candidate.pedestrian_delay_s),
         "scenario_seed": int(candidate.scenario_seed),
     }
+    if candidate.pedestrian_acceleration_mps2 is not None:
+        controls["pedestrian_acceleration_mps2"] = float(candidate.pedestrian_acceleration_mps2)
+    if candidate.group_size is not None:
+        controls["group_size"] = int(candidate.group_size)
+    if candidate.vru_profile is not None:
+        controls["vru_profile"] = str(candidate.vru_profile)
+    return controls
 
 
 def _candidate_from_controls(controls: dict[str, Any]) -> CandidateSpec:
@@ -426,6 +489,12 @@ def _candidate_from_controls(controls: dict[str, Any]) -> CandidateSpec:
     scenario_seed_value = float(controls["scenario_seed"])
     if not scenario_seed_value.is_integer():
         raise ValueError("candidate_controls.scenario_seed must be an integer")
+    group_size: int | None = None
+    if "group_size" in controls:
+        group_size_value = float(controls["group_size"])
+        if not group_size_value.is_integer():
+            raise ValueError("candidate_controls.group_size must be an integer")
+        group_size = int(group_size_value)
     start = _pose("start")
     goal = _pose("goal")
     return CandidateSpec(
@@ -435,6 +504,13 @@ def _candidate_from_controls(controls: dict[str, Any]) -> CandidateSpec:
         pedestrian_speed_mps=_float("pedestrian_speed_mps"),
         pedestrian_delay_s=_float("pedestrian_delay_s"),
         scenario_seed=int(scenario_seed_value),
+        pedestrian_acceleration_mps2=(
+            _float("pedestrian_acceleration_mps2")
+            if "pedestrian_acceleration_mps2" in controls
+            else None
+        ),
+        group_size=group_size,
+        vru_profile=str(controls["vru_profile"]).strip() if "vru_profile" in controls else None,
     )
 
 
@@ -573,6 +649,50 @@ def validate_manifest_payload(
     )
 
 
+def _validate_candidate_without_search_space(candidate: CandidateSpec) -> list[str]:
+    """Validate intrinsic candidate invariants when no search-space config is available."""
+    errors: list[str] = []
+    values = {
+        "start.x": candidate.start.x,
+        "start.y": candidate.start.y,
+        "goal.x": candidate.goal.x,
+        "goal.y": candidate.goal.y,
+        "spawn_time_s": candidate.spawn_time_s,
+        "pedestrian_speed_mps": candidate.pedestrian_speed_mps,
+        "pedestrian_delay_s": candidate.pedestrian_delay_s,
+    }
+    for name, value in values.items():
+        if not math.isfinite(float(value)):
+            errors.append(f"{name} must be finite")
+    if candidate.spawn_time_s < 0.0:
+        errors.append("spawn_time_s must be non-negative")
+    if candidate.pedestrian_speed_mps <= 0.0:
+        errors.append("pedestrian_speed_mps must be positive")
+    if candidate.pedestrian_delay_s < 0.0:
+        errors.append("pedestrian_delay_s must be non-negative")
+    if candidate.scenario_seed < 0:
+        errors.append("scenario_seed must be non-negative")
+    errors.extend(_validate_optional_candidate_controls(candidate))
+    return errors
+
+
+def _validate_optional_candidate_controls(candidate: CandidateSpec) -> list[str]:
+    """Validate optional explicit candidate controls."""
+    errors: list[str] = []
+    if candidate.pedestrian_acceleration_mps2 is not None:
+        if not math.isfinite(float(candidate.pedestrian_acceleration_mps2)):
+            errors.append("pedestrian_acceleration_mps2 must be finite")
+        elif candidate.pedestrian_acceleration_mps2 < 0.0:
+            errors.append("pedestrian_acceleration_mps2 must be non-negative")
+    if candidate.group_size is not None and candidate.group_size < 1:
+        errors.append("group_size must be >= 1")
+    if candidate.vru_profile is not None:
+        vru_profile = str(candidate.vru_profile).strip().lower()
+        if vru_profile not in {"pedestrian", "cyclist"}:
+            errors.append("vru_profile must be pedestrian or cyclist")
+    return errors
+
+
 def validate_candidate_manifest(
     candidate: CandidateSpec,
     search_space: SearchSpaceConfig | None = None,
@@ -589,26 +709,7 @@ def validate_candidate_manifest(
     if search_space is not None:
         errors.extend(search_space.validate_candidate(candidate))
     else:
-        values = {
-            "start.x": candidate.start.x,
-            "start.y": candidate.start.y,
-            "goal.x": candidate.goal.x,
-            "goal.y": candidate.goal.y,
-            "spawn_time_s": candidate.spawn_time_s,
-            "pedestrian_speed_mps": candidate.pedestrian_speed_mps,
-            "pedestrian_delay_s": candidate.pedestrian_delay_s,
-        }
-        for name, value in values.items():
-            if not math.isfinite(float(value)):
-                errors.append(f"{name} must be finite")
-        if candidate.spawn_time_s < 0.0:
-            errors.append("spawn_time_s must be non-negative")
-        if candidate.pedestrian_speed_mps <= 0.0:
-            errors.append("pedestrian_speed_mps must be positive")
-        if candidate.pedestrian_delay_s < 0.0:
-            errors.append("pedestrian_delay_s must be non-negative")
-        if candidate.scenario_seed < 0:
-            errors.append("scenario_seed must be non-negative")
+        errors.extend(_validate_candidate_without_search_space(candidate))
 
     if existing_hashes is not None:
         control_hash = compute_control_hash(candidate)

--- a/robot_sf/benchmark/schemas/generated_scenario_candidate.v1.json
+++ b/robot_sf/benchmark/schemas/generated_scenario_candidate.v1.json
@@ -308,7 +308,9 @@
           "enum": [
             "pedestrian_speed_mps",
             "pedestrian_delay_s",
-            "spawn_time_s"
+            "spawn_time_s",
+            "pedestrian_acceleration_mps2",
+            "group_size"
           ]
         },
         "min": {

--- a/tests/adversarial/test_adversarial_manifest_quality.py
+++ b/tests/adversarial/test_adversarial_manifest_quality.py
@@ -33,8 +33,11 @@ def _candidate_controls(
     goal_x: float,
     goal_y: float,
     scenario_seed: int = 7,
+    pedestrian_acceleration_mps2: float | None = None,
+    group_size: int | None = None,
+    vru_profile: str | None = None,
 ) -> dict:
-    return {
+    controls = {
         "start": {"x": float(start_x), "y": float(start_y)},
         "goal": {"x": float(goal_x), "y": float(goal_y)},
         "spawn_time_s": 0.0,
@@ -42,6 +45,13 @@ def _candidate_controls(
         "pedestrian_delay_s": 0.0,
         "scenario_seed": scenario_seed,
     }
+    if pedestrian_acceleration_mps2 is not None:
+        controls["pedestrian_acceleration_mps2"] = pedestrian_acceleration_mps2
+    if group_size is not None:
+        controls["group_size"] = group_size
+    if vru_profile is not None:
+        controls["vru_profile"] = vru_profile
+    return controls
 
 
 def _naturalistic_prior_payload(*, passed: bool, flags: list[str] | None = None) -> dict:
@@ -76,6 +86,13 @@ def _manifest_payload(
         pedestrian_speed_mps=float(controls["pedestrian_speed_mps"]),
         pedestrian_delay_s=float(controls["pedestrian_delay_s"]),
         scenario_seed=int(controls["scenario_seed"]),
+        pedestrian_acceleration_mps2=(
+            float(controls["pedestrian_acceleration_mps2"])
+            if "pedestrian_acceleration_mps2" in controls
+            else None
+        ),
+        group_size=int(controls["group_size"]) if "group_size" in controls else None,
+        vru_profile=str(controls["vru_profile"]) if "vru_profile" in controls else None,
     )
     payload = {
         "schema_version": "adversarial_scenario_manifest.v1",
@@ -293,6 +310,27 @@ def test_summarize_naturalistic_prior_rates_and_filters(tmp_path: Path) -> None:
     assert violated.naturalistic_prior_fail_count == 1
     assert missing.manifest_count == 1
     assert missing.naturalistic_prior_unavailable_count == 1
+
+
+def test_normalized_hash_fallback_includes_optional_explicit_controls(tmp_path: Path) -> None:
+    base_controls = _candidate_controls(start_x=1.0, start_y=2.0, goal_x=5.0, goal_y=2.0)
+    optional_controls = _candidate_controls(
+        start_x=1.0,
+        start_y=2.0,
+        goal_x=5.0,
+        goal_y=2.0,
+        pedestrian_acceleration_mps2=1.0,
+        group_size=2,
+        vru_profile="cyclist",
+    )
+    _write_manifest(tmp_path / "base.yaml", base_controls, "valid")
+    _write_manifest(tmp_path / "optional.yaml", optional_controls, "valid")
+
+    result = summarize_adversarial_manifest_quality([tmp_path])
+
+    assert result.manifest_count == 2
+    assert result.unique_hash_count == 2
+    assert result.duplicate_hash_count == 0
 
 
 def test_naturalistic_status_filter_rejects_unknown_value(tmp_path: Path) -> None:

--- a/tests/adversarial/test_adversarial_scenario_manifest.py
+++ b/tests/adversarial/test_adversarial_scenario_manifest.py
@@ -130,6 +130,23 @@ def test_compute_control_hash_changes_with_fields() -> None:
     assert compute_control_hash(modified) != base_hash
 
 
+def test_compute_control_hash_includes_optional_explicit_controls() -> None:
+    base = _valid_candidate()
+    modified = CandidateSpec(
+        start=base.start,
+        goal=base.goal,
+        spawn_time_s=base.spawn_time_s,
+        pedestrian_speed_mps=base.pedestrian_speed_mps,
+        pedestrian_delay_s=base.pedestrian_delay_s,
+        scenario_seed=base.scenario_seed,
+        pedestrian_acceleration_mps2=1.0,
+        group_size=2,
+        vru_profile="cyclist",
+    )
+
+    assert compute_control_hash(modified) != compute_control_hash(base)
+
+
 def test_compute_control_hash_normalizes_signed_zero() -> None:
     positive_zero = CandidateSpec(
         start=Pose2D(0.0, 0.0),
@@ -412,6 +429,91 @@ def test_naturalistic_prior_flags_unrealistic_speed_without_invalidating_control
     )
 
 
+def test_naturalistic_prior_keeps_legacy_scalar_controls_backward_compatible() -> None:
+    candidate = _valid_candidate()
+    manifest = build_manifest(candidate, source=_source(), generator=_generator())
+
+    assert manifest.candidate_controls is not None
+    assert "pedestrian_acceleration_mps2" not in manifest.candidate_controls
+    assert "group_size" not in manifest.candidate_controls
+    assert "vru_profile" not in manifest.candidate_controls
+    assert manifest.naturalistic_prior is not None
+    assert manifest.naturalistic_prior.profile == "urban_vru_default_v1"
+    assert tuple(c["field"] for c in manifest.naturalistic_prior.constraints) == (
+        "pedestrian_speed_mps",
+        "pedestrian_delay_s",
+        "spawn_time_s",
+    )
+
+
+def test_naturalistic_prior_uses_explicit_optional_controls() -> None:
+    candidate = CandidateSpec(
+        start=Pose2D(1.0, 2.0),
+        goal=Pose2D(5.0, 2.0),
+        spawn_time_s=0.0,
+        pedestrian_speed_mps=1.0,
+        pedestrian_delay_s=0.0,
+        scenario_seed=7,
+        pedestrian_acceleration_mps2=1.5,
+        group_size=3,
+    )
+
+    manifest = build_manifest(candidate, source=_source(), generator=_generator())
+
+    assert manifest.candidate_controls is not None
+    assert manifest.candidate_controls["pedestrian_acceleration_mps2"] == 1.5
+    assert manifest.candidate_controls["group_size"] == 3
+    assert manifest.naturalistic_prior is not None
+    assert manifest.naturalistic_prior.passed is True
+    assert {c["field"] for c in manifest.naturalistic_prior.constraints} == {
+        "pedestrian_speed_mps",
+        "pedestrian_delay_s",
+        "spawn_time_s",
+        "pedestrian_acceleration_mps2",
+        "group_size",
+    }
+
+
+def test_naturalistic_prior_flags_optional_control_violations() -> None:
+    candidate = CandidateSpec(
+        start=Pose2D(1.0, 2.0),
+        goal=Pose2D(5.0, 2.0),
+        spawn_time_s=0.0,
+        pedestrian_speed_mps=1.0,
+        pedestrian_delay_s=0.0,
+        scenario_seed=7,
+        pedestrian_acceleration_mps2=5.0,
+        group_size=5,
+    )
+
+    prior = evaluate_naturalistic_prior(candidate)
+
+    assert prior.passed is False
+    assert prior.violation_flags == (
+        "pedestrian_acceleration_mps2_outside_urban_vru_default_v1",
+        "group_size_outside_urban_vru_default_v1",
+    )
+
+
+def test_naturalistic_prior_uses_cyclist_profile_for_explicit_cyclist_controls() -> None:
+    candidate = CandidateSpec(
+        start=Pose2D(1.0, 2.0),
+        goal=Pose2D(5.0, 2.0),
+        spawn_time_s=0.0,
+        pedestrian_speed_mps=4.0,
+        pedestrian_delay_s=0.0,
+        scenario_seed=7,
+        pedestrian_acceleration_mps2=3.5,
+        vru_profile="cyclist",
+    )
+
+    prior = evaluate_naturalistic_prior(candidate)
+
+    assert prior.profile == "urban_cyclist_vru_default_v1"
+    assert prior.passed is True
+    assert prior.violation_flags == ()
+
+
 def test_validate_manifest_payload_rejects_inconsistent_naturalistic_prior_metadata() -> None:
     candidate = CandidateSpec(
         start=Pose2D(1.0, 2.0),
@@ -429,6 +531,27 @@ def test_validate_manifest_payload_rejects_inconsistent_naturalistic_prior_metad
 
     assert record.status == ManifestCategory.INVALID
     assert "naturalistic_prior.passed does not match candidate controls" in record.errors
+    assert "naturalistic_prior.violation_flags do not match candidate controls" in record.errors
+
+
+def test_validate_manifest_payload_rejects_inconsistent_optional_prior_metadata() -> None:
+    candidate = CandidateSpec(
+        start=Pose2D(1.0, 2.0),
+        goal=Pose2D(5.0, 2.0),
+        spawn_time_s=0.0,
+        pedestrian_speed_mps=1.0,
+        pedestrian_delay_s=0.0,
+        scenario_seed=7,
+        pedestrian_acceleration_mps2=5.0,
+    )
+    payload = build_manifest(candidate, source=_source(), generator=_generator()).to_dict()
+    payload["naturalistic_prior"]["violation_flags"] = [
+        "pedestrian_speed_mps_outside_urban_vru_default_v1"
+    ]
+
+    record = validate_manifest_payload(payload)
+
+    assert record.status == ManifestCategory.INVALID
     assert "naturalistic_prior.violation_flags do not match candidate controls" in record.errors
 
 

--- a/tests/benchmark/test_generated_scenario_candidate_schema.py
+++ b/tests/benchmark/test_generated_scenario_candidate_schema.py
@@ -87,14 +87,18 @@ def _heuristic_candidate() -> dict:
     }
 
 
-def _naturalistic_prior(*, passed: bool = True) -> dict:
+def _naturalistic_prior(
+    *,
+    passed: bool = True,
+    field: str = "pedestrian_speed_mps",
+) -> dict:
     """Return a generated-candidate naturalistic-prior payload."""
     return {
         "schema_version": "naturalistic_vru_prior.v1",
         "profile": "urban_vru_default_v1",
         "constraints": [
             {
-                "field": "pedestrian_speed_mps",
+                "field": field,
                 "min": 0.4,
                 "max": 2.2,
                 "observed": 1.2 if passed else 3.5,
@@ -186,9 +190,15 @@ class TestHeuristicCandidate:
     def test_naturalistic_prior_rejects_unsupported_field(self) -> None:
         payload = _heuristic_candidate()
         payload["naturalistic_prior"] = _naturalistic_prior()
-        payload["naturalistic_prior"]["constraints"][0]["field"] = "acceleration_mps2"
-        with pytest.raises(jsonschema.ValidationError, match="acceleration_mps2"):
+        payload["naturalistic_prior"]["constraints"][0]["field"] = "runtime_acceleration_mps2"
+        with pytest.raises(jsonschema.ValidationError, match="runtime_acceleration_mps2"):
             jsonschema.validate(instance=payload, schema=SCHEMA)
+
+    @pytest.mark.parametrize("field", ["pedestrian_acceleration_mps2", "group_size"])
+    def test_naturalistic_prior_accepts_explicit_optional_control_fields(self, field: str) -> None:
+        payload = _heuristic_candidate()
+        payload["naturalistic_prior"] = _naturalistic_prior(field=field)
+        jsonschema.validate(instance=payload, schema=SCHEMA)
 
 
 class TestRLAdversaryCandidate:

--- a/tests/benchmark/test_social_mini_game_families_issue_3279.py
+++ b/tests/benchmark/test_social_mini_game_families_issue_3279.py
@@ -126,7 +126,9 @@ def test_blind_corner_declares_l_corner_equivalent_and_generates_obstacles() -> 
         obstacle for obstacle in generated.obstacles if np.isclose(obstacle[1], obstacle[3])
     ]
     assert vertical_segments, "blind-corner equivalent should include vertical occluder geometry"
-    assert horizontal_segments, "blind-corner equivalent should include horizontal occluder geometry"
+    assert horizontal_segments, (
+        "blind-corner equivalent should include horizontal occluder geometry"
+    )
 
 
 def test_each_family_generates_a_deterministic_runnable_scenario() -> None:


### PR DESCRIPTION
## Summary

- Extend `CandidateSpec` and adversarial manifest serialization with optional explicit VRU controls:
  `pedestrian_acceleration_mps2`, `group_size`, and `vru_profile`.
- Evaluate naturalistic-prior acceleration/group constraints only when those controls are present,
  and use a cyclist-specific prior profile when `vru_profile: cyclist` is explicit.
- Update the generated-candidate schema, quality summary hash path, tests, and context notes while
  preserving the legacy scalar speed/timing behavior.

Closes #3374.

## Claim Boundary

This remains authored plausibility metadata, not real-world calibration or benchmark-strength
evidence. The implementation does not infer acceleration, density, route curvature, or group
behavior from runtime state; it only evaluates controls explicitly present in the generated manifest
surface.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/adversarial/test_adversarial_scenario_manifest.py tests/adversarial/test_adversarial_manifest_quality.py tests/benchmark/test_generated_scenario_candidate_schema.py -q`
  - 122 passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/adversarial/config.py robot_sf/adversarial/scenario_manifest.py robot_sf/adversarial/manifest_quality.py tests/adversarial/test_adversarial_scenario_manifest.py tests/adversarial/test_adversarial_manifest_quality.py tests/benchmark/test_generated_scenario_candidate_schema.py`
  - passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/adversarial/config.py robot_sf/adversarial/scenario_manifest.py robot_sf/adversarial/manifest_quality.py tests/adversarial/test_adversarial_scenario_manifest.py tests/adversarial/test_adversarial_manifest_quality.py tests/benchmark/test_generated_scenario_candidate_schema.py`
  - passed
- `git diff --check`
  - passed
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_active_doc_examples.py`
  - exited 0; two pre-existing diagnostics remain outside this PR's touched lines
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/summarize_adversarial_manifest_quality.py --help`
  - passed

## Downstream Propagation

- Updated `docs/context/issue_3281_naturalistic_vru_priors.md` and
  `docs/context/issue_2524_adversarial_manifests.md`.
- No benchmark report, leaderboard, registry, or artifact catalog update is needed because this PR
  changes generated-manifest metadata and tests only.

## Research Result Guidance

- target claim/hypothesis/blocker: generated-manifest naturalistic-prior metadata can cover new
  explicit VRU controls without inferring runtime state.
- comparator/baseline: prior v1 scalar speed/timing-only behavior.
- evidence tier: focused unit/schema validation.
- result classification: implementation support, not benchmark evidence.
- decision/stop rule: stop once optional controls serialize, validate, hash, summarize, and preserve
  legacy behavior under focused tests.
- synthesis surface/update target: `docs/context/issue_3281_naturalistic_vru_priors.md`.
