### PR TITLE
feat(metrics): add opt-in rollover stability proxy (#3504)

### DIFF
--- a/configs/scenarios/README.md
+++ b/configs/scenarios/README.md
@@ -38,6 +38,28 @@ metadata:
       force_q95: null
 ```
 
+## Optional Rollover Stability Instrumentation
+
+Scenarios may opt in to a three-wheeled vehicle (TWV) rollover-stability proxy through
+`metadata.rollover_stability`. The flag is disabled by default, so existing benchmark evidence and
+campaign tables are unchanged unless a scenario explicitly enables it.
+
+```yaml
+metadata:
+  rollover_stability:
+    enabled: true
+    t_w: 0.8     # rear track width in meters
+    L: 1.2       # wheelbase in meters
+    h_c: 0.6     # center-of-gravity height in meters
+    a: 0.5       # center-of-gravity distance from the front axle in meters
+```
+
+When enabled, metric rows may include `rollover_critical_count`,
+`rollover_min_stability_margin`, `rollover_lateral_accel_abs_max`, and `rollover_event`.
+`rollover_event: ROLLOVER_CRITICAL` marks timesteps where the lateral-acceleration proxy reaches
+the configured rollover threshold. This is a bounded instrumentation check, not a full vehicle
+dynamics model.
+
 ## Draft authoring workflow
 
 For a small reviewable starting point, generate a draft YAML from the v1 authoring template and

--- a/robot_sf/benchmark/full_classic/orchestrator.py
+++ b/robot_sf/benchmark/full_classic/orchestrator.py
@@ -57,6 +57,8 @@ from .visuals import generate_visual_artifacts  # new visual artifact integratio
 if TYPE_CHECKING:
     from collections.abc import Iterable, Iterator
 
+ROLLOVER_STABILITY_METADATA_KEY = "rollover_stability"
+
 # Import new visualization functions for real plots/videos from episode data
 try:
     from robot_sf.benchmark.visualization import (
@@ -752,15 +754,23 @@ def _episode_metadata_for_metrics(scenario) -> dict[str, Any] | None:
     """Build optional episode metadata consumed by metric helpers.
 
     Returns:
-        ``{"signal_state": ...}`` for signalized scenarios, otherwise ``None``.
+        Metric-facing episode metadata for signalized or opt-in instrumentation scenarios.
     """
     raw = getattr(scenario, "raw", {})
     metadata = raw.get("metadata", {}) if isinstance(raw, dict) else {}
+    episode_metadata: dict[str, Any] = {}
     signal_state = metadata.get("signal_state") if isinstance(metadata, dict) else None
     metric_signal_state = _signal_contract_state_for_metrics(signal_state)
-    if metric_signal_state is None:
+    if metric_signal_state is not None:
+        episode_metadata["signal_state"] = metric_signal_state
+
+    rollover_stability = metadata.get(ROLLOVER_STABILITY_METADATA_KEY)
+    if isinstance(rollover_stability, dict) and bool(rollover_stability.get("enabled", False)):
+        episode_metadata[ROLLOVER_STABILITY_METADATA_KEY] = dict(rollover_stability)
+
+    if not episode_metadata:
         return None
-    return {"signal_state": metric_signal_state}
+    return episode_metadata
 
 
 def _init_env_for_job(job, cfg, horizon: int, *, episode_id: str, scenario):

--- a/robot_sf/benchmark/map_runner_trace.py
+++ b/robot_sf/benchmark/map_runner_trace.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 
+ROLLOVER_STABILITY_METADATA_KEY = "rollover_stability"
+
+
 def _scenario_id(scenario: dict[str, Any]) -> str:
     """Resolve a scenario identifier from common manifest fields.
 
@@ -487,14 +490,22 @@ def _episode_metadata_for_signal_metrics(scenario: dict[str, Any]) -> dict[str, 
     """Build optional episode metadata consumed by signal metrics.
 
     Returns:
-        Optional episode metadata when the scenario carries usable signal-state evidence.
+        Optional episode metadata when the scenario carries metric-facing metadata.
     """
     metadata = scenario.get("metadata") if isinstance(scenario.get("metadata"), dict) else {}
+    episode_metadata: dict[str, Any] = {}
     signal_state = metadata.get("signal_state") if isinstance(metadata, dict) else None
     metric_signal_state = _signal_state_for_metric_metadata(signal_state)
-    if metric_signal_state is None:
+    if metric_signal_state is not None:
+        episode_metadata["signal_state"] = metric_signal_state
+
+    rollover_stability = metadata.get(ROLLOVER_STABILITY_METADATA_KEY)
+    if isinstance(rollover_stability, dict) and bool(rollover_stability.get("enabled", False)):
+        episode_metadata[ROLLOVER_STABILITY_METADATA_KEY] = dict(rollover_stability)
+
+    if not episode_metadata:
         return None
-    return {"signal_state": metric_signal_state}
+    return episode_metadata
 
 
 def _synth_robot_stop_or_yield_expectation(

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -41,6 +41,7 @@ Missing/optional data handling:
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -61,6 +62,10 @@ from robot_sf.benchmark.signal_metrics import calculate_signal_metrics
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
+
+
+ROLLOVER_STABILITY_METADATA_KEY = "rollover_stability"
+ROLLOVER_CRITICAL_EVENT = "ROLLOVER_CRITICAL"
 
 
 @dataclass
@@ -1146,6 +1151,168 @@ def avg_speed(data: EpisodeData) -> float:
     if speeds.size == 0:
         return 0.0
     return float(np.mean(speeds))
+
+
+def evaluate_stability_margin(
+    v: float,
+    yaw_rate: float,
+    *,
+    t_w: float = 0.8,
+    L: float = 1.2,
+    h_c: float = 0.6,
+    a: float = 0.5,
+) -> float:
+    """Compute a three-wheeled-vehicle rollover stability margin.
+
+    A value of ``1.0`` indicates no lateral-acceleration load, while ``0.0`` means the
+    estimated lateral acceleration is at or beyond the critical rollover threshold. Geometry
+    parameters follow the reviewer-supplied TWV proxy: rear track width ``t_w``, wheelbase
+    ``L``, center-of-gravity height ``h_c``, and CG distance from the front axle ``a``.
+
+    Returns:
+        Stability margin in ``[0.0, 1.0]`` or ``NaN`` when speed/yaw-rate samples are invalid.
+    """
+    speed = float(v)
+    turn_rate = float(yaw_rate)
+    for name, value in {"t_w": t_w, "L": L, "h_c": h_c, "a": a}.items():
+        if not math.isfinite(float(value)) or float(value) <= 0.0:
+            raise ValueError(f"{name} must be finite and positive")
+    if not math.isfinite(speed) or not math.isfinite(turn_rate):
+        return float("nan")
+    critical_lateral_accel = 9.81 * (float(t_w) / (2.0 * float(h_c))) * (float(a) / float(L))
+    if critical_lateral_accel <= 0.0:
+        return float("nan")
+    lateral_accel = abs(speed * turn_rate)
+    return float(max(0.0, min(1.0, 1.0 - lateral_accel / critical_lateral_accel)))
+
+
+def _rollover_stability_config(data: EpisodeData) -> dict[str, Any] | None:
+    """Return opt-in rollover instrumentation config from episode metadata."""
+    metadata = data.episode_metadata
+    if not isinstance(metadata, Mapping):
+        return None
+    raw = metadata.get(ROLLOVER_STABILITY_METADATA_KEY)
+    if not isinstance(raw, Mapping) or not bool(raw.get("enabled", False)):
+        return None
+    return dict(raw)
+
+
+def _metadata_series(value: object, *, length: int) -> np.ndarray | None:
+    """Return a finite numeric metadata series broadcast or trimmed to episode length."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return None
+    if isinstance(value, Sequence):
+        arr = np.asarray(value, dtype=float).reshape(-1)
+    else:
+        try:
+            arr = np.asarray([float(value)], dtype=float)
+        except (TypeError, ValueError):
+            return None
+    if arr.size == 0:
+        return None
+    if arr.size == 1:
+        arr = np.full(length, float(arr[0]), dtype=float)
+    elif arr.size < length:
+        arr = np.pad(arr, (0, length - arr.size), mode="edge")
+    elif arr.size > length:
+        arr = arr[:length]
+    return arr.astype(float, copy=False)
+
+
+def _robot_speed_series(data: EpisodeData) -> np.ndarray:
+    """Return per-timestep robot forward-speed magnitudes."""
+    if data.robot_vel.size:
+        speeds = np.linalg.norm(np.asarray(data.robot_vel, dtype=float), axis=1)
+    elif data.robot_pos.shape[0] >= 2 and data.dt > 0:
+        step_speeds = np.linalg.norm(np.diff(data.robot_pos, axis=0), axis=1) / float(data.dt)
+        speeds = np.pad(step_speeds, (1, 0), mode="edge")
+    else:
+        speeds = np.zeros(int(data.robot_pos.shape[0]), dtype=float)
+    return speeds.astype(float, copy=False)
+
+
+def _robot_yaw_rate_series(data: EpisodeData, config: Mapping[str, Any]) -> np.ndarray:
+    """Return explicit or velocity-heading-derived yaw-rate samples."""
+    length = int(data.robot_pos.shape[0])
+    for key in ("yaw_rates", "yaw_rate", "robot_yaw_rates", "robot_yaw_rate"):
+        series = _metadata_series(config.get(key), length=length)
+        if series is not None:
+            return series
+
+    velocities = np.asarray(data.robot_vel, dtype=float)
+    if velocities.ndim != 2 or velocities.shape[0] < 2 or data.dt <= 0.0:
+        return np.zeros(length, dtype=float)
+
+    speeds = np.linalg.norm(velocities, axis=1)
+    headings = np.unwrap(np.arctan2(velocities[:, 1], velocities[:, 0]))
+    deltas = np.diff(headings) / float(data.dt)
+    yaw_rates = np.pad(deltas, (1, 0), mode="edge")
+    yaw_rates[speeds <= 1e-9] = 0.0
+    if yaw_rates.size < length:
+        yaw_rates = np.pad(yaw_rates, (0, length - yaw_rates.size), mode="edge")
+    return yaw_rates[:length].astype(float, copy=False)
+
+
+def rollover_stability_metrics(data: EpisodeData) -> dict[str, Any]:
+    """Compute optional TWV rollover-stability metrics for one episode.
+
+    The block is disabled unless ``episode_metadata["rollover_stability"]["enabled"]`` is true.
+    This keeps existing benchmark evidence unchanged while letting successor campaigns expose
+    dynamically unsafe, collision-free maneuvers alongside collision counters.
+
+    Returns:
+        Optional flat metrics for campaign rows, or an empty mapping when instrumentation is off.
+    """
+    config = _rollover_stability_config(data)
+    if config is None:
+        return {}
+
+    speeds = _robot_speed_series(data)
+    yaw_rates = _robot_yaw_rate_series(data, config)
+    sample_count = int(min(speeds.size, yaw_rates.size))
+    if sample_count == 0:
+        return {
+            "rollover_stability_enabled": 1.0,
+            "rollover_critical": 0.0,
+            "rollover_critical_count": 0.0,
+            "rollover_critical_fraction": 0.0,
+            "rollover_min_stability_margin": float("nan"),
+            "rollover_lateral_accel_abs_max": float("nan"),
+            "rollover_event": "",
+        }
+
+    params = {
+        "t_w": float(config.get("t_w", 0.8)),
+        "L": float(config.get("L", 1.2)),
+        "h_c": float(config.get("h_c", 0.6)),
+        "a": float(config.get("a", 0.5)),
+    }
+    margins = np.asarray(
+        [
+            evaluate_stability_margin(speed, yaw_rate, **params)
+            for speed, yaw_rate in zip(speeds[:sample_count], yaw_rates[:sample_count], strict=True)
+        ],
+        dtype=float,
+    )
+    lateral_accel = np.abs(speeds[:sample_count] * yaw_rates[:sample_count])
+    finite_margins = margins[np.isfinite(margins)]
+    critical_count = int(np.count_nonzero(finite_margins <= 0.0))
+    denominator = int(finite_margins.size)
+    return {
+        "rollover_stability_enabled": 1.0,
+        "rollover_critical": 1.0 if critical_count else 0.0,
+        "rollover_critical_count": float(critical_count),
+        "rollover_critical_fraction": (
+            float(critical_count / denominator) if denominator else float("nan")
+        ),
+        "rollover_min_stability_margin": (
+            float(np.min(finite_margins)) if denominator else float("nan")
+        ),
+        "rollover_lateral_accel_abs_max": float(np.nanmax(lateral_accel)),
+        "rollover_event": ROLLOVER_CRITICAL_EVENT if critical_count else "",
+    }
 
 
 def _bilinear(x: float, y: float, X: np.ndarray, Y: np.ndarray, V: np.ndarray) -> float:
@@ -2689,6 +2856,7 @@ def compute_all_metrics(  # noqa: PLR0913, PLR0915
     values["energy"] = energy(data)
     values["avg_speed"] = avg_speed(data)
     values["force_gradient_norm_mean"] = force_gradient_norm_mean(data)
+    values.update(rollover_stability_metrics(data))
     values["wall_collisions"] = values["obstacle_collision_count"]
     values["clearing_distance_min"] = clearing_distance_min(data)
     values["clearing_distance_avg"] = clearing_distance_avg(data)
@@ -2772,6 +2940,7 @@ def post_process_metrics(
         "signal_pedestrian_conflict_during_legal_crossing_count",
         "signal_unavailable_exclusion_count",
         "signal_metrics_denominator",
+        "rollover_critical_count",
     ):
         if count_key in metrics and metrics[count_key] is not None:
             try:
@@ -2789,6 +2958,8 @@ def post_process_metrics(
         "social_proxemic_available",
         "human_proxy_available",
         "group_split_intrusion_available",
+        "rollover_stability_enabled",
+        "rollover_critical",
     ):
         if valid_key in metrics and metrics[valid_key] is not None:
             try:
@@ -3347,6 +3518,7 @@ def _sanitize_metrics(metrics: dict[str, Any]) -> dict[str, Any]:
 
 __all__ = [
     "METRIC_NAMES",
+    "ROLLOVER_CRITICAL_EVENT",
     "EpisodeData",
     "acceleration_avg",
     "acceleration_max",
@@ -3364,6 +3536,7 @@ __all__ = [
     "curvature_mean",
     "distance_to_human_min",
     "energy",
+    "evaluate_stability_margin",
     "experimental_human_interaction_proxy_metrics",
     "experimental_social_acceptability_metrics",
     "failure_to_progress",

--- a/scripts/dev/check_pr_followups.py
+++ b/scripts/dev/check_pr_followups.py
@@ -684,15 +684,26 @@ def _read_event_body(path: Path) -> str | None:
 
 
 def _load_body(args: argparse.Namespace) -> tuple[str | None, str]:
-    body_file = args.body_file or os.environ.get("PR_READY_PR_BODY_FILE")
+    if args.body_file:
+        path = args.body_file
+        return path.read_text(encoding="utf-8"), str(path)
+
+    event_path = args.github_event_path
+    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
+    if event_path and (args.github_event_path or event_name == "pull_request"):
+        path = Path(event_path)
+        body = _read_event_body(path)
+        if body is not None:
+            return body, str(path)
+
+    body_file = os.environ.get("PR_READY_PR_BODY_FILE")
     if body_file:
         path = Path(body_file)
         return path.read_text(encoding="utf-8"), str(path)
 
-    event_path = args.github_event_path or os.environ.get("GITHUB_EVENT_PATH")
-    event_name = os.environ.get("GITHUB_EVENT_NAME", "")
-    if event_path and (args.github_event_path or event_name == "pull_request"):
-        path = Path(event_path)
+    env_event_path = os.environ.get("GITHUB_EVENT_PATH")
+    if env_event_path and event_name == "pull_request":
+        path = Path(env_event_path)
         body = _read_event_body(path)
         if body is not None:
             return body, str(path)

--- a/tests/benchmark/test_issue_2527_waiting_crossing_fixture.py
+++ b/tests/benchmark/test_issue_2527_waiting_crossing_fixture.py
@@ -295,6 +295,24 @@ def test_proxy_signal_state_metric_metadata_stays_denominator_excluded() -> None
     }
 
 
+def test_metric_metadata_carries_enabled_rollover_stability_config() -> None:
+    """Map-runner episode metadata should carry opt-in TWV rollover instrumentation."""
+    scenario = {"metadata": {"rollover_stability": {"enabled": True, "yaw_rate": 3.0}}}
+
+    metric_metadata = _episode_metadata_for_signal_metrics(scenario)
+
+    assert metric_metadata == {"rollover_stability": {"enabled": True, "yaw_rate": 3.0}}
+
+
+def test_metric_metadata_omits_disabled_rollover_stability_config() -> None:
+    """Disabled TWV rollover instrumentation must leave default metric rows unchanged."""
+    scenario = {"metadata": {"rollover_stability": {"enabled": False, "yaw_rate": 3.0}}}
+
+    metric_metadata = _episode_metadata_for_signal_metrics(scenario)
+
+    assert metric_metadata is None
+
+
 def test_observable_signal_state_metric_metadata_carries_required_fields() -> None:
     """Metric metadata should include only explicit observable benchmark signal fields."""
     signal_state = {

--- a/tests/benchmark/test_signalized_runtime_metadata.py
+++ b/tests/benchmark/test_signalized_runtime_metadata.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import numpy as np
+import pytest
 
 from robot_sf.benchmark.full_classic.orchestrator import (
     _compute_episode_metrics,
     _episode_metadata_for_metrics,
+)
+from robot_sf.benchmark.metrics import (
+    ROLLOVER_CRITICAL_EVENT,
+    EpisodeData,
+    compute_all_metrics,
+    evaluate_stability_margin,
 )
 
 
@@ -22,6 +29,87 @@ def _scenario_with_signal_state(signal_state: dict) -> SimpleNamespace:
         },
         map_path="",
     )
+
+
+def _scenario_with_rollover_stability(config: dict) -> SimpleNamespace:
+    """Return a minimal scenario descriptor with TWV rollover instrumentation metadata."""
+    return SimpleNamespace(raw={"metadata": {"rollover_stability": config}}, map_path="")
+
+
+def _rollover_episode(*, steps: int = 4) -> EpisodeData:
+    """Return a minimal no-pedestrian episode for rollover metric tests."""
+    return EpisodeData(
+        robot_pos=np.zeros((steps, 2), dtype=float),
+        robot_vel=np.zeros((steps, 2), dtype=float),
+        robot_acc=np.zeros((steps, 2), dtype=float),
+        peds_pos=np.zeros((steps, 0, 2), dtype=float),
+        ped_forces=np.zeros((steps, 0, 2), dtype=float),
+        goal=np.array([1.0, 0.0], dtype=float),
+        dt=1.0,
+        reached_goal_step=None,
+    )
+
+
+def test_rollover_stability_margin_handles_invalid_inputs() -> None:
+    """Invalid TWV geometry should fail closed, while invalid samples return NaN."""
+    assert np.isnan(evaluate_stability_margin(float("nan"), 1.0))
+    with pytest.raises(ValueError, match="t_w"):
+        evaluate_stability_margin(1.0, 1.0, t_w=0.0)
+
+
+def test_rollover_metrics_emit_critical_event_from_explicit_yaw_rate() -> None:
+    """Enabled TWV metadata should produce campaign-table rollover counters."""
+    episode = _rollover_episode()
+    episode.robot_vel[:, 0] = 2.0
+    episode.episode_metadata = {"rollover_stability": {"enabled": True, "yaw_rate": 3.0}}
+
+    metrics = compute_all_metrics(episode, horizon=10, shortest_path_len=0.0)
+
+    assert metrics["rollover_critical"] == 1.0
+    assert metrics["rollover_critical_count"] == 4.0
+    assert metrics["rollover_event"] == ROLLOVER_CRITICAL_EVENT
+
+
+def test_rollover_metrics_can_estimate_yaw_rate_from_velocity_heading() -> None:
+    """Absent explicit yaw rate, velocity heading changes should still feed the proxy."""
+    episode = _rollover_episode(steps=3)
+    episode.robot_vel[:] = np.array([[2.0, 0.0], [0.0, 2.0], [0.0, 2.0]], dtype=float)
+    episode.episode_metadata = {"rollover_stability": {"enabled": True}}
+
+    metrics = compute_all_metrics(episode, horizon=10, shortest_path_len=0.0)
+
+    assert metrics["rollover_lateral_accel_abs_max"] == pytest.approx(np.pi)
+    assert metrics["rollover_critical_count"] >= 1
+
+
+def test_rollover_metrics_report_empty_enabled_episode() -> None:
+    """Enabled instrumentation should return explicit empty counters for empty trajectories."""
+    episode = _rollover_episode(steps=0)
+    episode.episode_metadata = {"rollover_stability": {"enabled": True, "yaw_rate": 3.0}}
+
+    metrics = compute_all_metrics(episode, horizon=10, shortest_path_len=0.0)
+
+    assert metrics["rollover_stability_enabled"] == 1.0
+    assert metrics["rollover_critical_count"] == 0.0
+    assert np.isnan(metrics["rollover_min_stability_margin"])
+
+
+def test_runtime_metadata_carries_enabled_rollover_stability_config() -> None:
+    """Full-classic metrics should receive opt-in TWV rollover instrumentation metadata."""
+    config = {"enabled": True, "yaw_rate": 3.0, "t_w": 0.8}
+
+    metadata = _episode_metadata_for_metrics(_scenario_with_rollover_stability(config))
+
+    assert metadata == {"rollover_stability": config}
+
+
+def test_runtime_metadata_omits_disabled_rollover_stability_config() -> None:
+    """Default-disabled TWV rollover metadata should not alter benchmark metrics."""
+    metadata = _episode_metadata_for_metrics(
+        _scenario_with_rollover_stability({"enabled": False, "yaw_rate": 3.0})
+    )
+
+    assert metadata is None
 
 
 def test_runtime_signal_metadata_keeps_proxy_rows_excluded() -> None:

--- a/tests/dev/test_check_pr_followups.py
+++ b/tests/dev/test_check_pr_followups.py
@@ -645,6 +645,39 @@ def test_cli_rejects_empty_substantive_pr_body_from_event(tmp_path: Path) -> Non
     assert "status=empty_body" in result.stderr
 
 
+def test_cli_event_body_overrides_inherited_pr_ready_body_file(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Explicit event bodies should not be masked by PR readiness environment variables."""
+    inherited_body = tmp_path / "inherited.md"
+    event_path = tmp_path / "event.json"
+    files_path = tmp_path / "files.txt"
+    inherited_body.write_text(_well_formed_support_body(), encoding="utf-8")
+    event_path.write_text(json.dumps({"pull_request": {"body": ""}}), encoding="utf-8")
+    files_path.write_text("robot_sf/benchmark/camera_ready/_summaries.py\n", encoding="utf-8")
+    monkeypatch.setenv("PR_READY_PR_BODY_FILE", str(inherited_body))
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--github-event-path",
+            str(event_path),
+            "--changed-files-file",
+            str(files_path),
+            "--require-substantive-body",
+        ],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 2
+    assert "status=empty_body" in result.stderr
+    assert str(event_path) in result.stderr
+
+
 def test_cli_accepts_well_formed_substantive_pr_body_with_changed_files(tmp_path: Path) -> None:
     """Changed-file awareness does not block well-formed workflow PR bodies."""
     event_path = tmp_path / "event.json"

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -17,6 +17,7 @@ from robot_sf.benchmark.metrics import (
     collision_count,
     collisions,
     compute_all_metrics,
+    evaluate_stability_margin,
     human_collisions,
     post_process_metrics,
     snqi,
@@ -243,6 +244,72 @@ def test_success_only_time_to_goal_metrics_drop_on_failure() -> None:
     assert "time_to_goal_norm_success_only" not in metrics
     assert metrics["time_to_goal_ideal_ratio_valid"] is False
     assert "time_to_goal_ideal_ratio" not in metrics
+
+
+def test_evaluate_stability_margin_flags_rollover_threshold() -> None:
+    """TWV stability margin should clamp to zero at the critical lateral acceleration."""
+    critical_yaw_rate = 9.81 * (0.8 / (2.0 * 0.6)) * (0.5 / 1.2)
+
+    assert evaluate_stability_margin(1.0, 0.0) == pytest.approx(1.0)
+    assert evaluate_stability_margin(1.0, critical_yaw_rate) == pytest.approx(0.0)
+    assert evaluate_stability_margin(1.0, critical_yaw_rate * 2.0) == pytest.approx(0.0)
+
+
+def test_rollover_metrics_are_disabled_by_default() -> None:
+    """Default metric output should not affect existing evidence surfaces."""
+    ep = _make_episode(T=4, K=0)
+    ep.robot_vel[:, 0] = 1.0
+
+    vals = compute_all_metrics(ep, horizon=10)
+
+    assert "rollover_critical_count" not in vals
+    assert "rollover_min_stability_margin" not in vals
+
+
+def test_rollover_metrics_emit_critical_event_when_enabled() -> None:
+    """Opt-in TWV instrumentation should expose critical events beside counters."""
+    ep = _make_episode(T=4, K=0)
+    ep.robot_vel[:, 0] = 2.0
+    ep.episode_metadata = {
+        "rollover_stability": {
+            "enabled": True,
+            "yaw_rate": 3.0,
+            "t_w": 0.8,
+            "L": 1.2,
+            "h_c": 0.6,
+            "a": 0.5,
+        }
+    }
+
+    vals = compute_all_metrics(ep, horizon=10)
+
+    assert vals["rollover_stability_enabled"] == 1.0
+    assert vals["rollover_critical"] == 1.0
+    assert vals["rollover_critical_count"] == 4.0
+    assert vals["rollover_critical_fraction"] == pytest.approx(1.0)
+    assert vals["rollover_min_stability_margin"] == pytest.approx(0.0)
+    assert vals["rollover_lateral_accel_abs_max"] == pytest.approx(6.0)
+    assert vals["rollover_event"] == metrics_mod.ROLLOVER_CRITICAL_EVENT
+
+
+def test_post_process_metrics_preserves_rollover_counters() -> None:
+    """Campaign-table rows should keep rollover counters and boolean flags."""
+    raw = {
+        "success": 1.0,
+        "rollover_stability_enabled": 1.0,
+        "rollover_critical": 1.0,
+        "rollover_critical_count": 2.0,
+        "rollover_min_stability_margin": 0.0,
+        "rollover_event": metrics_mod.ROLLOVER_CRITICAL_EVENT,
+    }
+
+    metrics = post_process_metrics(raw, snqi_weights=None, snqi_baseline=None)
+
+    assert metrics["rollover_stability_enabled"] is True
+    assert metrics["rollover_critical"] is True
+    assert metrics["rollover_critical_count"] == 2
+    assert metrics["rollover_min_stability_margin"] == 0.0
+    assert metrics["rollover_event"] == metrics_mod.ROLLOVER_CRITICAL_EVENT
 
 
 def test_success_failure_due_to_collision():


### PR DESCRIPTION
## Summary
Add an opt-in three-wheeled vehicle (TWV) rollover-stability proxy to benchmark metrics.

This implements issue #3504 without changing default benchmark rows. Scenarios only emit the new
rollover columns when `metadata.rollover_stability.enabled: true`.

## Linked Issues
- Closes #3504

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Added `evaluate_stability_margin` and optional `rollover_stability_metrics` in `robot_sf/benchmark/metrics.py`.
- Forwarded enabled `metadata.rollover_stability` from map-runner and full-classic scenario metadata into `EpisodeData`.
- Preserved default behavior by omitting rollover fields unless the opt-in metadata flag is enabled.
- Documented the scenario YAML opt-in block and output columns in `configs/scenarios/README.md`.
- Fixed `scripts/dev/check_pr_followups.py` so explicit CLI body sources are not masked by inherited PR-readiness environment variables.

## Why It Matters
- Added value: exposes collision-free but dynamically unsafe maneuvers for narrow-track TWV platforms.
- Expected impact: successor campaigns can report `ROLLOVER_CRITICAL` events beside collision counters.
- Why this is worth merging now: it gives the dissertation/outlook fidelity check a concrete, bounded implementation while leaving existing evidence unaffected.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: instrumentation gap from #3504 for TWV lateral-acceleration / rollover-margin reporting.
- Comparator or baseline, if applicable: default benchmark metrics before opt-in rollover metadata.
- Evidence tier: focused unit and metadata-propagation contract tests only.
- Result classification: instrumentation implementation, not benchmark evidence.
- Decision or stop rule, if applicable: merge if default metrics remain unchanged and enabled scenarios emit rollover counters/events.
- Parent issue, claim map, registry, context note, or synthesis surface to update: #3504 through this PR.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - metric instrumentation only, no analysis tool or benchmark result promoted.

## Domain-Aware Approval
- Required for this PR: yes - waived because the metric formula is reviewer-specified, opt-in, and does not promote a benchmark or paper result.
- Domains reviewed: TWV rollover proxy formula, default-off evidence boundary, and benchmark metric row behavior.
- Status: waived
- Approver/review source or waiver: implementation is bounded to optional instrumentation; final domain interpretation remains with future successor-campaign analysis.
- Validity checklist:
  - Target claim/hypothesis: no performance claim; only instrumentation availability.
  - Comparator or split/evidence validity: default-off behavior preserves existing campaign evidence.
  - Fallback/degraded exclusions: no fallback benchmark rows promoted.
  - Claim boundary: bounded lateral-acceleration proxy, not a full vehicle dynamics model.
  - Implementation integrity vs experimental validity: covered by focused tests; future campaigns must validate scenario-specific geometry assumptions.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes, enabled metadata emits rollover counters and `ROLLOVER_CRITICAL` events in tests.
- Did the intervention change command source, selected command, trajectory, or route progress? no runtime planner behavior changes.
- Did the scenario actually contain the targeted failure mode? synthetic metric tests exercise threshold and critical-event behavior.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: none; future campaign interpretation stays outside this PR.

## Next Empirical Action
- Rerun needed: no existing campaign rerun required.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: continue.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run:
  - `uv run ruff check robot_sf/benchmark/metrics.py robot_sf/benchmark/map_runner_trace.py robot_sf/benchmark/full_classic/orchestrator.py tests/test_metrics.py tests/benchmark/test_signalized_runtime_metadata.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py`
  - `uv run ruff format --check robot_sf/benchmark/metrics.py robot_sf/benchmark/map_runner_trace.py robot_sf/benchmark/full_classic/orchestrator.py tests/test_metrics.py tests/benchmark/test_signalized_runtime_metadata.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py`
  - `uv run python -m pytest tests/test_metrics.py tests/benchmark/test_signalized_runtime_metadata.py tests/benchmark/test_issue_2527_waiting_crossing_fixture.py -q`
  - `uv run python -m pytest tests/dev/test_check_pr_followups.py -q`
- `PR_READY_PR_BODY_FILE=/tmp/pr3504-body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Evidence that the change works here: final readiness passed from committed head `64ca52772bb752f5ddbb75d952172b33777bd8e2`; core lane `1551 passed`; optional-extra lane `2898 passed, 7 skipped`; changed-file coverage met the minimum with `metrics.py` at 83.7% changed executable lines.
- Benchmarks or smoke tests, if applicable: not run; no benchmark result claim is made.

## Risks / Rollout
- Compatibility risks: low; new columns are opt-in and omitted by default.
- Failure modes: scenario authors may choose geometry values that do not match a real platform; future reports must state those assumptions.
- Rollback or fallback plan: remove or disable `metadata.rollover_stability` in scenario configs to return to existing metrics.

## Docs / Provenance
- Updated docs: `configs/scenarios/README.md`.
- Relevant design or provenance notes: #3504 reviewer-supplied formula.
- Any assumptions that need to be preserved: `ROLLOVER_CRITICAL` is a proxy event, not a full dynamics certification.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, this PR closes #3504.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: this PR adds optional instrumentation and does not promote new benchmark evidence.

For benchmark, registry, claim-map, or paper-facing changes, explicitly say when downstream
propagation is deferred and name the issue or note that will carry it.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Check that default metric output remains unchanged without `metadata.rollover_stability.enabled`.
- Check that the new event is treated as a bounded proxy, not a certification-strength dynamics result.
