### PR TITLE
analysis: ORCA-residual progress-probe lane decision = stop (#2445)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Classified the ORCA-residual progress-probe lane decision (#2445):
+  [`scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py`](scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py)
+  reads the existing v1 bounded smoke result (SLURM job 12913) and applies the #2408/PR #2420 stop
+  rule deterministically. Decision: **`stop`** the current residual-BC lane shape — the v1 smoke
+  reproduces the v0 failure pattern (`success_rate=0.0` + `timeout_low_progress`) and is itself
+  `failed_closed` with all four required smoke-evidence fields null, either of which forbids
+  continuation/nominal escalation. Reopening requires a named objective/dataset redesign. The
+  classifier fails closed (missing/invalid artifact or absent required fields → `stop` naming the
+  gap). Analysis-only over failed-closed evidence — not readiness evidence; decision doc
+  [`docs/context/issue_2445_orca_residual_progress_probe_decision.md`](docs/context/issue_2445_orca_residual_progress_probe_decision.md)
+  with a #1358/#1475 handoff note (#2445).
 * Added the #3556 belief-mode safety campaign harness: [`scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py`](scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py) runs the `oracle` / `uncertain_retained` / `uncertain_dropped` contrast through the **real** `map_runner.run_map_batch` on a crossing scenario family + seed matrix and classifies the episode-level safety result (`revise` / `retention_dominates` / `inconclusive` / `inconclusive_oracle_unsafe`). Current result on `classic_crossing_subset` is **`inconclusive`**: the gate now acts (the dropped mode differs on worst-case clearance), but the oracle baseline collides every episode so there is no near-safe headroom to attribute a collision effect — the remaining #3556 gap is a near-safe crossing family. Evidence + reproduction: `docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/`.
 
 ### Added

--- a/docs/context/evidence/issue_2445_orca_residual_progress_probe_decision_2026-06-23/decision.json
+++ b/docs/context/evidence/issue_2445_orca_residual_progress_probe_decision_2026-06-23/decision.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "orca_residual_progress_probe_decision.v1",
+  "issue": 2445,
+  "evidence_grade": "analysis_only",
+  "git_head": "fedee58afe8c5834f4e6ccb1179cdc00a8354606",
+  "input_artifact": "docs/context/evidence/issue_1475_orca_residual_bc_smoke_12913_2026-06-17/summary.json",
+  "orca_residual_progress_probe_decision": {
+    "prior_decision_issue": 2408,
+    "v1_smoke_success_rate": 0.0,
+    "v1_smoke_failure_mode": "timeout_low_progress",
+    "artifact_pointer_status": "missing",
+    "missing_required_fields": [
+      "residual_clipping_rate",
+      "guard_veto_rate",
+      "fallback_degraded_status",
+      "artifact_pointer_status"
+    ],
+    "decision": "stop",
+    "reopen_condition": "Reopen only through a named objective/dataset redesign (a new BC objective, dataset, scenario, or instrumentation lane); do not rerun unchanged v0 BC and do not submit nominal_sanity from this failed-closed smoke.",
+    "rationale": "Fail-closed: the v1 smoke is missing required smoke-evidence fields ['residual_clipping_rate', 'guard_veto_rate', 'fallback_degraded_status', 'artifact_pointer_status'] (summary status='failed_closed', nominal_escalation_allowed=False). Missing required fields independently forbid nominal escalation; combined with success_rate=0.0 and failure_mode='timeout_low_progress', the #2408 stop rule applies. Reopen only via a named objective/dataset redesign."
+  }
+}

