### PR TITLE
bench: add issue 1554 s20 h500 launch packet

### DIFF
--- a/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
@@ -1,0 +1,119 @@
+# Issue #1554 S20 extension of the paper v1 matrix with h500-derived
+# per-scenario route-completion horizons.
+#
+# This config preserves the baseline-ready paper matrix and h500 horizon
+# contract, changing only the seed schedule from the S3 `eval` set to the
+# predeclared `paper_eval_s20` schedule. Treat outputs as paper-facing only
+# after the seed-sufficiency/rank-stability analysis and fail-closed row audit.
+
+name: paper_experiment_matrix_v1_scenario_horizons_h500_s20
+paper_facing: true
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+scenario_horizons: configs/policy_search/scenario_horizons_h500.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+route_clearance_certifications: configs/benchmarks/route_clearance_certifications_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+seed_policy:
+  mode: seed-set
+  seed_set: paper_eval_s20
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+workers: 2
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: false
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+
+kinematics_matrix:
+  - differential_drive
+
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: false
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: issue-1554-s20-scenario-horizons-h500
+
+planners:
+  - key: prediction_planner
+    algo: prediction_planner
+    planner_group: experimental
+    algo_config: configs/algos/prediction_planner_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: social_force
+    algo: social_force
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback
+
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_issue_791_eval_aligned_large_capacity.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+    workers: 1
+
+  - key: socnav_sampling
+    algo: socnav_sampling
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast
+
+  - key: sacadrl
+    algo: sacadrl
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fallback
+
+  - key: scenario_adaptive_hybrid_orca_v1
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+    benchmark_profile: experimental
+
+  - key: hybrid_rule_v3_fast_progress_static_escape
+    algo: hybrid_rule_local_planner
+    planner_group: experimental
+    algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+    benchmark_profile: experimental

--- a/docs/context/issue_1554_s20_h500_launch_packet.md
+++ b/docs/context/issue_1554_s20_h500_launch_packet.md
@@ -1,0 +1,77 @@
+# Issue #1554 S20 h500 Launch Packet
+
+This launch packet makes issue #1554 concrete enough for Slurm routing without
+turning it into an open-ended benchmark rerun. It targets the paper-facing
+scenario-horizon h500 matrix and extends only the seed schedule from the frozen
+S3 `eval` seeds to the predeclared S20 schedule in
+`configs/benchmarks/seed_sets_v1.yaml`.
+
+## Claim Gate
+
+- Target claim: the paper-facing h500 planner comparison is stable enough to
+  support planner-ranking or safety-delta language after confidence intervals
+  and rank-stability analysis.
+- Metric surface: success, collision, near-miss/clearance where available,
+  low-progress/timeout, `time_to_goal_norm`, and SNQI for rank stability.
+- Planner rows: the baseline-ready core rows in
+  `configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml`.
+- Seed tier: S20 via `paper_eval_s20` (`111` through `130`).
+- Why S10/S3 is insufficient: issue #3216 needs confidence intervals and
+  bootstrap rank stability before manuscript-relied planner rankings are
+  promoted beyond diagnostic or nominal status.
+
+## Runnable Config
+
+- Config:
+  `configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml`
+- Seed set: `paper_eval_s20`
+- Scenario matrix: `configs/scenarios/classic_interactions_francis2023.yaml`
+- Horizon schedule: `configs/policy_search/scenario_horizons_h500.yaml`
+- Kinematics: `differential_drive`
+- Publication bundle export: disabled until final analysis and artifact
+  promotion classify the result.
+
+Canonical command shape:
+
+```bash
+uv run python scripts/tools/run_camera_ready_benchmark.py \
+  --config configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml \
+  --campaign-id issue1554_s20_h500
+```
+
+The Slurm wrapper should submit this command from a dedicated public worktree,
+record the exact commit, and keep raw episode logs/checkpoints/videos out of
+git. Compact outputs and manifest pointers belong in `docs/context/evidence/`
+or an external durable artifact pointer after finalization.
+
+## Required Closeout
+
+After the campaign finishes, run seed sufficiency and headline-rank stability
+against the S20 root and any retained S3/S10 roots:
+
+```bash
+uv run python scripts/tools/analyze_seed_sufficiency.py \
+  --campaign-root <s3-or-s10-root> \
+  --campaign-root <issue1554_s20_h500_root> \
+  --headline-required-durable-root <issue1554_s20_h500_root> \
+  --output-dir docs/context/evidence/issue_1554_s20_h500_seed_sufficiency
+```
+
+Rows with fallback, degraded, failed, partial-failure, or unavailable execution
+must remain excluded from promoted claims and must carry explicit row status.
+
+## S30 Boundary
+
+No S30 seed set is tracked in `configs/benchmarks/seed_sets_v1.yaml` as of this
+packet. S30 is therefore blocked until a seed schedule is predeclared and tested.
+Do not synthesize ad hoc seeds at submit time.
+
+## Decision Outcomes
+
+Classify the final bundle as exactly one of:
+
+- `paper_grade_for_named_claims`
+- `not_distinguishable_at_s20`
+- `diagnostic_only_missing_rows`
+- `blocked_missing_durable_artifacts`
+- `failed_closed`

