### PR TITLE
feat(data): support shared external data root

### DIFF
--- a/configs/data/sdd_staging_manifest.yaml
+++ b/configs/data/sdd_staging_manifest.yaml
@@ -35,7 +35,9 @@ citation: >-
   Trajectory Understanding in Crowded Scenes." ECCV 2016.
 
 # --- Staging location (git-ignored) ----------------------------------------------------------
-# Path is repo-relative. `output/` is git-ignored, so raw SDD data never enters version control.
+# Path is repo-relative unless ROBOT_SF_EXTERNAL_DATA_ROOT is set; then the canonical staging tool
+# resolves this default to $ROBOT_SF_EXTERNAL_DATA_ROOT/sdd. `output/` is git-ignored, so raw SDD
+# data never enters version control in the default layout.
 staging_dir: output/external_data/sdd
 download_url: null  # No repository-approved direct download URL is encoded; see access_note.
 access_note: >-

--- a/docs/external_data_setup.md
+++ b/docs/external_data_setup.md
@@ -33,6 +33,14 @@ an aggregate tree checksum, and sample file hashes. Raw datasets, videos, pickle
 and private traces remain untracked; repo-local raw paths must be covered by `.gitignore` before a
 manifest can be written.
 
+For worktree-portable staging, set `ROBOT_SF_EXTERNAL_DATA_ROOT` to one machine-stable directory
+outside any checkout. When set, the assistant and downstream SDD/SocNavBench consumers resolve
+supported assets there instead of under the current worktree:
+
+```bash
+export ROBOT_SF_EXTERNAL_DATA_ROOT="$HOME/robot_sf_external_data"
+```
+
 ## Where to obtain and where to place each dataset
 
 All of these are **license/agreement-gated** — there is no scriptable direct download. Acquire each
@@ -59,46 +67,53 @@ For SocNavBench/ETH specifically, a successful `check` is what moves the `eth_fi
 
 ## Sharing external data across git worktrees
 
-The expected paths above (`output/external_data/<asset>`, `third_party/socnavbench`) resolve
-**relative to the current working tree**. Robot SF is frequently developed in
-[linked git worktrees](https://git-scm.com/docs/git-worktree), so data staged in one worktree is
-**not** visible from another — each worktree has its own `output/` and `third_party/`. Stage the
-data **once** at a machine-stable location outside any worktree, then expose it to every worktree.
+By default, the expected paths above (`output/external_data/<asset>`, `third_party/socnavbench`)
+resolve **relative to the current working tree**. Robot SF is frequently developed in
+[linked git worktrees](https://git-scm.com/docs/git-worktree), so data staged in one worktree is not
+visible from another unless you opt into a shared root or create links.
 
-Both options below target git-ignored paths, so nothing about the raw data is ever committed.
+### Recommended: one shared data root
 
-### Recommended today: symlink a shared location into each worktree
+Set `ROBOT_SF_EXTERNAL_DATA_ROOT` in your shell, `local.machine.md`, or job launcher environment and
+place each dataset under its shared subdirectory:
 
 ```bash
-# 1. Keep one physical copy outside the repo (any stable path you control):
-mkdir -p ~/robot_sf_external_data
-# ...place SDD under ~/robot_sf_external_data/sdd and SocNavBench under ~/robot_sf_external_data/socnavbench...
+export ROBOT_SF_EXTERNAL_DATA_ROOT="$HOME/robot_sf_external_data"
+mkdir -p "$ROBOT_SF_EXTERNAL_DATA_ROOT"
 
