### PR TITLE
fix: fail-closed NaN/Inf guards for diagnostic decision layers

### DIFF
--- a/robot_sf/benchmark/heterogeneous_population_metrics.py
+++ b/robot_sf/benchmark/heterogeneous_population_metrics.py
@@ -31,6 +31,20 @@ if TYPE_CHECKING:
 HETEROGENEOUS_POPULATION_METRICS_SCHEMA = "heterogeneous_population_metrics.v1"
 
 
+def _require_finite(name: str, value: float) -> None:
+    """Fail closed on a non-finite (NaN/Inf) metric value.
+
+    A degraded trace can leak NaN/Inf, after which ``min``/``max`` for the worst
+    stratum and ``np.mean`` for the CVaR evaluate inconsistently by element order
+    (fail-open). Raising names the offending field so the caller drops the input.
+
+    Raises:
+        ValueError: If ``value`` is not finite.
+    """
+    if not math.isfinite(value):
+        raise ValueError(f"{name} must be finite, got {value}")
+
+
 @dataclass(frozen=True, slots=True)
 class PedestrianMetric:
     """One per-pedestrian metric observation tagged with its archetype.
@@ -57,7 +71,10 @@ def cvar(values: Sequence[float], alpha: float, *, higher_is_safer: bool) -> flo
         raise ValueError("values must be non-empty")
     if not (0.0 < alpha <= 1.0):
         raise ValueError("alpha must be in (0, 1]")
-    arr = np.sort(np.asarray(values, dtype=np.float64))  # ascending
+    arr = np.asarray(values, dtype=np.float64)
+    if not np.all(np.isfinite(arr)):
+        raise ValueError("values must contain only finite values")
+    arr = np.sort(arr)  # ascending
     k = max(1, math.ceil(alpha * arr.size))
     tail = arr[:k] if higher_is_safer else arr[-k:]
     return float(np.mean(tail))
@@ -78,7 +95,9 @@ def per_archetype_metrics(
         raise ValueError("at least one observation is required")
     grouped: dict[str, list[float]] = {}
     for observation in observations:
-        grouped.setdefault(observation.archetype, []).append(float(observation.value))
+        value = float(observation.value)
+        _require_finite(f"observation value for archetype {observation.archetype!r}", value)
+        grouped.setdefault(observation.archetype, []).append(value)
 
     per_archetype: dict[str, Any] = {}
     for archetype in sorted(grouped):
@@ -120,6 +139,8 @@ def mean_matched_heterogeneity_effect(
     Returns:
         dict[str, Any]: Versioned report with the isolated effect and a validity flag.
     """
