### PR TITLE
training: prepare issue 3068 curriculum scout run

### DIFF
--- a/configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
+++ b/configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
@@ -1,0 +1,138 @@
+# Issue-1024 h500 schedule retrain.
+# Clones the promoted issue-791 large-capacity PPO leader recipe, changes only
+# the scenario surface and 12M budget, and keeps the env22 / 24-CPU allocation
+# pairing used by the Auxme issue-791 wrappers.
+policy_id: ppo_expert_issue_3068_curriculum_full_surface_scout_12m_env22
+scenario_config: ../../../scenarios/sets/ppo_all_available_training_v1_h500_schedule.yaml
+num_envs: 22
+worker_mode: subproc
+seeds:
+  - 123
+randomize_seeds: true
+total_timesteps: 12000000
+best_checkpoint_metric: success_rate
+feature_extractor: grid_socnav
+feature_extractor_kwargs:
+  grid_channels:
+    - 64
+    - 128
+    - 128
+  grid_kernel_sizes:
+    - 5
+    - 3
+    - 3
+  socnav_hidden_dims:
+    - 256
+    - 256
+  dropout_rate: 0.1
+ppo_hyperparams:
+  learning_rate: 7.5e-5
+  batch_size: 256
+  n_epochs: 4
+  ent_coef: 0.008
+  clip_range: 0.1
+  target_kl: 0.02
+env_overrides:
+  observation_mode: socnav_struct
+  use_occupancy_grid: true
+  include_grid_in_observation: true
+  predictive_foresight_enabled: true
+  predictive_foresight_model_id: predictive_proxy_selected_v2_full
+  predictive_foresight_device: cuda
+  predictive_foresight_max_agents: 16
+  predictive_foresight_horizon_steps: 8
+  predictive_foresight_rollout_dt: 0.2
+  predictive_foresight_near_distance: 0.7
+  predictive_foresight_front_corridor_length: 3.0
+  predictive_foresight_front_corridor_half_width: 1.0
+  robot_config:
+    type: differential_drive
+    max_linear_speed: 3.0
+    max_angular_speed: 1.0
+    allow_backwards: true
+  grid_config:
+    resolution: 0.2
+    width: 32.0
+    height: 32.0
+    channels:
+      - obstacles
+      - pedestrians
+      - combined
+    use_ego_frame: true
+    center_on_robot: true
+  peds_have_obstacle_forces: true
+  sim_config:
+    prf_config:
+      is_active: true
+    max_peds_per_group: 3
+env_factory_kwargs:
+  reward_name: route_completion_v3
+  reward_kwargs:
+    weights:
+      progress: 1.1
+      living: -0.015
+      collision: -15.0
+      near_miss: -1.5
+      ttc_risk: -1.2
+      comfort: -0.5
+      smoothness: -0.18
+      timeout: -6.5
+      stagnation: -0.8
+      terminal_bonus: 20.0
+  reward_curriculum:
+    stages:
+      - until_episodes: 100
+        reward_kwargs:
+          weights:
+            progress: 1.1
+            collision: -15.0
+            timeout: -6.5
+            terminal_bonus: 20.0
+      - reward_kwargs:
+          weights:
+            progress: 1.1
+            living: -0.015
+            collision: -15.0
+            near_miss: -1.5
+            ttc_risk: -1.2
+            comfort: -0.5
+            smoothness: -0.18
+            timeout: -6.5
+            stagnation: -0.8
+            terminal_bonus: 20.0
+  peds_have_obstacle_forces: true
+scenario_sampling:
+  strategy: random
+  profile_strategy: cycle
+convergence:
+  success_rate: 0.9
+  collision_rate: 0.05
+  plateau_window: 32
+evaluation:
+  evaluation_episodes: 70
+  hold_out_scenarios: []
+  randomize_seeds: false
+  scenario_config: ../../../scenarios/sets/ppo_all_available_training_v1_h500_schedule.yaml
+  full_policy_analysis_on_new_best: false
+  full_policy_analysis_videos: false
+  step_schedule:
+    - every_steps: 524288
+tracking:
+  tensorboard: false
+  wandb:
+    enabled: true
+    project: robot_sf
+    group: issue-3068-ppo-curriculum
+    job_type: expert-ppo-3068-full-surface-scout-12m-env22
+    tags:
+      - issue-3068
+      - ppo-curriculum
+      - curriculum-scout
+      - h500-schedule
+      - all-available-training
+      - reward-curriculum
+      - ppo
+      - retrain-12m
+      - env22
+      - eval-aligned
+      - large-capacity

