### PR TITLE
feat(robot): planner-agnostic safety wrapper, mitigation lever (#3501)

### DIFF
--- a/docs/context/issue_3501_safety_wrapper.md
+++ b/docs/context/issue_3501_safety_wrapper.md
@@ -1,0 +1,57 @@
+# Issue #3501 — Planner-agnostic safety wrapper (mitigation lever, first increment)
+
+**Status:** diagnostic / proxy. **Evidence grade:** idea-level; wrapper thresholds are
+predeclared modeling choices, diagnostic until durable evidence. No paper-facing
+deployment-safety claim before the with/without ablation runs.
+
+## What this is
+
+`robot_sf/robot/safety_wrapper.py` is the **mitigation lever** both external dissertation
+assessments flag as the largest improvement per implementation hour: a single, planner-agnostic
+safety wrapper that post-processes any planner's commanded action through fixed, predeclared
+stages, so a factorial `planner × {wrapper off, wrapper on}` ablation can quantify its causal
+effect — "the framework identifies a mitigation lever and quantifies its effect."
+
+## Wrapper (`safety_wrapper.v1`)
+
+`apply_safety_wrapper(linear_velocity, angular_velocity, context, config)` applies, in precedence
+order:
+
+1. **hard stop / yield veto** — zero forward speed when `min_ttc_s ≤ ttc_veto_threshold_s` or
+   `min_clearance_m ≤ clearance_veto_m` (angular velocity preserved so the robot can turn to yield);
+2. **speed cap near pedestrians** — clamp forward speed to `capped_speed_m_s` within
+   `pedestrian_caution_radius_m`;
+3. **pass-through** otherwise.
+
+It returns a versioned record with the corrected action, the `intervention` label
+(`disabled` / `none` / `speed_cap` / `hard_stop`), an `intervened` flag (for intervention-rate
+reporting), and the original action + context.
+
+### Predeclared defaults (`SafetyWrapperConfig`, planner-agnostic, no per-planner tuning)
+
+| field | default | meaning |
+| --- | --- | --- |
+| `enabled` | `False` | **off by default**, opt-in per run |
+| `pedestrian_caution_radius_m` | 2.0 | speed-cap radius |
+| `capped_speed_m_s` | 0.5 | defensive speed ceiling |
+| `ttc_veto_threshold_s` | 1.0 | hard-stop TTC gate |
+| `clearance_veto_m` | 0.3 | hard-stop clearance gate |
+
+## Scope boundary
+
+Pure per-step transform, **off by default** — changes no runtime/benchmark behavior. Deferred
+follow-ups: the factorial `planner × {off, on}` **ablation campaign** (SLURM runs over a fixed
+scenario set + paired seeds, emitting into the #3482 ledger), live wiring into
+`robot_sf/robot/action_adapters.py`, and a stateful deadlock-recovery stage.
+
+## Tests
+
+`tests/test_safety_wrapper.py` (12 tests): disabled pass-through, safe pass-through, speed cap
+near pedestrians (and no-cap when already slow), hard stop on low TTC and on low clearance, veto
+precedence over the speed cap, schema/record contract, and config validation.
+
+## Related
+
+- Safety-event ledger (ablation emit target): #3482.
+- Trace-level predicates (deadlock/oscillation/occlusion signals): #3483.
+- MOTP speed-cap contract (a related wrapper component): #3480.

--- a/robot_sf/robot/safety_wrapper.py
+++ b/robot_sf/robot/safety_wrapper.py
@@ -20,6 +20,7 @@ Thresholds are predeclared modeling choices, diagnostic until durable evidence.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
@@ -108,8 +109,14 @@ def apply_safety_wrapper(
         return _record(config, context, original, corrected, INTERVENTION_HARD_STOP)
 
     near_pedestrian = context.min_pedestrian_distance_m <= config.pedestrian_caution_radius_m
-    if near_pedestrian and float(linear_velocity) > config.capped_speed_m_s:
-        corrected = (config.capped_speed_m_s, float(angular_velocity))
+    # Cap on speed magnitude so a reversing robot (negative linear velocity, supported by
+    # both drive models via allow_backwards) is also limited near pedestrians; the cap keeps
+    # the original direction of travel.
+    if near_pedestrian and abs(float(linear_velocity)) > config.capped_speed_m_s:
+        corrected = (
+            math.copysign(config.capped_speed_m_s, linear_velocity),
+            float(angular_velocity),
+        )
         return _record(config, context, original, corrected, INTERVENTION_SPEED_CAP)
 
     return _record(config, context, original, original, INTERVENTION_NONE)

--- a/robot_sf/robot/safety_wrapper.py
+++ b/robot_sf/robot/safety_wrapper.py
@@ -1,0 +1,157 @@
+"""Planner-agnostic safety wrapper around the action interface (issue #3501).
+
+The strongest available thesis result is causal: *the framework identifies a mitigation lever
+and quantifies its effect*. This module provides that lever — a single, planner-agnostic safety
+wrapper that post-processes any planner's commanded action through fixed, predeclared safety
+stages:
+
+1. **clearance / TTC monitor** — read the per-step safety context;
+2. **speed cap near pedestrians** — clamp commanded speed within a caution radius;
+3. **hard stop / yield veto** — zero commanded speed when time-to-collision or clearance is
+   critical (turning is still permitted so the robot can yield).
+
+The wrapper is **off by default** and opt-in per run, with **fixed, predeclared thresholds** (no
+per-planner tuning), so a factorial ``planner × {wrapper off, wrapper on}`` ablation can quantify
+its effect. This module is the pure per-step transform; the ablation campaign, live wiring into the
+action adapters, and a stateful deadlock-recovery stage are deliberate follow-ups.
+
+Thresholds are predeclared modeling choices, diagnostic until durable evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+SAFETY_WRAPPER_SCHEMA = "safety_wrapper.v1"
+
+# Intervention labels (stable vocabulary).
+INTERVENTION_DISABLED = "disabled"
+INTERVENTION_NONE = "none"
+INTERVENTION_SPEED_CAP = "speed_cap"
+INTERVENTION_HARD_STOP = "hard_stop"
+
+
+@dataclass(frozen=True, slots=True)
+class SafetyWrapperConfig:
+    """Fixed, predeclared safety-wrapper thresholds (planner-agnostic).
+
+    Attributes:
+        enabled: Whether the wrapper is active. **Off by default** (opt-in per run).
+        pedestrian_caution_radius_m: Within this distance, the speed cap applies.
+        capped_speed_m_s: Defensive forward-speed ceiling near pedestrians.
+        ttc_veto_threshold_s: Time-to-collision at/below which a hard stop is vetoed in.
+        clearance_veto_m: Clearance at/below which a hard stop is vetoed in.
+    """
+
+    enabled: bool = False
+    pedestrian_caution_radius_m: float = 2.0
+    capped_speed_m_s: float = 0.5
+    ttc_veto_threshold_s: float = 1.0
+    clearance_veto_m: float = 0.3
+
+    def __post_init__(self) -> None:
+        """Validate that the thresholds are physically usable."""
+        for name in (
+            "pedestrian_caution_radius_m",
+            "capped_speed_m_s",
+            "ttc_veto_threshold_s",
+            "clearance_veto_m",
+        ):
+            value = getattr(self, name)
+            if not (value > 0.0):
+                raise ValueError(f"SafetyWrapperConfig.{name} must be > 0, got {value!r}")
+
+
+@dataclass(frozen=True, slots=True)
+class SafetyContext:
+    """Per-step safety signals consumed by the wrapper.
+
+    Attributes:
+        min_pedestrian_distance_m: Distance to the nearest pedestrian (m).
+        min_clearance_m: Minimum clearance to any obstacle (m).
+        min_ttc_s: Minimum time-to-collision (s); ``None`` when undefined/closing-free.
+    """
+
+    min_pedestrian_distance_m: float
+    min_clearance_m: float
+    min_ttc_s: float | None = None
+
+
+def apply_safety_wrapper(
+    linear_velocity: float,
+    angular_velocity: float,
+    context: SafetyContext,
+    config: SafetyWrapperConfig | None = None,
+) -> dict[str, Any]:
+    """Post-process a commanded action through the planner-agnostic safety stages.
+
+    Stage precedence: hard stop/yield veto (TTC or clearance critical) overrides the speed cap,
+    which overrides pass-through. Angular velocity is never reduced, so the robot can still turn
+    to yield.
+
+    Returns:
+        dict[str, Any]: Versioned record with the corrected action and the intervention applied.
+    """
+    config = config or SafetyWrapperConfig()
+    original = (float(linear_velocity), float(angular_velocity))
+
+    if not config.enabled:
+        return _record(config, context, original, original, INTERVENTION_DISABLED)
+
+    ttc_critical = (
+        context.min_ttc_s is not None and context.min_ttc_s <= config.ttc_veto_threshold_s
+    )
+    clearance_critical = context.min_clearance_m <= config.clearance_veto_m
+    if ttc_critical or clearance_critical:
+        corrected = (0.0, float(angular_velocity))
+        return _record(config, context, original, corrected, INTERVENTION_HARD_STOP)
+
+    near_pedestrian = context.min_pedestrian_distance_m <= config.pedestrian_caution_radius_m
+    if near_pedestrian and float(linear_velocity) > config.capped_speed_m_s:
+        corrected = (config.capped_speed_m_s, float(angular_velocity))
+        return _record(config, context, original, corrected, INTERVENTION_SPEED_CAP)
+
+    return _record(config, context, original, original, INTERVENTION_NONE)
+
+
+def _record(
+    config: SafetyWrapperConfig,
+    context: SafetyContext,
+    original: tuple[float, float],
+    corrected: tuple[float, float],
+    intervention: str,
+) -> dict[str, Any]:
+    """Build the versioned wrapper record.
+
+    Returns:
+        dict[str, Any]: The schema-tagged wrapper output record.
+    """
+    return {
+        "schema_version": SAFETY_WRAPPER_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "enabled": config.enabled,
+        "intervention": intervention,
+        "intervened": intervention in {INTERVENTION_SPEED_CAP, INTERVENTION_HARD_STOP},
+        "original_linear_velocity": original[0],
+        "original_angular_velocity": original[1],
+        "corrected_linear_velocity": corrected[0],
+        "corrected_angular_velocity": corrected[1],
+        "context": {
+            "min_pedestrian_distance_m": context.min_pedestrian_distance_m,
+            "min_clearance_m": context.min_clearance_m,
+            "min_ttc_s": context.min_ttc_s,
+        },
+    }
+
+
+__all__ = [
+    "INTERVENTION_DISABLED",
+    "INTERVENTION_HARD_STOP",
+    "INTERVENTION_NONE",
+    "INTERVENTION_SPEED_CAP",
+    "SAFETY_WRAPPER_SCHEMA",
+    "SafetyContext",
+    "SafetyWrapperConfig",
+    "apply_safety_wrapper",
+]

--- a/tests/test_safety_wrapper.py
+++ b/tests/test_safety_wrapper.py
@@ -1,0 +1,110 @@
+"""Tests for the planner-agnostic safety wrapper (issue #3501)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.robot.safety_wrapper import (
+    INTERVENTION_DISABLED,
+    INTERVENTION_HARD_STOP,
+    INTERVENTION_NONE,
+    INTERVENTION_SPEED_CAP,
+    SAFETY_WRAPPER_SCHEMA,
+    SafetyContext,
+    SafetyWrapperConfig,
+    apply_safety_wrapper,
+)
+
+_ENABLED = SafetyWrapperConfig(enabled=True)
+_SAFE = SafetyContext(min_pedestrian_distance_m=10.0, min_clearance_m=5.0, min_ttc_s=None)
+
+
+def test_disabled_by_default_is_pass_through() -> None:
+    """With the default (disabled) config the action must pass through unchanged."""
+    result = apply_safety_wrapper(1.5, 0.3, _SAFE)
+
+    assert result["intervention"] == INTERVENTION_DISABLED
+    assert result["enabled"] is False
+    assert result["corrected_linear_velocity"] == 1.5
+    assert result["corrected_angular_velocity"] == 0.3
+
+
+def test_safe_context_when_enabled_is_pass_through() -> None:
+    """An enabled wrapper must not intervene when the context is safe."""
+    result = apply_safety_wrapper(1.5, 0.3, _SAFE, _ENABLED)
+
+    assert result["intervention"] == INTERVENTION_NONE
+    assert result["intervened"] is False
+    assert result["corrected_linear_velocity"] == 1.5
+
+
+def test_speed_cap_near_pedestrians() -> None:
+    """Within the caution radius an over-cap speed must be clamped to the ceiling."""
+    context = SafetyContext(min_pedestrian_distance_m=1.0, min_clearance_m=5.0)
+    result = apply_safety_wrapper(2.0, 0.1, context, _ENABLED)
+
+    assert result["intervention"] == INTERVENTION_SPEED_CAP
+    assert result["corrected_linear_velocity"] == _ENABLED.capped_speed_m_s
+    assert result["corrected_angular_velocity"] == 0.1  # turning preserved
+
+
+def test_no_speed_cap_when_already_slow_near_pedestrians() -> None:
+    """A speed already below the cap must not be modified."""
+    context = SafetyContext(min_pedestrian_distance_m=1.0, min_clearance_m=5.0)
+    result = apply_safety_wrapper(0.4, 0.0, context, _ENABLED)
+
+    assert result["intervention"] == INTERVENTION_NONE
+    assert result["corrected_linear_velocity"] == 0.4
+
+
+def test_hard_stop_on_low_ttc() -> None:
+    """A critical time-to-collision must veto a hard stop (zero forward speed)."""
+    context = SafetyContext(min_pedestrian_distance_m=1.0, min_clearance_m=5.0, min_ttc_s=0.5)
+    result = apply_safety_wrapper(2.0, 0.2, context, _ENABLED)
+
+    assert result["intervention"] == INTERVENTION_HARD_STOP
+    assert result["corrected_linear_velocity"] == 0.0
+    assert result["corrected_angular_velocity"] == 0.2  # may still turn to yield
+
+
+def test_hard_stop_on_low_clearance() -> None:
+    """Critically low clearance must veto a hard stop."""
+    context = SafetyContext(min_pedestrian_distance_m=5.0, min_clearance_m=0.2)
+    result = apply_safety_wrapper(1.0, 0.0, context, _ENABLED)
+
+    assert result["intervention"] == INTERVENTION_HARD_STOP
+    assert result["corrected_linear_velocity"] == 0.0
+
+
+def test_veto_takes_precedence_over_speed_cap() -> None:
+    """When both apply, the hard-stop veto must override the speed cap."""
+    context = SafetyContext(min_pedestrian_distance_m=1.0, min_clearance_m=0.1, min_ttc_s=0.5)
+    result = apply_safety_wrapper(2.0, 0.0, context, _ENABLED)
+
+    assert result["intervention"] == INTERVENTION_HARD_STOP
+    assert result["corrected_linear_velocity"] == 0.0
+
+
+def test_record_is_schema_tagged_and_reports_original() -> None:
+    """The record must be versioned and preserve the original commanded action."""
+    result = apply_safety_wrapper(2.0, 0.5, _SAFE, _ENABLED)
+
+    assert result["schema_version"] == SAFETY_WRAPPER_SCHEMA
+    assert result["evidence_kind"] == "diagnostic_proxy"
+    assert result["original_linear_velocity"] == 2.0
+    assert result["original_angular_velocity"] == 0.5
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"pedestrian_caution_radius_m": 0.0},
+        {"capped_speed_m_s": -1.0},
+        {"ttc_veto_threshold_s": 0.0},
+        {"clearance_veto_m": -0.1},
+    ],
+)
+def test_invalid_config_is_rejected(kwargs: dict[str, float]) -> None:
+    """Non-physical thresholds must fail closed at construction."""
+    with pytest.raises(ValueError):
+        SafetyWrapperConfig(enabled=True, **kwargs)

