### PR TITLE
docs: add agent workflow navigation guide

### DIFF
--- a/.agents/README.md
+++ b/.agents/README.md
@@ -15,6 +15,8 @@ Tool-specific directories should point here when their formats allow it.
 
 `AGENTS.md` remains the top-level instruction source for repository rules, and
 `docs/maintainer_values.md` is the compact source for current values and hard contracts.
+Use `docs/ai/agent_workflow_entrypoints.md` for correct `uv run` command entrypoints,
+model registry lookup, and targeted large-file navigation.
 Tool-specific instruction files, such as `.github/copilot-instructions.md` and `.cursorrules`,
 should be thin pointers to those sources plus only the tool-specific details that cannot live there.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -105,6 +105,7 @@ thin: existing Markdown files remain the source of truth, and generated HTML und
 * **[Runtime Requirements](./dev_runtime_requirements.md)** - Non-`uv` host tools, system packages, optional Docker/`gh-act` support, and the local capability checker
 * **[External Data Setup Assistant](./external_data_setup.md)** - License-safe local staging and compact provenance manifests for SDD, SocNavBench, and AMV calibration-source assets
 * **[Context Retrieval Index](./context/INDEX.md)** - Retrieval-first catalog for current context-note entry points, status rules, optional context tools, and curated context-pack scopes
