### PR TITLE
benchmark: force PPO CPU for issue 1554 S20 matrix

### DIFF
--- a/configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml
+++ b/configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml
@@ -1,0 +1,34 @@
+# CPU-forced issue-791 PPO baseline for paper-matrix reruns that need
+# deterministic memory behavior over GPU throughput.
+#
+# Sibling of ppo_issue_791_eval_aligned_large_capacity_portable.yaml. It keeps
+# the same promoted model and observation contract, but pins both PPO inference
+# and predictive foresight to CPU so large multi-planner benchmark matrices do
+# not repeatedly load the policy onto a shared GPU and exhaust device memory.
+#
+# Source job: 11724 (auxme-imech093, l40s, 8h04m).
+# WandB run: ll7/robot_sf/ibo3aqus
+# Best eval (70 episodes, ppo_full_maintained_eval_v1):
+# success_rate=0.929, collision_rate=0.071, SNQI=0.353
+# Best step: 9,961,472 / 10,000,000.
+#
+# CAVEAT: policy was trained on eval superset
+# (configs/scenarios/sets/ppo_full_maintained_eval_v1.yaml). Eval numbers are
+# in-distribution; report benchmark-set performance, not OOD generalization.
+model_id: ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417
+device: cpu
+deterministic: true
+obs_mode: dict
+predictive_foresight_enabled: true
+predictive_foresight_model_id: predictive_proxy_selected_v2_full
+predictive_foresight_device: cpu
+predictive_foresight_max_agents: 16
+predictive_foresight_horizon_steps: 8
+predictive_foresight_rollout_dt: 0.2
+predictive_foresight_near_distance: 0.7
+predictive_foresight_front_corridor_length: 3.0
+predictive_foresight_front_corridor_half_width: 1.0
+action_space: unicycle
+v_max: 2.0
+omega_max: 1.0
+fallback_to_goal: false

--- a/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
@@ -63,57 +63,51 @@ release_tag: "{release_tag}"
 doi: 10.5281/zenodo.<record-id>
 paper_interpretation_profile: issue-1554-s20-scenario-horizons-h500
 
+# PPO is pinned to a CPU-forced config for the long S20 matrix. Job 13044 showed
+# repeated CUDA model loads can exhaust A30 memory before the PPO row completes.
 planners:
-  - key: prediction_planner
-    algo: prediction_planner
-    planner_group: experimental
-    algo_config: configs/algos/prediction_planner_camera_ready.yaml
-    benchmark_profile: experimental
-
-  - key: goal
-    algo: goal
-    planner_group: core
-    benchmark_profile: baseline-safe
-
-  - key: social_force
-    algo: social_force
-    planner_group: core
-    benchmark_profile: baseline-safe
-
-  - key: orca
-    algo: orca
-    planner_group: core
-    benchmark_profile: baseline-safe
-    socnav_missing_prereq_policy: fallback
-
-  - key: ppo
-    algo: ppo
-    planner_group: experimental
-    algo_config: configs/baselines/ppo_issue_791_eval_aligned_large_capacity.yaml
-    benchmark_profile: experimental
-    adapter_impact_eval: true
-    workers: 1
-
-  - key: socnav_sampling
-    algo: socnav_sampling
-    planner_group: experimental
-    benchmark_profile: experimental
-    socnav_missing_prereq_policy: fail-fast
-
-  - key: sacadrl
-    algo: sacadrl
-    planner_group: experimental
-    benchmark_profile: experimental
-    socnav_missing_prereq_policy: fallback
-
-  - key: scenario_adaptive_hybrid_orca_v1
-    algo: hybrid_rule_local_planner
-    planner_group: experimental
-    algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
-    benchmark_profile: experimental
-
-  - key: hybrid_rule_v3_fast_progress_static_escape
-    algo: hybrid_rule_local_planner
-    planner_group: experimental
-    algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
-    benchmark_profile: experimental
+- key: prediction_planner
+  algo: prediction_planner
+  planner_group: experimental
+  algo_config: configs/algos/prediction_planner_camera_ready.yaml
+  benchmark_profile: experimental
+- key: goal
+  algo: goal
+  planner_group: core
+  benchmark_profile: baseline-safe
+- key: social_force
+  algo: social_force
+  planner_group: core
+  benchmark_profile: baseline-safe
+- key: orca
+  algo: orca
+  planner_group: core
+  benchmark_profile: baseline-safe
+  socnav_missing_prereq_policy: fallback
+- key: ppo
+  algo: ppo
+  planner_group: experimental
+  algo_config: configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml
+  benchmark_profile: experimental
+  adapter_impact_eval: true
+  workers: 1
+- key: socnav_sampling
+  algo: socnav_sampling
+  planner_group: experimental
+  benchmark_profile: experimental
+  socnav_missing_prereq_policy: fail-fast
+- key: sacadrl
+  algo: sacadrl
+  planner_group: experimental
+  benchmark_profile: experimental
+  socnav_missing_prereq_policy: fallback
+- key: scenario_adaptive_hybrid_orca_v1
+  algo: hybrid_rule_local_planner
+  planner_group: experimental
+  algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+  benchmark_profile: experimental
+- key: hybrid_rule_v3_fast_progress_static_escape
+  algo: hybrid_rule_local_planner
+  planner_group: experimental
+  algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+  benchmark_profile: experimental

