### PR TITLE
docs(agents): add Canonical Owner Check before adding new modules/scripts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -276,6 +276,31 @@ Copilot, etc.) and the retrieval → planning → execution → verification dis
 ## Project Structure & Module Organization
 Core simulation code lives in `robot_sf/` with key subpackages: `gym_env` for Gymnasium bindings, `sim` for physics glue, `nav` for path planning, and `render` for playback tooling. Training and evaluation entry points sit in `scripts/`, while curated demos and notebooks live under `examples/`. Tests are split between `tests/` (unit and integration), `tests/pygame/` (GUI regressions), and the `fast-pysf/` subtree. Assets and checkpoints are versioned under `maps/svg_maps/` and `model/`; the canonical (git-ignored) artifact root for generated outputs is `output/` (legacy `results/` has been migrated there).
 
+## Canonical Owner Check (before adding a new module/script/config)
+
+Before creating a new module, script, config family, or asset registration for a concern, **find
+the existing canonical owner and extend it instead of duplicating it.** With multiple agents and
+machines working in parallel, the most common avoidable rework is two implementations of the same
+concern (e.g. a per-issue helper next to an existing subsystem that already owns it).
+
+- **Search first.** `grep`/`rg` the subsystem for the concept (e.g. `bootstrap`, `rank`, `staging`,
+  `evidence_contract`, `kendall`) and read the matches before writing new code. Statistics, staging,
+  provenance, evidence-contract, and rank/uncertainty concerns almost always already have an owner
+  in `robot_sf/benchmark/`, `robot_sf/research/`, `scripts/tools/`, or `scripts/validation/`.
+- **Extend, don't fork.** If an owner exists, add to it (a new function, a parameter, an asset spec
+  entry) rather than standing up a parallel `*_issue_<n>.py`. Reuse shared primitives
+  (`rank_metrics`, `seed_variance`, `snqi.bootstrap`, `manage_external_data` asset specs, the smoke
+  evidence builder, …) — do not re-implement them per issue.
+- **Per-issue scripts are for genuinely new orchestration**, not for re-deriving an existing
+  capability. A thin per-issue runner that composes canonical functions is fine; a second copy of a
+  canonical function is not.
+- **If you must introduce a new owner**, say so explicitly in the PR and name what it supersedes, so
+  the duplicate can be retired (cf. the SDD staging consolidation: a per-issue staging script was
+  later folded back into the canonical `manage_external_data.py`).
+
+This mirrors the existing note rule under *Knowledge Capture & Context Notes* ("prefer updating an
+existing canonical note"), applied to code and configs.
+
 ## Durable Artifacts & Worktree Output
 
 - Treat `output/` as temporary, worktree-local, and generally untracked. Do not assume files under `output/` exist in another checkout, worktree, or machine.


### PR DESCRIPTION
## Summary
Add a Canonical Owner Check to `AGENTS.md` so agents search for and extend the existing owner before creating new modules, scripts, configs, or asset registrations.

This captures a recurring workflow lesson from parallel agent work: duplicated ownership creates avoidable review and cleanup cost.

## Linked Issues
- Relates to #2657
- Relates to #3473
- Relates to #1554
- Relates to #3216

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added a `Canonical Owner Check` subsection in `AGENTS.md`.
- Directs agents to search existing subsystem ownership before adding new surfaces.
- Keeps per-issue scripts/configs reserved for genuinely new orchestration or explicitly named supersession.

## Why It Matters
- Added value: reduces duplicate implementations across parallel Codex, Claude, and other agent batches.
- Expected impact: less rework when multiple agents touch data staging, seed variance, bootstrap, or fidelity-stability tooling.
- Why this is worth merging now: it codifies a concrete lesson observed in recent high-volume workflow batches.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow instruction only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: docs/instruction validation.
- Result classification: workflow guidance, not benchmark evidence.
- Decision or stop rule, if applicable: merge if the guidance is clear and AI config sync stays clean.
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - no research tool added.

## Domain-Aware Approval
- Required for this PR: yes - waived because this is docs-only workflow guidance and does not change benchmark, metric, schema, or paper-facing evidence.
- Domains reviewed: workflow instruction clarity and evidence-claim boundary.
- Status: waived.
- Approver/review source or waiver: docs-only workflow guidance; no research or benchmark result is promoted.
- Validity checklist:
  - Target claim/hypothesis: NA.
  - Comparator or split/evidence validity: NA.
  - Fallback/degraded exclusions: NA.
  - Claim boundary: no benchmark or paper-facing claim.
  - Implementation integrity vs experimental validity: NA.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - docs-only instruction change.
- Did the intervention change command source, selected command, trajectory, or route progress? no.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: none.

## Next Empirical Action
- Rerun needed: no.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run python scripts/tools/sync_ai_config.py --check`
  - `pre-commit`
- Evidence that the change works here: PR author reports AI-config sync clean and pre-commit clean.
- Benchmarks or smoke tests, if applicable: NA.

## Risks / Rollout
- Compatibility risks: low; instruction-only change.
- Failure modes: agents may still need judgment when ownership is ambiguous.
- Rollback or fallback plan: revert the `AGENTS.md` subsection if it causes harmful over-consolidation.

## Docs / Provenance
- Updated docs: `AGENTS.md`.
- Relevant design or provenance notes: recurring duplicate-owner examples from #2657/#3473 and #1554/#3216 workflow batches.
- Any assumptions that need to be preserved: the check is guidance, not a ban on new owners when a new owner is clearly needed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: instruction-only workflow change with no evidence-producing artifact.

For benchmark, registry, claim-map, or paper-facing changes, explicitly say when downstream
propagation is deferred and name the issue or note that will carry it.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: NA - no deferred work.

## Reviewer Notes
- No unresolved review threads are present as of the review snapshot.