### PR TITLE
feat(benchmark): reactive-vs-replay reactivity-ablation quantifier (#3573)

### DIFF
--- a/docs/context/issue_3573_reactivity_ablation.md
+++ b/docs/context/issue_3573_reactivity_ablation.md
@@ -1,0 +1,32 @@
+# Issue #3573 — Reactive-vs-replay reactivity-ablation quantifier (increment)
+
+**Status:** diagnostic / analysis. **Evidence grade:** idea-level quantification layer.
+
+## What this is
+
+`robot_sf/benchmark/reactivity_ablation.py` is the pure **quantification layer** for #3573. A
+structural validity question for any pedestrian-interaction benchmark is whether the pedestrians
+react to the robot. Non-reactive replay lets a planner intrude and still accrue good downstream
+metrics (inflating apparent performance); fully reactive pedestrians may over-yield. This module
+turns a paired reactive-vs-replay ablation (run over identical scenarios + seeds with common random
+numbers) into the issue's deliverable.
+
+It mirrors the accepted decision-layer pattern in `failure_cause.py` (#3484) and siblings.
+
+## Quantifier (`reactivity_ablation.v1`)
+
+- `reactivity_delta(contrast)` → per-metric `reactive − replay` deltas and a `replay_flatters` flag
+  (replay shows fewer collisions/near-misses or more separation).
+- `assess_reactivity_ablation(contrasts)` → per-planner deltas, the mean replay collision/near-miss
+  inflation, the planners flattered by replay, and the **rank-reactivity-sensitive** planners
+  (collision rank changes between conditions).
+
+## Scope boundary
+
+Pure and side-effect free. Running the paired reactive-vs-replay ablation (and the open-loop replay
+pedestrian mode) needs benchmark runs and is the deliberate deferred follow-up.
+
+## Tests
+
+`tests/benchmark/test_reactivity_ablation.py` (7 tests): replay-flattering detection across metrics,
+mean-inflation aggregation, rank-reactivity sensitivity (flip vs stable), and empty-input rejection.

--- a/robot_sf/benchmark/reactivity_ablation.py
+++ b/robot_sf/benchmark/reactivity_ablation.py
@@ -1,0 +1,120 @@
+"""Quantify how much pedestrian (non-)reactivity flatters planners (issue #3573).
+
+A structural validity question for any pedestrian-interaction benchmark is whether the simulated
+pedestrians **react to the robot** or merely follow predetermined motion. Non-reactive replay
+(open-loop playback) lets a planner intrude and still accrue good downstream comfort/efficiency,
+inflating apparent performance; fully reactive social-force pedestrians may over-yield. This module
+is the pure **quantification layer** that turns a paired reactive-vs-replay ablation (run over
+identical scenarios + seeds with common random numbers) into the issue's deliverable: per-planner
+deltas attributable to reactivity, the replay inflation, and which planners' rank is
+reactivity-sensitive.
+
+The paired ablation runs (and the open-loop replay pedestrian mode) are deferred; this layer is
+pure and side-effect free, mirroring the accepted decision layers in
+``robot_sf/scenario_certification/failure_cause.py`` (#3484) and siblings.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+REACTIVITY_ABLATION_SCHEMA = "reactivity_ablation.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class ReactivityContrast:
+    """Paired reactive-vs-replay safety results for one planner (fixed scenarios + seeds).
+
+    Attributes:
+        planner: Planner name.
+        reactive_collision_rate: Collision rate with reactive social-force pedestrians.
+        replay_collision_rate: Collision rate with non-reactive open-loop replay.
+        reactive_near_miss_rate: Near-miss rate (reactive).
+        replay_near_miss_rate: Near-miss rate (replay).
+        reactive_min_separation_m: Mean minimum separation (reactive).
+        replay_min_separation_m: Mean minimum separation (replay).
+    """
+
+    planner: str
+    reactive_collision_rate: float
+    replay_collision_rate: float
+    reactive_near_miss_rate: float
+    replay_near_miss_rate: float
+    reactive_min_separation_m: float
+    replay_min_separation_m: float
+
+
+def reactivity_delta(contrast: ReactivityContrast) -> dict[str, Any]:
+    """Quantify the per-planner safety change attributable to pedestrian reactivity.
+
+    Deltas are ``reactive − replay``. A positive collision/near-miss delta means replay *under*
+    reports the hazard (replay flatters the planner); a positive separation delta means replay
+    overstates separation.
+
+    Returns:
+        dict[str, Any]: Per-metric deltas and a ``replay_flatters`` flag.
+    """
+    collision_delta = contrast.reactive_collision_rate - contrast.replay_collision_rate
+    near_miss_delta = contrast.reactive_near_miss_rate - contrast.replay_near_miss_rate
+    separation_delta = contrast.reactive_min_separation_m - contrast.replay_min_separation_m
+    return {
+        "planner": contrast.planner,
+        "collision_delta": collision_delta,
+        "near_miss_delta": near_miss_delta,
+        "min_separation_delta_m": separation_delta,
+        # Replay flatters when it shows fewer collisions/near-misses or more separation.
+        "replay_flatters": collision_delta > 0.0 or near_miss_delta > 0.0 or separation_delta < 0.0,
+    }
+
+
+def _rank_by_collision(rates: dict[str, float]) -> dict[str, int]:
+    """Rank planners by ascending collision rate (1 = safest); ties broken by name.
+
+    Returns:
+        dict[str, int]: Planner name → 1-based rank.
+    """
+    ordered = sorted(rates.items(), key=lambda kv: (kv[1], kv[0]))
+    return {planner: i + 1 for i, (planner, _) in enumerate(ordered)}
+
+
+def assess_reactivity_ablation(contrasts: list[ReactivityContrast]) -> dict[str, Any]:
+    """Summarize the reactive-vs-replay ablation across planners.
+
+    Returns:
+        dict[str, Any]: Versioned report with per-planner deltas, the mean replay collision/near-miss
+        inflation, the planners flattered by replay, and the rank-reactivity-sensitive planners.
+    """
+    if not contrasts:
+        raise ValueError("at least one planner contrast is required")
+    deltas = [reactivity_delta(contrast) for contrast in contrasts]
+
+    reactive_ranks = _rank_by_collision({c.planner: c.reactive_collision_rate for c in contrasts})
+    replay_ranks = _rank_by_collision({c.planner: c.replay_collision_rate for c in contrasts})
+    rank_sensitive = sorted(
+        planner for planner in reactive_ranks if reactive_ranks[planner] != replay_ranks[planner]
+    )
+
+    n = len(deltas)
+    return {
+        "schema_version": REACTIVITY_ABLATION_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "n_planners": n,
+        "per_planner": deltas,
+        # Mean (reactive − replay): positive means replay systematically under-reports the hazard.
+        "mean_replay_collision_inflation": sum(d["collision_delta"] for d in deltas) / n,
+        "mean_replay_near_miss_inflation": sum(d["near_miss_delta"] for d in deltas) / n,
+        "planners_flattered_by_replay": sorted(
+            d["planner"] for d in deltas if d["replay_flatters"]
+        ),
+        "rank_reactivity_sensitive_planners": rank_sensitive,
+        "ranking_is_reactivity_sensitive": bool(rank_sensitive),
+    }
+
+
+__all__ = [
+    "REACTIVITY_ABLATION_SCHEMA",
+    "ReactivityContrast",
+    "assess_reactivity_ablation",
+    "reactivity_delta",
+]

--- a/tests/benchmark/test_reactivity_ablation.py
+++ b/tests/benchmark/test_reactivity_ablation.py
@@ -1,0 +1,109 @@
+"""Tests for the reactive-vs-replay reactivity-ablation quantifier (issue #3573)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.reactivity_ablation import (
+    REACTIVITY_ABLATION_SCHEMA,
+    ReactivityContrast,
+    assess_reactivity_ablation,
+    reactivity_delta,
+)
+
+
+def _contrast(
+    planner: str,
+    *,
+    reactive_coll: float,
+    replay_coll: float,
+    reactive_nm: float = 0.1,
+    replay_nm: float = 0.1,
+    reactive_sep: float = 0.5,
+    replay_sep: float = 0.5,
+) -> ReactivityContrast:
+    """Build a paired reactive-vs-replay contrast for one planner."""
+    return ReactivityContrast(
+        planner=planner,
+        reactive_collision_rate=reactive_coll,
+        replay_collision_rate=replay_coll,
+        reactive_near_miss_rate=reactive_nm,
+        replay_near_miss_rate=replay_nm,
+        reactive_min_separation_m=reactive_sep,
+        replay_min_separation_m=replay_sep,
+    )
+
+
+def test_replay_flatters_when_it_underreports_collisions() -> None:
+    """More collisions under reactive than replay means replay flatters the planner."""
+    delta = reactivity_delta(_contrast("p", reactive_coll=0.20, replay_coll=0.05))
+
+    assert delta["collision_delta"] == pytest.approx(0.15)
+    assert delta["replay_flatters"] is True
+
+
+def test_no_flattering_when_replay_is_not_safer() -> None:
+    """If replay shows no fewer hazards and no more separation, it does not flatter."""
+    delta = reactivity_delta(
+        _contrast("p", reactive_coll=0.05, replay_coll=0.05, reactive_sep=0.5, replay_sep=0.5)
+    )
+
+    assert delta["replay_flatters"] is False
+
+
+def test_lower_separation_under_replay_does_not_flatter() -> None:
+    """Replay with *less* separation (separation_delta > 0) is not flattering on that axis."""
+    delta = reactivity_delta(
+        _contrast("p", reactive_coll=0.05, replay_coll=0.05, reactive_sep=0.6, replay_sep=0.4)
+    )
+
+    assert delta["min_separation_delta_m"] == pytest.approx(0.2)
+    assert delta["replay_flatters"] is False
+
+
+def test_ablation_reports_mean_inflation_and_flattered_planners() -> None:
+    """The ablation must aggregate mean replay inflation and the flattered planners."""
+    report = assess_reactivity_ablation(
+        [
+            _contrast("A", reactive_coll=0.20, replay_coll=0.05),  # flattered
+            _contrast("B", reactive_coll=0.05, replay_coll=0.05),  # not flattered
+        ]
+    )
+
+    assert report["schema_version"] == REACTIVITY_ABLATION_SCHEMA
+    assert report["mean_replay_collision_inflation"] == pytest.approx((0.15 + 0.0) / 2)
+    assert report["planners_flattered_by_replay"] == ["A"]
+
+
+def test_rank_reactivity_sensitivity_is_detected() -> None:
+    """A planner whose collision rank changes between conditions must be flagged."""
+    # Reactive: A(0.10) safer than B(0.20) -> A rank 1.
+    # Replay:   B(0.02) safer than A(0.08) -> B rank 1: the order flips.
+    report = assess_reactivity_ablation(
+        [
+            _contrast("A", reactive_coll=0.10, replay_coll=0.08),
+            _contrast("B", reactive_coll=0.20, replay_coll=0.02),
+        ]
+    )
+
+    assert report["ranking_is_reactivity_sensitive"] is True
+    assert set(report["rank_reactivity_sensitive_planners"]) == {"A", "B"}
+
+
+def test_stable_ranking_is_not_flagged() -> None:
+    """When the collision order is unchanged, no planner is reactivity-sensitive by rank."""
+    report = assess_reactivity_ablation(
+        [
+            _contrast("A", reactive_coll=0.05, replay_coll=0.02),
+            _contrast("B", reactive_coll=0.20, replay_coll=0.10),
+        ]
+    )
+
+    assert report["ranking_is_reactivity_sensitive"] is False
+    assert report["rank_reactivity_sensitive_planners"] == []
+
+
+def test_empty_input_is_rejected() -> None:
+    """An empty ablation cannot be summarized."""
+    with pytest.raises(ValueError):
+        assess_reactivity_ablation([])


### PR DESCRIPTION
## Summary

Pure **quantification layer** for #3573 — same accepted pattern as #3484 (merged #3586), #3558, #3557.

Whether simulated pedestrians react to the robot is a structural validity question: non-reactive
replay (open-loop playback) lets a planner intrude and still accrue good downstream comfort/efficiency,
inflating apparent performance; fully reactive pedestrians may over-yield. This adds the layer that
turns a paired reactive-vs-replay ablation (identical scenarios + seeds, common random numbers) into
the issue's deliverable.

## Quantifier (`reactivity_ablation.v1`)

- `reactivity_delta(contrast)` → per-metric `reactive − replay` deltas and a `replay_flatters` flag
  (replay shows fewer collisions/near-misses or more separation).
- `assess_reactivity_ablation(contrasts)` → per-planner deltas, the **mean replay collision/near-miss
  inflation**, the planners flattered by replay, and the **rank-reactivity-sensitive** planners
  (collision rank changes between conditions).

## Scope boundary

Pure and side-effect free. Running the paired reactive-vs-replay ablation (and the open-loop replay
pedestrian mode) needs benchmark runs and is the deliberate deferred follow-up.

## Validation

```
uv run pytest tests/benchmark/test_reactivity_ablation.py -q   # 7 passed
uv run python scripts/validation/check_broad_exceptions.py     # passes
ruff check / format                                            # clean
```

**Evidence grade:** smoke evidence (pure quantifier + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
