### PR TITLE
fix: align PPO SocNav dict observations

### DIFF
--- a/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml
@@ -4,7 +4,9 @@
 # This config is paper-facing for preflight/comparability/SNQI contracts and is
 # the current long-horizon benchmark collection. Publication bundle export stays
 # disabled because the 2026-05-06 candidate-augmented local full run completed
-# but has SNQI contract status=fail under warn enforcement.
+# but has SNQI contract status=fail under warn enforcement. Issue #3266 keeps
+# the recovered PR #3263 payload diagnostic-only until a post-PPO-repair rerun
+# produces valid PPO execution plus an explicit SNQI contract interpretation.
 
 name: paper_experiment_matrix_v1_scenario_horizons_h500
 paper_facing: true

--- a/robot_sf/baselines/ppo.py
+++ b/robot_sf/baselines/ppo.py
@@ -369,7 +369,7 @@ class PPOPlanner:
     ) -> dict[str, Any]:
         """Return dict observations plus any missing predictive feature payload."""
 
-        source_obs = dict(obs)
+        source_obs = self._flatten_nested_observation(obs)
         if self._predictive_foresight is not None:
             missing_predictive = [
                 key for key in spaces if key.startswith("predictive_") and key not in source_obs
@@ -380,6 +380,23 @@ class PPOPlanner:
                     {key: value for key, value in payload.items() if key in missing_predictive}
                 )
         return source_obs