--- a/docs/context/evidence/issue_2445_orca_residual_progress_probe_decision_2026-06-23/decision.md
+++ b/docs/context/evidence/issue_2445_orca_residual_progress_probe_decision_2026-06-23/decision.md
@@ -1,0 +1,28 @@
+# Issue #2445 ORCA-Residual Progress-Probe Decision
+
+- **Decision**: `stop`
+- **Evidence Grade**: `analysis_only`
+- **Prior decision issue**: #2408
+- **Input artifact**: `docs/context/evidence/issue_1475_orca_residual_bc_smoke_12913_2026-06-17/summary.json`
+- **Git HEAD**: `fedee58afe8c5834f4e6ccb1179cdc00a8354606`
+
+## V1 Smoke Facts (job 12913)
+
+| Field | Value |
+| --- | --- |
+| v1_smoke_success_rate | `0.0` |
+| v1_smoke_failure_mode | `timeout_low_progress` |
+| artifact_pointer_status | `missing` |
+| missing_required_fields | `['residual_clipping_rate', 'guard_veto_rate', 'fallback_degraded_status', 'artifact_pointer_status']` |
+
+## Rationale
+
+Fail-closed: the v1 smoke is missing required smoke-evidence fields ['residual_clipping_rate', 'guard_veto_rate', 'fallback_degraded_status', 'artifact_pointer_status'] (summary status='failed_closed', nominal_escalation_allowed=False). Missing required fields independently forbid nominal escalation; combined with success_rate=0.0 and failure_mode='timeout_low_progress', the #2408 stop rule applies. Reopen only via a named objective/dataset redesign.
+
+## Reopen Condition
+
+Reopen only through a named objective/dataset redesign (a new BC objective, dataset, scenario, or instrumentation lane); do not rerun unchanged v0 BC and do not submit nominal_sanity from this failed-closed smoke.
+
+## Claim Boundary
+
+This is an analysis-only routing decision over existing failed-closed smoke evidence. It is not a benchmark result, not a learned-component success claim, and must not justify nominal or larger SLURM reruns.

--- a/docs/context/evidence/issue_2445_orca_residual_progress_probe_decision_2026-06-23/provenance.json
+++ b/docs/context/evidence/issue_2445_orca_residual_progress_probe_decision_2026-06-23/provenance.json
@@ -1,0 +1,18 @@
+{
+  "schema_version": "orca_residual_progress_probe_decision_provenance.v1",
+  "issue": 2445,
+  "created_at": "2026-06-23",
+  "evidence_grade": "analysis_only",
+  "decision": "stop",
+  "command": "uv run python scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py --output-dir docs/context/evidence/issue_2445_orca_residual_progress_probe_decision_2026-06-23",
+  "source_commit": "fedee58afe8c5834f4e6ccb1179cdc00a8354606",
+  "prior_decision_issue": 2408,
+  "input_artifact": {
+    "path": "docs/context/evidence/issue_1475_orca_residual_bc_smoke_12913_2026-06-17/summary.json",
+    "sha256": "338a61b69690be8fe6375b4649d604777e3056b44bf1748f1828734387912c23",
+    "slurm_job_id": "12913",
+    "candidate": "orca_residual_guarded_ppo_progress_v1",
+    "smoke_source_commit": "dcb14927f08277d123d9666ad91b8d6abbc4fe9d"
+  },
+  "claim_boundary": "Analysis-only decision over failed-closed smoke evidence. Not readiness evidence; must not justify nominal or larger SLURM reruns."
+}

