### PR TITLE
docs: document policy-search candidate entrypoints

### DIFF
--- a/docs/benchmark_experimental_planners.md
+++ b/docs/benchmark_experimental_planners.md
@@ -18,6 +18,38 @@ This metadata is a compatibility guard only. It makes mismatched observation/act
 fail before benchmark execution, but it is not performance evidence and must not be cited as proof
 that a planner is baseline-ready, paper-facing, or high quality.
 
+## Policy-Search Candidate Configs
+
+Policy-search candidate planner configs live under
+`configs/policy_search/candidates/`. This is the first place to look for candidate variants such as
+`hybrid_rule_v3_static_margin0.yaml`, `hybrid_rule_v3_static_margin0_waypoint2.yaml`,
+`hybrid_rule_v3_fast_progress.yaml`, and `hybrid_rule_v3_fast_progress_static_escape.yaml`.
+
+`configs/algos/` is the benchmark-facing algorithm-config directory. It can contain promoted,
+compatibility, or direct benchmark wrappers, and some entries intentionally point back to candidate
+configs. Do not assume a candidate exists under `configs/algos/` just because a similarly named
+policy-search file exists under `configs/policy_search/candidates/`.
+
+Preferred local entrypoints:
+
+```bash
+uv run python scripts/validation/run_policy_search_candidate.py \
+  --candidate hybrid_rule_v3_fast_progress \
+  --stage smoke
+```
+
+```bash
+uv run python scripts/validation/run_policy_search_step_diagnostics.py \
+  --candidate hybrid_rule_v3_static_margin0 \
+  --stage smoke
+```
+
+The runners resolve candidate names through `docs/context/policy_search/candidate_registry.yaml`,
+whose entries point back to the candidate config files. Use the candidate runner for compact
+candidate smoke/evaluation loops. Use the step-diagnostics runner when debugging why a candidate
+action, clearance, progress, or recovery decision changed. Both commands load repository
+dependencies through `uv run python`, so they avoid accidental system-Python import failures.
+
 ## Testing-only planners
 
 The following planners are currently treated as testing-only and fail closed by default:

--- a/docs/context/policy_search/README.md
+++ b/docs/context/policy_search/README.md
@@ -127,7 +127,10 @@ Use it for three things only:
 
 - Retrieval index: `docs/context/policy_search/INDEX.md`
 - Candidate lifecycle summary: `docs/context/policy_search/candidate_registry_summary.md`
+- Candidate config home: `configs/policy_search/candidates/`
+- Benchmark-facing algorithm configs: `configs/algos/`
 - Candidate runner: `uv run python scripts/validation/run_policy_search_candidate.py`
+- Candidate step diagnostics: `uv run python scripts/validation/run_policy_search_step_diagnostics.py`
 - Candidate/learned-policy registry validator:
   `uv run python scripts/validation/validate_policy_search_registry.py`
 - Candidate portfolio overview: `uv run python scripts/tools/summarize_policy_search_portfolio.py`
@@ -137,6 +140,24 @@ Use it for three things only:
 - Pareto plot: `uv run python scripts/tools/plot_policy_search_pareto_front.py`
 - Promotion decision: `uv run python scripts/tools/promote_policy_search_candidate.py`
 - SLURM candidate sweep: `scripts/dev/sbatch_policy_search_sweep.sh --stage full_matrix --all-implemented`
+
+Candidate names are resolved through `docs/context/policy_search/candidate_registry.yaml`; registry
+entries point to files under `configs/policy_search/candidates/`. For example:
+
+```bash
+uv run python scripts/validation/run_policy_search_candidate.py \
+  --candidate hybrid_rule_v3_fast_progress \
+  --stage smoke
+```
+
+```bash
+uv run python scripts/validation/run_policy_search_step_diagnostics.py \
+  --candidate hybrid_rule_v3_static_margin0 \
+  --stage smoke
+```
+
+Use `configs/algos/` for benchmark-facing algorithm configs and wrappers. Do not assume a
+policy-search candidate lives there just because a similarly named benchmark config exists.
 
 ## Learned-Policy Intake
 


### PR DESCRIPTION
## Summary

- document `configs/policy_search/candidates/` as the policy-search candidate config home
- distinguish candidate configs from benchmark-facing `configs/algos/` wrappers
- add candidate runner and step-diagnostics `uv run python` examples that use registry candidate names
- make the same entrypoints discoverable from the policy-search README and experimental planner guardrail doc

Closes #3524.

## Validation

- `rg -n "configs/policy_search/candidates|configs/algos|run_policy_search_candidate|run_policy_search_step_diagnostics|uv run python|candidate_registry" docs/benchmark_experimental_planners.md docs/context/policy_search/README.md`
- referenced path checks for `configs/policy_search/candidates/hybrid_rule_v3_fast_progress.yaml`, `configs/policy_search/candidates/hybrid_rule_v3_static_margin0.yaml`, `scripts/validation/run_policy_search_candidate.py`, and `scripts/validation/run_policy_search_step_diagnostics.py`
- registry checks for `hybrid_rule_v3_fast_progress` and `hybrid_rule_v3_static_margin0` entries in `docs/context/policy_search/candidate_registry.yaml`
- `git diff --check`

Note: I did not use the runners' `--help` output as validation because these scripts import planner modules before argparse and this lightweight worktree environment lacks `torch`; the referenced paths and parser contract were verified from source and registry entries instead.

## Follow-Up Issues

Deferred work: None
Issues opened follow-up: No: this is a docs-only location and entrypoint clarification.

## Delegation

- Delegation skipped: tiny docs-only edit where direct implementation plus targeted validation was cheaper than worker review.
