### PR TITLE
feat(scenario): failure-cause classifier for universally-failing families (#3484)

### DIFF
--- a/docs/context/issue_3484_scenario_failure_cause.md
+++ b/docs/context/issue_3484_scenario_failure_cause.md
@@ -1,0 +1,53 @@
+# Issue #3484 — Universally-failing scenario failure-cause classifier (first increment)
+
+**Status:** diagnostic / proxy. **Evidence grade:** idea-level; verdicts are versioned
+modeling choices, diagnostic until validated. Answers the examiner challenge "no planner
+succeeds in several scenarios — are they valid?" by separating scenario defects from
+planner limits.
+
+## What this is
+
+`robot_sf/scenario_certification/failure_cause.py` is the **pure decision layer** that
+reclassifies a universally-failing scenario family from per-family diagnostic outcomes.
+A benchmark row no method can pass is useful for diagnosis but weak for comparative
+ranking, so the cause must be disambiguated before the row is used.
+
+## Classifier (`scenario_failure_cause.v1`)
+
+`classify_failure_cause(FamilyDiagnostics)` consumes:
+`any_planner_succeeded`, `route_feasible`, `actor_free_solved`, `extended_time_solved`,
+`oracle_solved` (each may be `None` when not run), and returns a verdict with `cause`,
+`comparable_for_ranking`, `evidence_complete`, `rationale`, and echoed `inputs`.
+
+Decision order (first match wins):
+
+1. a planner passed → `not_universally_failing`
+2. `route_feasible is False` → `infeasible_route` (scenario defect)
+3. `actor_free_solved is False` → `vehicle_infeasible` (footprint/adapter/limit defect)
+4. `extended_time_solved is True` → `time_limited` (time limit binds)
+5. `oracle_solved is True` → `planner_limited` (**only** rankable cause)
+6. route + actor-free succeed but `oracle_solved is False` →
+   `dynamic_blocking_or_deadlock`
+7. otherwise → `indeterminate`
+
+`comparable_for_ranking` is true **only** for `planner_limited`; every other cause is a
+scenario/time/feasibility defect that must be excluded from ranking claims.
+
+## Scope boundary
+
+Pure and side-effect free — no runtime/benchmark behavior change. The sim-integrated
+diagnostic **runners** (geometric clearance certification, oracle/scripted trajectory,
+actor-free run, extended-time, difficulty ramp) and ledger emission are deliberate
+follow-ups; this layer turns their outcomes into a reproducible verdict.
+
+## Tests
+
+`tests/scenario_certification/test_failure_cause.py`: each verdict branch, the
+precedence order, the rankability rule, `indeterminate` on missing diagnostics, and the
+versioned schema / input echo.
+
+## Related
+
+- Existing route-clearance certification: `configs/benchmarks/route_clearance_certifications_v1.yaml`,
+  `robot_sf/scenario_certification/v1.py`.
+- Safety-event ledger (emit target): #3482.

--- a/robot_sf/scenario_certification/failure_cause.py
+++ b/robot_sf/scenario_certification/failure_cause.py
@@ -1,0 +1,155 @@
+"""Reclassify universally-failing scenario families by failure cause (issue #3484).
+
+Some scenario families (bottleneck, cross-trap, head-on-corridor) are passed by *no*
+benchmark planner. A row no method can pass is useful for diagnosis but weak for
+comparative ranking, so before labeling such rows "universally hard" the cause must be
+disambiguated: an infeasible route, a vehicle-level infeasibility, a binding time limit,
+a genuine planner-capability gap, or reciprocal dynamic blocking.
+
+This module provides the **pure decision layer** that consumes the per-family diagnostic
+outcomes and emits a reproducible, versioned verdict. The sim-integrated diagnostic
+*runners* (geometric clearance certification, oracle/scripted trajectory, actor-free run,
+extended-time, difficulty ramp) are deliberate follow-ups; this layer is side-effect free
+and changes no runtime/benchmark behavior.
+
+Verdicts are versioned modeling choices, labeled diagnostic until validated.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+FAILURE_CAUSE_SCHEMA = "scenario_failure_cause.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class FamilyDiagnostics:
+    """Diagnostic outcomes for one universally-failing scenario family.
+
+    Each boolean may be ``None`` when that diagnostic was not run; the classifier then
+    degrades to ``indeterminate`` rather than guessing.
+
+    Attributes:
+        any_planner_succeeded: Whether any benchmark planner passed the family.
+        route_feasible: Whether a collision-free path exists for the vehicle footprint.
+        actor_free_solved: Whether the vehicle reaches goal with no pedestrians present.
+        extended_time_solved: Whether the family is solved under an extended time limit.
+        oracle_solved: Whether a privileged/scripted controller solves it within limits.
+    """
+
+    any_planner_succeeded: bool = False
+    route_feasible: bool | None = None
+    actor_free_solved: bool | None = None
+    extended_time_solved: bool | None = None
+    oracle_solved: bool | None = None
+
+
+# Stable verdict vocabulary.
+NOT_UNIVERSALLY_FAILING = "not_universally_failing"
+INFEASIBLE_ROUTE = "infeasible_route"
+VEHICLE_INFEASIBLE = "vehicle_infeasible"
+TIME_LIMITED = "time_limited"
+PLANNER_LIMITED = "planner_limited"
+DYNAMIC_BLOCKING_OR_DEADLOCK = "dynamic_blocking_or_deadlock"
+INDETERMINATE = "indeterminate"
+
+
+def classify_failure_cause(diagnostics: FamilyDiagnostics) -> dict[str, Any]:
+    """Map per-family diagnostics to a versioned failure-cause verdict.
+
+    Decision order (first match wins):
+
+    1. a planner did pass → ``not_universally_failing`` (premise violated);
+    2. ``route_feasible is False`` → ``infeasible_route`` (scenario defect);
+    3. ``actor_free_solved is False`` → ``vehicle_infeasible`` (footprint/adapter/limit
+       defect at the vehicle level, before pedestrians);
+    4. ``extended_time_solved is True`` → ``time_limited`` (the time limit binds);
+    5. ``oracle_solved is True`` → ``planner_limited`` (valid scenario; the gap is planner
+       capability — the only cause that is fair for comparative ranking);
+    6. ``oracle_solved is False`` with a feasible route and actor-free success →
+       ``dynamic_blocking_or_deadlock`` (reciprocal deadlock / unrealistic blocking);
+    7. otherwise → ``indeterminate`` (insufficient diagnostics).
+
+    Returns:
+        dict[str, Any]: Versioned verdict with ``cause``, ``comparable_for_ranking``,
+        ``evidence_complete``, and a human-readable ``rationale``.
+    """
+    cause, rationale = _decide(diagnostics)
+    evidence_complete = None not in (
+        diagnostics.route_feasible,
+        diagnostics.actor_free_solved,
+        diagnostics.extended_time_solved,
+        diagnostics.oracle_solved,
+    )
+    return {
+        "schema_version": FAILURE_CAUSE_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "cause": cause,
+        # Only a genuine planner-capability gap makes a universally-failing row a fair
+        # comparative-ranking signal; every other cause is a scenario/time/feasibility
+        # defect and must be excluded from ranking claims.
+        "comparable_for_ranking": cause == PLANNER_LIMITED,
+        "evidence_complete": evidence_complete,
+        "rationale": rationale,
+        "inputs": {
+            "any_planner_succeeded": diagnostics.any_planner_succeeded,
+            "route_feasible": diagnostics.route_feasible,
+            "actor_free_solved": diagnostics.actor_free_solved,
+            "extended_time_solved": diagnostics.extended_time_solved,
+            "oracle_solved": diagnostics.oracle_solved,
+        },
+    }
+
+
+def _decide(d: FamilyDiagnostics) -> tuple[str, str]:
+    """Return the (cause, rationale) for a diagnostics bundle."""
+    if d.any_planner_succeeded:
+        return (
+            NOT_UNIVERSALLY_FAILING,
+            "At least one planner passed; the family is not universally failing.",
+        )
+    if d.route_feasible is False:
+        return (
+            INFEASIBLE_ROUTE,
+            "No collision-free path exists for the vehicle footprint; scenario defect.",
+        )
+    if d.actor_free_solved is False:
+        return (
+            VEHICLE_INFEASIBLE,
+            "The vehicle cannot reach goal even with no pedestrians; vehicle-level defect.",
+        )
+    if d.extended_time_solved is True:
+        return (
+            TIME_LIMITED,
+            "Solved under an extended time limit; the time limit is the binding constraint.",
+        )
+    if d.oracle_solved is True:
+        return (
+            PLANNER_LIMITED,
+            "A privileged controller solves it within limits; the gap is planner capability.",
+        )
+    if d.oracle_solved is False and d.route_feasible is True and d.actor_free_solved is True:
+        return (
+            DYNAMIC_BLOCKING_OR_DEADLOCK,
+            "Route and actor-free runs succeed but even an oracle fails with reactive "
+            "pedestrians; reciprocal deadlock or unrealistic blocking.",
+        )
+    return (
+        INDETERMINATE,
+        "Insufficient diagnostics to disambiguate the failure cause.",
+    )
+
+
+__all__ = [
+    "DYNAMIC_BLOCKING_OR_DEADLOCK",
+    "FAILURE_CAUSE_SCHEMA",
+    "INDETERMINATE",
+    "INFEASIBLE_ROUTE",
+    "NOT_UNIVERSALLY_FAILING",
+    "PLANNER_LIMITED",
+    "TIME_LIMITED",
+    "VEHICLE_INFEASIBLE",
+    "FamilyDiagnostics",
+    "classify_failure_cause",
+]

--- a/tests/scenario_certification/test_failure_cause.py
+++ b/tests/scenario_certification/test_failure_cause.py
@@ -1,0 +1,100 @@
+"""Tests for the universally-failing scenario failure-cause classifier (issue #3484)."""
+
+from __future__ import annotations
+
+from robot_sf.scenario_certification.failure_cause import (
+    DYNAMIC_BLOCKING_OR_DEADLOCK,
+    FAILURE_CAUSE_SCHEMA,
+    INDETERMINATE,
+    INFEASIBLE_ROUTE,
+    NOT_UNIVERSALLY_FAILING,
+    PLANNER_LIMITED,
+    TIME_LIMITED,
+    VEHICLE_INFEASIBLE,
+    FamilyDiagnostics,
+    classify_failure_cause,
+)
+
+
+def test_not_universally_failing_when_a_planner_passed() -> None:
+    """If any planner passed, the premise is violated and ranking is unaffected."""
+    verdict = classify_failure_cause(FamilyDiagnostics(any_planner_succeeded=True))
+
+    assert verdict["cause"] == NOT_UNIVERSALLY_FAILING
+    assert verdict["comparable_for_ranking"] is False
+
+
+def test_infeasible_route_takes_precedence() -> None:
+    """An infeasible route is a scenario defect and wins over later checks."""
+    verdict = classify_failure_cause(FamilyDiagnostics(route_feasible=False, oracle_solved=True))
+
+    assert verdict["cause"] == INFEASIBLE_ROUTE
+    assert verdict["comparable_for_ranking"] is False
+
+
+def test_vehicle_infeasible_when_actor_free_run_fails() -> None:
+    """Failure with no pedestrians is a vehicle-level defect, not a planner gap."""
+    verdict = classify_failure_cause(
+        FamilyDiagnostics(route_feasible=True, actor_free_solved=False)
+    )
+
+    assert verdict["cause"] == VEHICLE_INFEASIBLE
+
+
+def test_time_limited_when_extended_time_solves() -> None:
+    """Solvability under extended time means the time limit is the binding constraint."""
+    verdict = classify_failure_cause(
+        FamilyDiagnostics(route_feasible=True, actor_free_solved=True, extended_time_solved=True)
+    )
+
+    assert verdict["cause"] == TIME_LIMITED
+
+
+def test_planner_limited_is_the_only_rankable_cause() -> None:
+    """An oracle-solvable family with no planner success is a fair planner comparison."""
+    verdict = classify_failure_cause(
+        FamilyDiagnostics(
+            route_feasible=True,
+            actor_free_solved=True,
+            extended_time_solved=False,
+            oracle_solved=True,
+        )
+    )
+
+    assert verdict["cause"] == PLANNER_LIMITED
+    assert verdict["comparable_for_ranking"] is True
+    assert verdict["evidence_complete"] is True
+
+
+def test_dynamic_blocking_when_oracle_also_fails() -> None:
+    """Route + actor-free succeed but the oracle fails ⇒ reciprocal deadlock/blocking."""
+    verdict = classify_failure_cause(
+        FamilyDiagnostics(
+            route_feasible=True,
+            actor_free_solved=True,
+            extended_time_solved=False,
+            oracle_solved=False,
+        )
+    )
+
+    assert verdict["cause"] == DYNAMIC_BLOCKING_OR_DEADLOCK
+    assert verdict["comparable_for_ranking"] is False
+
+
+def test_indeterminate_when_diagnostics_missing() -> None:
+    """With no diagnostics run, the verdict must be indeterminate, not a guess."""
+    verdict = classify_failure_cause(FamilyDiagnostics())
+
+    assert verdict["cause"] == INDETERMINATE
+    assert verdict["evidence_complete"] is False
+
+
+def test_verdict_is_schema_tagged_and_echoes_inputs() -> None:
+    """The verdict must be versioned, diagnostic-labeled, and echo its inputs."""
+    diagnostics = FamilyDiagnostics(route_feasible=False)
+    verdict = classify_failure_cause(diagnostics)
+
+    assert verdict["schema_version"] == FAILURE_CAUSE_SCHEMA
+    assert verdict["evidence_kind"] == "diagnostic_proxy"
+    assert verdict["inputs"]["route_feasible"] is False
+    assert isinstance(verdict["rationale"], str) and verdict["rationale"]


### PR DESCRIPTION
## Summary

First-increment decision layer for #3484.

Some scenario families (bottleneck, cross-trap, head-on-corridor) are passed by **no**
benchmark planner. Such a row is useful for diagnosis but weak for comparative ranking,
so before labeling it "universally hard" the cause must be disambiguated. This adds the
**pure decision layer** that reclassifies a family from its per-family diagnostic outcomes
— directly answering the examiner challenge *"no planner succeeds in several scenarios —
are they valid?"*

## Classifier (`scenario_failure_cause.v1`)

`classify_failure_cause(FamilyDiagnostics)` consumes `any_planner_succeeded`,
`route_feasible`, `actor_free_solved`, `extended_time_solved`, `oracle_solved` (each may
be `None` when not run) and returns `cause`, `comparable_for_ranking`, `evidence_complete`,
`rationale`, and echoed `inputs`. Decision order (first match wins):

1. a planner passed → `not_universally_failing`
2. `route_feasible is False` → `infeasible_route` (scenario defect)
3. `actor_free_solved is False` → `vehicle_infeasible` (footprint/adapter/limit defect)
4. `extended_time_solved is True` → `time_limited` (time limit binds)
5. `oracle_solved is True` → `planner_limited` (**only** rankable cause)
6. route + actor-free succeed but `oracle_solved is False` → `dynamic_blocking_or_deadlock`
7. otherwise → `indeterminate`

`comparable_for_ranking` is true **only** for `planner_limited`; every other cause is a
scenario/time/feasibility defect that must be excluded from ranking claims. Missing
diagnostics degrade to `indeterminate`, never a guess.

## Scope boundary

Pure and side-effect free — **no** runtime/benchmark behavior change. The sim-integrated
diagnostic **runners** (geometric clearance certification, oracle/scripted trajectory,
actor-free run, extended-time, difficulty ramp) and ledger emission are deliberate
follow-ups; this layer turns their outcomes into a reproducible verdict.

## Validation

```
uv run pytest tests/scenario_certification/test_failure_cause.py -q   # 8 passed
uv run python scripts/validation/check_broad_exceptions.py            # passes at 285
ruff check / format                                                   # clean
```

**Evidence grade:** smoke evidence (pure decision function + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
