### PR TITLE
fix: fail-close ScenarioBelief campaign screening

### DIFF
--- a/docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/README.md
+++ b/docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/README.md
@@ -1,7 +1,7 @@
 # Issue #3556 — ScenarioBelief drop-vs-retain through the REAL benchmark runner
 
 **Status:** campaign harness built + a real `stream_gap` bug fixed; the safety contrast is
-**`inconclusive`** on the crossing family because the oracle baseline is not near-safe.
+**`inconclusive_oracle_unsafe`** on the crossing family because the oracle baseline is not near-safe.
 
 ## Claim boundary (read first)
 
@@ -35,22 +35,22 @@ it stopped wandering) and the modes **differentiate**: `uncertain_dropped` shows
 worst-case clearance than `oracle`/`uncertain_retained`, confirming the gate now drops out-of-FOV
 agents in the real runner.
 
-## Result (8 seeds x 2 crossing scenarios, FOV 70°)
+## Result (12 seeds x 2 crossing scenarios, FOV 120°)
 
 | Mode | collision rate | near misses | worst min clearance | success |
 | --- | --- | --- | --- | --- |
-| `oracle` | 1.0 | 3 | -0.1123 | 0.0 |
-| `uncertain_retained` | 1.0 | 3 | -0.1123 | 0.0 |
-| `uncertain_dropped` | 1.0 | **-0.0782** | 0.0 | 0.0 |
+| `oracle` | 1.0 | 3 | -0.3487 | 0.0 |
+| `uncertain_retained` | 1.0 | 3 | -0.3487 | 0.0 |
+| `uncertain_dropped` | 1.0 | 3 | -0.3137 | 0.0 |
 
-**Decision: `inconclusive`** — the gate now acts (dropped differs on clearance), but with a
-collide-every-episode oracle there is no safe headroom to attribute a collision/near-miss effect.
+**Decision: `inconclusive_oracle_unsafe`** — the gate now acts (dropped differs on clearance),
+but the oracle baseline collides every episode (`oracle_near_safe: false`), so this contrast cannot
+attribute collision or near-miss effects to dropping uncertain agents.
 
 ## Reproduce
 
 ```bash
 uv run --with torch python scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py \
-  --seeds 101 102 103 104 105 106 107 108 --fov-degrees 70 \
   --out-dir output/issue_3556_belief_mode_campaign \
   --report-json docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/report.json
 ```

--- a/docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/report.json
+++ b/docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/report.json
@@ -2,42 +2,47 @@
   "by_mode": {
     "oracle": {
       "collision_rate": 1.0,
-      "episodes": 16,
-      "mean_min_clearance": 2.0834,
+      "episodes": 24,
+      "mean_min_clearance": 1.7309,
       "success_rate": 0.0,
-      "total_collisions": 16,
+      "total_collisions": 24,
       "total_near_misses": 3,
-      "worst_min_clearance": -0.1123
+      "worst_min_clearance": -0.3487
     },
     "uncertain_dropped": {
       "collision_rate": 1.0,
-      "episodes": 16,
-      "mean_min_clearance": 2.0911,
+      "episodes": 24,
+      "mean_min_clearance": 1.7347,
       "success_rate": 0.0,
-      "total_collisions": 16,
+      "total_collisions": 24,
       "total_near_misses": 3,
-      "worst_min_clearance": -0.0782
+      "worst_min_clearance": -0.3137
     },
     "uncertain_retained": {
       "collision_rate": 1.0,
-      "episodes": 16,
-      "mean_min_clearance": 2.0834,
+      "episodes": 24,
+      "mean_min_clearance": 1.7309,
       "success_rate": 0.0,
-      "total_collisions": 16,
+      "total_collisions": 24,
       "total_near_misses": 3,
-      "worst_min_clearance": -0.1123
+      "worst_min_clearance": -0.3487
     }
   },
   "claim_boundary": "Real benchmark-runner evidence on a bounded crossing family; FOV uncertainty source is not a calibrated perception model; not paper-grade until the predeclared matrix is run at seed-sufficiency budget with claim-card review.",
   "decision": {
     "collision_rate_delta_dropped_minus_retained": 0.0,
-    "decision": "inconclusive",
+    "decision": "inconclusive_oracle_unsafe",
+    "mode_is_discriminating": false,
     "near_miss_delta_dropped_minus_retained": 0,
-    "reason": "no measurable safety difference at this matrix"
+    "oracle_collision_rate": 1.0,
+    "oracle_near_safe": false,
+    "oracle_near_safe_threshold": 0.25,
+    "reason": "oracle baseline is itself unsafe (collision_rate 1.0); effect not cleanly attributable",
+    "screening_status": "oracle_unsafe"
   },
   "evidence_tier": "nominal_benchmark",
