### PR TITLE
feat: add evidence bundle mirror manifests

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -66,6 +66,28 @@ Each bundle writes:
 
 The schema contract lives at `robot_sf/benchmark/schemas/evidence_bundle.v1.json`.
 
+For large artifacts that should remain outside git, the same command supports opt-in mirror
+metadata:
+
+```bash
+uv run python scripts/tools/benchmark_publication_bundle.py evidence-bundle \
+  --source-root docs/context/evidence/<source-or-fixture> \
+  --out-dir docs/context/evidence \
+  --bundle-name <issue-or-claim-bundle> \
+  --file summary.json \
+  --command "<canonical reproduction validation command>" \
+  --commit <git-commit> \
+  --claim-boundary diagnostic_only_not_benchmark_evidence \
+  --mirror-dry-run-base-uri s3://example-bucket/evidence
+```
+
+`--mirror-dry-run-base-uri` writes `mirror_manifest.json` with deterministic remote URI targets,
+sizes, SHA-256 checksums, MIME hints, and `upload_status: dry_run` without contacting a remote
+service. `--mirror-local-dir <path>` is a credential-free local backend for tests and staging; it
+copies the selected payload files and records `file://` URIs with `upload_status: uploaded`.
+Mirroring is off by default, credentials must not appear in manifests or logs, and mirror metadata
+does not upgrade a diagnostic bundle into benchmark-strength or paper-facing evidence.
+
 ## Claim Readiness Check
 
 Before promoting compact evidence into a stronger claim, run the claim-readiness guardrail against

--- a/robot_sf/benchmark/artifact_publication.py
+++ b/robot_sf/benchmark/artifact_publication.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import mimetypes
 import shutil
 import tarfile
 from collections import defaultdict
@@ -25,6 +26,7 @@ from robot_sf.common.artifact_paths import get_repository_root
 
 PUBLICATION_BUNDLE_SCHEMA_VERSION = "benchmark-publication-bundle.v2"
 EVIDENCE_BUNDLE_SCHEMA_VERSION = "evidence_bundle.v1"
+EVIDENCE_MIRROR_MANIFEST_SCHEMA_VERSION = "evidence_bundle_mirror.v1"
 MANUSCRIPT_ARTIFACT_BUNDLE_SCHEMA_VERSION = "dissertation_artifact_bundle.v1"
 SIZE_REPORT_SCHEMA_VERSION = "benchmark-artifact-size-report.v1"
 _VIDEO_SUFFIXES = {".mp4", ".gif", ".webm", ".mov"}
@@ -77,6 +79,7 @@ class EvidenceBundleResult:
     checksums_path: Path
     file_count: int
     total_bytes: int
+    mirror_manifest_path: Path | None = None
 
 
 @dataclass(frozen=True)
@@ -465,6 +468,97 @@ def _resolve_evidence_files(source_root: Path, files: list[Path]) -> list[Path]:
     return sorted(set(resolved), key=lambda value: value.as_posix())
 
 