-# 2. In EACH worktree (and the main checkout), create ignored parent dirs and link the expected paths:
-mkdir -p output/external_data third_party
-ln -sfn ~/robot_sf_external_data/sdd        output/external_data/sdd
-ln -sfn ~/robot_sf_external_data/socnavbench third_party/socnavbench
+# ...place SDD under $ROBOT_SF_EXTERNAL_DATA_ROOT/sdd...
+# ...place SocNavBench under $ROBOT_SF_EXTERNAL_DATA_ROOT/socnavbench...
+
+uv run python scripts/tools/manage_external_data.py check sdd
+uv run python scripts/tools/manage_external_data.py check socnavbench-control
 ```
 
-`ln -sfn` is safe to re-run. The link lives at a `.gitignore`-covered path, so it is never tracked;
-the tool, the SDD importer, and the scenario-prior gate all then read the one shared copy. Re-create
-the two links after `git worktree add` (a future enhancement, below, removes this step).
+With that variable set, `list`, `explain`, `check`, `stage`, and `download` report the shared-root
+path. `stage` defaults to that path when `--source` is omitted. The SDD scenario-prior gate and the
+SocNavBench asset helper also consume the same resolved paths, so two worktrees pointed at the same
+root see one physical staged copy without per-worktree links.
 
-### Validate a shared copy without symlinks
+### Validate a one-off path
 
-`check`/`stage` accept `--source` with an absolute path, so you can validate a shared copy directly
-without linking it into the worktree:
+`check`/`stage` still accept `--source` with an absolute path when you need to validate a copy that
+is not under the shared root:
 
 ```bash
 uv run python scripts/tools/manage_external_data.py stage sdd --source ~/robot_sf_external_data/sdd
 ```
 
-Note: `--source` covers *validation and manifest writing*. Downstream consumers (the SDD importer,
-the scenario-prior gate, SocNavBench map conversion) still read the asset's expected repo-relative
-path, so use the symlink above when you need those to see a shared copy.
+`--source` affects only that validation/manifest command; downstream consumers use
+`ROBOT_SF_EXTERNAL_DATA_ROOT` or the default repo-relative path.
 
-### Planned: a single shared data root (no per-worktree symlinks)
+### Fallback: symlink a shared location into each worktree
 
-A follow-up will teach `manage_external_data.py` to honor a `ROBOT_SF_EXTERNAL_DATA_ROOT`
-environment variable so every worktree reads from one machine-level root automatically — removing
-the per-worktree symlink step entirely. Tracked on top of the staging-consolidation work (#3473).
+If you cannot set an environment variable for a given tool, expose the shared copy through
+git-ignored symlinks in each worktree:
+
+```bash
+mkdir -p output/external_data third_party
+ln -sfn ~/robot_sf_external_data/sdd        output/external_data/sdd
+ln -sfn ~/robot_sf_external_data/socnavbench third_party/socnavbench
+```
+
+`ln -sfn` is safe to re-run. The links live at `.gitignore`-covered paths, so they are never tracked.

--- a/scripts/data/stage_sdd_dataset_issue_2657.py
+++ b/scripts/data/stage_sdd_dataset_issue_2657.py
@@ -23,7 +23,8 @@ SAFETY CONTRACT (unchanged; enforced in the canonical module):
   closed when free space is insufficient.
 * A staged tree is validated against the pinned ``expected_tree_sha256`` before being marked
   ``staged``; a mismatch refuses to mark SDD as dataset-backed.
-* Raw data is staged into a **git-ignored** subfolder (``output/external_data/sdd`` by default).
+* Raw data is staged into a **git-ignored** subfolder (``output/external_data/sdd`` by default), or
+  into ``$ROBOT_SF_EXTERNAL_DATA_ROOT/sdd`` when that shared root is configured.
 
 Usage::
 

--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -12,6 +12,7 @@ import argparse
 import datetime as dt
 import hashlib
 import json
+import os
 import shutil
 import subprocess
 from dataclasses import dataclass
@@ -22,6 +23,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_MANIFEST_DIR = REPO_ROOT / "output" / "external_data" / "manifests"
+EXTERNAL_DATA_ROOT_ENV = "ROBOT_SF_EXTERNAL_DATA_ROOT"
 
 # Canonical SDD staging manifest. This is the single editable provenance contract for the SDD
 # asset (issues #2657, #3473): maintainers pin `expected_tree_sha256` and tune the disk-check size
@@ -57,6 +59,7 @@ class AssetSpec:
     asset_id: str
     title: str
     expected_local_path: Path
+    shared_root_subpath: Path
     source_url: str
     source_note: str
     license_note: str
@@ -77,6 +80,7 @@ ASSETS: tuple[AssetSpec, ...] = (
         asset_id="sdd",
         title="Stanford Drone Dataset annotations",
         expected_local_path=REPO_ROOT / "output" / "external_data" / "sdd",
+        shared_root_subpath=Path("sdd"),
         source_url="https://cvgl.stanford.edu/projects/uav_data/",
         source_note=(
             "Official Stanford Drone Dataset project page. Stage only files obtained under the "
@@ -106,6 +110,7 @@ ASSETS: tuple[AssetSpec, ...] = (
         asset_id="socnavbench-s3dis-eth",
         title="SocNavBench/S3DIS ETH traversible assets",
         expected_local_path=REPO_ROOT / "third_party" / "socnavbench",
+        shared_root_subpath=Path("socnavbench"),
         source_url="https://github.com/CMU-TBD/SocNavBench",
         source_note=(
             "SocNavBench code and install docs point to the official curated asset package; "
@@ -137,6 +142,7 @@ ASSETS: tuple[AssetSpec, ...] = (
         asset_id="socnavbench-control",
         title="SocNavBench control-pipeline assets",
         expected_local_path=REPO_ROOT / "third_party" / "socnavbench",
+        shared_root_subpath=Path("socnavbench"),
         source_url="https://github.com/CMU-TBD/SocNavBench",
         source_note=(
             "SocNavBench wayptnav_data assets used by the control/waypoint navigation pipeline."
@@ -162,6 +168,7 @@ ASSETS: tuple[AssetSpec, ...] = (
         asset_id="amv-calibration",
         title="AMV calibration source provenance",
         expected_local_path=REPO_ROOT / "output" / "external_data" / "amv_calibration",
+        shared_root_subpath=Path("amv_calibration"),
         source_url="https://github.com/ll7/robot_sf_ll7/issues/1585",
         source_note=(
             "Local-only accepted source bundle for AMV actuation calibration provenance. "
@@ -212,6 +219,27 @@ ASSETS: tuple[AssetSpec, ...] = (
         related_issues=(1585, 1559),
     ),
 )
+
+
+def external_data_root() -> Path | None:
+    """Return the configured shared external-data root, when one is set."""
+    raw_root = os.environ.get(EXTERNAL_DATA_ROOT_ENV)
+    if raw_root is None or not raw_root.strip():
+        return None
+    return Path(raw_root).expanduser().resolve()
+
+
+def resolve_asset_local_path(asset: AssetSpec) -> Path:
+    """Return the effective local path for an asset, honoring the shared-data root."""
+    root = external_data_root()
+    if root is None:
+        return asset.expected_local_path
+    return root / asset.shared_root_subpath
+
+
+def resolve_asset_local_path_by_id(asset_id: str) -> Path:
+    """Return the effective local path for a supported asset id."""
+    return resolve_asset_local_path(_get_asset(asset_id))
 
 
 def list_assets() -> tuple[AssetSpec, ...]:
@@ -316,12 +344,16 @@ def _tree_checksum(source_root: Path, matched_paths: list[Path]) -> dict[str, An
 def check_asset(asset_id: str, *, source_path: Path | None = None) -> dict[str, Any]:
     """Validate the local path for one external asset."""
     asset = _get_asset(asset_id)
-    root = (source_path or asset.expected_local_path).expanduser().resolve()
+    expected_local_path = resolve_asset_local_path(asset)
+    root = (source_path or expected_local_path).expanduser().resolve()
     report: dict[str, Any] = {
         "asset_id": asset.asset_id,
         "title": asset.title,
         "source_path": str(root),
-        "expected_local_path": str(asset.expected_local_path),
+        "expected_local_path": str(expected_local_path),
+        "default_local_path": str(asset.expected_local_path),
+        "external_data_root_env": EXTERNAL_DATA_ROOT_ENV,
+        "external_data_root": str(external_data_root()) if external_data_root() else None,
         "source_url": asset.source_url,
         "license_note": asset.license_note,
         "access_note": asset.access_note,
@@ -408,13 +440,13 @@ def _ensure_repo_local_raw_paths_ignored(
 def stage_asset(
     asset_id: str,
     *,
-    source_path: Path,
+    source_path: Path | None = None,
     manifest_out: Path | None = None,
     repo_root: Path = REPO_ROOT,
 ) -> dict[str, Any]:
     """Validate source_path and write a compact provenance manifest."""
     asset = _get_asset(asset_id)
-    source_root = source_path.expanduser().resolve()
+    source_root = (source_path or resolve_asset_local_path(asset)).expanduser().resolve()
     report = check_asset(asset_id, source_path=source_root)
     if not report["ok"]:
         raise ExternalDataError(f"Cannot stage {asset_id}: {report['action']}")
@@ -523,11 +555,18 @@ def _resolve_sdd_staging_dir(staging_dir_raw: str, *, manifest_path: Path) -> Pa
         raise ExternalDataError("Manifest staging_dir must not contain path traversal (`..`).")
 
     unresolved = staging_dir if staging_dir.is_absolute() else REPO_ROOT / staging_dir
+    if not staging_dir.is_absolute() and external_data_root() is not None:
+        sdd_asset = _get_asset("sdd")
+        repo_default = sdd_asset.expected_local_path.relative_to(REPO_ROOT)
+        if staging_dir == repo_default:
+            unresolved = external_data_root() / sdd_asset.shared_root_subpath
     if unresolved.is_symlink():
         raise ExternalDataError(f"Manifest staging_dir must not be a symlink: {unresolved}")
 
     resolved = unresolved.resolve(strict=False)
-    allowed_roots = (DEFAULT_STAGING_ROOT, manifest_path.resolve(strict=False).parent)
+    allowed_roots = [DEFAULT_STAGING_ROOT, manifest_path.resolve(strict=False).parent]
+    if external_data_root() is not None:
+        allowed_roots.append(external_data_root())
     if not any(resolved == root or resolved.is_relative_to(root) for root in allowed_roots):
         allowed = ", ".join(str(root) for root in allowed_roots)
         raise ExternalDataError(
@@ -979,10 +1018,14 @@ def _print_json(payload: Any) -> None:
 
 def _asset_summary(asset: AssetSpec, *, include_status: bool) -> dict[str, Any]:
     """Return one list/explain payload."""
+    expected_local_path = resolve_asset_local_path(asset)
     payload: dict[str, Any] = {
         "asset_id": asset.asset_id,
         "title": asset.title,
-        "expected_local_path": str(asset.expected_local_path),
+        "expected_local_path": str(expected_local_path),
+        "default_local_path": str(asset.expected_local_path),
+        "external_data_root_env": EXTERNAL_DATA_ROOT_ENV,
+        "external_data_root": str(external_data_root()) if external_data_root() else None,
         "source_url": asset.source_url,
         "license_note": asset.license_note,
         "access_note": asset.access_note,
@@ -1029,7 +1072,14 @@ def parse_args() -> argparse.Namespace:
 
     stage_parser = subparsers.add_parser("stage", help="Validate a local path and write manifest.")
     stage_parser.add_argument("asset_id")
-    stage_parser.add_argument("--source", type=Path, required=True)
+    stage_parser.add_argument(
+        "--source",
+        type=Path,
+        help=(
+            "Override local source path. Defaults to the resolved asset path, including "
+            f"{EXTERNAL_DATA_ROOT_ENV} when set."
+        ),
+    )
     stage_parser.add_argument("--manifest-out", type=Path)
 
     download_parser = subparsers.add_parser(

--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -229,17 +229,17 @@ def external_data_root() -> Path | None:
     return Path(raw_root).expanduser().resolve()
 
 
-def resolve_asset_local_path(asset: AssetSpec) -> Path:
+def resolve_asset_local_path(asset: AssetSpec, *, root: Path | None = None) -> Path:
     """Return the effective local path for an asset, honoring the shared-data root."""
-    root = external_data_root()
+    root = external_data_root() if root is None else root
     if root is None:
         return asset.expected_local_path
     return root / asset.shared_root_subpath
 
 
-def resolve_asset_local_path_by_id(asset_id: str) -> Path:
+def resolve_asset_local_path_by_id(asset_id: str, *, root: Path | None = None) -> Path:
     """Return the effective local path for a supported asset id."""
-    return resolve_asset_local_path(_get_asset(asset_id))
+    return resolve_asset_local_path(_get_asset(asset_id), root=root)
 
 
 def list_assets() -> tuple[AssetSpec, ...]:
@@ -344,7 +344,8 @@ def _tree_checksum(source_root: Path, matched_paths: list[Path]) -> dict[str, An
 def check_asset(asset_id: str, *, source_path: Path | None = None) -> dict[str, Any]:
     """Validate the local path for one external asset."""
     asset = _get_asset(asset_id)
-    expected_local_path = resolve_asset_local_path(asset)
+    ext_root = external_data_root()
+    expected_local_path = resolve_asset_local_path(asset, root=ext_root)
     root = (source_path or expected_local_path).expanduser().resolve()
     report: dict[str, Any] = {
         "asset_id": asset.asset_id,
@@ -353,7 +354,7 @@ def check_asset(asset_id: str, *, source_path: Path | None = None) -> dict[str, 
         "expected_local_path": str(expected_local_path),
         "default_local_path": str(asset.expected_local_path),
         "external_data_root_env": EXTERNAL_DATA_ROOT_ENV,
-        "external_data_root": str(external_data_root()) if external_data_root() else None,
+        "external_data_root": str(ext_root) if ext_root else None,
         "source_url": asset.source_url,
         "license_note": asset.license_note,
         "access_note": asset.access_note,
@@ -555,18 +556,19 @@ def _resolve_sdd_staging_dir(staging_dir_raw: str, *, manifest_path: Path) -> Pa
         raise ExternalDataError("Manifest staging_dir must not contain path traversal (`..`).")
 
     unresolved = staging_dir if staging_dir.is_absolute() else REPO_ROOT / staging_dir
-    if not staging_dir.is_absolute() and external_data_root() is not None:
+    ext_root = external_data_root()
+    if not staging_dir.is_absolute() and ext_root is not None:
         sdd_asset = _get_asset("sdd")
         repo_default = sdd_asset.expected_local_path.relative_to(REPO_ROOT)
         if staging_dir == repo_default:
-            unresolved = external_data_root() / sdd_asset.shared_root_subpath
+            unresolved = ext_root / sdd_asset.shared_root_subpath
     if unresolved.is_symlink():
         raise ExternalDataError(f"Manifest staging_dir must not be a symlink: {unresolved}")
 
     resolved = unresolved.resolve(strict=False)
     allowed_roots = [DEFAULT_STAGING_ROOT, manifest_path.resolve(strict=False).parent]
-    if external_data_root() is not None:
-        allowed_roots.append(external_data_root())
+    if ext_root is not None:
+        allowed_roots.append(ext_root)
     if not any(resolved == root or resolved.is_relative_to(root) for root in allowed_roots):
         allowed = ", ".join(str(root) for root in allowed_roots)
         raise ExternalDataError(
@@ -1018,14 +1020,15 @@ def _print_json(payload: Any) -> None:
 
 def _asset_summary(asset: AssetSpec, *, include_status: bool) -> dict[str, Any]:
     """Return one list/explain payload."""
-    expected_local_path = resolve_asset_local_path(asset)
+    ext_root = external_data_root()
+    expected_local_path = resolve_asset_local_path(asset, root=ext_root)
     payload: dict[str, Any] = {
         "asset_id": asset.asset_id,
         "title": asset.title,
         "expected_local_path": str(expected_local_path),
         "default_local_path": str(asset.expected_local_path),
         "external_data_root_env": EXTERNAL_DATA_ROOT_ENV,
-        "external_data_root": str(external_data_root()) if external_data_root() else None,
+        "external_data_root": str(ext_root) if ext_root else None,
         "source_url": asset.source_url,
         "license_note": asset.license_note,
         "access_note": asset.access_note,

--- a/scripts/tools/prepare_socnav_assets.py
+++ b/scripts/tools/prepare_socnav_assets.py
@@ -16,8 +16,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from scripts.tools.manage_external_data import resolve_asset_local_path_by_id
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
-DEFAULT_SOCNAV_ROOT = REPO_ROOT / "third_party" / "socnavbench"
+DEFAULT_SOCNAV_ROOT = resolve_asset_local_path_by_id("socnavbench-control")
 DEFAULT_SOURCE_ROOT = REPO_ROOT / "output" / "SocNavBench"
 
 

--- a/tests/tools/test_manage_external_data.py
+++ b/tests/tools/test_manage_external_data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 import pytest
@@ -19,6 +20,15 @@ def _init_git_repo(path: Path, *, gitignore: str = "") -> None:
     subprocess.run(["git", "init"], cwd=path, check=True, capture_output=True)
     if gitignore:
         (path / ".gitignore").write_text(gitignore, encoding="utf-8")
+
+
+def _write_sdd_fixture(path: Path) -> None:
+    """Create a minimal SDD annotation fixture."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / "annotations.txt").write_text(
+        "1 0 0 10 10 0 0 0 0 Pedestrian\n",
+        encoding="utf-8",
+    )
 
 
 def test_registry_covers_initial_required_asset_groups() -> None:
@@ -39,6 +49,101 @@ def test_missing_license_gated_asset_fails_closed(tmp_path: Path) -> None:
     assert report["status"] == "missing"
     assert report["auto_download_allowed"] is False
     assert "official acquisition" in report["action"]
+
+
+def test_unset_external_data_root_preserves_repo_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Without the shared-root env var, asset paths remain repo-local."""
+    monkeypatch.delenv(manage_external_data.EXTERNAL_DATA_ROOT_ENV, raising=False)
+    asset = manage_external_data._get_asset("sdd")
+
+    assert manage_external_data.external_data_root() is None
+    assert manage_external_data.resolve_asset_local_path(asset) == asset.expected_local_path
+
+
+def test_external_data_root_overrides_asset_paths(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A shared data root should replace repo-local default paths for all registered assets."""
+    shared_root = tmp_path / "robot_sf_external_data"
+    monkeypatch.setenv(manage_external_data.EXTERNAL_DATA_ROOT_ENV, str(shared_root))
+
+    assert manage_external_data.resolve_asset_local_path_by_id("sdd") == shared_root / "sdd"
+    assert (
+        manage_external_data.resolve_asset_local_path_by_id("socnavbench-control")
+        == shared_root / "socnavbench"
+    )
+    assert (
+        manage_external_data.resolve_asset_local_path_by_id("socnavbench-s3dis-eth")
+        == shared_root / "socnavbench"
+    )
+    assert (
+        manage_external_data.resolve_asset_local_path_by_id("amv-calibration")
+        == shared_root / "amv_calibration"
+    )
+
+
+def test_check_uses_external_data_root_by_default(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Default checks should validate the shared-root copy when configured."""
+    shared_root = tmp_path / "robot_sf_external_data"
+    _write_sdd_fixture(shared_root / "sdd")
+    monkeypatch.setenv(manage_external_data.EXTERNAL_DATA_ROOT_ENV, str(shared_root))
+
+    report = manage_external_data.check_asset("sdd")
+
+    assert report["ok"] is True
+    assert report["source_path"] == str((shared_root / "sdd").resolve())
+    assert report["expected_local_path"] == str(shared_root.resolve() / "sdd")
+    assert report["default_local_path"].endswith("output/external_data/sdd")
+    assert report["external_data_root"] == str(shared_root.resolve())
+
+
+def test_stage_defaults_to_external_data_root_when_source_omitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The stage subcommand path should be worktree-portable without per-worktree symlinks."""
+    shared_root = tmp_path / "robot_sf_external_data"
+    _write_sdd_fixture(shared_root / "sdd")
+    manifest_path = tmp_path / "sdd.provenance.json"
+    monkeypatch.setenv(manage_external_data.EXTERNAL_DATA_ROOT_ENV, str(shared_root))
+
+    manifest = manage_external_data.stage_asset("sdd", manifest_out=manifest_path)
+
+    assert manifest_path.is_file()
+    assert manifest["local_path"] == str((shared_root / "sdd").resolve())
+    assert manifest["validation_command"].endswith(
+        f"check sdd --source {(shared_root / 'sdd').resolve()}"
+    )
+
+
+def test_cli_list_and_check_report_external_data_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """CLI JSON output should expose the shared-root path for routing/debugging."""
+    shared_root = tmp_path / "robot_sf_external_data"
+    _write_sdd_fixture(shared_root / "sdd")
+    monkeypatch.setenv(manage_external_data.EXTERNAL_DATA_ROOT_ENV, str(shared_root))
+
+    list_result = subprocess.run(
+        [sys.executable, "scripts/tools/manage_external_data.py", "--json", "list"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    list_payload = json.loads(list_result.stdout)
+    sdd_entry = next(entry for entry in list_payload if entry["asset_id"] == "sdd")
+    assert sdd_entry["expected_local_path"] == str(shared_root.resolve() / "sdd")
+
+    check_result = subprocess.run(
+        [sys.executable, "scripts/tools/manage_external_data.py", "--json", "check", "sdd"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    check_payload = json.loads(check_result.stdout)
+    assert check_payload["ok"] is True
+    assert check_payload["source_path"] == str((shared_root / "sdd").resolve())
 
 
 def test_download_for_gated_asset_is_rejected() -> None:

--- a/tests/tools/test_prepare_socnav_assets.py
+++ b/tests/tools/test_prepare_socnav_assets.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
+import importlib
 from typing import TYPE_CHECKING
 
+import pytest
+
+from scripts.tools import manage_external_data, prepare_socnav_assets
 from scripts.tools.prepare_socnav_assets import copy_available_assets, evaluate_assets
 
 if TYPE_CHECKING:
@@ -27,6 +31,20 @@ def test_evaluate_assets_reports_missing_required_for_schematic(tmp_path: Path) 
     assert "sbpd_dataset" in missing
     assert "sbpd_traversibles" in missing
     assert "surreal_meshes" not in missing
+
+
+def test_default_socnav_root_honors_external_data_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """No-flag SocNav asset validation should use the shared external data root."""
+    shared_root = tmp_path / "robot_sf_external_data"
+    monkeypatch.setenv(manage_external_data.EXTERNAL_DATA_ROOT_ENV, str(shared_root))
+
+    reloaded = importlib.reload(prepare_socnav_assets)
+
+    assert reloaded.DEFAULT_SOCNAV_ROOT == shared_root.resolve() / "socnavbench"
+    monkeypatch.delenv(manage_external_data.EXTERNAL_DATA_ROOT_ENV)
+    importlib.reload(prepare_socnav_assets)
 
 
 def test_copy_available_assets_stages_from_source_root(tmp_path: Path) -> None:

--- a/tests/tools/test_sdd_staging_consolidation_issue_3473.py
+++ b/tests/tools/test_sdd_staging_consolidation_issue_3473.py
@@ -210,6 +210,18 @@ def test_repo_sdd_manifest_loads_through_canonical_asset() -> None:
     assert spec.expected_total_size_bytes > 0
 
 
+def test_repo_sdd_manifest_honors_external_data_root(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The default SDD staging gate should read the shared worktree-portable root when set."""
+    shared_root = tmp_path / "robot_sf_external_data"
+    monkeypatch.setenv(canonical.EXTERNAL_DATA_ROOT_ENV, str(shared_root))
+
+    spec = canonical.load_sdd_staging_spec()
+
+    assert spec.staging_dir == shared_root.resolve() / "sdd"
+
+
 def test_manifest_null_staging_dir_fails_closed(tmp_path: Path) -> None:
     """Explicit YAML null for the required staging dir must not become the string 'None'."""
     manifest_path = _write_manifest(tmp_path, staging_dir=tmp_path / "sdd")


### PR DESCRIPTION
## Summary
Adds `ROBOT_SF_EXTERNAL_DATA_ROOT` as a shared external-data root so supported licensed datasets can be staged once outside any worktree and reused by the external-data assistant plus SDD/SocNavBench consumers.

## Linked Issues
- Closes `#3492`
- Closes `#3494`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added shared-root resolution to `manage_external_data.py`, including JSON-visible `default_local_path`, `external_data_root_env`, and `external_data_root` fields.
- Made `stage` default to the resolved asset path when `--source` is omitted, while preserving explicit `--source` behavior.
- Routed the default SDD staging manifest and SocNavBench asset helper through the same resolver.
- Updated external-data docs, the SDD staging manifest comment, and compatibility wrapper docs.
- Added tests for unset/set env behavior, CLI reporting, default staging, SDD gate resolution, and SocNavBench default-root resolution.

