### PR TITLE
fix(benchmark): honest "missing" source when a safety predicate lacks its event key

### DIFF
--- a/robot_sf/benchmark/event_ledger.py
+++ b/robot_sf/benchmark/event_ledger.py
@@ -117,9 +117,15 @@ def _predicate_event(
     predicate_key: str,
     event_key: str,
 ) -> tuple[bool, str | None]:
-    """Return a predicate event boolean and source path when present."""
+    """Return a predicate event boolean and source path when present.
+
+    Returns ``(False, None)`` when the predicate record is missing or does not carry
+    ``event_key``. Reporting ``None`` (rather than a source path that points at an absent
+    field) keeps the reconciliation source honest as ``missing`` and lets the affected
+    surrogate event fall back to its metric-derived value instead of a defaulted ``False``.
+    """
     payload = predicates.get(predicate_key)
-    if not isinstance(payload, Mapping):
+    if not isinstance(payload, Mapping) or event_key not in payload:
         return False, None
     return _bool_at(payload, event_key), f"safety_predicates.{predicate_key}.{event_key}"
 

--- a/tests/benchmark/test_event_ledger.py
+++ b/tests/benchmark/test_event_ledger.py
@@ -96,6 +96,22 @@ def test_build_event_ledger_preserves_safety_predicate_records() -> None:
     assert surrogate_events["occlusion_near_miss_predicate"] == {"occlusion_near_miss": False}
 
 
+def test_build_event_ledger_predicate_without_event_key_falls_back_to_metric() -> None:
+    """A predicate record lacking its event key must not claim a source or override the metric."""
+    record = _record(collision_event=False, collisions=0.0)
+    record["metrics"]["oscillation_count"] = 3.0  # metric-derived oscillation is present and True
+    # Predicate record exists but omits the "oscillation" key (e.g. partial/forward-compat record).
+    record["safety_predicates"] = {"oscillatory_control_predicate": {"schema_version": "x"}}
+
+    ledger = build_event_ledger(record)
+
+    # Falls back to the metric-derived value instead of a defaulted False...
+    assert ledger["surrogate_events"]["oscillation"] is True
+    # ...and the reconciliation source stays honest (metric), not a path to the absent field.
+    assert ledger["metric_definitions"]["oscillation"]["source"] == "metrics.oscillation_count"
+    assert ledger["reconciliation"]["audit_result"] == "pass"
+
+
 def test_build_event_ledger_parses_string_booleans_without_truthiness_leaks() -> None:
     """String booleans from JSON-adjacent records should not rely on Python truthiness."""
     record = _record(collision_event=False, collisions=0.0)


### PR DESCRIPTION
## Summary
Make `build_event_ledger` record an honest `missing` reconciliation source (and fall back to the metric-derived value) when a safety-predicate payload is present but does not carry its event key. Follow-up hardening from the #3615 review.

## Linked Issues
- Relates to `#3483` (safety predicate emission, merged in #3615)

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, if any: NA

## What Changed
- `robot_sf/benchmark/event_ledger.py`: `_predicate_event` now returns `(False, None)` when the predicate record is missing **or** the requested `event_key` is absent from the payload. Previously it returned a source path pointing at the absent field, which (a) recorded a `safety_predicates.*` source that did not actually contain the key, and (b) overrode the metric-derived `oscillation` value with a defaulted `False`.
- `tests/benchmark/test_event_ledger.py`: regression test asserting that a predicate payload lacking its event key falls back to the metric value and keeps the reconciliation source honest (`metrics.oscillation_count`).

## Why It Matters
- Added value: reconciliation source attribution no longer claims a field that is not present; the `oscillation` surrogate event correctly falls back to its metric value instead of being silently forced to `False`.
- Expected impact: more accurate `metric_definitions` provenance for partial/forward-compatible predicate records. No change for records that carry the full predicate keys (the common case).
- Why this is worth merging now: small, isolated correctness fix surfaced during PR review; no benchmark semantics change.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - reconciliation-metadata correctness only.
- Comparator or baseline, if applicable: NA.
- Evidence tier: NA - focused unit test only.
- Result classification: NA - no research or benchmark result.
- Decision or stop rule, if applicable: NA.
- Parent issue, claim map, registry, context note, or synthesis surface to update: NA.
- New research/benchmark/metric/paper-facing analysis tool, if any: NA - support correctness fix.

## Domain-Aware Approval
- Required for this PR: no - no evidence classification, comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim surface changes.
- Domains reviewed: NA.
- Status: not required.
- Approver/review source or waiver: NA.

## Falsification / Non-Transfer Check
- Did the mechanism activate? NA - support correctness fix.
- Did the intervention change command source, selected command, trajectory, or route progress? NA.
- Did the scenario actually contain the targeted failure mode? NA.
- Result route: NA.
- Follow-up question or issue for weak, negative, or non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA.
- Extractor or analysis tool needed: NA.
- Artifact missing or unavailable: none.
- Stop / revise / continue decision: NA.
- Proposed child issue or existing follow-up: none.

## Validation / Proof
- Commands run: `uv run ruff check` + `ruff format --check` on the two changed files (clean); `pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_event_ledger_reconciliation.py tests/benchmark/test_map_runner_safety_predicates.py` -> 16 passed.
- Evidence that the change works here: new test `test_build_event_ledger_predicate_without_event_key_falls_back_to_metric` fails on the old code path and passes with the fix; existing reconciliation tests still pass.
- Benchmarks or smoke tests, if applicable: NA - support correctness fix.

## Risks / Rollout
- Compatibility risks: none expected; behavior only changes for predicate payloads that omit their event key (previously misattributed). Full predicate records are unaffected.
- Failure modes: none new.
- Rollback or fallback plan: revert the commit.

## Docs / Provenance
- Updated docs: none required.
- Relevant design or provenance notes: keeps `metric_definitions` source honest per the event-ledger reconciliation contract.
- Any assumptions that need to be preserved: a `None` predicate source must continue to fall back to the metric source.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened for deferred propagation (yes/no/NA): NA.
- Not applicable because: reconciliation-metadata correctness fix with no benchmark, registry, claim-map, or paper-facing surface.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: none.

## Reviewer Notes
- Anything a reviewer should verify closely: the fallback path for `oscillation` (predicate source `None` -> metric value) and the `missing` source attribution.
- Any known limitations: the reactivity-campaign finite-check robustness raised in the same review round is intentionally left to the shared `finite_checks` consolidation in #3618, not duplicated here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