+def _guess_mime_type(path: Path) -> str:
+    """Return a stable MIME/type hint for an evidence payload path."""
+    guessed, _ = mimetypes.guess_type(path.as_posix())
+    return guessed or "application/octet-stream"
+
+
+def _join_remote_uri(base_uri: str, relative_path: str) -> str:
+    """Join a mirror base URI and POSIX relative path without recording credentials.
+
+    Returns:
+        Joined remote URI string.
+    """
+    return f"{base_uri.rstrip('/')}/{relative_path.lstrip('/')}"
+
+
+def _write_evidence_mirror_manifest(
+    *,
+    bundle_dir: Path,
+    bundle_name: str,
+    payload_root: Path,
+    entries: list[PublicationFileEntry],
+    dry_run_base_uri: str | None,
+    local_dir: Path | None,
+    overwrite: bool,
+) -> Path | None:
+    """Write optional mirror manifest for evidence bundle payloads.
+
+    The dry-run URI mode records where payloads would be mirrored without touching any remote
+    service. The local backend is a credential-free concrete backend used for tests and local
+    staging; cloud backends can consume the same manifest shape later.
+
+    Returns:
+        Path to the mirror manifest when mirroring is enabled, otherwise ``None``.
+    """
+    if dry_run_base_uri and local_dir is not None:
+        raise ValueError("Choose only one evidence mirror backend")
+    if not dry_run_base_uri and local_dir is None:
+        return None
+
+    backend = "dry_run_uri" if dry_run_base_uri else "local_file"
+    mode = "dry_run" if dry_run_base_uri else "upload"
+    mirror_root: Path | None = None
+    if local_dir is not None:
+        mirror_root = local_dir.resolve()
+        if mirror_root.exists() and not mirror_root.is_dir():
+            raise ValueError(f"Evidence mirror local_dir is not a directory: {mirror_root}")
+        mirror_root.mkdir(parents=True, exist_ok=True)
+
+    assets: list[dict[str, Any]] = []
+    for entry in entries:
+        payload_rel = Path("payload") / entry.path
+        payload_path = payload_root / entry.path
+        if mirror_root is not None:
+            mirror_path = mirror_root / bundle_name / payload_rel
+            if mirror_path.exists() and not overwrite:
+                raise FileExistsError(f"Evidence mirror target already exists: {mirror_path}")
+            mirror_path.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(payload_path, mirror_path)
+            remote_uri = mirror_path.resolve().as_uri()
+            upload_status = "uploaded"
+        else:
+            remote_uri = _join_remote_uri(str(dry_run_base_uri), payload_rel.as_posix())
+            upload_status = "dry_run"
+        assets.append(
+            {
+                "path": entry.path,
+                "source_path": payload_rel.as_posix(),
+                "size_bytes": entry.size_bytes,
+                "sha256": entry.sha256,
+                "kind": entry.kind,
+                "mime_type": _guess_mime_type(Path(entry.path)),
+                "remote_uri": remote_uri,
+                "upload_status": upload_status,
+            }
+        )
+
+    manifest = {
+        "schema_version": EVIDENCE_MIRROR_MANIFEST_SCHEMA_VERSION,
+        "evidence_bundle_schema_version": EVIDENCE_BUNDLE_SCHEMA_VERSION,
+        "created_at_utc": _utc_now_iso(),
+        "bundle_name": bundle_name,
+        "backend": backend,
+        "mode": mode,
+        "credentials": "not_recorded",
+        "assets": assets,
+    }
+    manifest_path = bundle_dir / "mirror_manifest.json"
+    manifest_path.write_text(json.dumps(manifest, indent=2) + "\n", encoding="utf-8")
+    return manifest_path
+
+
 def _validate_non_empty(value: str, field: str, artifact_id: str) -> str:
     """Validate a required string field from an artifact spec.
 
@@ -689,7 +783,7 @@ def export_dissertation_artifact_bundle(
     )
 
 
-def export_evidence_bundle(
+def export_evidence_bundle(  # noqa: PLR0913
     source_root: Path,
     out_dir: Path,
     *,
@@ -699,6 +793,8 @@ def export_evidence_bundle(
     commit: str,
     claim_boundary: str,
     overwrite: bool = False,
+    mirror_dry_run_base_uri: str | None = None,
+    mirror_local_dir: Path | None = None,
 ) -> EvidenceBundleResult:
     """Export a compact reproducible evidence bundle.
 
@@ -781,6 +877,15 @@ def export_evidence_bundle(
     }
     manifest_path = bundle_dir / "evidence_bundle_manifest.json"
     manifest_path.write_text(json.dumps(manifest_payload, indent=2) + "\n", encoding="utf-8")
+    mirror_manifest_path = _write_evidence_mirror_manifest(
+        bundle_dir=bundle_dir,
+        bundle_name=target_name,
+        payload_root=payload_root,
+        entries=entries,
+        dry_run_base_uri=mirror_dry_run_base_uri,
+        local_dir=mirror_local_dir,
+        overwrite=overwrite,
+    )
 
     return EvidenceBundleResult(
         bundle_dir=bundle_dir,
@@ -788,6 +893,7 @@ def export_evidence_bundle(
         checksums_path=checksums_path,
         file_count=len(entries),
         total_bytes=total_bytes,
+        mirror_manifest_path=mirror_manifest_path,
     )
 
 

--- a/scripts/tools/benchmark_publication_bundle.py
+++ b/scripts/tools/benchmark_publication_bundle.py
@@ -227,6 +227,24 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help="Allow replacing an existing evidence bundle directory with the same name.",
     )
