### PR TITLE
security: replace blanket Ruff S suppression with an explicit baseline (#3477)

### DIFF
--- a/docs/context/issue_3477_ruff_security_baseline.md
+++ b/docs/context/issue_3477_ruff_security_baseline.md
@@ -1,0 +1,32 @@
+# Issue #3477 — explicit Ruff security (Bandit `S`) baseline
+
+**Status:** security-governance increment. Converts the blanket `S` suppression into an
+explicit scoped baseline so new categories of security finding are enforced.
+
+## What changed
+
+`pyproject.toml` previously ignored the entire Ruff `S` (Bandit) category. It now lists only
+the **15 codes currently present in the tree**, so every *other* `S` rule (≈50: `exec`/`eval`
+S102/S307, `yaml.load` S506, jinja autoescape S701, request-without-timeout S113, etc.) is now
+**enforced** repo-wide. No existing finding had to be fixed — `ruff check .` stays green — and a
+probe confirms a new `exec` (S102) now errors.
+
+## Baselined (suppressed) codes — the ratchet-down backlog
+
+`S101` assert · `S105` hardcoded-password (mostly false positives) · `S108` temp-file ·
+`S110`/`S112` try-except-pass/continue (also tracked by the broad-exception ratchet) · `S202`
+tarfile · `S301` pickle · `S310` url-open · `S311` non-crypto random · `S314` xml ·
+`S324` insecure-hash · `S602`/`S603`/`S607` subprocess · `S608` SQL string.
+
+These are the gradual-rollout backlog (the issue calls for an explicit baseline, then ratchet).
+`.github/workflows/security-baseline.yml` continues to expose full Bandit findings.
+
+## Guard
+
+`tests/test_ruff_security_baseline.py` asserts the `S` category is never blanket-ignored again
+(only specific codes) and that the explicit baseline codes remain listed until ratcheted down.
+
+## Follow-ups (out of scope here)
+
+Per-code triage to ratchet the backlog down — e.g. justify/scope the subprocess and pickle uses,
+replace insecure hashes used for security, audit the S105 hits — each as a small reviewed change.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -256,9 +256,26 @@ ignore = [
     # Research/scientific computing patterns that are acceptable
     "PLR0911",  # Too many return statements
     "PLR2004",  # Magic value comparison
-    # Legacy Ruff security baseline: keep normal lint non-blocking while
-    # .github/workflows/security-baseline.yml exposes Bandit findings for ratcheting.
-    "S",
+    # Explicit Ruff security (Bandit) baseline (issue #3477): instead of suppressing the
+    # whole `S` category, list only the codes currently present in the tree, so any *new*
+    # category of security finding (e.g. exec/eval, yaml.load, jinja autoescape, request
+    # without timeout) is now enforced. The codes below are the ratchet-down backlog;
+    # .github/workflows/security-baseline.yml continues to expose full Bandit findings.
+    "S101",   # assert (pervasive in tests/research)
+    "S105",   # possible hardcoded password string (audit: mostly false positives)
+    "S108",   # hardcoded temp-file path
+    "S110",   # try-except-pass (also tracked by the broad-exception ratchet)
+    "S112",   # try-except-continue
+    "S202",   # tarfile unsafe members
+    "S301",   # pickle usage (trusted local artifacts)
+    "S310",   # url open audit
+    "S311",   # non-cryptographic random (research RNG)
+    "S314",   # xml ElementTree usage
+    "S324",   # insecure hash (non-security fingerprints)
+    "S602",   # subprocess Popen with shell=True
+    "S603",   # subprocess without shell=True
+    "S607",   # start-process with partial path
+    "S608",   # hardcoded SQL expression
     "PGH003",   # Use specific rule codes when ignoring instead of categories
     "DTZ005",   # datetime.datetime.now() called without a 'tz' argument
     "ERA001",   # Found commented-out code

--- a/tests/test_ruff_security_baseline.py
+++ b/tests/test_ruff_security_baseline.py
@@ -1,0 +1,46 @@
+"""Guard that the Ruff security (Bandit `S`) suppression stays explicit (issue #3477)."""
+
+from __future__ import annotations
+
+import tomllib
+from pathlib import Path
+
+_PYPROJECT = Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+# Codes that are explicitly baselined (suppressed) pending gradual ratchet-down.
+_EXPECTED_BASELINE_CODES = {
+    "S101",
+    "S105",
+    "S108",
+    "S110",
+    "S112",
+    "S202",
+    "S301",
+    "S310",
+    "S311",
+    "S314",
+    "S324",
+    "S602",
+    "S603",
+    "S607",
+    "S608",
+}
+
+
+def _lint_ignore() -> list[str]:
+    """Return the `[tool.ruff.lint] ignore` list from pyproject.toml."""
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    return list(data["tool"]["ruff"]["lint"]["ignore"])
+
+
+def test_blanket_S_category_is_not_suppressed() -> None:
+    """The whole `S` category must not be blanket-ignored (only specific codes)."""
+    assert "S" not in _lint_ignore(), (
+        "Ruff must not blanket-ignore the S category; list specific S codes instead (issue #3477)"
+    )
+
+
+def test_explicit_S_baseline_codes_are_present() -> None:
+    """The explicit S-baseline codes must remain listed until ratcheted down."""
+    ignore = set(_lint_ignore())
+    assert _EXPECTED_BASELINE_CODES <= ignore


### PR DESCRIPTION
## Summary

Closes the core of #3477: replaces the **blanket Ruff `S` (Bandit) suppression** with an **explicit
scoped baseline** — zero-risk, no finding-fixes, and `ruff check .` stays green.

The audit flagged that Ruff *selects* the `S` security rules but globally *ignores* the whole
category. This lists only the **15 codes currently present in the tree**, so every *other* `S` rule
(≈50: `exec`/`eval` S102/S307, `yaml.load` S506, jinja autoescape S701, request-without-timeout S113,
unsafe deserialization, etc.) is now **enforced** repo-wide.

## What changed

- **`pyproject.toml`** — `ignore = [… "S" …]` → the 15 currently-violated S codes, each with a
  one-line rationale, documented as the ratchet-down backlog.
- **`tests/test_ruff_security_baseline.py`** — guards the `S` category is never blanket-ignored
  again and the explicit baseline codes stay listed until ratcheted.
- **`docs/context/issue_3477_ruff_security_baseline.md`** — the baseline + ratchet-down plan.

## Why this is safe

`ruff check .` passes unchanged (the 15 codes cover all current findings), and an `exec` probe
confirms a new S102 now **errors** — proving the blanket suppression is gone. Per-code triage of the
backlog (subprocess/pickle/hash/etc.) is deliberate follow-up, each a small reviewed change;
`security-baseline.yml` continues to expose full Bandit findings.

## Validation

```
uv run ruff check .                                  # All checks passed
uv run pytest tests/test_ruff_security_baseline.py   # 2 passed
ruff check ./<exec probe> --select S                 # S102 now flagged (new category enforced)
```

**Evidence grade:** smoke evidence (config + guard tests; lint green; new-category enforcement
demonstrated). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
