### PR TITLE
test: harden why-first report generator edge-case coverage (#3464)

### DIFF
--- a/tests/tools/test_generate_why_first_report.py
+++ b/tests/tools/test_generate_why_first_report.py
@@ -5,10 +5,17 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pytest
+
 from scripts.tools import generate_why_first_report
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+_NON_SUCCESS_STATUSES = ("fallback", "degraded", "failed", "not_available", "skipped")
+_LIMITATION_TEXT = (
+    "fallback/degraded/failed/not-available evidence and must not be counted as benchmark success"
+)
 
 
 def _compact_evidence() -> dict[str, object]:
@@ -130,3 +137,145 @@ def test_cli_dissertation_mode_writes_handoff_fields(tmp_path: Path) -> None:
     assert "## Dissertation-Facing Handoff" in report
     assert "`not_claimed`" in report
     assert "`allowed_wording`" in report
+
+
+def _minimal_evidence() -> dict[str, object]:
+    """Return near-empty evidence to exercise fallback rendering paths."""
+    return {"title": "Minimal report"}
+
+
+# --- Edge-case contract coverage (issue #3464) -------------------------------
+# The why-first report feeds research/dissertation decisions, so malformed or
+# incomplete compact evidence must render explicit "not specified" rows and
+# fail-closed status caveats rather than silently dropping report sections.
+
+
+def test_minimal_evidence_keeps_all_required_sections() -> None:
+    """Near-empty evidence must still render every required section and boundary."""
+    report = generate_why_first_report.generate_report(_minimal_evidence())
+
+    for section in generate_why_first_report.REQUIRED_SECTIONS:
+        assert f"## {section}" in report, f"missing required section: {section}"
+    assert "## Claim Boundary" in report
+    assert generate_why_first_report.CLAIM_BOUNDARY in report
+    # Sections must be explicit about missing inputs, never silently empty.
+    assert "Mechanism activation: not specified in compact evidence." in report
+    assert "No paired comparator was provided." in report
+    assert "No trace evidence reference was provided." in report
+    assert "No alternative explanations were provided." in report
+
+
+def test_malformed_mechanism_activation_renders_explicit_fallback() -> None:
+    """Non-mapping or empty mechanism activation must render an explicit fallback row."""
+    for malformed in ("activated", ["activated"], {}):
+        evidence = {**_minimal_evidence(), "mechanism_activation": malformed}
+        report = generate_why_first_report.generate_report(evidence)
+        assert "Mechanism activation: not specified in compact evidence." in report
+        assert "## Mechanism Activation" in report
+
+
+def test_partial_mechanism_activation_uses_named_unknown_defaults() -> None:
+    """A mapping missing keys must surface explicit unknown markers, not crash."""
+    evidence = {
+        **_minimal_evidence(),
+        "mechanism_activation": {"name": "route_offset_sensitivity"},
+    }
+    report = generate_why_first_report.generate_report(evidence)
+
+    assert "Mechanism: `route_offset_sensitivity`." in report
+    assert "Activation status: `unknown`." in report
+    assert "Evidence: not specified." in report
+
+
+def test_missing_trace_evidence_is_explicit_not_dropped() -> None:
+    """Missing trace-review references must be reported explicitly, never dropped."""
+    report = generate_why_first_report.generate_report(_minimal_evidence())
+
+    assert "## Trace Evidence" in report
+    assert "No trace evidence reference was provided." in report
+
+
+def test_trace_evidence_mapping_form_is_rendered() -> None:
+    """A mapping trace_evidence payload must render keyed references."""
+    evidence = {
+        **_minimal_evidence(),
+        "trace_evidence": {"trace_review": "docs/context/evidence/fixture/trace.json"},
+    }
+    report = generate_why_first_report.generate_report(evidence)
+
+    assert "trace_review: docs/context/evidence/fixture/trace.json." in report
+
+
+@pytest.mark.parametrize("status", _NON_SUCCESS_STATUSES)
+def test_non_success_statuses_emit_limitation_caveat(status: str) -> None:
+    """Every non-success execution status must emit the fail-closed limitation row."""
+    evidence = {**_minimal_evidence(), "execution_status": status}
+    report = generate_why_first_report.generate_report(evidence)
+
+    assert "- Limitation: this row is " + _LIMITATION_TEXT + "." in report
+    assert f"Execution status: `{status}`." in report
+
+
+@pytest.mark.parametrize("status", ("success", "completed", "native"))
+def test_success_statuses_do_not_emit_limitation_caveat(status: str) -> None:
+    """Success-style statuses must not be flagged as fallback/degraded evidence."""
+    evidence = {**_minimal_evidence(), "execution_status": status}
+    report = generate_why_first_report.generate_report(evidence)
+
+    assert "- Limitation: this row is " not in report
+    assert f"Execution status: `{status}`." in report
+
+
+def test_uppercase_status_is_normalized_before_caveat_check() -> None:
+    """Status comparison must be case-insensitive so caveats are not silently skipped."""
+    evidence = {**_minimal_evidence(), "execution_status": "FALLBACK"}
+    report = generate_why_first_report.generate_report(evidence)
+
+    assert "- Limitation: this row is " + _LIMITATION_TEXT + "." in report
+
+
+def test_readiness_status_used_when_execution_status_absent() -> None:
+    """The caveat must still fire when only readiness_status carries the flag."""
+    evidence = {**_minimal_evidence(), "readiness_status": "degraded"}
+    report = generate_why_first_report.generate_report(evidence)
+
+    assert "- Limitation: this row is " + _LIMITATION_TEXT + "." in report
+    assert "Execution status: `degraded`." in report
+
+
+def test_actuation_failure_label_from_string_classification() -> None:
+    """A bare-string failure mechanism (e.g. actuation failure) must classify cleanly."""
+    evidence = {**_minimal_evidence(), "failure_mechanism": "actuation_command_failure"}
+    report = generate_why_first_report.generate_report(evidence)
+
+    assert "Classification: `actuation_command_failure`." in report
+    assert "Rationale: not specified." in report
+
+
+def test_dissertation_handoff_declares_no_fallback_when_status_clean() -> None:
+    """Dissertation handoff must state plainly when no fallback flag was declared."""
+    evidence = {**_minimal_evidence(), "execution_status": "success"}
+    report = generate_why_first_report.generate_report(evidence, mode="dissertation")
+
+    assert "no fallback/degraded status was declared in the compact evidence" in report
+    assert "## Dissertation-Facing Handoff" in report
+
+
+def test_load_evidence_rejects_non_object_payload(tmp_path: Path) -> None:
+    """Fail-closed: a non-object JSON payload must raise WhyFirstReportError."""
+    input_path = tmp_path / "evidence.json"
+    input_path.write_text(json.dumps(["not", "an", "object"]), encoding="utf-8")
+
+    with pytest.raises(generate_why_first_report.WhyFirstReportError):
+        generate_why_first_report.load_evidence(input_path)
+
+
+def test_generate_report_rejects_unsupported_mode() -> None:
+    """Fail-closed: an unknown render mode must raise rather than emit a partial report."""
+    with pytest.raises(generate_why_first_report.WhyFirstReportError):
+        generate_why_first_report.generate_report(_minimal_evidence(), mode="unsupported")
+
+
+def test_non_success_status_fixture_tracks_generator_constant() -> None:
+    """Guard against drift: the covered statuses must match the generator's source set."""
+    assert set(_NON_SUCCESS_STATUSES) == generate_why_first_report._NON_SUCCESS_STATUSES


### PR DESCRIPTION
## Summary

Closes #3464.

Hardens edge-case coverage for the why-first benchmark report generator
(`scripts/tools/generate_why_first_report.py`). The literal skipped tests the
issue referenced (added with PR #2510) had drifted out of the suite, so per the
issue's own contingency ("if no skipped tests remain... replace the coverage
with deterministic fixtures") this converts the missing coverage into active,
deterministic contract tests.

## What changed

Test-only change in `tests/tools/test_generate_why_first_report.py` (+149 lines,
19 new tests; 4 → 24 total). New contracts:

- **Malformed mechanism activation**: non-mapping, empty, and partial payloads
  render explicit `not specified` / named-`unknown` rows instead of crashing or
  dropping the section.
- **Missing trace-review references**: stay explicit ("No trace evidence
  reference was provided."), never silently dropped; mapping-form traces render.
- **Fallback/degraded status flags**: every member of the generator's
  non-success status set (`fallback`, `degraded`, `failed`, `not_available`,
  `skipped`) emits the fail-closed limitation caveat — case-insensitively and
  via the `readiness_status` fallback — while success-style statuses do not.
- **Actuation-failure labels**: bare-string `failure_mechanism` classifications
  render cleanly.
- **Fail-closed inputs**: non-object JSON payloads and unsupported render modes
  raise `WhyFirstReportError`.
- **Drift guard**: a test couples the covered status set to the generator's
  source constant so future edits to the status set can't silently desync.

## Definition of Done

- [x] Current skipped/TODO coverage audited — no literal `@pytest.mark.skip`
      remained; coverage replaced with active deterministic tests.
- [x] Malformed mechanism activation, missing trace references, and
      actuation-label edge cases covered.
- [x] Fail-closed behavior (status caveats, raised errors) documented in the
      test docstrings/contract assertions.
- [x] Targeted tests pass.

## Validation

```
uv run pytest tests/tools/test_generate_why_first_report.py -q   # 24 passed
uv run ruff format / ruff check tests/tools/test_generate_why_first_report.py  # clean
```

**Evidence grade:** smoke evidence (test-only; no production behavior changed,
no benchmark/metric/semantic surface touched). **Confidence:** High for branch
head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved report generation reliability for edge cases with incomplete or malformed evidence.
  * Reports now consistently show required sections and clear fallback rows instead of omitting content when data is missing.
  * Added stronger fail-closed handling for non-success statuses and unsupported inputs, with clearer limitation messaging where applicable.
  * Ensured clean-status reports do not incorrectly show fallback caveats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->