### PR TITLE
feat(planner): run the #3558 stream_gap gate-threshold calibration sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   that live outside this repo) are exempted by annotating the line with `# allow-abs-path: <reason>`.
   Hook: [`hooks/check_config_abs_paths.py`](hooks/check_config_abs_paths.py); tests:
   [`tests/integration/test_check_config_abs_paths.py`](tests/integration/test_check_config_abs_paths.py) (#3605).
+* Ran the deferred #3558 **`stream_gap` gate-threshold calibration sweep**:
+  [`scripts/validation/run_stream_gap_gate_threshold_sweep_issue_3558.py`](scripts/validation/run_stream_gap_gate_threshold_sweep_issue_3558.py)
+  reuses the #3471 episode harness (now accepting optional per-run gate-threshold overrides;
+  backward-compatible, existing #3471 tests still pass) to roll the `uncertain_dropped` mode across a
+  grid of `uncertainty_min_existence_probability` thresholds and feeds the per-setting safety
+  aggregates + conservative-retention baseline into the merged `calibrate_stream_gap_gate` decision
+  layer. Diagnostic-tier result on the controlled crossing scenario: a **safe region exists** only at
+  thresholds permissive enough (≤ the degraded existence 0.2) to *retain* the corridor agent — every
+  setting that actually drops it (≥0.3, including the **0.5 production default**) is `less_safe`,
+  confirming the #3471 finding that the default gate is unsafe. The sweep exercises only the existence
+  axis (the scenario degrades existence alone) and does not change the production default (#3558).
 * Classified the ORCA-residual progress-probe lane decision (#2445):
   [`scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py`](scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py)
   reads the existing v1 bounded smoke result (SLURM job 12913) and applies the #2408/PR #2420 stop

--- a/docs/context/evidence/issue_3558_gate_threshold_sweep_2026-06-25/README.md
+++ b/docs/context/evidence/issue_3558_gate_threshold_sweep_2026-06-25/README.md
@@ -1,4 +1,4 @@
-# Issue #3558 — `stream_gap` uncertainty-gate threshold calibration sweep
+# Issue 3558 Stream-Gap Uncertainty-Gate Threshold Calibration Sweep (2026-06-25)
 
 **Status:** the deferred threshold sweep is built and run; it feeds the merged
 `calibrate_stream_gap_gate` decision layer. Diagnostic-tier result: a **safe operating region
@@ -54,5 +54,5 @@ uv run python scripts/validation/run_stream_gap_gate_threshold_sweep_issue_3558.
   --output-json output/issue_3558_gate_threshold_sweep.json
 ```
 
-Tests: `tests/validation/test_run_stream_gap_gate_threshold_sweep_issue_3558.py` (and the unchanged
-#3471 harness tests, which still pass with the additive `gate_thresholds` parameter).
+Tests: `tests/validation/test_run_stream_gap_gate_threshold_sweep_issue_3558.py` (and the
+unchanged issue-3471 harness tests, which still pass with the additive `gate_thresholds` parameter).

--- a/docs/context/evidence/issue_3558_gate_threshold_sweep_2026-06-25/README.md
+++ b/docs/context/evidence/issue_3558_gate_threshold_sweep_2026-06-25/README.md
@@ -1,0 +1,58 @@
+# Issue #3558 — `stream_gap` uncertainty-gate threshold calibration sweep
+
+**Status:** the deferred threshold sweep is built and run; it feeds the merged
+`calibrate_stream_gap_gate` decision layer. Diagnostic-tier result: a **safe operating region
+exists**, but only at gate thresholds permissive enough to *retain* the degraded agent — every
+threshold that actually drops it (including the **0.5 production default**) is `less_safe`,
+confirming the #3471 finding.
+
+## Claim boundary (read first)
+
+- **What landed:** (1) `scripts/validation/run_stream_gap_gate_threshold_sweep_issue_3558.py`, which
+  reuses the #3471 episode harness (extended with optional per-run gate-threshold overrides) to roll
+  the `uncertain_dropped` mode across a grid of `uncertainty_min_existence_probability` thresholds and
+  feed the per-setting safety aggregates + conservative-retention baseline into the pure
+  `robot_sf.planner.stream_gap_gate_calibration.calibrate_stream_gap_gate` decision layer.
+- **Evidence tier:** `diagnostic` — the real `stream_gap` planner + `ScenarioBelief` gate on one
+  synthetic controlled crossing scenario. **Not** the full benchmark environment, **not** paper-grade,
+  no trained-policy or traffic-realism claim.
+- **Active axis:** the #3471 scenario degrades only the corridor agent's *existence* confidence
+  (to 0.2), so the sweep exercises `uncertainty_min_existence_probability` only. The other three gate
+  thresholds are recorded and passed through but are not exercised by this single-source degradation.
+- **Out of scope:** changing the production default (a separate decision); benchmark-env promotion
+  (the #3471/#3556 follow-up).
+
+## Result (`report.json`, 12 seeds 101–112, `max_steps=120`)
+
+The gate drops an agent when `existence < min_existence_probability` (strict); the degraded agent
+sits at existence 0.2.
+
+| existence threshold | drops agent? | classification | unsafe-commit rate | collision rate | worst sep (m) |
+| --- | --- | --- | --- | --- | --- |
+| baseline (retention, gate off) | — | — | 0.833 | 0.417 | −0.169 |
+| 0.1 | no | `at_least_as_safe` | 0.833 | 0.417 | −0.169 |
+| 0.2 | no | `at_least_as_safe` | 0.833 | 0.417 | −0.169 |
+| 0.3 | yes | `less_safe` | 1.000 | 0.917 | −0.621 |
+| 0.5 (**default**) | yes | `less_safe` | 1.000 | 0.917 | −0.621 |
+| 0.7 | yes | `less_safe` | 1.000 | 0.917 | −0.621 |
+
+- **Conclusion:** `safe_region_exists`; safe region = `{0.1, 0.2}`; recommended setting = `0.1`.
+- **Interpretation:** the only gate settings that are at least as safe as conservative retention are
+  those permissive enough *not to drop* the (correctly present) degraded corridor agent. Every setting
+  that actually drops it is strictly less safe — so on this scenario the existence gate is "safe"
+  exactly when it is inert, and the **0.5 production default is unsafe**, reproducing #3471. This does
+  not recommend a *new* dropping default; it confirms conservative retention should stand for
+  safety-relevant use at this scenario's degradation level.
+- **Scenario note:** even the retention baseline collides in ~42% of seeds — this controlled crossing
+  is genuinely contested, so the signal is the *relative* contrast (dropping raises collisions from
+  0.417 → 0.917), not an absolute safety claim.
+
+## Reproduce
+
+```bash
+uv run python scripts/validation/run_stream_gap_gate_threshold_sweep_issue_3558.py \
+  --output-json output/issue_3558_gate_threshold_sweep.json
+```
+
+Tests: `tests/validation/test_run_stream_gap_gate_threshold_sweep_issue_3558.py` (and the unchanged
+#3471 harness tests, which still pass with the additive `gate_thresholds` parameter).

--- a/docs/context/evidence/issue_3558_gate_threshold_sweep_2026-06-25/report.json
+++ b/docs/context/evidence/issue_3558_gate_threshold_sweep_2026-06-25/report.json
@@ -1,0 +1,159 @@
+{
+  "active_gate_axis": "uncertainty_min_existence_probability",
+  "baseline_conservative_retention": {
+    "collision_rate": 0.4167,
+    "min_separation_m": -0.1694,
+    "unsafe_commit_rate": 0.8333
+  },
+  "calibration": {
+    "baseline": {
+      "collision_rate": 0.4167,
+      "min_separation_m": -0.1694,
+      "unsafe_commit_rate": 0.8333
+    },
+    "conclusion": "safe_region_exists",
+    "evidence_kind": "diagnostic_proxy",
+    "n_settings": 5,
+    "recommended_setting": {
+      "classification": "at_least_as_safe",
+      "collision_rate": 0.4167,
+      "min_separation_m": -0.1694,
+      "thresholds": {
+        "uncertainty_max_position_variance": 1.0,
+        "uncertainty_min_class_probability": 0.5,
+        "uncertainty_min_existence_probability": 0.1,
+        "uncertainty_min_position_confidence": 0.5
+      },
+      "unsafe_commit_rate": 0.8333
+    },
+    "safe_region": [
+      {
+        "classification": "at_least_as_safe",
+        "collision_rate": 0.4167,
+        "min_separation_m": -0.1694,
+        "thresholds": {
+          "uncertainty_max_position_variance": 1.0,
+          "uncertainty_min_class_probability": 0.5,
+          "uncertainty_min_existence_probability": 0.1,
+          "uncertainty_min_position_confidence": 0.5
+        },
+        "unsafe_commit_rate": 0.8333
+      },
+      {
+        "classification": "at_least_as_safe",
+        "collision_rate": 0.4167,
+        "min_separation_m": -0.1694,
+        "thresholds": {
+          "uncertainty_max_position_variance": 1.0,
+          "uncertainty_min_class_probability": 0.5,
+          "uncertainty_min_existence_probability": 0.2,
+          "uncertainty_min_position_confidence": 0.5
+        },
+        "unsafe_commit_rate": 0.8333
+      }
+    ],
+    "schema_version": "stream_gap_gate_calibration.v1",
+    "settings": [
+      {
+        "classification": "at_least_as_safe",
+        "collision_rate": 0.4167,
+        "min_separation_m": -0.1694,
+        "thresholds": {
+          "uncertainty_max_position_variance": 1.0,
+          "uncertainty_min_class_probability": 0.5,
+          "uncertainty_min_existence_probability": 0.1,
+          "uncertainty_min_position_confidence": 0.5
+        },
+        "unsafe_commit_rate": 0.8333
+      },
+      {
+        "classification": "at_least_as_safe",
+        "collision_rate": 0.4167,
+        "min_separation_m": -0.1694,
+        "thresholds": {
+          "uncertainty_max_position_variance": 1.0,
+          "uncertainty_min_class_probability": 0.5,
+          "uncertainty_min_existence_probability": 0.2,
+          "uncertainty_min_position_confidence": 0.5
+        },
+        "unsafe_commit_rate": 0.8333
+      },
+      {
+        "classification": "less_safe",
+        "collision_rate": 0.9167,
+        "min_separation_m": -0.6212,
+        "thresholds": {
+          "uncertainty_max_position_variance": 1.0,
+          "uncertainty_min_class_probability": 0.5,
+          "uncertainty_min_existence_probability": 0.3,
+          "uncertainty_min_position_confidence": 0.5
+        },
+        "unsafe_commit_rate": 1.0
+      },
+      {
+        "classification": "less_safe",
+        "collision_rate": 0.9167,
+        "min_separation_m": -0.6212,
+        "thresholds": {
+          "uncertainty_max_position_variance": 1.0,
+          "uncertainty_min_class_probability": 0.5,
+          "uncertainty_min_existence_probability": 0.5,
+          "uncertainty_min_position_confidence": 0.5
+        },
+        "unsafe_commit_rate": 1.0
+      },
+      {
+        "classification": "less_safe",
+        "collision_rate": 0.9167,
+        "min_separation_m": -0.6212,
+        "thresholds": {
+          "uncertainty_max_position_variance": 1.0,
+          "uncertainty_min_class_probability": 0.5,
+          "uncertainty_min_existence_probability": 0.7,
+          "uncertainty_min_position_confidence": 0.5
+        },
+        "unsafe_commit_rate": 1.0
+      }
+    ]
+  },
+  "claim_boundary": "Bounded existence-probability gate-threshold sweep on the #3471 controlled crossing scenario with the real stream_gap planner + ScenarioBelief gate. Only the existence axis is exercised (the scenario degrades existence alone); not the full benchmark environment, not paper-grade, no trained-policy or traffic-realism claim. Does not change the production default.",
+  "degraded_existence": 0.2,
+  "evidence_tier": "diagnostic",
+  "existence_grid": [
+    0.1,
+    0.2,
+    0.3,
+    0.5,
+    0.7
+  ],
+  "generated_at_utc": "2026-06-25T11:30:40.575119+00:00",
+  "issue": 3558,
+  "params": {
+    "corridor_x": 5.0,
+    "dt": 0.1,
+    "goal_x": 9.0,
+    "max_steps": 120,
+    "near_miss_margin": 0.6,
+    "path_y": 5.0,
+    "ped_cross_speed": 0.7,
+    "ped_radius": 0.3,
+    "robot_radius": 0.4,
+    "start_x": 2.0
+  },
+  "schema_version": "stream-gap-gate-threshold-sweep.v1",
+  "seed_count": 12,
+  "seeds": [
+    101,
+    102,
+    103,
+    104,
+    105,
+    106,
+    107,
+    108,
+    109,
+    110,
+    111,
+    112
+  ]
+}

--- a/scripts/validation/run_scenario_belief_episode_safety_issue_3471.py
+++ b/scripts/validation/run_scenario_belief_episode_safety_issue_3471.py
@@ -55,6 +55,14 @@ MODES: dict[str, dict[str, bool]] = {
 #: Existence confidence assigned to the degraded corridor agent (below the 0.5 gate threshold).
 _DEGRADED_EXISTENCE = 0.2
 
+#: The four stream_gap uncertainty-gate thresholds the #3558 sweep is allowed to override.
+GATE_THRESHOLD_FIELDS = (
+    "uncertainty_min_existence_probability",
+    "uncertainty_min_position_confidence",
+    "uncertainty_min_class_probability",
+    "uncertainty_max_position_variance",
+)
+
 
 @dataclass
 class EpisodeParams:
@@ -159,9 +167,21 @@ def build_belief_for_mode(state: ScenarioState, mode: str, params: EpisodeParams
     return replace(belief, agents=tuple(agents))
 
 
-def _planner_config(mode: str) -> StreamGapPlannerConfig:
-    """Return a stream_gap config with uncertainty gating set per ``mode``."""
-    return StreamGapPlannerConfig(uncertainty_gating_enabled=MODES[mode]["gate"])
+def _planner_config(
+    mode: str, gate_thresholds: dict[str, float] | None = None
+) -> StreamGapPlannerConfig:
+    """Return a stream_gap config with uncertainty gating set per ``mode``.
+
+    ``gate_thresholds`` optionally overrides one or more of the four uncertainty-gate
+    thresholds (``GATE_THRESHOLD_FIELDS``) so the #3558 calibration sweep can probe
+    whether any threshold setting makes dropping at least as safe as conservative
+    retention. Unknown keys fail closed rather than being silently ignored.
+    """
+    overrides = dict(gate_thresholds or {})
+    unknown = set(overrides) - set(GATE_THRESHOLD_FIELDS)
+    if unknown:
+        raise ValueError(f"unknown gate threshold override(s): {sorted(unknown)}")
+    return StreamGapPlannerConfig(uncertainty_gating_enabled=MODES[mode]["gate"], **overrides)
 
 
 def _advance(
@@ -194,12 +214,21 @@ def _is_commit(speed: float) -> bool:
     return abs(speed - StreamGapPlannerConfig.commit_speed) < 1e-6
 
 
-def run_episode(mode: str, seed: int, params: EpisodeParams) -> dict[str, Any]:
-    """Roll one controlled episode under ``mode`` and return episode-level safety metrics."""
+def run_episode(
+    mode: str,
+    seed: int,
+    params: EpisodeParams,
+    gate_thresholds: dict[str, float] | None = None,
+) -> dict[str, Any]:
+    """Roll one controlled episode under ``mode`` and return episode-level safety metrics.
+
+    ``gate_thresholds`` optionally overrides the uncertainty-gate thresholds (only meaningful
+    when the mode enables gating); see :func:`_planner_config`.
+    """
     if mode not in MODES:
         raise ValueError(f"unknown mode: {mode}")
     state = build_initial_state(seed, params)
-    planner = StreamGapPlannerAdapter(_planner_config(mode))
+    planner = StreamGapPlannerAdapter(_planner_config(mode, gate_thresholds))
 
     start = time.perf_counter()
     initial_goal_dist = float(np.linalg.norm(state.goal - state.robot_pos))

--- a/scripts/validation/run_stream_gap_gate_threshold_sweep_issue_3558.py
+++ b/scripts/validation/run_stream_gap_gate_threshold_sweep_issue_3558.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Sweep stream_gap uncertainty-gate thresholds for safe agent-dropping (#3558).
+
+#3471 found that dropping uncertain agents at the **current default** ``stream_gap``
+uncertainty-gate thresholds increases unsafe commitment. That is a finding about the
+defaults, not about gating in general. This script runs the missing **bounded threshold
+sweep** the issue asks for: it reuses the #3471 episode harness
+(``run_scenario_belief_episode_safety_issue_3471``) and rolls the ``uncertain_dropped``
+mode once per swept gate setting, then feeds the per-setting safety aggregates and the
+conservative-retention baseline into the merged pure decision layer
+``robot_sf.planner.stream_gap_gate_calibration.calibrate_stream_gap_gate``.
+
+The output is the issue deliverable: per-setting ``at_least_as_safe`` / ``less_safe``
+classifications, the safe operating region (if any), a recommended setting, or the
+``conservative_retention_dominates`` conclusion.
+
+**Active axis / claim boundary.** The #3471 scenario degrades only the corridor agent's
+*existence* confidence (to 0.2), so this sweep exercises the
+``uncertainty_min_existence_probability`` gate axis; the other three thresholds are
+recorded and passed through but are not exercised by this scenario's single-source
+degradation. The gate drops an agent when ``existence < min_existence_probability``
+(strict), so a threshold at or below 0.2 retains the degraded agent (behaviorally
+conservative retention) while a threshold above 0.2 drops it.
+
+This is **diagnostic-tier, controlled-scenario evidence** — the real stream_gap planner +
+ScenarioBelief gate on one synthetic crossing scenario, not the full benchmark
+environment, not paper-grade, and no trained-policy or traffic-realism claim. It does not
+change the production default; that is a separate decision once a safe region is or is not
+found.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from robot_sf.planner.stream_gap import StreamGapPlannerConfig
+from robot_sf.planner.stream_gap_gate_calibration import (
+    GateSettingResult,
+    SafetyTolerance,
+    calibrate_stream_gap_gate,
+)
+from scripts.validation.run_scenario_belief_episode_safety_issue_3471 import (
+    EpisodeParams,
+    run_episode,
+)
+
+SCHEMA_VERSION = "stream-gap-gate-threshold-sweep.v1"
+ISSUE = 3558
+
+#: Predeclared existence-probability gate grid. The degraded corridor agent sits at
+#: existence 0.2, so ``<= 0.2`` retains it (safe) and ``> 0.2`` drops it (the #3471 finding).
+DEFAULT_EXISTENCE_GRID: tuple[float, ...] = (0.1, 0.2, 0.3, 0.5, 0.7)
+
+#: Default values for the gate thresholds the scenario does not exercise (recorded for
+#: a self-describing report).
+_DEFAULTS = StreamGapPlannerConfig()
+_PASSTHROUGH_THRESHOLDS = {
+    "uncertainty_min_position_confidence": float(_DEFAULTS.uncertainty_min_position_confidence),
+    "uncertainty_min_class_probability": float(_DEFAULTS.uncertainty_min_class_probability),
+    "uncertainty_max_position_variance": float(_DEFAULTS.uncertainty_max_position_variance),
+}
+
+
+def _aggregate(rows: list[dict[str, Any]], thresholds: dict[str, float]) -> GateSettingResult:
+    """Aggregate per-seed episode rows for one gate setting into a ``GateSettingResult``.
+
+    Safety axes (lower is safer except separation):
+
+    * ``unsafe_commit_rate`` — fraction of episodes with any unsafe commitment;
+    * ``collision_rate`` — fraction of episodes with a collision;
+    * ``min_separation_m`` — worst (smallest) true surface separation across episodes
+      (the conservative, fail-closed choice).
+
+    Returns:
+        GateSettingResult: The per-setting safety aggregates.
+    """
+    n = len(rows)
+    if n == 0:
+        raise ValueError("cannot aggregate an empty set of episode rows")
+    unsafe_commit_rate = sum(1 for row in rows if row["unsafe_commit_steps"] > 0) / n
+    collision_rate = sum(1 for row in rows if row["collision"]) / n
+    worst_min_separation = min(row["min_separation"] for row in rows)
+    return GateSettingResult(
+        thresholds=thresholds,
+        unsafe_commit_rate=round(unsafe_commit_rate, 4),
+        collision_rate=round(collision_rate, 4),
+        min_separation_m=round(float(worst_min_separation), 4),
+    )
+
+
+def run_sweep(
+    seeds: list[int],
+    params: EpisodeParams,
+    existence_grid: tuple[float, ...] = DEFAULT_EXISTENCE_GRID,
+    tolerance: SafetyTolerance | None = None,
+) -> dict[str, Any]:
+    """Run the gate-threshold sweep and assemble the calibrated report.
+
+    The baseline is the ``uncertain_retained`` mode (conservative retention, gate off).
+    Each swept setting is the ``uncertain_dropped`` mode with gating on at the given
+    existence threshold.
+
+    Returns:
+        dict[str, Any]: Versioned report with the swept settings, the baseline, and the
+        :func:`calibrate_stream_gap_gate` decision.
+    """
+    if not seeds:
+        raise ValueError("at least one seed is required")
+    tolerance = tolerance or SafetyTolerance()
+
+    baseline_rows = [run_episode("uncertain_retained", seed, params) for seed in seeds]
+    baseline = _aggregate(baseline_rows, thresholds={})
+
+    settings: list[GateSettingResult] = []
+    for existence in existence_grid:
+        thresholds = {
+            "uncertainty_min_existence_probability": float(existence),
+            **_PASSTHROUGH_THRESHOLDS,
+        }
+        override = {"uncertainty_min_existence_probability": float(existence)}
+        rows = [
+            run_episode("uncertain_dropped", seed, params, gate_thresholds=override)
+            for seed in seeds
+        ]
+        settings.append(_aggregate(rows, thresholds=thresholds))
+
+    calibration = calibrate_stream_gap_gate(settings, baseline, tolerance)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "issue": ISSUE,
+        "evidence_tier": "diagnostic",
+        "claim_boundary": (
+            "Bounded existence-probability gate-threshold sweep on the #3471 controlled "
+            "crossing scenario with the real stream_gap planner + ScenarioBelief gate. Only "
+            "the existence axis is exercised (the scenario degrades existence alone); not the "
+            "full benchmark environment, not paper-grade, no trained-policy or traffic-realism "
+            "claim. Does not change the production default."
+        ),
+        "active_gate_axis": "uncertainty_min_existence_probability",
+        "degraded_existence": 0.2,
+        "seeds": seeds,
+        "seed_count": len(seeds),
+        "existence_grid": list(existence_grid),
+        "params": vars(params),
+        "baseline_conservative_retention": {
+            "unsafe_commit_rate": baseline.unsafe_commit_rate,
+            "collision_rate": baseline.collision_rate,
+            "min_separation_m": baseline.min_separation_m,
+        },
+        "calibration": calibration,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--seeds", type=int, nargs="+", default=None)
+    parser.add_argument("--max-steps", type=int, default=None)
+    parser.add_argument(
+        "--existence-grid",
+        type=float,
+        nargs="+",
+        default=None,
+        help="Existence-probability thresholds to sweep (default: 0.1 0.2 0.3 0.5 0.7).",
+    )
+    parser.add_argument("--output-json", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: run the sweep and emit the calibrated report."""
+    args = parse_args(argv)
+    from dataclasses import replace
+
+    seeds = args.seeds if args.seeds is not None else list(range(101, 113))
+    params = EpisodeParams()
+    if args.max_steps is not None:
+        params = replace(params, max_steps=args.max_steps)
+    grid = tuple(args.existence_grid) if args.existence_grid is not None else DEFAULT_EXISTENCE_GRID
+
+    report = run_sweep(seeds, params, existence_grid=grid)
+    report["generated_at_utc"] = datetime.now(UTC).isoformat()
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        print(f"\nwrote {args.output_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/test_run_stream_gap_gate_threshold_sweep_issue_3558.py
+++ b/tests/validation/test_run_stream_gap_gate_threshold_sweep_issue_3558.py
@@ -1,0 +1,105 @@
+"""Tests for the stream_gap gate-threshold calibration sweep (#3558).
+
+This exercises the deferred-run layer: the #3471 episode harness driven across a grid of
+uncertainty-gate thresholds and fed into the merged ``calibrate_stream_gap_gate`` decision
+layer. Evidence tier is diagnostic (controlled crossing scenario), matching the harness.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from scripts.validation.run_scenario_belief_episode_safety_issue_3471 import (
+    EpisodeParams,
+    _planner_config,
+    run_episode,
+)
+from scripts.validation.run_stream_gap_gate_threshold_sweep_issue_3558 import (
+    SCHEMA_VERSION,
+    run_sweep,
+)
+
+# Episodes are deterministic per seed, so a small matrix is enough to fix the safe/unsafe
+# classification; the sweep's value is the threshold contrast, not statistical power.
+_FAST = EpisodeParams(max_steps=50)
+_SEEDS = [101, 102, 103]
+
+
+def test_gate_threshold_override_changes_dropping_behavior() -> None:
+    """A permissive existence threshold (<= degraded 0.2) must retain the agent; a strict one drops it.
+
+    Retaining is behaviorally conservative retention, so it must match the gate-off contrast on
+    the safety metrics; dropping must be strictly worse.
+    """
+    permissive = run_episode(
+        "uncertain_dropped",
+        seed=101,
+        params=_FAST,
+        gate_thresholds={"uncertainty_min_existence_probability": 0.1},
+    )
+    strict = run_episode(
+        "uncertain_dropped",
+        seed=101,
+        params=_FAST,
+        gate_thresholds={"uncertainty_min_existence_probability": 0.5},
+    )
+    retained = run_episode("uncertain_retained", seed=101, params=_FAST)
+
+    # Permissive gate keeps the degraded agent -> identical to conservative retention.
+    assert permissive["unsafe_commit_steps"] == retained["unsafe_commit_steps"]
+    assert permissive["collision"] == retained["collision"]
+    # Strict gate drops it -> at least as much unsafe commitment as retention.
+    assert strict["unsafe_commit_steps"] >= retained["unsafe_commit_steps"]
+
+
+def test_unknown_gate_threshold_override_fails_closed() -> None:
+    """An unknown gate-threshold key must raise rather than be silently ignored."""
+    with pytest.raises(ValueError, match="unknown gate threshold"):
+        _planner_config("uncertain_dropped", {"not_a_real_threshold": 0.5})
+
+
+def test_sweep_finds_safe_region_below_degraded_existence() -> None:
+    """The sweep must classify <=0.2 thresholds safe and >0.2 thresholds less safe."""
+    report = run_sweep(_SEEDS, _FAST, existence_grid=(0.1, 0.2, 0.3, 0.5))
+
+    assert report["schema_version"] == SCHEMA_VERSION
+    assert report["issue"] == 3558
+    assert report["evidence_tier"] == "diagnostic"
+    assert report["active_gate_axis"] == "uncertainty_min_existence_probability"
+
+    calibration = report["calibration"]
+    by_existence = {
+        row["thresholds"]["uncertainty_min_existence_probability"]: row["classification"]
+        for row in calibration["settings"]
+    }
+    assert by_existence[0.1] == "at_least_as_safe"
+    assert by_existence[0.2] == "at_least_as_safe"
+    assert by_existence[0.3] == "less_safe"
+    assert by_existence[0.5] == "less_safe"
+
+
+def test_sweep_recommends_a_safe_setting_and_concludes_region_exists() -> None:
+    """When a safe region exists the calibration must recommend a member of it."""
+    report = run_sweep(_SEEDS, _FAST, existence_grid=(0.1, 0.2, 0.5))
+    calibration = report["calibration"]
+
+    assert calibration["conclusion"] == "safe_region_exists"
+    recommended = calibration["recommended_setting"]
+    assert recommended is not None
+    # The recommended (safest) setting must be permissive enough to retain the degraded agent.
+    assert recommended["thresholds"]["uncertainty_min_existence_probability"] <= 0.2
+
+
+def test_sweep_reports_strict_default_gate_is_less_safe() -> None:
+    """The production default (0.5) existence gate must land in the less-safe set, per #3471."""
+    report = run_sweep(_SEEDS, _FAST, existence_grid=(0.5,))
+    only = report["calibration"]["settings"][0]
+
+    assert only["thresholds"]["uncertainty_min_existence_probability"] == 0.5
+    assert only["classification"] == "less_safe"
+
+
+def test_sweep_rejects_empty_seeds() -> None:
+    """An empty seed set cannot be swept."""
+    with pytest.raises(ValueError):
+        run_sweep([], _FAST)


### PR DESCRIPTION
## Summary

#3558 asked whether any `stream_gap` uncertainty-gate threshold setting makes dropping uncertain agents at least as safe as conservative retention. Its pure decision layer (`calibrate_stream_gap_gate`) merged in #3592 with the **threshold sweep that feeds it deferred** ("the sweep that produces the per-setting safety aggregates needs benchmark runs and is deferred"). This PR lands that deferred run.

It reuses the existing #3471 episode harness (`run_scenario_belief_episode_safety_issue_3471.py`) — extended with an **additive, backward-compatible** `gate_thresholds` override — to roll the `uncertain_dropped` mode across a grid of `uncertainty_min_existence_probability` thresholds, then feeds the per-setting safety aggregates + the conservative-retention baseline into the merged decision layer.

## What's here

- **`scripts/validation/run_scenario_belief_episode_safety_issue_3471.py`** — `_planner_config` / `run_episode` gain an optional `gate_thresholds` dict (validated against the four gate fields; unknown keys fail closed). Existing #3471 tests unchanged and still green.
- **`scripts/validation/run_stream_gap_gate_threshold_sweep_issue_3558.py`** — new sweep + `calibrate_stream_gap_gate` integration; CLI with `--seeds` / `--max-steps` / `--existence-grid` / `--output-json`.
- **`tests/validation/test_run_stream_gap_gate_threshold_sweep_issue_3558.py`** — safe-region contrast, fail-closed unknown-override guard, empty-input guard, default-gate-is-less-safe.
- **`docs/context/evidence/issue_3558_gate_threshold_sweep_2026-06-25/`** — canonical 12-seed `report.json` + README.

## Result (diagnostic-tier, 12 seeds)

The gate drops an agent when `existence < min_existence_probability` (strict); the degraded corridor agent sits at existence 0.2.

| existence threshold | drops agent? | classification | unsafe-commit | collision | worst sep (m) |
| --- | --- | --- | --- | --- | --- |
| baseline (retention) | — | — | 0.833 | 0.417 | −0.169 |
| 0.1 / 0.2 | no | `at_least_as_safe` | 0.833 | 0.417 | −0.169 |
| 0.3 / **0.5 (default)** / 0.7 | yes | `less_safe` | 1.000 | 0.917 | −0.621 |

**Conclusion:** `safe_region_exists`; safe region = `{0.1, 0.2}`; recommended = `0.1`. The only "safe" gate settings are those permissive enough not to drop the (correctly present) degraded agent — every setting that actually drops it, including the **0.5 production default**, is strictly less safe, reproducing #3471.

## Claim boundary

Diagnostic-tier, controlled single crossing scenario, real `stream_gap` planner + `ScenarioBelief` gate. Only the **existence axis** is exercised (the scenario degrades existence alone; the other three thresholds are recorded but pass-through). Not the full benchmark environment, not paper-grade. **Does not change the production default** (a separate decision per the issue scope).

## Validation

- `uv run pytest tests/validation/test_run_stream_gap_gate_threshold_sweep_issue_3558.py tests/validation/test_run_scenario_belief_episode_safety_issue_3471.py tests/planner/test_stream_gap_gate_calibration.py` — all green (27 passed; the #3471 harness change is backward-compatible).
- `uv run ruff check` / format: clean.

Part of the #3471 follow-up family; pairs with the #3556 real-runner promotion. Builds on #3592 (decision layer) and #3603 (fail-closed guards on that layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostic sweep for tuning a stream-gating threshold, with a JSON-style report and optional file output.
  * Expanded the validation workflow to support per-run gate-threshold overrides.

* **Documentation**
  * Updated the changelog and evidence docs with sweep results, recommended settings, and reproduction steps.

* **Bug Fixes**
  * Improved validation so unknown threshold overrides are rejected, helping the process fail safely.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->