### PR TITLE
feat(benchmark): forecast-risk closed-loop coupling gate (#2916)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a bounded, same-seed forecast-risk closed-loop coupling gate (#2916): a deterministic risk
+  adapter [`robot_sf/benchmark/forecast_risk_adapter.py`](robot_sf/benchmark/forecast_risk_adapter.py)
+  mapping a `ForecastBatch.v1` to a bounded `[0,1]` per-step risk signal (fail-closed on
+  degraded/fallback/oracle batches), a config
+  [`configs/research/forecast_risk_coupling_issue_2916.yaml`](configs/research/forecast_risk_coupling_issue_2916.yaml)
+  with `no_forecast`/`cv_risk`/`semantic_risk`/`interaction_risk` rows pinned to identical
+  seed/scenario, and a fixture-driven runner
+  [`scripts/benchmark/run_forecast_risk_coupling_gate.py`](scripts/benchmark/run_forecast_risk_coupling_gate.py)
+  that scores collision/near-miss, route progress, stop/yield timing, false-positive stopping,
+  runtime, and SNQI per row and emits a `continue|revise|stop` verdict with the
+  false-positive-stopping vs safety-benefit trade-off explicit. On the bundled single-pedestrian
+  occluded-emergence fixture the gate returns `continue` (forecast risk removed the near-miss with 0
+  false-positive stops at a throughput cost). Evidence is `diagnostic_only`/`stress`, not
+  paper-grade, and promotes no learned predictor; the three forecast sources are indistinguishable on
+  this single fixture (caveat recorded). Tracked summary under
+  `docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/` (#2916).
 * Added a canonical [`docs/glossary.md`](docs/glossary.md) defining the project's acronyms and
   domain terms (VRU, AMV, AMMV, SNQI, occluder, the evidence ladder, and run modes) in plain
   language, and made "understandable" a first-class maintainer value. [`maintainer_values.md`](docs/maintainer_values.md#clarity)

--- a/configs/research/forecast_risk_coupling_issue_2916.yaml
+++ b/configs/research/forecast_risk_coupling_issue_2916.yaml
@@ -1,0 +1,92 @@
+# Forecast-risk closed-loop coupling gate (issue #2916)
+#
+# Bounded, same-seed harness that tests whether forecast-DERIVED risk improves
+# navigation OUTCOMES (collision/near-miss, progress, stop/yield timing,
+# false-positive stopping, runtime, SNQI) rather than only prediction metrics.
+#
+# evidence_tier: stress
+# claim_boundary: diagnostic_only
+# paper_grade: false
+#
+# Hard rules honored by the runner:
+#   - All four rows run against the SAME fixture frames, the SAME seed, and the
+#     SAME scenario.  The only thing that varies across rows is the forecast risk
+#     SOURCE feeding the bounded risk gate.
+#   - Degraded / fallback / not-available rows fail closed and never count as a
+#     success row.
+#   - No learned predictor is promoted; all risk sources are deterministic,
+#     hand-specified CV-family baselines from robot_sf.benchmark.pedestrian_forecast.
+
+schema_version: forecast_risk_coupling.v1
+issue: 2916
+evidence_tier: stress
+claim_boundary: diagnostic_only
+paper_grade: false
+
+# Identical across every row. The fixture provides per-frame ground-truth
+# pedestrian state (for forecast construction), deployable observed_pedestrians
+# (for the fail-closed observation tier), the robot trajectory, and conflict
+# timing with stop/yield feasibility.
+fixture:
+  trace_path: >-
+    tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json
+  scenario_id: issue_2756_occluded_emergence
+  seed: 111
+  dt_s: 0.1
+
+# Bounded risk-gate planner proxy. When the per-step forecast risk exceeds the
+# stop threshold the gate commands a STOP (defensive). A near-but-below value
+# commands a YIELD (slow). These are deterministic thresholds, not a learned
+# policy. They are shared across all forecast-driven rows so differences come
+# only from the risk SOURCE, never from the gate.
+risk_gate:
+  influence_radius_m: 3.0
+  stop_risk_threshold: 0.6
+  yield_risk_threshold: 0.35
+  # Distance (m) below which a real conflict exists. Used to label a stop as a
+  # true-positive (conflict present) vs a false-positive (no conflict present).
+  conflict_distance_m: 1.5
+
+# Verdict thresholds for the continue | revise | stop gate. The trade-off
+# between safety benefit and false-positive stopping is made explicit:
+#   continue: forecast risk reduces collisions/near-misses AND does not blow up
+#             false-positive stops or runtime.
+#   stop:     forecast risk makes outcomes WORSE (more collisions/near-misses or
+#             a false-positive-stop explosion) with no safety benefit.
+#   revise:   neither clear win nor clear regression (the conservative default).
+verdict:
+  # Minimum reduction in (collisions + near_misses) vs the no_forecast row for a
+  # forecast row to count as a safety benefit.
+  min_safety_event_reduction: 1
+  # A row whose false-positive stops exceed this multiple of the no_forecast row
+  # is flagged as a false-positive regression.
+  max_false_positive_stop_ratio: 3.0
+  # Runtime budget guard (seconds) per row; exceeding it is a runtime regression.
+  max_runtime_s: 5.0
+
+# Four rows; identical seed/scenario/fixture. Only the risk SOURCE differs.
+rows:
+  - name: no_forecast
+    risk_source: none
+    description: >-
+      Control row. No forecast risk is fed to the gate; the gate never stops or
+      yields on forecast risk. Establishes the baseline navigation outcome.
+  - name: cv_risk
+    risk_source: constant_velocity
+    description: >-
+      Risk derived from a deterministic constant-velocity Gaussian forecast
+      (constant_velocity_gaussian_baseline). Tests plain motion-extrapolation
+      risk coupling.
+  - name: semantic_risk
+    risk_source: semantic_cv
+    description: >-
+      Risk derived from the semantic CV forecast (semantic_cv_baseline) that
+      composes signal- and intent-aware adjustments. Tests whether semantic
+      context in the forecast changes navigation outcomes.
+  - name: interaction_risk
+    risk_source: interaction_aware_cv
+    description: >-
+      Risk derived from the interaction-aware CV forecast
+      (interaction_aware_cv_baseline) using neighbor context. Tests whether
+      modeling pedestrian-pedestrian interaction in the forecast changes
+      navigation outcomes.

--- a/docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/README.md
+++ b/docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/README.md
@@ -1,0 +1,48 @@
+# Forecast-Risk Closed-Loop Coupling Gate (issue #2916)
+
+## Claim boundary
+
+- evidence_tier: `stress`
+- claim_boundary: `diagnostic_only`
+- paper_grade: `False`
+
+Diagnostic-only forecast-risk closed-loop coupling gate on a single deterministic occluded-emergence fixture. Not paper-facing benchmark evidence. Tests whether forecast-derived risk changes navigation outcomes, not whether any predictor is accurate. No learned predictor is promoted.
+
+## Verdict
+
+**Decision: `continue`**
+
+At least one forecast-risk row reduced safety events vs the control without a false-positive-stop or runtime regression. Forecast-risk coupling shows a navigation-outcome benefit worth pursuing.
+
+## Reproducibility
+
+- Issue: #2916
+- Generated (UTC): 2026-06-23T07:34:20.813118+00:00
+- Command: `uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py --config configs/research/forecast_risk_coupling_issue_2916.yaml --output-dir output/issue_2916_coupling_gate`
+- Repo HEAD: `566d820e`
+- Config: `configs/research/forecast_risk_coupling_issue_2916.yaml`
+- Fixture: `tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json`
+- Seed: 111
+
+## Per-row outcomes
+
+| row | class | collision | near_miss | safety_events | progress_m | stop_step | FP_stops | runtime_s | SNQI |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| no_forecast | ok | False | True | 1 | 0.82 | None | 0 | 0.000115 | 0.273333 |
+| cv_risk | ok | False | False | 0 | 0.45 | 5 | 0 | 0.000756 | 0.65 |
+| semantic_risk | ok | False | False | 0 | 0.45 | 5 | 0 | 0.000602 | 0.65 |
+| interaction_risk | ok | False | False | 0 | 0.45 | 5 | 0 | 0.000603 | 0.65 |
+
+## Safety-benefit vs false-positive-stopping trade-off
+
+- **cv_risk**: safety_event_reduction=1, FP_stops=0, benefit=True, regression=False
+- **semantic_risk**: safety_event_reduction=1, FP_stops=0, benefit=True, regression=False
+- **interaction_risk**: safety_event_reduction=1, FP_stops=0, benefit=True, regression=False
+
+## Caveats
+
+- Single deterministic fixture (seed=111), single occluded-emergence scenario.
+- Closed-loop proxy: robot replays the fixture trajectory under a gate hold; no live planner or simulator is re-executed.
+- interaction_risk degrades to plain CV mean (single observed pedestrian, no neighbor context); it is reported honestly, not as interaction evidence.
+- Ground-truth pedestrian distance is used only for OUTCOME scoring, never as a risk source. Risk sources use the deployable tracked-agents observation tier.
+- Not statistically powered; diagnostic_only.

--- a/docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/forecast_risk_coupling_gate_report.json
+++ b/docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/forecast_risk_coupling_gate_report.json
@@ -1,0 +1,264 @@
+{
+  "schema_version": "forecast_risk_coupling_gate.v1",
+  "issue": 2916,
+  "evidence_tier": "stress",
+  "claim_boundary": "diagnostic_only",
+  "paper_grade": false,
+  "claim_boundary_text": "Diagnostic-only forecast-risk closed-loop coupling gate on a single deterministic occluded-emergence fixture. Not paper-facing benchmark evidence. Tests whether forecast-derived risk changes navigation outcomes, not whether any predictor is accurate. No learned predictor is promoted.",
+  "reproducibility": {
+    "issue": 2916,
+    "generated_at_utc": "2026-06-23T07:34:20.813118+00:00",
+    "command": "uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py --config configs/research/forecast_risk_coupling_issue_2916.yaml --output-dir output/issue_2916_coupling_gate",
+    "repo_head": "566d820e",
+    "config_path": "configs/research/forecast_risk_coupling_issue_2916.yaml"
+  },
+  "config": {
+    "config_path": "configs/research/forecast_risk_coupling_issue_2916.yaml",
+    "fixture": {
+      "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/occluded_emergence_episode_0000.json",
+      "scenario_id": "issue_2756_occluded_emergence",
+      "seed": 111,
+      "dt_s": 0.1
+    },
+    "risk_gate": {
+      "influence_radius_m": 3.0,
+      "stop_risk_threshold": 0.6,
+      "yield_risk_threshold": 0.35,
+      "conflict_distance_m": 1.5
+    },
+    "verdict_thresholds": {
+      "min_safety_event_reduction": 1,
+      "max_false_positive_stop_ratio": 3.0,
+      "max_runtime_s": 5.0
+    }
+  },
+  "rows": [
+    {
+      "row": "no_forecast",
+      "risk_source": "none",
+      "description": "Control row. No forecast risk is fed to the gate; the gate never stops or yields on forecast risk. Establishes the baseline navigation outcome.",
+      "classification": "ok",
+      "classification_reason": "control row; no forecast risk required",
+      "metrics": {
+        "collision": false,
+        "near_miss": true,
+        "safety_events": 1,
+        "min_distance_m": 0.5,
+        "progress_m": 0.82,
+        "first_stop_step": null,
+        "first_yield_step": null,
+        "stop_yield_timing_steps": null,
+        "false_positive_stops": 0,
+        "true_positive_stops": 0,
+        "runtime_s": 0.000115,
+        "snqi": 0.273333
+      },
+      "diagnostics": {
+        "conflict_steps": 15,
+        "risk_available_steps": 0,
+        "risk_unavailable_in_conflict": 0,
+        "gate_actions": [
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go",
+          "go"
+        ]
+      }
+    },
+    {
+      "row": "cv_risk",
+      "risk_source": "constant_velocity",
+      "description": "Risk derived from a deterministic constant-velocity Gaussian forecast (constant_velocity_gaussian_baseline). Tests plain motion-extrapolation risk coupling.",
+      "classification": "ok",
+      "classification_reason": "forecast risk available in the conflict window",
+      "metrics": {
+        "collision": false,
+        "near_miss": false,
+        "safety_events": 0,
+        "min_distance_m": 0.8,
+        "progress_m": 0.45,
+        "first_stop_step": 5,
+        "first_yield_step": 14,
+        "stop_yield_timing_steps": 5,
+        "false_positive_stops": 0,
+        "true_positive_stops": 9,
+        "runtime_s": 0.000756,
+        "snqi": 0.65
+      },
+      "diagnostics": {
+        "conflict_steps": 15,
+        "risk_available_steps": 11,
+        "risk_unavailable_in_conflict": 4,
+        "gate_actions": [
+          "go",
+          "go",
+          "go",
+          "go",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "yield",
+          "yield"
+        ]
+      }
+    },
+    {
+      "row": "semantic_risk",
+      "risk_source": "semantic_cv",
+      "description": "Risk derived from the semantic CV forecast (semantic_cv_baseline) that composes signal- and intent-aware adjustments. Tests whether semantic context in the forecast changes navigation outcomes.",
+      "classification": "ok",
+      "classification_reason": "forecast risk available in the conflict window",
+      "metrics": {
+        "collision": false,
+        "near_miss": false,
+        "safety_events": 0,
+        "min_distance_m": 0.8,
+        "progress_m": 0.45,
+        "first_stop_step": 5,
+        "first_yield_step": 14,
+        "stop_yield_timing_steps": 5,
+        "false_positive_stops": 0,
+        "true_positive_stops": 9,
+        "runtime_s": 0.000602,
+        "snqi": 0.65
+      },
+      "diagnostics": {
+        "conflict_steps": 15,
+        "risk_available_steps": 11,
+        "risk_unavailable_in_conflict": 4,
+        "gate_actions": [
+          "go",
+          "go",
+          "go",
+          "go",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "yield",
+          "yield"
+        ]
+      }
+    },
+    {
+      "row": "interaction_risk",
+      "risk_source": "interaction_aware_cv",
+      "description": "Risk derived from the interaction-aware CV forecast (interaction_aware_cv_baseline) using neighbor context. Tests whether modeling pedestrian-pedestrian interaction in the forecast changes navigation outcomes.",
+      "classification": "ok",
+      "classification_reason": "forecast risk available in the conflict window",
+      "metrics": {
+        "collision": false,
+        "near_miss": false,
+        "safety_events": 0,
+        "min_distance_m": 0.8,
+        "progress_m": 0.45,
+        "first_stop_step": 5,
+        "first_yield_step": 14,
+        "stop_yield_timing_steps": 5,
+        "false_positive_stops": 0,
+        "true_positive_stops": 9,
+        "runtime_s": 0.000603,
+        "snqi": 0.65
+      },
+      "diagnostics": {
+        "conflict_steps": 15,
+        "risk_available_steps": 11,
+        "risk_unavailable_in_conflict": 4,
+        "gate_actions": [
+          "go",
+          "go",
+          "go",
+          "go",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "stop",
+          "yield",
+          "yield"
+        ]
+      }
+    }
+  ],
+  "verdict": {
+    "decision": "continue",
+    "rationale": "At least one forecast-risk row reduced safety events vs the control without a false-positive-stop or runtime regression. Forecast-risk coupling shows a navigation-outcome benefit worth pursuing.",
+    "control_safety_events": 1,
+    "control_false_positive_stops": 0,
+    "blocked_rows": [],
+    "tradeoff": [
+      {
+        "row": "cv_risk",
+        "blocked": false,
+        "safety_events": 0,
+        "safety_event_reduction_vs_control": 1,
+        "false_positive_stops": 0,
+        "false_positive_stop_ratio_vs_control": 1.0,
+        "runtime_s": 0.000756,
+        "is_safety_benefit": true,
+        "fp_regression": false,
+        "runtime_regression": false,
+        "outcome_regression": false
+      },
+      {
+        "row": "semantic_risk",
+        "blocked": false,
+        "safety_events": 0,
+        "safety_event_reduction_vs_control": 1,
+        "false_positive_stops": 0,
+        "false_positive_stop_ratio_vs_control": 1.0,
+        "runtime_s": 0.000602,
+        "is_safety_benefit": true,
+        "fp_regression": false,
+        "runtime_regression": false,
+        "outcome_regression": false
+      },
+      {
+        "row": "interaction_risk",
+        "blocked": false,
+        "safety_events": 0,
+        "safety_event_reduction_vs_control": 1,
+        "false_positive_stops": 0,
+        "false_positive_stop_ratio_vs_control": 1.0,
+        "runtime_s": 0.000603,
+        "is_safety_benefit": true,
+        "fp_regression": false,
+        "runtime_regression": false,
+        "outcome_regression": false
+      }
+    ]
+  },
+  "caveats": [
+    "Single deterministic fixture (seed=111), single occluded-emergence scenario.",
+    "Closed-loop proxy: robot replays the fixture trajectory under a gate hold; no live planner or simulator is re-executed.",
+    "interaction_risk degrades to plain CV mean (single observed pedestrian, no neighbor context); it is reported honestly, not as interaction evidence.",
+    "Ground-truth pedestrian distance is used only for OUTCOME scoring, never as a risk source. Risk sources use the deployable tracked-agents observation tier.",
+    "Not statistically powered; diagnostic_only."
+  ]
+}

--- a/robot_sf/benchmark/forecast_risk_adapter.py
+++ b/robot_sf/benchmark/forecast_risk_adapter.py
@@ -1,0 +1,207 @@
+"""Map a ForecastBatch.v1 artifact into a per-step scalar risk signal.
+
+This adapter is the bounded bridge between a forecast artifact (see
+``robot_sf.benchmark.forecast_batch``) and a downstream risk gate or planner
+proxy.  It is deliberately small, pure, and deterministic: given a forecast
+batch and the robot position at the same step, it returns a single non-negative
+scalar risk value plus the metadata a fail-closed consumer needs.
+
+Design boundaries (issue #2916, evidence_tier: stress, diagnostic_only):
+
+- The risk scalar is a *geometric proximity-to-forecast-occupancy* signal, not a
+  learned or calibrated probability.  It rewards short predicted robot/pedestrian
+  separation and widens with forecast uncertainty.  It makes no benchmark claim.
+- Fail-closed contract: a batch that is degraded, fallback, oracle-sourced, or
+  carries no usable forecast payload yields ``available=False``.  A consumer must
+  treat ``available=False`` as *not a success row*, never as zero risk.
+- Pure and deterministic: no RNG, no I/O, no global state.  The same inputs
+  always produce the same output.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from robot_sf.benchmark.forecast_batch import ForecastBatch
+
+FORECAST_RISK_ADAPTER_SCHEMA_VERSION = "forecast_risk_signal.v1"
+
+# A row is treated as deployable only when both status fields declare a clean,
+# native execution.  Anything else fails closed.
+_CLEAN_FALLBACK_STATUSES = frozenset({"native", "none"})
+_CLEAN_DEGRADED_STATUSES = frozenset({"none"})
+
+
+@dataclass(frozen=True)
+class ForecastRiskSignal:
+    """Per-step scalar risk derived from a forecast batch.
+
+    Attributes:
+        risk: Non-negative scalar risk for the step (0.0 when no actor is within
+            the influence radius).  Higher means a closer / more uncertain
+            predicted encounter.
+        available: True only when the batch was deployable and at least one actor
+            forecast contributed.  False means fail-closed: the consumer must not
+            count this as a usable risk row.
+        reason: Short machine-readable reason, ``"ok"`` when available, otherwise
+            the fail-closed cause (e.g. ``"degraded_observation"``).
+        contributing_actor_count: Number of actor forecasts that contributed.
+        nearest_predicted_distance_m: Closest robot/forecast-mean distance across
+            actors and horizons, or ``None`` when nothing contributed.
+        metadata: Provenance echo for the evidence bundle.
+    """
+
+    risk: float
+    available: bool
+    reason: str
+    contributing_actor_count: int = 0
+    nearest_predicted_distance_m: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-compatible representation.
+
+        Returns:
+            Mapping with the schema version and all signal fields.
+        """
+        return {
+            "schema_version": FORECAST_RISK_ADAPTER_SCHEMA_VERSION,
+            "risk": self.risk,
+            "available": self.available,
+            "reason": self.reason,
+            "contributing_actor_count": self.contributing_actor_count,
+            "nearest_predicted_distance_m": self.nearest_predicted_distance_m,
+            "metadata": dict(self.metadata),
+        }
+
+
+def _batch_is_deployable(batch: ForecastBatch) -> tuple[bool, str]:
+    """Classify whether a forecast batch may feed a risk gate.
+
+    Returns:
+        ``(deployable, reason)``.  ``reason`` is ``"ok"`` when deployable, else a
+        machine-readable fail-closed cause.
+    """
+    prov = batch.provenance
+    if prov.oracle_state:
+        return False, "oracle_state"
+    fallback = prov.fallback_status.strip().lower()
+    if fallback not in _CLEAN_FALLBACK_STATUSES:
+        return False, f"fallback:{fallback}"
+    degraded = prov.degraded_status.strip().lower()
+    if degraded not in _CLEAN_DEGRADED_STATUSES:
+        return False, f"degraded:{degraded}"
+    if not any(included for included in prov.actor_mask):
+        return False, "no_actor_available"
+    if not batch.forecasts:
+        return False, "no_forecast_payload"
+    return True, "ok"
+
+
+def _actor_forecast_distance(
+    deterministic: np.ndarray,
+    robot_position: np.ndarray,
+) -> float:
+    """Closest robot/forecast-mean distance over horizons for one actor.
+
+    Returns:
+        Minimum Euclidean distance (meters) between the robot and the actor's
+        forecast occupancy means across all horizons.
+    """
+    diffs = deterministic - robot_position.reshape(1, 2)
+    distances = np.sqrt(np.sum(diffs**2, axis=1))
+    return float(np.min(distances))
+
+
+def compute_forecast_risk(
+    batch: ForecastBatch,
+    robot_position: np.ndarray | list[float] | tuple[float, float],
+    *,
+    influence_radius_m: float = 3.0,
+) -> ForecastRiskSignal:
+    """Map one forecast batch to a per-step scalar risk for a risk gate.
+
+    The risk is a bounded proximity signal in ``[0, 1]``: for each actor with a
+    deterministic forecast, the closest robot/forecast-mean distance across
+    horizons is converted to ``max(0, 1 - d / influence_radius_m)``.  The actor
+    risks are combined by taking the maximum (the single most threatening
+    predicted encounter drives the gate).  Actors beyond ``influence_radius_m``
+    contribute zero.
+
+    The function is pure and deterministic.  It fails closed: degraded, fallback,
+    oracle, or payload-less batches return ``available=False`` with ``risk=0.0``
+    and a reason, and the caller must not treat that as a usable low-risk row.
+
+    Args:
+        batch: A validated :class:`ForecastBatch`.
+        robot_position: The robot ``(x, y)`` position at the same step, in the
+            batch's coordinate frame.
+        influence_radius_m: Distance beyond which a predicted occupancy mean adds
+            no risk.  Must be positive.
+
+    Returns:
+        A :class:`ForecastRiskSignal` for the step.
+    """
+    if influence_radius_m <= 0.0:
+        raise ValueError("influence_radius_m must be positive")
+    robot = np.asarray(robot_position, dtype=float).reshape(2)
+    if not np.all(np.isfinite(robot)):
+        raise ValueError("robot_position must be finite")
+
+    deployable, reason = _batch_is_deployable(batch)
+    base_metadata = {
+        "predictor_id": batch.provenance.predictor_id,
+        "predictor_family": batch.provenance.predictor_family,
+        "observation_tier": batch.provenance.observation_tier,
+        "scenario_id": batch.provenance.scenario_id,
+        "seed": batch.provenance.seed,
+        "fallback_status": batch.provenance.fallback_status,
+        "degraded_status": batch.provenance.degraded_status,
+        "influence_radius_m": float(influence_radius_m),
+    }
+    if not deployable:
+        return ForecastRiskSignal(
+            risk=0.0,
+            available=False,
+            reason=reason,
+            metadata=base_metadata,
+        )
+
+    per_actor_risk: list[float] = []
+    distances: list[float] = []
+    for forecast in batch.forecasts:
+        if forecast.deterministic is None:
+            continue
+        distance = _actor_forecast_distance(forecast.deterministic, robot)
+        distances.append(distance)
+        proximity = 1.0 - distance / influence_radius_m
+        per_actor_risk.append(max(0.0, proximity))
+
+    if not per_actor_risk:
+        return ForecastRiskSignal(
+            risk=0.0,
+            available=False,
+            reason="no_deterministic_payload",
+            metadata=base_metadata,
+        )
+
+    risk = float(max(per_actor_risk))
+    return ForecastRiskSignal(
+        risk=risk,
+        available=True,
+        reason="ok",
+        contributing_actor_count=len(per_actor_risk),
+        nearest_predicted_distance_m=float(min(distances)),
+        metadata=base_metadata,
+    )
+
+
+__all__ = [
+    "FORECAST_RISK_ADAPTER_SCHEMA_VERSION",
+    "ForecastRiskSignal",
+    "compute_forecast_risk",
+]

--- a/scripts/benchmark/run_forecast_risk_coupling_gate.py
+++ b/scripts/benchmark/run_forecast_risk_coupling_gate.py
@@ -1,0 +1,765 @@
+#!/usr/bin/env python3
+"""Forecast-risk closed-loop coupling gate (issue #2916, evidence_tier: stress).
+
+Tests whether forecast-DERIVED risk improves navigation OUTCOMES rather than only
+prediction metrics.  Four rows -- ``no_forecast``, ``cv_risk``, ``semantic_risk``,
+``interaction_risk`` -- run against the SAME fixture frames, SAME seed, and SAME
+scenario.  Only the forecast risk SOURCE feeding a bounded deterministic risk gate
+differs across rows.
+
+This follows the bounded fixture-driven proxy pattern of
+``scripts/benchmark/run_observation_noise_envelope.py``.  It does NOT stand up the
+heavy ``robot_sf.benchmark.runner`` simulator and does NOT promote any learned
+predictor.  All risk sources are deterministic CV-family baselines.
+
+Closed-loop proxy: the robot follows the fixture trajectory, but the risk gate may
+hold the robot back (STOP / YIELD) when per-step forecast risk is high.  Metrics
+are computed on the gate-modified trajectory against the ground-truth pedestrian
+trajectory from the fixture.
+
+Fail-closed: any row whose forecast risk signal is unavailable (degraded,
+fallback, oracle, or empty) for the conflict window is marked ``blocked`` and
+never counts as a success row.
+
+Usage::
+
+    uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py
+    uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py --help
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import subprocess
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+import yaml
+
+from robot_sf.benchmark.forecast_risk_adapter import compute_forecast_risk
+from robot_sf.benchmark.metrics import snqi
+from robot_sf.benchmark.pedestrian_forecast import (
+    NeighborContext,
+    PedestrianState,
+    constant_velocity_gaussian_baseline,
+    interaction_aware_cv_baseline,
+    semantic_cv_baseline,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+DEFAULT_CONFIG = "configs/research/forecast_risk_coupling_issue_2916.yaml"
+DEFAULT_OUTPUT_DIR = "output/issue_2916_coupling_gate"
+
+# Near-miss / collision thresholds (meters) for the robot-pedestrian pair.
+COLLISION_DISTANCE_M = 0.3
+NEAR_MISS_DISTANCE_M = 0.7
+
+# Forecast horizons used to build per-step batches (short, bounded).
+FORECAST_HORIZONS_S = (0.5, 1.0)
+
+# Minimal feature schema required by ForecastBatch.v1 provenance.
+_FEATURE_SCHEMA = {"position": "xy_m", "velocity": "xy_m_s"}
+
+
+def _git_head() -> str:
+    """Return the short git HEAD, or empty string on failure.
+
+    Returns:
+        Short commit SHA or an empty string.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=5,
+            check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except Exception:
+        return ""
+
+
+def _load_fixture(path: pathlib.Path) -> dict[str, Any]:
+    """Load the trace fixture JSON.
+
+    Returns:
+        Parsed fixture mapping.
+    """
+    with open(path, encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def _ped_state_from_frame(frame: dict[str, Any]) -> PedestrianState | None:
+    """Build a PedestrianState from the first observed pedestrian in a frame.
+
+    Uses the deployable ``observed_pedestrians`` tier so the risk source reflects
+    what a deployable consumer could see, not oracle ground truth.
+
+    Returns:
+        A pedestrian state, or None when no pedestrian is observable in the frame.
+    """
+    observed = frame.get("observed_pedestrians") or []
+    if not observed:
+        return None
+    payload = dict(observed[0])
+    payload.setdefault("id", 0)
+    return PedestrianState.from_trace(payload)
+
+
+def _build_forecast_batch(
+    risk_source: str,
+    ped_state: PedestrianState,
+    *,
+    scenario_id: str,
+    seed: int,
+    dt_s: float,
+):
+    """Build a deterministic ForecastBatch for one risk source from a ped state.
+
+    Returns:
+        A validated ForecastBatch carrying a deterministic forecast for the actor.
+    """
+    from robot_sf.benchmark.forecast_batch import (
+        ActorForecast,
+        CoordinateFrame,
+        ForecastBatch,
+        ForecastBatchProvenance,
+    )
+
+    if risk_source == "constant_velocity":
+        forecast = constant_velocity_gaussian_baseline(ped_state, FORECAST_HORIZONS_S)
+        family = "constant_velocity"
+        predictor_id = "cv-gaussian-issue2916"
+    elif risk_source == "semantic_cv":
+        forecast = semantic_cv_baseline(ped_state, FORECAST_HORIZONS_S)
+        family = "semantic_cv"
+        predictor_id = "semantic-cv-issue2916"
+    elif risk_source == "interaction_aware_cv":
+        # Single observed pedestrian: no neighbor context available, so this
+        # degrades to plain CV mean. Deterministic and labeled.
+        neighbors: list[NeighborContext] = []
+        forecast = interaction_aware_cv_baseline(
+            ped_state, FORECAST_HORIZONS_S, neighbors=neighbors
+        )
+        family = "interaction_aware_cv"
+        predictor_id = "interaction-cv-issue2916"
+    else:
+        raise ValueError(f"unknown risk_source: {risk_source}")
+
+    actor_id = str(ped_state.id)
+    provenance = ForecastBatchProvenance(
+        predictor_id=predictor_id,
+        predictor_family=family,
+        observation_tier="tracked_agents",
+        frame=CoordinateFrame(name="world", units="m", axes=("x", "y")),
+        dt_s=dt_s,
+        horizons_s=list(FORECAST_HORIZONS_S),
+        scenario_id=scenario_id,
+        seed=seed,
+        fallback_status="native",
+        degraded_status="none",
+        actor_ids=[actor_id],
+        actor_mask=[True],
+        actor_mask_metadata={"semantics": "true means available in tracked tier"},
+        feature_schema=dict(_FEATURE_SCHEMA),
+        timestamp="1970-01-01T00:00:00+00:00",
+        oracle_state=False,
+    )
+    deterministic = np.asarray(
+        [prediction.mean for prediction in forecast.predictions], dtype=float
+    )
+    batch = ForecastBatch(
+        provenance=provenance,
+        forecasts=[ActorForecast(actor_id=actor_id, deterministic=deterministic)],
+        metadata={"artifact_role": "issue_2916_coupling_gate"},
+    )
+    return batch
+
+
+def _gate_decision(
+    risk: float,
+    *,
+    stop_threshold: float,
+    yield_threshold: float,
+) -> str:
+    """Map a scalar risk to a gate action.
+
+    Returns:
+        ``"stop"``, ``"yield"``, or ``"go"``.
+    """
+    if risk >= stop_threshold:
+        return "stop"
+    if risk >= yield_threshold:
+        return "yield"
+    return "go"
+
+
+@dataclass
+class _RowState:
+    """Mutable accumulator for one row's closed-loop replay."""
+
+    robot_pos: np.ndarray
+    min_distance_m: float = float("inf")
+    collision: bool = False
+    near_miss: bool = False
+    progress_m: float = 0.0
+    false_positive_stops: int = 0
+    true_positive_stops: int = 0
+    first_stop_step: int | None = None
+    first_yield_step: int | None = None
+    gate_actions: list[str] = field(default_factory=list)
+    risk_available_steps: int = 0
+    risk_unavailable_in_conflict: int = 0
+    conflict_steps: int = 0
+
+
+def _gate_action_for_step(
+    frame: dict[str, Any],
+    robot_pos: np.ndarray,
+    row: dict[str, Any],
+    cfg: dict[str, Any],
+    state: _RowState,
+) -> str:
+    """Compute the gate action for one step from the row's forecast risk source.
+
+    Increments ``state.risk_available_steps`` as a side effect when a usable
+    signal is produced.
+
+    Returns:
+        ``"stop"``, ``"yield"``, or ``"go"``.
+    """
+    risk_source = row["risk_source"]
+    if risk_source == "none":
+        return "go"
+    ped_state = _ped_state_from_frame(frame)
+    if ped_state is None:
+        return "go"
+    gate_cfg = cfg["risk_gate"]
+    batch = _build_forecast_batch(
+        risk_source,
+        ped_state,
+        scenario_id=cfg["fixture"]["scenario_id"],
+        seed=int(cfg["fixture"]["seed"]),
+        dt_s=float(cfg["fixture"]["dt_s"]),
+    )
+    signal = compute_forecast_risk(
+        batch, robot_pos, influence_radius_m=float(gate_cfg["influence_radius_m"])
+    )
+    if not signal.available:
+        return "go"
+    state.risk_available_steps += 1
+    return _gate_decision(
+        signal.risk,
+        stop_threshold=float(gate_cfg["stop_risk_threshold"]),
+        yield_threshold=float(gate_cfg["yield_risk_threshold"]),
+    )
+
+
+def _apply_gate_step(action: str, intended: np.ndarray, index: int, state: _RowState) -> np.ndarray:
+    """Apply the gate action to the intended forward step.
+
+    Returns:
+        The realized displacement vector after the gate hold.
+    """
+    if action == "stop":
+        if state.first_stop_step is None:
+            state.first_stop_step = index
+        return np.zeros(2, dtype=float)
+    if action == "yield":
+        if state.first_yield_step is None:
+            state.first_yield_step = index
+        return intended * 0.5
+    return intended
+
+
+def _score_outcome_step(
+    frame: dict[str, Any],
+    action: str,
+    risk_source: str,
+    conflict_distance_m: float,
+    state: _RowState,
+) -> None:
+    """Score one step against the ground-truth pedestrian (outcome only)."""
+    peds = frame.get("pedestrians") or []
+    if not peds:
+        return
+    ped_pos = np.asarray(peds[0]["position"], dtype=float)
+    distance = float(np.linalg.norm(state.robot_pos - ped_pos))
+    state.min_distance_m = min(state.min_distance_m, distance)
+    if distance <= COLLISION_DISTANCE_M:
+        state.collision = True
+    elif distance <= NEAR_MISS_DISTANCE_M:
+        state.near_miss = True
+    in_conflict = distance <= conflict_distance_m
+    if in_conflict:
+        state.conflict_steps += 1
+    if action == "stop":
+        if in_conflict:
+            state.true_positive_stops += 1
+        else:
+            state.false_positive_stops += 1
+    if in_conflict and risk_source != "none" and _ped_state_from_frame(frame) is None:
+        state.risk_unavailable_in_conflict += 1
+
+
+def _row_snqi(state: _RowState) -> float:
+    """Compute the bounded SNQI proxy for a row's outcome.
+
+    Returns:
+        The SNQI scalar (higher is better).
+    """
+    success = 1.0 if (state.progress_m > 0.3 and not state.collision) else 0.0
+    time_to_goal_norm = float(np.clip(1.0 - state.progress_m / 1.5, 0.0, 1.0))
+    return float(
+        snqi(
+            {
+                "success": success,
+                "time_to_goal_norm": time_to_goal_norm,
+                "collisions": float(int(state.collision)),
+                "near_misses": float(int(state.near_miss)),
+            },
+            weights={"w_success": 1.0, "w_time": 0.5, "w_collisions": 1.0, "w_near": 0.5},
+            baseline_stats={
+                "collisions": {"med": 0.0, "p95": 1.0},
+                "near_misses": {"med": 0.0, "p95": 1.0},
+            },
+        )
+    )
+
+
+def evaluate_row(
+    row: dict[str, Any],
+    frames: list[dict[str, Any]],
+    cfg: dict[str, Any],
+) -> dict[str, Any]:
+    """Evaluate one row's closed-loop outcome against the shared fixture frames.
+
+    The robot replays the fixture trajectory, but the gate may hold it back
+    (yield = half forward step, stop = no forward step) when forecast risk is
+    high.  Metrics are computed on the gate-modified trajectory.
+
+    Returns:
+        A compact per-row result with metrics, fail-closed classification, and
+        the SNQI proxy.
+    """
+    start = time.perf_counter()
+    risk_source = row["risk_source"]
+    conflict_distance_m = float(cfg["risk_gate"]["conflict_distance_m"])
+    state = _RowState(robot_pos=np.asarray(frames[0]["robot"]["position"], dtype=float).copy())
+
+    for index in range(1, len(frames)):
+        frame = frames[index]
+        intended = np.asarray(frame["robot"]["position"], dtype=float) - np.asarray(
+            frames[index - 1]["robot"]["position"], dtype=float
+        )
+        action = _gate_action_for_step(frame, state.robot_pos, row, cfg, state)
+        state.gate_actions.append(action)
+        step_vec = _apply_gate_step(action, intended, index, state)
+        state.robot_pos = state.robot_pos + step_vec
+        state.progress_m += float(np.linalg.norm(step_vec))
+        _score_outcome_step(frame, action, risk_source, conflict_distance_m, state)
+
+    runtime_s = time.perf_counter() - start
+    safety_events = int(state.collision) + int(state.near_miss)
+    classification, reason = _classify_row(
+        risk_source=risk_source,
+        conflict_steps=state.conflict_steps,
+        risk_available_steps=state.risk_available_steps,
+        risk_unavailable_in_conflict=state.risk_unavailable_in_conflict,
+    )
+
+    return {
+        "row": row["name"],
+        "risk_source": risk_source,
+        "description": row.get("description", ""),
+        "classification": classification,
+        "classification_reason": reason,
+        "metrics": {
+            "collision": state.collision,
+            "near_miss": state.near_miss,
+            "safety_events": safety_events,
+            "min_distance_m": round(state.min_distance_m, 4)
+            if np.isfinite(state.min_distance_m)
+            else None,
+            "progress_m": round(state.progress_m, 4),
+            "first_stop_step": state.first_stop_step,
+            "first_yield_step": state.first_yield_step,
+            "stop_yield_timing_steps": state.first_stop_step
+            if state.first_stop_step is not None
+            else state.first_yield_step,
+            "false_positive_stops": state.false_positive_stops,
+            "true_positive_stops": state.true_positive_stops,
+            "runtime_s": round(runtime_s, 6),
+            "snqi": round(_row_snqi(state), 6),
+        },
+        "diagnostics": {
+            "conflict_steps": state.conflict_steps,
+            "risk_available_steps": state.risk_available_steps,
+            "risk_unavailable_in_conflict": state.risk_unavailable_in_conflict,
+            "gate_actions": state.gate_actions,
+        },
+    }
+
+
+def _classify_row(
+    *,
+    risk_source: str,
+    conflict_steps: int,
+    risk_available_steps: int,
+    risk_unavailable_in_conflict: int,
+) -> tuple[str, str]:
+    """Classify a row under the fail-closed policy.
+
+    Returns:
+        ``(classification, reason)`` where classification is ``"ok"`` or
+        ``"blocked"``.
+    """
+    if risk_source == "none":
+        return "ok", "control row; no forecast risk required"
+    if risk_available_steps == 0:
+        return (
+            "blocked",
+            "forecast risk signal never available (fail-closed); row cannot test coupling",
+        )
+    if conflict_steps > 0 and risk_unavailable_in_conflict >= conflict_steps:
+        return (
+            "blocked",
+            "forecast risk unavailable across the entire conflict window (fail-closed)",
+        )
+    return "ok", "forecast risk available in the conflict window"
+
+
+def emit_verdict(
+    results: list[dict[str, Any]],
+    cfg: dict[str, Any],
+) -> dict[str, Any]:
+    """Emit a continue | revise | stop verdict from the per-row results.
+
+    Makes the false-positive-stopping vs safety-benefit trade-off explicit.
+
+    Returns:
+        A verdict mapping with the decision, rationale, and the trade-off table.
+    """
+    verdict_cfg = cfg["verdict"]
+    min_reduction = int(verdict_cfg["min_safety_event_reduction"])
+    max_fp_ratio = float(verdict_cfg["max_false_positive_stop_ratio"])
+    max_runtime = float(verdict_cfg["max_runtime_s"])
+
+    by_row = {r["row"]: r for r in results}
+    control = by_row.get("no_forecast")
+    if control is None:
+        return {
+            "decision": "stop",
+            "rationale": "no_forecast control row missing; cannot establish a baseline",
+            "tradeoff": [],
+        }
+
+    control_events = control["metrics"]["safety_events"]
+    control_fp = max(control["metrics"]["false_positive_stops"], 0)
+
+    tradeoff: list[dict[str, Any]] = []
+    any_safety_benefit = False
+    any_regression = False
+    blocked_rows: list[str] = []
+
+    for name in ("cv_risk", "semantic_risk", "interaction_risk"):
+        row = by_row.get(name)
+        if row is None:
+            continue
+        if row["classification"] == "blocked":
+            blocked_rows.append(name)
+            tradeoff.append(
+                {
+                    "row": name,
+                    "blocked": True,
+                    "reason": row["classification_reason"],
+                }
+            )
+            continue
+        events = row["metrics"]["safety_events"]
+        fp = row["metrics"]["false_positive_stops"]
+        runtime = row["metrics"]["runtime_s"]
+        safety_reduction = control_events - events
+        is_safety_benefit = safety_reduction >= min_reduction
+        # False-positive regression relative to control (guard divide-by-zero).
+        fp_ratio = (fp / control_fp) if control_fp > 0 else (float("inf") if fp > 0 else 1.0)
+        fp_regression = fp_ratio > max_fp_ratio
+        runtime_regression = runtime > max_runtime
+        outcome_regression = events > control_events
+        if is_safety_benefit and not fp_regression and not runtime_regression:
+            any_safety_benefit = True
+        if outcome_regression or fp_regression or runtime_regression:
+            any_regression = True
+        tradeoff.append(
+            {
+                "row": name,
+                "blocked": False,
+                "safety_events": events,
+                "safety_event_reduction_vs_control": safety_reduction,
+                "false_positive_stops": fp,
+                "false_positive_stop_ratio_vs_control": (
+                    None if fp_ratio == float("inf") else round(fp_ratio, 4)
+                ),
+                "runtime_s": runtime,
+                "is_safety_benefit": is_safety_benefit,
+                "fp_regression": fp_regression,
+                "runtime_regression": runtime_regression,
+                "outcome_regression": outcome_regression,
+            }
+        )
+
+    if any_safety_benefit and not any_regression:
+        decision = "continue"
+        rationale = (
+            "At least one forecast-risk row reduced safety events vs the control "
+            "without a false-positive-stop or runtime regression. Forecast-risk "
+            "coupling shows a navigation-outcome benefit worth pursuing."
+        )
+    elif any_regression and not any_safety_benefit:
+        decision = "stop"
+        rationale = (
+            "Forecast-risk rows showed regressions (worse safety events, "
+            "false-positive-stop explosion, or runtime) with no offsetting safety "
+            "benefit. Forecast-risk coupling is not justified on this evidence."
+        )
+    else:
+        decision = "revise"
+        rationale = (
+            "No clear navigation-outcome benefit and no clear regression. "
+            "Forecast-risk coupling is inconclusive on this bounded fixture; revise "
+            "the gate / scenario before investing further."
+        )
+
+    return {
+        "decision": decision,
+        "rationale": rationale,
+        "control_safety_events": control_events,
+        "control_false_positive_stops": control_fp,
+        "blocked_rows": blocked_rows,
+        "tradeoff": tradeoff,
+    }
+
+
+def build_report(
+    results: list[dict[str, Any]],
+    verdict: dict[str, Any],
+    cfg: dict[str, Any],
+    repro: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble the full JSON report.
+
+    Returns:
+        The complete report mapping.
+    """
+    return {
+        "schema_version": "forecast_risk_coupling_gate.v1",
+        "issue": 2916,
+        "evidence_tier": "stress",
+        "claim_boundary": "diagnostic_only",
+        "paper_grade": False,
+        "claim_boundary_text": (
+            "Diagnostic-only forecast-risk closed-loop coupling gate on a single "
+            "deterministic occluded-emergence fixture. Not paper-facing benchmark "
+            "evidence. Tests whether forecast-derived risk changes navigation "
+            "outcomes, not whether any predictor is accurate. No learned predictor "
+            "is promoted."
+        ),
+        "reproducibility": repro,
+        "config": {
+            "config_path": repro["config_path"],
+            "fixture": cfg["fixture"],
+            "risk_gate": cfg["risk_gate"],
+            "verdict_thresholds": cfg["verdict"],
+        },
+        "rows": results,
+        "verdict": verdict,
+        "caveats": [
+            "Single deterministic fixture (seed=111), single occluded-emergence scenario.",
+            "Closed-loop proxy: robot replays the fixture trajectory under a gate hold; "
+            "no live planner or simulator is re-executed.",
+            "interaction_risk degrades to plain CV mean (single observed pedestrian, no "
+            "neighbor context); it is reported honestly, not as interaction evidence.",
+            "Ground-truth pedestrian distance is used only for OUTCOME scoring, never as a "
+            "risk source. Risk sources use the deployable tracked-agents observation tier.",
+            "Not statistically powered; diagnostic_only.",
+        ],
+    }
+
+
+def generate_markdown(report: dict[str, Any]) -> str:
+    """Render the report as Markdown.
+
+    Returns:
+        Markdown document text.
+    """
+    repro = report["reproducibility"]
+    verdict = report["verdict"]
+    lines: list[str] = [
+        "# Forecast-Risk Closed-Loop Coupling Gate (issue #2916)",
+        "",
+        "## Claim boundary",
+        "",
+        f"- evidence_tier: `{report['evidence_tier']}`",
+        f"- claim_boundary: `{report['claim_boundary']}`",
+        f"- paper_grade: `{report['paper_grade']}`",
+        "",
+        report["claim_boundary_text"],
+        "",
+        "## Verdict",
+        "",
+        f"**Decision: `{verdict['decision']}`**",
+        "",
+        verdict["rationale"],
+        "",
+        "## Reproducibility",
+        "",
+        f"- Issue: #{report['issue']}",
+        f"- Generated (UTC): {repro['generated_at_utc']}",
+        f"- Command: `{repro['command']}`",
+        f"- Repo HEAD: `{repro['repo_head']}`",
+        f"- Config: `{repro['config_path']}`",
+        f"- Fixture: `{report['config']['fixture']['trace_path']}`",
+        f"- Seed: {report['config']['fixture']['seed']}",
+        "",
+        "## Per-row outcomes",
+        "",
+        "| row | class | collision | near_miss | safety_events | progress_m | "
+        "stop_step | FP_stops | runtime_s | SNQI |",
+        "| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for row in report["rows"]:
+        metrics = row["metrics"]
+        lines.append(
+            f"| {row['row']} | {row['classification']} | {metrics['collision']} | "
+            f"{metrics['near_miss']} | {metrics['safety_events']} | "
+            f"{metrics['progress_m']} | {metrics['stop_yield_timing_steps']} | "
+            f"{metrics['false_positive_stops']} | {metrics['runtime_s']} | "
+            f"{metrics['snqi']} |"
+        )
+    lines.extend(["", "## Safety-benefit vs false-positive-stopping trade-off", ""])
+    for entry in verdict["tradeoff"]:
+        if entry.get("blocked"):
+            lines.append(f"- **{entry['row']}**: BLOCKED -- {entry['reason']}")
+        else:
+            lines.append(
+                f"- **{entry['row']}**: safety_event_reduction="
+                f"{entry['safety_event_reduction_vs_control']}, "
+                f"FP_stops={entry['false_positive_stops']}, "
+                f"benefit={entry['is_safety_benefit']}, "
+                f"regression={entry['outcome_regression'] or entry['fp_regression'] or entry['runtime_regression']}"
+            )
+    lines.extend(["", "## Caveats", ""])
+    lines.extend(f"- {caveat}" for caveat in report["caveats"])
+    lines.append("")
+    return "\n".join(lines)
+
+
+def _verify_seed_identity(cfg: dict[str, Any]) -> None:
+    """Assert all rows share the same seed/scenario denominator.
+
+    Raises:
+        ValueError: when the config does not pin a single shared seed/scenario.
+    """
+    fixture = cfg.get("fixture", {})
+    if "seed" not in fixture or "scenario_id" not in fixture:
+        raise ValueError("config fixture must pin a single shared seed and scenario_id")
+    if not cfg.get("rows"):
+        raise ValueError("config must declare rows")
+
+
+def run(config_path: pathlib.Path, output_dir: pathlib.Path) -> dict[str, Any]:
+    """Execute all rows and write the evidence bundle.
+
+    Returns:
+        The full report mapping.
+    """
+    with open(config_path, encoding="utf-8") as handle:
+        cfg = yaml.safe_load(handle)
+    _verify_seed_identity(cfg)
+
+    fixture_path = REPO_ROOT / cfg["fixture"]["trace_path"]
+    trace = _load_fixture(fixture_path)
+    frames = trace["frames"]
+
+    results = [evaluate_row(row, frames, cfg) for row in cfg["rows"]]
+    verdict = emit_verdict(results, cfg)
+
+    repro = {
+        "issue": 2916,
+        "generated_at_utc": datetime.datetime.now(datetime.UTC).isoformat(),
+        "command": (
+            "uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py "
+            f"--config {config_path.relative_to(REPO_ROOT)} "
+            f"--output-dir {output_dir.relative_to(REPO_ROOT) if output_dir.is_relative_to(REPO_ROOT) else output_dir}"
+        ),
+        "repo_head": _git_head(),
+        "config_path": str(config_path.relative_to(REPO_ROOT))
+        if config_path.is_relative_to(REPO_ROOT)
+        else str(config_path),
+    }
+
+    report = build_report(results, verdict, cfg, repro)
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / "forecast_risk_coupling_gate_report.json"
+    with open(json_path, "w", encoding="utf-8") as handle:
+        json.dump(report, handle, indent=2)
+    md_path = output_dir / "README.md"
+    with open(md_path, "w", encoding="utf-8") as handle:
+        handle.write(generate_markdown(report))
+
+    print(f"Wrote {json_path}")
+    print(f"Wrote {md_path}")
+    print(f"Verdict: {verdict['decision']}")
+    for row in results:
+        metrics = row["metrics"]
+        print(
+            f"  [{row['classification']:>7s}] {row['row']:>16s}: "
+            f"collision={metrics['collision']} near_miss={metrics['near_miss']} "
+            f"progress_m={metrics['progress_m']} FP_stops={metrics['false_positive_stops']} "
+            f"snqi={metrics['snqi']}"
+        )
+    return report
+
+
+def main() -> None:
+    """Parse arguments and run the coupling gate."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Forecast-risk closed-loop coupling gate (issue #2916, stress tier). "
+            "Runs 4 same-seed rows and emits a continue|revise|stop verdict."
+        )
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=DEFAULT_CONFIG,
+        help="Path to the coupling-gate config YAML.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default=DEFAULT_OUTPUT_DIR,
+        help="Directory for the JSON + Markdown evidence bundle.",
+    )
+    args = parser.parse_args()
+
+    config_path = pathlib.Path(args.config)
+    if not config_path.is_absolute():
+        config_path = REPO_ROOT / config_path
+    output_dir = pathlib.Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = REPO_ROOT / output_dir
+
+    run(config_path, output_dir)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/benchmark/run_forecast_risk_coupling_gate.py
+++ b/scripts/benchmark/run_forecast_risk_coupling_gate.py
@@ -64,6 +64,12 @@ FORECAST_HORIZONS_S = (0.5, 1.0)
 
 # Minimal feature schema required by ForecastBatch.v1 provenance.
 _FEATURE_SCHEMA = {"position": "xy_m", "velocity": "xy_m_s"}
+_EXPECTED_ROW_RISK_SOURCES = {
+    "no_forecast": "none",
+    "cv_risk": "constant_velocity",
+    "semantic_risk": "semantic_cv",
+    "interaction_risk": "interaction_aware_cv",
+}
 
 
 def _git_head() -> str:
@@ -96,6 +102,25 @@ def _load_fixture(path: pathlib.Path) -> dict[str, Any]:
         return json.load(handle)
 
 
+def _finite_xy(value: Any) -> np.ndarray | None:
+    """Return a finite xy vector, or None when the payload is malformed."""
+    try:
+        vector = np.asarray(value, dtype=float)
+    except (TypeError, ValueError):
+        return None
+    if vector.shape != (2,) or not np.all(np.isfinite(vector)):
+        return None
+    return vector
+
+
+def _repo_relative_or_absolute(path: pathlib.Path) -> str:
+    """Return a repo-relative path when possible, otherwise an absolute/path string."""
+    try:
+        return str(path.relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
 def _ped_state_from_frame(frame: dict[str, Any]) -> PedestrianState | None:
     """Build a PedestrianState from the first observed pedestrian in a frame.
 
@@ -109,6 +134,11 @@ def _ped_state_from_frame(frame: dict[str, Any]) -> PedestrianState | None:
     if not observed:
         return None
     payload = dict(observed[0])
+    if _finite_xy(payload.get("position")) is None:
+        return None
+    velocity = payload.get("velocity")
+    if velocity is not None and _finite_xy(velocity) is None:
+        return None
     payload.setdefault("id", 0)
     return PedestrianState.from_trace(payload)
 
@@ -218,6 +248,7 @@ class _RowState:
     risk_available_steps: int = 0
     risk_unavailable_in_conflict: int = 0
     conflict_steps: int = 0
+    risk_unavailable_this_step: bool = False
 
 
 def _gate_action_for_step(
@@ -236,10 +267,12 @@ def _gate_action_for_step(
         ``"stop"``, ``"yield"``, or ``"go"``.
     """
     risk_source = row["risk_source"]
+    state.risk_unavailable_this_step = False
     if risk_source == "none":
         return "go"
     ped_state = _ped_state_from_frame(frame)
     if ped_state is None:
+        state.risk_unavailable_this_step = True
         return "go"
     gate_cfg = cfg["risk_gate"]
     batch = _build_forecast_batch(
@@ -253,6 +286,7 @@ def _gate_action_for_step(
         batch, robot_pos, influence_radius_m=float(gate_cfg["influence_radius_m"])
     )
     if not signal.available:
+        state.risk_unavailable_this_step = True
         return "go"
     state.risk_available_steps += 1
     return _gate_decision(
@@ -290,7 +324,9 @@ def _score_outcome_step(
     peds = frame.get("pedestrians") or []
     if not peds:
         return
-    ped_pos = np.asarray(peds[0]["position"], dtype=float)
+    ped_pos = _finite_xy(peds[0].get("position"))
+    if ped_pos is None:
+        raise ValueError("ground-truth pedestrian position must be a finite xy vector")
     distance = float(np.linalg.norm(state.robot_pos - ped_pos))
     state.min_distance_m = min(state.min_distance_m, distance)
     if distance <= COLLISION_DISTANCE_M:
@@ -305,7 +341,7 @@ def _score_outcome_step(
             state.true_positive_stops += 1
         else:
             state.false_positive_stops += 1
-    if in_conflict and risk_source != "none" and _ped_state_from_frame(frame) is None:
+    if in_conflict and risk_source != "none" and state.risk_unavailable_this_step:
         state.risk_unavailable_in_conflict += 1
 
 
@@ -670,8 +706,23 @@ def _verify_seed_identity(cfg: dict[str, Any]) -> None:
     fixture = cfg.get("fixture", {})
     if "seed" not in fixture or "scenario_id" not in fixture:
         raise ValueError("config fixture must pin a single shared seed and scenario_id")
-    if not cfg.get("rows"):
+    rows = cfg.get("rows")
+    if not rows:
         raise ValueError("config must declare rows")
+    observed: dict[str, str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError("config rows must be mappings")
+        name = str(row.get("name", "")).strip()
+        risk_source = str(row.get("risk_source", "")).strip()
+        if name in observed:
+            raise ValueError(f"duplicate config row: {name}")
+        observed[name] = risk_source
+    if observed != _EXPECTED_ROW_RISK_SOURCES:
+        raise ValueError(
+            "config must declare exactly the four forecast-risk rows with expected risk_source "
+            f"mapping: {_EXPECTED_ROW_RISK_SOURCES}"
+        )
 
 
 def run(config_path: pathlib.Path, output_dir: pathlib.Path) -> dict[str, Any]:
@@ -696,13 +747,11 @@ def run(config_path: pathlib.Path, output_dir: pathlib.Path) -> dict[str, Any]:
         "generated_at_utc": datetime.datetime.now(datetime.UTC).isoformat(),
         "command": (
             "uv run python scripts/benchmark/run_forecast_risk_coupling_gate.py "
-            f"--config {config_path.relative_to(REPO_ROOT)} "
-            f"--output-dir {output_dir.relative_to(REPO_ROOT) if output_dir.is_relative_to(REPO_ROOT) else output_dir}"
+            f"--config {_repo_relative_or_absolute(config_path)} "
+            f"--output-dir {_repo_relative_or_absolute(output_dir)}"
         ),
         "repo_head": _git_head(),
-        "config_path": str(config_path.relative_to(REPO_ROOT))
-        if config_path.is_relative_to(REPO_ROOT)
-        else str(config_path),
+        "config_path": _repo_relative_or_absolute(config_path),
     }
 
     report = build_report(results, verdict, cfg, repro)

--- a/tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py
+++ b/tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py
@@ -1,0 +1,329 @@
+"""Tests for the forecast-risk closed-loop coupling gate (issue #2916).
+
+Covers:
+- adapter risk mapping (proximity -> bounded scalar risk),
+- fail-closed on degraded / missing / oracle batches,
+- verdict logic for all three branches (continue | revise | stop),
+- seed-identity across rows in the runner.
+
+All inputs are small synthetic fixtures; no heavy simulator is started.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.forecast_batch import (
+    ActorForecast,
+    CoordinateFrame,
+    ForecastBatch,
+    ForecastBatchProvenance,
+)
+from robot_sf.benchmark.forecast_risk_adapter import (
+    FORECAST_RISK_ADAPTER_SCHEMA_VERSION,
+    compute_forecast_risk,
+)
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_RUNNER_PATH = REPO_ROOT / "scripts/benchmark/run_forecast_risk_coupling_gate.py"
+
+
+def _load_runner():
+    """Import the runner script as a module for verdict/seed-identity tests.
+
+    Returns:
+        The imported runner module.
+    """
+    module_name = "run_forecast_risk_coupling_gate"
+    spec = importlib.util.spec_from_file_location(module_name, _RUNNER_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    # Register before exec so dataclass type resolution can find the module.
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _make_batch(
+    deterministic: np.ndarray | None,
+    *,
+    fallback_status: str = "native",
+    degraded_status: str = "none",
+    oracle_state: bool = False,
+    actor_mask: list[bool] | None = None,
+    include_forecast: bool = True,
+) -> ForecastBatch:
+    """Build a minimal synthetic ForecastBatch for adapter tests.
+
+    Returns:
+        A validated ForecastBatch with one actor.
+    """
+    mask = actor_mask if actor_mask is not None else [True]
+    forecasts = []
+    if include_forecast and mask[0]:
+        forecasts.append(ActorForecast(actor_id="0", deterministic=deterministic))
+    provenance = ForecastBatchProvenance(
+        predictor_id="cv-test",
+        predictor_family="constant_velocity",
+        observation_tier="tracked_agents",
+        frame=CoordinateFrame(name="world", units="m", axes=("x", "y")),
+        dt_s=0.1,
+        horizons_s=[0.5, 1.0],
+        scenario_id="synthetic",
+        seed=7,
+        fallback_status=fallback_status,
+        degraded_status=degraded_status,
+        actor_ids=["0"],
+        actor_mask=mask,
+        actor_mask_metadata={"semantics": "true means available"},
+        feature_schema={"position": "xy_m"},
+        timestamp="1970-01-01T00:00:00+00:00",
+        oracle_state=oracle_state,
+    )
+    return ForecastBatch(
+        provenance=provenance,
+        forecasts=forecasts,
+        metadata={"artifact_role": "test"},
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Adapter risk mapping
+# --------------------------------------------------------------------------- #
+
+
+def test_adapter_close_forecast_gives_high_risk():
+    """A forecast mean very near the robot yields high, available risk."""
+    deterministic = np.array([[0.2, 0.0], [0.3, 0.0]], dtype=float)
+    batch = _make_batch(deterministic)
+    signal = compute_forecast_risk(batch, [0.0, 0.0], influence_radius_m=3.0)
+    assert signal.available is True
+    assert signal.reason == "ok"
+    assert signal.risk > 0.9  # 1 - 0.2/3.0 ~= 0.933
+    assert signal.contributing_actor_count == 1
+    assert signal.nearest_predicted_distance_m == pytest.approx(0.2)
+
+
+def test_adapter_far_forecast_gives_zero_risk():
+    """A forecast mean beyond the influence radius yields zero (but available) risk."""
+    deterministic = np.array([[10.0, 0.0], [11.0, 0.0]], dtype=float)
+    batch = _make_batch(deterministic)
+    signal = compute_forecast_risk(batch, [0.0, 0.0], influence_radius_m=3.0)
+    assert signal.available is True
+    assert signal.risk == 0.0
+
+
+def test_adapter_risk_is_bounded_and_monotone():
+    """Risk increases as the predicted occupancy approaches the robot."""
+    near = compute_forecast_risk(
+        _make_batch(np.array([[0.5, 0.0], [0.5, 0.0]])), [0.0, 0.0], influence_radius_m=3.0
+    )
+    far = compute_forecast_risk(
+        _make_batch(np.array([[2.0, 0.0], [2.0, 0.0]])), [0.0, 0.0], influence_radius_m=3.0
+    )
+    assert 0.0 <= far.risk <= near.risk <= 1.0
+
+
+def test_adapter_to_dict_has_schema_version():
+    """The signal serializes with the adapter schema version."""
+    signal = compute_forecast_risk(_make_batch(np.array([[1.0, 0.0], [1.0, 0.0]])), [0.0, 0.0])
+    payload = signal.to_dict()
+    assert payload["schema_version"] == FORECAST_RISK_ADAPTER_SCHEMA_VERSION
+    assert payload["available"] is True
+
+
+def test_adapter_rejects_non_positive_influence_radius():
+    """A non-positive influence radius is a hard error."""
+    with pytest.raises(ValueError, match="influence_radius_m"):
+        compute_forecast_risk(
+            _make_batch(np.array([[1.0, 0.0], [1.0, 0.0]])), [0.0, 0.0], influence_radius_m=0.0
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Fail-closed behavior
+# --------------------------------------------------------------------------- #
+
+
+def test_adapter_fails_closed_on_degraded_batch():
+    """A degraded batch is unavailable with risk 0.0 (never a low-risk success)."""
+    batch = _make_batch(np.array([[0.1, 0.0], [0.1, 0.0]]), degraded_status="degraded_observation")
+    signal = compute_forecast_risk(batch, [0.0, 0.0])
+    assert signal.available is False
+    assert signal.risk == 0.0
+    assert signal.reason.startswith("degraded:")
+
+
+def test_adapter_fails_closed_on_fallback_batch():
+    """A non-native fallback status fails closed."""
+    batch = _make_batch(np.array([[0.1, 0.0], [0.1, 0.0]]), fallback_status="fallback")
+    signal = compute_forecast_risk(batch, [0.0, 0.0])
+    assert signal.available is False
+    assert signal.reason.startswith("fallback:")
+
+
+def test_adapter_fails_closed_on_oracle_batch():
+    """An oracle-sourced batch fails closed even when geometry is close."""
+    batch = _make_batch(np.array([[0.1, 0.0], [0.1, 0.0]]), oracle_state=True)
+    signal = compute_forecast_risk(batch, [0.0, 0.0])
+    assert signal.available is False
+    assert signal.reason == "oracle_state"
+
+
+def test_adapter_fails_closed_on_missing_actor():
+    """A batch whose only actor is masked out (no forecast) fails closed."""
+    batch = _make_batch(None, actor_mask=[False], include_forecast=False)
+    signal = compute_forecast_risk(batch, [0.0, 0.0])
+    assert signal.available is False
+    assert signal.risk == 0.0
+
+
+# --------------------------------------------------------------------------- #
+# Verdict logic (all three branches)
+# --------------------------------------------------------------------------- #
+
+
+def _verdict_cfg() -> dict:
+    """Return a minimal verdict config block.
+
+    Returns:
+        Config mapping with the verdict thresholds.
+    """
+    return {
+        "verdict": {
+            "min_safety_event_reduction": 1,
+            "max_false_positive_stop_ratio": 3.0,
+            "max_runtime_s": 5.0,
+        }
+    }
+
+
+def _row(
+    name: str, risk_source: str, *, safety_events: int, fp_stops: int, classification: str = "ok"
+):
+    """Build a synthetic per-row result for verdict tests.
+
+    Returns:
+        A row result mapping shaped like ``evaluate_row`` output.
+    """
+    return {
+        "row": name,
+        "risk_source": risk_source,
+        "classification": classification,
+        "classification_reason": "synthetic",
+        "metrics": {
+            "collision": safety_events >= 2,
+            "near_miss": safety_events >= 1,
+            "safety_events": safety_events,
+            "false_positive_stops": fp_stops,
+            "runtime_s": 0.001,
+            "snqi": 0.0,
+        },
+    }
+
+
+def test_verdict_continue_on_safety_benefit():
+    """A forecast row that cuts safety events with no regression -> continue."""
+    module = _load_runner()
+    results = [
+        _row("no_forecast", "none", safety_events=2, fp_stops=0),
+        _row("cv_risk", "constant_velocity", safety_events=0, fp_stops=0),
+        _row("semantic_risk", "semantic_cv", safety_events=1, fp_stops=0),
+        _row("interaction_risk", "interaction_aware_cv", safety_events=1, fp_stops=0),
+    ]
+    verdict = module.emit_verdict(results, _verdict_cfg())
+    assert verdict["decision"] == "continue"
+
+
+def test_verdict_stop_on_regression_without_benefit():
+    """Forecast rows that worsen safety with no benefit -> stop."""
+    module = _load_runner()
+    results = [
+        _row("no_forecast", "none", safety_events=0, fp_stops=0),
+        _row("cv_risk", "constant_velocity", safety_events=2, fp_stops=0),
+        _row("semantic_risk", "semantic_cv", safety_events=2, fp_stops=0),
+        _row("interaction_risk", "interaction_aware_cv", safety_events=2, fp_stops=0),
+    ]
+    verdict = module.emit_verdict(results, _verdict_cfg())
+    assert verdict["decision"] == "stop"
+
+
+def test_verdict_revise_when_inconclusive():
+    """No safety benefit and no regression -> revise (conservative default)."""
+    module = _load_runner()
+    results = [
+        _row("no_forecast", "none", safety_events=1, fp_stops=0),
+        _row("cv_risk", "constant_velocity", safety_events=1, fp_stops=0),
+        _row("semantic_risk", "semantic_cv", safety_events=1, fp_stops=0),
+        _row("interaction_risk", "interaction_aware_cv", safety_events=1, fp_stops=0),
+    ]
+    verdict = module.emit_verdict(results, _verdict_cfg())
+    assert verdict["decision"] == "revise"
+
+
+def test_verdict_blocked_rows_do_not_count_as_benefit():
+    """A blocked forecast row never contributes a safety benefit."""
+    module = _load_runner()
+    results = [
+        _row("no_forecast", "none", safety_events=2, fp_stops=0),
+        _row("cv_risk", "constant_velocity", safety_events=0, fp_stops=0, classification="blocked"),
+        _row("semantic_risk", "semantic_cv", safety_events=2, fp_stops=0),
+        _row("interaction_risk", "interaction_aware_cv", safety_events=2, fp_stops=0),
+    ]
+    verdict = module.emit_verdict(results, _verdict_cfg())
+    assert "cv_risk" in verdict["blocked_rows"]
+    # Blocked benefit row removed; remaining rows match control -> not a benefit.
+    assert verdict["decision"] in {"revise", "stop"}
+
+
+def test_verdict_false_positive_explosion_blocks_continue():
+    """A safety benefit nullified by a false-positive-stop explosion -> not continue."""
+    module = _load_runner()
+    results = [
+        _row("no_forecast", "none", safety_events=2, fp_stops=1),
+        _row("cv_risk", "constant_velocity", safety_events=0, fp_stops=10),
+        _row("semantic_risk", "semantic_cv", safety_events=2, fp_stops=1),
+        _row("interaction_risk", "interaction_aware_cv", safety_events=2, fp_stops=1),
+    ]
+    verdict = module.emit_verdict(results, _verdict_cfg())
+    # cv_risk cut events but exploded FP stops (ratio 10 > 3) -> regression, no clean benefit.
+    assert verdict["decision"] != "continue"
+
+
+# --------------------------------------------------------------------------- #
+# Seed identity across rows
+# --------------------------------------------------------------------------- #
+
+
+def test_seed_identity_enforced_by_config():
+    """The runner requires a single shared seed and scenario across rows."""
+    module = _load_runner()
+    good = {
+        "fixture": {"seed": 111, "scenario_id": "s", "trace_path": "x", "dt_s": 0.1},
+        "rows": [{"name": "no_forecast", "risk_source": "none"}],
+    }
+    module._verify_seed_identity(good)  # does not raise
+
+    bad = {"fixture": {"scenario_id": "s"}, "rows": [{"name": "a", "risk_source": "none"}]}
+    with pytest.raises(ValueError, match="seed"):
+        module._verify_seed_identity(bad)
+
+
+def test_runner_rows_share_seed_and_scenario(tmp_path):
+    """End-to-end: all rows in the report carry the same seed/scenario denominator."""
+    module = _load_runner()
+    config_path = REPO_ROOT / "configs/research/forecast_risk_coupling_issue_2916.yaml"
+    report = module.run(config_path, tmp_path)
+    fixture = report["config"]["fixture"]
+    # Every row was evaluated against the same fixture seed/scenario.
+    assert fixture["seed"] == 111
+    assert fixture["scenario_id"] == "issue_2756_occluded_emergence"
+    row_names = {row["row"] for row in report["rows"]}
+    assert row_names == {"no_forecast", "cv_risk", "semantic_risk", "interaction_risk"}
+    # The verdict is one of the three allowed branches.
+    assert report["verdict"]["decision"] in {"continue", "revise", "stop"}

--- a/tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py
+++ b/tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import importlib.util
 import pathlib
+import shutil
 import sys
 
 import numpy as np
@@ -305,13 +306,96 @@ def test_seed_identity_enforced_by_config():
     module = _load_runner()
     good = {
         "fixture": {"seed": 111, "scenario_id": "s", "trace_path": "x", "dt_s": 0.1},
-        "rows": [{"name": "no_forecast", "risk_source": "none"}],
+        "rows": [
+            {"name": "no_forecast", "risk_source": "none"},
+            {"name": "cv_risk", "risk_source": "constant_velocity"},
+            {"name": "semantic_risk", "risk_source": "semantic_cv"},
+            {"name": "interaction_risk", "risk_source": "interaction_aware_cv"},
+        ],
     }
     module._verify_seed_identity(good)  # does not raise
 
     bad = {"fixture": {"scenario_id": "s"}, "rows": [{"name": "a", "risk_source": "none"}]}
     with pytest.raises(ValueError, match="seed"):
         module._verify_seed_identity(bad)
+
+
+def test_seed_identity_requires_four_row_matrix():
+    """Config validation should fail before evaluation when any required row is absent."""
+    module = _load_runner()
+    bad = {
+        "fixture": {"seed": 111, "scenario_id": "s", "trace_path": "x", "dt_s": 0.1},
+        "rows": [
+            {"name": "no_forecast", "risk_source": "none"},
+            {"name": "cv_risk", "risk_source": "constant_velocity"},
+        ],
+    }
+
+    with pytest.raises(ValueError, match="exactly the four forecast-risk rows"):
+        module._verify_seed_identity(bad)
+
+
+def test_observed_pedestrian_non_finite_position_is_unavailable():
+    """Malformed observed positions should make forecast risk unavailable, not crash."""
+    module = _load_runner()
+    frame = {"observed_pedestrians": [{"id": 1, "position": [float("nan"), 0.0]}]}
+
+    assert module._ped_state_from_frame(frame) is None
+
+
+def test_ground_truth_non_finite_position_fails_clearly():
+    """Outcome scoring should reject non-finite ground-truth pedestrian positions."""
+    module = _load_runner()
+    state = module._RowState(robot_pos=np.array([0.0, 0.0], dtype=float))
+    frame = {"pedestrians": [{"position": [float("inf"), 0.0]}]}
+
+    with pytest.raises(ValueError, match="finite xy vector"):
+        module._score_outcome_step(
+            frame,
+            action="go",
+            risk_source="constant_velocity",
+            conflict_distance_m=1.5,
+            state=state,
+        )
+
+
+def test_unavailable_signal_in_conflict_fails_closed():
+    """Unavailable forecast signals during a conflict window should block the row."""
+    module = _load_runner()
+    state = module._RowState(robot_pos=np.array([0.0, 0.0], dtype=float))
+    state.risk_unavailable_this_step = True
+    frame = {"pedestrians": [{"position": [0.5, 0.0]}]}
+
+    module._score_outcome_step(
+        frame,
+        action="go",
+        risk_source="constant_velocity",
+        conflict_distance_m=1.5,
+        state=state,
+    )
+
+    assert state.risk_unavailable_in_conflict == 1
+    classification, reason = module._classify_row(
+        risk_source="constant_velocity",
+        conflict_steps=1,
+        risk_available_steps=0,
+        risk_unavailable_in_conflict=1,
+    )
+    assert classification == "blocked"
+    assert "fail-closed" in reason
+
+
+def test_run_accepts_absolute_config_outside_repo(tmp_path: pathlib.Path):
+    """Repro command formatting should not crash for config paths outside the repo."""
+    module = _load_runner()
+    source_config = REPO_ROOT / "configs/research/forecast_risk_coupling_issue_2916.yaml"
+    config_path = tmp_path / "forecast_risk_coupling_issue_2916.yaml"
+    shutil.copy(source_config, config_path)
+
+    report = module.run(config_path, tmp_path / "out")
+
+    assert report["reproducibility"]["config_path"] == str(config_path)
+    assert f"--config {config_path}" in report["reproducibility"]["command"]
 
 
 def test_runner_rows_share_seed_and_scenario(tmp_path):


### PR DESCRIPTION
## Summary

Closes #2916. Implements the bounded, same-seed **forecast-risk closed-loop coupling gate** — testing whether forecast-derived risk improves navigation *outcomes*, not just prediction metrics. Local-only, `evidence_tier: stress`, `claim_boundary: diagnostic_only`, **not paper-grade**, and promotes **no** learned predictor.

This is the gate the learned-prediction lane (#2844/#2845) depends on for an evidence-based unblock decision.

## What landed

| File | Purpose |
| --- | --- |
| `robot_sf/benchmark/forecast_risk_adapter.py` | Pure `compute_forecast_risk(batch, robot_pos)` → bounded `[0,1]` per-step risk from a `ForecastBatch.v1`; **fails closed** (`available=False`, `risk=0.0`) on degraded/fallback/oracle/payload-less batches |
| `configs/research/forecast_risk_coupling_issue_2916.yaml` | Rows `no_forecast`/`cv_risk`/`semantic_risk`/`interaction_risk` pinned to identical seed (111)/scenario; only the risk **source** varies |
| `scripts/benchmark/run_forecast_risk_coupling_gate.py` | Fixture-driven proxy (modeled on `run_observation_noise_envelope.py`, no heavy `runner.py`); scores collision/near-miss, route progress, stop/yield timing, false-positive stopping, runtime, SNQI; emits `continue\|revise\|stop` with the FP-stop-vs-safety trade-off explicit; fail-closed rows |
| `tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py` | 16 tests: adapter mapping, fail-closed paths, all three verdict branches, seed identity |

## Result (from the actual run, commit `566d820e`)

Verdict: **`continue`** — forecast risk eliminated the near-miss with **0 false-positive stops** at a real throughput cost (route progress 0.82 → 0.45 m).

| row | collision | near_miss | safety_events | FP_stops | SNQI |
|---|---|---|---|---|---|
| no_forecast | False | **True** | 1 | 0 | 0.27 |
| cv_risk | False | False | 0 | 0 | 0.65 |
| semantic_risk | False | False | 0 | 0 | 0.65 |
| interaction_risk | False | False | 0 | 0 | 0.65 |

## Honesty / caveats (also in the tracked report + `result.json`)

- **Risk source is deployable observed-tier forecast only.** Ground truth is used *solely* for outcome scoring (collision/near-miss), never as a risk input — verified in audit.
- The three forecast sources produce **identical** outcomes on this single-pedestrian fixture (`semantic_cv` / `interaction_aware_cv` degrade to plain CV with no intent/neighbor context). The fixture shows *forecast-vs-no-forecast* coupling, **not** source discrimination. Labeled in the report.
- Single deterministic fixture (seed 111) → diagnostic stress evidence, not a population claim. The fail-closed `blocked` row path is exercised by unit tests, not by this fixture.

## Validation (independently re-run by orchestrator)

- `pytest tests/benchmark/test_forecast_risk_coupling_gate_issue_2916.py` → **16 passed**; broader `-k "forecast or risk or coupling"` → 475 passed, no regressions.
- Fresh `run_forecast_risk_coupling_gate.py` **reproduces** the committed report (verdict + all safety metrics identical; only sub-ms runtime jitter differs).
- `ruff check` / `pre-commit` on changed files → clean. `sync_ai_config.py --check` → no drift.

Tracked evidence: `docs/context/evidence/issue_2916_forecast_risk_coupling_2026-06-23/` (report + README with command/config/seed/SHA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a forecast-risk closed-loop safety gate with deterministic per-step risk assessment and fail-closed handling for degraded batches.
  * Introduced configurable risk thresholds for gate actions (stop/yield).

* **Documentation**
  * Added comprehensive evidence documentation detailing safety improvements and risk trade-offs.

* **Tests**
  * Added test suite validating risk computation, fail-closed behavior, and verdict logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->