### PR TITLE
infra: enforce shared finite checks in diagnostics

### DIFF
--- a/robot_sf/benchmark/counterfactual_pair.py
+++ b/robot_sf/benchmark/counterfactual_pair.py
@@ -17,10 +17,11 @@ scenario pair and generating traces lives with parent issue #2924; pair-manifest
 
 from __future__ import annotations
 
-import math
 from collections.abc import Mapping
 from dataclasses import dataclass
 from typing import Any
+
+from robot_sf.benchmark.finite_checks import require_finite_scalar
 
 COUNTERFACTUAL_PAIR_SCHEMA = "counterfactual_pair_result.v1"
 
@@ -116,10 +117,7 @@ def _metric_value(result: Mapping[str, Any], metric: str) -> float:
     metrics = result.get("metrics")
     if not isinstance(metrics, Mapping) or metric not in metrics:
         raise ValueError(f"result.metrics is missing required metric {metric!r}")
-    value = float(metrics[metric])
-    if not math.isfinite(value):
-        raise ValueError(f"metric {metric!r} value {value} is not finite")
-    return value
+    return require_finite_scalar(f"metric {metric!r} value", metrics[metric])
 
 
 def _direction_matches(delta: float, expected_direction: str, tolerance: float) -> bool:

--- a/robot_sf/benchmark/finite_checks.py
+++ b/robot_sf/benchmark/finite_checks.py
@@ -1,0 +1,36 @@
+"""Shared fail-closed finite-value checks for diagnostic producers."""
+
+from __future__ import annotations
+
+import math
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
+
+
+def require_finite_scalar(name: str, value: float) -> float:
+    """Return ``value`` as float or raise when it is NaN/Inf."""
+    numeric = float(value)
+    if not math.isfinite(numeric):
+        raise ValueError(f"{name} is not finite: {numeric}")
+    return numeric
+
+
+def require_finite_array(name: str, values: Any) -> np.ndarray:
+    """Return ``values`` as a float64 array or raise when any entry is NaN/Inf."""
+    arr = np.asarray(values, dtype=np.float64)
+    if not np.all(np.isfinite(arr)):
+        raise ValueError(f"{name} must contain only finite values")
+    return arr
+
+
+def require_finite_fields(label: str, obj: Any, fields: Iterable[str]) -> None:
+    """Raise when any named numeric field on ``obj`` is NaN/Inf."""
+    for field in fields:
+        require_finite_scalar(f"{label}.{field}", getattr(obj, field))
+
+
+__all__ = ["require_finite_array", "require_finite_fields", "require_finite_scalar"]

--- a/robot_sf/benchmark/heterogeneous_population_metrics.py
+++ b/robot_sf/benchmark/heterogeneous_population_metrics.py
@@ -25,6 +25,8 @@ from typing import TYPE_CHECKING, Any
 
 import numpy as np
 
+from robot_sf.benchmark.finite_checks import require_finite_array, require_finite_scalar
+
 if TYPE_CHECKING:
     from collections.abc import Sequence
 
@@ -41,8 +43,7 @@ def _require_finite(name: str, value: float) -> None:
     Raises:
         ValueError: If ``value`` is not finite.
     """
-    if not math.isfinite(value):
-        raise ValueError(f"{name} must be finite, got {value}")
+    require_finite_scalar(name, value)
 
 
 @dataclass(frozen=True, slots=True)
@@ -71,9 +72,7 @@ def cvar(values: Sequence[float], alpha: float, *, higher_is_safer: bool) -> flo
         raise ValueError("values must be non-empty")
     if not (0.0 < alpha <= 1.0):
         raise ValueError("alpha must be in (0, 1]")
-    arr = np.asarray(values, dtype=np.float64)
-    if not np.all(np.isfinite(arr)):
-        raise ValueError("values must contain only finite values")
+    arr = require_finite_array("values", values)
     arr = np.sort(arr)  # ascending
     k = max(1, math.ceil(alpha * arr.size))
     tail = arr[:k] if higher_is_safer else arr[-k:]

--- a/robot_sf/benchmark/reactivity_ablation.py
+++ b/robot_sf/benchmark/reactivity_ablation.py
@@ -16,9 +16,10 @@ pure and side-effect free, mirroring the accepted decision layers in
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any
+
+from robot_sf.benchmark.finite_checks import require_finite_fields
 
 REACTIVITY_ABLATION_SCHEMA = "reactivity_ablation.v1"
 
@@ -65,12 +66,9 @@ def reactivity_delta(contrast: ReactivityContrast) -> dict[str, Any]:
     Returns:
         dict[str, Any]: Per-metric deltas and a ``replay_flatters`` flag.
     """
