### PR TITLE
docs: tighten autopilot resume guard

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -53,6 +53,12 @@ In token-efficient mode:
 - Codex is the loop controller, reviewer, and final acceptance authority.
 - Delegate workers only when compact review cost is lower than direct Codex
   execution.
+- On every resume, compaction recovery, interruption return, or new user
+  message, first run a current-request guard: compare the newest request with
+  the active ledger action, identify active worktree/PR/issue/delegates, and
+  decide whether the previous goal action is still the current objective. If
+  the newest request supersedes it, park the old batch with a compact handoff
+  and cleanup status before editing or opening a new PR for the new request.
 - On continuation or after context compaction, rebuild state from the active
   ledger and compact PR/issue/worktree snapshots first. Reopen full skills,
   docs, raw CI output, or broad GitHub/worktree inventories only when the
@@ -344,6 +350,8 @@ final summaries.
 
 Track only the fields needed to resume safely in under one minute:
 
+- current request: newest user request, whether it supersedes the prior ledger
+  action, and the parked-work handoff path when a pivot occurs;
 - route: provider/tool, model or agent role, run ID or artifact path, and route status;
 - loaded context: skill/doc summaries already read for the active phase, plus the freshness keys
   that make them reusable or stale;
@@ -373,6 +381,12 @@ anti-pattern unless a stale-state trigger fired or the compact snapshot lacks th
 the next decision. Fresh live checks are still required before issue claim, push, PR publication,
 label/project mutation, merge-ready application, merge, claim release, or any benchmark/paper-facing
 publication decision.
+
+If the user switches from a goal loop to an instruction, review, cleanup, or
+single-PR request, do not continue implementing the old issue just because the
+ledger has a next action. Record the old worktree, dirty status, active PRs,
+subagent lifecycle state, and next safe resumption command in the ledger, then
+scope the new branch and PR to the new request only.
 
 Distinguish route success from task success. A delegate command exiting zero or producing a report
 only proves `route_status: completed`; the parent phase is not complete until the main agent has
@@ -485,6 +499,10 @@ one of:
 
 A phase is not complete until the cleanup checkpoint passes for every delegate used
 in that phase.
+
+Run the cleanup checkpoint again before honoring a user pivot or final handoff.
+The result should state `closed`, `preserved`, or `not_applicable` for each
+subagent/worker, and should explain any dirty worktree left behind.
 
 ### Spark Sidecar Routing
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -103,6 +103,13 @@ field, route-cache entry, worker prompt constraint, or docs patch before the nex
 For Slurm-backed phases, also record the private-queue freshness check, the submit-host worktree
 proof, and any model-route quota failures so resumes do not rediscover the same blockers.
 
+When a long thread resumes after compaction, interruption, or a new user message, run a one-screen
+current-request guard before continuing the previous ledger action. Confirm the newest user request,
+active goal or PR/issue, current worktree, active delegates, dirty worktrees, and next remote-visible
+mutation. If the newest request changes the objective, park the previous batch with a compact handoff
+instead of silently continuing stale goal work. Close or explicitly preserve no-longer-needed
+subagents, and record the cleanup or preservation decision in the common Git-dir ledger.
+
 ## Shared Knowledge Graph
 
 This repository tracks an Understand-Anything graph under `.understand-anything/` as a shared

--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -16,6 +16,7 @@ changes.
 - worktree: [absolute or repo-relative worktree path and branch]
 - context_budget: [compact snapshots first; raw logs only by artifact path]
 - resume_checkpoint: [active ledger path plus loaded skills/docs, current PR/issue/head SHA, and next stale-state trigger]
+- current_request_guard: [newest user request, whether it supersedes the active ledger action, and parked-work state]
 - loaded_context_cache: [skills/docs/snapshots already read this phase, plus the condition that requires rereading]
 - route_cache: [unavailable routes and reset times, known-good worker lane, and current CI monitor command]
 - delegation_artifacts: [RESULT.md, changed files, diffstat, validation, blockers, mutations]
@@ -43,6 +44,11 @@ changes.
 - `resume_checkpoint` should be the first thing refreshed after compaction or
   automatic continuation. If it is fresh, do not reread full skills, broad
   issue queues, or full worktree inventories before the next mutation.
+- `current_request_guard` prevents stale-goal continuation after compaction or
+  user pivots. Before taking the next action, compare the newest user request
+  with the active ledger action. If they differ, write a compact parked-work
+  handoff with dirty worktrees, active delegates, PR/issue state, and cleanup
+  status, then execute the newest request.
 - `loaded_context_cache` prevents compaction recovery from becoming another
   broad-read pass. Record each long skill, issue body, PR snapshot, and context
   note already loaded in the current phase, then reread only when the branch,