+    evidence.add_argument(
+        "--mirror-dry-run-base-uri",
+        type=str,
+        default=None,
+        help=(
+            "Optional URI prefix for a dry-run remote asset mirror manifest. "
+            "No upload is attempted and credentials must not be embedded in the URI."
+        ),
+    )
+    evidence.add_argument(
+        "--mirror-local-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Optional credential-free local filesystem mirror backend. Payload files are copied "
+            "under this directory and recorded as file:// URIs."
+        ),
+    )
 
     dissertation = subparsers.add_parser(
         "dissertation-bundle",
@@ -416,6 +434,8 @@ def _run_evidence_bundle(args: argparse.Namespace) -> int:
         commit=str(args.commit),
         claim_boundary=str(args.claim_boundary),
         overwrite=bool(args.overwrite),
+        mirror_dry_run_base_uri=args.mirror_dry_run_base_uri,
+        mirror_local_dir=args.mirror_local_dir,
     )
     payload = {
         "bundle_dir": str(result.bundle_dir),
@@ -424,6 +444,8 @@ def _run_evidence_bundle(args: argparse.Namespace) -> int:
         "file_count": result.file_count,
         "total_bytes": result.total_bytes,
     }
+    if result.mirror_manifest_path is not None:
+        payload["mirror_manifest_path"] = str(result.mirror_manifest_path)
     print(json.dumps(payload, indent=2))
     return 0
 