--- a/tests/test_safety_wrapper.py
+++ b/tests/test_safety_wrapper.py
@@ -48,6 +48,16 @@ def test_speed_cap_near_pedestrians() -> None:
     assert result["corrected_angular_velocity"] == 0.1  # turning preserved
 
 
+def test_speed_cap_on_reversing_robot_near_pedestrians() -> None:
+    """A robot reversing faster than the cap must be limited in magnitude, sign preserved."""
+    context = SafetyContext(min_pedestrian_distance_m=1.0, min_clearance_m=5.0)
+    result = apply_safety_wrapper(-2.0, 0.1, context, _ENABLED)
+
+    assert result["intervention"] == INTERVENTION_SPEED_CAP
+    assert result["corrected_linear_velocity"] == -_ENABLED.capped_speed_m_s  # still reversing
+    assert result["corrected_angular_velocity"] == 0.1  # turning preserved
+
+
 def test_no_speed_cap_when_already_slow_near_pedestrians() -> None:
     """A speed already below the cap must not be modified."""
     context = SafetyContext(min_pedestrian_distance_m=1.0, min_clearance_m=5.0)


### PR DESCRIPTION
## Summary

First-increment **mitigation lever** for #3501 — the causal result both external dissertation
assessments flag as the largest improvement per implementation hour: *"the framework identifies a
mitigation lever and quantifies its effect."*