+    _require_finite("homogeneous_mean", float(homogeneous_mean))
+    _require_finite("heterogeneous_mean", float(heterogeneous_mean))
     effect = float(heterogeneous_mean) - float(homogeneous_mean)
     return {
         "schema_version": HETEROGENEOUS_POPULATION_METRICS_SCHEMA,

--- a/robot_sf/benchmark/reactivity_ablation.py
+++ b/robot_sf/benchmark/reactivity_ablation.py
@@ -16,10 +16,20 @@ pure and side-effect free, mirroring the accepted decision layers in
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
 REACTIVITY_ABLATION_SCHEMA = "reactivity_ablation.v1"
+
+_CONTRAST_METRIC_FIELDS = (
+    "reactive_collision_rate",
+    "replay_collision_rate",
+    "reactive_near_miss_rate",
+    "replay_near_miss_rate",
+    "reactive_min_separation_m",
+    "replay_min_separation_m",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -55,6 +65,12 @@ def reactivity_delta(contrast: ReactivityContrast) -> dict[str, Any]:
     Returns:
         dict[str, Any]: Per-metric deltas and a ``replay_flatters`` flag.
     """
+    for field in _CONTRAST_METRIC_FIELDS:
+        value = getattr(contrast, field)
+        if not math.isfinite(value):
+            raise ValueError(
+                f"contrast.{field} for planner {contrast.planner!r} must be finite, got {value}"
+            )
     collision_delta = contrast.reactive_collision_rate - contrast.replay_collision_rate
     near_miss_delta = contrast.reactive_near_miss_rate - contrast.replay_near_miss_rate
     separation_delta = contrast.reactive_min_separation_m - contrast.replay_min_separation_m

--- a/robot_sf/benchmark/safety_predicates.py
+++ b/robot_sf/benchmark/safety_predicates.py
@@ -21,6 +21,7 @@ the in-sim runners is a deliberate follow-up.
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from itertools import pairwise
 from typing import TYPE_CHECKING, Any
@@ -33,6 +34,21 @@ if TYPE_CHECKING:
 OSCILLATORY_PREDICATE_SCHEMA = "safety_predicate.oscillatory_control.v1"
 LATE_EVASIVE_PREDICATE_SCHEMA = "safety_predicate.late_evasive.v1"
 OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA = "safety_predicate.occlusion_near_miss.v1"
+
+
+def _require_finite_array(name: str, arr: NDArray[np.float64]) -> None:
+    """Fail closed when a per-step signal carries a non-finite (NaN/Inf) value.
+
+    A degraded/fallback trace can leak NaN/Inf into the float signals; ``np.unwrap``,
+    ``np.diff``, and the ``min``/``argmin`` comparisons then poison or silently
+    mis-evaluate the diagnostic booleans (fail-open). Raising names the offending
+    field so the caller drops the trace instead of trusting a not-flagged result.
+
+    Raises:
+        ValueError: If ``arr`` contains any non-finite value.
+    """
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} must contain only finite values")
 
 
 def _sign_changes(values: NDArray[np.float64]) -> int:
@@ -85,6 +101,9 @@ def oscillatory_control_predicate(
         raise ValueError("command_sources must have length N when provided")
     if n < 2:
         raise ValueError("at least two steps are required")
+    _require_finite_array("positions", pos)
+    _require_finite_array("headings", head)
+    _require_finite_array("linear_velocities", vel)
 
     heading_rate = np.diff(np.unwrap(head)) / dt
     heading_rate_sign_changes = _sign_changes(heading_rate)
@@ -179,6 +198,8 @@ def late_evasive_predicate(
         raise ValueError("hazard_distances, hazard_visible, and speeds must share length N")
     if n < 2:
         raise ValueError("at least two steps are required")
+    _require_finite_array("hazard_distances", dist)
+    _require_finite_array("speeds", speed)
 
     first_visible = _first_true_index(visible)
     conflict_entry = _first_true_index(dist <= conflict_radius_m)
@@ -299,6 +320,15 @@ def occlusion_near_miss_predicate(
         raise ValueError("all per-step signals must share length N")
     if n < 2:
         raise ValueError("at least two steps are required")
+    _require_finite_array("hazard_distances", dist)
+    _require_finite_array("track_confidence", conf)
+    _require_finite_array("speeds", speed)
+    if predicted_minimum_separation_m is not None and not math.isfinite(
+        predicted_minimum_separation_m
+    ):
+        raise ValueError(
+            f"predicted_minimum_separation_m must be finite, got {predicted_minimum_separation_m}"
+        )
 
     min_sep_step = int(np.argmin(dist))
     actual_minimum_separation = float(dist[min_sep_step])

--- a/robot_sf/planner/stream_gap_gate_calibration.py
+++ b/robot_sf/planner/stream_gap_gate_calibration.py
@@ -14,10 +14,13 @@ this layer is pure and side-effect free, mirroring the failure-cause classifier 
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
 STREAM_GAP_CALIBRATION_SCHEMA = "stream_gap_gate_calibration.v1"
+
+_SETTING_METRIC_FIELDS = ("unsafe_commit_rate", "collision_rate", "min_separation_m")
 
 AT_LEAST_AS_SAFE = "at_least_as_safe"
 LESS_SAFE = "less_safe"
@@ -50,6 +53,23 @@ class SafetyTolerance:
     min_separation_abs: float = 0.0
 
 
+def _require_finite_setting(result: GateSettingResult, label: str) -> None:
+    """Fail closed on a non-finite (NaN/Inf) safety aggregate.
+
+    A degraded sweep point or baseline can carry NaN/Inf; the ``<=`` / ``>=`` safety
+    comparisons then evaluate ``False`` and the setting is silently classified
+    ``less_safe`` (or, for the baseline, lets settings pass) without flagging the
+    bad input. Raising names the offending field so the caller drops the trace.
+
+    Raises:
+        ValueError: If any safety aggregate of ``result`` is not finite.
+    """
+    for field in _SETTING_METRIC_FIELDS:
+        value = getattr(result, field)
+        if not math.isfinite(value):
+            raise ValueError(f"{label}.{field} must be finite, got {value}")
+
+
 def classify_setting_safety(
     setting: GateSettingResult,
     baseline: GateSettingResult,
@@ -63,6 +83,8 @@ def classify_setting_safety(
     Returns:
         str: ``at_least_as_safe`` or ``less_safe``.
     """
+    _require_finite_setting(setting, "setting")
+    _require_finite_setting(baseline, "baseline")
     tolerance = tolerance or SafetyTolerance()
     safe = (
         setting.unsafe_commit_rate <= baseline.unsafe_commit_rate + tolerance.unsafe_commit_abs

--- a/robot_sf/representation/uncertainty_source_generalization.py
+++ b/robot_sf/representation/uncertainty_source_generalization.py
@@ -16,10 +16,17 @@ builders); this layer is pure and side-effect free, mirroring the accepted decis
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Any
 
 UNCERTAINTY_SOURCE_GENERALIZATION_SCHEMA = "uncertainty_source_generalization.v1"
+
+_CONTRAST_METRIC_FIELDS = (
+    "retained_unsafe_commit_rate",
+    "dropped_unsafe_commit_rate",
+    "min_separation_delta_m",
+)
 
 REPRODUCES = "reproduces_unsafe_dropping"
 NO_EFFECT = "no_unsafe_dropping_effect"
@@ -67,6 +74,12 @@ def classify_source(contrast: SourceContrast, thresholds: EffectThresholds | Non
     Returns:
         str: ``reproduces_unsafe_dropping`` / ``no_unsafe_dropping_effect`` / ``inconclusive``.
     """
+    for field in _CONTRAST_METRIC_FIELDS:
+        value = getattr(contrast, field)
+        if not math.isfinite(value):
+            raise ValueError(
+                f"contrast.{field} for source {contrast.source!r} must be finite, got {value}"
+            )
     thresholds = thresholds or EffectThresholds()
     unsafe_delta = contrast.dropped_unsafe_commit_rate - contrast.retained_unsafe_commit_rate
     sep_delta = contrast.min_separation_delta_m
@@ -127,9 +140,9 @@ def assess_source_generalization(
         "evidence_kind": "diagnostic_proxy",
         "n_sources": len(contrasts),
         "per_source": per_source,
-        "reproducing_sources": sorted(row["source"] for row in reproduces),
+        "reproducing_sources": sorted({row["source"] for row in reproduces}),
         "inconclusive_sources": sorted(
-            row["source"] for row in per_source if row["verdict"] == INCONCLUSIVE
+            {row["source"] for row in per_source if row["verdict"] == INCONCLUSIVE}
         ),
         "generalization": generalization,
     }

--- a/tests/benchmark/test_heterogeneous_population_metrics.py
+++ b/tests/benchmark/test_heterogeneous_population_metrics.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from robot_sf.benchmark.heterogeneous_population_metrics import (
@@ -84,3 +86,27 @@ def test_effect_is_flagged_confounded_without_mean_matching() -> None:
 
     assert report["validity"] == "confounded_by_mean_shift"
     assert report["isolated_from_mean_shift"] is False
+
+
+# --- non-finite (NaN/Inf) inputs must fail closed -----------------------------
+
+
+@pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+def test_cvar_rejects_non_finite_values(bad: float) -> None:
+    """A NaN/Inf observation must raise, not let the tail-mean evaluate to NaN."""
+    with pytest.raises(ValueError, match="finite"):
+        cvar([1.0, 2.0, bad], 0.5, higher_is_safer=True)
+
+
+def test_per_archetype_rejects_non_finite_value() -> None:
+    """A non-finite per-pedestrian value must raise and name the archetype."""
+    observations = [PedestrianMetric("static", 0.2), PedestrianMetric("static", math.nan)]
+    with pytest.raises(ValueError, match="static"):
+        per_archetype_metrics(observations)
+
+
+@pytest.mark.parametrize("bad", [math.nan, math.inf])
+def test_mean_matched_effect_rejects_non_finite_mean(bad: float) -> None:
+    """A non-finite population mean must fail closed rather than propagate."""
+    with pytest.raises(ValueError, match="finite"):
+        mean_matched_heterogeneity_effect(bad, 0.62, homogeneous_is_mean_matched=True)

--- a/tests/benchmark/test_reactivity_ablation.py
+++ b/tests/benchmark/test_reactivity_ablation.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from robot_sf.benchmark.reactivity_ablation import (
@@ -107,3 +109,21 @@ def test_empty_input_is_rejected() -> None:
     """An empty ablation cannot be summarized."""
     with pytest.raises(ValueError):
         assess_reactivity_ablation([])
+
+
+# --- non-finite (NaN/Inf) inputs must fail closed -----------------------------
+
+
+@pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+def test_reactivity_delta_rejects_non_finite_metric(bad: float) -> None:
+    """A non-finite paired metric must raise, not propagate NaN into the deltas."""
+    with pytest.raises(ValueError, match="reactive_collision_rate"):
+        reactivity_delta(_contrast("p", reactive_coll=bad, replay_coll=0.05))
+
+
+def test_assess_propagates_non_finite_guard() -> None:
+    """The aggregate entry point must propagate the per-planner fail-closed guard."""
+    with pytest.raises(ValueError, match="replay_min_separation_m"):
+        assess_reactivity_ablation(
+            [_contrast("A", reactive_coll=0.20, replay_coll=0.05, replay_sep=math.inf)]
+        )

--- a/tests/benchmark/test_safety_predicates.py
+++ b/tests/benchmark/test_safety_predicates.py
@@ -274,3 +274,56 @@ def test_occlusion_predicate_rejects_bad_inputs() -> None:
         occlusion_near_miss_predicate(
             np.ones(4), np.ones(3, dtype=bool), np.ones(4), np.ones(4), dt=_DT
         )
+
+
+# --- non-finite (NaN/Inf) inputs must fail closed -----------------------------
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf, -np.inf])
+def test_oscillatory_rejects_non_finite_signal(bad: float) -> None:
+    """A NaN/Inf in any float signal must raise, not NaN-poison ``np.unwrap``."""
+    traj = _straight_trajectory()
+    headings = np.asarray(traj["headings"], dtype=float).copy()
+    headings[2] = bad
+    with pytest.raises(ValueError, match="headings"):
+        oscillatory_control_predicate(
+            positions=traj["positions"],
+            headings=headings,
+            linear_velocities=traj["linear_velocities"],
+            dt=_DT,
+        )
+
+
+@pytest.mark.parametrize("bad", [np.nan, np.inf])
+def test_late_evasive_rejects_non_finite_signal(bad: float) -> None:
+    """A NaN/Inf hazard distance must raise rather than silently not-flag."""
+    distances = _HAZARD_DISTANCES.copy()
+    distances[3] = bad
+    with pytest.raises(ValueError, match="hazard_distances"):
+        late_evasive_predicate(distances, _HAZARD_VISIBLE, np.ones(6), dt=_DT)
+
+
+def test_occlusion_rejects_non_finite_signal() -> None:
+    """A NaN distance must raise instead of letting ``argmin`` mis-locate the near miss."""
+    from robot_sf.benchmark.safety_predicates import occlusion_near_miss_predicate
+
+    distances = np.array([5.0, np.nan, 3.0, 0.3])
+    with pytest.raises(ValueError, match="hazard_distances"):
+        occlusion_near_miss_predicate(
+            distances, np.ones(4, dtype=bool), np.full(4, 0.9), np.ones(4), dt=_DT
+        )
+
+
+def test_occlusion_rejects_non_finite_predicted_separation() -> None:
+    """A non-finite predicted-separation passthrough must also fail closed."""
+    from robot_sf.benchmark.safety_predicates import occlusion_near_miss_predicate
+
+    with pytest.raises(ValueError, match="predicted_minimum_separation_m"):
+        occlusion_near_miss_predicate(
+            np.array([2.0, 1.0]),
+            np.array([True, True]),
+            np.array([0.9, 0.9]),
+            np.array([1.0, 1.0]),
+            dt=_DT,
+            predicted_minimum_separation_m=np.inf,
+        )

--- a/tests/planner/test_stream_gap_gate_calibration.py
+++ b/tests/planner/test_stream_gap_gate_calibration.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from robot_sf.planner.stream_gap_gate_calibration import (
@@ -91,3 +93,29 @@ def test_calibration_rejects_empty_sweep() -> None:
     """An empty sweep cannot be calibrated."""
     with pytest.raises(ValueError):
         calibrate_stream_gap_gate([], _BASELINE)
+
+
+# --- non-finite (NaN/Inf) inputs must fail closed -----------------------------
+
+
+@pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+def test_classify_rejects_non_finite_setting(bad: float) -> None:
+    """A non-finite safety aggregate must raise, not silently classify ``less_safe``."""
+    setting = _setting("s", unsafe=bad, collision=0.02, sep=0.50)
+    with pytest.raises(ValueError, match="setting.unsafe_commit_rate"):
+        classify_setting_safety(setting, _BASELINE)
+
+
+def test_classify_rejects_non_finite_baseline() -> None:
+    """A non-finite baseline aggregate must also fail closed."""
+    bad_baseline = _setting("base", unsafe=0.10, collision=math.nan, sep=0.50)
+    setting = _setting("s", unsafe=0.10, collision=0.02, sep=0.50)
+    with pytest.raises(ValueError, match="baseline.collision_rate"):
+        classify_setting_safety(setting, bad_baseline)
+
+
+def test_calibration_rejects_non_finite_setting() -> None:
+    """The calibration entry point must propagate the fail-closed guard."""
+    settings = [_setting("s", unsafe=0.10, collision=0.02, sep=math.inf)]
+    with pytest.raises(ValueError, match="min_separation_m"):
+        calibrate_stream_gap_gate(settings, _BASELINE)

--- a/tests/representation/test_uncertainty_source_generalization.py
+++ b/tests/representation/test_uncertainty_source_generalization.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import math
+
 import pytest
 
 from robot_sf.representation.uncertainty_source_generalization import (
@@ -102,3 +104,34 @@ def test_empty_input_is_rejected() -> None:
     """An empty set of source contrasts cannot be assessed."""
     with pytest.raises(ValueError):
         assess_source_generalization([])
+
+
+# --- non-finite (NaN/Inf) inputs must fail closed -----------------------------
+
+
+@pytest.mark.parametrize("bad", [math.nan, math.inf, -math.inf])
+def test_classify_source_rejects_non_finite_metric(bad: float) -> None:
+    """A non-finite contrast metric must raise, not silently evaluate ``inconclusive``."""
+    with pytest.raises(ValueError, match="existence"):
+        classify_source(_contrast("existence", bad, 0.25, -0.20))
+
+
+def test_assess_propagates_non_finite_guard() -> None:
+    """The aggregate entry point must propagate the per-source fail-closed guard."""
+    with pytest.raises(ValueError, match="min_separation_delta_m"):
+        assess_source_generalization([_contrast("occlusion", 0.10, 0.25, math.nan)])
+
+
+def test_reproducing_and_inconclusive_sources_are_deduped() -> None:
+    """Repeated source names must be de-duplicated in the reported source lists."""
+    report = assess_source_generalization(
+        [
+            _contrast("existence", 0.10, 0.25, -0.20),  # reproduces
+            _contrast("existence", 0.12, 0.30, -0.25),  # reproduces (same source name)
+            _contrast("covariance", 0.10, 0.105, 0.0),  # inconclusive
+            _contrast("covariance", 0.20, 0.205, 0.0),  # inconclusive (same source name)
+        ]
+    )
+
+    assert report["reproducing_sources"] == ["existence"]
+    assert report["inconclusive_sources"] == ["covariance"]


### PR DESCRIPTION
## Summary

Five diagnostic metric/decision-layer modules merged on 2026-06-25 lacked non-finite (NaN/Inf) input guards. The repo convention (e.g. [`counterfactual_pair.py`](robot_sf/benchmark/counterfactual_pair.py) raises `ValueError` on non-finite metrics) is to **fail closed**, but these modules silently propagated NaN through `np.unwrap` / `np.mean` / `min`/`max`, so their diagnostic booleans evaluated to a **fail-open** (silently not-flagged) result on degraded/fallback traces.

All five are still pure with no live-data importers (the one reference in `event_ledger_reconciliation.py` is a string registry entry, not a call), so the gap is **latent**. This closes it **before** each is wired into the real benchmark runner / `build_event_ledger`.

Per [`docs/maintainer_values.md`](docs/maintainer_values.md) fail-closed discipline, each producer now **raises `ValueError` naming the offending field** on non-finite input — no silent filtering/dropping. Evidence-grade / `diagnostic_proxy` framing is unchanged.

## Changes

| Module | Issue / merged PR | Guard |
| --- | --- | --- |
| `benchmark/safety_predicates.py` | #3483 / #3584 | finite-check on float per-step signals of all three producers (oscillatory `np.unwrap`, late-evasive, occlusion `argmin`) + predicted-separation passthrough |
| `benchmark/heterogeneous_population_metrics.py` | #3574 / #3595 | guard `cvar`, `per_archetype_metrics` values (names archetype), mean-matched means |
| `planner/stream_gap_gate_calibration.py` | #3558 / #3592 | guard setting **and** baseline aggregates in `classify_setting_safety` (covers `calibrate_stream_gap_gate`) |
| `representation/uncertainty_source_generalization.py` | #3557 / #3593 | guard contrast metrics in `classify_source` (covers `assess_*`); **also** dedupe `reproducing_sources` / `inconclusive_sources` via set comprehension |
| `benchmark/reactivity_ablation.py` | #3573 / #3594 | guard the six paired metrics in `reactivity_delta` (covers `assess_reactivity_ablation`) |

Adds a non-finite-input regression test block per module.

## Validation

- `uv run pytest` on all five affected suites: **79 passed**.
- `uv run ruff check` + `ruff format`: clean (1936 files unchanged).
- Import smoke of the one referencing module (`event_ledger_reconciliation`): OK.
- Confirmed no live (non-test) importer invokes the guarded producers — the gap was latent, so behavior on finite inputs is unchanged.

Evidence grade: **smoke / diagnostic** — narrow unit-execution proof of the fail-closed boundary; no benchmark claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
