### PR TITLE
perf(planner): cache motion-planning grid to unblock the #1554 S20 matrix

### DIFF
--- a/configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml
+++ b/configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml
@@ -1,0 +1,34 @@
+# CPU-forced issue-791 PPO baseline for paper-matrix reruns that need
+# deterministic memory behavior over GPU throughput.
+#
+# Sibling of ppo_issue_791_eval_aligned_large_capacity_portable.yaml. It keeps
+# the same promoted model and observation contract, but pins both PPO inference
+# and predictive foresight to CPU so large multi-planner benchmark matrices do
+# not repeatedly load the policy onto a shared GPU and exhaust device memory.
+#
+# Source job: 11724 (auxme-imech093, l40s, 8h04m).
+# WandB run: ll7/robot_sf/ibo3aqus
+# Best eval (70 episodes, ppo_full_maintained_eval_v1):
+# success_rate=0.929, collision_rate=0.071, SNQI=0.353
+# Best step: 9,961,472 / 10,000,000.
+#
+# CAVEAT: policy was trained on eval superset
+# (configs/scenarios/sets/ppo_full_maintained_eval_v1.yaml). Eval numbers are
+# in-distribution; report benchmark-set performance, not OOD generalization.
+model_id: ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417
+device: cpu
+deterministic: true
+obs_mode: dict
+predictive_foresight_enabled: true
+predictive_foresight_model_id: predictive_proxy_selected_v2_full
+predictive_foresight_device: cpu
+predictive_foresight_max_agents: 16
+predictive_foresight_horizon_steps: 8
+predictive_foresight_rollout_dt: 0.2
+predictive_foresight_near_distance: 0.7
+predictive_foresight_front_corridor_length: 3.0
+predictive_foresight_front_corridor_half_width: 1.0
+action_space: unicycle
+v_max: 2.0
+omega_max: 1.0
+fallback_to_goal: false

--- a/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
@@ -63,57 +63,51 @@ release_tag: "{release_tag}"
 doi: 10.5281/zenodo.<record-id>
 paper_interpretation_profile: issue-1554-s20-scenario-horizons-h500
 
+# PPO is pinned to a CPU-forced config for the long S20 matrix. Job 13044 showed
+# repeated CUDA model loads can exhaust A30 memory before the PPO row completes.
 planners:
-  - key: prediction_planner
-    algo: prediction_planner
-    planner_group: experimental
-    algo_config: configs/algos/prediction_planner_camera_ready.yaml
-    benchmark_profile: experimental
-
-  - key: goal
-    algo: goal
-    planner_group: core
-    benchmark_profile: baseline-safe
-
-  - key: social_force
-    algo: social_force
-    planner_group: core
-    benchmark_profile: baseline-safe
-
-  - key: orca
-    algo: orca
-    planner_group: core
-    benchmark_profile: baseline-safe
-    socnav_missing_prereq_policy: fallback
-
-  - key: ppo
-    algo: ppo
-    planner_group: experimental
-    algo_config: configs/baselines/ppo_issue_791_eval_aligned_large_capacity.yaml
-    benchmark_profile: experimental
-    adapter_impact_eval: true
-    workers: 1
-
-  - key: socnav_sampling
-    algo: socnav_sampling
-    planner_group: experimental
-    benchmark_profile: experimental
-    socnav_missing_prereq_policy: fail-fast
-
-  - key: sacadrl
-    algo: sacadrl
-    planner_group: experimental
-    benchmark_profile: experimental
-    socnav_missing_prereq_policy: fallback
-
-  - key: scenario_adaptive_hybrid_orca_v1
-    algo: hybrid_rule_local_planner
-    planner_group: experimental
-    algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
-    benchmark_profile: experimental
-
-  - key: hybrid_rule_v3_fast_progress_static_escape
-    algo: hybrid_rule_local_planner
-    planner_group: experimental
-    algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
-    benchmark_profile: experimental
+- key: prediction_planner
+  algo: prediction_planner
+  planner_group: experimental
+  algo_config: configs/algos/prediction_planner_camera_ready.yaml
+  benchmark_profile: experimental
+- key: goal
+  algo: goal
+  planner_group: core
+  benchmark_profile: baseline-safe
+- key: social_force
+  algo: social_force
+  planner_group: core
+  benchmark_profile: baseline-safe
+- key: orca
+  algo: orca
+  planner_group: core
+  benchmark_profile: baseline-safe
+  socnav_missing_prereq_policy: fallback
+- key: ppo
+  algo: ppo
+  planner_group: experimental
+  algo_config: configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml
+  benchmark_profile: experimental
+  adapter_impact_eval: true
+  workers: 1
+- key: socnav_sampling
+  algo: socnav_sampling
+  planner_group: experimental
+  benchmark_profile: experimental
+  socnav_missing_prereq_policy: fail-fast
+- key: sacadrl
+  algo: sacadrl
+  planner_group: experimental
+  benchmark_profile: experimental
+  socnav_missing_prereq_policy: fallback
+- key: scenario_adaptive_hybrid_orca_v1
+  algo: hybrid_rule_local_planner
+  planner_group: experimental
+  algo_config: configs/policy_search/candidates/scenario_adaptive_hybrid_orca_v1.yaml
+  benchmark_profile: experimental
+- key: hybrid_rule_v3_fast_progress_static_escape
+  algo: hybrid_rule_local_planner
+  planner_group: experimental
+  algo_config: configs/policy_search/candidates/hybrid_rule_v3_fast_progress_static_escape.yaml
+  benchmark_profile: experimental

