### PR TITLE
feat: gate proposal comparison on independent outcomes

### DIFF
--- a/robot_sf/adversarial/independent_outcomes.py
+++ b/robot_sf/adversarial/independent_outcomes.py
@@ -1,0 +1,203 @@
+"""Independent planner-outcome packet contract for issue #3275.
+
+This module validates the small artifact shape that a future planner-execution
+runner must produce before the proposal-vs-random report can move beyond
+circular archive-nearness plumbing. It deliberately does not execute planners.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from typing import Any
+
+from robot_sf.adversarial.disjoint_evaluation import (
+    ranking_permutation_test,
+    shuffled_outcome_null_test,
+)
+
+
+def payload_sha256(payload: dict[str, Any]) -> str:
+    """Return a deterministic SHA-256 digest for a JSON-like payload."""
+    encoded = json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def load_independent_outcomes(path: Path | None) -> tuple[str, str, dict[str, Any] | None]:
+    """Load an independent planner-outcome payload.
+
+    Returns:
+        ``(state, reason, payload)``. Missing payloads are not available; supplied
+        but unreadable payloads are blocked because the run explicitly requested
+        an independent outcome surface.
+    """
+    if path is None:
+        return (
+            "not_available",
+            "No independent outcome path provided; held-out evidence remains fail-closed.",
+            None,
+        )
+    if not path.exists():
+        return "blocked", f"Independent outcome path {path} does not exist.", None
+    if path.stat().st_size == 0:
+        return "blocked", f"Independent outcome file {path} is empty.", None
+
+    try:
+        with open(path, encoding="utf-8") as f:
+            payload = json.load(f)
+    except (ValueError, TypeError, json.JSONDecodeError, OSError) as exc:
+        return "blocked", f"Failed to load independent outcomes: {exc}.", None
+    if not isinstance(payload, dict):
+        return "blocked", "Independent outcome payload must be a JSON object.", None
+    return "active", "Independent planner-execution outcomes loaded successfully.", payload
+
+
+def _float_list(payload: dict[str, Any], key: str) -> list[float]:
+    """Return a list of numeric values from ``payload[key]``."""
+    values = payload.get(key)
+    if not isinstance(values, list):
+        raise ValueError(f"{key} must be a list")
+    return [float(value) for value in values]
+
+
+def _certification_available(payload: dict[str, Any], expected_count: int) -> bool:
+    """Return whether every expected row has passed certification."""
+    statuses = payload.get("certification_statuses")
+    if not isinstance(statuses, list) or len(statuses) < expected_count:
+        return False
+    return all(status == "passed" for status in statuses)
+
+
+def _metadata_allows_independent_outcomes(payload: dict[str, Any]) -> tuple[bool, str]:
+    """Reject known circular, fallback, degraded, or unavailable packet metadata."""
+    if payload.get("outcome_source") != "planner_execution":
+        return False, "outcome_source must be planner_execution"
+    if payload.get("objective") in {"archive_nearness", "objective_distance", "nearest_archive"}:
+        return False, "archive-nearness outcomes are circular for issue #3275"
+    row_statuses = payload.get("row_statuses", [])
+    if not isinstance(row_statuses, list):
+        return False, "row_statuses must be a list when provided"
+    bad_statuses = {"fallback", "degraded", "not_available", "failed", "blocked"}
+    observed_bad = sorted({status for status in row_statuses if status in bad_statuses})
+    if observed_bad:
+        return False, f"non-success planner rows present: {observed_bad}"
+    return True, "ok"
+
+
+def compute_metrics(values: list[float]) -> dict[str, Any]:
+    """Compute the small outcome summary used by the comparison report."""
+    return {
+        "mean_objective": round(sum(values) / len(values), 4) if values else 0.0,
+        "max_objective": round(max(values), 4) if values else 0.0,
+        "failure_count": sum(1 for value in values if value >= 8.0),
+    }
+
+
+def build_independent_outcome_evaluation(
+    payload: dict[str, Any] | None,
+    *,
+    budget: int,
+    n_permutations: int,
+    seed: int,
+    expected_eval_archive_sha256: str | None = None,
+) -> dict[str, Any]:
+    """Summarize an independent-outcome packet and its null-test readiness."""
+    if payload is None:
+        return {
+            "status": "not_available",
+            "independent_outcomes_available": False,
+            "certification_available": False,
+            "null_tests_reject_null": False,
+            "reason": "no_independent_outcome_payload",
+        }
+
+    metadata_ok, metadata_reason = _metadata_allows_independent_outcomes(payload)
+    if not metadata_ok:
+        return {
+            "status": "blocked_invalid_independent_outcomes",
+            "independent_outcomes_available": False,
+            "certification_available": False,
+            "null_tests_reject_null": False,
+            "reason": metadata_reason,
+            "payload_sha256": payload_sha256(payload),
+        }
+    if expected_eval_archive_sha256 is not None:
+        observed_eval_hash = payload.get("eval_archive_sha256")
+        if observed_eval_hash != expected_eval_archive_sha256:
+            return {
+                "status": "blocked_eval_archive_hash_mismatch",
+                "independent_outcomes_available": False,
+                "certification_available": False,
+                "null_tests_reject_null": False,
+                "reason": "independent outcome packet does not match the eval split hash",
+                "expected_eval_archive_sha256": expected_eval_archive_sha256,
+                "observed_eval_archive_sha256": observed_eval_hash,
+                "payload_sha256": payload_sha256(payload),
+            }
+
+    try:
+        proposal_outcomes = _float_list(payload, "proposal_outcomes")
+        random_outcomes = _float_list(payload, "random_outcomes")
+        ranked_outcomes = _float_list(payload, "ranked_outcomes")
+    except (TypeError, ValueError) as exc:
+        return {
+            "status": "blocked_malformed_outcomes",
+            "independent_outcomes_available": False,
+            "certification_available": False,
+            "null_tests_reject_null": False,
+            "reason": str(exc),
+            "payload_sha256": payload_sha256(payload),
+        }
+
+    expected_count = len(proposal_outcomes) + len(random_outcomes)
+    certification_available = _certification_available(payload, expected_count)
+    independent_available = bool(proposal_outcomes and random_outcomes and ranked_outcomes)
+    if not independent_available:
+        return {
+            "status": "not_available_empty_outcomes",
+            "independent_outcomes_available": False,
+            "certification_available": certification_available,
+            "null_tests_reject_null": False,
+            "reason": "proposal, random, and ranked outcomes must all be non-empty",
+            "payload_sha256": payload_sha256(payload),
+        }
+
+    shuffled = shuffled_outcome_null_test(
+        proposal_outcomes,
+        random_outcomes,
+        n_permutations=n_permutations,
+        seed=seed,
+    )
+    ranking = ranking_permutation_test(
+        ranked_outcomes,
+        selection_size=min(budget, len(ranked_outcomes)),
+        n_permutations=n_permutations,
+        seed=seed + 1,
+    )
+    nulls_reject = (
+        shuffled.get("status") == "complete"
+        and ranking.get("status") == "complete"
+        and float(shuffled.get("p_value", 1.0)) <= 0.05
+        and float(ranking.get("p_value", 1.0)) <= 0.05
+    )
+    return {
+        "schema_version": payload.get("schema_version"),
+        "status": "complete",
+        "source": payload.get("source", "unspecified"),
+        "objective": payload.get("objective", "unspecified"),
+        "artifact": payload.get("artifact"),
+        "eval_archive_sha256": payload.get("eval_archive_sha256"),
+        "outcome_source": payload.get("outcome_source"),
+        "independent_outcomes_available": True,
+        "certification_available": certification_available,
+        "null_tests_reject_null": nulls_reject,
+        "proposal_metrics": compute_metrics(proposal_outcomes),
+        "random_metrics": compute_metrics(random_outcomes),
+        "null_tests": {
+            "shuffled_archive_outcomes": shuffled,
+            "proposal_ranking_permutation": ranking,
+            "required_for_held_out_claim": True,
+        },
+        "payload_sha256": payload_sha256(payload),
+    }

--- a/scripts/adversarial/run_proposal_vs_random_issue_2921.py
+++ b/scripts/adversarial/run_proposal_vs_random_issue_2921.py
@@ -17,6 +17,14 @@ CLAIM_BOUNDARY = (
     "evidence, or evidence that learned proposals improve failure discovery."
 )
 
+HELD_OUT_DIAGNOSTIC_BOUNDARY = (
+    "held_out_diagnostic_only: proposal-vs-random deltas use externally supplied independent "
+    "planner-execution outcomes plus candidate certification and null-test checks. This is "
+    "diagnostic evidence for issue #3275 only; it is not benchmark evidence, paper evidence, or "
+    "a planner-performance claim without the durable execution artifacts named by the outcome "
+    "payload."
+)
+
 
 def create_synthetic_search_space() -> Any:
     """Create a default synthetic search space config for diagnostics."""
@@ -167,6 +175,7 @@ def build_archive_evaluation_provenance(
     state: str,
     synthetic_archive: bool,
     split_seed: int,
+    independent_evaluation: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build archive-evaluation provenance for the comparison report.
 
@@ -181,9 +190,10 @@ def build_archive_evaluation_provenance(
     Returns:
         A JSON-safe provenance dict.
     """
