### PR TITLE
feat: add run-ready launch packet manifest

### DIFF
--- a/experiments/README.md
+++ b/experiments/README.md
@@ -19,6 +19,18 @@ Each record must state:
 - `paper_relevance`
 - `status`
 
+## Run-Ready Launch-Packet Manifest
+
+`experiments/run_ready_manifest.yaml` is generated from launch packets under `configs/`:
+
+```bash
+uv run python scripts/dev/build_run_ready_manifest.py --output experiments/run_ready_manifest.yaml
+```
+
+The manifest is a preflight and discovery surface for queue tooling. `ready: true` only means the
+packet passed local path, checksum, seed-budget, command, and claim-boundary checks; it does not
+assert benchmark results, paper evidence, or permission to submit a job.
+
 ## Experiment Record v2
 
 `experiment-record.v2` is the authoritative research-control-plane schema for new sprint studies.

--- a/experiments/run_ready_manifest.yaml
+++ b/experiments/run_ready_manifest.yaml
@@ -1,0 +1,490 @@
+schema_version: run-ready-launch-packet-manifest.v1
+packet_glob: configs/**/*launch_packet*.yaml
+packet_count: 7
+ready_count: 1
+entries:
+- issue: 3216
+  packet_path: configs/benchmarks/headline_ci_rank_stability_issue_3216_launch_packet.yaml
+  schema_version: issue_3216_headline_ci_rank_stability_launch_packet.v1
+  kind: benchmark
+  ready: false
+  reasons:
+  - 'placeholder values remain: report_command, expected_artifacts[0].path, expected_artifacts[1].path,
+    expected_artifacts[2].path'
+  configs:
+  - field: runnable_config.config
+    path: configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
+    exists: true
+    sha256: 3bf75ebb05cc5523c33271e956b21b14749fc427fc9d986438c83d09eee8b75c
+    sha256_matches: true
+  - field: runnable_config.scenario_matrix
+    path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+    sha256: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5
+    sha256_matches: true
+  - field: runnable_config.horizon_schedule
+    path: configs/policy_search/scenario_horizons_h500.yaml
+    exists: true
+    sha256: 4da9f6eb78c98d1afdf9ac43fde1cbfcac9447edb8491520e8c51d85d3b14fce
+    sha256_matches: true
+  - field: runnable_config.seed_sets
+    path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+    sha256: 3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6
+    sha256_matches: true
+  - field: runnable_config.planner_matrix
+    path: configs/benchmarks/paper_experiment_matrix_7planners_v1.yaml
+    exists: true
+    sha256: 43eec70a34366239d18e2b5e3cb92f8deb5031990acb8ae1f7981b3aa3fed2f7
+    sha256_matches: true
+  - field: campaign_command.token[3]
+    path: scripts/tools/run_camera_ready_benchmark.py
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: campaign_command.token[6]
+    path: configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: report_command.token[3]
+    path: scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+    exists: true
+    sha256: null
+    sha256_matches: null
+  seed_budget:
+    primary:
+      tier: S20
+      seed_set: paper_eval_s20
+      status: available
+    optional:
+      tier: S30
+      seed_set: paper_eval_s30
+      status: available_for_launch
+      note: 'Issue #1554 added the predeclared paper_eval_s30 seed schedule. No S30
+        campaign rows exist yet, so S30 remains launch-only until the SLURM run produces
+        durable rows. Do NOT synthesize ad hoc seeds at submit time.'
+  command: "uv run python scripts/tools/run_camera_ready_benchmark.py \\\n  --config\
+    \ configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml\
+    \ \\\n  --campaign-id issue3216_s20_headline_ci"
+  claim_gate:
+    target_claim: The paper-facing 7x7 headline planner comparison is stable enough
+      to support planner-ranking or safety-delta language after per-cell confidence
+      intervals and bootstrap rank-stability analysis.
+    no_claim_until_run: true
+    why_s10_s3_insufficient: S10/S3 cannot support manuscript-relied planner rankings;
+      per-cell CIs and bootstrap rank-stability require the predeclared S20 (and ideally
+      S30) seed budget before any ranking/safety-delta claim is promoted beyond diagnostic.
+- issue: 1554
+  packet_path: configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml
+  schema_version: s20-s30-seed-budget-launch-packet.v1
+  kind: benchmark
+  ready: false
+  reasons:
+  - 'placeholder values remain: generating_commit, durable_storage_plan.promote_to_evidence'
+  configs:
+  - field: campaign_config.checksums.configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml
+    path: configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml
+    exists: true
+    sha256: 63314360ebcc146e93ed59ee3a528d7834a5ac1d22d6f0269cbb3b2cd8fd53a9
+    sha256_matches: true
+  - field: campaign_config.checksums.configs/scenarios/classic_interactions_francis2023.yaml
+    path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+    sha256: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5
+    sha256_matches: true
+  - field: campaign_config.checksums.configs/policy_search/scenario_horizons_h500.yaml
+    path: configs/policy_search/scenario_horizons_h500.yaml
+    exists: true
+    sha256: 4da9f6eb78c98d1afdf9ac43fde1cbfcac9447edb8491520e8c51d85d3b14fce
+    sha256_matches: true
+  - field: campaign_config.checksums.configs/benchmarks/alyassi_comparability_map_v1.yaml
+    path: configs/benchmarks/alyassi_comparability_map_v1.yaml
+    exists: true
+    sha256: 22fc166ea438aa30da79c4888e270eee4afba8f1b9611080a3d51f4bb2cf200d
+    sha256_matches: true
+  - field: campaign_config.checksums.configs/benchmarks/snqi_weights_camera_ready_v3.json
+    path: configs/benchmarks/snqi_weights_camera_ready_v3.json
+    exists: true
+    sha256: 71a67c3c02faff166f8c96bef8bcf898533981ca2b2c4493829988520fb1aeb2
+    sha256_matches: true
+  - field: campaign_config.checksums.configs/benchmarks/snqi_baseline_camera_ready_v3.json
+    path: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+    exists: true
+    sha256: 329ca5766491e1587979d0a435c7ba676e148ccdff97040a36546bbb9414035a
+    sha256_matches: true
+  - field: seed_policy.checksums.configs/benchmarks/seed_sets_v1.yaml
+    path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+    sha256: 3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6
+    sha256_matches: true
+  - field: campaign_config.base_config
+    path: configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: campaign_config.scenario_matrix
+    path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: seed_policy.seed_sets_path
+    path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: slurm_command_shape.token[15]
+    path: scripts/tools/run_camera_ready_benchmark.py
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: slurm_command_shape.token[17]
+    path: configs/benchmarks/issue_1454_s10_scenario_horizons_h500_candidates.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: validation_command.token[3]
+    path: scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py
+    exists: true
+    sha256: null
+    sha256_matches: null
+  seed_budget:
+    mode: seed-set
+    seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+    primary_seed_set: paper_eval_s20
+    escalation_seed_set: paper_eval_s30
+    escalate_to_s30_when: 'Run the bundle tool on the S20 result store; if seed_resampling_rank_flip
+      reports rank_flip_observed for a primary metric, or a primary delta is below
+      the issue #1545 effect-size threshold, escalate to paper_eval_s30.
+
+      '
+    checksums:
+      configs/benchmarks/seed_sets_v1.yaml: 3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6
+  command: uv run python scripts/benchmark/build_s20_s30_seed_budget_bundle_issue_1554.py
+    --rows output/campaign_result_store/s20_s30_h500_social_navigation --output-dir
+    output/issue_1554_s20_s30
+  claim_gate:
+    target_claim: 'On the h500 social-navigation surface, the per-planner safety/quality
+      ordering observed at S10 is stable under a paper-facing S20 (and, if rankings
+      still flip, S30) seed budget, with bootstrap per-seed uncertainty small enough
+      to support the declared primary deltas.
+
+      '
+    status: to_be_confirmed_by_maintainer
+    required_metric_surface:
+    - success
+    - collisions
+    - near_misses
+    - time_to_goal_norm
+    descriptive_only_metrics:
+    - min_clearance
+    - min_distance
+    - mean_clearance
+    - raw_timeout_or_unfinished_rate
+    - low_progress_rate
+    planner_rows_to_confirm:
+    - goal
+    - social_force
+    - orca
+    - ppo
+    - prediction_planner
+    - socnav_sampling
+    - sacadrl
+    seed_tier: s20_then_s30_if_rankflip
+    why_s10_insufficient: 'Issue #1545 records material aggregate seed instability
+      across the 10 fixed S10 seeds (e.g. success range across planner-level seed
+      means median 0.1875, max 0.2917) and SNQI contract status fail on the S10 h500
+      surface, so close paper-facing comparisons need a larger seed budget. To be
+      confirmed by maintainer before any paper claim.
+
+      '
+- issue: 1395
+  packet_path: configs/training/learned_risk_model_issue_1395_launch_packet.yaml
+  schema_version: learned-risk-launch-packet.v1
+  kind: training
+  ready: false
+  reasons:
+  - missing launch/validation command
+  configs:
+  - field: trace_input_contract.checksums.docs/context/evidence/issue_1395_learned_risk_launch_packet_2026-05-24/trace_contract_fixture.jsonl
+    path: docs/context/evidence/issue_1395_learned_risk_launch_packet_2026-05-24/trace_contract_fixture.jsonl
+    exists: true
+    sha256: 178b90c90f6a089bd9fd1d2d7bacc6289c65f8ce3cbde8383f39503a88dff168
+    sha256_matches: true
+  - field: baseline_comparison.checksums.docs/context/evidence/issue_1395_learned_risk_launch_packet_2026-05-24/baseline_summary_stub.json
+    path: docs/context/evidence/issue_1395_learned_risk_launch_packet_2026-05-24/baseline_summary_stub.json
+    exists: true
+    sha256: 1b8598dced652de2983d8919e29e22e9b48905049e30ee5340d381e8e8dc89f2
+    sha256_matches: true
+  - field: baseline_comparison.candidate_config
+    path: configs/policy_search/candidates/hybrid_rule_v3_static_margin0_waypoint2.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: execution_boundary.slurm_command_shape.token[14]
+    path: configs/training/learned_risk_model_issue_1395_launch_packet.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  seed_budget: null
+  command: null
+  claim_gate:
+    full_training_in_this_issue: false
+    submit_slurm_from_this_issue: false
+    local_preflight_command: 'uv run python scripts/validation/validate_learned_risk_launch_packet.py
+      --config configs/training/learned_risk_model_issue_1395_launch_packet.yaml --json
+
+      '
+    slurm_command_shape: 'Submit a dedicated follow-up issue after this packet lands.
+      The future command must use configs/training/learned_risk_model_issue_1395_launch_packet.yaml,
+      materialized trace artifact URIs, and candidate diagnostics that expose learned_risk_score,
+      hard_guard_decision, and auxiliary_cost_weight.
+
+      '
+- issue: 1615
+  packet_path: configs/training/lidar/lidar_learned_policy_launch_packet_issue_1615.yaml
+  schema_version: lidar-learned-policy-launch-packet.v1
+  kind: training
+  ready: false
+  reasons:
+  - missing launch/validation command
+  - missing claim gate or execution boundary
+  configs:
+  - field: candidate_baselines[0].base_config
+    path: configs/training/ppo/feature_extractor_sweep_base.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: candidate_baselines[1].base_config
+    path: configs/training/ppo/feature_extractor_sweep_base.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: candidate_baselines[2].base_config
+    path: configs/training/ppo/feature_extractor_sweep_base.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: candidate_baselines[3].base_config
+    path: configs/training/rllib_dreamerv3/drive_state_rays.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  seed_budget: null
+  command: null
+  claim_gate: null
+- issue: 3068
+  packet_path: configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+  schema_version: ppo-curriculum-launch-packet.v1
+  kind: training
+  ready: true
+  reasons: []
+  configs:
+  - field: training_starting_points.checksums.configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+    path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+    exists: true
+    sha256: a374a624eb38402e5e4e2612f92440c0f80ff1eb0554a34f33dd36c16920a426
+    sha256_matches: true
+  - field: training_starting_points.checksums.configs/algos/ppo_v3_camera_ready.yaml
+    path: configs/algos/ppo_v3_camera_ready.yaml
+    exists: true
+    sha256: 6e7efd7bef68d4cdbac23bda7a0fa12d206229d5c0566c1e38f84cd9122a73c8
+    sha256_matches: true
+  - field: training_starting_points.checksums.configs/algos/guarded_ppo_relaxed_v2.yaml
+    path: configs/algos/guarded_ppo_relaxed_v2.yaml
+    exists: true
+    sha256: 666eda5a47de6e452eba9b2f3cb15bda16fc97abcd7137434661a87ac9ff85d8
+    sha256_matches: true
+  - field: training_starting_points.checksums.configs/scenarios/classic_interactions_francis2023.yaml
+    path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+    sha256: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5
+    sha256_matches: true
+  - field: training_starting_points.checksums.configs/benchmarks/seed_sets_v1.yaml
+    path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+    sha256: 3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6
+    sha256_matches: true
+  - field: training_starting_points.base_ppo_training_config
+    path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: training_starting_points.ppo_algo_config
+    path: configs/algos/ppo_v3_camera_ready.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: training_starting_points.guarded_algo_config
+    path: configs/algos/guarded_ppo_relaxed_v2.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: training_starting_points.scenario_config
+    path: configs/scenarios/classic_interactions_francis2023.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: training_starting_points.seed_manifest
+    path: configs/benchmarks/seed_sets_v1.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: baseline_comparator.base_ppo_training_config
+    path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: execution_boundary.slurm_command_shape.token[14]
+    path: configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  seed_budget:
+    training:
+    - 123
+    - 231
+    - 777
+    - 992
+    - 1337
+    randomize_seeds: true
+    evaluation:
+      manifest: configs/benchmarks/seed_sets_v1.yaml
+      dev:
+      - 101
+      - 102
+      - 103
+      eval:
+      - 111
+      - 112
+      - 113
+    note: 'Training seeds match the base config. Evaluation uses the frozen dev/eval
+      seeds from the manifest. Training and evaluation seed roles are kept distinct;
+      eval seeds are excluded from training-curve readouts.
+
+      '
+  command: uv run python -c "import yaml; d=yaml.safe_load(open('configs/training/ppo_curriculum_issue_3068_launch_packet.yaml'));
+    assert d['no_training_result_claim'] is True; print('valid', d['campaign_id'])"
+  claim_gate:
+    full_training_in_this_issue: false
+    submit_slurm_from_this_issue: false
+    local_preflight_command: 'uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
+      -q
+
+      '
+    slurm_command_shape: 'Submit a dedicated follow-up issue after this packet lands.
+      The future command must use configs/training/ppo_curriculum_issue_3068_launch_packet.yaml,
+      run both the curriculum and fixed-difficulty baseline arms with matched total_timesteps
+      and seeds, and report both the training-curve AND final-benchmark metrics before
+      any curriculum claim.
+
+      '
+- issue: 1397
+  packet_path: configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
+  schema_version: oracle-imitation-launch-packet.v1
+  kind: training
+  ready: false
+  reasons:
+  - missing claim gate or execution boundary
+  configs:
+  - field: checksums.docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/dry_run_dataset_stub.json
+    path: docs/context/evidence/issue_1397_oracle_imitation_launch_packet_2026-05-24/dry_run_dataset_stub.json
+    exists: true
+    sha256: eb5ef938d15725ff29a013a196216d093dd549ae58ae805e642c98441777529f
+    sha256_matches: true
+  - field: source_candidate_config
+    path: configs/policy_search/candidates/hybrid_rule_v3_static_margin0_waypoint2.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: slurm_command_shape.token[0]
+    path: scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh
+    exists: true
+    sha256: null
+    sha256_matches: null
+  seed_budget: null
+  command: 'scripts/dev/sbatch_oracle_imitation_traces_issue1470.sh --dry-run --no-status
+    prepares the issue #1470 train-split source-candidate trace collection job. This
+    trace job is executable Slurm work, but it is not the final imitation NPZ dataset;
+    downstream imitation training still requires durable dataset materialization and
+    concrete artifact aliases after the trace run completes.'
+  claim_gate: null
+- issue: 1396
+  packet_path: configs/training/shielded_ppo_issue_1396_launch_packet.yaml
+  schema_version: shielded-ppo-repair-launch-packet.v1
+  kind: training
+  ready: false
+  reasons:
+  - missing launch/validation command
+  configs:
+  - field: training_starting_points.checksums.configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+    path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+    exists: true
+    sha256: a374a624eb38402e5e4e2612f92440c0f80ff1eb0554a34f33dd36c16920a426
+    sha256_matches: true
+  - field: training_starting_points.checksums.configs/policy_search/candidates/risk_guarded_ppo_v1.yaml
+    path: configs/policy_search/candidates/risk_guarded_ppo_v1.yaml
+    exists: true
+    sha256: 69030a865be80be5e3ba98db447551c3707f966de8ac5f216e66044d9ea50735
+    sha256_matches: true
+  - field: comparison_references.ppo_baseline.checksums.docs/context/evidence/issue_1396_shielded_ppo_launch_packet_2026-05-24/comparison_freeze_stub.json
+    path: docs/context/evidence/issue_1396_shielded_ppo_launch_packet_2026-05-24/comparison_freeze_stub.json
+    exists: true
+    sha256: 2eabbf7d6fbc5a22071a2aef2c8ebdbb1113a8d58090709dc46c45761876871f
+    sha256_matches: true
+  - field: comparison_references.risk_guarded_ppo_v1.checksums.docs/context/evidence/issue_1396_shielded_ppo_launch_packet_2026-05-24/comparison_freeze_stub.json
+    path: docs/context/evidence/issue_1396_shielded_ppo_launch_packet_2026-05-24/comparison_freeze_stub.json
+    exists: true
+    sha256: 2eabbf7d6fbc5a22071a2aef2c8ebdbb1113a8d58090709dc46c45761876871f
+    sha256_matches: true
+  - field: training_starting_points.base_ppo_training_config
+    path: configs/training/ppo/expert_ppo_issue_576_br06_v3_15m_all_maps_randomized.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: training_starting_points.guarded_candidate_config
+    path: configs/policy_search/candidates/risk_guarded_ppo_v1.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: training_starting_points.guarded_algo_config
+    path: configs/algos/guarded_ppo_relaxed_v2.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: runtime_guard.evaluation_candidate_config
+    path: configs/policy_search/candidates/risk_guarded_ppo_v1.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: comparison_references.ppo_baseline.config
+    path: configs/policy_search/candidates/ppo_issue791_best_v1.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: comparison_references.risk_guarded_ppo_v1.config
+    path: configs/policy_search/candidates/risk_guarded_ppo_v1.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  - field: execution_boundary.slurm_command_shape.token[14]
+    path: configs/training/shielded_ppo_issue_1396_launch_packet.yaml
+    exists: true
+    sha256: null
+    sha256_matches: null
+  seed_budget: null
+  command: null
+  claim_gate:
+    full_training_in_this_issue: false
+    submit_slurm_from_this_issue: false
+    local_preflight_command: 'uv run python scripts/validation/validate_shielded_ppo_launch_packet.py
+      --config configs/training/shielded_ppo_issue_1396_launch_packet.yaml --json
+
+      '
+    slurm_command_shape: 'Submit a dedicated follow-up issue after this packet lands.
+      The future command must use configs/training/shielded_ppo_issue_1396_launch_packet.yaml,
+      keep the runtime guard active, and report guard_veto_count, guard_fallback_count,
+      raw_ppo_action, guarded_action, and fallback_action_source before any stress/full-matrix
+      escalation.
+
+      '

