### PR TITLE
feat(robot): internal-proxy rollover stability margin, diagnostic-only (#3479)

### DIFF
--- a/docs/context/issue_3479_rollover_proxy.md
+++ b/docs/context/issue_3479_rollover_proxy.md
@@ -1,0 +1,55 @@
+# Issue #3479 — Internal-proxy rollover stability margin (diagnostic-only)
+
+**Status:** diagnostic / internal-proxy. **Evidence grade:** idea-level proxy, not
+hardware-calibrated and not paper-facing. **Governance:** honors the #2416 / #2417
+gate — blocked from hardware-calibrated AMV profiles or AMV safety claims until
+real-source provenance (#1585 / #2000) is accepted.
+
+## What this is
+
+`robot_sf/robot/rollover_proxy.py` implements the closed-form lateral-stability
+("dynamic rollover") proxy proposed in issue #3479, so a narrow-track three-wheeled
+platform's tip-over risk — invisible to planar bicycle / differential-drive /
+holonomic models — can be surfaced as a per-step signal.
+
+## Model (`rollover_proxy.v1`)
+
+- lateral acceleration `a_y ≈ v · ω`
+- critical lateral acceleration `a_y,crit = g · (t_w / (2 · h_c)) · (a / L)`
+- stability margin `= clamp(1 − |a_y| / a_y,crit, 0, 1)` (1 = stable, 0 = at/over the
+  proxy tip-over threshold)
+- `ROLLOVER_CRITICAL` when the margin reaches 0.
+
+### Versioned proxy geometry (`RolloverProxyParams`, non-hardware)
+
+| symbol | field | default (m) | meaning |
+| --- | --- | --- | --- |
+| `t_w` | `track_width_m` | 0.50 | lateral wheel track |
+| `h_c` | `cog_height_m` | 0.40 | centre-of-gravity height |
+| `a` | `front_axle_to_cog_m` | 0.30 | front axle → CoG |
+| `L` | `wheelbase_m` | 0.60 | wheelbase |
+| `g` | `gravity_m_s2` | 9.81 | gravity |
+
+These defaults exist only so the proxy is exercisable; they carry **no hardware
+authority**. For the defaults, `a_y,crit ≈ 3.07 m/s²`.
+
+## Scope boundary
+
+This increment is **diagnostic-only and side-effect free**: it computes the margin,
+the `ROLLOVER_CRITICAL` classifier, and a schema-tagged telemetry record, and changes
+**no** planner, training, or benchmark behavior. Wiring the terminal flag + an opt-in
+reward penalty into the stepping loop (and any benchmark comparison) is a deliberate
+follow-up so existing runs are not silently altered.
+
+## Tests
+
+`tests/test_rollover_proxy.py` proves a feasible command stays stable, an over-yaw
+command trips `ROLLOVER_CRITICAL`, the margin is clamped/monotonic/sign-independent,
+non-physical geometry fails closed, and telemetry is schema-tagged and labelled
+`internal_non_hardware`.
+
+## Related
+
+- #3466 — three-wheeled tip-over feasibility on the *benchmark-artifact* surface.
+- #2416 / #2417 — AMV governance gates (blocking hardware-calibrated profiles).
+- #1585 / #2000 — real-source provenance that would unblock hardware-facing claims.

--- a/robot_sf/robot/rollover_proxy.py
+++ b/robot_sf/robot/rollover_proxy.py
@@ -1,0 +1,159 @@
+"""Internal-proxy lateral-stability (rollover) margin for narrow-track platforms.
+
+Planar bicycle / differential-drive / holonomic models mask the *dynamic rollover*
+risk of an asymmetric (triangular-support) narrow-track three-wheeled platform: a
+maneuver certified "safe" under kinematics may demand a yaw rate that tips such a
+platform. This module provides the closed-form proxy from issue #3479 so a
+stability-margin signal and a ``ROLLOVER_CRITICAL`` classifier can be surfaced as
+telemetry.
+
+.. warning::
+
+   **Internal proxy only — governance gate #2416 / #2417.** The geometry parameters
+   here are explicit, documented, *non-hardware* proxy assumptions. They are NOT a
+   hardware-calibrated AMV profile and must NOT be read as validated tip-over limits
+   or used for paper-facing AMV safety claims. Those remain blocked until real-source
+   provenance (#1585 / #2000) is accepted.
+
+Model (issue #3479):
+
+- lateral acceleration ``a_y ≈ v · ω``
+- critical lateral acceleration ``a_y,crit = g · (t_w / (2 · h_c)) · (a / L)``
+- stability margin ``= clamp(1 − |a_y| / a_y,crit, 0, 1)`` (1 = fully stable,
+  0 = at/over the proxy tip-over threshold)
+
+This module is pure and side-effect free; it does not alter planner, training, or
+benchmark behavior. Wiring a terminal flag and reward penalty into the stepping
+loop is intentionally a separate, opt-in follow-up.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+GRAVITY_M_S2 = 9.81
+PROXY_SCHEMA_VERSION = "rollover_proxy.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class RolloverProxyParams:
+    """Versioned, documented **non-hardware** geometry for the rollover proxy.
+
+    Every value is an explicit internal-proxy assumption, not a measured hardware
+    parameter (governance gate #2416 / #2417). Defaults describe a small, narrow-track
+    three-wheeled platform purely so the proxy is exercisable; they carry no hardware
+    authority.
+
+    Attributes:
+        track_width_m: Lateral wheel track ``t_w`` (m).
+        cog_height_m: Centre-of-gravity height ``h_c`` (m).
+        front_axle_to_cog_m: Longitudinal distance from front axle to CoG ``a`` (m).
+        wheelbase_m: Wheelbase ``L`` (m).
+        gravity_m_s2: Gravitational acceleration ``g`` (m/s^2).
+        schema_version: Stable schema tag for reproducibility.
+    """
+
+    track_width_m: float = 0.50
+    cog_height_m: float = 0.40
+    front_axle_to_cog_m: float = 0.30
+    wheelbase_m: float = 0.60
+    gravity_m_s2: float = GRAVITY_M_S2
+    schema_version: str = PROXY_SCHEMA_VERSION
+
+    def __post_init__(self) -> None:
+        """Validate that the proxy geometry is physically usable."""
+        positive = {
+            "track_width_m": self.track_width_m,
+            "cog_height_m": self.cog_height_m,
+            "front_axle_to_cog_m": self.front_axle_to_cog_m,
+            "wheelbase_m": self.wheelbase_m,
+            "gravity_m_s2": self.gravity_m_s2,
+        }
+        for name, value in positive.items():
+            if not (value > 0.0):
+                raise ValueError(f"RolloverProxyParams.{name} must be > 0, got {value!r}")
+        if self.front_axle_to_cog_m > self.wheelbase_m:
+            raise ValueError(
+                "front_axle_to_cog_m must not exceed wheelbase_m "
+                f"({self.front_axle_to_cog_m} > {self.wheelbase_m})"
+            )
+
+
+def lateral_acceleration(linear_velocity: float, yaw_rate: float) -> float:
+    """Return the proxy lateral acceleration ``a_y ≈ v · ω`` (m/s^2)."""
+    return float(linear_velocity) * float(yaw_rate)
+
+
+def critical_lateral_acceleration(params: RolloverProxyParams) -> float:
+    """Return the proxy critical lateral acceleration ``a_y,crit`` (m/s^2)."""
+    return (
+        params.gravity_m_s2
+        * (params.track_width_m / (2.0 * params.cog_height_m))
+        * (params.front_axle_to_cog_m / params.wheelbase_m)
+    )
+
+
+def stability_margin(
+    linear_velocity: float,
+    yaw_rate: float,
+    params: RolloverProxyParams | None = None,
+) -> float:
+    """Return the rollover stability margin in ``[0, 1]``.
+
+    ``1`` means fully within the proxy tip-over threshold; ``0`` means the demanded
+    lateral acceleration meets or exceeds the critical value.
+
+    Returns:
+        float: ``clamp(1 − |a_y| / a_y,crit, 0, 1)``.
+    """
+    params = params or RolloverProxyParams()
+    a_y = abs(lateral_acceleration(linear_velocity, yaw_rate))
+    a_y_crit = critical_lateral_acceleration(params)
+    margin = 1.0 - (a_y / a_y_crit)
+    return max(0.0, min(1.0, margin))
+
+
+def is_rollover_critical(margin: float) -> bool:
+    """Return whether a stability margin indicates a ``ROLLOVER_CRITICAL`` condition."""
+    return margin <= 0.0
+
+
+def rollover_proxy_telemetry(
+    linear_velocity: float,
+    yaw_rate: float,
+    params: RolloverProxyParams | None = None,
+) -> dict[str, Any]:
+    """Return a compact, schema-tagged telemetry record for one step.
+
+    This is diagnostic only: it reports the proxy signals without altering behavior.
+
+    Returns:
+        dict[str, Any]: Margin, lateral accelerations, critical flag, and provenance.
+    """
+    params = params or RolloverProxyParams()
+    a_y = lateral_acceleration(linear_velocity, yaw_rate)
+    a_y_crit = critical_lateral_acceleration(params)
+    margin = stability_margin(linear_velocity, yaw_rate, params)
+    return {
+        "schema_version": params.schema_version,
+        "proxy_kind": "internal_non_hardware",
+        "linear_velocity": float(linear_velocity),
+        "yaw_rate": float(yaw_rate),
+        "lateral_acceleration": a_y,
+        "critical_lateral_acceleration": a_y_crit,
+        "stability_margin": margin,
+        "rollover_critical": is_rollover_critical(margin),
+    }
+
+
+__all__ = [
+    "GRAVITY_M_S2",
+    "PROXY_SCHEMA_VERSION",
+    "RolloverProxyParams",
+    "critical_lateral_acceleration",
+    "is_rollover_critical",
+    "lateral_acceleration",
+    "rollover_proxy_telemetry",
+    "stability_margin",
+]

--- a/tests/test_rollover_proxy.py
+++ b/tests/test_rollover_proxy.py
@@ -1,0 +1,100 @@
+"""Tests for the internal-proxy rollover stability margin (issue #3479)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.robot.rollover_proxy import (
+    PROXY_SCHEMA_VERSION,
+    RolloverProxyParams,
+    critical_lateral_acceleration,
+    is_rollover_critical,
+    lateral_acceleration,
+    rollover_proxy_telemetry,
+    stability_margin,
+)
+
+# a_y,crit = g * (t_w / (2 h_c)) * (a / L) for the documented default proxy geometry.
+_DEFAULT_CRIT = 9.81 * (0.50 / (2 * 0.40)) * (0.30 / 0.60)
+
+
+def test_critical_lateral_acceleration_matches_closed_form() -> None:
+    """The critical lateral acceleration must match the issue's closed form."""
+    assert critical_lateral_acceleration(RolloverProxyParams()) == pytest.approx(_DEFAULT_CRIT)
+
+
+def test_lateral_acceleration_is_v_times_omega() -> None:
+    """Proxy lateral acceleration must be ``v · ω``."""
+    assert lateral_acceleration(1.5, 2.0) == pytest.approx(3.0)
+
+
+def test_feasible_command_stays_stable() -> None:
+    """A low-speed, low-yaw command must stay well within the proxy threshold."""
+    margin = stability_margin(0.5, 0.5)  # a_y = 0.25 << a_y,crit ~ 3.07
+
+    assert margin == pytest.approx(1.0 - 0.25 / _DEFAULT_CRIT)
+    assert not is_rollover_critical(margin)
+
+
+def test_over_yaw_command_trips_rollover_critical() -> None:
+    """An over-yaw command exceeding the critical accel must trip ROLLOVER_CRITICAL."""
+    margin = stability_margin(2.0, 2.0)  # a_y = 4.0 > a_y,crit ~ 3.07
+
+    assert margin == 0.0
+    assert is_rollover_critical(margin)
+
+
+def test_margin_is_clamped_to_unit_interval() -> None:
+    """Zero motion yields full margin; gross over-demand clamps to zero."""
+    assert stability_margin(0.0, 0.0) == 1.0
+    assert stability_margin(100.0, 100.0) == 0.0
+
+
+def test_margin_at_exact_threshold_is_critical() -> None:
+    """Demanding exactly the critical lateral acceleration yields a zero margin."""
+    crit = critical_lateral_acceleration(RolloverProxyParams())
+    # Pick v, omega whose product equals the critical lateral acceleration.
+    margin = stability_margin(crit, 1.0)
+
+    assert margin == pytest.approx(0.0, abs=1e-12)
+    assert is_rollover_critical(margin)
+
+
+def test_margin_decreases_monotonically_with_demand() -> None:
+    """Higher |v · ω| must never increase the stability margin."""
+    margins = [stability_margin(v, 1.0) for v in (0.0, 0.5, 1.0, 2.0, 3.0)]
+    assert margins == sorted(margins, reverse=True)
+
+
+def test_margin_depends_on_magnitude_not_sign() -> None:
+    """Opposite yaw signs of equal magnitude must give the same margin."""
+    assert stability_margin(1.0, 1.5) == pytest.approx(stability_margin(1.0, -1.5))
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"track_width_m": 0.0},
+        {"cog_height_m": -0.1},
+        {"front_axle_to_cog_m": 0.0},
+        {"wheelbase_m": -1.0},
+        {"gravity_m_s2": 0.0},
+        {"front_axle_to_cog_m": 0.7, "wheelbase_m": 0.6},  # a > L
+    ],
+)
+def test_invalid_params_are_rejected(kwargs: dict[str, float]) -> None:
+    """Non-physical proxy geometry must fail closed at construction."""
+    with pytest.raises(ValueError):
+        RolloverProxyParams(**kwargs)
+
+
+def test_telemetry_is_schema_tagged_and_labels_non_hardware() -> None:
+    """Telemetry must carry the schema version and the internal-proxy provenance label."""
+    record = rollover_proxy_telemetry(2.0, 2.0)
+
+    assert record["schema_version"] == PROXY_SCHEMA_VERSION
+    assert record["proxy_kind"] == "internal_non_hardware"
+    assert record["rollover_critical"] is True
+    assert record["stability_margin"] == 0.0
+    assert record["lateral_acceleration"] == pytest.approx(4.0)
+    assert record["critical_lateral_acceleration"] == pytest.approx(_DEFAULT_CRIT)


