### PR TITLE
fix: keep stream-gap on current goal without next waypoint

### DIFF
--- a/robot_sf/planner/stream_gap.py
+++ b/robot_sf/planner/stream_gap.py
@@ -297,14 +297,15 @@ class StreamGapPlannerAdapter:
             robot_pos = np.zeros(2, dtype=float)
         heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
 
-        goal_next = np.asarray(goal.get("next", [0.0, 0.0]), dtype=float).reshape(-1)[:2]
-        goal_current = np.asarray(goal.get("current", [0.0, 0.0]), dtype=float).reshape(-1)[:2]
-        goal_pos = goal_next if goal_next.size == 2 else np.zeros(2, dtype=float)
+        goal_next = np.asarray(goal.get("next", [0.0, 0.0]), dtype=float).reshape(-1)
+        goal_current = np.asarray(goal.get("current", [0.0, 0.0]), dtype=float).reshape(-1)
         if (
-            goal_pos.size != 2
-            or not np.all(np.isfinite(goal_pos))
-            or np.linalg.norm(goal_pos - robot_pos) <= 1e-6
+            goal_next.size == 2
+            and np.all(np.isfinite(goal_next))
+            and np.linalg.norm(goal_next - robot_pos) > 1e-6
         ):
+            goal_pos = goal_next
+        else:
             goal_pos = goal_current if goal_current.size == 2 else np.zeros(2, dtype=float)
         if not np.all(np.isfinite(goal_pos)):
             goal_pos = np.zeros(2, dtype=float)

--- a/robot_sf/planner/stream_gap.py
+++ b/robot_sf/planner/stream_gap.py
@@ -300,8 +300,14 @@ class StreamGapPlannerAdapter:
         goal_next = np.asarray(goal.get("next", [0.0, 0.0]), dtype=float).reshape(-1)[:2]
         goal_current = np.asarray(goal.get("current", [0.0, 0.0]), dtype=float).reshape(-1)[:2]
         goal_pos = goal_next if goal_next.size == 2 else np.zeros(2, dtype=float)
-        if goal_pos.size != 2 or np.linalg.norm(goal_pos - robot_pos) <= 1e-6:
+        if (
+            goal_pos.size != 2
+            or not np.all(np.isfinite(goal_pos))
+            or np.linalg.norm(goal_pos - robot_pos) <= 1e-6
+        ):
             goal_pos = goal_current if goal_current.size == 2 else np.zeros(2, dtype=float)
+        if not np.all(np.isfinite(goal_pos)):
+            goal_pos = np.zeros(2, dtype=float)
 
         ped_pos = self._as_xy(pedestrians.get("positions"))
         ped_vel = self._as_xy(pedestrians.get("velocities"))

