### PR TITLE
analysis: define adversarial manifest quality metrics (#2601)

### DIFF
--- a/docs/context/adversarial_manifest_quality_metrics.md
+++ b/docs/context/adversarial_manifest_quality_metrics.md
@@ -1,0 +1,69 @@
+# Adversarial Manifest Quality Metrics
+
+Canonical metric vocabulary for generated adversarial scenario manifests.
+These metrics are **diagnostic generator-quality signals only** — they must not be
+treated as planner benchmark evidence or adversarial robustness claims.
+
+## Evidence Boundary
+
+```yaml
+evidence_tier: analysis_only
+claim_boundary: diagnostic generator-quality signals only; not planner benchmark evidence
+```
+
+## Metric Groups
+
+### Pre-Execution Metrics (computed from manifests alone, no planner iteration)
+
+| Metric | Numerator | Denominator | Units | Required Inputs | Status |
+|---|---|---|---|---|---|
+| `validity_rate` | `valid` manifests | total manifests | fraction | manifest status field | implemented |
+| `degeneracy_rate` | `degenerate` manifests | total manifests | fraction | manifest status field | implemented |
+| `novelty_from_seed` | unique control hashes | hashable manifests | fraction | control field comparison | implemented |
+| `perturbation_distance` | mean L2 distance from reference | perturbed manifests | meters | reference manifest controls | implemented |
+| `runner_compatibility_rate` | compatible manifests (total - parse_failures - degenerate) | total manifests | fraction | manifest parse + status + degenerate fields | implemented |
+| `invalid_rate` | `invalid` manifests | total manifests | fraction | manifest status field | implemented |
+| `duplicate_rate` | duplicate control hashes | hashable manifests | fraction | control field comparison | implemented |
+
+### Planner-Response Metrics (require smoke-level planner iteration)
+
+| Metric | Numerator | Denominator | Units | Required Inputs | Status |
+|---|---|---|---|---|---|
+| `failure_yield` | failure episodes | total episodes | fraction | planner smoke summary | implemented |
+| `near_miss_yield` | near-miss episodes | total episodes | fraction | planner smoke summary | implemented |
+| `low_progress_yield` | low-progress episodes (timeout + displacement < 0.25 m) | total episodes | fraction | planner smoke summary with termination + displacement | implemented |
+
+### Naturalistic Prior Metrics
+
+| Metric | Numerator | Denominator | Units | Required Inputs | Status |
+|---|---|---|---|---|---|
+| `naturalistic_prior_pass_rate` | passed prior checks | available checks | fraction | naturalistic prior annotations | implemented |
+| `naturalistic_prior_fail_rate` | failed prior checks | available checks | fraction | naturalistic prior annotations | implemented |
+
+### Not Yet Implemented (requires future data pipeline)
+
+These metrics are proposed but depend on runner/planner execution infrastructure
+not yet available in compact summary form:
+
+- `fallback_or_degraded_rate`: fraction of planner runs that fell back or degraded
+- Additional planner-response diagnostics: requires structured runner compatibility data
+
+## Pre-Execution vs Planner-Response Separation
+
+All metrics in the **Pre-Execution** group can be computed from manifest files alone
+without running any planner. Metrics in the **Planner-Response** group require
+smoke-level planner iteration results.
+
+## Fail-Closed Exclusion
+
+Per the repository's fail-closed benchmark policy (issue #691):
+- Fallback or degraded planner runs must be excluded from planner-response metric denominators
+  or explicitly caveated
+- The `degeneracy_rate` and `runner_compatibility_rate` pre-execution metrics already
+  track runner-fitness signals before planner iteration begins
+
+## Source Code
+
+- Implementation: `robot_sf/adversarial/manifest_quality.py`
+- CLI entry point: `python -m robot_sf.adversarial.manifest_quality`
+- Related issues: #2524 (manifest generation), #2599 (first applied smoke), #2920 (certification)

--- a/robot_sf/adversarial/manifest_quality.py
+++ b/robot_sf/adversarial/manifest_quality.py
@@ -257,6 +257,8 @@ class PlannerOutcome:
     near_miss_yield: float | None
     source: str
     note: str | None = None
+    low_progress_count: int | None = None
+    low_progress_yield: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return JSON-safe representation."""
@@ -267,6 +269,8 @@ class PlannerOutcome:
             "near_miss_count": self.near_miss_count,
             "failure_yield": self.failure_yield,
             "near_miss_yield": self.near_miss_yield,
+            "low_progress_count": self.low_progress_count,
+            "low_progress_yield": self.low_progress_yield,
             "source": self.source,
         }
         if self.note is not None:
@@ -320,6 +324,7 @@ class ManifestsQualitySummary:
     naturalistic_prior_fail_rate: float
     naturalistic_prior_violation_counts: dict[str, int]
     planner_outcomes: PlannerOutcomeSummary | None
+    runner_compatibility_rate: float | None = None
 
     def to_dict(self) -> dict[str, Any]:
         """Return JSON-safe representation."""
@@ -333,6 +338,7 @@ class ManifestsQualitySummary:
                 "validity_rate": self.validity_rate,
                 "invalid_rate": self.invalid_rate,
                 "degenerate_rate": self.degenerate_rate,
+                "runner_compatibility_rate": self.runner_compatibility_rate,
             },
             "novelty": {
                 "hashable_count": self.hashable_count,
@@ -573,6 +579,18 @@ def _has_near_miss(row: dict[str, Any]) -> bool:
     return near_miss_value is not None and near_miss_value > 0.0
 
 
+def _has_low_progress(row: dict[str, Any]) -> bool:
+    """Return whether one episode row reports low progress (timeout with minimal displacement)."""
+    termination = str(row.get("termination_reason", "")).strip().lower()
+    if not termination or termination == "success":
+        return False
+    if termination not in ("timeout", "truncated", "max_steps"):
+        return False
+    displacement = _safe_float(row.get("robot_displacement_m"))
+    low_progress_threshold = 0.25
+    return displacement is not None and displacement < low_progress_threshold
+
+
 def _metric_stat(metrics: dict[str, Any], metric_name: str, stat_name: str) -> float | None:
     """Read a finite metric statistic from an aggregate metric payload."""
     raw_metric = metrics.get(metric_name)
@@ -654,11 +672,14 @@ def _summarize_single_planner_run(
 
     failures = 0
     near_misses = 0
+    low_progress = 0
     for row in rows:
         if _row_is_failure(row):
             failures += 1
         if _has_near_miss(row):
             near_misses += 1
+        if _has_low_progress(row):
+            low_progress += 1
     total = len(rows)
     return PlannerOutcome(
         planner=planner,
@@ -667,6 +688,8 @@ def _summarize_single_planner_run(
         near_miss_count=near_misses,
         failure_yield=_safe_rate(failures, total),
         near_miss_yield=_safe_rate(near_misses, total),
+        low_progress_count=low_progress,
+        low_progress_yield=_safe_rate(low_progress, total),
         source="episode_rows",
     )
 
@@ -710,6 +733,14 @@ def _summarize_planner_run_from_aggregates(
         near_miss_count = near_miss_count_value
         near_miss_yield = _safe_rate(near_miss_count, episodes)
 
+    low_progress_count_value = _count_like_sum(
+        _metric_stat(metrics, "low_progress", "sum") if isinstance(metrics, dict) else None,
+        episodes,
+    )
+    low_progress_yield_val = None
+    if episodes is not None and low_progress_count_value is not None:
+        low_progress_yield_val = _safe_rate(low_progress_count_value, episodes)
+
     return PlannerOutcome(
         planner=planner,
         episodes=episodes,
@@ -717,6 +748,8 @@ def _summarize_planner_run_from_aggregates(
         near_miss_count=near_miss_count,
         failure_yield=failure_yield,
         near_miss_yield=near_miss_yield,
+        low_progress_count=low_progress_count_value,
+        low_progress_yield=low_progress_yield_val,
         source="aggregate_metrics",
         note=(
             "failure_yield derived from count-like aggregate success sums; near_miss_yield "
@@ -793,11 +826,15 @@ def summarize_adversarial_manifest_quality_records(
         Path(smoke_summary_json) if smoke_summary_json is not None else None
     )
     reference_manifest_path = Path(reference_manifest) if reference_manifest is not None else None
+    parse_failures = sum(1 for record in records if record.parse_error is not None)
+    compatible = total - parse_failures - degenerate
+    runner_compatibility_rate_val = _safe_rate(compatible, total) if total > 0 else None
 
     return ManifestsQualitySummary(
+        runner_compatibility_rate=runner_compatibility_rate_val,
         input_paths=sorted({record.path for record in records}),
         manifest_count=total,
-        parse_failures=sum(1 for record in records if record.parse_error is not None),
+        parse_failures=parse_failures,
         status_counts=dict(status_counts),
         validity_rate=_safe_rate(valid, total),
         invalid_rate=_safe_rate(invalid, total),

--- a/robot_sf/adversarial/manifest_quality.py
+++ b/robot_sf/adversarial/manifest_quality.py
@@ -734,7 +734,7 @@ def _summarize_planner_run_from_aggregates(
         near_miss_yield = _safe_rate(near_miss_count, episodes)
 
     low_progress_count_value = _count_like_sum(
-        _metric_stat(metrics, "low_progress", "sum") if isinstance(metrics, dict) else None,
+        _metric_stat(metrics, "low_progress", "sum"),
         episodes,
     )
     low_progress_yield_val = None

--- a/tests/adversarial/test_manifest_quality_metrics.py
+++ b/tests/adversarial/test_manifest_quality_metrics.py
@@ -1,0 +1,95 @@
+"""Tests for issue #2601 adversarial manifest quality metrics."""
+
+from __future__ import annotations
+
+from robot_sf.adversarial.manifest_quality import (
+    PlannerOutcome,
+    _has_low_progress,
+    _row_is_failure,
+)
+
+
+def test_has_low_progress_true_on_timeout_with_low_displacement() -> None:
+    """A timeout row with displacement below 0.25m should be low-progress."""
+    row = {"termination_reason": "timeout", "robot_displacement_m": 0.1}
+    assert _has_low_progress(row) is True
+
+
+def test_has_low_progress_false_on_success() -> None:
+    """A successful row should not be low-progress."""
+    row = {"termination_reason": "success", "robot_displacement_m": 0.1}
+    assert _has_low_progress(row) is False
+
+
+def test_has_low_progress_false_on_high_displacement() -> None:
+    """A timeout row with displacement above 0.25m should not be low-progress."""
+    row = {"termination_reason": "timeout", "robot_displacement_m": 1.0}
+    assert _has_low_progress(row) is False
+
+
+def test_has_low_progress_false_on_collision_termination() -> None:
+    """Collision-term rows should not be classified as low-progress."""
+    row = {"termination_reason": "collision", "robot_displacement_m": 0.1}
+    assert _has_low_progress(row) is False
+
+
+def test_has_low_progress_handles_missing_displacement() -> None:
+    """Rows without displacement should not be flagged as low-progress."""
+    row = {"termination_reason": "timeout"}
+    assert _has_low_progress(row) is False
+
+
+def test_planner_outcome_includes_low_progress_fields() -> None:
+    """PlannerOutcome should carry low_progress_count and low_progress_yield."""
+    outcome = PlannerOutcome(
+        planner="test",
+        episodes=10,
+        failure_count=2,
+        near_miss_count=1,
+        failure_yield=0.2,
+        near_miss_yield=0.1,
+        low_progress_count=3,
+        low_progress_yield=0.3,
+        source="test",
+    )
+    assert outcome.low_progress_count == 3
+    assert outcome.low_progress_yield == 0.3
+
+
+def test_planner_outcome_to_dict_includes_low_progress() -> None:
+    """PlannerOutcome.to_dict should include low_progress fields."""
+    outcome = PlannerOutcome(
+        planner="test",
+        episodes=10,
+        failure_count=2,
+        near_miss_count=1,
+        failure_yield=0.2,
+        near_miss_yield=0.1,
+        low_progress_count=3,
+        low_progress_yield=0.3,
+        source="test",
+    )
+    d = outcome.to_dict()
+    assert d["low_progress_count"] == 3
+    assert d["low_progress_yield"] == 0.3
+
+
+def test_has_low_progress_accepts_truncated_and_max_steps() -> None:
+    """Truncated and max_steps terminations should also be low-progress candidates."""
+    for term in ("truncated", "max_steps"):
+        row = {"termination_reason": term, "robot_displacement_m": 0.1}
+        assert _has_low_progress(row) is True, f"Failed for {term}"
+
+
+def test_row_is_failure_vs_low_progress_collision() -> None:
+    """A collision row is both a failure AND NOT low-progress."""
+    row = {"termination_reason": "collision", "robot_displacement_m": 0.1}
+    assert _row_is_failure(row) is True
+    assert _has_low_progress(row) is False
+
+
+def test_row_is_failure_vs_low_progress_timeout_low_disp() -> None:
+    """A timeout with low displacement is both a failure AND low-progress."""
+    row = {"termination_reason": "timeout", "robot_displacement_m": 0.1}
+    assert _row_is_failure(row) is True
+    assert _has_low_progress(row) is True


### PR DESCRIPTION
## Summary

Add `low_progress_yield` to PlannerOutcome and `runner_compatibility_rate` to ManifestsQualitySummary in the adversarial manifest quality pipeline. Write canonical metric vocabulary documentation with numerator/denominator/units/required-inputs and pre-execution vs planner-response grouping.

## Linked Issues

- Closes `#2601`
- Relates to `#2524`, `#2599`, `#2920`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Safe to review independently: yes

## What Changed

- **robot_sf/adversarial/manifest_quality.py**: Added `_has_low_progress` predicate (timeout/truncated/max_steps with displacement <0.25m); added `low_progress_count`/`low_progress_yield` to `PlannerOutcome` dataclass, serialization, and both episode-row and aggregate summarization paths; added `runner_compatibility_rate` to `ManifestsQualitySummary` (fraction of manifests that parse successfully and are non-degenerate)
- **docs/context/adversarial_manifest_quality_metrics.md**: Canonical metric vocabulary with 9 metrics, numerator/denominator/units/required-inputs, pre-execution vs planner-response grouping, status per metric, and fail-closed exclusion notes
- **tests/adversarial/test_manifest_quality_metrics.py**: 10 tests covering low_progress detection edge cases, PlannerOutcome field inclusion, to_dict serialization, and failure-vs-low-progress classification

## Why It Matters

- Added value: closes the metric gap between issue #2601's candidate vocabulary and the existing implementation; documents which metrics are computable pre-execution vs requiring planner iteration
- Expected impact: future generator-family comparisons can use the documented vocabulary without re-deriving metric definitions
- Why this is worth merging now: #2599 (first applied smoke) is already closed; all implemented metrics are tested

## Validation / Proof

- Commands run:
  - `ruff check robot_sf/adversarial/manifest_quality.py tests/adversarial/test_manifest_quality_metrics.py`
  - `pytest tests/adversarial/test_manifest_quality_metrics.py -v` (10/10 passed)
- Evidence that the change works here: all low_progress detection edge cases tested; PlannerOutcome serialization verified

## Risks / Rollout

- Compatibility risks: low; new fields have default None, existing consumers unaffected
- Failure modes: the runner_compatibility_rate is a proxy (parse_failures + degenerate); actual runner compatibility needs future data pipeline
- Rollback or fallback plan: revert the PR

## Docs / Provenance

- Updated docs: `docs/context/adversarial_manifest_quality_metrics.md`
- Relevant design or provenance notes: metric definitions align with #2601 spec; low_progress threshold (0.25m) matches trace_failure_predicates.py defaults

## Downstream Propagation

- Parent issue updated (yes/no/NA): NA - no parent
- Claim map / benchmark report updated (yes/no/NA): no
- Leaderboard / artifact catalog updated (yes/no/NA): no
- Registry or config index updated (yes/no/NA): no
- Context index / memory note updated (yes/no/NA): no
- Not applicable because: diagnostic-only metrics doc, no benchmark-facing changes
