### PR TITLE
benchmark: classify signal-specific failure predicates

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -1714,6 +1714,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_3546_signalized_failure_predicate_contract/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3546_signalized_failure_predicate_contract/summary.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -477,6 +477,10 @@ Policy caveats:
 - `issue_3544_signalized_failure_pack_real/`: live-execution signalized failure-pack negative
   control. Uses real trace exports and runtime metrics from the signalized smoke matrix; detected no
   failure cases, so the pack is analysis-only and figure-ineligible.
+- `issue_3546_signalized_failure_predicate_contract/`: contract-validation evidence that
+  planner-observable `signal_red_phase_violations` and
+  `signal_stop_line_crossings_under_red` intentionally count as signalized failure-pack
+  predicates. Not a live positive benchmark result.
 - `issue_2752_topology_reselection_mechanism/`: analysis-only mechanism diagnosis of three hard
   slices from Issue #2751 runtime evidence. All hard slices remained `horizon_exhausted`;
   `bottleneck_transfer` and `doorway_transfer` classified as `no_useful_topology_alternative`

--- a/docs/context/evidence/issue_3544_signalized_failure_pack_real/README.md
+++ b/docs/context/evidence/issue_3544_signalized_failure_pack_real/README.md
@@ -4,8 +4,8 @@ Evidence status: analysis-only real-run negative control.
 
 This directory records a local simulator-backed signalized-crossing run and the issue #2754
 failure-pack builder result. The run used real episode metric rows plus schema-valid trace exports
-generated from embedded simulation-step traces, but the builder found no failure-pack cases under
-its current failure predicate.
+generated from embedded simulation-step traces. The builder version used for issue #3544 found no
+failure-pack cases under the pre-#3546 failure predicate.
 
 ## Result
 
@@ -127,7 +127,6 @@ bb751dc888dfc9dd8a848598b28b7e9b5a069734c3659e937eb781d2d5acd00d  output/benchma
 
 ## Follow-Up
 
-A positive failure-pack case needs either a more adversarial signalized scenario or an explicit
-issue #2754 contract update that decides whether signal-specific metrics such as
-`signal_red_phase_violations` should be failure-pack predicates. Until then, this directory should
-remain negative-control evidence.
+A positive live failure-pack case still needs either a more adversarial signalized scenario or a
+rerun of this trace evidence under the post-#3546 builder contract. This directory remains the
+original issue #3544 negative-control evidence record.

--- a/docs/context/evidence/issue_3544_signalized_failure_pack_real/runtime_metrics/report.md
+++ b/docs/context/evidence/issue_3544_signalized_failure_pack_real/runtime_metrics/report.md
@@ -17,5 +17,7 @@ Summary:
 - Fail-closed excluded rows: 2.
 - Runtime evidence is planner-observable for the two denominator rows.
 
-The red required-stop row has `crossed_red=true`, but the current issue #2754 failure-pack builder
-does not classify that signal metric as a failure-pack case.
+The red required-stop row has `crossed_red=true`. The issue #3544 builder run did not classify that
+signal metric as a failure-pack case; issue #3546 updates the builder contract so future reruns can
+classify planner-observable red-phase and stop-line signal metrics as signalized failure-pack
+predicates.

--- a/docs/context/evidence/issue_3546_signalized_failure_predicate_contract/README.md
+++ b/docs/context/evidence/issue_3546_signalized_failure_predicate_contract/README.md
@@ -1,0 +1,41 @@
+# Issue #3546 Signalized Failure-Predicate Contract
+
+Evidence status: contract validation, not benchmark-result evidence.
+
+Issue #3544 proved the live signalized smoke run can produce planner-observable signal metric rows,
+but the issue #2754 failure-pack builder did not classify red-phase signal violations as
+failure-pack cases. This bundle records the #3546 contract decision: planner-observable
+signal-specific metrics are intentional failure-pack predicates when their thresholds are met.
+
+## Decision
+
+The signalized failure-pack builder now treats these metrics as signal-specific failure predicates:
+
+- `signal_red_phase_violations >= 1`
+- `signal_stop_line_crossings_under_red >= 1`
+
+Generic social-navigation predicates still apply through the canonical failure extractor:
+collisions, comfort exposure, and near misses. Unavailable, proxy-only, fallback, degraded,
+synthetic, stale, or denominator-excluded rows still fail closed for figure eligibility through the
+existing provenance and signal-denominator checks.
+
+## Claim Boundary
+
+This is a builder-contract update. It does not by itself produce a new live positive signalized
+failure-pack case, planner-ranking comparison, traffic-light realism claim, or paper-facing figure.
+A future positive pack still needs live or durable-replay trace and metric inputs with source-kind
+metadata.
+
+## Validation
+
+```bash
+uv run pytest tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py -q
+```
+
+The focused test suite includes a signal-specific positive fixture where generic failure metrics are
+zero and signal metrics trigger a case, plus a malformed/zero signal-metric fixture that remains a
+negative control.
+
+## Files
+
+- `summary.json`: machine-readable contract decision and validation boundary.

