### PR TITLE
feat(benchmark): aggregate CLEAR tracking diagnostics

### DIFF
--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -35,6 +35,33 @@ These outputs are a local demo only. They are not durable benchmark evidence and
 for paper-facing or promotion claims unless promoted separately with the repository's normal
 artifact provenance and validation process.
 
+## Tracking-Uncertainty Metrics
+
+Robot SF has a bounded CLEAR Multi-Object Tracking (CLEAR MOT) diagnostic layer for
+perception-gap evaluation. ScenarioBelief adapters can compare an oracle belief with a
+visibility-limited or tracking-noise belief and emit Multiple Object Tracking Accuracy (MOTA) and
+Multiple Object Tracking Precision (MOTP). MOTA counts missed detections, false positives, and ID
+switches against the ground-truth detection count. MOTP reports mean matched localization error in
+meters.
+
+Tracking uncertainty remains disabled by default. Scenarios opt into synthetic planner-facing
+visibility and centroid-offset stress through `observation_visibility.tracking_noise_std_m`; use
+`0.0` for exact zero-noise reproduction. Benchmark planner-input vector noise continues to use the
+existing `observation_noise` profile path in `robot_sf.benchmark.observation_noise`.
+
+When a noise or perception-limited evaluation records CLEAR metrics, store them under the existing
+`metrics.clear_tracking_uncertainty` block with `enabled`, `mota`, `motp_m`, and `counts` fields.
+The aggregate/reporting path flattens that block into columns such as `clear_mota`,
+`clear_motp_m`, `clear_missed_detection_count`, and `clear_false_positive_count`. These values are
+diagnostic unless backed by an explicit perception-gap campaign and provenance.
+
+Validation protocol:
+
+```bash
+uv run pytest tests/representation/test_scenario_belief.py \
+  tests/test_metrics.py tests/test_aggregate.py
+```
+
 ## Mechanism-Aware Diagnostic Reproduction
 
 For a bounded one-command reproduction of a mechanism-aware diagnostic case, run:

--- a/robot_sf/benchmark/aggregate.py
+++ b/robot_sf/benchmark/aggregate.py
@@ -446,6 +446,32 @@ def _flatten_social_mini_game_block(base: dict[str, Any], social_mini_game: Any)
             base[prefix] = row.get("value")
 
 