@@ -76,6 +82,9 @@ workflow only when the savings are reusable.
 - Start from the current `resume_checkpoint`, `loaded_context_cache`, and
   `phase_audit_record`. Reread long skills, issue bodies, PR snapshots, or
   context notes only when their recorded freshness key changed.
+- Re-anchor on the newest user request before continuing a prior goal ledger.
+  If the request changed, pause the old batch with a parked-work note instead
+  of mixing objectives in the same implementation branch or PR body.
 - Run one usage check per phase, record the reset window, and reuse it until a
   cooldown, direct user request, or new phase makes it stale.
 - Refresh the issue or PR head SHA before implementation and before review
@@ -118,6 +127,10 @@ workflow only when the savings are reusable.
 - After every accepted, rejected, or rerouted delegate, append a one-paragraph
   self-review note when the route created reusable evidence about output size,
   artifact quality, quota pressure, or validation cost.
+- Before final handoff or a user-requested pivot, list active app subagents and
+  long-running worker processes when the tooling supports it. Close obsolete
+  app subagents, record any preserved workers or worktrees, and do not leave
+  cleanup implicit behind a PR link.
 - When usage is close to the stop guard, finish the active PR or blocker record,
   then hand off instead of opening a fresh batch.
 
@@ -141,6 +154,8 @@ long goal near a usage guard:
   fields, route-cache entries, or worker prompt constraints.
 - `next_savings`: three to ten concrete changes, each phrased as a rule that
   prevents a repeated token leak and names the evidence that triggered it.
+- `parked_work`: prior worktrees, PRs, jobs, delegates, or claims intentionally
+  left active because the newest request superseded the old next action.
 
 ## Delegated Worker Artifact Contract
 


### PR DESCRIPTION
## Summary
- Tightens autonomous goal instructions so resumed or compacted threads re-anchor on the newest user request before continuing old ledger work.
- Adds a parked-work handoff rule for user pivots, dirty worktrees, active delegates, and remote-visible next actions.
- Extends goal-autopilot cleanup guidance so obsolete subagents/workers are closed or explicitly preserved before pivots and final handoff.

## Linked Issues
- NA - workflow instruction improvement from representative Codex thread review.

## Stack / Dependency
- Standalone docs/instruction update.

## What Changed
- `AGENTS.md`: adds a one-screen current-request guard for long autonomous threads.
- `docs/templates/token_efficient_thread_profile.md`: adds `current_request_guard` and `parked_work` fields plus phase-audit rules.
- `.agents/skills/goal-autopilot/SKILL.md`: makes the guard and cleanup checkpoint part of goal-autopilot resume/pivot behavior.

## Why It Matters
This thread showed a high-cost failure mode: after compaction and user pivots, an autonomous controller can keep following stale goal state, reopen old context, and leave subagent/worktree cleanup implicit. These rules make future runs cheaper and more reliable by forcing a small re-anchor before more work begins.

## Research Result Guidance
NA - support/workflow documentation only; no benchmark, metric, model, or paper-facing claim.

## Domain-Aware Approval
NA - docs/instruction-only change with no benchmark semantics or runtime behavior change.

## Falsification / Non-Transfer Check
NA - no empirical result. The rule is scoped to autonomous/delegated Codex goal workflows and should not be read as changing validation evidence requirements.

## Next Empirical Action
NA - no experiment required. Future workflow self-reviews can measure whether resume/pivot drift decreases.

## Validation / Proof
- `./scripts/dev/run_worktree_shared_venv.sh -- python scripts/tools/sync_ai_config.py --check` PASS
- `./scripts/dev/run_worktree_shared_venv.sh -- python scripts/dev/check_skills.py --preflight goal-autopilot` PASS
- `./scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_docs_proof_consistency.py --path AGENTS.md --path docs/templates/token_efficient_thread_profile.md --path .agents/skills/goal-autopilot/SKILL.md` PASS
- `git diff --check` PASS

## Risks / Rollout
- Low risk: instruction-only, additive wording.
- Main risk is process friction if future agents over-apply the guard; wording keeps it to long/resumed/pivoted autonomous threads.

## Docs / Provenance
- Source evidence: current representative Codex thread had repeated pivots, compaction, stale active-goal continuation risk, and explicit subagent cleanup concern.

## Downstream Propagation
- Compatibility links checked with `sync_ai_config.py --check`; no mirror edits required.

## Follow-Up Issues
- NA - no separate follow-up needed for this bounded instruction update.

## Reviewer Notes
- This intentionally avoids broad rewrites of the token-saving guidance; it adds the missing guard at the three surfaces future agents are likely to load.