-    for field in _CONTRAST_METRIC_FIELDS:
-        value = getattr(contrast, field)
-        if not math.isfinite(value):
-            raise ValueError(
-                f"contrast.{field} for planner {contrast.planner!r} must be finite, got {value}"
-            )
+    require_finite_fields(
+        f"contrast for planner {contrast.planner!r}", contrast, _CONTRAST_METRIC_FIELDS
+    )
     collision_delta = contrast.reactive_collision_rate - contrast.replay_collision_rate
     near_miss_delta = contrast.reactive_near_miss_rate - contrast.replay_near_miss_rate
     separation_delta = contrast.reactive_min_separation_m - contrast.replay_min_separation_m

--- a/robot_sf/benchmark/safety_predicates.py
+++ b/robot_sf/benchmark/safety_predicates.py
@@ -21,12 +21,13 @@ the in-sim runners is a deliberate follow-up.
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from itertools import pairwise
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
+
+from robot_sf.benchmark.finite_checks import require_finite_array, require_finite_scalar
 
 if TYPE_CHECKING:
     from numpy.typing import NDArray
@@ -34,21 +35,6 @@ if TYPE_CHECKING:
 OSCILLATORY_PREDICATE_SCHEMA = "safety_predicate.oscillatory_control.v1"
 LATE_EVASIVE_PREDICATE_SCHEMA = "safety_predicate.late_evasive.v1"
 OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA = "safety_predicate.occlusion_near_miss.v1"
-
-
-def _require_finite_array(name: str, arr: NDArray[np.float64]) -> None:
-    """Fail closed when a per-step signal carries a non-finite (NaN/Inf) value.
-
-    A degraded/fallback trace can leak NaN/Inf into the float signals; ``np.unwrap``,
-    ``np.diff``, and the ``min``/``argmin`` comparisons then poison or silently
-    mis-evaluate the diagnostic booleans (fail-open). Raising names the offending
-    field so the caller drops the trace instead of trusting a not-flagged result.
-
-    Raises:
-        ValueError: If ``arr`` contains any non-finite value.
-    """
-    if not np.all(np.isfinite(arr)):
-        raise ValueError(f"{name} must contain only finite values")
 
 
 def _sign_changes(values: NDArray[np.float64]) -> int:
