### PR TITLE
feat(dev): performance-PR evidence contract (prevents #3611-style unsubstantiated perf claims)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/pr_default.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pr_default.md
@@ -94,6 +94,19 @@ helpers that do not interpret research evidence should state `NA - support helpe
 - Evidence that the change works here:
 - Benchmarks or smoke tests, if applicable:
 
+## Performance Evidence
+Required for `perf`-typed changes (conventional-commit `perf(...)`); delete this section
+otherwise. Enforced by `scripts/dev/check_perf_evidence.py` so a claimed speed-up is
+substantiated on the real entry point (see the #3611 → #3613 wrong-layer revert). Use concrete
+values, not `NA`. The cache field is required only when the change claims caching/reuse.
+
+- Baseline runtime: `<time>` on `<representative slice + seeds>`
+- Changed runtime: `<time>` on the same slice + seeds
+- Representative command: `<command that reproduces the measurement>`
+- Hot-path call count or profile anchor: `<profile/counter on the real campaign entry point>`
+- Cache-hit or reuse counter: `<hits/misses or reuse count, or NA when no caching is claimed>`
+- Rollback or failure criterion: `<observable regression that triggers a revert>`
+
 ## Risks / Rollout
 - Compatibility risks:
 - Failure modes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **performance-PR evidence contract** that fails PR readiness when a `perf`-typed
+  conventional-commit change (the #3611 → #3613 failure mode: a `perf(planner): cache ...` whose
+  claimed speed-up targeted the wrong layer and had to be reverted) lacks a `## Performance
+  Evidence` PR-body section with concrete before/after runtime, a representative command, a
+  rollback criterion, and — when caching is claimed — a cache-hit/reuse counter. The trigger is the
+  local `perf(...)` commit subject (no GitHub label needed), so it runs identically in
+  `pr_ready_check.sh` (fail-closed in final mode, advisory in interim) and CI. Check:
+  [`scripts/dev/check_perf_evidence.py`](scripts/dev/check_perf_evidence.py); template section in
+  [`.github/PULL_REQUEST_TEMPLATE/pr_default.md`](.github/PULL_REQUEST_TEMPLATE/pr_default.md);
+  tests: [`tests/dev/test_check_perf_evidence.py`](tests/dev/test_check_perf_evidence.py).
 * Added a pre-commit lint that fails when a file under `configs/**` contains an absolute
   home-dir path (`/home/`, `/Users/`, `/root/`), which is non-portable for other contributors
   and automated runners. Intentional absolute paths (e.g. private-ops SLURM routing targets

--- a/scripts/dev/check_perf_evidence.py
+++ b/scripts/dev/check_perf_evidence.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Performance-PR evidence contract.
+
+Fires only for ``perf``-typed conventional-commit changes (the #3611 failure
+mode: a ``perf(planner): ...`` PR whose claimed speed-up targeted the wrong layer,
+was never substantiated on the real campaign entry point, and had to be reverted
+in #3613). When triggered, it requires the PR body to carry a ``Performance
+Evidence`` section with concrete before/after runtime, a representative command,
+a rollback/failure criterion, and — when the change claims caching — a
+cache-hit/reuse counter.
+
+The trigger (perf commit subjects) is read locally from ``git log`` so the check
+runs the same way in ``pr_ready_check.sh`` and in CI, without needing the GitHub
+``perf`` label. ``--commits-file`` injects subjects for tests.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from scripts.dev.check_pr_followups import (
+    _clean_value,
+    _extract_section,
+    _is_empty_or_option_placeholder,
+    _value_after_label,
+)
+
+# Conventional-commit perf type: ``perf``, optional ``(scope)``, optional ``!``, then ``:``.
+PERF_SUBJECT_RE = re.compile(r"^\s*perf(?:\([^)]*\))?!?:", re.IGNORECASE)
+# Caching is inferred from the perf subject only (not the body, which mentions
+# "cache"/"reuse" in its own field labels and would self-trigger).
+CACHING_RE = re.compile(r"\b(?:cache|caching|cached|memoi[sz]e?d?|reuse)\b", re.IGNORECASE)
+
+CORE_FIELDS = (
+    "Baseline runtime",
+    "Changed runtime",
+    "Representative command",
+    "Rollback or failure criterion",
+)
+CACHE_FIELD = "Cache-hit or reuse counter"
+SECTION_HEADING = "Performance Evidence"
+# A field is absent when it is empty/option-placeholder, or opens with an NA/none token —
+# even with a trailing reason ("NA - measured later"), which does not satisfy the contract.
+_NA_PREFIX_RE = re.compile(r"^(?:n/?a|none|no|not\s+applicable)\b", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class PerfEvidenceReport:
+    """Compact performance-evidence contract report."""
+
+    status: str
+    source: str
+    perf_subjects: tuple[str, ...]
+    caching_claimed: bool
+    missing_fields: tuple[str, ...] = field(default_factory=tuple)
+    message: str = ""
+
+
+def perf_commit_subjects(subjects: tuple[str, ...]) -> tuple[str, ...]:
+    """Return the subjects that are conventional-commit ``perf`` changes."""
+    return tuple(subject for subject in subjects if PERF_SUBJECT_RE.match(subject))
+
+
+def claims_caching(perf_subjects: tuple[str, ...]) -> bool:
+    """Return whether any perf commit subject claims a caching/reuse speed-up."""
+    return any(CACHING_RE.search(subject) for subject in perf_subjects)
+
+
+def _field_missing(section: str, label: str) -> bool:
+    """Return whether a required evidence field is empty, placeholder, or NA."""
+    value = _value_after_label(section, label)
+    if _is_empty_or_option_placeholder(value):
+        return True
+    return bool(_NA_PREFIX_RE.match(_clean_value(value)))
+
+
+def analyze_perf_evidence(
+    body: str,
+    *,
+    perf_subjects: tuple[str, ...],
+    source: str,
+) -> PerfEvidenceReport:
+    """Return the performance-evidence contract report for a PR body."""
+    triggers = perf_commit_subjects(perf_subjects)
+    if not triggers:
+        return PerfEvidenceReport(
+            status="skipped",
+            source=source,
+            perf_subjects=(),
+            caching_claimed=False,
+            message="No perf-typed conventional-commit change; contract not required.",
+        )
+
+    caching = claims_caching(triggers)
+    section = _extract_section(body, SECTION_HEADING)
+    if not section:
+        return PerfEvidenceReport(
+            status="missing_perf_evidence",
+            source=source,
+            perf_subjects=triggers,
+            caching_claimed=caching,
+            missing_fields=CORE_FIELDS,
+            message=(
+                f"perf change requires a '## {SECTION_HEADING}' section with baseline/changed "
+                "runtime, a representative command, and a rollback criterion."
+            ),
+        )
+
+    missing = [label for label in CORE_FIELDS if _field_missing(section, label)]
+    if missing:
+        return PerfEvidenceReport(
+            status="incomplete_perf_evidence",
+            source=source,
+            perf_subjects=triggers,
+            caching_claimed=caching,
+            missing_fields=tuple(missing),
+            message=(
+                "perf Performance Evidence section is missing concrete values for: "
+                f"{', '.join(missing)}."
+            ),
+        )
+
+    if caching and _field_missing(section, CACHE_FIELD):
+        return PerfEvidenceReport(
+            status="missing_cache_counter",
+            source=source,
+            perf_subjects=triggers,
+            caching_claimed=True,
+            missing_fields=(CACHE_FIELD,),
+            message=(
+                "perf change claims caching; provide a concrete "
+                f"'{CACHE_FIELD}' (hit/miss or reuse count on the real entry point)."
+            ),
+        )
+
+    return PerfEvidenceReport(
+        status="ok",
+        source=source,
+        perf_subjects=triggers,
+        caching_claimed=caching,
+        message="Performance evidence contract satisfied.",
+    )
+
+
+def _read_commit_subjects(base_ref: str) -> tuple[str, ...]:
+    """Return commit subjects in ``BASE_REF..HEAD`` (empty on git failure)."""
+    try:
+        result = subprocess.run(
+            ["git", "log", "--no-merges", "--format=%s", f"{base_ref}..HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=20,
+            check=False,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return ()
+    if result.returncode != 0:
+        return ()
+    return tuple(line.strip() for line in result.stdout.splitlines() if line.strip())
+
+
+def _load_commit_subjects(args: argparse.Namespace) -> tuple[str, ...]:
+    if args.commits_file:
+        return tuple(
+            line.strip()
+            for line in args.commits_file.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        )
+    return _read_commit_subjects(args.base_ref)
+
+
+def _load_body(args: argparse.Namespace) -> tuple[str | None, str]:
+    if args.body_file:
+        return args.body_file.read_text(encoding="utf-8"), str(args.body_file)
+    env_body = os.environ.get("PR_READY_PR_BODY_FILE")
+    if env_body:
+        path = Path(env_body)
+        return path.read_text(encoding="utf-8"), str(path)
+    return None, "none"
+
+
+def _format_report(report: PerfEvidenceReport) -> str:
+    subjects = "; ".join(report.perf_subjects) if report.perf_subjects else "none"
+    missing = ", ".join(report.missing_fields) if report.missing_fields else "none"
+    return (
+        "PR perf-evidence check: "
+        f"status={report.status}; source={report.source}; "
+        f"perf_subjects={subjects!r}; caching_claimed={report.caching_claimed}; "
+        f"missing_fields={missing}; {report.message}"
+    )
+
+
+def _emit_advisory_warning(message: str) -> None:
+    print(f"::warning title=Performance evidence contract (advisory)::{message}")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--body-file", type=Path, help="Markdown PR body to check.")
+    parser.add_argument(
+        "--base-ref",
+        default=os.environ.get("BASE_REF", "origin/main"),
+        help="Base ref for the perf-commit scan (default: origin/main or $BASE_REF).",
+    )
+    parser.add_argument(
+        "--commits-file",
+        type=Path,
+        help="Newline-delimited commit subjects (overrides git log; used by tests).",
+    )
+    parser.add_argument(
+        "--require-body",
+        action="store_true",
+        help="Fail closed for a perf change when no PR body source is available.",
+    )
+    parser.add_argument(
+        "--advisory",
+        action="store_true",
+        help="Report contract violations as warnings and exit 0 instead of failing.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable JSON.")
+    return parser
+
+
+FAILING_STATUSES = {
+    "missing_perf_evidence",
+    "incomplete_perf_evidence",
+    "missing_cache_counter",
+    "missing_body",
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the performance-evidence contract CLI."""
+    args = _build_parser().parse_args(argv)
+    advisory = args.advisory or os.environ.get("PR_READY_ADVISORY", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+    perf_subjects = _load_commit_subjects(args)
+    triggers = perf_commit_subjects(perf_subjects)
+    body, source = _load_body(args)
+
+    if body is None:
+        # No body to evaluate. Only a problem when there is a perf change and the
+        # caller demands a body (final readiness).
+        require = args.require_body and bool(triggers)
+        report = PerfEvidenceReport(
+            status="missing_body" if require else "skipped",
+            source=source,
+            perf_subjects=triggers,
+            caching_claimed=claims_caching(triggers),
+            message=(
+                "perf change requires a PR body; provide --body-file or PR_READY_PR_BODY_FILE."
+                if require
+                else "No PR body source configured; perf-evidence contract not enforced."
+            ),
+        )
+    else:
+        report = analyze_perf_evidence(body, perf_subjects=perf_subjects, source=source)
+
+    if args.json:
+        print(json.dumps(report.__dict__, sort_keys=True))
+    else:
+        stream = sys.stderr if report.status in FAILING_STATUSES else sys.stdout
+        print(_format_report(report), file=stream)
+
+    if report.status in FAILING_STATUSES:
+        if advisory:
+            _emit_advisory_warning(report.message)
+            return 0
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -196,6 +196,14 @@ if [[ "$pr_ready_final" == "1" ]]; then
   followup_args+=(--require-body)
 fi
 uv run python "$SCRIPT_DIR/check_pr_followups.py" "${followup_args[@]}"
+perf_args=(--base-ref "$BASE_REF")
+if [[ "$pr_ready_final" == "1" ]]; then
+  perf_args+=(--require-body)
+else
+  # Interim runs only advise: a WIP perf branch may not yet carry its evidence section.
+  perf_args+=(--advisory)
+fi
+uv run python "$SCRIPT_DIR/check_perf_evidence.py" "${perf_args[@]}"
 uv run python "$SCRIPT_DIR/check_fast_results_claim_map.py"
 "$SCRIPT_DIR/ruff_fix_format.sh"
 printf 'Running core readiness lane.\n' >&2

--- a/tests/dev/test_check_perf_evidence.py
+++ b/tests/dev/test_check_perf_evidence.py
@@ -1,0 +1,237 @@
+"""Tests for the performance-PR evidence contract check.
+
+The contract fires only for `perf`-typed conventional-commit changes (the #3611
+failure mode: a `perf(planner): ...` PR whose claimed speed-up was never
+substantiated and had to be reverted in #3613). It requires the PR body to carry
+concrete before/after evidence, a representative command, a rollback criterion,
+and — when caching is claimed — a cache-hit/reuse counter.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from scripts.dev.check_perf_evidence import (
+    analyze_perf_evidence,
+    claims_caching,
+    perf_commit_subjects,
+)
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "dev" / "check_perf_evidence.py"
+
+
+def _evidence_section(
+    *,
+    baseline: str = "42.0 s on the S20 planner slice (3 seeds)",
+    changed: str = "30.1 s on the same slice + seeds",
+    command: str = "scripts/dev/run_tests_parallel.sh --lane optional",
+    cache_counter: str = "NA - no caching claimed",
+    rollback: str = "revert if the slice regresses > 5% vs baseline",
+) -> str:
+    return f"""## Performance Evidence
+- Baseline runtime: {baseline}
+- Changed runtime: {changed}
+- Representative command: {command}
+- Hot-path call count or profile anchor: cProfile on compute_shortest_path_length
+- Cache-hit or reuse counter: {cache_counter}
+- Rollback or failure criterion: {rollback}
+"""
+
+
+def _body(section: str = "") -> str:
+    return f"""## Summary
+Speed up the planner hot path.
+
+{section}
+"""
+
+
+# --- trigger detection -------------------------------------------------------
+
+
+def test_perf_commit_subjects_detects_conventional_perf_types() -> None:
+    """Conventional-commit perf subjects trigger the contract; others do not."""
+    subjects = (
+        "perf(planner): cache motion-planning grid to unblock the #1554 S20 matrix",
+        "perf!: drop redundant recompute",
+        "feat(benchmark): add evaluator",
+        "fix: guard NaN",
+        "refactor(planner): rename helper",
+    )
+
+    triggered = perf_commit_subjects(subjects)
+
+    assert triggered == (
+        "perf(planner): cache motion-planning grid to unblock the #1554 S20 matrix",
+        "perf!: drop redundant recompute",
+    )
+
+
+def test_claims_caching_reads_perf_subjects_only() -> None:
+    """Caching is inferred from the perf commit subjects, not the body."""
+    assert claims_caching(("perf(planner): cache motion-planning grid",))
+    assert claims_caching(("perf: memoize feasibility lookups",))
+    assert not claims_caching(("perf(planner): pin CPU and raise worker count",))
+
+
+# --- analyze_perf_evidence ---------------------------------------------------
+
+
+def test_non_perf_change_is_skipped_regardless_of_body() -> None:
+    """A change with no perf commits is not subject to the contract."""
+    report = analyze_perf_evidence(_body(), perf_subjects=(), source="fixture")
+
+    assert report.status == "skipped"
+
+
+def test_full_evidence_section_passes() -> None:
+    """A perf change with a complete evidence section passes."""
+    report = analyze_perf_evidence(
+        _body(_evidence_section()),
+        perf_subjects=("perf(planner): pin CPU and raise worker count",),
+        source="fixture",
+    )
+
+    assert report.status == "ok", report.message
+
+
+def test_missing_section_fails() -> None:
+    """A perf change with no Performance Evidence section fails closed."""
+    report = analyze_perf_evidence(
+        _body(),
+        perf_subjects=("perf(planner): pin CPU and raise worker count",),
+        source="fixture",
+    )
+
+    assert report.status == "missing_perf_evidence"
+
+
+def test_placeholder_core_field_is_incomplete() -> None:
+    """A placeholder/NA baseline runtime is reported as a missing field."""
+    report = analyze_perf_evidence(
+        _body(_evidence_section(baseline="NA")),
+        perf_subjects=("perf(planner): pin CPU and raise worker count",),
+        source="fixture",
+    )
+
+    assert report.status == "incomplete_perf_evidence"
+    assert "Baseline runtime" in report.missing_fields
+
+
+def test_caching_claim_requires_cache_counter() -> None:
+    """When the perf subject claims caching, an NA cache counter fails."""
+    report = analyze_perf_evidence(
+        _body(_evidence_section(cache_counter="NA - no caching claimed")),
+        perf_subjects=("perf(planner): cache motion-planning grid",),
+        source="fixture",
+    )
+
+    assert report.status == "missing_cache_counter"
+    assert "Cache-hit or reuse counter" in report.missing_fields
+
+
+def test_caching_claim_passes_with_real_counter() -> None:
+    """A caching perf change passes when the cache counter is concrete."""
+    report = analyze_perf_evidence(
+        _body(_evidence_section(cache_counter="hits=18234 misses=512 (97.3% reuse)")),
+        perf_subjects=("perf(planner): cache motion-planning grid",),
+        source="fixture",
+    )
+
+    assert report.status == "ok", report.message
+
+
+def test_non_caching_change_does_not_require_cache_counter() -> None:
+    """A non-caching perf change with an NA cache counter still passes."""
+    report = analyze_perf_evidence(
+        _body(_evidence_section(cache_counter="NA")),
+        perf_subjects=("perf(planner): pin CPU and raise worker count",),
+        source="fixture",
+    )
+
+    assert report.status == "ok", report.message
+
+
+# --- CLI ---------------------------------------------------------------------
+
+
+def _run_cli(args: list[str], tmp_path: Path) -> subprocess.CompletedProcess[str]:
+    repo_root = SCRIPT.resolve().parents[2]
+    return subprocess.run(
+        [sys.executable, str(SCRIPT), *args],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        check=False,
+    )
+
+
+def _write(tmp_path: Path, name: str, text: str) -> Path:
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_cli_passes_for_complete_perf_evidence(tmp_path: Path) -> None:
+    """A perf change with a complete evidence section exits 0 via the CLI."""
+    body = _write(tmp_path, "body.md", _body(_evidence_section()))
+    commits = _write(tmp_path, "commits.txt", "perf(planner): pin CPU and raise worker count\n")
+
+    result = _run_cli(["--body-file", str(body), "--commits-file", str(commits)], tmp_path)
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_cli_fails_for_missing_perf_evidence(tmp_path: Path) -> None:
+    """A perf change with no evidence section exits 2 via the CLI."""
+    body = _write(tmp_path, "body.md", _body())
+    commits = _write(tmp_path, "commits.txt", "perf(planner): cache grid\n")
+
+    result = _run_cli(["--body-file", str(body), "--commits-file", str(commits)], tmp_path)
+
+    assert result.returncode == 2
+    assert "missing_perf_evidence" in (result.stderr + result.stdout)
+
+
+def test_cli_advisory_downgrades_failure(tmp_path: Path) -> None:
+    """Advisory mode emits a warning annotation and exits 0 on a violation."""
+    body = _write(tmp_path, "body.md", _body())
+    commits = _write(tmp_path, "commits.txt", "perf(planner): cache grid\n")
+
+    result = _run_cli(
+        ["--body-file", str(body), "--commits-file", str(commits), "--advisory"], tmp_path
+    )
+
+    assert result.returncode == 0
+    assert "::warning" in result.stdout
+
+
+def test_cli_skips_non_perf_change(tmp_path: Path) -> None:
+    """A change with no perf commits exits 0 regardless of the body."""
+    body = _write(tmp_path, "body.md", _body())
+    commits = _write(tmp_path, "commits.txt", "feat: add thing\nfix: guard\n")
+
+    result = _run_cli(["--body-file", str(body), "--commits-file", str(commits)], tmp_path)
+
+    assert result.returncode == 0
+
+
+def test_cli_requires_body_when_perf_change_and_no_body(tmp_path: Path) -> None:
+    """--require-body fails closed for a perf change with no body source."""
+    commits = _write(tmp_path, "commits.txt", "perf: cache grid\n")
+
+    result = _run_cli(["--commits-file", str(commits), "--require-body"], tmp_path)
+
+    assert result.returncode == 2
+    assert "missing_body" in (result.stderr + result.stdout)
+
+
+def test_cli_missing_body_without_require_is_lenient(tmp_path: Path) -> None:
+    """Without --require-body, a perf change with no body source exits 0."""
+    commits = _write(tmp_path, "commits.txt", "perf: cache grid\n")
+
+    result = _run_cli(["--commits-file", str(commits)], tmp_path)
+
+    assert result.returncode == 0

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -14,6 +14,7 @@ SCRIPTS_DEV = REPO_ROOT / "scripts" / "dev"
 
 _POST_PREFLIGHT_SCRIPTS = [
     "check_pr_followups.py",
+    "check_perf_evidence.py",
     "check_fast_results_claim_map.py",
     "ruff_fix_format.sh",
     "run_tests_parallel.sh",


### PR DESCRIPTION
## Summary
Add a performance-PR evidence contract that mechanically catches the #3611 → #3613 failure mode (a `perf(planner): cache ...` PR whose claimed speed-up targeted the wrong layer and had to be reverted).

## Linked Issues
- Relates to the #3611 → #3613 wrong-layer cache revert (process hardening; no issue number for the contract itself).

## What Changed
- **`scripts/dev/check_perf_evidence.py`** — new check. Triggers only on `perf(...)` conventional-commit subjects in `BASE_REF..HEAD` (no GitHub label needed). Requires a `## Performance Evidence` PR-body section with concrete baseline/changed runtime, a representative command, and a rollback criterion; requires a cache-hit/reuse counter only when the commit subject claims caching. Mirrors `check_pr_followups.py` conventions (advisory mode → `::warning::` + exit 0; `--require-body`; `--json`; `--commits-file` for test injection).
- **`scripts/dev/pr_ready_check.sh`** — wires the check in: fail-closed in `final` mode, advisory in interim.
- **`.github/PULL_REQUEST_TEMPLATE/pr_default.md`** — new `## Performance Evidence` section (deleted for non-perf PRs).
- **`tests/dev/test_check_perf_evidence.py`** — 15 unit + CLI tests.
- **`CHANGELOG.md`** — Added entry.

## Why It Matters
- Added value: turns the textual "perf claims need evidence" norm into a merge-blocking gate on the exact signal (`perf(...)`) that #3611 carried.
- Expected impact: a perf PR cannot claim a speed-up without before/after numbers, a reproducible command, a rollback criterion, and (for caching) a real reuse counter on the entry point.
- Why now: #3611 showed the discipline is currently only textual; this makes it mechanical without adding noise to non-perf PRs.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - workflow/tooling guard, no research claim.
- Evidence tier: NA - workflow guard only.
- Result classification: NA - no research claim.

## Validation / Proof
- Commands run:
  - `uv run pytest tests/dev/test_check_perf_evidence.py -q` → 15 passed; with the sibling follow-ups suite → 63 passed.
  - `uv run ruff check ...` clean; `bash -n scripts/dev/pr_ready_check.sh` clean.
  - `uv run python scripts/validation/check_broad_exceptions.py` → ratchet passes (283 entries, unchanged).
- Evidence that the change works here:
  - Integration A (this branch, no perf commits): `status=skipped`, exit 0.
  - Integration B (simulated `perf(planner): cache motion-planning grid...` + hand-wavy body): `status=missing_perf_evidence`, exit 2, `caching_claimed=True`.
- This PR is a `feat`/tooling change (not `perf`), so the new contract correctly skips it — no self-block.

## Risks / Rollout
- Compatibility risks: none for non-perf PRs (skipped). Perf PRs now need the evidence section.
- Failure modes: a perf change with placeholder/NA fields fails final readiness (intended).
- Rollback or fallback plan: advisory in interim mode already; set the perf check to `--advisory` in `pr_ready_check.sh`, or revert this commit, to disable blocking.

## Follow-Up Issues
- Deferred work: a finite-check coverage lint for diagnostic float producers was considered and deferred (reliable detection needs fragile AST heuristics; better as a review-checklist item).
- Issues opened for follow-up: none.
