### PR TITLE
feat(benchmark): add package-B adversarial sampler comparison

### DIFF
--- a/configs/adversarial/issue_3079_package_b_budget_matched.yaml
+++ b/configs/adversarial/issue_3079_package_b_budget_matched.yaml
@@ -1,0 +1,36 @@
+schema_version: adversarial-package-b-comparison.v1
+issue: 3079
+status: diagnostic_local_nominal
+claim_scope: not_paper_facing_benchmark_evidence
+runner: scripts/tools/compare_adversarial_samplers.py
+base_config:
+  scenario_template: configs/scenarios/templates/crossing_ttc.yaml
+  search_space: configs/adversarial/crossing_ttc_space.yaml
+  policy: goal
+  objective: worst_case_snqi
+budget_grid: [16, 32, 64]
+repeated_seeds: [1101, 2202, 3303]
+samplers:
+  - random
+  - coordinate
+  - optuna
+reporting_contract:
+  - first_failure_iteration
+  - best_valid_objective
+  - invalid_candidate_rate
+  - replay_success_rate
+  - certified_valid_failure_count
+  - replayable_valid_failure_count
+  - fallback_candidate_count
+  - degraded_candidate_count
+  - held_out_family_yield
+explicit_exclusions:
+  learned_failure_proposal_issue_2921: stretch_out_of_scope_until_base_comparison_succeeds
+  held_out_family_yield: not_evaluated_narrow_archive_caveat
+  paper_facing_success_claims: forbidden
+example_command: >
+  uv run python scripts/tools/compare_adversarial_samplers.py
+  --package-b-budget-grid
+  --seed 1101 --seed 2202 --seed 3303
+  --output-dir output/adversarial/issue_3079_package_b
+  --out-json output/adversarial/issue_3079_package_b/report.json

--- a/scripts/tools/compare_adversarial_samplers.py
+++ b/scripts/tools/compare_adversarial_samplers.py
@@ -6,7 +6,7 @@ import argparse
 import json
 from dataclasses import asdict, dataclass, replace
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from robot_sf.adversarial.attribution import attribution_from_episode_record
 from robot_sf.adversarial.bundle import write_trajectory_csv
@@ -31,13 +31,26 @@ class SamplerComparisonRow:
     """One sampler result row for the comparison report."""
 
     sampler: str
+    budget: int
+    seed: int
     manifest_path: str
     best_bundle_path: str | None
     best_objective_value: float | None
+    best_valid_objective: float | None
     num_candidates: int
     num_valid_candidates: int
     num_invalid_candidates: int
     num_failed_evaluations: int
+    invalid_candidate_rate: float
+    first_failure_iteration: int | None
+    certified_valid_failure_count: int
+    replayable_valid_failure_count: int
+    replay_success_rate: float | None
+    fallback_candidate_count: int
+    degraded_candidate_count: int
+    held_out_family_yield: float | None
+    held_out_family_status: str
+    caveats: tuple[str, ...]
 
 
 def build_sampler(name: str, search_space: SearchSpaceConfig, *, seed: int) -> CandidateSampler:
@@ -57,41 +70,190 @@ def run_sampler_comparison(
     config: SearchConfig,
     sampler_names: Sequence[str],
     synthetic: bool,
+    budgets: Sequence[int] | None = None,
+    seeds: Sequence[int] | None = None,
 ) -> list[SamplerComparisonRow]:
     """Run the configured search once per sampler and return compact rows."""
     rows: list[SamplerComparisonRow] = []
