### PR TITLE
config: align issue 3254 predictive schema

### DIFF
--- a/configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
+++ b/configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
@@ -46,7 +46,6 @@ mixing:
 
 training:
   model_id: predictive_crossing_conflict_weighted_issue_3254_xl_ego
-  model_family: predictive_ego_v1
   epochs: 400
   batch_size: 128
   lr: 0.0002

--- a/configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
+++ b/configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
@@ -4,6 +4,8 @@
 # #3214 weighting spec, but it does not publish a retrained checkpoint, benchmark
 # result, or predictive model-improvement claim.
 
+model_family: predictive_ego_v1
+
 experiment:
   run_id: predictive_crossing_conflict_weighted_issue_3254
 
@@ -44,6 +46,7 @@ mixing:
 
 training:
   model_id: predictive_crossing_conflict_weighted_issue_3254_xl_ego
+  model_family: predictive_ego_v1
   epochs: 400
   batch_size: 128
   lr: 0.0002

--- a/tests/training/test_run_predictive_training_pipeline.py
+++ b/tests/training/test_run_predictive_training_pipeline.py
@@ -456,7 +456,9 @@ def test_issue_3254_config_targets_crossing_conflict_weighting_spec() -> None:
     assert "shuffle_seed" not in mixing
     assert cfg["base_collection"]["ego_conditioning"] is True
     assert cfg["hardcase_collection"]["ego_conditioning"] is True
+    assert cfg["model_family"] == PREDICTIVE_EGO_FEATURE_SCHEMA
     assert cfg["training"]["model_id"] == "predictive_crossing_conflict_weighted_issue_3254_xl_ego"
+    assert cfg["training"]["model_family"] == PREDICTIVE_EGO_FEATURE_SCHEMA
     assert "prepare-only" in cfg["claim_boundary"].lower()
 
 

--- a/tests/training/test_run_predictive_training_pipeline.py
+++ b/tests/training/test_run_predictive_training_pipeline.py
@@ -458,7 +458,6 @@ def test_issue_3254_config_targets_crossing_conflict_weighting_spec() -> None:
     assert cfg["hardcase_collection"]["ego_conditioning"] is True
     assert cfg["model_family"] == PREDICTIVE_EGO_FEATURE_SCHEMA
     assert cfg["training"]["model_id"] == "predictive_crossing_conflict_weighted_issue_3254_xl_ego"
-    assert cfg["training"]["model_family"] == PREDICTIVE_EGO_FEATURE_SCHEMA
     assert "prepare-only" in cfg["claim_boundary"].lower()
 
 


### PR DESCRIPTION
## Summary
Align the #3254 crossing-conflict predictive retraining config with its ego-conditioned dataset contract.

The pipeline was collecting `predictive_ego_v1` datasets but the training stage still defaulted to `predictive_legacy_v1`; this makes the model family explicit at the top level so the train command receives the ego schema through the existing config contract.

## Linked Issues
- Relates to `#3254`
- Relates to `#3214`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added top-level `model_family: predictive_ego_v1` to `configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml`.
- Kept `training` focused on training hyperparameters rather than duplicating the top-level schema selector.
- Extended the existing #3254 config contract test to assert the top-level ego model-family declaration.

## Why It Matters
- Added value: unblocks the #3254 Slurm retraining path after the first rerun generated an ego dataset and failed closed on a legacy-vs-ego schema mismatch.
- Expected impact: future launches use the same predictive feature schema in dataset collection, mixing, and training.
- Why this is worth merging now: job `13042` is already running from this branch and passed the previous failure point with `--model-family predictive_ego_v1`.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker for the #3254 crossing-conflict predictive retraining launch.
- Comparator or baseline, if applicable: previous job `13036`, which generated an ego-schema mixed dataset but failed before training because the train stage expected `predictive_legacy_v1`.
- Evidence tier: launch packet / blocker-resolution.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: merge if the config contract is correct and the Slurm rerun can proceed into training; do not treat this PR as a model-improvement result.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3254 after job `13042` completes.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Domain-Aware Approval
- Required for this PR: yes - waived because this resolves a launch/config mismatch and does not change evidence classification or paper-facing claims.
- Domains reviewed: predictive training schema handoff, evidence classification, and paper-facing claim boundary.
- Status: waived
- Approver/review source or waiver: launch/config-only blocker fix; no benchmark or model-improvement result is promoted.
- Validity checklist:
  - Target claim/hypothesis: NA
  - Comparator or split/evidence validity: no new result claim.
  - Fallback/degraded exclusions: no benchmark rows promoted.
  - Claim boundary: launch/config only.
  - Implementation integrity vs experimental validity: implementation covered by config contract test; experimental validity deferred to #3254 result analysis.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes - job `13042` launched training with `--model-family predictive_ego_v1`.
- Did the intervention change command source, selected command, trajectory, or route progress? It changed the predictive training command's model-family argument.
- Did the scenario actually contain the targeted failure mode? yes - job `13036` failed on `expected 'predictive_legacy_v1', got 'predictive_ego_v1'`.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #3254 final result analysis after job `13042` completes.

## Next Empirical Action
- Rerun needed: already running as Slurm job `13042`.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: final `final_performance_summary.json` pending job completion.
- Stop / revise / continue decision: continue.
- Proposed child issue or existing follow-up: #3254.

## Validation / Proof
- Commands run:
  - `uv run ruff check tests/training/test_run_predictive_training_pipeline.py`
  - `uv run ruff format --check tests/training/test_run_predictive_training_pipeline.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/training/test_run_predictive_training_pipeline.py -k 'issue_3254_config or passes_obstacle_model_family'`
  - `git status --ignored --short -uall output`
- Evidence that the change works here: focused tests passed after merging latest `origin/main`; no generated `output/` artifacts needed preservation.
- Benchmarks or smoke tests, if applicable: Slurm job `13042` from this branch passed the previous early failure window and started W&B run `3tu3tmee`.

## Risks / Rollout
- Compatibility risks: low; the config was already ego-conditioned, and this makes the existing contract explicit.
- Failure modes: training may still fail later for unrelated predictive training or evaluation reasons.
- Rollback or fallback plan: revert these config declarations and return #3254 to blocked if a later analysis proves the ego schema was not intended.

## Docs / Provenance
- Updated docs: none.
- Relevant design or provenance notes: #3254 and #3214.
- Any assumptions that need to be preserved: this PR is not evidence that the retrained model improves outcomes; it only repairs the launch/config mismatch.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, update #3254 after final job analysis.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark/model result is promoted by this PR.

For benchmark, registry, claim-map, or paper-facing changes, explicitly say when downstream
propagation is deferred and name the issue or note that will carry it.

## Follow-Up Issues
- Deferred work: retrieve and analyze Slurm job `13042` under #3254.
- Issues opened for follow-up: none.

## Reviewer Notes
- Verify that the top-level `model_family` remains the single schema selector for this config.
- Known limitation: final model/evaluation evidence is pending `13042`; this PR should remain a blocker fix, not a result claim.