### PR TITLE
feat(tools): add recipe inventory mode to benchmark SQL recipe runner (#3467)

### DIFF
--- a/scripts/tools/run_benchmark_sql_recipe.py
+++ b/scripts/tools/run_benchmark_sql_recipe.py
@@ -15,6 +15,7 @@ import duckdb
 import yaml
 
 RECIPE_SCHEMA_VERSION = "benchmark_sql_recipes.v1"
+RECIPE_INVENTORY_SCHEMA = "benchmark_sql_recipe_inventory.v1"
 DEFAULT_RECIPE_ROOT = Path(__file__).with_name("benchmark_sql_recipes")
 TABLE_FILENAMES = {
     "episodes": "episodes.parquet",
@@ -95,6 +96,40 @@ def load_recipe_manifest(recipe_root: Path = DEFAULT_RECIPE_ROOT) -> RecipeManif
     return RecipeManifest(schema_version=schema_version, recipes=recipes)
 
 
+def inventory_recipes(recipe_root: Path = DEFAULT_RECIPE_ROOT) -> dict[str, Any]:
+    """Return a machine-readable inventory of recipe entry points and their schema contract.
+
+    This makes the versioned recipe/schema contract discoverable and auditable without
+    executing any SQL, so schema drift can be reviewed against the declared inputs and
+    outputs of every recipe.
+
+    Returns:
+        dict[str, Any]: Inventory payload tagged with ``RECIPE_INVENTORY_SCHEMA``.
+    """
+
+    manifest = load_recipe_manifest(recipe_root)
+    return {
+        "schema": RECIPE_INVENTORY_SCHEMA,
+        "recipe_schema_version": manifest.schema_version,
+        "recipe_root": recipe_root.as_posix(),
+        "recipe_count": len(manifest.recipes),
+        "recipes": [
+            {
+                "recipe_id": recipe.recipe_id,
+                "title": recipe.title,
+                "sql_file": recipe.sql_file.as_posix(),
+                "required_tables": list(recipe.required_tables),
+                "required_columns": {
+                    table: list(columns) for table, columns in recipe.required_columns.items()
+                },
+                "output_columns": list(recipe.output_columns),
+                "caveats": list(recipe.caveats),
+            }
+            for recipe in manifest.recipes
+        ],
+    }
+
+
 def run_recipe(
     recipe_id: str,
     *,
@@ -144,12 +179,22 @@ def build_arg_parser() -> argparse.ArgumentParser:
     """Build the recipe runner argument parser."""
 
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--recipe", required=True, help="Stable recipe ID to run.")
+    parser.add_argument(
+        "--recipe",
+        default=None,
+        help="Stable recipe ID to run. Required unless --list is given.",
+    )
+    parser.add_argument(
+        "--list",
+        action="store_true",
+        dest="list_recipes",
+        help="Inventory available recipes and their schema contract as JSON, then exit.",
+    )
     parser.add_argument(
         "--export-dir",
         type=Path,
-        required=True,
-        help="Directory containing benchmark Parquet export tables.",
+        default=None,
+        help="Directory containing benchmark Parquet export tables. Required unless --list.",
     )
     parser.add_argument("--output-csv", type=Path, default=None, help="Optional CSV output path.")
     parser.add_argument(
@@ -172,6 +217,17 @@ def main(argv: list[str] | None = None) -> int:
     """Run one SQL recipe and return a shell-friendly exit code."""
 
     args = build_arg_parser().parse_args(argv)
+    if args.list_recipes:
+        try:
+            inventory = inventory_recipes(args.recipe_root)
+        except RecipeValidationError as exc:
+            sys.stderr.write(f"{exc}\n")
+            return 2
+        sys.stdout.write(json.dumps(inventory, indent=2, sort_keys=True) + "\n")
+        return 0
+    if args.recipe is None or args.export_dir is None:
+        sys.stderr.write("--recipe and --export-dir are required unless --list is given\n")
+        return 2
     try:
         result = run_recipe(
             args.recipe,

--- a/tests/tools/test_run_benchmark_sql_recipe.py
+++ b/tests/tools/test_run_benchmark_sql_recipe.py
@@ -11,7 +11,9 @@ import pytest
 
 from robot_sf.benchmark.parquet_export import export_episodes_jsonl_to_parquet
 from scripts.tools.run_benchmark_sql_recipe import (
+    RECIPE_INVENTORY_SCHEMA,
     RecipeValidationError,
+    inventory_recipes,
     load_recipe_manifest,
     main,
     run_recipe,
@@ -363,3 +365,43 @@ def test_markdown_float_cells_use_compact_fixed_precision(tmp_path: Path) -> Non
     )
 
     assert "0.5000" in md_path.read_text(encoding="utf-8")
+
+
+def test_inventory_recipes_exposes_full_schema_contract() -> None:
+    """The inventory must expose every recipe's declared schema contract (issue #3467)."""
+    manifest = load_recipe_manifest()
+    inventory = inventory_recipes()
+
+    assert inventory["schema"] == RECIPE_INVENTORY_SCHEMA
+    assert inventory["recipe_schema_version"] == manifest.schema_version
+    assert inventory["recipe_count"] == len(manifest.recipes)
+
+    inventoried = {entry["recipe_id"]: entry for entry in inventory["recipes"]}
+    assert inventoried.keys() == {recipe.recipe_id for recipe in manifest.recipes}
+    for recipe in manifest.recipes:
+        entry = inventoried[recipe.recipe_id]
+        assert entry["title"] == recipe.title
+        assert entry["required_tables"] == list(recipe.required_tables)
+        assert entry["output_columns"] == list(recipe.output_columns)
+        assert entry["required_columns"] == {
+            table: list(columns) for table, columns in recipe.required_columns.items()
+        }
+
+
+def test_cli_list_emits_recipe_inventory_json(capsys) -> None:
+    """`--list` must emit a parseable inventory and skip execution (no --export-dir needed)."""
+    exit_code = main(["--list"])
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema"] == RECIPE_INVENTORY_SCHEMA
+    assert payload["recipe_count"] == len(payload["recipes"])
+    assert any(entry["recipe_id"] == "planner_outcome_summary" for entry in payload["recipes"])
+
+
+def test_cli_requires_recipe_or_list(capsys) -> None:
+    """Omitting both --recipe and --list must fail closed with an actionable message."""
+    exit_code = main([])
+
+    assert exit_code == 2
+    assert "--recipe and --export-dir are required" in capsys.readouterr().err


### PR DESCRIPTION
## Summary

Incremental progress on #3467.

The benchmark SQL recipe runner (`scripts/tools/run_benchmark_sql_recipe.py`) is
**already** versioned (`benchmark_sql_recipes.v1`), typed (frozen dataclasses),
fail-closed (`RecipeValidationError`), and validates schema drift on required
tables/columns and declared output columns — with existing regression tests for
missing columns, malformed manifests, and SQL execution errors. So most of the
issue's "versioned, schema-aware recipe layer" intent is satisfied by prior
hardening.

The one unmet **Definition of Done** item — *"Current SQL recipe entry points and
schemas are inventoried"* — is closed here without touching execution semantics.

## What changed

- **`inventory_recipes()`** returns a machine-readable payload tagged
  `benchmark_sql_recipe_inventory.v1` exposing each recipe's `recipe_id`, `title`,
  `sql_file`, `required_tables`, `required_columns`, `output_columns`, and
  `caveats` — the full declared schema contract, computed without executing SQL.
- **`--list` CLI flag** emits that inventory as JSON and exits. `--recipe` and
  `--export-dir` become optional and fail closed with an actionable message when
  neither a recipe nor `--list` is provided.
- **Tests** cover the inventory contract vs. the manifest, the `--list` CLI path,
  and the recipe-or-list requirement.

## Scope boundary

Read-only, additive. No change to `run_recipe`, recipe SQL, or outputs; existing
fixtures and the broad-exception ratchet are unaffected. Heavier migration of the
recipe representation (e.g. SQLAlchemy Core) remains out of scope per the issue's
"don't rewrite the full analytics stack in one pass" guidance.

## Validation

```
uv run pytest tests/tools/test_run_benchmark_sql_recipe.py -q            # 16 passed (13 existing + 3 new)
uv run python scripts/tools/run_benchmark_sql_recipe.py --list           # emits benchmark_sql_recipe_inventory.v1 JSON
uv run python scripts/validation/check_broad_exceptions.py               # passes at 285 (no new broad catches)
ruff check / format on touched files                                     # clean
```

**Evidence grade:** smoke evidence (additive read-only capability + tests; no
metric/recipe semantics changed). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
