### PR TITLE
benchmark: add #3574 per-pedestrian control-trace logging

### DIFF
--- a/docs/context/issue_3574_heterogeneous_population_metrics.md
+++ b/docs/context/issue_3574_heterogeneous_population_metrics.md
@@ -1,37 +1,59 @@
-# Issue #3574 — Per-archetype metrics + mean-matched heterogeneity effect (increment)
+# Issue #3574 - Per-Archetype Metrics And Mean-Matched Heterogeneity Effect
 
-**Status:** diagnostic / analysis. **Evidence grade:** idea-level analysis primitives.
+**Status:** diagnostic logging prerequisite.
+**Evidence grade:** analysis primitives plus local trace logging tests; no ablation evidence.
 
-## What this is
+## Plain-Language Summary
 
-`robot_sf/benchmark/heterogeneous_population_metrics.py` provides the pure analysis primitives #3574
-needs before any heterogeneity effect can be claimed. The #3206 smoke could not isolate heterogeneity
-from a population-mean shift, nor compute per-archetype metrics. This adds both, mirroring the
-accepted decision/analysis-layer pattern in this run (#3484, #3558, #3557, #3573).
+This issue now has the analysis helpers and the first logging input needed to compare pedestrian
+archetypes, but it still has no mean-matched ablation runs and no heterogeneous-population effect
+claim.
 
-## Primitives (`heterogeneous_population_metrics.v1`)
+## Analysis Primitives (`heterogeneous_population_metrics.v1`)
 
-- `cvar(values, alpha, higher_is_safer)` — mean of the worst `alpha` tail (lowest values when higher
-  is safer, e.g. clearance; highest when lower is safer, e.g. exposure).
-- `per_archetype_metrics(observations, higher_is_safer, cvar_alpha)` — per-archetype `mean`,
-  `worst_stratum`, and `cvar`, plus the worst archetype by mean, so the worst-served archetype is
-  visible rather than averaged away.
-- `mean_matched_heterogeneity_effect(homogeneous_mean, heterogeneous_mean, homogeneous_is_mean_matched)`
-  — the heterogeneity effect, flagged `isolated` only when the homogeneous arm uses the population
-  mean (`theta_i = E[theta]`); otherwise `confounded_by_mean_shift`.
+`robot_sf/benchmark/heterogeneous_population_metrics.py` provides pure analysis primitives that
+Issue #3574 needs before any heterogeneity effect can be claimed. Issue #3206 smoke evidence could
+not isolate heterogeneity from a population-mean shift and could not compute per-archetype metrics.
 
-## Scope boundary
+- `cvar(values, alpha, higher_is_safer)`: Conditional Value at Risk (CVaR), the mean of the worst
+  `alpha` tail. Higher-is-safer metrics use the lowest values; lower-is-safer metrics use the
+  highest values.
+- `per_archetype_metrics(observations, higher_is_safer, cvar_alpha)`: per-archetype `mean`,
+  `worst_stratum`, `cvar`, and worst archetype by mean, so the worst-served archetype is not hidden
+  by averaging.
+- `mean_matched_heterogeneity_effect(homogeneous_mean, heterogeneous_mean,
+  homogeneous_is_mean_matched)`: effect delta, flagged `isolated` only when the homogeneous arm uses
+  the population mean (`theta_i = E[theta]`); otherwise `confounded_by_mean_shift`.
 
-Pure and side-effect free. Logging per-pedestrian control traces in the sim (the missing input infra),
-and running the mean-matched paired ablation / response-law mixture sweep, need code+runs and are the
-deliberate deferred follow-ups.
+## Per-Pedestrian Control Trace (`pedestrian-control-trace.v1`)
+
+`run_map_episode(..., record_simulation_step_trace=True)` attaches
+`algorithm_metadata.pedestrian_control_trace` when a scenario has explicit per-pedestrian archetype
+metadata under `single_pedestrians`.
+
+The trace records:
+
+- `dt`, `pedestrian_count`, and `step_count`;
+- one `pedestrians[]` entry per simulator pedestrian with `id`, `simulator_index`, and `archetype`;
+- per-step `x_m`, `y_m`, `vx_m_s`, `vy_m_s`, and `speed_m_s`;
+- optional per-step `force_x`, `force_y`, and `force_norm` when map-runner force recording is
+  enabled.
+
+The recorder fails closed on non-finite positions, forces, or derived speeds. It also rejects a
+labeled control trace without per-pedestrian archetype metadata, because that payload cannot feed
+the per-archetype harness honestly.
+
+## Scope Boundary
+
+This remains logging and pure analysis support only. It does not run mean-matched paired ablations,
+does not submit Slurm jobs, and does not claim heterogeneous-population effects.
 
 ## Tests
 
-`tests/benchmark/test_heterogeneous_population_metrics.py` (9 tests): CVaR tail direction + alpha
-validation, per-archetype aggregation for higher- and lower-is-safer metrics, empty rejection, and
-the isolated-vs-confounded mean-matched effect.
-
-## Related
-
-- Follows #3206 (heterogeneous archetype axis). Sibling analysis layers: #3573, #3558, #3557.
+- `tests/benchmark/test_heterogeneous_population_metrics.py`: Conditional Value at Risk tail
+  direction and alpha validation, plus per-archetype aggregation for higher- and lower-is-safer
+  metrics.
+- `tests/benchmark/test_pedestrian_control_trace.py`: emitted control-trace shape, archetype
+  detection, and fail-closed non-finite or missing-archetype handling.
+- `tests/benchmark/test_map_runner_utils.py`: episode metadata integration for the map-runner trace
+  seam.

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -85,6 +85,9 @@ from robot_sf.benchmark.observation_noise import (
 )
 from robot_sf.benchmark.obstacle_sampling import sample_obstacle_points
 from robot_sf.benchmark.path_utils import compute_shortest_path_length
+from robot_sf.benchmark.pedestrian_control_trace import (
+    attach_pedestrian_control_trace,
+)
 from robot_sf.benchmark.planner_command_contract import (
     validate_planner_contract as _validate_planner_contract,
 )
@@ -735,6 +738,13 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             "initial_goal_distance_m": initial_goal_distance,
             "steps": simulation_step_trace,
         }
