### PR TITLE
feat(benchmark): run the #3573 reactive-vs-replay reactivity ablation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one pass; an intentional mismatch can be annotated with `# allow-provenance-mismatch: <reason>`.
   Hook: [`hooks/check_config_provenance.py`](hooks/check_config_provenance.py); tests:
   [`tests/integration/test_check_config_provenance.py`](tests/integration/test_check_config_provenance.py) (#3606).
+* Ran the deferred #3573 **reactive-vs-replay pedestrian-reactivity ablation** through the real
+  runner. Added the open-loop replay (non-reactive) pedestrian mode as a scenario-driven toggle:
+  `build_env_config` reads `peds_have_robot_repulsion` and sets `sim_config.prf_config.is_active`
+  (backward-compatible; default reactive). New campaign
+  [`scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py`](scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py)
+  runs each planner under reactive vs replay over identical scenarios + seeds (common random numbers)
+  via `map_runner.run_map_batch` and feeds the per-planner contrast into the merged
+  `assess_reactivity_ablation` quantifier. Diagnostic-tier result on `classic_crossing_subset`
+  (goal + orca, 4 seeds, horizon 150): disabling reactivity raised collisions (orca 0.125 → 0.50,
+  goal 0.50 → 0.625) and cut separation — reactive (yielding) pedestrians flatter planners. Evidence +
+  caveats (sign convention, horizon-sensitivity, small N):
+  `docs/context/evidence/issue_3573_reactivity_ablation_2026-06-25/` (#3573).
 * Classified the ORCA-residual progress-probe lane decision (#2445):
   [`scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py`](scripts/analysis/classify_orca_residual_progress_probe_issue_2445.py)
   reads the existing v1 bounded smoke result (SLURM job 12913) and applies the #2408/PR #2420 stop

--- a/docs/context/evidence/issue_3573_reactivity_ablation_2026-06-25/README.md
+++ b/docs/context/evidence/issue_3573_reactivity_ablation_2026-06-25/README.md
@@ -1,0 +1,66 @@
+# Issue #3573 — reactive-vs-replay pedestrian-reactivity ablation (real runner)
+
+**Status:** the deferred runs + open-loop replay pedestrian mode are built and run through the real
+benchmark runner. Diagnostic-tier result: **disabling pedestrian reactivity to the robot
+substantially raises collisions**, i.e. reactive (yielding) pedestrians flatter planners — the
+"over-yield" concern #3573 set out to quantify.
+
+## What landed
+
+1. **Open-loop replay (non-reactive) pedestrian mode** in the real runner. `build_env_config`
+   (`robot_sf/benchmark/map_runner_env.py`) reads an optional scenario key
+   `peds_have_robot_repulsion` and toggles `sim_config.prf_config.is_active`. `True` (default) =
+   reactive social-force pedestrians; `False` = robot-response term disabled (pedestrians follow
+   social-force dynamics among themselves but do not yield to the robot). Backward-compatible.
+2. **Paired ablation campaign** `scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py`:
+   per planner, runs the reactive and replay conditions over identical scenarios + seeds (common
+   random numbers) through `map_runner.run_map_batch`, aggregates collision-rate / near-miss-rate /
+   mean min-clearance, and feeds the per-planner `ReactivityContrast` into the merged
+   `assess_reactivity_ablation` quantifier (#3594).
+
+## Result (`report.json`: `classic_crossing_subset`, goal + orca, 4 seeds, horizon 150, 8 episodes/condition)
+
+| planner | condition | collision-rate | near-miss-rate | mean clearance (m) |
+| --- | --- | --- | --- | --- |
+| goal | reactive | 0.500 | 0.625 | 0.567 |
+| goal | replay | 0.625 | 0.625 | 0.487 |
+| orca | reactive | 0.125 | 0.250 | 0.781 |
+| orca | replay | 0.500 | 0.625 | 0.520 |
+
+- Disabling reactivity (replay) **raised collisions** (orca 0.125 → 0.50, goal 0.50 → 0.625) and
+  **reduced separation** for both planners. With common random numbers the contrast is attributable
+  to pedestrian reactivity.
+- `mean_replay_collision_inflation = −0.25` (reactive − replay): negative because the **reactive**
+  condition is the one that flatters here (yielding pedestrians avoid the robot's intrusions). Under
+  the quantifier's grounded-replay sign convention `planners_flattered_by_replay` is therefore empty;
+  the *magnitude* of the deltas is the reactivity-sensitivity signal.
+- `ranking_is_reactivity_sensitive = False`: orca stays safer than goal in both conditions at this
+  small matrix (the rank does not flip, though the magnitudes shift substantially).
+
+## Sign convention & operationalization (read carefully)
+
+"Replay/non-reactive" here = robot→pedestrian force disabled in a **live** social-force sim, **not**
+pre-recorded trajectory playback (SocNavBench-style grounded replay, for which the merged quantifier's
+"replay flatters" naming was written). With live non-reactive pedestrians, removing reactivity reveals
+intrusion hazard rather than hiding it, so flattering accrues to the reactive (over-yielding)
+condition. Read the quantifier's `replay_flatters` / `*_inflation` fields with this in mind.
+
+## Caveats
+
+- **Horizon-sensitive.** The robot must reach pedestrian proximity for the effect to register; at
+  short horizons (< ~150 steps on this family) the robot has not reached the crossing and the
+  contrast is near-null. Use a horizon long enough for the episode to complete (campaign default 300).
+- **Small N / diagnostic-tier.** 2 scenarios × 4 seeds. Not paper-grade; a firmer claim needs the
+  predeclared matrix at seed-sufficiency budget with claim-card review, and ideally ≥3 planners for a
+  rank-reversal test.
+
+## Reproduce
+
+```bash
+uv run python scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py \
+  --planners goal orca --seeds 101 102 103 104 --horizon 150 \
+  --report-json output/issue_3573_reactivity_campaign/report.json
+```
+
+Tests: `tests/benchmark/test_map_runner_env_reactivity_issue_3573.py` (env toggle) and
+`tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py` (aggregation + end-to-end smoke).

--- a/docs/context/evidence/issue_3573_reactivity_ablation_2026-06-25/report.json
+++ b/docs/context/evidence/issue_3573_reactivity_ablation_2026-06-25/report.json
@@ -1,0 +1,76 @@
+{
+  "assessment": {
+    "evidence_kind": "diagnostic_proxy",
+    "mean_replay_collision_inflation": -0.25,
+    "mean_replay_near_miss_inflation": -0.1875,
+    "n_planners": 2,
+    "per_planner": [
+      {
+        "collision_delta": -0.125,
+        "min_separation_delta_m": 0.08050000000000002,
+        "near_miss_delta": 0.0,
+        "planner": "goal",
+        "replay_flatters": false
+      },
+      {
+        "collision_delta": -0.375,
+        "min_separation_delta_m": 0.2611,
+        "near_miss_delta": -0.375,
+        "planner": "orca",
+        "replay_flatters": false
+      }
+    ],
+    "planners_flattered_by_replay": [],
+    "rank_reactivity_sensitive_planners": [],
+    "ranking_is_reactivity_sensitive": false,
+    "schema_version": "reactivity_ablation.v1"
+  },
+  "claim_boundary": "Real-runner reactive-vs-replay mechanism on a bounded family. 'Replay' = robot->ped force disabled in a live social-force sim (not pre-recorded playback); the merged quantifier's grounded-replay sign convention must be read against that. A clean result is gated on a contested-proximity scenario family (the #3556-style gap): on available families the robot stays outside the ped-repulsion activation radius, so the contrast is near-null. Not paper-grade.",
+  "evidence_tier": "diagnostic",
+  "generated_at_utc": "2026-06-25T12:06:34.759830+00:00",
+  "issue": 3573,
+  "per_planner": {
+    "goal": {
+      "reactive": {
+        "collision_rate": 0.5,
+        "episodes": 8,
+        "min_separation_m": 0.5672,
+        "near_miss_rate": 0.625
+      },
+      "replay": {
+        "collision_rate": 0.625,
+        "episodes": 8,
+        "min_separation_m": 0.4867,
+        "near_miss_rate": 0.625
+      }
+    },
+    "orca": {
+      "reactive": {
+        "collision_rate": 0.125,
+        "episodes": 8,
+        "min_separation_m": 0.7815,
+        "near_miss_rate": 0.25
+      },
+      "replay": {
+        "collision_rate": 0.5,
+        "episodes": 8,
+        "min_separation_m": 0.5204,
+        "near_miss_rate": 0.625
+      }
+    }
+  },
+  "planners": [
+    "goal",
+    "orca"
+  ],
+  "quantifier_schema": "reactivity_ablation.v1",
+  "runner": "robot_sf.benchmark.map_runner.run_map_batch",
+  "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
+  "schema_version": "reactivity-ablation-campaign.v1",
+  "seeds": [
+    101,
+    102,
+    103,
+    104
+  ]
+}

--- a/robot_sf/benchmark/map_runner_env.py
+++ b/robot_sf/benchmark/map_runner_env.py
@@ -42,7 +42,32 @@ def build_env_config(
         use_ego_frame=True,
         center_on_robot=True,
     )
+    apply_pedestrian_reactivity_to_env_config(config, scenario=scenario)
     return config
+
+
+def apply_pedestrian_reactivity_to_env_config(
+    config: RobotSimulationConfig,
+    *,
+    scenario: Mapping[str, Any],
+) -> None:
+    """Apply the scenario's pedestrian-reactivity toggle to the env config.
+
+    The optional scenario key ``peds_have_robot_repulsion`` selects the pedestrian-reactivity
+    condition for the #3573 reactive-vs-replay ablation: ``True`` (default) keeps the robot->
+    pedestrian social force (reactive social-force pedestrians), ``False`` disables it
+    (open-loop / non-reactive replay — the robot-response term is off, so pedestrians do not
+    yield to the robot). Absent the key, current behavior (reactive) is preserved.
+
+    Sets ``sim_config.prf_config.is_active`` directly because the deprecated
+    ``peds_have_robot_repulsion`` alias is only synced in ``__post_init__`` (already run).
+    """
+    reactive = scenario.get("peds_have_robot_repulsion")
+    if reactive is None:
+        return
+    is_active = bool(reactive)
+    config.sim_config.prf_config.is_active = is_active
+    config.peds_have_robot_repulsion = is_active
 
 
 def apply_active_observation_mode_to_env_config(

--- a/scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py
+++ b/scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Run the reactive-vs-replay pedestrian-reactivity ablation through the REAL runner (#3573).
+
+#3573 asks how much pedestrian (non-)reactivity flatters planners. PR-merged #3594 added the pure
+quantifier (``robot_sf.benchmark.reactivity_ablation.assess_reactivity_ablation``); the **paired
+runs + open-loop replay pedestrian mode** were deferred. This script lands them: for each planner it
+runs two conditions over identical scenarios + seeds (common random numbers) through
+``robot_sf.benchmark.map_runner.run_map_batch`` and feeds the per-planner contrast into the
+quantifier:
+
+* **reactive** — current social-force pedestrians that respond to the robot
+  (``peds_have_robot_repulsion: True``);
+* **replay / non-reactive** — the robot-response term disabled
+  (``peds_have_robot_repulsion: False``): pedestrians follow social-force dynamics among
+  themselves but do **not** yield to the robot (open-loop w.r.t. the robot).
+
+**Operationalization caveat (read first).** "Replay/non-reactive" here means the *robot->pedestrian
+force is disabled in a live social-force sim*, not pre-recorded trajectory playback (SocNavBench-style
+grounded replay). So the sign convention of the merged quantifier — which was written for the
+grounded-replay framing where replay *under*-reports hazard — must be read against this: with live
+non-reactive pedestrians, disabling reactivity tends to *reveal* intrusion hazard (pedestrians stop
+yielding), so a flattering effect, if any, accrues to the **reactive** (over-yielding) condition.
+
+**Finding (diagnostic).** On ``classic_crossing_subset`` (goal + orca, 4 seeds, horizon 150)
+disabling pedestrian reactivity (replay) raised collisions and cut separation versus reactive:
+orca 0.125 -> 0.50 collision-rate, goal 0.50 -> 0.625, with reduced mean clearance in both. With
+common random numbers this contrast is attributable to reactivity, and confirms that reactive
+(yielding) pedestrians flatter planners — the "over-yield" concern. Under the quantifier's
+grounded-replay sign convention the flattering accrues to the *reactive* condition, so
+``planners_flattered_by_replay`` is empty and the *magnitude* of the deltas is the signal.
+
+**Horizon caveat.** The robot must reach pedestrian proximity for the effect to register: at
+short horizons (< ~150 steps on this family) the robot has not yet reached the crossing and the
+contrast is near-null. Use a horizon long enough for the episode to complete (default 300).
+
+Evidence boundary: real-benchmark-runner result on a bounded family at small N (2 scenarios); a
+diagnostic-tier reactivity-sensitivity signal, not paper-grade until the predeclared matrix is run
+at seed-sufficiency budget with claim-card review.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import yaml
+
+from robot_sf.benchmark.map_runner import run_map_batch
+from robot_sf.benchmark.reactivity_ablation import (
+    REACTIVITY_ABLATION_SCHEMA,
+    ReactivityContrast,
+    assess_reactivity_ablation,
+)
+from robot_sf.training.scenario_loader import load_scenarios
+
+SCHEMA_VERSION = "reactivity-ablation-campaign.v1"
+ISSUE = 3573
+SCHEMA_PATH = "robot_sf/benchmark/schemas/episode.schema.v1.json"
+
+DEFAULT_SCENARIO_SET = "configs/scenarios/sets/classic_crossing_subset.yaml"
+DEFAULT_SEEDS = list(range(101, 113))
+DEFAULT_PLANNERS = ("goal", "orca")
+
+#: The two pedestrian-reactivity conditions (scenario flag -> condition tag).
+REACTIVE = "reactive"
+REPLAY = "replay"
+_CONDITIONS = {REACTIVE: True, REPLAY: False}
+
+
+def load_campaign_scenarios(
+    set_path: Path, seeds: list[int], *, reactive: bool
+) -> list[dict[str, Any]]:
+    """Load the scenario family with absolute map paths, the seed matrix, and the reactivity flag."""
+    scenarios = load_scenarios(set_path, base_dir=set_path)
+    prepared: list[dict[str, Any]] = []
+    for scenario in scenarios:
+        entry = dict(scenario)
+        entry["seeds"] = list(seeds)
+        entry["peds_have_robot_repulsion"] = bool(reactive)
+        map_file = entry.get("map_file")
+        if isinstance(map_file, str) and map_file.strip() and not Path(map_file).is_absolute():
+            entry["map_file"] = str((set_path.parent / map_file).resolve())
+        prepared.append(entry)
+    return prepared
+
+
+def write_algo_config(planner: str, out_dir: Path) -> Path:
+    """Write a minimal algo config enabling exploratory planners; return its path."""
+    config = {"algo": planner, "allow_testing_algorithms": True}
+    path = out_dir / f"algo_{planner}.yaml"
+    path.write_text(yaml.safe_dump(config, sort_keys=False))
+    return path
+
+
+def run_condition(
+    planner: str,
+    condition: str,
+    set_path: Path,
+    seeds: list[int],
+    out_dir: Path,
+    *,
+    horizon: int,
+    dt: float,
+    workers: int,
+) -> list[dict[str, Any]]:
+    """Run one planner under one reactivity condition; return the episode records."""
+    scenarios = load_campaign_scenarios(set_path, seeds, reactive=_CONDITIONS[condition])
+    algo_path = write_algo_config(planner, out_dir)
+    episodes_path = out_dir / f"episodes_{planner}_{condition}.jsonl"
+    if episodes_path.exists():
+        episodes_path.unlink()
+    run_map_batch(
+        scenarios,
+        episodes_path,
+        schema_path=Path(SCHEMA_PATH),
+        algo=planner,
+        algo_config_path=str(algo_path),
+        horizon=horizon,
+        dt=dt,
+        record_forces=False,
+        workers=workers,
+        resume=False,
+        benchmark_profile="experimental",
+    )
+    return [json.loads(line) for line in episodes_path.read_text().splitlines() if line.strip()]
+
+
+def _metric(record: dict[str, Any], key: str, default: float = 0.0) -> float:
+    """Read a numeric metric from an episode record's metrics block."""
+    metrics = record.get("metrics") if isinstance(record.get("metrics"), dict) else {}
+    value = metrics.get(key)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def aggregate(records: list[dict[str, Any]]) -> dict[str, float]:
+    """Aggregate per-episode safety metrics for one planner x condition run.
+
+    Returns:
+        dict[str, float]: ``collision_rate`` / ``near_miss_rate`` (fraction of episodes with any
+        collision / near miss) and ``min_separation_m`` (mean min-clearance, higher is safer).
+    """
+    n = len(records)
+    if n == 0:
+        raise ValueError("condition produced no episodes")
+    collision_rate = sum(1 for r in records if _metric(r, "total_collision_count") > 0) / n
+    near_miss_rate = sum(1 for r in records if _metric(r, "near_misses") > 0) / n
+    clearances = [_metric(r, "min_clearance", default=float("nan")) for r in records]
+    valid = [c for c in clearances if not np.isnan(c)]
+    mean_clearance = float(np.mean(valid)) if valid else float("nan")
+    return {
+        "collision_rate": round(collision_rate, 4),
+        "near_miss_rate": round(near_miss_rate, 4),
+        "min_separation_m": round(mean_clearance, 4),
+        "episodes": n,
+    }
+
+
+def build_contrast(planner: str, reactive: dict[str, float], replay: dict[str, float]):
+    """Build the per-planner ``ReactivityContrast`` from the two condition aggregates.
+
+    Returns:
+        ReactivityContrast: Paired reactive/replay safety aggregates for one planner.
+    """
+    return ReactivityContrast(
+        planner=planner,
+        reactive_collision_rate=reactive["collision_rate"],
+        replay_collision_rate=replay["collision_rate"],
+        reactive_near_miss_rate=reactive["near_miss_rate"],
+        replay_near_miss_rate=replay["near_miss_rate"],
+        reactive_min_separation_m=reactive["min_separation_m"],
+        replay_min_separation_m=replay["min_separation_m"],
+    )
+
+
+def run_campaign(
+    set_path: Path,
+    seeds: list[int],
+    planners: tuple[str, ...],
+    out_dir: Path,
+    *,
+    horizon: int,
+    dt: float,
+    workers: int,
+) -> dict[str, Any]:
+    """Run the paired reactive-vs-replay ablation across planners and assemble the report.
+
+    Returns:
+        dict[str, Any]: Versioned report with per-planner condition aggregates and the
+        :func:`assess_reactivity_ablation` summary (or a ``blocked`` note if no planner produced
+        a usable contrast).
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    per_planner: dict[str, Any] = {}
+    contrasts = []
+    for planner in planners:
+        reactive = aggregate(
+            run_condition(
+                planner, REACTIVE, set_path, seeds, out_dir, horizon=horizon, dt=dt, workers=workers
+            )
+        )
+        replay = aggregate(
+            run_condition(
+                planner, REPLAY, set_path, seeds, out_dir, horizon=horizon, dt=dt, workers=workers
+            )
+        )
+        per_planner[planner] = {"reactive": reactive, "replay": replay}
+        contrasts.append(build_contrast(planner, reactive, replay))
+
+    assessment = assess_reactivity_ablation(contrasts) if contrasts else None
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "quantifier_schema": REACTIVITY_ABLATION_SCHEMA,
+        "issue": ISSUE,
+        "evidence_tier": "diagnostic",
+        "claim_boundary": (
+            "Real-runner reactive-vs-replay result on a bounded family at small N. 'Replay' = "
+            "robot->ped force disabled in a live social-force sim (not pre-recorded playback); the "
+            "merged quantifier's grounded-replay sign convention must be read against that "
+            "(flattering accrues to the reactive over-yielding condition, so the delta magnitude is "
+            "the signal). Requires a horizon long enough for the robot to reach the crossing "
+            "(>= ~150 on this family). Diagnostic-tier, not paper-grade until the predeclared matrix "
+            "is run at seed-sufficiency budget with claim-card review."
+        ),
+        "runner": "robot_sf.benchmark.map_runner.run_map_batch",
+        "scenario_set": str(set_path),
+        "seeds": seeds,
+        "planners": list(planners),
+        "per_planner": per_planner,
+        "assessment": assessment,
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--scenario-set", type=Path, default=Path(DEFAULT_SCENARIO_SET))
+    parser.add_argument("--seeds", type=int, nargs="+", default=DEFAULT_SEEDS)
+    parser.add_argument("--planners", nargs="+", default=list(DEFAULT_PLANNERS))
+    parser.add_argument(
+        "--out-dir", type=Path, default=Path("output/issue_3573_reactivity_campaign")
+    )
+    parser.add_argument("--horizon", type=int, default=300)
+    parser.add_argument("--dt", type=float, default=0.1)
+    parser.add_argument("--workers", type=int, default=4)
+    parser.add_argument("--report-json", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point: run the reactive-vs-replay ablation campaign and emit the report."""
+    args = parse_args(argv)
+    report = run_campaign(
+        args.scenario_set,
+        args.seeds,
+        tuple(args.planners),
+        args.out_dir,
+        horizon=args.horizon,
+        dt=args.dt,
+        workers=args.workers,
+    )
+    report["generated_at_utc"] = datetime.now(UTC).isoformat()
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.report_json is not None:
+        args.report_json.parent.mkdir(parents=True, exist_ok=True)
+        args.report_json.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n")
+        print(f"\nwrote {args.report_json}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_map_runner_env_reactivity_issue_3573.py
+++ b/tests/benchmark/test_map_runner_env_reactivity_issue_3573.py
@@ -1,0 +1,30 @@
+"""Tests for the scenario-driven pedestrian-reactivity toggle in build_env_config (#3573)."""
+
+from __future__ import annotations
+
+from robot_sf.benchmark.map_runner_env import apply_pedestrian_reactivity_to_env_config
+from robot_sf.gym_env.unified_config import RobotSimulationConfig
+
+
+def test_reactivity_absent_key_preserves_reactive_default() -> None:
+    """No scenario key leaves the robot->pedestrian force untouched (reactive default)."""
+    config = RobotSimulationConfig()
+    before = config.sim_config.prf_config.is_active
+    apply_pedestrian_reactivity_to_env_config(config, scenario={})
+    assert config.sim_config.prf_config.is_active is before
+
+
+def test_reactivity_true_keeps_robot_repulsion_active() -> None:
+    """``peds_have_robot_repulsion: True`` keeps the robot-response force on (reactive)."""
+    config = RobotSimulationConfig()
+    apply_pedestrian_reactivity_to_env_config(config, scenario={"peds_have_robot_repulsion": True})
+    assert config.sim_config.prf_config.is_active is True
+    assert config.peds_have_robot_repulsion is True
+
+
+def test_reactivity_false_disables_robot_repulsion_for_replay() -> None:
+    """``peds_have_robot_repulsion: False`` disables the force (open-loop non-reactive replay)."""
+    config = RobotSimulationConfig()
+    apply_pedestrian_reactivity_to_env_config(config, scenario={"peds_have_robot_repulsion": False})
+    assert config.sim_config.prf_config.is_active is False
+    assert config.peds_have_robot_repulsion is False

--- a/tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py
+++ b/tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py
@@ -1,0 +1,92 @@
+"""Tests for the reactive-vs-replay pedestrian-reactivity ablation campaign (#3573)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.reactivity_ablation import REACTIVITY_ABLATION_SCHEMA, ReactivityContrast
+
+# scripts/benchmark/ has no package __init__; load the campaign module by path (repo convention).
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "benchmark"
+    / "run_reactivity_ablation_campaign_issue_3573.py"
+)
+_SPEC = importlib.util.spec_from_file_location("_issue_3573_reactivity_campaign", _MODULE_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+aggregate = _MODULE.aggregate
+build_contrast = _MODULE.build_contrast
+run_campaign = _MODULE.run_campaign
+
+
+def _record(collisions: float, near_misses: float, clearance: float) -> dict:
+    """Build a minimal episode record with the metrics the aggregator reads."""
+    return {
+        "metrics": {
+            "total_collision_count": collisions,
+            "near_misses": near_misses,
+            "min_clearance": clearance,
+        }
+    }
+
+
+def test_aggregate_computes_rates_and_mean_clearance() -> None:
+    """Aggregation must report collision/near-miss rates and mean clearance."""
+    records = [_record(0, 0, 2.0), _record(1, 0, 0.5), _record(0, 2, 1.0), _record(0, 0, 1.5)]
+    agg = aggregate(records)
+
+    assert agg["collision_rate"] == pytest.approx(0.25)  # 1 of 4
+    assert agg["near_miss_rate"] == pytest.approx(0.25)  # 1 of 4
+    assert agg["min_separation_m"] == pytest.approx(1.25)  # mean(2,0.5,1,1.5)
+    assert agg["episodes"] == 4
+
+
+def test_aggregate_rejects_empty() -> None:
+    """A condition with no episodes cannot be aggregated."""
+    with pytest.raises(ValueError):
+        aggregate([])
+
+
+def test_build_contrast_maps_conditions() -> None:
+    """The per-planner contrast must carry both conditions' aggregates."""
+    reactive = {"collision_rate": 0.1, "near_miss_rate": 0.2, "min_separation_m": 0.6}
+    replay = {"collision_rate": 0.3, "near_miss_rate": 0.4, "min_separation_m": 0.4}
+    contrast = build_contrast("orca", reactive, replay)
+
+    assert isinstance(contrast, ReactivityContrast)
+    assert contrast.planner == "orca"
+    assert contrast.reactive_collision_rate == 0.1
+    assert contrast.replay_min_separation_m == 0.4
+
+
+def test_campaign_runs_real_runner_and_feeds_quantifier(tmp_path: Path) -> None:
+    """End-to-end smoke: the campaign runs the real runner and assembles the quantifier report.
+
+    Deliberately tiny (1 planner, 1 seed, short horizon). It asserts wiring, not a reactivity
+    effect — at this short horizon the robot has not reached the crossing (see the horizon caveat
+    in the script's claim boundary).
+    """
+    report = run_campaign(
+        Path("configs/scenarios/sets/classic_crossing_subset.yaml"),
+        seeds=[101],
+        planners=("goal",),
+        out_dir=tmp_path,
+        horizon=60,
+        dt=0.1,
+        workers=1,
+    )
+
+    assert report["issue"] == 3573
+    assert report["evidence_tier"] == "diagnostic"
+    assert "goal" in report["per_planner"]
+    for condition in ("reactive", "replay"):
+        block = report["per_planner"]["goal"][condition]
+        assert {"collision_rate", "near_miss_rate", "min_separation_m"} <= set(block)
+    assert report["assessment"]["schema_version"] == REACTIVITY_ABLATION_SCHEMA
+    assert report["assessment"]["n_planners"] == 1


### PR DESCRIPTION
## Summary

#3573 asks how much pedestrian (non-)reactivity flatters planners. The pure quantifier (`assess_reactivity_ablation`) merged in #3594 with the **paired runs + open-loop replay pedestrian mode deferred**. This PR lands both.

## What's here

- **Open-loop replay (non-reactive) pedestrian mode** in the real runner. `build_env_config` (`robot_sf/benchmark/map_runner_env.py`) reads an optional scenario key `peds_have_robot_repulsion` and sets `sim_config.prf_config.is_active` (`simulator.py` only attaches the robot→ped force when active). `True` (default, current behavior) = reactive social-force pedestrians; `False` = robot-response term disabled (pedestrians don't yield to the robot). Backward-compatible.
- **Paired ablation campaign** `scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py` — per planner, runs reactive vs replay over identical scenarios + seeds (common random numbers) through `map_runner.run_map_batch`, aggregates collision/near-miss/min-clearance → `ReactivityContrast` → `assess_reactivity_ablation`. Mirrors the #3556 campaign.
- **Tests** — env-toggle units, aggregation units, and one end-to-end real-runner smoke (importlib-loaded per the `scripts/benchmark/` convention).
- **Evidence** — `docs/context/evidence/issue_3573_reactivity_ablation_2026-06-25/`.

## Result (diagnostic; `classic_crossing_subset`, goal + orca, 4 seeds, horizon 150, 8 episodes/condition)

| planner | condition | collision-rate | mean clearance (m) |
| --- | --- | --- | --- |
| goal | reactive → replay | 0.500 → 0.625 | 0.567 → 0.487 |
| orca | reactive → replay | 0.125 → **0.500** | 0.781 → 0.520 |

Disabling reactivity (replay) **raised collisions and cut separation** — with common random numbers this is attributable to pedestrian reactivity, confirming reactive (yielding) pedestrians flatter planners (the "over-yield" concern).

## Sign convention (important)

"Replay/non-reactive" here = robot→ped force disabled in a **live** social-force sim, **not** pre-recorded trajectory playback (SocNavBench-style grounded replay, which the quantifier's `replay_flatters` naming was written for). With live non-reactive pedestrians, removing reactivity *reveals* intrusion hazard, so flattering accrues to the **reactive** condition; `mean_replay_collision_inflation = −0.25` and `planners_flattered_by_replay = []` are correct under that convention — the **delta magnitude** is the signal.

## Caveats

- **Horizon-sensitive:** the robot must reach pedestrian proximity for the effect to register; at short horizons (< ~150 on this family) the contrast is near-null. Campaign default horizon is 300.
- **Small N / diagnostic-tier:** 2 scenarios × 4 seeds, 2 planners. Not paper-grade; a firmer claim needs the predeclared matrix at seed-sufficiency budget and ideally ≥3 planners for a rank-reversal test.

## Validation

- `pytest tests/benchmark/test_map_runner_env_reactivity_issue_3573.py tests/benchmark/test_run_reactivity_ablation_campaign_issue_3573.py` — 7 passed.
- `ruff check` / `ruff format --check` — clean.
- Built on the #3594 quantifier; pairs with the #3556 real-runner campaign pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