## Why It Matters
- Added value: two worktrees can point at one machine-level data root and see the same staged copy without per-worktree symlinks.
- Expected impact: fewer duplicated bulky external assets and less setup friction for SDD/SocNavBench workflows.
- Why this is worth merging now: it directly unblocks the external-data staging follow-up from the worktree-sharing docs.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/tooling path for licensed external-data staging, no research result claim.
- Comparator or baseline, if applicable: NA
- Evidence tier: NA
- Result classification: NA
- Decision or stop rule, if applicable: NA
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support helper; it routes local data paths and does not interpret evidence.

## Domain-Aware Approval
- Required for this PR: no - support/tooling change with no benchmark, metric, or paper-facing result interpretation.
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: NA
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: NA
  - Fallback/degraded exclusions: NA
  - Claim boundary: NA
  - Implementation integrity vs experimental validity: implementation covered by focused tests; no experimental-validity claim.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no research mechanism.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: NA
- Follow-up question or issue for weak, negative, or non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA - support/tooling change.
- Extractor or analysis tool needed: NA
- Artifact missing or unavailable: NA
- Stop / revise / continue decision: NA
- Proposed child issue or existing follow-up: NA

## Validation / Proof
- Commands run:
  - `uv run ruff check scripts/tools/manage_external_data.py scripts/tools/prepare_socnav_assets.py scripts/data/stage_sdd_dataset_issue_2657.py tests/tools/test_manage_external_data.py tests/tools/test_sdd_staging_consolidation_issue_3473.py tests/tools/test_prepare_socnav_assets.py`
  - `uv run ruff format --check scripts/tools/manage_external_data.py scripts/tools/prepare_socnav_assets.py scripts/data/stage_sdd_dataset_issue_2657.py tests/tools/test_manage_external_data.py tests/tools/test_sdd_staging_consolidation_issue_3473.py tests/tools/test_prepare_socnav_assets.py`
  - `uv run python -m pytest tests/tools/test_manage_external_data.py tests/tools/test_sdd_staging_consolidation_issue_3473.py tests/tools/test_prepare_socnav_assets.py tests/data/test_stage_sdd_dataset_issue_2657.py tests/research/test_scenario_distribution_prior_manifest.py -q`
  - `ROBOT_SF_EXTERNAL_DATA_ROOT=/tmp/robot_sf_external_data_issue3492 uv run python scripts/tools/manage_external_data.py --json explain sdd`
  - `uv run python scripts/tools/sync_ai_config.py --check`
  - `git diff --check`