+    independent_evaluation = independent_evaluation or {}
     provenance: dict[str, Any] = {
         "archive_sha256": _payload_sha256(archive_data),
-        "evaluation_outcome_sha256": None,
+        "evaluation_outcome_sha256": independent_evaluation.get("payload_sha256"),
         "split_policy": "none_plumbing_fixture",
         "scenario_family_overlap": "not_checked",
         "seed_overlap": "not_checked",
@@ -208,12 +218,16 @@ def build_archive_evaluation_provenance(
     provenance.update(overlap)
     provenance["fit_archive_sha256"] = archive_sha256(split.fit_entries)
     provenance["eval_archive_sha256"] = archive_sha256(split.eval_entries)
-    provenance["independent_outcome_evaluation"] = "not_available_requires_planner_execution"
+    provenance["independent_outcome_evaluation"] = independent_evaluation.get(
+        "status", "not_available_requires_planner_execution"
+    )
     provenance["held_out_evidence_status"] = classify_held_out_evidence(
         disjointness_checks_passed=overlap["disjointness_checks_passed"],
-        independent_outcomes_available=False,
-        certification_available=False,
-        null_tests_reject_null=False,
+        independent_outcomes_available=bool(
+            independent_evaluation.get("independent_outcomes_available")
+        ),
+        certification_available=bool(independent_evaluation.get("certification_available")),
+        null_tests_reject_null=bool(independent_evaluation.get("null_tests_reject_null")),
     )
     return provenance
 
@@ -263,9 +277,26 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Path to write the comparison JSON report.",
     )
+    parser.add_argument(
+        "--evaluation-outcomes",
+        type=Path,
+        default=None,
+        help=(
+            "Optional JSON payload with independent planner-execution outcomes. "
+            "Absent payload keeps held-out evidence fail-closed."
+        ),
+    )
+    parser.add_argument(
+        "--null-test-permutations",
+        type=int,
+        default=1000,
+        help="Number of permutations for independent-outcome null tests.",
+    )
     args = parser.parse_args()
     if args.budget < 0:
         parser.error("--budget must be >= 0")
+    if args.null_test_permutations < 1:
+        parser.error("--null-test-permutations must be >= 1")
     return args
 
 
@@ -277,12 +308,22 @@ def main() -> int:
         load_search_space(args.search_space)
     )
     archive_state, archive_reason, archive_data, synthetic_archive = load_archive(args.archive)
