### PR TITLE
refactor(data): consolidate SDD staging into manage_external_data.py (#3473)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -217,6 +217,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Consolidated SDD staging into the canonical external-data subsystem (#3473): the SDD asset
+  checksum policy, proxy-vs-dataset-backed availability gate, pinned-`expected_tree_sha256`
+  validation, disk-space fail-closed check, and no-auto-download safety contract (originally added
+  for #2657) now live in
+  [`scripts/tools/manage_external_data.py`](scripts/tools/manage_external_data.py) (new
+  `load_sdd_staging_spec`/`validate_sdd_staging`/`resolve_sdd_scenario_prior_mode`/`run_sdd_download`
+  functions and `sdd-plan|sdd-status|sdd-validate|sdd-mode|sdd-download` CLI commands). The `sdd`
+  `AssetSpec` now references the single staging manifest
+  ([`configs/data/sdd_staging_manifest.yaml`](configs/data/sdd_staging_manifest.yaml)) and carries
+  the availability/mode states, removing the previous two-sources-of-truth split.
+  [`scripts/data/stage_sdd_dataset_issue_2657.py`](scripts/data/stage_sdd_dataset_issue_2657.py) is
+  reduced to a thin compatibility wrapper that delegates to the canonical subsystem while preserving
+  its CLI/exit surface, and scenario-prior gating
+  ([`scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py`](scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py))
+  now consumes the canonical gate. Behavior preserved: the proxy-vs-dataset-backed gate stays
+  fail-closed and downloads still require explicit `--confirm-download` + y/N (or `--yes`). Migration
+  tests in
+  [`tests/tools/test_sdd_staging_consolidation_issue_3473.py`](tests/tools/test_sdd_staging_consolidation_issue_3473.py)
+  prove the proxy and dataset-backed decisions are identical through the canonical and wrapper paths
+  (#3473).
 * Refined the `goal-pr-review` skill (`.agents/skills/goal-pr-review/SKILL.md`) for clarity and
   determinism: added a mapping table that bridges `scripts/dev/pr_loop_policy.py` classifications
   (`pending_ci`, `failed_ci`, `missing_artifacts`, `stale_worktree`, `ready_to_merge`, `no_action`)

--- a/configs/data/sdd_staging_manifest.yaml
+++ b/configs/data/sdd_staging_manifest.yaml
@@ -1,8 +1,10 @@
-# Stanford Drone Dataset (SDD) staging manifest -- Issue #2657
+# Stanford Drone Dataset (SDD) staging manifest -- Issues #2657, #3473
 #
-# This manifest is the reproducible provenance contract for staging the Stanford Drone Dataset
-# locally so that scenario-prior generation can run in `dataset_backed_prior` mode. It is consumed
-# by scripts/data/stage_sdd_dataset_issue_2657.py.
+# This manifest is the single editable provenance contract for staging the Stanford Drone Dataset
+# locally so that scenario-prior generation can run in `dataset_backed_prior` mode. As of #3473 the
+# canonical owner is the external-data subsystem `scripts/tools/manage_external_data.py` (the `sdd`
+# AssetSpec references this manifest and the staging behavior lives there). The legacy entry point
+# `scripts/data/stage_sdd_dataset_issue_2657.py` is preserved as a thin wrapper that delegates here.
 #
 # SAFETY CONTRACT (enforced by the staging script):
 #   * The script NEVER auto-downloads. A default run only PLANS/REPORTS and exits.
@@ -77,3 +79,4 @@ related_issues:
   - 1497
   - 1126
   - 3161
+  - 3473

--- a/docs/context/issue_2657_sdd_staging.md
+++ b/docs/context/issue_2657_sdd_staging.md
@@ -4,6 +4,14 @@ This note makes SDD scenario-prior staging reproducible and connects staging sta
 scenario-prior generation, so dataset-backed claims cannot be implied without dataset-backed
 input. It follows [`docs/templates/external_data_audit.md`](../templates/external_data_audit.md).
 
+> **Consolidated under Issue #3473.** The SDD staging behavior now lives in the canonical
+> external-data subsystem `scripts/tools/manage_external_data.py` (the `sdd` `AssetSpec` references
+> the manifest `configs/data/sdd_staging_manifest.yaml`; canonical functions are
+> `load_sdd_staging_spec`, `validate_sdd_staging`, `resolve_sdd_scenario_prior_mode`,
+> `run_sdd_download`, with CLI `sdd-plan|sdd-status|sdd-validate|sdd-mode|sdd-download`).
+> `scripts/data/stage_sdd_dataset_issue_2657.py` is preserved as a thin wrapper that delegates to
+> the canonical subsystem, so the commands below still work unchanged.
+
 ## Summary
 
 - Dataset or asset name: Stanford Drone Dataset (SDD) annotations
@@ -75,7 +83,9 @@ Acquisition steps (user action, outside this tooling):
 - `dataset_backed_prior` — SDD staged **and** validated (expected files present and, if pinned,
   checksum match).
 
-The gate is exposed by `resolve_scenario_prior_mode()` in the staging tool and consumed by
+The gate is exposed by `resolve_sdd_scenario_prior_mode()` in the canonical subsystem
+`scripts/tools/manage_external_data.py` (still reachable as `resolve_scenario_prior_mode()` via the
+thin `scripts/data/stage_sdd_dataset_issue_2657.py` wrapper) and consumed by
 scenario-prior generation (`scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py`
 surfaces `scenario_prior_mode` / `dataset_backed` / `sdd_staging_gate` in its registry YAML and
 `report.json`). A missing or unvalidated SDD copy forces `proxy_schema_smoke`; only a

--- a/scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py
+++ b/scripts/analysis/calibrate_scenario_priors_from_traces_issue_2726.py
@@ -26,10 +26,11 @@ import yaml
 # parent 1 is scripts/analysis, parent 2 is scripts, parent 3 is the repo root.
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
 
-# scenario-prior staging mode tags (Issue #2657). Kept in sync with the staging tool.
+# scenario-prior staging mode tags (Issue #2657). Kept in sync with the canonical staging tool.
 MODE_PROXY = "proxy_schema_smoke"
 MODE_DATASET_BACKED = "dataset_backed_prior"
-SDD_STAGING_SCRIPT = REPO_ROOT / "scripts" / "data" / "stage_sdd_dataset_issue_2657.py"
+# Canonical external-data subsystem (issue #3473): the SDD scenario-prior gate lives here now.
+CANONICAL_EXTERNAL_DATA_SCRIPT = REPO_ROOT / "scripts" / "tools" / "manage_external_data.py"
 
 CLAIM_BOUNDARY = (
     "repository_trace_grounded_not_real_world_calibrated: this report and generated prior "
@@ -55,15 +56,17 @@ def resolve_staging_mode() -> dict[str, Any]:
             "are never dataset-backed regardless of SDD state."
         ),
     }
-    if not SDD_STAGING_SCRIPT.is_file():
+    if not CANONICAL_EXTERNAL_DATA_SCRIPT.is_file():
         return fallback
     try:
-        spec = importlib.util.spec_from_file_location("_sdd_staging_gate", SDD_STAGING_SCRIPT)
+        spec = importlib.util.spec_from_file_location(
+            "_sdd_staging_gate", CANONICAL_EXTERNAL_DATA_SCRIPT
+        )
         if spec is None or spec.loader is None:
             return fallback
         module = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(module)
-        gate = module.resolve_scenario_prior_mode()
+        gate = module.resolve_sdd_scenario_prior_mode()
     except Exception as exc:
         fallback["reason"] = f"SDD staging gate error ({exc}); defaulting to proxy_schema_smoke."
         return fallback

--- a/scripts/data/stage_sdd_dataset_issue_2657.py
+++ b/scripts/data/stage_sdd_dataset_issue_2657.py
@@ -1,26 +1,29 @@
 #!/usr/bin/env python3
-"""Reproducible Stanford Drone Dataset (SDD) staging for Issue #2657.
+"""Thin compatibility wrapper for SDD staging (Issue #2657, consolidated under Issue #3473).
 
-This tool makes local SDD staging reproducible and connects staging state to scenario-prior
-generation, so dataset-backed claims cannot be implied without dataset-backed input.
+The SDD staging subsystem (manifest parsing, pinned-checksum validation, the proxy-vs-dataset-backed
+scenario-prior gate, the disk-space check, and the no-auto-download safety contract) now lives in
+the canonical external-data subsystem:
 
-SAFETY CONTRACT (all enforced here):
+    scripts/tools/manage_external_data.py
 
-* **Never auto-download.** A default invocation only PLANS/REPORTS (what would be downloaded,
-  where, expected size, disk check) and exits WITHOUT touching the network.
-* A network fetch requires an explicit ``--confirm-download`` flag AND an interactive ``y/N``
-  prompt. The prompt is skipped only when ``--yes`` is also given for non-interactive use.
-* Available disk space is checked against the manifest's expected size BEFORE any fetch; the tool
-  fails closed (refuses) if free space is insufficient, reporting required vs available.
-* After a download completes the tool validates the expected files/structure and records an
-  aggregate SHA-256 tree checksum, reporting success or failure clearly.
+That module owns the ``sdd`` asset specification and is the single source of truth for the SDD
+checksum policy and availability states. This file is preserved only as a thin shim so existing
+callers, tests, and the documented CLI surface keep working. New code should import the canonical
+``manage_external_data`` functions (``load_sdd_staging_spec``, ``validate_sdd_staging``,
+``resolve_sdd_scenario_prior_mode``, ``run_sdd_download`` ...) directly.
+
+SAFETY CONTRACT (unchanged; enforced in the canonical module):
+
+* **Never auto-download.** A default invocation only PLANS/REPORTS and exits without touching the
+  network.
+* A network fetch requires an explicit ``--confirm-download`` flag AND an interactive ``y/N`` prompt
+  (skipped only when ``--yes`` is also given for non-interactive use).
+* Free disk space is checked against the manifest's expected size BEFORE any fetch; the tool fails
+  closed when free space is insufficient.
+* A staged tree is validated against the pinned ``expected_tree_sha256`` before being marked
+  ``staged``; a mismatch refuses to mark SDD as dataset-backed.
 * Raw data is staged into a **git-ignored** subfolder (``output/external_data/sdd`` by default).
-* ``--check`` reports local availability (``staged`` vs ``missing``) and checksums WITHOUT
-  downloading.
-
-The manifest at ``configs/data/sdd_staging_manifest.yaml`` is the provenance contract: source URL,
-license/readme pointer, version tag, expected files, expected size, checksum placeholders, and the
-``local_availability`` gate.
 
 Usage::
 
@@ -32,511 +35,68 @@ Usage::
     uv run python scripts/data/stage_sdd_dataset_issue_2657.py validate
     # Real staging requires explicit confirmation AND a configured download URL:
     uv run python scripts/data/stage_sdd_dataset_issue_2657.py download --confirm-download
+
+The canonical CLI equivalents are ``manage_external_data.py sdd-plan|sdd-status|sdd-validate|
+sdd-mode|sdd-download``.
 """
 
 from __future__ import annotations
 
 import argparse
-import datetime as dt
-import hashlib
 import json
-import shutil
-from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-import yaml
+from scripts.tools import manage_external_data as _canonical
+from scripts.tools.manage_external_data import (
+    DEFAULT_SDD_STAGING_MANIFEST as DEFAULT_MANIFEST_PATH,
+)
+from scripts.tools.manage_external_data import (
+    ExternalDataError,
+)
+from scripts.tools.manage_external_data import (
+    SddStagingSpec as SddManifest,
+)
 
-# parent 1 is scripts/data, parent 2 is scripts, parent 3 is the repo root.
-REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_MANIFEST_PATH = REPO_ROOT / "configs" / "data" / "sdd_staging_manifest.yaml"
-STAGING_STATUS_FILENAME = "sdd_staging_status.json"
-DEFAULT_STAGING_ROOT = (REPO_ROOT / "output").resolve()
+# Backwards-compatible alias: the #2657 module raised SddStagingError. The canonical subsystem uses
+# ExternalDataError; alias it so callers/tests catching SddStagingError keep working.
+SddStagingError = ExternalDataError
 
-# Mode tags surfaced to scenario-prior generation. These names are part of the public contract.
-MODE_PROXY = "proxy_schema_smoke"
-MODE_DATASET_BACKED = "dataset_backed_prior"
+REPO_ROOT = _canonical.REPO_ROOT
 
+# Re-export canonical names under their historical #2657 names so existing imports/tests and the
+# documented CLI surface keep working after consolidation. These are module-level assignments (not
+# `import as`) so the linter does not strip them as unused re-exports.
+MODE_PROXY = _canonical.SDD_MODE_PROXY
+MODE_DATASET_BACKED = _canonical.SDD_MODE_DATASET_BACKED
+STAGING_STATUS_FILENAME = _canonical.SDD_STAGING_STATUS_FILENAME
+DEFAULT_STAGING_ROOT = _canonical.DEFAULT_STAGING_ROOT
+ExpectedFile = _canonical.SddExpectedFile
 
-class SddStagingError(RuntimeError):
-    """Raised when SDD staging cannot be planned, validated, or completed safely."""
-
-
-@dataclass(frozen=True)
-class ExpectedFile:
-    """One expected-file pattern declared by the staging manifest."""
-
-    pattern: str
-    kind: str
-    description: str
-    min_count: int = 1
-
-
-@dataclass(frozen=True)
-class SddManifest:
-    """Parsed SDD staging manifest contract."""
-
-    asset_id: str
-    title: str
-    version_tag: str
-    source_url: str
-    license: str
-    license_url: str
-    readme_pointer: str
-    staging_dir: Path
-    download_url: str | None
-    access_note: str
-    expected_files: tuple[ExpectedFile, ...]
-    expected_total_size_bytes: int
-    checksum_algorithm: str
-    expected_tree_sha256: str | None
-    local_availability_declared: str
-
-    @property
-    def expected_total_size_mib(self) -> float:
-        """Expected footprint in MiB for human-readable reporting."""
-        return self.expected_total_size_bytes / (1024 * 1024)
-
-
-def load_manifest(manifest_path: Path = DEFAULT_MANIFEST_PATH) -> SddManifest:
-    """Load and validate the SDD staging manifest."""
-    if not manifest_path.is_file():
-        raise SddStagingError(f"Staging manifest not found: {manifest_path}")
-    raw = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-    if not isinstance(raw, dict):
-        raise SddStagingError(f"Manifest is not a mapping: {manifest_path}")
-
-    staging_dir_raw = str(raw.get("staging_dir", "")).strip()
-    if not staging_dir_raw:
-        raise SddStagingError("Manifest is missing required `staging_dir`.")
-    staging_dir = _resolve_staging_dir(staging_dir_raw, manifest_path=manifest_path)
-
-    expected_files_raw = raw.get("expected_files") or []
-    if not isinstance(expected_files_raw, list) or not expected_files_raw:
-        raise SddStagingError("Manifest must declare a non-empty `expected_files` list.")
-    expected_files = _parse_expected_files(expected_files_raw)
-
-    size_bytes = int(raw.get("expected_total_size_bytes", 0))
-    if size_bytes <= 0:
-        raise SddStagingError("Manifest must declare a positive `expected_total_size_bytes`.")
-
-    checksums = raw.get("checksums") or {}
-    download_url = raw.get("download_url")
-
-    return SddManifest(
-        asset_id=str(raw.get("asset_id", "sdd")),
-        title=str(raw.get("title", "Stanford Drone Dataset")),
-        version_tag=str(raw.get("version_tag", "unknown")),
-        source_url=str(raw.get("source_url", "")),
-        license=str(raw.get("license", "")),
-        license_url=str(raw.get("license_url", "")),
-        readme_pointer=str(raw.get("readme_pointer", "")),
-        staging_dir=staging_dir,
-        download_url=str(download_url) if download_url else None,
-        access_note=str(raw.get("access_note", "")),
-        expected_files=expected_files,
-        expected_total_size_bytes=size_bytes,
-        checksum_algorithm=str(checksums.get("algorithm", "SHA-256")),
-        expected_tree_sha256=(
-            str(checksums["expected_tree_sha256"])
-            if checksums.get("expected_tree_sha256")
-            else None
-        ),
-        local_availability_declared=str(raw.get("local_availability", "missing")),
-    )
-
-
-def _parse_expected_files(expected_files_raw: list[Any]) -> tuple[ExpectedFile, ...]:
-    """Parse manifest expected-file entries with fail-closed error messages."""
-    expected_files: list[ExpectedFile] = []
-    for index, entry in enumerate(expected_files_raw):
-        if not isinstance(entry, dict):
-            raise SddStagingError(f"`expected_files[{index}]` must be a mapping.")
-        pattern = str(entry.get("pattern", "")).strip()
-        if not pattern:
-            raise SddStagingError(f"`expected_files[{index}].pattern` is required.")
-        try:
-            min_count = int(entry.get("min_count", 1))
-        except (TypeError, ValueError) as exc:
-            raise SddStagingError(
-                f"`expected_files[{index}].min_count` must be an integer."
-            ) from exc
-        if min_count <= 0:
-            raise SddStagingError(f"`expected_files[{index}].min_count` must be positive.")
-        expected_files.append(
-            ExpectedFile(
-                pattern=pattern,
-                kind=str(entry.get("kind", "file")),
-                description=str(entry.get("description", "")),
-                min_count=min_count,
-            )
-        )
-    return tuple(expected_files)
-
-
-def _resolve_staging_dir(staging_dir_raw: str, *, manifest_path: Path) -> Path:
-    """Resolve a manifest staging dir while rejecting unsafe path escapes."""
-    staging_dir = Path(staging_dir_raw).expanduser()
-    if ".." in staging_dir.parts:
-        raise SddStagingError("Manifest staging_dir must not contain path traversal (`..`).")
-
-    unresolved = staging_dir if staging_dir.is_absolute() else REPO_ROOT / staging_dir
-    if unresolved.is_symlink():
-        raise SddStagingError(f"Manifest staging_dir must not be a symlink: {unresolved}")
-
-    resolved = unresolved.resolve(strict=False)
-    allowed_roots = (DEFAULT_STAGING_ROOT, manifest_path.resolve(strict=False).parent)
-    if not any(resolved == root or resolved.is_relative_to(root) for root in allowed_roots):
-        allowed = ", ".join(str(root) for root in allowed_roots)
-        raise SddStagingError(
-            f"Manifest staging_dir resolves outside allowed roots: {resolved}. "
-            f"Allowed roots: {allowed}."
-        )
-    return resolved
-
-
-def _cached_staging_gate(manifest: SddManifest) -> dict[str, Any] | None:
-    """Return a dataset-backed gate from cached status when it is still structurally valid."""
-    status_path = manifest.staging_dir / STAGING_STATUS_FILENAME
-    if not status_path.is_file():
-        return None
-    try:
-        status = json.loads(status_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
-        return None
-    if not isinstance(status, dict):
-        return None
-    if status.get("local_availability") != "staged":
-        return None
-    if (
-        status.get("asset_id") != manifest.asset_id
-        or status.get("version_tag") != manifest.version_tag
-    ):
-        return None
-
-    for expected in manifest.expected_files:
-        if len(_match_expected(manifest.staging_dir, expected)) < expected.min_count:
-            return None
-
-    return {
-        "mode": MODE_DATASET_BACKED,
-        "dataset_backed": True,
-        "reason": f"SDD is staged and validated (cached via {STAGING_STATUS_FILENAME}).",
-        "asset_id": manifest.asset_id,
-        "version_tag": manifest.version_tag,
-        "tree_sha256": status.get("tree_sha256"),
-        "staging_dir": str(manifest.staging_dir),
-        "report": status,
-    }
-
-
-def _match_expected(staging_dir: Path, expected: ExpectedFile) -> list[Path]:
-    """Return files under staging_dir matching one expected-file pattern."""
-    if not staging_dir.exists():
-        return []
-    matches = sorted(staging_dir.glob(expected.pattern))
-    if expected.kind == "file":
-        return [path for path in matches if path.is_file()]
-    if expected.kind == "directory":
-        return [path for path in matches if path.is_dir()]
-    raise SddStagingError(f"Unsupported expected-file kind: {expected.kind}")
-
-
-def _iter_files(paths: list[Path]) -> list[Path]:
-    """Expand matched paths into a deterministic, de-duplicated file list."""
-    files: list[Path] = []
-    for path in paths:
-        if path.is_file():
-            files.append(path)
-        elif path.is_dir():
-            files.extend(child for child in path.rglob("*") if child.is_file())
-    return sorted({path.resolve() for path in files})
-
-
-def _tree_checksum(staging_dir: Path, matched_paths: list[Path]) -> dict[str, Any]:
-    """Compute an aggregate SHA-256 tree checksum over matched files."""
-    digest = hashlib.sha256()
-    sample_files: list[dict[str, Any]] = []
-    total_size = 0
-    files = _iter_files(matched_paths)
-    for file_path in files:
-        file_digest = hashlib.sha256()
-        with file_path.open("rb") as handle:
-            for chunk in iter(lambda: handle.read(1024 * 1024), b""):
-                file_digest.update(chunk)
-        size = file_path.stat().st_size
-        total_size += size
-        rel = file_path.relative_to(staging_dir).as_posix()
-        file_sha = file_digest.hexdigest()
-        digest.update(rel.encode("utf-8"))
-        digest.update(b"\0")
-        digest.update(str(size).encode("ascii"))
-        digest.update(b"\0")
-        digest.update(file_sha.encode("ascii"))
-        digest.update(b"\0")
-        if len(sample_files) < 10:
-            sample_files.append({"path": rel, "size_bytes": size, "sha256": file_sha})
-    return {
-        "file_count": len(files),
-        "total_size_bytes": total_size,
-        "tree_sha256": digest.hexdigest() if files else None,
-        "sample_files": sample_files,
-    }
-
-
-def validate_staging(manifest: SddManifest, *, compute_checksum: bool = True) -> dict[str, Any]:
-    """Validate the locally-staged SDD copy against the manifest contract.
-
-    Returns a report dict. ``ok`` is True only when every expected-file group meets its minimum
-    count; ``local_availability`` is ``staged`` only when ``ok`` is True.
-    """
-    staging_dir = manifest.staging_dir
-    report: dict[str, Any] = {
-        "asset_id": manifest.asset_id,
-        "version_tag": manifest.version_tag,
-        "staging_dir": str(staging_dir),
-        "staging_dir_exists": staging_dir.exists(),
-        "expected_files": [
-            {
-                "pattern": expected.pattern,
-                "kind": expected.kind,
-                "description": expected.description,
-                "min_count": expected.min_count,
-            }
-            for expected in manifest.expected_files
-        ],
-        "matched_files": [],
-        "missing_expected": [],
-        "ok": False,
-        "local_availability": "missing",
-        "mode": MODE_PROXY,
-    }
-
-    matched_paths: list[Path] = []
-    for expected in manifest.expected_files:
-        group_matches = _match_expected(staging_dir, expected)
-        if len(group_matches) < expected.min_count:
-            report["missing_expected"].append(
-                f"{expected.pattern} (need >= {expected.min_count}, found {len(group_matches)})"
-            )
-            continue
-        matched_paths.extend(group_matches)
-
-    if matched_paths and staging_dir.exists():
-        report["matched_files"] = [
-            path.relative_to(staging_dir).as_posix() for path in sorted(matched_paths)
-        ]
-
-    if report["missing_expected"]:
-        report["action"] = (
-            "SDD is not staged or is incomplete. Follow the manifest access_note to acquire SDD "
-            "under its license, then re-run validation. Until then, scenario-prior generation is "
-            f"forced to `{MODE_PROXY}`."
-        )
-        return report
-
-    if not compute_checksum:
-        report["checksum_skipped"] = (
-            "tree checksum omitted for plan/status speed; run `validate` for checksum proof"
-        )
-        report["local_availability"] = "present_unvalidated"
-        report["action"] = (
-            f"SDD expected files are present. Run `validate` to compute checksums before treating "
-            f"the copy as `{MODE_DATASET_BACKED}` evidence."
-        )
-        return report
-
-    checksum = _tree_checksum(staging_dir, matched_paths)
-    report["file_count"] = checksum["file_count"]
-    report["total_size_bytes"] = checksum["total_size_bytes"]
-    report["tree_sha256"] = checksum["tree_sha256"]
-    report["sample_files"] = checksum["sample_files"]
-    report["checksum_algorithm"] = manifest.checksum_algorithm
-
-    if manifest.expected_tree_sha256 is None:
-        report["local_availability"] = "present_unpinned_checksum"
-        report["action"] = (
-            "Expected SDD files are present and a tree checksum was computed, but the manifest does "
-            "not pin `expected_tree_sha256`. Refusing to mark SDD as dataset-backed until a trusted "
-            f"checksum is pinned. Scenario-prior generation remains forced to `{MODE_PROXY}`."
-        )
-        return report
-
-    report["expected_tree_sha256"] = manifest.expected_tree_sha256
-    report["checksum_match"] = checksum["tree_sha256"] == manifest.expected_tree_sha256
-    if not report["checksum_match"]:
-        report["action"] = (
-            "Staged files do not match the pinned `expected_tree_sha256` in the manifest. "
-            "Refusing to mark SDD as staged; treat as untrusted and re-acquire. Scenario-prior "
-            f"generation remains forced to `{MODE_PROXY}`."
-        )
-        return report
-
-    report["ok"] = True
-    report["local_availability"] = "staged"
-    report["mode"] = MODE_DATASET_BACKED
-    report["action"] = (
-        f"SDD is staged and validated. Scenario-prior generation may run in `{MODE_DATASET_BACKED}` "
-        "mode for dataset-backed input."
-    )
-    return report
-
-
-def resolve_scenario_prior_mode(
-    manifest: SddManifest | None = None,
-    *,
-    manifest_path: Path = DEFAULT_MANIFEST_PATH,
-) -> dict[str, Any]:
-    """Resolve the scenario-prior generation mode from SDD staging state.
-
-    This is the gate scenario-prior generation imports. A missing or unvalidated SDD copy forces
-    ``proxy_schema_smoke``; only a staged-and-validated copy unlocks ``dataset_backed_prior``.
-
-    Returns a compact dict: ``mode``, ``dataset_backed`` (bool), ``reason``, and the validation
-    ``report`` for provenance.
-    """
-    manifest = manifest or load_manifest(manifest_path)
-    if cached_gate := _cached_staging_gate(manifest):
-        return cached_gate
-
-    report = validate_staging(manifest)
-    dataset_backed = bool(report["ok"])
-    return {
-        "mode": MODE_DATASET_BACKED if dataset_backed else MODE_PROXY,
-        "dataset_backed": dataset_backed,
-        "reason": report["action"],
-        "asset_id": manifest.asset_id,
-        "version_tag": manifest.version_tag,
-        "tree_sha256": report.get("tree_sha256"),
-        "staging_dir": str(manifest.staging_dir),
-        "report": report,
-    }
-
-
-def check_disk_space(manifest: SddManifest) -> dict[str, Any]:
-    """Check free disk space at the staging location against the expected dataset size."""
-    # Walk up to the first existing ancestor so disk_usage works before the dir is created.
-    probe = manifest.staging_dir
-    while not probe.exists() and probe != probe.parent:
-        probe = probe.parent
-    usage = shutil.disk_usage(probe)
-    required = manifest.expected_total_size_bytes
-    sufficient = usage.free >= required
-    return {
-        "probe_path": str(probe),
-        "required_bytes": required,
-        "required_mib": round(required / (1024 * 1024), 1),
-        "available_bytes": usage.free,
-        "available_mib": round(usage.free / (1024 * 1024), 1),
-        "sufficient": sufficient,
-    }
-
-
-def build_plan(manifest: SddManifest) -> dict[str, Any]:
-    """Build the plan/report payload for a default (non-downloading) invocation."""
-    validation = validate_staging(manifest, compute_checksum=False)
-    disk = check_disk_space(manifest)
-    return {
-        "schema": "sdd_staging_plan.v1",
-        "asset_id": manifest.asset_id,
-        "title": manifest.title,
-        "version_tag": manifest.version_tag,
-        "source_url": manifest.source_url,
-        "license": manifest.license,
-        "license_url": manifest.license_url,
-        "readme_pointer": manifest.readme_pointer,
-        "staging_dir": str(manifest.staging_dir),
-        "download_url": manifest.download_url,
-        "access_note": manifest.access_note,
-        "expected_total_size_bytes": manifest.expected_total_size_bytes,
-        "expected_total_size_mib": round(manifest.expected_total_size_mib, 1),
-        "disk_check": disk,
-        "would_download": False,
-        "auto_download": False,
-        "local_availability": validation["local_availability"],
-        "scenario_prior_mode": validation["mode"],
-        "validation": validation,
-        "next_step": (
-            "This is a PLAN ONLY; nothing was downloaded. To stage SDD you must (1) obtain it under "
-            "its license per access_note, (2) configure a download URL or place files under the "
-            "staging_dir, and (3) re-run with `download --confirm-download` to explicitly confirm."
-        ),
-    }
-
-
-def _write_staging_status(manifest: SddManifest, report: dict[str, Any]) -> Path:
-    """Write a staging-status manifest into the staging dir after validation."""
-    manifest.staging_dir.mkdir(parents=True, exist_ok=True)
-    status_path = manifest.staging_dir / STAGING_STATUS_FILENAME
-    payload = {
-        "schema": "sdd_staging_status.v1",
-        "asset_id": manifest.asset_id,
-        "version_tag": manifest.version_tag,
-        "source_url": manifest.source_url,
-        "license": manifest.license,
-        "checksum_algorithm": manifest.checksum_algorithm,
-        "tree_sha256": report.get("tree_sha256"),
-        "file_count": report.get("file_count"),
-        "total_size_bytes": report.get("total_size_bytes"),
-        "sample_files": report.get("sample_files", []),
-        "local_availability": report["local_availability"],
-        "validated_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat(),
-    }
-    status_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
-    return status_path
-
-
-def _confirm_download(args: argparse.Namespace) -> bool:
-    """Return True only when the user has explicitly confirmed a network download.
-
-    Requires the ``--confirm-download`` flag AND an interactive y/N (or ``--yes`` for
-    non-interactive confirmation). Default behavior never confirms.
-    """
-    if not args.confirm_download:
-        return False
-    if args.yes:
-        return True
-    try:
-        answer = input(
-            "About to download the Stanford Drone Dataset to a git-ignored folder. "
-            "This consumes disk and network. Proceed? [y/N]: "
-        )
-    except EOFError:
-        return False
-    return answer.strip().lower() in {"y", "yes"}
+# Re-export canonical primitives under their historical #2657 names.
+_tree_checksum = _canonical._tree_checksum
+load_manifest = _canonical.load_sdd_staging_spec
+validate_staging = _canonical.validate_sdd_staging
+resolve_scenario_prior_mode = _canonical.resolve_sdd_scenario_prior_mode
+check_disk_space = _canonical.check_sdd_disk_space
+build_plan = _canonical.build_sdd_plan
+_write_staging_status = _canonical.write_sdd_staging_status
 
 
 def run_download(manifest: SddManifest, args: argparse.Namespace) -> dict[str, Any]:
-    """Run the guarded download path. Fails closed at every safety gate."""
-    if not _confirm_download(args):
-        raise SddStagingError(
-            "Download not confirmed. This tool never auto-downloads: pass `--confirm-download` and "
-            "answer the y/N prompt (or add `--yes` for non-interactive confirmation). A default run "
-            "only plans and reports."
-        )
+    """Compatibility wrapper preserving the #2657 ``run_download(manifest, args)`` signature."""
+    return _canonical.run_sdd_download(
+        manifest,
+        confirm_download=getattr(args, "confirm_download", False),
+        yes=getattr(args, "yes", False),
+    )
 
-    disk = check_disk_space(manifest)
-    if not disk["sufficient"]:
-        raise SddStagingError(
-            "Insufficient disk space at "
-            f"{disk['probe_path']}: required {disk['required_mib']} MiB, "
-            f"available {disk['available_mib']} MiB. Refusing to download (fail closed)."
-        )
 
-    if not manifest.download_url:
-        raise SddStagingError(
-            "No download URL is configured for SDD. SDD is license-gated and the repository encodes "
-            "no approved direct download URL. Obtain it from the official project page "
-            f"({manifest.source_url}) under its license, place the annotation files under "
-            f"{manifest.staging_dir}, then run validation. {manifest.access_note}"
-        )
-
-    # A real network fetch would happen here using manifest.download_url. It is intentionally NOT
-    # implemented because SDD is license-gated and no approved URL is encoded; reaching this point
-    # requires a maintainer to add a URL to the manifest first.
-    raise SddStagingError(
-        "Confirmed and disk-checked, but no downloader is wired for the configured URL. A "
-        "maintainer must implement the fetch for the license-approved URL before this path runs."
+def _confirm_download(args: argparse.Namespace) -> bool:
+    """Compatibility wrapper around the canonical confirmation gate."""
+    return _canonical.confirm_sdd_download(
+        confirm_download=getattr(args, "confirm_download", False),
+        yes=getattr(args, "yes", False),
     )
 
 
@@ -585,7 +145,7 @@ def _validation_lines(report: dict[str, Any]) -> list[str]:
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    """Parse CLI arguments."""
+    """Parse CLI arguments (preserved #2657 surface)."""
     parser = argparse.ArgumentParser(
         description=__doc__,
         formatter_class=argparse.RawDescriptionHelpFormatter,
@@ -624,7 +184,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 
 def main(argv: list[str] | None = None) -> int:
-    """Run the SDD staging tool."""
+    """Run the SDD staging tool via the canonical subsystem (preserved #2657 CLI)."""
     args = parse_args(argv)
     try:
         manifest = load_manifest(args.manifest)

--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -12,13 +12,28 @@ import argparse
 import datetime as dt
 import hashlib
 import json
+import shutil
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST_DIR = REPO_ROOT / "output" / "external_data" / "manifests"
+
+# Canonical SDD staging manifest. This is the single editable provenance contract for the SDD
+# asset (issues #2657, #3473): maintainers pin `expected_tree_sha256` and tune the disk-check size
+# here, while all behavior lives in this module (the former scripts/data wrapper just delegates).
+DEFAULT_SDD_STAGING_MANIFEST = REPO_ROOT / "configs" / "data" / "sdd_staging_manifest.yaml"
+DEFAULT_STAGING_ROOT = (REPO_ROOT / "output").resolve()
+SDD_STAGING_STATUS_FILENAME = "sdd_staging_status.json"
+
+# Scenario-prior mode tags surfaced to scenario-prior generation. These names are part of the
+# public gate contract consumed by scripts/analysis/calibrate_scenario_priors_from_traces_*.
+SDD_MODE_PROXY = "proxy_schema_smoke"
+SDD_MODE_DATASET_BACKED = "dataset_backed_prior"
 
 
 class ExternalDataError(RuntimeError):
@@ -49,6 +64,12 @@ class AssetSpec:
     required_paths: tuple[RequiredPath, ...]
     related_issues: tuple[int, ...]
     auto_download_allowed: bool = False
+    # Optional pointer to a checksum/availability staging manifest. When set, this asset carries a
+    # pinned-checksum policy and proxy-vs-dataset-backed availability states (see the SDD asset).
+    staging_manifest_path: Path | None = None
+    # Availability/proxy-vs-dataset-backed gate mode tags for assets that gate downstream evidence.
+    proxy_mode: str | None = None
+    dataset_backed_mode: str | None = None
 
 
 ASSETS: tuple[AssetSpec, ...] = (
@@ -73,7 +94,13 @@ ASSETS: tuple[AssetSpec, ...] = (
                 description="Original SDD annotation text file.",
             ),
         ),
-        related_issues=(1497, 1126),
+        related_issues=(2657, 1497, 1126, 3161, 3473),
+        # Single source of truth for the SDD checksum/availability policy (issues #2657, #3473):
+        # the staging manifest pins `expected_tree_sha256` and the disk-check size, while the
+        # availability states + scenario-prior gate live in this module.
+        staging_manifest_path=DEFAULT_SDD_STAGING_MANIFEST,
+        proxy_mode=SDD_MODE_PROXY,
+        dataset_backed_mode=SDD_MODE_DATASET_BACKED,
     ),
     AssetSpec(
         asset_id="socnavbench-s3dis-eth",
@@ -438,6 +465,451 @@ def download_asset(asset_id: str) -> None:
     raise ExternalDataError(f"No downloader is implemented for {asset.asset_id}.")
 
 
+# --------------------------------------------------------------------------------------------
+# Canonical SDD staging subsystem (consolidated from scripts/data/stage_sdd_dataset_issue_2657.py
+# for issue #3473). This module is the single source of truth for the SDD checksum policy, the
+# proxy-vs-dataset-backed availability gate, and the no-auto-download safety contract from #2657.
+# --------------------------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class SddExpectedFile:
+    """One expected-file pattern declared by the SDD staging manifest."""
+
+    pattern: str
+    kind: str
+    description: str
+    min_count: int = 1
+
+
+@dataclass(frozen=True)
+class SddStagingSpec:
+    """Parsed SDD staging manifest contract (checksum policy + availability gate)."""
+
+    asset_id: str
+    title: str
+    version_tag: str
+    source_url: str
+    license: str
+    license_url: str
+    readme_pointer: str
+    staging_dir: Path
+    download_url: str | None
+    access_note: str
+    expected_files: tuple[SddExpectedFile, ...]
+    expected_total_size_bytes: int
+    checksum_algorithm: str
+    expected_tree_sha256: str | None
+    local_availability_declared: str
+
+    @property
+    def expected_total_size_mib(self) -> float:
+        """Expected footprint in MiB for human-readable reporting."""
+        return self.expected_total_size_bytes / (1024 * 1024)
+
+
+def _sdd_manifest_path(spec: AssetSpec | None = None) -> Path:
+    """Resolve the canonical SDD staging manifest path from the asset registry."""
+    asset = spec or _get_asset("sdd")
+    if asset.staging_manifest_path is None:
+        raise ExternalDataError(f"Asset '{asset.asset_id}' declares no staging manifest path.")
+    return asset.staging_manifest_path
+
+
+def _resolve_sdd_staging_dir(staging_dir_raw: str, *, manifest_path: Path) -> Path:
+    """Resolve a manifest staging dir while rejecting unsafe path escapes."""
+    staging_dir = Path(staging_dir_raw).expanduser()
+    if ".." in staging_dir.parts:
+        raise ExternalDataError("Manifest staging_dir must not contain path traversal (`..`).")
+
+    unresolved = staging_dir if staging_dir.is_absolute() else REPO_ROOT / staging_dir
+    if unresolved.is_symlink():
+        raise ExternalDataError(f"Manifest staging_dir must not be a symlink: {unresolved}")
+
+    resolved = unresolved.resolve(strict=False)
+    allowed_roots = (DEFAULT_STAGING_ROOT, manifest_path.resolve(strict=False).parent)
+    if not any(resolved == root or resolved.is_relative_to(root) for root in allowed_roots):
+        allowed = ", ".join(str(root) for root in allowed_roots)
+        raise ExternalDataError(
+            f"Manifest staging_dir resolves outside allowed roots: {resolved}. "
+            f"Allowed roots: {allowed}."
+        )
+    return resolved
+
+
+def _parse_sdd_expected_files(expected_files_raw: list[Any]) -> tuple[SddExpectedFile, ...]:
+    """Parse manifest expected-file entries with fail-closed error messages."""
+    expected_files: list[SddExpectedFile] = []
+    for index, entry in enumerate(expected_files_raw):
+        if not isinstance(entry, dict):
+            raise ExternalDataError(f"`expected_files[{index}]` must be a mapping.")
+        pattern = str(entry.get("pattern", "")).strip()
+        if not pattern:
+            raise ExternalDataError(f"`expected_files[{index}].pattern` is required.")
+        try:
+            min_count = int(entry.get("min_count", 1))
+        except (TypeError, ValueError) as exc:
+            raise ExternalDataError(
+                f"`expected_files[{index}].min_count` must be an integer."
+            ) from exc
+        if min_count <= 0:
+            raise ExternalDataError(f"`expected_files[{index}].min_count` must be positive.")
+        expected_files.append(
+            SddExpectedFile(
+                pattern=pattern,
+                kind=str(entry.get("kind", "file")),
+                description=str(entry.get("description", "")),
+                min_count=min_count,
+            )
+        )
+    return tuple(expected_files)
+
+
+def load_sdd_staging_spec(manifest_path: Path | None = None) -> SddStagingSpec:
+    """Load and validate the canonical SDD staging manifest."""
+    path = manifest_path or _sdd_manifest_path()
+    if not path.is_file():
+        raise ExternalDataError(f"Staging manifest not found: {path}")
+    raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, dict):
+        raise ExternalDataError(f"Manifest is not a mapping: {path}")
+
+    staging_dir_raw = str(raw.get("staging_dir", "")).strip()
+    if not staging_dir_raw:
+        raise ExternalDataError("Manifest is missing required `staging_dir`.")
+    staging_dir = _resolve_sdd_staging_dir(staging_dir_raw, manifest_path=path)
+
+    expected_files_raw = raw.get("expected_files") or []
+    if not isinstance(expected_files_raw, list) or not expected_files_raw:
+        raise ExternalDataError("Manifest must declare a non-empty `expected_files` list.")
+    expected_files = _parse_sdd_expected_files(expected_files_raw)
+
+    size_bytes = int(raw.get("expected_total_size_bytes", 0))
+    if size_bytes <= 0:
+        raise ExternalDataError("Manifest must declare a positive `expected_total_size_bytes`.")
+
+    checksums = raw.get("checksums") or {}
+    download_url = raw.get("download_url")
+
+    return SddStagingSpec(
+        asset_id=str(raw.get("asset_id", "sdd")),
+        title=str(raw.get("title", "Stanford Drone Dataset")),
+        version_tag=str(raw.get("version_tag", "unknown")),
+        source_url=str(raw.get("source_url", "")),
+        license=str(raw.get("license", "")),
+        license_url=str(raw.get("license_url", "")),
+        readme_pointer=str(raw.get("readme_pointer", "")),
+        staging_dir=staging_dir,
+        download_url=str(download_url) if download_url else None,
+        access_note=str(raw.get("access_note", "")),
+        expected_files=expected_files,
+        expected_total_size_bytes=size_bytes,
+        checksum_algorithm=str(checksums.get("algorithm", "SHA-256")),
+        expected_tree_sha256=(
+            str(checksums["expected_tree_sha256"])
+            if checksums.get("expected_tree_sha256")
+            else None
+        ),
+        local_availability_declared=str(raw.get("local_availability", "missing")),
+    )
+
+
+def _match_sdd_expected(staging_dir: Path, expected: SddExpectedFile) -> list[Path]:
+    """Return files under staging_dir matching one expected-file pattern."""
+    if not staging_dir.exists():
+        return []
+    matches = sorted(staging_dir.glob(expected.pattern))
+    if expected.kind == "file":
+        return [path for path in matches if path.is_file()]
+    if expected.kind == "directory":
+        return [path for path in matches if path.is_dir()]
+    raise ExternalDataError(f"Unsupported expected-file kind: {expected.kind}")
+
+
+def validate_sdd_staging(spec: SddStagingSpec, *, compute_checksum: bool = True) -> dict[str, Any]:
+    """Validate the locally-staged SDD copy against the manifest contract.
+
+    ``ok`` is True only when every expected-file group meets its minimum count AND the staged tree
+    matches the pinned ``expected_tree_sha256``; ``local_availability`` is ``staged`` only then.
+    """
+    staging_dir = spec.staging_dir
+    report: dict[str, Any] = {
+        "asset_id": spec.asset_id,
+        "version_tag": spec.version_tag,
+        "staging_dir": str(staging_dir),
+        "staging_dir_exists": staging_dir.exists(),
+        "expected_files": [
+            {
+                "pattern": expected.pattern,
+                "kind": expected.kind,
+                "description": expected.description,
+                "min_count": expected.min_count,
+            }
+            for expected in spec.expected_files
+        ],
+        "matched_files": [],
+        "missing_expected": [],
+        "ok": False,
+        "local_availability": "missing",
+        "mode": SDD_MODE_PROXY,
+    }
+
+    matched_paths: list[Path] = []
+    for expected in spec.expected_files:
+        group_matches = _match_sdd_expected(staging_dir, expected)
+        if len(group_matches) < expected.min_count:
+            report["missing_expected"].append(
+                f"{expected.pattern} (need >= {expected.min_count}, found {len(group_matches)})"
+            )
+            continue
+        matched_paths.extend(group_matches)
+
+    if matched_paths and staging_dir.exists():
+        report["matched_files"] = [
+            path.relative_to(staging_dir).as_posix() for path in sorted(matched_paths)
+        ]
+
+    if report["missing_expected"]:
+        report["action"] = (
+            "SDD is not staged or is incomplete. Follow the manifest access_note to acquire SDD "
+            "under its license, then re-run validation. Until then, scenario-prior generation is "
+            f"forced to `{SDD_MODE_PROXY}`."
+        )
+        return report
+
+    if not compute_checksum:
+        report["checksum_skipped"] = (
+            "tree checksum omitted for plan/status speed; run `validate` for checksum proof"
+        )
+        report["local_availability"] = "present_unvalidated"
+        report["action"] = (
+            "SDD expected files are present. Run `validate` to compute checksums before treating "
+            f"the copy as `{SDD_MODE_DATASET_BACKED}` evidence."
+        )
+        return report
+
+    checksum = _tree_checksum(staging_dir, matched_paths)
+    report["file_count"] = checksum["file_count"]
+    report["total_size_bytes"] = checksum["total_size_bytes"]
+    report["tree_sha256"] = checksum["tree_sha256"]
+    report["sample_files"] = checksum["sample_files"]
+    report["checksum_algorithm"] = spec.checksum_algorithm
+
+    if spec.expected_tree_sha256 is None:
+        report["local_availability"] = "present_unpinned_checksum"
+        report["action"] = (
+            "Expected SDD files are present and a tree checksum was computed, but the manifest does "
+            "not pin `expected_tree_sha256`. Refusing to mark SDD as dataset-backed until a trusted "
+            f"checksum is pinned. Scenario-prior generation remains forced to `{SDD_MODE_PROXY}`."
+        )
+        return report
+
+    report["expected_tree_sha256"] = spec.expected_tree_sha256
+    report["checksum_match"] = checksum["tree_sha256"] == spec.expected_tree_sha256
+    if not report["checksum_match"]:
+        report["action"] = (
+            "Staged files do not match the pinned `expected_tree_sha256` in the manifest. "
+            "Refusing to mark SDD as staged; treat as untrusted and re-acquire. Scenario-prior "
+            f"generation remains forced to `{SDD_MODE_PROXY}`."
+        )
+        return report
+
+    report["ok"] = True
+    report["local_availability"] = "staged"
+    report["mode"] = SDD_MODE_DATASET_BACKED
+    report["action"] = (
+        f"SDD is staged and validated. Scenario-prior generation may run in "
+        f"`{SDD_MODE_DATASET_BACKED}` mode for dataset-backed input."
+    )
+    return report
+
+
+def _cached_sdd_staging_gate(spec: SddStagingSpec) -> dict[str, Any] | None:
+    """Return a dataset-backed gate from cached status when it is still structurally valid."""
+    status_path = spec.staging_dir / SDD_STAGING_STATUS_FILENAME
+    if not status_path.is_file():
+        return None
+    try:
+        status = json.loads(status_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if not isinstance(status, dict):
+        return None
+    if status.get("local_availability") != "staged":
+        return None
+    if status.get("asset_id") != spec.asset_id or status.get("version_tag") != spec.version_tag:
+        return None
+
+    for expected in spec.expected_files:
+        if len(_match_sdd_expected(spec.staging_dir, expected)) < expected.min_count:
+            return None
+
+    return {
+        "mode": SDD_MODE_DATASET_BACKED,
+        "dataset_backed": True,
+        "reason": f"SDD is staged and validated (cached via {SDD_STAGING_STATUS_FILENAME}).",
+        "asset_id": spec.asset_id,
+        "version_tag": spec.version_tag,
+        "tree_sha256": status.get("tree_sha256"),
+        "staging_dir": str(spec.staging_dir),
+        "report": status,
+    }
+
+
+def resolve_sdd_scenario_prior_mode(
+    spec: SddStagingSpec | None = None,
+    *,
+    manifest_path: Path | None = None,
+) -> dict[str, Any]:
+    """Resolve the scenario-prior generation mode from canonical SDD staging state.
+
+    This is the gate scenario-prior generation consumes. A missing or unvalidated SDD copy forces
+    ``proxy_schema_smoke``; only a staged-and-validated copy unlocks ``dataset_backed_prior``.
+    """
+    spec = spec or load_sdd_staging_spec(manifest_path)
+    if cached_gate := _cached_sdd_staging_gate(spec):
+        return cached_gate
+
+    report = validate_sdd_staging(spec)
+    dataset_backed = bool(report["ok"])
+    return {
+        "mode": SDD_MODE_DATASET_BACKED if dataset_backed else SDD_MODE_PROXY,
+        "dataset_backed": dataset_backed,
+        "reason": report["action"],
+        "asset_id": spec.asset_id,
+        "version_tag": spec.version_tag,
+        "tree_sha256": report.get("tree_sha256"),
+        "staging_dir": str(spec.staging_dir),
+        "report": report,
+    }
+
+
+def check_sdd_disk_space(spec: SddStagingSpec) -> dict[str, Any]:
+    """Check free disk space at the staging location against the expected dataset size."""
+    probe = spec.staging_dir
+    while not probe.exists() and probe != probe.parent:
+        probe = probe.parent
+    usage = shutil.disk_usage(probe)
+    required = spec.expected_total_size_bytes
+    sufficient = usage.free >= required
+    return {
+        "probe_path": str(probe),
+        "required_bytes": required,
+        "required_mib": round(required / (1024 * 1024), 1),
+        "available_bytes": usage.free,
+        "available_mib": round(usage.free / (1024 * 1024), 1),
+        "sufficient": sufficient,
+    }
+
+
+def build_sdd_plan(spec: SddStagingSpec) -> dict[str, Any]:
+    """Build the plan/report payload for a default (non-downloading) invocation."""
+    validation = validate_sdd_staging(spec, compute_checksum=False)
+    disk = check_sdd_disk_space(spec)
+    return {
+        "schema": "sdd_staging_plan.v1",
+        "asset_id": spec.asset_id,
+        "title": spec.title,
+        "version_tag": spec.version_tag,
+        "source_url": spec.source_url,
+        "license": spec.license,
+        "license_url": spec.license_url,
+        "readme_pointer": spec.readme_pointer,
+        "staging_dir": str(spec.staging_dir),
+        "download_url": spec.download_url,
+        "access_note": spec.access_note,
+        "expected_total_size_bytes": spec.expected_total_size_bytes,
+        "expected_total_size_mib": round(spec.expected_total_size_mib, 1),
+        "disk_check": disk,
+        "would_download": False,
+        "auto_download": False,
+        "local_availability": validation["local_availability"],
+        "scenario_prior_mode": validation["mode"],
+        "validation": validation,
+        "next_step": (
+            "This is a PLAN ONLY; nothing was downloaded. To stage SDD you must (1) obtain it under "
+            "its license per access_note, (2) configure a download URL or place files under the "
+            "staging_dir, and (3) re-run with `download --confirm-download` to explicitly confirm."
+        ),
+    }
+
+
+def write_sdd_staging_status(spec: SddStagingSpec, report: dict[str, Any]) -> Path:
+    """Write a staging-status manifest into the staging dir after validation."""
+    spec.staging_dir.mkdir(parents=True, exist_ok=True)
+    status_path = spec.staging_dir / SDD_STAGING_STATUS_FILENAME
+    payload = {
+        "schema": "sdd_staging_status.v1",
+        "asset_id": spec.asset_id,
+        "version_tag": spec.version_tag,
+        "source_url": spec.source_url,
+        "license": spec.license,
+        "checksum_algorithm": spec.checksum_algorithm,
+        "tree_sha256": report.get("tree_sha256"),
+        "file_count": report.get("file_count"),
+        "total_size_bytes": report.get("total_size_bytes"),
+        "sample_files": report.get("sample_files", []),
+        "local_availability": report["local_availability"],
+        "validated_at_utc": dt.datetime.now(dt.UTC).replace(microsecond=0).isoformat(),
+    }
+    status_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+    return status_path
+
+
+def confirm_sdd_download(*, confirm_download: bool, yes: bool) -> bool:
+    """Return True only when the user has explicitly confirmed a network download.
+
+    Requires the ``--confirm-download`` flag AND an interactive y/N (or ``--yes`` for
+    non-interactive confirmation). Default behavior never confirms.
+    """
+    if not confirm_download:
+        return False
+    if yes:
+        return True
+    try:
+        answer = input(
+            "About to download the Stanford Drone Dataset to a git-ignored folder. "
+            "This consumes disk and network. Proceed? [y/N]: "
+        )
+    except EOFError:
+        return False
+    return answer.strip().lower() in {"y", "yes"}
+
+
+def run_sdd_download(spec: SddStagingSpec, *, confirm_download: bool, yes: bool) -> dict[str, Any]:
+    """Run the guarded SDD download path. Fails closed at every safety gate."""
+    if not confirm_sdd_download(confirm_download=confirm_download, yes=yes):
+        raise ExternalDataError(
+            "Download not confirmed. This tool never auto-downloads: pass `--confirm-download` and "
+            "answer the y/N prompt (or add `--yes` for non-interactive confirmation). A default run "
+            "only plans and reports."
+        )
+
+    disk = check_sdd_disk_space(spec)
+    if not disk["sufficient"]:
+        raise ExternalDataError(
+            "Insufficient disk space at "
+            f"{disk['probe_path']}: required {disk['required_mib']} MiB, "
+            f"available {disk['available_mib']} MiB. Refusing to download (fail closed)."
+        )
+
+    if not spec.download_url:
+        raise ExternalDataError(
+            "No download URL is configured for SDD. SDD is license-gated and the repository encodes "
+            "no approved direct download URL. Obtain it from the official project page "
+            f"({spec.source_url}) under its license, place the annotation files under "
+            f"{spec.staging_dir}, then run validation. {spec.access_note}"
+        )
+
+    # A real network fetch would happen here using spec.download_url. It is intentionally NOT
+    # implemented because SDD is license-gated and no approved URL is encoded; reaching this point
+    # requires a maintainer to add a URL to the manifest first.
+    raise ExternalDataError(
+        "Confirmed and disk-checked, but no downloader is wired for the configured URL. A "
+        "maintainer must implement the fetch for the license-approved URL before this path runs."
+    )
+
+
 def _print_json(payload: Any) -> None:
     """Print a stable JSON payload."""
     print(json.dumps(payload, indent=2, sort_keys=True))
@@ -502,6 +974,35 @@ def parse_args() -> argparse.Namespace:
         "download", help="Download only approved direct assets."
     )
     download_parser.add_argument("asset_id")
+
+    # Canonical SDD staging subsystem (issues #2657, #3473). These commands own the no-auto-download
+    # safety contract and the proxy-vs-dataset-backed scenario-prior gate.
+    sdd_plan = subparsers.add_parser(
+        "sdd-plan", help="Plan/report only for SDD staging (default; never downloads)."
+    )
+    sdd_plan.add_argument("--manifest", type=Path, default=None)
+
+    sdd_status = subparsers.add_parser(
+        "sdd-status", help="Report SDD local availability/checksums WITHOUT downloading."
+    )
+    sdd_status.add_argument("--manifest", type=Path, default=None)
+
+    sdd_validate = subparsers.add_parser(
+        "sdd-validate", help="Validate the locally-staged SDD copy and write its status file."
+    )
+    sdd_validate.add_argument("--manifest", type=Path, default=None)
+
+    sdd_mode = subparsers.add_parser(
+        "sdd-mode", help="Print the SDD scenario-prior mode gate (proxy vs dataset-backed)."
+    )
+    sdd_mode.add_argument("--manifest", type=Path, default=None)
+
+    sdd_download = subparsers.add_parser(
+        "sdd-download", help="Guarded SDD staging: requires explicit confirmation; fails closed."
+    )
+    sdd_download.add_argument("--manifest", type=Path, default=None)
+    sdd_download.add_argument("--confirm-download", action="store_true")
+    sdd_download.add_argument("--yes", action="store_true")
 
     return parser.parse_args()
 
@@ -584,6 +1085,47 @@ def _handle_download(args: argparse.Namespace) -> int:
     return 0
 
 
+def _handle_sdd_plan(args: argparse.Namespace) -> int:
+    """Handle the sdd-plan subcommand."""
+    spec = load_sdd_staging_spec(args.manifest)
+    _print_json(build_sdd_plan(spec))
+    return 0
+
+
+def _handle_sdd_status(args: argparse.Namespace) -> int:
+    """Handle the sdd-status subcommand."""
+    spec = load_sdd_staging_spec(args.manifest)
+    report = validate_sdd_staging(spec)
+    _print_json(report)
+    return 0 if report["ok"] else 2
+
+
+def _handle_sdd_validate(args: argparse.Namespace) -> int:
+    """Handle the sdd-validate subcommand."""
+    spec = load_sdd_staging_spec(args.manifest)
+    report = validate_sdd_staging(spec)
+    if report["ok"]:
+        write_sdd_staging_status(spec, report)
+    _print_json(report)
+    return 0 if report["ok"] else 2
+
+
+def _handle_sdd_mode(args: argparse.Namespace) -> int:
+    """Handle the sdd-mode subcommand."""
+    spec = load_sdd_staging_spec(args.manifest)
+    gate = resolve_sdd_scenario_prior_mode(spec)
+    _print_json(gate)
+    return 0 if gate["dataset_backed"] else 2
+
+
+def _handle_sdd_download(args: argparse.Namespace) -> int:
+    """Handle the sdd-download subcommand."""
+    spec = load_sdd_staging_spec(args.manifest)
+    report = run_sdd_download(spec, confirm_download=args.confirm_download, yes=args.yes)
+    _print_json(report)
+    return 0 if report.get("ok") else 2
+
+
 def _handle_error(exc: ExternalDataError, *, as_json: bool) -> int:
     """Print one user-facing CLI error."""
     if as_json:
@@ -602,6 +1144,11 @@ def main() -> int:
         "check": _handle_check,
         "stage": _handle_stage,
         "download": _handle_download,
+        "sdd-plan": _handle_sdd_plan,
+        "sdd-status": _handle_sdd_status,
+        "sdd-validate": _handle_sdd_validate,
+        "sdd-mode": _handle_sdd_mode,
+        "sdd-download": _handle_sdd_download,
     }
     try:
         return handlers[args.command](args)

--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -565,6 +565,31 @@ def _parse_sdd_expected_files(expected_files_raw: list[Any]) -> tuple[SddExpecte
     return tuple(expected_files)
 
 
+def _manifest_text(raw: dict[str, Any], key: str, default: str = "") -> str:
+    """Return a stripped manifest string, treating explicit YAML null as missing."""
+    value = raw.get(key, default)
+    if value is None:
+        value = default
+    return str(value).strip()
+
+
+def _required_manifest_text(raw: dict[str, Any], key: str) -> str:
+    """Return a required manifest string or fail closed when it is absent/empty/null."""
+    value = _manifest_text(raw, key)
+    if not value:
+        raise ExternalDataError(f"Manifest is missing required `{key}`.")
+    return value
+
+
+def _optional_checksum_text(checksums: dict[str, Any], key: str) -> str | None:
+    """Return an optional checksum string, preserving null/empty as unpinned."""
+    value = checksums.get(key)
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
 def load_sdd_staging_spec(manifest_path: Path | None = None) -> SddStagingSpec:
     """Load and validate the canonical SDD staging manifest."""
     path = manifest_path or _sdd_manifest_path()
@@ -574,9 +599,7 @@ def load_sdd_staging_spec(manifest_path: Path | None = None) -> SddStagingSpec:
     if not isinstance(raw, dict):
         raise ExternalDataError(f"Manifest is not a mapping: {path}")
 
-    staging_dir_raw = str(raw.get("staging_dir", "")).strip()
-    if not staging_dir_raw:
-        raise ExternalDataError("Manifest is missing required `staging_dir`.")
+    staging_dir_raw = _required_manifest_text(raw, "staging_dir")
     staging_dir = _resolve_sdd_staging_dir(staging_dir_raw, manifest_path=path)
 
     expected_files_raw = raw.get("expected_files") or []
@@ -589,28 +612,24 @@ def load_sdd_staging_spec(manifest_path: Path | None = None) -> SddStagingSpec:
         raise ExternalDataError("Manifest must declare a positive `expected_total_size_bytes`.")
 
     checksums = raw.get("checksums") or {}
-    download_url = raw.get("download_url")
+    download_url = _manifest_text(raw, "download_url")
 
     return SddStagingSpec(
-        asset_id=str(raw.get("asset_id", "sdd")),
-        title=str(raw.get("title", "Stanford Drone Dataset")),
-        version_tag=str(raw.get("version_tag", "unknown")),
-        source_url=str(raw.get("source_url", "")),
-        license=str(raw.get("license", "")),
-        license_url=str(raw.get("license_url", "")),
-        readme_pointer=str(raw.get("readme_pointer", "")),
+        asset_id=_manifest_text(raw, "asset_id", "sdd"),
+        title=_manifest_text(raw, "title", "Stanford Drone Dataset"),
+        version_tag=_manifest_text(raw, "version_tag", "unknown"),
+        source_url=_manifest_text(raw, "source_url"),
+        license=_manifest_text(raw, "license"),
+        license_url=_manifest_text(raw, "license_url"),
+        readme_pointer=_manifest_text(raw, "readme_pointer"),
         staging_dir=staging_dir,
-        download_url=str(download_url) if download_url else None,
-        access_note=str(raw.get("access_note", "")),
+        download_url=download_url or None,
+        access_note=_manifest_text(raw, "access_note"),
         expected_files=expected_files,
         expected_total_size_bytes=size_bytes,
-        checksum_algorithm=str(checksums.get("algorithm", "SHA-256")),
-        expected_tree_sha256=(
-            str(checksums["expected_tree_sha256"])
-            if checksums.get("expected_tree_sha256")
-            else None
-        ),
-        local_availability_declared=str(raw.get("local_availability", "missing")),
+        checksum_algorithm=_manifest_text(checksums, "algorithm", "SHA-256"),
+        expected_tree_sha256=_optional_checksum_text(checksums, "expected_tree_sha256"),
+        local_availability_declared=_manifest_text(raw, "local_availability", "missing"),
     )
 
 

--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -543,9 +543,21 @@ def _parse_sdd_expected_files(expected_files_raw: list[Any]) -> tuple[SddExpecte
     for index, entry in enumerate(expected_files_raw):
         if not isinstance(entry, dict):
             raise ExternalDataError(f"`expected_files[{index}]` must be a mapping.")
-        pattern = str(entry.get("pattern", "")).strip()
+        pattern_value = entry.get("pattern", "")
+        pattern = "" if pattern_value is None else str(pattern_value).strip()
         if not pattern:
             raise ExternalDataError(f"`expected_files[{index}].pattern` is required.")
+        pattern_path = Path(pattern)
+        if pattern_path.is_absolute() or ".." in pattern_path.parts:
+            raise ExternalDataError(
+                f"`expected_files[{index}].pattern` must stay within staging_dir."
+            )
+        kind_value = entry.get("kind", "file")
+        kind = "file" if kind_value is None else str(kind_value).strip()
+        if kind not in {"file", "directory"}:
+            raise ExternalDataError(
+                f"`expected_files[{index}].kind` must be one of: file, directory."
+            )
         try:
             min_count = int(entry.get("min_count", 1))
         except (TypeError, ValueError) as exc:
@@ -557,8 +569,8 @@ def _parse_sdd_expected_files(expected_files_raw: list[Any]) -> tuple[SddExpecte
         expected_files.append(
             SddExpectedFile(
                 pattern=pattern,
-                kind=str(entry.get("kind", "file")),
-                description=str(entry.get("description", "")),
+                kind=kind,
+                description=str(entry.get("description") or ""),
                 min_count=min_count,
             )
         )
@@ -607,11 +619,20 @@ def load_sdd_staging_spec(manifest_path: Path | None = None) -> SddStagingSpec:
         raise ExternalDataError("Manifest must declare a non-empty `expected_files` list.")
     expected_files = _parse_sdd_expected_files(expected_files_raw)
 
-    size_bytes = int(raw.get("expected_total_size_bytes", 0))
+    try:
+        size_bytes = int(raw.get("expected_total_size_bytes", 0))
+    except (TypeError, ValueError) as exc:
+        raise ExternalDataError("Manifest `expected_total_size_bytes` must be an integer.") from exc
     if size_bytes <= 0:
         raise ExternalDataError("Manifest must declare a positive `expected_total_size_bytes`.")
 
-    checksums = raw.get("checksums") or {}
+    checksums_raw = raw.get("checksums")
+    if checksums_raw is None:
+        checksums: dict[str, Any] = {}
+    elif isinstance(checksums_raw, dict):
+        checksums = checksums_raw
+    else:
+        raise ExternalDataError("Manifest `checksums` must be a mapping when provided.")
     download_url = _manifest_text(raw, "download_url")
 
     return SddStagingSpec(
@@ -698,12 +719,12 @@ def validate_sdd_staging(spec: SddStagingSpec, *, compute_checksum: bool = True)
 
     if not compute_checksum:
         report["checksum_skipped"] = (
-            "tree checksum omitted for plan/status speed; run `validate` for checksum proof"
+            "tree checksum omitted for plan/status speed; run `sdd-validate` for checksum proof"
         )
         report["local_availability"] = "present_unvalidated"
         report["action"] = (
-            "SDD expected files are present. Run `validate` to compute checksums before treating "
-            f"the copy as `{SDD_MODE_DATASET_BACKED}` evidence."
+            "SDD expected files are present. Run `sdd-validate` to compute checksums before "
+            f"treating the copy as `{SDD_MODE_DATASET_BACKED}` evidence."
         )
         return report
 
@@ -743,6 +764,21 @@ def validate_sdd_staging(spec: SddStagingSpec, *, compute_checksum: bool = True)
     return report
 
 
+def _current_sdd_tree_matches_cached_status(
+    spec: SddStagingSpec,
+    status: dict[str, Any],
+    matched_paths: list[Path],
+) -> bool:
+    """Return True only when cached status still matches the current staged tree."""
+    cached_tree_sha256 = status.get("tree_sha256")
+    if not isinstance(cached_tree_sha256, str) or not cached_tree_sha256:
+        return False
+    if spec.expected_tree_sha256 is None or cached_tree_sha256 != spec.expected_tree_sha256:
+        return False
+    current_checksum = _tree_checksum(spec.staging_dir, matched_paths)
+    return current_checksum["tree_sha256"] == cached_tree_sha256
+
+
 def _cached_sdd_staging_gate(spec: SddStagingSpec) -> dict[str, Any] | None:
     """Return a dataset-backed gate from cached status when it is still structurally valid."""
     status_path = spec.staging_dir / SDD_STAGING_STATUS_FILENAME
@@ -759,9 +795,15 @@ def _cached_sdd_staging_gate(spec: SddStagingSpec) -> dict[str, Any] | None:
     if status.get("asset_id") != spec.asset_id or status.get("version_tag") != spec.version_tag:
         return None
 
+    matched_paths: list[Path] = []
     for expected in spec.expected_files:
-        if len(_match_sdd_expected(spec.staging_dir, expected)) < expected.min_count:
+        group_matches = _match_sdd_expected(spec.staging_dir, expected)
+        if len(group_matches) < expected.min_count:
             return None
+        matched_paths.extend(group_matches)
+
+    if not _current_sdd_tree_matches_cached_status(spec, status, matched_paths):
+        return None
 
     return {
         "mode": SDD_MODE_DATASET_BACKED,
@@ -769,7 +811,7 @@ def _cached_sdd_staging_gate(spec: SddStagingSpec) -> dict[str, Any] | None:
         "reason": f"SDD is staged and validated (cached via {SDD_STAGING_STATUS_FILENAME}).",
         "asset_id": spec.asset_id,
         "version_tag": spec.version_tag,
-        "tree_sha256": status.get("tree_sha256"),
+        "tree_sha256": status["tree_sha256"],
         "staging_dir": str(spec.staging_dir),
         "report": status,
     }
@@ -848,7 +890,8 @@ def build_sdd_plan(spec: SddStagingSpec) -> dict[str, Any]:
         "next_step": (
             "This is a PLAN ONLY; nothing was downloaded. To stage SDD you must (1) obtain it under "
             "its license per access_note, (2) configure a download URL or place files under the "
-            "staging_dir, and (3) re-run with `download --confirm-download` to explicitly confirm."
+            "staging_dir, and (3) re-run with `sdd-download --confirm-download` to explicitly "
+            "confirm."
         ),
     }
 

--- a/tests/tools/test_sdd_staging_consolidation_issue_3473.py
+++ b/tests/tools/test_sdd_staging_consolidation_issue_3473.py
@@ -1,0 +1,210 @@
+"""Migration tests for the SDD staging consolidation (Issue #3473).
+
+PR #3457 (Issue #2657) added an issue-specific SDD staging script and manifest. Issue #3473
+consolidates that logic into the canonical external-data subsystem
+(``scripts/tools/manage_external_data.py``). These tests prove that:
+
+* the proxy-vs-dataset-backed gate decision is byte-for-byte identical whether resolved through the
+  canonical functions or through the preserved ``stage_sdd_dataset_issue_2657`` wrapper;
+* the no-auto-download safety contract from #2657 is preserved by the canonical subsystem;
+* the canonical ``sdd`` asset specification carries the checksum policy and the manifest pointer so
+  there is a single source of truth.
+
+They never touch the network and never download anything.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from scripts.data import stage_sdd_dataset_issue_2657 as wrapper
+from scripts.tools import manage_external_data as canonical
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_manifest(
+    tmp_path: Path,
+    *,
+    staging_dir: Path,
+    expected_tree_sha256: str | None = None,
+    expected_size_bytes: int = 1024,
+    download_url: str | None = None,
+) -> Path:
+    """Write a minimal SDD staging manifest pointing at a temp staging dir."""
+    manifest = {
+        "schema": "robot_sf_sdd_staging_manifest.v1",
+        "asset_id": "sdd",
+        "title": "Stanford Drone Dataset annotations",
+        "version_tag": "sdd-test",
+        "source_url": "https://cvgl.stanford.edu/projects/uav_data/",
+        "license": "CC BY-NC-SA 3.0",
+        "license_url": "https://creativecommons.org/licenses/by-nc-sa/3.0/",
+        "readme_pointer": "docs/context/issue_2657_sdd_staging.md",
+        "staging_dir": str(staging_dir),
+        "download_url": download_url,
+        "access_note": "License-gated; manual acquisition only.",
+        "expected_files": [
+            {
+                "pattern": "**/annotations.txt",
+                "kind": "file",
+                "description": "Original SDD annotation text file.",
+                "min_count": 1,
+            }
+        ],
+        "expected_total_size_bytes": expected_size_bytes,
+        "checksums": {
+            "algorithm": "SHA-256",
+            "tree_sha256": None,
+            "expected_tree_sha256": expected_tree_sha256,
+        },
+        "local_availability": "missing",
+    }
+    path = tmp_path / "manifest.yaml"
+    path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _stage_annotation(staging_dir: Path) -> None:
+    """Create a valid SDD annotation file under the staging dir."""
+    staging_dir.mkdir(parents=True, exist_ok=True)
+    (staging_dir / "annotations.txt").write_text(
+        "1 0 0 10 10 0 0 0 0 Pedestrian\n", encoding="utf-8"
+    )
+
+
+# --- single source of truth ------------------------------------------------------------------
+
+
+def test_sdd_asset_carries_checksum_policy_and_manifest_pointer() -> None:
+    """The canonical ``sdd`` asset declares the staging manifest + availability gate states."""
+    asset = canonical._get_asset("sdd")
+    assert asset.staging_manifest_path == canonical.DEFAULT_SDD_STAGING_MANIFEST
+    assert asset.proxy_mode == canonical.SDD_MODE_PROXY
+    assert asset.dataset_backed_mode == canonical.SDD_MODE_DATASET_BACKED
+
+
+def test_wrapper_delegates_to_canonical_symbols() -> None:
+    """The #2657 wrapper re-exports the canonical implementations (no second source of truth)."""
+    assert wrapper.load_manifest is canonical.load_sdd_staging_spec
+    assert wrapper.validate_staging is canonical.validate_sdd_staging
+    assert wrapper.resolve_scenario_prior_mode is canonical.resolve_sdd_scenario_prior_mode
+    assert wrapper.MODE_PROXY == canonical.SDD_MODE_PROXY
+    assert wrapper.MODE_DATASET_BACKED == canonical.SDD_MODE_DATASET_BACKED
+    assert wrapper.SddStagingError is canonical.ExternalDataError
+
+
+# --- proxy decision parity -------------------------------------------------------------------
+
+
+def test_proxy_decision_identical_canonical_and_wrapper(tmp_path: Path) -> None:
+    """A missing SDD copy yields the same proxy gate via canonical and wrapper paths."""
+    manifest_path = _write_manifest(tmp_path, staging_dir=tmp_path / "sdd")
+
+    canonical_gate = canonical.resolve_sdd_scenario_prior_mode(manifest_path=manifest_path)
+    wrapper_gate = wrapper.resolve_scenario_prior_mode(manifest_path=manifest_path)
+
+    assert canonical_gate == wrapper_gate
+    assert canonical_gate["mode"] == canonical.SDD_MODE_PROXY
+    assert canonical_gate["dataset_backed"] is False
+
+
+# --- dataset-backed decision parity ----------------------------------------------------------
+
+
+def test_dataset_backed_decision_identical_canonical_and_wrapper(tmp_path: Path) -> None:
+    """A staged+validated copy yields the same dataset-backed gate via both paths."""
+    staging_dir = tmp_path / "sdd"
+    _stage_annotation(staging_dir)
+    unpinned = canonical.load_sdd_staging_spec(_write_manifest(tmp_path, staging_dir=staging_dir))
+    unpinned_report = canonical.validate_sdd_staging(unpinned)
+    manifest_path = _write_manifest(
+        tmp_path,
+        staging_dir=staging_dir,
+        expected_tree_sha256=unpinned_report["tree_sha256"],
+    )
+
+    canonical_gate = canonical.resolve_sdd_scenario_prior_mode(manifest_path=manifest_path)
+    wrapper_gate = wrapper.resolve_scenario_prior_mode(manifest_path=manifest_path)
+
+    assert canonical_gate == wrapper_gate
+    assert canonical_gate["mode"] == canonical.SDD_MODE_DATASET_BACKED
+    assert canonical_gate["dataset_backed"] is True
+    assert canonical_gate["tree_sha256"]
+
+
+def test_pinned_checksum_mismatch_fails_closed_in_canonical(tmp_path: Path) -> None:
+    """A pinned-but-wrong checksum refuses dataset-backed mode through the canonical path."""
+    staging_dir = tmp_path / "sdd"
+    _stage_annotation(staging_dir)
+    spec = canonical.load_sdd_staging_spec(
+        _write_manifest(tmp_path, staging_dir=staging_dir, expected_tree_sha256="0" * 64)
+    )
+
+    report = canonical.validate_sdd_staging(spec)
+
+    assert report["ok"] is False
+    assert report["checksum_match"] is False
+    assert report["mode"] == canonical.SDD_MODE_PROXY
+
+
+# --- no-auto-download safety preserved -------------------------------------------------------
+
+
+def test_canonical_download_refuses_without_confirmation(tmp_path: Path) -> None:
+    """The canonical guarded download fails closed without explicit confirmation."""
+    spec = canonical.load_sdd_staging_spec(_write_manifest(tmp_path, staging_dir=tmp_path / "sdd"))
+
+    with pytest.raises(canonical.ExternalDataError, match="never auto-download"):
+        canonical.run_sdd_download(spec, confirm_download=False, yes=False)
+
+
+def test_canonical_download_fails_closed_on_insufficient_disk(tmp_path: Path) -> None:
+    """Confirmed download still fails closed when free disk space is insufficient."""
+    spec = canonical.load_sdd_staging_spec(
+        _write_manifest(
+            tmp_path,
+            staging_dir=tmp_path / "sdd",
+            expected_size_bytes=10**18,
+            download_url="https://example.invalid/sdd.zip",
+        )
+    )
+
+    with pytest.raises(canonical.ExternalDataError, match="Insufficient disk space"):
+        canonical.run_sdd_download(spec, confirm_download=True, yes=True)
+
+
+def test_canonical_download_fails_closed_without_url(tmp_path: Path) -> None:
+    """Even confirmed + disk-OK, a missing download URL fails closed (license-gated)."""
+    spec = canonical.load_sdd_staging_spec(
+        _write_manifest(tmp_path, staging_dir=tmp_path / "sdd", download_url=None)
+    )
+
+    with pytest.raises(canonical.ExternalDataError, match="No download URL is configured"):
+        canonical.run_sdd_download(spec, confirm_download=True, yes=True)
+
+
+def test_canonical_plan_never_downloads_and_reports_disk_check(tmp_path: Path) -> None:
+    """A canonical plan reports the disk check and declares no download."""
+    spec = canonical.load_sdd_staging_spec(_write_manifest(tmp_path, staging_dir=tmp_path / "sdd"))
+
+    plan = canonical.build_sdd_plan(spec)
+
+    assert plan["would_download"] is False
+    assert plan["auto_download"] is False
+    assert plan["scenario_prior_mode"] == canonical.SDD_MODE_PROXY
+    assert plan["disk_check"]["required_bytes"] == spec.expected_total_size_bytes
+
+
+def test_repo_sdd_manifest_loads_through_canonical_asset() -> None:
+    """The shipped manifest referenced by the asset parses and declares no download URL."""
+    spec = canonical.load_sdd_staging_spec()
+
+    assert spec.asset_id == "sdd"
+    assert spec.download_url is None
+    assert spec.local_availability_declared == "missing"
+    assert spec.expected_total_size_bytes > 0

--- a/tests/tools/test_sdd_staging_consolidation_issue_3473.py
+++ b/tests/tools/test_sdd_staging_consolidation_issue_3473.py
@@ -239,3 +239,86 @@ def test_manifest_null_optional_strings_remain_empty_or_unpinned(tmp_path: Path)
     assert spec.local_availability_declared == "missing"
     assert spec.checksum_algorithm == "SHA-256"
     assert spec.expected_tree_sha256 is None
+
+
+@pytest.mark.parametrize("pattern", ["../secret.txt", "/tmp/secret.txt"])
+def test_manifest_rejects_expected_file_patterns_outside_staging_dir(
+    tmp_path: Path, pattern: str
+) -> None:
+    """Expected-file globs must not escape the staging directory."""
+    manifest_path = _write_manifest(tmp_path, staging_dir=tmp_path / "sdd")
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    manifest["expected_files"][0]["pattern"] = pattern
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(canonical.ExternalDataError, match="must stay within staging_dir"):
+        canonical.load_sdd_staging_spec(manifest_path)
+
+
+def test_manifest_rejects_invalid_expected_file_kind(tmp_path: Path) -> None:
+    """Expected-file kind should fail during manifest parsing, before glob matching."""
+    manifest_path = _write_manifest(tmp_path, staging_dir=tmp_path / "sdd")
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    manifest["expected_files"][0]["kind"] = "symlink"
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(canonical.ExternalDataError, match="must be one of"):
+        canonical.load_sdd_staging_spec(manifest_path)
+
+
+@pytest.mark.parametrize(
+    ("field", "value", "message"),
+    [
+        ("expected_total_size_bytes", "not-an-int", "must be an integer"),
+        ("checksums", [], "must be a mapping"),
+    ],
+)
+def test_manifest_type_errors_raise_external_data_error(
+    tmp_path: Path, field: str, value: object, message: str
+) -> None:
+    """Manifest type errors should use the CLI's fail-closed ExternalDataError path."""
+    manifest_path = _write_manifest(tmp_path, staging_dir=tmp_path / "sdd")
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    manifest[field] = value
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(canonical.ExternalDataError, match=message):
+        canonical.load_sdd_staging_spec(manifest_path)
+
+
+def test_plan_guidance_uses_registered_sdd_cli_command_names(tmp_path: Path) -> None:
+    """User guidance should name the actual sdd-* subcommands."""
+    staging_dir = tmp_path / "sdd"
+    _stage_annotation(staging_dir)
+    spec = canonical.load_sdd_staging_spec(_write_manifest(tmp_path, staging_dir=staging_dir))
+
+    plan = canonical.build_sdd_plan(spec)
+
+    assert "sdd-validate" in plan["validation"]["checksum_skipped"]
+    assert "sdd-validate" in plan["validation"]["action"]
+    assert "sdd-download --confirm-download" in plan["next_step"]
+
+
+def test_cached_sdd_gate_revalidates_current_tree_checksum(tmp_path: Path) -> None:
+    """A stale status file must not unlock dataset-backed mode after files change."""
+    staging_dir = tmp_path / "sdd"
+    _stage_annotation(staging_dir)
+    unpinned = canonical.load_sdd_staging_spec(_write_manifest(tmp_path, staging_dir=staging_dir))
+    unpinned_report = canonical.validate_sdd_staging(unpinned)
+    manifest_path = _write_manifest(
+        tmp_path,
+        staging_dir=staging_dir,
+        expected_tree_sha256=unpinned_report["tree_sha256"],
+    )
+    spec = canonical.load_sdd_staging_spec(manifest_path)
+    valid_report = canonical.validate_sdd_staging(spec)
+    canonical.write_sdd_staging_status(spec, valid_report)
+    (staging_dir / "annotations.txt").write_text(
+        "1 0 0 99 99 0 0 0 0 Pedestrian\n", encoding="utf-8"
+    )
+
+    gate = canonical.resolve_sdd_scenario_prior_mode(manifest_path=manifest_path)
+
+    assert gate["dataset_backed"] is False
+    assert gate["mode"] == canonical.SDD_MODE_PROXY
+    assert gate["report"]["checksum_match"] is False

--- a/tests/tools/test_sdd_staging_consolidation_issue_3473.py
+++ b/tests/tools/test_sdd_staging_consolidation_issue_3473.py
@@ -208,3 +208,34 @@ def test_repo_sdd_manifest_loads_through_canonical_asset() -> None:
     assert spec.download_url is None
     assert spec.local_availability_declared == "missing"
     assert spec.expected_total_size_bytes > 0
+
+
+def test_manifest_null_staging_dir_fails_closed(tmp_path: Path) -> None:
+    """Explicit YAML null for the required staging dir must not become the string 'None'."""
+    manifest_path = _write_manifest(tmp_path, staging_dir=tmp_path / "sdd")
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    manifest["staging_dir"] = None
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+
+    with pytest.raises(canonical.ExternalDataError, match="missing required `staging_dir`"):
+        canonical.load_sdd_staging_spec(manifest_path)
+
+
+def test_manifest_null_optional_strings_remain_empty_or_unpinned(tmp_path: Path) -> None:
+    """Explicit YAML nulls for optional manifest fields should stay missing, not 'None'."""
+    manifest_path = _write_manifest(tmp_path, staging_dir=tmp_path / "sdd")
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    manifest["source_url"] = None
+    manifest["download_url"] = None
+    manifest["local_availability"] = None
+    manifest["checksums"]["algorithm"] = None
+    manifest["checksums"]["expected_tree_sha256"] = None
+    manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
+
+    spec = canonical.load_sdd_staging_spec(manifest_path)
+
+    assert spec.source_url == ""
+    assert spec.download_url is None
+    assert spec.local_availability_declared == "missing"
+    assert spec.checksum_algorithm == "SHA-256"
+    assert spec.expected_tree_sha256 is None


### PR DESCRIPTION
## Summary

**Closes #3473.** Resolves the two-sources-of-truth situation that my #2657 (PR #3457) introduced: it added a separate `stage_sdd_dataset_issue_2657.py` while `manage_external_data.py` already owned the `sdd` asset. This folds the staging behavior into the canonical subsystem. Surfaced by the issue-audit pass — I introduced the duplication, so resolving it here.

## What landed

- **`scripts/tools/manage_external_data.py`** — now owns all SDD staging behavior as first-class `sdd`-asset features: manifest parsing, expected-file matching, aggregate tree checksum, **pinned `expected_tree_sha256`** validation, the **proxy-vs-dataset-backed** scenario-prior gate (cached-status fast path), disk-space fail-closed check, plan/report builder, status-file writer, and the guarded `--confirm-download` flow. New CLI: `sdd-plan` / `sdd-status` / `sdd-validate` / `sdd-mode` / `sdd-download`. `AssetSpec` gains `staging_manifest_path` / `proxy_mode` / `dataset_backed_mode`.
- **`scripts/data/stage_sdd_dataset_issue_2657.py`** — reduced to a **thin compatibility wrapper** (586 → ~250 lines) re-exporting the canonical names under their #2657 identifiers; exact CLI/exit surface preserved. Nothing deleted — existing imports/usage keep working.
- **`configs/data/sdd_staging_manifest.yaml`** — kept as the single editable manifest, now referenced by the `sdd` `AssetSpec` (lowest-duplication option).
- Scenario-prior gating repointed to `resolve_sdd_scenario_prior_mode` in the canonical module.
- **tests** — all pre-existing tests pass unchanged; added 10 **migration tests** proving proxy and dataset-backed decisions are byte-for-byte identical via canonical vs wrapper paths.

## Behavior preservation (independently audited)

- **No-auto-download safety intact:** default run is plan-only ("never auto-downloads"); `download` **refuses** without `--confirm-download`; staging dir `output/external_data/sdd` is gitignored.
- **Proxy/dataset-backed gate stays fail-closed:** missing/unvalidated/unpinned/mismatched → `proxy_schema_smoke`; only staged + checksum-matched → `dataset_backed_prior`.
- **96 tests pass** (`-k "sdd or stage or external_data or scenario_prior or 2657 or 3473"`), no lost coverage; `ruff`/`pre-commit` clean; `sync_ai_config.py --check` no drift.
- #1497 remains the owner of real licensed-data acquisition (unchanged).

## Carried-forward open question (from #3473)

Unify the SDD staging-status file and the general `stage_asset` provenance manifest so every asset's canonical record carries an availability/mode field — noted as a follow-up, not done here.

## Follow-Up Issues

- Deferred work: unify SDD staging-status and generic `stage_asset` provenance status shapes.
- Issues opened for follow-up: #3493.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new CLI commands for SDD staging management, validation, and status monitoring
  * Implemented checksum verification and file pattern validation for datasets
  * Added disk-space pre-flight checks before download operations

* **Improvements**
  * Strengthened download safety by requiring explicit confirmation flags
  * Consolidated SDD staging under a unified, centralized system with manifest-driven validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
