### PR TITLE
docs: suppress guardrail-only blocked-asset trackers

### DIFF
--- a/.agents/skills/gh-issue-creator/SKILL.md
+++ b/.agents/skills/gh-issue-creator/SKILL.md
@@ -38,13 +38,20 @@ execution.
    `docs/context/issue_1512_issue_archetypes.md`. Include the archetype metadata block in
    the issue body. Use only the canonical values from that note. When the archetype is unclear,
    default to `archetype: workflow` with `evidence_tier: idea` and note the assumption.
-5. Create issue:
+5. Before creating standalone `blocked-asset` issues, check whether proposed payload
+   is only a guardrail, reminder, or "track pasted follow-up anyway" note already
+   enforced by existing parent issue `state:blocked` or `evidence:blocked` status.
+   If so, do not create new issue; record reminder on parent as comment, label,
+   or status update instead. Still create legitimate `blocked-asset` issues when
+   they carry unique technical state such as paths, checksums, missing-file
+   specifics, asset identifiers, or per-step unblock conditions.
+6. Create issue:
    - use GitHub MCP / GitHub app tools when available; use `gh` for deterministic fallback
    - `gh issue create --title "<title>" --body-file <body.md> --template <template> --label "<labels>"`
    - prefer existing labels; avoid inventing taxonomy
    - prefer GitHub MCP / GitHub app tools for interactive issue creation when available; keep `gh`
      for scripted or fallback paths
-6. Project routing:
+7. Project routing:
    - use `gh project item-add` when the CLI route is the active Project #5 write path
    - use `gh project item-edit` for explicit field updates when the CLI route is active
    - add issue to Project #5 and update only expected fields (`Priority`, `Expected Duration in Hours`,

--- a/docs/context/issue_1512_issue_archetypes.md
+++ b/docs/context/issue_1512_issue_archetypes.md
@@ -30,6 +30,19 @@ Every issue should declare exactly one `archetype` from this set:
 | `refactor` | Restructuring existing code without changing intended behavior |
 | `data` | Acquiring, staging, ingesting, or making reproducible a dataset/trace/artifact input (often paired with `blocked` evidence when the source is external) |
 
+### `blocked-asset` Guardrail-Only Trackers
+
+Do not create a standalone `blocked-asset` issue when the proposed payload is only a
+guardrail, reminder, or "track pasted follow-up anyway" note already enforced by an
+existing parent issue's `state:blocked` or `evidence:blocked` status. Record the reminder
+on the parent issue instead, for example as a comment, label, or status note.
+
+Standalone `blocked-asset` issues remain valid when they carry unique technical state such
+as paths, checksums, missing-file specifics, asset identifiers, or per-step unblock
+conditions.
+
+Closed guardrail-only tracker examples: #2416, #2417, #2413, and #2414.
+
 ### Deprecated archetype spellings
 
 These are accepted on read and treated as their canonical value; prefer the canonical form for new


### PR DESCRIPTION
## Summary

- document `blocked-asset` guardrail-only tracker suppression rule in the issue archetype note
- sync canonical `gh-issue-creator` skill source so issue creation checks duplicate blocked-parent guardrails before minting standalone issues

Closes #3519.

## Validation

- `uv run python scripts/tools/sync_ai_config.py && uv run python scripts/tools/sync_ai_config.py --check`
- `uv run python scripts/dev/check_skills.py --preflight gh-issue-creator`
- `git diff --check`

## Follow-Up Issues

Deferred work: None - this PR only documents and syncs the guardrail rule for #3519.
Issues opened follow-up: None - no residual implementation or cleanup scope remains.

## Delegation

- Spark subagent route attempted bounded edit but hit usage-limit before producing artifacts; app-agent handle was closed route failure was recorded in common Git-dir self-review inbox.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation & Process Updates**
  * Enhanced workflow validation to prevent duplicate reminder issues when parent issues already track the same status
  * Clarified guidelines distinguishing when to create standalone asset-blocked issues versus adding to existing parent issues
  * Improved issue creation workflow guidance to reduce redundant tracking

<!-- end of auto-generated comment: release notes by coderabbit.ai -->