### PR TITLE
feat(benchmark): constraints-first scoring layer + report + CLI (#3572)

### DIFF
--- a/docs/context/issue_3572_constraints_first_scoring.md
+++ b/docs/context/issue_3572_constraints_first_scoring.md
@@ -34,16 +34,24 @@ default. This layer does **not** touch the simulator or the metric producers.
   the ranking-inversion block, using each planner's admissible rate as the constraints-first
   ranking score.
 
+## CLI
+
+`python -m robot_sf.benchmark.constraints_first_scoring --episodes <episodes.jsonl>
+[--planner-key planner] [--compensatory <scores.json>] [--output <report.json>]` groups a
+flat episode JSONL by planner and writes the constraints-first report (per-planner summaries
+plus, with `--compensatory`, the ranking-inversion block). It reads already-collected records
+and fails closed (exit 2) on load/validation errors.
+
 ## Scope boundary
 
 Pure and side-effect free — no change to the simulator, metric producers, or default
-benchmark reporting. The report consumes already-collected episode records; wiring it into
-the benchmark **CLI** (reading a campaign's episode JSONL and writing the report artifact)
-is a deliberate follow-up.
+benchmark reporting; the CLI only **reads** an existing episode JSONL. Emitting this report
+automatically as part of a campaign run (rather than as a post-hoc command) is the only
+remaining follow-up.
 
 ## Tests
 
-`tests/benchmark/test_constraints_first_scoring.py` (19 tests): rule-of-three at k=0, UCB
+`tests/benchmark/test_constraints_first_scoring.py` (21 tests): rule-of-three at k=0, UCB
 monotonicity and validation, each admissibility gate, the survivorship delta, the planner
 summary contract, ranking-inversion detection / no-inversion / mismatched-set handling, and
 the end-to-end report builder (per-planner summaries + ranking inversion vs a composite).

--- a/docs/context/issue_3572_constraints_first_scoring.md
+++ b/docs/context/issue_3572_constraints_first_scoring.md
@@ -1,0 +1,49 @@
+# Issue #3572 — Constraints-first (non-compensatory) scoring layer (first increment)
+
+**Status:** diagnostic / post-hoc analysis. **Evidence grade:** idea-level; claims no
+planner is "safe" — it only ranks under explicit admissibility. Keeps the existing
+compensatory composite available for comparison.
+
+## What this is
+
+`robot_sf/benchmark/constraints_first_scoring.py` adds an **optional, post-hoc** scoring
+layer over existing episode records. The headline scoring is *compensatory* (a collision
+can be offset by faster/smoother motion); for safety-relevant navigation that is the wrong
+default. This layer does **not** touch the simulator or the metric producers.
+
+## Primitives (`constraints_first_scoring.v1`)
+
+- **`collision_upper_confidence_bound(n_events, n_episodes, confidence=0.95)`** — one-sided
+  Clopper–Pearson upper bound. At `n_events = 0` it reproduces the rule-of-three
+  (`≈ 3/N`), so a low-N planner with zero observed collisions is not reported as
+  collision-free.
+- **`AdmissibilityGates` + `is_episode_admissible`** — lexicographic gates
+  (collision → near-miss severity → timeout/deadlock); comfort/efficiency rank only among
+  admissible runs.
+- **`survivorship_aware_metric`** — each metric reported unconditionally and conditioned on
+  safe success, plus the survivorship-bias delta (conditioning flatters planners that fail
+  more often).
+- **`constraints_first_planner_summary`** — admissibility rate, collision rate + UCB, and
+  survivorship-aware comfort/efficiency for one planner.
+- **`ranking_inversion`** — per-planner ranks under the compensatory composite vs the
+  constraints-first order, and the planners whose rank changes (the empirical justification
+  for non-compensatory evaluation).
+
+## Scope boundary
+
+Pure and side-effect free — no change to the simulator, metric producers, or default
+benchmark reporting. Wiring these primitives into the benchmark report/CLI (and emitting a
+ranking-inversion table per campaign) is a deliberate follow-up.
+
+## Tests
+
+`tests/benchmark/test_constraints_first_scoring.py` (16 tests): rule-of-three at k=0, UCB
+monotonicity and validation, each admissibility gate, the survivorship delta, the planner
+summary contract, and ranking-inversion detection / no-inversion / mismatched-set handling.
+
+## References
+
+- Francis et al., *Principles and Guidelines for Evaluating Social Robot Navigation
+  Algorithms*, ACM THRI 2025.
+- Stratton et al., *Characterizing the Complexity of Social Robot Navigation Scenarios*,
+  RA-L 2025.

--- a/docs/context/issue_3572_constraints_first_scoring.md
+++ b/docs/context/issue_3572_constraints_first_scoring.md
@@ -29,17 +29,24 @@ default. This layer does **not** touch the simulator or the metric producers.
   constraints-first order, and the planners whose rank changes (the empirical justification
   for non-compensatory evaluation).
 
+- **`build_constraints_first_report`** — end-to-end report over per-planner episode records:
+  a constraints-first summary per planner plus (when a compensatory composite is supplied)
+  the ranking-inversion block, using each planner's admissible rate as the constraints-first
+  ranking score.
+
 ## Scope boundary
 
 Pure and side-effect free — no change to the simulator, metric producers, or default
-benchmark reporting. Wiring these primitives into the benchmark report/CLI (and emitting a
-ranking-inversion table per campaign) is a deliberate follow-up.
+benchmark reporting. The report consumes already-collected episode records; wiring it into
+the benchmark **CLI** (reading a campaign's episode JSONL and writing the report artifact)
+is a deliberate follow-up.
 
 ## Tests
 
-`tests/benchmark/test_constraints_first_scoring.py` (16 tests): rule-of-three at k=0, UCB
+`tests/benchmark/test_constraints_first_scoring.py` (19 tests): rule-of-three at k=0, UCB
 monotonicity and validation, each admissibility gate, the survivorship delta, the planner
-summary contract, and ranking-inversion detection / no-inversion / mismatched-set handling.
+summary contract, ranking-inversion detection / no-inversion / mismatched-set handling, and
+the end-to-end report builder (per-planner summaries + ranking inversion vs a composite).
 
 ## References
 

--- a/robot_sf/benchmark/constraints_first_scoring.py
+++ b/robot_sf/benchmark/constraints_first_scoring.py
@@ -233,9 +233,62 @@ def _mean(values: Sequence[float | None]) -> float | None:
     return sum(present) / len(present) if present else None
 
 
+def build_constraints_first_report(
+    planner_episodes: Mapping[str, Sequence[Mapping[str, Any]]],
+    *,
+    compensatory_scores: Mapping[str, float] | None = None,
+    gates: AdmissibilityGates | None = None,
+    comfort_key: str = "comfort",
+    efficiency_key: str = "efficiency",
+    collision_key: str = "collisions",
+    safe_key: str = "safe_success",
+    confidence: float = 0.95,
+) -> dict[str, Any]:
+    """Build the end-to-end constraints-first report over per-planner episode records.
+
+    For each planner this emits the constraints-first summary (admissibility, collision UCB,
+    survivorship-aware comfort/efficiency). When ``compensatory_scores`` is supplied, it also
+    emits the ranking-inversion diagnostic using the **admissible rate** as the
+    constraints-first ranking score — the empirical contrast between the soft composite and
+    the constraints-first order.
+
+    Returns:
+        dict[str, Any]: Versioned report with ``per_planner`` summaries and an optional
+        ``ranking_inversion`` block.
+    """
+    if not planner_episodes:
+        raise ValueError("at least one planner is required")
+    per_planner = {
+        planner: constraints_first_planner_summary(
+            episodes,
+            gates=gates,
+            comfort_key=comfort_key,
+            efficiency_key=efficiency_key,
+            collision_key=collision_key,
+            safe_key=safe_key,
+            confidence=confidence,
+        )
+        for planner, episodes in planner_episodes.items()
+    }
+    report: dict[str, Any] = {
+        "schema_version": CONSTRAINTS_FIRST_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "per_planner": per_planner,
+    }
+    if compensatory_scores is not None:
+        constraints_first_scores = {
+            planner: summary["admissible_rate"] for planner, summary in per_planner.items()
+        }
+        report["ranking_inversion"] = ranking_inversion(
+            compensatory_scores, constraints_first_scores
+        )
+    return report
+
+
 __all__ = [
     "CONSTRAINTS_FIRST_SCHEMA",
     "AdmissibilityGates",
+    "build_constraints_first_report",
     "collision_upper_confidence_bound",
     "constraints_first_planner_summary",
     "is_episode_admissible",

--- a/robot_sf/benchmark/constraints_first_scoring.py
+++ b/robot_sf/benchmark/constraints_first_scoring.py
@@ -21,7 +21,11 @@ admissibility.
 
 from __future__ import annotations
 
+import argparse
+import json
+import sys
 from dataclasses import dataclass
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from scipy.stats import beta
@@ -285,13 +289,102 @@ def build_constraints_first_report(
     return report
 
 
+def group_episodes_by_planner(
+    records: Sequence[Mapping[str, Any]], *, planner_key: str = "planner"
+) -> dict[str, list[dict[str, Any]]]:
+    """Group flat episode records into per-planner lists by ``planner_key``.
+
+    Returns:
+        dict[str, list[dict[str, Any]]]: Planner name → its episode records.
+    """
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for record in records:
+        planner = record.get(planner_key)
+        if planner is None:
+            raise ValueError(f"episode record is missing planner key {planner_key!r}")
+        grouped.setdefault(str(planner), []).append(dict(record))
+    return grouped
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load a JSONL file of episode records.
+
+    Returns:
+        list[dict[str, Any]]: One dict per non-empty JSONL line.
+    """
+    records: list[dict[str, Any]] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        record = json.loads(stripped)
+        if not isinstance(record, dict):
+            raise ValueError(f"{path}: each JSONL line must be a JSON object")
+        records.append(record)
+    return records
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the constraints-first report CLI parser.
+
+    Returns:
+        argparse.ArgumentParser: The configured parser.
+    """
+    parser = argparse.ArgumentParser(description="Build a constraints-first scoring report.")
+    parser.add_argument("--episodes", type=Path, required=True, help="Episode JSONL input.")
+    parser.add_argument("--planner-key", default="planner", help="Record field naming the planner.")
+    parser.add_argument(
+        "--compensatory",
+        type=Path,
+        default=None,
+        help="Optional JSON mapping planner -> compensatory composite score.",
+    )
+    parser.add_argument("--output", type=Path, default=None, help="Report JSON output path.")
+    parser.add_argument("--confidence", type=float, default=0.95, help="Confidence for the UCB.")
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Apply the constraints-first report to an existing episode JSONL file.
+
+    Returns:
+        int: ``0`` on success, ``2`` on a load/validation error.
+    """
+    args = _build_parser().parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        records = _load_jsonl(args.episodes)
+        planner_episodes = group_episodes_by_planner(records, planner_key=args.planner_key)
+        compensatory = None
+        if args.compensatory is not None:
+            compensatory = json.loads(args.compensatory.read_text(encoding="utf-8"))
+        report = build_constraints_first_report(
+            planner_episodes, compensatory_scores=compensatory, confidence=args.confidence
+        )
+    except (OSError, ValueError) as exc:
+        sys.stderr.write(f"{exc}\n")
+        return 2
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    else:
+        sys.stdout.write(rendered + "\n")
+    return 0
+
+
 __all__ = [
     "CONSTRAINTS_FIRST_SCHEMA",
     "AdmissibilityGates",
     "build_constraints_first_report",
     "collision_upper_confidence_bound",
     "constraints_first_planner_summary",
+    "group_episodes_by_planner",
     "is_episode_admissible",
+    "main",
     "ranking_inversion",
     "survivorship_aware_metric",
 ]
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/robot_sf/benchmark/constraints_first_scoring.py
+++ b/robot_sf/benchmark/constraints_first_scoring.py
@@ -1,0 +1,244 @@
+"""Constraints-first (non-compensatory) scoring layer over episode records (issue #3572).
+
+The headline benchmark scoring is *compensatory*: safety, progress, comfort, and efficiency
+are combined so a collision can be numerically offset by faster or smoother motion. For
+safety-relevant navigation this is the wrong default. This module adds an **optional,
+post-hoc** scoring layer over existing episode records that:
+
+1. gates runs **lexicographically** (collision → near-miss severity → deadlock/timeout) so
+   comfort/efficiency only rank among admissible runs;
+2. reports each comfort/efficiency metric **twice** — unconditional and conditioned on safe
+   success — and surfaces the survivorship-bias delta;
+3. reports an **upper confidence bound** on collision/near-miss probability so low-N planners
+   cannot appear collision-free; and
+4. produces a **ranking-inversion** diagnostic between the compensatory composite and the
+   constraints-first ordering.
+
+It does **not** touch the simulator or the metric producers, keeps the existing composite
+available for comparison, and claims no planner is "safe" — it only ranks under explicit
+admissibility.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from scipy.stats import beta
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+CONSTRAINTS_FIRST_SCHEMA = "constraints_first_scoring.v1"
+
+
+def collision_upper_confidence_bound(
+    n_events: int, n_episodes: int, *, confidence: float = 0.95
+) -> float:
+    """Return the one-sided Clopper–Pearson upper bound on an event probability.
+
+    With ``n_events`` collisions (or near misses) in ``n_episodes`` runs, this is the upper
+    end of the one-sided ``confidence``-level exact binomial interval. At ``n_events == 0``
+    it reproduces the familiar rule-of-three (``≈ 3/N`` at 95%), so a planner with zero
+    observed collisions over few episodes is not reported as collision-free.
+
+    Returns:
+        float: Upper confidence bound in ``[0, 1]``.
+    """
+    if n_episodes <= 0:
+        raise ValueError("n_episodes must be > 0")
+    if not (0 <= n_events <= n_episodes):
+        raise ValueError("n_events must satisfy 0 <= n_events <= n_episodes")
+    if not (0.0 < confidence < 1.0):
+        raise ValueError("confidence must be in (0, 1)")
+    if n_events == n_episodes:
+        return 1.0
+    return float(beta.ppf(confidence, n_events + 1, n_episodes - n_events))
+
+
+@dataclass(frozen=True, slots=True)
+class AdmissibilityGates:
+    """Lexicographic admissibility gates for a single episode.
+
+    Attributes:
+        max_collisions: Maximum collisions an admissible episode may have (default 0).
+        max_near_miss_severity: Optional cap on near-miss severity; ``None`` disables it.
+        forbid_timeout: Whether a timed-out episode is inadmissible.
+        forbid_deadlock: Whether a deadlocked episode is inadmissible.
+    """
+
+    max_collisions: int = 0
+    max_near_miss_severity: float | None = None
+    forbid_timeout: bool = True
+    forbid_deadlock: bool = True
+
+
+def is_episode_admissible(
+    episode: Mapping[str, Any],
+    gates: AdmissibilityGates | None = None,
+    *,
+    collision_key: str = "collisions",
+    near_miss_key: str = "near_miss_severity",
+    timeout_key: str = "timeout",
+    deadlock_key: str = "deadlock",
+) -> bool:
+    """Return whether an episode clears the lexicographic admissibility gates."""
+    gates = gates or AdmissibilityGates()
+    if _as_float(episode.get(collision_key), default=0.0) > gates.max_collisions:
+        return False
+    if gates.max_near_miss_severity is not None:
+        severity = episode.get(near_miss_key)
+        if severity is not None and _as_float(severity, default=0.0) > gates.max_near_miss_severity:
+            return False
+    if gates.forbid_timeout and bool(episode.get(timeout_key, False)):
+        return False
+    return not (gates.forbid_deadlock and bool(episode.get(deadlock_key, False)))
+
+
+def survivorship_aware_metric(
+    episodes: Sequence[Mapping[str, Any]],
+    metric_key: str,
+    *,
+    safe_key: str = "safe_success",
+) -> dict[str, Any]:
+    """Report a metric unconditionally and conditioned on safe success, with the delta.
+
+    Comfort/efficiency metrics computed only over successful episodes flatter planners that
+    fail more often; the delta exposes that survivorship bias.
+
+    Returns:
+        dict[str, Any]: ``unconditional_mean``, ``conditioned_on_safe_success_mean``,
+        ``survivorship_delta`` (conditioned − unconditional), and the two sample sizes.
+    """
+    all_values = [
+        _as_float(e[metric_key], default=None) for e in episodes if e.get(metric_key) is not None
+    ]
+    safe_values = [
+        _as_float(e[metric_key], default=None)
+        for e in episodes
+        if e.get(metric_key) is not None and bool(e.get(safe_key, False))
+    ]
+    unconditional = _mean(all_values)
+    conditioned = _mean(safe_values)
+    delta = None
+    if unconditional is not None and conditioned is not None:
+        delta = conditioned - unconditional
+    return {
+        "metric": metric_key,
+        "unconditional_mean": unconditional,
+        "conditioned_on_safe_success_mean": conditioned,
+        "survivorship_delta": delta,
+        "n_all": len(all_values),
+        "n_safe_success": len(safe_values),
+    }
+
+
+def constraints_first_planner_summary(
+    episodes: Sequence[Mapping[str, Any]],
+    *,
+    gates: AdmissibilityGates | None = None,
+    comfort_key: str = "comfort",
+    efficiency_key: str = "efficiency",
+    collision_key: str = "collisions",
+    safe_key: str = "safe_success",
+    confidence: float = 0.95,
+) -> dict[str, Any]:
+    """Summarize one planner under constraints-first scoring.
+
+    Returns:
+        dict[str, Any]: Versioned summary with admissibility rate, collision rate + upper
+        confidence bound, and survivorship-aware comfort/efficiency.
+    """
+    gates = gates or AdmissibilityGates()
+    n = len(episodes)
+    if n == 0:
+        raise ValueError("at least one episode is required")
+    admissible_flags = [
+        is_episode_admissible(e, gates, collision_key=collision_key) for e in episodes
+    ]
+    n_collision_episodes = sum(
+        1 for e in episodes if _as_float(e.get(collision_key), default=0.0) > 0
+    )
+    return {
+        "schema_version": CONSTRAINTS_FIRST_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "n_episodes": n,
+        "admissible_rate": sum(admissible_flags) / n,
+        "collision_rate": n_collision_episodes / n,
+        "collision_upper_confidence_bound": collision_upper_confidence_bound(
+            n_collision_episodes, n, confidence=confidence
+        ),
+        "comfort": survivorship_aware_metric(episodes, comfort_key, safe_key=safe_key),
+        "efficiency": survivorship_aware_metric(episodes, efficiency_key, safe_key=safe_key),
+    }
+
+
+def ranking_inversion(
+    compensatory_scores: Mapping[str, float],
+    constraints_first_scores: Mapping[str, float],
+) -> dict[str, Any]:
+    """Diagnose rank changes between the compensatory and constraints-first orderings.
+
+    Both mappings are planner → score (higher is better). Returns each planner's rank under
+    both orderings, the rank delta, and the planners whose rank changes — the empirical
+    justification for non-compensatory evaluation.
+
+    Returns:
+        dict[str, Any]: Per-planner ranks/deltas and the list of inverted planners.
+    """
+    if set(compensatory_scores) != set(constraints_first_scores):
+        raise ValueError("both rankings must cover the same planners")
+    comp_rank = _ranks(compensatory_scores)
+    cons_rank = _ranks(constraints_first_scores)
+    per_planner = {
+        name: {
+            "compensatory_rank": comp_rank[name],
+            "constraints_first_rank": cons_rank[name],
+            "rank_delta": cons_rank[name] - comp_rank[name],
+        }
+        for name in compensatory_scores
+    }
+    inverted = sorted(name for name, r in per_planner.items() if r["rank_delta"] != 0)
+    return {
+        "schema_version": CONSTRAINTS_FIRST_SCHEMA,
+        "per_planner": per_planner,
+        "inverted_planners": inverted,
+        "any_inversion": bool(inverted),
+    }
+
+
+def _ranks(scores: Mapping[str, float]) -> dict[str, int]:
+    """Return 1-based ranks (1 = best); ties broken by planner name for determinism."""
+    ordered = sorted(scores.items(), key=lambda kv: (-kv[1], kv[0]))
+    return {name: i + 1 for i, (name, _) in enumerate(ordered)}
+
+
+def _as_float(value: Any, *, default: float | None) -> float | None:
+    """Coerce a value to float.
+
+    Returns:
+        float | None: The float value, or ``default`` on missing/non-numeric input.
+    """
+    if value is None:
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _mean(values: Sequence[float | None]) -> float | None:
+    """Return the mean of the present values, or ``None`` when empty."""
+    present = [v for v in values if v is not None]
+    return sum(present) / len(present) if present else None
+
+
+__all__ = [
+    "CONSTRAINTS_FIRST_SCHEMA",
+    "AdmissibilityGates",
+    "collision_upper_confidence_bound",
+    "constraints_first_planner_summary",
+    "is_episode_admissible",
+    "ranking_inversion",
+    "survivorship_aware_metric",
+]

--- a/robot_sf/benchmark/constraints_first_scoring.py
+++ b/robot_sf/benchmark/constraints_first_scoring.py
@@ -115,12 +115,17 @@ def survivorship_aware_metric(
         ``survivorship_delta`` (conditioned − unconditional), and the two sample sizes.
     """
     all_values = [
-        _as_float(e[metric_key], default=None) for e in episodes if e.get(metric_key) is not None
+        v
+        for e in episodes
+        if e.get(metric_key) is not None
+        and (v := _as_float(e[metric_key], default=None)) is not None
     ]
     safe_values = [
-        _as_float(e[metric_key], default=None)
+        v
         for e in episodes
-        if e.get(metric_key) is not None and bool(e.get(safe_key, False))
+        if e.get(metric_key) is not None
+        and bool(e.get(safe_key, False))
+        and (v := _as_float(e[metric_key], default=None)) is not None
     ]
     unconditional = _mean(all_values)
     conditioned = _mean(safe_values)

--- a/tests/benchmark/test_constraints_first_scoring.py
+++ b/tests/benchmark/test_constraints_first_scoring.py
@@ -1,0 +1,128 @@
+"""Tests for the constraints-first scoring layer (issue #3572)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.constraints_first_scoring import (
+    CONSTRAINTS_FIRST_SCHEMA,
+    AdmissibilityGates,
+    collision_upper_confidence_bound,
+    constraints_first_planner_summary,
+    is_episode_admissible,
+    ranking_inversion,
+    survivorship_aware_metric,
+)
+
+
+def test_collision_ucb_reproduces_rule_of_three() -> None:
+    """Zero observed collisions must still yield a non-trivial upper bound (~3/N)."""
+    ub = collision_upper_confidence_bound(0, 100)
+
+    assert ub == pytest.approx(1 - 0.05 ** (1 / 100))
+    assert ub == pytest.approx(0.03, abs=0.005)
+
+
+def test_collision_ucb_is_one_when_all_collide() -> None:
+    """If every episode collides the upper bound is 1.0."""
+    assert collision_upper_confidence_bound(5, 5) == 1.0
+
+
+def test_collision_ucb_decreases_with_more_episodes() -> None:
+    """The same zero-collision rate must tighten as N grows."""
+    assert collision_upper_confidence_bound(0, 1000) < collision_upper_confidence_bound(0, 10)
+
+
+@pytest.mark.parametrize(
+    ("n_events", "n_episodes", "confidence"),
+    [(-1, 10, 0.95), (5, 4, 0.95), (0, 0, 0.95), (1, 10, 0.0), (1, 10, 1.0)],
+)
+def test_collision_ucb_rejects_invalid_inputs(
+    n_events: int, n_episodes: int, confidence: float
+) -> None:
+    """Out-of-range counts or confidence must fail closed."""
+    with pytest.raises(ValueError):
+        collision_upper_confidence_bound(n_events, n_episodes, confidence=confidence)
+
+
+def test_admissibility_gates_collision_first() -> None:
+    """A collision makes an episode inadmissible regardless of comfort/efficiency."""
+    assert not is_episode_admissible({"collisions": 1, "comfort": 1.0})
+    assert is_episode_admissible({"collisions": 0, "comfort": 0.0})
+
+
+def test_admissibility_respects_near_miss_timeout_deadlock() -> None:
+    """Near-miss severity, timeout, and deadlock gates must each block admissibility."""
+    gates = AdmissibilityGates(max_near_miss_severity=0.5)
+
+    assert not is_episode_admissible({"collisions": 0, "near_miss_severity": 0.9}, gates)
+    assert is_episode_admissible({"collisions": 0, "near_miss_severity": 0.3}, gates)
+    assert not is_episode_admissible({"collisions": 0, "timeout": True})
+    assert not is_episode_admissible({"collisions": 0, "deadlock": True})
+
+
+def test_survivorship_delta_exposes_conditioning_bias() -> None:
+    """Comfort over only-successful episodes must differ from the unconditional mean."""
+    episodes = [
+        {"comfort": 1.0, "safe_success": True},
+        {"comfort": 1.0, "safe_success": True},
+        {"comfort": 0.0, "safe_success": False},
+    ]
+    report = survivorship_aware_metric(episodes, "comfort")
+
+    assert report["unconditional_mean"] == pytest.approx(2 / 3)
+    assert report["conditioned_on_safe_success_mean"] == pytest.approx(1.0)
+    assert report["survivorship_delta"] == pytest.approx(1 / 3)
+    assert report["n_all"] == 3
+    assert report["n_safe_success"] == 2
+
+
+def test_planner_summary_is_versioned_and_complete() -> None:
+    """The planner summary must expose admissibility, collision UCB, and survivorship."""
+    episodes = [
+        {"collisions": 0, "comfort": 0.9, "efficiency": 0.8, "safe_success": True},
+        {"collisions": 1, "comfort": 0.2, "efficiency": 0.9, "safe_success": False},
+        {"collisions": 0, "comfort": 0.7, "efficiency": 0.6, "safe_success": True},
+    ]
+    summary = constraints_first_planner_summary(episodes)
+
+    assert summary["schema_version"] == CONSTRAINTS_FIRST_SCHEMA
+    assert summary["n_episodes"] == 3
+    assert summary["admissible_rate"] == pytest.approx(2 / 3)
+    assert summary["collision_rate"] == pytest.approx(1 / 3)
+    assert 0.0 < summary["collision_upper_confidence_bound"] <= 1.0
+    assert summary["comfort"]["survivorship_delta"] is not None
+
+
+def test_planner_summary_rejects_empty() -> None:
+    """A planner with no episodes cannot be summarized."""
+    with pytest.raises(ValueError):
+        constraints_first_planner_summary([])
+
+
+def test_ranking_inversion_detects_order_change() -> None:
+    """A planner that looks good only under the soft composite must surface as inverted."""
+    compensatory = {"A": 0.9, "B": 0.8, "C": 0.5}
+    # Under constraints-first, B (a frequent collider) drops below C.
+    constraints_first = {"A": 0.9, "B": 0.3, "C": 0.6}
+    result = ranking_inversion(compensatory, constraints_first)
+
+    assert result["any_inversion"] is True
+    assert set(result["inverted_planners"]) == {"B", "C"}
+    assert result["per_planner"]["B"]["compensatory_rank"] == 2
+    assert result["per_planner"]["B"]["constraints_first_rank"] == 3
+
+
+def test_ranking_inversion_none_when_orders_match() -> None:
+    """Identical orderings must report no inversion."""
+    scores = {"A": 0.9, "B": 0.5}
+    result = ranking_inversion(scores, {"A": 0.8, "B": 0.1})
+
+    assert result["any_inversion"] is False
+    assert result["inverted_planners"] == []
+
+
+def test_ranking_inversion_requires_same_planner_set() -> None:
+    """Mismatched planner sets must fail closed."""
+    with pytest.raises(ValueError):
+        ranking_inversion({"A": 1.0}, {"B": 1.0})

--- a/tests/benchmark/test_constraints_first_scoring.py
+++ b/tests/benchmark/test_constraints_first_scoring.py
@@ -126,3 +126,61 @@ def test_ranking_inversion_requires_same_planner_set() -> None:
     """Mismatched planner sets must fail closed."""
     with pytest.raises(ValueError):
         ranking_inversion({"A": 1.0}, {"B": 1.0})
+
+
+# --- end-to-end report builder -----------------------------------------------
+
+
+def _planner_episodes() -> dict[str, list[dict[str, object]]]:
+    """Two planners: A is admissible-heavy, B looks good but collides often."""
+    return {
+        "A": [
+            {"collisions": 0, "comfort": 0.8, "efficiency": 0.7, "safe_success": True},
+            {"collisions": 0, "comfort": 0.9, "efficiency": 0.6, "safe_success": True},
+        ],
+        "B": [
+            {"collisions": 1, "comfort": 1.0, "efficiency": 1.0, "safe_success": False},
+            {"collisions": 0, "comfort": 0.9, "efficiency": 0.9, "safe_success": True},
+        ],
+    }
+
+
+def test_report_builds_per_planner_summaries() -> None:
+    """The report must include a constraints-first summary for every planner."""
+    from robot_sf.benchmark.constraints_first_scoring import (
+        CONSTRAINTS_FIRST_SCHEMA,
+        build_constraints_first_report,
+    )
+
+    report = build_constraints_first_report(_planner_episodes())
+
+    assert report["schema_version"] == CONSTRAINTS_FIRST_SCHEMA
+    assert set(report["per_planner"]) == {"A", "B"}
+    assert report["per_planner"]["A"]["admissible_rate"] == pytest.approx(1.0)
+    assert report["per_planner"]["B"]["admissible_rate"] == pytest.approx(0.5)
+    assert "ranking_inversion" not in report
+
+
+def test_report_surfaces_ranking_inversion_against_composite() -> None:
+    """When B leads the soft composite but fails the gate, the report must flag inversion."""
+    from robot_sf.benchmark.constraints_first_scoring import build_constraints_first_report
+
+    # Compensatory composite ranks B above A (B's comfort/efficiency are higher).
+    report = build_constraints_first_report(
+        _planner_episodes(), compensatory_scores={"A": 0.78, "B": 0.95}
+    )
+
+    inversion = report["ranking_inversion"]
+    assert inversion["any_inversion"] is True
+    # Constraints-first ranks A (admissible_rate 1.0) above B (0.5).
+    assert inversion["per_planner"]["A"]["constraints_first_rank"] == 1
+    assert inversion["per_planner"]["B"]["constraints_first_rank"] == 2
+    assert inversion["per_planner"]["B"]["compensatory_rank"] == 1
+
+
+def test_report_rejects_empty_input() -> None:
+    """A report with no planners cannot be built."""
+    from robot_sf.benchmark.constraints_first_scoring import build_constraints_first_report
+
+    with pytest.raises(ValueError):
+        build_constraints_first_report({})

--- a/tests/benchmark/test_constraints_first_scoring.py
+++ b/tests/benchmark/test_constraints_first_scoring.py
@@ -184,3 +184,55 @@ def test_report_rejects_empty_input() -> None:
 
     with pytest.raises(ValueError):
         build_constraints_first_report({})
+
+
+# --- CLI ----------------------------------------------------------------------
+
+
+def test_cli_writes_report_from_jsonl(tmp_path) -> None:
+    """The CLI must group a flat episode JSONL by planner and write the report."""
+    import json
+
+    from robot_sf.benchmark.constraints_first_scoring import main
+
+    episodes = tmp_path / "episodes.jsonl"
+    lines = [
+        {"planner": "A", "collisions": 0, "comfort": 0.8, "efficiency": 0.7, "safe_success": True},
+        {"planner": "B", "collisions": 1, "comfort": 1.0, "efficiency": 1.0, "safe_success": False},
+        {"planner": "B", "collisions": 0, "comfort": 0.9, "efficiency": 0.9, "safe_success": True},
+    ]
+    episodes.write_text("\n".join(json.dumps(line) for line in lines) + "\n", encoding="utf-8")
+    compensatory = tmp_path / "comp.json"
+    compensatory.write_text(json.dumps({"A": 0.78, "B": 0.95}), encoding="utf-8")
+    out = tmp_path / "report.json"
+
+    code = main(
+        [
+            "--episodes",
+            str(episodes),
+            "--compensatory",
+            str(compensatory),
+            "--output",
+            str(out),
+        ]
+    )
+
+    assert code == 0
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert set(report["per_planner"]) == {"A", "B"}
+    assert report["ranking_inversion"]["any_inversion"] is True
+
+
+def test_cli_reports_missing_planner_key_without_traceback(tmp_path, capsys) -> None:
+    """A record missing the planner key must fail closed with exit code 2."""
+    import json
+
+    from robot_sf.benchmark.constraints_first_scoring import main
+
+    episodes = tmp_path / "episodes.jsonl"
+    episodes.write_text(json.dumps({"collisions": 0}) + "\n", encoding="utf-8")
+
+    code = main(["--episodes", str(episodes)])
+
+    assert code == 2
+    assert "planner" in capsys.readouterr().err

--- a/tests/benchmark/test_constraints_first_scoring.py
+++ b/tests/benchmark/test_constraints_first_scoring.py
@@ -77,6 +77,22 @@ def test_survivorship_delta_exposes_conditioning_bias() -> None:
     assert report["n_safe_success"] == 2
 
 
+def test_survivorship_sample_sizes_exclude_non_numeric_values() -> None:
+    """A non-numeric metric value must be dropped from both the mean and the sample count."""
+    episodes = [
+        {"comfort": 1.0, "safe_success": True},
+        {"comfort": "n/a", "safe_success": True},  # unparseable -> excluded everywhere
+        {"comfort": 0.0, "safe_success": False},
+    ]
+    report = survivorship_aware_metric(episodes, "comfort")
+
+    # The non-numeric value is excluded from the mean, so it must not inflate n_all/n_safe_success.
+    assert report["n_all"] == 2
+    assert report["n_safe_success"] == 1
+    assert report["unconditional_mean"] == pytest.approx(0.5)
+    assert report["conditioned_on_safe_success_mean"] == pytest.approx(1.0)
+
+
 def test_planner_summary_is_versioned_and_complete() -> None:
     """The planner summary must expose admissibility, collision UCB, and survivorship."""
     episodes = [


### PR DESCRIPTION
## Summary

First-increment, pure post-hoc scoring layer for #3572.

The headline benchmark scoring is **compensatory** — a collision can be numerically
offset by faster or smoother motion, which is the wrong default for safety-relevant
navigation. This adds an **optional, post-hoc** constraints-first scoring layer over
existing episode records. It does **not** touch the simulator or the metric producers and
keeps the compensatory composite available for comparison.

## Primitives (`constraints_first_scoring.v1`)

- **`collision_upper_confidence_bound`** — one-sided Clopper–Pearson upper bound on
  collision/near-miss probability. At `k = 0` it reproduces the rule-of-three (`≈ 3/N`), so
  a low-N planner with zero observed collisions is **not** reported as collision-free.
- **`AdmissibilityGates` + `is_episode_admissible`** — lexicographic gates
  (collision → near-miss severity → timeout/deadlock); comfort/efficiency rank only among
  admissible runs.
- **`survivorship_aware_metric`** — each metric reported unconditionally and conditioned on
  safe success, plus the survivorship-bias delta (conditioning flatters planners that fail
  more often).
- **`constraints_first_planner_summary`** + **`ranking_inversion`** — the per-planner
  constraints-first summary and the compensatory-vs-constraints-first rank-change diagnostic
  (the empirical justification for non-compensatory evaluation).

## Scope boundary

Pure and side-effect free — no change to the simulator, metric producers, or default
benchmark reporting. Wiring these primitives into the benchmark report/CLI (a per-campaign
ranking-inversion table) is a deliberate follow-up. Claims no planner is "safe" — only ranks
under explicit admissibility.

## Validation

```
uv run pytest tests/benchmark/test_constraints_first_scoring.py -q   # 16 passed
uv run python scripts/validation/check_broad_exceptions.py           # passes at 285
ruff check / format                                                  # clean
```

**Evidence grade:** smoke evidence (pure analytical primitives + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new constraints-first scoring view for episode results, with admissibility checks, collision risk bounds, survivorship-aware metrics, and planner ranking comparisons.
  * Introduced a new reference document describing how the scoring layer works and what it reports.

* **Tests**
  * Added coverage for collision risk calculations, admissibility rules, summary outputs, survivorship metrics, and ranking inversion detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->