+    from robot_sf.adversarial.independent_outcomes import (
+        build_independent_outcome_evaluation,
+        load_independent_outcomes,
+    )
+
+    outcome_state, outcome_reason, outcome_data = load_independent_outcomes(
+        args.evaluation_outcomes
+    )
     state = archive_state
-    reason_parts = [archive_reason, search_space_reason]
+    reason_parts = [archive_reason, search_space_reason, outcome_reason]
     if not synthetic_archive and synthetic_search_space:
         state = "blocked"
         reason_parts.append("Real-archive runs require a real search-space config.")
     if search_space_state == "blocked" and state == "active":
+        state = "blocked"
+    if outcome_state == "blocked":
         state = "blocked"
     reason = " ".join(reason_parts)
 
@@ -336,14 +377,32 @@ def main() -> int:
         synthetic_archive=synthetic_archive,
         split_seed=args.seed,
     )
+    independent_evaluation = build_independent_outcome_evaluation(
+        outcome_data,
+        budget=args.budget,
+        n_permutations=args.null_test_permutations,
+        seed=args.seed,
+        expected_eval_archive_sha256=provenance.get("eval_archive_sha256"),
+    )
+    provenance = build_archive_evaluation_provenance(
+        archive_data,
+        state=state,
+        synthetic_archive=synthetic_archive,
+        split_seed=args.seed,
+        independent_evaluation=independent_evaluation,
+    )
+    held_out_status = provenance.get("held_out_evidence_status")
+    held_out_evidence = held_out_status == "eligible_held_out_diagnostic"
 
     report = {
         "schema_version": "adversarial_proposal_comparison.v1",
         "state": state,
         "reason": reason,
-        "claim_boundary": CLAIM_BOUNDARY,
-        "result_classification": "plumbing_validation_only",
-        "held_out_evidence": False,
+        "claim_boundary": HELD_OUT_DIAGNOSTIC_BOUNDARY if held_out_evidence else CLAIM_BOUNDARY,
+        "result_classification": (
+            "held_out_diagnostic_only" if held_out_evidence else "plumbing_validation_only"
+        ),
+        "held_out_evidence": held_out_evidence,
         "benchmark_evidence": False,
         "planner_performance_claim": False,
         "synthetic_archive": synthetic_archive,
@@ -354,7 +413,11 @@ def main() -> int:
         "random_metrics": random_metrics,
         "proposal_metrics": proposal_metrics,
         "comparison": {
-            "interpretation": "plumbing_only_circular_archive_nearness_objective",
+            "interpretation": (
+                "independent_planner_execution_outcomes"
+                if held_out_evidence
+                else "plumbing_only_circular_archive_nearness_objective"
+            ),
             "mean_objective_improvement": round(
                 proposal_metrics["mean_objective"] - random_metrics["mean_objective"], 4
             ),
@@ -366,11 +429,15 @@ def main() -> int:
             ),
         },
         "archive_evaluation_provenance": provenance,
