### PR TITLE
docs: tighten token-efficient goal thread guidance

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -59,6 +59,11 @@ In token-efficient mode:
   decide whether the previous goal action is still the current objective. If
   the newest request supersedes it, park the old batch with a compact handoff
   and cleanup status before editing or opening a new PR for the new request.
+- If the newest request is meta-workflow work, such as improving instructions
+  from this thread, stop treating the old ledger next action as active work.
+  Preserve its exact resumption point, create a fresh docs-or-workflow worktree
+  from `origin/main`, and limit the new PR to reusable guidance proven by the
+  observed thread failures or token leaks.
 - On continuation or after context compaction, rebuild state from the active
   ledger and compact PR/issue/worktree snapshots first. Reopen full skills,
   docs, raw CI output, or broad GitHub/worktree inventories only when the
@@ -100,6 +105,11 @@ In token-efficient mode:
   the watched branch.
 - Keep final GitHub mutation, publication, merge-readiness, benchmark, paper,
   and safety decisions local.
+- When the user makes SLURM capacity or training submission a high priority,
+  route the phase through `goal-slurm-experiment` for the single background
+  training lane or `slurm-campaign-submit` for explicit capacity-aware batches.
+  Do the private-ops submit-host, queue, duplicate, and health-check preflight
+  before assigning implementation workers or opening unrelated PR review work.
 
 The default user prompt can be short:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -110,6 +110,23 @@ mutation. If the newest request changes the objective, park the previous batch w
 instead of silently continuing stale goal work. Close or explicitly preserve no-longer-needed
 subagents, and record the cleanup or preservation decision in the common Git-dir ledger.
 
+For meta-workflow requests such as "review this thread", "improve instructions", or "make this
+workflow more token efficient", treat the request as a new bounded docs-or-workflow task. Do not keep
+executing the prior goal ledger unless the user explicitly asks to resume it. Start from a fresh
+worktree on `origin/main`, summarize the parked batch by worktree, PR/issue, dirty status, active
+delegates, and next safe command, then scope the PR to reusable instruction changes. Review the
+last thread only for decision-level evidence: repeated broad reads, command failures, unclear
+instruction loops, stale-state drift, delegate lifecycle leaks, and missed route choices.
+
+When the user elevates SLURM work as a current priority, make it a first-class lane in the next
+phase audit instead of treating it as optional background work. Use `goal-slurm-experiment` for the
+single prioritized training lane and `slurm-campaign-submit` for explicit capacity-aware batches.
+Before any submission, read the private submit guidance from `~/git/robot_sf_ll7-private-ops` on the
+submit path, prove the owning worktree exists and is clean on the submit host, refresh live queue
+state, and record duplicate checks plus immediate health-check expectations. If those checks are
+not available, classify the candidate as blocked or analysis-only rather than burning Codex turns on
+speculative job setup.
+
 ## Shared Knowledge Graph
 
 This repository tracks an Understand-Anything graph under `.understand-anything/` as a shared

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Clarified token-efficient goal-thread startup rules for workflow-improvement turns: agents now
+  explicitly park stale prior work after compaction or user pivots, scope meta-workflow requests to
+  fresh docs-or-workflow worktrees, and classify high-priority SLURM work through the appropriate
+  single-lane or capacity-aware submit workflow before burning parent-thread context.
 * Added legacy PPO snapshot parity checks (#3469):
   [`scripts/validation/check_legacy_ppo_snapshot_parity.py`](scripts/validation/check_legacy_ppo_snapshot_parity.py)
   inventories supported BR-06 PPO registry checkpoints, verifies durable GitHub-release pointers,

--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -79,6 +79,17 @@ At each phase boundary, review the active thread for token leaks before starting
 new work. Keep the audit to one compact paragraph or checklist, and patch the
 workflow only when the savings are reusable.
 
+Start every resumed or user-pivoted phase with a five-minute startup gate:
+
+- `newest_request`: quote or paraphrase the latest user request in one line.
+- `parked_work`: list any previous PR, worktree, dirty state, active delegate,
+  or running job that is being preserved instead of continued.
+- `next_mutation`: name the next branch, PR body edit, label, comment, merge,
+  job submission, or issue mutation before doing it.
+- `freshness_key`: record the PR/issue head SHA, branch base, queue timestamp,
+  usage snapshot, or submit-host proof that makes the next action safe.
+- `stop_or_continue`: explicitly choose continue, park, handoff, or stop.
+
 - Start from the current `resume_checkpoint`, `loaded_context_cache`, and
   `phase_audit_record`. Reread long skills, issue bodies, PR snapshots, or
   context notes only when their recorded freshness key changed.
@@ -105,6 +116,12 @@ workflow only when the savings are reusable.
 - For Slurm work, prove the owning worktree exists on the submit host before
   submitting. A local worktree preflight is not enough when the private submit
   wrapper reaches the cluster through SSH.
+- When SLURM is the user's current priority, classify it in the phase audit as
+  `single goal-slurm-experiment (gse) lane`, `capacity-aware batch`, `blocked`,
+  or `analysis-only`.
+  Read only the relevant private-ops submit instructions for the chosen route,
+  then record queue freshness, duplicate checks, submit-host worktree proof, and
+  immediate health-check plan before any `sbatch` or remote wrapper call.
 - Keep CI and validation loops bounded in the parent thread. Store full output
   in compact-validation artifacts and report only command, exit code, failing
   node IDs, artifact paths, and the next action.
@@ -156,6 +173,9 @@ long goal near a usage guard:
   prevents a repeated token leak and names the evidence that triggered it.
 - `parked_work`: prior worktrees, PRs, jobs, delegates, or claims intentionally
   left active because the newest request superseded the old next action.
+- `instruction_pr_scope`: exact instruction files to change, validation tier,
+  and why the change belongs in reusable guidance instead of one-off handoff
+  prose.
 
 ## Delegated Worker Artifact Contract
 


### PR DESCRIPTION
## Summary

- adds a five-minute startup gate to the token-efficient active-thread profile so resumed or user-pivoted phases must name the newest request, parked work, next mutation, freshness key, and stop/continue decision
- clarifies that meta-workflow requests should become fresh bounded docs-or-workflow branches instead of continuing stale goal-ledger work
- elevates user-prioritized SLURM work into an explicit phase-audit lane with private-ops, submit-host, queue, duplicate, and health-check preflight requirements

## Validation

- `uv run python scripts/dev/check_skills.py`
- `uv run python scripts/dev/check_skills.py --preflight goal-autopilot`
- `uv run python scripts/tools/sync_ai_config.py --check`
- `git diff --check`

## Follow-Up Issues

None.

## Downstream Propagation

NA - instruction-only guidance update; no research artifact, benchmark result, registry, or claim surface changes.

## Research Result Guidance

NA - workflow/instruction hygiene only; no experiment, benchmark, metric, or paper-facing result claim.