--- a/tests/tools/test_benchmark_publication_bundle.py
+++ b/tests/tools/test_benchmark_publication_bundle.py
@@ -330,6 +330,132 @@ def test_evidence_bundle_command_creates_manifest_and_checksums(tmp_path: Path, 
     assert "metric_table.csv" in checksums
 
 
+def test_evidence_bundle_command_writes_dry_run_mirror_manifest(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Dry-run mirroring should record deterministic remote asset pointers without upload."""
+    source_root = tmp_path / "evidence_source"
+    _make_evidence_source(source_root)
+    out_dir = tmp_path / "bundles"
+
+    exit_code = benchmark_publication_bundle.main(
+        [
+            "evidence-bundle",
+            "--source-root",
+            str(source_root),
+            "--out-dir",
+            str(out_dir),
+            "--bundle-name",
+            "issue_3468_dry_run",
+            "--file",
+            "summary.json",
+            "--command",
+            "uv run python scripts/example.py --config tracked.yaml",
+            "--commit",
+            "abc123",
+            "--claim-boundary",
+            "diagnostic_only_not_benchmark_evidence",
+            "--mirror-dry-run-base-uri",
+            "s3://example-bucket/evidence",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    mirror_manifest_path = Path(payload["mirror_manifest_path"])
+    mirror_manifest = json.loads(mirror_manifest_path.read_text(encoding="utf-8"))
+    asset = mirror_manifest["assets"][0]
+
+    assert mirror_manifest["schema_version"] == "evidence_bundle_mirror.v1"
+    assert mirror_manifest["backend"] == "dry_run_uri"
+    assert mirror_manifest["mode"] == "dry_run"
+    assert mirror_manifest["credentials"] == "not_recorded"
+    assert asset["path"] == "summary.json"
+    assert asset["source_path"] == "payload/summary.json"
+    assert asset["size_bytes"] == len('{"result_classification":"diagnostic-only"}\n')
+    assert asset["kind"] == "aggregates"
+    assert asset["mime_type"] == "application/json"
+    assert asset["remote_uri"] == "s3://example-bucket/evidence/payload/summary.json"
+    assert asset["upload_status"] == "dry_run"
+
+
+def test_evidence_bundle_command_copies_local_mirror_backend(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Local mirror backend provides credential-free upload-path coverage."""
+    source_root = tmp_path / "evidence_source"
+    _make_evidence_source(source_root)
+    out_dir = tmp_path / "bundles"
+    mirror_dir = tmp_path / "mirror"
+
+    exit_code = benchmark_publication_bundle.main(
+        [
+            "evidence-bundle",
+            "--source-root",
+            str(source_root),
+            "--out-dir",
+            str(out_dir),
+            "--bundle-name",
+            "issue_3468_local",
+            "--file",
+            "metric_table.csv",
+            "--command",
+            "uv run python scripts/example.py --config tracked.yaml",
+            "--commit",
+            "abc123",
+            "--claim-boundary",
+            "diagnostic_only_not_benchmark_evidence",
+            "--mirror-local-dir",
+            str(mirror_dir),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out)
+    mirrored_file = mirror_dir / "issue_3468_local" / "payload" / "metric_table.csv"
+    assert mirrored_file.read_text(encoding="utf-8") == "metric,value\nsuccess_rate,0.5\n"
+    mirror_manifest = json.loads(Path(payload["mirror_manifest_path"]).read_text(encoding="utf-8"))
+    asset = mirror_manifest["assets"][0]
+    assert asset["upload_status"] == "uploaded"
+    assert asset["remote_uri"] == mirrored_file.resolve().as_uri()
+    assert asset["mime_type"] == "text/csv"
+
+
+def test_evidence_bundle_command_fails_closed_for_invalid_mirror_local_dir(
+    tmp_path: Path,
+) -> None:
+    """Invalid local mirror targets should fail closed with an actionable error."""
+    source_root = tmp_path / "evidence_source"
+    _make_evidence_source(source_root)
+    invalid_mirror = tmp_path / "mirror-is-file"
+    invalid_mirror.write_text("not a directory", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="local_dir is not a directory"):
+        benchmark_publication_bundle.main(
+            [
+                "evidence-bundle",
+                "--source-root",
+                str(source_root),
+                "--out-dir",
+                str(tmp_path / "bundles"),
+                "--bundle-name",
+                "issue_3468_invalid",
+                "--file",
+                "summary.json",
+                "--command",
+                "uv run python scripts/example.py --config tracked.yaml",
+                "--commit",
+                "abc123",
+                "--claim-boundary",
+                "diagnostic_only_not_benchmark_evidence",
+                "--mirror-local-dir",
+                str(invalid_mirror),
+            ]
+        )
+
+
 def test_evidence_bundle_command_fails_closed_for_missing_file(tmp_path: Path) -> None:
     """Evidence bundles should fail before writing manifests when a requested file is missing."""
     source_root = tmp_path / "evidence_source"


### PR DESCRIPTION
## Summary

- add optional evidence bundle mirror manifests with dry-run URI metadata and a credential-free local mirror backend
- expose mirror flags on `scripts/tools/benchmark_publication_bundle.py evidence-bundle`
- document the opt-in mirroring workflow and keep mirror metadata explicitly non-claim-upgrading
- cover local-only, dry-run mirror, local mirror, and invalid mirror-target behavior in CLI tests

Closes #3468.

## Validation

- `uv run pytest tests/tools/test_benchmark_publication_bundle.py -q tests/benchmark/test_artifact_publication.py -q`
- `uv run ruff check robot_sf/benchmark/artifact_publication.py scripts/tools/benchmark_publication_bundle.py tests/tools/test_benchmark_publication_bundle.py`
- `uv run ruff format --check robot_sf/benchmark/artifact_publication.py scripts/tools/benchmark_publication_bundle.py tests/tools/test_benchmark_publication_bundle.py`
- `git diff --check`
- sample dry-run CLI invocation inspected `mirror_manifest.json` for schema version, backend, credentials marker, URI, size, hash, MIME hint, and dry-run status

## Follow-Up Issues

Deferred work: None
Issues opened follow-up: No: no follow-up issue required for this first implementation slice.

## Delegation

- Antigravity large-context scout completed read-only owner mapping and identified `robot_sf/benchmark/artifact_publication.py`, `scripts/tools/benchmark_publication_bundle.py`, and the evidence bundle tests/docs as the canonical owner set.
- Parent Codex reviewed the route output, implemented the accepted design, and ran local validation.
