### PR TITLE
docs: tighten implementation thread audits

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,8 +97,9 @@ batch: reuse recorded usage and route-cache facts, check issue/PR freshness befo
 prefer filtered worktree/status snapshots, bound CI polling output, and hand off instead of starting
 new work when usage is close to the stop guard. The audit must also identify the largest
 parent-thread outputs since the previous phase, including broad searches, full skill or doc rereads,
-raw validation logs, and verbose delegate notifications. Convert repeated leaks into a compact
-ledger field, route-cache entry, or worker prompt constraint before the next batch.
+raw validation logs, verbose delegate notifications, failed command families, repeated monitor
+noise, and unclear instructions that caused retries. Convert repeated leaks into a compact ledger
+field, route-cache entry, worker prompt constraint, or docs patch before the next batch.
 
 ## Shared Knowledge Graph
 

--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -361,6 +361,12 @@ payload also includes `monitor.local_stop_reason: "max_wall_seconds"`. Monitor s
 evidence only; reassess the current PR head SHA and normal readiness proof before labeling or
 merging.
 
+When CI polling repeats similar JSON in the parent thread, switch to status-change summaries and
+write the full monitor payload to the active ledger or a common-Git-dir artifact. For in-progress
+run debugging, inspect job metadata first; fetch direct job-log excerpts only for the failing or
+suspect step, and avoid `gh run view --log` dumps until the run is complete enough for that command
+to return useful output.
+
 For routine goal-autopilot orientation, prefer the compact state snapshot helper before broad parent
 thread reads:
 
@@ -530,6 +536,8 @@ starting another delegated batch:
 - largest parent-thread outputs since the previous audit, such as broad
   multi-directory `rg` results, full skill rereads, raw validation output, raw
   GitHub JSON, or verbose delegate final messages;
+- failed command patterns, confusing helper contracts, repeated monitor noise,
+  and unclear instructions that caused retries or semantic drift;
 - cache hits and misses for loaded skills, issue or PR snapshots, route quota
   facts, CI monitor commands, and validation artifacts;
 - accepted, rejected, rerouted, and skipped delegates, with the reason the route
@@ -541,6 +549,11 @@ starting another delegated batch:
 Keep the row in the active ledger or a common-Git-dir self-review note. Promote
 it into durable docs only when the same leak repeats, the leak was expensive, or
 the user explicitly asks for workflow improvements.
+
+For implementation-thread reviews over a recent time window, do not reopen the full transcript in
+the parent thread. Generate a bounded session-summary artifact that records the time window, record
+counts, largest output records, broad commands, failed commands, and unclear-instruction themes; use
+that artifact plus existing self-review notes as the evidence base for any workflow patch.
 
 For historical route audits, add `--dashboard` and pass multiple routed-worker
 manifest files. Dashboard mode emits `route_efficiency_dashboard.v1` JSON or
@@ -1405,6 +1418,9 @@ All figures must be **reproducible from code** and directly **integratable into 
 - Tests: `uv run pytest tests`
 - Lint: `uv run ruff check .` and `uv run ruff format --check .`
 - The pipeline mirrors the local quality gates. Ensure green locally first.
+- After merging fresh `origin/main`, or after CI reports a formatting failure outside the files you
+  intentionally touched, run the repo-wide lightweight lint/format gate that CI uses. A changed-file
+  format check can be stale when the shared baseline moved.
 
 CI mapping to local tasks and CLI:
 - `fast-feedback` job → `scripts/dev/ci_driver.sh lint typecheck test`

--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -81,6 +81,11 @@ workflow only when the savings are reusable.
   discovery (`rg --files | rg <focused-pattern>`), `rg -l`, and bounded
   `sed -n` ranges; redirect broad `rg -n` or multi-directory searches to a
   private artifact and report only paths plus the decision-relevant excerpt.
+- For implementation-thread audits, summarize the last relevant time window
+  into a common-Git-dir artifact first. Report only record counts, top output
+  offenders, failed command families, unclear-instruction themes, and the
+  artifact path; do not replay raw session JSONL or old transcript chunks in
+  the parent thread.
 - Use filtered status helpers for local state:
   `uv run python scripts/dev/worktree_hygiene_snapshot.py --repo-status --filter <branch> --json`
   for branch cleanup, and raw `git worktree list --porcelain` only when the
@@ -88,6 +93,13 @@ workflow only when the savings are reusable.
 - Keep CI and validation loops bounded in the parent thread. Store full output
   in compact-validation artifacts and report only command, exit code, failing
   node IDs, artifact paths, and the next action.
+- For CI polling, surface only status changes and terminal conclusions when
+  repeated JSON payloads would be noisy. If a workflow is still running, prefer
+  job metadata and filtered direct job-log excerpts over `gh run view --log`
+  dumps that can fail or flood the parent context.
+- If GitHub CI runs repo-wide lint/format gates after a branch merges fresh
+  `origin/main`, run the matching repo-wide lightweight gate locally when a
+  focused changed-file check would miss unrelated-but-current format drift.
 - Check `route_cache` before spawning a delegate. If a model or helper is
   quota-blocked, reuse the recorded reset time and route directly to the next
   eligible worker.
@@ -112,6 +124,9 @@ long goal near a usage guard:
   whether the stop guard is close.
 - `largest_parent_outputs`: broad commands, full skill reads, raw logs, or
   verbose delegate messages that entered the parent thread.
+- `failed_command_patterns`: repeated helper failures, confusing command
+  contracts, CI log endpoints that fail while runs are pending, or unclear
+  instruction wording that caused retries.
 - `delegation_economics`: delegates accepted, rejected, rerouted, or skipped,
   plus whether reviewing them was cheaper than direct Codex work.
 - `cache_hits`: skills, docs, snapshots, issue state, route facts, and usage


### PR DESCRIPTION
## Summary

- Tighten phase audits to include failed command families, repeated monitor noise, and unclear instructions that caused retries.
- Add a bounded implementation-thread review rule so agents summarize recent session windows into common-Git-dir artifacts instead of replaying raw transcript context.
- Clarify CI polling/log triage and when to run repo-wide lightweight lint/format after fresh `origin/main` merges or CI format drift.

## Validation

- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_active_doc_examples.py`
  - Exited 0 with the existing two diagnostics at `docs/dev_guide.md:341` and `examples/plotting/paper_figures/README.md:29`.
- Diff-scoped line-length sanity check: no newly changed prose lines over 100 columns.

## Downstream Propagation

- NA - docs-only workflow guidance. No benchmark, metric, schema, or artifact registry update required.

## Research Result Guidance

- NA - support/workflow documentation only; no research claim or benchmark result.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Strengthened contributor guidelines with enhanced procedures for audits, code reviews, and workflow optimization
  * Expanded development templates with detailed guidance for debugging, monitoring, status reporting, and analysis
  * Added step-by-step instructions for CI pipeline improvements and development best practices
  * Updated reference materials to improve team consistency and support collaborative workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->