### PR TITLE
benchmark: add hardcase authority sweep grid

### DIFF
--- a/configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml
+++ b/configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml
@@ -1,0 +1,64 @@
+# Bounded maneuver-authority sweep grid for issue #3213.
+#
+# This grid is consumed by scripts/validation/run_predictive_success_campaign.py.
+# It mirrors a minimal subset of the generated full algo configs under
+# configs/algos/hardcase_authority/ so the first local run can test the core
+# authority levers without launching the full nine-variant family.
+variants:
+  - name: baseline
+    params: {}
+
+  - name: high_angular
+    params:
+      max_angular_speed: 1.8
+      predictive_candidate_heading_deltas:
+        [-1.047198, -0.785398, -0.523599, -0.261799, 0.0, 0.261799, 0.523599, 0.785398, 1.047198]
+
+  - name: dense_lattice
+    params:
+      predictive_candidate_heading_deltas:
+        [-1.047198, -0.785398, -0.523599, -0.261799, 0.0, 0.261799, 0.523599, 0.785398, 1.047198]
+      predictive_candidate_speeds: [0.0, 0.15, 0.3, 0.45, 0.6, 0.8, 1.0]
+
+  - name: nearfield_turn
+    params:
+      predictive_near_field_heading_deltas:
+        [
+          -1.570796,
+          -1.047198,
+          -0.785398,
+          -0.523599,
+          -0.261799,
+          0.0,
+          0.261799,
+          0.523599,
+          0.785398,
+          1.047198,
+          1.570796,
+        ]
+      predictive_near_field_speed_cap: 0.8
+
+  - name: combined_max_authority
+    params:
+      max_angular_speed: 1.8
+      predictive_candidate_heading_deltas:
+        [-1.047198, -0.785398, -0.523599, -0.261799, 0.0, 0.261799, 0.523599, 0.785398, 1.047198]
+      predictive_candidate_speeds: [0.0, 0.15, 0.3, 0.45, 0.6, 0.8, 1.0]
+      predictive_sequence_segments: 4
+      predictive_sequence_branch_factor: 6
+      predictive_sequence_beam_width: 12
+      predictive_near_field_heading_deltas:
+        [
+          -1.570796,
+          -1.047198,
+          -0.785398,
+          -0.523599,
+          -0.261799,
+          0.0,
+          0.261799,
+          0.523599,
+          0.785398,
+          1.047198,
+          1.570796,
+        ]
+      predictive_near_field_speed_cap: 0.8

--- a/docs/context/issue_3213_maneuver_authority_setup.md
+++ b/docs/context/issue_3213_maneuver_authority_setup.md
@@ -1,0 +1,37 @@
+# Issue #3213 Maneuver-Authority Sweep Setup
+
+Status: setup/preflight only, not benchmark evidence.
+
+Issue #3213 asks whether richer predictive-planner maneuver authority improves the hard-case seed
+portfolio without safety regressions. The first bounded setup adds
+`configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml`, a five-variant campaign
+grid for `scripts/validation/run_predictive_success_campaign.py`.
+
+## Grid Scope
+
+The grid includes:
+
+- `baseline`
+- `high_angular`
+- `dense_lattice`
+- `nearfield_turn`
+- `combined_max_authority`
+
+This covers the required minimum of at least three authority settings while keeping the first local
+campaign smaller than the full generated nine-config family under `configs/algos/hardcase_authority/`.
+
+## Canonical Next Command
+
+Use the hard-seed manifest and fixed planner checkpoint inputs required by the issue contract:
+
+```bash
+scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_predictive_success_campaign.py \
+  --checkpoints <checkpoint-or-model-reference> \
+  --hard-seed-manifest configs/benchmarks/predictive_hard_seeds_v1.yaml \
+  --planner-grid configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml \
+  --workers 1 \
+  --output-dir output/benchmarks/issue_3213_maneuver_authority
+```
+
+Do not treat this setup note or the grid as evidence that any authority variant improves success.
+Benchmark evidence starts only after the campaign writes valid result artifacts with provenance.


### PR DESCRIPTION
## Summary
- Adds `configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml`, a bounded five-variant planner grid for the #3213 maneuver-authority sweep.
- Adds `docs/context/issue_3213_maneuver_authority_setup.md` with the exact next campaign command and claim boundary.
- Keeps this as setup/preflight only: no benchmark result or authority-success claim is made.

## Evidence Boundary
- This PR does not close #3213; it prepares the canonical grid for the local sweep.
- The grid covers baseline plus four authority levers: high angular speed, dense lattice, near-field turn budget, and combined max-authority.
- Benchmark evidence starts only after `run_predictive_success_campaign.py` writes valid result artifacts with provenance.

## Validation
- `python3 - <<'PY' ... yaml.safe_load('configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml') ... PY`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python - <<'PY' ... _load_planner_variants(Path('configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml')) ... PY`
- `git diff --check`

## Follow-Up Issues
- Deferred work: run the bounded maneuver-authority campaign and classify hard-success, overall-success, and safety tradeoffs.
- Issues opened for follow-up: #3213

Refs #3213
