### PR TITLE
Fix #3483 in-sim safety predicate emission

### DIFF
--- a/robot_sf/benchmark/event_ledger.py
+++ b/robot_sf/benchmark/event_ledger.py
@@ -28,6 +28,8 @@ class SurrogateEvents:
     clearance_breach: bool = False
     ttc_breach: bool = False
     oscillation: bool = False
+    late_evasive: bool = False
+    occlusion_near_miss: bool = False
 
 
 @dataclass(frozen=True, slots=True)
@@ -104,6 +106,24 @@ def _metric_value(metrics: Mapping[str, Any], *keys: str) -> tuple[float | None,
     return None, None
 
 
+def _safety_predicate_records(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Return safety predicate records from an episode record."""
+    predicates = record.get("safety_predicates")
+    return dict(predicates) if isinstance(predicates, Mapping) else {}
+
+
+def _predicate_event(
+    predicates: Mapping[str, Any],
+    predicate_key: str,
+    event_key: str,
+) -> tuple[bool, str | None]:
+    """Return a predicate event boolean and source path when present."""
+    payload = predicates.get(predicate_key)
+    if not isinstance(payload, Mapping):
+        return False, None
+    return _bool_at(payload, event_key), f"safety_predicates.{predicate_key}.{event_key}"
+
+
 def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
     """Build an ``EpisodeEventLedger.v1`` payload from an episode record.
 
@@ -131,6 +151,24 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
         "oscillation_count",
         "heading_rate_sign_changes",
     )
+    safety_predicates = _safety_predicate_records(record)
+    predicate_oscillation, predicate_oscillation_source = _predicate_event(
+        safety_predicates,
+        "oscillatory_control_predicate",
+        "oscillation",
+    )
+    late_evasive, late_evasive_source = _predicate_event(
+        safety_predicates,
+        "late_evasive_predicate",
+        "late_evasive",
+    )
+    occlusion_near_miss, occlusion_near_miss_source = _predicate_event(
+        safety_predicates,
+        "occlusion_near_miss_predicate",
+        "occlusion_near_miss",
+    )
+    if predicate_oscillation_source is not None:
+        oscillation_source = predicate_oscillation_source
 
     metric_definitions = {
         "collision_count": {
@@ -153,6 +191,14 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
             "kind": "derived",
             "source": oscillation_source or "missing",
         },
+        "late_evasive": {
+            "kind": "derived",
+            "source": late_evasive_source or "missing",
+        },
+        "occlusion_near_miss": {
+            "kind": "derived",
+            "source": occlusion_near_miss_source or "missing",
+        },
     }
     exact = ExactEvents(
         collision=_bool_at(outcome, "collision_event") or termination_reason == "collision",
@@ -165,7 +211,11 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
         near_miss=near_miss_value is not None and near_miss_value > 0.0,
         clearance_breach=min_clearance is not None and min_clearance <= 0.0,
         ttc_breach=ttc_value is not None and ttc_value > 0.0,
-        oscillation=oscillation_value is not None and oscillation_value > 0.0,
+        oscillation=predicate_oscillation
+        if predicate_oscillation_source is not None
+        else oscillation_value is not None and oscillation_value > 0.0,
+        late_evasive=late_evasive,
+        occlusion_near_miss=occlusion_near_miss,
     )
     reconciliation = {
         "collision_metric_value": collision_value,
@@ -187,6 +237,8 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
         provenance={"source": "episode_record"},
     )
     payload = ledger.to_dict()
+    if safety_predicates:
+        payload["surrogate_events"].update(safety_predicates)
     payload["reconciliation"]["audit_result"] = (
         "pass" if not reconcile_event_ledger(payload) else "fail"
     )
@@ -231,6 +283,8 @@ def reconcile_event_ledger(ledger: Mapping[str, Any]) -> list[str]:
             "clearance_breach",
             "ttc_breach",
             "oscillation",
+            "late_evasive",
+            "occlusion_near_miss",
         )
         if not isinstance(metric_definitions.get(name), Mapping)
         or not metric_definitions[name].get("kind")