--- a/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
@@ -43,7 +43,7 @@ snqi_contract:
   calibration_seed: 123
   calibration_trials: 6000
 
-workers: 2
+workers: 12
 dt: 0.1
 record_forces: true
 resume: true

--- a/robot_sf/planner/classic_global_planner.py
+++ b/robot_sf/planner/classic_global_planner.py
@@ -690,6 +690,7 @@ class ClassicGlobalPlanner:
         self._width_cells = math.ceil(self.map_def.width * self.config.cells_per_meter)
         self._height_cells = math.ceil(self.map_def.height * self.config.cells_per_meter)
         self._grid: Grid | None = None
+        self._base_grids: dict[int | None, Grid] = {}
         self._last_path_world: list[tuple[float, float]] | None = None
         self._last_path_grid: list[tuple[int, int]] | None = None
         self._last_path_info: dict | None = None
@@ -737,6 +738,21 @@ class ClassicGlobalPlanner:
             inflation=inflate_radius_cells,
         )
         return grid
+
+    def _base_grid_for(self, inflate_radius_cells: int | None) -> Grid:
+        """Return a cached obstacle grid for the given inflation radius.
+
+        The rasterized grid depends only on the static map and the inflation
+        radius, so it is built once per radius and reused across plan() calls
+        instead of re-rasterizing the map on every call. Callers that mutate the
+        grid (e.g. writing START/GOAL cells) must copy it first; see
+        ``_run_single_plan``.
+        """
+        cached = self._base_grids.get(inflate_radius_cells)
+        if cached is None:
+            cached = self._build_grid(inflate_radius_cells)
+            self._base_grids[inflate_radius_cells] = cached
+        return cached
 
     def _world_to_grid(self, world_x: float, world_y: float) -> tuple[int, int]:
         """Convert world coordinates to grid indices.
@@ -922,7 +938,9 @@ class ClassicGlobalPlanner:
             algo: Normalized algorithm name.
             inflation: Inflation radius in cells for this attempt.
         """
-        grid = self._build_grid(inflation)
+        # Reuse a cached base grid for this inflation radius and copy it so the
+        # per-call START/GOAL mutations below never leak into the cache.
+        grid = copy.deepcopy(self._base_grid_for(inflation))
         self._validate_grid_point("start", *start_grid, grid=grid)
         self._validate_grid_point("goal", *goal_grid, grid=grid)
         grid.type_map[start_grid[0]][start_grid[1]] = TYPES.START

--- a/tests/baselines/test_ppo_planner.py
+++ b/tests/baselines/test_ppo_planner.py
@@ -440,7 +440,9 @@ def test_issue_791_cpu_baseline_forces_cpu_inference(monkeypatch, tmp_path):
     resolved_model = tmp_path / "model.zip"
     resolved_model.write_text("checkpoint", encoding="utf-8")
 
