### PR TITLE
docs: tighten autopilot output guards

### DIFF
--- a/.agents/skills/goal-autopilot/SKILL.md
+++ b/.agents/skills/goal-autopilot/SKILL.md
@@ -254,10 +254,11 @@ When a PR reaches `awaiting_ci` and the local proof bar is otherwise ready:
    ```
 
    For longer delegated monitor waits, add `--emit-progress-json-every <seconds>` so the worker
-   returns compact progress evidence instead of silent polling. Do not leave
-   long JSON poll streams in the parent thread when no decision changes; store
-   verbose progress in the ledger or private artifacts and surface only check
-   counts, failures, stale-head state, and terminal status.
+   returns compact progress evidence instead of silent polling. Do not run
+   multi-attempt JSON polling directly into the parent thread when no decision
+   changes; either use `--once`, route the wait to a monitor worker, or redirect
+   the stream to a private artifact. Surface only check counts, status deltas,
+   failures, stale-head state, terminal status, and the expected head SHA.
 
 3. Continue with non-conflicting work on the main thread: review other PRs, merge already-green
    `merge-ready` PRs, or run bounded discovery. Do not mutate the waiting PR branch or resolve its

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,9 +211,11 @@ or abandoned exploration. Once a worktree is no longer needed for active validat
 artifact recovery, or handoff, either remove it safely or record why it must be preserved.
 
 Before removing or pruning worktrees, enumerate them with `git worktree list --porcelain` from the
-main checkout. For each candidate, inspect `git -C <path> status --short --branch`; when generated
-outputs may matter, also inspect ignored output paths such as
-`[ -d "<path>/output" ] && git -C <path> status --ignored --short -uall output`.
+main checkout. For each candidate, inspect `git -C <path> status --short --branch`. When generated
+outputs may matter, classify ignored output with counts and top-level paths first; do not print a
+full `git status --ignored --short -uall output` listing into the parent thread. If the count-first
+view shows potentially durable files, redirect the full ignored-output listing to a private
+artifact and paste only the relevant path excerpts.
 For token-sensitive autonomous cleanup or repositories with many linked worktrees, start with the
 compact hygiene helper instead of printing the full worktree inventory in the parent thread:
 `uv run python scripts/dev/worktree_hygiene_snapshot.py --repo-status --json`. Add `--filter
@@ -229,6 +231,9 @@ that needs manual inspection.
 - Inspect large ignored directories such as `output/` before removal. Classify them as disposable,
   ignored cache, tracked manifest/evidence, durable-required, or handoff-needed; never treat
   worktree-local `output/` contents as durable artifact storage.
+- For routine validation leftovers such as `output/coverage/`, `output/validation/pr_ready/`, and
+  hydrated model caches, record only the category and count unless a file is being promoted or used
+  as durable evidence.
 - Prefer `git worktree remove <path>` for clean worktrees and `git worktree prune` only after
   verifying stale administrative entries no longer point at useful local state.
 
@@ -394,10 +399,11 @@ resolving lint or test failures locally before requesting review.
 - Do not wait until PR creation to pick up `main` branch improvements on long-lived branches.
   Merge the latest `origin/main` into the current branch at the start of active work, and repeat
   that sync before PR creation so validation covers the newest shared baseline.
-- Before creating a PR, inspect newly created `output/*` files, including ignored paths via
-  `[ -d output ] && git status --ignored --short -uall output`. Decide whether each output is
-  disposable, should remain ignored, should be represented by a tracked manifest or registry entry,
-  or must be uploaded to a durable artifact store before the branch is handed off.
+- Before creating a PR, inspect newly created `output/*` files with a compact count-first view of
+  ignored paths. Decide whether each output class is disposable, should remain ignored, should be
+  represented by a tracked manifest or registry entry, or must be uploaded to a durable artifact
+  store before the branch is handed off. Keep full ignored-output listings in private artifacts
+  unless the PR depends on a specific path excerpt.
 - Fill the PR template's `Downstream Propagation` section for evidence-producing PRs. Check whether
   the parent issue, claim map or benchmark report, leaderboard or artifact catalog, registry or
   config index, context index or memory note, and deferred follow-up issue need updates. For
@@ -444,6 +450,9 @@ resolving lint or test failures locally before requesting review.
   `uv run python scripts/dev/autopilot_state_snapshot.py --include-worktrees` or another compact
   helper so generated `.venv`, `.opencode`, `node_modules`, and `output` trees are summarized
   instead of dumped into agent context.
+- For repeated PR CI polling in the parent thread, prefer single snapshots or redirect multi-poll
+  JSON streams to a private artifact. Report only status deltas, terminal state, failed check names,
+  and the exact head SHA; repeated unchanged pending payloads should stay out of the parent thread.
 Prefer GitHub MCP / GitHub app tools for interactive repository interactions such as viewing,
 commenting on, and triaging issues and PRs. Keep the GitHub CLI (`gh`) for scripted batch
 operations, auth debugging, and fallback when MCP coverage is insufficient.