--- a/robot_sf/benchmark/event_ledger_reconciliation.py
+++ b/robot_sf/benchmark/event_ledger_reconciliation.py
@@ -28,6 +28,8 @@ _REPRESENTATIVE_CONSUMERS: dict[str, tuple[str, ...]] = {
     "clearance_breach": ("aggregate", "hybrid_evidence_matrix"),
     "ttc_breach": ("aggregate",),
     "oscillation": ("safety_predicates", "aggregate"),
+    "late_evasive": ("safety_predicates", "aggregate"),
+    "occlusion_near_miss": ("safety_predicates", "aggregate"),
 }
 
 

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -88,6 +88,11 @@ from robot_sf.benchmark.path_utils import compute_shortest_path_length
 from robot_sf.benchmark.planner_command_contract import (
     validate_planner_contract as _validate_planner_contract,
 )
+from robot_sf.benchmark.safety_predicates import (
+    late_evasive_predicate,
+    occlusion_near_miss_predicate,
+    oscillatory_control_predicate,
+)
 from robot_sf.benchmark.synthetic_actuation import (
     SyntheticActuationController,
     not_available_saturation_metrics,
@@ -114,6 +119,73 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 PolicyBuilder = Callable[..., tuple[Any, dict[str, Any]]]
+
+
+def _nearest_hazard_distances(
+    robot_pos_arr: np.ndarray,
+    ped_pos_arr: np.ndarray,
+) -> np.ndarray:
+    """Return nearest pedestrian distance per episode step."""
+    step_count = int(robot_pos_arr.shape[0])
+    if step_count == 0:
+        return np.asarray([], dtype=float)
+    if ped_pos_arr.ndim < 3 or ped_pos_arr.shape[1] == 0:
+        return np.full(step_count, 1.0e9, dtype=float)
+    peds = ped_pos_arr[:step_count]
+    robot = robot_pos_arr[:step_count, np.newaxis, :]
+    return np.min(np.linalg.norm(peds - robot, axis=2), axis=1)
+
+
+def _safety_predicates_for_episode(
+    *,
+    robot_pos_arr: np.ndarray,
+    robot_vel_arr: np.ndarray,
+    robot_headings: list[float],
+    ped_pos_arr: np.ndarray,
+    dt: float,
+) -> dict[str, dict[str, Any]]:
+    """Build diagnostic safety predicate records for a completed episode.
+
+    Returns:
+        Mapping of ledger predicate keys to versioned predicate records.
+    """
+    step_count = min(len(robot_headings), int(robot_pos_arr.shape[0]))
+    if step_count < 2 or not dt > 0.0:
+        return {}
+
+    positions = np.asarray(robot_pos_arr[:step_count], dtype=float)
+    headings = np.asarray(robot_headings[:step_count], dtype=float)
+    velocities = np.asarray(robot_vel_arr[:step_count], dtype=float)
+    speeds = np.linalg.norm(velocities, axis=1) if velocities.size else np.zeros(step_count)
+    hazard_distances = _nearest_hazard_distances(positions, ped_pos_arr)[:step_count]
+
+    # Map-runner currently has simulator full-state traces, not per-step occlusion labels.
+    # Treat actors as visible with full track confidence and let the predicate emit false
+    # unless future visibility evidence shows an occluded actor emerging near a miss.
+    hazard_visible = np.ones(step_count, dtype=bool)
+    track_confidence = np.ones(step_count, dtype=float)
+
+    return {
+        "oscillatory_control_predicate": oscillatory_control_predicate(
+            positions,
+            headings,
+            speeds,
+            dt=dt,
+        ),
+        "late_evasive_predicate": late_evasive_predicate(
+            hazard_distances,
+            hazard_visible,
+            speeds,
+            dt=dt,
+        ),
+        "occlusion_near_miss_predicate": occlusion_near_miss_predicate(
+            hazard_distances,
+            hazard_visible,
+            track_confidence,
+            speeds,
+            dt=dt,
+        ),
+    }
 
 
 def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
@@ -309,6 +381,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         previous_trace_robot_pos = np.array(initial_robot_pos, dtype=float, copy=True)
         previous_trace_ped_pos: np.ndarray | None = None
         previous_trace_heading = _observation_heading(obs)
+        robot_headings: list[float] = []
         for step_idx in range(horizon_val):
             policy_obs, step_noise_stats = apply_observation_noise(obs, noise_spec, noise_rng)
             merge_observation_noise_stats(noise_stats, step_noise_stats)
@@ -375,6 +448,8 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             ped_positions.append(peds)
             if record_forces:
                 ped_forces.append(forces_arr)
+            heading = _observation_heading(obs, default=previous_trace_heading)
+            robot_headings.append(float(heading))
             if record_simulation_step_trace:
                 dt_seconds = float(config.sim_config.time_per_step_in_secs)
                 robot_velocity = (
@@ -382,7 +457,6 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     if dt_seconds > 0.0
                     else np.zeros(2, dtype=float)
                 )
-                heading = _observation_heading(obs, default=previous_trace_heading)
                 planner_payload: dict[str, Any] = {
                     "event": "step",
                     "selected_action": _command_action_payload(policy_command),
@@ -561,6 +635,13 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         _stack_ped_positions(ped_forces, fill_value=np.nan)
         if record_forces
         else np.zeros_like(ped_pos_arr, dtype=float)
+    )
+    safety_predicates = _safety_predicates_for_episode(
+        robot_pos_arr=robot_pos_arr,
+        robot_vel_arr=robot_vel_arr,
+        robot_headings=robot_headings,
+        ped_pos_arr=ped_pos_arr,
+        dt=float(config.sim_config.time_per_step_in_secs),
     )
 
     obstacles = (
@@ -772,6 +853,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         "seed": seed,
         "scenario_params": scenario_params,
         "metrics": metrics,
+        "safety_predicates": safety_predicates,
         "algorithm_metadata": algo_meta,
         "observation_noise": noise_spec,
         "observation_noise_hash": observation_noise_hash(noise_spec),

--- a/tests/benchmark/test_event_ledger.py
+++ b/tests/benchmark/test_event_ledger.py
@@ -76,6 +76,26 @@ def test_build_event_ledger_records_exact_and_surrogate_events() -> None:
     assert ledger["reconciliation"]["audit_result"] == "pass"
 
 
+def test_build_event_ledger_preserves_safety_predicate_records() -> None:
+    """Safety predicate records should be emitted inside surrogate events."""
+    record = _record(collision_event=False, collisions=0.0)
+    record["safety_predicates"] = {
+        "oscillatory_control_predicate": {"oscillation": True},
+        "late_evasive_predicate": {"late_evasive": True},
+        "occlusion_near_miss_predicate": {"occlusion_near_miss": False},
+    }
+
+    ledger = build_event_ledger(record)
+
+    surrogate_events = ledger["surrogate_events"]
+    assert surrogate_events["oscillation"] is True
+    assert surrogate_events["late_evasive"] is True
+    assert surrogate_events["occlusion_near_miss"] is False
+    assert surrogate_events["oscillatory_control_predicate"] == {"oscillation": True}
+    assert surrogate_events["late_evasive_predicate"] == {"late_evasive": True}
+    assert surrogate_events["occlusion_near_miss_predicate"] == {"occlusion_near_miss": False}
+
+
 def test_build_event_ledger_parses_string_booleans_without_truthiness_leaks() -> None:
     """String booleans from JSON-adjacent records should not rely on Python truthiness."""
     record = _record(collision_event=False, collisions=0.0)

--- a/tests/benchmark/test_event_ledger_reconciliation.py
+++ b/tests/benchmark/test_event_ledger_reconciliation.py
@@ -14,6 +14,8 @@ _EXPECTED_FIELDS = {
     "clearance_breach",
     "ttc_breach",
     "oscillation",
+    "late_evasive",
+    "occlusion_near_miss",
 }
 
 
@@ -47,6 +49,15 @@ def test_table_has_one_row_per_reported_field() -> None:
         assert row["kind"] in {"exact_or_sampled", "derived"}
         assert row["producer"]
         assert isinstance(row["representative_consumers"], list)
+    rows_by_field = {row["field"]: row for row in table["rows"]}
+    assert rows_by_field["late_evasive"]["representative_consumers"] == [
+        "safety_predicates",
+        "aggregate",
+    ]
+    assert rows_by_field["occlusion_near_miss"]["representative_consumers"] == [
+        "safety_predicates",
+        "aggregate",
+    ]
 
 
 def test_collision_count_is_exact_or_sampled_with_a_producer() -> None:

--- a/tests/benchmark/test_map_runner_safety_predicates.py
+++ b/tests/benchmark/test_map_runner_safety_predicates.py
@@ -1,0 +1,67 @@
+"""Tests for map-runner safety predicate emission."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from robot_sf.benchmark.event_ledger import build_event_ledger
+from robot_sf.benchmark.map_runner_episode import _safety_predicates_for_episode
+
+
+def test_map_runner_safety_predicates_feed_event_ledger_surrogates() -> None:
+    """Episode arrays should produce ledger-ready safety predicate records."""
+    robot_pos_arr = np.asarray(
+        [
+            [0.0, 0.0],
+            [0.1, 0.0],
+            [0.0, 0.0],
+            [0.1, 0.0],
+            [0.0, 0.0],
+            [0.1, 0.0],
+        ],
+        dtype=float,
+    )
+    robot_vel_arr = np.tile(np.asarray([[1.0, 0.0]], dtype=float), (robot_pos_arr.shape[0], 1))
+    robot_headings = [0.0, 1.0, -1.0, 1.0, -1.0, 1.0]
+    ped_pos_arr = np.tile(
+        np.asarray([[[0.2, 0.0]]], dtype=float),
+        (robot_pos_arr.shape[0], 1, 1),
+    )
+
+    safety_predicates = _safety_predicates_for_episode(
+        robot_pos_arr=robot_pos_arr,
+        robot_vel_arr=robot_vel_arr,
+        robot_headings=robot_headings,
+        ped_pos_arr=ped_pos_arr,
+        dt=0.1,
+    )
+
+    assert safety_predicates["oscillatory_control_predicate"]["oscillation"] is True
+    assert safety_predicates["late_evasive_predicate"]["late_evasive"] is True
+    assert safety_predicates["occlusion_near_miss_predicate"]["occlusion_near_miss"] is False
+
+    ledger = build_event_ledger(
+        {
+            "scenario_id": "scenario-1",
+            "seed": 7,
+            "algo": "goal",
+            "git_hash": "abc123",
+            "metrics": {"collisions": 0.0},
+            "termination_reason": "success",
+            "outcome": {
+                "route_complete": True,
+                "collision_event": False,
+                "timeout_event": False,
+            },
+            "safety_predicates": safety_predicates,
+        }
+    )
+
+    surrogate_events = ledger["surrogate_events"]
+    assert surrogate_events["oscillation"] is True
+    assert surrogate_events["late_evasive"] is True
+    assert surrogate_events["occlusion_near_miss"] is False
+    assert (
+        surrogate_events["oscillatory_control_predicate"]["schema_version"]
+        == "safety_predicate.oscillatory_control.v1"
+    )


### PR DESCRIPTION
Fixes #3483

## Scope summary
- Emits versioned safety predicate records from real map-runner episode traces under `safety_predicates`.
- Carries predicate booleans into `EpisodeEventLedger.v1` `surrogate_events`, preserving existing `SurrogateEvents.oscillation` compatibility.
- Adds first-class `late_evasive` and `occlusion_near_miss` surrogate event booleans plus reconciliation-table metadata.
- Uses the existing pure producers in `robot_sf/benchmark/safety_predicates.py`; no new benchmark semantics are introduced.

## Validation
- `git diff --check` -> passed.
- `python -m py_compile tests/benchmark/test_map_runner_safety_predicates.py robot_sf/benchmark/event_ledger.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_event_ledger_reconciliation.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_safety_predicates.py tests/benchmark/test_event_ledger.py tests/benchmark/test_event_ledger_reconciliation.py tests/benchmark/test_map_runner_safety_predicates.py -q` -> 43 passed in 4.63s.

## Out of scope
- Manuscript predicate-rate reporting.
- Real-world label validation (#3278).
- #3574, #3557, broad benchmark runs, GPU-heavy validation, or Slurm submissions.

## Residual risks
- Map-runner currently lacks per-step occlusion labels, so in-sim occlusion-near-miss emission uses full simulator visibility and should remain false until visibility evidence is wired in.
- This is focused bridge/ledger proof, not benchmark-strength evidence about predicate prevalence or planner safety rates.

## Follow-Up Issues
- #3278 tracks real-world label validation for late-evasive and oscillatory predicates; this PR only emits diagnostic in-sim predicate records.
