### PR TITLE
feat(benchmark): per-archetype metrics + mean-matched heterogeneity effect (#3574)

### DIFF
--- a/docs/context/issue_3574_heterogeneous_population_metrics.md
+++ b/docs/context/issue_3574_heterogeneous_population_metrics.md
@@ -1,0 +1,37 @@
+# Issue #3574 — Per-archetype metrics + mean-matched heterogeneity effect (increment)
+
+**Status:** diagnostic / analysis. **Evidence grade:** idea-level analysis primitives.
+
+## What this is
+
+`robot_sf/benchmark/heterogeneous_population_metrics.py` provides the pure analysis primitives #3574
+needs before any heterogeneity effect can be claimed. The #3206 smoke could not isolate heterogeneity
+from a population-mean shift, nor compute per-archetype metrics. This adds both, mirroring the
+accepted decision/analysis-layer pattern in this run (#3484, #3558, #3557, #3573).
+
+## Primitives (`heterogeneous_population_metrics.v1`)
+
+- `cvar(values, alpha, higher_is_safer)` — mean of the worst `alpha` tail (lowest values when higher
+  is safer, e.g. clearance; highest when lower is safer, e.g. exposure).
+- `per_archetype_metrics(observations, higher_is_safer, cvar_alpha)` — per-archetype `mean`,
+  `worst_stratum`, and `cvar`, plus the worst archetype by mean, so the worst-served archetype is
+  visible rather than averaged away.
+- `mean_matched_heterogeneity_effect(homogeneous_mean, heterogeneous_mean, homogeneous_is_mean_matched)`
+  — the heterogeneity effect, flagged `isolated` only when the homogeneous arm uses the population
+  mean (`theta_i = E[theta]`); otherwise `confounded_by_mean_shift`.
+
+## Scope boundary
+
+Pure and side-effect free. Logging per-pedestrian control traces in the sim (the missing input infra),
+and running the mean-matched paired ablation / response-law mixture sweep, need code+runs and are the
+deliberate deferred follow-ups.
+
+## Tests
+
+`tests/benchmark/test_heterogeneous_population_metrics.py` (9 tests): CVaR tail direction + alpha
+validation, per-archetype aggregation for higher- and lower-is-safer metrics, empty rejection, and
+the isolated-vs-confounded mean-matched effect.
+
+## Related
+
+- Follows #3206 (heterogeneous archetype axis). Sibling analysis layers: #3573, #3558, #3557.

--- a/robot_sf/benchmark/heterogeneous_population_metrics.py
+++ b/robot_sf/benchmark/heterogeneous_population_metrics.py
@@ -1,0 +1,141 @@
+"""Per-archetype metrics + mean-matched heterogeneity-effect isolation (issue #3574).
+
+The #3206 heterogeneous-pedestrian smoke showed a mean-clearance change under a mixed population but
+could not (a) isolate heterogeneity from a population-mean shift, nor (b) compute per-archetype
+metrics. The literature is explicit that heterogeneity effects are real but planner-specific and are
+not a single difficulty scalar. This module provides the pure analysis primitives needed before any
+heterogeneity effect can be claimed:
+
+1. a **per-archetype metric harness** — per-archetype mean, worst-stratum, and CVaR over the
+   dangerous tail (so the worst-served archetype is visible, not averaged away);
+2. **mean-matched heterogeneity-effect isolation** — comparing a heterogeneous population against a
+   homogeneous one whose parameter is the population mean (``theta_i = E[theta]``), so the effect is
+   separated from a mean shift.
+
+The per-pedestrian control-trace logging that feeds the per-archetype harness, and the mean-matched
+paired ablation runs, are deferred; this module is pure and side-effect free, mirroring the accepted
+analysis layers in this run (#3484, #3558, #3557, #3573).
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+HETEROGENEOUS_POPULATION_METRICS_SCHEMA = "heterogeneous_population_metrics.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class PedestrianMetric:
+    """One per-pedestrian metric observation tagged with its archetype.
+
+    Attributes:
+        archetype: Pedestrian archetype label (e.g. ``cooperative``, ``static``, ``rushed``).
+        value: The per-pedestrian metric value (e.g. clearance, near-field exposure).
+    """
+
+    archetype: str
+    value: float
+
+
+def cvar(values: Sequence[float], alpha: float, *, higher_is_safer: bool) -> float:
+    """Return the CVaR (mean of the worst ``alpha`` tail) of a metric.
+
+    For a metric where higher is safer (e.g. clearance), the worst tail is the lowest values; for a
+    metric where lower is safer (e.g. exposure), it is the highest values.
+
+    Returns:
+        float: Mean of the worst ``ceil(alpha * n)`` observations.
+    """
+    if not values:
+        raise ValueError("values must be non-empty")
+    if not (0.0 < alpha <= 1.0):
+        raise ValueError("alpha must be in (0, 1]")
+    arr = np.sort(np.asarray(values, dtype=np.float64))  # ascending
+    k = max(1, math.ceil(alpha * arr.size))
+    tail = arr[:k] if higher_is_safer else arr[-k:]
+    return float(np.mean(tail))
+
+
+def per_archetype_metrics(
+    observations: Sequence[PedestrianMetric],
+    *,
+    higher_is_safer: bool = True,
+    cvar_alpha: float = 0.1,
+) -> dict[str, Any]:
+    """Aggregate a per-pedestrian metric by archetype with mean, worst-stratum, and CVaR.
+
+    Returns:
+        dict[str, Any]: Versioned report with a per-archetype block and the worst archetype by mean.
+    """
+    if not observations:
+        raise ValueError("at least one observation is required")
+    grouped: dict[str, list[float]] = {}
+    for observation in observations:
+        grouped.setdefault(observation.archetype, []).append(float(observation.value))
+
+    per_archetype: dict[str, Any] = {}
+    for archetype in sorted(grouped):
+        values = grouped[archetype]
+        per_archetype[archetype] = {
+            "n": len(values),
+            "mean": float(np.mean(values)),
+            "worst_stratum": float(min(values) if higher_is_safer else max(values)),
+            "cvar": cvar(values, cvar_alpha, higher_is_safer=higher_is_safer),
+        }
+
+    worst_archetype = (
+        min(per_archetype, key=lambda a: per_archetype[a]["mean"])
+        if higher_is_safer
+        else max(per_archetype, key=lambda a: per_archetype[a]["mean"])
+    )
+    return {
+        "schema_version": HETEROGENEOUS_POPULATION_METRICS_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "higher_is_safer": higher_is_safer,
+        "cvar_alpha": cvar_alpha,
+        "per_archetype": per_archetype,
+        "worst_archetype_by_mean": worst_archetype,
+    }
+
+
+def mean_matched_heterogeneity_effect(
+    homogeneous_mean: float,
+    heterogeneous_mean: float,
+    *,
+    homogeneous_is_mean_matched: bool,
+) -> dict[str, Any]:
+    """Isolate the heterogeneity effect against a mean-matched homogeneous baseline.
+
+    The homogeneous arm must use the population mean of the heterogeneous parameter distribution
+    (``theta_i = E[theta]``); otherwise the difference confounds heterogeneity with a mean shift and
+    is flagged invalid.
+
+    Returns:
+        dict[str, Any]: Versioned report with the isolated effect and a validity flag.
+    """
+    effect = float(heterogeneous_mean) - float(homogeneous_mean)
+    return {
+        "schema_version": HETEROGENEOUS_POPULATION_METRICS_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "homogeneous_mean": float(homogeneous_mean),
+        "heterogeneous_mean": float(heterogeneous_mean),
+        "heterogeneity_effect": effect,
+        "isolated_from_mean_shift": bool(homogeneous_is_mean_matched),
+        "validity": "isolated" if homogeneous_is_mean_matched else "confounded_by_mean_shift",
+    }
+
+
+__all__ = [
+    "HETEROGENEOUS_POPULATION_METRICS_SCHEMA",
+    "PedestrianMetric",
+    "cvar",
+    "mean_matched_heterogeneity_effect",
+    "per_archetype_metrics",
+]

--- a/tests/benchmark/test_heterogeneous_population_metrics.py
+++ b/tests/benchmark/test_heterogeneous_population_metrics.py
@@ -1,0 +1,86 @@
+"""Tests for per-archetype metrics + mean-matched heterogeneity effect (issue #3574)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.heterogeneous_population_metrics import (
+    HETEROGENEOUS_POPULATION_METRICS_SCHEMA,
+    PedestrianMetric,
+    cvar,
+    mean_matched_heterogeneity_effect,
+    per_archetype_metrics,
+)
+
+
+def test_cvar_takes_lowest_tail_when_higher_is_safer() -> None:
+    """For a higher-is-safer metric, CVaR must average the lowest (most dangerous) tail."""
+    values = [1.0, 2.0, 3.0, 4.0, 10.0]
+    # alpha=0.4 -> ceil(0.4*5)=2 worst (lowest) values -> mean(1,2)=1.5
+    assert cvar(values, 0.4, higher_is_safer=True) == pytest.approx(1.5)
+
+
+def test_cvar_takes_highest_tail_when_lower_is_safer() -> None:
+    """For a lower-is-safer metric (e.g. exposure), CVaR must average the highest tail."""
+    values = [1.0, 2.0, 3.0, 4.0, 10.0]
+    assert cvar(values, 0.4, higher_is_safer=False) == pytest.approx(7.0)  # mean(4,10)
+
+
+@pytest.mark.parametrize("alpha", [0.0, 1.5])
+def test_cvar_rejects_invalid_alpha(alpha: float) -> None:
+    """Alpha outside (0, 1] must fail closed."""
+    with pytest.raises(ValueError):
+        cvar([1.0, 2.0], alpha, higher_is_safer=True)
+
+
+def test_per_archetype_aggregates_mean_worst_and_cvar() -> None:
+    """Per-archetype aggregation must expose mean, worst-stratum, and CVaR."""
+    observations = [
+        PedestrianMetric("static", 0.2),
+        PedestrianMetric("static", 0.4),
+        PedestrianMetric("cooperative", 0.9),
+        PedestrianMetric("cooperative", 1.1),
+    ]
+    report = per_archetype_metrics(observations, higher_is_safer=True, cvar_alpha=0.5)
+
+    assert report["schema_version"] == HETEROGENEOUS_POPULATION_METRICS_SCHEMA
+    static = report["per_archetype"]["static"]
+    assert static["mean"] == pytest.approx(0.3)
+    assert static["worst_stratum"] == pytest.approx(0.2)
+    assert report["worst_archetype_by_mean"] == "static"
+
+
+def test_per_archetype_worst_is_max_when_lower_is_safer() -> None:
+    """When lower is safer, the worst stratum and worst archetype flip to the high end."""
+    observations = [
+        PedestrianMetric("a", 0.1),
+        PedestrianMetric("b", 0.9),
+        PedestrianMetric("b", 0.8),
+    ]
+    report = per_archetype_metrics(observations, higher_is_safer=False)
+
+    assert report["per_archetype"]["b"]["worst_stratum"] == pytest.approx(0.9)
+    assert report["worst_archetype_by_mean"] == "b"
+
+
+def test_per_archetype_rejects_empty() -> None:
+    """An empty observation set cannot be aggregated."""
+    with pytest.raises(ValueError):
+        per_archetype_metrics([])
+
+
+def test_mean_matched_effect_is_isolated_when_baseline_is_mean_matched() -> None:
+    """A mean-matched homogeneous baseline yields an isolated heterogeneity effect."""
+    report = mean_matched_heterogeneity_effect(0.50, 0.62, homogeneous_is_mean_matched=True)
+
+    assert report["heterogeneity_effect"] == pytest.approx(0.12)
+    assert report["isolated_from_mean_shift"] is True
+    assert report["validity"] == "isolated"
+
+
+def test_effect_is_flagged_confounded_without_mean_matching() -> None:
+    """Without a mean-matched baseline the effect must be flagged confounded."""
+    report = mean_matched_heterogeneity_effect(0.50, 0.62, homogeneous_is_mean_matched=False)
+
+    assert report["validity"] == "confounded_by_mean_shift"
+    assert report["isolated_from_mean_shift"] is False


### PR DESCRIPTION
## Summary

Pure **analysis primitives** for #3574 — same accepted pattern as #3484 (merged #3586), #3558, #3557, #3573.

The #3206 heterogeneous-pedestrian smoke showed a mean-clearance change but could not (a) isolate
heterogeneity from a population-mean shift, nor (b) compute per-archetype metrics. This adds both,
the prerequisites the literature requires before any heterogeneity effect can be claimed.

## Primitives (`heterogeneous_population_metrics.v1`)

- `cvar(values, alpha, higher_is_safer)` — mean of the worst `alpha` tail (lowest values when higher
  is safer e.g. clearance; highest when lower is safer e.g. exposure).
- `per_archetype_metrics(...)` — per-archetype `mean`, `worst_stratum`, and `cvar` + the worst
  archetype by mean, so the worst-served archetype is visible, not averaged away.
- `mean_matched_heterogeneity_effect(...)` — the heterogeneity effect, flagged `isolated` **only**
  against a mean-matched homogeneous baseline (`theta_i = E[theta]`), else `confounded_by_mean_shift`.

## Scope boundary

Pure and side-effect free. Logging per-pedestrian control traces in the sim (the missing input infra)
and running the mean-matched paired ablation / response-law mixture sweep need code+runs and are the
deliberate deferred follow-ups.

## Validation

```
uv run pytest tests/benchmark/test_heterogeneous_population_metrics.py -q   # 9 passed
uv run python scripts/validation/check_broad_exceptions.py                  # passes
ruff check / format                                                         # clean
```

**Evidence grade:** smoke evidence (pure analysis primitives + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
