### PR TITLE
docs: harden Slurm autopilot guidance

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -195,7 +195,10 @@ Before each phase, run a delegation checkpoint:
 - Before spawning a Spark sidecar, check the active ledger or most recent route
   snapshot for a Spark quota reset/usage-limit marker. If Spark is unavailable,
   record the reset time and route directly to the next eligible cheap worker
-  instead of discovering the quota limit by failed spawn.
+  instead of discovering the quota limit by failed spawn. If a spawn still
+  returns a usage-limit error, close the app-agent handle immediately, add the
+  reset time to the route cache, and continue locally or with the next eligible
+  route rather than retrying Spark.
 - If no helper is used, record `delegation_skipped: <reason>` with one of: `tiny`,
   `critical-path-blocker`, `route-unavailable`, `sensitive-context`, `pure-synthesis`, or
   `local-publication-step`.
@@ -497,6 +500,10 @@ one of:
 
 Spark prompts must require compact output: files inspected, exact evidence, uncertainty, and
 recommended next prompt.
+
+When Spark is rate-limited, treat the failed spawn as a routing signal, not as
+task evidence. Close the app-agent handle when one was allocated, cache the
+reset timestamp in the active ledger, and skip Spark for the rest of the phase.
 
 Do not route Spark to:
 

--- a/.agents/skills/slurm-campaign-submit/SKILL.md
+++ b/.agents/skills/slurm-campaign-submit/SKILL.md
@@ -50,19 +50,27 @@ Use this skill for generic SLURM campaign submission: learned-risk, shielded PPO
    `uv run python scripts/dev/submit_training_jobs.py --dry-run` and submit through
    `uv run python scripts/dev/submit_training_jobs.py --submit` only when the generated manifest
    shows the intended config, launcher, job name, output root, and duplicate-check evidence.
-8. Submit non-queue campaigns with explicit config and job name; capture job ID plus stdout/stderr paths.
-9. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
-10. Classify pre-health status as `route_accepted`, `blocked`, or `failed_preflight`; classify
+8. When a private queue entry is blocked by a named prerequisite, reconcile that
+   blocker against current public code, issue comments, and merged PRs before
+   treating it as still blocked. If the prerequisite is now satisfied, record
+   the evidence and proceed as a rerun; if it is ambiguous, stop before
+   submitting.
+9. Submit non-queue campaigns with explicit config and job name; capture job ID plus stdout/stderr paths.
+   If submission is routed through a remote host, first prove the owning public
+   worktree exists and is clean on that host at the intended commit. A local
+   worktree with the same branch name is not sufficient evidence.
+10. Record output root and expected artifacts: manifest, checkpoint, report, metrics, videos, or release bundle.
+11. Classify pre-health status as `route_accepted`, `blocked`, or `failed_preflight`; classify
     successful route acceptance with missing issue/PR or private-ledger traceability as
     `partial_traceable`; classify failures as config, cluster capacity, wrapper, dependency, or unknown.
-11. Immediately run a submission health check (`squeue`, `sacct`, initial stderr availability) and apply the
+12. Immediately run a submission health check (`squeue`, `sacct`, initial stderr availability) and apply the
     shared checklist in `docs/dev/slurm_submission.md`.
-12. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
-13. A clean `submitted` state requires both immediate health-check success and the checklist traceability update
+13. Hand artifact classification to `artifact-provenance` before downstream reports depend on local `output/`.
+14. A clean `submitted` state requires both immediate health-check success and the checklist traceability update
     (issue/PR comment plus private-ledger or handoff reference). If route acceptance succeeds but
     either traceability record is missing, keep `partial_traceable`. `sbatch`/`sacct` acceptance alone is only
     route evidence and does not imply benchmark or report proof.
-14. After completion or predeclared cancellation, route results before rerunning:
+15. After completion or predeclared cancellation, route results before rerunning:
     - cancelled runs may be diagnostic evidence only when the early-stop criteria were declared and
       the configured preservation action captured logs, manifest, config, commit, and artifact
       status;
@@ -104,6 +112,11 @@ mode. The single `gse-` background lane in `goal-slurm-experiment` remains indep
 - Do not bypass `scripts/dev/submit_training_jobs.py` for queue-backed training jobs unless the
   helper cannot represent the launcher; record the exception and the equivalent duplicate checks.
 - Do not submit from an unintended branch or dirty tree without calling that out.
