### PR TITLE
feat(scenario): add #3484 feasibility manifest skeleton

### DIFF
--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -120,6 +120,13 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_3484_feasibility_diagnostics/`: reserved location for small dry-run
+  manifests and follow-up summaries for universally-failing scenario-family
+  feasibility diagnostics. Outputs from
+  `scripts/tools/build_feasibility_diagnostic_manifest.py` are diagnostic planning
+  artifacts only: rows start as `not_run` / `needs_evidence`, do not run planners,
+  do not certify route clearance, and are not benchmark, safety, paper, or
+  dissertation evidence.
 - `issue_3254_predictive_crossing_conflict_13042_2026-06-23/`: analysis-only
   negative result for the schema-fixed Issue #3254 predictive crossing-conflict
   rerun. Training completed on a non-degenerate `predictive_ego_v1` dataset, but

--- a/robot_sf/scenario_certification/failure_cause.py
+++ b/robot_sf/scenario_certification/failure_cause.py
@@ -17,10 +17,22 @@ Verdicts are versioned modeling choices, labeled diagnostic until validated.
 
 from __future__ import annotations
 
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
 
 FAILURE_CAUSE_SCHEMA = "scenario_failure_cause.v1"
+FEASIBILITY_DIAGNOSTIC_MANIFEST_SCHEMA = "scenario_feasibility_diagnostic_manifest.v1"
+
+DIAGNOSTIC_STATUS_NOT_RUN = "not_run"
+DIAGNOSTIC_STATUS_NEEDS_EVIDENCE = "needs_evidence"
+
+REQUIRED_DIAGNOSTIC_LANES = (
+    "route_clearance",
+    "actor_free_run",
+    "extended_time_run",
+    "oracle_or_scripted_controller",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +55,25 @@ class FamilyDiagnostics:
     actor_free_solved: bool | None = None
     extended_time_solved: bool | None = None
     oracle_solved: bool | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class FeasibilityDiagnosticRow:
+    """Dry-run diagnostic planning row for one scenario in a candidate family.
+
+    Rows created by this model are deliberately not benchmark evidence. They record
+    which scenario-family entries need follow-up feasibility diagnostics and keep the
+    failure-cause classifier in its fail-closed ``indeterminate`` state until real
+    evidence is supplied.
+    """
+
+    scenario_id: str
+    family_id: str
+    source: str
+    diagnostic_status: str = DIAGNOSTIC_STATUS_NOT_RUN
+    evidence_status: str = DIAGNOSTIC_STATUS_NEEDS_EVIDENCE
+    required_diagnostics: tuple[str, ...] = REQUIRED_DIAGNOSTIC_LANES
+    notes: str = "Dry-run planning row only; no feasibility diagnostic was executed."
 
 
 # Stable verdict vocabulary.
@@ -102,6 +133,100 @@ def classify_failure_cause(diagnostics: FamilyDiagnostics) -> dict[str, Any]:
     }
 
 
+def build_feasibility_diagnostic_manifest(
+    scenarios: Iterable[Mapping[str, Any]],
+    *,
+    source: str,
+    family_ids: Sequence[str] | None = None,
+) -> dict[str, Any]:
+    """Build a dry-run feasibility diagnostic manifest for candidate families.
+
+    The manifest prepares issue #3484 classification work without running a campaign
+    or inferring scenario validity. Every row remains ``not_run`` and
+    ``needs_evidence`` until route-clearance, actor-free, extended-time, and oracle
+    diagnostics are populated by follow-up tooling.
+
+    Returns:
+        Versioned dry-run manifest with one row per selected scenario.
+    """
+
+    selected_families = {family.casefold() for family in family_ids or ()}
+    rows: list[dict[str, Any]] = []
+    skipped = 0
+
+    for scenario in scenarios:
+        family_id = _scenario_family_id(scenario)
+        if selected_families and family_id.casefold() not in selected_families:
+            skipped += 1
+            continue
+        row = FeasibilityDiagnosticRow(
+            scenario_id=_scenario_id(scenario),
+            family_id=family_id,
+            source=source,
+        )
+        rows.append(feasibility_diagnostic_row_to_dict(row))
+
+    return {
+        "schema_version": FEASIBILITY_DIAGNOSTIC_MANIFEST_SCHEMA,
+        "issue": "3484",
+        "evidence_kind": "diagnostic_planning",
+        "claim_boundary": "diagnostic_only_not_benchmark_evidence",
+        "source": source,
+        "family_filter": list(family_ids or []),
+        "row_count": len(rows),
+        "skipped_count": skipped,
+        "required_diagnostics": list(REQUIRED_DIAGNOSTIC_LANES),
+        "rows": rows,
+    }
+
+
+def feasibility_diagnostic_row_to_dict(row: FeasibilityDiagnosticRow) -> dict[str, Any]:
+    """Convert a diagnostic planning row to JSON-safe primitives.
+
+    Returns:
+        Dictionary representation including a fail-closed indeterminate verdict.
+    """
+
+    verdict = classify_failure_cause(FamilyDiagnostics())
+    return {
+        "scenario_id": row.scenario_id,
+        "family_id": row.family_id,
+        "source": row.source,
+        "diagnostic_status": row.diagnostic_status,
+        "evidence_status": row.evidence_status,
+        "required_diagnostics": list(row.required_diagnostics),
+        "failure_cause_verdict": verdict,
+        "notes": row.notes,
+    }
+
+
+def _scenario_family_id(scenario: Mapping[str, Any]) -> str:
+    """Return the best available scenario-family identifier."""
+
+    metadata = scenario.get("metadata")
+    metadata_map = metadata if isinstance(metadata, Mapping) else {}
+    for value in (
+        metadata_map.get("scenario_family"),
+        metadata_map.get("family"),
+        metadata_map.get("archetype"),
+        scenario.get("scenario_family"),
+        scenario.get("family"),
+    ):
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "unknown"
+
+
+def _scenario_id(scenario: Mapping[str, Any]) -> str:
+    """Return a stable scenario identifier for manifest rows."""
+
+    for key in ("scenario_id", "name", "id"):
+        value = scenario.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return "unknown"
+
+
 def _decide(d: FamilyDiagnostics) -> tuple[str, str]:
     """Return the (cause, rationale) for a diagnostics bundle."""
     if d.any_planner_succeeded:
@@ -142,14 +267,21 @@ def _decide(d: FamilyDiagnostics) -> tuple[str, str]:
 
 
 __all__ = [
+    "DIAGNOSTIC_STATUS_NEEDS_EVIDENCE",
+    "DIAGNOSTIC_STATUS_NOT_RUN",
     "DYNAMIC_BLOCKING_OR_DEADLOCK",
     "FAILURE_CAUSE_SCHEMA",
+    "FEASIBILITY_DIAGNOSTIC_MANIFEST_SCHEMA",
     "INDETERMINATE",
     "INFEASIBLE_ROUTE",
     "NOT_UNIVERSALLY_FAILING",
     "PLANNER_LIMITED",
+    "REQUIRED_DIAGNOSTIC_LANES",
     "TIME_LIMITED",
     "VEHICLE_INFEASIBLE",
     "FamilyDiagnostics",
+    "FeasibilityDiagnosticRow",
+    "build_feasibility_diagnostic_manifest",
     "classify_failure_cause",
+    "feasibility_diagnostic_row_to_dict",
 ]

--- a/scripts/tools/build_feasibility_diagnostic_manifest.py
+++ b/scripts/tools/build_feasibility_diagnostic_manifest.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""Build a dry-run feasibility diagnostic manifest for issue #3484.
+
+This tool prepares the universally-failing scenario-family diagnostic worklist. It
+does not run planners, certify route feasibility, or produce benchmark evidence.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.scenario_certification.failure_cause import build_feasibility_diagnostic_manifest
+from robot_sf.training.scenario_loader import load_scenarios
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the CLI argument parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("scenario_config", type=Path, help="Scenario YAML manifest to inspect.")
+    parser.add_argument(
+        "--family",
+        action="append",
+        default=[],
+        help=(
+            "Scenario family/archetype to include. May be supplied multiple times. "
+            "Defaults to all families in the manifest."
+        ),
+    )
+    parser.add_argument("--output", type=Path, help="Write JSON report to this path.")
+    return parser
+
+
+def main() -> int:
+    """Build and emit the diagnostic planning manifest."""
+
+    args = _build_parser().parse_args()
+    scenarios = load_scenarios(args.scenario_config)
+    manifest = build_feasibility_diagnostic_manifest(
+        scenarios,
+        source=args.scenario_config.as_posix(),
+        family_ids=args.family,
+    )
+    rendered = json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    if args.output:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered, encoding="utf-8")
+    else:
+        print(rendered, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/scenario_certification/test_feasibility_diagnostic_manifest.py
+++ b/tests/scenario_certification/test_feasibility_diagnostic_manifest.py
@@ -1,0 +1,56 @@
+"""Tests issue #3484 feasibility diagnostic dry-run manifests."""
+
+from __future__ import annotations
+
+from robot_sf.scenario_certification.failure_cause import (
+    DIAGNOSTIC_STATUS_NEEDS_EVIDENCE,
+    DIAGNOSTIC_STATUS_NOT_RUN,
+    FEASIBILITY_DIAGNOSTIC_MANIFEST_SCHEMA,
+    INDETERMINATE,
+    REQUIRED_DIAGNOSTIC_LANES,
+    FeasibilityDiagnosticRow,
+    build_feasibility_diagnostic_manifest,
+    feasibility_diagnostic_row_to_dict,
+)
+
+
+def test_feasibility_diagnostic_row_is_not_run_until_evidence_exists() -> None:
+    """Dry-run rows must not imply feasibility or benchmark evidence."""
+
+    row = feasibility_diagnostic_row_to_dict(
+        FeasibilityDiagnosticRow(
+            scenario_id="classic_bottleneck_low",
+            family_id="bottleneck",
+            source="configs/scenarios/classic_interactions.yaml",
+        )
+    )
+
+    assert row["diagnostic_status"] == DIAGNOSTIC_STATUS_NOT_RUN
+    assert row["evidence_status"] == DIAGNOSTIC_STATUS_NEEDS_EVIDENCE
+    assert row["required_diagnostics"] == list(REQUIRED_DIAGNOSTIC_LANES)
+    assert row["failure_cause_verdict"]["cause"] == INDETERMINATE
+    assert row["failure_cause_verdict"]["evidence_complete"] is False
+    assert row["failure_cause_verdict"]["comparable_for_ranking"] is False
+
+
+def test_build_feasibility_manifest_filters_candidate_family() -> None:
+    """Manifest builder selects candidate families without classifying outcomes."""
+
+    scenarios = [
+        {"name": "classic_bottleneck_low", "metadata": {"archetype": "bottleneck"}},
+        {"name": "classic_cross_trap_high", "metadata": {"archetype": "cross_trap"}},
+    ]
+
+    manifest = build_feasibility_diagnostic_manifest(
+        scenarios,
+        source="configs/scenarios/classic_interactions.yaml",
+        family_ids=["bottleneck"],
+    )
+
+    assert manifest["schema_version"] == FEASIBILITY_DIAGNOSTIC_MANIFEST_SCHEMA
+    assert manifest["claim_boundary"] == "diagnostic_only_not_benchmark_evidence"
+    assert manifest["row_count"] == 1
+    assert manifest["skipped_count"] == 1
+    assert manifest["rows"][0]["scenario_id"] == "classic_bottleneck_low"
+    assert manifest["rows"][0]["family_id"] == "bottleneck"
+    assert manifest["rows"][0]["failure_cause_verdict"]["cause"] == INDETERMINATE


### PR DESCRIPTION
## Summary
- add dry-run scenario_feasibility_diagnostic_manifest.v1 row and manifest model for #3484
- add a small CLI to build diagnostic-planning manifests from scenario config metadata
- document that the generated bundle is planning-only and not benchmark, safety, paper, or dissertation evidence

## Validation
- python -m py_compile robot_sf/scenario_certification/failure_cause.py scripts/tools/build_feasibility_diagnostic_manifest.py tests/scenario_certification/test_feasibility_diagnostic_manifest.py
- git diff --check
- uv run ruff check robot_sf/scenario_certification/failure_cause.py scripts/tools/build_feasibility_diagnostic_manifest.py tests/scenario_certification/test_feasibility_diagnostic_manifest.py
- uv run pytest tests/scenario_certification/test_feasibility_diagnostic_manifest.py -q

## Claim boundary
This PR does not run planners, certify route clearance, change benchmark semantics, or make dissertation/paper-facing conclusions. It only creates a fail-closed manifest skeleton for follow-up feasibility diagnostics.

Refs #3484. Follow-up to the merged classifier slice in #3586.