--- a/tests/baselines/test_ppo_planner.py
+++ b/tests/baselines/test_ppo_planner.py
@@ -440,7 +440,9 @@ def test_issue_791_cpu_baseline_forces_cpu_inference(monkeypatch, tmp_path):
     resolved_model = tmp_path / "model.zip"
     resolved_model.write_text("checkpoint", encoding="utf-8")
 
-    monkeypatch.setattr("robot_sf.baselines.ppo.resolve_model_path", lambda _model_id: resolved_model)
+    monkeypatch.setattr(
+        "robot_sf.baselines.ppo.resolve_model_path", lambda _model_id: resolved_model
+    )
     monkeypatch.setattr(
         "robot_sf.baselines.ppo.PPO",
         SimpleNamespace(load=lambda path, **kwargs: {"path": path, **kwargs}),

--- a/tests/baselines/test_ppo_planner.py
+++ b/tests/baselines/test_ppo_planner.py
@@ -433,6 +433,26 @@ def test_issue_791_portable_baseline_uses_registry_and_auto_device(monkeypatch, 
     assert planner._model["path"] == str(resolved_model)
 
 
+def test_issue_791_cpu_baseline_forces_cpu_inference(monkeypatch, tmp_path):
+    """The issue-1554 CPU-safe baseline must not load PPO or foresight on CUDA."""
+    config_path = Path("configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml")
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    resolved_model = tmp_path / "model.zip"
+    resolved_model.write_text("checkpoint", encoding="utf-8")
+
+    monkeypatch.setattr("robot_sf.baselines.ppo.resolve_model_path", lambda _model_id: resolved_model)
+    monkeypatch.setattr(
+        "robot_sf.baselines.ppo.PPO",
+        SimpleNamespace(load=lambda path, **kwargs: {"path": path, **kwargs}),
+    )
+
+    planner = PPOPlanner(config)
+
+    assert config["device"] == "cpu"
+    assert config["predictive_foresight_device"] == "cpu"
+    assert planner._model["device"] == "cpu"
+
+
 def test_load_model_resolution_failure_falls_back(monkeypatch):
     """Registry resolution failures should trigger fallback_to_goal when enabled."""
     monkeypatch.setattr(

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -1994,7 +1994,7 @@ def test_paper_extended_seed_configs_preserve_v1_matrix_contract() -> None:
 
 
 def test_issue_1554_h500_s20_config_preserves_h500_matrix_contract() -> None:
-    """Issue #1554 S20 config should change only the h500 seed schedule."""
+    """Issue #1554 S20 config preserves h500 matrix except PPO CPU safety."""
     base_cfg = load_campaign_config(
         Path("configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml")
     )
@@ -2010,7 +2010,29 @@ def test_issue_1554_h500_s20_config_preserves_h500_matrix_contract() -> None:
     assert s20_cfg.kinematics_matrix == base_cfg.kinematics_matrix == ("differential_drive",)
     assert s20_cfg.seed_policy.mode == "seed-set"
     assert s20_cfg.seed_policy.seed_set == "paper_eval_s20"
-    assert s20_cfg.planners == base_cfg.planners
+
+    base_planners = {planner.key: planner for planner in base_cfg.planners}
+    s20_planners = {planner.key: planner for planner in s20_cfg.planners}
+    assert set(s20_planners) == set(base_planners)
+    for key, planner in s20_planners.items():
+        if key == "ppo":
+            continue
+        assert planner == base_planners[key]
+
+    assert s20_planners["ppo"].workers_override == base_planners["ppo"].workers_override == 1
+    assert s20_planners["ppo"].algo == base_planners["ppo"].algo == "ppo"
+    assert (
+        s20_planners["ppo"].algo_config_path
+        == Path("configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml").resolve()
+    )
+    ppo_cfg = yaml.safe_load(s20_planners["ppo"].algo_config_path.read_text(encoding="utf-8"))
+    assert (
+        ppo_cfg["model_id"]
+        == "ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417"
+    )
+    assert ppo_cfg["device"] == "cpu"
+    assert ppo_cfg["predictive_foresight_device"] == "cpu"
+    assert ppo_cfg["fallback_to_goal"] is False
     assert _resolved_seed_inventory(_load_campaign_scenarios(s20_cfg)) == list(range(111, 131))
 
 


### PR DESCRIPTION
## Summary
- add a CPU-forced issue-791 PPO baseline config for long paper-matrix reruns
- point the #1554 S20 H500 matrix at that config so repeated PPO loads do not exhaust A30 CUDA memory
- add tests for the CPU-safe baseline and the intentional #1554 matrix difference

## Validation
- uv run pytest tests/benchmark/test_camera_ready_campaign.py::test_issue_1554_h500_s20_config_preserves_h500_matrix_contract tests/baselines/test_ppo_planner.py::test_issue_791_cpu_baseline_forces_cpu_inference tests/baselines/test_ppo_planner.py::test_issue_791_portable_baseline_uses_registry_and_auto_device -q
- uv run --extra training pytest tests/validation/test_preflight_evidence_contract.py tests/validation/test_orca_residual_smoke_evidence_emission_issue_1475.py -q
- uv run --extra training python scripts/validation/preflight_evidence_contract.py orca_residual_smoke --json
- git diff --check

## Runtime plan
- private-ops wrapper now runs the #1475 evidence-contract preflight before expensive smoke work
- follow-up jobs can submit from this branch for #1475 and #1554