--- a/docs/context/evidence/issue_3546_signalized_failure_predicate_contract/summary.json
+++ b/docs/context/evidence/issue_3546_signalized_failure_predicate_contract/summary.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "signalized_failure_predicate_contract.v1",
+  "issue": 3546,
+  "status": "contract_updated",
+  "evidence_status": "contract_validation",
+  "benchmark_result_evidence": false,
+  "figure_eligible": false,
+  "trace_source_kind": "fixture",
+  "metric_source_kind": "fixture",
+  "execution_performed": false,
+  "failure_predicates_added": [
+    {
+      "metric": "signal_red_phase_violations",
+      "threshold": 1.0
+    },
+    {
+      "metric": "signal_stop_line_crossings_under_red",
+      "threshold": 1.0
+    }
+  ],
+  "fail_closed_preserved_for": [
+    "signal_metrics_denominator<=0",
+    "signal_metrics_evidence.state!=planner_observable",
+    "signal_metrics_evidence.exclusion_reason",
+    "synthetic_or_fixture_source_kind",
+    "fallback_or_degraded",
+    "stale_or_unknown_artifact_status"
+  ],
+  "validation": [
+    "uv run pytest tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py -q"
+  ],
+  "claim_boundary": "Builder-contract validation only; not a live positive signalized failure-pack, planner-ranking comparison, traffic-light realism claim, or paper-facing figure."
+}

--- a/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
+++ b/scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py
@@ -86,6 +86,17 @@ class FailurePackProvenance:
     claim_matrix_status: str
 
 