+
+    @staticmethod
+    def _flatten_nested_observation(obs: dict[str, Any]) -> dict[str, Any]:
+        """Return observation values with nested SocNav leaves promoted to flat keys."""
+
+        flattened: dict[str, Any] = dict(obs)
+
+        def _flatten_recursive(payload: dict[str, Any], prefix: str = "") -> None:
+            for key, value in payload.items():
+                full_key = f"{prefix}_{key}" if prefix else str(key)
+                if isinstance(value, dict):
+                    _flatten_recursive(value, full_key)
+                elif full_key not in flattened:
+                    flattened[full_key] = value
+
+        _flatten_recursive(obs)
+        return flattened
 
     def _align_model_obs_dict(
         self,
@@ -394,13 +411,18 @@ class PPOPlanner:
 
         converted: dict[str, np.ndarray] = {}
         missing: list[str] = []
+        aliases: dict[str, tuple[str, ...]] = {
+            "robot_speed": ("robot_velocity_xy",),
+            "robot_velocity_xy": ("robot_speed",),
+        }
         for key, sub_space in spaces.items():
-            if key not in source_obs:
+            source = self._resolve_dict_observation_source(source_obs, str(key), aliases)
+            if source is None:
                 missing.append(str(key))
                 continue
             target_shape = getattr(sub_space, "shape", None)
             target_dtype = getattr(sub_space, "dtype", None)
-            arr = np.asarray(source_obs[key], dtype=target_dtype)
+            arr = np.asarray(source, dtype=target_dtype)
             if target_shape is not None and tuple(arr.shape) != tuple(target_shape):
                 target_size = int(np.prod(target_shape))
                 if int(arr.size) != target_size:
@@ -414,6 +436,26 @@ class PPOPlanner:
             missing_preview = ", ".join(missing[:6])
             raise ValueError(f"Missing required dict observation keys: {missing_preview}")
         return converted
+
+    @staticmethod
+    def _resolve_dict_observation_source(
+        obs: dict[str, Any],
+        key: str,
+        aliases: dict[str, tuple[str, ...]],
+    ) -> Any | None:
+        """Resolve a model observation field from direct keys or known aliases.
+
+        Returns:
+            The resolved observation value, or None when the key is unavailable.
+        """
+
+        source = obs.get(key)
+        if source is not None:
+            return source
+        for alias in aliases.get(key, ()):
+            if alias in obs:
+                return obs[alias]
+        return None
 
     def _validate_runtime_observation_space(self) -> None:
         """Fail closed when a flat checkpoint cannot match runtime observations."""

--- a/tests/baselines/test_ppo_planner.py
+++ b/tests/baselines/test_ppo_planner.py
@@ -86,6 +86,40 @@ def test_build_model_obs_dict_reshapes_to_model_space():
     assert converted["occupancy_grid"].dtype == np.float32
 
 
+def test_build_model_obs_dict_flattens_structured_socnav_observation() -> None:
+    """PPO dict mode should align structured SocNav observations to flat SB3 keys."""
+    planner = PPOPlanner(_planner_config(obs_mode="dict"))
+    planner._model = SimpleNamespace(
+        observation_space=SimpleNamespace(
+            spaces={
+                "robot_position": SimpleNamespace(shape=(2,), dtype=np.float32),
+                "robot_speed": SimpleNamespace(shape=(2,), dtype=np.float32),
+                "goal_current": SimpleNamespace(shape=(2,), dtype=np.float32),
+                "pedestrians_positions": SimpleNamespace(shape=(1, 2), dtype=np.float32),
+                "sim_timestep": SimpleNamespace(shape=(1,), dtype=np.float32),
+            },
+        ),
+    )
+
+    converted = planner._build_model_obs_dict(
+        {
+            "robot": {
+                "position": np.array([1.0, 2.0], dtype=np.float32),
+                "velocity_xy": np.array([0.3, 0.4], dtype=np.float32),
+            },
+            "goal": {"current": np.array([5.0, 6.0], dtype=np.float32)},
+            "pedestrians": {"positions": np.array([[2.0, 3.0]], dtype=np.float32)},
+            "sim": {"timestep": np.array([0.1], dtype=np.float32)},
+        }
+    )
+
+    assert converted["robot_position"].tolist() == pytest.approx([1.0, 2.0])
+    assert converted["robot_speed"].tolist() == pytest.approx([0.3, 0.4])
+    assert converted["goal_current"].tolist() == pytest.approx([5.0, 6.0])
+    assert converted["pedestrians_positions"].shape == (1, 2)
+    assert converted["sim_timestep"].tolist() == pytest.approx([0.1])
+
+
 def test_step_dict_mode_flattens_runtime_dict_for_box_checkpoint() -> None:
     """BC checkpoints trained with FlattenObservation should receive flat Box inputs."""
     planner = PPOPlanner(_planner_config(obs_mode="dict", action_space="unicycle"))


### PR DESCRIPTION
## Summary
Repair the PPO dict-observation adapter so structured SocNav observations can satisfy flat SB3 MultiInput checkpoint keys, and keep the scenario-horizon h500 config explicitly diagnostic-only until a post-repair rerun proves PPO plus SNQI validity.

## Linked Issues
- Relates to #3266
- Relates to #3263
- Relates to #3203

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: `NA`

## What Changed
- Flatten nested SocNav observation leaves in `PPOPlanner` before aligning dict observations to the loaded model's declared observation space.
- Add `robot_speed` / `robot_velocity_xy` aliases for compatible SocNav runtime/checkpoint key naming.
- Add a focused PPO planner unit test for structured SocNav dict input.
- Update the scenario-horizon h500 config header so PR #3263 payloads remain diagnostic-only until a valid post-repair rerun resolves PPO execution and SNQI interpretation.

## Why It Matters
- Added value: removes a concrete PPO observation-key mismatch blocker while preserving fail-closed behavior for truly missing fields.
- Expected impact: PPO can consume the structured SocNav dict already passed by the benchmark runner when model keys are the flattened SB3-compatible names.
- Why this is worth merging now: it resolves the local adapter blocker and makes the remaining benchmark evidence boundary explicit.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: PPO/SNQI validity blockers for scenario-horizon Results evidence.
- Comparator or baseline, if applicable: existing PPO adapter behavior that required top-level flattened keys and failed on structured SocNav dicts.
- Evidence tier: targeted smoke / diagnostic probe.
- Result classification: blocker-resolution; not benchmark-success evidence.
- Decision or stop rule, if applicable: full Results promotion still requires a post-repair scenario-horizon rerun with valid PPO execution and explicit SNQI contract interpretation.
- Parent issue, claim map, registry, context note, or synthesis surface to update: issue #3266; scenario-horizon h500 config header updated.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no new analysis tool.

## Domain-Aware Approval
- Required for this PR: yes - benchmark/paper-facing claim boundary is touched.
- Domains reviewed: evidence classification / benchmark interpretation / paper-facing claims.
- Status: waived for implementation PR; reviewer should confirm boundary wording.
- Approver/review source or waiver: current issue #3266 maintainer decision says repair PPO and keep PR #3263 diagnostic until valid rerun.
- Validity checklist:
  - Target claim/hypothesis: adapter repair for PPO observation contract.
  - Comparator or split/evidence validity: targeted unit and preflight proof only.
  - Fallback/degraded exclusions: fallback remains fail-closed for missing keys; this PR does not claim fallback/degraded benchmark success.
  - Claim boundary: diagnostic-only until post-repair rerun.
  - Implementation integrity vs experimental validity: implementation proof passed; full experimental validity remains deferred.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, structured SocNav dict fields now flatten to expected PPO keys in unit coverage.
- Did the intervention change command source, selected command, trajectory, or route progress? no live trajectory rerun in this PR.
- Did the scenario actually contain the targeted failure mode? yes, the unit reproduces the structured-to-flat key mismatch that caused missing-key failure.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: rerun the smallest scenario-horizon slice and classify SNQI contract output before Results promotion.

## Next Empirical Action
- Rerun needed: yes.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: full post-repair scenario-horizon rerun evidence.
- Stop / revise / continue decision: continue to rerun proof after merge.
- Proposed child issue or existing follow-up: existing #3266 tracks this follow-up; if this PR is merged before full rerun, keep the issue open manually or open a child rerun issue.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/baselines/test_ppo_planner.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- python -c "import robot_sf.baselines.ppo; import robot_sf.gym_env.snqi_proxy"`
  - `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/baselines/test_ppo_planner.py tests/benchmark/test_camera_ready_campaign.py::test_run_campaign_surfaces_snqi_contract_warn_mode -q`
  - `scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml --output-root output/benchmarks/issue_3266 --campaign-id issue3266_scenario_horizon_preflight --mode preflight --skip-publication-bundle --log-level WARNING`
  - `scripts/dev/run_compact_validation.py -- scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/ -k "ppo or snqi or observation" -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- python -m ruff check robot_sf/baselines/ppo.py tests/baselines/test_ppo_planner.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- python -m ruff format --check robot_sf/baselines/ppo.py tests/baselines/test_ppo_planner.py`
  - `git diff --check`
- Evidence that the change works here: focused PPO unit coverage passes; issue-requested `ppo or snqi or observation` selector exits 0.
- Benchmarks or smoke tests, if applicable: scenario-horizon h500 preflight succeeds; full run intentionally not claimed.

## Risks / Rollout
- Compatibility risks: low; direct flat keys still win and structured keys are only used when model keys need them.
- Failure modes: incompatible checkpoints can still fail on true missing keys or shape mismatch, as intended.
- Rollback or fallback plan: revert the adapter helper and unit test; existing fallback behavior remains otherwise unchanged.

## Docs / Provenance
- Updated docs: config header in `configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml`.
- Relevant design or provenance notes: issue #3266 and PR #3263 diagnostic boundary.
- Any assumptions that need to be preserved: this PR is not full benchmark/Results evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via PR link.
- Claim map / benchmark report updated (yes/no/NA): no, deferred until post-repair rerun.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): config header updated only.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no, existing #3266 covers the rerun unless maintainers prefer a child issue.
- Not applicable because: no benchmark result is promoted.

## Follow-Up Issues
- Deferred work: run the smallest valid scenario-horizon proof after merge and classify SNQI contract output before Results wording.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: whether `robot_speed` / `robot_velocity_xy` aliasing matches the relevant PPO checkpoint expectation.
- Any known limitations: no full benchmark rerun in this PR; preflight and tests only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved observation preprocessing to handle nested observation structures more robustly
  * Added support for observation key aliasing, enabling greater flexibility in observation format mapping

* **Tests**
  * Added test coverage for observation preprocessing in dict-mode model observations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
