### PR TITLE
feat(benchmark): tracking-precision drift mask + speed contract, diagnostic-only (#3480)

### DIFF
--- a/docs/context/issue_3480_tracking_precision_contract.md
+++ b/docs/context/issue_3480_tracking_precision_contract.md
@@ -1,0 +1,55 @@
+# Issue #3480 — Tracking-precision drift mask + speed contract (diagnostic-only)
+
+**Status:** diagnostic / internal-proxy. **Evidence grade:** idea-level proxy, not a
+measured sensor-noise model and not paper-facing. Reuse durable runtime evidence and
+the observation-noise portfolio (#2777 / #2927) before any perception-robustness claim.
+
+## What this is
+
+`robot_sf/benchmark/tracking_precision_contract.py` implements the tracking-precision
+lever from issue #3480 so the "perfect sensing" assumption (uncorrupted raycast truth,
+zero tracking decay) can be stressed:
+
+- a **tracking-drift mask** that perturbs tracked actor coordinates by a target
+  MOTP-like precision, and
+- a precision→speed **operational contract** that drops the planner max-speed cap to a
+  defensive ceiling once tracking precision degrades past a threshold `T_u`.
+
+## Model (`tracking_precision_contract.v1`)
+
+- MOTP is the mean Euclidean tracking error. For an isotropic 2D Gaussian with per-axis
+  std `σ`, the mean Euclidean error is `σ·√(π/2)` (Rayleigh mean), so a target
+  `MOTP = m` uses `σ = m / √(π/2)`. **MOTP = 0 ⇒ exact pass-through.**
+- Minimum-separation safety is computed on the **corrupted** observation vector, not on
+  ground truth.
+- Operational contract: `speed_cap = defensive_speed_cap` when `MOTP ≥ T_u`, else
+  `default_speed_cap`. `is_contract_honored` checks an applied cap respects the ceiling.
+
+### Versioned contract defaults (non-hardware proxy)
+
+| field | default | meaning |
+| --- | --- | --- |
+| `precision_threshold_m` (`T_u`) | 2.5 m | MOTP at/above which the defensive cap applies |
+| `default_speed_cap` | 2.0 m/s | cap under good tracking precision |
+| `defensive_speed_cap` | 0.5 m/s | cap under degraded precision |
+
+## Scope boundary
+
+**Diagnostic-only and side-effect free.** It does not alter the live perception, action,
+or benchmark loop. Wiring the drift mask and speed-cap into the stepping loop (and any
+benchmark safety-vs-precision sweep) is a deliberate opt-in follow-up so existing runs
+are not silently altered. The Gaussian drift is a **proxy**, not a hardware sensor model.
+
+## Tests
+
+`tests/benchmark/test_tracking_precision_contract.py` proves MOTP=0 pass-through, that a
+large drifted sample's mean error matches the target MOTP (Rayleigh mapping), seed
+reproducibility, minimum-separation on the observed vector, the speed-cap threshold
+behavior, honored/violated contract checks, parameter validation, and the telemetry
+schema.
+
+## Related
+
+- #3300 — false-positive actor-injection replay (related, distinct).
+- #2777 / #2927 — observation-noise live replay / portfolio.
+- #3293 — sim↔real evidence integration.

--- a/robot_sf/benchmark/tracking_precision_contract.py
+++ b/robot_sf/benchmark/tracking_precision_contract.py
@@ -1,0 +1,182 @@
+"""Tracking-precision drift mask and a precision-to-speed operational contract.
+
+Line-of-sight raycasting is otherwise treated as an uncorrupted truth stream with
+zero tracking decay. A defensible pre-deployment safety case must instead show the
+planner holds a separation buffer that absorbs *tracking localization error*. This
+module provides the tracking-precision lever from issue #3480:
+
+- a stochastic **tracking-drift mask** that perturbs tracked actor coordinates by a
+  target MOTP-like precision (MOTP = 0 ⇒ pass-through ground truth), and
+- a precision-to-speed **operational contract** that drops the planner max-speed cap
+  to a defensive ceiling once tracking precision crosses a threshold ``T_u``.
+
+.. warning::
+
+   The Gaussian drift is an explicit **proxy**, not a measured or hardware-calibrated
+   sensor-noise model, and these signals are not paper-facing perception-robustness
+   evidence. Reuse durable runtime evidence and the observation-noise portfolio
+   (#2777 / #2927) before any such claim.
+
+MOTP convention: MOTP is the mean Euclidean position error of tracked actors. For an
+isotropic 2D Gaussian with per-axis standard deviation ``σ``, the mean Euclidean error
+is ``σ·√(π/2)`` (the Rayleigh mean). To hit a target ``MOTP = m`` we therefore use
+``σ = m / √(π/2)``, so the realized mean drift matches the requested precision.
+
+This module is pure and side-effect free; it does not alter the live perception, action,
+or benchmark loop. Wiring the mask and speed-cap into the stepping loop is a deliberate
+opt-in follow-up.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+TRACKING_PRECISION_SCHEMA = "tracking_precision_contract.v1"
+# Rayleigh mean factor: mean Euclidean error = per-axis sigma * sqrt(pi/2).
+_RAYLEIGH_MEAN_FACTOR = math.sqrt(math.pi / 2.0)
+
+
+def drift_std_for_motp(motp_m: float) -> float:
+    """Return the per-axis Gaussian std that realizes a target MOTP (mean error).
+
+    Args:
+        motp_m: Target mean Euclidean tracking error in metres (>= 0).
+
+    Returns:
+        float: Per-axis standard deviation ``σ = MOTP / √(π/2)``.
+    """
+    if motp_m < 0.0:
+        raise ValueError(f"motp_m must be >= 0, got {motp_m!r}")
+    return float(motp_m) / _RAYLEIGH_MEAN_FACTOR
+
+
+def apply_tracking_drift(
+    positions: NDArray[np.floating] | object,
+    motp_m: float,
+    rng: np.random.Generator,
+) -> NDArray[np.float64]:
+    """Return tracked positions perturbed by a MOTP-parameterized Gaussian drift.
+
+    ``motp_m == 0`` is an exact pass-through (a copy of the input). Otherwise each
+    coordinate gets independent zero-mean Gaussian noise with std
+    :func:`drift_std_for_motp`.
+
+    Returns:
+        NDArray[np.float64]: Perturbed positions with the same shape as the input.
+    """
+    arr = np.asarray(positions, dtype=np.float64)
+    if motp_m == 0.0:
+        return arr.copy()
+    std = drift_std_for_motp(motp_m)
+    return arr + rng.normal(0.0, std, size=arr.shape)
+
+
+def minimum_separation(
+    observed_positions: NDArray[np.floating] | object,
+    reference_point: NDArray[np.floating] | object,
+) -> float:
+    """Return the minimum distance from ``reference_point`` to any observed actor.
+
+    Computed on the (possibly corrupted) observation vector, not ground truth.
+
+    Returns:
+        float: Minimum Euclidean distance, or ``inf`` when no actors are observed.
+    """
+    actors = np.asarray(observed_positions, dtype=np.float64).reshape(-1, 2)
+    if actors.shape[0] == 0:
+        return float("inf")
+    ref = np.asarray(reference_point, dtype=np.float64).reshape(2)
+    return float(np.min(np.linalg.norm(actors - ref, axis=1)))
+
+
+@dataclass(frozen=True, slots=True)
+class TrackingPrecisionContract:
+    """Precision-to-speed operational contract (non-hardware proxy thresholds).
+
+    Attributes:
+        precision_threshold_m: ``T_u`` — MOTP at/above which the defensive cap applies.
+        default_speed_cap: Max-speed cap under good tracking precision (m/s).
+        defensive_speed_cap: Reduced cap once precision is degraded (m/s).
+        schema_version: Stable schema tag for reproducibility.
+    """
+
+    precision_threshold_m: float = 2.5
+    default_speed_cap: float = 2.0
+    defensive_speed_cap: float = 0.5
+    schema_version: str = TRACKING_PRECISION_SCHEMA
+
+    def __post_init__(self) -> None:
+        """Validate that the contract is well-formed."""
+        if not (self.precision_threshold_m > 0.0):
+            raise ValueError("precision_threshold_m must be > 0")
+        if not (self.default_speed_cap > 0.0) or not (self.defensive_speed_cap > 0.0):
+            raise ValueError("speed caps must be > 0")
+        if self.defensive_speed_cap > self.default_speed_cap:
+            raise ValueError("defensive_speed_cap must not exceed default_speed_cap")
+
+
+def speed_cap_for_precision(
+    motp_m: float, contract: TrackingPrecisionContract | None = None
+) -> float:
+    """Return the contracted max-speed cap for an observed tracking precision."""
+    contract = contract or TrackingPrecisionContract()
+    if motp_m < 0.0:
+        raise ValueError(f"motp_m must be >= 0, got {motp_m!r}")
+    if motp_m >= contract.precision_threshold_m:
+        return contract.defensive_speed_cap
+    return contract.default_speed_cap
+
+
+def is_contract_honored(
+    applied_speed_cap: float,
+    motp_m: float,
+    contract: TrackingPrecisionContract | None = None,
+) -> bool:
+    """Return whether an applied speed cap respects the contracted ceiling."""
+    contract = contract or TrackingPrecisionContract()
+    expected = speed_cap_for_precision(motp_m, contract)
+    return applied_speed_cap <= expected + 1e-9
+
+
+def tracking_precision_telemetry(
+    motp_m: float,
+    applied_speed_cap: float,
+    contract: TrackingPrecisionContract | None = None,
+) -> dict[str, Any]:
+    """Return a compact, schema-tagged telemetry record (diagnostic only).
+
+    Returns:
+        dict[str, Any]: Precision, drift std, contracted/applied caps, and honored flag.
+    """
+    contract = contract or TrackingPrecisionContract()
+    expected = speed_cap_for_precision(motp_m, contract)
+    return {
+        "schema_version": contract.schema_version,
+        "proxy_kind": "internal_non_hardware",
+        "motp_m": float(motp_m),
+        "drift_std_m": drift_std_for_motp(motp_m),
+        "precision_threshold_m": contract.precision_threshold_m,
+        "contracted_speed_cap": expected,
+        "applied_speed_cap": float(applied_speed_cap),
+        "contract_honored": is_contract_honored(applied_speed_cap, motp_m, contract),
+        "defensive_regime": motp_m >= contract.precision_threshold_m,
+    }
+
+
+__all__ = [
+    "TRACKING_PRECISION_SCHEMA",
+    "TrackingPrecisionContract",
+    "apply_tracking_drift",
+    "drift_std_for_motp",
+    "is_contract_honored",
+    "minimum_separation",
+    "speed_cap_for_precision",
+    "tracking_precision_telemetry",
+]

--- a/tests/benchmark/test_tracking_precision_contract.py
+++ b/tests/benchmark/test_tracking_precision_contract.py
@@ -1,0 +1,120 @@
+"""Tests for the tracking-precision drift mask + speed contract (issue #3480)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.tracking_precision_contract import (
+    TRACKING_PRECISION_SCHEMA,
+    TrackingPrecisionContract,
+    apply_tracking_drift,
+    drift_std_for_motp,
+    is_contract_honored,
+    minimum_separation,
+    speed_cap_for_precision,
+    tracking_precision_telemetry,
+)
+
+
+def test_motp_zero_is_exact_pass_through() -> None:
+    """MOTP = 0 must return the ground-truth positions unchanged."""
+    rng = np.random.default_rng(0)
+    positions = np.array([[1.0, 2.0], [3.0, -4.0]])
+
+    out = apply_tracking_drift(positions, 0.0, rng)
+
+    assert np.array_equal(out, positions)
+    assert out is not positions  # a copy, not the same buffer
+
+
+def test_drift_std_matches_rayleigh_mapping() -> None:
+    """The per-axis std must invert the Rayleigh mean so realized MOTP matches target."""
+    assert drift_std_for_motp(2.5) == pytest.approx(2.5 / math.sqrt(math.pi / 2.0))
+    assert drift_std_for_motp(0.0) == 0.0
+
+
+def test_realized_mean_error_matches_target_motp() -> None:
+    """A large drifted sample must have mean Euclidean error close to the target MOTP."""
+    rng = np.random.default_rng(1234)
+    target_motp = 2.5
+    positions = np.zeros((20000, 2))
+
+    drifted = apply_tracking_drift(positions, target_motp, rng)
+    mean_error = float(np.mean(np.linalg.norm(drifted, axis=1)))
+
+    assert mean_error == pytest.approx(target_motp, rel=0.03)
+
+
+def test_drift_is_deterministic_for_a_seed() -> None:
+    """The same seed must reproduce the same drift (reproducibility)."""
+    positions = np.array([[0.0, 0.0], [1.0, 1.0]])
+    a = apply_tracking_drift(positions, 1.0, np.random.default_rng(7))
+    b = apply_tracking_drift(positions, 1.0, np.random.default_rng(7))
+
+    assert np.array_equal(a, b)
+
+
+def test_minimum_separation_on_observed_vector() -> None:
+    """Minimum separation must be computed against the provided (corrupted) actors."""
+    actors = np.array([[3.0, 0.0], [0.0, 4.0], [10.0, 10.0]])
+
+    assert minimum_separation(actors, [0.0, 0.0]) == pytest.approx(3.0)
+    assert minimum_separation(np.empty((0, 2)), [0.0, 0.0]) == float("inf")
+
+
+def test_speed_cap_drops_to_defensive_above_threshold() -> None:
+    """The contract must drop the cap to the defensive ceiling at/above T_u."""
+    contract = TrackingPrecisionContract()
+
+    assert speed_cap_for_precision(1.0, contract) == contract.default_speed_cap
+    assert speed_cap_for_precision(2.4999, contract) == contract.default_speed_cap
+    assert speed_cap_for_precision(2.5, contract) == contract.defensive_speed_cap
+    assert speed_cap_for_precision(5.0, contract) == contract.defensive_speed_cap
+
+
+def test_contract_honored_and_violated() -> None:
+    """A cap within the contracted ceiling is honored; exceeding it is a violation."""
+    contract = TrackingPrecisionContract()
+
+    # Degraded precision requires the defensive ceiling.
+    assert is_contract_honored(contract.defensive_speed_cap, 3.0, contract)
+    assert not is_contract_honored(contract.default_speed_cap, 3.0, contract)
+    # Good precision permits the default cap.
+    assert is_contract_honored(contract.default_speed_cap, 0.5, contract)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"precision_threshold_m": 0.0},
+        {"default_speed_cap": 0.0},
+        {"defensive_speed_cap": -1.0},
+        {"default_speed_cap": 1.0, "defensive_speed_cap": 2.0},  # defensive > default
+    ],
+)
+def test_invalid_contract_is_rejected(kwargs: dict[str, float]) -> None:
+    """Non-physical contract parameters must fail closed at construction."""
+    with pytest.raises(ValueError):
+        TrackingPrecisionContract(**kwargs)
+
+
+def test_negative_motp_is_rejected() -> None:
+    """Negative MOTP is meaningless and must be rejected."""
+    with pytest.raises(ValueError):
+        drift_std_for_motp(-0.1)
+    with pytest.raises(ValueError):
+        speed_cap_for_precision(-0.1)
+
+
+def test_telemetry_is_schema_tagged() -> None:
+    """Telemetry must carry the schema tag, provenance label, and regime flags."""
+    record = tracking_precision_telemetry(3.0, 2.0)
+
+    assert record["schema_version"] == TRACKING_PRECISION_SCHEMA
+    assert record["proxy_kind"] == "internal_non_hardware"
+    assert record["defensive_regime"] is True
+    assert record["contracted_speed_cap"] == TrackingPrecisionContract().defensive_speed_cap
+    assert record["contract_honored"] is False  # applied 2.0 > defensive ceiling


