### PR TITLE
refactor: narrow broad catches in benchmark failure_extractor result path (#3478)

### DIFF
--- a/robot_sf/benchmark/failure_extractor.py
+++ b/robot_sf/benchmark/failure_extractor.py
@@ -30,7 +30,10 @@ def _metric(rec: dict[str, Any], name: str, default: float = 0.0) -> float:
     v = m.get(name, default)
     try:
         return float(v)
-    except Exception:
+    except (TypeError, ValueError):
+        # JSON metric values are scalars/containers; only non-numeric coercion
+        # raises here. Narrow the catch so unrelated programming errors are not
+        # swallowed and silently misclassify the episode.
         return float(default)
 
 
@@ -65,7 +68,9 @@ def is_failure(
             try:
                 if float(m["snqi"]) < float(snqi_below):
                     return True
-            except Exception:
+            except (TypeError, ValueError):
+                # A non-numeric snqi value cannot be compared; treat as
+                # "criterion not met" rather than swallowing other errors.
                 pass
     return False
 

--- a/scripts/validation/broad_exception_baseline.json
+++ b/scripts/validation/broad_exception_baseline.json
@@ -7,7 +7,6 @@
       "robot_sf/benchmark/camera_ready_campaign.py": 3,
       "robot_sf/benchmark/cli.py": 47,
       "robot_sf/benchmark/doctor.py": 1,
-      "robot_sf/benchmark/failure_extractor.py": 2,
       "robot_sf/benchmark/figure_qa.py": 2,
       "robot_sf/benchmark/freeze_manifest.py": 1,
       "robot_sf/benchmark/full_classic/orchestrator.py": 11,
@@ -124,7 +123,7 @@
       "scripts/validation/verify_maps.py": 1,
       "scripts/validation/verify_sf_implementation.py": 4
     },
-    "total": 285
+    "total": 283
   },
   "description": "Broad exception handler baseline for benchmark/script surfaces. Run scripts/validation/check_broad_exceptions.py --write-baseline to refresh after intentionally removing or approving entries.",
   "entries": [
@@ -625,24 +624,6 @@
     },
     {
       "col_offset": 4,
-      "context": "_metric",
-      "fingerprint": "bf8688976ab60cac",
-      "handler": "Exception",
-      "lineno": 33,
-      "path": "robot_sf/benchmark/failure_extractor.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 12,
-      "context": "is_failure",
-      "fingerprint": "e02f5a0c6261599d",
-      "handler": "Exception",
-      "lineno": 68,
-      "path": "robot_sf/benchmark/failure_extractor.py",
-      "source": "except Exception:"
-    },
-    {
-      "col_offset": 4,
       "context": "_check_image_content",
       "fingerprint": "c007497d97e35eac",
       "handler": "Exception",
@@ -979,7 +960,7 @@
       "context": "_preflight_policy",
       "fingerprint": "9d6addfc4094f787",
       "handler": "Exception",
-      "lineno": 674,
+      "lineno": 682,
       "path": "robot_sf/benchmark/map_runner.py",
       "source": "except Exception as exc:"
     },
@@ -988,7 +969,7 @@
       "context": "_preflight_policy",
       "fingerprint": "3f6860893c2f6ced",
       "handler": "Exception",
-      "lineno": 704,
+      "lineno": 712,
       "path": "robot_sf/benchmark/map_runner.py",
       "source": "except Exception as fallback_exc:"
     },
@@ -1384,7 +1365,7 @@
       "context": "_scan_json_file",
       "fingerprint": "9b8a4af46905cca8",
       "handler": "Exception",
-      "lineno": 491,
+      "lineno": 532,
       "path": "scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py",
       "source": "except Exception:"
     },
@@ -1393,7 +1374,7 @@
       "context": "_scan_single_directory",
       "fingerprint": "b9636cf3e1bafb9d",
       "handler": "Exception",
-      "lineno": 541,
+      "lineno": 582,
       "path": "scripts/analysis/build_signalized_crossing_failure_pack_issue_2754.py",
       "source": "except Exception as e:"
     },

