### PR TITLE
ci: fix stale label workflow gh fields

### DIFF
--- a/.github/workflows/strip-closed-state-labels.yml
+++ b/.github/workflows/strip-closed-state-labels.yml
@@ -42,19 +42,19 @@ jobs:
           echo "Live state labels: ${LIVE_LABELS[*]}"
 
           # Read-then-write (defense-in-depth): the trigger already implies the issue is closed,
-          # but re-confirm CLOSED and non-PR via the API before any write.
+          # but re-confirm CLOSED and non-PR-shaped URL via the API before any write.
           issue_state=$(
-            gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json state,isPullRequest \
-              --jq '[.state, (.isPullRequest | tostring)] | @tsv'
+            gh issue view "$ISSUE_NUMBER" --repo "$REPO" --json state,url \
+              --jq '[.state, .url] | @tsv'
           )
-          read -r state is_pull_request <<<"$issue_state"
-          echo "Issue #$ISSUE_NUMBER state: $state isPullRequest: $is_pull_request"
+          read -r state issue_url <<<"$issue_state"
+          echo "Issue #$ISSUE_NUMBER state: $state url: $issue_url"
           if [ "$state" != "CLOSED" ]; then
             echo "Issue #$ISSUE_NUMBER is not CLOSED ($state); skipping (no-op)."
             exit 0
           fi
