### PR TITLE
refactor: reconcile rollover proxy with benchmark-surface source of truth (#3587)

### DIFF
--- a/docs/context/issue_3479_rollover_proxy.md
+++ b/docs/context/issue_3479_rollover_proxy.md
@@ -24,14 +24,18 @@ holonomic models — can be surfaced as a per-step signal.
 
 | symbol | field | default (m) | meaning |
 | --- | --- | --- | --- |
-| `t_w` | `track_width_m` | 0.50 | lateral wheel track |
-| `h_c` | `cog_height_m` | 0.40 | centre-of-gravity height |
-| `a` | `front_axle_to_cog_m` | 0.30 | front axle → CoG |
-| `L` | `wheelbase_m` | 0.60 | wheelbase |
+| `t_w` | `track_width_m` | 0.80 | lateral wheel track |
+| `h_c` | `cog_height_m` | 0.60 | centre-of-gravity height |
+| `a` | `front_axle_to_cog_m` | 0.50 | front axle → CoG |
+| `L` | `wheelbase_m` | 1.20 | wheelbase |
 | `g` | `gravity_m_s2` | 9.81 | gravity |
 
-These defaults exist only so the proxy is exercisable; they carry **no hardware
-authority**. For the defaults, `a_y,crit ≈ 3.07 m/s²`.
+These defaults are **aligned with the benchmark-surface source of truth**
+`robot_sf.benchmark.metrics.evaluate_stability_margin` (the reviewer-supplied TWV proxy
+`t_w=0.8`, `L=1.2`, `h_c=0.6`, `a=0.5`) so the runtime diagnostic and the benchmark column
+`rollover_min_stability_margin` cannot diverge (issue #3587); a parametrized test cross-checks
+that the two produce identical margins. They carry **no hardware authority**. For the defaults,
+`a_y,crit ≈ 2.73 m/s²`.
 
 ## Scope boundary
 

--- a/robot_sf/robot/rollover_proxy.py
+++ b/robot_sf/robot/rollover_proxy.py
@@ -45,6 +45,12 @@ class RolloverProxyParams:
     three-wheeled platform purely so the proxy is exercisable; they carry no hardware
     authority.
 
+    The default geometry is **aligned with the benchmark-surface source of truth**
+    ``robot_sf.benchmark.metrics.evaluate_stability_margin`` (the reviewer-supplied TWV proxy:
+    ``t_w=0.8``, ``L=1.2``, ``h_c=0.6``, ``a=0.5``) so the runtime diagnostic and the benchmark
+    column ``rollover_min_stability_margin`` cannot diverge (issue #3587). The closed form here is
+    identical to that function; ``test_rollover_proxy`` cross-checks numerical agreement.
+
     Attributes:
         track_width_m: Lateral wheel track ``t_w`` (m).
         cog_height_m: Centre-of-gravity height ``h_c`` (m).
@@ -54,10 +60,10 @@ class RolloverProxyParams:
         schema_version: Stable schema tag for reproducibility.
     """
 
-    track_width_m: float = 0.50
-    cog_height_m: float = 0.40
-    front_axle_to_cog_m: float = 0.30
-    wheelbase_m: float = 0.60
+    track_width_m: float = 0.80
+    cog_height_m: float = 0.60
+    front_axle_to_cog_m: float = 0.50
+    wheelbase_m: float = 1.20
     gravity_m_s2: float = GRAVITY_M_S2
     schema_version: str = PROXY_SCHEMA_VERSION
 

--- a/tests/test_rollover_proxy.py
+++ b/tests/test_rollover_proxy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import pytest
 
+from robot_sf.benchmark.metrics import evaluate_stability_margin
 from robot_sf.robot.rollover_proxy import (
     PROXY_SCHEMA_VERSION,
     RolloverProxyParams,
@@ -14,8 +15,9 @@ from robot_sf.robot.rollover_proxy import (
     stability_margin,
 )
 
-# a_y,crit = g * (t_w / (2 h_c)) * (a / L) for the documented default proxy geometry.
-_DEFAULT_CRIT = 9.81 * (0.50 / (2 * 0.40)) * (0.30 / 0.60)
+# a_y,crit = g * (t_w / (2 h_c)) * (a / L) for the default proxy geometry, aligned with the
+# benchmark-surface source of truth metrics.evaluate_stability_margin (t_w=0.8, L=1.2, h_c=0.6, a=0.5).
+_DEFAULT_CRIT = 9.81 * (0.80 / (2 * 0.60)) * (0.50 / 1.20)
 
 
 def test_critical_lateral_acceleration_matches_closed_form() -> None:
@@ -30,7 +32,7 @@ def test_lateral_acceleration_is_v_times_omega() -> None:
 
 def test_feasible_command_stays_stable() -> None:
     """A low-speed, low-yaw command must stay well within the proxy threshold."""
-    margin = stability_margin(0.5, 0.5)  # a_y = 0.25 << a_y,crit ~ 3.07
+    margin = stability_margin(0.5, 0.5)  # a_y = 0.25 << a_y,crit ~ 2.73
 
     assert margin == pytest.approx(1.0 - 0.25 / _DEFAULT_CRIT)
     assert not is_rollover_critical(margin)
@@ -38,7 +40,7 @@ def test_feasible_command_stays_stable() -> None:
 
 def test_over_yaw_command_trips_rollover_critical() -> None:
     """An over-yaw command exceeding the critical accel must trip ROLLOVER_CRITICAL."""
-    margin = stability_margin(2.0, 2.0)  # a_y = 4.0 > a_y,crit ~ 3.07
+    margin = stability_margin(2.0, 2.0)  # a_y = 4.0 > a_y,crit ~ 2.73
 
     assert margin == 0.0
     assert is_rollover_critical(margin)
@@ -98,3 +100,28 @@ def test_telemetry_is_schema_tagged_and_labels_non_hardware() -> None:
     assert record["stability_margin"] == 0.0
     assert record["lateral_acceleration"] == pytest.approx(4.0)
     assert record["critical_lateral_acceleration"] == pytest.approx(_DEFAULT_CRIT)
+
+
+@pytest.mark.parametrize(
+    ("v", "omega"),
+    [(0.0, 0.0), (0.5, 0.5), (1.0, 1.5), (2.0, 2.0), (3.0, 1.0), (1.0, -2.0)],
+)
+def test_proxy_agrees_with_benchmark_surface_source_of_truth(v: float, omega: float) -> None:
+    """The runtime proxy must match metrics.evaluate_stability_margin (issue #3587).
+
+    Both implement the same closed form; with the default geometry now aligned to the
+    benchmark-surface values, the two must produce identical stability margins so the runtime
+    diagnostic and the benchmark column cannot diverge.
+    """
+    params = RolloverProxyParams()
+    proxy_margin = stability_margin(v, omega, params)
+    benchmark_margin = evaluate_stability_margin(
+        v,
+        omega,
+        t_w=params.track_width_m,
+        L=params.wheelbase_m,
+        h_c=params.cog_height_m,
+        a=params.front_axle_to_cog_m,
+    )
+
+    assert proxy_margin == pytest.approx(benchmark_margin)


### PR DESCRIPTION
## Summary

Closes #3587 — reconciles the duplicate rollover stability-margin implementations flagged in review
of #3582, **before** any #3479 runtime wiring, so they cannot drift.

Review found `robot_sf/robot/rollover_proxy.py` (added by #3582, diagnostic-only) is a second
implementation of the existing `robot_sf/benchmark/metrics.py:evaluate_stability_margin` — same
closed form, but **divergent default geometry** (`0.50/0.40/0.30/0.60` vs the benchmark-surface
`0.8/0.6/0.5/1.2`). `evaluate_stability_margin` already feeds the `rollover_min_stability_margin` /
`ROLLOVER_CRITICAL` benchmark columns, so two divergent proxies would produce inconsistent numbers
once the proxy is wired into runtime/reward.

## What changed

- **Aligned** `RolloverProxyParams` defaults to the benchmark-surface reviewer-supplied TWV proxy
  (`t_w=0.8`, `L=1.2`, `h_c=0.6`, `a=0.5`; `a_y,crit ≈ 2.73 m/s²`).
- **Documented** `metrics.evaluate_stability_margin` as the source of truth (module docstring + the
  #3479 context note).
- **Added a parametrized cross-check test** asserting `stability_margin` equals
  `evaluate_stability_margin` for the same inputs — a regression guard that keeps the two consistent.

## Scope boundary

No runtime behavior change — the proxy stays diagnostic-only and unwired. This satisfies the #3587
acceptance ("reconcile … before any PR wires `rollover_proxy.py` into runtime/reward/control").

## Validation

```
uv run pytest tests/test_rollover_proxy.py -q                # 21 passed (incl. the new cross-check)
uv run python scripts/validation/check_broad_exceptions.py   # passes
ruff check / format                                          # clean
```

**Evidence grade:** smoke evidence (constant alignment + cross-check regression test). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default rollover proxy geometry values so stability-related calculations now match the benchmark results.
  * Adjusted expected critical lateral acceleration values to reflect the new defaults.

* **Tests**
  * Added coverage to confirm runtime rollover stability margins stay in sync with benchmark calculations across multiple scenarios.

* **Documentation**
  * Clarified that the documented default geometry aligns with the benchmark metric, reducing the risk of inconsistent stability readings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->