+def _flatten_clear_tracking_block(base: dict[str, Any], clear_tracking: Any) -> None:
+    """Flatten schema-backed CLEAR tracking diagnostics into aggregate/report columns."""
+    if not isinstance(clear_tracking, dict):
+        return
+    if "enabled" in clear_tracking:
+        base["clear_tracking_enabled"] = clear_tracking.get("enabled")
+    if "mota" in clear_tracking:
+        base["clear_mota"] = clear_tracking.get("mota")
+    if "motp_m" in clear_tracking:
+        base["clear_motp_m"] = clear_tracking.get("motp_m")
+    counts = clear_tracking.get("counts") or {}
+    if not isinstance(counts, dict):
+        return
+    count_fields = {
+        "ground_truth": "clear_ground_truth_count",
+        "detections": "clear_detection_count",
+        "missed_detections": "clear_missed_detection_count",
+        "false_positives": "clear_false_positive_count",
+        "id_switches": "clear_id_switch_count",
+        "motp_matches": "clear_motp_match_count",
+    }
+    for source_key, target_key in count_fields.items():
+        if source_key in counts:
+            base[target_key] = counts.get(source_key)
+
+
 def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     """Flatten metrics dict into a flat per-episode row.
 
@@ -464,6 +490,7 @@ def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     social_acceptability = metrics.pop("social_acceptability", {}) or {}
     human_interaction_proxy = metrics.pop("human_interaction_proxy", {}) or {}
     social_mini_game = metrics.pop("social_mini_game", {}) or {}
+    clear_tracking = metrics.pop("clear_tracking_uncertainty", {}) or {}
     inter_robot = metrics.pop("inter_robot", {}) or {}
     # Flatten known force quantiles
     for qk in ("q50", "q90", "q95"):
@@ -475,6 +502,7 @@ def flatten_metrics(rec: dict[str, Any]) -> dict[str, Any]:
     _flatten_social_acceptability_block(base, social_acceptability)
     _flatten_human_interaction_proxy_block(base, human_interaction_proxy)
     _flatten_social_mini_game_block(base, social_mini_game)
+    _flatten_clear_tracking_block(base, clear_tracking)
     if isinstance(inter_robot, dict):
         for key, value in inter_robot.items():
             base[str(key)] = value

--- a/tests/test_aggregate.py
+++ b/tests/test_aggregate.py
@@ -598,6 +598,71 @@ def test_flatten_metrics_skips_empty_social_mini_game_block() -> None:
     assert "social_mini_game_mechanism_family" not in flat
 
 
+def test_compute_aggregates_flattens_clear_tracking_uncertainty_block() -> None:
+    """CLEAR tracking uncertainty blocks should expose MOTA/MOTP as aggregate columns."""
+    records = [
+        {
+            "episode_id": "ep-1",
+            "scenario_id": "sc-1",
+            "seed": 1,
+            "algo": "planner-a",
+            "metrics": {
+                "success": True,
+                "clear_tracking_uncertainty": {
+                    "schema_version": "clear-tracking-metrics.v1",
+                    "enabled": True,
+                    "mota": 0.5,
+                    "motp_m": 0.25,
+                    "counts": {
+                        "ground_truth": 2,
+                        "detections": 1,
+                        "missed_detections": 1,
+                        "false_positives": 0,
+                        "id_switches": 0,
+                        "motp_matches": 1,
+                    },
+                },
+            },
+        },
+        {
+            "episode_id": "ep-2",
+            "scenario_id": "sc-1",
+            "seed": 2,
+            "algo": "planner-a",
+            "metrics": {
+                "success": True,
+                "clear_tracking_uncertainty": {
+                    "schema_version": "clear-tracking-metrics.v1",
+                    "enabled": True,
+                    "mota": 1.0,
+                    "motp_m": 0.0,
+                    "counts": {
+                        "ground_truth": 2,
+                        "detections": 2,
+                        "missed_detections": 0,
+                        "false_positives": 0,
+                        "id_switches": 0,
+                        "motp_matches": 2,
+                    },
+                },
+            },
+        },
+    ]
+
+    flat = flatten_metrics(records[0])
+    assert "clear_tracking_uncertainty" not in flat
+    assert flat["clear_mota"] == 0.5
+    assert flat["clear_motp_m"] == 0.25
+    assert flat["clear_missed_detection_count"] == 1
+
+    summary = compute_aggregates(records, group_by="algo")
+
+    metrics = summary["planner-a"]
+    assert metrics["clear_mota"]["mean"] == pytest.approx(0.75)
+    assert metrics["clear_motp_m"]["mean"] == pytest.approx(0.125)
+    assert metrics["clear_missed_detection_count"]["mean"] == pytest.approx(0.5)
+
+
 def test_flatten_metrics_keeps_distributional_disruption_nested_out_of_scalar_rows() -> None:
     """Distributional disruption is a schema block, not a scalar aggregate metric."""
     record = {


### PR DESCRIPTION
## Summary
Completes the CLEAR tracking-uncertainty reporting surface by flattening the existing `clear_tracking_uncertainty` metric block into aggregate/report columns and documenting the ScenarioBelief-based MOTA/MOTP contract.

## Linked Issues
- Closes `#3505`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- Extended `robot_sf.benchmark.aggregate.flatten_metrics` to flatten the existing `metrics.clear_tracking_uncertainty` block into columns such as `clear_mota`, `clear_motp_m`, and CLEAR count fields.
- Added aggregate coverage proving MOTA/MOTP and missed-detection counts appear in grouped summaries.
- Documented the existing ScenarioBelief tracking-noise and CLEAR diagnostic contract in `docs/benchmark.md`.

## Why It Matters
- Added value: perception-gap diagnostics can now flow from episode metadata into normal campaign table/report columns.
- Expected impact: benchmark and review tooling can report MOTA/MOTP without custom post-processing once a scenario emits the existing `clear_tracking_uncertainty` block.
- Why this is worth merging now: issue `#3505` identified this as a dissertation-reviewer-facing future-work direction and the missing reporting link was small and canonical.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: uncertainty-aware observation contracts can expose tracking degradation through diagnostic MOTA/MOTP columns.
- Comparator or baseline, if applicable: zero-noise/oracle ScenarioBelief path versus visibility-limited or tracking-noise ScenarioBelief path.
- Evidence tier: targeted smoke.
- Result classification: diagnostic-only.
- Decision or stop rule, if applicable: stop when CLEAR block fields flatten into aggregate columns and existing zero-noise/CLEAR tests still pass.
- Parent issue, claim map, registry, context note, or synthesis surface to update: `#3505`.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - this extends an existing metric/reporting surface rather than introducing a new standalone analysis tool.

## Domain-Aware Approval
- Required for this PR: yes - metric-facing diagnostic reporting surface.
- Domains reviewed: evidence classification, benchmark interpretation
- Status: waived
- Approver/review source or waiver: maintainer waiver for diagnostic-only reporting; no safety, planner-performance, calibrated sensor, or paper-facing result claim is made.
- Validity checklist:
  - Target claim/hypothesis: MOTA/MOTP fields are reportable diagnostics when the existing CLEAR block is present.
  - Comparator or split/evidence validity: targeted unit tests cover flattening and existing ScenarioBelief zero-noise/noise behavior.
  - Fallback/degraded exclusions: values remain diagnostic unless backed by an explicit perception-gap campaign and provenance.
  - Claim boundary: diagnostic metric/reporting plumbing only; no benchmark-strength improvement claim.
  - Implementation integrity vs experimental validity: tests prove aggregation/reporting behavior, not real-world sensor validity.

## Falsification / Non-Transfer Check
- Did the mechanism activate? yes - `clear_tracking_uncertainty` fields flatten into aggregate metrics.
- Did the intervention change command source, selected command, trajectory, or route progress? no.
- Did the scenario actually contain the targeted failure mode? NA - targeted metric/reporting test, not a live campaign.
- Result route: continue.
- Follow-up question or issue for weak, negative, or non-transfer results: a future perception-gap campaign should emit the block from live ScenarioBelief observation traces and decide whether planner rank changes under 0.25 m tracking noise.

## Next Empirical Action
- Rerun needed: yes - for a future campaign, not for this reporting PR.
- Extractor or analysis tool needed: no.
- Artifact missing or unavailable: no durable perception-gap campaign artifact in this PR.
- Stop / revise / continue decision: continue toward live campaign validation after this plumbing lands.
- Proposed child issue or existing follow-up: none opened in this batch; issue `#3505` names the 0.25 m rank-stability campaign as the next empirical step.

## Validation / Proof
- Commands run:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_aggregate.py::test_compute_aggregates_flattens_clear_tracking_uncertainty_block tests/test_metrics.py::test_clear_tracking_metrics_emit_from_episode_metadata tests/test_metrics.py::test_post_process_metrics_adds_clear_tracking_block tests/representation/test_scenario_belief.py::test_clear_tracking_metrics_are_perfect_for_oracle_vs_oracle tests/representation/test_scenario_belief.py::test_clear_tracking_metrics_report_configured_centroid_noise -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_aggregate.py tests/test_metrics.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/aggregate.py tests/test_aggregate.py docs/benchmark.md`
  - `scripts/dev/check_docs_proof_consistency_diff.sh`
  - `git diff --check`
- Evidence that the change works here: focused and broader tests prove CLEAR metadata emits, post-processes, and aggregates as scalar MOTA/MOTP/count columns.
- Benchmarks or smoke tests, if applicable: targeted smoke/unit validation only; no benchmark-strength campaign result is claimed.

## Risks / Rollout
- Compatibility risks: low; default rows without `clear_tracking_uncertainty` remain unchanged.
- Failure modes: future emitters must use the existing block shape (`enabled`, `mota`, `motp_m`, `counts`) for aggregation.
- Rollback or fallback plan: revert the aggregate flattener and docs section.

## Docs / Provenance
- Updated docs: `docs/benchmark.md`.
- Relevant design or provenance notes: issue `#3505`, existing `docs/benchmark_observation_visibility.md`, existing ScenarioBelief CLEAR tests.
- Any assumptions that need to be preserved: CLEAR fields are diagnostic unless tied to an explicit perception-gap campaign and durable provenance.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): no.
- Not applicable because: this PR changes reporting plumbing and docs, not a benchmark result or registry row.

## Follow-Up Issues
- Deferred work: run a perception-gap campaign that emits `clear_tracking_uncertainty` from live ScenarioBelief observation traces and evaluates planner rank stability under 0.25 m tracking noise.