@@ -101,9 +87,9 @@ def oscillatory_control_predicate(
         raise ValueError("command_sources must have length N when provided")
     if n < 2:
         raise ValueError("at least two steps are required")
-    _require_finite_array("positions", pos)
-    _require_finite_array("headings", head)
-    _require_finite_array("linear_velocities", vel)
+    require_finite_array("positions", pos)
+    require_finite_array("headings", head)
+    require_finite_array("linear_velocities", vel)
 
     heading_rate = np.diff(np.unwrap(head)) / dt
     heading_rate_sign_changes = _sign_changes(heading_rate)
@@ -198,8 +184,8 @@ def late_evasive_predicate(
         raise ValueError("hazard_distances, hazard_visible, and speeds must share length N")
     if n < 2:
         raise ValueError("at least two steps are required")
-    _require_finite_array("hazard_distances", dist)
-    _require_finite_array("speeds", speed)
+    require_finite_array("hazard_distances", dist)
+    require_finite_array("speeds", speed)
 
     first_visible = _first_true_index(visible)
     conflict_entry = _first_true_index(dist <= conflict_radius_m)
@@ -320,14 +306,12 @@ def occlusion_near_miss_predicate(
         raise ValueError("all per-step signals must share length N")
     if n < 2:
         raise ValueError("at least two steps are required")
-    _require_finite_array("hazard_distances", dist)
-    _require_finite_array("track_confidence", conf)
-    _require_finite_array("speeds", speed)
-    if predicted_minimum_separation_m is not None and not math.isfinite(
-        predicted_minimum_separation_m
-    ):
-        raise ValueError(
-            f"predicted_minimum_separation_m must be finite, got {predicted_minimum_separation_m}"
+    require_finite_array("hazard_distances", dist)
+    require_finite_array("track_confidence", conf)
+    require_finite_array("speeds", speed)
+    if predicted_minimum_separation_m is not None:
+        predicted_minimum_separation_m = require_finite_scalar(
+            "predicted_minimum_separation_m", predicted_minimum_separation_m
         )
 
     min_sep_step = int(np.argmin(dist))

--- a/robot_sf/planner/stream_gap_gate_calibration.py
+++ b/robot_sf/planner/stream_gap_gate_calibration.py
@@ -14,9 +14,10 @@ this layer is pure and side-effect free, mirroring the failure-cause classifier 
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any
+
+from robot_sf.benchmark.finite_checks import require_finite_fields
 
 STREAM_GAP_CALIBRATION_SCHEMA = "stream_gap_gate_calibration.v1"
 
@@ -64,10 +65,7 @@ def _require_finite_setting(result: GateSettingResult, label: str) -> None:
     Raises:
         ValueError: If any safety aggregate of ``result`` is not finite.
     """
-    for field in _SETTING_METRIC_FIELDS:
-        value = getattr(result, field)
-        if not math.isfinite(value):
-            raise ValueError(f"{label}.{field} must be finite, got {value}")
+    require_finite_fields(label, result, _SETTING_METRIC_FIELDS)
 
 
 def classify_setting_safety(

--- a/robot_sf/representation/uncertainty_source_generalization.py
+++ b/robot_sf/representation/uncertainty_source_generalization.py
@@ -16,9 +16,10 @@ builders); this layer is pure and side-effect free, mirroring the accepted decis
 
 from __future__ import annotations
 
-import math
 from dataclasses import dataclass
 from typing import Any
+
+from robot_sf.benchmark.finite_checks import require_finite_fields
 
 UNCERTAINTY_SOURCE_GENERALIZATION_SCHEMA = "uncertainty_source_generalization.v1"
 
@@ -74,12 +75,9 @@ def classify_source(contrast: SourceContrast, thresholds: EffectThresholds | Non
     Returns:
         str: ``reproduces_unsafe_dropping`` / ``no_unsafe_dropping_effect`` / ``inconclusive``.
     """
-    for field in _CONTRAST_METRIC_FIELDS:
-        value = getattr(contrast, field)
-        if not math.isfinite(value):
-            raise ValueError(
-                f"contrast.{field} for source {contrast.source!r} must be finite, got {value}"
-            )
+    require_finite_fields(
+        f"contrast for source {contrast.source!r}", contrast, _CONTRAST_METRIC_FIELDS
+    )
     thresholds = thresholds or EffectThresholds()
     unsafe_delta = contrast.dropped_unsafe_commit_rate - contrast.retained_unsafe_commit_rate
     sep_delta = contrast.min_separation_delta_m

--- a/tests/benchmark/test_finite_checks.py
+++ b/tests/benchmark/test_finite_checks.py
@@ -1,0 +1,86 @@
+"""Shared finite-check policy tests for diagnostic producers."""
+
+from __future__ import annotations
+
+import inspect
+import math
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark import (
+    counterfactual_pair,
+    heterogeneous_population_metrics,
+    reactivity_ablation,
+    safety_predicates,
+)
+from robot_sf.benchmark.finite_checks import (
+    require_finite_array,
+    require_finite_fields,
+    require_finite_scalar,
+)
+from robot_sf.planner import stream_gap_gate_calibration
+from robot_sf.representation import uncertainty_source_generalization
+
+
+def test_require_finite_scalar_rejects_nan_and_inf() -> None:
+    """Scalar diagnostics fail closed on NaN/Inf."""
+    assert require_finite_scalar("metric", "1.25") == pytest.approx(1.25)
+    for bad in (math.nan, math.inf, -math.inf):
+        with pytest.raises(ValueError, match="metric"):
+            require_finite_scalar("metric", bad)
+
+
+def test_require_finite_array_rejects_nan_and_inf() -> None:
+    """Array diagnostics fail closed if any element is NaN/Inf."""
+    assert require_finite_array("trace", [0.0, 1.0]).tolist() == [0.0, 1.0]
+    with pytest.raises(ValueError, match="trace"):
+        require_finite_array("trace", np.array([0.0, math.nan]))
+    with pytest.raises(ValueError, match="trace"):
+        require_finite_array("trace", np.array([0.0, math.inf]))
+
+
+def test_require_finite_fields_names_offending_field() -> None:
+    """Field diagnostics identify the object and field that failed closed."""
+
+    class Row:
+        safe = 0.0
+        unsafe = math.inf
+
+    with pytest.raises(ValueError, match=r"row\.unsafe"):
+        require_finite_fields("row", Row(), ("safe", "unsafe"))
+
+
+def test_stream_gap_classifier_rejects_non_finite_safety_aggregate() -> None:
+    """The stream-gap pure decision layer raises instead of classifying NaN input."""
+    baseline = stream_gap_gate_calibration.GateSettingResult(
+        thresholds={"existence": 0.0},
+        unsafe_commit_rate=0.0,
+        collision_rate=0.0,
+        min_separation_m=1.0,
+    )
+    setting = stream_gap_gate_calibration.GateSettingResult(
+        thresholds={"existence": 0.5},
+        unsafe_commit_rate=math.nan,
+        collision_rate=0.0,
+        min_separation_m=1.0,
+    )
+
+    with pytest.raises(ValueError, match="setting.unsafe_commit_rate"):
+        stream_gap_gate_calibration.classify_setting_safety(setting, baseline)
+
+
+@pytest.mark.parametrize(
+    "module",
+    [
+        counterfactual_pair,
+        heterogeneous_population_metrics,
+        reactivity_ablation,
+        safety_predicates,
+        stream_gap_gate_calibration,
+        uncertainty_source_generalization,
+    ],
+)
+def test_diagnostic_producers_import_shared_finite_policy(module: object) -> None:
+    """Recent diagnostic producers use the shared fail-closed finite policy."""
+    assert "robot_sf.benchmark.finite_checks" in inspect.getsource(module)


### PR DESCRIPTION
## Summary
Adds a shared fail-closed finite-value helper for diagnostic producers and routes the recent NaN/Inf guards through that helper.

This is enforcement/tooling only. It does not add benchmark evidence, change metric semantics, change scenario taxonomy, change planner defaults, or update aggregate benchmark interpretations.

## Linked Issues
- Closes #3604

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `robot_sf.benchmark.finite_checks` with reusable scalar, array, and dataclass-field finite checks.
- Switched scoped diagnostic producers to the shared helper: counterfactual pairs, heterogeneous population metrics, safety predicates, reactivity ablation, stream-gap gate calibration, and uncertainty-source generalization.
- Added focused tests for the shared helper, producer policy imports, and stream-gap fail-closed behavior.

## Why Matters
- Added value: diagnostic producers now share one finite-input enforcement path instead of growing ad hoc NaN/Inf checks.
- Expected impact: non-finite diagnostic inputs raise before downstream comparisons or deltas can silently evaluate to a non-flagged result.
- Why worth merging now: issue #3604 targets evidence-quality guardrails without requiring heavy benchmarks.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/helper enforcement only.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - focused unit/policy tests only.
- Result classification: NA - no research or benchmark result.
- Decision stop rule, applicable: NA.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue linked by PR closure only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper; no research evidence interpretation.

## Domain-Aware Approval
- approval concerns experimental validity and waived / pending / blocked / not required: not required.
- Approver/review source waiver: NA.
- Validity checklist: NA.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: non-finite fallback/degraded traces fail closed at diagnostic helper boundaries; no benchmark success claim.
- Claim boundary: implementation integrity only.
- Implementation integrity vs experimental validity: validates guard behavior only, not experimental validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA.
- Extractor analysis tool needed: NA.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: NA.
- Proposed child issue existing follow-up: none.

## Validation / Proof
- `git diff --check`
- `python -m py_compile robot_sf/benchmark/finite_checks.py robot_sf/benchmark/safety_predicates.py robot_sf/benchmark/heterogeneous_population_metrics.py robot_sf/benchmark/reactivity_ablation.py robot_sf/benchmark/counterfactual_pair.py robot_sf/planner/stream_gap_gate_calibration.py robot_sf/representation/uncertainty_source_generalization.py tests/benchmark/test_finite_checks.py`
- `uv run ruff check robot_sf/benchmark/finite_checks.py robot_sf/benchmark/safety_predicates.py robot_sf/benchmark/heterogeneous_population_metrics.py robot_sf/benchmark/reactivity_ablation.py robot_sf/benchmark/counterfactual_pair.py robot_sf/planner/stream_gap_gate_calibration.py robot_sf/representation/uncertainty_source_generalization.py tests/benchmark/test_finite_checks.py`
- `uv run pytest tests/benchmark/test_finite_checks.py tests/benchmark/test_safety_predicates.py tests/benchmark/test_heterogeneous_population_metrics.py tests/benchmark/test_reactivity_ablation.py tests/benchmark/test_counterfactual_pair.py tests/representation/test_uncertainty_source_generalization.py -q` -> 90 passed.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> exit 1 because PR-ready stamp is missing; tree state was clean. Full `scripts/dev/pr_ready_check.sh` was skipped because this delegated task required CPU-light work and no broad pytest.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA - PR links and closes #3604; no separate issue comment authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: enforcement/tooling only, no benchmark evidence or paper-facing claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the helper remains a fail-closed guard only and does not alter diagnostic thresholds or aggregate semantics.
- Known limitation: broad PR-ready validation was intentionally not run under the CPU-light/no-broad-pytest delegation constraint.