This implements the lever's pure core: a single, **planner-agnostic** safety wrapper that
post-processes any planner's commanded action through fixed, predeclared stages, so a factorial
`planner × {wrapper off, wrapper on}` ablation can later quantify its effect.

## Wrapper (`safety_wrapper.v1`)

`apply_safety_wrapper(linear_velocity, angular_velocity, context, config)` applies, in precedence:

1. **hard stop / yield veto** — zero forward speed when `min_ttc_s ≤ ttc_veto_threshold_s` or
   `min_clearance_m ≤ clearance_veto_m` (angular velocity preserved so the robot can turn to yield);
2. **speed cap near pedestrians** — clamp forward speed to `capped_speed_m_s` within
   `pedestrian_caution_radius_m`;
3. **pass-through** otherwise.

Returns a versioned record with the corrected action, the `intervention` label
(`disabled`/`none`/`speed_cap`/`hard_stop`), an `intervened` flag (intervention-rate reporting),
and the original action + context. `SafetyWrapperConfig` holds **fixed, predeclared,
planner-agnostic** thresholds, is **off by default / opt-in per run**, and fails closed on
non-physical values.

## Scope boundary

Pure per-step transform, **off by default** — changes **no** runtime/benchmark behavior. Deferred
follow-ups (as the issue specifies): the factorial `planner × {off, on}` **ablation campaign**
(SLURM runs over a fixed scenario set + paired seeds, emitting into the #3482 ledger), live wiring
into `action_adapters.py`, and a stateful deadlock-recovery stage. No per-planner tuning; no
paper-facing safety claim before durable evidence.

## Validation

```
uv run pytest tests/test_safety_wrapper.py -q                # 12 passed
uv run python scripts/validation/check_broad_exceptions.py   # passes (no broad catches)
ruff check / format                                          # clean
```

**Evidence grade:** smoke evidence (pure transform + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