+        attach_pedestrian_control_trace(
+            algo_meta,
+            scenario=scenario,
+            ped_positions=ped_pos_arr,
+            ped_forces=ped_forces_arr if record_forces else None,
+            dt=float(config.sim_config.time_per_step_in_secs),
+        )
     intent_summary = _intent_conditioned_behavior_summary(
         scenario,
         single_pedestrian_intent_metadata,

--- a/robot_sf/benchmark/pedestrian_control_trace.py
+++ b/robot_sf/benchmark/pedestrian_control_trace.py
@@ -1,0 +1,210 @@
+"""Per-pedestrian control-trace logging for heterogeneous-population analysis."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.finite_checks import require_finite_array, require_finite_scalar
+
+PEDESTRIAN_CONTROL_TRACE_SCHEMA = "pedestrian-control-trace.v1"
+
+_ARCHETYPE_KEYS = (
+    "archetype",
+    "pedestrian_archetype",
+    "behavior_archetype",
+    "speed_archetype",
+)
+
+
+def has_pedestrian_control_trace_metadata(scenario: Mapping[str, Any]) -> bool:
+    """Return true when a scenario carries explicit per-pedestrian archetype labels."""
+
+    single_pedestrians = _single_pedestrians(scenario)
+    return any(_pedestrian_archetype(pedestrian) is not None for pedestrian in single_pedestrians)
+
+
+def attach_pedestrian_control_trace(
+    metadata: dict[str, Any],
+    *,
+    scenario: Mapping[str, Any],
+    ped_positions: np.ndarray,
+    ped_forces: np.ndarray | None,
+    dt: float,
+) -> None:
+    """Attach a control trace to episode metadata when archetype labels are available.
+
+    Args:
+        metadata: Mutable algorithm metadata payload receiving `pedestrian_control_trace`.
+        scenario: Scenario dictionary containing optional `single_pedestrians` metadata.
+        ped_positions: Simulator pedestrian positions shaped `(steps, pedestrians, 2)`.
+        ped_forces: Optional simulator pedestrian force vectors with the same shape.
+        dt: Episode time step in seconds.
+    """
+
+    if not has_pedestrian_control_trace_metadata(scenario):
+        return
+    metadata["pedestrian_control_trace"] = build_pedestrian_control_trace(
+        scenario=scenario,
+        ped_positions=ped_positions,
+        ped_forces=ped_forces,
+        dt=dt,
+    )
+
+
+def build_pedestrian_control_trace(
+    *,
+    scenario: Mapping[str, Any],
+    ped_positions: np.ndarray,
+    ped_forces: np.ndarray | None,
+    dt: float,
+) -> dict[str, Any]:
+    """Build a finite, per-pedestrian control trace grouped by simulator pedestrian index.
+
+    Returns:
+        Versioned JSON-serializable pedestrian control trace payload.
+
+    Raises:
+        ValueError: Missing archetype metadata, shape mismatch, or non-finite trace values.
+    """
+
+    dt_value = require_finite_scalar("pedestrian_control_trace.dt", dt)
+    if dt_value <= 0.0:
+        raise ValueError("pedestrian_control_trace.dt must be positive")
+
+    positions = require_finite_array("pedestrian_control_trace.ped_positions", ped_positions)
+    if positions.ndim != 3 or positions.shape[2] != 2:
+        raise ValueError(
+            "pedestrian_control_trace.ped_positions must have shape (steps, pedestrians, 2)"
+        )
+
+    forces: np.ndarray | None = None
+    if ped_forces is not None:
+        forces = require_finite_array("pedestrian_control_trace.ped_forces", ped_forces)
+        if forces.shape != positions.shape:
+            raise ValueError("pedestrian_control_trace.ped_forces must match ped_positions shape")
+
+    step_count = int(positions.shape[0])
+    pedestrian_count = int(positions.shape[1])
+    metadata = _aligned_pedestrian_metadata(scenario, pedestrian_count)
+    pedestrians: list[dict[str, Any]] = []
+    for simulator_index, pedestrian_metadata in enumerate(metadata):
+        archetype = _pedestrian_archetype(pedestrian_metadata)
+        if archetype is None:
+            raise ValueError(
+                "pedestrian_control_trace requires archetype metadata for "
+                f"simulator pedestrian {simulator_index}"
+            )
+        pedestrian_steps: list[dict[str, Any]] = []
+        previous_position: np.ndarray | None = None
+        for step in range(step_count):
+            position = positions[step, simulator_index]
+            velocity = (
+                (position - previous_position) / dt_value
+                if previous_position is not None
+                else np.zeros(2, dtype=float)
+            )
+            speed = float(np.linalg.norm(velocity))
+            require_finite_scalar(
+                f"pedestrian_control_trace.pedestrians[{simulator_index}].steps[{step}].speed_m_s",
+                speed,
+            )
+            payload: dict[str, Any] = {
+                "step": step,
+                "x_m": float(position[0]),
+                "y_m": float(position[1]),
+                "vx_m_s": float(velocity[0]),
+                "vy_m_s": float(velocity[1]),
+                "speed_m_s": speed,
+            }
+            if forces is not None:
+                force = forces[step, simulator_index]
+                force_norm = float(np.linalg.norm(force))
+                require_finite_scalar(
+                    "pedestrian_control_trace."
+                    f"pedestrians[{simulator_index}].steps[{step}].force_norm",
+                    force_norm,
+                )
+                payload.update(
+                    {
+                        "force_x": float(force[0]),
+                        "force_y": float(force[1]),
+                        "force_norm": force_norm,
+                    }
+                )
+            pedestrian_steps.append(payload)
+            previous_position = np.array(position, dtype=float, copy=True)
+
+        pedestrians.append(
+            {
+                "id": str(pedestrian_metadata.get("id") or f"pedestrian_{simulator_index}"),
+                "simulator_index": simulator_index,
+                "archetype": archetype,
+                "steps": pedestrian_steps,
+            }
+        )
+
+    return {
+        "schema_version": PEDESTRIAN_CONTROL_TRACE_SCHEMA,
+        "dt": dt_value,
+        "source": "map_runner_episode",
+        "archetype_source": "scenario.single_pedestrians.metadata",
+        "pedestrian_count": pedestrian_count,
+        "step_count": step_count,
+        "pedestrians": pedestrians,
+    }
+
+
+def _single_pedestrians(scenario: Mapping[str, Any]) -> list[Mapping[str, Any]]:
+    single_pedestrians = scenario.get("single_pedestrians")
+    if not isinstance(single_pedestrians, Sequence) or isinstance(single_pedestrians, str):
+        return []
+    return [ped for ped in single_pedestrians if isinstance(ped, Mapping)]
+
+
+def _aligned_pedestrian_metadata(
+    scenario: Mapping[str, Any],
+    pedestrian_count: int,
+) -> list[Mapping[str, Any]]:
+    single_pedestrians = _single_pedestrians(scenario)
+    if pedestrian_count == 0:
+        return []
+    if not single_pedestrians:
+        raise ValueError("pedestrian_control_trace requires scenario.single_pedestrians metadata")
+    if len(single_pedestrians) > pedestrian_count:
+        raise ValueError(
+            "pedestrian_control_trace single_pedestrians metadata exceeds simulator pedestrian count"
+        )
+    offset = pedestrian_count - len(single_pedestrians)
+    metadata: list[Mapping[str, Any]] = [{} for _ in range(offset)]
+    metadata.extend(single_pedestrians)
+    return metadata
+
+
+def _pedestrian_archetype(pedestrian: Mapping[str, Any]) -> str | None:
+    metadata = pedestrian.get("metadata") if isinstance(pedestrian.get("metadata"), Mapping) else {}
+    for source in (metadata, pedestrian):
+        for key in _ARCHETYPE_KEYS:
+            value = source.get(key)
+            if value is None:
+                continue
+            label = str(value).strip()
+            if label:
+                return label
+    speed = pedestrian.get("speed_m_s")
+    if isinstance(speed, int | float | np.integer | np.floating):
+        speed_value = float(speed)
+        if math.isfinite(speed_value):
+            return f"speed_m_s:{speed_value:g}"
+    return None
+
+
+__all__ = [
+    "PEDESTRIAN_CONTROL_TRACE_SCHEMA",
+    "attach_pedestrian_control_trace",
+    "build_pedestrian_control_trace",
+    "has_pedestrian_control_trace_metadata",
+]

--- a/tests/benchmark/test_pedestrian_control_trace.py
+++ b/tests/benchmark/test_pedestrian_control_trace.py
@@ -1,0 +1,131 @@
+"""Tests for per-pedestrian control-trace logging."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.pedestrian_control_trace import (
+    PEDESTRIAN_CONTROL_TRACE_SCHEMA,
+    attach_pedestrian_control_trace,
+    build_pedestrian_control_trace,
+    has_pedestrian_control_trace_metadata,
+)
+
+
+def _scenario() -> dict[str, object]:
+    return {
+        "name": "heterogeneous_trace_smoke",
+        "single_pedestrians": [
+            {"id": "ped_cautious", "metadata": {"archetype": "cautious"}},
+            {"id": "ped_hurried", "metadata": {"archetype": "hurried"}},
+        ],
+    }
+
+
+def test_build_pedestrian_control_trace_records_archetype_controls() -> None:
+    """Recorder emits finite per-pedestrian controls aligned with authored archetypes."""
+
+    positions = np.array(
+        [
+            [[0.0, 0.0], [1.0, 0.0]],
+            [[0.1, 0.0], [1.0, 0.2]],
+        ],
+        dtype=float,
+    )
+    forces = np.array(
+        [
+            [[0.0, 0.0], [0.0, 0.0]],
+            [[0.3, 0.4], [0.0, 0.5]],
+        ],
+        dtype=float,
+    )
+
+    trace = build_pedestrian_control_trace(
+        scenario=_scenario(),
+        ped_positions=positions,
+        ped_forces=forces,
+        dt=0.1,
+    )
+
+    assert trace["schema_version"] == PEDESTRIAN_CONTROL_TRACE_SCHEMA
+    assert trace["dt"] == pytest.approx(0.1)
+    assert trace["pedestrian_count"] == 2
+    assert trace["step_count"] == 2
+    cautious, hurried = trace["pedestrians"]
+    assert cautious["id"] == "ped_cautious"
+    assert cautious["archetype"] == "cautious"
+    assert cautious["steps"][1]["vx_m_s"] == pytest.approx(1.0)
+    assert cautious["steps"][1]["force_norm"] == pytest.approx(0.5)
+    assert hurried["id"] == "ped_hurried"
+    assert hurried["archetype"] == "hurried"
+    assert hurried["steps"][1]["speed_m_s"] == pytest.approx(2.0)
+
+
+def test_has_pedestrian_control_trace_metadata_detects_archetypes() -> None:
+    """Episode integration should only attach the trace for explicitly labeled pedestrians."""
+
+    assert has_pedestrian_control_trace_metadata(_scenario()) is True
+    assert has_pedestrian_control_trace_metadata({"single_pedestrians": [{"id": "ped"}]}) is False
+
+
+def test_attach_pedestrian_control_trace_adds_metadata_payload() -> None:
+    """Episode integration helper attaches the versioned trace when labels are present."""
+
+    metadata: dict[str, object] = {}
+    attach_pedestrian_control_trace(
+        metadata,
+        scenario=_scenario(),
+        ped_positions=np.zeros((1, 2, 2), dtype=float),
+        ped_forces=None,
+        dt=0.1,
+    )
+
+    trace = metadata["pedestrian_control_trace"]
+    assert trace["schema_version"] == PEDESTRIAN_CONTROL_TRACE_SCHEMA
+    assert trace["pedestrians"][0]["archetype"] == "cautious"
+    assert trace["pedestrians"][1]["archetype"] == "hurried"
+
+
+def test_attach_pedestrian_control_trace_skips_unlabeled_scenarios() -> None:
+    """Episode integration helper preserves existing records without archetype metadata."""
+
+    metadata: dict[str, object] = {"existing": True}
+    attach_pedestrian_control_trace(
+        metadata,
+        scenario={"single_pedestrians": [{"id": "ped"}]},
+        ped_positions=np.zeros((1, 1, 2), dtype=float),
+        ped_forces=None,
+        dt=0.1,
+    )
+
+    assert metadata == {"existing": True}
+
+
+@pytest.mark.parametrize("bad_value", [math.nan, math.inf])
+def test_build_pedestrian_control_trace_rejects_non_finite_positions(bad_value: float) -> None:
+    """Non-finite simulator trace values fail closed instead of leaking to JSON."""
+
+    positions = np.array([[[bad_value, 0.0]]], dtype=float)
+    with pytest.raises(ValueError, match="ped_positions"):
+        build_pedestrian_control_trace(
+            scenario={"single_pedestrians": [{"metadata": {"archetype": "cautious"}}]},
+            ped_positions=positions,
+            ped_forces=None,
+            dt=0.1,
+        )
+
+
+def test_build_pedestrian_control_trace_rejects_missing_archetype() -> None:
+    """A control trace without per-pedestrian archetypes cannot feed per-archetype analysis."""
+
+    positions = np.zeros((1, 1, 2), dtype=float)
+    with pytest.raises(ValueError, match="archetype metadata"):
+        build_pedestrian_control_trace(
+            scenario={"single_pedestrians": [{"id": "ped_unlabeled"}]},
+            ped_positions=positions,
+            ped_forces=None,
+            dt=0.1,
+        )


