### PR TITLE
feat(benchmark): all three trace-level safety-predicate producers (#3483)

### DIFF
--- a/docs/context/issue_3483_safety_predicate_producers.md
+++ b/docs/context/issue_3483_safety_predicate_producers.md
@@ -1,4 +1,4 @@
-# Issue #3483 — Trace-level safety-predicate producers (oscillatory + late-evasive)
+# Issue #3483 — Trace-level safety-predicate producers (all three)
 
 **Status:** diagnostic / proxy. **Evidence grade:** idea-level; predicate definitions are
 versioned modeling choices, labeled diagnostic until real-world label validation
@@ -11,10 +11,11 @@ fields are emitted and validated.
 safety predicates the thesis motivates, so their fields become reproducible and
 fixture-backed instead of simulation-only assumptions.
 
-This increment implements two of the three predicates: **oscillatory local-control** and
-**late-evasive reaction**. The oscillatory boolean is compatible with the existing
-`SurrogateEvents.oscillation` slot in `robot_sf/benchmark/event_ledger.py`; both detailed
-field records are intended for the ledger `surrogate_events` block.
+This implements all three motivated predicates: **oscillatory local-control**,
+**late-evasive reaction**, and **occlusion-triggered near miss**. The oscillatory boolean
+is compatible with the existing `SurrogateEvents.oscillation` slot in
+`robot_sf/benchmark/event_ledger.py`; all detailed field records are intended for the
+ledger `surrogate_events` block.
 
 ## Producer 1 — `safety_predicate.oscillatory_control.v1`
 
@@ -39,13 +40,22 @@ action is the first deceleration past `decel_threshold_m_s2` at/after the hazard
 visible. Diagnostic classification: `late_evasive` when the hazard is visible and the
 reaction is absent, slower than `max_response_latency_s`, or only after conflict-zone entry.
 
+## Producer 3 — `safety_predicate.occlusion_near_miss.v1`
+
+`occlusion_near_miss_predicate(hazard_distances, visible, track_confidence, speeds, *, dt,
+params=…)` emits `was_occluded_before_min`, `emergence_step`, `first_detection_step`,
+`first_response_step`, `min_separation_step`, `actual_minimum_separation_m`,
+`predicted_minimum_separation_m`, `near_miss`, `n_steps`. Diagnostic classification:
+`occlusion_near_miss` fires when a near miss occurs, the actor was occluded before the
+closest approach, and it later emerged (occluded→visible) — the failure family where the
+separation buffer is too thin to absorb a late detection. Thresholds live in
+`OcclusionNearMissParams`.
+
 ## Scope boundary
 
-Pure and side-effect free — changes no runtime/benchmark behavior. Deferred follow-ups:
-
-- the **occlusion-triggered-near-miss** producer;
-- wiring live emission into `build_event_ledger` / the stepping loop (needs per-step
-  visibility, track-confidence, and command-source signals verified as exposed).
+Pure and side-effect free — changes no runtime/benchmark behavior. Deferred follow-up:
+wiring live emission into `build_event_ledger` / the stepping loop (needs per-step
+visibility, track-confidence, and command-source signals verified as exposed).
 
 ## Tests
 

--- a/docs/context/issue_3483_safety_predicate_producers.md
+++ b/docs/context/issue_3483_safety_predicate_producers.md
@@ -1,0 +1,50 @@
+# Issue #3483 — Trace-level safety-predicate producers (oscillatory, first increment)
+
+**Status:** diagnostic / proxy. **Evidence grade:** idea-level; predicate definitions are
+versioned modeling choices, labeled diagnostic until real-world label validation
+(externally blocked, #3278). Do **not** report predicate rates in the manuscript until
+fields are emitted and validated.
+
+## What this is
+
+`robot_sf/benchmark/safety_predicates.py` provides in-sim producers for the trace-level
+safety predicates the thesis motivates, so their fields become reproducible and
+fixture-backed instead of simulation-only assumptions.
+
+This increment implements the **oscillatory local-control** predicate (the most
+self-contained of the three). Its boolean output is compatible with the existing
+`SurrogateEvents.oscillation` slot in `robot_sf/benchmark/event_ledger.py`; the detailed
+field record is intended for the ledger `surrogate_events` block.
+
+## Producer (`safety_predicate.oscillatory_control.v1`)
+
+`oscillatory_control_predicate(positions, headings, linear_velocities, *, dt, …)` emits:
+
+- `heading_rate_sign_changes`, `linear_velocity_sign_changes`, `command_source_changes`
+- `net_progress_m`, `path_length_m`, `progress_ratio`
+- `mean_abs_jerk`, `n_steps`
+
+Diagnostic classification: `oscillation = (heading_rate_sign_changes ≥ T_h) and
+(progress_ratio ≤ T_p)` with defaults `T_h = 4`, `T_p = 0.5`. Thresholds are explicit and
+overridable, and the raw fields are always emitted so a different threshold can be applied
+downstream without recomputation.
+
+## Scope boundary
+
+Pure and side-effect free — changes no runtime/benchmark behavior. Deferred follow-ups:
+
+- the **late-evasive** and **occlusion-triggered-near-miss** producers;
+- wiring live emission into `build_event_ledger` / the stepping loop (needs per-step
+  visibility, track-confidence, and command-source signals verified as exposed).
+
+## Tests
+
+`tests/benchmark/test_safety_predicates.py`: a zig-zag-in-place trajectory is flagged, a
+smooth straight run is not, fields/thresholds are correct and overridable, command-source
+and velocity sign changes are counted, and invalid inputs (bad `dt`, length mismatch,
+single step) fail closed.
+
+## Related
+
+- Canonical safety-event ledger (emit target): `robot_sf/benchmark/event_ledger.py`.
+- Real-world trace validation of these labels (externally blocked): #3278.

--- a/docs/context/issue_3483_safety_predicate_producers.md
+++ b/docs/context/issue_3483_safety_predicate_producers.md
@@ -1,4 +1,4 @@
-# Issue #3483 — Trace-level safety-predicate producers (oscillatory, first increment)
+# Issue #3483 — Trace-level safety-predicate producers (oscillatory + late-evasive)
 
 **Status:** diagnostic / proxy. **Evidence grade:** idea-level; predicate definitions are
 versioned modeling choices, labeled diagnostic until real-world label validation
@@ -11,12 +11,12 @@ fields are emitted and validated.
 safety predicates the thesis motivates, so their fields become reproducible and
 fixture-backed instead of simulation-only assumptions.
 
-This increment implements the **oscillatory local-control** predicate (the most
-self-contained of the three). Its boolean output is compatible with the existing
-`SurrogateEvents.oscillation` slot in `robot_sf/benchmark/event_ledger.py`; the detailed
-field record is intended for the ledger `surrogate_events` block.
+This increment implements two of the three predicates: **oscillatory local-control** and
+**late-evasive reaction**. The oscillatory boolean is compatible with the existing
+`SurrogateEvents.oscillation` slot in `robot_sf/benchmark/event_ledger.py`; both detailed
+field records are intended for the ledger `surrogate_events` block.
 
-## Producer (`safety_predicate.oscillatory_control.v1`)
+## Producer 1 — `safety_predicate.oscillatory_control.v1`
 
 `oscillatory_control_predicate(positions, headings, linear_velocities, *, dt, …)` emits:
 
@@ -29,20 +29,31 @@ Diagnostic classification: `oscillation = (heading_rate_sign_changes ≥ T_h) an
 overridable, and the raw fields are always emitted so a different threshold can be applied
 downstream without recomputation.
 
+## Producer 2 — `safety_predicate.late_evasive.v1`
+
+`late_evasive_predicate(hazard_distances, hazard_visible, speeds, *, dt, …)` emits
+`first_hazard_visible_step`, `conflict_zone_entry_step`,
+`first_clearance_restoring_action_step`, `minimum_distance_m`,
+`required_deceleration_m_s2`, `response_latency_s`, `n_steps`. The clearance-restoring
+action is the first deceleration past `decel_threshold_m_s2` at/after the hazard becomes
+visible. Diagnostic classification: `late_evasive` when the hazard is visible and the
+reaction is absent, slower than `max_response_latency_s`, or only after conflict-zone entry.
+
 ## Scope boundary
 
 Pure and side-effect free — changes no runtime/benchmark behavior. Deferred follow-ups:
 
-- the **late-evasive** and **occlusion-triggered-near-miss** producers;
+- the **occlusion-triggered-near-miss** producer;
 - wiring live emission into `build_event_ledger` / the stepping loop (needs per-step
   visibility, track-confidence, and command-source signals verified as exposed).
 
 ## Tests
 
-`tests/benchmark/test_safety_predicates.py`: a zig-zag-in-place trajectory is flagged, a
-smooth straight run is not, fields/thresholds are correct and overridable, command-source
-and velocity sign changes are counted, and invalid inputs (bad `dt`, length mismatch,
-single step) fail closed.
+`tests/benchmark/test_safety_predicates.py` (16 tests): oscillatory flagging on a
+zig-zag-in-place vs straight run with correct fields/thresholds and sign-change counts;
+late-evasive flagging for absent/slow reactions vs a prompt deceleration, latency-threshold
+override, no-visible-hazard handling, the required-deceleration formula; and fail-closed
+validation for both producers.
 
 ## Related
 

--- a/robot_sf/benchmark/safety_predicates.py
+++ b/robot_sf/benchmark/safety_predicates.py
@@ -1,0 +1,134 @@
+"""Trace-level safety-predicate producers (issue #3483).
+
+The thesis motivates several trace-level failure families but cannot report their
+rates until in-sim *producers* emit auditable fields. This module implements those
+producers as pure, versioned functions over a per-step trajectory, so the fields are
+reproducible and fixture-backed instead of simulation-only assumptions.
+
+This increment provides the **oscillatory local-control** predicate. Its boolean output
+populates the existing ``SurrogateEvents.oscillation`` ledger slot; the detailed field
+record is intended for the ledger ``surrogate_events`` block. The late-evasive and
+occlusion-triggered-near-miss producers, and live emission wiring, are deliberate
+follow-ups.
+
+.. note::
+
+   Predicate definitions are **versioned modeling choices**, labeled diagnostic until
+   real-world label validation (externally blocked, #3278). Thresholds are explicit and
+   overridable; the producer always emits the raw fields so a different threshold can be
+   applied downstream without recomputation.
+"""
+
+from __future__ import annotations
+
+from itertools import pairwise
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+OSCILLATORY_PREDICATE_SCHEMA = "safety_predicate.oscillatory_control.v1"
+
+
+def _sign_changes(values: NDArray[np.float64]) -> int:
+    """Count sign changes in a 1D sequence, ignoring zeros.
+
+    Returns:
+        int: Number of times the (nonzero) sign flips between successive entries.
+    """
+    signs = np.sign(values)
+    nonzero = signs[signs != 0.0]
+    if nonzero.size < 2:
+        return 0
+    return int(np.count_nonzero(np.diff(nonzero) != 0))
+
+
+def oscillatory_control_predicate(
+    positions: NDArray[np.floating] | object,
+    headings: NDArray[np.floating] | object,
+    linear_velocities: NDArray[np.floating] | object,
+    *,
+    dt: float,
+    command_sources: list[Any] | None = None,
+    min_heading_rate_sign_changes: int = 4,
+    max_progress_ratio: float = 0.5,
+) -> dict[str, Any]:
+    """Produce the oscillatory local-control predicate fields for one episode.
+
+    Args:
+        positions: ``(N, 2)`` robot positions (m).
+        headings: ``(N,)`` robot headings (radians); unwrapped internally.
+        linear_velocities: ``(N,)`` signed forward velocity (m/s).
+        dt: Per-step timestep (s, > 0).
+        command_sources: Optional ``(N,)`` per-step command-source labels.
+        min_heading_rate_sign_changes: Classification threshold on heading-rate flips.
+        max_progress_ratio: Classification threshold on net/path progress ratio.
+
+    Returns:
+        dict[str, Any]: Versioned record with the motivated fields and the diagnostic
+        ``oscillation`` boolean (compatible with ``SurrogateEvents.oscillation``).
+    """
+    if not (dt > 0.0):
+        raise ValueError(f"dt must be > 0, got {dt!r}")
+    pos = np.asarray(positions, dtype=np.float64).reshape(-1, 2)
+    head = np.asarray(headings, dtype=np.float64).reshape(-1)
+    vel = np.asarray(linear_velocities, dtype=np.float64).reshape(-1)
+    n = pos.shape[0]
+    if not (head.shape[0] == n == vel.shape[0]):
+        raise ValueError("positions, headings, and linear_velocities must share length N")
+    if command_sources is not None and len(command_sources) != n:
+        raise ValueError("command_sources must have length N when provided")
+    if n < 2:
+        raise ValueError("at least two steps are required")
+
+    heading_rate = np.diff(np.unwrap(head)) / dt
+    heading_rate_sign_changes = _sign_changes(heading_rate)
+    linear_velocity_sign_changes = _sign_changes(vel)
+
+    command_source_changes = 0
+    if command_sources is not None:
+        command_source_changes = int(sum(1 for a, b in pairwise(command_sources) if a != b))
+
+    step_vectors = np.diff(pos, axis=0)
+    path_length = float(np.sum(np.linalg.norm(step_vectors, axis=1)))
+    net_progress = float(np.linalg.norm(pos[-1] - pos[0]))
+    progress_ratio = 1.0 if path_length == 0.0 else net_progress / path_length
+
+    # Jerk: third derivative of position via successive finite differences of velocity.
+    if vel.size >= 3:
+        accel = np.diff(vel) / dt
+        jerk = np.diff(accel) / dt
+        mean_abs_jerk = float(np.mean(np.abs(jerk)))
+    else:
+        mean_abs_jerk = 0.0
+
+    oscillation = bool(
+        heading_rate_sign_changes >= min_heading_rate_sign_changes
+        and progress_ratio <= max_progress_ratio
+    )
+
+    return {
+        "schema_version": OSCILLATORY_PREDICATE_SCHEMA,
+        "predicate": "oscillatory_control",
+        "evidence_kind": "diagnostic_proxy",
+        "oscillation": oscillation,
+        "fields": {
+            "heading_rate_sign_changes": heading_rate_sign_changes,
+            "linear_velocity_sign_changes": linear_velocity_sign_changes,
+            "command_source_changes": command_source_changes,
+            "net_progress_m": net_progress,
+            "path_length_m": path_length,
+            "progress_ratio": progress_ratio,
+            "mean_abs_jerk": mean_abs_jerk,
+            "n_steps": n,
+        },
+        "thresholds": {
+            "min_heading_rate_sign_changes": min_heading_rate_sign_changes,
+            "max_progress_ratio": max_progress_ratio,
+        },
+    }
+
+
+__all__ = ["OSCILLATORY_PREDICATE_SCHEMA", "oscillatory_control_predicate"]

--- a/robot_sf/benchmark/safety_predicates.py
+++ b/robot_sf/benchmark/safety_predicates.py
@@ -5,11 +5,11 @@ rates until in-sim *producers* emit auditable fields. This module implements tho
 producers as pure, versioned functions over a per-step trajectory, so the fields are
 reproducible and fixture-backed instead of simulation-only assumptions.
 
-This increment provides the **oscillatory local-control** predicate. Its boolean output
+This module provides three trace-level predicates: **oscillatory local-control**,
+**late-evasive**, and **occlusion-triggered-near-miss**. The oscillatory boolean output
 populates the existing ``SurrogateEvents.oscillation`` ledger slot; the detailed field
-record is intended for the ledger ``surrogate_events`` block. The late-evasive and
-occlusion-triggered-near-miss producers, and live emission wiring, are deliberate
-follow-ups.
+records are intended for the ledger ``surrogate_events`` block. Live emission wiring into
+the in-sim runners is a deliberate follow-up.
 
 .. note::
 

--- a/robot_sf/benchmark/safety_predicates.py
+++ b/robot_sf/benchmark/safety_predicates.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 OSCILLATORY_PREDICATE_SCHEMA = "safety_predicate.oscillatory_control.v1"
+LATE_EVASIVE_PREDICATE_SCHEMA = "safety_predicate.late_evasive.v1"
 
 
 def _sign_changes(values: NDArray[np.float64]) -> int:
@@ -131,4 +132,110 @@ def oscillatory_control_predicate(
     }
 
 
-__all__ = ["OSCILLATORY_PREDICATE_SCHEMA", "oscillatory_control_predicate"]
+def _first_true_index(flags: NDArray[np.bool_]) -> int | None:
+    """Return the index of the first ``True`` flag, or ``None`` when there is none."""
+    hits = np.flatnonzero(flags)
+    return int(hits[0]) if hits.size else None
+
+
+def late_evasive_predicate(
+    hazard_distances: NDArray[np.floating] | object,
+    hazard_visible: NDArray[np.bool_] | object,
+    speeds: NDArray[np.floating] | object,
+    *,
+    dt: float,
+    conflict_radius_m: float = 2.0,
+    decel_threshold_m_s2: float = 0.5,
+    max_response_latency_s: float = 1.0,
+) -> dict[str, Any]:
+    """Produce the late-evasive-reaction predicate fields for one episode.
+
+    A late evasive reaction is a clearance-restoring action (here: the first significant
+    deceleration) that comes too long after the hazard first becomes visible, or only
+    after the robot has already entered the conflict zone.
+
+    Args:
+        hazard_distances: ``(N,)`` distance to the nearest hazard per step (m).
+        hazard_visible: ``(N,)`` boolean — whether the hazard is visible per step.
+        speeds: ``(N,)`` robot speed per step (m/s).
+        dt: Per-step timestep (s, > 0).
+        conflict_radius_m: Distance defining conflict-zone entry.
+        decel_threshold_m_s2: Deceleration magnitude that counts as an evasive action.
+        max_response_latency_s: Latency above which a reaction is "late".
+
+    Returns:
+        dict[str, Any]: Versioned record with the motivated fields and the diagnostic
+        ``late_evasive`` boolean.
+    """
+    if not (dt > 0.0):
+        raise ValueError(f"dt must be > 0, got {dt!r}")
+    dist = np.asarray(hazard_distances, dtype=np.float64).reshape(-1)
+    visible = np.asarray(hazard_visible, dtype=bool).reshape(-1)
+    speed = np.asarray(speeds, dtype=np.float64).reshape(-1)
+    n = dist.shape[0]
+    if not (visible.shape[0] == n == speed.shape[0]):
+        raise ValueError("hazard_distances, hazard_visible, and speeds must share length N")
+    if n < 2:
+        raise ValueError("at least two steps are required")
+
+    first_visible = _first_true_index(visible)
+    conflict_entry = _first_true_index(dist <= conflict_radius_m)
+    minimum_distance = float(np.min(dist))
+
+    # Clearance-restoring action: first step whose deceleration exceeds the threshold,
+    # at or after the hazard becomes visible.
+    decel = -np.diff(speed) / dt  # positive when slowing down; index i is step i->i+1
+    action_step: int | None = None
+    if first_visible is not None:
+        candidates = np.flatnonzero(decel >= decel_threshold_m_s2)
+        candidates = candidates[candidates >= first_visible]
+        action_step = int(candidates[0]) + 1 if candidates.size else None
+
+    response_latency_s: float | None = None
+    if first_visible is not None and action_step is not None:
+        response_latency_s = float((action_step - first_visible) * dt)
+
+    # Required deceleration to stop within the visible distance, at first visibility.
+    required_deceleration_m_s2 = 0.0
+    if first_visible is not None:
+        v0 = speed[first_visible]
+        d0 = max(dist[first_visible], 1e-9)
+        required_deceleration_m_s2 = float(v0 * v0 / (2.0 * d0))
+
+    late_evasive = bool(
+        first_visible is not None
+        and (
+            action_step is None
+            or (response_latency_s is not None and response_latency_s > max_response_latency_s)
+            or (conflict_entry is not None and action_step > conflict_entry)
+        )
+    )
+
+    return {
+        "schema_version": LATE_EVASIVE_PREDICATE_SCHEMA,
+        "predicate": "late_evasive",
+        "evidence_kind": "diagnostic_proxy",
+        "late_evasive": late_evasive,
+        "fields": {
+            "first_hazard_visible_step": first_visible,
+            "conflict_zone_entry_step": conflict_entry,
+            "first_clearance_restoring_action_step": action_step,
+            "minimum_distance_m": minimum_distance,
+            "required_deceleration_m_s2": required_deceleration_m_s2,
+            "response_latency_s": response_latency_s,
+            "n_steps": n,
+        },
+        "thresholds": {
+            "conflict_radius_m": conflict_radius_m,
+            "decel_threshold_m_s2": decel_threshold_m_s2,
+            "max_response_latency_s": max_response_latency_s,
+        },
+    }
+
+
+__all__ = [
+    "LATE_EVASIVE_PREDICATE_SCHEMA",
+    "OSCILLATORY_PREDICATE_SCHEMA",
+    "late_evasive_predicate",
+    "oscillatory_control_predicate",
+]

--- a/robot_sf/benchmark/safety_predicates.py
+++ b/robot_sf/benchmark/safety_predicates.py
@@ -21,6 +21,7 @@ follow-ups.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from itertools import pairwise
 from typing import TYPE_CHECKING, Any
 
@@ -31,6 +32,7 @@ if TYPE_CHECKING:
 
 OSCILLATORY_PREDICATE_SCHEMA = "safety_predicate.oscillatory_control.v1"
 LATE_EVASIVE_PREDICATE_SCHEMA = "safety_predicate.late_evasive.v1"
+OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA = "safety_predicate.occlusion_near_miss.v1"
 
 
 def _sign_changes(values: NDArray[np.float64]) -> int:
@@ -233,9 +235,121 @@ def late_evasive_predicate(
     }
 
 
+def _emergence_step(visible: NDArray[np.bool_]) -> int | None:
+    """Return the first occluded->visible transition index, or ``None``."""
+    for i in range(1, visible.shape[0]):
+        if visible[i] and not visible[i - 1]:
+            return i
+    return None
+
+
+@dataclass(frozen=True, slots=True)
+class OcclusionNearMissParams:
+    """Tunable thresholds for the occlusion-near-miss predicate.
+
+    Attributes:
+        near_miss_radius_m: Minimum-separation threshold defining a near miss.
+        detection_confidence_threshold: Track confidence counting as a detection.
+        decel_threshold_m_s2: Deceleration magnitude counting as a first response.
+    """
+
+    near_miss_radius_m: float = 0.5
+    detection_confidence_threshold: float = 0.5
+    decel_threshold_m_s2: float = 0.5
+
+
+def occlusion_near_miss_predicate(
+    hazard_distances: NDArray[np.floating] | object,
+    visible: NDArray[np.bool_] | object,
+    track_confidence: NDArray[np.floating] | object,
+    speeds: NDArray[np.floating] | object,
+    *,
+    dt: float,
+    params: OcclusionNearMissParams | None = None,
+    predicted_minimum_separation_m: float | None = None,
+) -> dict[str, Any]:
+    """Produce the occlusion-triggered-near-miss predicate fields for one episode.
+
+    The predicate fires when a previously **occluded** actor emerges and a near miss
+    follows — the failure family where the planner's separation buffer is too thin to
+    absorb a late detection.
+
+    Args:
+        hazard_distances: ``(N,)`` distance to the actor per step (m).
+        visible: ``(N,)`` boolean line-of-sight visibility per step.
+        track_confidence: ``(N,)`` track-existence confidence per step in ``[0, 1]``.
+        speeds: ``(N,)`` robot speed per step (m/s).
+        dt: Per-step timestep (s, > 0).
+        params: Tunable thresholds; defaults to :class:`OcclusionNearMissParams`.
+        predicted_minimum_separation_m: Optional predicted min separation under occlusion.
+
+    Returns:
+        dict[str, Any]: Versioned record with the motivated fields and the diagnostic
+        ``occlusion_near_miss`` boolean.
+    """
+    if not (dt > 0.0):
+        raise ValueError(f"dt must be > 0, got {dt!r}")
+    params = params or OcclusionNearMissParams()
+    dist = np.asarray(hazard_distances, dtype=np.float64).reshape(-1)
+    vis = np.asarray(visible, dtype=bool).reshape(-1)
+    conf = np.asarray(track_confidence, dtype=np.float64).reshape(-1)
+    speed = np.asarray(speeds, dtype=np.float64).reshape(-1)
+    n = dist.shape[0]
+    if not (vis.shape[0] == n == conf.shape[0] == speed.shape[0]):
+        raise ValueError("all per-step signals must share length N")
+    if n < 2:
+        raise ValueError("at least two steps are required")
+
+    min_sep_step = int(np.argmin(dist))
+    actual_minimum_separation = float(dist[min_sep_step])
+    near_miss = actual_minimum_separation <= params.near_miss_radius_m
+
+    # The actor was occluded at some point up to (and including) the closest approach.
+    was_occluded_before_min = bool(np.any(~vis[: min_sep_step + 1]))
+    emergence_step = _emergence_step(vis)
+
+    detected = np.flatnonzero(conf >= params.detection_confidence_threshold)
+    first_detection_step = int(detected[0]) if detected.size else None
+
+    decel = -np.diff(speed) / dt
+    first_response_step: int | None = None
+    if first_detection_step is not None:
+        candidates = np.flatnonzero(decel >= params.decel_threshold_m_s2)
+        candidates = candidates[candidates >= first_detection_step]
+        first_response_step = int(candidates[0]) + 1 if candidates.size else None
+
+    occlusion_near_miss = bool(near_miss and was_occluded_before_min and emergence_step is not None)
+
+    return {
+        "schema_version": OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA,
+        "predicate": "occlusion_near_miss",
+        "evidence_kind": "diagnostic_proxy",
+        "occlusion_near_miss": occlusion_near_miss,
+        "fields": {
+            "was_occluded_before_min": was_occluded_before_min,
+            "emergence_step": emergence_step,
+            "first_detection_step": first_detection_step,
+            "first_response_step": first_response_step,
+            "min_separation_step": min_sep_step,
+            "actual_minimum_separation_m": actual_minimum_separation,
+            "predicted_minimum_separation_m": predicted_minimum_separation_m,
+            "near_miss": near_miss,
+            "n_steps": n,
+        },
+        "thresholds": {
+            "near_miss_radius_m": params.near_miss_radius_m,
+            "detection_confidence_threshold": params.detection_confidence_threshold,
+            "decel_threshold_m_s2": params.decel_threshold_m_s2,
+        },
+    }
+
+
 __all__ = [
     "LATE_EVASIVE_PREDICATE_SCHEMA",
+    "OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA",
     "OSCILLATORY_PREDICATE_SCHEMA",
+    "OcclusionNearMissParams",
     "late_evasive_predicate",
+    "occlusion_near_miss_predicate",
     "oscillatory_control_predicate",
 ]

--- a/tests/benchmark/test_safety_predicates.py
+++ b/tests/benchmark/test_safety_predicates.py
@@ -1,0 +1,113 @@
+"""Tests for trace-level safety-predicate producers (issue #3483)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.safety_predicates import (
+    OSCILLATORY_PREDICATE_SCHEMA,
+    oscillatory_control_predicate,
+)
+
+_DT = 0.1
+
+
+def _oscillatory_trajectory() -> dict[str, object]:
+    """A zig-zag-in-place trajectory: many heading flips, ~zero net progress."""
+    positions = np.array(
+        [[0.0, 0.0], [0.5, 0.0], [0.0, 0.0], [0.5, 0.0], [0.0, 0.0], [0.5, 0.0], [0.0, 0.0]]
+    )
+    headings = np.array([0.0, 0.5, -0.5, 0.5, -0.5, 0.5, -0.5])
+    velocities = np.array([0.5, -0.5, 0.5, -0.5, 0.5, -0.5, 0.5])
+    return {"positions": positions, "headings": headings, "linear_velocities": velocities}
+
+
+def _straight_trajectory() -> dict[str, object]:
+    """A smooth straight run: no heading flips, full progress."""
+    positions = np.array([[float(i), 0.0] for i in range(7)])
+    headings = np.zeros(7)
+    velocities = np.ones(7)
+    return {"positions": positions, "headings": headings, "linear_velocities": velocities}
+
+
+def test_oscillatory_trajectory_is_flagged() -> None:
+    """A zig-zag-in-place trajectory must classify as oscillation with auditable fields."""
+    result = oscillatory_control_predicate(**_oscillatory_trajectory(), dt=_DT)
+
+    assert result["oscillation"] is True
+    fields = result["fields"]
+    assert fields["heading_rate_sign_changes"] >= 4
+    assert fields["progress_ratio"] == pytest.approx(0.0)
+    assert fields["path_length_m"] == pytest.approx(3.0)
+
+
+def test_straight_trajectory_is_not_flagged() -> None:
+    """A smooth straight run must not classify as oscillation."""
+    result = oscillatory_control_predicate(**_straight_trajectory(), dt=_DT)
+
+    assert result["oscillation"] is False
+    fields = result["fields"]
+    assert fields["heading_rate_sign_changes"] == 0
+    assert fields["progress_ratio"] == pytest.approx(1.0)
+
+
+def test_record_is_schema_tagged_and_labeled_diagnostic() -> None:
+    """The produced record must carry the versioned schema and diagnostic label."""
+    result = oscillatory_control_predicate(**_straight_trajectory(), dt=_DT)
+
+    assert result["schema_version"] == OSCILLATORY_PREDICATE_SCHEMA
+    assert result["predicate"] == "oscillatory_control"
+    assert result["evidence_kind"] == "diagnostic_proxy"
+    assert result["thresholds"]["min_heading_rate_sign_changes"] == 4
+
+
+def test_command_source_changes_are_counted() -> None:
+    """Command-source changes must be counted when the optional signal is provided."""
+    traj = _straight_trajectory()
+    sources = ["planner", "planner", "fallback", "fallback", "planner", "planner", "planner"]
+    result = oscillatory_control_predicate(**traj, dt=_DT, command_sources=sources)
+
+    assert result["fields"]["command_source_changes"] == 2
+
+
+def test_velocity_sign_changes_counted() -> None:
+    """Linear-velocity sign changes must reflect forward/reverse oscillation."""
+    result = oscillatory_control_predicate(**_oscillatory_trajectory(), dt=_DT)
+
+    # velocities = [0.5,-0.5,0.5,-0.5,0.5,-0.5,0.5] -> 6 sign changes
+    assert result["fields"]["linear_velocity_sign_changes"] == 6
+
+
+def test_thresholds_are_overridable() -> None:
+    """A stricter heading-flip threshold must be able to declassify a borderline case."""
+    traj = _oscillatory_trajectory()
+    strict = oscillatory_control_predicate(**traj, dt=_DT, min_heading_rate_sign_changes=99)
+
+    assert strict["oscillation"] is False
+
+
+@pytest.mark.parametrize(
+    "mutate",
+    [
+        lambda kw: kw.update(dt=0.0),
+        lambda kw: kw.update(headings=np.zeros(3)),  # length mismatch
+    ],
+)
+def test_invalid_inputs_are_rejected(mutate) -> None:
+    """Bad dt or mismatched signal lengths must fail closed."""
+    kwargs = {**_straight_trajectory(), "dt": _DT}
+    mutate(kwargs)
+    with pytest.raises(ValueError):
+        oscillatory_control_predicate(**kwargs)
+
+
+def test_single_step_is_rejected() -> None:
+    """A trajectory shorter than two steps cannot be evaluated."""
+    with pytest.raises(ValueError):
+        oscillatory_control_predicate(
+            positions=np.array([[0.0, 0.0]]),
+            headings=np.array([0.0]),
+            linear_velocities=np.array([0.0]),
+            dt=_DT,
+        )

--- a/tests/benchmark/test_safety_predicates.py
+++ b/tests/benchmark/test_safety_predicates.py
@@ -185,3 +185,92 @@ def test_late_evasive_rejects_bad_inputs() -> None:
         late_evasive_predicate(_HAZARD_DISTANCES, _HAZARD_VISIBLE, np.ones(3), dt=_DT)
     with pytest.raises(ValueError):
         late_evasive_predicate(np.array([1.0]), np.array([True]), np.array([1.0]), dt=_DT)
+
+
+# --- occlusion-triggered near-miss predicate ---------------------------------
+
+
+def test_occlusion_near_miss_fires_on_emerging_actor() -> None:
+    """A previously-occluded actor that emerges into a near miss must be flagged."""
+    from robot_sf.benchmark.safety_predicates import occlusion_near_miss_predicate
+
+    distances = np.array([5.0, 4.0, 3.0, 0.3, 1.0, 2.0])
+    visible = np.array([False, False, True, True, True, True])
+    confidence = np.array([0.0, 0.0, 0.6, 0.9, 0.9, 0.9])
+    speeds = np.array([1.0, 1.0, 1.0, 0.4, 0.2, 0.1])
+
+    result = occlusion_near_miss_predicate(distances, visible, confidence, speeds, dt=_DT)
+
+    assert result["occlusion_near_miss"] is True
+    fields = result["fields"]
+    assert fields["emergence_step"] == 2
+    assert fields["first_detection_step"] == 2
+    assert fields["near_miss"] is True
+    assert fields["min_separation_step"] == 3
+    assert fields["actual_minimum_separation_m"] == pytest.approx(0.3)
+
+
+def test_always_visible_actor_is_not_occlusion_triggered() -> None:
+    """The same near miss without any occlusion must not be occlusion-triggered."""
+    from robot_sf.benchmark.safety_predicates import occlusion_near_miss_predicate
+
+    distances = np.array([5.0, 4.0, 3.0, 0.3, 1.0, 2.0])
+    visible = np.ones(6, dtype=bool)
+    confidence = np.full(6, 0.9)
+    speeds = np.ones(6)
+
+    result = occlusion_near_miss_predicate(distances, visible, confidence, speeds, dt=_DT)
+
+    assert result["occlusion_near_miss"] is False
+    assert result["fields"]["emergence_step"] is None
+    assert result["fields"]["was_occluded_before_min"] is False
+
+
+def test_emerging_actor_without_near_miss_is_not_flagged() -> None:
+    """An emerging actor that never breaches the near-miss radius is not flagged."""
+    from robot_sf.benchmark.safety_predicates import occlusion_near_miss_predicate
+
+    distances = np.array([5.0, 4.0, 3.0, 2.0, 1.5, 1.2])  # min 1.2 > 0.5
+    visible = np.array([False, False, True, True, True, True])
+    confidence = np.array([0.0, 0.0, 0.7, 0.9, 0.9, 0.9])
+    speeds = np.ones(6)
+
+    result = occlusion_near_miss_predicate(distances, visible, confidence, speeds, dt=_DT)
+
+    assert result["occlusion_near_miss"] is False
+    assert result["fields"]["near_miss"] is False
+
+
+def test_occlusion_predicted_separation_passthrough_and_schema() -> None:
+    """Predicted min separation is echoed and the record carries its schema tag."""
+    from robot_sf.benchmark.safety_predicates import (
+        OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA,
+        occlusion_near_miss_predicate,
+    )
+
+    result = occlusion_near_miss_predicate(
+        np.array([2.0, 1.0]),
+        np.array([True, True]),
+        np.array([0.9, 0.9]),
+        np.array([1.0, 1.0]),
+        dt=_DT,
+        predicted_minimum_separation_m=3.0,
+    )
+
+    assert result["schema_version"] == OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA
+    assert result["predicate"] == "occlusion_near_miss"
+    assert result["fields"]["predicted_minimum_separation_m"] == pytest.approx(3.0)
+
+
+def test_occlusion_predicate_rejects_bad_inputs() -> None:
+    """Bad dt and mismatched signal lengths must fail closed."""
+    from robot_sf.benchmark.safety_predicates import occlusion_near_miss_predicate
+
+    with pytest.raises(ValueError):
+        occlusion_near_miss_predicate(
+            np.ones(4), np.ones(4, dtype=bool), np.ones(4), np.ones(4), dt=0.0
+        )
+    with pytest.raises(ValueError):
+        occlusion_near_miss_predicate(
+            np.ones(4), np.ones(3, dtype=bool), np.ones(4), np.ones(4), dt=_DT
+        )

--- a/tests/benchmark/test_safety_predicates.py
+++ b/tests/benchmark/test_safety_predicates.py
@@ -6,7 +6,9 @@ import numpy as np
 import pytest
 
 from robot_sf.benchmark.safety_predicates import (
+    LATE_EVASIVE_PREDICATE_SCHEMA,
     OSCILLATORY_PREDICATE_SCHEMA,
+    late_evasive_predicate,
     oscillatory_control_predicate,
 )
 
@@ -111,3 +113,75 @@ def test_single_step_is_rejected() -> None:
             linear_velocities=np.array([0.0]),
             dt=_DT,
         )
+
+
+# --- late-evasive reaction predicate -----------------------------------------
+
+_HAZARD_DISTANCES = np.array([5.0, 4.0, 3.0, 2.0, 1.0, 0.5])
+_HAZARD_VISIBLE = np.array([False, True, True, True, True, True])
+
+
+def test_late_evasive_when_no_clearance_action_taken() -> None:
+    """Hazard visible but constant speed (no deceleration) ⇒ late evasive."""
+    result = late_evasive_predicate(_HAZARD_DISTANCES, _HAZARD_VISIBLE, np.ones(6), dt=_DT)
+
+    assert result["late_evasive"] is True
+    fields = result["fields"]
+    assert fields["first_hazard_visible_step"] == 1
+    assert fields["first_clearance_restoring_action_step"] is None
+    assert fields["minimum_distance_m"] == pytest.approx(0.5)
+
+
+def test_prompt_deceleration_is_not_late() -> None:
+    """A prompt deceleration right after visibility is not late."""
+    speeds = np.array([1.0, 1.0, 0.5, 0.2, 0.1, 0.0])
+    result = late_evasive_predicate(_HAZARD_DISTANCES, _HAZARD_VISIBLE, speeds, dt=_DT)
+
+    assert result["late_evasive"] is False
+    assert result["fields"]["first_clearance_restoring_action_step"] == 2
+    assert result["fields"]["response_latency_s"] == pytest.approx(0.1)
+
+
+def test_latency_threshold_can_flag_a_borderline_reaction() -> None:
+    """A reaction within default latency becomes late under a stricter threshold."""
+    speeds = np.array([1.0, 1.0, 0.5, 0.2, 0.1, 0.0])
+    result = late_evasive_predicate(
+        _HAZARD_DISTANCES, _HAZARD_VISIBLE, speeds, dt=_DT, max_response_latency_s=0.05
+    )
+
+    assert result["late_evasive"] is True
+
+
+def test_no_visible_hazard_is_not_late_evasive() -> None:
+    """With no hazard ever visible, the predicate must not fire."""
+    result = late_evasive_predicate(_HAZARD_DISTANCES, np.zeros(6, dtype=bool), np.ones(6), dt=_DT)
+
+    assert result["late_evasive"] is False
+    assert result["fields"]["first_hazard_visible_step"] is None
+
+
+def test_required_deceleration_uses_visibility_state() -> None:
+    """Required deceleration must be v^2/(2 d) at first visibility."""
+    result = late_evasive_predicate(_HAZARD_DISTANCES, _HAZARD_VISIBLE, np.full(6, 2.0), dt=_DT)
+
+    # At step 1: v=2.0, d=4.0 -> 4/(2*4) = 0.5
+    assert result["fields"]["required_deceleration_m_s2"] == pytest.approx(0.5)
+
+
+def test_late_evasive_record_is_schema_tagged() -> None:
+    """The late-evasive record must carry its versioned schema and diagnostic label."""
+    result = late_evasive_predicate(_HAZARD_DISTANCES, _HAZARD_VISIBLE, np.ones(6), dt=_DT)
+
+    assert result["schema_version"] == LATE_EVASIVE_PREDICATE_SCHEMA
+    assert result["predicate"] == "late_evasive"
+    assert result["evidence_kind"] == "diagnostic_proxy"
+
+
+def test_late_evasive_rejects_bad_inputs() -> None:
+    """Bad dt, mismatched lengths, and single-step inputs must fail closed."""
+    with pytest.raises(ValueError):
+        late_evasive_predicate(_HAZARD_DISTANCES, _HAZARD_VISIBLE, np.ones(6), dt=0.0)
+    with pytest.raises(ValueError):
+        late_evasive_predicate(_HAZARD_DISTANCES, _HAZARD_VISIBLE, np.ones(3), dt=_DT)
+    with pytest.raises(ValueError):
+        late_evasive_predicate(np.array([1.0]), np.array([True]), np.array([1.0]), dt=_DT)


### PR DESCRIPTION
## Summary

First-increment producer for #3483.

The thesis motivates trace-level failure families but cannot report their rates until
**in-sim producers** emit auditable fields. This adds the **oscillatory local-control**
producer (the most self-contained of the three) as a pure, versioned function over a
per-step trajectory. Its boolean output is compatible with the existing
`SurrogateEvents.oscillation` slot in `robot_sf/benchmark/event_ledger.py`.

## Producer (`safety_predicate.oscillatory_control.v1`)

`oscillatory_control_predicate(positions, headings, linear_velocities, *, dt, …)` emits:

- `heading_rate_sign_changes`, `linear_velocity_sign_changes`, `command_source_changes`
- `net_progress_m`, `path_length_m`, `progress_ratio`, `mean_abs_jerk`, `n_steps`

Diagnostic classification: `oscillation = (heading_rate_sign_changes ≥ T_h) and
(progress_ratio ≤ T_p)` (defaults `T_h=4`, `T_p=0.5`). Thresholds are explicit and
overridable, and the raw fields are always emitted so a different threshold can be applied
downstream without recomputation.

## What changed

- `robot_sf/benchmark/safety_predicates.py` — the producer.
- `tests/benchmark/test_safety_predicates.py` — 9 tests (zig-zag flagged, straight run
  not flagged, field/threshold correctness, override, sign-change counts, fail-closed
  validation).
- `docs/context/issue_3483_safety_predicate_producers.md` — definitions and boundary.

## Scope boundary

Pure and side-effect free — **no** runtime/benchmark behavior change. Deferred follow-ups:
the **late-evasive** and **occlusion-triggered-near-miss** producers, and wiring live
emission into `build_event_ledger` / the stepping loop (needs per-step
visibility/track-confidence/command-source signals verified exposed). Predicate
definitions are versioned modeling choices, **diagnostic** until real-world label
validation (externally blocked, #3278) — rates must not be reported in the manuscript yet.

## Validation

```
uv run pytest tests/benchmark/test_safety_predicates.py -q   # 9 passed
uv run python scripts/validation/check_broad_exceptions.py   # passes at 285
ruff check / format                                          # clean
```

**Evidence grade:** smoke evidence (pure producer + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
