### PR TITLE
test: audit headline planners for silent-blind-planner bug + regression guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Audited the headline 7-planner benchmark comparison for the silent-blind-planner failure mode found in #3556 (`stream_gap` read nested observations while `map_runner` feeds flat ones, so it saw nothing yet emitted collision "results"). **Result: the headline comparison is clean** — its classical planners share `socnav_occupancy._socnav_fields`, which handles both nested and flat observations; `stream_gap` was a standalone exception (not in the headline) and is already fixed (#3567). Added a regression guard `tests/benchmark/test_planner_observation_contract.py` pinning that the shared extractor returns a non-degenerate view of the flat benchmark observation (sees the robot pose and real pedestrian count, not the `[0,0]`/empty blind default) and stays backward-compatible. Audit write-up: `docs/context/evidence/issue_3556_planner_obs_audit_2026-06-24/`.
 ### Changed
 
 * Made the `pr-body-contracts` CI check **advisory** and fixed two false-positive sources in `scripts/dev/check_pr_followups.py`. (1) The domain-approval trigger is now **negation-aware**: a body that honestly *describes* an evidence boundary ("makes no paper-facing claim") no longer trips the gate meant for bodies that *make* such a claim. (2) The **Follow-Up Issues section is optional** — it is only required when a PR closes an issue while declaring residual scope, so self-contained PRs no longer need a boilerplate "Follow-Up Issues: none" section. (3) New `--advisory` flag (used by `.github/workflows/pr-body-contracts.yml`) reports violations as GitHub `::warning::` annotations and exits 0 instead of blocking the PR; re-promote to blocking by dropping the flag once body conventions settle. Covered by 5 new tests (48 total).

