### PR TITLE
docs(context): register recovered reward-curriculum seeds as diagnostic evidence

### DIFF
--- a/docs/context/README.md
+++ b/docs/context/README.md
@@ -1302,6 +1302,10 @@ knowledge, not every transient iteration detail.
 * [Issue #1024 H500 PPO Retrain](issue_1024_h500_ppo_retrain.md)
   records the all-available scenario surface, PR #1025 h500 horizon alignment, and SLURM job
   `12350` for the first 12M-step PPO retrain.
+* [Issue #2557 Recovered Reward-Curriculum Seed Runs](issue_2557_recovered_diagnostic_seeds.md)
+  records three reward-curriculum seed runs (506/508/509) whose manifests were lost to the
+  cross-worktree serializer bug and backfilled via #3590; diagnostic-tier only (marginal SNQI,
+  elevated collision), with an in-flight 501–511 variance fill.
 
 ## Performance Notes
 

--- a/docs/context/dissertation_evidence_ledger.md
+++ b/docs/context/dissertation_evidence_ledger.md
@@ -130,6 +130,20 @@ explicitly blocked from manuscript promotion.
 | **Claim gap** | Payload absence is resolved, but the tables remain diagnostic/provenance artifacts until the PPO observation contract and SNQI contract caveats are repaired or explicitly scoped out by a new issue contract. |
 | **Evidence promotion path** | **invalid campaign repair**: fix or intentionally scope the PPO observation-contract failure and SNQI contract caveat, then rerun a fresh bounded campaign before any benchmark or Results wording. |
 
+### 7. Recovered Reward-Curriculum Seed Runs (Diagnostic)
+
+| Field | Value |
+|---|---|
+| **Claim** | Three reward-curriculum expert-policy seed runs (seeds 506/508/509) completed training and 70-scenario evaluation, lost their manifests to a cross-worktree serializer bug, and were recovered by backfilling manifests from retained artefacts; they are diagnostic seed evidence, not benchmark success. |
+| **Artifact status** | current (manifests backfilled, evidence retrieved local) |
+| **Evidence tier** | diagnostic |
+| **Allowed wording** | "Recovered reward-curriculum expert-policy seed runs exist with payload-complete, provenance-tracked manifests for seed-variance bookkeeping and pipeline diagnostics only; their marginal SNQI and elevated collision rate mean they do not establish benchmark-success or Results-chapter evidence." |
+| **Caveat** | Aggregate success 0.81–0.85 but SNQI is at/below zero (−0.069 / +0.017 / −0.111) and collision is 14–19%, failing the issue_2557 success criterion ("improve success without increased collision"). Each manifest is single-seed (`validation_state: draft`); cross-seed variance is not yet established. A 501–511 variance fill is in flight (jobs 13153/13154/13155) under an explicit override of the campaign do-not-rerun policy. |
+| **Source PR/issue** | [#2557](https://github.com/ll7/robot_sf_ll7/issues/2557), [#2919](https://github.com/ll7/robot_sf_ll7/issues/2919), [#3203](https://github.com/ll7/robot_sf_ll7/issues/3203), [#3266](https://github.com/ll7/robot_sf_ll7/issues/3266), [recovered-seeds note](issue_2557_recovered_diagnostic_seeds.md), [#3590](https://github.com/ll7/robot_sf_ll7/pull/3590) |
+| **Dissertation chapter** | Methods, Limitations |
+| **Claim gap** | Manifest/evidence loss is resolved, but the runs remain diagnostic until SNQI validity and collision-rate regressions are repaired under a new hypothesis and a consolidated multi-seed variance analysis supersedes the recovered-seeds stub. |
+| **Evidence promotion path** | **new hypothesis + consolidated variance**: complete the 501–511 seed fill, retrieve/analyse, then author a consolidated seed-variance note; do not promote past diagnostic until the SNQI and collision caveats are repaired or explicitly scoped by a new issue contract. |
+
 ## Stale-Artifact Summary
 
 | Artifact | State | Reason |
@@ -156,6 +170,9 @@ explicitly blocked from manuscript promotion.
 7. **Exported tables**: Discussion/Limitations only. Use as payload-complete table provenance
    with the Issue #3203 invalid-campaign caveat; do not cite as benchmark-success or ranking
    evidence.
+8. **Recovered reward-curriculum seeds**: Methods/Limitations only. Use as provenance-tracked
+   seed-variance bookkeeping and a manifest-recovery case study; do not cite as benchmark-success
+   given marginal SNQI and elevated collision rate.
 
 ## Claim Boundaries
 

--- a/docs/context/issue_2557_recovered_diagnostic_seeds.md
+++ b/docs/context/issue_2557_recovered_diagnostic_seeds.md
@@ -1,0 +1,72 @@
+# Issue #2557 Recovered Reward-Curriculum Seed Runs (updated 2026-06-26)
+
+Related issues: [#2557](https://github.com/ll7/robot_sf_ll7/issues/2557),
+[#2919](https://github.com/ll7/robot_sf_ll7/issues/2919),
+[#3203](https://github.com/ll7/robot_sf_ll7/issues/3203),
+[#3266](https://github.com/ll7/robot_sf_ll7/issues/3266). Recovery tooling:
+[#3590](https://github.com/ll7/robot_sf_ll7/pull/3590) (merged).
+
+## Status
+
+Diagnostic as of 2026-06-26. Three completed `expert_ppo_issue_2557_reward_curriculum_promotion_10m`
+seed runs trained and evaluated successfully but lost their training-run manifests to the
+cross-worktree serializer failure (the manifest write raised on an `evaluation_scenario_config`
+path materialised under a sibling worktree). The training compute was intact on the cluster; only
+the `benchmarks/ppo_imitation/runs/<run_id>.json` manifest was missing. All three manifests were
+**backfilled from the retained artefacts** with
+`scripts/tools/backfill_training_run_manifest.py` (added in the now-merged #3590), and the full
+~2.1 GB evidence per run (checkpoints, W&B, episode logs, per-scenario eval) was retrieved locally.
+
+These runs are recorded here as **diagnostic-tier seed evidence only**. They are **not**
+benchmark-success or paper-grade results (see caveats below).
+
+## Recovered Runs
+
+| Job | Issue | Seed | Success (mean, CI95) | Collision | SNQI | Path eff. | Episode return | Wall | Scenarios |
+|---|---|---|---|---|---|---|---|---|---|
+| 13024 | #3266 | 509 | 0.831 [0.810, 0.851] | 0.167 | −0.0692 | 0.832 | 18.64 | 16.23 h | 70 |
+| 12949 | #2919 | 506 | 0.851 [0.831, 0.870] | 0.144 | +0.0169 | 0.826 | 18.49 | 13.76 h | 70 |
+| 12950 | #3203 | 508 | 0.810 [0.790, 0.831] | 0.187 | −0.1115 | 0.830 | 17.33 | 16.07 h | 70 |
+
+Metrics are aggregate means across the 70-scenario evaluation profile, taken from each run's
+backfilled `expert_policies/<policy>.json` manifest. All three carry `validation_state: draft`.
+
+## Provenance & Recovery
+
+- **Failure mode**: cross-worktree manifest loss — `serialize_training_run` raised on a path
+  outside both the artefact root and the repo root, aborting the post-training manifest write and
+  discarding evidence. Fixed forward in #3590 (lenient basename fallback for optional eval/config
+  path fields; `episode_log_path` stays strict).
+- **Recovery**: `backfill_training_run_manifest.py` reconstructs the training-run manifest from
+  the artefacts the pipeline already wrote (expert-policy manifest → metrics/seeds, perf json →
+  run_id/wall-clock, eval-by-scenario → scenario coverage, episode/eval/perf files → path fields).
+  No training or evaluation was re-run. Each recovered manifest is tagged as backfilled in its
+  `notes`.
+- **Wall-clock cross-checks**: backfilled wall-clock (16.23 / 13.76 / 16.07 h) matches the
+  private ledger's recorded elapsed for each job, confirming the perf-summary provenance.
+
+## Diagnostic Classification & Caveats
+
+These runs **must not** be cited as benchmark-success, ranking, or Results-chapter evidence:
+
+- **SNQI is at or below zero** (−0.069 / +0.017 / −0.111). #3266 is specifically the
+  "resolve PPO SNQI validity blockers" campaign; these values indicate the social-navigation
+  quality index is marginal/unestablished, not a positive result.
+- **Collision rate is high** (14–19%). The issue_2557 campaign success criterion is "final success
+  improves over baseline **without increased collision rate**"; these runs do not clear it.
+- **Single-seed manifests**: each manifest covers one seed; cross-seed variance statistics are not
+  yet established (see next section).
+
+Allowed wording: *"Recovered reward-curriculum expert-policy seed runs exist with payload-complete,
+provenance-tracked manifests for seed-variance bookkeeping and pipeline diagnostics only; their
+marginal SNQI and elevated collision rate mean they do not establish benchmark-success or
+Results-chapter evidence."*
+
+## In-flight Sweep & Next Steps
+
+A bounded seed-variance fill of the contiguous 501–511 block is in flight on the a30 partition
+(jobs 13153/13154/13155, seeds 507/510/511), submitted for variance statistics only under an
+explicit override of the campaign `do_not_rerun_without_new_hypothesis` policy. Once those finish,
+retrieve, and analyse, a **consolidated 501–511 seed-variance evidence note** should supersede this
+stub with mean ± CI across the full block, still classified diagnostic until the SNQI/collision
+caveats are repaired under a new hypothesis.


### PR DESCRIPTION
## What

Registers three recovered reward-curriculum expert-policy seed runs as **diagnostic-tier seed evidence** in the dissertation context docs. Follows up the manifest fix + backfill tool from #3590 (merged).

These runs (seeds 506/508/509; jobs 12949/12950/13024) trained and evaluated successfully but lost their training-run manifests to the cross-worktree serializer bug. Their manifests were backfilled from retained artefacts via `scripts/tools/backfill_training_run_manifest.py` and the full ~2.1 GB evidence per run retrieved locally. No training was re-run.

## Why diagnostic-only (not benchmark evidence)

| Seed | Success (CI95) | Collision | SNQI |
|------|----------------|-----------|------|
| 506 (#2919) | 0.851 [0.831, 0.870] | 0.144 | +0.017 |
| 508 (#3203) | 0.810 [0.790, 0.831] | 0.187 | −0.112 |
| 509 (#3266) | 0.831 [0.810, 0.851] | 0.167 | −0.069 |

SNQI is at/below zero and collision is 14–19%, failing the issue_2557 success criterion ("improve success **without increased collision**"). #3266 is the SNQI-validity-blocker campaign, so these are explicitly marginal. They are recorded for **seed-variance bookkeeping and manifest-recovery provenance only**.

## Changes

- New context note `docs/context/issue_2557_recovered_diagnostic_seeds.md` (metrics, recovery provenance, caveats, allowed wording).
- `dissertation_evidence_ledger.md`: new row **7. Recovered Reward-Curriculum Seed Runs (Diagnostic)** + reuse recommendation 8.
- `README.md`: Training Notes index entry.

## Follow-up

A bounded 501–511 seed-variance fill is in flight (jobs 13153/13154/13155). Once complete + analysed, a **consolidated variance note** should supersede this stub with mean ± CI across the full block — still diagnostic until the SNQI/collision caveats are repaired under a new hypothesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new diagnostic note for recovered reward-curriculum seed runs, including provenance, recovery details, and current variance-fill status.
  * Expanded the evidence ledger with guidance on how these runs may be cited, along with caveats and conditions for stronger claim status.
  * Created a dedicated page summarizing the recovered seed runs, their metrics, and restrictions on using them as benchmark evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->