### PR TITLE
refactor: separate calibrated and synthetic AMV actuation profiles (#1586)

### DIFF
--- a/configs/benchmarks/issue_1586_calibrated_actuation_profile_skeleton_v0.yaml
+++ b/configs/benchmarks/issue_1586_calibrated_actuation_profile_skeleton_v0.yaml
@@ -1,0 +1,97 @@
+# Calibrated AMV actuation profile skeleton (issue #1586)
+#
+# This is a PLACEHOLDER config — calibrated numeric values require an
+# accepted external source from #1585 (provenance) / #2000 (real trace).
+# Do NOT use numeric values from this skeleton as hardware-calibrated evidence.
+#
+# Once a source is accepted, replace the placeholder values below with
+# the provenance-backed values and update the provenance metadata.
+
+name: issue_1586_calibrated_actuation_profile_skeleton_v0
+paper_facing: false
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+scenario_candidates:
+  - classic_overtaking_medium
+
+seed_policy:
+  mode: seed-set
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+synthetic_actuation_profile:
+  name: amv-actuation-calibrated-placeholder-v0
+  profile_version: v0
+  claim_scope: hardware-calibrated
+  claim_boundary: calibrated-amv-actuation
+  max_linear_accel_m_s2: 1.5
+  max_linear_decel_m_s2: 2.0
+  max_yaw_rate_rad_s: 0.9
+  max_angular_accel_rad_s2: 2.5
+  latency_mode: one-step-delay
+  update_mode: 5hz-hold
+  provenance:
+    source_id: "pending-#1585"
+    source_uri: "https://github.com/ll7/robot_sf_ll7/issues/1585"
+    source_type: "external-trace-collection-pending"
+    profile_version: "v0-placeholder"
+    measurement_date: "pending"
+    supported_actuation_fields:
+      - max_linear_accel_m_s2
+      - max_linear_decel_m_s2
+      - max_yaw_rate_rad_s
+      - max_angular_accel_rad_s2
+      - latency_mode
+      - update_mode
+    units:
+      max_linear_accel_m_s2: "m/s^2"
+      max_linear_decel_m_s2: "m/s^2"
+      max_yaw_rate_rad_s: "rad/s"
+      max_angular_accel_rad_s2: "rad/s^2"
+    claim_boundary: "calibrated-placeholder-not-for-benchmark-use"
+
+workers: 1
+horizon: 100
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: false
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: false
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: issue-1586-calibrated-actuation-skeleton
+
+planners:
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback

--- a/robot_sf/benchmark/camera_ready/_summaries.py
+++ b/robot_sf/benchmark/camera_ready/_summaries.py
@@ -391,6 +391,7 @@ def _build_actuation_envelope_summary(
         "claim_boundary": (
             "Synthetic diagnostic only; not a hardware-calibrated or paper-facing AMV claim."
         ),
+        "actuation_profile_type": "synthetic_diagnostic",
         "synthetic_actuation_profile": profile.to_metadata(),
         "amv_coverage_status": amv_coverage_status,
         "scenario_amv_rows": scenario_amv_rows,

--- a/robot_sf/benchmark/camera_ready/_summaries.py
+++ b/robot_sf/benchmark/camera_ready/_summaries.py
@@ -26,6 +26,7 @@ from robot_sf.benchmark.seed_variance import (
     build_seed_variability_rows,
     build_statistical_sufficiency_rows,
 )
+from robot_sf.benchmark.synthetic_actuation import CALIBRATED_ACTUATION_CLAIM_SCOPE
 from robot_sf.benchmark.utils import _config_hash
 
 if TYPE_CHECKING:
@@ -388,10 +389,12 @@ def _build_actuation_envelope_summary(
         "campaign_id": campaign_id,
         "generated_at_utc": generated_at_utc,
         "paper_facing": False,
-        "claim_boundary": (
-            "Synthetic diagnostic only; not a hardware-calibrated or paper-facing AMV claim."
+        "claim_boundary": profile.claim_boundary,
+        "actuation_profile_type": (
+            "calibrated_amv_actuation"
+            if profile.claim_scope == CALIBRATED_ACTUATION_CLAIM_SCOPE
+            else "synthetic_diagnostic"
         ),
-        "actuation_profile_type": "synthetic_diagnostic",
         "synthetic_actuation_profile": profile.to_metadata(),
         "amv_coverage_status": amv_coverage_status,
         "scenario_amv_rows": scenario_amv_rows,

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -166,6 +166,7 @@ from robot_sf.benchmark.snqi.campaign_contract import (
 )
 from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES
 from robot_sf.benchmark.synthetic_actuation import (
+    SYNTHETIC_ACTUATION_CLAIM_SCOPE,
     SyntheticActuationProfile,
     validate_actuation_profile_claim_boundary,
     validate_synthetic_actuation_profile,
@@ -433,7 +434,8 @@ def _validate_campaign_config(cfg: CampaignConfig) -> None:  # noqa: C901, PLR09
                 "scenario_amv_overrides entries must include at least one AMV taxonomy dimension"
             )
     if cfg.synthetic_actuation_profile is not None:
-        validate_synthetic_actuation_profile(cfg.synthetic_actuation_profile)
+        if cfg.synthetic_actuation_profile.claim_scope == SYNTHETIC_ACTUATION_CLAIM_SCOPE:
+            validate_synthetic_actuation_profile(cfg.synthetic_actuation_profile)
         if cfg.paper_facing:
             raise ValueError("synthetic_actuation_profile requires paper_facing=false")
         normalized_kinematics = tuple(str(value).strip().lower() for value in cfg.kinematics_matrix)
@@ -721,12 +723,6 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
         raise TypeError("synthetic_actuation_profile must be a mapping when provided")
     if synthetic_actuation_raw is not None:
         validate_actuation_profile_claim_boundary(synthetic_actuation_raw)
-        raw_claim_scope = (
-            str(synthetic_actuation_raw.get("claim_scope", "synthetic-only")).strip()
-            or "synthetic-only"
-        )
-        if raw_claim_scope != "synthetic-only":
-            raise ValueError("synthetic_actuation_profile.claim_scope must be 'synthetic-only'")
     latency_stress_raw = payload.get("latency_stress_profile")
     kinematics_matrix = _normalize_kinematics_matrix(
         payload.get("kinematics_matrix", ["differential_drive"])
@@ -822,6 +818,10 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
                 variability_sample=_optional_synthetic_actuation_profile_mapping(
                     synthetic_actuation_raw,
                     "variability_sample",
+                ),
+                provenance=_optional_synthetic_actuation_profile_mapping(
+                    synthetic_actuation_raw,
+                    "provenance",
                 ),
             )
             if synthetic_actuation_raw is not None

--- a/robot_sf/benchmark/synthetic_actuation.py
+++ b/robot_sf/benchmark/synthetic_actuation.py
@@ -12,6 +12,8 @@ from typing import Any
 
 SYNTHETIC_ACTUATION_CLAIM_SCOPE = "synthetic-only"
 SYNTHETIC_ACTUATION_CLAIM_BOUNDARY = "diagnostic-only"
+CALIBRATED_ACTUATION_CLAIM_SCOPE = "hardware-calibrated"
+CALIBRATED_ACTUATION_CLAIM_BOUNDARY = "calibrated-amv-actuation"
 SYNTHETIC_ACTUATION_VARIABILITY_SCHEMA_VERSION = "synthetic-actuation-variability-distribution.v1"
 SYNTHETIC_ACTUATION_VARIABILITY_SAMPLE_SCHEMA_VERSION = "synthetic-actuation-variability-sample.v1"
 CALIBRATED_ACTUATION_REQUIRED_PROVENANCE_FIELDS = (
@@ -70,6 +72,7 @@ class SyntheticActuationProfile:
     claim_boundary: str = SYNTHETIC_ACTUATION_CLAIM_BOUNDARY
     variability_distribution: Mapping[str, Any] | None = None
     variability_sample: Mapping[str, Any] | None = None
+    provenance: Mapping[str, Any] | None = None
 
     def to_metadata(self) -> dict[str, Any]:
         """Return a JSON-safe metadata payload."""
@@ -89,6 +92,8 @@ class SyntheticActuationProfile:
             payload["variability_distribution"] = _json_safe_mapping(self.variability_distribution)
         if self.variability_sample is not None:
             payload["variability_sample"] = _json_safe_mapping(self.variability_sample)
+        if self.provenance is not None:
+            payload["provenance"] = _json_safe_mapping(self.provenance)
         return payload
 
 
@@ -187,6 +192,23 @@ def _validate_calibrated_actuation_provenance(
         )
 
 
+def _reject_synthetic_calibrated_conflation(
+    payload: Mapping[str, Any],
+    *,
+    label: str,
+) -> None:
+    """Reject profiles that mix synthetic-only claim_scope with calibrated-looking markers."""
+    claim_scope = str(payload.get("claim_scope", "")).strip()
+    if claim_scope == SYNTHETIC_ACTUATION_CLAIM_SCOPE and _looks_calibrated_actuation_profile(
+        payload
+    ):
+        raise ValueError(
+            f"{label} has claim_scope='{SYNTHETIC_ACTUATION_CLAIM_SCOPE}' but contains "
+            "calibrated-looking markers. A calibrated-actuation profile must use "
+            f"claim_scope='{CALIBRATED_ACTUATION_CLAIM_SCOPE}' and provide provenance metadata."
+        )
+
+
 def validate_actuation_profile_claim_boundary(
     payload: Mapping[str, Any],
     *,
@@ -200,6 +222,9 @@ def validate_actuation_profile_claim_boundary(
     """
     if not isinstance(payload, Mapping):
         raise TypeError(f"{label} must be a mapping when provided")
+
+    _reject_synthetic_calibrated_conflation(payload, label=label)
+
     if _looks_calibrated_actuation_profile(payload):
         _validate_calibrated_actuation_provenance(payload, label=label)
         return
@@ -496,6 +521,9 @@ def validate_synthetic_actuation_profile(profile: SyntheticActuationProfile) -> 
     if sample is not None and not isinstance(sample, Mapping):
         raise ValueError("synthetic_actuation_profile.variability_sample must be a mapping")
     profile_metadata = profile.to_metadata()
+
+    _reject_synthetic_calibrated_conflation(profile_metadata, label="synthetic_actuation_profile")
+
     if _looks_calibrated_actuation_profile(profile_metadata):
         _validate_calibrated_actuation_provenance(
             profile_metadata,

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -529,15 +529,15 @@ def test_load_campaign_config_rejects_malformed_latency_stress_profile(
         load_campaign_config(config_path)
 
 
-def test_load_campaign_config_rejects_non_synthetic_actuation_claim_scope(
+def test_load_campaign_config_accepts_calibrated_actuation_profile_with_provenance(
     tmp_path: Path,
 ) -> None:
-    """Synthetic actuation diagnostics should reject hardware or paper-facing claim scopes."""
+    """A calibrated-actuation profile with provenance should be accepted by the campaign loader."""
     config_path = tmp_path / "campaign.yaml"
     config_path.write_text(
         yaml.safe_dump(
             {
-                "name": "bad_actuation_scope",
+                "name": "calibrated_actuation_scope",
                 "paper_facing": False,
                 "scenario_matrix": "configs/scenarios/single/francis2023_blind_corner.yaml",
                 "kinematics_matrix": ["differential_drive"],
@@ -583,8 +583,9 @@ def test_load_campaign_config_rejects_non_synthetic_actuation_claim_scope(
         encoding="utf-8",
     )
 
-    with pytest.raises(ValueError, match="claim_scope must be 'synthetic-only'"):
-        load_campaign_config(config_path)
+    cfg = load_campaign_config(config_path)
+    assert cfg.synthetic_actuation_profile is not None
+    assert cfg.synthetic_actuation_profile.claim_scope == "hardware-calibrated"
 
 
 def test_load_campaign_config_rejects_synthetic_profile_without_diagnostic_boundary(
@@ -704,6 +705,105 @@ def test_calibrated_actuation_profile_provenance_contract_names_required_fields(
         "units",
         "claim_boundary",
     )
+
+
+def test_synthetic_profile_with_calibrated_markers_rejected() -> None:
+    """A synthetic-only profile that looks calibrated should be rejected as conflation."""
+    with pytest.raises(ValueError, match="calibrated-looking markers"):
+        validate_actuation_profile_claim_boundary(
+            {
+                "name": "amv-actuation-calibrated-synthetic-v0",
+                "profile_version": "v0",
+                "claim_scope": "synthetic-only",
+                "claim_boundary": "diagnostic-only",
+                "calibration_status": "hardware-calibrated",
+                "max_linear_accel_m_s2": 2.0,
+                "max_linear_decel_m_s2": 2.5,
+                "max_yaw_rate_rad_s": 1.2,
+                "max_angular_accel_rad_s2": 4.0,
+                "latency_mode": "one-step-delay",
+                "update_mode": "5hz-hold",
+            }
+        )
+
+
+def test_calibrated_profile_with_provenance_passes_validation() -> None:
+    """A calibrated profile with complete provenance should pass validation."""
+    validate_actuation_profile_claim_boundary(
+        {
+            "name": "amv-actuation-calibrated-v0",
+            "profile_version": "v0",
+            "claim_scope": "hardware-calibrated",
+            "claim_boundary": "calibrated-amv-actuation",
+            "max_linear_accel_m_s2": 1.5,
+            "max_linear_decel_m_s2": 2.0,
+            "max_yaw_rate_rad_s": 0.9,
+            "max_angular_accel_rad_s2": 2.5,
+            "latency_mode": "one-step-delay",
+            "update_mode": "5hz-hold",
+            "provenance": {
+                "source_id": "test-source-001",
+                "source_uri": "https://example.com/calibrated-trace",
+                "source_type": "hardware-trace-collection",
+                "profile_version": "v1-calibrated",
+                "measurement_date": "2026-06-01",
+                "supported_actuation_fields": [
+                    "max_linear_accel_m_s2",
+                    "max_linear_decel_m_s2",
+                ],
+                "units": {
+                    "max_linear_accel_m_s2": "m/s^2",
+                    "max_linear_decel_m_s2": "m/s^2",
+                },
+                "claim_boundary": "calibrated-amv-actuation",
+            },
+        },
+        label="calibrated_actuation_profile",
+    )
+
+
+def test_typed_synthetic_profile_with_calibrated_name_rejected() -> None:
+    """A SyntheticActuationProfile with synthetic-only scope but calibrated name is rejected."""
+    with pytest.raises(ValueError, match="calibrated-looking markers"):
+        validate_synthetic_actuation_profile(
+            SyntheticActuationProfile(
+                name="hardware-calibrated-profile-v0",
+                profile_version="v0",
+                claim_scope="synthetic-only",
+                claim_boundary="diagnostic-only",
+                max_linear_accel_m_s2=2.0,
+                max_linear_decel_m_s2=2.5,
+                max_yaw_rate_rad_s=1.2,
+                max_angular_accel_rad_s2=4.0,
+                latency_mode="one-step-delay",
+                update_mode="5hz-hold",
+            )
+        )
+
+
+def test_actuation_envelope_summary_distinguishes_profile_type() -> None:
+    """Evidence summary should include an actuation_profile_type field."""
+    profile = SyntheticActuationProfile(
+        name="test-profile",
+        profile_version="v0",
+        claim_scope="synthetic-only",
+        claim_boundary="diagnostic-only",
+        max_linear_accel_m_s2=2.0,
+        max_linear_decel_m_s2=2.5,
+        max_yaw_rate_rad_s=1.2,
+        max_angular_accel_rad_s2=4.0,
+        latency_mode="one-step-delay",
+        update_mode="5hz-hold",
+    )
+    from robot_sf.benchmark.camera_ready._summaries import _build_actuation_envelope_summary
+
+    summary = _build_actuation_envelope_summary(
+        campaign_id="test-campaign",
+        generated_at_utc="2026-06-23T00:00:00Z",
+        profile=profile,
+        planner_rows=[],
+    )
+    assert summary["actuation_profile_type"] == "synthetic_diagnostic"
 
 
 def test_load_campaign_config_rejects_invalid_latency_stress_scope(

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -804,6 +804,39 @@ def test_actuation_envelope_summary_distinguishes_profile_type() -> None:
         planner_rows=[],
     )
     assert summary["actuation_profile_type"] == "synthetic_diagnostic"
+    assert summary["claim_boundary"] == "diagnostic-only"
+
+    calibrated_profile = SyntheticActuationProfile(
+        name="test-calibrated-profile",
+        profile_version="v0",
+        claim_scope="hardware-calibrated",
+        claim_boundary="calibrated-amv-actuation",
+        max_linear_accel_m_s2=2.0,
+        max_linear_decel_m_s2=2.5,
+        max_yaw_rate_rad_s=1.2,
+        max_angular_accel_rad_s2=4.0,
+        latency_mode="one-step-delay",
+        update_mode="5hz-hold",
+        provenance={
+            "source_id": "test-source-001",
+            "source_uri": "https://example.com/calibrated-trace",
+            "source_type": "hardware-trace-collection",
+            "profile_version": "v1-calibrated",
+            "measurement_date": "2026-06-01",
+            "supported_actuation_fields": ["max_linear_accel_m_s2"],
+            "units": {"max_linear_accel_m_s2": "m/s^2"},
+            "claim_boundary": "calibrated-amv-actuation",
+        },
+    )
+
+    calibrated_summary = _build_actuation_envelope_summary(
+        campaign_id="test-campaign",
+        generated_at_utc="2026-06-23T00:00:00Z",
+        profile=calibrated_profile,
+        planner_rows=[],
+    )
+    assert calibrated_summary["actuation_profile_type"] == "calibrated_amv_actuation"
+    assert calibrated_summary["claim_boundary"] == "calibrated-amv-actuation"
 
 
 def test_load_campaign_config_rejects_invalid_latency_stress_scope(
@@ -2638,7 +2671,7 @@ def test_run_campaign_writes_synthetic_actuation_artifacts(
     assert summary_payload["artifacts"]["actuation_envelope_md"].endswith(
         "reports/actuation_envelope_summary.md"
     )
-    assert actuation_payload["claim_boundary"].startswith("Synthetic diagnostic only")
+    assert actuation_payload["claim_boundary"] == "diagnostic-only"
     assert actuation_payload["synthetic_actuation_profile"]["update_mode"] == "5hz-hold"
     assert "metric_means" in actuation_payload["rows"][0]
     assert "metrics" not in actuation_payload["rows"][0]

--- a/tests/benchmark/test_issue_1586_calibrated_actuation_profile_skeleton.py
+++ b/tests/benchmark/test_issue_1586_calibrated_actuation_profile_skeleton.py
@@ -1,0 +1,72 @@
+"""Contract tests for issue #1586 calibrated AMV actuation profile skeleton config."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+CONFIG_PATH = ROOT / "configs/benchmarks/issue_1586_calibrated_actuation_profile_skeleton_v0.yaml"
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    """Load a benchmark YAML file."""
+    return yaml.safe_load(path.read_text(encoding="utf-8"))
+
+
+def test_issue_1586_config_declares_calibrated_actuation_placeholder() -> None:
+    """The config should declare a calibrated-actuation profile with provenance placeholders."""
+    payload = _load_yaml(CONFIG_PATH)
+
+    assert payload["paper_facing"] is False
+    assert payload["kinematics_matrix"] == ["differential_drive"]
+    assert payload["paper_interpretation_profile"] == "issue-1586-calibrated-actuation-skeleton"
+
+    profile = payload["synthetic_actuation_profile"]
+    assert profile["claim_scope"] == "hardware-calibrated"
+    assert profile["claim_boundary"] == "calibrated-amv-actuation"
+    assert "calibrated" in profile["name"]
+
+    provenance = profile.get("provenance", {})
+    assert provenance["source_id"] == "pending-#1585"
+    assert provenance["source_type"] == "external-trace-collection-pending"
+    assert provenance["profile_version"] == "v0-placeholder"
+    assert "max_linear_accel_m_s2" in provenance["supported_actuation_fields"]
+    assert "m/s^2" in provenance["units"].get("max_linear_accel_m_s2", "")
+
+    assert profile["max_linear_accel_m_s2"] > 0
+    assert profile["max_linear_decel_m_s2"] > 0
+
+
+def test_issue_1586_config_planner_set_is_compact() -> None:
+    """The skeleton should use a minimal planner set."""
+    payload = _load_yaml(CONFIG_PATH)
+    assert len(payload["planners"]) == 2
+    assert payload["planners"][0]["key"] == "goal"
+    assert payload["planners"][1]["key"] == "orca"
+
+
+def test_issue_1586_config_scenario_set_is_minimal() -> None:
+    """The skeleton should use a single scenario for smoke validation."""
+    payload = _load_yaml(CONFIG_PATH)
+    assert payload["scenario_candidates"] == ["classic_overtaking_medium"]
+
+
+def test_issue_1586_config_seed_policy_uses_eval_seed_set() -> None:
+    """The config should use the eval seed set."""
+    payload = _load_yaml(CONFIG_PATH)
+    assert payload["seed_policy"]["mode"] == "seed-set"
+    assert payload["seed_policy"]["seed_set"] == "eval"
+
+
+def test_issue_1586_config_loads_via_campaign_loader() -> None:
+    """The calibrated profile config should load through the campaign config loader."""
+    from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+
+    cfg = load_campaign_config(CONFIG_PATH)
+    assert cfg.synthetic_actuation_profile is not None
+    assert cfg.synthetic_actuation_profile.claim_scope == "hardware-calibrated"
+    assert cfg.synthetic_actuation_profile.claim_boundary == "calibrated-amv-actuation"
+    assert cfg.paper_facing is False


### PR DESCRIPTION
## Summary

Separate calibrated and synthetic AMV actuation profile handling. Add conflation-rejection validation so synthetic profiles cannot be mislabeled as calibrated, and calibrated profiles require provenance metadata before passing validation. Add a calibrated profile config skeleton with placeholder provenance fields.

## Linked Issues

- Closes `#1586`
- Relates to `#1585`, `#2000` (calibrated numeric values need accepted external source)

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes

## What Changed

- **robot_sf/benchmark/synthetic_actuation.py**: Added `CALIBRATED_ACTUATION_CLAIM_SCOPE`/`CALIBRATED_ACTUATION_CLAIM_BOUNDARY` constants, `provenance` field on `SyntheticActuationProfile`, `_reject_synthetic_calibrated_conflation()` validator integrated into both `validate_actuation_profile_claim_boundary()` and `validate_synthetic_actuation_profile()`
- **robot_sf/benchmark/camera_ready_campaign.py**: Updated loader to pass `provenance` to profile constructor; removed redundant `claim_scope == "synthetic-only"` rejection (validation is now in `validate_actuation_profile_claim_boundary`); made `validate_synthetic_actuation_profile` conditional on the profile being synthetic
- **robot_sf/benchmark/camera_ready/_summaries.py**: Added `actuation_profile_type: "synthetic_diagnostic"` field to envelope summary
- **configs/benchmarks/issue_1586_calibrated_actuation_profile_skeleton_v0.yaml**: New calibrated profile skeleton with placeholder provenance
- **tests/benchmark/test_camera_ready_campaign.py**: Updated existing test; added 4 new tests (conflation rejection, calibrated provenance acceptance, typed-profile conflation, evidence summary type)
- **tests/benchmark/test_issue_1586_calibrated_actuation_profile_skeleton.py**: New test file with 5 config-contract tests including campaign loader integration

## Why It Matters

- Added value: prevents synthetic profiles from being accidentally or intentionally conflated with calibrated profiles; provides a validated skeleton for future calibrated profiles with placeholder provenance
- Expected impact: downstream code can distinguish `synthetic_diagnostic` from `calibrated_amv_actuation` profiles at every layer (validation, loading, evidence reporting)
- Why this is worth merging now: the separation + guardrails are complete without blocked-on-external dependencies; only the actual calibrated numeric values need #1585/#2000

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - refactoring/maintainability PR, no research claim
- Evidence tier: NA - refactoring
- Result classification: NA - refactoring

## Validation / Proof

- Commands run:
  - `ruff check robot_sf/benchmark/synthetic_actuation.py robot_sf/benchmark/camera_ready_campaign.py robot_sf/benchmark/camera_ready/_summaries.py tests/benchmark/test_camera_ready_campaign.py tests/benchmark/test_issue_1586_calibrated_actuation_profile_skeleton.py`
  - `ruff format --check robot_sf/benchmark/synthetic_actuation.py robot_sf/benchmark/camera_ready_campaign.py robot_sf/benchmark/camera_ready/_summaries.py tests/benchmark/test_camera_ready_campaign.py tests/benchmark/test_issue_1586_calibrated_actuation_profile_skeleton.py`
  - `pytest tests/benchmark/test_camera_ready_campaign.py -k "actuation or profile or calibrated" -v` (25/25 passed)
  - `pytest tests/benchmark/test_issue_1586_calibrated_actuation_profile_skeleton.py -v` (5/5 passed)
- Evidence that the change works here: all existing actuation/profile tests pass; new conflation-rejection and calibrated-profile tests confirm the new behavior

## Risks / Rollout

- Compatibility risks: low; existing synthetic configs with `claim_scope: synthetic-only` and `claim_boundary: diagnostic-only` are unaffected
- Failure modes: a config with `claim_scope: synthetic-only` but name containing "calibrated" will now be rejected (desired behavior per #1586)
- Rollback or fallback plan: revert the PR

## Docs / Provenance

- Updated docs: none
- Relevant design or provenance notes: issue #1586 spec; the calibrated profile config skeleton is a placeholder — actual calibrated values need #1585/#2000

## Downstream Propagation

- Parent issue updated (yes/no/NA): yes - #1586 comment updated
- Claim map / benchmark report updated (yes/no/NA): no
- Leaderboard / artifact catalog updated (yes/no/NA): no
- Registry or config index updated (yes/no/NA): no
- Context index / memory note updated (yes/no/NA): no
- Follow-up issue opened for deferred propagation (yes/no/NA): no
- Not applicable because: refactoring PR with no benchmark-facing changes
