### PR TITLE
infra: run-ready launch-packet manifest + preflight helper (#3549)

### DIFF
--- a/experiments/run_ready_manifest.yaml
+++ b/experiments/run_ready_manifest.yaml
@@ -1,0 +1,204 @@
+schema_version: run-ready-launch-packet-manifest.v1
+preflight_schema_version: run-ready-launch-packet-preflight.v1
+generated_from_commit: 42f6944d9cd90aecf48d7055a70c2cf765423757
+packet_glob: configs/**/*launch_packet*.yaml
+summary:
+  total: 7
+  ready: 5
+  drift_guarded: 1
+packets:
+- issue: 1395
+  packet_path: configs/training/learned_risk_model_issue_1395_launch_packet.yaml
+  schema_version: learned-risk-launch-packet.v1
+  kind: training
+  ready: true
+  drift_guarded: false
+  reasons: []
+  sha_pairs: []
+  config_paths:
+  - path: configs/policy_search/candidates/hybrid_rule_v3_static_margin0_waypoint2.yaml
+    exists: true
+  seed_budget_present: true
+  seed_set: null
+  seed_count: null
+  command_keys:
+  - slurm_command_shape
+  claim_gate_keys:
+  - execution_boundary
+- issue: 1396
+  packet_path: configs/training/shielded_ppo_issue_1396_launch_packet.yaml
+  schema_version: shielded-ppo-repair-launch-packet.v1
+  kind: training
+  ready: true
+  drift_guarded: false
+  reasons: []
+  sha_pairs: []
+  config_paths:
+  - path: configs/algos/guarded_ppo_relaxed_v2.yaml
+    exists: true
+  - path: configs/policy_search/candidates/ppo_issue791_best_v1.yaml
+    exists: true
+  - path: configs/policy_search/candidates/risk_guarded_ppo_v1.yaml
+    exists: true
+  - path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+    exists: true
+  seed_budget_present: true
+  seed_set: null
+  seed_count: null
+  command_keys:
+  - slurm_command_shape
+  claim_gate_keys:
+  - execution_boundary
+- issue: 1397
+  packet_path: configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
+  schema_version: oracle-imitation-launch-packet.v1
+  kind: training
+  ready: false
+  drift_guarded: false
+  reasons:
+  - no claim/evidence boundary declared
+  sha_pairs: []
+  config_paths:
+  - path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+  - path: configs/policy_search/candidates/hybrid_rule_v3_static_margin0_waypoint2.yaml
+    exists: true
+  - path: configs/policy_search/nominal_sanity_matrix.yaml
+    exists: true
+  seed_budget_present: true
+  seed_set: paper_eval_s20
+  seed_count: 20
+  command_keys:
+  - slurm_command_shape
+  claim_gate_keys: []
+- issue: 1554
+  packet_path: configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml
+  schema_version: s20-s30-seed-budget-launch-packet.v1
+  kind: benchmark
+  ready: true
+  drift_guarded: false
+  reasons: []
+  sha_pairs: []
+  config_paths:
+  - path: configs/benchmarks/alyassi_comparability_map_v1.yaml
+    exists: true
+  - path: configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml
+    exists: true
+  - path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+  - path: configs/policy_search/scenario_horizons_h500.yaml
+    exists: true
+  - path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+  seed_budget_present: true
+  seed_set: paper_eval_s20
+  seed_count: 20
+  command_keys:
+  - slurm_command_shape
+  - validation_command
+  claim_gate_keys:
+  - claim_map_gate
+  - evidence_status
+  - execution_boundary
+  - no_claim_statement
+- issue: 1615
+  packet_path: configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml
+  schema_version: lidar-learned-policy-launch-packet.v1
+  kind: training
+  ready: false
+  drift_guarded: false
+  reasons:
+  - no runnable command/payload key present
+  - no claim/evidence boundary declared
+  sha_pairs: []
+  config_paths:
+  - path: configs/training/lidar/lidar_perception_adapter_eligibility_issue_1615.yaml
+    exists: true
+  - path: configs/training/lidar/lidar_ppo_mlp_eligibility_issue_1615.yaml
+    exists: true
+  - path: configs/training/ppo/feature_extractor_sweep_base.yaml
+    exists: true
+  - path: configs/training/rllib_dreamerv3/drive_state_rays.yaml
+    exists: true
+  seed_budget_present: false
+  seed_set: null
+  seed_count: null
+  command_keys: []
+  claim_gate_keys: []
+- issue: 3068
+  packet_path: configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+  schema_version: ppo-curriculum-launch-packet.v1
+  kind: training
+  ready: true
+  drift_guarded: false
+  reasons: []
+  sha_pairs: []
+  config_paths:
+  - path: configs/algos/guarded_ppo_relaxed_v2.yaml
+    exists: true
+  - path: configs/algos/ppo_v3_camera_ready.yaml
+    exists: true
+  - path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+  - path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+  - path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+    exists: true
+  seed_budget_present: true
+  seed_set: null
+  seed_count: null
+  command_keys:
+  - slurm_command_shape
+  - validation_command
+  claim_gate_keys:
+  - evidence_status
+  - execution_boundary
+  - no_claim_statement
+- issue: 3216
+  packet_path: configs/benchmarks/headline_ci_rank_stability_issue_3216_launch_packet.yaml
+  schema_version: issue_3216_headline_ci_rank_stability_launch_packet.v1
+  kind: benchmark
+  ready: true
+  drift_guarded: true
+  reasons: []
+  sha_pairs:
+  - path: configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
+    expected_sha256: 3bf75ebb05cc5523c33271e956b21b14749fc427fc9d986438c83d09eee8b75c
+    actual_sha256: 3bf75ebb05cc5523c33271e956b21b14749fc427fc9d986438c83d09eee8b75c
+    ok: true
+  - path: configs/scenarios/classic_interactions_francis2023.yaml
+    expected_sha256: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5
+    actual_sha256: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5
+    ok: true
+  - path: configs/policy_search/scenario_horizons_h500.yaml
+    expected_sha256: 4da9f6eb78c98d1afdf9ac43fde1cbfcac9447edb8491520e8c51d85d3b14fce
+    actual_sha256: 4da9f6eb78c98d1afdf9ac43fde1cbfcac9447edb8491520e8c51d85d3b14fce
+    ok: true
+  - path: configs/benchmarks/seed_sets_v1.yaml
+    expected_sha256: 3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6
+    actual_sha256: 3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6
+    ok: true
+  - path: configs/benchmarks/paper_experiment_matrix_7planners_v1.yaml
+    expected_sha256: 43eec70a34366239d18e2b5e3cb92f8deb5031990acb8ae1f7981b3aa3fed2f7
+    actual_sha256: 43eec70a34366239d18e2b5e3cb92f8deb5031990acb8ae1f7981b3aa3fed2f7
+    ok: true
+  config_paths:
+  - path: configs/benchmarks/paper_experiment_matrix_7planners_v1.yaml
+    exists: true
+  - path: configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
+    exists: true
+  - path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+  - path: configs/policy_search/scenario_horizons_h500.yaml
+    exists: true
+  - path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+  seed_budget_present: true
+  seed_set: paper_eval_s20
+  seed_count: 20
+  command_keys:
+  - campaign_command
+  - report_command
+  claim_gate_keys:
+  - claim_gate
+  - no_claim_until_run

--- a/scripts/dev/build_run_ready_manifest.py
+++ b/scripts/dev/build_run_ready_manifest.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Build the machine-readable run-ready launch-packet manifest (#3549).
+
+Plain-language summary: scan the repository's SLURM launch packets, preflight each one (drift guard +
+seed resolve + config existence + claim-gate presence via ``preflight_launch_packet``), and emit a
+single manifest the private autonomous-queue discovery can read to propose queue entries. This is the
+public half of closing the throughput gap; the private companions are the scheduler and queue
+auto-population (robot_sf_ll7-private-ops #2 / #3).
+
+The manifest reports *preflight* readiness only. It asserts no benchmark/paper-grade result and never
+submits anything; submission stays gated by the private engine's budget + fair-use rules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.dev.preflight_launch_packet import (
+    SCHEMA_VERSION as PREFLIGHT_SCHEMA_VERSION,
+)
+from scripts.dev.preflight_launch_packet import (
+    _repo_root,
+    preflight_packet,
+)
+
+MANIFEST_SCHEMA_VERSION = "run-ready-launch-packet-manifest.v1"
+DEFAULT_GLOB = "configs/**/*launch_packet*.yaml"
+DEFAULT_OUTPUT = "experiments/run_ready_manifest.yaml"
+
+
+def discover_packets(repo_root: Path, glob: str = DEFAULT_GLOB) -> list[Path]:
+    """Return the sorted unique list of launch-packet files under ``repo_root``."""
+    return sorted({p.resolve() for p in repo_root.glob(glob) if p.is_file()})
+
+
+def _git_head(repo_root: Path) -> str | None:
+    """Return the short git HEAD sha for provenance, or None if unavailable."""
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=True,
+        )
+        return out.stdout.strip()
+    except (subprocess.SubprocessError, OSError):
+        return None
+
+
+def build_manifest(repo_root: Path, glob: str = DEFAULT_GLOB) -> dict[str, Any]:
+    """Preflight every discovered packet and assemble the manifest dict."""
+    packets = discover_packets(repo_root, glob)
+    entries = [preflight_packet(p, repo_root) for p in packets]
+    entries.sort(key=lambda e: (e.get("issue") is None, e.get("issue") or 0, e["packet_path"]))
+    ready = [e for e in entries if e["ready"]]
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "preflight_schema_version": PREFLIGHT_SCHEMA_VERSION,
+        "generated_from_commit": _git_head(repo_root),
+        "packet_glob": glob,
+        "summary": {
+            "total": len(entries),
+            "ready": len(ready),
+            "drift_guarded": sum(1 for e in entries if e.get("drift_guarded")),
+        },
+        "packets": entries,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: build the manifest and write it to disk (yaml or json)."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--repo-root", type=Path, default=None, help="Repository root (auto-detected)."
+    )
+    parser.add_argument(
+        "--glob", type=str, default=DEFAULT_GLOB, help="Launch-packet glob pattern."
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=f"Output path (default: {DEFAULT_OUTPUT}). Use '-' for stdout.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of YAML.")
+    args = parser.parse_args(argv)
+
+    repo_root = (args.repo_root or _repo_root(Path.cwd())).resolve()
+    manifest = build_manifest(repo_root, args.glob)
+
+    text = (
+        json.dumps(manifest, indent=2, sort_keys=True)
+        if args.json
+        else yaml.safe_dump(manifest, sort_keys=False, width=100)
+    )
+
+    if args.output is not None and str(args.output) == "-":
+        print(text)
+    else:
+        out_path = (args.output or (repo_root / DEFAULT_OUTPUT)).resolve()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(text if text.endswith("\n") else text + "\n")
+        s = manifest["summary"]
+        print(
+            f"wrote {out_path.relative_to(repo_root)} — "
+            f"{s['ready']}/{s['total']} ready ({s['drift_guarded']} drift-guarded)"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/preflight_launch_packet.py
+++ b/scripts/dev/preflight_launch_packet.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Preflight a SLURM launch packet and report machine-readable run-readiness (#3549).
+
+Plain-language summary: a "launch packet" is a YAML file that pins the exact configs, seed budget,
+and command a SLURM campaign should run (e.g. the #3216 headline packet). This tool checks whether a
+packet is *safe to submit right now* — every pinned config still exists and its sha256 still matches
+(drift guard), the seed budget resolves, a runnable command is present, and a claim/evidence boundary
+is declared — and emits a structured result the autonomous queue discovery can consume.
+
+It is honest and fail-closed: launch packets use heterogeneous schemas, so anything this tool cannot
+verify (drifted sha, missing config, no command, no claim gate) yields ``ready: false`` with an
+explicit reason. It NEVER submits anything and makes no benchmark/paper-grade claim.
+
+Generalizes the inline drift-guard + seed-resolve checks in
+``scripts/benchmark/run_issue3216_headline_campaign.sh``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from collections.abc import Iterable, Mapping
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_VERSION = "run-ready-launch-packet-preflight.v1"
+
+# Scalar string values that look like in-repo asset paths we can existence-check.
+_PATH_RE = re.compile(r"^(configs|scripts|SLURM)/[\w./-]+\.(ya?ml|sh|sl|py)$")
+# Seed-set tokens like ``paper_eval_s20`` we can resolve to a seed count.
+_SEED_SET_RE = re.compile(r"\b(paper_eval_s\d+|[\w]*_s\d+)\b")
+_SEED_SETS_FILE = "configs/benchmarks/seed_sets_v1.yaml"
+
+# Keys whose presence indicates a runnable command / payload.
+_COMMAND_KEYS = (
+    "campaign_command",
+    "report_command",
+    "validation_command",
+    "slurm_command_shape",
+)
+# Keys whose presence indicates a declared claim / evidence boundary.
+_CLAIM_GATE_KEYS = (
+    "claim_gate",
+    "claim_map_gate",
+    "claim_boundary",
+    "no_claim_until_run",
+    "no_claim_statement",
+    "evidence_status",
+    "execution_boundary",
+)
+
+
+def sha256_of(path: Path) -> str:
+    """Return the hex sha256 digest of a file's bytes."""
+    h = hashlib.sha256()
+    with path.open("rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _walk(node: Any) -> Iterable[Any]:
+    """Yield every mapping and scalar reachable from ``node`` (depth-first)."""
+    yield node
+    if isinstance(node, Mapping):
+        for value in node.values():
+            yield from _walk(value)
+    elif isinstance(node, (list, tuple)):
+        for value in node:
+            yield from _walk(value)
+
+
+def find_sha_pairs(packet: Any) -> list[dict[str, str]]:
+    """Find ``<key>`` / ``<key>_sha256`` sibling pairs anywhere in the packet.
+
+    Returns a list of ``{"path": ..., "expected_sha256": ...}`` dicts.
+    """
+    pairs: list[dict[str, str]] = []
+    for node in _walk(packet):
+        if not isinstance(node, Mapping):
+            continue
+        for key, value in node.items():
+            sha_key = f"{key}_sha256"
+            if isinstance(value, str) and sha_key in node and isinstance(node[sha_key], str):
+                pairs.append({"path": value, "expected_sha256": node[sha_key]})
+    return pairs
+
+
+def find_config_paths(packet: Any) -> list[str]:
+    """Return the sorted unique set of in-repo asset paths referenced as scalars."""
+    found: set[str] = set()
+    for node in _walk(packet):
+        if isinstance(node, str) and _PATH_RE.match(node):
+            found.add(node)
+    return sorted(found)
+
+
+def _has_key(packet: Any, keys: Iterable[str]) -> list[str]:
+    """Return which of ``keys`` appear anywhere in the packet mappings."""
+    present: set[str] = set()
+    keyset = set(keys)
+    for node in _walk(packet):
+        if isinstance(node, Mapping):
+            present.update(keyset.intersection(node.keys()))
+    return sorted(present)
+
+
+def _issue_from_path(packet_path: Path) -> int | None:
+    """Parse an issue number from a packet filename like ``..._issue_3216_...``."""
+    m = re.search(r"issue[_-]?(\d+)", packet_path.name)
+    return int(m.group(1)) if m else None
+
+
+def _kind_from_path(packet_path: Path) -> str:
+    """Infer a coarse packet kind from its location."""
+    parts = packet_path.parts
+    if "benchmarks" in parts or "benchmark" in parts:
+        return "benchmark"
+    if "training" in parts:
+        return "training"
+    return "unknown"
+
+
+def _deep_find(node: Any, name: str) -> Any:
+    """Return the first value stored under key ``name`` anywhere in ``node``."""
+    if isinstance(node, Mapping):
+        for key, value in node.items():
+            if key == name:
+                return value
+            hit = _deep_find(value, name)
+            if hit is not None:
+                return hit
+    elif isinstance(node, (list, tuple)):
+        for value in node:
+            hit = _deep_find(value, name)
+            if hit is not None:
+                return hit
+    return None
+
+
+def _resolve_seed_count(packet: Any, repo_root: Path) -> dict[str, Any]:
+    """Best-effort resolve a declared seed-set token to a concrete seed count."""
+    text = yaml.safe_dump(packet)
+    seeds_file = repo_root / _SEED_SETS_FILE
+    tokens = sorted({m.group(1) for m in _SEED_SET_RE.finditer(text)})
+    if not tokens or not seeds_file.exists():
+        return {"seed_set": tokens[0] if tokens else None, "seed_count": None}
+    seed_sets = yaml.safe_load(seeds_file.read_text()) or {}
+
+    for token in tokens:
+        resolved = _deep_find(seed_sets, token)
+        seeds = resolved.get("seeds") if isinstance(resolved, Mapping) else resolved
+        if isinstance(seeds, list):
+            return {"seed_set": token, "seed_count": len(seeds)}
+    return {"seed_set": tokens[0], "seed_count": None}
+
+
+def preflight_packet(packet_path: Path, repo_root: Path) -> dict[str, Any]:
+    """Validate one launch packet and return a structured readiness report.
+
+    Args:
+        packet_path: Path to the launch-packet YAML.
+        repo_root: Repository root used to resolve referenced asset paths.
+
+    Returns:
+        A dict with readiness fields; ``ready`` is True only when all pinned configs exist,
+        all declared sha256 pairs match, a command and a claim gate are present, and at least
+        one config path is referenced.
+    """
+    reasons: list[str] = []
+    try:
+        packet = yaml.safe_load(packet_path.read_text())
+    except (yaml.YAMLError, OSError) as exc:
+        return {
+            "issue": _issue_from_path(packet_path),
+            "packet_path": str(packet_path.relative_to(repo_root))
+            if packet_path.is_absolute()
+            else str(packet_path),
+            "ready": False,
+            "reasons": [f"unparseable packet: {exc}"],
+        }
+
+    rel_packet = (
+        str(packet_path.relative_to(repo_root)) if packet_path.is_absolute() else str(packet_path)
+    )
+    schema_version = packet.get("schema_version") if isinstance(packet, Mapping) else None
+
+    # sha-pinned config pairs (drift guard).
+    sha_pairs = find_sha_pairs(packet)
+    checked_pairs: list[dict[str, Any]] = []
+    for pair in sha_pairs:
+        target = repo_root / pair["path"]
+        if not target.exists():
+            checked_pairs.append({**pair, "actual_sha256": None, "ok": False})
+            reasons.append(f"sha-pinned config missing: {pair['path']}")
+            continue
+        actual = sha256_of(target)
+        ok = actual == pair["expected_sha256"]
+        checked_pairs.append({**pair, "actual_sha256": actual, "ok": ok})
+        if not ok:
+            reasons.append(f"sha256 drift: {pair['path']}")
+
+    # All referenced in-repo asset paths exist.
+    config_paths = find_config_paths(packet)
+    checked_paths: list[dict[str, Any]] = []
+    for rel in config_paths:
+        exists = (repo_root / rel).exists()
+        checked_paths.append({"path": rel, "exists": exists})
+        if not exists:
+            reasons.append(f"referenced path missing: {rel}")
+
+    if not config_paths:
+        reasons.append("no in-repo config paths referenced")
+
+    command_keys = _has_key(packet, _COMMAND_KEYS)
+    if not command_keys:
+        reasons.append("no runnable command/payload key present")
+
+    claim_gate_keys = _has_key(packet, _CLAIM_GATE_KEYS)
+    if not claim_gate_keys:
+        reasons.append("no claim/evidence boundary declared")
+
+    seed_info = _resolve_seed_count(packet, repo_root)
+    seed_budget_present = bool(
+        _has_key(packet, ("seed_budget", "seed_policy", "seeds")) or seed_info["seed_set"]
+    )
+
+    drift_guarded = bool(checked_pairs) and all(p["ok"] for p in checked_pairs)
+    ready = (
+        all(p["ok"] for p in checked_pairs)
+        and all(p["exists"] for p in checked_paths)
+        and bool(config_paths)
+        and bool(command_keys)
+        and bool(claim_gate_keys)
+    )
+
+    return {
+        "issue": _issue_from_path(packet_path),
+        "packet_path": rel_packet,
+        "schema_version": schema_version,
+        "kind": _kind_from_path(packet_path),
+        "ready": ready,
+        "drift_guarded": drift_guarded,
+        "reasons": reasons,
+        "sha_pairs": checked_pairs,
+        "config_paths": checked_paths,
+        "seed_budget_present": seed_budget_present,
+        "seed_set": seed_info["seed_set"],
+        "seed_count": seed_info["seed_count"],
+        "command_keys": command_keys,
+        "claim_gate_keys": claim_gate_keys,
+    }
+
+
+def _repo_root(start: Path) -> Path:
+    """Find the repository root by walking up to a directory containing ``configs``."""
+    for candidate in [start, *start.parents]:
+        if (candidate / "configs").is_dir() and (candidate / "scripts").is_dir():
+            return candidate
+    return start
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: preflight one packet and print the JSON report."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--packet", type=Path, required=True, help="Path to the launch-packet YAML."
+    )
+    parser.add_argument(
+        "--repo-root", type=Path, default=None, help="Repository root (auto-detected)."
+    )
+    parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Exit non-zero when the packet is not run-ready.",
+    )
+    args = parser.parse_args(argv)
+
+    packet_path = args.packet.resolve()
+    repo_root = (args.repo_root or _repo_root(packet_path.parent)).resolve()
+    report = preflight_packet(packet_path, repo_root)
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.require_ready and not report["ready"]:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dev/test_build_run_ready_manifest.py
+++ b/tests/dev/test_build_run_ready_manifest.py
@@ -1,0 +1,78 @@
+"""Tests for the run-ready launch-packet manifest builder (#3549)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.dev.build_run_ready_manifest import build_manifest, discover_packets
+from scripts.dev.preflight_launch_packet import sha256_of
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "scripts").mkdir()
+    return tmp_path
+
+
+def _ready_packet(repo: Path, issue: int) -> None:
+    cfg = repo / "configs" / f"cfg_{issue}.yaml"
+    cfg.write_text("a: 1\n")
+    packet = {
+        "runnable_config": {"config": f"configs/cfg_{issue}.yaml", "config_sha256": sha256_of(cfg)},
+        "campaign_command": "run",
+        "claim_gate": "no_claim_until_run",
+    }
+    (repo / "configs" / f"r_issue_{issue}_launch_packet.yaml").write_text(yaml.safe_dump(packet))
+
+
+def _broken_packet(repo: Path, issue: int) -> None:
+    # references a missing config -> not ready
+    packet = {
+        "runnable_config": {"config": "configs/missing.yaml", "config_sha256": "a" * 64},
+        "campaign_command": "run",
+        "claim_gate": "x",
+    }
+    (repo / "configs" / f"b_issue_{issue}_launch_packet.yaml").write_text(yaml.safe_dump(packet))
+
+
+def test_discover_packets_globs_launch_packets(tmp_path: Path):
+    """Only files matching the launch-packet glob are discovered."""
+    repo = _make_repo(tmp_path)
+    _ready_packet(repo, 10)
+    (repo / "configs" / "not_a_packet.yaml").write_text("x: 1\n")
+    found = discover_packets(repo)
+    assert len(found) == 1
+    assert found[0].name == "r_issue_10_launch_packet.yaml"
+
+
+def test_manifest_summary_counts_and_sorting(tmp_path: Path):
+    """Summary tallies ready/total and entries sort by issue number."""
+    repo = _make_repo(tmp_path)
+    _ready_packet(repo, 30)
+    _ready_packet(repo, 10)
+    _broken_packet(repo, 20)
+    manifest = build_manifest(repo)
+
+    assert manifest["schema_version"] == "run-ready-launch-packet-manifest.v1"
+    assert manifest["summary"] == {"total": 3, "ready": 2, "drift_guarded": 2}
+    # sorted by issue number ascending
+    assert [e["issue"] for e in manifest["packets"]] == [10, 20, 30]
+    # the broken one is reported not-ready with a reason
+    broken = next(e for e in manifest["packets"] if e["issue"] == 20)
+    assert broken["ready"] is False
+    assert broken["reasons"]
+
+
+def test_manifest_entries_have_relative_paths(tmp_path: Path):
+    """Packet paths in the manifest are repo-relative, not absolute."""
+    repo = _make_repo(tmp_path)
+    _ready_packet(repo, 42)
+    manifest = build_manifest(repo)
+    entry = manifest["packets"][0]
+    assert entry["packet_path"] == "configs/r_issue_42_launch_packet.yaml"
+    assert not entry["packet_path"].startswith("/")

--- a/tests/dev/test_preflight_launch_packet.py
+++ b/tests/dev/test_preflight_launch_packet.py
@@ -1,0 +1,157 @@
+"""Tests for the launch-packet preflight helper (#3549)."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.dev.preflight_launch_packet import (
+    find_sha_pairs,
+    preflight_packet,
+    sha256_of,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_repo(tmp_path: Path) -> Path:
+    """Create a minimal repo root with configs/ and scripts/ dirs."""
+    (tmp_path / "configs").mkdir()
+    (tmp_path / "scripts").mkdir()
+    return tmp_path
+
+
+def _write_config(repo: Path, rel: str, body: str = "a: 1\n") -> tuple[str, str]:
+    """Write a config file and return (rel_path, sha256)."""
+    path = repo / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(body)
+    return rel, sha256_of(path)
+
+
+def _write_packet(repo: Path, name: str, packet: dict) -> Path:
+    """Write a launch packet YAML under configs/ and return its path."""
+    path = repo / "configs" / name
+    path.write_text(yaml.safe_dump(packet))
+    return path
+
+
+def _ready_packet(repo: Path, name: str = "x_issue_4242_launch_packet.yaml") -> Path:
+    """A fully run-ready packet referencing a real, sha-matched config."""
+    rel, sha = _write_config(repo, "configs/real_config.yaml")
+    packet = {
+        "schema_version": "test-packet.v1",
+        "runnable_config": {"config": rel, "config_sha256": sha},
+        "campaign_command": "uv run python run.py",
+        "claim_gate": {"no_claim_until_run": True},
+        "seed_budget": {"primary": {"seed_set": "paper_eval_s20"}},
+    }
+    return _write_packet(repo, name, packet)
+
+
+def test_clean_packet_is_ready(tmp_path: Path):
+    """A packet with matched sha, command, and claim gate is run-ready."""
+    repo = _make_repo(tmp_path)
+    report = preflight_packet(_ready_packet(repo), repo)
+    assert report["ready"] is True
+    assert report["drift_guarded"] is True
+    assert report["issue"] == 4242
+    assert report["reasons"] == []
+    assert report["command_keys"] == ["campaign_command"]
+
+
+def test_sha_drift_fails_closed(tmp_path: Path):
+    """A drifted sha256 makes the packet not run-ready."""
+    repo = _make_repo(tmp_path)
+    rel, _ = _write_config(repo, "configs/real_config.yaml")
+    packet = {
+        "runnable_config": {"config": rel, "config_sha256": "0" * 64},
+        "campaign_command": "run",
+        "claim_gate": "x",
+    }
+    report = preflight_packet(_write_packet(repo, "p_issue_1_launch_packet.yaml", packet), repo)
+    assert report["ready"] is False
+    assert report["drift_guarded"] is False
+    assert any("sha256 drift" in r for r in report["reasons"])
+
+
+def test_missing_config_fails_closed(tmp_path: Path):
+    """A sha-pinned config that does not exist fails closed."""
+    repo = _make_repo(tmp_path)
+    packet = {
+        "runnable_config": {"config": "configs/does_not_exist.yaml", "config_sha256": "a" * 64},
+        "campaign_command": "run",
+        "claim_gate": "x",
+    }
+    report = preflight_packet(_write_packet(repo, "p_issue_2_launch_packet.yaml", packet), repo)
+    assert report["ready"] is False
+    assert any("missing" in r for r in report["reasons"])
+
+
+def test_missing_command_fails_closed(tmp_path: Path):
+    """A packet with no runnable command key is not ready."""
+    repo = _make_repo(tmp_path)
+    rel, sha = _write_config(repo, "configs/real_config.yaml")
+    packet = {"runnable_config": {"config": rel, "config_sha256": sha}, "claim_gate": "x"}
+    report = preflight_packet(_write_packet(repo, "p_issue_3_launch_packet.yaml", packet), repo)
+    assert report["ready"] is False
+    assert any("command" in r for r in report["reasons"])
+
+
+def test_missing_claim_gate_fails_closed(tmp_path: Path):
+    """A packet without a claim/evidence boundary is not ready."""
+    repo = _make_repo(tmp_path)
+    rel, sha = _write_config(repo, "configs/real_config.yaml")
+    packet = {"runnable_config": {"config": rel, "config_sha256": sha}, "campaign_command": "run"}
+    report = preflight_packet(_write_packet(repo, "p_issue_4_launch_packet.yaml", packet), repo)
+    assert report["ready"] is False
+    assert any("claim" in r or "evidence" in r for r in report["reasons"])
+
+
+def test_unparseable_packet_fails_closed(tmp_path: Path):
+    """Invalid YAML yields not-ready with an unparseable reason."""
+    repo = _make_repo(tmp_path)
+    path = repo / "configs" / "broken_issue_9_launch_packet.yaml"
+    path.write_text("a: [unbalanced\n")
+    report = preflight_packet(path, repo)
+    assert report["ready"] is False
+    assert any("unparseable" in r for r in report["reasons"])
+
+
+def test_no_config_reference_fails_closed(tmp_path: Path):
+    """A packet referencing no in-repo config is not ready."""
+    repo = _make_repo(tmp_path)
+    packet = {"campaign_command": "run", "claim_gate": "x", "schema_version": "v"}
+    report = preflight_packet(_write_packet(repo, "p_issue_5_launch_packet.yaml", packet), repo)
+    assert report["ready"] is False
+    assert any("no in-repo config paths" in r for r in report["reasons"])
+
+
+def test_find_sha_pairs_sibling_rule():
+    """Only keys with a sibling <key>_sha256 form sha pairs."""
+    packet = {
+        "runnable_config": {
+            "config": "configs/a.yaml",
+            "config_sha256": "aa",
+            "matrix": "configs/b.yaml",
+            "matrix_sha256": "bb",
+            "kinematics": "differential_drive",  # no sibling sha -> not a pair
+        }
+    }
+    pairs = find_sha_pairs(packet)
+    paths = {p["path"]: p["expected_sha256"] for p in pairs}
+    assert paths == {"configs/a.yaml": "aa", "configs/b.yaml": "bb"}
+
+
+def test_seed_count_resolution(tmp_path: Path):
+    """A declared seed-set token resolves to its concrete seed count."""
+    repo = _make_repo(tmp_path)
+    (repo / "configs" / "benchmarks").mkdir(parents=True)
+    (repo / "configs" / "benchmarks" / "seed_sets_v1.yaml").write_text(
+        yaml.safe_dump({"paper_eval_s20": {"seeds": list(range(111, 131))}})
+    )
+    report = preflight_packet(_ready_packet(repo), repo)
+    assert report["seed_set"] == "paper_eval_s20"
+    assert report["seed_count"] == 20


### PR DESCRIPTION
## Claim boundary

Workflow/infra tooling. The manifest reports **preflight readiness only** (configs present, sha256
matches, seed budget resolves, runnable command + claim/evidence boundary present). It makes **no
benchmark or paper-grade claim** and **submits nothing** — submission stays gated by the private
autonomous-queue engine's budget + fair-use rules.

## Why

High-leverage SLURM work only gets submitted once someone hand-writes a queue entry in the private
ops engine; its discovery (`queue_discovery.py`) is read-only and has no machine-readable public
source for *which issues are run-ready*. This adds that source.

## What

- **`scripts/dev/preflight_launch_packet.py`** — validate one launch packet: re-verify every
  `<path>`/`<path>_sha256` pair (drift guard), resolve the declared seed budget, confirm referenced
  configs exist, and require a runnable command + a claim/evidence boundary. Fail-closed and honest
  across heterogeneous packet schemas; emits structured JSON; `--require-ready` for non-zero exit on
  drift. Generalizes the inline checks in `scripts/benchmark/run_issue3216_headline_campaign.sh`.
- **`scripts/dev/build_run_ready_manifest.py`** — glob `configs/**/*launch_packet*.yaml`, preflight
  each, emit `experiments/run_ready_manifest.yaml` with per-packet ready status + reasons + the
  metadata the private discovery needs, plus a summary.
- **`experiments/run_ready_manifest.yaml`** — generated artifact. Current state: **5/7 ready, 1
  drift-guarded** — only #3216 pins sha256, an honest signal to pin shas in the other packets before
  auto-submit.
- **Tests** — 12 cases (clean→ready, sha drift, missing config, no command, no claim gate,
  unparseable, sibling-sha rule, seed resolution, manifest counts/sorting).

## Validation

```bash
uv run python -m pytest tests/dev/test_preflight_launch_packet.py tests/dev/test_build_run_ready_manifest.py -q   # 12 passed
uv run ruff check scripts/dev/preflight_launch_packet.py scripts/dev/build_run_ready_manifest.py tests/dev/test_*launch* tests/dev/test_*manifest*   # clean
uv run python scripts/dev/preflight_launch_packet.py --packet configs/benchmarks/headline_ci_rank_stability_issue_3216_launch_packet.yaml --require-ready   # exit 0
```

## Companions (private overlay)

- `robot_sf_ll7-private-ops#2` — bounded continuous scheduler for the autonomous queue.
- `robot_sf_ll7-private-ops#3` — auto-populate `queue.yaml` from this manifest (proposed entries).

Closes #3549.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a run-readiness preflight check for launch-packet YAMLs, including file-existence, SHA verification, command/claim checks, and seed-set resolution.
  * Added a manifest builder that scans launch packets and produces an aggregated readiness report.

* **Bug Fixes**
  * Launch-packet manifest entries now use repo-relative paths and include readiness/drift status with clear reasons.
  * Unparseable or incomplete packets are now treated as not ready.

* **Tests**
  * Added coverage for packet discovery, readiness summaries, SHA drift detection, missing files, and YAML parsing failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Follow-Up Issues
- Deferred work: no deferred work.
- Issues opened for follow-up: NA - no follow-up issue needed.


<!-- pr-body-contract-refresh: 2026-06-24T12:08Z -->