--- a/docs/context/issue_2445_orca_residual_progress_probe_decision.md
+++ b/docs/context/issue_2445_orca_residual_progress_probe_decision.md
@@ -1,0 +1,106 @@
+# Issue #2445 ORCA-Residual Progress-Probe Decision
+
+Date: 2026-06-23
+Issue: <https://github.com/ll7/robot_sf_ll7/issues/2445>
+Parents: <https://github.com/ll7/robot_sf_ll7/issues/1475>,
+<https://github.com/ll7/robot_sf_ll7/issues/1358>
+Prior decision: [issue_2408_orca_residual_low_progress_analysis.md](issue_2408_orca_residual_low_progress_analysis.md)
+(stop rule), PR #2420.
+
+## Scope
+
+This note classifies the ORCA-residual progress-probe target **after** the revised v1 bounded smoke
+result (SLURM job 12913) and decides whether the ORCA-residual BC lane should **continue, revise, or
+stop**. It is a decision over *existing* evidence: there is no training to run here. It does not
+launch training, submit SLURM jobs, promote checkpoints, or claim learned-residual success.
+
+The compact machine-readable decision artifact lives under
+`docs/context/evidence/issue_2445_orca_residual_progress_probe_decision_2026-06-23/`.
+
+## Evidence Source
+
+- `docs/context/evidence/issue_1475_orca_residual_bc_smoke_12913_2026-06-17/summary.json` — the
+  revised v1 bounded smoke result (SLURM job 12913, candidate
+  `orca_residual_guarded_ppo_progress_v1`, source commit
+  `dcb14927f08277d123d9666ad91b8d6abbc4fe9d`).
+
+## The #2408 Stop Rule (input decision rule)
+
+From [issue_2408_orca_residual_low_progress_analysis.md](issue_2408_orca_residual_low_progress_analysis.md)
+and PR #2420:
+
+> If the v1 bounded smoke also produces `success_rate=0.0` with `timeout_low_progress`, **stop** the
+> current residual-BC lane shape or reopen only through a **named objective/dataset redesign**. Do
+> not rerun unchanged v0 BC and do not submit `nominal_sanity` from the failed v0 row.
+
+## Observed v1 Smoke (job 12913)
+
+| Field | Value |
+| --- | ---: |
+| Episodes | 1 |
+| Success rate | `0.0` |
+| Failure mode | `timeout_low_progress` (count 1) |
+| Termination reason | `max_steps` |
+| Mean average speed | 0.8041 |
+| Status | `failed_closed` |
+| Classification | `missing_required_smoke_evidence` |
+| `nominal_escalation_allowed` | `false` |
+| `residual_clipping_rate` | `null` (missing) |
+| `guard_veto_rate` | `null` (missing) |
+| `fallback_degraded_status` | `null` (missing) |
+| `artifact_pointer_status` | `null` (missing) |
+
+Two independent triggers fire on this row:
+
+1. **Reproduced v0 failure pattern**: `success_rate=0.0` **and** `timeout_low_progress`, exactly the
+   pattern the #2408 stop rule names.
+2. **Missing required smoke-evidence fields**: all four required fields
+   (`residual_clipping_rate`, `guard_veto_rate`, `fallback_degraded_status`, `artifact_pointer_status`)
+   are null, so the smoke is itself `failed_closed` / `missing_required_smoke_evidence`. This
+   independently forbids nominal escalation (`nominal_escalation_allowed=false`).
+
+## Decision
+
+Selected decision output: **`stop`** the current ORCA-residual BC lane shape.
+
+The deterministic classifier
+(`scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py`) reports the
+`orca_residual_progress_probe_decision` block with `decision: stop`, grounded in the two triggers
+above. The fail-closed branch reports the missing-required-fields trigger first; even if the fields
+were present, the reproduced-v0-failure branch (`success_rate=0.0` + `timeout_low_progress`) would
+still return `stop`.
+
+Recommendation for Issue #1475 and Issue #1358 (handoff note — this lane does not edit GitHub):
+
+- **Stop** the current residual-BC lane shape. Do not rerun the unchanged v0/v1 BC smoke and do not
+  submit `nominal_sanity` from this failed-closed row.
+- **Reopen only through a named objective/dataset redesign**: a new BC objective, dataset, scenario,
+  or instrumentation lane that (a) emits and tests the four required smoke-evidence fields and
+  (b) changes the residual objective/data so the progress probe is not a relabeled unchanged rerun.
+- Update #1358 / #1475 with this decision (handoff only; do not edit GitHub from this lane).
+
+## What a Valid Reopen Requires
+
+A reopen is valid only if it is a *named redesign*, not a relabeled rerun:
+
+1. The smoke runner/finalizer emits the four required fields (`residual_clipping_rate`,
+   `guard_veto_rate`, `fallback_degraded_status`, `artifact_pointer_status`) and they are tested.
+2. The BC objective, dataset, or scenario is materially changed (e.g. the larger BC dataset pending
+   as a wandb artifact, a revised progress objective, or a different scenario split) — not the same
+   v0/v1 packet rerun.
+3. A single bounded smoke is rerun under the redesigned lane *before* any nominal escalation.
+
+## Claim Boundary
+
+This is analysis-only routing evidence over a **failed-closed** smoke. It explains why the current
+residual-BC lane shape stops and what a valid reopen requires. It is **not** readiness evidence, not
+a new benchmark result, not a learned-component success claim, and must **not** be used to justify
+nominal or larger SLURM reruns.
+
+## Validation
+
+```bash
+uv run python scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py --help
+uv run python scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py   # real run on 12913 => stop
+uv run python -m pytest tests/ -k "orca_residual_progress_probe or 2445" -q
+```

