### PR TITLE
feat(benchmark): metric-semantics reconciliation table over event ledger (#3482)

### DIFF
--- a/docs/context/issue_3482_metric_semantics_reconciliation.md
+++ b/docs/context/issue_3482_metric_semantics_reconciliation.md
@@ -1,0 +1,39 @@
+# Issue #3482 — Metric-semantics reconciliation table (increment)
+
+**Status:** integrity infra. The core `EpisodeEventLedger.v1` and its reconciliation guard
+(exact collision ⇒ collision metric > 0; goal/invalid_run mutual exclusion; metric-definition
+presence) already exist and are property-tested in `robot_sf/benchmark/event_ledger.py` +
+`tests/benchmark/test_event_ledger.py`. This increment adds the remaining DoD artifact.
+
+## What this is
+
+`robot_sf/benchmark/event_ledger_reconciliation.py` builds the **metric-semantics
+reconciliation table** for one episode ledger: for each reported metric field it records the
+producer, sampling level, kind (`exact_or_sampled` | `derived`), representative downstream
+consumers, and surfaces the overall audit result + any reconciliation violations. It is a pure
+function over an `EpisodeEventLedger.v1` payload, so every table in the empirical chapter gets a
+single, testable provenance row — closing the "easiest examiner attack" (an exact collision flag
+silently coexisting with a zero collision count).
+
+## Output (`event_ledger_reconciliation.v1`)
+
+`build_metric_semantics_table(ledger)` →
+
+- `rows`: one per metric field (`field`, `level`, `kind`, `producer`, `representative_consumers`)
+  for `collision_count`, `near_miss`, `clearance_breach`, `ttc_breach`, `oscillation`;
+- `audit_result`, `reconciles`, and `violations` from `reconcile_event_ledger`.
+
+`representative_consumers` is intentionally conservative (audit orientation, not an exhaustive
+dependency graph).
+
+## Scope boundary
+
+Pure and side-effect free. The remaining DoD item — re-running the frozen `0.0.2` traces through
+the corrected analyzer for a before/after numerical diff — needs the archived artifacts and is a
+deliberate follow-up.
+
+## Tests
+
+`tests/benchmark/test_event_ledger_reconciliation.py`: one row per reported field with valid
+kind/producer, collision field is exact/sampled with a named producer, a clean ledger reconciles
+(audit pass), and an exact-collision-vs-zero-metric disagreement surfaces as a violation.

--- a/robot_sf/benchmark/event_ledger_reconciliation.py
+++ b/robot_sf/benchmark/event_ledger_reconciliation.py
@@ -1,0 +1,78 @@
+"""Metric-semantics reconciliation table over an episode event ledger (issue #3482).
+
+The paired protocol that motivated `EpisodeEventLedger.v1` found that an exact environment
+collision flag could fire while sampled collision metrics stayed zero. The ledger and its
+reconciliation guard (`robot_sf/benchmark/event_ledger.py`) already surface that exact-vs-derived
+disagreement instead of silently resolving it. This module adds the remaining integrity artifact:
+a **metric-semantics reconciliation table** that, for each reported field, records its producer,
+sampling level, kind (exact/sampled/derived), representative downstream consumers, and the audit
+result — so every table in the empirical chapter has a single, testable provenance row.
+
+The table is built purely from a ledger payload; it is reproducible and changes no behavior.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from robot_sf.benchmark.event_ledger import reconcile_event_ledger
+
+RECONCILIATION_TABLE_SCHEMA = "event_ledger_reconciliation.v1"
+
+# Representative (not exhaustive) downstream consumers per ledger metric field, for audit
+# orientation. Derived from the current benchmark tree; intentionally conservative.
+_REPRESENTATIVE_CONSUMERS: dict[str, tuple[str, ...]] = {
+    "collision_count": ("map_runner_metrics", "camera_ready_campaign", "aggregate"),
+    "near_miss": ("failure_extractor", "hybrid_evidence_matrix", "seed_variance"),
+    "clearance_breach": ("aggregate", "hybrid_evidence_matrix"),
+    "ttc_breach": ("aggregate",),
+    "oscillation": ("safety_predicates", "aggregate"),
+}
+
+
+def build_metric_semantics_table(ledger: Mapping[str, Any]) -> dict[str, Any]:
+    """Build the metric-semantics reconciliation table for one episode ledger.
+
+    Args:
+        ledger: An ``EpisodeEventLedger.v1`` payload (e.g. from ``build_event_ledger``).
+
+    Returns:
+        dict[str, Any]: A versioned table with one row per reported metric field
+        (field, level, kind, producer, representative consumers), plus the overall audit
+        result and any reconciliation violations.
+    """
+    metric_definitions = ledger.get("metric_definitions")
+    metric_definitions = metric_definitions if isinstance(metric_definitions, Mapping) else {}
+    reconciliation = ledger.get("reconciliation")
+    reconciliation = reconciliation if isinstance(reconciliation, Mapping) else {}
+    violations = list(reconcile_event_ledger(ledger))
+
+    rows = []
+    for field in sorted(metric_definitions):
+        definition = metric_definitions[field]
+        definition = definition if isinstance(definition, Mapping) else {}
+        rows.append(
+            {
+                "field": field,
+                "level": "episode",
+                "kind": str(definition.get("kind", "unknown")),
+                "producer": str(definition.get("source", "missing")),
+                "representative_consumers": list(_REPRESENTATIVE_CONSUMERS.get(field, ())),
+            }
+        )
+
+    return {
+        "schema_version": RECONCILIATION_TABLE_SCHEMA,
+        "ledger_schema_version": ledger.get("schema_version"),
+        "audit_result": str(reconciliation.get("audit_result", "unchecked")),
+        "reconciles": not violations,
+        "violations": violations,
+        "rows": rows,
+    }
+
+
+__all__ = [
+    "RECONCILIATION_TABLE_SCHEMA",
+    "build_metric_semantics_table",
+]

--- a/tests/benchmark/test_event_ledger_reconciliation.py
+++ b/tests/benchmark/test_event_ledger_reconciliation.py
@@ -1,0 +1,79 @@
+"""Tests for the metric-semantics reconciliation table (issue #3482)."""
+
+from __future__ import annotations
+
+from robot_sf.benchmark.event_ledger import build_event_ledger
+from robot_sf.benchmark.event_ledger_reconciliation import (
+    RECONCILIATION_TABLE_SCHEMA,
+    build_metric_semantics_table,
+)
+
+_EXPECTED_FIELDS = {
+    "collision_count",
+    "near_miss",
+    "clearance_breach",
+    "ttc_breach",
+    "oscillation",
+}
+
+
+def _record(*, collision_event: bool = False, collisions: float = 0.0) -> dict:
+    """Build a minimal episode record (mirrors the event-ledger test fixture)."""
+    return {
+        "scenario_id": "s",
+        "seed": 0,
+        "algo": "demo",
+        "metrics": {
+            "success": 0.0 if collision_event else 1.0,
+            "collisions": collisions,
+        },
+        "termination_reason": "collision" if collision_event else "success",
+        "outcome": {
+            "route_complete": not collision_event,
+            "collision_event": collision_event,
+        },
+    }
+
+
+def test_table_has_one_row_per_reported_field() -> None:
+    """The table must expose a provenance row for every reported metric field."""
+    ledger = build_event_ledger(_record(collision_event=True, collisions=1.0))
+    table = build_metric_semantics_table(ledger)
+
+    assert table["schema_version"] == RECONCILIATION_TABLE_SCHEMA
+    assert {row["field"] for row in table["rows"]} == _EXPECTED_FIELDS
+    for row in table["rows"]:
+        assert row["level"] == "episode"
+        assert row["kind"] in {"exact_or_sampled", "derived"}
+        assert row["producer"]
+        assert isinstance(row["representative_consumers"], list)
+
+
+def test_collision_count_is_exact_or_sampled_with_a_producer() -> None:
+    """The collision field must be exact/sampled and name its producing metric."""
+    ledger = build_event_ledger(_record(collision_event=True, collisions=1.0))
+    table = build_metric_semantics_table(ledger)
+
+    collision_row = next(r for r in table["rows"] if r["field"] == "collision_count")
+    assert collision_row["kind"] == "exact_or_sampled"
+    assert collision_row["producer"] != "missing"
+
+
+def test_clean_ledger_reconciles() -> None:
+    """A consistent ledger must report a passing audit and no violations."""
+    ledger = build_event_ledger(_record(collision_event=False, collisions=0.0))
+    table = build_metric_semantics_table(ledger)
+
+    assert table["reconciles"] is True
+    assert table["violations"] == []
+    assert table["audit_result"] == "pass"
+
+
+def test_exact_collision_with_zero_metric_surfaces_violation() -> None:
+    """An exact collision with zero collision metric must surface, not be silently resolved."""
+    ledger = build_event_ledger(_record(collision_event=True, collisions=1.0))
+    ledger["reconciliation"]["collision_metric_value"] = 0.0
+    table = build_metric_semantics_table(ledger)
+
+    assert table["reconciles"] is False
+    assert any("collision" in violation for violation in table["violations"])


### PR DESCRIPTION
## Summary

Increment on #3482 ("the easiest examiner attack on the entire empirical chapter").

The core `EpisodeEventLedger.v1` and its reconciliation **regression guard** (exact collision ⇒
collision metric > 0; goal/invalid_run mutual exclusion; metric-definition presence) already exist
and are property-tested in `robot_sf/benchmark/event_ledger.py`. This PR adds the remaining DoD
artifact: the **metric-semantics reconciliation table**.

## What changed

- **`robot_sf/benchmark/event_ledger_reconciliation.py`** (`event_ledger_reconciliation.v1`):
  `build_metric_semantics_table(ledger)` emits, for each reported metric field, a provenance row —
  `field`, `level`, `kind` (`exact_or_sampled` | `derived`), `producer`, and representative
  downstream consumers — plus the overall `audit_result`, `reconciles`, and `violations`. It is a
  pure function over an `EpisodeEventLedger.v1` payload, so every empirical-chapter table gets a
  single, testable provenance row.
- **`tests/benchmark/test_event_ledger_reconciliation.py`** — 4 tests: one row per field with valid
  kind/producer, collision field is exact/sampled with a named producer, clean ledger reconciles
  (audit pass), and an exact-collision-vs-zero-metric disagreement surfaces as a violation.
- **docs context note**.

## Scope boundary

Pure and side-effect free. `representative_consumers` is intentionally conservative (audit
orientation, not an exhaustive dependency graph). The remaining DoD item — re-running the frozen
`0.0.2` traces through the corrected analyzer for a before/after numerical diff — needs the archived
artifacts and is a deliberate follow-up.

## Validation

```
uv run pytest tests/benchmark/test_event_ledger_reconciliation.py -q   # 4 passed
uv run python scripts/validation/check_broad_exceptions.py             # passes (no broad catches)
ruff check / format                                                    # clean
```

**Evidence grade:** smoke evidence (pure function + fixtures over the existing ledger). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
