### PR TITLE
infra: lint training-config issue provenance after clone (#3606)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,9 @@ repos:
         language: system
         files: ^configs/.*\.(ya?ml|json|toml|cfg|ini)$
         pass_filenames: true
+      - id: check-config-provenance
+        name: Check Training Config Issue Provenance
+        entry: uv run python hooks/check_config_provenance.py
+        language: system
+        files: ^configs/training/.*\.ya?ml$
+        pass_filenames: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   setting that actually drops it (≥0.3, including the **0.5 production default**) is `less_safe`,
   confirming the #3471 finding that the default gate is unsafe. The sweep exercises only the existence
   axis (the scenario degrades existence alone) and does not change the production default (#3558).
+* Added a pre-commit lint that catches issue-provenance mismatches in cloned training configs:
+  when a config under `configs/training/**` has identity fields (`policy_id` / tracking `group` /
+  `tags` / `campaign_id`) that agree on a single issue number, its leading header comment must not
+  name a *different* issue (the #3570 pattern, where a header read "Issue-1024" while every identity
+  field targeted issue-3068). Headers that also cite a source/leader issue alongside the canonical
+  one pass; an intentional mismatch can be annotated with `# allow-provenance-mismatch: <reason>`.
+  Hook: [`hooks/check_config_provenance.py`](hooks/check_config_provenance.py); tests:
+  [`tests/integration/test_check_config_provenance.py`](tests/integration/test_check_config_provenance.py) (#3606).
 * Classified the ORCA-residual progress-probe lane decision (#2445):
   [`scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py`](scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py)
   reads the existing v1 bounded smoke result (SLURM job 12913) and applies the #2408/PR #2420 stop

--- a/hooks/check_config_provenance.py
+++ b/hooks/check_config_provenance.py
@@ -1,0 +1,212 @@
+"""
+Git hook to catch issue-provenance mismatches in cloned training configs.
+
+Training configs are cloned from a "leader" recipe (the intended workflow), but
+the leading header comment's issue reference is not always updated to match the
+clone's identity fields. The result is a config whose top-of-file comment names
+the wrong issue while its ``policy_id`` / tracking ``group`` / ``tags`` /
+``campaign_id`` all target the correct one (see #3570, where the header read
+"Issue-1024" while every identity field targeted issue-3068).
+
+This hook keys off the in-file identity fields as the source of truth: if those
+agree on a single canonical issue number and the leading comment block mentions
+issue numbers but NOT that canonical one, the header is flagged as
+misattributed. A header that mentions the canonical issue (even alongside a
+source/leader issue, e.g. "clones issue-791 for issue-3068") passes.
+
+Immutable consideration: configs under ``configs/training/ppo/ablations/`` map
+to already-run SLURM jobs and are treated as historical records. Correcting a
+*comment* does not change run semantics, so the check still applies, but a line
+annotated with ``allow-provenance-mismatch: <reason>`` is exempt for the rare
+case where editing the historical header is undesirable.
+
+See issue #3606.
+"""
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+logging.basicConfig(level=logging.WARNING)
+
+TRAINING_ROOT = Path("configs/training")
+
+# Matches "issue-3068", "issue_3068", "Issue 3068", "issue3068".
+ISSUE_RE = re.compile(r"issue[\s_-]?(\d+)", re.IGNORECASE)
+
+# A header carrying this marker intentionally references a different issue.
+ALLOW_MARKER = "allow-provenance-mismatch"
+
+
+def _issue_numbers(text: str) -> set[int]:
+    """Return the set of issue numbers referenced in ``text``."""
+    return {int(m) for m in ISSUE_RE.findall(text)}
+
+
+def _leading_comment_block(text: str) -> str:
+    """Return the contiguous comment lines at the very top of the file."""
+    lines: list[str] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if stripped.startswith("#"):
+            lines.append(stripped)
+        elif stripped == "":
+            # Allow blank lines interleaved within the leading block.
+            if lines:
+                lines.append("")
+            continue
+        else:
+            break
+    return "\n".join(lines)
+
+
+def _identity_issue(data: object) -> set[int]:
+    """Collect issue numbers referenced by a config's identity fields."""
+    issues: set[int] = set()
+    if not isinstance(data, dict):
+        return issues
+    for key in ("policy_id", "campaign_id"):
+        value = data.get(key)
+        if isinstance(value, str):
+            issues |= _issue_numbers(value)
+    tracking = data.get("tracking")
+    if isinstance(tracking, dict):
+        wandb = tracking.get("wandb")
+        if isinstance(wandb, dict):
+            group = wandb.get("group")
+            if isinstance(group, str):
+                issues |= _issue_numbers(group)
+            tags = wandb.get("tags")
+            if isinstance(tags, list):
+                for tag in tags:
+                    if isinstance(tag, str):
+                        issues |= _issue_numbers(tag)
+    return issues
+
+
+def _iter_training_configs(files: list[str]) -> list[Path]:
+    """Return the subset of ``files`` that are training YAML configs."""
+    selected: list[Path] = []
+    for f in files:
+        path = Path(f)
+        parts = path.parts
+        in_training = "configs" in parts and "training" in parts
+        if in_training and path.suffix in {".yaml", ".yml"} and path.is_file():
+            selected.append(path)
+    return selected
+
+
+def find_provenance_mismatches(files: list[str]) -> dict:
+    """
+    Scan training configs for header/identity issue-provenance mismatches.
+
+    Args:
+        files: Candidate file paths (only training YAML configs are checked).
+
+    Returns:
+        Dict with ``status`` ("pass"/"fail"), ``violations`` (list of
+        ``{file, header_issues, identity_issue}``), and a ``message``.
+    """
+    configs = _iter_training_configs(files)
+    if not configs:
+        return {
+            "status": "pass",
+            "violations": [],
+            "message": "No training configs in scope - nothing to check.",
+        }
+
+    violations: list[dict] = []
+    for path in configs:
+        try:
+            text = path.read_text(encoding="utf-8")
+            data = yaml.safe_load(text)
+        except (UnicodeDecodeError, OSError, yaml.YAMLError):
+            # Unreadable / unparseable config - not this hook's concern.
+            continue
+
+        identity = _identity_issue(data)
+        # Only act when identity fields agree on a single canonical issue.
+        if len(identity) != 1:
+            continue
+        canonical = next(iter(identity))
+
+        header = _leading_comment_block(text)
+        if ALLOW_MARKER in header:
+            continue
+        header_issues = _issue_numbers(header)
+        if header_issues and canonical not in header_issues:
+            violations.append(
+                {
+                    "file": str(path),
+                    "header_issues": sorted(header_issues),
+                    "identity_issue": canonical,
+                }
+            )
+
+    if violations:
+        return {
+            "status": "fail",
+            "violations": violations,
+            "message": (
+                f"Found {len(violations)} training config(s) whose header comment "
+                f"names a different issue than their identity fields "
+                f"(policy_id/group/tags/campaign_id). Update the header to match, "
+                f"or annotate it with '# {ALLOW_MARKER}: <reason>' if intentional."
+            ),
+        }
+
+    return {
+        "status": "pass",
+        "violations": [],
+        "message": f"Checked {len(configs)} training config(s); provenance consistent.",
+    }
+
+
+def main() -> None:
+    """CLI entry point for the git hook."""
+    parser = argparse.ArgumentParser(
+        description="Catch issue-provenance mismatches in cloned training configs"
+    )
+    parser.add_argument(
+        "files",
+        nargs="*",
+        help="Files to check (only training YAML configs are scanned).",
+    )
+    parser.add_argument(
+        "--all",
+        action="store_true",
+        help="Scan every YAML file under configs/training/ instead of the list.",
+    )
+    args = parser.parse_args()
+
+    if args.all:
+        files = [
+            str(p)
+            for p in TRAINING_ROOT.rglob("*")
+            if p.is_file() and p.suffix in {".yaml", ".yml"}
+        ]
+    else:
+        files = args.files
+
+    result = find_provenance_mismatches(files)
+
+    for v in result["violations"]:
+        logging.error(
+            "Provenance mismatch: %s\n  header references issue(s) %s but identity "
+            "fields target issue %s",
+            v["file"],
+            v["header_issues"],
+            v["identity_issue"],
+        )
+    if result["violations"]:
+        logging.error(result["message"])
+
+    sys.exit(0 if result["status"] == "pass" else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/integration/test_check_config_provenance.py
+++ b/tests/integration/test_check_config_provenance.py
@@ -1,0 +1,115 @@
+"""
+Tests for the training-config provenance lint hook (issue #3606).
+
+Covers the misattribution case (the #3570 pattern: header names a different
+issue than the identity fields), the consistent case, the source-issue case
+(header references both a leader issue and the canonical one), the
+allow-annotation escape hatch, and the ambiguous/absent-identity skips.
+"""
+
+from pathlib import Path
+
+from hooks.check_config_provenance import find_provenance_mismatches
+
+_IDENTITY_3068 = """\
+policy_id: ppo_expert_issue_3068_scout
+tracking:
+  wandb:
+    group: issue-3068-ppo-curriculum
+    tags:
+      - issue-3068
+      - ppo
+"""
+
+
+def _write(base: Path, rel: str, content: str) -> str:
+    path = base / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return str(path)
+
+
+class TestCheckConfigProvenance:
+    """Behavioural tests for ``find_provenance_mismatches``."""
+
+    def test_flags_misattributed_header(self, tmp_path):
+        """Header naming issue-1024 while identity targets 3068 is flagged."""
+        f = _write(
+            tmp_path,
+            "configs/training/ppo/ablations/scout.yaml",
+            "# Issue-1024 h500 schedule retrain.\n" + _IDENTITY_3068,
+        )
+        result = find_provenance_mismatches([f])
+        assert result["status"] == "fail"
+        assert result["violations"][0]["identity_issue"] == 3068
+        assert result["violations"][0]["header_issues"] == [1024]
+
+    def test_passes_consistent_header(self, tmp_path):
+        """Header naming the same issue as identity passes."""
+        f = _write(
+            tmp_path,
+            "configs/training/ppo/ablations/scout.yaml",
+            "# Issue-3068 PPO curriculum scout.\n" + _IDENTITY_3068,
+        )
+        result = find_provenance_mismatches([f])
+        assert result["status"] == "pass"
+
+    def test_passes_when_header_cites_source_and_canonical(self, tmp_path):
+        """Header citing a leader issue AND the canonical one passes."""
+        f = _write(
+            tmp_path,
+            "configs/training/ppo/ablations/scout.yaml",
+            "# Issue-3068 scout; clones the issue-791 leader recipe.\n" + _IDENTITY_3068,
+        )
+        result = find_provenance_mismatches([f])
+        assert result["status"] == "pass"
+
+    def test_allow_marker_exempts_mismatch(self, tmp_path):
+        """An annotated header is exempt even on mismatch."""
+        f = _write(
+            tmp_path,
+            "configs/training/ppo/ablations/scout.yaml",
+            "# Issue-1024 retrain.  # allow-provenance-mismatch: historical record\n"
+            + _IDENTITY_3068,
+        )
+        result = find_provenance_mismatches([f])
+        assert result["status"] == "pass"
+
+    def test_skips_when_header_has_no_issue(self, tmp_path):
+        """A header with no issue reference cannot be wrong - skipped."""
+        f = _write(
+            tmp_path,
+            "configs/training/ppo/ablations/scout.yaml",
+            "# Full-surface scout recipe.\n" + _IDENTITY_3068,
+        )
+        result = find_provenance_mismatches([f])
+        assert result["status"] == "pass"
+
+    def test_skips_when_identity_ambiguous(self, tmp_path):
+        """Identity fields referencing multiple issues are not actioned."""
+        content = (
+            "# Issue-1024 retrain.\n"
+            "policy_id: ppo_issue_3068_issue_999_mix\n"
+            "tracking:\n  wandb:\n    group: issue-3068\n"
+        )
+        f = _write(tmp_path, "configs/training/ppo/ablations/mix.yaml", content)
+        result = find_provenance_mismatches([f])
+        assert result["status"] == "pass"
+
+    def test_ignores_non_training_configs(self, tmp_path):
+        """Configs outside configs/training/ are not scanned."""
+        f = _write(
+            tmp_path,
+            "configs/benchmarks/scout.yaml",
+            "# Issue-1024 retrain.\n" + _IDENTITY_3068,
+        )
+        result = find_provenance_mismatches([f])
+        assert result["status"] == "pass"
+        assert "nothing to check" in result["message"].lower()
+
+    def test_repo_training_tree_is_consistent(self):
+        """The real configs/training/ tree must already pass."""
+        root = Path("configs/training")
+        files = [str(p) for p in root.rglob("*") if p.is_file() and p.suffix in {".yaml", ".yml"}]
+        result = find_provenance_mismatches(files)
+        assert result["status"] == "pass", result["message"]


### PR DESCRIPTION
## Summary

Closes #3606. Adds a pre-commit lint that catches issue-provenance mismatches
in cloned training configs — the #3570 pattern, where a config's leading header
comment named "Issue-1024" while its `policy_id`, tracking `group`, and `tags`
all targeted issue-3068.

One of the reliability follow-ups from the 2026-06-25 PR review batch (sibling
issues #3604, #3605, #3607).

## How it works

Training configs are cloned from a "leader" recipe (the intended workflow), so
the header issue reference is easy to leave stale. The check keys off the
**in-file identity fields as the source of truth**:

- Collects issue numbers from `policy_id`, tracking `group`, `tags`, and
  `campaign_id`.
- Acts only when those agree on a **single canonical issue**.
- Reads the **leading comment block** and flags it if it references issue
  numbers but **not** the canonical one.

Deliberately conservative to avoid false positives:

- A header that cites a leader/source issue *alongside* the canonical one passes
  (e.g. "Issue-3068 scout; clones the issue-791 leader recipe").
- A header with no issue reference passes (can't be wrong).
- Ambiguous identity (multiple distinct issue numbers) is skipped.

**Immutable-config consideration** (raised by CodeRabbit on #3570): ablation
configs map to already-run SLURM jobs and are treated as historical records.
Correcting a *comment* does not change run semantics, so the check still
applies — but a header annotated with `# allow-provenance-mismatch: <reason>`
is exempt for the rare case where editing a historical header is undesirable.

## What landed

- `hooks/check_config_provenance.py` — the check (mirrors the existing
  `hooks/prevent_schema_duplicates.py` convention; structured pass/fail result).
- `.pre-commit-config.yaml` — wired as `check-config-provenance`, scoped to
  `^configs/training/.*\.ya?ml$`.
- `tests/integration/test_check_config_provenance.py` — 8 tests: misattribution
  flagged, consistent passes, source+canonical passes, allow-annotation exempts,
  no-issue header skipped, ambiguous identity skipped, non-training ignored, and
  a real-tree consistency check over `configs/training/`.

## Validation

- `uv run pytest tests/integration/test_check_config_provenance.py -q` → 8 passed
- `uv run python hooks/check_config_provenance.py --all` → exit 0 (real
  `configs/training/` tree is already consistent)
- `uv run ruff check` / `ruff format` → clean

## Claim boundary

Tooling/provenance hardening. No behavioral change to training or benchmark
runs; no config content edited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
