### PR TITLE
docs(skill): refine goal-pr-review for clarity and determinism

### DIFF
--- a/.agents/skills/goal-pr-review/SKILL.md
+++ b/.agents/skills/goal-pr-review/SKILL.md
@@ -48,15 +48,20 @@ Do not use it for:
 
 ## Read First
 
+Always read:
+
 - `AGENTS.md`
 - `docs/code_review.md`
 - `docs/dev_guide.md`
 - `docs/context/goal_driven_agent_loops_2026-05-13.md`
 - `.github/PULL_REQUEST_TEMPLATE/pr_default.md`
 - `.agents/skills/implementation-verification/SKILL.md`
-- `.agents/skills/gh-pr-comment-fixer/SKILL.md`
-- `.agents/skills/review-benchmark-change/SKILL.md`
 - `scripts/dev/check_skills.py --preflight goal-pr-review` (for preflight validation before review loop)
+
+Read when applicable:
+
+- `.agents/skills/gh-pr-comment-fixer/SKILL.md` (only when a PR has unresolved review threads to fix)
+- `.agents/skills/review-benchmark-change/SKILL.md` (only for benchmark-facing PRs)
 
 ## Preflight
 
@@ -83,6 +88,24 @@ Each PR is in one state:
 
 Avoid loops:
 - do not bounce `fixing` ↔ `awaiting_ci` without changes affecting proof.
+
+### Mapping policy output to states
+
+`scripts/dev/pr_loop_policy.py` (see Review Workflow) classifies PRs with its own vocabulary.
+Map each policy classification to a state in this skill so policy output drives state transitions
+deterministically:
+
+| `pr_loop_policy.py` classification | Recommended action | This skill's state |
+| --- | --- | --- |
+| `pending_ci` | `wait_ci` | `awaiting_ci` |
+| `failed_ci` | `inspect_failed_ci` | `fixing` if the failure is a fixable regression on a writable branch, else `blocked_external` |
+| `missing_artifacts` | `verify_artifacts` | `under_review` |
+| `stale_worktree` | `refresh_snapshot` | `under_review` (re-snapshot the advanced head before deciding) |
+| `ready_to_merge` | `mark_ready_candidate` | `merge_ready` only after the full proof bar in `## Proof and Validation` closes; otherwise `under_review` |
+| `no_action` | `no_action` | keep the current state (`awaiting_reviewer`, `blocked_external`, `deferred_scope`, or `closed_out`) |
+
+`ready_to_merge` is a candidate signal, not a merge decision: the policy only checks CI and label
+presence, so `merge_ready` still requires the intended-design and proof gates below.
 
 ## Review Workflow
 
@@ -266,10 +289,11 @@ For each reviewed PR, report:
 - `merge-ready` decision + confidence,
 - blockers and `follow-up` issues,
 - artifact classification decision.
+
 ## When to use
 
 Use this skill for the scope named in its frontmatter description and registry metadata.
-
+See `## Trigger Boundary` for the precise in-scope and out-of-scope actions.
 
 ## Guardrails
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Refined the `goal-pr-review` skill (`.agents/skills/goal-pr-review/SKILL.md`) for clarity and
+  determinism: added a mapping table that bridges `scripts/dev/pr_loop_policy.py` classifications
+  (`pending_ci`, `failed_ci`, `missing_artifacts`, `stale_worktree`, `ready_to_merge`, `no_action`)
+  to the skill's own state machine, noting that `ready_to_merge` is a candidate signal still gated by
+  the intended-design and proof bars; split `## Read First` into always-read versus
+  read-when-applicable (`gh-pr-comment-fixer` only for unresolved threads, `review-benchmark-change`
+  only for benchmark-facing PRs); and tidied the `## When to use` section formatting. Docs-only; the
+  skill validator (`scripts/dev/check_skills.py`) passes.
 * Continued the `_build_policy` decomposition (#3384) by migrating the `risk_surface_dwa` and
   `lidar_social_force` adapter families from the inline dispatcher into
   `robot_sf/benchmark/map_runner_policies/adapters.py`, registered in `_POLICY_BUILDERS`. The builders


### PR DESCRIPTION
## Summary

Refines the `goal-pr-review` skill (`.agents/skills/goal-pr-review/SKILL.md`) based on a review of its content. Docs-only — no code or behavior changes.

Four items were requested; three landed, one was intentionally dropped (see below).

### 1. State ↔ policy mapping (the substantive gap)
The skill defines its own state machine (`queued`, `under_review`, `fixing`, `awaiting_ci`, …) but drives decisions off `scripts/dev/pr_loop_policy.py`, which emits a *different* vocabulary (`pending_ci`, `failed_ci`, `missing_artifacts`, `stale_worktree`, `ready_to_merge`, `no_action`). Nothing told the agent how to bridge the two. Added a mapping table in the State Machine section, plus an explicit note that `ready_to_merge` is only a candidate signal (the policy checks CI + label presence only) and still requires the intended-design and proof gates.

### 2. `Read First` split into always-read vs conditional
`review-benchmark-change` (benchmark PRs only) and `gh-pr-comment-fixer` (only when there are unresolved threads) are now under "Read when applicable" so the loop doesn't front-load unnecessary context on, e.g., a docs-only PR.

### 3. `When to use` formatting fix
Added the missing blank line before the heading (was a markdownlint MD022 violation — the Output Requirements list ran straight into it), dropped a stray double blank line, and cross-referenced `## Trigger Boundary`.

### Dropped: deleting the `When to use` section
The original review suggested removing it as redundant boilerplate. That's **not valid** — `scripts/dev/check_skills.py` requires a `## When to use` section in every skill. Kept and cleaned up instead.

## Validation

- `uv run python scripts/dev/check_skills.py` → validates all 53 skills, regenerates registry/README/routing tests (no further changes produced; generation is idempotent).
- `uv run python scripts/dev/check_skills.py --preflight goal-pr-review` → PASS.
- `uv run python scripts/tools/sync_ai_config.py --check` → AI config links validated, no drift.
- `pre-commit` on changed files → clean.
- Verified all paths and cross-references the skill points to still exist (14 referenced paths + `goal-autopilot` "Async CI Wait Policy" / "Active Delegation Ledger" sections + the `Downstream Propagation` PR-template section).

🤖 Generated with [Claude Code](https://claude.com/claude-code)