### PR TITLE
feat(benchmark): sensor-noise / partial-observability robustness slice (#3067)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a bounded sensor-noise / partial-observability robustness slice (#3067):
+  [`scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py`](scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py)
+  runs a same-seed clean / noisy / partial-observation comparison on a pedestrian-dominated fixture,
+  reusing the observation-noise/perturbation wrappers, and reports clean-vs-perturbed deltas
+  (min observed distance, observation continuity, near-field exposure, observation count) per row
+  with fail-closed status — and the overall classification kept separate from nominal performance.
+  Result: `diagnostic` (non-null — perturbations measurably change the observed state the policy
+  would consume; partial observation drops actor observations/continuity/near-field), trace-derived,
+  single fixture/seed. Diagnostic-only/smoke, not paper-grade; explicitly NOT a real-sensor
+  certification or sim-to-real claim. Tracked summary under
+  `docs/context/evidence/issue_3067_sensor_noise_robustness_2026-06-23/`. Unblocked once #3062 merged
+  (#3067).
+
 * Added a bounded, same-seed forecast-risk closed-loop coupling gate (#2916): a deterministic risk
   adapter [`robot_sf/benchmark/forecast_risk_adapter.py`](robot_sf/benchmark/forecast_risk_adapter.py)
   mapping a `ForecastBatch.v1` to a bounded `[0,1]` per-step risk signal (fail-closed on

--- a/docs/context/evidence/issue_3067_sensor_noise_robustness_2026-06-23/README.md
+++ b/docs/context/evidence/issue_3067_sensor_noise_robustness_2026-06-23/README.md
@@ -1,0 +1,69 @@
+# Issue #3067: Sensor-Noise Robustness Slice (clean / noisy / partial)
+
+**Claim boundary:** `diagnostic_only`. **Evidence tier:** `smoke`. **Paper-grade:** `false`.
+
+This is a bounded, trace-derived observation-robustness slice. It is **NOT** a
+real-sensor certification and **NOT** a sim-to-real transfer claim. Perturbations
+are non-calibrated benchmark robustness noise applied to observed actor state, not
+a hardware sensor model. Robustness is interpreted **separately** from nominal
+(stored-trace) policy performance.
+
+## Reproducibility
+
+- **Command:**
+  `uv run python scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py --output-dir output/issue_3067_sensor_noise/run`
+- **Seed:** 3067 (same seed across all rows)
+- **Repo HEAD:** `cbec866b` (worktree branch `issue-3067-sensor-noise-robustness`)
+- **Fixture:** `tests/fixtures/analysis_workbench/simulation_trace_export_v1/dense_pedestrian_stress_episode_0000.json`
+  (pedestrian-dominated, 3 converging actors, 20 frames, scenario `dense_pedestrian_stress`)
+- **Generated:** 2026-06-23
+
+## Matrix (clean / noisy / partial)
+
+| row | family | observation level | status |
+| --- | --- | --- | --- |
+| clean | clean | oracle_full_state | ok |
+| noisy_low | noisy | tracked_agents_with_noise (std 0.10 m / bound 0.20 m) | ok |
+| noisy_medium | noisy | tracked_agents_with_noise (std 0.30 m / bound 0.60 m) | ok |
+| partial_occlusion | partial | occluded_partial_state (occlude nearest actor) | ok |
+| partial_missed_detection | partial | occluded_partial_state (50% missed detection) | ok |
+
+## Headline clean-vs-perturbed deltas
+
+Clean reference: `min_observed_distance_m=0.1562`, `observation_continuity=1.0`,
+`near_field_exposure_frames=20`, `total_observed_actor_observations=60`.
+
+| row | d(min_obs_dist_m) | d(continuity) | d(near_field_frames) | d(obs_count) |
+| --- | --- | --- | --- | --- |
+| noisy_low | +0.0055 | 0.0 | 0 | 0 |
+| noisy_medium | +0.0492 | 0.0 | 0 | 0 |
+| partial_occlusion | +0.2212 | 0.0 | 0 | -20 |
+| partial_missed_detection | +0.1465 | -0.15 | -5 | -36 |
+
+**Non-null result:** observation perturbations measurably change the observed state
+the policy would consume. Bounded Gaussian noise shifts the nearest-observed
+distance; partial observation (occlusion / missed detection) drops actor
+observations, reduces observation continuity, and removes near-field exposure
+frames.
+
+## Overall classification: `diagnostic`
+
+Perturbations ran on a same-seed pedestrian-dominated fixture and moved
+observed-state metrics beyond the clean reference (non-null deltas). This is
+diagnostic-only: single fixture, single seed, trace-derived (no live planner
+replay). Not a benchmark, not a certification, not a sim-to-real claim.
+
+## Fail-closed behavior
+
+- Incomplete per-row perturbation metadata -> overall `blocked`.
+- All perturbed rows degraded (all actors suppressed) -> overall `non-claim`.
+- Degraded / invalid rows are never counted as success.
+- Vocabulary is stable: overall ∈ {benchmark, diagnostic, blocked, non-claim};
+  row status ∈ {ok, degraded, invalid, not-available}.
+
+## Caveats
+
+- Single deterministic pedestrian-dominated fixture, single seed.
+- Metrics are observed-state proxies, not re-executed planner outcomes.
+- Nominal performance (stored-trace behavior on the clean observation) is kept
+  distinct from robustness (how the observed state changes under perturbation).

--- a/docs/context/evidence/issue_3067_sensor_noise_robustness_2026-06-23/summary.json
+++ b/docs/context/evidence/issue_3067_sensor_noise_robustness_2026-06-23/summary.json
@@ -1,0 +1,446 @@
+{
+  "schema_version": "sensor_noise_robustness_slice.v1",
+  "issue": 3067,
+  "claim_boundary": "Diagnostic, trace-derived observation-robustness slice. NOT a real-sensor certification and NOT a sim-to-real transfer claim. Perturbations are non-calibrated benchmark robustness noise on observed actor state. Robustness is interpreted separately from nominal performance.",
+  "evidence_tier": "smoke",
+  "paper_grade": false,
+  "overall_classification": {
+    "label": "diagnostic",
+    "rationale": "Perturbations changed the observed state the policy would consume (non-null clean-vs-perturbed deltas). Diagnostic-only: trace-derived, single fixture, single seed; not a benchmark, certification, or sim-to-real claim."
+  },
+  "allowed_overall_classifications": [
+    "benchmark",
+    "diagnostic",
+    "blocked",
+    "non-claim"
+  ],
+  "allowed_row_statuses": [
+    "ok",
+    "degraded",
+    "invalid",
+    "not-available"
+  ],
+  "reproducibility": {
+    "issue": 3067,
+    "generated_at_utc": "2026-06-23T10:24:25.931522+00:00",
+    "command": "uv run python scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py --output-dir output/issue_3067_sensor_noise/run",
+    "repo_head": "cbec866b",
+    "seed": 3067
+  },
+  "fixture": {
+    "trace_path": "tests/fixtures/analysis_workbench/simulation_trace_export_v1/dense_pedestrian_stress_episode_0000.json",
+    "scenario_id": "dense_pedestrian_stress",
+    "seed": 2765,
+    "planner_id": "hybrid_rule_v0_minimal",
+    "episode_id": "dense_pedestrian_stress_ep0000",
+    "frame_count": 20,
+    "pedestrian_count": 3
+  },
+  "matrix_families": [
+    "clean",
+    "noisy",
+    "partial"
+  ],
+  "rows": [
+    {
+      "row": "clean",
+      "family": "clean",
+      "observation_level": {
+        "key": "oracle_full_state",
+        "display_name": "Oracle full state",
+        "perception_assumption": "privileged_sim_state",
+        "active_observation_mode": null,
+        "compatible_observation_modes": [
+          "goal_state",
+          "socnav_state",
+          "headed_socnav_state",
+          "gst_human_state"
+        ],
+        "required_inputs": [
+          "robot_state",
+          "goal",
+          "pedestrians"
+        ],
+        "noise_policy": "none",
+        "occlusion_policy": "none",
+        "interpretation": "benchmark_metadata_not_sensor_certification"
+      },
+      "description": "No perturbation; same-seed clean reference observation.",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "none",
+        "is_noop": true,
+        "seed": null
+      },
+      "perturbation_metadata": {
+        "metadata_complete": true,
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 0,
+        "frames_with_observation_signal": 20,
+        "total_frames": 20,
+        "ground_truth_observed_actor_observations": 60,
+        "observation_quality": {
+          "schema_version": "observation_quality.v1",
+          "fields": {
+            "visibility": [
+              "trace_fixture_observed_pedestrians"
+            ],
+            "occlusion": [
+              "fixture_declared_visibility_boundary"
+            ],
+            "latency_s": 0.0,
+            "dropout_probability": 0.0,
+            "range_limit_m": null,
+            "angular_noise_std_rad": 0.0,
+            "false_negative_rate": 0.0,
+            "false_positive_rate": 0.0,
+            "notes": "Diagnostic simulator observation-quality metadata only; non-calibrated benchmark robustness noise, not a hardware sensor model."
+          }
+        }
+      },
+      "metrics": {
+        "min_observed_distance_m": 0.1562,
+        "observation_continuity": 1.0,
+        "near_field_exposure_frames": 20,
+        "perturbation_runtime_s": 0.000357,
+        "total_observed_actor_observations": 60
+      },
+      "status": "ok",
+      "status_reason": "Row produced a usable perturbed observation stream."
+    },
+    {
+      "row": "noisy_low",
+      "family": "noisy",
+      "observation_level": {
+        "key": "tracked_agents_with_noise",
+        "display_name": "Noisy tracked agents",
+        "perception_assumption": "tracked_agents_with_synthetic_noise",
+        "active_observation_mode": null,
+        "compatible_observation_modes": [
+          "socnav_state",
+          "headed_socnav_state",
+          "gst_human_state"
+        ],
+        "required_inputs": [
+          "robot_state",
+          "goal",
+          "tracked_agents"
+        ],
+        "noise_policy": "benchmark_observation_noise",
+        "occlusion_policy": "none",
+        "interpretation": "synthetic_noise_robustness_not_real_sensor_calibration"
+      },
+      "description": "Bounded Gaussian position noise std=0.10 m, bound=0.20 m.",
+      "spec": {
+        "position_noise_std_m": 0.1,
+        "position_noise_bound_m": 0.2,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "bounded_gaussian",
+        "is_noop": false,
+        "seed": 3067
+      },
+      "perturbation_metadata": {
+        "metadata_complete": true,
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 0,
+        "frames_with_observation_signal": 20,
+        "total_frames": 20,
+        "ground_truth_observed_actor_observations": 60,
+        "observation_quality": {
+          "schema_version": "observation_quality.v1",
+          "fields": {
+            "visibility": [
+              "trace_fixture_observed_pedestrians"
+            ],
+            "occlusion": [
+              "fixture_declared_visibility_boundary"
+            ],
+            "latency_s": 0.0,
+            "dropout_probability": 0.0,
+            "range_limit_m": null,
+            "angular_noise_std_rad": 0.0,
+            "false_negative_rate": 0.0,
+            "false_positive_rate": 0.0,
+            "notes": "Diagnostic simulator observation-quality metadata only; non-calibrated benchmark robustness noise, not a hardware sensor model."
+          }
+        }
+      },
+      "metrics": {
+        "min_observed_distance_m": 0.1617,
+        "observation_continuity": 1.0,
+        "near_field_exposure_frames": 20,
+        "perturbation_runtime_s": 0.000811,
+        "total_observed_actor_observations": 60
+      },
+      "status": "ok",
+      "status_reason": "Row produced a usable perturbed observation stream."
+    },
+    {
+      "row": "noisy_medium",
+      "family": "noisy",
+      "observation_level": {
+        "key": "tracked_agents_with_noise",
+        "display_name": "Noisy tracked agents",
+        "perception_assumption": "tracked_agents_with_synthetic_noise",
+        "active_observation_mode": null,
+        "compatible_observation_modes": [
+          "socnav_state",
+          "headed_socnav_state",
+          "gst_human_state"
+        ],
+        "required_inputs": [
+          "robot_state",
+          "goal",
+          "tracked_agents"
+        ],
+        "noise_policy": "benchmark_observation_noise",
+        "occlusion_policy": "none",
+        "interpretation": "synthetic_noise_robustness_not_real_sensor_calibration"
+      },
+      "description": "Bounded Gaussian position noise std=0.30 m, bound=0.60 m.",
+      "spec": {
+        "position_noise_std_m": 0.3,
+        "position_noise_bound_m": 0.6,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "bounded_gaussian",
+        "is_noop": false,
+        "seed": 3067
+      },
+      "perturbation_metadata": {
+        "metadata_complete": true,
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 0,
+        "frames_with_observation_signal": 20,
+        "total_frames": 20,
+        "ground_truth_observed_actor_observations": 60,
+        "observation_quality": {
+          "schema_version": "observation_quality.v1",
+          "fields": {
+            "visibility": [
+              "trace_fixture_observed_pedestrians"
+            ],
+            "occlusion": [
+              "fixture_declared_visibility_boundary"
+            ],
+            "latency_s": 0.0,
+            "dropout_probability": 0.0,
+            "range_limit_m": null,
+            "angular_noise_std_rad": 0.0,
+            "false_negative_rate": 0.0,
+            "false_positive_rate": 0.0,
+            "notes": "Diagnostic simulator observation-quality metadata only; non-calibrated benchmark robustness noise, not a hardware sensor model."
+          }
+        }
+      },
+      "metrics": {
+        "min_observed_distance_m": 0.2054,
+        "observation_continuity": 1.0,
+        "near_field_exposure_frames": 20,
+        "perturbation_runtime_s": 0.000713,
+        "total_observed_actor_observations": 60
+      },
+      "status": "ok",
+      "status_reason": "Row produced a usable perturbed observation stream."
+    },
+    {
+      "row": "partial_occlusion",
+      "family": "partial",
+      "observation_level": {
+        "key": "occluded_partial_state",
+        "display_name": "Occluded partial state",
+        "perception_assumption": "partial_state_with_occlusion",
+        "active_observation_mode": null,
+        "compatible_observation_modes": [
+          "socnav_state",
+          "sensor_fusion_state"
+        ],
+        "required_inputs": [
+          "robot_state",
+          "goal",
+          "visible_agents"
+        ],
+        "noise_policy": "none",
+        "occlusion_policy": "scenario_visibility_or_sensor_mask",
+        "interpretation": "occlusion_metadata_not_sim_to_real_validity"
+      },
+      "description": "Occlude the nearest crossing actor (ped_a); others visible.",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 0.0,
+        "has_occlusion_mask": true,
+        "delay_steps": 0,
+        "noise_profile": "occlusion_mask",
+        "is_noop": false,
+        "seed": null
+      },
+      "perturbation_metadata": {
+        "metadata_complete": true,
+        "missed_actor_observations_total": 0,
+        "occluded_actor_observations_total": 20,
+        "frames_with_observation_signal": 20,
+        "total_frames": 20,
+        "ground_truth_observed_actor_observations": 60,
+        "observation_quality": {
+          "schema_version": "observation_quality.v1",
+          "fields": {
+            "visibility": [
+              "trace_fixture_observed_pedestrians"
+            ],
+            "occlusion": [
+              "explicit_occlusion_mask"
+            ],
+            "latency_s": 0.0,
+            "dropout_probability": 0.0,
+            "range_limit_m": null,
+            "angular_noise_std_rad": 0.0,
+            "false_negative_rate": 0.0,
+            "false_positive_rate": 0.0,
+            "notes": "Diagnostic simulator observation-quality metadata only; non-calibrated benchmark robustness noise, not a hardware sensor model."
+          }
+        }
+      },
+      "metrics": {
+        "min_observed_distance_m": 0.3774,
+        "observation_continuity": 1.0,
+        "near_field_exposure_frames": 20,
+        "perturbation_runtime_s": 0.000679,
+        "total_observed_actor_observations": 40
+      },
+      "status": "ok",
+      "status_reason": "Row produced a usable perturbed observation stream."
+    },
+    {
+      "row": "partial_missed_detection",
+      "family": "partial",
+      "observation_level": {
+        "key": "occluded_partial_state",
+        "display_name": "Occluded partial state",
+        "perception_assumption": "partial_state_with_occlusion",
+        "active_observation_mode": null,
+        "compatible_observation_modes": [
+          "socnav_state",
+          "sensor_fusion_state"
+        ],
+        "required_inputs": [
+          "robot_state",
+          "goal",
+          "visible_agents"
+        ],
+        "noise_policy": "none",
+        "occlusion_policy": "scenario_visibility_or_sensor_mask",
+        "interpretation": "occlusion_metadata_not_sim_to_real_validity"
+      },
+      "description": "50% per-actor missed-detection probability (same seed).",
+      "spec": {
+        "position_noise_std_m": 0.0,
+        "position_noise_bound_m": 0.0,
+        "missed_detection_probability": 0.5,
+        "has_occlusion_mask": false,
+        "delay_steps": 0,
+        "noise_profile": "missed_detection",
+        "is_noop": false,
+        "seed": 3067
+      },
+      "perturbation_metadata": {
+        "metadata_complete": true,
+        "missed_actor_observations_total": 36,
+        "occluded_actor_observations_total": 0,
+        "frames_with_observation_signal": 17,
+        "total_frames": 20,
+        "ground_truth_observed_actor_observations": 60,
+        "observation_quality": {
+          "schema_version": "observation_quality.v1",
+          "fields": {
+            "visibility": [
+              "trace_fixture_observed_pedestrians"
+            ],
+            "occlusion": [
+              "fixture_declared_visibility_boundary"
+            ],
+            "latency_s": 0.0,
+            "dropout_probability": 0.5,
+            "range_limit_m": null,
+            "angular_noise_std_rad": 0.0,
+            "false_negative_rate": 0.5,
+            "false_positive_rate": 0.0,
+            "notes": "Diagnostic simulator observation-quality metadata only; non-calibrated benchmark robustness noise, not a hardware sensor model."
+          }
+        }
+      },
+      "metrics": {
+        "min_observed_distance_m": 0.3027,
+        "observation_continuity": 0.85,
+        "near_field_exposure_frames": 15,
+        "perturbation_runtime_s": 0.000719,
+        "total_observed_actor_observations": 24
+      },
+      "status": "ok",
+      "status_reason": "Row produced a usable perturbed observation stream."
+    }
+  ],
+  "clean_vs_perturbed_deltas": {
+    "available": true,
+    "reference_row": "clean",
+    "any_perturbed_metric_moved": true,
+    "rows": {
+      "noisy_low": {
+        "status": "ok",
+        "counts_as_success": true,
+        "deltas": {
+          "min_observed_distance_m": 0.0055,
+          "observation_continuity": 0.0,
+          "near_field_exposure_frames": 0.0,
+          "total_observed_actor_observations": 0.0,
+          "perturbation_runtime_s": 0.000454
+        },
+        "moved_a_metric": true
+      },
+      "noisy_medium": {
+        "status": "ok",
+        "counts_as_success": true,
+        "deltas": {
+          "min_observed_distance_m": 0.0492,
+          "observation_continuity": 0.0,
+          "near_field_exposure_frames": 0.0,
+          "total_observed_actor_observations": 0.0,
+          "perturbation_runtime_s": 0.000356
+        },
+        "moved_a_metric": true
+      },
+      "partial_occlusion": {
+        "status": "ok",
+        "counts_as_success": true,
+        "deltas": {
+          "min_observed_distance_m": 0.2212,
+          "observation_continuity": 0.0,
+          "near_field_exposure_frames": 0.0,
+          "total_observed_actor_observations": -20.0,
+          "perturbation_runtime_s": 0.000322
+        },
+        "moved_a_metric": true
+      },
+      "partial_missed_detection": {
+        "status": "ok",
+        "counts_as_success": true,
+        "deltas": {
+          "min_observed_distance_m": 0.1465,
+          "observation_continuity": -0.15,
+          "near_field_exposure_frames": -5.0,
+          "total_observed_actor_observations": -36.0,
+          "perturbation_runtime_s": 0.000362
+        },
+        "moved_a_metric": true
+      }
+    }
+  },
+  "nominal_vs_robustness_note": "Nominal performance = stored-trace policy behavior on the clean observation. Robustness = how the observed state the policy consumes changes under perturbation. These are reported separately and must not be conflated."
+}

--- a/scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py
+++ b/scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py
@@ -1,0 +1,651 @@
+#!/usr/bin/env python3
+"""Issue #3067: bounded clean / noisy / partial observation-robustness slice.
+
+Runs a same-seed clean / noisy / partial-observation comparison over a
+pedestrian-dominated trace fixture and reports clean-vs-perturbed deltas for
+safety (near-field), progress (observation continuity), runtime (perturbation
+compute), and a social-compliance proxy.  Robustness is interpreted SEPARATELY
+from nominal (stored-trace) performance.
+
+This is a diagnostic slice, NOT a real-sensor certification and NOT a
+sim-to-real transfer claim.  The perturbations are non-calibrated benchmark
+robustness noise applied to ground-truth observed actor state; they are not a
+hardware sensor model.  Every reported number comes from an actual run.
+
+Fail-closed rules:
+- If observation wrappers / perturbation metadata are incomplete -> ``blocked``.
+- If the perturbation envelope is too narrow to move any observed-state metric
+  -> ``diagnostic-only`` (null result documented honestly).
+- Degraded / invalid / not-available rows are never counted as success.
+
+Usage::
+
+    uv run python scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py
+    uv run python scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py \\
+        --output-dir output/issue_3067_sensor_noise/run
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import pathlib
+import shutil
+import subprocess
+import time
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.observation_levels import observation_level_spec
+from robot_sf.benchmark.observation_perturbation import (
+    ObservationPerturbationSpec,
+    ObservationPerturbationState,
+    perturb_ground_truth,
+)
+from robot_sf.benchmark.observation_quality import ObservationQuality
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+FIXTURE_PATH = (
+    REPO_ROOT / "tests/fixtures/analysis_workbench/simulation_trace_export_v1/"
+    "dense_pedestrian_stress_episode_0000.json"
+)
+SCHEMA_VERSION = "sensor_noise_robustness_slice.v1"
+OBSERVATION_QUALITY_SCHEMA_VERSION = "observation_quality.v1"
+DT_S = 0.1
+SEED = 3067
+NEAR_FIELD_THRESHOLD_M = 2.0
+
+# Allowed overall-classification vocabulary (acceptance criterion).
+OVERALL_CLASSIFICATIONS = ("benchmark", "diagnostic", "blocked", "non-claim")
+# Allowed per-row status vocabulary (fail-closed).
+ROW_STATUSES = ("ok", "degraded", "invalid", "not-available")
+
+# Clean / noisy / partial matrix.  Each row carries an observation level + a
+# perturbation spec.  "clean" is the same-seed reference all deltas compare to.
+MATRIX: dict[str, dict[str, Any]] = {
+    "clean": {
+        "family": "clean",
+        "observation_level": "oracle_full_state",
+        "description": "No perturbation; same-seed clean reference observation.",
+        "spec_kw": {},
+    },
+    "noisy_low": {
+        "family": "noisy",
+        "observation_level": "tracked_agents_with_noise",
+        "description": "Bounded Gaussian position noise std=0.10 m, bound=0.20 m.",
+        "spec_kw": {
+            "position_noise_std_m": 0.10,
+            "position_noise_bound_m": 0.20,
+            "seed": SEED,
+        },
+    },
+    "noisy_medium": {
+        "family": "noisy",
+        "observation_level": "tracked_agents_with_noise",
+        "description": "Bounded Gaussian position noise std=0.30 m, bound=0.60 m.",
+        "spec_kw": {
+            "position_noise_std_m": 0.30,
+            "position_noise_bound_m": 0.60,
+            "seed": SEED,
+        },
+    },
+    "partial_occlusion": {
+        "family": "partial",
+        "observation_level": "occluded_partial_state",
+        "description": "Occlude the nearest crossing actor (ped_a); others visible.",
+        "spec_kw": {"occlusion_mask": np.array([True, False, False])},
+    },
+    "partial_missed_detection": {
+        "family": "partial",
+        "observation_level": "occluded_partial_state",
+        "description": "50% per-actor missed-detection probability (same seed).",
+        "spec_kw": {"missed_detection_probability": 0.5, "seed": SEED},
+    },
+}
+
+
+def _load_fixture(path: pathlib.Path) -> dict[str, Any]:
+    """Load the pedestrian-dominated trace fixture."""
+    with open(path, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+def _git_head() -> str:
+    """Return the short git HEAD, or empty string on failure."""
+    git_exe = shutil.which("git")
+    if git_exe is None:
+        return ""
+    try:
+        result = subprocess.run(
+            [git_exe, "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(REPO_ROOT),
+            timeout=5,
+            check=False,
+        )
+        return result.stdout.strip() if result.returncode == 0 else ""
+    except (OSError, subprocess.SubprocessError):
+        return ""
+
+
+def _extract_frame_arrays(frame: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Extract ground-truth robot position and observed pedestrian arrays."""
+    robot_pos = np.array(frame["robot"]["position"], dtype=np.float64)
+    observed = frame.get("observed_pedestrians", [])
+    if not observed:
+        return robot_pos, np.empty((0, 2), dtype=np.float64), []
+    positions = np.array([p["position"] for p in observed], dtype=np.float64)
+    ids = [str(p["id"]) for p in observed]
+    return robot_pos, positions, ids
+
+
+def _extract_observed_arrays(frame: dict[str, Any]) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Extract fixture-visible pedestrian observation positions and velocities."""
+    observed = frame.get("observed_pedestrians", [])
+    if not observed:
+        return (
+            np.empty((0, 2), dtype=np.float64),
+            np.empty((0, 2), dtype=np.float64),
+            [],
+        )
+    positions = np.array([p["position"] for p in observed], dtype=np.float64)
+    velocities = np.array([p["velocity"] for p in observed], dtype=np.float64)
+    ids = [str(p["id"]) for p in observed]
+    return positions, velocities, ids
+
+
+def _min_distance(robot_pos: np.ndarray, ped_pos: np.ndarray) -> float:
+    """Return Euclidean distance from robot to the nearest pedestrian position."""
+    if ped_pos.size == 0:
+        return float("inf")
+    diffs = ped_pos - robot_pos
+    return float(np.min(np.sqrt(np.sum(diffs**2, axis=1))))
+
+
+def _spec_for_actor_count(
+    spec: ObservationPerturbationSpec, actor_count: int
+) -> ObservationPerturbationSpec:
+    """Adapt a fixed-size occlusion mask to a frame's observed-actor count."""
+    if spec.occlusion_mask is None:
+        return spec
+    mask = np.asarray(spec.occlusion_mask, dtype=bool)
+    if mask.size == actor_count:
+        return spec
+    if actor_count == 0:
+        new_mask: np.ndarray = np.zeros(0, dtype=bool)
+    elif mask.size > actor_count:
+        new_mask = mask[:actor_count]
+    else:
+        new_mask = np.pad(mask, (0, actor_count - mask.size), constant_values=False)
+    return ObservationPerturbationSpec(
+        position_noise_std_m=spec.position_noise_std_m,
+        position_noise_bound_m=spec.position_noise_bound_m,
+        missed_detection_probability=spec.missed_detection_probability,
+        occlusion_mask=new_mask,
+        delay_steps=spec.delay_steps,
+        seed=spec.seed,
+    )
+
+
+def _observation_quality_group(spec: ObservationPerturbationSpec) -> dict[str, Any]:
+    """Return the bounded observation-quality metadata for a perturbation spec."""
+    quality = ObservationQuality(
+        visibility=["trace_fixture_observed_pedestrians"],
+        occlusion=(
+            ["explicit_occlusion_mask"]
+            if spec.occlusion_mask is not None
+            else ["fixture_declared_visibility_boundary"]
+        ),
+        latency_s=float(spec.delay_steps) * DT_S,
+        dropout_probability=float(spec.missed_detection_probability),
+        range_limit_m=None,
+        angular_noise_std_rad=0.0,
+        false_negative_rate=float(spec.missed_detection_probability),
+        false_positive_rate=0.0,
+        notes=(
+            "Diagnostic simulator observation-quality metadata only; "
+            "non-calibrated benchmark robustness noise, not a hardware sensor model."
+        ),
+    )
+    return {
+        "schema_version": OBSERVATION_QUALITY_SCHEMA_VERSION,
+        "fields": quality.to_dict(),
+    }
+
+
+def _metadata_complete(meta: dict[str, Any]) -> bool:
+    """Return True when per-step perturbation metadata carries the required keys."""
+    required = {
+        "noise_profile",
+        "evidence_class",
+        "missed_actor_count",
+        "occluded_actor_count",
+        "observed_actor_count",
+        "actor_count",
+        "step",
+    }
+    return required.issubset(meta.keys())
+
+
+def evaluate_row(
+    row_name: str,
+    row_cfg: dict[str, Any],
+    frames: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Evaluate one clean/noisy/partial row over the same-seed trace.
+
+    Returns a per-row dict with observation-derived metrics, perturbation
+    metadata, a fail-closed status, and runtime.  Metric values are derived
+    from the perturbed observed state the policy would consume.
+    """
+    spec_kw = dict(row_cfg.get("spec_kw", {}))
+    spec = ObservationPerturbationSpec(**spec_kw)
+    state = (
+        ObservationPerturbationState(delay_steps=spec.delay_steps) if spec.delay_steps > 0 else None
+    )
+    level_spec = observation_level_spec(row_cfg["observation_level"])
+
+    metadata_complete = True
+    perturb_failed = False
+    min_observed_distances: list[float] = []
+    observed_actor_counts: list[int] = []
+    gt_observed_actor_counts: list[int] = []
+    missed_total = 0
+    occluded_total = 0
+    frames_with_signal = 0
+
+    start = time.perf_counter()
+    for frame in frames:
+        robot_pos = np.array(frame["robot"]["position"], dtype=np.float64)
+        obs_pos, obs_vel, obs_ids = _extract_observed_arrays(frame)
+        gt_observed_actor_counts.append(len(obs_ids))
+        step_spec = _spec_for_actor_count(spec, len(obs_ids))
+        try:
+            result = perturb_ground_truth(
+                obs_pos,
+                obs_vel,
+                obs_ids,
+                spec=step_spec,
+                step=int(frame["step"]),
+                state=state,
+            )
+        except (ValueError, TypeError):
+            perturb_failed = True
+            break
+
+        meta = result["metadata"]
+        if not _metadata_complete(meta):
+            metadata_complete = False
+        observed = result["observed"]
+
+        # Visible (non-zeroed) observed positions the policy would actually see.
+        positions = np.asarray(observed["positions"], dtype=np.float64).reshape(-1, 2)
+        if positions.size > 0:
+            visible_mask = np.any(positions != 0.0, axis=1)
+            visible_positions = positions[visible_mask]
+        else:
+            visible_positions = positions
+        observed_actor_counts.append(int(visible_positions.shape[0]))
+        if visible_positions.shape[0] > 0:
+            frames_with_signal += 1
+        min_observed_distances.append(_min_distance(robot_pos, visible_positions))
+        missed_total += int(meta["missed_actor_count"])
+        occluded_total += int(meta["occluded_actor_count"])
+    runtime_s = time.perf_counter() - start
+
+    # --- fail-closed status determination ---
+    if perturb_failed:
+        status = "invalid"
+        status_reason = "Perturbation wrapper raised on a frame; observed state unavailable."
+    elif not metadata_complete:
+        status = "invalid"
+        status_reason = "Per-step perturbation metadata incomplete; cannot certify the row."
+    elif row_cfg["family"] != "clean" and frames_with_signal == 0:
+        status = "degraded"
+        status_reason = (
+            "All actors suppressed after perturbation; no observation signal reaches the policy."
+        )
+    else:
+        status = "ok"
+        status_reason = "Row produced a usable perturbed observation stream."
+
+    finite_dists = [d for d in min_observed_distances if np.isfinite(d)]
+    metrics = {
+        # Safety / near-miss proxy: closest observed actor across the episode.
+        "min_observed_distance_m": (round(min(finite_dists), 4) if finite_dists else None),
+        # Progress proxy: fraction of frames where the policy still sees an actor.
+        "observation_continuity": (round(frames_with_signal / len(frames), 4) if frames else None),
+        # Social-compliance proxy: near-field exposure count (frames within threshold).
+        "near_field_exposure_frames": int(
+            sum(1 for d in finite_dists if d <= NEAR_FIELD_THRESHOLD_M)
+        ),
+        # Runtime of the perturbation pass (diagnostic compute cost).
+        "perturbation_runtime_s": round(runtime_s, 6),
+        "total_observed_actor_observations": int(sum(observed_actor_counts)),
+    }
+
+    return {
+        "row": row_name,
+        "family": row_cfg["family"],
+        "observation_level": level_spec.to_metadata(),
+        "description": row_cfg["description"],
+        "spec": {
+            "position_noise_std_m": spec.position_noise_std_m,
+            "position_noise_bound_m": spec.position_noise_bound_m,
+            "missed_detection_probability": spec.missed_detection_probability,
+            "has_occlusion_mask": spec.occlusion_mask is not None,
+            "delay_steps": spec.delay_steps,
+            "noise_profile": spec.noise_profile,
+            "is_noop": spec.is_noop,
+            "seed": spec.seed,
+        },
+        "perturbation_metadata": {
+            "metadata_complete": metadata_complete,
+            "missed_actor_observations_total": missed_total,
+            "occluded_actor_observations_total": occluded_total,
+            "frames_with_observation_signal": frames_with_signal,
+            "total_frames": len(frames),
+            "ground_truth_observed_actor_observations": int(sum(gt_observed_actor_counts)),
+            "observation_quality": _observation_quality_group(spec),
+        },
+        "metrics": metrics,
+        "status": status,
+        "status_reason": status_reason,
+    }
+
+
+def _delta(perturbed: Any, clean: Any) -> float | None:
+    """Return perturbed - clean for numeric metrics, else None."""
+    if perturbed is None or clean is None:
+        return None
+    return round(float(perturbed) - float(clean), 6)
+
+
+def compute_deltas(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    """Compute clean-vs-perturbed deltas per metric for every non-clean row.
+
+    Deltas are only reported against an ``ok`` clean reference.  Degraded /
+    invalid rows are surfaced but never folded into a success summary.
+    """
+    clean = next((r for r in rows if r["family"] == "clean"), None)
+    if clean is None or clean["status"] != "ok":
+        return {
+            "available": False,
+            "reason": "No usable clean reference row; deltas cannot be computed.",
+            "rows": {},
+        }
+
+    clean_metrics = clean["metrics"]
+    delta_rows: dict[str, Any] = {}
+    any_metric_moved = False
+    for row in rows:
+        if row["family"] == "clean":
+            continue
+        m = row["metrics"]
+        row_delta = {
+            metric: _delta(m.get(metric), clean_metrics.get(metric))
+            for metric in (
+                "min_observed_distance_m",
+                "observation_continuity",
+                "near_field_exposure_frames",
+                "total_observed_actor_observations",
+            )
+        }
+        # Runtime delta tracked separately (diagnostic, not a robustness signal).
+        row_delta["perturbation_runtime_s"] = _delta(
+            m.get("perturbation_runtime_s"), clean_metrics.get("perturbation_runtime_s")
+        )
+        moved = any(
+            d not in (None, 0, 0.0) for k, d in row_delta.items() if k != "perturbation_runtime_s"
+        )
+        if row["status"] == "ok" and moved:
+            any_metric_moved = True
+        delta_rows[row["row"]] = {
+            "status": row["status"],
+            "counts_as_success": row["status"] == "ok",
+            "deltas": row_delta,
+            "moved_a_metric": moved,
+        }
+    return {
+        "available": True,
+        "reference_row": clean["row"],
+        "any_perturbed_metric_moved": any_metric_moved,
+        "rows": delta_rows,
+    }
+
+
+def classify_overall(rows: list[dict[str, Any]], deltas: dict[str, Any]) -> dict[str, str]:
+    """Return the overall classification in the stable vocabulary, fail-closed."""
+    metadata_incomplete = any(not r["perturbation_metadata"]["metadata_complete"] for r in rows)
+    clean = next((r for r in rows if r["family"] == "clean"), None)
+
+    if metadata_incomplete or not deltas.get("available"):
+        return {
+            "label": "blocked",
+            "rationale": (
+                "Observation-perturbation metadata incomplete or no usable clean "
+                "reference; fail-closed to blocked per issue #3067."
+            ),
+        }
+    if clean is None or clean["status"] != "ok":
+        return {
+            "label": "blocked",
+            "rationale": "Clean reference row did not produce a usable observation stream.",
+        }
+
+    ok_perturbed = [r for r in rows if r["family"] != "clean" and r["status"] == "ok"]
+    if not ok_perturbed:
+        return {
+            "label": "non-claim",
+            "rationale": (
+                "Every perturbed row was degraded/invalid (all actors suppressed). "
+                "No usable robustness signal; not a claim."
+            ),
+        }
+    if not deltas.get("any_perturbed_metric_moved"):
+        return {
+            "label": "diagnostic",
+            "rationale": (
+                "Perturbations ran but moved no observed-state metric beyond the clean "
+                "reference (null result). Envelope too narrow; diagnostic-only."
+            ),
+        }
+    return {
+        "label": "diagnostic",
+        "rationale": (
+            "Perturbations changed the observed state the policy would consume "
+            "(non-null clean-vs-perturbed deltas). Diagnostic-only: trace-derived, "
+            "single fixture, single seed; not a benchmark, certification, or "
+            "sim-to-real claim."
+        ),
+    }
+
+
+def build_report(
+    rows: list[dict[str, Any]],
+    deltas: dict[str, Any],
+    overall: dict[str, str],
+    fixture_meta: dict[str, Any],
+    repro: dict[str, Any],
+) -> dict[str, Any]:
+    """Assemble the full JSON report."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": 3067,
+        "claim_boundary": (
+            "Diagnostic, trace-derived observation-robustness slice. "
+            "NOT a real-sensor certification and NOT a sim-to-real transfer claim. "
+            "Perturbations are non-calibrated benchmark robustness noise on observed "
+            "actor state. Robustness is interpreted separately from nominal performance."
+        ),
+        "evidence_tier": "smoke",
+        "paper_grade": False,
+        "overall_classification": overall,
+        "allowed_overall_classifications": list(OVERALL_CLASSIFICATIONS),
+        "allowed_row_statuses": list(ROW_STATUSES),
+        "reproducibility": repro,
+        "fixture": fixture_meta,
+        "matrix_families": sorted({r["family"] for r in rows}),
+        "rows": rows,
+        "clean_vs_perturbed_deltas": deltas,
+        "nominal_vs_robustness_note": (
+            "Nominal performance = stored-trace policy behavior on the clean observation. "
+            "Robustness = how the observed state the policy consumes changes under "
+            "perturbation. These are reported separately and must not be conflated."
+        ),
+    }
+
+
+def generate_markdown(report: dict[str, Any]) -> str:
+    """Render a compact Markdown report from the JSON report."""
+    repro = report["reproducibility"]
+    fixture = report["fixture"]
+    overall = report["overall_classification"]
+    lines = [
+        "# Issue #3067: Sensor-Noise Robustness Slice (clean / noisy / partial)",
+        "",
+        "## Claim Boundary",
+        "",
+        f"**{report['claim_boundary']}**",
+        "",
+        f"- **Evidence tier:** {report['evidence_tier']}",
+        f"- **Paper-grade:** {report['paper_grade']}",
+        f"- **Overall classification:** `{overall['label']}` — {overall['rationale']}",
+        "",
+        "## Reproducibility",
+        "",
+        f"- **Issue:** #{repro['issue']}",
+        f"- **Generated at (UTC):** {repro['generated_at_utc']}",
+        f"- **Command:** `{repro['command']}`",
+        f"- **Repo HEAD:** `{repro['repo_head']}`",
+        f"- **Seed:** {repro['seed']}",
+        f"- **Fixture:** `{fixture['trace_path']}`",
+        f"- **Scenario:** {fixture['scenario_id']} (pedestrian_count="
+        f"{fixture['pedestrian_count']})",
+        "",
+        "## Matrix Rows",
+        "",
+        "| row | family | obs level | status | min_obs_dist_m | continuity | near_field_frames |",
+        "| --- | --- | --- | --- | --- | --- | --- |",
+    ]
+    for r in report["rows"]:
+        m = r["metrics"]
+        lines.append(
+            f"| {r['row']} | {r['family']} | {r['observation_level']['key']} | "
+            f"`{r['status']}` | {m['min_observed_distance_m']} | "
+            f"{m['observation_continuity']} | {m['near_field_exposure_frames']} |"
+        )
+    lines += ["", "## Clean-vs-Perturbed Deltas", ""]
+    deltas = report["clean_vs_perturbed_deltas"]
+    if not deltas.get("available"):
+        lines.append(f"_Deltas unavailable: {deltas.get('reason')}_")
+    else:
+        lines.append(f"Reference row: `{deltas['reference_row']}`")
+        lines.append("")
+        lines.append(
+            "| row | status | counts_as_success | d(min_obs_dist) | d(continuity) | "
+            "d(near_field) | moved? |"
+        )
+        lines.append("| --- | --- | --- | --- | --- | --- | --- |")
+        for name, d in deltas["rows"].items():
+            dd = d["deltas"]
+            lines.append(
+                f"| {name} | `{d['status']}` | {d['counts_as_success']} | "
+                f"{dd['min_observed_distance_m']} | {dd['observation_continuity']} | "
+                f"{dd['near_field_exposure_frames']} | {d['moved_a_metric']} |"
+            )
+    lines += [
+        "",
+        "## Nominal vs Robustness",
+        "",
+        report["nominal_vs_robustness_note"],
+        "",
+        "## Caveats",
+        "",
+        "- Single deterministic pedestrian-dominated fixture, single seed.",
+        "- Trace-derived: no live planner replay; metrics are observed-state proxies.",
+        "- Non-calibrated benchmark robustness noise, not a hardware sensor model.",
+        "- Degraded/invalid rows are fail-closed and never counted as success.",
+        "- NOT a real-sensor certification and NOT a sim-to-real transfer claim.",
+    ]
+    return "\n".join(lines)
+
+
+def run_slice(output_dir: pathlib.Path, *, command: str) -> dict[str, Any]:
+    """Execute the full clean/noisy/partial slice and write artifacts.
+
+    Returns the JSON report dict.
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+    trace = _load_fixture(FIXTURE_PATH)
+    frames = trace["frames"]
+    dense_meta = trace.get("dense_stress_metadata", {})
+
+    fixture_meta = {
+        "trace_path": str(FIXTURE_PATH.relative_to(REPO_ROOT)),
+        "scenario_id": trace["source"]["scenario_id"],
+        "seed": trace["source"]["seed"],
+        "planner_id": trace["source"]["planner_id"],
+        "episode_id": trace["source"]["episode_id"],
+        "frame_count": len(frames),
+        "pedestrian_count": dense_meta.get("pedestrian_count"),
+    }
+    repro = {
+        "issue": 3067,
+        "generated_at_utc": datetime.datetime.now(datetime.UTC).isoformat(),
+        "command": command,
+        "repo_head": _git_head(),
+        "seed": SEED,
+    }
+
+    rows = [evaluate_row(name, cfg, frames) for name, cfg in MATRIX.items()]
+    deltas = compute_deltas(rows)
+    overall = classify_overall(rows, deltas)
+    report = build_report(rows, deltas, overall, fixture_meta, repro)
+
+    json_path = output_dir / "summary.json"
+    with open(json_path, "w", encoding="utf-8") as fh:
+        json.dump(report, fh, indent=2)
+    md_path = output_dir / "README.md"
+    with open(md_path, "w", encoding="utf-8") as fh:
+        fh.write(generate_markdown(report))
+
+    print(f"Wrote {json_path}")
+    print(f"Wrote {md_path}")
+    print(f"Overall classification: {overall['label']}")
+    for r in rows:
+        print(f"  [{r['status']:>13s}] {r['row']} ({r['family']})")
+    return report
+
+
+def main() -> None:
+    """Parse arguments and run the issue #3067 robustness slice."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Issue #3067 bounded clean / noisy / partial observation-robustness "
+            "slice (diagnostic; not sensor certification or sim-to-real)."
+        )
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=str,
+        default="output/issue_3067_sensor_noise/run",
+        help="Output directory for the JSON + Markdown report.",
+    )
+    args = parser.parse_args()
+
+    output_dir = pathlib.Path(args.output_dir)
+    if not output_dir.is_absolute():
+        output_dir = REPO_ROOT / output_dir
+    command = (
+        "uv run python scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py "
+        f"--output-dir {args.output_dir}"
+    )
+    run_slice(output_dir, command=command)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/benchmark/test_sensor_noise_robustness_slice_issue_3067.py
+++ b/tests/benchmark/test_sensor_noise_robustness_slice_issue_3067.py
@@ -1,0 +1,176 @@
+"""Tests for the issue #3067 clean/noisy/partial observation-robustness slice."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import numpy as np
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = REPO_ROOT / "scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py"
+FIXTURE_PATH = (
+    REPO_ROOT / "tests/fixtures/analysis_workbench/simulation_trace_export_v1/"
+    "dense_pedestrian_stress_episode_0000.json"
+)
+_LOADED = None
+
+
+def _load_module():
+    """Load the slice runner as an importable module."""
+    global _LOADED
+    if _LOADED is not None:
+        return _LOADED
+    spec = importlib.util.spec_from_file_location(
+        "run_sensor_noise_robustness_slice_issue_3067", SCRIPT_PATH
+    )
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    _LOADED = mod
+    return _LOADED
+
+
+def _frames():
+    """Return the fixture frames."""
+    return json.loads(FIXTURE_PATH.read_text(encoding="utf-8"))["frames"]
+
+
+def _eval_all():
+    """Evaluate every matrix row against the fixture."""
+    mod = _load_module()
+    frames = _frames()
+    return mod, [mod.evaluate_row(name, cfg, frames) for name, cfg in mod.MATRIX.items()]
+
+
+def test_clean_noisy_partial_rows_present_with_metadata():
+    """Matrix yields clean, noisy, and partial rows, each with perturbation metadata."""
+    _mod, rows = _eval_all()
+    families = {r["family"] for r in rows}
+    assert {"clean", "noisy", "partial"} <= families
+    for row in rows:
+        meta = row["perturbation_metadata"]
+        assert meta["metadata_complete"] is True
+        assert "observation_quality" in meta
+        assert row["observation_level"]["key"]  # observation-level metadata present
+        assert "noise_profile" in row["spec"]
+
+
+def test_clean_vs_perturbed_delta_computed():
+    """Deltas are computed per metric against the clean reference row."""
+    mod, rows = _eval_all()
+    deltas = mod.compute_deltas(rows)
+    assert deltas["available"] is True
+    assert deltas["reference_row"] == "clean"
+    # Every non-clean row gets a delta entry with the core metrics.
+    perturbed = [r for r in rows if r["family"] != "clean"]
+    assert set(deltas["rows"]) == {r["row"] for r in perturbed}
+    for entry in deltas["rows"].values():
+        assert "min_observed_distance_m" in entry["deltas"]
+        assert "observation_continuity" in entry["deltas"]
+
+
+def test_perturbations_move_a_metric_non_null():
+    """The pedestrian-dominated fixture yields a non-null clean-vs-perturbed delta."""
+    mod, rows = _eval_all()
+    deltas = mod.compute_deltas(rows)
+    assert deltas["any_perturbed_metric_moved"] is True
+
+
+def test_incomplete_metadata_blocks_overall_classification():
+    """Incomplete per-row metadata fails closed to a blocked overall classification."""
+    mod, rows = _eval_all()
+    deltas = mod.compute_deltas(rows)
+    # Corrupt metadata on a perturbed row.
+    rows[1]["perturbation_metadata"]["metadata_complete"] = False
+    overall = mod.classify_overall(rows, deltas)
+    assert overall["label"] == "blocked"
+    assert overall["label"] in mod.OVERALL_CLASSIFICATIONS
+
+
+def test_unavailable_deltas_block():
+    """A missing/unusable clean reference fails closed to blocked."""
+    mod, _rows = _eval_all()
+    overall = mod.classify_overall(_rows, {"available": False, "rows": {}})
+    assert overall["label"] == "blocked"
+
+
+def test_degraded_row_never_counts_as_success():
+    """A fully-suppressed perturbed row is degraded and not counted as success."""
+    mod = _load_module()
+    frames = _frames()
+    row = mod.evaluate_row(
+        "all_missed",
+        {
+            "family": "partial",
+            "observation_level": "occluded_partial_state",
+            "description": "All actors missed.",
+            "spec_kw": {"missed_detection_probability": 1.0, "seed": mod.SEED},
+        },
+        frames,
+    )
+    assert row["status"] == "degraded"
+    deltas = mod.compute_deltas([r for r in _eval_all()[1] if r["family"] == "clean"] + [row])
+    assert deltas["rows"]["all_missed"]["counts_as_success"] is False
+
+
+def test_all_perturbed_degraded_yields_non_claim():
+    """If every perturbed row is degraded, the overall is a non-claim."""
+    mod = _load_module()
+    frames = _frames()
+    clean = mod.evaluate_row("clean", mod.MATRIX["clean"], frames)
+    degraded = mod.evaluate_row(
+        "all_missed",
+        {
+            "family": "partial",
+            "observation_level": "occluded_partial_state",
+            "description": "All actors missed.",
+            "spec_kw": {"missed_detection_probability": 1.0, "seed": mod.SEED},
+        },
+        frames,
+    )
+    rows = [clean, degraded]
+    deltas = mod.compute_deltas(rows)
+    overall = mod.classify_overall(rows, deltas)
+    assert overall["label"] == "non-claim"
+
+
+def test_determinism_same_seed_same_metrics():
+    """Two evaluations with the same seed produce identical metrics."""
+    mod = _load_module()
+    frames = _frames()
+    a = mod.evaluate_row("noisy_medium", mod.MATRIX["noisy_medium"], frames)
+    b = mod.evaluate_row("noisy_medium", mod.MATRIX["noisy_medium"], frames)
+    # Drop runtime (wall-clock, non-deterministic) before comparing.
+    a["metrics"].pop("perturbation_runtime_s")
+    b["metrics"].pop("perturbation_runtime_s")
+    assert a["metrics"] == b["metrics"]
+
+
+def test_classification_vocabulary_stable():
+    """Overall and row-status vocabularies are the stable expected sets."""
+    mod = _load_module()
+    assert mod.OVERALL_CLASSIFICATIONS == ("benchmark", "diagnostic", "blocked", "non-claim")
+    assert mod.ROW_STATUSES == ("ok", "degraded", "invalid", "not-available")
+
+
+def test_full_run_writes_report(tmp_path):
+    """run_slice emits a JSON report with the diagnostic claim boundary."""
+    mod = _load_module()
+    report = mod.run_slice(tmp_path, command="pytest")
+    assert report["paper_grade"] is False
+    assert report["evidence_tier"] == "smoke"
+    assert report["overall_classification"]["label"] in mod.OVERALL_CLASSIFICATIONS
+    assert "sim-to-real" in report["claim_boundary"].lower()
+    assert (tmp_path / "summary.json").exists()
+    assert (tmp_path / "README.md").exists()
+
+
+def test_occlusion_mask_adapts_to_actor_count():
+    """A larger occlusion mask is truncated to the frame actor count."""
+    mod = _load_module()
+    spec = mod.ObservationPerturbationSpec(occlusion_mask=np.array([True, False, False, True]))
+    adapted = mod._spec_for_actor_count(spec, 3)
+    assert np.asarray(adapted.occlusion_mask).size == 3


### PR DESCRIPTION
## Summary

**Closes #3067.** A bounded clean / noisy / partial-observation robustness diagnostic — **unblocked** during this enablement pass: its sole remaining prerequisite, #3062 (research campaign manifest), is now merged (#3427), so its `state:blocked` label was stale. Local, `evidence_tier: smoke`, `claim_boundary: diagnostic_only`, **not** paper-grade.

## What landed

- `scripts/benchmark/run_sensor_noise_robustness_slice_issue_3067.py` — same-seed clean/noisy/partial matrix on a pedestrian-dominated fixture, reusing the existing `observation_noise.py` / `observation_perturbation.py` / `observation_levels.py` wrappers (mirrors the `run_observation_noise_envelope.py` idiom). Reports clean-vs-perturbed deltas per row with fail-closed status; overall classification ∈ {benchmark, diagnostic, blocked, non-claim} kept **separate** from nominal performance.
- `tests/benchmark/test_sensor_noise_robustness_slice_issue_3067.py` — 11 tests incl. fail-closed paths.

## Result: `diagnostic` (non-null)

Fixture `dense_pedestrian_stress_episode_0000.json` (3 converging actors, seed 3067). Clean reference: min_obs_dist 0.1562 m, continuity 1.0, near-field 20, obs_count 60.

| row | family | status | Δmin_obs_dist | Δcontinuity | Δnear_field | Δobs_count |
|---|---|---|---|---|---|---|
| noisy_low | noisy | ok | +0.0055 | 0 | 0 | 0 |
| noisy_medium | noisy | ok | +0.0492 | 0 | 0 | 0 |
| partial_occlusion | partial | ok | +0.2212 | 0 | 0 | −20 |
| partial_missed_detection | partial | ok | +0.1465 | −0.15 | −5 | −36 |

Perturbations measurably change the observed state the policy would consume (noise shifts nearest-observed distance; partial observation drops actor observations, continuity, near-field). Single fixture/seed, trace-derived → diagnostic-only.

## Validation (independently audited)

- `pytest` new file → 11 passed; `-k "sensor_noise or 3067 or observation_noise or observation_perturbation"` → **145 passed**, no regressions.
- Fresh run **reproduces** the committed classification (`diagnostic`) and deltas. `ruff`/`pre-commit` clean.

## Claim boundary

Diagnostic, trace-derived observation-robustness slice — robustness interpreted **separately** from nominal performance; **NOT** a real-sensor certification or sim-to-real transfer claim; perturbations are non-calibrated benchmark robustness noise. Tracked under `docs/context/evidence/issue_3067_sensor_noise_robustness_2026-06-23/`.

> Sibling #3066 (robot-influence-on-pedestrian-flow v0) was also unblocked by the same #3062 merge and relabeled `state:ready` — a natural follow-up using the same pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)