### PR TITLE
feat(benchmark): AMMV command-feasibility / tip-over evaluator (#3466)

### DIFF
--- a/docs/context/issue_3466_ammv_command_feasibility.md
+++ b/docs/context/issue_3466_ammv_command_feasibility.md
@@ -1,0 +1,40 @@
+# Issue #3466 — AMMV command-feasibility / tip-over evaluator (increment)
+
+**Status:** diagnostic / internal-proxy. Thresholds are explicit non-hardware assumptions; no
+paper-facing AMMV safety claim before benchmark evidence exists.
+
+## What this is
+
+`robot_sf/benchmark/ammv_feasibility.py` evaluates whether a planner's command sequence respects a
+three-wheeled AMMV's tip-over and proxy non-holonomic limits — flagging commands that look fine under
+the current robot abstraction but a three-wheeled platform could not safely execute. It does **not**
+change planner behavior.
+
+It reuses the benchmark-surface source of truth `metrics.evaluate_stability_margin` (reconciled in
+#3587) for the tip-over margin, so this lens and the `rollover_min_stability_margin` column stay
+consistent (a test cross-checks this).
+
+## Evaluator (`ammv_feasibility.v1`)
+
+`evaluate_command_feasibility(velocities, turn_rates, params)` emits `min_stability_margin`,
+`tip_over_violation` + `n_tip_over_steps` (+ `rollover_event` = `ROLLOVER_CRITICAL`),
+`n_curvature_violations` (proxy non-holonomic `|ω| ≤ max_curvature·v`, with an in-place yaw allowance
+at near-zero speed), and an overall `feasible` verdict. `AmmvFeasibilityParams` defaults align with
+the benchmark-surface stability geometry.
+
+## Scope boundary
+
+Pure and side-effect free — no planner-behavior change. Surfacing these fields in benchmark
+artifacts / evidence summaries (the artifact-pipeline wiring, Tier-2) is the deliberate deferred
+follow-up.
+
+## Tests
+
+`tests/benchmark/test_ammv_feasibility.py` (7 tests): feasible sequence passes, over-yaw trips
+tip-over, excess curvature flagged, in-place yaw limit, agreement with
+`metrics.evaluate_stability_margin`, and length/empty/param validation.
+
+## Related
+
+- Tip-over computation source of truth + #3479/#3587 reconciliation: `robot_sf/benchmark/metrics.py`,
+  `robot_sf/robot/rollover_proxy.py`.

--- a/robot_sf/benchmark/ammv_feasibility.py
+++ b/robot_sf/benchmark/ammv_feasibility.py
@@ -1,0 +1,145 @@
+"""AMMV kinematic-feasibility and tip-over evaluation over a command sequence (issue #3466).
+
+Some planner outputs that look acceptable under the current robot abstraction may violate a
+three-wheeled Autonomous Micromobility Vehicle's lateral-stability (tip-over) or non-holonomic
+limits, especially in dense pedestrian interactions. This module is the pure evaluator that flags
+such commands over a per-step ``(velocity, turn_rate)`` sequence, **without** changing planner
+behavior.
+
+It reuses the benchmark-surface source of truth
+``robot_sf.benchmark.metrics.evaluate_stability_margin`` (reconciled in #3587) for the tip-over
+margin, so this lens and the existing ``rollover_min_stability_margin`` column stay consistent. The
+non-holonomic curvature limit is an explicit **internal proxy**, not a hardware-AMMV claim.
+
+Surfacing these fields in benchmark artifacts / evidence summaries (the artifact-pipeline wiring) is
+a deliberate follow-up; this evaluator is pure and side-effect free.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from robot_sf.benchmark.metrics import ROLLOVER_CRITICAL_EVENT, evaluate_stability_margin
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+AMMV_FEASIBILITY_SCHEMA = "ammv_feasibility.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class AmmvFeasibilityParams:
+    """Internal-proxy AMMV geometry and kinematic limits (non-hardware).
+
+    Stability geometry defaults match ``metrics.evaluate_stability_margin`` so the tip-over margin
+    is identical to the benchmark-surface column. The curvature limit is a proxy non-holonomic bound.
+
+    Attributes:
+        track_width_m: ``t_w`` for the stability margin.
+        wheelbase_m: ``L`` for the stability margin.
+        cog_height_m: ``h_c`` for the stability margin.
+        front_axle_to_cog_m: ``a`` for the stability margin.
+        max_curvature_per_m: Proxy maximum path curvature ``|ω| / v`` while moving (1 / min radius).
+        in_place_yaw_rate_max: Proxy maximum yaw rate permitted at near-zero speed.
+        zero_speed_eps: Speed below which the in-place yaw limit applies instead of curvature.
+    """
+
+    track_width_m: float = 0.80
+    wheelbase_m: float = 1.20
+    cog_height_m: float = 0.60
+    front_axle_to_cog_m: float = 0.50
+    max_curvature_per_m: float = 1.0
+    in_place_yaw_rate_max: float = 0.5
+    zero_speed_eps: float = 1e-6
+
+    def __post_init__(self) -> None:
+        """Validate the proxy parameters."""
+        for name in (
+            "track_width_m",
+            "wheelbase_m",
+            "cog_height_m",
+            "front_axle_to_cog_m",
+            "max_curvature_per_m",
+            "in_place_yaw_rate_max",
+        ):
+            if not (getattr(self, name) > 0.0):
+                raise ValueError(f"AmmvFeasibilityParams.{name} must be > 0")
+
+
+def _stability_margin(v: float, omega: float, params: AmmvFeasibilityParams) -> float:
+    """Return the tip-over stability margin via the benchmark-surface source of truth."""
+    return evaluate_stability_margin(
+        v,
+        omega,
+        t_w=params.track_width_m,
+        L=params.wheelbase_m,
+        h_c=params.cog_height_m,
+        a=params.front_axle_to_cog_m,
+    )
+
+
+def _curvature_feasible(v: float, omega: float, params: AmmvFeasibilityParams) -> bool:
+    """Return whether one ``(v, ω)`` command respects the proxy non-holonomic limit."""
+    if abs(v) <= params.zero_speed_eps:
+        return abs(omega) <= params.in_place_yaw_rate_max
+    return abs(omega) <= params.max_curvature_per_m * abs(v)
+
+
+def evaluate_command_feasibility(
+    velocities: NDArray[np.floating] | object,
+    turn_rates: NDArray[np.floating] | object,
+    params: AmmvFeasibilityParams | None = None,
+) -> dict[str, Any]:
+    """Evaluate AMMV tip-over and non-holonomic feasibility over a command sequence.
+
+    Args:
+        velocities: ``(N,)`` commanded forward speeds (m/s).
+        turn_rates: ``(N,)`` commanded yaw rates (rad/s).
+        params: Internal-proxy parameters; defaults to :class:`AmmvFeasibilityParams`.
+
+    Returns:
+        dict[str, Any]: Versioned telemetry — minimum stability margin, per-step tip-over and
+        curvature violation counts, and the overall feasibility verdict.
+    """
+    params = params or AmmvFeasibilityParams()
+    v = np.asarray(velocities, dtype=np.float64).reshape(-1)
+    omega = np.asarray(turn_rates, dtype=np.float64).reshape(-1)
+    if v.shape[0] != omega.shape[0]:
+        raise ValueError("velocities and turn_rates must share length N")
+    if v.shape[0] == 0:
+        raise ValueError("at least one command is required")
+
+    margins = [
+        _stability_margin(float(vi), float(wi), params) for vi, wi in zip(v, omega, strict=True)
+    ]
+    tip_over_steps = [i for i, m in enumerate(margins) if m <= 0.0]
+    curvature_violation_steps = [
+        i
+        for i, (vi, wi) in enumerate(zip(v, omega, strict=True))
+        if not _curvature_feasible(vi, wi, params)
+    ]
+    min_margin = float(min(margins))
+    feasible = not tip_over_steps and not curvature_violation_steps
+
+    return {
+        "schema_version": AMMV_FEASIBILITY_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "proxy_kind": "internal_non_hardware",
+        "n_commands": int(v.shape[0]),
+        "min_stability_margin": min_margin,
+        "tip_over_violation": bool(tip_over_steps),
+        "n_tip_over_steps": len(tip_over_steps),
+        "rollover_event": ROLLOVER_CRITICAL_EVENT if tip_over_steps else "",
+        "n_curvature_violations": len(curvature_violation_steps),
+        "feasible": feasible,
+    }
+
+
+__all__ = [
+    "AMMV_FEASIBILITY_SCHEMA",
+    "AmmvFeasibilityParams",
+    "evaluate_command_feasibility",
+]

--- a/robot_sf/benchmark/ammv_feasibility.py
+++ b/robot_sf/benchmark/ammv_feasibility.py
@@ -111,6 +111,11 @@ def evaluate_command_feasibility(
         raise ValueError("velocities and turn_rates must share length N")
     if v.shape[0] == 0:
         raise ValueError("at least one command is required")
+    # Fail closed on non-finite commands: NaN would make the tip-over check (``m <= 0.0``)
+    # and ``min(margins)`` silently pass/hide the bad step, and +inf would clear the
+    # curvature check, so a degraded command must never be reported as feasible.
+    if not (np.isfinite(v).all() and np.isfinite(omega).all()):
+        raise ValueError("velocities and turn_rates must be finite (no NaN/Inf)")
 
     margins = [
         _stability_margin(float(vi), float(wi), params) for vi, wi in zip(v, omega, strict=True)

--- a/tests/benchmark/test_ammv_feasibility.py
+++ b/tests/benchmark/test_ammv_feasibility.py
@@ -89,6 +89,16 @@ def test_length_mismatch_and_empty_are_rejected() -> None:
         evaluate_command_feasibility(np.array([]), np.array([]))
 
 
+def test_non_finite_commands_fail_closed() -> None:
+    """NaN/Inf commands must raise rather than be silently reported feasible."""
+    with pytest.raises(ValueError):
+        evaluate_command_feasibility(np.array([1.0, np.nan]), np.array([0.1, 0.1]))
+    with pytest.raises(ValueError):
+        evaluate_command_feasibility(np.array([1.0, np.inf]), np.array([0.1, 0.1]))
+    with pytest.raises(ValueError):
+        evaluate_command_feasibility(np.array([1.0, 1.0]), np.array([0.1, np.nan]))
+
+
 def test_invalid_params_rejected() -> None:
     """Non-physical proxy params must fail closed."""
     with pytest.raises(ValueError):

--- a/tests/benchmark/test_ammv_feasibility.py
+++ b/tests/benchmark/test_ammv_feasibility.py
@@ -1,0 +1,95 @@
+"""Tests for the AMMV command-feasibility / tip-over evaluator (issue #3466)."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.ammv_feasibility import (
+    AMMV_FEASIBILITY_SCHEMA,
+    AmmvFeasibilityParams,
+    evaluate_command_feasibility,
+)
+
+
+def test_feasible_command_sequence_is_classified_feasible() -> None:
+    """Gentle commands within stability and curvature limits must be feasible."""
+    velocities = np.array([0.5, 0.6, 0.5])
+    turn_rates = np.array([0.2, 0.1, 0.2])  # |omega| <= max_curvature * v; low lateral accel
+
+    report = evaluate_command_feasibility(velocities, turn_rates)
+
+    assert report["schema_version"] == AMMV_FEASIBILITY_SCHEMA
+    assert report["feasible"] is True
+    assert report["tip_over_violation"] is False
+    assert report["n_curvature_violations"] == 0
+    assert report["min_stability_margin"] > 0.0
+
+
+def test_over_yaw_command_trips_tip_over() -> None:
+    """A high speed*yaw command exceeding the critical lateral accel must flag tip-over."""
+    velocities = np.array([0.5, 2.0, 0.5])
+    turn_rates = np.array([0.2, 2.0, 0.2])  # step 1: a_y = 4.0 > a_y,crit ~ 2.73
+
+    report = evaluate_command_feasibility(velocities, turn_rates)
+
+    assert report["tip_over_violation"] is True
+    assert report["n_tip_over_steps"] == 1
+    assert report["rollover_event"] == "ROLLOVER_CRITICAL"
+    assert report["min_stability_margin"] == 0.0
+    assert report["feasible"] is False
+
+
+def test_excess_curvature_is_flagged_infeasible() -> None:
+    """A tight turn beyond the proxy non-holonomic curvature limit must be flagged."""
+    params = AmmvFeasibilityParams(max_curvature_per_m=1.0)
+    velocities = np.array([0.5])
+    turn_rates = np.array([0.9])  # |omega|/v = 1.8 > 1.0; but a_y=0.45 small (no tip-over)
+
+    report = evaluate_command_feasibility(velocities, turn_rates, params)
+
+    assert report["n_curvature_violations"] == 1
+    assert report["tip_over_violation"] is False
+    assert report["feasible"] is False
+
+
+def test_in_place_rotation_uses_in_place_yaw_limit() -> None:
+    """At near-zero speed the in-place yaw limit applies instead of curvature."""
+    params = AmmvFeasibilityParams(in_place_yaw_rate_max=0.5)
+    ok = evaluate_command_feasibility(np.array([0.0]), np.array([0.4]), params)
+    too_fast = evaluate_command_feasibility(np.array([0.0]), np.array([0.9]), params)
+
+    assert ok["feasible"] is True
+    assert too_fast["n_curvature_violations"] == 1
+
+
+def test_matches_benchmark_surface_stability_margin() -> None:
+    """The min stability margin must match metrics.evaluate_stability_margin for the same params."""
+    from robot_sf.benchmark.metrics import evaluate_stability_margin
+
+    params = AmmvFeasibilityParams()
+    report = evaluate_command_feasibility(np.array([1.0]), np.array([1.5]), params)
+    expected = evaluate_stability_margin(
+        1.0,
+        1.5,
+        t_w=params.track_width_m,
+        L=params.wheelbase_m,
+        h_c=params.cog_height_m,
+        a=params.front_axle_to_cog_m,
+    )
+
+    assert report["min_stability_margin"] == pytest.approx(expected)
+
+
+def test_length_mismatch_and_empty_are_rejected() -> None:
+    """Mismatched lengths and empty sequences must fail closed."""
+    with pytest.raises(ValueError):
+        evaluate_command_feasibility(np.array([1.0, 2.0]), np.array([0.1]))
+    with pytest.raises(ValueError):
+        evaluate_command_feasibility(np.array([]), np.array([]))
+
+
+def test_invalid_params_rejected() -> None:
+    """Non-physical proxy params must fail closed."""
+    with pytest.raises(ValueError):
+        AmmvFeasibilityParams(max_curvature_per_m=0.0)


### PR DESCRIPTION
## Summary

Pure tip-over / kinematic-feasibility evaluator for #3466 — defers the artifact-pipeline wiring,
same accepted pattern, and builds on the #3587 rollover reconciliation.

Some planner outputs that look acceptable under the current robot abstraction would violate a
three-wheeled AMMV's lateral-stability (tip-over) or non-holonomic limits. This flags them over a
per-step `(velocity, turn_rate)` command sequence, **without changing planner behavior**.

## Evaluator (`ammv_feasibility.v1`)

`evaluate_command_feasibility(velocities, turn_rates, params)` reuses the benchmark-surface source of
truth `metrics.evaluate_stability_margin` for the tip-over margin (so this lens and the
`rollover_min_stability_margin` column stay consistent — a test cross-checks it) and adds a proxy
non-holonomic curvature check (`|ω| ≤ max_curvature·v`, with an in-place yaw allowance at near-zero
speed). Emits `min_stability_margin`, `tip_over_violation` (+ `ROLLOVER_CRITICAL`),
`n_curvature_violations`, and an overall `feasible` verdict. Thresholds are explicit internal-proxy
assumptions (non-hardware).

## Scope boundary

Pure and side-effect free — no planner-behavior change. Surfacing these fields in benchmark artifacts
/ evidence summaries (the artifact-pipeline wiring, Tier-2) is the deliberate deferred follow-up.

## Validation

```
uv run pytest tests/benchmark/test_ammv_feasibility.py -q     # 7 passed (incl. feasible/infeasible fixtures + benchmark-surface agreement)
uv run python scripts/validation/check_broad_exceptions.py    # passes
ruff check / format                                           # clean
```

**Evidence grade:** smoke evidence (pure evaluator + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-feasibility evaluator for AMMV motion commands, returning a feasibility verdict along with stability and violation details.
  * Supports detecting tip-over risk and excessive curvature, including special handling for near-zero-speed in-place turning.

* **Documentation**
  * Added a new page explaining how the feasibility check works, what it reports, and its intended scope.

* **Tests**
  * Added coverage for feasible and infeasible command sequences, edge cases, invalid inputs, and consistency with stability calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->