--- a/docs/context/issue_1554_s20_h500_launch_packet.md
+++ b/docs/context/issue_1554_s20_h500_launch_packet.md
@@ -1,4 +1,4 @@
-# Issue #1554 S20 h500 Launch Packet
+# Issue #1554 S20 H500 Launch Packet 2026-06-23
 
 This launch packet makes issue #1554 concrete enough for Slurm routing without
 turning it into an open-ended benchmark rerun. It targets the paper-facing

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -1993,6 +1993,27 @@ def test_paper_extended_seed_configs_preserve_v1_matrix_contract() -> None:
         assert _resolved_seed_inventory(_load_campaign_scenarios(cfg)) == expected_seeds
 
 
+def test_issue_1554_h500_s20_config_preserves_h500_matrix_contract() -> None:
+    """Issue #1554 S20 config should change only the h500 seed schedule."""
+    base_cfg = load_campaign_config(
+        Path("configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml")
+    )
+    s20_cfg = load_campaign_config(
+        Path("configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml")
+    )
+
+    assert s20_cfg.paper_facing is True
+    assert s20_cfg.paper_profile_version == base_cfg.paper_profile_version == "paper-matrix-v1"
+    assert s20_cfg.scenario_matrix_path == base_cfg.scenario_matrix_path
+    assert s20_cfg.scenario_horizons_path == base_cfg.scenario_horizons_path
+    assert s20_cfg.comparability_mapping_path == base_cfg.comparability_mapping_path
+    assert s20_cfg.kinematics_matrix == base_cfg.kinematics_matrix == ("differential_drive",)
+    assert s20_cfg.seed_policy.mode == "seed-set"
+    assert s20_cfg.seed_policy.seed_set == "paper_eval_s20"
+    assert s20_cfg.planners == base_cfg.planners
+    assert _resolved_seed_inventory(_load_campaign_scenarios(s20_cfg)) == list(range(111, 131))
+
+
 def test_issue_821_extended_matrix_is_evidence_only_until_release_doi_exists() -> None:
     """Issue 821 matrix should not export bundles while its DOI is a placeholder."""
     cfg = load_campaign_config(


### PR DESCRIPTION
## Summary
Add a concrete #1554 S20 h500 launch packet and runnable benchmark config.

This turns the previously vague S20/S30 seed-budget request into a reviewable S20-only Slurm launch surface while keeping S30 blocked until a seed schedule is predeclared.

## Linked Issues
- Relates to `#1554`
- Relates to `#3216`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml`.
- Added `docs/context/issue_1554_s20_h500_launch_packet.md` with claim gate, command shape, closeout analysis, and S30 boundary.
- Added a focused config test proving the S20 config preserves the h500 matrix contract and changes only the seed schedule.

## Why It Matters
- Added value: makes #1554 submit-ready as an S20 h500 campaign instead of an underspecified broad rerun.
- Expected impact: gives #3216 a concrete source for increased-seed h500 rows and seed-sufficiency/rank-stability analysis.
- Why this is worth merging now: Slurm routing can use a reviewed config/packet and fail closed on missing S30 schedule instead of inventing submit-time seeds.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3216 paper-facing headline comparison stability and #1554 S20 evidence generation.
- Comparator or baseline, if applicable: existing S3/S10 h500 evidence surfaces.
- Evidence tier: launch packet.
- Result classification: blocker-resolution / launch-packet.
- Decision or stop rule, if applicable: do not promote rankings until S20 completes and `analyze_seed_sufficiency.py` classifies confidence intervals/rank stability.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #1554, #3216, and the post-run seed-sufficiency evidence bundle.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - reuses existing seed-sufficiency tooling.

## Domain-Aware Approval
- Required for this PR: yes - it creates a paper-facing benchmark launch packet.
- Domains reviewed: evidence classification, experimental comparison, and paper-facing claim boundary for the S20 launch packet.
- Status: waived
- Approver/review source or waiver: Waived by scope because this PR adds a launch packet/config only, makes no benchmark result claim, and keeps S30 fail-closed until a tracked seed schedule exists.
- Validity checklist:
  - Target claim/hypothesis: h500 planner comparison rank/safety stability under S20.
  - Comparator or split/evidence validity: preserves existing h500 matrix and switches to `paper_eval_s20`.
  - Fallback/degraded exclusions: launch packet requires fail-closed row status before promotion.
  - Claim boundary: launch packet only, not result evidence.
  - Implementation integrity vs experimental validity: config contract test covers wiring; reviewers own claim scope.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no benchmark run in this PR.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: #3216 after S20 evidence exists.

## Next Empirical Action
- Rerun needed: yes - submit the S20 h500 campaign from this reviewed config.
- Extractor or analysis tool needed: no - use `scripts/tools/analyze_seed_sufficiency.py`.
- Artifact missing or unavailable: S20 campaign root and durable evidence bundle.
- Stop / revise / continue decision: continue to Slurm submission after review/capacity approval.
- Proposed child issue or existing follow-up: #1554 and #3216.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark/test_camera_ready_campaign.py -k '1554 or extended_seed_configs'`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/analyze_seed_sufficiency.py --help`
  - `git diff --check`
- Evidence that the change works here: focused tests passed and resolved `paper_eval_s20` to seeds `111..130`.
- Benchmarks or smoke tests, if applicable: no benchmark campaign run in this PR.

## Risks / Rollout
- Compatibility risks: low; the config mirrors the existing h500 matrix and changes the seed schedule.
- Failure modes: S20 may expose fallback/degraded rows or statistically unstable rankings.
- Rollback or fallback plan: revert the new config/packet or keep #1554 blocked if reviewers reject the claim gate.

## Docs / Provenance
- Updated docs: `docs/context/issue_1554_s20_h500_launch_packet.md`
- Relevant design or provenance notes: #1554, #3216, `docs/benchmark_camera_ready.md`.
- Any assumptions that need to be preserved: S30 remains blocked because no S30 seed set is tracked.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, via PR and issue comments.
- Claim map / benchmark report updated (yes/no/NA): deferred until S20 run completes.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): no.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - existing #1554 and #3216 carry the S20 run and post-run analysis.
- Not applicable because: this is a launch packet, not final evidence.

For benchmark, registry, claim-map, or paper-facing changes, explicitly say when downstream
propagation is deferred and name the issue or note that will carry it.

## Follow-Up Issues
- Deferred work: submit S20 campaign, archive durable root, run seed-sufficiency/rank-stability analysis under #1554 and #3216.
- Issues opened for follow-up: none - existing #1554 and #3216 cover the deferred work.

## Reviewer Notes
- Please verify the S20-only scope and S30 fail-closed boundary.
- Known limitation: no Slurm job is submitted by this PR.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Added launch packet documentation for the S20 H500 benchmark configuration, including runnable specifications, validation requirements, and decision outcomes.

* **Tests**
  * Added validation test to verify the S20 H500 configuration preserves contract requirements and correctly resolves seed inventory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->