### PR TITLE
fix(benchmark): preserve + recover completed-run manifests on cross-worktree paths

### DIFF
--- a/robot_sf/benchmark/imitation_manifest.py
+++ b/robot_sf/benchmark/imitation_manifest.py
@@ -65,6 +65,37 @@ def _path_to_manifest(path: Path) -> str:
             ) from None
 
 
+def _path_to_manifest_lenient(path: Path, *, field: str) -> str:
+    """Serialise ``path`` portably, degrading to the basename for foreign paths.
+
+    Unlike :func:`_path_to_manifest`, this never raises when ``path`` resolves outside the
+    artefact and repository roots. That situation is legitimate when a run executes from one
+    git worktree but references a config or evaluation artefact materialised under a sibling
+    worktree: the strict helper would raise and abort the manifest write *after* training has
+    already completed, discarding the entire run's evidence.
+
+    Instead, foreign absolute paths degrade to their basename — portable and free of any
+    host-specific directory leakage — and the loss of the full path is logged so it remains
+    traceable.
+
+    Returns:
+        Portable path string, or the basename when the path is outside the allowed roots.
+    """
+
+    try:
+        return _path_to_manifest(path)
+    except ValueError:
+        basename = Path(path).name
+        logger.warning(
+            "Manifest field '{}' path {} is outside allowed roots; recording basename '{}' "
+            "to preserve the completed run's evidence.",
+            field,
+            path,
+            basename,
+        )
+        return basename
+
+
 def _serialize_metric(metric: MetricAggregate) -> dict[str, Any]:
     """Serialize a metric aggregate into a JSON-friendly dict.
 
@@ -174,22 +205,26 @@ def serialize_training_run(artifact: TrainingRunArtifact) -> dict[str, Any]:
         "metrics": _serialize_metrics_map(artifact.metrics),
         "episode_log_path": _path_to_manifest(artifact.episode_log_path),
         "eval_timeline_path": (
-            _path_to_manifest(artifact.eval_timeline_path)
+            _path_to_manifest_lenient(artifact.eval_timeline_path, field="eval_timeline_path")
             if artifact.eval_timeline_path is not None
             else None
         ),
         "eval_per_scenario_path": (
-            _path_to_manifest(artifact.eval_per_scenario_path)
+            _path_to_manifest_lenient(
+                artifact.eval_per_scenario_path, field="eval_per_scenario_path"
+            )
             if artifact.eval_per_scenario_path is not None
             else None
         ),
         "perf_summary_path": (
-            _path_to_manifest(artifact.perf_summary_path)
+            _path_to_manifest_lenient(artifact.perf_summary_path, field="perf_summary_path")
             if artifact.perf_summary_path is not None
             else None
         ),
         "evaluation_scenario_config": (
-            _path_to_manifest(artifact.evaluation_scenario_config)
+            _path_to_manifest_lenient(
+                artifact.evaluation_scenario_config, field="evaluation_scenario_config"
+            )
             if artifact.evaluation_scenario_config is not None
             else None
         ),

--- a/scripts/tools/backfill_training_run_manifest.py
+++ b/scripts/tools/backfill_training_run_manifest.py
@@ -1,0 +1,253 @@
+#!/usr/bin/env python3
+"""Backfill a training-run manifest from a completed run's retained artefacts.
+
+This recovers runs that trained and evaluated successfully but lost their
+``benchmarks/ppo_imitation/runs/<run_id>.json`` manifest because the manifest
+write raised on a cross-worktree path (see ``imitation_manifest`` and the
+``manifest_path_outside_allowed_roots_after_training`` failure mode). The
+training compute is intact on disk; only the manifest JSON is missing, so it is
+reconstructed from the artefacts the pipeline already wrote:
+
+* ``benchmarks/expert_policies/<policy>.json``        -> metrics, seeds
+* ``benchmarks/ppo_imitation/perf/<run>.json``        -> run_id, wall-clock
+* ``benchmarks/ppo_imitation/eval_by_scenario/<run>.json`` -> scenario coverage
+* ``benchmarks/ppo_imitation/{episodes,eval_timeline,perf}/*`` -> path fields
+
+No training or evaluation is re-run. The reconstructed manifest is marked as
+backfilled in its notes so downstream consumers can tell it apart from a manifest
+written inline by the training pipeline.
+
+Usage::
+
+    python scripts/tools/backfill_training_run_manifest.py --run-dir <dir> [--dry-run]
+
+``--run-dir`` is the directory that contains ``benchmarks/`` (the per-job output
+root). Pass ``--benchmarks-dir`` to point directly at a ``benchmarks`` tree.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.imitation_manifest import (
+    write_training_run_manifest,
+)
+from robot_sf.common import (
+    MetricAggregate,
+    TrainingRunArtifact,
+    TrainingRunStatus,
+    TrainingRunType,
+)
+
+
+class BackfillError(RuntimeError):
+    """Raised when the retained artefacts are insufficient to rebuild a manifest."""
+
+
+def _load_json(path: Path) -> Any:
+    """Load a JSON file, raising :class:`BackfillError` with context on failure."""
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:  # pragma: no cover - defensive
+        raise BackfillError(f"Could not read {path}: {exc}") from exc
+
+
+def _single(paths: list[Path], label: str, *, required: bool = True) -> Path | None:
+    """Return the lone path in ``paths`` or raise/return ``None`` per ``required``."""
+    real = [p for p in paths if "checkpoints" not in p.parts]
+    if len(real) == 1:
+        return real[0]
+    if not real:
+        if required:
+            raise BackfillError(f"No {label} artefact found")
+        return None
+    raise BackfillError(f"Expected exactly one {label} artefact, found {len(real)}: {real}")
+
+
+def _metric_from_payload(payload: dict[str, Any]) -> MetricAggregate:
+    """Rebuild a :class:`MetricAggregate` from a serialized metric mapping."""
+    ci95 = payload.get("ci95")
+    return MetricAggregate(
+        mean=payload["mean"],
+        median=payload["median"],
+        p95=payload["p95"],
+        ci95=(ci95[0], ci95[1]) if ci95 else None,
+    )
+
+
+def _scenario_coverage(eval_by_scenario: list[dict[str, Any]]) -> dict[str, int]:
+    """Sum evaluated episodes per scenario at the final evaluation checkpoint."""
+    if not eval_by_scenario:
+        return {}
+    final_step = max(int(row.get("eval_step", 0)) for row in eval_by_scenario)
+    coverage: dict[str, int] = defaultdict(int)
+    for row in eval_by_scenario:
+        if int(row.get("eval_step", 0)) != final_step:
+            continue
+        scenario = str(row.get("scenario_id", "unknown"))
+        coverage[scenario] += int(row.get("episodes", 0))
+    return dict(sorted(coverage.items()))
+
+
+def build_artifact(
+    benchmarks_dir: Path,
+    *,
+    run_type: TrainingRunType = TrainingRunType.EXPERT_TRAINING,
+    evaluation_scenario_config: Path | None = None,
+    input_artefacts: tuple[str, ...] = (),
+) -> tuple[TrainingRunArtifact, Path]:
+    """Reconstruct a :class:`TrainingRunArtifact` from retained artefacts.
+
+    Returns:
+        The reconstructed artifact and the ``ppo_imitation`` directory it was
+        rebuilt from (used to locate the manifest destination).
+    """
+    imitation_dir = benchmarks_dir / "ppo_imitation"
+    if not imitation_dir.is_dir():
+        raise BackfillError(f"No ppo_imitation directory under {benchmarks_dir}")
+
+    # Record artefact paths relative to the run's output root (the parent of benchmarks/), so
+    # the manifest stores portable ``benchmarks/...`` paths exactly like an inline-written one.
+    # This keeps serialization independent of which checkout/worktree runs the backfill.
+    output_root = benchmarks_dir.parent
+
+    def _rel(path: Path) -> Path:
+        try:
+            return path.resolve(strict=False).relative_to(output_root.resolve(strict=False))
+        except ValueError:  # pragma: no cover - artefacts always live under output_root
+            return path
+
+    perf_path = _single(list((imitation_dir / "perf").glob("*.json")), "perf summary")
+    episode_path = _single(list((imitation_dir / "episodes").glob("*.jsonl")), "episode log")
+    eval_scenario_path = _single(
+        list((imitation_dir / "eval_by_scenario").glob("*.json")), "eval-by-scenario"
+    )
+    eval_timeline_path = _single(
+        list((imitation_dir / "eval_timeline").glob("*.json")), "eval timeline", required=False
+    )
+    expert_path = _single(
+        list((benchmarks_dir / "expert_policies").glob("*.json")), "expert policy manifest"
+    )
+
+    assert perf_path is not None and episode_path is not None
+    assert eval_scenario_path is not None and expert_path is not None
+
+    perf = _load_json(perf_path)
+    expert = _load_json(expert_path)
+    eval_by_scenario = _load_json(eval_scenario_path)
+
+    run_id = perf.get("run_id") or episode_path.stem
+    wall_sec = perf.get("total_wall_clock_sec")
+    wall_clock_hours = round(float(wall_sec) / 3600.0, 4) if wall_sec is not None else 0.0
+
+    metrics = {
+        name: _metric_from_payload(payload) for name, payload in expert.get("metrics", {}).items()
+    }
+    seeds = tuple(int(seed) for seed in expert.get("seeds", ()))
+
+    artifact = TrainingRunArtifact(
+        run_id=run_id,
+        run_type=run_type,
+        input_artefacts=input_artefacts,
+        seeds=seeds,
+        metrics=metrics,
+        episode_log_path=_rel(episode_path),
+        wall_clock_hours=wall_clock_hours,
+        status=TrainingRunStatus.COMPLETED,
+        eval_timeline_path=_rel(eval_timeline_path) if eval_timeline_path else None,
+        eval_per_scenario_path=_rel(eval_scenario_path),
+        perf_summary_path=_rel(perf_path),
+        evaluation_scenario_config=evaluation_scenario_config,
+        scenario_coverage=_scenario_coverage(eval_by_scenario),
+        notes=[
+            "Backfilled by scripts/tools/backfill_training_run_manifest.py from retained "
+            "artefacts after the inline manifest write failed (cross-worktree path).",
+        ],
+    )
+    return artifact, imitation_dir
+
+
+def backfill(
+    run_dir: Path,
+    *,
+    benchmarks_dir: Path | None = None,
+    evaluation_scenario_config: Path | None = None,
+    dry_run: bool = False,
+    force: bool = False,
+) -> Path:
+    """Rebuild and write the training-run manifest for a single run directory.
+
+    Returns:
+        The manifest path that was (or would be) written.
+    """
+    bench = benchmarks_dir or (run_dir / "benchmarks")
+    if not bench.is_dir():
+        raise BackfillError(f"No benchmarks directory at {bench}")
+
+    artifact, imitation_dir = build_artifact(
+        bench, evaluation_scenario_config=evaluation_scenario_config
+    )
+    target = imitation_dir / "runs" / f"{artifact.run_id}.json"
+
+    if target.exists() and not force:
+        raise BackfillError(f"Manifest already exists at {target}; pass --force to overwrite")
+
+    if dry_run:
+        print(f"[dry-run] would write manifest for run_id={artifact.run_id}")
+        print(f"[dry-run]   metrics: {sorted(artifact.metrics)}")
+        print(f"[dry-run]   seeds={artifact.seeds} wall_clock_hours={artifact.wall_clock_hours}")
+        print(f"[dry-run]   scenarios covered: {len(artifact.scenario_coverage)}")
+        print(f"[dry-run]   target: {target}")
+        return target
+
+    target.parent.mkdir(parents=True, exist_ok=True)
+    written = write_training_run_manifest(artifact, manifest_path=target)
+    print(f"Wrote training-run manifest: {written}")
+    return written
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    src = parser.add_mutually_exclusive_group(required=True)
+    src.add_argument("--run-dir", type=Path, help="Per-job output root containing benchmarks/")
+    src.add_argument("--benchmarks-dir", type=Path, help="Path to the benchmarks/ tree directly")
+    parser.add_argument(
+        "--evaluation-scenario-config",
+        type=Path,
+        default=None,
+        help="Optional path to the evaluation scenario config to record (degrades to basename).",
+    )
+    parser.add_argument("--dry-run", action="store_true", help="Report without writing.")
+    parser.add_argument("--force", action="store_true", help="Overwrite an existing manifest.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point.
+
+    Returns:
+        Process exit code (0 on success, 1 on a recoverable backfill error).
+    """
+    args = _parse_args(argv)
+    try:
+        backfill(
+            run_dir=args.run_dir if args.run_dir else args.benchmarks_dir.parent,
+            benchmarks_dir=args.benchmarks_dir,
+            evaluation_scenario_config=args.evaluation_scenario_config,
+            dry_run=args.dry_run,
+            force=args.force,
+        )
+    except BackfillError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_backfill_training_run_manifest.py
+++ b/tests/test_backfill_training_run_manifest.py
@@ -1,0 +1,101 @@
+"""Tests for the training-run manifest backfill tool."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.common import TrainingRunStatus
+from scripts.tools import backfill_training_run_manifest as backfill
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, payload: object) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle)
+
+
+def _make_run_tree(root: Path, run_id: str = "ppo_expert_demo_20260622T142053") -> Path:
+    """Build a minimal retained-artefact tree mirroring a completed run."""
+    bench = root / "benchmarks"
+    imitation = bench / "ppo_imitation"
+
+    _write(
+        bench / "expert_policies" / "ppo_expert_demo.json",
+        {
+            "policy_id": "ppo_expert_demo",
+            "seeds": [509],
+            "scenario_profile": ["classic_doorway_low", "classic_doorway_high"],
+            "metrics": {
+                "success_rate": {"mean": 0.9, "median": 1.0, "p95": 1.0, "ci95": [0.85, 0.95]},
+                "collision_rate": {"mean": 0.1, "median": 0.0, "p95": 1.0},
+            },
+        },
+    )
+    _write(
+        imitation / "perf" / f"{run_id}.json",
+        {"run_id": run_id, "total_wall_clock_sec": 58414.5},
+    )
+    _write(
+        imitation / "eval_by_scenario" / f"{run_id}.json",
+        [
+            {"scenario_id": "classic_doorway_low", "eval_step": 524288, "episodes": 5},
+            {"scenario_id": "classic_doorway_low", "eval_step": 1000000, "episodes": 7},
+            {"scenario_id": "classic_doorway_high", "eval_step": 1000000, "episodes": 3},
+        ],
+    )
+    _write(imitation / "eval_timeline" / f"{run_id}.json", [{"eval_step": 1000000}])
+    episode_log = imitation / "episodes" / f"{run_id}.jsonl"
+    episode_log.parent.mkdir(parents=True, exist_ok=True)
+    episode_log.write_text('{"episode": 1}\n', encoding="utf-8")
+    return bench
+
+
+def test_backfill_rebuilds_manifest_from_artifacts(tmp_path: Path) -> None:
+    """A completed run with no runs/ manifest is reconstructed from its artefacts."""
+    run_id = "ppo_expert_demo_20260622T142053"
+    _make_run_tree(tmp_path, run_id)
+
+    written = backfill.backfill(run_dir=tmp_path)
+
+    assert written == tmp_path / "benchmarks" / "ppo_imitation" / "runs" / f"{run_id}.json"
+    payload = json.loads(written.read_text(encoding="utf-8"))
+
+    assert payload["run_id"] == run_id
+    assert payload["status"] == TrainingRunStatus.COMPLETED.value
+    assert payload["seeds"] == [509]
+    # Portable relative paths, independent of the running checkout.
+    assert payload["episode_log_path"] == f"benchmarks/ppo_imitation/episodes/{run_id}.jsonl"
+    assert payload["perf_summary_path"].startswith("benchmarks/ppo_imitation/perf/")
+    # wall clock derived from total_wall_clock_sec (58414.5 / 3600).
+    assert payload["wall_clock_hours"] == pytest.approx(16.2263, abs=1e-3)
+    # Coverage counted at the final eval step only (7 + 3), not summed across checkpoints.
+    assert payload["scenario_coverage"] == {"classic_doorway_low": 7, "classic_doorway_high": 3}
+    assert payload["metrics"]["success_rate"]["mean"] == 0.9
+    assert any("Backfilled" in note for note in payload["notes"])
+    assert "/tmp" not in json.dumps(payload) or payload["episode_log_path"].startswith(
+        "benchmarks/"
+    )
+
+
+def test_backfill_refuses_to_overwrite_without_force(tmp_path: Path) -> None:
+    """An existing manifest is preserved unless --force is given."""
+    _make_run_tree(tmp_path)
+    backfill.backfill(run_dir=tmp_path)
+    with pytest.raises(backfill.BackfillError, match="already exists"):
+        backfill.backfill(run_dir=tmp_path)
+    # Force overwrites cleanly.
+    backfill.backfill(run_dir=tmp_path, force=True)
+
+
+def test_backfill_dry_run_writes_nothing(tmp_path: Path) -> None:
+    """Dry-run reports the target without creating a manifest."""
+    run_id = "ppo_expert_demo_20260622T142053"
+    _make_run_tree(tmp_path, run_id)
+    target = backfill.backfill(run_dir=tmp_path, dry_run=True)
+    assert not target.exists()

--- a/tests/test_benchmark_imitation_manifest.py
+++ b/tests/test_benchmark_imitation_manifest.py
@@ -199,6 +199,47 @@ def test_path_to_manifest_fails_closed_for_absolute_paths_outside_repo() -> None
         imitation_manifest._path_to_manifest(outside_path)
 
 
+def test_training_run_manifest_preserves_completed_run_with_cross_worktree_config(
+    metrics_summary: dict[str, MetricAggregate],
+) -> None:
+    """A completed run is preserved even when an eval/config path lives in a sibling worktree.
+
+    Reproduces the cross-worktree failure mode (jobs 13024/12949/12950): training finished, but
+    ``evaluation_scenario_config`` resolved under a different git worktree — outside both the
+    artefact and repository roots — so the strict serializer raised and the whole manifest write
+    aborted, discarding the run. The lenient serializer must instead persist the manifest, record
+    the foreign path's basename (no host-directory leak), and keep all other fields intact.
+    """
+    foreign_config = Path(
+        "/home/user/git/robot_sf_ll7.worktrees/sibling-branch/configs/scenarios/sets/eval_v1.yaml"
+    )
+    episode_log = get_imitation_report_dir() / "ppo_imitation" / "episodes.jsonl"
+    artifact = TrainingRunArtifact(
+        run_id="run_cross_worktree",
+        run_type=TrainingRunType.BEHAVIOURAL_CLONING,
+        input_artefacts=("policy:ppo_expert_v1",),
+        seeds=(509,),
+        metrics=metrics_summary,
+        episode_log_path=episode_log,
+        wall_clock_hours=16.2,
+        status=TrainingRunStatus.COMPLETED,
+        evaluation_scenario_config=foreign_config,
+        scenario_coverage={"scenario_a": 1},
+        notes=["training complete"],
+    )
+
+    output_path = imitation_manifest.write_training_run_manifest(artifact)
+    with output_path.open("r", encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    # Run is preserved, foreign path degraded to a portable basename with no host directory.
+    assert payload["run_id"] == "run_cross_worktree"
+    assert payload["evaluation_scenario_config"] == "eval_v1.yaml"
+    assert "/home/user/" not in json.dumps(payload)
+    assert payload["status"] == TrainingRunStatus.COMPLETED.value
+    assert payload["episode_log_path"].startswith("benchmarks/ppo_imitation/")
+
+
 @pytest.mark.parametrize(
     "manifest_path",
     [None, Path("custom/output/expert.json")],


### PR DESCRIPTION
## Problem

`serialize_training_run` serialized several path fields through the strict
`_path_to_manifest`, which **raises `ValueError`** for a path outside both the
artefact root and the repository root. Because the manifest is written *after*
training completes, a single foreign path aborted the whole write and **discarded
a completed run's evidence**.

This fires when a run executes from one git worktree but references an
**evaluation scenario config materialised under a sibling worktree** — normal in
the Slurm campaign flow (configs/maps load from a different worktree than the one
the training process runs in).

### Observed impact (dissertation runs)

Three GPU runs trained + evaluated successfully and were then thrown away:

| Job | Issue | Seed | Result | Outcome |
|-----|-------|------|--------|---------|
| 13024 | #3266 | 509 | 10M steps, success ~0.90 | `manifest_path_outside_allowed_roots_after_training` |
| 12949 | #2919 | 506 | success ~0.91 | same |
| 12950 | #3203 | 508 | success ~0.89 | same |

## Part 1 — Fix (`imitation_manifest.py`)

- Add `_path_to_manifest_lenient(path, field=...)`: tries the strict serializer;
  on `ValueError` degrades to the path **basename** (portable, no host-directory
  leak) with a logged warning.
- Use it for the **optional** eval/config path fields in `serialize_training_run`.
- `episode_log_path` (governed core artefact) stays strict.
- `_path_to_manifest` and its fail-closed host-path-leak test are **unchanged**.

## Part 2 — Recovery tool (`scripts/tools/backfill_training_run_manifest.py`)

Reconstructs a lost training-run manifest from the artefacts the pipeline already
wrote (expert-policy manifest → metrics/seeds, perf json → run_id/wall-clock,
eval-by-scenario → coverage, episode/eval/perf files → path fields). No training
is re-run. Paths are recorded relative to the run's output root, so the manifest
is portable and independent of which checkout runs the backfill. Supports
`--dry-run`; refuses to overwrite without `--force`.

**Already used to recover all three runs above** — their evidence (2.1 GB each,
checkpoints + W&B + eval) was intact on the cluster; only the manifest JSON was
missing. Manifests regenerated, verified (status=completed, 70 scenarios, seeds
509/506/508, wall-clocks 16.2/13.8/16.1 h), and the full evidence retrieved local.

## Tests

- `test_path_to_manifest_fails_closed_for_absolute_paths_outside_repo` — unchanged, still passes.
- `test_training_run_manifest_preserves_completed_run_with_cross_worktree_config` — new regression.
- `tests/test_backfill_training_run_manifest.py` — 3 tests (rebuild, no-overwrite, dry-run).
- Full: `pytest tests/test_benchmark_imitation_manifest.py tests/test_backfill_training_run_manifest.py` → 11 passed. `ruff check` / `format` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)