-          if [ "$is_pull_request" = "true" ]; then
-            echo "Issue #$ISSUE_NUMBER is a pull request; skipping (no-op)."
+          if [[ "$issue_url" == */pull/* ]]; then
+            echo "Issue #$ISSUE_NUMBER has a pull request URL; skipping (no-op)."
             exit 0
           fi
 

--- a/scripts/dev/closed_state_label_hygiene.py
+++ b/scripts/dev/closed_state_label_hygiene.py
@@ -13,6 +13,7 @@ import subprocess
 import sys
 from dataclasses import dataclass
 from typing import Any
+from urllib.parse import urlsplit
 
 DEFAULT_REPO = "ll7/robot_sf_ll7"
 LIVE_STATE_LABELS = ("state:ready", "state:running", "state:blocked")
@@ -56,7 +57,14 @@ def _label_names(raw_labels: object) -> set[str]:
 
 def _is_pull_request_url(raw_url: object) -> bool:
     """Return True for GitHub pull-request URLs returned by issue search/view commands."""
-    return isinstance(raw_url, str) and "/pull/" in raw_url
+    if not isinstance(raw_url, str):
+        return False
+
+    path_parts = [part for part in urlsplit(raw_url).path.split("/") if part]
+    if len(path_parts) != 4:
+        return False
+    owner, repo, resource, number = path_parts
+    return bool(owner and repo and resource == "pull" and number.isdecimal())
 
 
 def build_search_command(*, repo: str, label: str, limit: int) -> list[str]:

--- a/scripts/dev/closed_state_label_hygiene.py
+++ b/scripts/dev/closed_state_label_hygiene.py
@@ -16,7 +16,7 @@ from typing import Any
 
 DEFAULT_REPO = "ll7/robot_sf_ll7"
 LIVE_STATE_LABELS = ("state:ready", "state:running", "state:blocked")
-JSON_FIELDS = "number,title,url,state,isPullRequest,labels"
+JSON_FIELDS = "number,title,url,state,labels"
 
 
 @dataclass(frozen=True)
@@ -52,6 +52,11 @@ def _label_names(raw_labels: object) -> set[str]:
         elif isinstance(label, dict) and isinstance(label.get("name"), str):
             names.add(label["name"])
     return names
+
+
+def _is_pull_request_url(raw_url: object) -> bool:
+    """Return True for GitHub pull-request URLs returned by issue search/view commands."""
+    return isinstance(raw_url, str) and "/pull/" in raw_url
 
 
 def build_search_command(*, repo: str, label: str, limit: int) -> list[str]:
@@ -111,7 +116,7 @@ def collect_stale_issues(
 
     for search_label, rows in rows_by_label.items():
         for row in rows:
-            if row.get("isPullRequest") is True:
+            if _is_pull_request_url(row.get("url")):
                 continue
             if str(row.get("state", "")).lower() != "closed":
                 continue
@@ -155,7 +160,7 @@ def build_view_command(*, repo: str, number: int) -> list[str]:
         "--repo",
         repo,
         "--json",
-        "number,state,isPullRequest",
+        "number,state,url",
     ]
 
 
@@ -201,7 +206,7 @@ def confirm_issue_closed(*, repo: str, number: int) -> bool:
         ) from exc
     if not isinstance(payload, dict):
         raise ValueError(f"Expected a JSON object from gh issue view for issue {number}")
-    if payload.get("isPullRequest") is True:
+    if _is_pull_request_url(payload.get("url")):
         return False
     return str(payload.get("state", "")).lower() == "closed"
 

--- a/tests/dev/test_closed_state_label_hygiene.py
+++ b/tests/dev/test_closed_state_label_hygiene.py
@@ -63,6 +63,22 @@ def test_collect_stale_issues_ignores_pull_request_rows() -> None:
     assert closed_state_label_hygiene.collect_stale_issues(rows_by_label) == []
 
 
+@pytest.mark.parametrize(
+    ("url", "expected"),
+    [
+        ("https://github.com/ll7/robot_sf_ll7/pull/12", True),
+        ("https://github.com/ll7/robot_sf_ll7/issues/12?next=/pull/12", False),
+        ("https://github.com/ll7/robot_sf_ll7/issues/pull", False),
+        ("https://github.com/ll7/robot_sf_ll7/pull/not-a-number", False),
+        ("https://github.com/ll7/robot_sf_ll7/pulls/12", False),
+        (None, False),
+    ],
+)
+def test_is_pull_request_url_requires_canonical_pull_path(url: object, expected: bool) -> None:
+    """PR detection should not treat arbitrary '/pull/' substrings as pull requests."""
+    assert closed_state_label_hygiene._is_pull_request_url(url) is expected
+
+
 def test_build_report_emits_machine_readable_failure_summary() -> None:
     """Reports should expose a stable failure summary when stale labels exist."""
     stale = [

--- a/tests/dev/test_closed_state_label_hygiene.py
+++ b/tests/dev/test_closed_state_label_hygiene.py
@@ -55,7 +55,6 @@ def test_collect_stale_issues_ignores_pull_request_rows() -> None:
                 "title": "closed PR with a state label",
                 "url": "https://github.com/ll7/robot_sf_ll7/pull/12",
                 "state": "closed",
-                "isPullRequest": True,
                 "labels": [{"name": "state:ready"}],
             }
         ],
@@ -103,7 +102,8 @@ def test_build_search_command_uses_read_only_closed_issue_search() -> None:
     assert command[command.index("--state") + 1] == "closed"
     assert "--label" in command
     assert command[command.index("--label") + 1] == "state:ready"
-    assert "isPullRequest" in command[command.index("--json") + 1].split(",")
+    assert "url" in command[command.index("--json") + 1].split(",")
+    assert "isPullRequest" not in command[command.index("--json") + 1].split(",")
     assert "--project" not in command
     assert "edit" not in command
 
@@ -290,7 +290,10 @@ def test_confirm_issue_closed_reads_state_via_gh(monkeypatch: pytest.MonkeyPatch
         return subprocess.CompletedProcess(
             args=tuple(command),
             returncode=0,
-            stdout='{"number": 12, "state": "CLOSED", "isPullRequest": false}',
+            stdout=(
+                '{"number": 12, "state": "CLOSED", '
+                '"url": "https://github.com/ll7/robot_sf_ll7/issues/12"}'
+            ),
         )
 
     monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run)
@@ -304,7 +307,9 @@ def test_confirm_issue_closed_is_false_for_open_or_pr(monkeypatch: pytest.Monkey
 
     def fake_run_open(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
-            args=tuple(command), returncode=0, stdout='{"state": "OPEN", "isPullRequest": false}'
+            args=tuple(command),
+            returncode=0,
+            stdout='{"state": "OPEN", "url": "https://github.com/ll7/robot_sf_ll7/issues/12"}',
         )
 
     monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run_open)
@@ -312,7 +317,9 @@ def test_confirm_issue_closed_is_false_for_open_or_pr(monkeypatch: pytest.Monkey
 
     def fake_run_pr(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
         return subprocess.CompletedProcess(
-            args=tuple(command), returncode=0, stdout='{"state": "CLOSED", "isPullRequest": true}'
+            args=tuple(command),
+            returncode=0,
+            stdout='{"state": "CLOSED", "url": "https://github.com/ll7/robot_sf_ll7/pull/12"}',
         )
 
     monkeypatch.setattr(closed_state_label_hygiene.subprocess, "run", fake_run_pr)
@@ -356,7 +363,7 @@ def test_main_fix_mode_strips_labels_and_reports(
             return subprocess.CompletedProcess(
                 args=tuple(command),
                 returncode=0,
-                stdout='{"state": "CLOSED", "isPullRequest": false}',
+                stdout='{"state": "CLOSED", "url": "https://github.com/ll7/robot_sf_ll7/issues/12"}',
             )
         edits.append(command)
         return subprocess.CompletedProcess(args=tuple(command), returncode=0, stdout="")


### PR DESCRIPTION
## Summary
Fix the closed-issue state-label cleanup workflow so it no longer asks GitHub CLI for the unsupported `isPullRequest` JSON field.

## Linked Issues
- Relates to failing workflow run: https://github.com/ll7/robot_sf_ll7/actions/runs/28022433608

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Updated `.github/workflows/strip-closed-state-labels.yml` to re-confirm issues with supported `state,url` fields.
- Updated `scripts/dev/closed_state_label_hygiene.py` to stop requesting `isPullRequest` and identify PR-shaped rows from `/pull/` URLs.
- Updated focused tests for the new GitHub CLI field contract.

## Why It Matters
- Added value: restores the automatic cleanup of stale live `state:*` labels when issues close.
- Expected impact: future `issues: closed` workflow runs should no longer fail on GitHub CLI field drift.
- Why this is worth merging now: the current workflow fails before it can remove labels.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/CI workflow compatibility fix only.
- Comparator or baseline, if applicable: failing workflow run 28022433608 rejected `--json isPullRequest`.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: supported `gh` fields parse locally and focused helper tests pass.
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper only; no research interpretation.

## Domain-Aware Approval
- Required for this PR: yes - the PR body uses evidence-tier and result-classification terms even though the implementation is a CI/support workflow compatibility fix.
- Domains reviewed: CI/support workflow contract; no benchmark, metric, paper-facing, or research-result claim is made.
- Status: approved
- Approver/review source or waiver: maintainer-aligned self-review using the PR body contract and focused validation evidence
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: NA
  - Fallback/degraded exclusions: NA
  - Claim boundary: NA
  - Implementation integrity vs experimental validity: implementation integrity covered by focused tests and live `gh` field probes.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this support fix; GitHub Actions will exercise the workflow on the next issue closure.
- Extractor or analysis tool needed: no
- Artifact missing or unavailable: none
- Stop / revise / continue decision: stop; merge after review/CI.
- Proposed child issue or existing follow-up: none

## Validation / Proof
- Commands run:
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_closed_state_label_hygiene.py -q`
  - `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/closed_state_label_hygiene.py tests/dev/test_closed_state_label_hygiene.py`
  - Parsed `.github/workflows/strip-closed-state-labels.yml` with Python YAML and ran `bash -n` on the embedded `run:` script.
  - `gh issue view 3456 --repo ll7/robot_sf_ll7 --json state,url --jq '[.state, .url] | @tsv'`
  - `gh search issues --repo ll7/robot_sf_ll7 --state closed --label state:ready --json number,title,url,state,labels --limit 1`
  - `git diff --check`
- Evidence that the change works here: focused tests passed (`16 passed`), Ruff passed, workflow YAML and shell parsed, and live GitHub CLI probes accepted the replacement field list.
- Benchmarks or smoke tests, if applicable: targeted CI-helper smoke only; full benchmark/readiness suite not run because this is a low-risk workflow/helper compatibility fix.

## Risks / Rollout
- Compatibility risks: URL-shape PR detection depends on GitHub issue/PR URLs retaining `/pull/` for pull requests.
- Failure modes: if GitHub CLI removes `url` from issue view/search, this would need another field update.
- Rollback or fallback plan: revert this PR to restore the previous workflow behavior.

## Docs / Provenance
- Updated docs: none
- Relevant design or provenance notes: failing Actions run linked above.
- Any assumptions that need to be preserved: `gh issue view/search` support `state,url` on current GitHub CLI.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: support/CI workflow compatibility fix only; no research claim, benchmark result, registry, or durable artifact.

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none

## Reviewer Notes
- Anything a reviewer should verify closely: the workflow now uses `state,url` instead of `isPullRequest` and skips `/pull/` URLs.
- Any known limitations: the exact workflow trigger can only be fully exercised by a future `issues: closed` event after merge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal automation tooling to improve reliability of pull request detection in the issue label management workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
