### PR TITLE
Fix #3624 PPO observation keys for flat map-runner dicts

### DIFF
--- a/robot_sf/baselines/ppo.py
+++ b/robot_sf/baselines/ppo.py
@@ -370,6 +370,7 @@ class PPOPlanner:
         """Return dict observations plus any missing predictive feature payload."""
 
         source_obs = self._flatten_nested_observation(obs)
+        source_obs = self._expand_flat_observation_for_spaces(source_obs, spaces)
         if self._predictive_foresight is not None:
             missing_predictive = [
                 key for key in spaces if key.startswith("predictive_") and key not in source_obs
@@ -398,18 +399,66 @@ class PPOPlanner:
         _flatten_recursive(obs)
         return flattened
 
+    @classmethod
+    def _expand_flat_observation_for_spaces(
+        cls,
+        obs: dict[str, Any],
+        spaces: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Return observation with flat map-runner leaves exposed as nested Dict keys."""
+
+        expanded: dict[str, Any] = dict(obs)
+        for key, sub_space in spaces.items():
+            key_str = str(key)
+            if key_str in expanded:
+                continue
+            sub_spaces = getattr(sub_space, "spaces", None)
+            if not isinstance(sub_spaces, dict):
+                continue
+            nested = cls._nested_observation_from_flat_prefix(expanded, key_str, sub_spaces)
+            if nested:
+                expanded[key_str] = nested
+        return expanded
+
+    @classmethod
+    def _nested_observation_from_flat_prefix(
+        cls,
+        obs: dict[str, Any],
+        prefix: str,
+        spaces: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build a nested observation block from ``prefix_child`` flat keys.
+
+        Returns:
+            Nested observation payload containing the available declared leaves.
+        """
+
+        nested: dict[str, Any] = {}
+        for key, sub_space in spaces.items():
+            key_str = str(key)
+            flat_key = f"{prefix}_{key_str}"
+            sub_spaces = getattr(sub_space, "spaces", None)
+            if isinstance(sub_spaces, dict):
+                child = cls._nested_observation_from_flat_prefix(obs, flat_key, sub_spaces)
+                if child:
+                    nested[key_str] = child
+                continue
+            if flat_key in obs:
+                nested[key_str] = obs[flat_key]
+        return nested
+
     def _align_model_obs_dict(
         self,
         source_obs: dict[str, Any],
         spaces: dict[str, Any],
-    ) -> dict[str, np.ndarray]:
+    ) -> dict[str, Any]:
         """Align source observation fields to a model-declared Dict space.
 
         Returns:
             Dict payload shaped and typed to match the model-declared subspaces.
         """
 
-        converted: dict[str, np.ndarray] = {}
+        converted: dict[str, Any] = {}
         missing: list[str] = []
         aliases: dict[str, tuple[str, ...]] = {
             "robot_speed": ("robot_velocity_xy",),
@@ -419,6 +468,15 @@ class PPOPlanner:
             source = self._resolve_dict_observation_source(source_obs, str(key), aliases)
             if source is None:
                 missing.append(str(key))
+                continue
+            sub_spaces = getattr(sub_space, "spaces", None)
+            if isinstance(sub_spaces, dict):
+                if not isinstance(source, dict):
+                    raise ValueError(
+                        f"Observation key '{key}' expected nested Dict payload, "
+                        f"got {type(source).__name__}",
+                    )
+                converted[key] = self._align_model_obs_dict(source, sub_spaces)
                 continue
             target_shape = getattr(sub_space, "shape", None)
             target_dtype = getattr(sub_space, "dtype", None)
@@ -695,8 +753,11 @@ class PPOPlanner:
         Returns:
             Goal-directed fallback action dict.
         """
-        robot_pos = np.asarray(obs.get("robot_position", [0.0, 0.0]), dtype=float).reshape(-1)
-        goal_pos = np.asarray(obs.get("goal_current", [0.0, 0.0]), dtype=float).reshape(-1)
+        source_obs = self._flatten_nested_observation(obs)
+        robot_pos = np.asarray(source_obs.get("robot_position", [0.0, 0.0]), dtype=float).reshape(
+            -1
+        )
+        goal_pos = np.asarray(source_obs.get("goal_current", [0.0, 0.0]), dtype=float).reshape(-1)
         if robot_pos.size < 2 or goal_pos.size < 2:
             if self.config.action_space == "unicycle":
                 return {"v": 0.0, "omega": 0.0}

--- a/tests/test_baseline_ppo_observation_keys.py
+++ b/tests/test_baseline_ppo_observation_keys.py
@@ -1,0 +1,129 @@
+"""Regression tests for PPO dict observation key normalization."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+import pytest
+from gymnasium import spaces as gym_spaces
+
+from robot_sf.baselines.ppo import PPOPlanner, PPOPlannerConfig
+
+
+class _FakePPOModel:
+    """Small Stable-Baselines3-like model double for observation adapter tests."""
+
+    def __init__(self, observation_space: gym_spaces.Dict) -> None:
+        self.observation_space = observation_space
+        self.last_obs: dict[str, Any] | None = None
+
+    def predict(
+        self,
+        obs: dict[str, Any],
+        *,
+        deterministic: bool,
+    ) -> tuple[np.ndarray, None]:
+        """Capture model-ready observation and return a deterministic velocity action."""
+        self.last_obs = obs
+        return np.array([0.4, -0.2], dtype=np.float32), None
+
+
+def _box(shape: tuple[int, ...]) -> gym_spaces.Box:
+    """Return a float32 Box leaf for PPO Dict observation spaces."""
+    return gym_spaces.Box(low=-np.inf, high=np.inf, shape=shape, dtype=np.float32)
+
+
+def _planner_with_model(model: _FakePPOModel) -> PPOPlanner:
+    """Build a PPOPlanner with a fake loaded model and no checkpoint IO."""
+    planner = PPOPlanner.__new__(PPOPlanner)
+    planner.config = PPOPlannerConfig(
+        obs_mode="dict",
+        action_space="velocity",
+        fallback_to_goal=False,
+    )
+    planner._seed = None
+    planner._model = model
+    planner._status = "ok"
+    planner._fallback_reason = None
+    planner._predictive_foresight = None
+    planner._runtime_observation_space = None
+    return planner
+
+
+def test_ppo_dict_obs_maps_flat_runner_keys_to_nested_model_space() -> None:
+    """Flat map-runner observations should satisfy nested robot_env-style PPO spaces."""
+    model = _FakePPOModel(
+        gym_spaces.Dict(
+            {
+                "robot": gym_spaces.Dict(
+                    {
+                        "position": _box((2,)),
+                        "velocity": _box((2,)),
+                    }
+                ),
+                "goal": gym_spaces.Dict({"current": _box((2,))}),
+                "pedestrians": gym_spaces.Dict(
+                    {
+                        "positions": _box((2, 2)),
+                        "velocities": _box((2, 2)),
+                        "count": _box((1,)),
+                        "radius": _box((1,)),
+                    }
+                ),
+            }
+        )
+    )
+    planner = _planner_with_model(model)
+    flat_obs = {
+        "robot_position": np.array([1.0, 2.0], dtype=np.float32),
+        "robot_velocity": np.array([0.1, 0.2], dtype=np.float32),
+        "goal_current": np.array([4.0, 5.0], dtype=np.float32),
+        "pedestrians_positions": np.array([[2.0, 2.0], [3.0, 3.0]], dtype=np.float32),
+        "pedestrians_velocities": np.zeros((2, 2), dtype=np.float32),
+        "pedestrians_count": np.array([2.0], dtype=np.float32),
+        "pedestrians_radius": np.array([0.35], dtype=np.float32),
+    }
+
+    action = planner.step(flat_obs)
+
+    assert action == {"vx": pytest.approx(0.4), "vy": pytest.approx(-0.2)}
+    assert model.last_obs is not None
+    np.testing.assert_allclose(model.last_obs["robot"]["position"], [1.0, 2.0])
+    np.testing.assert_allclose(model.last_obs["robot"]["velocity"], [0.1, 0.2])
+    np.testing.assert_allclose(model.last_obs["goal"]["current"], [4.0, 5.0])
+    np.testing.assert_allclose(
+        model.last_obs["pedestrians"]["positions"],
+        [[2.0, 2.0], [3.0, 3.0]],
+    )
+
+
+def test_ppo_dict_obs_keeps_nested_env_obs_compatible_with_flat_model_space() -> None:
+    """Nested env observations should continue to satisfy flattened SB3-compatible spaces."""
+    model = _FakePPOModel(
+        gym_spaces.Dict(
+            {
+                "robot_position": _box((2,)),
+                "goal_current": _box((2,)),
+                "pedestrians_positions": _box((2, 2)),
+            }
+        )
+    )
+    planner = _planner_with_model(model)
+    nested_obs = {
+        "robot": {"position": np.array([1.0, 2.0], dtype=np.float32)},
+        "goal": {"current": np.array([4.0, 5.0], dtype=np.float32)},
+        "pedestrians": {"positions": np.array([[2.0, 2.0], [3.0, 3.0]], dtype=np.float32)},
+    }
+
+    action = planner.step(nested_obs)
+
+    assert action == {"vx": pytest.approx(0.4), "vy": pytest.approx(-0.2)}
+    assert model.last_obs is not None
+    assert set(model.last_obs) == {
+        "robot_position",
+        "goal_current",
+        "pedestrians_positions",
+    }
+    np.testing.assert_allclose(model.last_obs["robot_position"], [1.0, 2.0])
+    np.testing.assert_allclose(model.last_obs["goal_current"], [4.0, 5.0])


### PR DESCRIPTION
## Summary
Fixes the PPO dict-observation adapter so flat map-runner observations can satisfy PPO model observation spaces that declare nested robot_env-style dictionary keys.

Issue link: https://github.com/ll7/robot_sf_ll7/issues/3624

## Linked Issues
- Relates to #3624

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added bidirectional PPO dict observation normalization in robot_sf/baselines/ppo.py:
  - nested env observations are still flattened for flat SB3-compatible model keys;
  - flat map-runner keys such as robot_position and goal_current are expanded into nested Dict payloads when the model observation space declares nested keys.
- Added focused regression tests using a fake PPO model observation_space for both flat-to-nested and nested-to-flat observation shapes.

## Why Matters
- Added value: removes the missing-key adapter mismatch for PPO map-runner dict observations without changing benchmark semantics or model artifacts.
- Expected impact: PPO dict-mode map-runner paths can reach model prediction instead of failing on observation-key shape mismatch.
- Why worth merging now: small first implementation slice for #3624 with targeted coverage.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for PPO observation adapter key mismatch in #3624.
- Comparator or baseline, applicable: NA; no benchmark claim.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision stop rule, applicable: focused tests prove flat map-runner keys map into nested model spaces and nested env observations still map into flat model spaces.
- Parent issue, claim map, registry, context note, synthesis surface update: #3624 only; no claim map or registry update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA

## Domain-Aware Approval
- Approver/review source waiver: not required; no benchmark result, metric change, model provenance change, paper-facing claim, or dissertation claim.
- Validity checklist: NA
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: no fallback/degraded benchmark outcome claimed.
- Claim boundary: adapter-unit and map-runner bridge tests only.
- Implementation integrity vs experimental validity: implementation-only adapter fix; no experimental validity claim.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes in targeted fake-model tests.
- Did intervention change command source, selected command, trajectory, route progress? no route or trajectory run; adapter payload only.
- Did scenario actually contain targeted failure mode? targeted unit test reproduces flat map-runner keys against nested model observation_space.
- Result route: continue to full PR gate by follow-up owner.
- Follow-up question issue weak, negative, non-transfer results: #3624 remains the parent for any broader benchmark follow-up.

## Next Empirical Action
- Rerun needed: yes, follow-up owner should run full PR gate if required.
- Extractor analysis tool needed: no
- Artifact missing unavailable: no model or benchmark artifact expected for this slice.
- Stop / revise / continue decision: continue review.
- Proposed child issue existing follow-up: none opened.

## Validation / Proof
- git fetch --prune origin: passed
- gh pr list open search for #3624 / PPO observation key overlap: passed, returned no matching open PRs
- uv run python -m py_compile robot_sf/baselines/ppo.py tests/test_baseline_ppo_observation_keys.py: passed
- uv run ruff check robot_sf/baselines/ppo.py tests/test_baseline_ppo_observation_keys.py: passed
- uv run ruff format --check robot_sf/baselines/ppo.py tests/test_baseline_ppo_observation_keys.py: passed
- uv run pytest tests/test_baseline_ppo_observation_keys.py: passed, 2 passed
- uv run pytest tests/test_map_runner_ppo.py: passed, 13 passed
- git diff --check: passed
- git diff --cached --check: passed before commit
- uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree: clean tree, but failed with reason missing because no full pr_ready stamp was produced for this targeted slice

Explicitly out of scope: no full benchmark campaign run, no full scenario-horizon benchmark campaign run, no Slurm/GPU submission, no PPO retraining, no model artifact changes, no paper/dissertation claim edits.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; prompt disallowed issue/PR comments outside PR open flow.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA; no obvious issue_3624 context note existed.
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this is an adapter bugfix slice, not benchmark evidence or model provenance work.

## Follow-Up Issues
- Deferred work: Claude Code on imech156-u owns the full PR gate, improvement cycle, and merge authority per handoff prompt.
- Issues opened follow-up: none

## Reviewer Notes
- Review the recursive Dict alignment in robot_sf/baselines/ppo.py closely; it intentionally only expands flat keys when the model-declared observation subspace is nested.
- Known limitations: targeted tests use fake model spaces and do not run an actual PPO checkpoint or scenario-horizon campaign.