-        "null_tests": {
-            "shuffled_archive_outcomes": "not_run_requires_real_certified_archive",
-            "proposal_ranking_permutation": "not_run_requires_real_certified_archive",
-            "required_for_held_out_claim": True,
-        },
+        "independent_outcome_evaluation": independent_evaluation,
+        "null_tests": independent_evaluation.get(
+            "null_tests",
+            {
+                "shuffled_archive_outcomes": "not_run_requires_real_certified_archive",
+                "proposal_ranking_permutation": "not_run_requires_real_certified_archive",
+                "required_for_held_out_claim": True,
+            },
+        ),
     }
 
     report_str = json.dumps(report, indent=2, sort_keys=True)

--- a/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
+++ b/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
@@ -368,3 +368,127 @@ def test_active_real_archive_computes_disjoint_provenance_but_fails_closed(
     assert provenance["held_out_evidence_status"] == (
         "not_available_requires_independent_planner_outcomes"
     )
+
+
+def test_real_archive_with_independent_outcomes_becomes_diagnostic_only(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A valid independent outcome packet opens only the diagnostic held-out gate."""
+    from scripts.adversarial.run_proposal_vs_random_issue_2921 import main as script_main
+
+    archive_path = tmp_path / "archive.json"
+    search_space_path = tmp_path / "search_space.yaml"
+    outcomes_path = tmp_path / "outcomes.json"
+    output_json = tmp_path / "report.json"
+    archive = _two_family_archive()
+    archive_path.write_text(json.dumps(archive), encoding="utf-8")
+    search_space_path.write_text(_SEARCH_SPACE_YAML, encoding="utf-8")
+    from robot_sf.adversarial.disjoint_evaluation import archive_sha256, disjoint_family_split
+
+    split = disjoint_family_split(archive["entries"], eval_fraction=0.5, seed=7)
+    outcomes_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "adversarial_independent_outcomes.v1",
+                "source": "unit-test-fixture",
+                "artifact": "docs/context/evidence/unit-test.json",
+                "eval_archive_sha256": archive_sha256(split.eval_entries),
+                "outcome_source": "planner_execution",
+                "objective": "certified_failure_outcome",
+                "proposal_outcomes": [10.0, 10.0, 10.0, 10.0],
+                "random_outcomes": [0.0, 0.0, 0.0, 0.0],
+                "ranked_outcomes": [10.0, 10.0, 10.0, 10.0, 0.0, 0.0, 0.0, 0.0],
+                "certification_statuses": ["passed"] * 8,
+                "row_statuses": ["success"] * 8,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_proposal_vs_random_issue_2921.py",
+            "--archive",
+            archive_path.as_posix(),
+            "--search-space",
+            search_space_path.as_posix(),
+            "--evaluation-outcomes",
+            outcomes_path.as_posix(),
+            "--budget",
+            "4",
+            "--seed",
+            "7",
+            "--null-test-permutations",
+            "200",
+            "--output",
+            output_json.as_posix(),
+        ],
+    )
+
+    assert script_main() == 0
+    report = json.loads(output_json.read_text(encoding="utf-8"))
+    assert report["held_out_evidence"] is True
+    assert report["benchmark_evidence"] is False
+    assert report["planner_performance_claim"] is False
+    assert report["result_classification"] == "held_out_diagnostic_only"
+    assert report["archive_evaluation_provenance"]["held_out_evidence_status"] == (
+        "eligible_held_out_diagnostic"
+    )
+    assert report["independent_outcome_evaluation"]["certification_available"] is True
+    assert report["independent_outcome_evaluation"]["null_tests_reject_null"] is True
+
+
+def test_real_archive_with_circular_outcomes_stays_fail_closed(tmp_path: Path, monkeypatch) -> None:
+    """Archive-nearness outcome packets are rejected as circular."""
+    from scripts.adversarial.run_proposal_vs_random_issue_2921 import main as script_main
+
+    archive_path = tmp_path / "archive.json"
+    search_space_path = tmp_path / "search_space.yaml"
+    outcomes_path = tmp_path / "outcomes.json"
+    output_json = tmp_path / "report.json"
+    archive_path.write_text(json.dumps(_two_family_archive()), encoding="utf-8")
+    search_space_path.write_text(_SEARCH_SPACE_YAML, encoding="utf-8")
+    outcomes_path.write_text(
+        json.dumps(
+            {
+                "outcome_source": "planner_execution",
+                "objective": "archive_nearness",
+                "proposal_outcomes": [10.0],
+                "random_outcomes": [0.0],
+                "ranked_outcomes": [10.0, 0.0],
+                "certification_statuses": ["passed", "passed"],
+                "row_statuses": ["success", "success"],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(
+        "sys.argv",
+        [
+            "run_proposal_vs_random_issue_2921.py",
+            "--archive",
+            archive_path.as_posix(),
+            "--search-space",
+            search_space_path.as_posix(),
+            "--evaluation-outcomes",
+            outcomes_path.as_posix(),
+            "--budget",
+            "1",
+            "--seed",
+            "7",
+            "--output",
+            output_json.as_posix(),
+        ],
+    )
+
+    assert script_main() == 0
+    report = json.loads(output_json.read_text(encoding="utf-8"))
+    assert report["held_out_evidence"] is False
+    assert report["archive_evaluation_provenance"]["held_out_evidence_status"] == (
+        "not_available_requires_independent_planner_outcomes"
+    )
+    assert report["independent_outcome_evaluation"]["status"] == (
+        "blocked_invalid_independent_outcomes"
+    )

--- a/tests/adversarial/test_independent_outcomes.py
+++ b/tests/adversarial/test_independent_outcomes.py
@@ -1,0 +1,128 @@
+"""Tests for independent planner-outcome packet handling."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_sf.adversarial.independent_outcomes import (
+    build_independent_outcome_evaluation,
+    load_independent_outcomes,
+)
+
+
+def _valid_payload() -> dict:
+    """Build a small packet with separable proposal/random outcome signal."""
+    return {
+        "schema_version": "adversarial_independent_outcomes.v1",
+        "source": "unit-test-fixture",
+        "artifact": "docs/context/evidence/unit-test.json",
+        "outcome_source": "planner_execution",
+        "objective": "certified_failure_outcome",
+        "proposal_outcomes": [10.0, 10.0, 10.0, 10.0],
+        "random_outcomes": [0.0, 0.0, 0.0, 0.0],
+        "ranked_outcomes": [10.0, 10.0, 10.0, 10.0, 0.0, 0.0, 0.0, 0.0],
+        "certification_statuses": ["passed"] * 8,
+        "row_statuses": ["success"] * 8,
+    }
+
+
+def test_load_independent_outcomes_missing_is_not_available() -> None:
+    """Absence of a packet is a fail-closed not-available state."""
+    state, reason, payload = load_independent_outcomes(None)
+    assert state == "not_available"
+    assert "No independent outcome path" in reason
+    assert payload is None
+
+
+def test_load_independent_outcomes_malformed_file_blocks(tmp_path: Path) -> None:
+    """Supplied malformed payloads block instead of falling back."""
+    path = tmp_path / "outcomes.json"
+    path.write_text("{not json", encoding="utf-8")
+
+    state, reason, payload = load_independent_outcomes(path)
+
+    assert state == "blocked"
+    assert "Failed to load independent outcomes" in reason
+    assert payload is None
+
+
+def test_build_independent_outcome_evaluation_rejects_circular_objective() -> None:
+    """Archive-nearness outcomes are circular and cannot open the claim gate."""
+    payload = _valid_payload()
+    payload["objective"] = "archive_nearness"
+
+    result = build_independent_outcome_evaluation(payload, budget=4, n_permutations=100, seed=0)
+
+    assert result["status"] == "blocked_invalid_independent_outcomes"
+    assert result["independent_outcomes_available"] is False
+    assert "archive-nearness" in result["reason"]
+
+
+def test_build_independent_outcome_evaluation_requires_certification() -> None:
+    """Independent outcomes without passed certification stay fail-closed."""
+    payload = _valid_payload()
+    payload["certification_statuses"][-1] = "not_available"
+
+    result = build_independent_outcome_evaluation(payload, budget=4, n_permutations=100, seed=0)
+
+    assert result["status"] == "complete"
+    assert result["independent_outcomes_available"] is True
+    assert result["certification_available"] is False
+
+
+def test_build_independent_outcome_evaluation_complete_packet_rejects_nulls() -> None:
+    """A strong packet can satisfy independent outcome, certification, and null-test gates."""
+    result = build_independent_outcome_evaluation(
+        _valid_payload(), budget=4, n_permutations=200, seed=0
+    )
+
+    assert result["status"] == "complete"
+    assert result["independent_outcomes_available"] is True
+    assert result["certification_available"] is True
+    assert result["null_tests_reject_null"] is True
+    assert result["null_tests"]["shuffled_archive_outcomes"]["status"] == "complete"
+    assert result["null_tests"]["proposal_ranking_permutation"]["status"] == "complete"
+
+
+def test_build_independent_outcome_evaluation_rejects_degraded_rows() -> None:
+    """Fallback or degraded rows must not count as successful evidence."""
+    payload = _valid_payload()
+    payload["row_statuses"][-1] = "degraded"
+
+    result = build_independent_outcome_evaluation(payload, budget=4, n_permutations=100, seed=0)
+
+    assert result["status"] == "blocked_invalid_independent_outcomes"
+    assert "degraded" in result["reason"]
+
+
+def test_build_independent_outcome_evaluation_rejects_eval_hash_mismatch() -> None:
+    """Outcome packets must match the held-out eval split they claim to score."""
+    payload = _valid_payload()
+    payload["eval_archive_sha256"] = "wrong"
+
+    result = build_independent_outcome_evaluation(
+        payload,
+        budget=4,
+        n_permutations=100,
+        seed=0,
+        expected_eval_archive_sha256="expected",
+    )
+
+    assert result["status"] == "blocked_eval_archive_hash_mismatch"
+    assert result["independent_outcomes_available"] is False
+    assert result["expected_eval_archive_sha256"] == "expected"
+    assert result["observed_eval_archive_sha256"] == "wrong"
+
+
+def test_load_independent_outcomes_reads_json_payload(tmp_path: Path) -> None:
+    """Readable JSON objects are passed through for report integration."""
+    path = tmp_path / "outcomes.json"
+    path.write_text(json.dumps(_valid_payload()), encoding="utf-8")
+
+    state, reason, payload = load_independent_outcomes(path)
+
+    assert state == "active"
+    assert "loaded successfully" in reason
+    assert payload is not None
+    assert payload["outcome_source"] == "planner_execution"


### PR DESCRIPTION
## Summary

- Add `robot_sf.adversarial.independent_outcomes` to validate optional planner-execution outcome packets for issue #3275.
- Wire `run_proposal_vs_random_issue_2921.py` to keep held-out evidence fail-closed unless the packet is non-circular, tied to the eval split hash, fully certified, and rejects the null tests.
- Preserve claim boundaries: even an eligible packet is `held_out_diagnostic_only`, with `benchmark_evidence=false` and `planner_performance_claim=false`.

## Linked Issues

- Relates to #3275

## Stack / Dependency

- Base dependency: PR #3389
- Required prior PRs: #3389 is merged
- Stack follow-up issues: #3275 remains open for the actual planner-execution/certification campaign
- Safe to review independently: yes
- Review dependency reason, if any: this consumes the disjoint split/null-test hooks from #3389

## What Changed

- Added an independent-outcome packet contract for `outcome_source=planner_execution`.
- Rejects archive-nearness/circular objectives, degraded/fallback rows, missing certification, malformed payloads, and eval-split hash mismatches.
- Adds tests for missing/malformed packets, circular outcomes, certification gating, eval-hash binding, and a diagnostic-only eligible packet.

## Why It Matters

- Added value: converts #3275 Batch 2 from an implicit TODO into a fail-closed artifact contract.
- Expected impact: future planner-execution work can produce a compact packet and get deterministic report classification.
- Why this is worth merging now: it prevents the next execution PR from accidentally overclaiming circular or mismatched outcomes.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #3275 held-out proposal-vs-random evidence gate.
- Comparator or baseline, if applicable: proposal vs random, but this PR only gates supplied outcome artifacts.
- Evidence tier: targeted smoke / analysis-only contract.
- Result classification: blocker-resolution for the artifact contract; no benchmark result.
- Decision or stop rule, if applicable: held-out evidence remains unavailable unless disjointness, independent outcomes, certification, and null rejection all pass.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3275.
- New research/benchmark/metric/paper-facing analysis tool, if any: no new execution tool; support parser/gate for a later planner-execution artifact.

## Domain-Aware Approval

- Required for this PR: yes - it changes evidence classification gates for a research-facing script.
- Domains reviewed: evidence classification / benchmark interpretation.
- Status: approved by Codex goal-pr-review..
- Approver/review source or waiver: Codex goal-pr-review on head 8eb73ff33ae61ce3ecf7199c54c6266984d907eb.
- Validity checklist:
  - Target claim/hypothesis: held-out proposal-vs-random evidence for #3275.
  - Comparator or split/evidence validity: requires disjoint eval split hash match and independent planner outcomes.
  - Fallback/degraded exclusions: fallback, degraded, failed, blocked, and not-available rows are rejected.
  - Claim boundary: eligible packets are diagnostic-only; benchmark and planner-performance flags remain false.
  - Implementation integrity vs experimental validity: this PR proves gating behavior, not a real experimental result.

## Falsification / Non-Transfer Check

- Did the mechanism activate? yes, in focused tests with synthetic valid/invalid packets.
- Did the intervention change command source, selected command, trajectory, or route progress? no.
- Did the scenario actually contain the targeted failure mode? NA - no planner execution run in this PR.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #3275 remains open for actual planner execution/certification.

## Next Empirical Action

- Rerun needed: yes, future planner-execution campaign.
- Extractor or analysis tool needed: yes, a runner must produce the packet contract introduced here.
- Artifact missing or unavailable: durable independent planner-execution outcome packet.
- Stop / revise / continue decision: continue with execution packet production.
- Proposed child issue or existing follow-up: existing #3275.

## Validation / Proof

- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/adversarial/test_independent_outcomes.py tests/adversarial/test_disjoint_evaluation.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py -q`
  - `ruff check robot_sf/adversarial/independent_outcomes.py scripts/adversarial/run_proposal_vs_random_issue_2921.py tests/adversarial/test_independent_outcomes.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py`
  - `ruff format --check robot_sf/adversarial/independent_outcomes.py scripts/adversarial/run_proposal_vs_random_issue_2921.py tests/adversarial/test_independent_outcomes.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- bash -lc 'BASE_REF=origin/main scripts/dev/pr_ready_check.sh'`
- Evidence that the change works here: focused tests cover valid, missing, malformed, circular, uncertified, degraded, and eval-hash-mismatched outcome packets; readiness gate passed at branch head `8eb73ff33ae61ce3ecf7199c54c6266984d907eb`.
- Benchmarks or smoke tests, if applicable: no benchmark claim; core readiness lane passed 1513 tests.

## Risks / Rollout

- Compatibility risks: the new CLI arguments are optional; no-outcome behavior remains fail-closed.
- Failure modes: later execution packets must compute the exact eval split hash and avoid circular objective labels.
- Rollback or fallback plan: omit `--evaluation-outcomes` to retain prior plumbing-only classification.

## Docs / Provenance

- Updated docs: module and CLI docstrings.
- Relevant design or provenance notes: #3275 and PR #3389.
- Any assumptions that need to be preserved: `held_out_evidence=true` is diagnostic-only and does not imply benchmark or planner-performance evidence.

## Downstream Propagation

- Parent issue updated (yes/no/NA): yes, claim/comment added.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark result.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no, #3275 remains the active follow-up.
- Not applicable because: this PR adds a fail-closed contract, not a durable evidence result.

## Follow-Up Issues

- Deferred work: actual planner-execution/certification packet production and evaluation.
- Issues opened for follow-up: none; tracked by existing #3275.

## Reviewer Notes

- Verify closely that `benchmark_evidence` and `planner_performance_claim` remain false even when diagnostic held-out evidence becomes eligible.
- Known limitation: this does not execute planners or certify new candidates; it only validates the packet that later execution work must produce.

