### PR TITLE
test: manifest-drive AI config mirrors

### DIFF
--- a/.agents/mirror_manifest.yaml
+++ b/.agents/mirror_manifest.yaml
@@ -1,0 +1,30 @@
+version: 1
+symlink_mirrors:
+  - path: .claude/skills
+    target: ../.agents/skills
+    description: Claude-compatible repo-local workflow skills.
+  - path: .codex/skills
+    target: ../.agents/skills
+    description: Codex-compatible repo-local workflow skills.
+  - path: .opencode/skills
+    target: ../.agents/skills
+    description: OpenCode-compatible repo-local workflow skills.
+  - path: .codex/prompts
+    target: ../.agents/prompts/codex
+    description: Codex prompt files.
+  - path: .github/prompts
+    target: ../.agents/prompts/github
+    description: GitHub prompt wrappers.
+  - path: .github/agents
+    target: ../.agents/agents/github
+    description: GitHub agent definitions.
+  - path: .gemini/commands
+    target: ../.agents/commands/gemini
+    description: Gemini command definitions.
+pointer_files:
+  - path: .cursorrules
+    must_reference: AGENTS.md
+    description: Cursor instruction pointer.
+  - path: .github/copilot-instructions.md
+    must_reference: AGENTS.md
+    description: GitHub Copilot instruction pointer.

--- a/scripts/tools/sync_ai_config.py
+++ b/scripts/tools/sync_ai_config.py
@@ -7,26 +7,34 @@ import argparse
 from dataclasses import dataclass
 from pathlib import Path
 
+import yaml
+
 REPO_ROOT = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = ".agents/mirror_manifest.yaml"
 
 
 @dataclass(frozen=True)
 class LinkSpec:
-    """Expected compatibility symlink from a tool-specific path to `.agents`."""
+    """Expected compatibility symlink from a tool-specific path into `.agents`."""
 
     path: str
     target: str
 
 
-LINK_SPECS = (
-    LinkSpec(".claude/skills", "../.agents/skills"),
-    LinkSpec(".codex/skills", "../.agents/skills"),
-    LinkSpec(".opencode/skills", "../.agents/skills"),
-    LinkSpec(".codex/prompts", "../.agents/prompts/codex"),
-    LinkSpec(".github/prompts", "../.agents/prompts/github"),
-    LinkSpec(".github/agents", "../.agents/agents/github"),
-    LinkSpec(".gemini/commands", "../.agents/commands/gemini"),
-)
+@dataclass(frozen=True)
+class PointerSpec:
+    """Expected thin instruction pointer file contract."""
+
+    path: str
+    must_reference: str
+
+
+@dataclass(frozen=True)
+class MirrorManifest:
+    """Supported AI assistant compatibility surfaces."""
+
+    symlink_mirrors: tuple[LinkSpec, ...]
+    pointer_files: tuple[PointerSpec, ...]
 
 
 def _repo_path(path: str) -> Path:
@@ -35,6 +43,53 @@ def _repo_path(path: str) -> Path:
     if not candidate.parent.resolve(strict=False).is_relative_to(REPO_ROOT):
         raise ValueError(f"Path escapes repository root: {path}")
     return candidate
+
+
+def _manifest_entries(manifest: object, key: str) -> list[dict[str, object]]:
+    """Return a manifest list section after light shape validation."""
+    if not isinstance(manifest, dict):
+        raise ValueError(f"{MANIFEST_PATH}: expected mapping at document root")
+    entries = manifest.get(key, [])
+    if not isinstance(entries, list):
+        raise ValueError(f"{MANIFEST_PATH}: {key} must be a list")
+    for index, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            raise ValueError(f"{MANIFEST_PATH}: {key}[{index}] must be a mapping")
+    return entries
+
+
+def _manifest_str(entry: dict[str, object], section: str, index: int, field: str) -> str:
+    """Read a required string field from a manifest entry."""
+    value = entry.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{MANIFEST_PATH}: {section}[{index}].{field} must be a non-empty string")
+    return value
+
+
+def load_manifest() -> MirrorManifest:
+    """Load the supported AI configuration mirror manifest."""
+    manifest_path = _repo_path(MANIFEST_PATH)
+    with manifest_path.open(encoding="utf-8") as stream:
+        manifest = yaml.safe_load(stream)
+
+    symlink_mirrors = tuple(
+        LinkSpec(
+            path=_manifest_str(entry, "symlink_mirrors", index, "path"),
+            target=_manifest_str(entry, "symlink_mirrors", index, "target"),
+        )
+        for index, entry in enumerate(_manifest_entries(manifest, "symlink_mirrors"))
+    )
+    pointer_files = tuple(
+        PointerSpec(
+            path=_manifest_str(entry, "pointer_files", index, "path"),
+            must_reference=_manifest_str(entry, "pointer_files", index, "must_reference"),
+        )
+        for index, entry in enumerate(_manifest_entries(manifest, "pointer_files"))
+    )
+    return MirrorManifest(symlink_mirrors=symlink_mirrors, pointer_files=pointer_files)
+
+
+LINK_SPECS = load_manifest().symlink_mirrors
 
 
 def _check_link(spec: LinkSpec, *, fix: bool) -> list[str]:
@@ -52,38 +107,30 @@ def _check_link(spec: LinkSpec, *, fix: bool) -> list[str]:
                 f"{spec.path}: target does not exist: {expected_abs.relative_to(REPO_ROOT)}"
             )
             return errors
-        if path.readlink() == target and path.resolve() == expected_abs:
-            return errors
-        if fix:
-            path.unlink()
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.symlink_to(target)
-            return errors
-        errors.append(f"{spec.path}: expected symlink to {spec.target}, got {path.readlink()}")
+        actual = Path(path.readlink())
+        if actual == target:
+            return []
+        if not fix:
+            return [f"{spec.path}: expected symlink to {spec.target}, found {actual}"]
+        path.unlink()
+    elif path.exists():
+        return [f"{spec.path}: exists but is not a symlink"]
+    elif not expected_abs.exists():
+        errors.append(f"{spec.path}: target does not exist: {expected_abs.relative_to(REPO_ROOT)}")
         return errors
+    elif not fix:
+        return [f"{spec.path}: missing symlink to {spec.target}"]
 
-    if path.exists():
-        errors.append(f"{spec.path}: exists but is not a symlink")
-        return errors
-
-    if fix:
-        if not expected_abs.exists():
-            errors.append(
-                f"{spec.path}: target does not exist: {expected_abs.relative_to(REPO_ROOT)}"
-            )
-        else:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            path.symlink_to(target)
-    else:
-        errors.append(f"{spec.path}: missing symlink to {spec.target}")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.symlink_to(target)
     return errors
 
 
 def _check_pointer_file(path: str, expected_text: str) -> list[str]:
-    """Check that a small tool-specific pointer file references the canonical source."""
+    """Return drift errors when a tool-specific instruction pointer stops pointing canonical."""
     pointer_path = _repo_path(path)
     if not pointer_path.exists():
-        return [f"{path}: missing pointer file"]
+        return [f"{path}: missing pointer file referencing {expected_text!r}"]
     if not pointer_path.is_file():
         return [f"{path}: pointer path exists but is not a file"]
     try:
@@ -104,18 +151,19 @@ def main() -> int:
     args = parser.parse_args()
 
     fix = args.fix
+    manifest = load_manifest()
     errors: list[str] = []
-    for spec in LINK_SPECS:
+    for spec in manifest.symlink_mirrors:
         errors.extend(_check_link(spec, fix=fix))
 
-    errors.extend(_check_pointer_file(".cursorrules", "AGENTS.md"))
-    errors.extend(_check_pointer_file(".github/copilot-instructions.md", "AGENTS.md"))
+    for spec in manifest.pointer_files:
+        errors.extend(_check_pointer_file(spec.path, spec.must_reference))
 
     if errors:
         raise SystemExit("AI config drift detected:\n- " + "\n- ".join(errors))
 
     mode = "repaired" if fix else "validated"
-    print(f"AI config links {mode}: {len(LINK_SPECS)} symlinks.")
+    print(f"AI config links {mode}: {len(manifest.symlink_mirrors)} symlinks.")
     return 0
 
 

--- a/tests/tools/test_sync_ai_config.py
+++ b/tests/tools/test_sync_ai_config.py
@@ -9,20 +9,33 @@ import pytest
 from scripts.tools import sync_ai_config
 
 
