### PR TITLE
feat(benchmark): add episode event ledger guard

### DIFF
--- a/robot_sf/benchmark/event_ledger.py
+++ b/robot_sf/benchmark/event_ledger.py
@@ -1,0 +1,261 @@
+"""Canonical per-episode safety-event ledger helpers."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from typing import Any
+
+EPISODE_EVENT_LEDGER_SCHEMA_VERSION = "EpisodeEventLedger.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class ExactEvents:
+    """Exact simulator outcome events for one episode."""
+
+    collision: bool
+    goal_reached: bool
+    timeout: bool
+    invalid_run: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class SurrogateEvents:
+    """Derived diagnostic safety events for one episode."""
+
+    near_miss: bool = False
+    clearance_breach: bool = False
+    ttc_breach: bool = False
+    oscillation: bool = False
+
+
+@dataclass(frozen=True, slots=True)
+class EpisodeEventLedger:
+    """Versioned source-of-truth event block for benchmark episode records."""
+
+    schema_version: str
+    scenario_id: str
+    seed: int
+    planner: str
+    software_commit: str | None
+    exact_events: ExactEvents
+    surrogate_events: SurrogateEvents = field(default_factory=SurrogateEvents)
+    metric_definitions: dict[str, dict[str, str]] = field(default_factory=dict)
+    reconciliation: dict[str, Any] = field(default_factory=dict)
+    provenance: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable ledger payload."""
+        return asdict(self)
+
+
+def _bool_at(payload: Mapping[str, Any], key: str, *, default: bool = False) -> bool:
+    """Read a boolean-like field from a mapping.
+
+    Returns:
+        Parsed boolean value, or ``default`` when the key is absent or unrecognized.
+    """
+    if key not in payload:
+        return default
+    value = payload.get(key)
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)) and math.isfinite(float(value)):
+        return value != 0
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "1", "yes", "y", "on"}:
+            return True
+        if normalized in {"false", "0", "no", "n", "off", ""}:
+            return False
+    return default
+
+
+def _safe_int(value: Any, *, default: int = 0) -> int:
+    """Return an integer value when available.
+
+    Returns:
+        Parsed integer, or ``default`` when parsing fails.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _finite_float(value: Any) -> float | None:
+    """Return a finite float value when available."""
+    try:
+        result = float(value)
+    except (TypeError, ValueError):
+        return None
+    return result if math.isfinite(result) else None
+
+
+def _metric_value(metrics: Mapping[str, Any], *keys: str) -> tuple[float | None, str | None]:
+    """Return the first finite metric value and source path."""
+    for key in keys:
+        if key not in metrics:
+            continue
+        value = _finite_float(metrics.get(key))
+        if value is not None:
+            return value, f"metrics.{key}"
+    return None, None
+
+
+def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Build an ``EpisodeEventLedger.v1`` payload from an episode record.
+
+    Returns:
+        JSON-serializable ledger payload.
+    """
+    metrics = record.get("metrics")
+    metrics = metrics if isinstance(metrics, Mapping) else {}
+    outcome = record.get("outcome")
+    outcome = outcome if isinstance(outcome, Mapping) else {}
+    termination_reason = str(record.get("termination_reason") or "")
+
+    collision_value, collision_source = _metric_value(
+        metrics,
+        "total_collision_count",
+        "collisions",
+        "collision_count",
+        "collision_rate",
+    )
+    near_miss_value, near_miss_source = _metric_value(metrics, "near_misses", "near_miss_count")
+    min_clearance, min_clearance_source = _metric_value(metrics, "min_clearance", "min_distance")
+    ttc_value, ttc_source = _metric_value(metrics, "ttc_breach_count", "ttc_violations")
+    oscillation_value, oscillation_source = _metric_value(
+        metrics,
+        "oscillation_count",
+        "heading_rate_sign_changes",
+    )
+
+    metric_definitions = {
+        "collision_count": {
+            "kind": "exact_or_sampled",
+            "source": collision_source or "missing",
+        },
+        "near_miss": {
+            "kind": "derived",
+            "source": near_miss_source or "missing",
+        },
+        "clearance_breach": {
+            "kind": "derived",
+            "source": min_clearance_source or "missing",
+        },
+        "ttc_breach": {
+            "kind": "derived",
+            "source": ttc_source or "missing",
+        },
+        "oscillation": {
+            "kind": "derived",
+            "source": oscillation_source or "missing",
+        },
+    }
+    exact = ExactEvents(
+        collision=_bool_at(outcome, "collision_event") or termination_reason == "collision",
+        goal_reached=_bool_at(outcome, "route_complete") or termination_reason == "success",
+        timeout=_bool_at(outcome, "timeout_event")
+        or termination_reason in {"max_steps", "truncated"},
+        invalid_run=termination_reason == "error" or record.get("status") in {"error", "invalid"},
+    )
+    surrogate = SurrogateEvents(
+        near_miss=near_miss_value is not None and near_miss_value > 0.0,
+        clearance_breach=min_clearance is not None and min_clearance <= 0.0,
+        ttc_breach=ttc_value is not None and ttc_value > 0.0,
+        oscillation=oscillation_value is not None and oscillation_value > 0.0,
+    )
+    reconciliation = {
+        "collision_metric_value": collision_value,
+        "collision_metric_source": collision_source,
+        "audit_result": "unchecked",
+    }
+    ledger = EpisodeEventLedger(
+        schema_version=EPISODE_EVENT_LEDGER_SCHEMA_VERSION,
+        scenario_id=str(record.get("scenario_id") or "unknown"),
+        seed=_safe_int(record.get("seed"), default=0),
+        planner=str(record.get("algo") or record.get("planner") or "unknown"),
+        software_commit=(
+            str(record.get("git_hash")) if record.get("git_hash") is not None else None
+        ),
+        exact_events=exact,
+        surrogate_events=surrogate,
+        metric_definitions=metric_definitions,
+        reconciliation=reconciliation,
+        provenance={"source": "episode_record"},
+    )
+    payload = ledger.to_dict()
+    payload["reconciliation"]["audit_result"] = (
+        "pass" if not reconcile_event_ledger(payload) else "fail"
+    )
+    return payload
+
+
+def ensure_event_ledger(record: dict[str, Any]) -> dict[str, Any]:
+    """Attach a canonical event ledger to an episode record when missing.
+
+    Returns:
+        The existing or newly attached event ledger payload.
+    """
+    ledger = record.get("event_ledger")
+    if (
+        not isinstance(ledger, dict)
+        or ledger.get("schema_version") != EPISODE_EVENT_LEDGER_SCHEMA_VERSION
+    ):
+        record["event_ledger"] = build_event_ledger(record)
+    return record["event_ledger"]
+
+
+def reconcile_event_ledger(ledger: Mapping[str, Any]) -> list[str]:
+    """Return reconciliation violations for one event ledger."""
+    violations: list[str] = []
+    exact = ledger.get("exact_events")
+    exact = exact if isinstance(exact, Mapping) else {}
+    reconciliation = ledger.get("reconciliation")
+    reconciliation = reconciliation if isinstance(reconciliation, Mapping) else {}
+    metric_definitions = ledger.get("metric_definitions")
+    metric_definitions = metric_definitions if isinstance(metric_definitions, Mapping) else {}
+
+    collision_metric = _finite_float(reconciliation.get("collision_metric_value"))
+    if bool(exact.get("collision")) and (collision_metric is None or collision_metric <= 0.0):
+        violations.append("exact collision event requires collision metric > 0")
+    if bool(exact.get("goal_reached")) and bool(exact.get("invalid_run")):
+        violations.append("goal_reached and invalid_run are mutually exclusive")
+    missing_definitions = [
+        name
+        for name in (
+            "collision_count",
+            "near_miss",
+            "clearance_breach",
+            "ttc_breach",
+            "oscillation",
+        )
+        if not isinstance(metric_definitions.get(name), Mapping)
+        or not metric_definitions[name].get("kind")
+    ]
+    if missing_definitions:
+        violations.append("missing metric definitions: " + ", ".join(missing_definitions))
+    return violations
+
+
+def validate_record_event_ledger(record: dict[str, Any]) -> list[str]:
+    """Ensure and reconcile the event ledger on one episode record.
+
+    Returns:
+        Reconciliation violation messages, if any.
+    """
+    return reconcile_event_ledger(ensure_event_ledger(record))
+
+
+__all__ = [
+    "EPISODE_EVENT_LEDGER_SCHEMA_VERSION",
+    "EpisodeEventLedger",
+    "ExactEvents",
+    "SurrogateEvents",
+    "build_event_ledger",
+    "ensure_event_ledger",
+    "reconcile_event_ledger",
+    "validate_record_event_ledger",
+]