### PR DESCRIPTION
## Summary

Adds the first per-pedestrian control-trace logging prerequisite for #3574. The trace is emitted only when simulation step tracing is enabled and explicit per-pedestrian archetype metadata is present.

## Issue

Relates to #3574.

## Scope

- Added `robot_sf/benchmark/pedestrian_control_trace.py` with a versioned `pedestrian-control-trace.v1` payload.
- Hooked `run_map_episode(..., record_simulation_step_trace=True)` to attach `algorithm_metadata.pedestrian_control_trace` when `single_pedestrians` carries archetype labels.
- Added focused tests for emitted fields, finite-value rejection, missing-archetype rejection, and the attach/skip helper used by the episode runner.
- Updated `docs/context/issue_3574_heterogeneous_population_metrics.md` with emitted fields and scope boundaries.

## Validation

- `python -m py_compile robot_sf/benchmark/pedestrian_control_trace.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_map_runner_utils.py` - passed.
- `git diff --check` - passed.
- `git diff --cached --check` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/pedestrian_control_trace.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_map_runner_utils.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_pedestrian_control_trace.py tests/benchmark/test_map_runner_utils.py::test_run_map_episode_records_synthetic_actuation_metrics` - passed, 8 tests.

## Explicit Out Of Scope

No ablation runs, no benchmark effect claims, and no Slurm submission.

## Deferred Work

Mean-matched ablation runs, GPU-heavy benchmark sweeps, and heterogeneous-population effect interpretation remain deferred to #3574.

## Notes

- Unlabeled scenarios do not emit the new trace.
- Partially labeled scenarios fail closed when emitting the trace would mix labeled and unlabeled pedestrian rows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added per-pedestrian control-trace logging for simulation episodes when archetype metadata is available.
  - Episode metadata can now include richer trace details such as pedestrian counts, step-by-step motion, and force information.

- **Documentation**
  - Updated the issue notes to better explain the logging workflow, validation behavior, and scope boundaries.
  - Expanded the testing notes to cover trace shape, metadata detection, and episode metadata integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->