### PR TITLE
feat: add headless recording frame export (#3614)

### DIFF
--- a/robot_sf/render/frame_export.py
+++ b/robot_sf/render/frame_export.py
@@ -1,0 +1,223 @@
+"""Headless frame and filmstrip export for recorded simulation pickle states."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+from PIL import Image
+
+from robot_sf.render.playback_recording import load_states
+from robot_sf.render.sim_view import SimulationView
+
+if TYPE_CHECKING:
+    from robot_sf.nav.map_config import MapDefinition
+    from robot_sf.render.sim_state import VisualizableSimState
+
+
+def select_evenly_spaced_indices(total_frames: int, count: int) -> list[int]:
+    """Select deterministic, unique frame indices spanning a recording.
+
+    Returns:
+        Frame indices in ascending order.
+    """
+    if total_frames < 0:
+        raise ValueError(f"total_frames must be non-negative, got {total_frames}")
+    if count < 1:
+        raise ValueError(f"count must be positive, got {count}")
+    if total_frames == 0:
+        return []
+    if count >= total_frames:
+        return list(range(total_frames))
+    if count == 1:
+        return [0]
+
+    last_index = total_frames - 1
+    return [round(i * last_index / (count - 1)) for i in range(count)]
+
+
+def render_selected_frames(
+    states: list[VisualizableSimState],
+    map_def: MapDefinition,
+    indices: list[int],
+    *,
+    width: int = 1280,
+    height: int = 720,
+    scaling: float = 10,
+) -> list[np.ndarray]:
+    """Render selected states to RGB arrays using the headless-safe renderer path.
+
+    Returns:
+        Rendered RGB frames in the same order as ``indices``.
+    """
+    if not states or not indices:
+        return []
+
+    invalid_indices = [index for index in indices if index < 0 or index >= len(states)]
+    if invalid_indices:
+        raise IndexError(f"Frame indices out of range for {len(states)} states: {invalid_indices}")
+
+    sim_view = SimulationView(
+        width=width,
+        height=height,
+        scaling=scaling,
+        map_def=map_def,
+        caption="RobotSF Frame Export",
+        record_video=True,
+        video_path=None,
+        display_text=False,
+    )
+    try:
+        for index in indices:
+            sim_view.render(states[index])
+        return sim_view.exit_simulation(return_frames=True) or []
+    finally:
+        if not sim_view.is_exit_requested:
+            sim_view.exit_simulation()
+
+
+def write_png_frames(
+    frames: list[np.ndarray],
+    output_dir: Path | str,
+    *,
+    prefix: str = "frame",
+    indices: list[int] | None = None,
+) -> list[Path]:
+    """Write RGB frame arrays as PNG files.
+
+    Returns:
+        Paths to written PNG files in frame order.
+    """
+    output_path = Path(output_dir)
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    if indices is not None and len(indices) != len(frames):
+        raise ValueError("indices length must match frames length")
+
+    written_paths: list[Path] = []
+    for ordinal, frame in enumerate(frames):
+        frame_index = indices[ordinal] if indices is not None else ordinal
+        path = output_path / f"{prefix}_{frame_index:06d}.png"
+        Image.fromarray(np.asarray(frame, dtype=np.uint8)).save(path)
+        written_paths.append(path)
+    return written_paths
+
+
+def write_filmstrip(
+    frames: list[np.ndarray],
+    output_path: Path | str,
+    *,
+    columns: int | None = None,
+) -> Path:
+    """Write selected frames into a simple PNG filmstrip grid.
+
+    Returns:
+        Path to the written filmstrip PNG.
+    """
+    if not frames:
+        raise ValueError("Cannot write a filmstrip without frames")
+    if columns is not None and columns < 1:
+        raise ValueError(f"columns must be positive, got {columns}")
+
+    frame_images = [Image.fromarray(np.asarray(frame, dtype=np.uint8)) for frame in frames]
+    frame_width, frame_height = frame_images[0].size
+    for image in frame_images:
+        if image.size != (frame_width, frame_height):
+            raise ValueError("All filmstrip frames must have the same dimensions")
+
+    resolved_columns = columns or len(frame_images)
+    rows = int(np.ceil(len(frame_images) / resolved_columns))
+    filmstrip = Image.new("RGB", (resolved_columns * frame_width, rows * frame_height), "white")
+    for ordinal, image in enumerate(frame_images):
+        x = (ordinal % resolved_columns) * frame_width
+        y = (ordinal // resolved_columns) * frame_height
+        filmstrip.paste(image, (x, y))
+
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    filmstrip.save(path)
+    return path
+
+
+def export_pickle_frames(
+    state_file: Path | str,
+    output_dir: Path | str,
+    *,
+    count: int = 8,
+    prefix: str = "frame",
+    filmstrip_path: Path | str | None = None,
+    filmstrip_columns: int | None = None,
+    render_size: tuple[int, int] = (1280, 720),
+    scaling: float = 10,
+) -> tuple[list[Path], Path | None]:
+    """Export evenly spaced PNG frames, optionally with a filmstrip, from a pickle recording.
+
+    Returns:
+        Tuple containing written frame paths and optional filmstrip path.
+    """
+    states, map_def = load_states(str(state_file))
+    indices = select_evenly_spaced_indices(len(states), count)
+    frames = render_selected_frames(
+        states,
+        map_def,
+        indices,
+        width=render_size[0],
+        height=render_size[1],
+        scaling=scaling,
+    )
+    frame_paths = write_png_frames(frames, output_dir, prefix=prefix, indices=indices)
+    filmstrip = (
+        write_filmstrip(frames, filmstrip_path, columns=filmstrip_columns)
+        if filmstrip_path
+        else None
+    )
+    return frame_paths, filmstrip
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Export deterministic PNG frames from Robot SF pickle recordings.",
+    )
+    parser.add_argument("state_file", type=Path, help="Pickle file containing (states, map_def).")
+    parser.add_argument("output_dir", type=Path, help="Directory for exported PNG frames.")
+    parser.add_argument("--count", type=int, default=8, help="Number of evenly spaced frames.")
+    parser.add_argument("--prefix", default="frame", help="PNG filename prefix.")
+    parser.add_argument("--filmstrip", type=Path, help="Optional output PNG filmstrip path.")
+    parser.add_argument("--filmstrip-columns", type=int, help="Optional filmstrip column count.")
+    parser.add_argument("--width", type=int, default=1280, help="Render width in pixels.")
+    parser.add_argument("--height", type=int, default=720, help="Render height in pixels.")
+    parser.add_argument(
+        "--scaling", type=float, default=10, help="Renderer world-to-pixel scaling."
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for ``python -m robot_sf.render.frame_export``.
+
+    Returns:
+        Process exit code.
+    """
+    args = _build_parser().parse_args(argv)
+    frame_paths, filmstrip_path = export_pickle_frames(
+        args.state_file,
+        args.output_dir,
+        count=args.count,
+        prefix=args.prefix,
+        filmstrip_path=args.filmstrip,
+        filmstrip_columns=args.filmstrip_columns,
+        render_size=(args.width, args.height),
+        scaling=args.scaling,
+    )
+    for path in frame_paths:
+        sys.stdout.write(f"{path}\n")
+    if filmstrip_path:
+        sys.stdout.write(f"{filmstrip_path}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/robot_sf/render/playback_recording.py
+++ b/robot_sf/render/playback_recording.py
@@ -22,7 +22,8 @@ import pickle
 import loguru
 
 from robot_sf.nav.map_config import MapDefinition
-from robot_sf.render.sim_view import SimulationView, VisualizableSimState
+from robot_sf.render.sim_state import VisualizableSimState
+from robot_sf.render.sim_view import SimulationView
 
 logger = loguru.logger
 

--- a/tests/pygame/test_frame_export.py
+++ b/tests/pygame/test_frame_export.py
@@ -1,0 +1,133 @@
+"""Tests for headless frame export from pickle recordings."""
+
+from __future__ import annotations
+
+import pickle
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pytest
+from PIL import Image
+
+from robot_sf.render import frame_export
+from robot_sf.render.playback_recording import load_states
+from robot_sf.render.sim_state import VisualizableSimState
+from robot_sf.render.sim_view import _empty_map_definition
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _state(timestep: int = 0) -> VisualizableSimState:
+    """Return a small renderable state for pickle/export tests."""
+    return VisualizableSimState(
+        timestep=timestep,
+        robot_action=None,
+        robot_pose=((0.5, 0.5), 0.0),
+        pedestrian_positions=np.array([[0.25, 0.25]], dtype=float),
+        ray_vecs=np.zeros((0, 2), dtype=float),
+        ped_actions=np.array([[[0.25, 0.25], [0.35, 0.25]]], dtype=float),
+    )
+
+
+def test_load_states_accepts_base_visualizable_sim_state(tmp_path: Path) -> None:
+    """Fresh pickle states using the base sim_state dataclass are valid."""
+    pickle_path = tmp_path / "states.pkl"
+    states = [_state()]
+    map_def = _empty_map_definition()
+    with pickle_path.open("wb") as handle:
+        pickle.dump((states, map_def), handle)
+
+    loaded_states, loaded_map = load_states(str(pickle_path))
+
+    assert isinstance(loaded_states[0], VisualizableSimState)
+    assert loaded_states[0].timestep == states[0].timestep
+    np.testing.assert_array_equal(
+        loaded_states[0].pedestrian_positions,
+        states[0].pedestrian_positions,
+    )
+    assert loaded_map.width == map_def.width
+    assert loaded_map.height == map_def.height
+
+
+def test_load_states_rejects_arbitrary_objects(tmp_path: Path) -> None:
+    """The broader base-type acceptance does not accept arbitrary objects."""
+    pickle_path = tmp_path / "states.pkl"
+    with pickle_path.open("wb") as handle:
+        pickle.dump(([object()], _empty_map_definition()), handle)
+
+    with pytest.raises(TypeError, match="Invalid states"):
+        load_states(str(pickle_path))
+
+
+def test_select_evenly_spaced_indices_spans_recording() -> None:
+    """Evenly spaced selection spans endpoints and avoids duplicate requests."""
+    assert frame_export.select_evenly_spaced_indices(10, 4) == [0, 3, 6, 9]
+    assert frame_export.select_evenly_spaced_indices(3, 8) == [0, 1, 2]
+    assert frame_export.select_evenly_spaced_indices(0, 4) == []
+
+
+def test_write_png_frames_and_filmstrip(tmp_path: Path) -> None:
+    """PNG frame and filmstrip writers produce inspectable image files."""
+    frames = [
+        np.full((2, 3, 3), fill_value=0, dtype=np.uint8),
+        np.full((2, 3, 3), fill_value=255, dtype=np.uint8),
+    ]
+
+    frame_paths = frame_export.write_png_frames(
+        frames,
+        tmp_path / "frames",
+        prefix="sample",
+        indices=[0, 9],
+    )
+    filmstrip_path = frame_export.write_filmstrip(
+        frames,
+        tmp_path / "filmstrip.png",
+        columns=2,
+    )
+
+    assert [path.name for path in frame_paths] == ["sample_000000.png", "sample_000009.png"]
+    assert all(path.exists() for path in frame_paths)
+    assert Image.open(frame_paths[0]).size == (3, 2)
+    assert Image.open(filmstrip_path).size == (6, 2)
+
+
+def test_export_pickle_frames_uses_pickle_map_and_selected_states(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    """High-level export loads pickle payloads and forwards selected states/map."""
+    states = [_state(0), _state(1), _state(2)]
+    map_def = _empty_map_definition()
+    pickle_path = tmp_path / "states.pkl"
+    with pickle_path.open("wb") as handle:
+        pickle.dump((states, map_def), handle)
+
+    calls: dict[str, object] = {}
+
+    def fake_render_selected_frames(render_states, render_map, indices, **kwargs):
+        calls["states"] = render_states
+        calls["map"] = render_map
+        calls["indices"] = list(indices)
+        calls["kwargs"] = kwargs
+        return [np.zeros((2, 2, 3), dtype=np.uint8) for _ in indices]
+
+    monkeypatch.setattr(frame_export, "render_selected_frames", fake_render_selected_frames)
+
+    frame_paths, filmstrip_path = frame_export.export_pickle_frames(
+        pickle_path,
+        tmp_path / "frames",
+        count=2,
+        filmstrip_path=tmp_path / "filmstrip.png",
+        render_size=(160, 90),
+    )
+
+    render_states = calls["states"]
+    assert [state.timestep for state in render_states] == [0, 1, 2]
+    render_map = calls["map"]
+    assert render_map.width == map_def.width
+    assert render_map.height == map_def.height
+    assert calls["indices"] == [0, 2]
+    assert calls["kwargs"] == {"width": 160, "height": 90, "scaling": 10}
+    assert [path.name for path in frame_paths] == ["frame_000000.png", "frame_000002.png"]
+    assert filmstrip_path == tmp_path / "filmstrip.png"


### PR DESCRIPTION
## Summary
Adds first-class headless PNG frame and filmstrip export for pickle recordings, and fixes `load_states` so base `sim_state.VisualizableSimState` pickle states are accepted without accepting arbitrary objects.

## Linked Issues
- Closes `#3614`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Updated pickle state validation to accept the canonical base `robot_sf.render.sim_state.VisualizableSimState` type while still rejecting arbitrary objects.
- Added `robot_sf.render.frame_export` with deterministic evenly spaced frame selection, headless rendering through `SimulationView`, PNG frame writing, optional PNG filmstrip writing, and a `python -m robot_sf.render.frame_export` CLI.
- Added focused headless tests for pickle loading, state validation, frame selection, PNG writing, filmstrip writing, and pickle map/state forwarding.

## Why Matters
- Added value: regenerated still frames and filmstrips are reproducible from pickle recordings.
- Expected impact: easier visual artifact generation without manual copy/paste rendering recipes.
- Why worth merging now: it closes a small tooling gap with focused tests and no benchmark-scope change.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - artifact-generation tooling only.
- Comparator or baseline, applicable: NA.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision stop rule, applicable: issue acceptance criteria for pickle load acceptance and headless frame/filmstrip export.
- Parent issue, claim map, registry, context note, synthesis surface update: `#3614` only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - this exports images from existing recordings and makes no dissertation, paper, benchmark, metric, or research claim.

## Domain-Aware Approval
- Approver/review source waiver: not required.
- Validity checklist: NA - no evidence classification, experimental comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim surface changed.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: NA.
- Claim boundary: no dissertation/paper claim is made; this is artifact-generation tooling only.
- Implementation integrity vs experimental validity: implementation-only helper; no experimental validity claim.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - support tooling.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: NA.
- Proposed child issue existing follow-up: none.

## Validation / Proof
- `python -m py_compile robot_sf/render/playback_recording.py robot_sf/render/frame_export.py tests/pygame/test_frame_export.py`
- `git diff --check`
- `uv run ruff check robot_sf/render/playback_recording.py robot_sf/render/frame_export.py tests/pygame/test_frame_export.py`
- `uv run pytest tests/pygame/test_frame_export.py -q` (`5 passed`)
- Tiny CLI smoke: generated a temporary pickle with three `VisualizableSimState` frames and ran `uv run python -m robot_sf.render.frame_export <states.pkl> <frames-dir> --count 2 --filmstrip <filmstrip.png> --width 160 --height 90`; wrote two PNG frames and one PNG filmstrip.
- Full `scripts/dev/pr_ready_check.sh` not run: the local wrapper executes the broad core pytest lane, which is outside this issue's explicit no-broad-pytest constraint.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR links/closes issue only.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: this is support tooling for artifact generation and makes no benchmark, registry, claim-map, paper-facing, dissertation, or research-evidence change.

## Follow-Up Issues
- Deferred work: JSONL map metadata support remains optional and intentionally out of scope for this bounded issue.
- Issues opened follow-up: none.

## Reviewer Notes
- Please verify `SimulationView(record_video=True, video_path=None)` is acceptable as the offscreen frame capture path for exported stills.
- Known limitations: the new CLI targets pickle `(states, map_def)` recordings only; JSONL metadata support was intentionally not added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command-line tool to export recorded simulation playback as PNG images.
  * Supports saving individual frames and an optional filmstrip overview image.
  * Allows configuring frame count, output naming, image size, layout, and scaling.

* **Bug Fixes**
  * Improved handling of edge cases when selecting frames from recordings.
  * Ensures rendering exits cleanly even if the process is interrupted or already closed.

* **Tests**
  * Added coverage for frame selection, image export, filmstrip generation, and recording import validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->