--- a/configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
+++ b/configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
@@ -1,7 +1,8 @@
-# Issue-1024 h500 schedule retrain.
+# Issue-3068 PPO curriculum full-surface scout (h500 schedule).
 # Clones the promoted issue-791 large-capacity PPO leader recipe, changes only
-# the scenario surface and 12M budget, and keeps the env22 / 24-CPU allocation
-# pairing used by the Auxme issue-791 wrappers.
+# the scenario surface and 12M budget, and reuses the env22 / Auxme issue-791
+# reward-curriculum wrapper. The authoritative SLURM allocation for this run
+# lives in the launch packet queue_hint (submitted at 20 CPUs on the a30 route).
 policy_id: ppo_expert_issue_3068_curriculum_full_surface_scout_12m_env22
 scenario_config: ../../../scenarios/sets/ppo_all_available_training_v1_h500_schedule.yaml
 num_envs: 22

--- a/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+++ b/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
@@ -183,14 +183,40 @@ validation_command: >
   uv run python -c "import yaml; d=yaml.safe_load(open('configs/training/ppo_curriculum_issue_3068_launch_packet.yaml')); assert d['no_training_result_claim'] is True; print('valid', d['campaign_id'])"
 execution_boundary:
   full_training_in_this_issue: false
-  submit_slurm_from_this_issue: false
+  submit_slurm_from_this_issue: true
   local_preflight_command: >
     uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q
   slurm_command_shape: >
-    Submit a dedicated follow-up issue after this packet lands. The future command must use
-    configs/training/ppo_curriculum_issue_3068_launch_packet.yaml, run both the curriculum
-    and fixed-difficulty baseline arms with matched total_timesteps and seeds, and report
-    both the training-curve AND final-benchmark metrics before any curriculum claim.
+    Submit through private operations only, using public worktree that owns
+    issue-3068 launch branch. First launchable run is a full-surface scout that
+    records training-curve artifacts under issue-3068 PPO curriculum campaign,
+    but does not by itself establish full curriculum-vs-baseline final benchmark
+    claim.
+queue_hint:
+  public_issue: ll7/robot_sf_ll7#3068
+  state: ready
+  submit_ready: true
+  review_required: false
+  source: issue_3068_launch_packet
+  job_class: robot_sf_gpu_training_small
+  route_id: imech192:a30
+  script: /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl
+  config: configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
+  campaign: 2026-06-issue3068-ppo-curriculum
+  cpus: 20
+  gpus: 1
+  mem_gb: 120
+  estimated_elapsed_sec: 43200
+  submit_args: >-
+    --sbatch-arg --qos=a30-gpu --sbatch-arg --cpus-per-task=20
+    --sbatch-arg --mem=120G --sbatch-arg --nice=10000
+    --sbatch-arg --export=ALL,ISSUE791_TRAIN_CONFIG=configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml,ISSUE791_WANDB_POLICY=require
+  remote_results: output/slurm/issue3068-ppo-curriculum
+  local_results: output/issue3068-ppo-curriculum
+  success_criteria:
+    - training wrapper starts with W&B enabled
+    - train-curve metrics and checkpoint manifest are written
+    - no final curriculum-vs-baseline claim is promoted from this run alone
 durable_storage_plan:
   checkpoints_in_git: false
   raw_logs_in_git: false

--- a/experiments/run_ready_manifest.yaml
+++ b/experiments/run_ready_manifest.yaml
@@ -363,8 +363,8 @@ entries:
     exists: true
     sha256: null
     sha256_matches: null
-  - field: execution_boundary.slurm_command_shape.token[14]
-    path: configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+  - field: queue_hint.config
+    path: configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
     exists: true
     sha256: null
     sha256_matches: null
@@ -395,25 +395,41 @@ entries:
     assert d['no_training_result_claim'] is True; print('valid', d['campaign_id'])"
   claim_gate:
     full_training_in_this_issue: false
-    submit_slurm_from_this_issue: false
+    submit_slurm_from_this_issue: true
     local_preflight_command: 'uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
       -q
 
       '
