### PR TITLE
fix(planner): emit residual_clipped on no-residual GuardedPPO decisions (#1475)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -208,6 +208,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed the ORCA-residual BC smoke evidence contract (#1475): the per-decision `action_adaptation`
+  payload from `GuardedPPOAdapter` now always carries a truthful `residual_clipped` signal — on the
+  direct pass-through, guard-fallback, and default branches no bounded residual is applied, so
+  `residual_clipped: False` is emitted (a real signal, not fabricated). This lets the smoke
+  finalizer populate `residual_clipping_rate` (and, with the existing `shield_stats`,
+  `guard_veto_rate`, `fallback_degraded_status`, `artifact_pointer_status`) instead of failing
+  closed on `missing_required_smoke_evidence` — which is what blocked the #1475 SLURM smoke rerun
+  (job 12913). Contract-completeness only: it does not make the BC lane succeed (the run may still
+  be `timeout_low_progress`/`success_rate=0.0` per #2445), and no fail-closed gate is weakened
+  (a genuinely degraded run still classifies degraded). (#1475)
+
 * Fixed `scripts/tools/issue_template_audit.py` so it recognizes the repo's own YAML issue
   forms (`epic`/`execution-run`/`test-debt`/`blocked-external-artifact`) and agent-authored
   bodies instead of only the markdown templates. The audit previously matched a single strict

--- a/robot_sf/planner/guarded_ppo.py
+++ b/robot_sf/planner/guarded_ppo.py
@@ -379,6 +379,11 @@ class GuardedPPOAdapter(OccupancyAwarePlannerMixin):
             "mode": "direct_policy_command",
             "raw_policy_action": [float(ppo_command[0]), float(ppo_command[1])],
             "adapted_action": [float(ppo_command[0]), float(ppo_command[1])],
+            # No bounded residual was applied on a direct pass-through, so the
+            # residual was genuinely not clipped this decision. Emitting the key
+            # keeps the per-decision residual-clip signal present even when no
+            # learned checkpoint surfaces aggregate residual_clipping_stats.
+            "residual_clipped": False,
             "hard_guard_authoritative": True,
         }
         robot_pos, _heading, goal, ped_pos, _ped_vel = self._extract_state(observation)
@@ -559,6 +564,7 @@ class GuardedPPOAdapter(OccupancyAwarePlannerMixin):
         )
         action_adaptation = self._last_action_adaptation or {
             "mode": "unknown",
+            "residual_clipped": False,
             "hard_guard_authoritative": True,
         }
         selected_matches_ppo = np.isclose(float(ppo_command[0]), float(filtered_command[0])) and (
@@ -576,6 +582,9 @@ class GuardedPPOAdapter(OccupancyAwarePlannerMixin):
                 "mode": "guard_selected_command",
                 "raw_policy_action": [float(ppo_command[0]), float(ppo_command[1])],
                 "adapted_action": [float(filtered_command[0]), float(filtered_command[1])],
+                # The guard selected a fallback/prior command rather than a
+                # bounded residual, so no residual clipping occurred this step.
+                "residual_clipped": False,
                 "hard_guard_authoritative": True,
             }
         return ShieldDecision(

--- a/robot_sf/planner/guarded_ppo.py
+++ b/robot_sf/planner/guarded_ppo.py
@@ -567,6 +567,14 @@ class GuardedPPOAdapter(OccupancyAwarePlannerMixin):
             "residual_clipped": False,
             "hard_guard_authoritative": True,
         }
+        if label != "prior_residual_safe" and action_adaptation.get("mode") == "prior_residual":
+            action_adaptation = {
+                "mode": "direct_policy_command",
+                "raw_policy_action": [float(ppo_command[0]), float(ppo_command[1])],
+                "adapted_action": [float(ppo_command[0]), float(ppo_command[1])],
+                "residual_clipped": False,
+                "hard_guard_authoritative": True,
+            }
         selected_matches_ppo = np.isclose(float(ppo_command[0]), float(filtered_command[0])) and (
             np.isclose(float(ppo_command[1]), float(filtered_command[1]))
         )

--- a/tests/planner/test_guarded_ppo.py
+++ b/tests/planner/test_guarded_ppo.py
@@ -325,6 +325,59 @@ def test_guarded_ppo_residual_mode_keeps_safer_orca_prior() -> None:
     assert adaptation["adapted_action"] == [0.5, -0.1]
 
 
+def test_guarded_ppo_rejected_residual_does_not_leak_into_prior_safe_metadata() -> None:
+    """Rejected residual metadata should not describe a later prior-safe selection."""
+    guard = GuardedPPOAdapter(
+        config=build_guarded_ppo_config(
+            {
+                "prior_residual_mode": True,
+                "prior_residual_max_linear_delta": 0.0,
+                "prior_residual_max_angular_delta": 0.0,
+                "prior_near_field_only": False,
+            }
+        ),
+        fallback_adapter=_FallbackAdapter((0.0, 0.0)),
+        prior_adapter=_PriorAdapter((0.5, -0.1)),
+    )
+    evaluations = iter(
+        [
+            {
+                "safe": False,
+                "progress": 0.5,
+                "min_ped_clear": 0.2,
+                "first_ped_clear": 0.2,
+                "min_obs_clear": float("inf"),
+                "min_ttc": 0.4,
+            },
+            {
+                "safe": True,
+                "progress": 0.48,
+                "min_ped_clear": 0.9,
+                "first_ped_clear": 0.9,
+                "min_obs_clear": float("inf"),
+                "min_ttc": 1.4,
+            },
+            {
+                "safe": True,
+                "progress": 0.48,
+                "min_ped_clear": 0.9,
+                "first_ped_clear": 0.9,
+                "min_obs_clear": float("inf"),
+                "min_ttc": 1.4,
+            },
+        ]
+    )
+    guard._evaluate_command = lambda observation, command: next(evaluations)  # type: ignore[method-assign]
+
+    decision = guard.choose_command_decision(_obs(), (0.8, -0.5))
+
+    assert decision.decision_label == "prior_safe"
+    assert decision.filtered_action == (0.5, -0.1)
+    adaptation = decision.fallback_controller_state["action_adaptation"]
+    assert adaptation["mode"] == "guard_selected_command"
+    assert adaptation["adapted_action"] == [0.5, -0.1]
+
+
 def test_guarded_ppo_residual_mode_falls_through_when_not_safe() -> None:
     """Unsafe residual proposals should fall through to prior or fallback safety handling."""
     guard = GuardedPPOAdapter(

--- a/tests/validation/test_orca_residual_smoke_evidence_emission_issue_1475.py
+++ b/tests/validation/test_orca_residual_smoke_evidence_emission_issue_1475.py
@@ -1,0 +1,184 @@
+"""Contract-completeness tests for ORCA-residual smoke evidence emission (issue #1475).
+
+These tests pin the public-repo seam that makes the four required smoke-evidence
+fields populate from real rollout signals:
+
+* ``residual_clipping_rate``
+* ``guard_veto_rate``
+* ``fallback_degraded_status``
+* ``artifact_pointer_status``
+
+The historical fail-closed regression (SLURM job 12913) produced episode rows whose
+``algorithm_metadata`` carried ``shield_stats`` but no ``residual_clipping_stats`` and
+whose shield ``last_decision.action_adaptation`` (a ``direct_policy_command``
+pass-through) lacked a ``residual_clipped`` key, so the residual extractor returned
+``None`` and the stage classified ``missing_required_smoke_evidence``.
+
+This is a contract-completeness fix: it guarantees the four fields are non-null
+diagnostics, NOT that the smoke lane succeeds (``success_rate`` may still be 0.0).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+from robot_sf.planner.guarded_ppo import (
+    GuardedPPOAdapter,
+    build_guarded_ppo_config,
+)
+from robot_sf.planner.safety_shield import new_shield_stats, update_shield_stats
+from scripts.validation.run_policy_search_candidate import (
+    _attach_orca_residual_smoke_evidence,
+    _row_residual_clipping_rate,
+)
+
+
+def _far_field_observation() -> dict[str, Any]:
+    """Return a structured socnav observation with no pedestrians and a distant goal.
+
+    Such an observation drives a guarded-PPO pass-through (``ppo_clear``) so the
+    emitted action adaptation is a ``direct_policy_command`` with no residual applied.
+    """
+    return {
+        "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+        "goal": {"current": [10.0, 0.0], "next": [12.0, 0.0]},
+        "pedestrians": {"positions": [], "velocities": [], "count": [0]},
+    }
+
+
+def _pass_through_adapter() -> GuardedPPOAdapter:
+    """Return a guarded-PPO adapter configured for the residual smoke contract."""
+    config = build_guarded_ppo_config(
+        {
+            "prior_residual_mode": True,
+            "prior_residual_max_linear_delta": 0.35,
+            "prior_residual_max_angular_delta": 0.35,
+            # No prior adapter wired here, so far-field safe PPO commands pass through
+            # as ``direct_policy_command`` decisions (the historical null path).
+            "prior_policy": "none",
+        }
+    )
+    return GuardedPPOAdapter(config=config, fallback_adapter=None, prior_adapter=None)
+
+
+def test_pass_through_decision_emits_residual_clipped_signal() -> None:
+    """A direct pass-through decision must still carry a ``residual_clipped`` flag.
+
+    Before the fix this metadata was absent for ``direct_policy_command`` steps, which
+    starved the residual-clipping extractor of evidence on any rollout where the PPO
+    command was already safe.
+    """
+    adapter = _pass_through_adapter()
+    decision = adapter.choose_command_decision(_far_field_observation(), (0.8, 0.0))
+
+    metadata = decision.to_metadata()
+    fallback_state = metadata["fallback_controller_state"]
+    action_adaptation = fallback_state["action_adaptation"]
+
+    # No bounded residual was applied on this pass-through, so the residual was
+    # genuinely not clipped: the key must be present and False (a real signal).
+    assert "residual_clipped" in action_adaptation
+    assert action_adaptation["residual_clipped"] is False
+
+
+def _representative_row(residual_clipped: bool) -> dict[str, Any]:
+    """Build an episode row mirroring the guarded-PPO smoke rollout structure.
+
+    The shield stats are accumulated through the production ``update_shield_stats``
+    helper so the row carries the same ``last_decision`` shape that the map runner
+    writes into ``algorithm_metadata`` during a real rollout.
+    """
+    adapter = _pass_through_adapter()
+    decision = adapter.choose_command_decision(_far_field_observation(), (0.8, 0.0))
+    # Force the residual-clipped flag for the clipped variant without fabricating the
+    # rest of the rollout-derived decision payload.
+    decision_metadata = decision.to_metadata()
+    decision_metadata["fallback_controller_state"]["action_adaptation"]["residual_clipped"] = bool(
+        residual_clipped
+    )
+
+    shield_stats = new_shield_stats()
+    update_shield_stats(shield_stats, decision)
+    shield_stats["last_decision"] = decision_metadata
+
+    return {
+        "status": "completed",
+        "termination_reason": "max_steps",
+        "metrics": {
+            "shield_intervention_rate": 0.0,
+        },
+        "algorithm_metadata": {
+            "shield_stats": shield_stats,
+        },
+    }
+
+
+def test_residual_extractor_resolves_from_shield_last_decision() -> None:
+    """The residual extractor must recover a rate from the shield ``last_decision``.
+
+    This is the fallback path used when no aggregate ``residual_clipping_stats`` block
+    is present (e.g. an older runtime), and it is the exact null path from job 12913.
+    """
+    not_clipped_rate, not_clipped_source = _row_residual_clipping_rate(
+        _representative_row(residual_clipped=False)
+    )
+    assert not_clipped_rate == 0.0
+    assert not_clipped_source.endswith("action_adaptation")
+
+    clipped_rate, _clipped_source = _row_residual_clipping_rate(
+        _representative_row(residual_clipped=True)
+    )
+    assert clipped_rate == 1.0
+
+
+def test_attach_smoke_evidence_populates_all_required_fields(tmp_path: Path) -> None:
+    """All four required smoke-evidence fields must be non-null with no missing fields.
+
+    Contract-completeness boundary: this asserts the evidence block is complete, not
+    that the lane passed. A degraded run would still classify degraded via the same
+    helper; here the representative rows are non-degraded.
+    """
+    rows = [_representative_row(residual_clipped=False)]
+    jsonl_path = tmp_path / "smoke.jsonl"
+    jsonl_path.write_text("{}\n", encoding="utf-8")
+
+    summary: dict[str, Any] = {}
+    _attach_orca_residual_smoke_evidence(
+        summary,
+        rows,
+        jsonl_path,
+        missing_jsonl=False,
+    )
+
+    for field in (
+        "residual_clipping_rate",
+        "guard_veto_rate",
+        "fallback_degraded_status",
+        "artifact_pointer_status",
+    ):
+        assert summary.get(field) is not None, f"{field} should be populated"
+        assert summary.get(field) != "", f"{field} should not be blank"
+
+    evidence = summary["orca_residual_smoke_evidence"]
+    assert evidence["missing_required_fields"] == []
+    assert summary["fallback_degraded_status"] == "clear"
+    assert summary["artifact_pointer_status"] == "local_jsonl_present"
+
+
+def test_attach_smoke_evidence_preserves_degraded_classification(tmp_path: Path) -> None:
+    """A genuinely degraded row must still classify degraded (fail-closed intact)."""
+    row = _representative_row(residual_clipped=False)
+    row["status"] = "fallback_degraded"
+
+    jsonl_path = tmp_path / "smoke.jsonl"
+    jsonl_path.write_text("{}\n", encoding="utf-8")
+
+    summary: dict[str, Any] = {}
+    _attach_orca_residual_smoke_evidence(summary, [row], jsonl_path, missing_jsonl=False)
+
+    assert summary["fallback_degraded_status"] == "degraded"
+    # The contract block stays complete even when the run is degraded.
+    assert summary["orca_residual_smoke_evidence"]["missing_required_fields"] == []


### PR DESCRIPTION
## Summary
Fixes the #1475 ORCA-residual BC smoke evidence contract by ensuring no-residual GuardedPPO decisions emit `residual_clipped: False`, and addresses review feedback preventing rejected residual metadata from leaking into later prior/fallback decisions.

## Linked Issues
- Relates to `#1475`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- `GuardedPPOAdapter` emits a truthful `residual_clipped: False` signal for direct/no-residual decision paths.
- Rejected `prior_residual` metadata is discarded unless the selected label is `prior_residual_safe`, preventing stale metadata from describing a later selected prior/fallback command.
- Added regression coverage for smoke-evidence extraction and the stale residual-adaptation case.

## Why It Matters
- Added value: unblocks contract-complete smoke evidence for the #1475 ORCA-residual BC rerun without weakening fail-closed degraded-run behavior.
- Expected impact: the rerun can produce the required evidence fields instead of failing closed on missing `residual_clipping_rate`.
- Why this is worth merging now: Slurm job `13034` is queued for the #1475 smoke rerun and depends on this public-repo evidence emission fix.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #1475 smoke-evidence blocker; contract completeness for ORCA-residual BC smoke summaries.
- Comparator or baseline, if applicable: failed SLURM job `12913` missing required smoke evidence.
- Evidence tier: targeted smoke / contract regression tests.
- Result classification: blocker-resolution.
- Decision or stop rule, if applicable: produce all required smoke-evidence fields while preserving degraded-run fail-closed classification.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #1475 follow-up / private-ops smoke rerun state after merge.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no new analysis tool; this is runtime evidence emission and regression coverage.

## Domain-Aware Approval
- Required for this PR: yes - touches benchmark smoke-evidence validity and fail-closed classification boundary.
- Domains reviewed: evidence classification and benchmark interpretation for the #1475 smoke-evidence contract.
- Status: waived
- Approver/review source or waiver: Waived by scope because this PR repairs missing evidence fields and preserves degraded fail-closed classification, with targeted regression tests and no new benchmark-success claim.
- Validity checklist:
  - Target claim/hypothesis: smoke-evidence contract completeness for #1475.
  - Comparator or split/evidence validity: failed job `12913` missing required fields; local tests cover required-field population and degraded classification.
  - Fallback/degraded exclusions: degraded rows still classify `degraded` and are not converted into success.
  - Claim boundary: contract completeness only, not lane success or paper-facing performance evidence.
  - Implementation integrity vs experimental validity: implementation integrity covered by planner/validation tests and CI; experimental validity limited to preserving the evidence boundary.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes - tests assert `residual_clipped` is present for no-residual decisions and required smoke fields populate.
- Did the intervention change command source, selected command, trajectory, or route progress? no intended command change; metadata emission and stale metadata cleanup only.
- Did the scenario actually contain the targeted failure mode? yes - job `12913` lacked residual clipping evidence despite shield stats.
- Result route: continue - rerun smoke after merge.
- Follow-up question or issue for weak, negative, or non-transfer results: #1475 rerun / job `13034` outcome.

## Next Empirical Action
- Rerun needed: yes - use queued #1475 smoke rerun job after merge.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: current rerun artifact pending; job `13034` is queued.
- Stop / revise / continue decision: continue to smoke rerun; do not claim lane success from this PR.
- Proposed child issue or existing follow-up: #1475.

## Validation / Proof
- Commands run:
  - `ruff check robot_sf/planner/guarded_ppo.py tests/planner/test_guarded_ppo.py tests/validation/test_orca_residual_smoke_evidence_emission_issue_1475.py`
  - `ruff format --check robot_sf/planner/guarded_ppo.py tests/planner/test_guarded_ppo.py tests/validation/test_orca_residual_smoke_evidence_emission_issue_1475.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/planner/test_guarded_ppo.py tests/validation/test_orca_residual_smoke_evidence_emission_issue_1475.py -q`
  - `uv run python scripts/dev/check_pr_followups.py --body-file <temp> --changed-files-file <temp> --require-body --require-substantive-body --require-open-issues`
- Evidence that the change works here: focused planner and smoke-evidence regression tests pass (`28 passed`).
- Benchmarks or smoke tests, if applicable: targeted smoke-evidence regression tests; full smoke rerun remains pending in SLURM job `13034`.

## Risks / Rollout
- Compatibility risks: low; metadata-only correction for no-residual and rejected-residual decision paths.
- Failure modes: downstream consumers may still classify the rerun as degraded or timeout; this PR does not claim success.
- Rollback or fallback plan: revert the planner metadata change if it causes unexpected decision metadata regressions.

## Docs / Provenance
- Updated docs: `CHANGELOG.md`.
- Relevant design or provenance notes: #1475 and failed job `12913` evidence gap.
- Any assumptions that need to be preserved: `residual_clipped: False` means no bounded residual was clipped, not that the planner succeeded.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - #1475 remains the follow-up surface.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark result claim yet.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - existing #1475 / job `13034` carries the rerun.
- Not applicable because: this PR only repairs evidence emission; downstream result propagation waits for the rerun artifact.

## Follow-Up Issues
- Deferred work: #1475 smoke rerun / job `13034` must be inspected after completion.
- Issues opened for follow-up: none - existing #1475 is the follow-up issue.

## Reviewer Notes
- Anything a reviewer should verify closely: the stale residual metadata guard should only preserve `prior_residual` mode for actual `prior_residual_safe` selections.
- Any known limitations: contract-completeness only; does not prove the ORCA-residual BC lane succeeds.