-    for offset, sampler_name in enumerate(sampler_names):
-        sampler_output_dir = config.output_dir / sampler_name
-        sampler_config = replace(
-            config,
-            output_dir=sampler_output_dir,
-            seed=config.seed + offset,
-        )
-        result = run_adversarial_search(
-            sampler_config,
-            sampler=build_sampler(sampler_name, config.search_space, seed=config.seed + offset),
-            evaluator=_synthetic_evaluator if synthetic else None,
-            certifier=(
-                (lambda _candidate, _path, _required: passed_status("synthetic comparison"))
-                if synthetic
-                else None
-            ),
-        )
-        rows.append(
-            SamplerComparisonRow(
-                sampler=sampler_name,
-                manifest_path=result.manifest_path.as_posix(),
-                best_bundle_path=(
-                    result.best_bundle_path.as_posix() if result.best_bundle_path else None
-                ),
-                best_objective_value=result.best_objective_value,
-                num_candidates=result.num_candidates,
-                num_valid_candidates=result.num_valid_candidates,
-                num_invalid_candidates=result.num_invalid_candidates,
-                num_failed_evaluations=result.num_failed_evaluations,
-            )
-        )
+    active_budgets = tuple(budgets or (config.budget,))
+    active_seeds = tuple(seeds or (config.seed,))
+    for budget in active_budgets:
+        if budget <= 0:
+            raise ValueError("budgets must be positive")
+        for base_seed in active_seeds:
+            for sampler_name in sampler_names:
+                run_seed = int(base_seed)
+                sampler_output_dir = (
+                    config.output_dir
+                    / f"budget_{int(budget):04d}"
+                    / f"seed_{int(base_seed)}"
+                    / sampler_name
+                )
+                sampler_config = replace(
+                    config,
+                    budget=int(budget),
+                    output_dir=sampler_output_dir,
+                    seed=run_seed,
+                )
+                result = run_adversarial_search(
+                    sampler_config,
+                    sampler=build_sampler(sampler_name, config.search_space, seed=run_seed),
+                    evaluator=_synthetic_evaluator if synthetic else None,
+                    certifier=(
+                        (lambda _candidate, _path, _required: passed_status("synthetic comparison"))
+                        if synthetic
+                        else None
+                    ),
+                )
+                rows.append(
+                    _comparison_row_from_manifest(
+                        sampler=sampler_name,
+                        budget=int(budget),
+                        seed=run_seed,
+                        manifest_path=result.manifest_path,
+                        best_bundle_path=result.best_bundle_path,
+                        best_objective_value=result.best_objective_value,
+                        num_candidates=result.num_candidates,
+                        num_valid_candidates=result.num_valid_candidates,
+                        num_invalid_candidates=result.num_invalid_candidates,
+                        num_failed_evaluations=result.num_failed_evaluations,
+                    )
+                )
     return rows
