### PR TITLE
feat(representation): uncertainty-source generalization decision layer (#3557)

### DIFF
--- a/docs/context/issue_3557_uncertainty_source_generalization.md
+++ b/docs/context/issue_3557_uncertainty_source_generalization.md
@@ -1,0 +1,42 @@
+# Issue #3557 — Uncertainty-source generalization decision layer (increment)
+
+**Status:** diagnostic / proxy (same caveats as #3471). **Evidence grade:** idea-level decision
+layer.
+
+## What this is
+
+`robot_sf/representation/uncertainty_source_generalization.py` is the pure **decision layer** for
+#3557. #3471 found the unsafe-dropping effect using a single uncertainty source
+(existence-degradation); `ScenarioBelief` supports others (visibility/occlusion, covariance,
+class-probability, tracking noise). This module turns a per-source retained-vs-dropped safety
+contrast — run via the #3471 harness parameterized by source — into the issue's deliverable: a
+per-source verdict plus whether the finding **generalizes**.
+
+It mirrors the accepted decision-layer pattern in `failure_cause.py` (#3484) and
+`stream_gap_gate_calibration.py` (#3558).
+
+## Decision layer (`uncertainty_source_generalization.v1`)
+
+- `classify_source(contrast, thresholds)` → `reproduces_unsafe_dropping` (dropping raises
+  unsafe-commit or lowers separation beyond the detectable threshold), `no_unsafe_dropping_effect`,
+  or `inconclusive` (sub-threshold difference / too-few episodes).
+- `assess_source_generalization(contrasts, thresholds)` → per-source verdicts and a generalization
+  verdict: `generalizes` (all measurable sources reproduce), `does_not_generalize` (none do),
+  `source_specific` (mixed), or `inconclusive` (no measurable source). Inconclusive sources are
+  excluded from the generalization call.
+
+## Scope boundary
+
+Pure and side-effect free. Parameterizing the #3471 episode harness by uncertainty source and
+running it per source (reusing the #3450 condition builders) needs benchmark runs and is the
+deliberate deferred follow-up.
+
+## Tests
+
+`tests/representation/test_uncertainty_source_generalization.py` (9 tests): reproduce / no-effect /
+inconclusive (sub-threshold and thin-evidence) classification, and generalizes / source-specific /
+does-not-generalize / inconclusive aggregation, plus empty-input rejection.
+
+## Related
+
+- Follows #3471 (PR #3553), #3450, #2546. Sibling: #3558 (gate-threshold calibration).

--- a/robot_sf/representation/uncertainty_source_generalization.py
+++ b/robot_sf/representation/uncertainty_source_generalization.py
@@ -1,0 +1,150 @@
+"""Generalize the uncertainty-drop safety effect across uncertainty sources (issue #3557).
+
+#3471 found, using a single uncertainty source (existence-degradation), that dropping uncertain
+agents is unsafe at the default gate. `ScenarioBelief` supports other sources too — visibility /
+occlusion, covariance inflation, class-probability ambiguity, tracking noise. This module is the
+pure **decision layer** that turns a per-source retained-vs-dropped safety contrast (run via the
+#3471 harness parameterized by source) into the issue's deliverable: a per-source verdict plus
+whether the unsafe-dropping finding **generalizes** across sources or is specific to
+existence-degradation.
+
+The parameterized harness runs are deferred (they need benchmark execution + the #3450 condition
+builders); this layer is pure and side-effect free, mirroring the accepted decision layers in
+``robot_sf/scenario_certification/failure_cause.py`` (#3484) and
+``robot_sf/planner/stream_gap_gate_calibration.py`` (#3558).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+UNCERTAINTY_SOURCE_GENERALIZATION_SCHEMA = "uncertainty_source_generalization.v1"
+
+REPRODUCES = "reproduces_unsafe_dropping"
+NO_EFFECT = "no_unsafe_dropping_effect"
+INCONCLUSIVE = "inconclusive"
+
+GENERALIZES = "generalizes"
+SOURCE_SPECIFIC = "source_specific"
+DOES_NOT_GENERALIZE = "does_not_generalize"
+
+
+@dataclass(frozen=True, slots=True)
+class SourceContrast:
+    """Retained-vs-dropped safety contrast for one uncertainty source.
+
+    Attributes:
+        source: Uncertainty-source name (e.g. ``existence``, ``occlusion``, ``covariance``).
+        retained_unsafe_commit_rate: Unsafe-commit rate under conservative retention.
+        dropped_unsafe_commit_rate: Unsafe-commit rate when dropping uncertain agents.
+        min_separation_delta_m: ``dropped − retained`` minimum separation (negative = dropping worse).
+        n_episodes: Episodes per arm (used only to flag thin evidence).
+    """
+
+    source: str
+    retained_unsafe_commit_rate: float
+    dropped_unsafe_commit_rate: float
+    min_separation_delta_m: float
+    n_episodes: int
+
+
+@dataclass(frozen=True, slots=True)
+class EffectThresholds:
+    """Predeclared effect-size thresholds for classifying a source contrast."""
+
+    min_detectable_unsafe_delta: float = 0.02
+    min_detectable_separation_delta_m: float = 0.05
+    min_episodes: int = 1
+
+
+def classify_source(contrast: SourceContrast, thresholds: EffectThresholds | None = None) -> str:
+    """Classify whether a source reproduces the unsafe-dropping effect.
+
+    Dropping is "unsafe" when it raises unsafe-commit or lowers separation beyond the detectable
+    threshold; a difference below the threshold (or too-few episodes) is ``inconclusive``.
+
+    Returns:
+        str: ``reproduces_unsafe_dropping`` / ``no_unsafe_dropping_effect`` / ``inconclusive``.
+    """
+    thresholds = thresholds or EffectThresholds()
+    unsafe_delta = contrast.dropped_unsafe_commit_rate - contrast.retained_unsafe_commit_rate
+    sep_delta = contrast.min_separation_delta_m
+
+    detectable = (
+        abs(unsafe_delta) >= thresholds.min_detectable_unsafe_delta
+        or abs(sep_delta) >= thresholds.min_detectable_separation_delta_m
+    )
+    if contrast.n_episodes < thresholds.min_episodes or not detectable:
+        return INCONCLUSIVE
+    dropping_worse = (
+        unsafe_delta >= thresholds.min_detectable_unsafe_delta
+        or sep_delta <= -thresholds.min_detectable_separation_delta_m
+    )
+    return REPRODUCES if dropping_worse else NO_EFFECT
+
+
+def assess_source_generalization(
+    contrasts: list[SourceContrast],
+    thresholds: EffectThresholds | None = None,
+) -> dict[str, Any]:
+    """Assess whether the unsafe-dropping effect generalizes across uncertainty sources.
+
+    Returns:
+        dict[str, Any]: Versioned report with per-source verdicts and a generalization verdict —
+        ``generalizes`` (all measurable sources reproduce), ``does_not_generalize`` (none do), or
+        ``source_specific`` (mixed). Inconclusive sources are excluded from the generalization call.
+    """
+    if not contrasts:
+        raise ValueError("at least one source contrast is required")
+    thresholds = thresholds or EffectThresholds()
+    per_source = [
+        {
+            "source": contrast.source,
+            "unsafe_commit_delta": (
+                contrast.dropped_unsafe_commit_rate - contrast.retained_unsafe_commit_rate
+            ),
+            "min_separation_delta_m": contrast.min_separation_delta_m,
+            "n_episodes": contrast.n_episodes,
+            "verdict": classify_source(contrast, thresholds),
+        }
+        for contrast in contrasts
+    ]
+    measurable = [row for row in per_source if row["verdict"] != INCONCLUSIVE]
+    reproduces = [row for row in measurable if row["verdict"] == REPRODUCES]
+
+    if not measurable:
+        generalization = INCONCLUSIVE
+    elif len(reproduces) == len(measurable):
+        generalization = GENERALIZES
+    elif not reproduces:
+        generalization = DOES_NOT_GENERALIZE
+    else:
+        generalization = SOURCE_SPECIFIC
+
+    return {
+        "schema_version": UNCERTAINTY_SOURCE_GENERALIZATION_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "n_sources": len(contrasts),
+        "per_source": per_source,
+        "reproducing_sources": sorted(row["source"] for row in reproduces),
+        "inconclusive_sources": sorted(
+            row["source"] for row in per_source if row["verdict"] == INCONCLUSIVE
+        ),
+        "generalization": generalization,
+    }
+
+
+__all__ = [
+    "DOES_NOT_GENERALIZE",
+    "GENERALIZES",
+    "INCONCLUSIVE",
+    "NO_EFFECT",
+    "REPRODUCES",
+    "SOURCE_SPECIFIC",
+    "UNCERTAINTY_SOURCE_GENERALIZATION_SCHEMA",
+    "EffectThresholds",
+    "SourceContrast",
+    "assess_source_generalization",
+    "classify_source",
+]

--- a/tests/representation/test_uncertainty_source_generalization.py
+++ b/tests/representation/test_uncertainty_source_generalization.py
@@ -1,0 +1,104 @@
+"""Tests for the uncertainty-source generalization decision layer (issue #3557)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.representation.uncertainty_source_generalization import (
+    DOES_NOT_GENERALIZE,
+    GENERALIZES,
+    INCONCLUSIVE,
+    NO_EFFECT,
+    REPRODUCES,
+    SOURCE_SPECIFIC,
+    UNCERTAINTY_SOURCE_GENERALIZATION_SCHEMA,
+    EffectThresholds,
+    SourceContrast,
+    assess_source_generalization,
+    classify_source,
+)
+
+
+def _contrast(source: str, retained: float, dropped: float, sep_delta: float, n: int = 50):
+    """Build a per-source retained-vs-dropped safety contrast."""
+    return SourceContrast(
+        source=source,
+        retained_unsafe_commit_rate=retained,
+        dropped_unsafe_commit_rate=dropped,
+        min_separation_delta_m=sep_delta,
+        n_episodes=n,
+    )
+
+
+def test_dropping_worse_reproduces_effect() -> None:
+    """A clear rise in unsafe commitment when dropping must reproduce the effect."""
+    assert classify_source(_contrast("existence", 0.10, 0.25, -0.20)) == REPRODUCES
+
+
+def test_dropping_at_least_as_safe_is_no_effect() -> None:
+    """When dropping is at least as safe, the effect must not reproduce."""
+    assert classify_source(_contrast("occlusion", 0.20, 0.18, 0.10)) == NO_EFFECT
+
+
+def test_tiny_difference_is_inconclusive() -> None:
+    """A difference below the detectable threshold must be inconclusive."""
+    assert classify_source(_contrast("covariance", 0.10, 0.105, 0.01)) == INCONCLUSIVE
+
+
+def test_thin_evidence_is_inconclusive() -> None:
+    """Too-few episodes must be inconclusive regardless of the measured delta."""
+    thresholds = EffectThresholds(min_episodes=30)
+    assert classify_source(_contrast("class_prob", 0.1, 0.3, -0.2, n=5), thresholds) == INCONCLUSIVE
+
+
+def test_effect_generalizes_when_all_measurable_sources_reproduce() -> None:
+    """If every measurable source reproduces, the finding generalizes."""
+    report = assess_source_generalization(
+        [
+            _contrast("existence", 0.10, 0.25, -0.20),
+            _contrast("occlusion", 0.12, 0.22, -0.10),
+            _contrast("covariance", 0.10, 0.105, 0.0),  # inconclusive, excluded
+        ]
+    )
+
+    assert report["schema_version"] == UNCERTAINTY_SOURCE_GENERALIZATION_SCHEMA
+    assert report["generalization"] == GENERALIZES
+    assert set(report["reproducing_sources"]) == {"existence", "occlusion"}
+    assert report["inconclusive_sources"] == ["covariance"]
+
+
+def test_effect_is_source_specific_when_mixed() -> None:
+    """When some sources reproduce and others do not, the effect is source-specific."""
+    report = assess_source_generalization(
+        [
+            _contrast("existence", 0.10, 0.25, -0.20),  # reproduces
+            _contrast("tracking_noise", 0.20, 0.18, 0.10),  # no effect
+        ]
+    )
+
+    assert report["generalization"] == SOURCE_SPECIFIC
+
+
+def test_effect_does_not_generalize_when_none_reproduce() -> None:
+    """When no measurable source reproduces, the effect does not generalize."""
+    report = assess_source_generalization(
+        [
+            _contrast("occlusion", 0.20, 0.18, 0.10),
+            _contrast("tracking_noise", 0.15, 0.14, 0.08),
+        ]
+    )
+
+    assert report["generalization"] == DOES_NOT_GENERALIZE
+
+
+def test_all_inconclusive_yields_inconclusive_generalization() -> None:
+    """If no source is measurable, the generalization verdict is inconclusive."""
+    report = assess_source_generalization([_contrast("covariance", 0.10, 0.105, 0.0)])
+
+    assert report["generalization"] == INCONCLUSIVE
+
+
+def test_empty_input_is_rejected() -> None:
+    """An empty set of source contrasts cannot be assessed."""
+    with pytest.raises(ValueError):
+        assess_source_generalization([])


### PR DESCRIPTION
## Summary

Pure **decision layer** for #3557 — same accepted pattern as #3484 (merged #3586) and #3558.

#3471 found the "dropping uncertain agents is unsafe" effect using a single uncertainty source
(existence-degradation). `ScenarioBelief` supports others (visibility/occlusion, covariance,
class-probability, tracking noise). This adds the layer that turns a per-source retained-vs-dropped
safety contrast (run via the #3471 harness parameterized by source) into the issue's deliverable:
a per-source verdict + whether the finding **generalizes**.

## Decision layer (`uncertainty_source_generalization.v1`)

- `classify_source` → `reproduces_unsafe_dropping` (dropping raises unsafe-commit or lowers
  separation beyond the detectable threshold), `no_unsafe_dropping_effect`, or `inconclusive`
  (sub-threshold difference / too-few episodes).
- `assess_source_generalization` → per-source verdicts and a generalization verdict
  (`generalizes` / `does_not_generalize` / `source_specific` / `inconclusive`); inconclusive
  sources are excluded from the generalization call.

## Scope boundary

Pure and side-effect free. Parameterizing the #3471 episode harness by uncertainty source and
running it per source (reusing the #3450 condition builders) needs benchmark runs and is the
deliberate deferred follow-up.

## Validation

```
uv run pytest tests/representation/test_uncertainty_source_generalization.py -q   # 9 passed
uv run python scripts/validation/check_broad_exceptions.py                        # passes
ruff check / format                                                               # clean
```

**Evidence grade:** smoke evidence (pure decision function + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
