### PR TITLE
feat(analysis): run annotation model for the analysis workbench (#1646 child)

### DIFF
--- a/docs/context/issue_1646_run_annotation_model.md
+++ b/docs/context/issue_1646_run_annotation_model.md
@@ -1,0 +1,41 @@
+# Issue #1646 child — run annotation model (`run_annotation.v1`)
+
+**Status:** schema/data deliverable for the analysis-workbench epic #1646. **Respects the epic's
+queue note:** browser/Three.js UI stays blocked; the sanctioned next step is trace/schema/report
+evidence — which this provides. No UI.
+
+## What this is
+
+`robot_sf/analysis/run_annotation.py` adds the annotation model the epic names: a way for humans and
+agents to attach comments to important moments in a run, anchored to durable evidence (frame ranges,
+event IDs, entities, a source artifact) and keeping **observation separate from hypothesis**. It
+complements the existing renderer-neutral timeline (`simulation_timeline.v1`), which annotations
+anchor to.
+
+## Model (`run_annotation.v1`)
+
+- `RunAnnotation` — `annotation_id`, `author` + `author_kind` (`human`/`agent`), `frame_start` ≤
+  `frame_end`, a **canonical** `label` (`success` / `near_miss` / `collision_precursor` / `deadlock`
+  / `social_force_artifact` / `planner_issue` / `policy_uncertainty`), a `statement_kind`
+  (`observation`/`hypothesis`), `text`, `source_artifact` (provenance), and optional `event_ids` /
+  `entity_ids`. Fails closed on contract violations.
+- `AnnotationSet` — a validated collection over one source artifact (unique ids, consistent
+  provenance) with `observations()` / `hypotheses()` accessors and an observation/hypothesis split in
+  `to_dict()`.
+
+## Scope boundary
+
+Pure schema/data — no UI, no runs. Anchors to the existing `simulation_timeline.v1` artifact. The
+inspector, agent-discussion workflow, and review-report generation remain separate (de-emphasized)
+children.
+
+## Tests
+
+`tests/analysis/test_run_annotation.py` (11 tests): valid serialization with anchors, fail-closed
+validation of every contract field, observation/hypothesis separability, duplicate-id rejection, and
+source-artifact consistency.
+
+## Related
+
+- Epic: #1646. Renderer-neutral timeline: `scripts/analysis/export_trace_timeline_issue_1646.py`
+  (`simulation_timeline.v1`).

--- a/robot_sf/analysis/run_annotation.py
+++ b/robot_sf/analysis/run_annotation.py
@@ -1,0 +1,171 @@
+"""Annotation model for simulation-run analysis (issue #1646 child).
+
+The analysis-workbench epic (#1646) needs a way for humans and agents to attach comments to
+important moments in a run, anchored to durable evidence rather than loose screenshots, and to keep
+**observation separate from hypothesis**. The renderer-neutral run/event timeline already exists
+(``simulation_timeline.v1``); this module adds the matching pure, versioned **annotation model**:
+comments anchored to frame ranges, event IDs, entities, and a source artifact.
+
+This is schema/data only — no UI. Per the epic's queue note, browser/Three.js work stays blocked;
+the sanctioned next step is trace/schema/report evidence, which this provides.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+RUN_ANNOTATION_SCHEMA = "run_annotation.v1"
+
+# Who authored the annotation.
+AUTHOR_HUMAN = "human"
+AUTHOR_AGENT = "agent"
+_AUTHOR_KINDS = frozenset({AUTHOR_HUMAN, AUTHOR_AGENT})
+
+# Observation vs hypothesis must stay separable (epic requirement).
+STATEMENT_OBSERVATION = "observation"
+STATEMENT_HYPOTHESIS = "hypothesis"
+_STATEMENT_KINDS = frozenset({STATEMENT_OBSERVATION, STATEMENT_HYPOTHESIS})
+
+# Canonical moment labels named by the epic.
+CANONICAL_LABELS = frozenset(
+    {
+        "success",
+        "near_miss",
+        "collision_precursor",
+        "deadlock",
+        "social_force_artifact",
+        "planner_issue",
+        "policy_uncertainty",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class RunAnnotation:
+    """One annotation anchored to a frame range and durable evidence.
+
+    Attributes:
+        annotation_id: Stable identifier for the annotation.
+        author: Author identifier (human handle or agent name).
+        author_kind: ``human`` or ``agent``.
+        frame_start: First anchored frame index (inclusive, >= 0).
+        frame_end: Last anchored frame index (inclusive, >= frame_start).
+        label: A canonical moment label (see ``CANONICAL_LABELS``).
+        statement_kind: ``observation`` or ``hypothesis`` — kept separable by contract.
+        text: The annotation text.
+        source_artifact: Provenance — the timeline/trace artifact the annotation references.
+        event_ids: Optional anchored event IDs.
+        entity_ids: Optional anchored entity IDs (robot/pedestrian).
+    """
+
+    annotation_id: str
+    author: str
+    author_kind: str
+    frame_start: int
+    frame_end: int
+    label: str
+    statement_kind: str
+    text: str
+    source_artifact: str
+    event_ids: tuple[str, ...] = ()
+    entity_ids: tuple[str, ...] = ()
+
+    def __post_init__(self) -> None:
+        """Validate the annotation contract."""
+        if self.author_kind not in _AUTHOR_KINDS:
+            raise ValueError(f"author_kind must be one of {sorted(_AUTHOR_KINDS)}")
+        if self.statement_kind not in _STATEMENT_KINDS:
+            raise ValueError(f"statement_kind must be one of {sorted(_STATEMENT_KINDS)}")
+        if self.label not in CANONICAL_LABELS:
+            raise ValueError(f"label must be one of {sorted(CANONICAL_LABELS)}, got {self.label!r}")
+        if self.frame_start < 0:
+            raise ValueError("frame_start must be >= 0")
+        if self.frame_end < self.frame_start:
+            raise ValueError("frame_end must be >= frame_start")
+        if not self.source_artifact:
+            raise ValueError("source_artifact (provenance) is required")
+        if not self.text.strip():
+            raise ValueError("annotation text must be non-empty")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-serializable annotation record.
+
+        Returns:
+            dict[str, Any]: Schema-tagged annotation payload.
+        """
+        return {
+            "schema_version": RUN_ANNOTATION_SCHEMA,
+            "annotation_id": self.annotation_id,
+            "author": self.author,
+            "author_kind": self.author_kind,
+            "frame_start": self.frame_start,
+            "frame_end": self.frame_end,
+            "label": self.label,
+            "statement_kind": self.statement_kind,
+            "text": self.text,
+            "source_artifact": self.source_artifact,
+            "event_ids": list(self.event_ids),
+            "entity_ids": list(self.entity_ids),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class AnnotationSet:
+    """A validated collection of annotations over a single run/timeline artifact."""
+
+    source_artifact: str
+    annotations: tuple[RunAnnotation, ...] = field(default_factory=tuple)
+
+    def __post_init__(self) -> None:
+        """Validate annotation-id uniqueness and source consistency."""
+        seen: set[str] = set()
+        for annotation in self.annotations:
+            if annotation.annotation_id in seen:
+                raise ValueError(f"duplicate annotation_id: {annotation.annotation_id}")
+            seen.add(annotation.annotation_id)
+            if annotation.source_artifact != self.source_artifact:
+                raise ValueError("all annotations must reference the set's source_artifact")
+
+    def observations(self) -> tuple[RunAnnotation, ...]:
+        """Return only the observation annotations.
+
+        Returns:
+            tuple[RunAnnotation, ...]: Annotations whose ``statement_kind`` is observation.
+        """
+        return tuple(a for a in self.annotations if a.statement_kind == STATEMENT_OBSERVATION)
+
+    def hypotheses(self) -> tuple[RunAnnotation, ...]:
+        """Return only the hypothesis annotations.
+
+        Returns:
+            tuple[RunAnnotation, ...]: Annotations whose ``statement_kind`` is hypothesis.
+        """
+        return tuple(a for a in self.annotations if a.statement_kind == STATEMENT_HYPOTHESIS)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return the JSON-serializable annotation-set record.
+
+        Returns:
+            dict[str, Any]: Schema-tagged annotation-set payload with observation/hypothesis split.
+        """
+        return {
+            "schema_version": RUN_ANNOTATION_SCHEMA,
+            "source_artifact": self.source_artifact,
+            "n_annotations": len(self.annotations),
+            "n_observations": len(self.observations()),
+            "n_hypotheses": len(self.hypotheses()),
+            "annotations": [annotation.to_dict() for annotation in self.annotations],
+        }
+
+
+__all__ = [
+    "AUTHOR_AGENT",
+    "AUTHOR_HUMAN",
+    "CANONICAL_LABELS",
+    "RUN_ANNOTATION_SCHEMA",
+    "STATEMENT_HYPOTHESIS",
+    "STATEMENT_OBSERVATION",
+    "AnnotationSet",
+    "RunAnnotation",
+]

--- a/tests/analysis/test_run_annotation.py
+++ b/tests/analysis/test_run_annotation.py
@@ -1,0 +1,107 @@
+"""Tests for the run annotation model (issue #1646 child)."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.analysis.run_annotation import (
+    RUN_ANNOTATION_SCHEMA,
+    STATEMENT_HYPOTHESIS,
+    STATEMENT_OBSERVATION,
+    AnnotationSet,
+    RunAnnotation,
+)
+
+
+def _annotation(**overrides) -> RunAnnotation:
+    """Build a valid annotation with optional overrides."""
+    kwargs = {
+        "annotation_id": "a1",
+        "author": "ll7",
+        "author_kind": "human",
+        "frame_start": 10,
+        "frame_end": 20,
+        "label": "near_miss",
+        "statement_kind": STATEMENT_OBSERVATION,
+        "text": "robot passed within 0.2 m of a pedestrian",
+        "source_artifact": "docs/context/evidence/run/timeline.json",
+        "event_ids": ("evt_3",),
+        "entity_ids": ("ped_7",),
+    }
+    kwargs.update(overrides)
+    return RunAnnotation(**kwargs)
+
+
+def test_valid_annotation_serializes_with_anchors() -> None:
+    """A valid annotation must serialize with its frame range, anchors, and provenance."""
+    payload = _annotation().to_dict()
+
+    assert payload["schema_version"] == RUN_ANNOTATION_SCHEMA
+    assert payload["frame_start"] == 10
+    assert payload["frame_end"] == 20
+    assert payload["event_ids"] == ["evt_3"]
+    assert payload["entity_ids"] == ["ped_7"]
+    assert payload["source_artifact"]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"author_kind": "robot"},  # not human/agent
+        {"statement_kind": "guess"},  # not observation/hypothesis
+        {"label": "vibes"},  # not canonical
+        {"frame_start": -1},
+        {"frame_start": 30, "frame_end": 20},  # end < start
+        {"source_artifact": ""},  # missing provenance
+        {"text": "   "},  # empty text
+    ],
+)
+def test_invalid_annotations_fail_closed(overrides: dict[str, object]) -> None:
+    """Contract violations must fail closed at construction."""
+    with pytest.raises(ValueError):
+        _annotation(**overrides)
+
+
+def test_observation_and_hypothesis_stay_separable() -> None:
+    """The set must split observation from hypothesis annotations."""
+    src = "docs/context/evidence/run/timeline.json"
+    annotations = (
+        _annotation(annotation_id="a1", statement_kind=STATEMENT_OBSERVATION, source_artifact=src),
+        _annotation(
+            annotation_id="a2",
+            statement_kind=STATEMENT_HYPOTHESIS,
+            label="planner_issue",
+            text="the planner likely under-weighted the crossing pedestrian",
+            source_artifact=src,
+        ),
+    )
+    annotation_set = AnnotationSet(source_artifact=src, annotations=annotations)
+
+    assert len(annotation_set.observations()) == 1
+    assert len(annotation_set.hypotheses()) == 1
+    payload = annotation_set.to_dict()
+    assert payload["n_observations"] == 1
+    assert payload["n_hypotheses"] == 1
+    assert payload["n_annotations"] == 2
+
+
+def test_duplicate_annotation_id_is_rejected() -> None:
+    """Duplicate annotation ids within a set must fail closed."""
+    src = "x.json"
+    with pytest.raises(ValueError):
+        AnnotationSet(
+            source_artifact=src,
+            annotations=(
+                _annotation(annotation_id="dup", source_artifact=src),
+                _annotation(annotation_id="dup", source_artifact=src),
+            ),
+        )
+
+
+def test_annotation_must_reference_set_source_artifact() -> None:
+    """An annotation pointing at a different artifact than its set must fail closed."""
+    with pytest.raises(ValueError):
+        AnnotationSet(
+            source_artifact="a.json",
+            annotations=(_annotation(source_artifact="b.json"),),
+        )