### PR DESCRIPTION
## Summary

Diagnostic-only first increment for #3480.

Line-of-sight raycasting is treated as an uncorrupted truth stream with zero tracking
decay. A defensible safety case must instead show the planner holds a separation buffer
that absorbs **tracking localization error**. This adds the tracking-precision lever as
a **pure, side-effect-free** module.

## Model (`tracking_precision_contract.v1`)

- **Drift mask:** MOTP-parameterized Gaussian noise on tracked actor positions. MOTP = 0
  ⇒ exact pass-through. MOTP is the mean Euclidean error, so with per-axis `σ` the mean
  error is `σ·√(π/2)` (Rayleigh) ⇒ `σ = MOTP/√(π/2)` makes the **realized** mean drift
  match the requested precision (verified by a 20k-sample test, mean error ≈ target MOTP).
- **Minimum separation** computed on the *corrupted* observation vector, not ground truth.
- **Operational contract:** drop the max-speed cap to a defensive ceiling once
  `MOTP ≥ T_u` (default 2.5 m); `is_contract_honored` checks an applied cap respects it.

## What changed

- `robot_sf/benchmark/tracking_precision_contract.py` — `apply_tracking_drift`,
  `drift_std_for_motp`, `minimum_separation`, `TrackingPrecisionContract`,
  `speed_cap_for_precision`, `is_contract_honored`, schema-tagged telemetry labelled
  `internal_non_hardware`.
- `tests/benchmark/test_tracking_precision_contract.py` — 13 tests (pass-through,
  Rayleigh mapping, realized-MOTP, reproducibility, threshold, honored/violated,
  validation, telemetry).
- `docs/context/issue_3480_tracking_precision_contract.md` — model, defaults, boundary.

## Scope boundary

Pure and side-effect free — **no** live perception/action/benchmark behavior changes.
Wiring the mask + speed-cap into the stepping loop (and the safety-vs-precision sweep) is
a deliberate opt-in follow-up so existing runs are not silently altered. The Gaussian
drift is an explicit **proxy**, not a measured sensor model, and not paper-facing
(reuse #2777/#2927 portfolio first). Distinct from the false-positive replay in #3300.

## Validation

```
uv run pytest tests/benchmark/test_tracking_precision_contract.py -q   # 13 passed
uv run python scripts/validation/check_broad_exceptions.py             # passes at 285
ruff check / format                                                    # clean
```

**Evidence grade:** smoke evidence (new pure module + tests; no runtime surface touched).
**Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