--- a/docs/templates/token_efficient_thread_profile.md
+++ b/docs/templates/token_efficient_thread_profile.md
@@ -129,6 +129,9 @@ Start every resumed or user-pivoted phase with a five-minute startup gate:
   repeated JSON payloads would be noisy. If a workflow is still running, prefer
   job metadata and filtered direct job-log excerpts over `gh run view --log`
   dumps that can fail or flood the parent context.
+- If the parent thread must poll CI directly, use one-shot snapshots or redirect
+  multi-attempt JSON streams to a private artifact. Repeated unchanged
+  `pending` payloads should update the ledger, not the parent transcript.
 - If GitHub CI runs repo-wide lint/format gates after a branch merges fresh
   `origin/main`, run the matching repo-wide lightweight gate locally when a
   focused changed-file check would miss unrelated-but-current format drift.
@@ -148,6 +151,10 @@ Start every resumed or user-pivoted phase with a five-minute startup gate:
   long-running worker processes when the tooling supports it. Close obsolete
   app subagents, record any preserved workers or worktrees, and do not leave
   cleanup implicit behind a PR link.
+- For worktree cleanup, classify ignored `output/` contents by top-level
+  directory, count, and durable-evidence category before expanding paths. Full
+  ignored-output listings belong in private artifacts unless a specific path is
+  being preserved, promoted, or explained.
 - When usage is close to the stop guard, finish the active PR or blocker record,
   then hand off instead of opening a fresh batch.
 


### PR DESCRIPTION
## Summary
Tightens token-efficient autopilot instructions to keep repeated CI polling JSON and ignored-output inventories out of the parent Codex thread.

## Linked Issues
- Relates to `#3482`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Updated worktree cleanup guidance to classify ignored `output/` contents with counts before expanding paths.
- Updated CI polling guidance to use one-shot snapshots, monitor workers, or private artifacts for repeated polling streams.
- Mirrored the guardrails in the token-efficient active-thread profile and goal-autopilot skill.

## Why It Matters
- Added value: reduces parent-thread token waste in the repo's main autonomous workflow.
- Expected impact: fewer large ignored-output dumps and repeated unchanged CI payloads during goal-autopilot runs.
- Why this is worth merging now: the guidance comes from an observed representative Codex workflow failure mode.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - docs/instruction-only workflow guidance, no research result claim.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA - docs/instruction-only workflow guidance, no research evidence claim.
- Result classification: NA.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no analysis tool added.

## Domain-Aware Approval
- Required for this PR: yes - waiver required only because the PR template contains evidence-validity fields; waived by docs-only scope.
- Domains reviewed: NA - docs/instruction-only workflow guidance, no evidence classification, benchmark interpretation, or paper-facing claim change.
- Status: waived.
- Approver/review source or waiver: waived by scope; normal review and CI remain applicable.
- Validity checklist:
  - Target claim/hypothesis: NA.
  - Comparator or split/evidence validity: NA.
  - Fallback/degraded exclusions: NA.
  - Claim boundary: no research claim.
  - Implementation integrity vs experimental validity: implementation integrity covered by docs diff review and skill preflight; experimental validity NA.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - docs-only workflow guidance.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA - docs-only guidance.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: NA.
- Stop / revise / continue decision: NA.
- Proposed child issue or existing follow-up: NA.

## Validation / Proof
- Commands run:
  - `git diff --check`
  - `uv run python scripts/dev/check_skills.py --preflight goal-autopilot`
  - `uv run python scripts/dev/check_pr_followups.py --body-file <temp> --changed-files-file <temp> --require-body --require-substantive-body --require-open-issues`
- Evidence that the change works here: skill preflight passes and PR body contract passes locally after body update.
- Benchmarks or smoke tests, if applicable: NA - docs/instruction-only.

## Risks / Rollout
- Compatibility risks: low; guidance-only change.
- Failure modes: wording could still be too verbose or insufficiently specific for future agents.
- Rollback or fallback plan: revert the docs commit if the guidance causes confusion.

## Docs / Provenance
- Updated docs: `AGENTS.md`, `docs/templates/token_efficient_thread_profile.md`, `.agents/skills/goal-autopilot/SKILL.md`.
- Relevant design or provenance notes: derived from observed token waste in a representative long Codex autopilot thread.
- Any assumptions that need to be preserved: full ignored-output listings remain available via private artifacts when a specific path must be preserved or explained.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA - no parent implementation issue.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a docs/instruction-only workflow improvement with no benchmark, registry, claim-map, or paper-facing surface.

## Follow-Up Issues
- Deferred work: none - no deferred follow-up required for this docs-only guidance change.
- Issues opened for follow-up: none - no follow-up issue required.

## Reviewer Notes
- Anything a reviewer should verify closely: confirm the new instructions reduce output noise without hiding durable-artifact preservation obligations.
- Any known limitations: this does not add a new helper for count-first ignored-output classification; it only updates guidance.