+@dataclass(frozen=True)
+class FailurePredicateThresholds:
+    """Thresholds for generic and signal-specific failure-pack predicates."""
+
+    collision: float = 1.0
+    comfort: float = 0.2
+    near_miss: float = 0.0
+    signal_red_phase_violation: float = 1.0
+    signal_stop_line_crossing: float = 1.0
+
+
 def _sanitize(val: Any) -> Any:
     """Recursively sanitize a value to make it JSON-serializable.
 
@@ -151,6 +162,29 @@ def find_failure_step(trace: SimulationTraceExport) -> int:
                 min_dist = dist
                 closest_step = frame.step
     return closest_step
+
+
+def signal_specific_failure_predicates(
+    rec: dict[str, Any],
+    *,
+    red_phase_violation_threshold: float = 1.0,
+    stop_line_crossing_threshold: float = 1.0,
+) -> list[str]:
+    """Return signal-specific metric predicates that intentionally define a failure-pack case."""
+    metrics = rec.get("metrics") or {}
+
+    def _metric(name: str) -> float:
+        try:
+            return float(metrics.get(name, 0.0) or 0.0)
+        except (TypeError, ValueError):
+            return 0.0
+
+    predicates: list[str] = []
+    if _metric("signal_red_phase_violations") >= float(red_phase_violation_threshold):
+        predicates.append("signal_red_phase_violations")
+    if _metric("signal_stop_line_crossings_under_red") >= float(stop_line_crossing_threshold):
+        predicates.append("signal_stop_line_crossings_under_red")
+    return predicates
 
 
 def get_signal_phase_at_step(
@@ -275,9 +309,7 @@ def build_failure_pack(
     traces: list[SimulationTraceExport],
     records: list[dict[str, Any]],
     allowed_claim_wording: str,
-    collision_threshold: float,
-    comfort_threshold: float,
-    near_miss_threshold: float,
+    thresholds: FailurePredicateThresholds,
     provenance: FailurePackProvenance,
     trace_input_paths: dict[str, str] | None = None,
 ) -> dict[str, Any]:
@@ -299,11 +331,19 @@ def build_failure_pack(
             continue
 
         metrics = matched_rec.get("metrics") or {}
-        if not is_failure(
+        signal_failure_predicates = signal_specific_failure_predicates(
             matched_rec,
-            collision_threshold=collision_threshold,
-            comfort_threshold=comfort_threshold,
-            near_miss_threshold=near_miss_threshold,
+            red_phase_violation_threshold=thresholds.signal_red_phase_violation,
+            stop_line_crossing_threshold=thresholds.signal_stop_line_crossing,
+        )
+        if (
+            not is_failure(
+                matched_rec,
+                collision_threshold=thresholds.collision,
+                comfort_threshold=thresholds.comfort,
+                near_miss_threshold=thresholds.near_miss,
+            )
+            and not signal_failure_predicates
         ):
             continue
 
@@ -375,6 +415,7 @@ def build_failure_pack(
                 "robot_state": robot_state,
                 "pedestrian_state": ped_state,
                 "metric_row": metrics,
+                "signal_failure_predicates": signal_failure_predicates,
                 "denominator_status": denominator_status,
                 "stale_current_status": provenance.artifact_status,
                 "artifact_status": provenance.artifact_status,
@@ -696,6 +737,19 @@ def main(argv: list[str] | None = None) -> int:
         help="Minimum near-misses to flag a failure.",
     )
     parser.add_argument(
+        "--signal-red-phase-violation-threshold",
+        type=float,
+        default=1.0,
+        help="Minimum signal red-phase violations flag signal-specific failure.",
+    )
+    parser.add_argument(
+        "--signal-stop-line-crossing-threshold",
+        type=float,
+        default=1.0,
+        help="Minimum stop-line crossings under red flag signal-specific failure.",
+    )
+
+    parser.add_argument(
         "--scan-evidence",
         action="store_true",
         help="Scan docs/context/evidence/ for prose vs machine-readable eligibility disagreements.",
@@ -725,9 +779,13 @@ def main(argv: list[str] | None = None) -> int:
         traces=loaded_traces,
         records=loaded_records,
         allowed_claim_wording=args.allowed_claim_wording,
-        collision_threshold=args.collision_threshold,
-        comfort_threshold=args.comfort_threshold,
-        near_miss_threshold=args.near_miss_threshold,
+        thresholds=FailurePredicateThresholds(
+            collision=args.collision_threshold,
+            comfort=args.comfort_threshold,
+            near_miss=args.near_miss_threshold,
+            signal_red_phase_violation=args.signal_red_phase_violation_threshold,
+            signal_stop_line_crossing=args.signal_stop_line_crossing_threshold,
+        ),
         provenance=FailurePackProvenance(
             trace_source_kind=args.trace_source_kind,
             metric_source_kind=args.metric_source_kind,

--- a/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
+++ b/tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py
@@ -744,3 +744,117 @@ def test_scanner_finds_nested_disagreements(tmp_path: Path) -> None:
     (nested_dir / "summary.json").write_text(json.dumps({"figure_eligible": True}))
 
     assert run_evidence_scan(evidence_dir) == 1
+
+
+def test_signal_red_phase_violation_can_define_failure_case(tmp_path: Path) -> None:
+    """Signal-specific red violations are an explicit failure-pack predicate."""
+    trace_data = _make_dummy_trace("signal_fail_ep", "signal_fail_scen")
+    trace_path = tmp_path / "signal_trace.json"
+    trace_path.write_text(json.dumps(trace_data))
+    record = {
+        "episode_id": "signal_fail_ep",
+        "scenario_id": "signal_fail_scen",
+        "seed": 123,
+        "metrics": {
+            "collisions": 0.0,
+            "comfort_exposure": 0.0,
+            "near_misses": 0,
+            "signal_red_phase_violations": 1,
+            "signal_stop_line_crossings_under_red": 1,
+            "signal_metrics_denominator": 1,
+            "signal_metrics_evidence": {
+                "state": "planner_observable",
+                "exclusion_reason": "",
+            },
+        },
+        "scenario_params": {
+            "metadata": {
+                "signal_state": {
+                    "timeline": [{"state": "red", "duration": 5.0}],
+                    "stop_line": [[1.0, 1.0], [1.0, -1.0]],
+                }
+            }
+        },
+    }
+    record_path = tmp_path / "episodes.jsonl"
+    record_path.write_text(json.dumps(record) + "\n")
+    output_path = tmp_path / "result.json"
+
+    exit_code = main(
+        [
+            "--traces",
+            str(trace_path),
+            "--episodes-jsonl",
+            str(record_path),
+            "--output-json",
+            str(output_path),
+            *_eligible_runtime_args(),
+        ]
+    )
+
+    assert exit_code == 0
+    result = json.loads(output_path.read_text())
+    assert result["negative_control"] is False
+    assert result["status"] == "failures_present"
+    assert len(result["cases"]) == 1
+    case = result["cases"][0]
+    assert case["signal_failure_predicates"] == [
+        "signal_red_phase_violations",
+        "signal_stop_line_crossings_under_red",
+    ]
+    assert case["metric_row"]["signal_red_phase_violations"] == 1
+    assert case["metric_row"]["collisions"] == 0.0
+    assert case["figure_eligible"] is True
+
+
+def test_signal_failure_predicate_requires_positive_signal_metrics(tmp_path: Path) -> None:
+    """Zero or malformed signal-specific metrics do not create false positive cases."""
+    trace_data = _make_dummy_trace("signal_nonfail_ep", "signal_nonfail_scen")
+    trace_path = tmp_path / "signal_trace.json"
+    trace_path.write_text(json.dumps(trace_data))
+    record = {
+        "episode_id": "signal_nonfail_ep",
+        "scenario_id": "signal_nonfail_scen",
+        "seed": 123,
+        "metrics": {
+            "collisions": 0.0,
+            "comfort_exposure": 0.0,
+            "near_misses": 0,
+            "signal_red_phase_violations": "not-a-number",
+            "signal_stop_line_crossings_under_red": 0,
+            "signal_metrics_denominator": 1,
+            "signal_metrics_evidence": {
+                "state": "planner_observable",
+                "exclusion_reason": "",
+            },
+        },
+        "scenario_params": {
+            "metadata": {
+                "signal_state": {
+                    "timeline": [{"state": "red", "duration": 5.0}],
+                    "stop_line": [[1.0, 1.0], [1.0, -1.0]],
+                }
+            }
+        },
+    }
+    record_path = tmp_path / "episodes.jsonl"
+    record_path.write_text(json.dumps(record) + "\n")
+    output_path = tmp_path / "result.json"
+
+    exit_code = main(
+        [
+            "--traces",
+            str(trace_path),
+            "--episodes-jsonl",
+            str(record_path),
+            "--output-json",
+            str(output_path),
+            *_eligible_runtime_args(),
+        ]
+    )
+
+    assert exit_code == 0
+    result = json.loads(output_path.read_text())
+    assert result["negative_control"] is True
+    assert result["status"] == "insufficiently_adversarial"
+    assert result["cases"] == []


### PR DESCRIPTION
## Summary
- Updates the signalized failure-pack builder contract so planner-observable `signal_red_phase_violations` and `signal_stop_line_crossings_under_red` can define signal-specific failure-pack cases.
- Emits `signal_failure_predicates` in each case so signal-triggered cases are machine-readable.
- Adds #3546 contract evidence and updates the #3544 negative-control notes so their pre-#3546 claim boundary remains historical and non-stale.

## Evidence Boundary
- This PR chooses the contract path from #3546; it does not claim a new live positive signalized benchmark run.
- The new evidence bundle is contract validation only, not planner-ranking evidence, traffic-light realism evidence, or a paper-facing figure.
- Fail-closed provenance and denominator checks remain in place for unavailable, proxy-only, synthetic, fixture, fallback, degraded, stale, and excluded rows.

## Validation
- `uv run ruff check scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py`
- `uv run ruff format --check scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py`
- `uv run pytest tests/analysis/test_build_signalized_crossing_failure_pack_issue_2754.py -q`
- `uv run python scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py --scan-evidence`
- `uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml`
- `python3 -m json.tool docs/context/evidence/issue_3546_signalized_failure_predicate_contract/summary.json >/dev/null && git diff --check`

## Follow-Up Issues
- Deferred work: a future positive live signalized failure-pack still needs a live or durable-replay rerun under this post-#3546 contract.
- Issues opened for follow-up: none; the remaining work is already captured by the claim boundary in #3546 and the evidence bundle.

Closes #3546


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for recognizing signal-related failure cases when red-phase and stop-line signal conditions are met.
  * Output now includes signal-specific failure details alongside existing failure results.

* **Documentation**
  * Updated evidence notes to clarify the contract for signalized failure cases and the expected validation behavior.
  * Refined guidance for future reruns and live-result interpretation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->