+- Do not submit through a remote wrapper until the submit-host worktree, branch,
+  commit, and cleanliness have been checked on that host.
+- Do not preserve a stale queue blocker after the blocking prerequisite is
+  proven satisfied by current code, merged PRs, or issue comments; update the
+  queue/ledger rationale or classify the mismatch as an ambiguity.
 - Do not treat a queued job as completed evidence.
 - Do not cancel a low-signal training job as diagnostic evidence unless the early-stop rule was
   predeclared and the diagnostic-preservation action has been completed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,8 @@ parent-thread outputs since the previous phase, including broad searches, full s
 raw validation logs, verbose delegate notifications, failed command families, repeated monitor
 noise, and unclear instructions that caused retries. Convert repeated leaks into a compact ledger
 field, route-cache entry, worker prompt constraint, or docs patch before the next batch.
+For Slurm-backed phases, also record the private-queue freshness check, the submit-host worktree
+proof, and any model-route quota failures so resumes do not rediscover the same blockers.
 
 ## Shared Knowledge Graph
 
@@ -539,6 +541,8 @@ recommended next prompt.
 For long autonomous runs, cache Spark usage-limit failures in the active ledger with the reset time.
 Before spawning another Spark sidecar in the same run, check that ledger entry and route directly to
 the next eligible cheap worker if Spark is still unavailable.
+If a Spark spawn still fails for quota, close any allocated subagent handle immediately and treat
+the failure as route evidence only.
 
 Spark is explicitly excluded from:
 

--- a/docs/dev/slurm_submission.md
+++ b/docs/dev/slurm_submission.md
@@ -208,6 +208,10 @@ This isolates branches, not file snapshots. Pending jobs normally read the workt
 they start, so avoid incompatible edits to that worktree's configs or scripts while a queued job is
 waiting.
 
+If submission is performed by a private wrapper over SSH, create or refresh the owning worktree on
+the submit host before `sbatch`, then record the host-side branch, commit, and clean status. A local
+dry run proves the command shape, but it does not prove that the cluster can see the same worktree.
+
 `local.machine.md` is gitignored. If the same login-node policy should apply to every local
 worktree, symlink it from the original checkout:
 
@@ -248,6 +252,11 @@ For worktrees, prefer one sibling private overlay shared by all checkouts:
 ~/git/robot_sf_ll7.worktrees/<branch>/
 ~/git/robot_sf_ll7-private-ops/
 ```
+
+When a private overlay queue entry is blocked on a prerequisite that may have changed, reconcile the
+blocker against current public issue comments, merged PRs, and the relevant source/tests before
+submitting. If the prerequisite is satisfied, record that evidence in the private ledger or handoff;
+if the queue and public state conflict without clear evidence, keep the job blocked.
 
 ## Auxme issue-791 private helper
 

--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -51,6 +51,9 @@ changes.
 - `route_cache` keeps quota and invocation facts close to the active work:
   Spark usage-limit resets, failed helper flags, the exact bounded CI monitor
   command, and the current fallback worker. Reuse it before retrying a route.
+  If a Codex app subagent spawn fails because the model quota is exhausted,
+  record the reset time immediately, close the handle when possible, and do not
+  retry that model during the same phase.
 - `delegation_artifacts` are route evidence, not task acceptance. Codex still
   inspects the diff, verifies changed files, and runs the selected validation.
 - `output_budget` should return the result, changed files, validation status,
@@ -90,6 +93,9 @@ workflow only when the savings are reusable.
   `uv run python scripts/dev/worktree_hygiene_snapshot.py --repo-status --filter <branch> --json`
   for branch cleanup, and raw `git worktree list --porcelain` only when the
   helper reports a stale entry or missing detail.
+- For Slurm work, prove the owning worktree exists on the submit host before
+  submitting. A local worktree preflight is not enough when the private submit
+  wrapper reaches the cluster through SSH.
 - Keep CI and validation loops bounded in the parent thread. Store full output
   in compact-validation artifacts and report only command, exit code, failing
   node IDs, artifact paths, and the next action.


### PR DESCRIPTION
## Summary
- tighten token-efficient profile guidance for route-cache reuse, Spark quota failures, and submit-host worktree proof
- update goal-autopilot Spark sidecar rules to close quota-failed app agents and avoid retry loops
- update Slurm submission guidance to reconcile stale private queue blockers against current public evidence and prove remote worktree visibility before submitting

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/dev/check_skills.py --preflight goal-autopilot`
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sync_ai_config.py --check`
- `git diff --check`
- Expected local limitation: `scripts/dev/run_worktree_shared_venv.sh -- python scripts/dev/check_skills.py --preflight slurm-campaign-submit` reports `sbatch: not found on PATH` on this non-Slurm shell.

## Downstream Propagation
- Updated canonical agent-facing instruction surfaces directly: `AGENTS.md`, token-efficient thread profile, goal-autopilot skill, Slurm campaign skill, and Slurm submission docs.
- No generated index or compatibility mirror changes were required; `sync_ai_config.py --check` passed.

## Research Result Guidance
NA - instruction-only reliability patch. No benchmark, metric, model, or paper-facing claim is changed.