--- a/robot_sf/benchmark/map_runner_jsonl.py
+++ b/robot_sf/benchmark/map_runner_jsonl.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING, Any
 
+from robot_sf.benchmark.event_ledger import validate_record_event_ledger
 from robot_sf.benchmark.schema_validator import validate_episode
 from robot_sf.benchmark.utils import validate_episode_success_integrity
 
@@ -19,6 +20,7 @@ def write_validated_to_handle(
 ) -> None:
     """Validate one episode record and append it to an open JSONL handle."""
     violations = validate_episode_success_integrity(record)
+    violations.extend(validate_record_event_ledger(record))
     if violations:
         raise ValueError("Episode integrity contradictions detected: " + "; ".join(violations))
     validate_episode(record, schema)

--- a/robot_sf/benchmark/runner.py
+++ b/robot_sf/benchmark/runner.py
@@ -53,6 +53,7 @@ else:
 
 from robot_sf.benchmark.algorithm_metadata import enrich_algorithm_metadata
 from robot_sf.benchmark.constants import EPISODE_SCHEMA_VERSION
+from robot_sf.benchmark.event_ledger import validate_record_event_ledger
 from robot_sf.benchmark.local_model_artifacts import validate_no_local_model_artifacts
 from robot_sf.benchmark.manifest import load_manifest, save_manifest
 from robot_sf.benchmark.map_runner import run_map_batch