+* **[Agent Workflow Entrypoints And Large-File Navigation](./ai/agent_workflow_entrypoints.md)** - Correct `uv run` command patterns, validation entrypoints, model registry path, and targeted large-file reading guidance for agents
 * **[Issue #2013 Backend Adapter Contract](./context/issue_2013_backend_adapter_contract.md)** - Required adapter fields, fail-closed behavior, and claim boundaries for alternate simulator backend integration
 * **[Context Notes Workflow](./context/README.md)** - Canonical rules for linked Markdown handoff notes, note updates vs new notes, stale-note handling, and discoverability
 * **[Planner Contribution Guide](./contributing_planner.md)** - Minimum path for adding a planner with adapter/protocol metadata, config-first invocation, smoke proof, registry status, and benchmark boundaries

--- a/docs/ai/agent_workflow_entrypoints.md
+++ b/docs/ai/agent_workflow_entrypoints.md
@@ -1,0 +1,77 @@
+# Agent Workflow Entrypoints And Large-File Navigation
+
+[Back to Documentation Index](../README.md)
+
+This guide helps agents start from the right command and read only the code region they need.
+Use it when a task needs repository commands, model lookup, validation, or navigation through
+large files.
+
+## Command Entrypoints
+
+Run Python through the project environment so imports such as `robot_sf` resolve consistently:
+
+```bash
+uv run python scripts/<path>.py
+```
+
+Use the same `uv run` prefix for focused validation:
+
+```bash
+uv run pytest tests/<path> -q
+uv run ruff check <changed-file>
+uv run ruff format --check <changed-file>
+```
+
+For broad pull request readiness, use the repository wrapper from the repository root:
+
+```bash
+BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh
+```
+
+For final handoff readiness on a clean tree, prefer:
+
+```bash
+PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh
+```
+
+Model resolution is owned by `robot_sf/models/registry.py`. Search or extend that registry
+instead of guessing there is a flat `robot_sf/models.py` module.
+
+## Large-File Navigation
+
+Large file work should be targeted. Locate an anchor first, read a bounded range, then re-locate
+the anchor after edits because line numbers drift.
+
+Useful commands:
+
+```bash
+rg -n "anchor text|function_name|class_name" <file-or-dir>
+sed -n 'A,Bp' <file>
+tail -n 120 <file>
+```
+
+Do not read a full large file just to find one function. If the first range is wrong, search for a
+nearby symbol or heading again and then read another narrow range.
+
+Common large or fragile files:
+
+| File | Purpose | Navigation hint |
+| --- | --- | --- |
+| `robot_sf/benchmark/camera_ready_campaign.py` | Camera-ready benchmark orchestration and reporting. | Search for the specific command, planner family, or artifact phase before reading. |
+| `robot_sf/benchmark/map_runner.py` | Benchmark map execution and policy construction. | Search for policy names, `_build_policy`, or scenario/map handling branches. |
+| `robot_sf/benchmark/metrics.py` | Benchmark metric calculations and aggregation helpers. | Search for the metric name or schema field before changing formulas. |
+| `scripts/training/train_ppo.py` | Proximal Policy Optimization training entrypoint. | Search for config loading, checkpoint, or callback anchors. |
+| `scripts/validation/run_policy_search_step_diagnostics.py` | Policy-search step diagnostics launcher. | Search by candidate, diagnostic stage, or output field. |
+| `docs/context/INDEX.md` | Retrieval-first context-note catalog. | Search by issue number, status marker, or topic before opening ranges. |
+| `docs/dev_guide.md` | Broad development guide and command reference. | Search for the workflow or command family being edited. |
+| `.agents/skills/goal-autopilot/SKILL.md` | Autonomous issue/PR workflow instructions. | Search for the phase name, claim protocol, or stop guard. |
+| `docs/context/policy_search/experiment_ledger.md` | Policy-search result ledger. | Search by candidate, stage, date, or result keyword. |
+
+## Editing Pattern
+
+1. Search for the owner: `rg -n "<concept>" robot_sf scripts docs .agents`.
+2. Read the smallest useful range around the best anchor: `sed -n 'A,Bp' <file>`.
+3. Make the scoped edit.
+4. Re-run `rg -n` for the anchor after editing before follow-up reads or line-specific claims.
+5. Validate with focused commands first, then escalate only if the change affects shared runtime,
+   benchmark semantics, schemas, or paper-facing evidence.

--- a/docs/ai/ai-workflow.md
+++ b/docs/ai/ai-workflow.md
@@ -24,6 +24,7 @@ Read these first when working in this workflow:
 - [docs/dev_guide.md](../dev_guide.md)
 - [docs/README.md](../README.md)
 - [docs/ai/repo_overview.md](repo_overview.md)
+- [docs/ai/agent_workflow_entrypoints.md](agent_workflow_entrypoints.md)
 - [docs/context/README.md](../context/README.md)
 - [docs/context/issue_713_batch_first_issue_workflow.md](../context/issue_713_batch_first_issue_workflow.md)
 - [docs/context/issue_728_coding_agents_compatibility.md](../context/issue_728_coding_agents_compatibility.md)

--- a/docs/ai/repo_overview.md
+++ b/docs/ai/repo_overview.md
@@ -35,6 +35,7 @@ Then branch by task type:
 - planner family support: `docs/benchmark_planner_family_coverage.md`
 - training/eval workflow: `docs/AGENT_INDEX.md`, `docs/training/`
 - end-to-end AI workflow: `docs/ai/ai-workflow.md`
+- command entrypoints and targeted large-file reads: `docs/ai/agent_workflow_entrypoints.md`
 - prediction/forecast research lane routing: `docs/ai/prediction_lane.md`
 - issue execution history and handoff knowledge base: `docs/context/`
 - context note workflow: `docs/context/README.md`


### PR DESCRIPTION
## Summary
- Add `docs/ai/agent_workflow_entrypoints.md` with correct `uv run` Python/pytest/ruff patterns, PR readiness commands, and `robot_sf/models/registry.py` model-resolution guidance.
- Document targeted large-file navigation with `rg -n`, bounded `sed -n 'A,Bp'`, `tail`, anchor re-location after edits, and the fragile files named in #3522.
- Link the guide from `docs/README.md`, `docs/ai/repo_overview.md`, `docs/ai/ai-workflow.md`, and `.agents/README.md`.

## Validation
- `rg -n "uv run python|pr_ready_check|robot_sf/models/registry.py" docs .agents README.md`
- `rg -n "targeted|large file|camera_ready_campaign|experiment_ledger" docs .agents README.md`
- `rg -n "uv run python|pr_ready_check|robot_sf/models/registry.py|targeted|large file|camera_ready_campaign|experiment_ledger" docs/ai/agent_workflow_entrypoints.md docs/README.md docs/ai/repo_overview.md docs/ai/ai-workflow.md .agents/README.md`
- referenced path existence checks for guide targets
- `git diff --check`
- `uv run python scripts/tools/sync_ai_config.py --check`
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
- Not run: `uv run ruff check <changed files>` because no Python files changed.

## Follow-Up Issues
Deferred work: None.
Issues opened follow-up: No: this PR covers both scoped docs requests in #3521 and #3522.

Closes #3521
Closes #3522


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new guide for recommended task entrypoints, validation commands, and efficient large-file navigation.
  * Updated several documentation indexes and overview pages to point readers to the new guide.
  * Clarified where to find the correct command patterns and reference information for project workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->