--- a/tests/test_failure_extractor.py
+++ b/tests/test_failure_extractor.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from robot_sf.benchmark.failure_extractor import extract_failures, is_failure
+import pytest
+
+from robot_sf.benchmark.failure_extractor import _metric, extract_failures, is_failure
 
 
 def _rec(ep: str, **metrics):
@@ -34,3 +36,30 @@ def test_extract_failures_max_count():
     ]
     out = extract_failures(recs, snqi_below=0.2, max_count=2)
     assert len(out) == 2
+
+
+@pytest.mark.parametrize("bad_value", [None, "not-a-number", [1, 2], {"x": 1}, "", "nan!"])
+def test_metric_coercion_falls_back_on_non_numeric(bad_value: object) -> None:
+    """Non-numeric JSON metric values must fall back to the default, not raise.
+
+    The handler was narrowed from a broad ``except Exception`` to
+    ``(TypeError, ValueError)`` (issue #3478); this confirms every realistic
+    bad-input shape from JSON still resolves to the numeric default so the
+    episode is not silently misclassified.
+    """
+    rec = {"metrics": {"collisions": bad_value}}
+    assert _metric(rec, "collisions", 7.0) == 7.0
+
+
+def test_metric_coercion_preserves_valid_numbers() -> None:
+    """Valid numeric and numeric-string metrics must still coerce unchanged."""
+    assert _metric({"metrics": {"collisions": 3}}, "collisions") == 3.0
+    assert _metric({"metrics": {"collisions": "2.5"}}, "collisions") == 2.5
+    assert _metric({"metrics": {}}, "collisions", 1.5) == 1.5
+
+
+def test_is_failure_ignores_non_numeric_snqi() -> None:
+    """A non-numeric snqi must be treated as "criterion not met", not an error."""
+    assert not is_failure({"metrics": {"snqi": "unavailable"}}, snqi_below=0.5)
+    # A valid snqi below the threshold still triggers failure.
+    assert is_failure({"metrics": {"snqi": 0.1}}, snqi_below=0.5)


### PR DESCRIPTION
## Summary

Incremental baseline reduction on #3478, building on the now-enforced ratchet (#3577).

Narrows the two broad `except Exception` catches in `robot_sf/benchmark/failure_extractor.py`
— a **benchmark result path** where a swallowed exception can silently change an
episode's failure classification (the surface #3478 prioritizes).

## Why this is safe

`_metric` and `is_failure` wrap `float()` coercion of metric values. Those values
come from JSON (scalars/containers), and `float()` on such inputs can only raise
`TypeError`/`ValueError`. Narrowing `except Exception` → `except (TypeError, ValueError)`
is therefore **behavior-preserving for every realistic input**, while it stops
masking unrelated programming errors that would otherwise misclassify an episode.

## Changes

- `failure_extractor.py`: both catches narrowed to `(TypeError, ValueError)` with
  explanatory comments.
- `tests/test_failure_extractor.py`: added coercion tests over
  `None / "not-a-number" / [1,2] / {…} / "" / "nan!"` and a non-numeric `snqi`,
  plus valid-number preservation.
- `broad_exception_baseline.json`: ratcheted **285 → 283** via the sanctioned
  `--write-baseline`. Besides removing the two narrowed entries this also refreshes
  a few stale line numbers for entries whose files shifted on `main`; the
  ratchet fingerprints (path/handler/context/source) are unchanged, so ratchet
  behavior is identical.

## Scope boundary

This is one bounded increment; the remaining ~283 catches are left to further
incremental PRs per the issue's "don't rewrite every boundary in one PR" guidance.

## Validation

```
uv run pytest tests/test_failure_extractor.py tests/test_cli_extract_failures.py \
              tests/adversarial/test_manifest_quality_metrics.py -q   # all pass
uv run python scripts/validation/check_broad_exceptions.py            # passes at 283
ruff check / format on touched files                                  # clean
```

**Evidence grade:** smoke evidence (behavior-preserving narrowing + new coercion
tests; no metric semantics or classification thresholds changed). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