@@ -1398,6 +1399,7 @@ def validate_and_write(
     """Validate an episode record against schema and append to JSONL."""
     schema = load_schema(schema_path)
     violations = validate_episode_success_integrity(record)
+    violations.extend(validate_record_event_ledger(record))
     if violations:
         raise ValueError("Episode integrity contradictions detected: " + "; ".join(violations))
     validate_episode(record, schema)
@@ -1466,6 +1468,7 @@ def _run_job_worker(job: tuple[dict[str, Any], int, dict[str, Any]]) -> dict[str
 def _write_validated_record(out_path: Path, schema: dict[str, Any], rec: dict[str, Any]) -> None:
     """Validate a record against schema and append to JSONL."""
     violations = validate_episode_success_integrity(rec)
+    violations.extend(validate_record_event_ledger(rec))
     if violations:
         raise ValueError("Episode integrity contradictions detected: " + "; ".join(violations))
     validate_episode(rec, schema)

--- a/tests/benchmark/test_event_ledger.py
+++ b/tests/benchmark/test_event_ledger.py
@@ -1,0 +1,154 @@
+"""Tests for the canonical episode event ledger."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.event_ledger import (
+    EPISODE_EVENT_LEDGER_SCHEMA_VERSION,
+    build_event_ledger,
+    reconcile_event_ledger,
+    validate_record_event_ledger,
+)
+from robot_sf.benchmark.map_runner_jsonl import write_validated_to_handle
+from robot_sf.benchmark.runner import validate_and_write
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _record(*, collision_event: bool = False, collisions: float = 0.0) -> dict:
+    """Return a minimal episode record with outcome and metric fields."""
+    return {
+        "version": "v1",
+        "episode_id": "episode-1",
+        "scenario_id": "scenario-1",
+        "seed": 7,
+        "algo": "goal",
+        "git_hash": "abc123",
+        "metrics": {
+            "success": 0.0 if collision_event else 1.0,
+            "collisions": collisions,
+            "near_misses": 1.0,
+            "min_clearance": 0.2,
+        },
+        "termination_reason": "collision" if collision_event else "success",
+        "outcome": {
+            "route_complete": not collision_event,
+            "collision_event": collision_event,
+            "timeout_event": False,
+        },
+    }
+
+
+def _schema(path: Path) -> Path:
+    """Write a permissive schema for writer-path tests."""
+    schema_path = path / "episode.schema.json"
+    schema_path.write_text(
+        json.dumps(
+            {
+                "$schema": "https://json-schema.org/draft/2020-12/schema",
+                "type": "object",
+                "additionalProperties": True,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return schema_path
+
+
+def test_build_event_ledger_records_exact_and_surrogate_events() -> None:
+    """Ledger payloads should expose exact outcomes and derived event definitions."""
+    ledger = build_event_ledger(_record(collision_event=True, collisions=1.0))
+
+    assert ledger["schema_version"] == EPISODE_EVENT_LEDGER_SCHEMA_VERSION
+    assert ledger["scenario_id"] == "scenario-1"
+    assert ledger["seed"] == 7
+    assert ledger["planner"] == "goal"
+    assert ledger["software_commit"] == "abc123"
+    assert ledger["exact_events"]["collision"] is True
+    assert ledger["exact_events"]["goal_reached"] is False
+    assert ledger["surrogate_events"]["near_miss"] is True
+    assert ledger["metric_definitions"]["collision_count"]["source"] == "metrics.collisions"
+    assert ledger["reconciliation"]["audit_result"] == "pass"
+
+
+def test_build_event_ledger_parses_string_booleans_without_truthiness_leaks() -> None:
+    """String booleans from JSON-adjacent records should not rely on Python truthiness."""
+    record = _record(collision_event=False, collisions=0.0)
+    record["outcome"]["collision_event"] = "false"
+    record["outcome"]["timeout_event"] = "0"
+    record["outcome"]["route_complete"] = "true"
+
+    ledger = build_event_ledger(record)
+
+    assert ledger["exact_events"]["collision"] is False
+    assert ledger["exact_events"]["timeout"] is False
+    assert ledger["exact_events"]["goal_reached"] is True
+
+
+def test_build_event_ledger_defaults_malformed_seed() -> None:
+    """Malformed seed values should not break the validation write path."""
+    record = _record(collision_event=False, collisions=0.0)
+    record["seed"] = "not-an-int"
+
+    assert build_event_ledger(record)["seed"] == 0
+
+
+def test_reconcile_event_ledger_surfaces_exact_collision_metric_disagreement() -> None:
+    """An exact collision event must not silently coexist with zero collision metrics."""
+    record = _record(collision_event=True, collisions=1.0)
+    ledger = build_event_ledger(record)
+    ledger["reconciliation"]["collision_metric_value"] = 0.0
+
+    assert reconcile_event_ledger(ledger) == ["exact collision event requires collision metric > 0"]
+
+
+def test_reconcile_event_ledger_rejects_goal_and_invalid_run_overlap() -> None:
+    """Goal and invalid-run exact events are mutually exclusive."""
+    ledger = build_event_ledger(_record(collision_event=False, collisions=0.0))
+    ledger["exact_events"]["invalid_run"] = True
+
+    assert reconcile_event_ledger(ledger) == ["goal_reached and invalid_run are mutually exclusive"]
+
+
+def test_reconcile_event_ledger_requires_metric_definitions() -> None:
+    """Every ledger metric family should carry a definition entry."""
+    ledger = build_event_ledger(_record(collision_event=False, collisions=0.0))
+    del ledger["metric_definitions"]["ttc_breach"]
+
+    assert reconcile_event_ledger(ledger) == ["missing metric definitions: ttc_breach"]
+
+
+def test_validate_record_event_ledger_attaches_canonical_payload() -> None:
+    """Validation should materialize the canonical ledger on legacy episode records."""
+    record = _record(collision_event=False, collisions=0.0)
+
+    assert validate_record_event_ledger(record) == []
+    assert record["event_ledger"]["schema_version"] == EPISODE_EVENT_LEDGER_SCHEMA_VERSION
+
+
+def test_jsonl_writer_rejects_collision_ledger_disagreement(tmp_path: Path) -> None:
+    """The write path should fail closed when a supplied ledger contradicts exact events."""
+    record = _record(collision_event=True, collisions=1.0)
+    record["event_ledger"] = build_event_ledger(record)
+    record["event_ledger"]["reconciliation"]["collision_metric_value"] = 0.0
+
+    with (tmp_path / "episodes.jsonl").open("w", encoding="utf-8") as handle:
+        with pytest.raises(ValueError, match="exact collision event requires collision metric > 0"):
+            write_validated_to_handle(handle, json.loads(_schema(tmp_path).read_text()), record)
+
+
+def test_runner_validate_and_write_attaches_event_ledger(tmp_path: Path) -> None:
+    """The classic runner writer should persist a canonical event ledger on legacy records."""
+    record = _record(collision_event=False, collisions=0.0)
+    out_path = tmp_path / "episodes.jsonl"
+
+    validate_and_write(record, _schema(tmp_path), out_path)
+
+    payload = json.loads(out_path.read_text(encoding="utf-8"))
+    assert payload["event_ledger"]["schema_version"] == EPISODE_EVENT_LEDGER_SCHEMA_VERSION
+    assert payload["event_ledger"]["exact_events"]["goal_reached"] is True


### PR DESCRIPTION
## Summary
- add `EpisodeEventLedger.v1` helpers for exact simulator events, surrogate diagnostic events, metric definitions, and reconciliation status
- attach/reconcile the ledger in classic and map benchmark JSONL write paths
- add regression coverage for exact collision events, goal/invalid mutual exclusion, missing metric definitions, and both writer paths

Refs #3482

## Validation
- `uv run ruff check robot_sf/benchmark/event_ledger.py robot_sf/benchmark/runner.py robot_sf/benchmark/map_runner_jsonl.py tests/benchmark/test_event_ledger.py`
- `uv run ruff format --check robot_sf/benchmark/event_ledger.py robot_sf/benchmark/runner.py robot_sf/benchmark/map_runner_jsonl.py tests/benchmark/test_event_ledger.py`
- `uv run python -m pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_termination_reason.py tests/benchmark/test_runner_exception_logging.py -q` (16 passed)
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (1550 core passed; 2886 optional passed, 7 skipped; changed-file coverage 100% before review-fix amend; focused checks above passed after amend)

## Follow-Up Issues
- #3482 remains open for the larger frozen `0.0.2` trace rerun, before/after diff, and downstream analyzer/table consumer migration.

## Domain-Aware Approval
- Required for this PR: yes - PR body includes evidence-tier/result-classification language for a benchmark integrity guard.
- Domains reviewed: benchmark interpretation
- Status: waived
- Approver/review source or waiver: self-waived because this PR only adds implementation integrity guardrails; #3482 remains the blocker for experimental validity review before any paper-facing numerical claim.
- Validity checklist:
  - Target claim/hypothesis: Exact simulator events should not silently disagree with derived/sample metrics at write time.
  - Comparator or split/evidence validity: NA - no comparison, split, benchmark run, or frozen trace rerun is introduced.
  - Fallback/degraded exclusions: NA - no fallback/degraded rows are introduced or counted as evidence.
  - Claim boundary: Infrastructure/preflight guard only; not benchmark evidence and not a manuscript result.
  - Implementation integrity vs experimental validity: Tests and CI cover implementation integrity; experimental validity remains blocked on #3482 follow-up rerun/diff work.

## Downstream Propagation
- Parent issue: #3482 stays open; this PR is the first schema/reconciliation guard slice.
- Benchmark/metric surfaces: write-path validation now attaches and checks `event_ledger`; no benchmark result or paper-facing conclusion is produced here.
- Context/index updates: not needed for this narrow code slice; PR notes record the remaining issue work.
- Generated artifacts: readiness/coverage outputs under `output/` are ignored local validation artifacts and not committed.

## Research Result Guidance
- Target blocker: exact simulator events must not silently disagree with derived/sample metrics.
- Evidence tier: implementation/preflight guard only.
- Result classification: infrastructure guard, not benchmark evidence.
- Stop rule: no paper-facing numerical claim until #3482 reruns frozen traces and records before/after diffs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced an episode event ledger system to track and validate safety-critical events during simulations, including collisions, goal achievements, and timeouts, along with diagnostic event detection such as near misses and clearance breaches.

* **Tests**
  * Added comprehensive test coverage for event ledger functionality and benchmarking workflow integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->