### PR DESCRIPTION
## Summary

Implements a sanctioned **non-UI** child of the analysis-workbench epic #1646: the run **annotation
model**. The epic's queue note keeps browser/Three.js UI blocked and names *trace/schema/report
evidence* as the next useful step; the renderer-neutral timeline (`simulation_timeline.v1`) already
exists, so this adds the matching annotation layer it anchors to.

## Model (`run_annotation.v1`)

- `RunAnnotation` — a human/agent comment anchored to a **frame range**, **event IDs**, **entities**,
  and a **source artifact** (provenance), with **canonical** moment labels (`success` / `near_miss`
  / `collision_precursor` / `deadlock` / `social_force_artifact` / `planner_issue` /
  `policy_uncertainty`) and explicit **observation-vs-hypothesis** separation. Fails closed on every
  contract violation.
- `AnnotationSet` — a validated collection over one source artifact (unique ids, consistent
  provenance) with `observations()` / `hypotheses()` accessors and an observation/hypothesis split.

## Scope boundary

Pure schema/data — **no UI, no runs**. The inspector, agent-discussion workflow, and review-report
generation remain separate (de-emphasized) children, and browser/Three.js work stays blocked per the
epic.

## Validation

```
uv run pytest tests/analysis/test_run_annotation.py -q       # 11 passed
uv run python scripts/validation/check_broad_exceptions.py   # passes
ruff check / format                                          # clean
```

**Evidence grade:** smoke evidence (pure schema + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