-    monkeypatch.setattr("robot_sf.baselines.ppo.resolve_model_path", lambda _model_id: resolved_model)
+    monkeypatch.setattr(
+        "robot_sf.baselines.ppo.resolve_model_path", lambda _model_id: resolved_model
+    )
     monkeypatch.setattr(
         "robot_sf.baselines.ppo.PPO",
         SimpleNamespace(load=lambda path, **kwargs: {"path": path, **kwargs}),

--- a/tests/baselines/test_ppo_planner.py
+++ b/tests/baselines/test_ppo_planner.py
@@ -433,6 +433,26 @@ def test_issue_791_portable_baseline_uses_registry_and_auto_device(monkeypatch, 
     assert planner._model["path"] == str(resolved_model)
 
 
+def test_issue_791_cpu_baseline_forces_cpu_inference(monkeypatch, tmp_path):
+    """The issue-1554 CPU-safe baseline must not load PPO or foresight on CUDA."""
+    config_path = Path("configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml")
+    config = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    resolved_model = tmp_path / "model.zip"
+    resolved_model.write_text("checkpoint", encoding="utf-8")
+
+    monkeypatch.setattr("robot_sf.baselines.ppo.resolve_model_path", lambda _model_id: resolved_model)
+    monkeypatch.setattr(
+        "robot_sf.baselines.ppo.PPO",
+        SimpleNamespace(load=lambda path, **kwargs: {"path": path, **kwargs}),
+    )
+
+    planner = PPOPlanner(config)
+
+    assert config["device"] == "cpu"
+    assert config["predictive_foresight_device"] == "cpu"
+    assert planner._model["device"] == "cpu"
+
+
 def test_load_model_resolution_failure_falls_back(monkeypatch):
     """Registry resolution failures should trigger fallback_to_goal when enabled."""
     monkeypatch.setattr(

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -1994,7 +1994,7 @@ def test_paper_extended_seed_configs_preserve_v1_matrix_contract() -> None:
 
 
 def test_issue_1554_h500_s20_config_preserves_h500_matrix_contract() -> None:
-    """Issue #1554 S20 config should change only the h500 seed schedule."""
+    """Issue #1554 S20 config preserves h500 matrix except PPO CPU safety."""
     base_cfg = load_campaign_config(
         Path("configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml")
     )
@@ -2010,7 +2010,29 @@ def test_issue_1554_h500_s20_config_preserves_h500_matrix_contract() -> None:
     assert s20_cfg.kinematics_matrix == base_cfg.kinematics_matrix == ("differential_drive",)
     assert s20_cfg.seed_policy.mode == "seed-set"
     assert s20_cfg.seed_policy.seed_set == "paper_eval_s20"
-    assert s20_cfg.planners == base_cfg.planners
+
+    base_planners = {planner.key: planner for planner in base_cfg.planners}
+    s20_planners = {planner.key: planner for planner in s20_cfg.planners}
+    assert set(s20_planners) == set(base_planners)
+    for key, planner in s20_planners.items():
+        if key == "ppo":
+            continue
+        assert planner == base_planners[key]
+
+    assert s20_planners["ppo"].workers_override == base_planners["ppo"].workers_override == 1
+    assert s20_planners["ppo"].algo == base_planners["ppo"].algo == "ppo"
+    assert (
+        s20_planners["ppo"].algo_config_path
+        == Path("configs/baselines/ppo_issue_791_eval_aligned_large_capacity_cpu.yaml").resolve()
+    )
+    ppo_cfg = yaml.safe_load(s20_planners["ppo"].algo_config_path.read_text(encoding="utf-8"))
+    assert (
+        ppo_cfg["model_id"]
+        == "ppo_expert_issue_791_reward_curriculum_eval_aligned_large_capacity_20260417"
+    )
+    assert ppo_cfg["device"] == "cpu"
+    assert ppo_cfg["predictive_foresight_device"] == "cpu"
+    assert ppo_cfg["fallback_to_goal"] is False
     assert _resolved_seed_inventory(_load_campaign_scenarios(s20_cfg)) == list(range(111, 131))
 
 

--- a/tests/test_classic_global_planner_unit.py
+++ b/tests/test_classic_global_planner_unit.py
@@ -9,6 +9,7 @@ from python_motion_planning.common import TYPES
 
 from robot_sf.nav.svg_map_parser import convert_map
 from robot_sf.planner import ClassicGlobalPlanner, ClassicPlannerConfig, PlanningError
+from robot_sf.planner.classic_global_planner import _grid_type_map_array
 
 
 def _make_basic_map(tmp_path):
@@ -182,6 +183,64 @@ def test_plan_returns_expand_metadata(tmp_path):
     assert info.get("expand")
     assert info.get("inflation_cells") == 0
     assert info.get("length", 0) == pytest.approx(expected_goal[0] - expected_start[0])
+
+
+def test_plan_caches_grid_per_inflation_radius(tmp_path):
+    """plan() should rasterize the grid once per inflation radius, not per call."""
+    map_def = _make_basic_map(tmp_path)
+    planner = ClassicGlobalPlanner(
+        map_def,
+        ClassicPlannerConfig(
+            cells_per_meter=1.0,
+            inflate_radius_cells=0,
+            add_boundary_obstacles=False,
+        ),
+    )
+
+    build_calls = {"n": 0}
+    original_build = planner._build_grid
+
+    def counting_build(inflation):
+        build_calls["n"] += 1
+        return original_build(inflation)
+
+    planner._build_grid = counting_build  # type: ignore[method-assign]
+
+    start = (0.5, 0.5)
+    goal = (4.5, 0.5)
+    path1, _ = planner.plan(start, goal)
+    path2, _ = planner.plan(start, goal)
+
+    assert path1 and path2
+    assert path1 == path2
+    # The grid depends only on the static map + inflation radius, so it must be
+    # built once for inflation=0 and reused on the second plan() call.
+    assert build_calls["n"] == 1
+
+
+def test_cached_grid_is_not_mutated_by_plan(tmp_path):
+    """START/GOAL writes must land on per-call copies, never the cached base grid."""
+    map_def = _make_basic_map(tmp_path)
+    planner = ClassicGlobalPlanner(
+        map_def,
+        ClassicPlannerConfig(
+            cells_per_meter=1.0,
+            inflate_radius_cells=0,
+            add_boundary_obstacles=False,
+        ),
+    )
+
+    first, _ = planner.plan((0.5, 0.5), (4.5, 0.5))
+    planner.plan((0.5, 0.5), (3.5, 0.5))  # a different goal must not corrupt the cache
+    repeat, _ = planner.plan((0.5, 0.5), (4.5, 0.5))
+
+    # Deterministic: reusing the cached grid does not leak state between calls.
+    assert first == repeat
+
+    cached = planner._base_grids[0]
+    type_map = _grid_type_map_array(cached)
+    assert not (type_map == TYPES.START).any()
+    assert not (type_map == TYPES.GOAL).any()
 
 
 def test_plan_accepts_algorithm_override(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Throughput unblockers for the #1554 S20 H500 camera-ready matrix, which timed out
at 12h (job 13084) after finishing only ~8 planner families and writing no
`matrix_summary.json`.

### Root cause of the slowness
`ClassicGlobalPlanner` rebuilt the rasterized motion-planning grid on **every**
`plan()` call (`_run_single_plan -> _build_grid`). In job 13084 this re-rasterized
the 88x80 grid **7,146 times** (once per `theta_star` plan call) — exactly the
dominant cost: `prediction_planner` took 4h43m and the two hybrid-rule planners
~3h50m + ~2h17m (killed mid-run).

### Changes
- **Cache the grid per inflation radius** (`self._base_grids`). The grid depends
  only on the static map + inflation radius, so it is built once per radius and
  reused. `_run_single_plan` gets a `deepcopy` so the per-call START/GOAL writes
  never leak into the cache — behavior is identical to a freshly built grid.
- **Raise matrix workers 2 -> 12** in
  `paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml` (the job requests
  20 CPUs but ran ~18 idle). PPO stays pinned at `workers=1`.
- (already on branch) **force PPO to CPU** for the long S20 matrix to avoid the
  A30 CUDA OOM seen in job 13044.

### Tests
- `test_plan_caches_grid_per_inflation_radius`: grid built once per inflation
  radius across multiple `plan()` calls.
- `test_cached_grid_is_not_mutated_by_plan`: the cached base grid carries no
  START/GOAL cells after planning, and repeated plans stay deterministic.

All 16 tests in `tests/test_classic_global_planner_unit.py` pass; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
