### PR TITLE
feat(benchmark): fail-closed planner observation-view integrity guard (#3634)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **fail-closed planner observation-view integrity guard** in the benchmark runner (#3634,
+  the runtime guard deferred from #3568). New `robot_sf/benchmark/map_runner_view_integrity.py`
+  (`evaluate_effective_view_integrity` + `DegeneratePlannerViewError`, reason `degenerate_planner_view`)
+  is checked on the first step in `map_runner_episode.py`: when the observation handed to the planner
+  contains pedestrians (`observation_ped_count > 0`) but the planner's own extractor returns zero — and
+  the planner is not pedestrian-blind-by-design (per its `observation_spec.inputs`) — the runner raises
+  **before any metrics are recorded**, instead of silently emitting collision "results" from a blind
+  planner (the `stream_gap` failure class fixed in #3567). Ground truth is the *observation's own*
+  pedestrian count, so visibility-masked/occluded or genuinely-empty scenarios do not false-trip. The
+  passing diagnostic is stored at `record["integrity"]["effective_view"]`. 20 guard tests + 145
+  regression + 13 end-to-end episode tests pass.
 * Began the #3463 corrective engineering for the topology near-parity selector lane (diagnostic-tier,
   no benchmark claim). `TopologyGuidedLocalPolicyConfig` gains two current-behavior-preserving knobs:
   `primary_route_progress_gate_use_monotone_accounting` (default `False`) hardens primary-route

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -74,6 +74,10 @@ from robot_sf.benchmark.map_runner_trace import (
     _single_pedestrian_vru_metadata,
     _trace_pedestrians,
 )
+from robot_sf.benchmark.map_runner_view_integrity import (
+    DegeneratePlannerViewError,
+    evaluate_effective_view_integrity,
+)
 from robot_sf.benchmark.metrics import EpisodeData, compute_all_metrics, post_process_metrics
 from robot_sf.benchmark.observation_noise import (
     apply_observation_noise,
@@ -385,10 +389,25 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         previous_trace_ped_pos: np.ndarray | None = None
         previous_trace_heading = _observation_heading(obs)
         robot_headings: list[float] = []
+        view_integrity: dict[str, Any] | None = None
         for step_idx in range(horizon_val):
             policy_obs, step_noise_stats = apply_observation_noise(obs, noise_spec, noise_rng)
             merge_observation_noise_stats(noise_stats, step_noise_stats)
             policy_command = policy_fn(policy_obs)
+            if view_integrity is None:
+                # Runtime fail-closed guard (#3634): probe the planner's effective observation view
+                # once. The extractor signature is deterministic across steps, so a single probe
+                # detects a silent-blind planner before any benchmark metrics are recorded. Fail
+                # closed per docs/context/issue_691_benchmark_fallback_policy.md instead of emitting
+                # results produced by a planner that drives blind to the pedestrians it was shown.
+                integrity = evaluate_effective_view_integrity(
+                    policy_fn=policy_fn,
+                    observation=policy_obs,
+                    algo_meta=algo_meta,
+                )
+                view_integrity = integrity.to_metadata()
+                if integrity.degraded:
+                    raise DegeneratePlannerViewError(integrity)
             actuation_step = None
             planner_step_decision = None
             if record_planner_decision_trace and callable(planner_stats):
@@ -881,7 +900,10 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         "timing": timing,
         "termination_reason": termination_reason,
         "outcome": outcome,
-        "integrity": {"contradictions": contradictions},
+        "integrity": {
+            "contradictions": contradictions,
+            "effective_view": view_integrity,
+        },
     }
     record.update(static_deadlock_fields)
     if benchmark_track is not None:

--- a/robot_sf/benchmark/map_runner_view_integrity.py
+++ b/robot_sf/benchmark/map_runner_view_integrity.py
@@ -1,0 +1,297 @@
+"""Runtime fail-closed guard for degenerate planner observation views (#3634).
+
+Motivation: ``stream_gap`` was *silently blind* in the real benchmark runner (#3556/#3567) — its
+standalone extractor read the wrong observation keys, so it saw ``robot=[0,0], n_peds=0`` and drove
+blind every episode while still emitting collision "results". #3567 fixed the extractor and #3568
+audited the seven headline planners with a *static* contract test, but explicitly deferred the
+*runtime* guard. This module is that guard: the comprehensive, planner-agnostic version.
+
+The invariant this enforces, at the ``map_runner`` planner-adapter boundary:
+
+    the observation handed to the planner carries a nonzero pedestrian count
+    AND the planner's own extractor sees zero pedestrians
+    AND the planner is NOT declared pedestrian-blind by design
+    --> the row is degenerate; ``map_runner`` must FAIL CLOSED
+        (per docs/context/issue_691_benchmark_fallback_policy.md) instead of
+        silently recording collision metrics produced by a blind planner.
+
+Design choices that keep the guard conservative (no false trips):
+
+* Ground truth is the *observation's own* pedestrian count — what was actually presented to the
+  planner — not the raw simulator count. The SocNav observation is visibility-masked and truncated
+  to ``max_pedestrians`` (see ``robot_sf.sensor.socnav_observation``), so a scenario where every
+  pedestrian is occluded/out of range legitimately presents zero pedestrians; that is not
+  degenerate and must not trip the guard.
+* "What the planner sees" is probed through the planner adapter's *own* extractor
+  (``_socnav_fields`` for the shared classical/reference planners, ``_extract_state`` for
+  ``stream_gap``). When no extractor is discoverable, the view is treated as *not probeable* and the
+  guard stays silent — it never fabricates a failure.
+* A planner that ignores pedestrians by design (e.g. the ``goal`` reference, whose declared
+  ``observation_spec.inputs`` omit ``pedestrians``) declares itself via that contract and is
+  exempt. #3568 rejected a behavioural "reacts to pedestrians" guard for exactly this reason: the
+  check inspects *what the planner sees*, not how it reacts.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+#: Canonical degraded-reason code recorded when the guard trips (named in issue #3634/#3568).
+DEGENERATE_PLANNER_VIEW_REASON = "degenerate_planner_view"
+
+
+class DegeneratePlannerViewError(RuntimeError):
+    """Raised to fail a benchmark episode closed when a planner's effective view is degenerate.
+
+    Carrying the structured diagnostic lets callers record an explicit non-success row
+    (``degraded_reason: degenerate_planner_view``) rather than a misleading benchmark result.
+    """
+
+    def __init__(self, diagnostic: EffectiveViewIntegrity) -> None:
+        """Store the integrity diagnostic and build a human-readable fail-closed message."""
+        self.diagnostic = diagnostic
+        super().__init__(diagnostic.message())
+
+
+@dataclass(frozen=True)
+class EffectiveViewIntegrity:
+    """Outcome of the planner effective-view integrity diagnostic for one observation.
+
+    Attributes:
+        degraded: ``True`` when the planner's effective view is degenerate (fail-closed trigger).
+        degraded_reason: Reason code when degraded, else ``None``.
+        observation_ped_count: Pedestrian count carried by the observation handed to the planner.
+        extracted_ped_count: Pedestrian count the planner's own extractor saw, or ``None`` when the
+            view could not be probed.
+        pedestrian_blind_by_design: ``True`` when the planner declares it ignores pedestrians.
+        probed: ``True`` when the planner's effective extraction was actually inspected.
+    """
+
+    degraded: bool
+    degraded_reason: str | None
+    observation_ped_count: int
+    extracted_ped_count: int | None
+    pedestrian_blind_by_design: bool
+    probed: bool
+
+    def to_metadata(self) -> dict[str, Any]:
+        """Return a JSON-serializable summary for episode/row metadata.
+
+        Returns:
+            dict[str, Any]: Stable diagnostic payload with the canonical reason key.
+        """
+        return {
+            "degraded": self.degraded,
+            "degraded_reason": self.degraded_reason,
+            "observation_ped_count": self.observation_ped_count,
+            "extracted_ped_count": self.extracted_ped_count,
+            "pedestrian_blind_by_design": self.pedestrian_blind_by_design,
+            "probed": self.probed,
+        }
+
+    def message(self) -> str:
+        """Return a human-readable fail-closed explanation.
+
+        Returns:
+            str: Diagnostic message describing the degenerate-view trigger.
+        """
+        return (
+            "degenerate planner observation view: the observation carried "
+            f"{self.observation_ped_count} pedestrian(s) but the planner extracted "
+            f"{self.extracted_ped_count}; failing closed with "
+            f"degraded_reason={DEGENERATE_PLANNER_VIEW_REASON} "
+            "(planner is not declared pedestrian-blind by design)."
+        )
+
+
+def _ped_count_from_value(value: Any) -> int:
+    """Resolve a non-negative integer pedestrian count from a scalar/array payload.
+
+    Returns:
+        int: Parsed count, or ``0`` when the payload is missing/malformed.
+    """
+    if value is None:
+        return 0
+    try:
+        arr = np.asarray(value, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        return 0
+    if arr.size == 0:
+        return 0
+    first = arr[0]
+    if not np.isfinite(first):
+        return 0
+    return max(0, int(first))
+
+
+def _rows_count(value: Any) -> int:
+    """Count finite ``(N, 2)`` position rows in a positions payload.
+
+    Returns:
+        int: Number of position rows, or ``0`` when the payload is empty/malformed.
+    """
+    if value is None:
+        return 0
+    try:
+        arr = np.asarray(value, dtype=float)
+    except (TypeError, ValueError):
+        return 0
+    if arr.size == 0:
+        return 0
+    if arr.ndim == 1:
+        return 1 if arr.size >= 2 else 0
+    return int(arr.shape[0])
+
+
+def observation_ped_count(observation: Any) -> int:
+    """Return the pedestrian count carried by a benchmark observation (nested or flat).
+
+    This is the ground truth for the guard: it is exactly what was presented to the planner. The
+    declared ``count`` field is preferred (it already reflects visibility masking/truncation); the
+    number of position rows is used as a fallback.
+
+    Returns:
+        int: Non-negative pedestrian count, or ``0`` when no pedestrian payload is present.
+    """
+    if not isinstance(observation, dict):
+        return 0
+    peds = observation.get("pedestrians")
+    if isinstance(peds, dict):
+        if peds.get("count") is not None:
+            return _ped_count_from_value(peds.get("count"))
+        return _rows_count(peds.get("positions"))
+    # Flat map-runner observation keys.
+    if observation.get("pedestrians_count") is not None:
+        return _ped_count_from_value(observation.get("pedestrians_count"))
+    return _rows_count(observation.get("pedestrians_positions"))
+
+
+def is_pedestrian_blind_by_design(algo_meta: Any) -> bool:
+    """Return whether a planner declares (via its observation contract) that it ignores pedestrians.
+
+    A planner is pedestrian-blind by design when its ``observation_spec.inputs`` contract omits the
+    ``pedestrians`` channel (e.g. the ``goal`` reference). Such planners must not be false-flagged,
+    so they are exempt from the degenerate-view guard.
+
+    Returns:
+        bool: ``True`` when the declared inputs omit the pedestrian channel.
+    """
+    if not isinstance(algo_meta, dict):
+        return False
+    spec = algo_meta.get("observation_spec")
+    if not isinstance(spec, dict):
+        return False
+    inputs = spec.get("inputs")
+    if inputs is None:
+        return False
+    try:
+        declared = {str(value).strip().lower() for value in inputs}
+    except TypeError:
+        return False
+    return "pedestrians" not in declared
+
+
+def _resolve_adapter(policy_fn: Any) -> Any:
+    """Return the planner adapter attached to a built policy callable, if any.
+
+    Returns:
+        Any: The adapter object, or ``None`` when the policy exposes no adapter.
+    """
+    return getattr(policy_fn, "_planner_adapter", None)
+
+
+def probe_extracted_ped_count(policy_fn: Any, observation: Any) -> int | None:
+    """Probe how many pedestrians the planner's *own* extractor sees in ``observation``.
+
+    The probe invokes the adapter's own extraction so the result reflects the planner's effective
+    view, mirroring the silent-blind failure class: a planner whose extractor reads the wrong keys
+    returns zero here even when the observation carries pedestrians.
+
+    Supported extractors (checked in order):
+
+    * ``adapter._socnav_fields(obs) -> (robot, goal, ped_state)`` — shared classical/reference
+      planners; the pedestrian count is read from ``ped_state``.
+    * ``adapter._extract_state(obs) -> (robot_pos, heading, goal_pos, ped_pos, ped_vel)`` —
+      ``stream_gap``; the pedestrian count is ``ped_pos`` row count.
+
+    Returns:
+        int | None: Extracted pedestrian count, or ``None`` when the view is not probeable
+        (no recognised extractor, or the extractor raised).
+    """
+    adapter = _resolve_adapter(policy_fn)
+    if adapter is None:
+        return None
+
+    socnav_fields = getattr(adapter, "_socnav_fields", None)
+    if callable(socnav_fields):
+        try:
+            _robot, _goal, ped_state = socnav_fields(observation)
+        except (TypeError, ValueError, KeyError, IndexError):
+            return None
+        if isinstance(ped_state, dict):
+            if ped_state.get("count") is not None:
+                return _ped_count_from_value(ped_state.get("count"))
+            return _rows_count(ped_state.get("positions"))
+        return None
+
+    extract_state = getattr(adapter, "_extract_state", None)
+    if callable(extract_state):
+        try:
+            extracted = extract_state(observation)
+        except (TypeError, ValueError, KeyError, IndexError):
+            return None
+        # (robot_pos, heading, goal_pos, ped_pos, ped_vel)
+        if isinstance(extracted, tuple) and len(extracted) >= 4:
+            return _rows_count(extracted[3])
+        return None
+
+    return None
+
+
+def evaluate_effective_view_integrity(
+    *,
+    policy_fn: Callable[..., Any],
+    observation: Any,
+    algo_meta: Any,
+) -> EffectiveViewIntegrity:
+    """Evaluate whether a planner's effective observation view is degenerate (fail-closed guard).
+
+    The guard trips only when *all* of the following hold:
+
+    1. the observation carries a nonzero pedestrian count (something was presented to the planner);
+    2. the planner is not declared pedestrian-blind by design;
+    3. the planner's own extractor was probeable and saw zero pedestrians.
+
+    Returns:
+        EffectiveViewIntegrity: Structured diagnostic; ``degraded`` is ``True`` only on a real trip.
+    """
+    obs_count = observation_ped_count(observation)
+    blind_by_design = is_pedestrian_blind_by_design(algo_meta)
+
+    if obs_count <= 0 or blind_by_design:
+        return EffectiveViewIntegrity(
+            degraded=False,
+            degraded_reason=None,
+            observation_ped_count=obs_count,
+            extracted_ped_count=None,
+            pedestrian_blind_by_design=blind_by_design,
+            probed=False,
+        )
+
+    extracted_count = probe_extracted_ped_count(policy_fn, observation)
+    probed = extracted_count is not None
+    degraded = probed and extracted_count == 0
+    return EffectiveViewIntegrity(
+        degraded=degraded,
+        degraded_reason=DEGENERATE_PLANNER_VIEW_REASON if degraded else None,
+        observation_ped_count=obs_count,
+        extracted_ped_count=extracted_count,
+        pedestrian_blind_by_design=blind_by_design,
+        probed=probed,
+    )

--- a/tests/benchmark/test_map_runner_view_integrity.py
+++ b/tests/benchmark/test_map_runner_view_integrity.py
@@ -1,0 +1,387 @@
+"""Runtime fail-closed guard for degenerate planner observation views (#3634).
+
+These tests pin the comprehensive runtime version of the #3568 static observation-format contract:
+``map_runner`` must FAIL CLOSED when a planner's effective view is degenerate (the observation
+carries pedestrians but the planner's own extractor sees none), unless the planner is declared
+pedestrian-blind by design. They cover the three planner cases named in the issue Definition of
+Done — ``stream_gap`` (post-#3567 fix), a shared-SOCNAV classical planner, and the trivial
+reference planner — plus the silent-blind failure class and the conservative no-false-trip cases.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.algorithm_metadata import observation_spec_for_algorithm
+from robot_sf.benchmark.map_runner import _build_policy, _run_map_episode
+from robot_sf.benchmark.map_runner_view_integrity import (
+    DEGENERATE_PLANNER_VIEW_REASON,
+    DegeneratePlannerViewError,
+    evaluate_effective_view_integrity,
+    is_pedestrian_blind_by_design,
+    observation_ped_count,
+    probe_extracted_ped_count,
+)
+from robot_sf.planner.socnav import SocialForcePlannerAdapter, SocNavPlannerConfig
+from robot_sf.planner.stream_gap import StreamGapPlannerAdapter, build_stream_gap_config
+from tests.benchmark.test_map_runner_utils import _minimal_map_def
+
+
+def _nested_observation(n_peds: int) -> dict[str, Any]:
+    """Build the nested SOCNAV observation map_runner feeds, with ``n_peds`` pedestrians."""
+    positions = [[8.0 + i, 5.0] for i in range(n_peds)]
+    return {
+        "robot": {"position": [5.0, 5.0], "heading": [0.0], "speed": [0.0], "radius": [0.4]},
+        "goal": {"current": [12.0, 5.0], "next": [12.0, 5.0]},
+        "pedestrians": {
+            "positions": positions,
+            "velocities": [[0.0, 0.0] for _ in range(n_peds)],
+            "count": [float(n_peds)],
+            "radius": [0.3],
+        },
+    }
+
+
+def _flat_observation(n_peds: int) -> dict[str, Any]:
+    """Build the flat map_runner-style observation with ``n_peds`` pedestrians."""
+    positions = [[8.0 + i, 5.0] for i in range(n_peds)]
+    return {
+        "robot_position": [5.0, 5.0],
+        "robot_heading": [0.0],
+        "goal_current": [12.0, 5.0],
+        "goal_next": [12.0, 5.0],
+        "pedestrians_positions": positions,
+        "pedestrians_velocities": [[0.0, 0.0] for _ in range(n_peds)],
+        "pedestrians_count": [float(n_peds)],
+    }
+
+
+class _PolicyStub:
+    """Minimal stand-in for a built policy callable carrying a planner adapter."""
+
+    def __init__(self, adapter: Any) -> None:
+        """Attach the adapter the way ``build_adapter_policy`` does."""
+        self._planner_adapter = adapter
+
+    def __call__(self, observation: dict[str, Any]) -> tuple[float, float]:
+        """Defer to the adapter's planner (unused by the guard, present for realism)."""
+        return self._planner_adapter.plan(observation)
+
+
+class _BlindSocnavAdapter:
+    """Adapter whose extractor reads the wrong keys and returns zero peds (pre-#3567 bug class)."""
+
+    def _socnav_fields(self, observation: dict[str, Any]) -> tuple[dict, dict, dict]:
+        """Return an origin/empty view regardless of the real observation."""
+        del observation
+        return {"position": [0.0, 0.0]}, {"current": [0.0, 0.0]}, {"positions": None, "count": [0]}
+
+
+class _OpaqueAdapter:
+    """Adapter that exposes no recognised extractor, so its view is not probeable."""
+
+
+def _goal_meta() -> dict[str, Any]:
+    """Return algo_meta for the pedestrian-blind ``goal`` reference planner."""
+    return {"observation_spec": observation_spec_for_algorithm("goal")}
+
+
+def _socnav_meta(algo: str = "social_force") -> dict[str, Any]:
+    """Return algo_meta for a pedestrian-consuming planner."""
+    return {"observation_spec": observation_spec_for_algorithm(algo)}
+
+
+# --- observation_ped_count: ground truth presented to the planner -------------------------------
+
+
+def test_observation_ped_count_reads_nested_count() -> None:
+    """The nested SOCNAV observation's declared count is the ground truth."""
+    assert observation_ped_count(_nested_observation(3)) == 3
+
+
+def test_observation_ped_count_reads_flat_count() -> None:
+    """The flat map_runner observation's pedestrian count is read too."""
+    assert observation_ped_count(_flat_observation(2)) == 2
+
+
+def test_observation_ped_count_zero_when_absent() -> None:
+    """An observation with no pedestrian payload reports zero (no phantom agents)."""
+    assert observation_ped_count({"robot": {"position": [0.0, 0.0]}}) == 0
+
+
+# --- pedestrian-blind-by-design registry --------------------------------------------------------
+
+
+def test_goal_reference_declares_itself_pedestrian_blind() -> None:
+    """The ``goal`` reference omits pedestrians from its inputs and is exempt by declaration."""
+    assert is_pedestrian_blind_by_design(_goal_meta()) is True
+
+
+def test_pedestrian_consuming_planner_is_not_blind_by_design() -> None:
+    """A planner whose inputs include pedestrians is not exempt."""
+    assert is_pedestrian_blind_by_design(_socnav_meta("orca")) is False
+
+
+def test_missing_observation_spec_is_not_treated_as_blind() -> None:
+    """Absent contract metadata must not silently exempt a planner (fail-closed default)."""
+    assert is_pedestrian_blind_by_design({}) is False
+
+
+# --- effective-view probe against real adapters -------------------------------------------------
+
+
+def test_shared_socnav_planner_extracts_pedestrians_no_false_trip() -> None:
+    """A shared-SOCNAV classical planner sees the pedestrians; the guard does not trip."""
+    policy = _PolicyStub(SocialForcePlannerAdapter(config=SocNavPlannerConfig()))
+    obs = _nested_observation(2)
+    assert probe_extracted_ped_count(policy, obs) == 2
+    result = evaluate_effective_view_integrity(
+        policy_fn=policy, observation=obs, algo_meta=_socnav_meta("social_force")
+    )
+    assert result.degraded is False
+    assert result.probed is True
+    assert result.extracted_ped_count == 2
+
+
+def test_stream_gap_post_fix_extracts_pedestrians_no_false_trip() -> None:
+    """``stream_gap`` (post-#3567) extracts the pedestrians it was shown; the guard does not trip."""
+    policy = _PolicyStub(StreamGapPlannerAdapter(config=build_stream_gap_config({})))
+    obs = _nested_observation(2)
+    assert probe_extracted_ped_count(policy, obs) == 2
+    result = evaluate_effective_view_integrity(
+        policy_fn=policy, observation=obs, algo_meta=_socnav_meta("stream_gap")
+    )
+    assert result.degraded is False
+
+
+def test_stream_gap_reads_flat_observation_no_false_trip() -> None:
+    """``stream_gap``'s flat-observation fallback (the #3567 fix) is not flagged as blind."""
+    policy = _PolicyStub(StreamGapPlannerAdapter(config=build_stream_gap_config({})))
+    assert probe_extracted_ped_count(policy, _flat_observation(2)) == 2
+
+
+# --- the silent-blind failure class: fail closed ------------------------------------------------
+
+
+def test_degenerate_view_trips_with_canonical_reason() -> None:
+    """A planner that extracts zero peds from a peds-carrying observation fails closed."""
+    policy = _PolicyStub(_BlindSocnavAdapter())
+    obs = _nested_observation(2)
+    assert probe_extracted_ped_count(policy, obs) == 0
+    result = evaluate_effective_view_integrity(
+        policy_fn=policy, observation=obs, algo_meta=_socnav_meta("stream_gap")
+    )
+    assert result.degraded is True
+    assert result.degraded_reason == DEGENERATE_PLANNER_VIEW_REASON
+    assert result.observation_ped_count == 2
+    assert result.extracted_ped_count == 0
+
+
+def test_degenerate_view_error_carries_diagnostic() -> None:
+    """The fail-closed error carries the structured diagnostic and the canonical reason."""
+    policy = _PolicyStub(_BlindSocnavAdapter())
+    result = evaluate_effective_view_integrity(
+        policy_fn=policy, observation=_nested_observation(2), algo_meta=_socnav_meta("stream_gap")
+    )
+    error = DegeneratePlannerViewError(result)
+    assert error.diagnostic.degraded_reason == DEGENERATE_PLANNER_VIEW_REASON
+    assert DEGENERATE_PLANNER_VIEW_REASON in str(error)
+
+
+# --- conservative no-false-trip guards ----------------------------------------------------------
+
+
+def test_blind_by_design_planner_is_exempt_even_with_peds_present() -> None:
+    """The ``goal`` reference is not flagged even though it ignores the pedestrians it was shown."""
+    policy = _PolicyStub(_BlindSocnavAdapter())
+    result = evaluate_effective_view_integrity(
+        policy_fn=policy, observation=_nested_observation(2), algo_meta=_goal_meta()
+    )
+    assert result.degraded is False
+    assert result.pedestrian_blind_by_design is True
+    assert result.probed is False  # exempt planners are not probed
+
+
+def test_genuinely_zero_pedestrian_scenario_is_not_degenerate() -> None:
+    """A scenario that legitimately presents zero pedestrians never trips the guard."""
+    policy = _PolicyStub(_BlindSocnavAdapter())
+    result = evaluate_effective_view_integrity(
+        policy_fn=policy, observation=_nested_observation(0), algo_meta=_socnav_meta("stream_gap")
+    )
+    assert result.degraded is False
+    assert result.observation_ped_count == 0
+
+
+def test_unprobeable_planner_does_not_trip() -> None:
+    """When the planner exposes no extractor the view is not probeable and the guard stays silent."""
+    policy = _PolicyStub(_OpaqueAdapter())
+    result = evaluate_effective_view_integrity(
+        policy_fn=policy, observation=_nested_observation(2), algo_meta=_socnav_meta("orca")
+    )
+    assert result.degraded is False
+    assert result.probed is False
+    assert result.extracted_ped_count is None
+
+
+def test_policy_without_adapter_is_not_probeable() -> None:
+    """A bare policy callable with no attached adapter is treated as not probeable."""
+
+    def _bare_policy(_obs: dict[str, Any]) -> tuple[float, float]:
+        return 0.0, 0.0
+
+    assert probe_extracted_ped_count(_bare_policy, _nested_observation(2)) is None
+
+
+@pytest.mark.parametrize("count", [1, 4, 7])
+def test_no_false_trip_scales_with_pedestrian_count(count: int) -> None:
+    """A healthy shared-SOCNAV planner never trips regardless of how many peds are present."""
+    policy = _PolicyStub(SocialForcePlannerAdapter(config=SocNavPlannerConfig()))
+    result = evaluate_effective_view_integrity(
+        policy_fn=policy,
+        observation=_nested_observation(count),
+        algo_meta=_socnav_meta("social_force"),
+    )
+    assert result.degraded is False
+    assert result.extracted_ped_count == count
+
+
+# --- end-to-end: the guard fires inside the real map_runner episode loop -------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCENARIO_PATH = _REPO_ROOT / "configs/scenarios/sanity_v1.yaml"
+
+
+class _PedPresentSim:
+    """Simulator stub that always reports two pedestrians present in the world."""
+
+    def __init__(self) -> None:
+        """Seed the deterministic robot/goal/pedestrian buffers."""
+        self.robot_pos = [np.array([5.0, 5.0], dtype=float)]
+        self.ped_pos = np.array([[8.0, 5.0], [9.0, 5.0]], dtype=float)
+        self.goal_pos = [np.array([12.0, 5.0], dtype=float)]
+        self.map_def = _minimal_map_def()
+        self.last_ped_forces = np.zeros((2, 2), dtype=float)
+
+
+class _PedPresentEnv:
+    """Environment stub emitting a nested SOCNAV observation that carries two pedestrians."""
+
+    def __init__(self) -> None:
+        """Attach the pedestrian-present simulator stub."""
+        self.simulator = _PedPresentSim()
+
+    @staticmethod
+    def _observation() -> dict[str, Any]:
+        """Return a nested SOCNAV observation with two visible pedestrians."""
+        return {
+            "robot": {
+                "position": np.array([5.0, 5.0], dtype=np.float32),
+                "heading": np.array([0.0], dtype=np.float32),
+                "speed": np.array([0.0], dtype=np.float32),
+                "radius": np.array([0.4], dtype=np.float32),
+            },
+            "goal": {
+                "current": np.array([12.0, 5.0], dtype=np.float32),
+                "next": np.array([12.0, 5.0], dtype=np.float32),
+            },
+            "pedestrians": {
+                "positions": np.array([[8.0, 5.0], [9.0, 5.0]], dtype=np.float32),
+                "velocities": np.zeros((2, 2), dtype=np.float32),
+                "count": np.array([2.0], dtype=np.float32),
+                "radius": np.array([0.3], dtype=np.float32),
+            },
+        }
+
+    def reset(self, seed: int | None = None):
+        """Return the pedestrian-carrying observation."""
+        del seed
+        return self._observation(), {}
+
+    def step(self, action):
+        """Advance one step and terminate (the guard fires on the first step anyway)."""
+        del action
+        return self._observation(), 0.0, True, False, {"success": False}
+
+    def close(self) -> None:
+        """Accept map-runner cleanup."""
+        return None
+
+
+def _patch_episode_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Patch map_runner env construction and metrics so the episode loop runs in isolation."""
+    dummy_config = type(
+        "Cfg",
+        (),
+        {"sim_config": type("SC", (), {"time_per_step_in_secs": 0.1})()},
+    )()
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._build_env_config",
+        lambda scenario, scenario_path: dummy_config,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.make_robot_env",
+        lambda config, seed, debug: _PedPresentEnv(),
+    )
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.sample_obstacle_points", lambda *args: None)
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_shortest_path_length", lambda *args: 1.0
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_all_metrics",
+        lambda *args, **kwargs: {"success": 0.0, "collisions": 0.0},
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.post_process_metrics", lambda metrics, **kwargs: metrics
+    )
+
+
+def _run_stream_gap_episode() -> dict[str, Any]:
+    """Run a single ``stream_gap`` episode through the real map_runner loop."""
+    return _run_map_episode(
+        {"name": "view-integrity-smoke", "simulation_config": {"max_episode_steps": 1}},
+        seed=1,
+        horizon=1,
+        dt=0.1,
+        record_forces=False,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo="stream_gap",
+        algo_config={},
+        scenario_path=_SCENARIO_PATH,
+    )
+
+
+def test_map_episode_fails_closed_on_degenerate_planner_view(monkeypatch) -> None:
+    """A blind planner with pedestrians present must fail the episode closed, not emit a result."""
+    _patch_episode_env(monkeypatch)
+
+    real_build_policy = _build_policy
+
+    def _blind_build_policy(algo, algo_config, **kwargs):
+        """Build the real policy/metadata, then swap in a blind extractor adapter."""
+        policy_fn, algo_meta = real_build_policy(algo, algo_config, **kwargs)
+        policy_fn._planner_adapter = _BlindSocnavAdapter()
+        return policy_fn, algo_meta
+
+    monkeypatch.setattr("robot_sf.benchmark.map_runner._build_policy", _blind_build_policy)
+
+    with pytest.raises(DegeneratePlannerViewError, match=DEGENERATE_PLANNER_VIEW_REASON):
+        _run_stream_gap_episode()
+
+
+def test_map_episode_records_clean_effective_view_for_healthy_planner(monkeypatch) -> None:
+    """A healthy ``stream_gap`` planner produces a record with a clean (non-degraded) view."""
+    _patch_episode_env(monkeypatch)
+
+    record = _run_stream_gap_episode()
+
+    effective_view = record["integrity"]["effective_view"]
+    assert effective_view is not None
+    assert effective_view["degraded"] is False
+    assert effective_view["degraded_reason"] is None
+    assert effective_view["observation_ped_count"] == 2
+    assert effective_view["extracted_ped_count"] == 2


### PR DESCRIPTION
## Summary

The runtime fail-closed guard deferred from #3568. `stream_gap` was silently blind in the real benchmark runner — it read a nested SOCNAV observation while `map_runner` feeds a **flat** observation, extracted `robot=[0,0], n_peds=0`, and drove blind **while still emitting collision "results"** (the extractor itself was fixed in #3567). This adds the runtime guard so a degenerate planner view can no longer pass silently and corrupt benchmark evidence.

## What's here

- **`robot_sf/benchmark/map_runner_view_integrity.py`** (new) — pure guard module: `observation_ped_count`, `is_pedestrian_blind_by_design`, `probe_extracted_ped_count`, `evaluate_effective_view_integrity` + `EffectiveViewIntegrity` + `DegeneratePlannerViewError` (reason `degenerate_planner_view`).
- **`robot_sf/benchmark/map_runner_episode.py`** — first-step guard that raises **before any metrics are recorded**; stores the passing diagnostic at `record["integrity"]["effective_view"]`.

## Fail-closed trigger

`observation_ped_count(obs) > 0` **AND** the planner is not pedestrian-blind-by-design (its `observation_spec.inputs` lacks `"pedestrians"`) **AND** the planner's own extractor (`_socnav_fields`/`_extract_state`) was probeable and returned 0 → raise.

**Key design choice (no false trips):** ground truth is the *observation's own* pedestrian count — what was actually handed to the planner — not the raw simulator count. The SOCNAV observation is visibility-masked / truncated to `max_pedestrians`, so legitimately-occluded or genuinely-empty scenarios present 0 peds and must not trip. Unprobeable planners are treated as not-probeable and never fabricate a failure (the static #3568 contract remains the second line of defense).

## Validation

- ruff check + format: clean.
- **20** guard unit tests (incl. two end-to-end `_run_map_episode`: degenerate view → raises with no record; healthy `stream_gap` → record with clean `effective_view`).
- **145** regression tests pass (`test_map_runner_utils`, `test_planner_observation_contract`, lidar/provenance/belief-hook).
- **13** end-to-end episode tests pass (healthy pedestrian-consuming planners/scenarios don't false-trip; JSONL schema unaffected).

**Residual risk:** the probe covers planners exposing `_socnav_fields`/`_extract_state`; a future planner with a different private extractor and a degenerate view would be treated as not-probeable and pass (conservative to avoid false trips — static #3568 contract is the backstop).

Closes #3634. Part of the goal-driven implementation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