+
+
+def _comparison_row_from_manifest(  # noqa: PLR0913
+    *,
+    sampler: str,
+    budget: int,
+    seed: int,
+    manifest_path: Path,
+    best_bundle_path: Path | None,
+    best_objective_value: float | None,
+    num_candidates: int,
+    num_valid_candidates: int,
+    num_invalid_candidates: int,
+    num_failed_evaluations: int,
+) -> SamplerComparisonRow:
+    """Derive conservative package-B diagnostics from one search manifest."""
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    candidates = manifest.get("candidates") if isinstance(manifest, dict) else []
+    if not isinstance(candidates, list):
+        candidates = []
+
+    certified_valid_failures = [
+        (index, item)
+        for index, item in enumerate(candidates, start=1)
+        if _is_certified_valid_failure(item)
+    ]
+    replayable_failures = [
+        item for _index, item in certified_valid_failures if _has_replay_paths(item)
+    ]
+    valid_objectives = [
+        float(item["objective_value"]) for item in candidates if _is_valid_scored_candidate(item)
+    ]
+    replay_success_rate = (
+        len(replayable_failures) / len(certified_valid_failures)
+        if certified_valid_failures
+        else None
+    )
+    caveats = (
+        "diagnostic/local nominal report; not paper-facing benchmark evidence",
+        "held-out-family yield is not evaluated in package B; narrow archive caveat applies",
+        "learned failure proposal #2921 remains stretch/out of scope",
+    )
+    return SamplerComparisonRow(
+        sampler=sampler,
+        budget=budget,
+        seed=seed,
+        manifest_path=manifest_path.as_posix(),
+        best_bundle_path=best_bundle_path.as_posix() if best_bundle_path else None,
+        best_objective_value=best_objective_value,
+        best_valid_objective=max(valid_objectives) if valid_objectives else None,
+        num_candidates=num_candidates,
+        num_valid_candidates=num_valid_candidates,
+        num_invalid_candidates=num_invalid_candidates,
+        num_failed_evaluations=num_failed_evaluations,
+        invalid_candidate_rate=(num_invalid_candidates / num_candidates if num_candidates else 0.0),
+        first_failure_iteration=(
+            certified_valid_failures[0][0] if certified_valid_failures else None
+        ),
+        certified_valid_failure_count=len(certified_valid_failures),
+        replayable_valid_failure_count=len(replayable_failures),
+        replay_success_rate=replay_success_rate,
+        fallback_candidate_count=sum(
+            1 for item in candidates if _candidate_mode(item) == "fallback"
+        ),
+        degraded_candidate_count=sum(
+            1 for item in candidates if _candidate_mode(item) == "degraded"
+        ),
+        held_out_family_yield=None,
+        held_out_family_status="not_evaluated_narrow_archive",
+        caveats=caveats,
+    )
+
+
+def _is_certified_valid_failure(item: Any) -> bool:
+    """Return whether a manifest candidate is a certified, valid behavioral failure."""
+    if not isinstance(item, dict):
+        return False
+    if item.get("error") is not None:
+        return False
+    certification = item.get("certification_status")
+    if not isinstance(certification, dict) or certification.get("status") != "passed":
+        return False
+    attribution = item.get("failure_attribution")
+    if not isinstance(attribution, dict):
+        return False
+    return attribution.get("primary_failure") in {
+        "collision",
+        "timeout",
+        "near_miss",
+        "comfort_violation",
+        "incomplete",
+    }
+
+
+def _is_valid_scored_candidate(item: Any) -> bool:
+    """Return whether a candidate has a usable objective score and no exclusion status."""
+    if not isinstance(item, dict):
+        return False
+    if item.get("error") is not None or item.get("objective_value") is None:
+        return False
+    certification = item.get("certification_status")
+    if not isinstance(certification, dict) or certification.get("status") != "passed":
+        return False
+    attribution = item.get("failure_attribution")
+    if isinstance(attribution, dict) and attribution.get("primary_failure") in {
+        "invalid_candidate",
+        "evaluation_error",
+    }:
+        return False
+    return True
+
+
+def _has_replay_paths(item: dict[str, Any]) -> bool:
+    """Return whether manifest paths needed for local replay inspection exist."""
+    for key in ("scenario_yaml_path", "episode_record_path", "trajectory_csv_path", "bundle_path"):
+        raw_path = item.get(key)
+        if not raw_path or not Path(str(raw_path)).exists():
+            return False
+    return True
+
+
+def _candidate_mode(item: Any) -> str | None:
+    """Extract fallback/degraded mode tags when evaluators report them."""
+    if not isinstance(item, dict):
+        return None
+    attribution = item.get("failure_attribution")
+    details = attribution.get("details") if isinstance(attribution, dict) else None
+    if not isinstance(details, dict):
+        return None
+    for key in ("execution_mode", "readiness_status", "availability_status"):
+        value = details.get(key)
+        if str(value).lower() in {"fallback", "degraded"}:
+            return str(value).lower()
+    return None
 
 
 def _synthetic_evaluator(
@@ -146,8 +308,28 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--policy", default="goal")
     parser.add_argument("--objective", default="worst_case_snqi")
     parser.add_argument("--output-dir", type=Path, required=True)
-    parser.add_argument("--budget", type=int, default=8)
-    parser.add_argument("--seed", type=int, default=123)
+    parser.add_argument(
+        "--budget",
+        type=int,
+        action="append",
+        default=None,
+        help=(
+            "Candidate budget to run; repeat for a budget grid. "
+            "Defaults to 8 unless --package-b-budget-grid is set."
+        ),
+    )
+    parser.add_argument(
+        "--package-b-budget-grid",
+        action="store_true",
+        help="Run the issue #3079 package-B fixed budgets: 16, 32, and 64.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        action="append",
+        default=None,
+        help="Base seed to run; repeat for repeated-seed budget matching. Defaults to 123.",
+    )
     parser.add_argument(
         "--sampler",
         action="append",
@@ -174,16 +356,28 @@ def main(argv: Sequence[str] | None = None) -> int:
         search_space=args.search_space,
         objective=args.objective,
         output_dir=args.output_dir,
-        budget=args.budget,
-        seed=args.seed,
+        budget=(args.budget or [8])[0],
+        seed=(args.seed or [123])[0],
     )
+    budgets = (16, 32, 64) if args.package_b_budget_grid and args.budget is None else args.budget
+    seeds = args.seed or [123]
     rows = run_sampler_comparison(
         config=config,
         sampler_names=tuple(args.samplers or ("random", "coordinate", "optuna")),
         synthetic=bool(args.synthetic),
+        budgets=budgets,
+        seeds=seeds,
     )
     payload = {
-        "schema_version": "adversarial-sampler-comparison.v1",
+        "schema_version": "adversarial-sampler-comparison.v2",
+        "report_status": "diagnostic_local_nominal",
+        "claim_scope": "not_paper_facing_benchmark_evidence",
+        "budget_grid": list(budgets or [config.budget]),
+        "seeds": list(seeds),
+        "package_b_notes": {
+            "learned_failure_proposal_issue_2921": "stretch_out_of_scope",
+            "held_out_family_yield": "not_evaluated_narrow_archive",
+        },
         "rows": [asdict(r) for r in rows],
     }
     if args.out_json is not None:

--- a/tests/adversarial/test_adversarial_search.py
+++ b/tests/adversarial/test_adversarial_search.py
@@ -53,7 +53,10 @@ from robot_sf.nav.global_route import GlobalRoute
 from robot_sf.nav.map_config import MapDefinition
 from robot_sf.nav.obstacle import Obstacle
 from robot_sf.ped_npc.ped_population import populate_single_pedestrians
-from scripts.tools.compare_adversarial_samplers import run_sampler_comparison
+from scripts.tools.compare_adversarial_samplers import (
+    _comparison_row_from_manifest,
+    run_sampler_comparison,
+)
 
 _MULTI_PED_FAMILY_FIXTURES = (
     (
@@ -1435,6 +1438,118 @@ def test_sampler_comparison_synthetic_smoke(tmp_path: Path) -> None:
     assert {row.num_candidates for row in rows} == {2}
     assert all(Path(row.manifest_path).exists() for row in rows)
     assert all(row.num_failed_evaluations == 0 for row in rows)
+    assert all(row.best_valid_objective is not None for row in rows)
+
+
+def test_sampler_comparison_package_b_budget_seed_grid(tmp_path: Path) -> None:
+    """Package-B helper should run fixed candidate budgets under repeated seeds."""
+    template = tmp_path / "template.yaml"
+    search_space = tmp_path / "space.yaml"
+    _write_template(template)
+    _write_space(search_space)
+    config = SearchConfig.from_files(
+        policy="goal",
+        scenario_template=template,
+        search_space=search_space,
+        objective="worst_case_snqi",
+        output_dir=tmp_path / "comparison",
+        budget=1,
+        seed=23,
+    )
+
+    rows = run_sampler_comparison(
+        config=config,
+        sampler_names=("random", "coordinate"),
+        synthetic=True,
+        budgets=(16, 32, 64),
+        seeds=(101, 202),
+    )
+
+    assert {(row.budget, row.seed) for row in rows} == {
+        (16, 101),
+        (16, 202),
+        (32, 101),
+        (32, 202),
+        (64, 101),
+        (64, 202),
+    }
+    assert {row.num_candidates for row in rows} == {16, 32, 64}
+    assert all(row.held_out_family_status == "not_evaluated_narrow_archive" for row in rows)
+    assert all("learned failure proposal #2921" in " ".join(row.caveats) for row in rows)
+
+
+def test_sampler_comparison_reports_certified_replayable_failures(tmp_path: Path) -> None:
+    """Manifest-derived rows should separate certified failures from exclusions."""
+    bundle_dir = tmp_path / "bundle"
+    bundle_dir.mkdir()
+    scenario_path = bundle_dir / "scenario.yaml"
+    episode_path = bundle_dir / "episode_records.jsonl"
+    trajectory_path = bundle_dir / "trajectory.csv"
+    for path in (scenario_path, episode_path, trajectory_path):
+        path.write_text("fixture\n", encoding="utf-8")
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "adversarial-search-manifest.v1",
+                "candidates": [
+                    {
+                        "certification_status": {"status": "passed"},
+                        "objective_value": 4.0,
+                        "failure_attribution": {
+                            "primary_failure": "collision",
+                            "details": {},
+                        },
+                        "scenario_yaml_path": scenario_path.as_posix(),
+                        "episode_record_path": episode_path.as_posix(),
+                        "trajectory_csv_path": trajectory_path.as_posix(),
+                        "bundle_path": bundle_dir.as_posix(),
+                        "error": None,
+                    },
+                    {
+                        "certification_status": {"status": "failed"},
+                        "objective_value": None,
+                        "failure_attribution": {
+                            "primary_failure": "invalid_candidate",
+                            "details": {},
+                        },
+                        "error": "invalid",
+                    },
+                    {
+                        "certification_status": {"status": "passed"},
+                        "objective_value": 2.0,
+                        "failure_attribution": {
+                            "primary_failure": "success",
+                            "details": {"readiness_status": "fallback"},
+                        },
+                        "error": None,
+                    },
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    row = _comparison_row_from_manifest(
+        sampler="random",
+        budget=3,
+        seed=11,
+        manifest_path=manifest_path,
+        best_bundle_path=bundle_dir,
+        best_objective_value=4.0,
+        num_candidates=3,
+        num_valid_candidates=2,
+        num_invalid_candidates=1,
+        num_failed_evaluations=0,
+    )
+
+    assert row.first_failure_iteration == 1
+    assert row.best_valid_objective == 4.0
+    assert row.invalid_candidate_rate == pytest.approx(1 / 3)
+    assert row.certified_valid_failure_count == 1
+    assert row.replayable_valid_failure_count == 1
+    assert row.replay_success_rate == 1.0
+    assert row.fallback_candidate_count == 1
 
 
 def test_invalid_optimizer_proposals_are_rejected_before_evaluation(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- extend `scripts/tools/compare_adversarial_samplers.py` with the issue #3079 package-B budget/seed grid (`16`, `32`, `64`) across random, coordinate, and Optuna-backed samplers
- add conservative v2 report fields for first failure, best valid objective, invalid rate, certified/replayable failures, replay success, fallback/degraded exclusions, and held-out-yield caveat status
- add a reviewable package-B config plus adversarial tests for the budget/seed grid and certified/replayable failure accounting

Refs #3079

## Evidence Status / Claim Boundary

This PR is harness/config smoke evidence, not paper-facing benchmark evidence. It proves the package-B comparison path is runnable and report-shaped. It does not run the full non-synthetic package-B campaign, and the held-out-family yield remains `not_evaluated_narrow_archive` until a reviewed archive run is available.

## Validation

- `rtk uv run ruff format scripts/tools/compare_adversarial_samplers.py tests/adversarial/test_adversarial_search.py`
- `rtk uv run python -c "import yaml; yaml.safe_load(open('configs/adversarial/issue_1500_adversarial_comparison_manifest.v1.yaml')); yaml.safe_load(open('configs/adversarial/issue_3079_package_b_budget_matched.yaml')); print('manifest ok')"`
- `rtk uv run ruff check scripts/tools/compare_adversarial_samplers.py tests/adversarial/test_adversarial_search.py`
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/adversarial/ -k "search or budget or certif" -q` — 79 passed, 124 deselected
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/compare_adversarial_samplers.py --synthetic --package-b-budget-grid --seed 101 ...` — v2 rows for random/coordinate/optuna at budgets 16/32/64
- `rtk scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/compare_adversarial_samplers.py --budget 1 --sampler random --seed 101 ...` — non-synthetic evaluator smoke emitted one v2 report row
- `rtk git diff --check`

## Notes

A fresh worktree `.venv` adversarial pytest collection failed because `torch` was not installed there; the same test slice passed through `scripts/dev/run_worktree_shared_venv.sh` against the initialized main environment.

## Downstream Propagation

NA - this PR adds the package-B runner/report contract and config. Full package-B campaign execution and durable evidence publication remain follow-up work under #3079.

## Follow-Up Issues

Full package-B non-synthetic campaign execution and durable evidence publication remain tracked by #3079. This PR only adds the runner/report contract, config, tests, and smoke evidence.