-def test_supported_ai_config_mirror_set_is_explicit() -> None:
-    """Only currently supported tool mirrors should be recreated by the sync set."""
-    assert sync_ai_config.LINK_SPECS == (
-        sync_ai_config.LinkSpec(".claude/skills", "../.agents/skills"),
-        sync_ai_config.LinkSpec(".codex/skills", "../.agents/skills"),
-        sync_ai_config.LinkSpec(".opencode/skills", "../.agents/skills"),
-        sync_ai_config.LinkSpec(".codex/prompts", "../.agents/prompts/codex"),
-        sync_ai_config.LinkSpec(".github/prompts", "../.agents/prompts/github"),
-        sync_ai_config.LinkSpec(".github/agents", "../.agents/agents/github"),
-        sync_ai_config.LinkSpec(".gemini/commands", "../.agents/commands/gemini"),
+def test_supported_ai_config_mirror_set_comes_from_manifest() -> None:
+    """Supported tool mirrors come from the manifest consumed by the sync tool."""
+    manifest = sync_ai_config.load_manifest()
+
+    assert sync_ai_config.LINK_SPECS == manifest.symlink_mirrors
+    assert (
+        sync_ai_config.LinkSpec(".claude/skills", "../.agents/skills") in manifest.symlink_mirrors
     )
+    assert sync_ai_config.PointerSpec(".cursorrules", "AGENTS.md") in manifest.pointer_files
 
 
-def test_check_link_accepts_expected_symlink(tmp_path: Path, monkeypatch) -> None:
+def test_load_manifest_rejects_malformed_entries(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Manifest shape errors should fail before drift checks run."""
+    monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
+    manifest = tmp_path / ".agents" / "mirror_manifest.yaml"
+    manifest.parent.mkdir()
+    manifest.write_text("symlink_mirrors:\n  - path: .codex/skills\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="symlink_mirrors\\[0\\].target"):
+        sync_ai_config.load_manifest()
+
+
+def test_check_link_accepts_expected_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """An exact compatibility symlink should be accepted without errors."""
     monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
     target = tmp_path / ".agents" / "skills"
@@ -39,51 +52,129 @@ def test_check_link_accepts_expected_symlink(tmp_path: Path, monkeypatch) -> Non
     assert errors == []
 
 
-def test_check_link_repairs_missing_symlink(tmp_path: Path, monkeypatch) -> None:
-    """The fix path should recreate supported mirrors from canonical `.agents` content."""
+def test_check_link_repairs_missing_symlink(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The fix path should recreate mirrors from canonical `.agents` content."""
     monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
-    (tmp_path / ".agents" / "prompts" / "codex").mkdir(parents=True)
+    target = tmp_path / ".agents" / "skills"
+    target.mkdir(parents=True)
 
     errors = sync_ai_config._check_link(
-        sync_ai_config.LinkSpec(".codex/prompts", "../.agents/prompts/codex"),
+        sync_ai_config.LinkSpec(".codex/skills", "../.agents/skills"),
         fix=True,
     )
 
     assert errors == []
-    assert (tmp_path / ".codex" / "prompts").is_symlink()
-    assert (tmp_path / ".codex" / "prompts").readlink() == Path("../.agents/prompts/codex")
+    assert (tmp_path / ".codex" / "skills").is_symlink()
+    assert (tmp_path / ".codex" / "skills").readlink() == Path("../.agents/skills")
 
 
-def test_check_link_rejects_paths_outside_repo(tmp_path: Path, monkeypatch) -> None:
-    """Repo mirror specs should not be able to write outside the checkout."""
+def test_check_link_reports_missing_symlink_without_fix(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Check mode reports missing mirrors instead of mutating the tree."""
+    monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
+    (tmp_path / ".agents" / "skills").mkdir(parents=True)
+
+    errors = sync_ai_config._check_link(
+        sync_ai_config.LinkSpec(".codex/skills", "../.agents/skills"),
+        fix=False,
+    )
+
+    assert errors == [".codex/skills: missing symlink to ../.agents/skills"]
+    assert not (tmp_path / ".codex" / "skills").exists()
+
+
+def test_check_link_reports_non_symlink_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Real directories should never be silently replaced."""
+    monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
+    (tmp_path / ".agents" / "skills").mkdir(parents=True)
+    (tmp_path / ".codex" / "skills").mkdir(parents=True)
+
+    errors = sync_ai_config._check_link(
+        sync_ai_config.LinkSpec(".codex/skills", "../.agents/skills"),
+        fix=True,
+    )
+
+    assert errors == [".codex/skills: exists but is not a symlink"]
+
+
+def test_check_link_rejects_paths_outside_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mirror paths should not be able to write outside the checkout."""
     monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
 
-    with pytest.raises(ValueError, match="escapes repository root"):
+    with pytest.raises(ValueError, match="Path escapes repository root"):
         sync_ai_config._check_link(
-            sync_ai_config.LinkSpec("../outside", "target"),
+            sync_ai_config.LinkSpec("../outside", ".agents/skills"),
             fix=True,
         )
 
 
-def test_pointer_file_must_reference_canonical_agents_file(
-    tmp_path: Path,
-    monkeypatch,
+def test_check_link_rejects_targets_outside_repo(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """Pointer files should direct agents back to the canonical `AGENTS.md` surface."""
+    """Mirror targets should stay inside the checkout."""
     monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
-    cursor_rules = tmp_path / ".cursorrules"
-    cursor_rules.write_text("See AGENTS.md.\n", encoding="utf-8")
 
-    assert sync_ai_config._check_pointer_file(".cursorrules", "AGENTS.md") == []
+    with pytest.raises(ValueError, match="Symlink target escapes repository root"):
+        sync_ai_config._check_link(
+            sync_ai_config.LinkSpec(".codex/skills", "../../outside"),
+            fix=True,
+        )
 
-    cursor_rules.write_text("See .github/copilot-instructions.md.\n", encoding="utf-8")
-    assert sync_ai_config._check_pointer_file(".cursorrules", "AGENTS.md") == [
-        ".cursorrules: expected to reference 'AGENTS.md'"
+
+def test_check_link_repairs_stale_symlink(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fix mode should replace stale symlink targets."""
+    monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
+    (tmp_path / ".agents" / "skills").mkdir(parents=True)
+    link = tmp_path / ".codex" / "skills"
+    link.parent.mkdir()
+    link.symlink_to(Path("../wrong"))
+
+    errors = sync_ai_config._check_link(
+        sync_ai_config.LinkSpec(".codex/skills", "../.agents/skills"),
+        fix=True,
+    )
+
+    assert errors == []
+    assert link.readlink() == Path("../.agents/skills")
+
+
+def test_check_pointer_file_accepts_reference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pointer files should mention their canonical instruction source."""
+    monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
+    pointer = tmp_path / ".github" / "copilot-instructions.md"
+    pointer.parent.mkdir()
+    pointer.write_text("Follow AGENTS.md.\n", encoding="utf-8")
+
+    assert sync_ai_config._check_pointer_file(".github/copilot-instructions.md", "AGENTS.md") == []
+
+
+def test_check_pointer_file_reports_missing_reference(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Pointer files should fail when they drift away from the canonical source."""
+    monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
+    pointer = tmp_path / ".github" / "copilot-instructions.md"
+    pointer.parent.mkdir()
+    pointer.write_text("Only local instructions.\n", encoding="utf-8")
+
+    assert sync_ai_config._check_pointer_file(".github/copilot-instructions.md", "AGENTS.md") == [
+        ".github/copilot-instructions.md: expected to reference 'AGENTS.md'"
     ]
 
 
-def test_pointer_file_reports_non_file_paths(tmp_path: Path, monkeypatch) -> None:
-    """Pointer validation should report directory drift instead of raising."""
+def test_check_pointer_file_reports_directory(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A directory at a pointer path should report a drift error instead of raising."""
     monkeypatch.setattr(sync_ai_config, "REPO_ROOT", tmp_path)
     (tmp_path / ".cursorrules").mkdir()
 


### PR DESCRIPTION
## Summary
- Add `.agents/mirror_manifest.yaml` as the single machine-readable owner for supported AI config mirrors and pointer files.
- Make `scripts/tools/sync_ai_config.py` load symlink and pointer contracts from that manifest.
- Update sync contract tests so the mirror set is not duplicated in test code, while keeping missing/stale/wrong-target symlink coverage.

Closes #3475

## Validation
- `uv run python scripts/tools/sync_ai_config.py --check`
- `uv run pytest tests/tools/test_sync_ai_config.py -q`
- `uv run ruff check scripts/tools/sync_ai_config.py tests/tools/test_sync_ai_config.py`

## Follow-Up Issues
- Deferred work: none
- Issues opened for follow-up: none
