### PR TITLE
infra: lint against absolute home-dir paths in configs/** (#3605)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -16,3 +16,9 @@ repos:
         language: system
         files: \.schema\.v[0-9]+\.json$
         pass_filenames: true
+      - id: check-config-abs-paths
+        name: Check Configs For Absolute Home-Dir Paths
+        entry: uv run python hooks/check_config_abs_paths.py
+        language: system
+        files: ^configs/.*\.(ya?ml|json|toml|cfg|ini)$
+        pass_filenames: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a pre-commit lint that fails when a file under `configs/**` contains an absolute
+  home-dir path (`/home/`, `/Users/`, `/root/`), which is non-portable for other contributors
+  and automated runners. Intentional absolute paths (e.g. private-ops SLURM routing targets
+  that live outside this repo) are exempted by annotating the line with `# allow-abs-path: <reason>`.
+  Hook: [`hooks/check_config_abs_paths.py`](hooks/check_config_abs_paths.py); tests:
+  [`tests/integration/test_check_config_abs_paths.py`](tests/integration/test_check_config_abs_paths.py) (#3605).
 * Classified the ORCA-residual progress-probe lane decision (#2445):
   [`scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py`](scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py)
   reads the existing v1 bounded smoke result (SLURM job 12913) and applies the #2408/PR #2420 stop

--- a/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+++ b/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
@@ -200,7 +200,7 @@ queue_hint:
   source: issue_3068_launch_packet
   job_class: robot_sf_gpu_training_small
   route_id: imech192:a30
-  script: /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl
+  script: /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl  # allow-abs-path: private-ops SLURM routing target (lives outside this repo)
   config: configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
   campaign: 2026-06-issue3068-ppo-curriculum
   cpus: 20

--- a/hooks/check_config_abs_paths.py
+++ b/hooks/check_config_abs_paths.py
@@ -1,0 +1,134 @@
+"""
+Git hook to prevent accidental absolute home-dir paths in ``configs/**``.
+
+Autonomously-generated configs occasionally hardcode absolute user-home paths
+(``/home/<user>/...``), which are non-portable for other contributors and
+automated runners. This hook fails when a tracked config file contains such a
+path, UNLESS the line is explicitly annotated as intentional (e.g. private-ops
+SLURM routing) with an ``allow-abs-path`` marker.
+
+See issue #3605.
+"""
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+
+logging.basicConfig(level=logging.WARNING)
+
+# Absolute home-dir prefixes that should not appear in portable configs.
+ABS_PATH_PATTERN = re.compile(r"(/home/|/Users/|/root/)")
+
+# A line carrying this marker is an intentional, documented absolute path.
+ALLOW_MARKER = "allow-abs-path"
+
+CONFIG_ROOT = Path("configs")
+
+
+def _iter_config_files(files: list[str]) -> list[Path]:
+    """
+    Return the subset of ``files`` that live under a ``configs/`` directory.
+
+    Accepts both repo-relative paths (as pre-commit passes them, e.g.
+    ``configs/training/x.yaml``) and absolute paths (as tests / direct calls may
+    pass), so membership is keyed on a ``configs`` path component rather than a
+    fixed relative prefix.
+    """
+    selected: list[Path] = []
+    for f in files:
+        path = Path(f)
+        if CONFIG_ROOT.name in path.parts and path.is_file():
+            selected.append(path)
+    return selected
+
+
+def find_abs_path_violations(files: list[str]) -> dict:
+    """
+    Scan config files for unannotated absolute home-dir paths.
+
+    Args:
+        files: Candidate file paths (only those under ``configs/`` are checked).
+
+    Returns:
+        Dict with ``status`` ("pass"/"fail"), ``violations`` (list of
+        ``{file, line, text}``), and a human-readable ``message``.
+    """
+    config_files = _iter_config_files(files)
+
+    if not config_files:
+        return {
+            "status": "pass",
+            "violations": [],
+            "message": "No config files in scope - nothing to check.",
+        }
+
+    violations: list[dict] = []
+    for path in config_files:
+        try:
+            text = path.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            # Non-text or unreadable config (e.g. binary asset) - skip.
+            continue
+        for lineno, line in enumerate(text.splitlines(), start=1):
+            if not ABS_PATH_PATTERN.search(line):
+                continue
+            if ALLOW_MARKER in line:
+                # Explicitly annotated as an intentional absolute path.
+                continue
+            violations.append({"file": str(path), "line": lineno, "text": line.strip()})
+
+    if violations:
+        return {
+            "status": "fail",
+            "violations": violations,
+            "message": (
+                f"Found {len(violations)} unannotated absolute home-dir path(s) "
+                f"in configs/. Use a repo-relative path, or annotate the line "
+                f"with '# {ALLOW_MARKER}: <reason>' if the absolute path is "
+                f"intentional (e.g. private-ops routing)."
+            ),
+        }
+
+    return {
+        "status": "pass",
+        "violations": [],
+        "message": f"Checked {len(config_files)} config file(s); no leaks found.",
+    }
+
+
+def main() -> None:
+    """CLI entry point for the git hook."""
+    parser = argparse.ArgumentParser(
+        description="Prevent accidental absolute home-dir paths in configs/**"
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files to check (only those under configs/ are scanned).",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Scan every tracked file under configs/ instead of the given list.",
+    )
+    args = parser.parse_args()
+
+    if args.all:
+        files = [str(p) for p in CONFIG_ROOT.rglob("*") if p.is_file()]
+    else:
+        files = args.files
+
+    result = find_abs_path_violations(files)
+
+    for v in result["violations"]:
+        logging.error("Absolute path in config: %s:%s\n  %s", v["file"], v["line"], v["text"])
+    if result["violations"]:
+        logging.error(result["message"])
+
+    sys.exit(0 if result["status"] == "pass" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_check_config_abs_paths.py
+++ b/tests/integration/test_check_config_abs_paths.py
@@ -1,0 +1,85 @@
+"""
+Tests for the configs/** absolute-path lint hook (issue #3605).
+
+Covers the reject path (an unannotated `/home/...` leak), the allowlist path
+(an intentional, annotated absolute path), the clean path, and that files
+outside `configs/` are ignored.
+"""
+
+from pathlib import Path
+
+from hooks.check_config_abs_paths import find_abs_path_violations
+
+
+def _write(base: Path, rel: str, content: str) -> str:
+    path = base / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+class TestCheckConfigAbsPaths:
+    """Behavioural tests for ``find_abs_path_violations``."""
+
+    def test_rejects_unannotated_home_dir_path(self, tmp_path, monkeypatch):
+        """An unannotated /home/ path under configs/ is a violation."""
+        monkeypatch.chdir(tmp_path)
+        f = _write(
+            tmp_path,
+            "configs/training/leaky.yaml",
+            "script: /home/someone/git/thing/run.sl\n",
+        )
+        result = find_abs_path_violations([f])
+        assert result["status"] == "fail"
+        assert len(result["violations"]) == 1
+        assert result["violations"][0]["line"] == 1
+
+    def test_allows_annotated_path(self, tmp_path, monkeypatch):
+        """A line marked with `allow-abs-path` is permitted."""
+        monkeypatch.chdir(tmp_path)
+        f = _write(
+            tmp_path,
+            "configs/training/routed.yaml",
+            "script: /home/u/private-ops/run.sl  # allow-abs-path: private-ops routing\n",
+        )
+        result = find_abs_path_violations([f])
+        assert result["status"] == "pass"
+        assert result["violations"] == []
+
+    def test_passes_clean_relative_config(self, tmp_path, monkeypatch):
+        """A config using only repo-relative paths passes."""
+        monkeypatch.chdir(tmp_path)
+        f = _write(
+            tmp_path,
+            "configs/training/clean.yaml",
+            "config: configs/training/ppo/recipe.yaml\nnum_envs: 22\n",
+        )
+        result = find_abs_path_violations([f])
+        assert result["status"] == "pass"
+
+    def test_detects_users_and_root_prefixes(self, tmp_path, monkeypatch):
+        """/Users/ and /root/ prefixes are flagged alongside /home/."""
+        monkeypatch.chdir(tmp_path)
+        f = _write(
+            tmp_path,
+            "configs/a.yaml",
+            "a: /Users/x/y\nb: /root/z\n",
+        )
+        result = find_abs_path_violations([f])
+        assert result["status"] == "fail"
+        assert len(result["violations"]) == 2
+
+    def test_ignores_files_outside_configs(self, tmp_path, monkeypatch):
+        """Files outside a configs/ directory are not scanned."""
+        monkeypatch.chdir(tmp_path)
+        f = _write(tmp_path, "scripts/run.sh", "echo /home/someone/x\n")
+        result = find_abs_path_violations([f])
+        assert result["status"] == "pass"
+        assert "nothing to check" in result["message"].lower()
+
+    def test_repo_baseline_is_clean(self):
+        """The real configs/ tree must already pass (only annotated paths)."""
+        configs = Path("configs")
+        files = [str(p) for p in configs.rglob("*") if p.is_file()]
+        result = find_abs_path_violations(files)
+        assert result["status"] == "pass", result["message"]


### PR DESCRIPTION
## Summary

Closes #3605. Adds a pre-commit lint that fails when a file under `configs/**`
contains an absolute home-dir path (`/home/`, `/Users/`, `/root/`), which is
non-portable for other contributors and automated runners.

This is one of the reliability follow-ups from the 2026-06-25 PR review batch
(sibling issues #3604, #3606, #3607).

## Motivation

Autonomously-generated configs occasionally hardcode absolute user-home paths.
Concrete instance: #3570 set
`configs/training/ppo_curriculum_issue_3068_launch_packet.yaml`'s
`queue_hint.script` to `/home/luttkule/git/robot_sf_ll7-private-ops/...`
(flagged by gemini-code-assist). The generator does this reflexively, so it
recurs.

## What landed

- `hooks/check_config_abs_paths.py` — scans config files for unannotated
  absolute home-dir paths; returns a structured pass/fail result; exits non-zero
  with a clear message on violation. Mirrors the existing
  `hooks/prevent_schema_duplicates.py` convention.
- **Allowlist escape hatch:** some absolute paths are *intentional* (private-ops
  SLURM routing targets that live outside this repo). A line annotated with
  `# allow-abs-path: <reason>` is exempt. The one existing intentional path
  (#3570's `queue_hint.script`) is annotated accordingly, so the real tree
  passes.
- Wired into `.pre-commit-config.yaml` as `check-config-abs-paths`, scoped to
  `^configs/.*\.(ya?ml|json|toml|cfg|ini)$`.
- `tests/integration/test_check_config_abs_paths.py` — 6 tests: reject
  unannotated `/home/`, allow annotated, clean relative passes, detect
  `/Users/` + `/root/`, ignore non-config files, and a baseline test asserting
  the real `configs/` tree already passes.

## Validation

- `uv run pytest tests/integration/test_check_config_abs_paths.py -q` → 6 passed
- `uv run pre-commit run check-config-abs-paths --all-files` → Passed
- `uv run ruff check` / `ruff format` → clean

## Claim boundary

Tooling/portability hardening. No behavioral change to training or benchmark
runs; the only config edit is an explanatory annotation comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
