### PR TITLE
feat(benchmark): near-parity promotion-gate decision layer (#3465)

### DIFF
--- a/docs/context/issue_3465_near_parity_promotion_gate.md
+++ b/docs/context/issue_3465_near_parity_promotion_gate.md
@@ -1,0 +1,36 @@
+# Issue #3465 — near-parity promotion-gate decision (increment)
+
+**Status:** diagnostic / decision layer. Provides the formal claim-boundary verdict #2540 deferred.
+
+## What this is
+
+`robot_sf/benchmark/near_parity_promotion_gate.py` is the pure decision layer for #3465. It turns the
+paired gate-enabled-vs-disabled comparison of the topology near-parity selector into the issue's
+verdict — `diagnostic`, `revise`, `stop`, or `eligible_for_promotion` — fail-closed about
+fallback/degraded execution. It mirrors the accepted decision-layer pattern (#3484, #3558, #3557).
+
+## Decision (`near_parity_promotion_gate.v1`)
+
+`classify_near_parity_promotion(NearParityComparison, thresholds)` decides (first match wins):
+
+1. corrective work (#3463) not complete → `diagnostic` (formal test not runnable);
+2. improvement relies on fallback/degraded rows → `revise` (fail-closed);
+3. measurable safety/efficiency **regression** → `stop`;
+4. measurable, **paired-significant** native improvement → `eligible_for_promotion` (only promote);
+5. otherwise → `revise`.
+
+## Scope boundary
+
+Pure and side-effect free. Freezing the paired benchmark config and **running** the gate-enabled/
+disabled arms over common seeds needs the #3463 corrective work plus cluster execution and is the
+deliberate deferred follow-up; this layer turns those results into the verdict.
+
+## Tests
+
+`tests/benchmark/test_near_parity_promotion_gate.py` (6 tests): each verdict branch — diagnostic
+(corrective incomplete), revise (fallback-reliant / non-significant / no-difference), stop
+(regression), and eligible_for_promotion (significant native improvement).
+
+## Related
+
+- Predecessor: #2540 (`revise`). Corrective implementation: #3463.

--- a/robot_sf/benchmark/near_parity_promotion_gate.py
+++ b/robot_sf/benchmark/near_parity_promotion_gate.py
@@ -1,0 +1,125 @@
+"""Promotion-gate decision for the topology near-parity lane (issue #3465).
+
+#2540 isolated the topology near-parity selector as diagnostic-only and classified it ``revise``.
+The formal successor (this issue) compares the gate **enabled vs disabled** on the same
+scenario/seed contract and decides whether the lane stays diagnostic, revises, stops, or becomes
+eligible for stack promotion. This module is the pure **decision layer** that turns the paired
+comparison results into that verdict — fail-closed about fallback/degraded execution.
+
+The paired benchmark run itself (frozen config, gate-enabled/disabled arms over common seeds) needs
+the #3463 corrective work plus cluster execution and is deferred; this layer is pure and
+side-effect free, mirroring the accepted decision layers in this run (#3484, #3558, #3557).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+NEAR_PARITY_GATE_SCHEMA = "near_parity_promotion_gate.v1"
+
+DIAGNOSTIC = "diagnostic"
+REVISE = "revise"
+STOP = "stop"
+ELIGIBLE_FOR_PROMOTION = "eligible_for_promotion"
+
+
+@dataclass(frozen=True, slots=True)
+class NearParityComparison:
+    """Paired gate-enabled-vs-disabled comparison results for the near-parity lane.
+
+    Improvements are ``enabled − disabled`` on native execution; positive means the gate helped.
+
+    Attributes:
+        safety_improvement: Safety-metric improvement (positive = safer with the gate on).
+        efficiency_improvement: Efficiency/progress improvement (positive = better with the gate on).
+        paired_significant: Whether the improvement is paired-statistically significant.
+        relies_on_fallback: Whether the improvement depends on fallback/degraded rows.
+        corrective_complete: Whether the #3463 corrective implementation is complete or waived.
+    """
+
+    safety_improvement: float
+    efficiency_improvement: float
+    paired_significant: bool
+    relies_on_fallback: bool
+    corrective_complete: bool
+
+
+@dataclass(frozen=True, slots=True)
+class PromotionThresholds:
+    """Minimum effect size for a measurable near-parity improvement/regression."""
+
+    min_improvement: float = 0.02
+
+
+def classify_near_parity_promotion(
+    comparison: NearParityComparison,
+    thresholds: PromotionThresholds | None = None,
+) -> dict[str, Any]:
+    """Record the near-parity promotion-gate verdict from a paired comparison.
+
+    Decision order (first match wins):
+
+    1. corrective work not complete → ``diagnostic`` (the formal test is not yet runnable);
+    2. improvement relies on fallback/degraded rows → ``revise`` (fail-closed: it does not count);
+    3. a measurable safety or efficiency **regression** → ``stop``;
+    4. a measurable, paired-significant safety or efficiency improvement →
+       ``eligible_for_promotion`` (the only promote verdict);
+    5. otherwise (no measurable / non-significant difference) → ``revise``.
+
+    Returns:
+        dict[str, Any]: Versioned verdict with ``promote`` flag and rationale.
+    """
+    thresholds = thresholds or PromotionThresholds()
+    verdict, rationale = _decide(comparison, thresholds)
+    return {
+        "schema_version": NEAR_PARITY_GATE_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "verdict": verdict,
+        "promote": verdict == ELIGIBLE_FOR_PROMOTION,
+        "rationale": rationale,
+        "inputs": {
+            "safety_improvement": comparison.safety_improvement,
+            "efficiency_improvement": comparison.efficiency_improvement,
+            "paired_significant": comparison.paired_significant,
+            "relies_on_fallback": comparison.relies_on_fallback,
+            "corrective_complete": comparison.corrective_complete,
+        },
+    }
+
+
+def _decide(c: NearParityComparison, t: PromotionThresholds) -> tuple[str, str]:
+    """Return the (verdict, rationale) for a comparison."""
+    if not c.corrective_complete:
+        return (
+            DIAGNOSTIC,
+            "Corrective implementation (#3463) not complete; formal test not runnable.",
+        )
+    if c.relies_on_fallback:
+        return REVISE, "Improvement relies on fallback/degraded rows; fail-closed, does not count."
+    regression = (
+        c.safety_improvement <= -t.min_improvement or c.efficiency_improvement <= -t.min_improvement
+    )
+    if regression:
+        return STOP, "Gate-enabled shows a measurable safety/efficiency regression."
+    improvement = (
+        c.safety_improvement >= t.min_improvement or c.efficiency_improvement >= t.min_improvement
+    )
+    if improvement and c.paired_significant:
+        return (
+            ELIGIBLE_FOR_PROMOTION,
+            "Measurable, paired-significant native improvement without fallback reliance.",
+        )
+    return REVISE, "No measurable or non-significant difference; remain diagnostic / revise."
+
+
+__all__ = [
+    "DIAGNOSTIC",
+    "ELIGIBLE_FOR_PROMOTION",
+    "NEAR_PARITY_GATE_SCHEMA",
+    "REVISE",
+    "STOP",
+    "NearParityComparison",
+    "PromotionThresholds",
+    "classify_near_parity_promotion",
+]

--- a/tests/benchmark/test_near_parity_promotion_gate.py
+++ b/tests/benchmark/test_near_parity_promotion_gate.py
@@ -1,0 +1,81 @@
+"""Tests for the near-parity promotion-gate decision (issue #3465)."""
+
+from __future__ import annotations
+
+from robot_sf.benchmark.near_parity_promotion_gate import (
+    DIAGNOSTIC,
+    ELIGIBLE_FOR_PROMOTION,
+    NEAR_PARITY_GATE_SCHEMA,
+    REVISE,
+    STOP,
+    NearParityComparison,
+    classify_near_parity_promotion,
+)
+
+
+def _comparison(**overrides) -> NearParityComparison:
+    """Build a comparison with sensible defaults."""
+    kwargs = {
+        "safety_improvement": 0.0,
+        "efficiency_improvement": 0.0,
+        "paired_significant": True,
+        "relies_on_fallback": False,
+        "corrective_complete": True,
+    }
+    kwargs.update(overrides)
+    return NearParityComparison(**kwargs)
+
+
+def test_diagnostic_when_corrective_not_complete() -> None:
+    """Without the corrective implementation, the verdict is diagnostic (not runnable)."""
+    verdict = classify_near_parity_promotion(
+        _comparison(corrective_complete=False, safety_improvement=0.5)
+    )
+
+    assert verdict["schema_version"] == NEAR_PARITY_GATE_SCHEMA
+    assert verdict["verdict"] == DIAGNOSTIC
+    assert verdict["promote"] is False
+
+
+def test_fallback_reliant_improvement_is_revise() -> None:
+    """An improvement that relies on fallback/degraded rows must not count (fail-closed)."""
+    verdict = classify_near_parity_promotion(
+        _comparison(safety_improvement=0.5, relies_on_fallback=True)
+    )
+
+    assert verdict["verdict"] == REVISE
+    assert verdict["promote"] is False
+
+
+def test_regression_is_stop() -> None:
+    """A measurable safety/efficiency regression must stop the lane."""
+    verdict = classify_near_parity_promotion(_comparison(efficiency_improvement=-0.1))
+
+    assert verdict["verdict"] == STOP
+
+
+def test_significant_native_improvement_is_eligible_for_promotion() -> None:
+    """A measurable, paired-significant native improvement is the only promote verdict."""
+    verdict = classify_near_parity_promotion(
+        _comparison(safety_improvement=0.05, paired_significant=True)
+    )
+
+    assert verdict["verdict"] == ELIGIBLE_FOR_PROMOTION
+    assert verdict["promote"] is True
+
+
+def test_improvement_without_significance_is_revise() -> None:
+    """A non-significant improvement must not be promoted."""
+    verdict = classify_near_parity_promotion(
+        _comparison(safety_improvement=0.05, paired_significant=False)
+    )
+
+    assert verdict["verdict"] == REVISE
+    assert verdict["promote"] is False
+
+
+def test_no_difference_is_revise() -> None:
+    """No measurable difference keeps the lane at revise."""
+    verdict = classify_near_parity_promotion(_comparison())
+
+    assert verdict["verdict"] == REVISE


### PR DESCRIPTION
## Summary

Pure **promotion-gate decision layer** for #3465 — the formal claim-boundary verdict #2540 deferred.
Same accepted pattern as #3484 (merged #3586), #3558, #3557.

It turns the paired gate-enabled-vs-disabled comparison of the topology near-parity selector into the
issue's verdict — `diagnostic` / `revise` / `stop` / `eligible_for_promotion` — fail-closed about
fallback/degraded execution.

## Decision (`near_parity_promotion_gate.v1`)

`classify_near_parity_promotion(NearParityComparison, thresholds)` (first match wins):

1. corrective work (#3463) not complete → `diagnostic` (formal test not runnable);
2. improvement relies on fallback/degraded rows → `revise` (fail-closed — it does not count);
3. measurable safety/efficiency **regression** → `stop`;
4. measurable, **paired-significant** native improvement → `eligible_for_promotion` (only promote);
5. otherwise → `revise`.

## Scope boundary

Pure and side-effect free. Freezing the paired benchmark config and **running** the gate-enabled/
disabled arms over common seeds needs the #3463 corrective work plus cluster execution and is the
deliberate deferred follow-up; this layer turns those results into the verdict.

## Validation

```
uv run pytest tests/benchmark/test_near_parity_promotion_gate.py -q   # 6 passed
uv run python scripts/validation/check_broad_exceptions.py            # passes
ruff check / format                                                   # clean
```

**Evidence grade:** smoke evidence (pure decision function + fixtures). **Confidence:** High.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