--- a/scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py
+++ b/scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Classify the ORCA-residual progress-probe decision for issue #2445.
+
+This script applies the issue #2408 / PR #2420 stop rule deterministically to the
+revised v1 bounded smoke result (SLURM job 12913) and decides whether the
+ORCA-residual BC lane should ``continue``, ``revise``, or ``stop``.
+
+It is a *decision over existing evidence*. It does not launch training, submit
+SLURM jobs, promote checkpoints, or claim learned-residual success.
+
+Decision rule (from issue #2408 / PR #2420, cited in #2445):
+    "If the v1 bounded smoke also has success_rate=0.0 with timeout_low_progress,
+    stop the current residual-BC lane shape, or reopen only through a named
+    objective/dataset redesign; do NOT rerun unchanged v0 or submit
+    nominal_sanity."
+
+Fail-closed posture (repository top value: honest, transparent, reproducible):
+    If the input artifact is missing or invalid, or required smoke-evidence
+    fields are absent, the decision is ``stop`` (the smoke cannot justify
+    continuation or escalation) and the missing input/fields are named
+    explicitly. A failed-closed smoke is never readiness evidence and must not
+    justify nominal or larger reruns.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import pathlib
+import subprocess
+import sys
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _rel(path: pathlib.Path) -> str:
+    """Render a path repo-relative when possible, for reproducible artifacts.
+
+    Absolute machine/worktree paths must not be baked into promoted evidence, so
+    paths under the repo root are recorded relative to it; others are returned as-is.
+    """
+    resolved = pathlib.Path(path).resolve()
+    try:
+        return resolved.relative_to(REPO_ROOT).as_posix()
+    except ValueError:
+        return str(path)
+
+
+DEFAULT_SMOKE_SUMMARY = (
+    REPO_ROOT
+    / "docs/context/evidence/issue_1475_orca_residual_bc_smoke_12913_2026-06-17/summary.json"
+)
+
+PRIOR_DECISION_ISSUE = 2408
+REQUIRED_SMOKE_FIELDS = (
+    "residual_clipping_rate",
+    "guard_veto_rate",
+    "fallback_degraded_status",
+    "artifact_pointer_status",
+)
+REOPEN_CONDITION = (
+    "Reopen only through a named objective/dataset redesign (a new BC objective, "
+    "dataset, scenario, or instrumentation lane); do not rerun unchanged v0 BC and "
+    "do not submit nominal_sanity from this failed-closed smoke."
+)
+
+
+def capture_git_head() -> str:
+    """Return the current git HEAD commit, or 'unknown' if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        return result.stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return "unknown"
+
+
+def load_summary(path: pathlib.Path) -> dict[str, Any] | None:
+    """Load the smoke summary JSON, returning None on missing/invalid input."""
+    if not path.exists():
+        return None
+    try:
+        with open(path, encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (json.JSONDecodeError, OSError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    return data
+
+
+def _missing_required_fields(summary: dict[str, Any]) -> list[str]:
+    """Return the list of required smoke-evidence fields that are absent/null."""
+    block = summary.get("required_smoke_evidence")
+    if not isinstance(block, dict):
+        # The whole block is missing: every required field is missing.
+        return list(REQUIRED_SMOKE_FIELDS)
+    missing: list[str] = []
+    for field in REQUIRED_SMOKE_FIELDS:
+        if block.get(field) is None:
+            missing.append(field)
+    return missing
+
+
+def classify_decision(
+    summary: dict[str, Any] | None,
+    summary_path: pathlib.Path,
+) -> dict[str, Any]:
+    """Apply the #2408 stop rule and return the decision block.
+
+    Fail-closed: a missing/invalid artifact or absent required fields yields a
+    ``stop`` decision naming the missing input/fields. A reproduced v0 failure
+    pattern (success_rate 0.0 + timeout_low_progress) yields ``stop``. A clean
+    passing smoke (success_rate > 0, no timeout_low_progress, all required
+    fields present) yields ``continue``.
+    """
+    git_head = capture_git_head()
+
+    # --- Fail closed on missing/invalid artifact ---------------------------------
+    if summary is None:
+        return {
+            "schema_version": "orca_residual_progress_probe_decision.v1",
+            "issue": 2445,
+            "evidence_grade": "analysis_only",
+            "git_head": git_head,
+            "input_artifact": _rel(summary_path),
+            "orca_residual_progress_probe_decision": {
+                "prior_decision_issue": PRIOR_DECISION_ISSUE,
+                "v1_smoke_success_rate": None,
+                "v1_smoke_failure_mode": None,
+                "artifact_pointer_status": "missing_or_invalid",
+                "missing_required_fields": list(REQUIRED_SMOKE_FIELDS),
+                "decision": "stop",
+                "reopen_condition": REOPEN_CONDITION,
+                "rationale": (
+                    f"Fail-closed: the required v1 smoke summary artifact at "
+                    f"'{summary_path}' is missing or invalid, so no smoke evidence "
+                    "exists to justify continuation or escalation. Per the #2408 "
+                    "stop rule, the lane stops until a valid smoke (or a named "
+                    "objective/dataset redesign) is supplied."
+                ),
+            },
+        }
+
+    metrics = summary.get("metrics") or {}
+    success_rate = metrics.get("success_rate")
+    failure_mode_counts = metrics.get("failure_mode_counts") or {}
+    timeout_low_progress = int(failure_mode_counts.get("timeout_low_progress", 0) or 0)
+    failure_mode = (
+        "timeout_low_progress"
+        if timeout_low_progress > 0
+        else (next(iter(failure_mode_counts), None) if failure_mode_counts else None)
+    )
+
+    missing_fields = _missing_required_fields(summary)
+    smoke_evidence = summary.get("required_smoke_evidence") or {}
+    raw_pointer = smoke_evidence.get("artifact_pointer_status")
+    artifact_pointer_status = raw_pointer if raw_pointer is not None else "missing"
+
+    status = summary.get("status")
+    nominal_escalation_allowed = summary.get("nominal_escalation_allowed")
+
+    # --- Fail closed on missing required smoke-evidence fields -------------------
+    if missing_fields:
+        return {
+            "schema_version": "orca_residual_progress_probe_decision.v1",
+            "issue": 2445,
+            "evidence_grade": "analysis_only",
+            "git_head": git_head,
+            "input_artifact": _rel(summary_path),
+            "orca_residual_progress_probe_decision": {
+                "prior_decision_issue": PRIOR_DECISION_ISSUE,
+                "v1_smoke_success_rate": success_rate,
+                "v1_smoke_failure_mode": failure_mode,
+                "artifact_pointer_status": artifact_pointer_status,
+                "missing_required_fields": missing_fields,
+                "decision": "stop",
+                "reopen_condition": REOPEN_CONDITION,
+                "rationale": (
+                    "Fail-closed: the v1 smoke is missing required smoke-evidence "
+                    f"fields {missing_fields} (summary status="
+                    f"'{status}', nominal_escalation_allowed="
+                    f"{nominal_escalation_allowed}). Missing required fields "
+                    "independently forbid nominal escalation; combined with "
+                    f"success_rate={success_rate} and failure_mode='{failure_mode}', "
+                    "the #2408 stop rule applies. Reopen only via a named "
+                    "objective/dataset redesign."
+                ),
+            },
+        }
+
+    # --- Reproduced v0 failure pattern => stop ----------------------------------
+    reproduced_v0_failure = (success_rate == 0.0) and (timeout_low_progress > 0)
+    if reproduced_v0_failure:
+        decision = "stop"
+        rationale = (
+            f"The v1 bounded smoke reproduces the v0 failure pattern: "
+            f"success_rate={success_rate} with failure_mode='timeout_low_progress' "
+            f"(summary status='{status}'). Per the #2408 / PR #2420 stop rule, this "
+            "stops the current residual-BC lane shape. Reopen only via a named "
+            "objective/dataset redesign; do not rerun unchanged v0 or submit "
+            "nominal_sanity."
+        )
+    else:
+        # All required fields present AND not the v0 failure pattern => continue.
+        decision = "continue"
+        rationale = (
+            f"The v1 bounded smoke did not reproduce the v0 failure pattern "
+            f"(success_rate={success_rate}, failure_mode='{failure_mode}') and all "
+            "required smoke-evidence fields are present. The current lane shape may "
+            "continue to the next predeclared gate; this remains smoke evidence only "
+            "and does not by itself justify nominal/paper-grade claims."
+        )
+
+    return {
+        "schema_version": "orca_residual_progress_probe_decision.v1",
+        "issue": 2445,
+        "evidence_grade": "analysis_only",
+        "git_head": git_head,
+        "input_artifact": _rel(summary_path),
+        "orca_residual_progress_probe_decision": {
+            "prior_decision_issue": PRIOR_DECISION_ISSUE,
+            "v1_smoke_success_rate": success_rate,
+            "v1_smoke_failure_mode": failure_mode,
+            "artifact_pointer_status": artifact_pointer_status,
+            "missing_required_fields": missing_fields,
+            "decision": decision,
+            "reopen_condition": REOPEN_CONDITION,
+            "rationale": rationale,
+        },
+    }
+
+
+def render_markdown(report: dict[str, Any]) -> str:
+    """Render the decision block to Markdown."""
+    block = report["orca_residual_progress_probe_decision"]
+    lines = [
+        "# Issue #2445 ORCA-Residual Progress-Probe Decision",
+        "",
+        f"- **Decision**: `{block['decision']}`",
+        f"- **Evidence Grade**: `{report['evidence_grade']}`",
+        f"- **Prior decision issue**: #{block['prior_decision_issue']}",
+        f"- **Input artifact**: `{report['input_artifact']}`",
+        f"- **Git HEAD**: `{report['git_head']}`",
+        "",
+        "## V1 Smoke Facts (job 12913)",
+        "",
+        "| Field | Value |",
+        "| --- | --- |",
+        f"| v1_smoke_success_rate | `{block['v1_smoke_success_rate']}` |",
+        f"| v1_smoke_failure_mode | `{block['v1_smoke_failure_mode']}` |",
+        f"| artifact_pointer_status | `{block['artifact_pointer_status']}` |",
+        f"| missing_required_fields | `{block['missing_required_fields']}` |",
+        "",
+        "## Rationale",
+        "",
+        block["rationale"],
+        "",
+        "## Reopen Condition",
+        "",
+        block["reopen_condition"],
+        "",
+        "## Claim Boundary",
+        "",
+        "This is an analysis-only routing decision over existing failed-closed smoke "
+        "evidence. It is not a benchmark result, not a learned-component success "
+        "claim, and must not justify nominal or larger SLURM reruns.",
+    ]
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Main CLI entry point."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Classify the ORCA-residual progress-probe decision (issue #2445) by "
+            "applying the #2408 stop rule to the v1 bounded smoke summary. "
+            "Fails closed on a missing/invalid artifact or absent required fields."
+        )
+    )
+    parser.add_argument(
+        "--smoke-summary",
+        type=pathlib.Path,
+        default=DEFAULT_SMOKE_SUMMARY,
+        help="Path to the #1475 v1 smoke summary JSON (default: the 12913 bundle).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=pathlib.Path,
+        default=None,
+        help="Optional directory to write decision.json and decision.md.",
+    )
+    args = parser.parse_args()
+
+    summary = load_summary(args.smoke_summary)
+    report = classify_decision(summary, args.smoke_summary)
+
+    print(json.dumps(report, indent=2))
+
+    if args.output_dir is not None:
+        output_dir: pathlib.Path = args.output_dir
+        output_dir.mkdir(parents=True, exist_ok=True)
+        json_path = output_dir / "decision.json"
+        with open(json_path, "w", encoding="utf-8") as fh:
+            json.dump(report, fh, indent=2)
+        md_path = output_dir / "decision.md"
+        with open(md_path, "w", encoding="utf-8") as fh:
+            fh.write(render_markdown(report))
+        print(f"Wrote decision JSON: {json_path}", file=sys.stderr)
+        print(f"Wrote decision Markdown: {md_path}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/analysis/test_classify_orca_residual_progress_probe_issue_2445.py
+++ b/tests/analysis/test_classify_orca_residual_progress_probe_issue_2445.py
@@ -1,0 +1,148 @@
+"""Tests for the issue #2445 ORCA-residual progress-probe decision classifier."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+import pytest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPTS_DIR = REPO_ROOT / "scripts" / "analysis"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+import classify_orca_residual_progress_probe_issue_2445 as clf  # noqa: E402
+
+FIXTURE_12913 = (
+    REPO_ROOT
+    / "docs/context/evidence/issue_1475_orca_residual_bc_smoke_12913_2026-06-17/summary.json"
+)
+
+
+def _decision(report: dict) -> dict:
+    return report["orca_residual_progress_probe_decision"]
+
+
+def test_12913_fixture_yields_stop():
+    """The real failed-closed v1 smoke (job 12913) must classify as stop."""
+    summary = clf.load_summary(FIXTURE_12913)
+    assert summary is not None, "12913 fixture must exist and be valid"
+    report = clf.classify_decision(summary, FIXTURE_12913)
+    block = _decision(report)
+
+    assert block["decision"] == "stop"
+    assert block["prior_decision_issue"] == 2408
+    assert block["v1_smoke_success_rate"] == 0.0
+    assert block["v1_smoke_failure_mode"] == "timeout_low_progress"
+    # All four required fields are null in the fixture => named as missing.
+    assert set(block["missing_required_fields"]) == set(clf.REQUIRED_SMOKE_FIELDS)
+    assert "redesign" in block["reopen_condition"].lower()
+
+
+def _passing_summary() -> dict:
+    """A synthetic clean passing smoke: success>0, no timeout, all fields present."""
+    return {
+        "issue": 1475,
+        "status": "completed",
+        "metrics": {
+            "episodes": 1,
+            "success_rate": 1.0,
+            "failure_mode_counts": {},
+        },
+        "required_smoke_evidence": {
+            "residual_clipping_rate": 0.12,
+            "guard_veto_rate": 0.0,
+            "fallback_degraded_status": "nominal",
+            "artifact_pointer_status": "present",
+            "missing_required_fields": [],
+        },
+        "nominal_escalation_allowed": True,
+    }
+
+
+def test_passing_smoke_yields_continue(tmp_path):
+    """A clean passing smoke with all required fields => continue."""
+    path = tmp_path / "summary.json"
+    path.write_text(json.dumps(_passing_summary()), encoding="utf-8")
+    summary = clf.load_summary(path)
+    report = clf.classify_decision(summary, path)
+    block = _decision(report)
+
+    assert block["decision"] == "continue"
+    assert block["v1_smoke_success_rate"] == 1.0
+    assert block["missing_required_fields"] == []
+    assert block["artifact_pointer_status"] == "present"
+
+
+def test_missing_artifact_fails_closed(tmp_path):
+    """A missing/invalid artifact must fail closed to stop, naming the input."""
+    missing = tmp_path / "does_not_exist.json"
+    summary = clf.load_summary(missing)
+    assert summary is None
+    report = clf.classify_decision(summary, missing)
+    block = _decision(report)
+
+    assert block["decision"] == "stop"
+    assert block["artifact_pointer_status"] == "missing_or_invalid"
+    assert "missing or invalid" in block["rationale"].lower()
+    assert str(missing) in block["rationale"]
+
+
+def test_invalid_json_fails_closed(tmp_path):
+    """Malformed JSON is treated as a missing/invalid artifact (fail closed)."""
+    bad = tmp_path / "bad.json"
+    bad.write_text("{not valid json", encoding="utf-8")
+    summary = clf.load_summary(bad)
+    assert summary is None
+    report = clf.classify_decision(summary, bad)
+    assert _decision(report)["decision"] == "stop"
+
+
+def test_missing_required_fields_fails_closed(tmp_path):
+    """A smoke with absent required fields must fail closed even if success>0."""
+    data = _passing_summary()
+    data["required_smoke_evidence"]["guard_veto_rate"] = None
+    data["required_smoke_evidence"]["artifact_pointer_status"] = None
+    path = tmp_path / "summary.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    summary = clf.load_summary(path)
+    report = clf.classify_decision(summary, path)
+    block = _decision(report)
+
+    assert block["decision"] == "stop"
+    assert "guard_veto_rate" in block["missing_required_fields"]
+    assert "artifact_pointer_status" in block["missing_required_fields"]
+    assert "missing required" in block["rationale"].lower()
+
+
+def test_missing_required_evidence_block_fails_closed(tmp_path):
+    """An absent required_smoke_evidence block names all required fields as missing."""
+    data = _passing_summary()
+    del data["required_smoke_evidence"]
+    path = tmp_path / "summary.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    summary = clf.load_summary(path)
+    report = clf.classify_decision(summary, path)
+    block = _decision(report)
+
+    assert block["decision"] == "stop"
+    assert set(block["missing_required_fields"]) == set(clf.REQUIRED_SMOKE_FIELDS)
+
+
+@pytest.mark.parametrize("rate", [0.0])
+def test_zero_success_with_timeout_is_stop_even_with_fields(tmp_path, rate):
+    """success_rate=0 + timeout_low_progress => stop even if all fields present."""
+    data = _passing_summary()
+    data["metrics"]["success_rate"] = rate
+    data["metrics"]["failure_mode_counts"] = {"timeout_low_progress": 1}
+    path = tmp_path / "summary.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    summary = clf.load_summary(path)
+    report = clf.classify_decision(summary, path)
+    block = _decision(report)
+
+    assert block["decision"] == "stop"
+    assert block["v1_smoke_failure_mode"] == "timeout_low_progress"
+    assert "reproduces the v0 failure pattern" in block["rationale"]


### PR DESCRIPTION
## Summary

**Closes #2445.** Classifies the ORCA-residual BC progress-probe lane after the revised v1 bounded smoke, instead of rerunning unchanged command-imitation. A **decision over existing evidence** — no training run. (Enablement note: the earlier "local micro-BC tier" idea was both unnecessary and infeasible — the v1 smoke artifact already exists from SLURM job 12913, and the BC dataset itself is a pending wandb artifact. So #2445 is implemented directly against the existing smoke, which is what it actually needs.)

## Decision: `stop` (current ORCA-residual BC lane shape)

Grounded in the real job-12913 v1 smoke summary:
- `status: failed_closed`, `classification: missing_required_smoke_evidence`
- `metrics.success_rate: 0.0`, `failure_mode_counts.timeout_low_progress: 1`
- `required_smoke_evidence.missing_required_fields`: all four null (`residual_clipping_rate`, `guard_veto_rate`, `fallback_degraded_status`, `artifact_pointer_status`)
- `nominal_escalation_allowed: false`

Two independent triggers fire per the #2408/PR #2420 stop rule: (1) the v1 smoke reproduces the v0 failure pattern (`success_rate=0.0` + `timeout_low_progress`); (2) it is missing all four required smoke-evidence fields, which independently forbids nominal escalation. **Reopen only through a named objective/dataset redesign** — do not rerun unchanged v0/v1 or submit `nominal_sanity`.

## What landed

- `scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py` — deterministic classifier, **fails closed** (missing/invalid artifact or absent required fields → `stop` naming the gap), JSON+markdown, `--help`, git-HEAD capture, repo-relative artifact pointer.
- `tests/analysis/test_classify_orca_residual_progress_probe_issue_2445.py` — 7 tests (12913→stop; synthetic passing→continue; missing artifact / invalid JSON / missing fields / absent block → fail-closed; zero-success+timeout→stop).
- `docs/context/issue_2445_orca_residual_progress_probe_decision.md` — decision doc + #1358/#1475 handoff note.
- `docs/context/evidence/issue_2445_orca_residual_progress_probe_decision_2026-06-23/` — decision.json/md + provenance (command, input pointer + sha256, commit).

## Validation (independently audited)

- `pytest` → 7 passed; real run on 12913 → `decision: stop` (reproduced); `ruff`/`pre-commit` clean; `sync_ai_config.py --check` no drift. Fixed an absolute-path leak in the promoted evidence (now repo-relative).

## Claim boundary

Analysis-only routing decision over **failed-closed** smoke evidence — not readiness evidence, not a benchmark result, and must not justify nominal or larger SLURM reruns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)