### PR TITLE
fix: reserve adversarial candidate outcome buckets

### DIFF
--- a/robot_sf/adversarial/batch_certification.py
+++ b/robot_sf/adversarial/batch_certification.py
@@ -14,6 +14,11 @@ produced by running the planner and are classified by the fail-closed benchmark
 row-status policy, not here. Emitting them would require planner execution,
 which this gate exists to avoid for rejected candidates.
 
+The emitted payload reserves explicit post-execution outcome buckets so downstream
+reports keep simulation failure, fallback, degraded rows, and genuine behavioral
+failures distinct. Pre-planner certification leaves those counts at zero and marks
+them as not derived because computing them would require planner execution.
+
 This is quality-signal-only evidence: it measures generator/candidate health and
 makes no planner benchmark claim.
 """
@@ -50,6 +55,16 @@ ADVERSARIAL_CANDIDATE_QUALITY_SCHEMA = "adversarial_candidate_quality.v1"
 REASON_INVALID = "invalid"
 REASON_DEGENERATE = "degenerate"
 REASON_DUPLICATE = "duplicate"
+POST_EXECUTION_OUTCOME_COUNTS: dict[str, int] = {
+    "simulation_failure": 0,
+    "fallback": 0,
+    "degraded": 0,
+    "genuine_behavioral_failure": 0,
+}
+POST_EXECUTION_OUTCOME_NOTE: str = (
+    "Reserved post-execution buckets; pre-planner certification does not execute planners, "
+    "so these counts are not derived here."
+)
 
 
 @dataclass(frozen=True)
@@ -142,6 +157,8 @@ class BatchCertification:
             "rejected_count": self.rejected_count,
             "validity_rate": self.validity_rate,
             "rejection_counts": dict(self.rejection_counts),
+            "post_execution_outcome_counts": dict(POST_EXECUTION_OUTCOME_COUNTS),
+            "post_execution_outcome_note": POST_EXECUTION_OUTCOME_NOTE,
             "policy": self.policy.to_dict(),
             "candidates": [candidate.to_dict() for candidate in self.candidates],
         }

--- a/robot_sf/benchmark/schemas/adversarial_candidate_quality.v1.json
+++ b/robot_sf/benchmark/schemas/adversarial_candidate_quality.v1.json
@@ -14,6 +14,8 @@
     "rejected_count",
     "validity_rate",
     "rejection_counts",
+    "post_execution_outcome_counts",
+    "post_execution_outcome_note",
     "policy",
     "candidates"
   ],
@@ -54,6 +56,38 @@
         "type": "integer",
         "minimum": 0
       }
+    },
+    "post_execution_outcome_counts": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "simulation_failure",
+        "fallback",
+        "degraded",
+        "genuine_behavioral_failure"
+      ],
+      "properties": {
+        "simulation_failure": {
+          "type": "integer",
+          "const": 0
+        },
+        "fallback": {
+          "type": "integer",
+          "const": 0
+        },
+        "degraded": {
+          "type": "integer",
+          "const": 0
+        },
+        "genuine_behavioral_failure": {
+          "type": "integer",
+          "const": 0
+        }
+      }
+    },
+    "post_execution_outcome_note": {
+      "type": "string",
+      "minLength": 1
     },
     "policy": {
       "type": "object",

--- a/tests/adversarial/test_batch_certification.py
+++ b/tests/adversarial/test_batch_certification.py
@@ -161,6 +161,16 @@ def test_to_dict_emits_candidate_quality_v1() -> None:
         "reject_duplicates": True,
         "min_batch_validity_rate": None,
     }
+    assert payload["post_execution_outcome_counts"] == {
+        "simulation_failure": 0,
+        "fallback": 0,
+        "degraded": 0,
+        "genuine_behavioral_failure": 0,
+    }
+    assert (
+        "pre-planner certification does not execute planners"
+        in payload["post_execution_outcome_note"]
+    )
     assert payload["total"] == 1
     assert payload["candidates"][0]["path"] == "a"
 
@@ -281,6 +291,18 @@ def test_candidate_quality_payload_validates_against_schema(tmp_path: Path) -> N
     schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
 
     jsonschema.Draft202012Validator(schema).validate(payload)
+
+
+def test_candidate_quality_schema_keeps_post_execution_counts_reserved(tmp_path: Path) -> None:
+    """Pre-planner summaries reserve post-execution buckets without deriving them."""
+    _write_manifest(tmp_path / "a.yaml", _controls(0.0), "valid")
+
+    payload = certify_candidate_batch([tmp_path]).to_dict()
+    payload["post_execution_outcome_counts"]["fallback"] = 1
+    schema = json.loads(_SCHEMA_PATH.read_text(encoding="utf-8"))
+
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.Draft202012Validator(schema).validate(payload)
 
 
 def test_batch_certification_cli_writes_output_json_and_exits_zero(


### PR DESCRIPTION
## Summary
Reserve explicit post-execution outcome buckets in `adversarial_candidate_quality.v1` while preserving the pre-planner certification boundary.

## Linked Issues
- Closes #2920

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added reserved zero-count `simulation_failure`, `fallback`, `degraded`, and `genuine_behavioral_failure` buckets to the candidate-quality payload.
- Updated the v1 schema to require those buckets and keep them zero for pre-planner certification artifacts.
- Added focused tests that validate the emitted payload and reject nonzero post-execution counts in this pre-planner schema.

## Why It Matters
- Added value: reports now distinguish invalidity/degeneracy/duplicates from the post-execution categories named by #2920 without running planners inside the certification gate.
- Expected impact: clearer fail-closed evidence vocabulary for adversarial candidate batches.
- Why this is worth merging now: it closes the remaining acceptance gap on an already-existing local certification path.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #2920 blocker that adversarial candidate quality summaries must separate pre-planner rejection reasons from post-execution failure/fallback/degraded outcome categories.
- Comparator or baseline, if applicable: previous `adversarial_candidate_quality.v1` payload only exposed pre-planner rejection counts.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: pre-planner gate remains non-benchmark evidence; post-execution counts are reserved only and not derived here.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #2920
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - schema/support helper; no research interpretation is added.

## Domain-Aware Approval
- Required for this PR: yes - evidence vocabulary and fallback/degraded boundary are touched.
- Domains reviewed: evidence classification / benchmark interpretation
- Status: approved
- Approver/review source or waiver: Codex goal-pr-review local diff, issue-contract, test, CI, and review-thread check
- Validity checklist:
  - Target claim/hypothesis: candidate-quality summaries distinguish named rejection/outcome categories.
  - Comparator or split/evidence validity: schema-level and fixture-level smoke tests only; no benchmark comparison.
  - Fallback/degraded exclusions: fallback and degraded are reserved post-execution buckets and cannot be nonzero in this pre-planner payload.
  - Claim boundary: quality-signal-only; no planner benchmark claim.
  - Implementation integrity vs experimental validity: implementation covered by focused tests; experimental validity requires reviewer confirmation.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support/schema boundary change.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop for #2920 after review if accepted
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/adversarial/test_batch_certification.py tests/tools/test_run_adversarial_manifest_smoke.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/adversarial/batch_certification.py tests/adversarial/test_batch_certification.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/adversarial/batch_certification.py tests/adversarial/test_batch_certification.py`
  - `git diff --check`
- Evidence that the change works here: 32 focused tests passed; schema validation test rejects nonzero post-execution counts for pre-planner payloads.
- Benchmarks or smoke tests, if applicable: adversarial manifest smoke tests passed; no benchmark campaign run because this is a schema/support gate.

## Risks / Rollout
- Compatibility risks: schema consumers must tolerate two new required fields in v1 payloads.
- Failure modes: downstream consumers assuming a closed key set may need to handle the new fields.
- Rollback or fallback plan: revert the schema/payload additions if a consumer break is found.

## Docs / Provenance
- Updated docs: module boundary prose in `batch_certification.py`.
- Relevant design or provenance notes: #2920 issue contract and fallback policy boundary.
- Any assumptions that need to be preserved: pre-planner certification does not execute planners.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - PR links and closes #2920.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: support/schema boundary change only; no benchmark result or durable artifact.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Verify that requiring zero post-execution buckets in this v1 pre-planner payload is the desired compatibility tradeoff.
- Known limitation: this does not classify real planner execution rows; it only reserves and names those categories for this pre-planner artifact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Certification payload now reserves and documents post-execution outcome buckets (simulation failure, fallback, degraded, behavioral failure).

* **Tests**
  * Added schema validation tests to ensure post-execution outcome counts remain properly constrained in certified outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
