### PR TITLE
ci: enforce the broad-exception ratchet in lint + pr_ready gates (#3478)

### DIFF
--- a/scripts/dev/ci_driver.sh
+++ b/scripts/dev/ci_driver.sh
@@ -8,7 +8,7 @@ Usage: scripts/dev/ci_driver.sh [--list-phases] <phase> [<phase> ...]
 Run one or more canonical CI validation phases.
 
 Phases:
-  lint             Ruff lint + format check
+  lint             Ruff lint + format check + broad-exception ratchet
   typecheck        Ty type check (advisory; reports findings but exits zero)
   test             Main pytest suite, excluding example smoke tests
   examples-smoke   Example script smoke tests
@@ -222,6 +222,9 @@ run_phase() {
     lint)
       uv run ruff check .
       uv run ruff format --check .
+      # Ratchet: fail if broad (Exception/BaseException/bare) catches increase on
+      # benchmark/script surfaces beyond the approved baseline (issue #3478).
+      uv run python scripts/validation/check_broad_exceptions.py
       ;;
     typecheck)
       echo "Running ty in advisory mode (--exit-zero); findings are reported but do not fail this phase."

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -213,6 +213,7 @@ fi
 "$SCRIPT_DIR/check_changed_coverage.sh"
 "$SCRIPT_DIR/check_docstring_todos_diff.sh"
 "$SCRIPT_DIR/check_docstring_todos_ratchet.sh"
+uv run python "$SCRIPT_DIR/../validation/check_broad_exceptions.py"
 
 freshness_args=(write --base-ref "$BASE_REF")
 if [[ "$pr_ready_final" == "1" ]]; then

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -94,6 +94,14 @@ def _make_fake_scripts(repo: Path) -> None:
         else:
             stub.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
             stub.chmod(0o755)
+    # pr_ready_check.sh also invokes scripts/validation/check_broad_exceptions.py,
+    # which lives outside scripts/dev/; stub it so the preflight lane reaches the
+    # post-preflight scripts without a missing-file error.
+    validation_dir = repo / "scripts" / "validation"
+    validation_dir.mkdir(parents=True, exist_ok=True)
+    (validation_dir / "check_broad_exceptions.py").write_text(
+        "import sys\nsys.exit(0)\n", encoding="utf-8"
+    )
 
 
 def _write_lane_logging_stub(repo: Path) -> Path:

--- a/tests/validation/test_check_broad_exceptions.py
+++ b/tests/validation/test_check_broad_exceptions.py
@@ -160,3 +160,19 @@ def test_broad_exception_ratchet_fails_on_unapproved_replacement(tmp_path: Path)
     assert "Broad exception count increased" not in result.stderr
     assert "Unapproved broad exception handlers were added:" in result.stderr
     assert "scripts/demo/tool.py:4: except Exception:" in result.stderr
+
+
+def test_ratchet_is_wired_into_ci_lint_phase() -> None:
+    """The CI lint phase must invoke the ratchet so it is actually enforced (issue #3478)."""
+    ci_driver = (ROOT / "scripts" / "dev" / "ci_driver.sh").read_text(encoding="utf-8")
+    assert "check_broad_exceptions.py" in ci_driver, (
+        "broad-exception ratchet is not invoked by ci_driver.sh; the guard would be dead"
+    )
+
+
+def test_ratchet_is_wired_into_pr_ready_check() -> None:
+    """The local PR-readiness gate must also invoke the ratchet (issue #3478)."""
+    pr_ready = (ROOT / "scripts" / "dev" / "pr_ready_check.sh").read_text(encoding="utf-8")
+    assert "check_broad_exceptions.py" in pr_ready, (
+        "broad-exception ratchet is not invoked by pr_ready_check.sh; local enforcement is missing"
+    )


### PR DESCRIPTION
## Summary

Incremental progress on #3478.

The broad-exception inventory ratchet (`scripts/validation/check_broad_exceptions.py`
+ `broad_exception_baseline.json`, with tests) already existed, but was **wired into
nothing** — neither CI, `pr_ready_check.sh`, nor pre-commit ran it. A guard that is
never executed cannot prevent regressions, so new broad `except Exception` /
`BaseException` / bare catches could still land on the ratcheted benchmark/script
surfaces unnoticed.

This PR **activates** the existing guard — the issue's core scope item *"Add a ratchet
preventing the broad-catch count from increasing"* — with **no change to any benchmark
exception semantics**.

## What changed

- **`ci_driver.sh` `lint` phase** runs the ratchet after ruff (covers the CI **Lint**
  step); `--list-phases`/help text updated.
- **`pr_ready_check.sh`** runs the ratchet beside the existing
  `check_docstring_todos_ratchet.sh` (covers the local PR-readiness gate).
- **Two guard tests** assert the ratchet stays wired into both entry points, so the
  enforcement can't be silently un-wired later.

## Scope boundary

Per the issue's explicit guidance (*"Out of scope: rewriting every exception boundary
in one PR if the baseline is large"*), the **285 existing catches are not modified**.
Reducing the baseline — prioritizing `robot_sf/benchmark/` result paths where a
swallowed exception could change evidence classification (e.g. `runner.py`,
`aggregate.py`, `failure_extractor.py`) — is left to follow-up incremental PRs, which
the now-active ratchet will support via downward `--write-baseline` refreshes.

## Validation

```
uv run pytest tests/validation/test_check_broad_exceptions.py -q   # 5 passed (3 existing + 2 wiring guards)
scripts/dev/ci_driver.sh lint                                       # passes; "Broad exception ratchet passed with 285 entries."
uv run ruff check (touched test) ; bash -n on both shell scripts    # clean
```

The ratchet passes at the current 285-entry baseline, so enabling enforcement does
**not** break `main`.

**Evidence grade:** smoke evidence (CI-wiring + guard tests; no runtime/benchmark
behavior changed). **Confidence:** High for branch head.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an extra validation check to the lint workflow to catch broad exceptions earlier.
  * PR readiness checks now include the same validation, keeping local checks aligned with CI.
* **Tests**
  * Added coverage to ensure the new validation step is wired into both CI and pre-merge checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->