### PR TITLE
feat(benchmark): S20/S30 seed-budget archival tooling + launch packet (#1554)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added S20/S30 seed-budget archival tooling + SLURM launch packet (#1554): [`scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py`](scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py) builds a durable per-planner-by-seed comparison bundle (success/collision/near-miss/timeout/clearance-uncertainty/`time_to_goal_norm`) with bootstrap/per-seed uncertainty and a seed-resampling rank-flip analysis, REUSING the canonical stats (`seed_variance`, `snqi.bootstrap.bootstrap_stability`, `rank_metrics.kendall_tau`/`rank_order`) rather than reinventing them. Fail-closed (fallback/degraded/unavailable/failed/partial/not_available/diagnostic_only rows never count as success); when no real S20/S30 rows exist it emits `blocked_until_run` instead of fabricating a bundle. Ships the SLURM run as a launch packet (`configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml`, real referenced configs + sha256) and a context note recording the claim-map gate and #1545 seed-budget methodology. The heavy S20/S30 h500 run remains SLURM (Refs #1554).
+
 * Clarified token-efficient goal-thread startup rules for workflow-improvement turns: agents now
   explicitly park stale prior work after compaction or user pivots, scope meta-workflow requests to
   fresh docs-or-workflow worktrees, and classify high-priority SLURM work through the appropriate

--- a/configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml
+++ b/configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml
@@ -1,0 +1,126 @@
+schema_version: s20-s30-seed-budget-launch-packet.v1
+campaign_id: issue_1554_s20_s30_h500_social_navigation_v1
+generating_commit: "{generating_commit}"
+# This packet is a PRE-LAUNCH specification authored BEFORE any S20/S30 campaign run.
+# The heavy run is SLURM and is a separate downstream issue. Authoring this packet does
+# not produce S20/S30 results.
+evidence_status: proposal
+no_benchmark_result_claim: true
+no_claim_statement: >
+  No S20/S30 comparison, significance, ranking, or safety claim exists for this campaign.
+  The repository currently has durable S10 h500 comparison evidence (issue #1454), not
+  durable S20 or S30 comparison evidence. Any future S20/S30 claim requires the SLURM run
+  below, the predeclared primary metric surface, fail-closed row classification, and durable
+  artifacts recorded under durable_storage_plan. Until then, the
+  build_s20_s30_seed_budget_bundle_issue_1554.py bundle is blocked_until_run.
+
+# Target claim recorded conservatively for the claim-map gate. All claim-map inputs are
+# "to be confirmed by maintainer"; this packet asserts no paper claim.
+claim_map_gate:
+  target_claim: >
+    On the h500 social-navigation surface, the per-planner safety/quality ordering observed
+    at S10 is stable under a paper-facing S20 (and, if rankings still flip, S30) seed budget,
+    with bootstrap per-seed uncertainty small enough to support the declared primary deltas.
+  status: to_be_confirmed_by_maintainer
+  required_metric_surface: [success, collisions, near_misses, time_to_goal_norm]
+  descriptive_only_metrics: [min_clearance, min_distance, mean_clearance,
+                             raw_timeout_or_unfinished_rate, low_progress_rate]
+  planner_rows_to_confirm: [goal, social_force, orca, ppo, prediction_planner,
+                            socnav_sampling, sacadrl]
+  seed_tier: s20_then_s30_if_rankflip
+  why_s10_insufficient: >
+    Issue #1545 records material aggregate seed instability across the 10 fixed S10 seeds
+    (e.g. success range across planner-level seed means median 0.1875, max 0.2917) and
+    SNQI contract status fail on the S10 h500 surface, so close paper-facing comparisons
+    need a larger seed budget. To be confirmed by maintainer before any paper claim.
+
+methodology_reference: docs/context/issue_1545_power_aware_seed_budget_planning.md
+
+# Canonical campaign config + scenario matrix. The S10 candidate config is the closest
+# durable h500 social-navigation comparison surface; the S20/S30 run reuses it with the
+# larger seed set. Checksums computed at authoring time.
+campaign_config:
+  base_config: configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml
+  scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+  scenario_horizons: configs/policy_search/scenario_horizons_h500.yaml
+  comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+  snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+  snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+  checksums:
+    configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml: 63314360ebcc146e93ed59ee3a528d7834a5ac1d22d6f0269cbb3b2cd8fd53a9
+    configs/scenarios/classic_interactions_francis2023.yaml: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5
+    configs/policy_search/scenario_horizons_h500.yaml: 4da9f6eb78c98d1afdf9ac43fde1cbfcac9447edb8491520e8c51d85d3b14fce
+    configs/benchmarks/alyassi_comparability_map_v1.yaml: 22fc166ea438aa30da79c4888e270eee4afba8f1b9611080a3d51f4bb2cf200d
+    configs/benchmarks/snqi_weights_camera_ready_v3.json: 71a67c3c02faff166f8c96bef8bcf898533981ca2b2c4493829988520fb1aeb2
+    configs/benchmarks/snqi_baseline_camera_ready_v3.json: 329ca5766491e1587979d0a435c7ba676e148ccdff97040a36546bbb9414035a
+
+# Seed set. paper_eval_s20 already exists (111-130); paper_eval_s30 (111-140) was added by
+# this issue and preserves the frozen S3 eval seeds (111-113) and S10/S20 ordering.
+seed_policy:
+  mode: seed-set
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+  primary_seed_set: paper_eval_s20
+  escalation_seed_set: paper_eval_s30
+  escalate_to_s30_when: >
+    Run the bundle tool on the S20 result store; if seed_resampling_rank_flip reports
+    rank_flip_observed for a primary metric, or a primary delta is below the issue #1545
+    effect-size threshold, escalate to paper_eval_s30.
+  checksums:
+    configs/benchmarks/seed_sets_v1.yaml: 3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6
+
+planner_rows:
+  - goal
+  - social_force
+  - orca
+  - ppo
+  - prediction_planner
+  - socnav_sampling
+  - sacadrl
+
+# Fail-closed policy (issue #691). These statuses never count as benchmark-success evidence
+# and are classified fail-closed by the bundle tool.
+fail_closed_policy:
+  valid_row_statuses: [native, adapter]
+  fail_closed_statuses: [fallback, degraded, unavailable, failed, partial, not_available,
+                         diagnostic_only]
+
+expected_artifacts:
+  result_store: output/campaign_result_store/s20_s30_h500_social_navigation
+  result_store_required_files:
+    - episodes.parquet
+    - summary.json
+    - analysis.json
+    - claim_card.yaml
+    - reproduction.md
+  bundle:
+    - output/issue_1554_s20_s30/bundle.json
+    - output/issue_1554_s20_s30/BUNDLE.md
+
+slurm_command_shape: >
+  Submit a dedicated follow-up SLURM issue after this packet lands. The future command must
+  run scripts/tools/run_camera_ready_benchmark.py against
+  configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml with
+  seed_policy.seed_set overridden to paper_eval_s20 (then paper_eval_s30 on rank flip),
+  write a canonical campaign result store, and keep fail-closed row classification intact
+  before any S20/S30 claim.
+
+validation_command: >
+  uv run python scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py
+  --rows output/campaign_result_store/s20_s30_h500_social_navigation
+  --output-dir output/issue_1554_s20_s30
+
+durable_storage_plan:
+  checkpoints_in_git: false
+  raw_logs_in_git: false
+  raw_archive: >
+    Preserve the full raw campaign tree as a namespaced artifact/* GitHub release (mirroring
+    the issue #1454 S10 h500 bundle) and record its sha256 in the evidence README.
+  promote_to_evidence: >
+    Promote only compact reviewable outputs (campaign_summary, seed_variability,
+    statistical_sufficiency, bundle.json/BUNDLE.md) under
+    docs/context/evidence/issue_1554_s20_s30_seed_budget_<date>/ after the run.
+
+execution_boundary:
+  full_campaign_in_this_issue: false
+  submit_slurm_from_this_issue: false
+  bundle_status_until_run: blocked_until_run

--- a/configs/benchmarks/seed_sets_v1.yaml
+++ b/configs/benchmarks/seed_sets_v1.yaml
@@ -55,3 +55,39 @@ paper_eval_s20:
   - 128
   - 129
   - 130
+
+# Issue #1554 paper-facing S30 extension. Extends the S20 set with ten more
+# contiguous seeds while preserving the frozen S3 `eval` seeds (111-113) and the
+# S10/S20 ordering. Used by the S20/S30 seed-budget launch packet; no S30 campaign
+# rows exist yet, so this set is a launch-only reference until the SLURM run lands.
+paper_eval_s30:
+  - 111
+  - 112
+  - 113
+  - 114
+  - 115
+  - 116
+  - 117
+  - 118
+  - 119
+  - 120
+  - 121
+  - 122
+  - 123
+  - 124
+  - 125
+  - 126
+  - 127
+  - 128
+  - 129
+  - 130
+  - 131
+  - 132
+  - 133
+  - 134
+  - 135
+  - 136
+  - 137
+  - 138
+  - 139
+  - 140

--- a/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+++ b/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
@@ -79,7 +79,7 @@ training_starting_points:
     configs/algos/ppo_v3_camera_ready.yaml: 6e7efd7bef68d4cdbac23bda7a0fa12d206229d5c0566c1e38f84cd9122a73c8
     configs/algos/guarded_ppo_relaxed_v2.yaml: 666eda5a47de6e452eba9b2f3cb15bda16fc97abcd7137434661a87ac9ff85d8
     configs/scenarios/classic_interactions_francis2023.yaml: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5
-    configs/benchmarks/seed_sets_v1.yaml: 50cfb61a41b3e64a93cbd7d232c0eb38f656a87d69ab01ccf4cbdee8b4eecbac
+    configs/benchmarks/seed_sets_v1.yaml: 3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6
 curriculum:
   # Density/complexity stages, expressed over real env knobs:
   #   - ped_density: scenario simulation_config.ped_density (peds per m^2)

--- a/docs/context/issue_1554_s20_s30_seed_budget.md
+++ b/docs/context/issue_1554_s20_s30_seed_budget.md
@@ -1,0 +1,72 @@
+# Issue #1554 S20/S30 Seed-Budget Bundle
+
+Related issue: <https://github.com/ll7/robot_sf_ll7/issues/1554>
+
+## Scope
+
+This note records the **local archival/uncertainty tooling and SLURM launch packet** for an
+S20/S30 (20/30-seed) seed-budget comparison bundle on the h500 social-navigation surface. It does
+**not** run the S20/S30 campaign (that is the SLURM half), and it does **not** assert any S20/S30
+result, ranking, significance, or safety claim. The repository currently has durable **S10** h500
+comparison evidence (issue #1454), not durable S20 or S30 comparison evidence, so the bundle status
+is **`blocked_until_run`** until the SLURM S20/S30 campaign produces valid rows.
+
+## Deliverables
+
+- Tool: `scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py`
+- Launch packet: `configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml`
+- Tests: `tests/benchmark/test_s20_s30_seed_budget_bundle_issue_1554.py`
+- Seed set added: `configs/benchmarks/seed_sets_v1.yaml` (`paper_eval_s30`, 111-140)
+
+## Reused canonical statistics (no reinvention)
+
+The tool reuses existing canonical helpers rather than hand-rolling statistics:
+
+- `robot_sf.benchmark.seed_variance.build_seed_variability_rows` /
+  `compute_seed_variance` — per-planner-by-seed summaries and per-metric variance with bootstrap
+  per-seed CIs (`bootstrap_mean_over_seed_means`, 1000 samples, seed 123).
+- `robot_sf.benchmark.snqi.bootstrap.bootstrap_stability` — deterministic stratified bootstrap SNQI
+  ranking stability (`rng=np.random.default_rng(seed)`).
+- `robot_sf.benchmark.rank_metrics.rank_order` / `kendall_tau` — seed-resampling rank-flip analysis
+  on the direct outcome metrics.
+
+## Claim-map gate inputs (recorded conservatively)
+
+All inputs below are **to be confirmed by maintainer**; this note asserts no paper claim.
+
+- **Target claim**: the per-planner safety/quality ordering observed at S10 on the h500
+  social-navigation surface is stable under a paper-facing S20 (then S30 on rank flip) seed budget,
+  with bootstrap per-seed uncertainty small enough for the declared primary deltas.
+- **Required metric surface**: `success`, `collisions`, `near_misses`, `time_to_goal_norm`.
+  Descriptive-only (no uncertainty claim by default): min/mean clearance, min distance,
+  timeout/unfinished rate, low-progress rate — consistent with issue #1545.
+- **Planner rows**: `goal`, `social_force`, `orca`, `ppo`, `prediction_planner`,
+  `socnav_sampling`, `sacadrl`.
+- **Seed tier**: `paper_eval_s20`, escalating to `paper_eval_s30` if rankings flip under seed
+  resampling or a primary delta is below the issue #1545 effect-size threshold.
+- **Why S10 is insufficient** (to be confirmed by maintainer): issue #1545 records material
+  aggregate seed instability across the 10 fixed S10 seeds (e.g. success range across planner-level
+  seed means median `0.1875`, max `0.2917`) and `snqi_contract_status="fail"` on the S10 h500
+  surface, so close paper-facing comparisons need a larger seed budget.
+
+## Methodology and fail-closed policy
+
+- Seed-budget methodology: [issue_1545_power_aware_seed_budget_planning.md](issue_1545_power_aware_seed_budget_planning.md).
+- Fail-closed (issue #691): only `native`/`adapter` rows count as benchmark-success evidence;
+  `fallback`, `degraded`, `unavailable`, `failed`, `partial`, `not_available`, and
+  `diagnostic_only` rows are classified fail-closed with exact per-planner reasons and never
+  counted as success. Missing/absent planner rows are classified fail-closed.
+
+## Status
+
+`blocked_until_run` pending the SLURM S20/S30 h500 social-navigation campaign. Run the campaign per
+the launch packet, write a canonical campaign result store, then run:
+
+```bash
+uv run python scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py \
+  --rows output/campaign_result_store/s20_s30_h500_social_navigation \
+  --output-dir output/issue_1554_s20_s30
+```
+
+The tool emits a real bundle only when valid S20+ rows exist for at least two planners; otherwise it
+honestly reports `blocked_until_run` naming the missing seed tier.

--- a/scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py
+++ b/scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py
@@ -1,0 +1,666 @@
+#!/usr/bin/env python3
+"""Build the issue #1554 S20/S30 seed-budget uncertainty bundle (or block it).
+
+The repository has durable S10 h500 comparison evidence but no S20/S30 (20/30
+seed) comparison rows. This tool reads S20/S30 comparison rows from a canonical
+campaign result store, classifies them fail-closed, and -- only when real rows
+exist -- computes per-planner-by-seed summaries plus bootstrap/per-seed
+uncertainty and a seed-resampling rank-flip analysis.
+
+It REUSES canonical statistics helpers and never reinvents them:
+
+- ``robot_sf.benchmark.seed_variance.build_seed_variability_rows`` /
+  ``compute_seed_variance`` for per-seed grouping and per-metric variance.
+- ``robot_sf.benchmark.snqi.bootstrap.bootstrap_stability`` for deterministic
+  stratified bootstrap ranking stability (SNQI surface).
+- ``robot_sf.benchmark.rank_metrics`` (``kendall_tau``, ``rank_order``) for the
+  seed-resampling rank-flip analysis on direct outcome metrics.
+
+Honesty contract: if the S20/S30 rows are absent or insufficient, this tool
+emits a ``blocked_until_run`` status naming the missing seed tier instead of a
+fabricated bundle. Fallback / degraded / failed / unavailable / partial /
+``not_available`` rows are never counted as success.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from robot_sf.benchmark.rank_metrics import kendall_tau, rank_order
+from robot_sf.benchmark.seed_variance import (
+    build_seed_variability_rows,
+    compute_seed_variance,
+)
+from robot_sf.benchmark.snqi.bootstrap import bootstrap_stability
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable, Sequence
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Default canonical store location. The repository ships no durable S20/S30
+# store, so this default normally resolves to a missing path and the tool blocks.
+DEFAULT_STORE = "output/campaign_result_store/s20_s30_h500_social_navigation"
+
+# Seed tiers this bundle expects. A store must reach at least the S20 tier on the
+# primary metric surface to produce a real (non-blocked) bundle.
+S20_MIN_SEEDS = 20
+S30_MIN_SEEDS = 30
+
+# Primary direct-outcome metric surface (artifact-equivalent names accepted).
+PRIMARY_METRICS = (
+    "success",
+    "collisions",
+    "near_misses",
+    "time_to_goal_norm",
+)
+# Secondary descriptive-only metrics (no per-seed uncertainty claim by default).
+DESCRIPTIVE_METRICS = (
+    "min_clearance",
+    "min_distance",
+    "mean_clearance",
+    "raw_timeout_or_unfinished_rate",
+    "low_progress_rate",
+)
+
+# Fail-closed row statuses: never counted as benchmark-success evidence.
+# Mirrors campaign_result_store / issue #691 fallback policy.
+VALID_ROW_STATUSES = frozenset({"native", "adapter"})
+FAIL_CLOSED_STATUSES = frozenset(
+    {
+        "fallback",
+        "degraded",
+        "unavailable",
+        "failed",
+        "partial",
+        "not_available",
+        "diagnostic_only",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class StoreRows:
+    """Loaded episode rows plus the source description."""
+
+    rows: list[dict[str, Any]]
+    source: str
+    source_kind: str
+
+
+def _git_head() -> str:
+    """Return the short git HEAD for provenance, or ``unknown``."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return "unknown"
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def _load_rows(rows_path: Path) -> StoreRows:
+    """Load episode rows from a JSON list, a result-store dir, or a parquet file.
+
+    Returns:
+        Loaded rows plus their source description. An empty row list is a valid
+        outcome and drives the ``blocked_until_run`` path downstream.
+    """
+    if not rows_path.exists():
+        return StoreRows(rows=[], source=str(rows_path), source_kind="missing")
+
+    if rows_path.is_dir():
+        parquet = rows_path / "episodes.parquet"
+        if parquet.is_file():
+            return _load_parquet(parquet)
+        # Allow a plain JSON rows file inside the store directory for fixtures.
+        json_rows = rows_path / "episode_rows.json"
+        if json_rows.is_file():
+            return _load_json(json_rows)
+        return StoreRows(rows=[], source=str(rows_path), source_kind="empty_store")
+
+    if rows_path.suffix == ".parquet":
+        return _load_parquet(rows_path)
+    return _load_json(rows_path)
+
+
+def _load_json(path: Path) -> StoreRows:
+    """Load episode rows from a JSON file (list or ``{"rows": [...]}``)."""
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    rows = payload.get("rows", payload) if isinstance(payload, dict) else payload
+    if not isinstance(rows, list):
+        raise ValueError(f"{path} must contain a JSON list of episode rows")
+    return StoreRows(rows=list(rows), source=str(path), source_kind="json")
+
+
+def _load_parquet(path: Path) -> StoreRows:
+    """Load episode rows from a canonical result-store parquet file."""
+    from scripts.tools.campaign_result_store import read_parquet_frame
+
+    frame = read_parquet_frame(path)
+    rows = frame.to_dict(orient="records")
+    return StoreRows(rows=rows, source=str(path), source_kind="parquet")
+
+
+def _row_status(row: dict[str, Any]) -> str:
+    """Return the row's fail-closed status label (defaults to ``unavailable``)."""
+    status = row.get("row_status")
+    if status is None or (isinstance(status, str) and not status.strip()):
+        return "unavailable"
+    return str(status).strip()
+
+
+def _planner_key(row: dict[str, Any]) -> str:
+    """Return a planner identifier for grouping."""
+    return str(row.get("planner") or row.get("planner_key") or row.get("algo") or "unknown")
+
+
+def _metric_value(row: dict[str, Any], metric: str) -> float | None:
+    """Read a metric from a flat row or a ``metrics``-nested record.
+
+    The canonical seed-variance helpers flatten episode records whose outcome
+    metrics live under ``metrics.*``; thin result-store rows may carry the same
+    metric at the top level. Accept both.
+
+    Returns:
+        The metric value as-is (caller coerces), or ``None`` when absent.
+    """
+    if metric in row and row[metric] is not None:
+        return row[metric]
+    metrics = row.get("metrics")
+    if isinstance(metrics, dict) and metrics.get(metric) is not None:
+        return metrics.get(metric)
+    return None
+
+
+def classify_rows(rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    """Partition rows into valid vs fail-closed, with exact per-planner reasons.
+
+    Returns:
+        A classification payload listing valid rows, fail-closed rows, the seeds
+        observed per planner, and explicit fail-closed reasons.
+    """
+    valid: list[dict[str, Any]] = []
+    fail_closed: list[dict[str, Any]] = []
+    reasons: dict[str, dict[str, Any]] = {}
+    seeds_by_planner: dict[str, set[int]] = {}
+    status_counts: dict[str, int] = {}
+
+    for row in rows:
+        status = _row_status(row)
+        status_counts[status] = status_counts.get(status, 0) + 1
+        planner = _planner_key(row)
+        if status in VALID_ROW_STATUSES:
+            valid.append(row)
+            try:
+                seeds_by_planner.setdefault(planner, set()).add(int(row.get("seed", -1)))
+            except (TypeError, ValueError):
+                pass
+        else:
+            fail_closed.append(row)
+            entry = reasons.setdefault(
+                planner,
+                {"planner": planner, "statuses": {}, "count": 0},
+            )
+            entry["statuses"][status] = entry["statuses"].get(status, 0) + 1
+            entry["count"] += 1
+
+    return {
+        "valid_rows": valid,
+        "fail_closed_rows": fail_closed,
+        "fail_closed_reasons": sorted(reasons.values(), key=lambda item: item["planner"]),
+        "seeds_by_planner": {k: sorted(v) for k, v in sorted(seeds_by_planner.items())},
+        "row_status_counts": dict(sorted(status_counts.items())),
+    }
+
+
+def _seed_tier(seed_count: int) -> str:
+    """Classify a per-planner seed count into a budget tier."""
+    if seed_count >= S30_MIN_SEEDS:
+        return "s30"
+    if seed_count >= S20_MIN_SEEDS:
+        return "s20"
+    if seed_count >= 10:
+        return "s10"
+    return "below_s10"
+
+
+def _achieved_tier(seeds_by_planner: dict[str, list[int]]) -> tuple[str, int]:
+    """Return the minimum seed tier achieved across all valid planner rows.
+
+    The bundle can only be as strong as its weakest planner row, so the
+    governing tier is the minimum per-planner seed count.
+
+    Returns:
+        The governing tier label and the minimum seed count observed.
+    """
+    if not seeds_by_planner:
+        return "no_valid_rows", 0
+    min_seeds = min(len(seeds) for seeds in seeds_by_planner.values())
+    return _seed_tier(min_seeds), min_seeds
+
+
+def _bootstrap_settings() -> dict[str, Any]:
+    """Return the deterministic bootstrap settings used for seed-mean CIs."""
+    return {
+        "method": "bootstrap_mean_over_seed_means",
+        "confidence": 0.95,
+        "bootstrap_samples": 1000,
+        "bootstrap_seed": 123,
+    }
+
+
+def _planner_seed_means(
+    valid_rows: Sequence[dict[str, Any]], *, metric: str
+) -> dict[str, dict[int, float]]:
+    """Build planner -> {seed: mean metric value} from valid rows.
+
+    Returns:
+        Per-planner mapping of seed to the mean finite metric value.
+    """
+    per_planner_seed_vals: dict[str, dict[int, list[float]]] = {}
+    for row in valid_rows:
+        value = _metric_value(row, metric)
+        if value is None:
+            continue
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        if not np.isfinite(numeric):
+            continue
+        planner = _planner_key(row)
+        try:
+            seed_val = int(row.get("seed", -1))
+        except (TypeError, ValueError):
+            continue
+        per_planner_seed_vals.setdefault(planner, {}).setdefault(seed_val, []).append(numeric)
+
+    return {
+        planner: {s: float(np.mean(vals)) for s, vals in seed_vals.items()}
+        for planner, seed_vals in per_planner_seed_vals.items()
+    }
+
+
+def _seed_resampling_rank_flip(
+    valid_rows: Sequence[dict[str, Any]],
+    *,
+    metric: str,
+    higher_is_better: bool,
+    samples: int = 200,
+    seed: int = 1554,
+) -> dict[str, Any]:
+    """Detect whether planner rankings flip under seed resampling for a metric.
+
+    Reuses ``rank_metrics.rank_order`` / ``kendall_tau``: the baseline ordering
+    uses all observed seeds; each resample draws seeds with replacement, ranks
+    planners by their resampled per-seed mean, and measures Kendall tau against
+    baseline. Any tau below 1.0 indicates at least one rank flip.
+
+    Returns:
+        A payload with the baseline ordering, flip fraction, and tau summary.
+    """
+    planner_seed_means = _planner_seed_means(valid_rows, metric=metric)
+    planners = sorted(p for p, sm in planner_seed_means.items() if sm)
+    if len(planners) < 2:
+        return {
+            "metric": metric,
+            "status": "insufficient_planners",
+            "planner_count": len(planners),
+        }
+
+    # Common seed universe used for resampling.
+    seed_universe = sorted({s for sm in planner_seed_means.values() for s in sm})
+    if len(seed_universe) < 2:
+        return {"metric": metric, "status": "insufficient_seeds", "seed_count": len(seed_universe)}
+
+    baseline_means = {
+        planner: float(np.mean(list(sm.values()))) for planner, sm in planner_seed_means.items()
+    }
+    baseline_order = rank_order(baseline_means, higher_is_better=higher_is_better)
+
+    rng = np.random.default_rng(seed)
+    taus: list[float] = []
+    flips = 0
+    for _ in range(samples):
+        drawn = rng.integers(0, len(seed_universe), size=len(seed_universe))
+        sampled_seeds = [seed_universe[int(i)] for i in drawn]
+        sample_means: dict[str, float] = {}
+        for planner, sm in planner_seed_means.items():
+            vals = [sm[s] for s in sampled_seeds if s in sm]
+            if vals:
+                sample_means[planner] = float(np.mean(vals))
+        if len(sample_means) < 2:
+            continue
+        sample_order = rank_order(sample_means, higher_is_better=higher_is_better)
+        tau = kendall_tau(baseline_order, sample_order, degenerate=None)
+        if tau is None:
+            continue
+        taus.append(float(tau))
+        if float(tau) < 1.0:
+            flips += 1
+
+    if not taus:
+        return {"metric": metric, "status": "no_valid_resamples"}
+
+    return {
+        "metric": metric,
+        "status": "ok",
+        "higher_is_better": higher_is_better,
+        "baseline_order": baseline_order,
+        "samples": len(taus),
+        "rank_flip_observed": flips > 0,
+        "rank_flip_fraction": flips / len(taus),
+        "kendall_tau_mean": float(np.mean(taus)),
+        "kendall_tau_min": float(np.min(taus)),
+        "method": "seed_resampling_kendall_tau",
+        "seed_resample_seed": seed,
+    }
+
+
+_METRIC_DIRECTION = {
+    "success": True,
+    "collisions": False,
+    "near_misses": False,
+    "time_to_goal_norm": False,
+}
+
+
+def build_bundle(store: StoreRows, *, git_head: str) -> dict[str, Any]:
+    """Build the S20/S30 bundle payload, or a ``blocked_until_run`` status.
+
+    Returns:
+        A JSON-compatible bundle. ``status`` is ``ok`` only when real S20+ valid
+        rows exist for at least two planners; otherwise it is ``blocked_until_run``.
+    """
+    classification = classify_rows(store.rows)
+    valid_rows = classification["valid_rows"]
+    seeds_by_planner = classification["seeds_by_planner"]
+    tier, min_seeds = _achieved_tier(seeds_by_planner)
+
+    base: dict[str, Any] = {
+        "schema_version": "s20-s30-seed-budget-bundle.v1",
+        "issue": 1554,
+        "surface": "h500_social_navigation",
+        "git_head": git_head,
+        "source": store.source,
+        "source_kind": store.source_kind,
+        "fail_closed_policy": {
+            "valid_row_statuses": sorted(VALID_ROW_STATUSES),
+            "fail_closed_statuses": sorted(FAIL_CLOSED_STATUSES),
+        },
+        "row_status_counts": classification["row_status_counts"],
+        "fail_closed_reasons": classification["fail_closed_reasons"],
+        "seeds_by_planner": seeds_by_planner,
+        "achieved_seed_tier": tier,
+        "min_seeds_per_planner": min_seeds,
+        "primary_metrics": list(PRIMARY_METRICS),
+        "descriptive_only_metrics": list(DESCRIPTIVE_METRICS),
+        "methodology_reference": "docs/context/issue_1545_power_aware_seed_budget_planning.md",
+        "reused_canonical_functions": [
+            "robot_sf.benchmark.seed_variance.build_seed_variability_rows",
+            "robot_sf.benchmark.seed_variance.compute_seed_variance",
+            "robot_sf.benchmark.snqi.bootstrap.bootstrap_stability",
+            "robot_sf.benchmark.rank_metrics.rank_order",
+            "robot_sf.benchmark.rank_metrics.kendall_tau",
+        ],
+    }
+
+    # Fail-closed / blocked path: no rows, no valid rows, fewer than two planners,
+    # or the governing per-planner seed budget is below the S20 paper tier.
+    distinct_planners = len(seeds_by_planner)
+    if not store.rows or not valid_rows or distinct_planners < 2 or min_seeds < S20_MIN_SEEDS:
+        missing_tier = "s20_and_s30" if min_seeds < S20_MIN_SEEDS else "s30"
+        if not store.rows:
+            reason = (
+                f"no S20/S30 comparison rows found at source {store.source!r}; "
+                "the durable repository evidence is S10, not S20/S30"
+            )
+        elif not valid_rows:
+            reason = "all rows classified fail-closed; no native/adapter rows to summarize"
+        elif distinct_planners < 2:
+            reason = f"only {distinct_planners} valid planner row(s); need >=2 to compare"
+        else:
+            reason = (
+                f"governing per-planner seed budget is {min_seeds} (tier {tier}), "
+                f"below the S20 paper-facing tier of {S20_MIN_SEEDS}"
+            )
+        base.update(
+            {
+                "status": "blocked_until_run",
+                "missing_seed_tier": missing_tier,
+                "blocked_reason": reason,
+                "claim_boundary": (
+                    "No S20/S30 comparison claim exists. This bundle is blocked until the "
+                    "SLURM S20/S30 h500 social-navigation campaign produces valid rows."
+                ),
+            }
+        )
+        return base
+
+    # Real-bundle path. Compute per-planner-by-seed summaries with bootstrap CIs.
+    confidence_settings = _bootstrap_settings()
+    seed_variability_rows = build_seed_variability_rows(
+        valid_rows,
+        metrics=PRIMARY_METRICS,
+        campaign_id="issue_1554_s20_s30_h500_social_navigation",
+        config_hash="from_result_store",
+        git_hash=git_head,
+        seed_policy={"mode": "seed-set", "seed_set": f"paper_eval_{tier}"},
+        confidence_settings=confidence_settings,
+    )
+    scenario_variance = compute_seed_variance(
+        valid_rows,
+        group_by="planner",
+        fallback_group_by="planner",
+        metrics=PRIMARY_METRICS,
+    )
+
+    # Seed-resampling rank-flip analysis on each primary metric.
+    rank_flip = {
+        metric: _seed_resampling_rank_flip(
+            valid_rows,
+            metric=metric,
+            higher_is_better=_METRIC_DIRECTION.get(metric, False),
+        )
+        for metric in PRIMARY_METRICS
+        if metric in _METRIC_DIRECTION
+    }
+
+    # SNQI ranking stability via the canonical bootstrap helper (only when the
+    # rows carry per-episode metrics.snqi; otherwise mark not-available).
+    snqi_stability = _maybe_bootstrap_stability(valid_rows, git_head=git_head)
+
+    any_flip = any(
+        isinstance(entry, dict) and entry.get("rank_flip_observed") for entry in rank_flip.values()
+    )
+    base.update(
+        {
+            "status": "ok",
+            "claim_boundary": (
+                "Descriptive S20/S30 comparison summary with per-seed bootstrap uncertainty. "
+                "Treat as effect-size-planned per issue #1545; not a significance claim."
+            ),
+            "confidence_settings": confidence_settings,
+            "per_planner_seed_variability": seed_variability_rows,
+            "per_planner_metric_variance": scenario_variance,
+            "seed_resampling_rank_flip": rank_flip,
+            "snqi_ranking_stability": snqi_stability,
+            "rank_conclusion_flips_under_resampling": any_flip,
+        }
+    )
+    return base
+
+
+def _maybe_bootstrap_stability(
+    valid_rows: Sequence[dict[str, Any]], *, git_head: str
+) -> dict[str, Any]:
+    """Run canonical SNQI bootstrap stability when per-episode SNQI is present.
+
+    Returns:
+        The canonical ``bootstrap_stability`` payload, or a not-available marker.
+    """
+    episodes: list[dict[str, Any]] = []
+    for row in valid_rows:
+        snqi = _nested_snqi(row)
+        if snqi is None:
+            continue
+        episodes.append({"algo": _planner_key(row), "metrics": {"snqi": snqi}})
+    distinct = {ep["algo"] for ep in episodes}
+    if len(distinct) < 2:
+        return {
+            "status": "not_available",
+            "reason": "fewer than two planner groups carry finite metrics.snqi",
+        }
+    try:
+        return bootstrap_stability(
+            episodes,
+            weights={"snqi": 1.0},
+            rng=np.random.default_rng(123),
+            samples=200,
+            group_key="algo",
+        )
+    except ValueError as exc:
+        return {"status": "not_available", "reason": str(exc)}
+
+
+def _nested_snqi(row: dict[str, Any]) -> float | None:
+    """Read a finite SNQI value from a flat or ``metrics``-nested row."""
+    candidates: Iterable[Any] = (
+        row.get("snqi"),
+        (row.get("metrics") or {}).get("snqi") if isinstance(row.get("metrics"), dict) else None,
+    )
+    for value in candidates:
+        if value is None:
+            continue
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        if np.isfinite(numeric):
+            return numeric
+    return None
+
+
+def render_markdown(bundle: dict[str, Any]) -> str:
+    """Render a compact human-readable bundle summary.
+
+    Returns:
+        Markdown text describing the bundle status, tier, and key conclusions.
+    """
+    lines: list[str] = []
+    lines.append("# Issue #1554 S20/S30 Seed-Budget Bundle")
+    lines.append("")
+    lines.append(f"- Status: `{bundle.get('status')}`")
+    lines.append(f"- Surface: `{bundle.get('surface')}`")
+    lines.append(f"- Git HEAD: `{bundle.get('git_head')}`")
+    lines.append(f"- Source: `{bundle.get('source')}` (`{bundle.get('source_kind')}`)")
+    lines.append(f"- Achieved seed tier: `{bundle.get('achieved_seed_tier')}`")
+    lines.append(f"- Min seeds per planner: `{bundle.get('min_seeds_per_planner')}`")
+    lines.append(f"- Methodology reference: `{bundle.get('methodology_reference')}`")
+    lines.append("")
+    lines.append("## Claim boundary")
+    lines.append("")
+    lines.append(str(bundle.get("claim_boundary", "")))
+    lines.append("")
+    if bundle.get("status") == "blocked_until_run":
+        lines.append("## Blocked")
+        lines.append("")
+        lines.append(f"- Missing seed tier: `{bundle.get('missing_seed_tier')}`")
+        lines.append(f"- Reason: {bundle.get('blocked_reason')}")
+        lines.append("")
+        lines.append(
+            "Run the SLURM S20/S30 campaign from "
+            "`configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml` "
+            "and re-run this tool against the resulting result store."
+        )
+    else:
+        lines.append("## Conclusions")
+        lines.append("")
+        lines.append(
+            f"- Rank conclusion flips under seed resampling: "
+            f"`{bundle.get('rank_conclusion_flips_under_resampling')}`"
+        )
+        flip = bundle.get("seed_resampling_rank_flip", {})
+        for metric, entry in flip.items():
+            if isinstance(entry, dict) and entry.get("status") == "ok":
+                lines.append(
+                    f"  - `{metric}`: flip_fraction="
+                    f"`{entry.get('rank_flip_fraction'):.3f}`, "
+                    f"tau_min=`{entry.get('kendall_tau_min'):.3f}`"
+                )
+    lines.append("")
+    lines.append("## Reused canonical functions")
+    lines.append("")
+    for fn in bundle.get("reused_canonical_functions", []):
+        lines.append(f"- `{fn}`")
+    lines.append("")
+    if bundle.get("fail_closed_reasons"):
+        lines.append("## Fail-closed rows")
+        lines.append("")
+        for reason in bundle["fail_closed_reasons"]:
+            lines.append(
+                f"- `{reason['planner']}`: {reason['count']} row(s) statuses={reason['statuses']}"
+            )
+        lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rows",
+        type=Path,
+        default=None,
+        help="Path to a result-store dir, episodes.parquet, or a JSON rows file.",
+    )
+    parser.add_argument(
+        "--campaign",
+        type=Path,
+        default=None,
+        help="Alias for --rows (canonical campaign result-store path).",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("output/issue_1554_s20_s30"),
+        help="Directory for bundle.json and BUNDLE.md.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Build the bundle (or block it) and write JSON + markdown."""
+    args = parse_args(argv)
+    rows_path = args.rows or args.campaign or (REPO_ROOT / DEFAULT_STORE)
+    store = _load_rows(Path(rows_path))
+    bundle = build_bundle(store, git_head=_git_head())
+
+    output_dir = Path(args.output_dir)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "bundle.json").write_text(
+        json.dumps(bundle, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    (output_dir / "BUNDLE.md").write_text(render_markdown(bundle), encoding="utf-8")
+
+    print(f"status={bundle['status']} tier={bundle.get('achieved_seed_tier')}")
+    print(f"wrote {output_dir / 'bundle.json'}")
+    # blocked_until_run is an honest, expected outcome -> exit 0.
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py
+++ b/scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py
@@ -185,6 +185,14 @@ def _metric_value(row: dict[str, Any], metric: str) -> float | None:
     return None
 
 
+def _optional_seed_id(row: dict[str, Any]) -> int | None:
+    """Return an integer seed identifier when a row carries one."""
+    try:
+        return int(row.get("seed", -1))
+    except (TypeError, ValueError):
+        return None
+
+
 def classify_rows(rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
     """Partition rows into valid vs fail-closed, with exact per-planner reasons.
 
@@ -204,10 +212,9 @@ def classify_rows(rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
         planner = _planner_key(row)
         if status in VALID_ROW_STATUSES:
             valid.append(row)
-            try:
-                seeds_by_planner.setdefault(planner, set()).add(int(row.get("seed", -1)))
-            except (TypeError, ValueError):
-                pass
+            seed_id = _optional_seed_id(row)
+            if seed_id is not None:
+                seeds_by_planner.setdefault(planner, set()).add(seed_id)
         else:
             fail_closed.append(row)
             entry = reasons.setdefault(
@@ -282,9 +289,8 @@ def _planner_seed_means(
         if not np.isfinite(numeric):
             continue
         planner = _planner_key(row)
-        try:
-            seed_val = int(row.get("seed", -1))
-        except (TypeError, ValueError):
+        seed_val = _optional_seed_id(row)
+        if seed_val is None:
             continue
         per_planner_seed_vals.setdefault(planner, {}).setdefault(seed_val, []).append(numeric)
 
@@ -336,7 +342,7 @@ def _seed_resampling_rank_flip(
     flips = 0
     for _ in range(samples):
         drawn = rng.integers(0, len(seed_universe), size=len(seed_universe))
-        sampled_seeds = [seed_universe[int(i)] for i in drawn]
+        sampled_seeds = [seed_universe[i] for i in drawn.tolist()]
         sample_means: dict[str, float] = {}
         for planner, sm in planner_seed_means.items():
             vals = [sm[s] for s in sampled_seeds if s in sm]

--- a/tests/benchmark/test_s20_s30_seed_budget_bundle_issue_1554.py
+++ b/tests/benchmark/test_s20_s30_seed_budget_bundle_issue_1554.py
@@ -1,0 +1,197 @@
+"""Tests for the issue #1554 S20/S30 seed-budget bundle builder.
+
+These exercise the small-synthetic-rows contract: per-planner-by-seed summary
+shape, bootstrap-uncertainty wiring through the canonical functions, the
+seed-resampling rank-flip detection, fail-closed classification on degraded /
+missing rows, and the blocked_until_run path when S20/S30 rows are absent.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MODULE_PATH = REPO_ROOT / "scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py"
+
+
+def _load_module():
+    """Import the bundle builder script as a module."""
+    spec = importlib.util.spec_from_file_location("s20_s30_bundle", MODULE_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["s20_s30_bundle"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+mod = _load_module()
+
+
+def _make_rows(*, planners, seeds, status="native", success_by_planner=None):
+    """Build small synthetic episode rows for the given planners/seeds."""
+    success_by_planner = success_by_planner or dict.fromkeys(planners, 0.5)
+    rows = []
+    for planner in planners:
+        base_success = success_by_planner[planner]
+        for seed in seeds:
+            # Deterministic per-seed variation so rank-flip can be exercised.
+            local = base_success + ((seed % 3) - 1) * 0.15
+            rows.append(
+                {
+                    "run_id": "r1",
+                    "episode_id": f"{planner}-{seed}",
+                    "planner": planner,
+                    "planner_key": planner,
+                    "algo": planner,
+                    "scenario_id": "s1",
+                    "scenario_family": "crossing",
+                    "seed": seed,
+                    "row_status": status,
+                    "artifact_uri": "x",
+                    "artifact_sha256": "y",
+                    # Canonical episode-record shape: outcome metrics under metrics.*
+                    # so build_seed_variability_rows / flatten_metrics consume them.
+                    "metrics": {
+                        "success": 1.0 if local > 0.5 else 0.0,
+                        "collisions": 0.0,
+                        "near_misses": float(seed % 4),
+                        "time_to_goal_norm": 0.4 + 0.01 * (seed % 5),
+                        "snqi": base_success - 0.01 * (seed % 3),
+                    },
+                }
+            )
+    return rows
+
+
+def _store(rows, source="synthetic", kind="json"):
+    """Wrap rows in a StoreRows instance."""
+    return mod.StoreRows(rows=list(rows), source=source, source_kind=kind)
+
+
+def test_blocked_when_no_rows():
+    """Empty store yields blocked_until_run naming the missing tier."""
+    bundle = mod.build_bundle(_store([], source="missing", kind="missing"), git_head="abc")
+    assert bundle["status"] == "blocked_until_run"
+    assert bundle["missing_seed_tier"] == "s20_and_s30"
+    assert "S10" in bundle["blocked_reason"]
+
+
+def test_blocked_when_below_s20_tier():
+    """A 10-seed (S10) store blocks because it is below the S20 paper tier."""
+    rows = _make_rows(planners=["goal", "orca"], seeds=range(111, 121))
+    bundle = mod.build_bundle(_store(rows), git_head="abc")
+    assert bundle["status"] == "blocked_until_run"
+    assert bundle["achieved_seed_tier"] == "s10"
+    assert bundle["min_seeds_per_planner"] == 10
+
+
+def test_blocked_when_all_rows_fail_closed():
+    """A store of only degraded rows blocks (no native/adapter rows)."""
+    rows = _make_rows(planners=["goal", "orca"], seeds=range(111, 131), status="degraded")
+    bundle = mod.build_bundle(_store(rows), git_head="abc")
+    assert bundle["status"] == "blocked_until_run"
+    assert "fail-closed" in bundle["blocked_reason"]
+
+
+def test_fail_closed_classification_reasons():
+    """Degraded/missing rows are partitioned out with explicit reasons."""
+    rows = _make_rows(planners=["goal"], seeds=range(111, 131), status="native")
+    rows += _make_rows(planners=["orca"], seeds=range(111, 131), status="fallback")
+    rows.append({"planner": "broken", "seed": 111, "success": 1.0})  # missing row_status
+    classification = mod.classify_rows(rows)
+    assert all(r["row_status"] == "native" for r in classification["valid_rows"])
+    reasons = {r["planner"]: r for r in classification["fail_closed_reasons"]}
+    assert "orca" in reasons
+    assert reasons["orca"]["statuses"].get("fallback") == 20
+    # Missing row_status defaults to a fail-closed 'unavailable' classification.
+    assert "broken" in reasons
+    assert reasons["broken"]["statuses"].get("unavailable") == 1
+
+
+def test_ok_bundle_shape_and_bootstrap_wiring():
+    """S20 native rows for >=2 planners produce a real bundle with CI fields."""
+    rows = _make_rows(
+        planners=["goal", "social_force", "orca"],
+        seeds=range(111, 131),
+        success_by_planner={"goal": 0.4, "social_force": 0.8, "orca": 0.6},
+    )
+    bundle = mod.build_bundle(_store(rows), git_head="abc")
+    assert bundle["status"] == "ok"
+    assert bundle["achieved_seed_tier"] == "s20"
+    # Per-planner-by-seed summary shape: one variability row per planner.
+    var_rows = bundle["per_planner_seed_variability"]
+    assert len(var_rows) == 3
+    sample = var_rows[0]
+    assert "per_seed" in sample and "summary" in sample
+    assert sample["seed_count"] == 20
+    # Bootstrap CI fields come from the canonical _stats_for_vals wiring.
+    success_summary = sample["summary"]["success"]
+    for field in ("mean", "std", "ci_low", "ci_high", "ci_half_width"):
+        assert field in success_summary
+    # The confidence settings drove a real (non-zero) bootstrap sample count.
+    assert bundle["confidence_settings"]["bootstrap_samples"] == 1000
+
+
+def test_seed_resampling_rank_flip_present():
+    """Rank-flip analysis runs via rank_metrics and reports the flip fraction."""
+    rows = _make_rows(
+        planners=["goal", "social_force", "orca"],
+        seeds=range(111, 131),
+        success_by_planner={"goal": 0.5, "social_force": 0.52, "orca": 0.48},
+    )
+    bundle = mod.build_bundle(_store(rows), git_head="abc")
+    flip = bundle["seed_resampling_rank_flip"]["success"]
+    assert flip["status"] == "ok"
+    assert flip["method"] == "seed_resampling_kendall_tau"
+    assert 0.0 <= flip["rank_flip_fraction"] <= 1.0
+    assert "baseline_order" in flip
+    # Aggregated conclusion key is present and boolean.
+    assert isinstance(bundle["rank_conclusion_flips_under_resampling"], bool)
+
+
+def test_snqi_ranking_stability_uses_canonical_bootstrap():
+    """SNQI stability is the canonical bootstrap_stability payload when present."""
+    rows = _make_rows(
+        planners=["goal", "social_force"],
+        seeds=range(111, 131),
+        success_by_planner={"goal": 0.4, "social_force": 0.8},
+    )
+    bundle = mod.build_bundle(_store(rows), git_head="abc")
+    snqi = bundle["snqi_ranking_stability"]
+    assert snqi["status"] == "ok"
+    assert snqi["method"] == "bootstrap_spearman"
+    assert 0.0 <= snqi["stability"] <= 1.0
+
+
+def test_reused_canonical_functions_recorded():
+    """The bundle records the canonical functions it reuses (no reinvention)."""
+    bundle = mod.build_bundle(_store([], kind="missing"), git_head="abc")
+    reused = set(bundle["reused_canonical_functions"])
+    assert "robot_sf.benchmark.seed_variance.build_seed_variability_rows" in reused
+    assert "robot_sf.benchmark.snqi.bootstrap.bootstrap_stability" in reused
+    assert "robot_sf.benchmark.rank_metrics.kendall_tau" in reused
+
+
+def test_s30_tier_detection():
+    """A 30-seed store is classified at the s30 tier."""
+    rows = _make_rows(
+        planners=["goal", "orca"],
+        seeds=range(111, 141),
+        success_by_planner={"goal": 0.4, "orca": 0.7},
+    )
+    bundle = mod.build_bundle(_store(rows), git_head="abc")
+    assert bundle["status"] == "ok"
+    assert bundle["achieved_seed_tier"] == "s30"
+    assert bundle["min_seeds_per_planner"] == 30
+
+
+@pytest.mark.parametrize("status", sorted(mod.FAIL_CLOSED_STATUSES))
+def test_each_fail_closed_status_excluded(status):
+    """Every fail-closed status is excluded from the valid set."""
+    rows = _make_rows(planners=["goal", "orca"], seeds=range(111, 131), status=status)
+    classification = mod.classify_rows(rows)
+    assert classification["valid_rows"] == []


### PR DESCRIPTION
## Summary
Refs #1554. This PR adds the local S20/S30 seed-budget archival tooling and launch packet needed before the heavy h500 campaign can run on SLURM. It remains a launch/readiness PR only: the S20/S30 result bundle is blocked until real campaign rows exist.

## Linked Issues
- Relates to `#1554`
- Unblocks the queued S20/S30 SLURM campaign preparation for `#3216` follow-on evidence.

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py`, which builds a per-planner-by-seed uncertainty bundle only when real S20/S30 rows exist.
- Added `configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml`, including config checksums, seed policy, expected artifacts, validation, and durable storage expectations.
- Extended `configs/benchmarks/seed_sets_v1.yaml` with `paper_eval_s30` while preserving existing seed order.
- Added tests for the bundle builder and updated the older PPO curriculum launch-packet checksum affected by the shared seed-set file.
- Added `docs/context/issue_1554_s20_s30_seed_budget.md` to record the claim boundary and #1545 seed-budget method.

## Why It Matters
- Added value: turns #1554 from scanned-but-not-submit-ready into a concrete launch packet plus archival checker.
- Expected impact: lets the S20/S30 run produce reviewable uncertainty artifacts instead of ad hoc local output.
- Why this is worth merging now: the branch is a prerequisite for the next SLURM-backed evidence step and fails closed until that step exists.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker for S20/S30 seed-budget evidence; no S20/S30 result is claimed in this PR.
- Comparator or baseline, if applicable: existing S10 durable evidence is referenced as context only, not promoted to S20/S30 evidence.
- Evidence tier: targeted smoke / launch packet
- Result classification: blocker-resolution
- Decision or stop rule, if applicable: merge only the launch packet/tooling; do not treat S20/S30 as complete until the SLURM campaign archives real JSONL/result-store rows.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #1554 and `docs/context/issue_1554_s20_s30_seed_budget.md`.
- New research/benchmark/metric/paper-facing analysis tool, if any: `scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py`; representative blocked-mode and fixture-backed tests are included, while real durable-input use depends on the downstream SLURM campaign.

## Domain-Aware Approval
- Required for this PR: yes - benchmark launch-packet and analysis-tool surface, but no result claim.
- Domains reviewed: evidence classification and benchmark interpretation
- Status: waived
- Approver/review source or waiver: waived because this PR only creates fail-closed tooling and a launch packet; it explicitly does not promote S20/S30 benchmark results.
- Validity checklist:
  - Target claim/hypothesis: S20/S30 uncertainty evidence remains blocked until the campaign runs.
  - Comparator or split/evidence validity: no comparator conclusion is made from S10/S3 data.
  - Fallback/degraded exclusions: fallback/degraded/unavailable/failed/partial/not_available/diagnostic_only rows are excluded from success evidence.
  - Claim boundary: launch readiness and blocked-mode tooling only.
  - Implementation integrity vs experimental validity: tests/checks prove the tooling contract; experimental validity still depends on the future SLURM run.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - no S20/S30 campaign result is evaluated in this PR.
- Did the intervention change command source, selected command, trajectory, or route progress? NA
- Did the scenario actually contain the targeted failure mode? NA
- Result route: continue - run the launch packet after merge.
- Follow-up question or issue for weak, negative, or non-transfer results: downstream S20/S30 campaign execution remains the empirical next step.

## Next Empirical Action
- Rerun needed: yes - submit/run the S20/S30 SLURM campaign from the launch packet.
- Extractor or analysis tool needed: no - this PR adds the extractor/bundle builder.
- Artifact missing or unavailable: real S20/S30 per-episode JSONL/result-store rows are not available yet.
- Stop / revise / continue decision: continue to the SLURM campaign; stop any S20/S30 claim until durable rows exist.
- Proposed child issue or existing follow-up: #1554 / #3216 follow-on evidence path.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/benchmark/test_s20_s30_seed_budget_bundle_issue_1554.py tests/benchmark/test_seed_variance.py tests/test_snqi/test_bootstrap_stability.py -q`
  - `uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py::test_referenced_configs_exist_and_checksums_match -q`
  - `uv run ruff check scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py tests/benchmark/test_s20_s30_seed_budget_bundle_issue_1554.py`
  - `uv run python scripts/dev/check_pr_followups.py --body-file /tmp/pr3506-body.md --changed-files-file /tmp/pr3506-changed-files.txt --require-body --require-substantive-body --require-open-issues`
- Evidence that the change works here: targeted tests cover blocked-mode behavior, fixture-backed bundle construction, canonical seed/bootstrap reuse, fail-closed row handling, and the updated shared seed-set checksum.
- Benchmarks or smoke tests, if applicable: targeted smoke only; no S20/S30 benchmark result is claimed.

## Risks / Rollout
- Compatibility risks: low to medium; shared `seed_sets_v1.yaml` checksum consumers need updated manifests, and this PR updates the observed stale checksum.
- Failure modes: future campaign output may lack the richer per-episode JSONL required for uncertainty math; the launch packet documents this as a required artifact.
- Rollback or fallback plan: revert this PR or leave the bundle status at `blocked_until_run` until the archive contract is satisfied.

## Docs / Provenance
- Updated docs: `docs/context/issue_1554_s20_s30_seed_budget.md`
- Relevant design or provenance notes: launch packet records config checksums, seed policy, artifact expectations, and no-claim-until-run boundary.
- Any assumptions that need to be preserved: thin `episodes.parquet` provenance alone is not enough for the uncertainty bundle; richer per-episode JSONL rows must be archived.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - PR links the issue; update after CI/review completion or merge.
- Claim map / benchmark report updated (yes/no/NA): yes - context note added for the launch/blocker boundary.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no durable S20/S30 result artifact yet.
- Registry or config index updated (yes/no/NA): yes - launch packet and seed set are tracked configs.
- Context index / memory note updated (yes/no/NA): no - context note is directly linked from this PR.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA - downstream campaign path already exists in #1554/#3216.
- Not applicable because: no benchmark result, leaderboard row, or artifact-catalog entry exists until the SLURM run completes.

## Follow-Up Issues
- Deferred work: run the S20/S30 SLURM campaign and archive real per-episode rows before producing the final uncertainty bundle.
- Issues opened for follow-up: NA - existing #1554/#3216 path covers the deferred empirical run.

## Reviewer Notes
- Verify closely that the bundle builder remains fail-closed and does not count fallback/degraded rows as success.
- Known limitations: this PR does not submit or complete the heavy S20/S30 campaign; it prepares the launch packet and blocked-mode bundle tooling.