### PR TITLE
infra: reject numeric strings in finite scalar checks

### DIFF
--- a/robot_sf/benchmark/finite_checks.py
+++ b/robot_sf/benchmark/finite_checks.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from numbers import Real
 from typing import TYPE_CHECKING, Any
 
 import numpy as np
@@ -11,8 +12,10 @@ if TYPE_CHECKING:
     from collections.abc import Iterable
 
 
-def require_finite_scalar(name: str, value: float) -> float:
-    """Return ``value`` as float or raise when it is NaN/Inf."""
+def require_finite_scalar(name: str, value: Real) -> float:
+    """Return a real numeric scalar as float or raise when it is non-finite."""
+    if not isinstance(value, Real):
+        raise TypeError(f"{name} must be a real numeric scalar, got {type(value).__name__}")
     numeric = float(value)
     if not math.isfinite(numeric):
         raise ValueError(f"{name} is not finite: {numeric}")

--- a/tests/benchmark/test_finite_checks.py
+++ b/tests/benchmark/test_finite_checks.py
@@ -25,10 +25,16 @@ from robot_sf.representation import uncertainty_source_generalization
 
 def test_require_finite_scalar_rejects_nan_and_inf() -> None:
     """Scalar diagnostics fail closed on NaN/Inf."""
-    assert require_finite_scalar("metric", "1.25") == pytest.approx(1.25)
+    assert require_finite_scalar("metric", 1.25) == pytest.approx(1.25)
     for bad in (math.nan, math.inf, -math.inf):
         with pytest.raises(ValueError, match="metric"):
             require_finite_scalar("metric", bad)
+
+
+def test_require_finite_scalar_rejects_numeric_string() -> None:
+    """Diagnostic scalar fields must not coerce numeric strings."""
+    with pytest.raises(TypeError, match="metric"):
+        require_finite_scalar("metric", "1.25")
 
 
 def test_require_finite_array_rejects_nan_and_inf() -> None:
@@ -49,6 +55,16 @@ def test_require_finite_fields_names_offending_field() -> None:
 
     with pytest.raises(ValueError, match=r"row\.unsafe"):
         require_finite_fields("row", Row(), ("safe", "unsafe"))
+
+
+def test_require_finite_fields_rejects_numeric_string_field() -> None:
+    """Dataclass-style diagnostic fields also reject numeric strings."""
+
+    class Row:
+        metric = "1.25"
+
+    with pytest.raises(TypeError, match=r"row\.metric"):
+        require_finite_fields("row", Row(), ("metric",))
 
 
 def test_stream_gap_classifier_rejects_non_finite_safety_aggregate() -> None:


### PR DESCRIPTION
## Summary
Follow-up to #3604 / PR #3618: make shared diagnostic scalar finite checks strict about scalar type, so numeric strings such as `"1.25"` fail closed instead of being coerced with `float(...)`.

This is enforcement-only tooling. It does not add benchmark evidence, change metric semantics, change planner defaults, change scenario taxonomy, or update aggregate benchmark interpretation.

## Linked Issues
- Follow-up to #3604
- Follow-up to #3618

## Stack / Dependency
- Base dependency: current `main` after #3618 merged
- Required prior PRs: #3618
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: scoped regression fix on the shared helper introduced by #3618

## What Changed
- `require_finite_scalar` now requires a real numeric scalar object before checking finiteness.
- `require_finite_fields` inherits that stricter behavior for dataclass-style diagnostic fields.
- Focused tests now reject numeric strings through both scalar and field helper paths.

## Why Matters
- Added value: restores fail-closed behavior for diagnostic scalar fields that would previously reject strings under direct `math.isfinite(value)` checks.
- Expected impact: diagnostic producer fields do not silently accept stringly-typed numeric values.
- Why worth merging now: small correction to the #3618 enforcement helper before more diagnostic producers reuse it.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/helper enforcement only.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - focused unit tests only.
- Result classification: NA - no research or benchmark result.
- Decision stop rule, applicable: NA.
- Parent issue, claim map, registry, context note, synthesis surface update: NA.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper; no research evidence interpretation.

## Domain-Aware Approval
- approval concerns experimental validity and waived / pending / blocked / not required: not required.
- Approver/review source waiver: NA.
- Validity checklist: NA.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: non-finite and non-numeric scalar diagnostics fail closed; no benchmark success claim.
- Claim boundary: implementation integrity only.
- Implementation integrity vs experimental validity: validates helper behavior only, not experimental validity.

## Validation / Proof
- `python -m py_compile robot_sf/benchmark/finite_checks.py tests/benchmark/test_finite_checks.py`
- `git diff --check`
- `uv run ruff check robot_sf/benchmark/finite_checks.py tests/benchmark/test_finite_checks.py`
- `uv run pytest tests/benchmark/test_finite_checks.py -q` -> 12 passed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA - no separate issue/PR comment authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: enforcement-only helper correction, no benchmark evidence or paper-facing claim.

## Follow-Up Issues
- Deferred work: none.
- Issues opened for follow-up: NA - no follow-up needed because this PR is a self-contained enforcement-only helper correction with no deferred implementation or propagation work.

## Reviewer Notes
- Please verify the stricter scalar type check is appropriate for diagnostic scalar fields and that array handling remains unchanged.


