### PR TITLE
revert(planner): drop ineffective grid cache (follow-up to #3611)

### DIFF
--- a/robot_sf/planner/classic_global_planner.py
+++ b/robot_sf/planner/classic_global_planner.py
@@ -690,7 +690,6 @@ class ClassicGlobalPlanner:
         self._width_cells = math.ceil(self.map_def.width * self.config.cells_per_meter)
         self._height_cells = math.ceil(self.map_def.height * self.config.cells_per_meter)
         self._grid: Grid | None = None
-        self._base_grids: dict[int | None, Grid] = {}
         self._last_path_world: list[tuple[float, float]] | None = None
         self._last_path_grid: list[tuple[int, int]] | None = None
         self._last_path_info: dict | None = None
@@ -738,21 +737,6 @@ class ClassicGlobalPlanner:
             inflation=inflate_radius_cells,
         )
         return grid
-
-    def _base_grid_for(self, inflate_radius_cells: int | None) -> Grid:
-        """Return a cached obstacle grid for the given inflation radius.
-
-        The rasterized grid depends only on the static map and the inflation
-        radius, so it is built once per radius and reused across plan() calls
-        instead of re-rasterizing the map on every call. Callers that mutate the
-        grid (e.g. writing START/GOAL cells) must copy it first; see
-        ``_run_single_plan``.
-        """
-        cached = self._base_grids.get(inflate_radius_cells)
-        if cached is None:
-            cached = self._build_grid(inflate_radius_cells)
-            self._base_grids[inflate_radius_cells] = cached
-        return cached
 
     def _world_to_grid(self, world_x: float, world_y: float) -> tuple[int, int]:
         """Convert world coordinates to grid indices.
@@ -938,9 +922,7 @@ class ClassicGlobalPlanner:
             algo: Normalized algorithm name.
             inflation: Inflation radius in cells for this attempt.
         """
-        # Reuse a cached base grid for this inflation radius and copy it so the
-        # per-call START/GOAL mutations below never leak into the cache.
-        grid = copy.deepcopy(self._base_grid_for(inflation))
+        grid = self._build_grid(inflation)
         self._validate_grid_point("start", *start_grid, grid=grid)
         self._validate_grid_point("goal", *goal_grid, grid=grid)
         grid.type_map[start_grid[0]][start_grid[1]] = TYPES.START

--- a/tests/test_classic_global_planner_unit.py
+++ b/tests/test_classic_global_planner_unit.py
@@ -9,7 +9,6 @@ from python_motion_planning.common import TYPES
 
 from robot_sf.nav.svg_map_parser import convert_map
 from robot_sf.planner import ClassicGlobalPlanner, ClassicPlannerConfig, PlanningError
-from robot_sf.planner.classic_global_planner import _grid_type_map_array
 
 
 def _make_basic_map(tmp_path):
@@ -183,64 +182,6 @@ def test_plan_returns_expand_metadata(tmp_path):
     assert info.get("expand")
     assert info.get("inflation_cells") == 0
     assert info.get("length", 0) == pytest.approx(expected_goal[0] - expected_start[0])
-
-
-def test_plan_caches_grid_per_inflation_radius(tmp_path):
-    """plan() should rasterize the grid once per inflation radius, not per call."""
-    map_def = _make_basic_map(tmp_path)
-    planner = ClassicGlobalPlanner(
-        map_def,
-        ClassicPlannerConfig(
-            cells_per_meter=1.0,
-            inflate_radius_cells=0,
-            add_boundary_obstacles=False,
-        ),
-    )
-
-    build_calls = {"n": 0}
-    original_build = planner._build_grid
-
-    def counting_build(inflation):
-        build_calls["n"] += 1
-        return original_build(inflation)
-
-    planner._build_grid = counting_build  # type: ignore[method-assign]
-
-    start = (0.5, 0.5)
-    goal = (4.5, 0.5)
-    path1, _ = planner.plan(start, goal)
-    path2, _ = planner.plan(start, goal)
-
-    assert path1 and path2
-    assert path1 == path2
-    # The grid depends only on the static map + inflation radius, so it must be
-    # built once for inflation=0 and reused on the second plan() call.
-    assert build_calls["n"] == 1
-
-
-def test_cached_grid_is_not_mutated_by_plan(tmp_path):
-    """START/GOAL writes must land on per-call copies, never the cached base grid."""
-    map_def = _make_basic_map(tmp_path)
-    planner = ClassicGlobalPlanner(
-        map_def,
-        ClassicPlannerConfig(
-            cells_per_meter=1.0,
-            inflate_radius_cells=0,
-            add_boundary_obstacles=False,
-        ),
-    )
-
-    first, _ = planner.plan((0.5, 0.5), (4.5, 0.5))
-    planner.plan((0.5, 0.5), (3.5, 0.5))  # a different goal must not corrupt the cache
-    repeat, _ = planner.plan((0.5, 0.5), (4.5, 0.5))
-
-    # Deterministic: reusing the cached grid does not leak state between calls.
-    assert first == repeat
-
-    cached = planner._base_grids[0]
-    type_map = _grid_type_map_array(cached)
-    assert not (type_map == TYPES.START).any()
-    assert not (type_map == TYPES.GOAL).any()
 
 
 def test_plan_accepts_algorithm_override(monkeypatch, tmp_path):


### PR DESCRIPTION
## Summary

Follow-up to #3611 (already merged): remove the per-inflation grid cache from
`ClassicGlobalPlanner`. Verification on the live resubmit (job 13142) showed it
was the **wrong layer** — the camera-ready matrix's hot path
(`compute_shortest_path_length`) builds a throwaway planner per call, so the
per-instance cache is never reused and grid builds stayed 1:1 with plan calls.

The change that actually fixed the #1554 12h timeout — **workers `2 -> 12`** and
**CPU-pinned PPO** — is already on `main` and is untouched here.

This reverts only the planner caching code and its two now-pointless tests; the
14 remaining `test_classic_global_planner_unit.py` tests pass and ruff is clean.

A proper per-`map_def` grid cache (the redundant grid build is ~1s and happens
~once per episode) could be done separately if the CPU cost is worth reclaiming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