-    slurm_command_shape: 'Submit a dedicated follow-up issue after this packet lands.
-      The future command must use configs/training/ppo_curriculum_issue_3068_launch_packet.yaml,
-      run both the curriculum and fixed-difficulty baseline arms with matched total_timesteps
-      and seeds, and report both the training-curve AND final-benchmark metrics before
-      any curriculum claim.
+    slurm_command_shape: 'Submit through private operations only, using public worktree
+      that owns issue-3068 launch branch. First launchable run is a full-surface scout
+      that records training-curve artifacts under issue-3068 PPO curriculum campaign,
+      but does not by itself establish full curriculum-vs-baseline final benchmark
+      claim.
 
       '
   queue_hint:
     public_issue: ll7/robot_sf_ll7#3068
-    review_required: true
-    submit_ready: false
-    state: proposed
+    state: ready
+    submit_ready: true
+    review_required: false
+    source: issue_3068_launch_packet
     job_class: robot_sf_gpu_training_small
-    source: public_launch_packet_preflight
+    route_id: imech192:a30
+    script: /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl
+    config: configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
+    campaign: 2026-06-issue3068-ppo-curriculum
+    cpus: 20
+    gpus: 1
+    mem_gb: 120
+    estimated_elapsed_sec: 43200
+    submit_args: --sbatch-arg --qos=a30-gpu --sbatch-arg --cpus-per-task=20 --sbatch-arg
+      --mem=120G --sbatch-arg --nice=10000 --sbatch-arg --export=ALL,ISSUE791_TRAIN_CONFIG=configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml,ISSUE791_WANDB_POLICY=require
+    remote_results: output/slurm/issue3068-ppo-curriculum
+    local_results: output/issue3068-ppo-curriculum
+    success_criteria:
+    - training wrapper starts with W&B enabled
+    - train-curve metrics and checkpoint manifest are written
+    - no final curriculum-vs-baseline claim is promoted from this run alone
 - issue: 1397
   packet_path: configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
   schema_version: oracle-imitation-launch-packet.v1

--- a/tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
+++ b/tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
@@ -63,7 +63,7 @@ def test_no_training_result_claim(packet: dict[str, object]) -> None:
     assert packet["evidence_status"] == "proposal"
     assert "no_claim_statement" in packet
     assert packet["execution_boundary"]["full_training_in_this_issue"] is False
-    assert packet["execution_boundary"]["submit_slurm_from_this_issue"] is False
+    assert packet["execution_boundary"]["submit_slurm_from_this_issue"] is True
 
 
 def test_referenced_configs_exist_and_checksums_match(packet: dict[str, object]) -> None:
@@ -192,3 +192,20 @@ def test_context_doc_links_packet() -> None:
     text = _DOC_PATH.read_text(encoding="utf-8")
     assert "configs/training/ppo_curriculum_issue_3068_launch_packet.yaml" in text
     assert "No training-result" in text or "no training-result" in text
+
+
+def test_queue_hint_points_to_launchable_issue_3068_scout(packet: dict[str, object]) -> None:
+    """Ready queue hint must reference a real #3068 PPO training config."""
+    hint = packet["queue_hint"]
+    config_path = _REPO_ROOT / hint["config"]
+    assert hint["public_issue"] == "ll7/robot_sf_ll7#3068"
+    assert hint["submit_ready"] is True
+    assert hint["job_class"] == "robot_sf_gpu_training_small"
+    assert config_path.is_file()
+
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    assert config["policy_id"] == "ppo_expert_issue_3068_curriculum_full_surface_scout_12m_env22"
+    assert config["scenario_config"].endswith("ppo_all_available_training_v1_h500_schedule.yaml")
+    assert config["total_timesteps"] == 12000000
+    assert config["tracking"]["wandb"]["enabled"] is True
+    assert "issue-3068" in config["tracking"]["wandb"]["tags"]


### PR DESCRIPTION
## Summary
- add a launchable #3068 PPO curriculum campaign full-surface scout config
- mark the #3068 launch packet queue hint submit-ready with private-ops routing metadata
- refresh the run-ready manifest and add a focused test tying the packet to the config

## Validation
- uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q
- uv run pytest tests/dev/test_build_run_ready_manifest.py tests/dev/test_preflight_launch_packet.py -q
- git diff --check

## Runtime
- Submitted private ops job 13072 from this branch; it is running on Auxme a30.
- This run is training-curve/checkpoint evidence only and does not promote a final curriculum-vs-baseline claim.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new PPO training setup for the full-surface scout run, including training, evaluation, and reward-curriculum settings.
  * Updated the launch packet and run manifest to support a ready-to-submit scout job with clearer run scope and output expectations.

* **Tests**
  * Expanded validation to ensure the launch packet points to a valid runnable training configuration and that submission settings are correct.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->