--- a/docs/context/evidence/issue_3556_planner_obs_audit_2026-06-24/README.md
+++ b/docs/context/evidence/issue_3556_planner_obs_audit_2026-06-24/README.md
@@ -1,0 +1,54 @@
+# Benchmark planner observation-format audit (silent-blind-planner check)
+
+**Question:** the #3556 work found that `stream_gap` was *silently blind* in the real benchmark
+runner (it read the nested SOCNAV observation while `map_runner` feeds a flat observation, so it
+extracted `robot=[0,0], n_peds=0` and drove blind while still emitting collision "results"). Does any
+planner in the **headline 7-planner comparison** share this failure?
+
+**Answer: no — the headline comparison is clean.**
+
+## Method
+
+The bug class is an observation-*format* mismatch: a planner reading nested keys (`obs["robot"]`,
+`obs["pedestrians"]`) on the flat benchmark observation (`robot_position`, `pedestrians_positions`,
+`goal_current`). Audited by tracing each headline planner's observation extractor.
+
+## Finding
+
+The headline planners (`prediction_planner`, `goal`, `social_force`, `orca`, `ppo`,
+`socnav_sampling`, `sacadrl`) are built on the shared `SamplingPlannerAdapter` /
+`OccupancyAwarePlannerMixin` base, whose extractor `robot_sf/planner/socnav_occupancy.py::_socnav_fields`
+**explicitly handles both the nested and the flat observation** (its docstring: "Normalize SocNav
+observation (nested or flattened)"):
+
+```python
+if "robot" in observation:           # nested SOCNAV
+    robot_state = observation["robot"]; ...
+else:                                 # flat benchmark observation
+    pos = observation.get("robot_position", [0.0, 0.0]); ...
+    ped_state = {"positions": observation.get("pedestrians_positions"), ...}
+```
+
+So all the classical headline planners see the robot pose and the real pedestrians in `map_runner`.
+
+`stream_gap` was the **lone exception**: a standalone adapter that rolled its own *nested-only*
+`_extract_state` and never used `_socnav_fields`. It is **not in the headline 7-planner comparison**,
+so the headline table was never affected. `stream_gap`'s extractor was fixed to accept the flat
+observation in the #3556 PR (#3567).
+
+## Conclusion for the dissertation
+
+The headline planner-ranking comparison is **not corrupted** by the silent-blind-planner failure
+mode. The one planner that exhibited it (`stream_gap`) is outside the comparison and is now fixed.
+
+## Regression guard (this PR)
+
+`tests/benchmark/test_planner_observation_contract.py` pins the invariant going forward: the shared
+classical-planner extractor must return a non-degenerate view of the flat benchmark observation (sees
+the robot pose and the actual pedestrian count, not the `[0,0]`/empty blind default), and must stay
+backward-compatible with the nested observation. `stream_gap`'s extractor has its own flat-observation
+regression test in `tests/benchmark/test_scenario_belief_policy_hook_issue_3556.py`.
+
+A behavioural "reacts to pedestrians" check was rejected as the guard: it false-positives on the
+`goal` trivial reference planner, which ignores pedestrians by design. The contract checks *what the
+planner sees*, not how it reacts.

--- a/tests/benchmark/test_planner_observation_contract.py
+++ b/tests/benchmark/test_planner_observation_contract.py
@@ -1,0 +1,94 @@
+"""Observation-format contract for benchmark planners (anti-"silent blind planner" guard).
+
+Motivation: ``stream_gap`` was found to be silently blind in the real benchmark runner (#3556) — it
+read the nested SOCNAV observation (``obs["robot"]``/``obs["pedestrians"]``) while ``map_runner``
+feeds a flat observation (``robot_position``/``pedestrians_positions``), so it extracted
+``robot=[0,0], n_peds=0`` and drove blind every episode while still emitting collision "results".
+
+This contract pins the invariant that protects the headline benchmark comparison: a planner's
+observation extractor must return a *non-degenerate* view of the flat benchmark observation — it must
+see the robot pose and the actual pedestrian count, not an empty/origin default. A behavioural
+"reacts to pedestrians" check would false-positive on the trivial reference planner (which ignores
+pedestrians by design), so the contract checks *what the planner sees*, not how it reacts.
+
+The 7-planner headline comparison's classical planners all share ``_socnav_fields`` (which handles
+both nested and flat observations); ``stream_gap``'s standalone extractor is covered in
+``tests/benchmark/test_scenario_belief_policy_hook_issue_3556.py``.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from robot_sf.planner.socnav import SocialForcePlannerAdapter, SocNavPlannerConfig
+
+
+def _flat_benchmark_observation(n_peds: int) -> dict:
+    """Build a flat map_runner-style observation with a known robot pose and ``n_peds`` pedestrians."""
+    positions = [[8.0 + i, 5.0] for i in range(n_peds)]
+    return {
+        "robot_position": [5.0, 5.0],
+        "robot_heading": [0.0],
+        "robot_speed": [0.0],
+        "robot_radius": [0.4],
+        "robot_velocity_xy": [0.0, 0.0],
+        "goal_current": [12.0, 5.0],
+        "goal_next": [12.0, 5.0],
+        "pedestrians_positions": positions,
+        "pedestrians_velocities": [[0.0, 0.0] for _ in range(n_peds)],
+        "pedestrians_count": [n_peds],
+        "pedestrians_radius": [0.3],
+        "map_size": [40.0, 40.0],
+        "sim_timestep": 0.1,
+    }
+
+
+def _nested_socnav_observation(n_peds: int) -> dict:
+    """Build the nested SOCNAV equivalent for the backward-compatibility check."""
+    positions = [[8.0 + i, 5.0] for i in range(n_peds)]
+    return {
+        "robot": {"position": [5.0, 5.0], "heading": [0.0]},
+        "goal": {"current": [12.0, 5.0], "next": [12.0, 5.0]},
+        "pedestrians": {
+            "positions": positions,
+            "velocities": [[0.0, 0.0] for _ in range(n_peds)],
+            "count": [n_peds],
+        },
+    }
+
+
+def _shared_extractor():
+    """Return the ``_socnav_fields`` extractor shared by the classical headline planners."""
+    return SocialForcePlannerAdapter(config=SocNavPlannerConfig())._socnav_fields
+
+
+def test_shared_extractor_sees_flat_benchmark_observation():
+    """The classical-planner extractor must read the flat benchmark observation, not come back blind."""
+    robot_state, goal_state, ped_state = _shared_extractor()(_flat_benchmark_observation(n_peds=2))
+    robot_pos = np.asarray(robot_state["position"], dtype=float).reshape(-1)[:2]
+    goal = np.asarray(goal_state["current"], dtype=float).reshape(-1)[:2]
+    positions = np.asarray(ped_state.get("positions"), dtype=float)
+    count = int(np.asarray(ped_state.get("count", [0]), dtype=float).reshape(-1)[0])
+
+    assert list(robot_pos) == [5.0, 5.0]  # not the [0, 0] blind default
+    assert list(goal) == [12.0, 5.0]
+    assert count == 2
+    assert positions.shape[0] == 2
+
+
+def test_shared_extractor_still_reads_nested_observation():
+    """Backward compatibility: the nested SOCNAV observation must still extract correctly."""
+    robot_state, _goal_state, ped_state = _shared_extractor()(_nested_socnav_observation(n_peds=2))
+    robot_pos = np.asarray(robot_state["position"], dtype=float).reshape(-1)[:2]
+    count = int(np.asarray(ped_state.get("count", [0]), dtype=float).reshape(-1)[0])
+    assert list(robot_pos) == [5.0, 5.0]
+    assert count == 2
+
+
+def test_extractor_does_not_invent_pedestrians_when_absent():
+    """With no pedestrians the extractor reports zero — fail-closed, no phantom agents."""
+    _robot_state, _goal_state, ped_state = _shared_extractor()(
+        _flat_benchmark_observation(n_peds=0)
+    )
+    positions = np.asarray(ped_state.get("positions") or [], dtype=float).reshape(-1, 2)
+    assert positions.shape[0] == 0


### PR DESCRIPTION
## Summary

Audits the headline 7-planner benchmark comparison for the silent-blind-planner failure mode found in #3556, and adds a regression guard. **Result: the headline comparison is clean.**

## Why

The #3556 work found `stream_gap` was *silently blind* in the real benchmark runner: it read the nested SOCNAV observation (`obs["robot"]`/`obs["pedestrians"]`) while `map_runner` feeds a flat observation (`robot_position`/`pedestrians_positions`), so it extracted `robot=[0,0], n_peds=0` and drove blind every episode — while still emitting collision "results". For a falsification benchmark, garbage that masquerades as evidence is the worst failure mode, so the natural question is: **does any planner in the headline comparison share this?**

## Finding — headline is clean

The headline planners (`prediction_planner`, `goal`, `social_force`, `orca`, `ppo`, `socnav_sampling`, `sacadrl`) all extract via the shared `socnav_occupancy._socnav_fields`, which **explicitly handles both nested and flat observations** ("Normalize SocNav observation (nested or flattened)"). `stream_gap` was the lone exception — a standalone adapter with its own nested-only extractor — and it is **not in the headline comparison** and is already fixed (#3567). So the headline planner-ranking table was never corrupted.

## Guard

`tests/benchmark/test_planner_observation_contract.py` pins the invariant: the shared extractor must return a non-degenerate view of the flat benchmark observation (sees the robot pose + real pedestrian count, not the `[0,0]`/empty blind default) and stay backward-compatible with nested observations.

A behavioural "reacts to pedestrians" guard was **rejected** — it false-positives on the `goal` trivial reference planner, which ignores pedestrians by design. The contract checks *what the planner sees*, not how it reacts.

## Validation

```bash
uv run --with torch python -m pytest tests/benchmark/test_planner_observation_contract.py -q   # 3 passed
```

Audit write-up: `docs/context/evidence/issue_3556_planner_obs_audit_2026-06-24/`.

## Follow-Up Issues
- Deferred work: a runtime fail-closed `map_runner` row status for any planner whose effective view is degenerate would be the comprehensive version of this guard; deferred because the audit confirms no current headline planner needs it.
- Issues opened for follow-up: none.

Refs #3556.