--- a/scripts/dev/build_run_ready_manifest.py
+++ b/scripts/dev/build_run_ready_manifest.py
@@ -1,0 +1,101 @@
+#!/usr/bin/env python3
+"""Build a machine-readable run-ready manifest from launch packets."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from scripts.dev.preflight_launch_packet import preflight_launch_packet
+
+SCHEMA_VERSION = "run-ready-launch-packet-manifest.v1"
+DEFAULT_GLOB = "configs/**/*launch_packet*.yaml"
+
+
+def _manifest_entry(report: dict[str, Any]) -> dict[str, Any]:
+    """Return compact manifest entry from one preflight report."""
+
+    configs = [
+        {
+            "field": item.get("field"),
+            "path": item.get("path"),
+            "exists": item.get("exists"),
+            "sha256": item.get("sha256_expected"),
+            "sha256_matches": item.get("sha256_matches"),
+        }
+        for item in report.get("configs", [])
+    ]
+    return {
+        "issue": report.get("issue"),
+        "packet_path": report.get("packet_path"),
+        "schema_version": report.get("packet_schema_version"),
+        "kind": report.get("kind"),
+        "ready": bool(report.get("ready")),
+        "reasons": list(report.get("reasons", [])),
+        "configs": configs,
+        "seed_budget": report.get("seed_budget"),
+        "command": report.get("command"),
+        "claim_gate": report.get("claim_gate"),
+    }
+
+
+def build_run_ready_manifest(
+    *,
+    repo_root: Path,
+    pattern: str = DEFAULT_GLOB,
+) -> dict[str, Any]:
+    """Build a run-ready manifest payload."""
+
+    repo_root = repo_root.resolve()
+    packets = sorted(repo_root.glob(pattern))
+    entries = []
+    for packet in packets:
+        report = preflight_launch_packet(packet, repo_root=repo_root)
+        entries.append(_manifest_entry(report))
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "packet_glob": pattern,
+        "packet_count": len(entries),
+        "ready_count": sum(1 for entry in entries if entry["ready"]),
+        "entries": entries,
+    }
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd(), help="Repository root.")
+    parser.add_argument("--glob", default=DEFAULT_GLOB, help="Launch-packet glob relative to repo.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("experiments/run_ready_manifest.yaml"),
+        help="Output YAML path.",
+    )
+    parser.add_argument("--json", action="store_true", help="Print JSON instead of YAML.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+
+    args = _parse_args(argv)
+    manifest = build_run_ready_manifest(repo_root=args.repo_root, pattern=args.glob)
+    if args.json:
+        text = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    else:
+        text = yaml.safe_dump(manifest, sort_keys=False)
+    output = args.output if args.output.is_absolute() else args.repo_root / args.output
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/preflight_launch_packet.py
+++ b/scripts/dev/preflight_launch_packet.py
@@ -1,0 +1,381 @@
+#!/usr/bin/env python3
+"""Preflight a heterogeneous launch-packet YAML for run-ready discovery."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+import shlex
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+SCHEMA_VERSION = "launch-packet-preflight.v1"
+SHA256_RE = re.compile(r"^[0-9a-fA-F]{64}$")
+ISSUE_RE = re.compile(r"issue[_-](\d+)|#(\d+)", re.IGNORECASE)
+PATH_TOKEN_RE = re.compile(r"^(?:configs|scripts|docs|experiments|robot_sf|tests)/.+")
+PATH_KEY_RE = re.compile(
+    r"(^path$|_path$|_config$|_manifest$|_matrix$|_script$|^config$|^launcher$|^script$)"
+)
+PLACEHOLDER_RE = re.compile(r"(<[^>]+>|\{[^}]+\}|TODO|TBD)", re.IGNORECASE)
+COMMAND_KEYS = (
+    "campaign_command",
+    "report_command",
+    "validation_command",
+    "slurm_command_shape",
+    "command",
+)
+CLAIM_KEYS = ("claim_gate", "claim_map_gate", "execution_boundary", "no_claim_statement")
+SEED_KEYS = ("seed_budget", "seed_policy", "seeds")
+
+
+@dataclass(frozen=True, slots=True)
+class PathCheck:
+    """One checked path and optional checksum."""
+
+    field: str
+    path: str
+    exists: bool
+    sha256_expected: str | None = None
+    sha256_observed: str | None = None
+    sha256_matches: bool | None = None
+
+
+def _sha256(path: Path) -> str:
+    """Return SHA-256 digest for *path*."""
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _repo_path(repo_root: Path, raw_path: str) -> Path:
+    """Resolve a launch-packet path relative to repository root."""
+
+    path = Path(raw_path)
+    return path if path.is_absolute() else repo_root / path
+
+
+def _looks_like_placeholder(value: str) -> bool:
+    """Return whether value contains an unresolved placeholder."""
+
+    return bool(PLACEHOLDER_RE.search(value))
+
+
+def _looks_like_repo_path(value: str) -> bool:
+    """Return whether a scalar string is a repository path worth preflighting."""
+
+    if "\n" in value or _looks_like_placeholder(value):
+        return False
+    return bool(PATH_TOKEN_RE.match(value.strip()))
+
+
+def _iter_mappings(payload: Any, prefix: str = "") -> Iterable[tuple[str, dict[str, Any]]]:
+    """Yield nested mappings with dotted prefixes."""
+
+    if isinstance(payload, dict):
+        yield prefix, payload
+        for key, value in payload.items():
+            next_prefix = f"{prefix}.{key}" if prefix else str(key)
+            yield from _iter_mappings(value, next_prefix)
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            yield from _iter_mappings(value, f"{prefix}[{index}]")
+
+
+def _collect_checksum_pairs(payload: dict[str, Any]) -> dict[str, tuple[str, str]]:
+    """Collect path -> expected sha256 declarations from common packet shapes."""
+
+    checks: dict[str, tuple[str, str]] = {}
+    for prefix, mapping in _iter_mappings(payload):
+        raw_checksums = mapping.get("checksums")
+        if isinstance(raw_checksums, dict):
+            for raw_path, raw_sha in raw_checksums.items():
+                if isinstance(raw_path, str) and isinstance(raw_sha, str):
+                    field = f"{prefix}.checksums.{raw_path}" if prefix else f"checksums.{raw_path}"
+                    checks[field] = (raw_path, raw_sha.strip())
+        for key, value in mapping.items():
+            key_text = str(key)
+            if not key_text.endswith("_sha256") or not isinstance(value, str):
+                continue
+            base_key = key_text[: -len("_sha256")]
+            raw_path = mapping.get(base_key)
+            if isinstance(raw_path, str):
+                field = f"{prefix}.{base_key}" if prefix else base_key
+                checks[field] = (raw_path, value.strip())
+    return checks
+
+
+def _collect_path_refs(payload: Any, *, prefix: str = "") -> dict[str, str]:
+    """Collect likely repository path references from keys and command tokens."""
+
+    refs: dict[str, str] = {}
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            key_text = str(key)
+            field = f"{prefix}.{key_text}" if prefix else key_text
+            if isinstance(value, str):
+                if PATH_KEY_RE.search(key_text) and _looks_like_repo_path(value):
+                    refs[field] = value.strip()
+                if key_text in COMMAND_KEYS:
+                    refs.update(_command_path_refs(value, field=field))
+            elif isinstance(value, (dict, list)):
+                refs.update(_collect_path_refs(value, prefix=field))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            refs.update(_collect_path_refs(value, prefix=f"{prefix}[{index}]"))
+    return refs
+
+
+def _command_path_refs(command: str, *, field: str) -> dict[str, str]:
+    """Extract repository path tokens from a shell-ish command string."""
+
+    refs: dict[str, str] = {}
+    try:
+        tokens = shlex.split(command, comments=True, posix=True)
+    except ValueError:
+        tokens = command.split()
+    output_flags = {"--output", "--output-dir", "--output-root", "--report-dir", "--artifact-dir"}
+    for index, token in enumerate(tokens):
+        previous = tokens[index - 1] if index > 0 else ""
+        if previous in output_flags:
+            continue
+        clean = token.strip().strip("'\"").rstrip(",.:;)]}")
+        if _looks_like_repo_path(clean):
+            refs[f"{field}.token[{index}]"] = clean
+    return refs
+
+
+def _check_path(  # noqa: C901
+    repo_root: Path, *, field: str, path_text: str, expected_sha: str | None = None
+) -> tuple[PathCheck, list[str]]:
+    """Check one path and optional SHA-256."""
+
+    reasons: list[str] = []
+    exists = False
+    observed: str | None = None
+    matches: bool | None = None
+    if _looks_like_placeholder(path_text):
+        reasons.append(f"{field}: path contains placeholder: {path_text}")
+    else:
+        path = _repo_path(repo_root, path_text)
+        if path.is_symlink():
+            reasons.append(f"{field}: path is a symlink and is not allowed: {path_text}")
+            path = path.resolve(strict=False)
+        resolved_path = path.resolve(strict=False)
+        if not resolved_path.is_relative_to(repo_root):
+            reasons.append(f"{field}: path escapes repository root: {path_text}")
+        else:
+            exists = resolved_path.is_file()
+            if not exists:
+                reasons.append(f"{field}: path is not an existing file: {path_text}")
+        if expected_sha is not None:
+            if not SHA256_RE.fullmatch(expected_sha):
+                reasons.append(f"{field}: sha256 is not a 64-character hex digest")
+                matches = False
+            elif exists:
+                try:
+                    observed = _sha256(resolved_path)
+                except OSError as exc:
+                    reasons.append(f"{field}: cannot read path for sha256: {exc}")
+                    matches = False
+                else:
+                    matches = observed == expected_sha.lower()
+                    if not matches:
+                        reasons.append(
+                            f"{field}: sha256 mismatch expected {expected_sha.lower()} observed {observed}"
+                        )
+            elif not matches:
+                matches = False
+    return (
+        PathCheck(
+            field=field,
+            path=path_text,
+            exists=exists,
+            sha256_expected=expected_sha,
+            sha256_observed=observed,
+            sha256_matches=matches,
+        ),
+        reasons,
+    )
+
+
+def _extract_issue(packet_path: Path, payload: dict[str, Any]) -> int | None:
+    """Extract issue number from payload or filename."""
+
+    issue = payload.get("issue")
+    if isinstance(issue, int):
+        return issue
+    if isinstance(issue, str) and issue.isdigit():
+        return int(issue)
+    match = ISSUE_RE.search(packet_path.name)
+    if match:
+        return int(next(group for group in match.groups() if group))
+    return None
+
+
+def _first_command(payload: dict[str, Any]) -> str | None:
+    """Return first recognized command string."""
+
+    for key in COMMAND_KEYS:
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _seed_budget(payload: dict[str, Any]) -> Any:
+    """Return declared seed budget surface if present."""
+
+    for key in SEED_KEYS:
+        if key in payload:
+            return payload[key]
+    return None
+
+
+def preflight_launch_packet(  # noqa: C901
+    packet_path: Path, *, repo_root: Path | None = None
+) -> dict[str, Any]:
+    """Preflight one launch packet and return a machine-readable report."""
+
+    repo_root = (repo_root or Path.cwd()).resolve()
+    packet_path = packet_path if packet_path.is_absolute() else repo_root / packet_path
+    reasons: list[str] = []
+    path_checks: list[PathCheck] = []
+
+    try:
+        payload = yaml.safe_load(packet_path.read_text(encoding="utf-8")) or {}
+    except OSError as exc:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "packet_path": str(packet_path),
+            "ready": False,
+            "reasons": [f"cannot read packet: {exc}"],
+        }
+    except yaml.YAMLError as exc:
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "packet_path": str(packet_path),
+            "ready": False,
+            "reasons": [f"invalid YAML: {exc}"],
+        }
+    if not isinstance(payload, dict):
+        reasons.append("packet YAML must be a mapping")
+        payload = {}
+
+    packet_rel = (
+        packet_path.relative_to(repo_root) if packet_path.is_relative_to(repo_root) else packet_path
+    )
+    schema = payload.get("schema_version")
+    if not isinstance(schema, str) or not schema.strip():
+        reasons.append("missing schema_version")
+    issue = _extract_issue(packet_path, payload)
+    if issue is None:
+        reasons.append("missing issue number")
+    command = _first_command(payload)
+    if command is None:
+        reasons.append("missing launch/validation command")
+    if not any(key in payload for key in CLAIM_KEYS):
+        reasons.append("missing claim gate or execution boundary")
+
+    path_refs = _collect_path_refs(payload)
+    checksum_pairs = _collect_checksum_pairs(payload)
+    for field, (path_text, sha) in checksum_pairs.items():
+        path_refs.pop(field, None)
+        check, check_reasons = _check_path(
+            repo_root, field=field, path_text=path_text, expected_sha=sha
+        )
+        path_checks.append(check)
+        reasons.extend(check_reasons)
+    for field, path_text in path_refs.items():
+        check, check_reasons = _check_path(repo_root, field=field, path_text=path_text)
+        path_checks.append(check)
+        reasons.extend(check_reasons)
+
+    placeholders = [
+        field
+        for field, value in _collect_scalar_strings(payload).items()
+        if _looks_like_placeholder(value)
+    ]
+    if placeholders:
+        reasons.append(f"placeholder values remain: {', '.join(placeholders[:8])}")
+
+    ready = not reasons
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "packet_path": str(packet_rel),
+        "packet_schema_version": schema,
+        "issue": issue,
+        "kind": _packet_kind(packet_path),
+        "ready": ready,
+        "reasons": reasons,
+        "configs": [asdict(check) for check in path_checks],
+        "seed_budget": _seed_budget(payload),
+        "command": command,
+        "claim_gate": payload.get("claim_gate")
+        or payload.get("claim_map_gate")
+        or payload.get("execution_boundary"),
+    }
+
+
+def _packet_kind(packet_path: Path) -> str:
+    """Infer packet kind from path."""
+
+    parts = set(packet_path.parts)
+    if "benchmarks" in parts:
+        return "benchmark"
+    if "training" in parts:
+        return "training"
+    return "launch_packet"
+
+
+def _collect_scalar_strings(payload: Any, *, prefix: str = "") -> dict[str, str]:
+    """Collect scalar strings for placeholder detection."""
+
+    out: dict[str, str] = {}
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            field = f"{prefix}.{key}" if prefix else str(key)
+            out.update(_collect_scalar_strings(value, prefix=field))
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            out.update(_collect_scalar_strings(value, prefix=f"{prefix}[{index}]"))
+    elif isinstance(payload, str):
+        out[prefix] = payload
+    return out
+
+
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--packet", required=True, type=Path, help="Launch-packet YAML path.")
+    parser.add_argument("--repo-root", default=Path.cwd(), type=Path, help="Repository root.")
+    parser.add_argument("--output", type=Path, default=None, help="Optional JSON output path.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+
+    args = _parse_args(argv)
+    report = preflight_launch_packet(args.packet, repo_root=args.repo_root)
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0 if report.get("ready") else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/dev/test_build_run_ready_manifest.py
+++ b/tests/dev/test_build_run_ready_manifest.py
@@ -1,0 +1,74 @@
+"""Tests run-ready launch-packet manifest builder."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path  # noqa: TC003
+
+import yaml
+
+from scripts.dev.build_run_ready_manifest import build_run_ready_manifest, main
+
+
+def _write_packet(path: Path, *, issue: int, command: str = "echo ok") -> None:
+    """Write a minimal launch packet."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "example.v1",
+                "issue": issue,
+                "claim_gate": {"target_claim": "diagnostic only"},
+                "seed_budget": {"primary": {"seed_set": "tiny"}},
+                "campaign_command": command,
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+
+def test_build_run_ready_manifest_summarizes_packets(tmp_path: Path) -> None:
+    """Manifest should include compact readiness entries for each packet."""
+
+    _write_packet(tmp_path / "configs" / "benchmarks" / "issue_1_launch_packet.yaml", issue=1)
+    _write_packet(
+        tmp_path / "configs" / "training" / "issue_2_launch_packet.yaml",
+        issue=2,
+        command="echo <placeholder>",
+    )
+
+    manifest = build_run_ready_manifest(repo_root=tmp_path)
+
+    assert manifest["schema_version"] == "run-ready-launch-packet-manifest.v1"
+    assert manifest["packet_count"] == 2
+    assert manifest["ready_count"] == 1
+    by_issue = {entry["issue"]: entry for entry in manifest["entries"]}
+    assert by_issue[1]["ready"] is True
+    assert by_issue[1]["kind"] == "benchmark"
+    assert by_issue[2]["ready"] is False
+    assert by_issue[2]["kind"] == "training"
+
+
+def test_build_run_ready_manifest_cli_writes_yaml_or_json(tmp_path: Path, capsys) -> None:
+    """CLI should write output and print the same payload."""
+
+    _write_packet(tmp_path / "configs" / "benchmarks" / "issue_3_launch_packet.yaml", issue=3)
+    output = tmp_path / "experiments" / "run_ready_manifest.yaml"
+
+    rc = main(["--repo-root", str(tmp_path), "--output", str(output)])
+    printed = yaml.safe_load(capsys.readouterr().out)
+    written = yaml.safe_load(output.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert printed == written
+    assert written["ready_count"] == 1
+
+    json_output = tmp_path / "run_ready_manifest.json"
+    rc = main(["--repo-root", str(tmp_path), "--output", str(json_output), "--json"])
+    printed_json = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert printed_json["packet_count"] == 1
+    assert json.loads(json_output.read_text(encoding="utf-8"))["ready_count"] == 1

--- a/tests/dev/test_preflight_launch_packet.py
+++ b/tests/dev/test_preflight_launch_packet.py
@@ -1,0 +1,176 @@
+"""Tests generic launch-packet preflight helper."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path  # noqa: TC003
+
+import yaml
+
+from scripts.dev.preflight_launch_packet import main, preflight_launch_packet
+
+
+def _sha256(path: Path) -> str:
+    """Return SHA-256 for fixture file."""
+
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def test_preflight_launch_packet_accepts_checked_paths(tmp_path: Path) -> None:
+    """A concrete packet with valid paths, SHA, seed, command, and gate is ready."""
+
+    repo = tmp_path
+    config = repo / "configs" / "benchmarks" / "example.yaml"
+    script = repo / "scripts" / "tools" / "run_example.py"
+    packet = repo / "configs" / "benchmarks" / "issue_999_launch_packet.yaml"
+    config.parent.mkdir(parents=True)
+    script.parent.mkdir(parents=True)
+    config.write_text("ok: true\n", encoding="utf-8")
+    script.write_text("print('ok')\n", encoding="utf-8")
+    packet.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "example.v1",
+                "issue": 999,
+                "claim_gate": {"target_claim": "diagnostic only"},
+                "seed_budget": {"primary": {"seed_set": "tiny"}},
+                "campaign_config": "configs/benchmarks/example.yaml",
+                "campaign_config_sha256": _sha256(config),
+                "campaign_command": (
+                    "uv run python scripts/tools/run_example.py "
+                    "--config configs/benchmarks/example.yaml"
+                ),
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    report = preflight_launch_packet(packet, repo_root=repo)
+
+    assert report["ready"] is True
+    assert report["issue"] == 999
+    assert report["kind"] == "benchmark"
+    assert report["reasons"] == []
+    assert any(item["sha256_matches"] is True for item in report["configs"])
+
+
+def test_preflight_launch_packet_fails_closed_on_placeholder_and_sha_drift(
+    tmp_path: Path,
+) -> None:
+    """Placeholders and checksum drift should make readiness explicit false."""
+
+    repo = tmp_path
+    config = repo / "configs" / "training" / "example.yaml"
+    packet = repo / "configs" / "training" / "issue_1000_launch_packet.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("changed: true\n", encoding="utf-8")
+    packet.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "example.v1",
+                "issue": 1000,
+                "execution_boundary": "launch-packet only",
+                "seed_policy": {"seed_set": "<seed-set>"},
+                "training_config": "configs/training/example.yaml",
+                "training_config_sha256": "0" * 64,
+                "validation_command": "uv run python <script>",
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    report = preflight_launch_packet(packet, repo_root=repo)
+
+    assert report["ready"] is False
+    assert any("sha256 mismatch" in reason for reason in report["reasons"])
+    assert any("placeholder values remain" in reason for reason in report["reasons"])
+
+
+def test_preflight_launch_packet_rejects_path_escape_with_sha(tmp_path: Path) -> None:
+    """Checksum preflight must not hash paths outside the repository root."""
+
+    repo = tmp_path / "repo"
+    outside = tmp_path / "outside.txt"
+    packet = repo / "configs" / "benchmarks" / "issue_1001_launch_packet.yaml"
+    packet.parent.mkdir(parents=True)
+    outside.write_text("secret-ish\n", encoding="utf-8")
+    packet.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "example.v1",
+                "issue": 1001,
+                "claim_gate": {"target_claim": "none"},
+                "campaign_command": "echo no-op",
+                "checksums": {"../outside.txt": _sha256(outside)},
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    report = preflight_launch_packet(packet, repo_root=repo)
+    checked = report["configs"][0]
+
+    assert report["ready"] is False
+    assert checked["sha256_observed"] is None
+    assert any("escapes repository root" in reason for reason in report["reasons"])
+
+
+def test_preflight_launch_packet_strips_command_path_punctuation(tmp_path: Path) -> None:
+    """Command token paths may appear in prose with trailing punctuation."""
+
+    repo = tmp_path
+    config = repo / "configs" / "training" / "example.yaml"
+    packet = repo / "configs" / "training" / "issue_1002_launch_packet.yaml"
+    config.parent.mkdir(parents=True)
+    config.write_text("ok: true\n", encoding="utf-8")
+    packet.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "example.v1",
+                "issue": 1002,
+                "execution_boundary": "launch-packet only",
+                "seed_policy": {"seed_set": "tiny"},
+                "slurm_command_shape": (
+                    "submit configs/training/example.yaml, then write output elsewhere."
+                ),
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    report = preflight_launch_packet(packet, repo_root=repo)
+
+    assert report["ready"] is True
+    assert any(item["path"] == "configs/training/example.yaml" for item in report["configs"])
+
+
+def test_preflight_launch_packet_cli_writes_json(tmp_path: Path, capsys) -> None:
+    """CLI should emit and optionally write JSON preflight reports."""
+
+    packet = tmp_path / "configs" / "benchmarks" / "issue_5_launch_packet.yaml"
+    output = tmp_path / "preflight.json"
+    packet.parent.mkdir(parents=True)
+    packet.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "example.v1",
+                "issue": 5,
+                "claim_gate": {"target_claim": "none"},
+                "campaign_command": "echo no-op",
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rc = main(["--packet", str(packet), "--repo-root", str(tmp_path), "--output", str(output)])
+    stdout = json.loads(capsys.readouterr().out)
+    written = json.loads(output.read_text(encoding="utf-8"))
+
+    assert rc == 0
+    assert stdout["ready"] is True
+    assert written["issue"] == 5


### PR DESCRIPTION
## Summary

- Adds `scripts/dev/preflight_launch_packet.py` to validate heterogeneous launch-packet YAMLs for local run readiness.
- Adds `scripts/dev/build_run_ready_manifest.py` plus tracked `experiments/run_ready_manifest.yaml` for machine-readable discovery by queue tooling.
- Documents the preflight evidence boundary in `experiments/README.md`.

Closes #3549.

## Evidence Boundary

This is workflow/preflight evidence only. `ready: true` means local paths, SHA-256 declarations, command/config references, seed-budget surface, and claim/execution boundary checks passed. It does not assert benchmark results, paper evidence, or permission to submit a SLURM job.

Current generated manifest has `packet_count: 7` and `ready_count: 0`; historical packets remain fail-closed with explicit reasons such as placeholders or missing concrete run-ready fields.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_preflight_launch_packet.py tests/dev/test_build_run_ready_manifest.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/dev/preflight_launch_packet.py scripts/dev/build_run_ready_manifest.py tests/dev/test_preflight_launch_packet.py tests/dev/test_build_run_ready_manifest.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/build_run_ready_manifest.py --output experiments/run_ready_manifest.yaml`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/preflight_launch_packet.py --packet configs/benchmarks/headline_ci_rank_stability_issue_3216_launch_packet.yaml --output output/issue_3549/preflight_3216.json` exited fail-closed for the current packet (`ready: false`, 1 placeholder reason, 8 checked config/path entries).

## Follow-Up Issues

None.