### PR DESCRIPTION
## Summary

Diagnostic-only first increment for #3479.

Planar bicycle / differential-drive / holonomic models mask the **dynamic-rollover**
risk of a narrow-track three-wheeled platform — a maneuver "safe" under kinematics may
demand a yaw rate that tips it. This adds the issue's closed-form lateral-stability
proxy as a **pure, side-effect-free** module so the stability margin and a
`ROLLOVER_CRITICAL` classifier can be surfaced as telemetry.

## Model (`rollover_proxy.v1`)

- `a_y ≈ v·ω`
- `a_y,crit = g·(t_w/(2·h_c))·(a/L)`  (defaults → `a_y,crit ≈ 3.07 m/s²`)
- `margin = clamp(1 − |a_y|/a_y,crit, 0, 1)`; `ROLLOVER_CRITICAL` at margin 0.

## What changed

- **`robot_sf/robot/rollover_proxy.py`** — `RolloverProxyParams` (versioned,
  documented, **non-hardware** geometry; fails closed on non-physical values),
  `stability_margin`, `is_rollover_critical`, and a schema-tagged
  `rollover_proxy_telemetry` record labelled `internal_non_hardware`.
- **`tests/test_rollover_proxy.py`** — 15 tests: feasible command stays stable,
  over-yaw trips `ROLLOVER_CRITICAL`, margin clamped/monotonic/sign-independent,
  invalid geometry rejected, telemetry contract.
- **`docs/context/issue_3479_rollover_proxy.md`** — model, versioned params, and the
  diagnostic-only / governance boundary.

## Scope boundary & governance

- **Diagnostic-only:** changes **no** planner/training/benchmark behavior. Wiring the
  terminal flag + an **opt-in** reward penalty into the stepping loop (with a
  benchmark comparison) is a deliberate follow-up so existing runs are not silently
  altered — directly addressing the issue's "don't default the penalty on" non-goal.
- **Governance #2416/#2417:** parameters are explicit internal-proxy assumptions,
  **not** hardware-calibrated and **not** paper-facing AMV evidence (blocked until
  #1585/#2000 provenance is accepted). The module and telemetry label this explicitly.

## Validation

```
uv run pytest tests/test_rollover_proxy.py -q              # 15 passed
uv run python scripts/validation/check_broad_exceptions.py # passes at 285 (no broad catches)
ruff check / format                                        # clean
```

**Evidence grade:** smoke evidence (new pure module + tests; no runtime/benchmark
surface touched). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
