### PR TITLE
chore: drop deprecated rtk wrapper guidance from forward-facing surfaces

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -36,8 +36,8 @@ When using a specific tool or agent, read these first:
 - **Local machine config**: optional `local.machine.md` at the repository root when present
 - **Disk artifacts**: All generated output must go to git-ignored `output/` directory; small,
   durable evidence may be promoted to `docs/context/evidence/`
-- **Token optimization**: prefix shell commands with `rtk` when following this repository's agent
-  guidance.
+- **Shell commands**: use ordinary repository commands directly unless current maintainer
+  direction names a specific wrapper.
 
 ## Quick Start for Claude Code Tasks
 

--- a/.github/ISSUE_TEMPLATE/blocked-external-artifact.yml
+++ b/.github/ISSUE_TEMPLATE/blocked-external-artifact.yml
@@ -69,7 +69,7 @@ body:
     attributes:
       label: Validation / Testing
       description: Provide the availability check, smoke command, or docs validation.
-      placeholder: rtk uv run --active ...
+      placeholder: uv run --active ...
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/research-validation.yml
+++ b/.github/ISSUE_TEMPLATE/research-validation.yml
@@ -126,7 +126,7 @@ body:
     attributes:
       label: Validation command
       description: Provide the canonical command or explain why this is docs-only.
-      placeholder: rtk uv run --active ...
+      placeholder: uv run --active ...
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/test-debt.yml
+++ b/.github/ISSUE_TEMPLATE/test-debt.yml
@@ -64,7 +64,7 @@ body:
     attributes:
       label: Targeted validation
       description: Name the test command that proves the change.
-      placeholder: rtk uv run --active pytest ...
+      placeholder: uv run --active pytest ...
     validations:
       required: true
   - type: textarea

--- a/scripts/reporting/generate_result_card.py
+++ b/scripts/reporting/generate_result_card.py
@@ -162,7 +162,7 @@ def _extract_commands(summary: dict[str, Any], cli_commands: list[str]) -> list[
 
 def _has_exact_command(commands: list[str]) -> bool:
     vague_markers = ("see readme", "see docs", "n/a", "unknown", "not recorded")
-    command_prefixes = ("uv ", "python ", "rtk ", "bash ", "scripts/", "./scripts/")
+    command_prefixes = ("uv ", "python ", "bash ", "scripts/", "./scripts/")
     for command in commands:
         normalized = command.strip().lower()
         if not normalized or any(marker in normalized for marker in vague_markers):


### PR DESCRIPTION
## Summary

Drops the deprecated `rtk` shell-command wrapper prefix from **forward-facing surfaces** so new commands aren't authored with it. The `rtk` prefix was previously recommended for token optimization; this removes that recommendation from active guidance and contributor templates.

## Changes

- **`.claude/CLAUDE.md`** — replaces the `rtk` token-optimization note with neutral guidance: *"use ordinary repository commands directly unless current maintainer direction names a specific wrapper."*
- **Issue templates** (`blocked-external-artifact`, `research-validation`, `test-debt`) — validation-command placeholders now show `uv run --active ...` instead of `rtk uv run --active ...`.
- **`scripts/reporting/generate_result_card.py`** — removes `"rtk "` from the set of accepted exact-command prefixes in `_has_exact_command`.

## Scope boundary

Historical `docs/context/` evidence and trace docs (~86 references) are **intentionally left untouched** — they record commands as they were actually run and should remain faithful to history.

## Validation

- `uv run pytest tests/reporting/test_generate_result_card.py -q` → **11 passed**. No test depends on the `rtk` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
