### PR TITLE
feat(planner): stream_gap gate-threshold calibration decision layer (#3558)

### DIFF
--- a/docs/context/issue_3558_stream_gap_gate_calibration.md
+++ b/docs/context/issue_3558_stream_gap_gate_calibration.md
@@ -1,0 +1,42 @@
+# Issue #3558 — stream_gap gate-threshold calibration decision layer (increment)
+
+**Status:** diagnostic / proxy. **Evidence grade:** idea-level decision layer; no change to the
+production dropping default (a separate decision once a safe region is or isn't found).
+
+## What this is
+
+`robot_sf/planner/stream_gap_gate_calibration.py` is the pure **decision layer** for #3558.
+#3471 found that dropping uncertain agents at the *current default* `stream_gap` uncertainty-gate
+thresholds increases unsafe commitment. This module turns a gate-threshold sweep — run over the
+#3471 episode harness — into the issue's actionable guidance: it classifies each swept setting
+against the conservative-retention baseline and reports whether any safe operating region exists,
+or confirms that conservative retention dominates.
+
+It mirrors the accepted decision-layer pattern in
+`robot_sf/scenario_certification/failure_cause.py` (#3484).
+
+## Decision layer (`stream_gap_gate_calibration.v1`)
+
+- `classify_setting_safety(setting, baseline, tolerance)` → `at_least_as_safe` only when a setting
+  worsens no safety axis (unsafe-commit, collision, min-separation) beyond the allowed tolerance.
+- `calibrate_stream_gap_gate(settings, baseline, tolerance)` → per-setting classifications, the
+  `safe_region`, and either a `recommended_setting` (the safest member: fewest unsafe commits, then
+  fewest collisions, then largest separation) with `conclusion = safe_region_exists`, or
+  `conclusion = conservative_retention_dominates` when none clears the bar.
+
+## Scope boundary
+
+Pure and side-effect free — changes no behavior. The threshold **sweep** that produces the
+per-setting safety aggregates needs benchmark runs over the #3471 harness and is the deliberate
+deferred follow-up; this layer turns those results into the gate guidance.
+
+## Tests
+
+`tests/planner/test_stream_gap_gate_calibration.py` (6 tests): no-worse-than-baseline is safe,
+worsening any axis is less safe, tolerance allows a small regression, the safest safe-region member
+is recommended, retention dominates when none is safe, and empty-sweep rejection.
+
+## Related
+
+- Follows #3471 (PR #3553) — the negative result this converts into gate guidance.
+- Sibling ScenarioBelief follow-ups: #3556, #3557.

--- a/robot_sf/planner/stream_gap_gate_calibration.py
+++ b/robot_sf/planner/stream_gap_gate_calibration.py
@@ -1,0 +1,144 @@
+"""Calibrate stream_gap uncertainty-gate thresholds for safe agent-dropping (issue #3558).
+
+#3471 found that dropping uncertain agents at the **current default** ``stream_gap``
+uncertainty-gate thresholds increases unsafe commitment. That is a finding about the defaults,
+not about gating in general. This module is the pure **decision layer** that turns a
+gate-threshold sweep (run over the #3471 episode harness) into actionable guidance: it classifies
+each swept setting against the conservative-retention baseline and reports whether any safe
+operating region exists, or confirms that conservative retention dominates.
+
+The sweep that produces the per-setting safety aggregates needs benchmark runs and is deferred;
+this layer is pure and side-effect free, mirroring the failure-cause classifier in
+``robot_sf/scenario_certification/failure_cause.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+STREAM_GAP_CALIBRATION_SCHEMA = "stream_gap_gate_calibration.v1"
+
+AT_LEAST_AS_SAFE = "at_least_as_safe"
+LESS_SAFE = "less_safe"
+CONSERVATIVE_RETENTION_DOMINATES = "conservative_retention_dominates"
+
+
+@dataclass(frozen=True, slots=True)
+class GateSettingResult:
+    """Per-setting safety aggregates from one point of the gate-threshold sweep.
+
+    Attributes:
+        thresholds: The four gate thresholds defining this setting.
+        unsafe_commit_rate: Fraction of episodes with an unsafe commitment (lower is safer).
+        collision_rate: Collision probability (lower is safer).
+        min_separation_m: Minimum robot-pedestrian separation (higher is safer).
+    """
+
+    thresholds: dict[str, float]
+    unsafe_commit_rate: float
+    collision_rate: float
+    min_separation_m: float
+
+
+@dataclass(frozen=True, slots=True)
+class SafetyTolerance:
+    """Slack allowed when comparing a dropping setting to the retained baseline."""
+
+    unsafe_commit_abs: float = 0.0
+    collision_abs: float = 0.0
+    min_separation_abs: float = 0.0
+
+
+def classify_setting_safety(
+    setting: GateSettingResult,
+    baseline: GateSettingResult,
+    tolerance: SafetyTolerance | None = None,
+) -> str:
+    """Classify a dropping setting against the conservative-retention baseline.
+
+    A setting is ``at_least_as_safe`` only when it does not worsen any safety axis beyond the
+    allowed tolerance (unsafe-commit, collision, and minimum separation).
+
+    Returns:
+        str: ``at_least_as_safe`` or ``less_safe``.
+    """
+    tolerance = tolerance or SafetyTolerance()
+    safe = (
+        setting.unsafe_commit_rate <= baseline.unsafe_commit_rate + tolerance.unsafe_commit_abs
+        and setting.collision_rate <= baseline.collision_rate + tolerance.collision_abs
+        and setting.min_separation_m >= baseline.min_separation_m - tolerance.min_separation_abs
+    )
+    return AT_LEAST_AS_SAFE if safe else LESS_SAFE
+
+
+def calibrate_stream_gap_gate(
+    settings: list[GateSettingResult],
+    baseline: GateSettingResult,
+    tolerance: SafetyTolerance | None = None,
+) -> dict[str, Any]:
+    """Turn a gate-threshold sweep into actionable safe-region guidance.
+
+    Identifies the safe operating region (settings at least as safe as retention) and recommends
+    the safest member, or concludes that conservative retention dominates.
+
+    Returns:
+        dict[str, Any]: Versioned report with per-setting classifications, the safe region, and a
+        recommended setting or the ``conservative_retention_dominates`` conclusion.
+    """
+    if not settings:
+        raise ValueError("at least one swept setting is required")
+    tolerance = tolerance or SafetyTolerance()
+    classified = [
+        {
+            "thresholds": dict(setting.thresholds),
+            "unsafe_commit_rate": setting.unsafe_commit_rate,
+            "collision_rate": setting.collision_rate,
+            "min_separation_m": setting.min_separation_m,
+            "classification": classify_setting_safety(setting, baseline, tolerance),
+        }
+        for setting in settings
+    ]
+    safe_region = [row for row in classified if row["classification"] == AT_LEAST_AS_SAFE]
+
+    recommendation: dict[str, Any] | None = None
+    conclusion = CONSERVATIVE_RETENTION_DOMINATES
+    if safe_region:
+        # Recommend the safe setting with the strongest safety margin (fewest unsafe commits,
+        # then fewest collisions, then largest separation).
+        recommendation = min(
+            safe_region,
+            key=lambda row: (
+                row["unsafe_commit_rate"],
+                row["collision_rate"],
+                -row["min_separation_m"],
+            ),
+        )
+        conclusion = "safe_region_exists"
+
+    return {
+        "schema_version": STREAM_GAP_CALIBRATION_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "baseline": {
+            "unsafe_commit_rate": baseline.unsafe_commit_rate,
+            "collision_rate": baseline.collision_rate,
+            "min_separation_m": baseline.min_separation_m,
+        },
+        "n_settings": len(settings),
+        "settings": classified,
+        "safe_region": safe_region,
+        "recommended_setting": recommendation,
+        "conclusion": conclusion,
+    }
+
+
+__all__ = [
+    "AT_LEAST_AS_SAFE",
+    "CONSERVATIVE_RETENTION_DOMINATES",
+    "LESS_SAFE",
+    "STREAM_GAP_CALIBRATION_SCHEMA",
+    "GateSettingResult",
+    "SafetyTolerance",
+    "calibrate_stream_gap_gate",
+    "classify_setting_safety",
+]

--- a/tests/planner/test_stream_gap_gate_calibration.py
+++ b/tests/planner/test_stream_gap_gate_calibration.py
@@ -1,0 +1,93 @@
+"""Tests for the stream_gap gate-threshold calibration decision layer (issue #3558)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.planner.stream_gap_gate_calibration import (
+    AT_LEAST_AS_SAFE,
+    CONSERVATIVE_RETENTION_DOMINATES,
+    LESS_SAFE,
+    STREAM_GAP_CALIBRATION_SCHEMA,
+    GateSettingResult,
+    SafetyTolerance,
+    calibrate_stream_gap_gate,
+    classify_setting_safety,
+)
+
+_BASELINE = GateSettingResult(
+    thresholds={"retain": 1.0},
+    unsafe_commit_rate=0.10,
+    collision_rate=0.02,
+    min_separation_m=0.50,
+)
+
+
+def _setting(name: str, unsafe: float, collision: float, sep: float) -> GateSettingResult:
+    """Build a swept gate setting with the given safety aggregates."""
+    return GateSettingResult(
+        thresholds={"name": name},
+        unsafe_commit_rate=unsafe,
+        collision_rate=collision,
+        min_separation_m=sep,
+    )
+
+
+def test_setting_no_worse_than_baseline_is_at_least_as_safe() -> None:
+    """A setting that does not worsen any safety axis is at least as safe as retention."""
+    setting = _setting("s", unsafe=0.10, collision=0.02, sep=0.50)
+
+    assert classify_setting_safety(setting, _BASELINE) == AT_LEAST_AS_SAFE
+
+
+def test_setting_worse_on_any_axis_is_less_safe() -> None:
+    """Worsening any single safety axis must classify the setting as less safe."""
+    worse_unsafe = _setting("a", unsafe=0.20, collision=0.02, sep=0.50)
+    worse_collision = _setting("b", unsafe=0.10, collision=0.05, sep=0.50)
+    worse_sep = _setting("c", unsafe=0.10, collision=0.02, sep=0.30)
+
+    assert classify_setting_safety(worse_unsafe, _BASELINE) == LESS_SAFE
+    assert classify_setting_safety(worse_collision, _BASELINE) == LESS_SAFE
+    assert classify_setting_safety(worse_sep, _BASELINE) == LESS_SAFE
+
+
+def test_tolerance_allows_small_regression() -> None:
+    """A small regression within tolerance must still count as at least as safe."""
+    setting = _setting("s", unsafe=0.11, collision=0.02, sep=0.50)
+    tolerance = SafetyTolerance(unsafe_commit_abs=0.02)
+
+    assert classify_setting_safety(setting, _BASELINE, tolerance) == AT_LEAST_AS_SAFE
+
+
+def test_calibration_recommends_safest_member_of_safe_region() -> None:
+    """When a safe region exists, the safest setting must be recommended."""
+    settings = [
+        _setting("strict", unsafe=0.05, collision=0.01, sep=0.60),  # safe, safest
+        _setting("mid", unsafe=0.09, collision=0.02, sep=0.55),  # safe
+        _setting("loose", unsafe=0.30, collision=0.06, sep=0.20),  # unsafe
+    ]
+    report = calibrate_stream_gap_gate(settings, _BASELINE)
+
+    assert report["schema_version"] == STREAM_GAP_CALIBRATION_SCHEMA
+    assert report["conclusion"] == "safe_region_exists"
+    assert len(report["safe_region"]) == 2
+    assert report["recommended_setting"]["thresholds"]["name"] == "strict"
+
+
+def test_calibration_concludes_retention_dominates_when_none_safe() -> None:
+    """If no setting clears the bar, conservative retention must dominate."""
+    settings = [
+        _setting("a", unsafe=0.30, collision=0.05, sep=0.30),
+        _setting("b", unsafe=0.40, collision=0.07, sep=0.20),
+    ]
+    report = calibrate_stream_gap_gate(settings, _BASELINE)
+
+    assert report["conclusion"] == CONSERVATIVE_RETENTION_DOMINATES
+    assert report["safe_region"] == []
+    assert report["recommended_setting"] is None
+
+
+def test_calibration_rejects_empty_sweep() -> None:
+    """An empty sweep cannot be calibrated."""
+    with pytest.raises(ValueError):
+        calibrate_stream_gap_gate([], _BASELINE)


### PR DESCRIPTION
## Summary

Pure **decision layer** for #3558 — same accepted pattern as the #3484 failure-cause classifier
(merged as #3586).

#3471 found that dropping uncertain agents at the *current default* `stream_gap` uncertainty-gate
thresholds increases unsafe commitment — a finding about the defaults, not gating in general. This
adds the layer that turns a gate-threshold sweep (run over the #3471 episode harness) into the
issue's actionable guidance: is there a threshold region where dropping is at least as safe as
conservative retention, or does retention dominate?

## Decision layer (`stream_gap_gate_calibration.v1`)

- `classify_setting_safety(setting, baseline, tolerance)` → `at_least_as_safe` only when a setting
  worsens **no** safety axis (unsafe-commit / collision / min-separation) beyond the allowed
  tolerance vs the retained baseline.
- `calibrate_stream_gap_gate(settings, baseline, tolerance)` → per-setting classifications, the
  `safe_region`, and either a `recommended_setting` (safest: fewest unsafe commits → fewest
  collisions → largest separation) with `conclusion = safe_region_exists`, or
  `conclusion = conservative_retention_dominates` when none clears the bar.

## Scope boundary

Pure and side-effect free — **no** change to the production dropping default (a separate decision
once a safe region is or isn't found). Running the actual threshold **sweep** over the #3471
episode harness (needs benchmark runs) is the deliberate deferred follow-up.

## Validation

```
uv run pytest tests/planner/test_stream_gap_gate_calibration.py -q   # 6 passed
uv run python scripts/validation/check_broad_exceptions.py           # passes (no broad catches)
ruff check / format                                                  # clean
```

**Evidence grade:** smoke evidence (pure decision function + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