--- a/robot_sf/representation/scenario_belief.py
+++ b/robot_sf/representation/scenario_belief.py
@@ -792,8 +792,14 @@ def _scenario_belief_from_simulator(
 
     goal = np.asarray(simulator.goal_pos[robot_index], dtype=np.float32)
     next_goal = simulator.next_goal_pos[robot_index]
-    next_goal_arr = goal if next_goal is None else np.asarray(next_goal)
-    next_goal_confidence = 0.0 if next_goal is None else 1.0
+    next_goal_candidate = None if next_goal is None else np.asarray(next_goal, dtype=np.float32)
+    next_goal_valid = (
+        next_goal_candidate is not None
+        and next_goal_candidate.reshape(-1).size == 2
+        and np.all(np.isfinite(next_goal_candidate))
+    )
+    next_goal_arr = next_goal_candidate if next_goal_valid else goal
+    next_goal_confidence = 1.0 if next_goal_valid else 0.0
 
     return ScenarioBelief(
         frame_id="map",

--- a/robot_sf/representation/scenario_belief.py
+++ b/robot_sf/representation/scenario_belief.py
@@ -392,7 +392,11 @@ class ScenarioBelief:
         robot_pos = self._clip_position(self.ego.position.as_array())
         goal = self.goals[0] if self.goals else _empty_goal(self.source_summary)
         current_goal = self._clip_position(goal.current.as_array())
-        next_goal = self._clip_position(goal.next.as_array())
+        next_goal = (
+            self._clip_position(goal.next.as_array())
+            if goal.next.confidence > 0.0
+            else current_goal
+        )
 
         ordered_agents = sorted(
             visible_agents,
@@ -788,7 +792,8 @@ def _scenario_belief_from_simulator(
 
     goal = np.asarray(simulator.goal_pos[robot_index], dtype=np.float32)
     next_goal = simulator.next_goal_pos[robot_index]
-    next_goal_arr = np.zeros(2, dtype=np.float32) if next_goal is None else np.asarray(next_goal)
+    next_goal_arr = goal if next_goal is None else np.asarray(next_goal)
+    next_goal_confidence = 0.0 if next_goal is None else 1.0
 
     return ScenarioBelief(
         frame_id="map",
@@ -817,7 +822,11 @@ def _scenario_belief_from_simulator(
         goals=(
             GoalBelief(
                 current=Estimate2D.point(goal, confidence=1.0, variance=1e-6),
-                next=Estimate2D.point(next_goal_arr, confidence=1.0, variance=1e-6),
+                next=Estimate2D.point(
+                    next_goal_arr,
+                    confidence=next_goal_confidence,
+                    variance=1e-6,
+                ),
                 source=source,
             ),
         ),

--- a/tests/planner/test_stream_gap_planner.py
+++ b/tests/planner/test_stream_gap_planner.py
@@ -122,6 +122,18 @@ def test_stream_gap_uses_current_goal_when_projected_next_goal_absent() -> None:
     np.testing.assert_allclose(goal_pos, [4.0, 0.0])
 
 
+def test_stream_gap_uses_current_goal_when_projected_next_goal_malformed() -> None:
+    """Malformed next-goal arrays must not collapse stream_gap's target to origin."""
+
+    planner = StreamGapPlannerAdapter(StreamGapPlannerConfig())
+    observation = _obs(robot=(1.0, 1.0), goal=(4.0, 0.0))
+    observation["goal"]["next"] = np.asarray([9.0], dtype=float)
+
+    _robot_pos, _heading, goal_pos, _ped_pos, _ped_vel = planner._extract_state(observation)
+
+    np.testing.assert_allclose(goal_pos, [4.0, 0.0])
+
+
 def test_stream_gap_commits_in_open_space() -> None:
     """Planner should commit when no pedestrian blocks the corridor."""
     planner = StreamGapPlannerAdapter(StreamGapPlannerConfig(commit_speed=0.9))

--- a/tests/planner/test_stream_gap_planner.py
+++ b/tests/planner/test_stream_gap_planner.py
@@ -90,6 +90,38 @@ def _low_confidence_blocker_belief():
     return replace(belief, agents=(low_confidence_agent,))
 
 
+def test_stream_gap_uses_current_goal_when_projected_next_goal_absent() -> None:
+    """ScenarioBelief projection with no next-goal should not steer stream_gap to origin."""
+    simulator = SimpleNamespace(
+        ped_pos=np.empty((0, 2), dtype=np.float32),
+        ped_vel=np.empty((0, 2), dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((1.0, 1.0), 0.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=0.4),
+            )
+        ],
+        goal_pos=[np.array([4.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=8.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+    belief = scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=RobotSimulationConfig(),
+        max_pedestrians=4,
+    )
+    projection = project_scenario_belief_for_planner(belief, planner_key="stream_gap")
+
+    planner = StreamGapPlannerAdapter(StreamGapPlannerConfig())
+    _robot_pos, _heading, goal_pos, _ped_pos, _ped_vel = planner._extract_state(
+        projection.observation
+    )
+
+    np.testing.assert_allclose(goal_pos, [4.0, 0.0])
+
+
 def test_stream_gap_commits_in_open_space() -> None:
     """Planner should commit when no pedestrian blocks the corridor."""
     planner = StreamGapPlannerAdapter(StreamGapPlannerConfig(commit_speed=0.9))

--- a/tests/representation/test_scenario_belief.py
+++ b/tests/representation/test_scenario_belief.py
@@ -72,6 +72,32 @@ def test_oracle_projection_preserves_valid_next_goal() -> None:
     np.testing.assert_allclose(observation["goal"]["next"], [6.0, 1.0])
 
 
+@pytest.mark.parametrize(
+    "next_goal",
+    [
+        np.array([np.nan, 1.0], dtype=np.float32),
+        np.array([6.0], dtype=np.float32),
+    ],
+)
+def test_oracle_projection_uses_current_goal_when_next_goal_invalid(
+    next_goal: np.ndarray,
+) -> None:
+    """Invalid simulator next-goals should fall back to current goal with no confidence."""
+
+    simulator = _simulator_fixture()
+    simulator.next_goal_pos = [next_goal]
+
+    belief = scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=RobotSimulationConfig(),
+        max_pedestrians=4,
+    )
+    observation = belief.to_socnav_struct()
+
+    assert belief.goals[0].next.confidence == 0.0
+    np.testing.assert_allclose(observation["goal"]["next"], observation["goal"]["current"])
+
+
 def test_oracle_and_partial_adapters_share_schema_and_projection_keys() -> None:
     """Different input paths should keep the same belief and policy-observation contracts."""
     env_config = RobotSimulationConfig()

--- a/tests/representation/test_scenario_belief.py
+++ b/tests/representation/test_scenario_belief.py
@@ -40,6 +40,38 @@ def _simulator_fixture() -> SimpleNamespace:
     )
 
 
+def test_oracle_projection_uses_current_goal_when_next_goal_absent() -> None:
+    """Missing simulator next-goal must not project as a spurious origin waypoint."""
+    belief = scenario_belief_from_simulator_oracle(
+        _simulator_fixture(),
+        env_config=RobotSimulationConfig(),
+        max_pedestrians=4,
+    )
+
+    observation = belief.to_socnav_struct()
+
+    assert belief.goals[0].next.confidence == 0.0
+    np.testing.assert_allclose(observation["goal"]["current"], [5.0, 0.0])
+    np.testing.assert_allclose(observation["goal"]["next"], observation["goal"]["current"])
+
+
+def test_oracle_projection_preserves_valid_next_goal() -> None:
+    """A real next-goal should still be projected for planners that consume it."""
+    simulator = _simulator_fixture()
+    simulator.next_goal_pos = [np.array([6.0, 1.0], dtype=np.float32)]
+    belief = scenario_belief_from_simulator_oracle(
+        simulator,
+        env_config=RobotSimulationConfig(),
+        max_pedestrians=4,
+    )
+
+    observation = belief.to_socnav_struct()
+
+    assert belief.goals[0].next.confidence == 1.0
+    np.testing.assert_allclose(observation["goal"]["current"], [5.0, 0.0])
+    np.testing.assert_allclose(observation["goal"]["next"], [6.0, 1.0])
+
+
 def test_oracle_and_partial_adapters_share_schema_and_projection_keys() -> None:
     """Different input paths should keep the same belief and policy-observation contracts."""
     env_config = RobotSimulationConfig()


### PR DESCRIPTION
## Summary
Fixes `stream_gap` steering toward world origin when a `ScenarioBelief` scenario has no next-goal. Missing simulator `next_goal_pos` now projects as the current goal with zero confidence instead of a fake `(0,0)` waypoint, while valid next-goals are preserved.

## Issue
Closes #3555.

## Changes
- Treat absent simulator next-goal as an absent/low-confidence goal estimate, not an origin waypoint.
- Make `ScenarioBelief.to_socnav_struct()` emit `goal.next == goal.current` when the next-goal estimate is absent.
- Add a defensive `stream_gap` extraction guard for invalid/degenerate next-goal values.
- Add regression coverage for absent next-goal projection, valid next-goal preservation, and stream-gap planner extraction.

## Validation
```bash
scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/representation/test_scenario_belief.py tests/planner/test_stream_gap_planner.py -q
scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/representation/scenario_belief.py robot_sf/planner/stream_gap.py tests/representation/test_scenario_belief.py tests/planner/test_stream_gap_planner.py
```

## Evidence Boundary
Targeted planner/projection regression proof only. This PR does not claim new benchmark results or revise #3471 outcomes.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, closes #3555.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: this is a targeted planner/projection bug fix with regression tests, not a benchmark or paper-facing result.

## Follow-Up Issues
- Deferred work: no deferred work.
- Issues opened for follow-up: NA - no follow-up issue needed.

## Reviewer Notes
- Verify the source fix and planner guard do not change behavior for valid next-goals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved goal-handling so the app falls back to the current goal when the next goal is missing, invalid, non-finite, or too close to the robot.
  * Prevented unexpected fallback behavior by treating missing next-goal information as unavailable instead of using a default waypoint.
  * Added coverage for cases where the next goal is absent or provided normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