-  "fov_degrees": 70.0,
-  "generated_at_utc": "2026-06-24T14:43:37.378889+00:00",
+  "fov_degrees": 120.0,
+  "generated_at_utc": "2026-06-24T15:37:07.885956+00:00",
   "issue": 3556,
   "metric_note": "real benchmark near_misses + collisions + min_clearance (no scripted unsafe-commit)",
   "runner": "robot_sf.benchmark.map_runner.run_map_batch",
@@ -55,6 +60,10 @@
     105,
     106,
     107,
-    108
+    108,
+    109,
+    110,
+    111,
+    112
   ]
 }

--- a/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
+++ b/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
@@ -43,6 +43,7 @@ DEFAULT_FOV = 120.0
 NEAR_MISS_NOTE = (
     "real benchmark near_misses + collisions + min_clearance (no scripted unsafe-commit)"
 )
+NEAR_SAFE_ORACLE_COLLISION_RATE = 0.25
 
 
 def load_campaign_scenarios(set_path: Path, seeds: list[int]) -> list[dict[str, Any]]:
@@ -177,6 +178,67 @@ def classify_decision(by_mode: dict[str, dict[str, Any]]) -> dict[str, Any]:
     }
 
 
+def classify_screened_decision(by_mode: dict[str, dict[str, Any]]) -> dict[str, Any]:
+    """Classify contrast while exposing #3556 scenario-screening gates.
+
+    The campaign must not interpret a dropped-vs-retained contrast unless the
+    oracle baseline is near-safe and the dropped mode differs from retention.
+    """
+    oracle = by_mode.get("oracle", {})
+    retained = by_mode.get("uncertain_retained", {})
+    dropped = by_mode.get("uncertain_dropped", {})
+    if not (oracle.get("episodes") and retained.get("episodes") and dropped.get("episodes")):
+        return {
+            "decision": "blocked",
+            "reason": "one or more modes produced no episodes",
+            "screening_status": "missing_episodes",
+            "oracle_near_safe": False,
+            "mode_is_discriminating": False,
+        }
+
+    coll_delta = dropped["collision_rate"] - retained["collision_rate"]
+    nm_delta = dropped["total_near_misses"] - retained["total_near_misses"]
+    worse = coll_delta > 0 or nm_delta > 0
+    oracle_collision_rate = float(oracle["collision_rate"])
+    oracle_unsafe = oracle_collision_rate > NEAR_SAFE_ORACLE_COLLISION_RATE
+
+    if oracle_unsafe:
+        decision = "inconclusive_oracle_unsafe"
+        reason = (
+            "oracle baseline is itself unsafe "
+            f"(collision_rate {oracle_collision_rate}); effect not cleanly attributable"
+        )
+        screening_status = "oracle_unsafe"
+    elif worse:
+        decision = "revise"
+        reason = (
+            f"dropping uncertain agents raised collisions ({retained['collision_rate']}->"
+            f"{dropped['collision_rate']}) and/or near-misses (+{nm_delta}) vs retention, "
+            f"with a near-safe oracle ({oracle_collision_rate}); revise/block dropping default"
+        )
+        screening_status = "near_safe_discriminating"
+    elif coll_delta == 0 and nm_delta == 0:
+        decision = "inconclusive"
+        reason = "no measurable safety difference at this matrix"
+        screening_status = "near_safe_nondiscriminating"
+    else:
+        decision = "retention_dominates"
+        reason = "dropping did not increase unsafe outcomes here"
+        screening_status = "near_safe_nonworsening"
+
+    return {
+        "decision": decision,
+        "reason": reason,
+        "screening_status": screening_status,
+        "oracle_collision_rate": round(oracle_collision_rate, 4),
+        "oracle_near_safe": not oracle_unsafe,
+        "oracle_near_safe_threshold": NEAR_SAFE_ORACLE_COLLISION_RATE,
+        "mode_is_discriminating": worse,
+        "collision_rate_delta_dropped_minus_retained": round(coll_delta, 4),
+        "near_miss_delta_dropped_minus_retained": nm_delta,
+    }
+
+
 def run_campaign(
     set_path: Path,
     seeds: list[int],
@@ -218,7 +280,7 @@ def run_campaign(
         "fov_degrees": fov_degrees,
         "metric_note": NEAR_MISS_NOTE,
         "by_mode": by_mode,
-        "decision": classify_decision(by_mode),
+        "decision": classify_screened_decision(by_mode),
     }
 
 

--- a/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
+++ b/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
@@ -1,0 +1,76 @@
+"""Tests for issue #3556 belief-mode campaign decision screening."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "benchmark"
+    / "run_belief_mode_safety_campaign_issue_3556.py"
+)
+_SPEC = importlib.util.spec_from_file_location("_issue_3556_campaign", _MODULE_PATH)
+assert _SPEC is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MODULE)
+classify_screened_decision = _MODULE.classify_screened_decision
+
+
+def _mode(collision_rate: float, near_misses: int) -> dict[str, float | int]:
+    """Build the minimal aggregate shape consumed by the decision classifier."""
+    return {
+        "episodes": 3,
+        "collision_rate": collision_rate,
+        "total_near_misses": near_misses,
+    }
+
+
+def test_oracle_unsafe_blocks_interpretation_even_without_mode_delta() -> None:
+    """A collide-heavy oracle cannot support a dropped-vs-retained safety claim."""
+    decision = classify_screened_decision(
+        {
+            "oracle": _mode(collision_rate=1.0, near_misses=3),
+            "uncertain_retained": _mode(collision_rate=1.0, near_misses=3),
+            "uncertain_dropped": _mode(collision_rate=1.0, near_misses=3),
+        }
+    )
+
+    assert decision["decision"] == "inconclusive_oracle_unsafe"
+    assert decision["screening_status"] == "oracle_unsafe"
+    assert decision["oracle_near_safe"] is False
+    assert decision["mode_is_discriminating"] is False
+
+
+def test_near_safe_nondiscriminating_matrix_stays_inconclusive() -> None:
+    """Near-safe oracle alone is not enough when dropped and retained match."""
+    decision = classify_screened_decision(
+        {
+            "oracle": _mode(collision_rate=0.0, near_misses=0),
+            "uncertain_retained": _mode(collision_rate=0.0, near_misses=0),
+            "uncertain_dropped": _mode(collision_rate=0.0, near_misses=0),
+        }
+    )
+
+    assert decision["decision"] == "inconclusive"
+    assert decision["screening_status"] == "near_safe_nondiscriminating"
+    assert decision["oracle_near_safe"] is True
+    assert decision["mode_is_discriminating"] is False
+
+
+def test_near_safe_discriminating_matrix_recommends_revise() -> None:
+    """Dropped mode becoming less safe under a near-safe oracle is actionable."""
+    decision = classify_screened_decision(
+        {
+            "oracle": _mode(collision_rate=0.0, near_misses=0),
+            "uncertain_retained": _mode(collision_rate=0.0, near_misses=1),
+            "uncertain_dropped": _mode(collision_rate=0.0, near_misses=4),
+        }
+    )
+
+    assert decision["decision"] == "revise"
+    assert decision["screening_status"] == "near_safe_discriminating"
+    assert decision["oracle_near_safe"] is True
+    assert decision["mode_is_discriminating"] is True


### PR DESCRIPTION
## Summary
Tightens the #3556 belief-mode campaign decision gate so oracle-unsafe scenario families fail closed as `inconclusive_oracle_unsafe`, and refreshes the durable evidence report accordingly.

## Linked Issues
- Relates to `#3556`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: `#3567`, `#3568` merged on `origin/main`
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: uses the #3567 real-runner harness and #3568 observation-integrity guard already on `origin/main`.

## What Changed
- Added screened decision fields to `scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py`: `screening_status`, `oracle_near_safe`, `oracle_near_safe_threshold`, and `mode_is_discriminating`.
- Regenerated `docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/report.json` and aligned the README to `inconclusive_oracle_unsafe`.
- Added focused tests for oracle-unsafe, near-safe nondiscriminating, and near-safe discriminating matrices.

## Why Matters
- Added value: prevents the #3556 campaign from treating collide-heavy oracle baselines as interpretable dissertation evidence.
- Expected impact: makes the next #3556 step deterministic: find or author a near-safe, discriminating crossing family before claiming the drop-vs-retain effect.
- Why worth merging now: the harness is already on `main`; this PR tightens the evidence gate before more campaign runs reuse it.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3556 real-runner ScenarioBelief drop-vs-retain evidence gate.
- Comparator or baseline, applicable: `oracle`, `uncertain_retained`, and `uncertain_dropped` stream_gap modes.
- Evidence tier: nominal benchmark evidence for the bounded current report; not paper-grade.
- Result classification: `inconclusive_oracle_unsafe`.
- Decision stop rule, applicable: oracle collision rate above 0.25 blocks attributable dropped-vs-retained interpretation.
- Parent issue, claim map, registry, context note, synthesis surface update: #3556 plus `docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/`.
- New research/benchmark/metric/paper-facing analysis tool, any: campaign classifier fields only; representative use is the regenerated tracked report.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: pending reviewer approval; this PR narrows/clarifies evidence classification and does not promote a positive safety claim.
- Approver/review source waiver: none.
- Validity checklist:
  - Target claim/hypothesis: blocked by oracle-unsafe current family.
  - Comparator split/evidence validity: three modes remain identical except `belief_mode`.
  - Fallback/degraded exclusions: no fallback/degraded rows counted as success.
  - Claim boundary: real runner, bounded crossing family, FOV uncertainty source, not calibrated perception or paper-grade.
  - Implementation integrity vs experimental validity: implementation integrity tested; experimental validity remains limited by oracle-unsafe family.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes; dropped mode differs on clearance in the tracked report.
- Did intervention change command source, selected command, trajectory, route progress? yes for clearance, not for collision/near-miss decision.
- Did scenario actually contain targeted failure mode? no cleanly attributable failure mode, because oracle collides every episode.
- Result route: revise; find near-safe discriminating scenario family before further claim movement.
- Follow-up question issue weak, negative, non-transfer results: #3556 remains open.

## Next Empirical Action
- Rerun needed: yes, on a near-safe and occlusion-bearing/discriminating family.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no durable tracked summary missing; raw `output/` files are reproducible and intentionally untracked.
- Stop / revise / continue decision: continue #3556 with scenario search, not claim promotion.
- Proposed child issue existing follow-up: none opened; existing #3556 carries remaining gap.

## Validation / Proof
Focused:
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py tests/benchmark/test_scenario_belief_policy_hook_issue_3556.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py`
- `python3 -m json.tool docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/report.json`
- Regenerated report via compact wrapper:
  `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py --out-dir output/issue_3556_belief_mode_campaign --report-json docs/context/evidence/issue_3556_belief_mode_real_runner_2026-06-24/report.json`

Readiness:
- `BASE_REF=origin/main uv run python scripts/dev/run_compact_validation.py --artifact-dir <common-git-dir>/codex-agent-runs/issue3556-pr-ready-shared-venv --timeout-seconds 1800 --json -- scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh`
- Direct worktree-local readiness first failed before code validation because the auto-created worktree `.venv` lacked `torch`; shared-venv readiness passed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, PR will link #3556; issue remains open.
- Claim map / benchmark report updated (yes/no/NA): yes, tracked #3556 evidence README/report updated.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR tightens one issue-specific campaign gate and durable evidence note; it does not publish leaderboard or paper-grade results.

## Follow-Up Issues
- Deferred work: find or author a near-safe, occlusion-bearing, mode-discriminating crossing family.
- Issues opened follow-up: none; #3556 remains open.

## Reviewer Notes
- Verify that `inconclusive_oracle_unsafe` is the right classification for oracle collision rate 1.0.
- Known limitation: this PR does not solve the remaining scenario search; it prevents overclaiming while that work continues.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated benchmark results and report output with expanded scenario coverage and refreshed safety metrics.
  * Added clearer decision labeling that distinguishes unsafe oracle behavior from cases where modes are only partially informative.

* **Bug Fixes**
  * Improved safety classification so near-safe results are handled more accurately, including cases that should remain inconclusive versus those that should recommend revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->