- Evidence that the change works here: focused tests pass (`64 passed`), and CLI `explain sdd` reports `expected_local_path` under the shared root while retaining the repo-local `default_local_path`.
- Benchmarks or smoke tests, if applicable: NA - not a benchmark/runtime behavior change.

## Risks / Rollout
- Compatibility risks: low; unset env preserves repo-local defaults, and explicit `--source` remains supported.
- Failure modes: a mis-set shared root reports missing/incomplete assets at the shared path instead of the worktree path.
- Rollback or fallback plan: unset `ROBOT_SF_EXTERNAL_DATA_ROOT` or use documented per-worktree symlinks.

## Docs / Provenance
- Updated docs: `docs/external_data_setup.md`, `configs/data/sdd_staging_manifest.yaml`, `scripts/data/stage_sdd_dataset_issue_2657.py`.
- Relevant design or provenance notes: raw external data remains local/untracked; no download path is added.
- Any assumptions that need to be preserved: shared-root subpaths are `sdd`, `socnavbench`, and `amv_calibration`.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - this PR closes #3492 and #3494.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): yes - asset registry behavior and SDD manifest comment updated.
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened for deferred propagation (yes/no/NA): NA
- Not applicable because: this is support/tooling for local licensed-data staging, not evidence production.

## Follow-Up Issues
- Deferred work: none known.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the SDD manifest override only rewrites the default repo-relative `output/external_data/sdd` path; custom manifests keep their explicit staging paths.
- Any known limitations: `download` remains fail-closed for current licensed assets because no license-safe direct downloader is encoded.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable shared external-data root via `ROBOT_SF_EXTERNAL_DATA_ROOT` environment variable for portable, multi-worktree setups
  * Made asset source paths auto-resolved and optional (defaults to configured shared root when set)

* **Documentation**
  * Updated external data setup guide with shared-root configuration recommendations and instructions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->