### PR TITLE
fix(benchmark): fail-closed collision-metric aggregation vs exact flag (#3627)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed collision **undercounting** in `summarize_collision_metrics` (#3627): the aggregator read the
+  sampled `metrics.collisions` value even when it was a finite `0.0`, only falling back to the exact
+  `outcome.collision_event` flag when the metric key was entirely absent — so an episode whose exact
+  environment collision fired but whose sampled metric missed the contact was silently aggregated as
+  **zero** collisions (a validation-integrity hole independent of the per-episode write-time and
+  `EpisodeEventLedger.v1` guards, since this aggregator also reads resumed/loaded JSONL records).
+  `_episode_collision_value` now fails closed: when the exact collision flag fired and the sampled
+  value is `<= 0`, the count is floored to `1` (sourced as `episode.outcome.collision_event`). No
+  inflation — no-collision episodes stay `0` and a larger sampled count is never reduced.
 * **`stream_gap` was blind in the real benchmark runner** (found while promoting the #3556 belief-mode safety contrast to `map_runner`). `StreamGapPlannerAdapter._extract_state` read the nested SOCNAV observation (`obs["robot"]`, `obs["pedestrians"]`) but `map_runner` feeds a flat observation (`robot_position`, `pedestrians_positions`, `goal_current`), so the planner extracted `robot=[0,0]`, `n_peds=0` and drove blind every episode. `_extract_state` now accepts both the nested and flat observation formats (backward-compatible; the ScenarioBelief harness and 24 existing tests still pass), and `robot_sf/benchmark/scenario_belief_policy_hook.py` reads the flat observation and writes the uncertainty sidecar to `pedestrians_uncertainty` where the fixed extractor reads it. After the fix the planner engages pedestrians and the belief modes differentiate in the real runner.
 
 ### Added

--- a/robot_sf/benchmark/map_runner_metrics.py
+++ b/robot_sf/benchmark/map_runner_metrics.py
@@ -54,22 +54,45 @@ def _finite_float(value: Any) -> float | None:
     return result if math.isfinite(result) else None
 
 
+def _exact_collision_event(record: dict[str, Any]) -> bool | None:
+    """Return the exact environment collision flag for one episode record.
+
+    Returns:
+        ``True``/``False`` when ``outcome.collision_event`` is present and not null,
+        otherwise ``None`` when the exact flag is unavailable.
+    """
+    outcome = record.get("outcome")
+    if not isinstance(outcome, dict) or "collision_event" not in outcome:
+        return None
+    event = outcome.get("collision_event")
+    if event is None:
+        return None
+    return bool(event)
+
+
 def _episode_collision_value(record: dict[str, Any]) -> tuple[float | None, str | None]:
-    """Return one episode's collision value and source path when available."""
+    """Return one episode's collision value and source path when available.
+
+    Fails closed against silent collision undercounting: when the exact environment
+    collision flag (``outcome.collision_event``) fired, the returned value is floored to at
+    least 1.0 even if the sampled collision metrics missed the contact and report zero. The
+    no-collision case is never inflated -- an exact flag of ``False`` (or an unavailable flag)
+    leaves the sampled metric untouched.
+    """
+    exact_event = _exact_collision_event(record)
+
     metrics = record.get("metrics")
     if isinstance(metrics, dict):
         for key in ("collisions", "total_collision_count", "collision_count"):
             if key in metrics:
                 value = _finite_float(metrics.get(key))
                 if value is not None:
+                    if exact_event and value <= 0.0:
+                        return 1.0, "episode.outcome.collision_event"
                     return value, f"episode.metrics.{key}"
 
-    outcome = record.get("outcome")
-    if isinstance(outcome, dict) and "collision_event" in outcome:
-        event = outcome.get("collision_event")
-        if event is None:
-            return None, None
-        return 1.0 if bool(event) else 0.0, "episode.outcome.collision_event"
+    if exact_event is not None:
+        return (1.0 if exact_event else 0.0), "episode.outcome.collision_event"
     return None, None
 
 

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -56,7 +56,10 @@ from robot_sf.benchmark.map_runner_batch_plan import (
     build_worker_fixed_params,
     resolve_batch_kinematics_tag,
 )
-from robot_sf.benchmark.map_runner_metrics import summarize_collision_metrics
+from robot_sf.benchmark.map_runner_metrics import (
+    _episode_collision_value,
+    summarize_collision_metrics,
+)
 from robot_sf.benchmark.map_runner_policies import safety_barrier as safety_barrier_policy_builder
 from robot_sf.benchmark.policy_builders import build_registered_adapter_policy_spec
 from robot_sf.common.types import Rect
@@ -3719,6 +3722,48 @@ def test_summarize_collision_metrics_preserves_missing_collision_events() -> Non
         "denominator": 3,
         "source": "episode.outcome.collision_event",
     }
+
+
+def test_summarize_collision_metrics_floors_exact_event_over_zero_sampled_metric() -> None:
+    """Issue #3627: an exact collision flag must yield a non-zero aggregated count.
+
+    A sampled collision metric of zero must not silently mask an exact environment collision
+    event for the same episode, while the no-collision episode stays exactly zero.
+    """
+    summary = summarize_collision_metrics(
+        [
+            # Exact env flag fired but the sampled metric missed the contact.
+            {"metrics": {"collisions": 0.0}, "outcome": {"collision_event": True}},
+            # Genuine no-collision episode must not be inflated.
+            {"metrics": {"collisions": 0.0}, "outcome": {"collision_event": False}},
+        ]
+    )
+
+    assert summary["collision"] == pytest.approx(1.0)
+    assert summary["collision_count"] == pytest.approx(1.0)
+    assert summary["collision_rate"] == pytest.approx(0.5)
+    assert summary["collision_status"]["status"] == "available"
+    assert "episode.outcome.collision_event" in summary["collision_status"]["source"]
+
+
+def test_episode_collision_value_preserves_larger_sampled_count_with_exact_event() -> None:
+    """A sampled count above the exact floor must survive (no downward clobber)."""
+    value, source = _episode_collision_value(
+        {"metrics": {"collisions": 3.0}, "outcome": {"collision_event": True}}
+    )
+
+    assert value == pytest.approx(3.0)
+    assert source == "episode.metrics.collisions"
+
+
+def test_episode_collision_value_keeps_zero_when_no_collision_event() -> None:
+    """No exact collision event must leave a zero sampled metric untouched."""
+    value, source = _episode_collision_value(
+        {"metrics": {"collisions": 0.0}, "outcome": {"collision_event": False}}
+    )
+
+    assert value == pytest.approx(0.0)
+    assert source == "episode.metrics.collisions"
 
 
 def test_run_map_batch_rejects_unsupported_observation_override(


### PR DESCRIPTION
## Summary
`summarize_collision_metrics` undercounted collisions: `_episode_collision_value` returned the sampled `metrics.collisions` value even when it was a finite `0.0`, only falling back to the exact `outcome.collision_event` flag when the metric key was absent. An episode whose **exact** environment collision fired but whose **sampled** metric missed the contact was silently aggregated as **zero** — a validation-integrity hole (this aggregator also reads resumed/loaded JSONL records, independent of the per-episode write-time and `EpisodeEventLedger.v1` guards from #3482/#3498).

## Fix
`_episode_collision_value` now **fails closed**: when the exact collision flag fired and the sampled value is `<= 0`, the count is floored to `1` (sourced as `episode.outcome.collision_event`). **No inflation** — no-collision episodes stay `0.0`, and a larger sampled count is never reduced.

## Validation
- ruff clean; `pytest tests/benchmark/test_map_runner_utils.py`: **125 passed** (3 new regression — exact-flag-over-zero floors to non-zero; larger sampled count preserved; no-collision stays zero).
- Collision-consuming modules (safety_predicates, planner_tradeoff_plot, failure_mechanism_classifier) pass.

Closes #3627. Part of the goal-driven implementation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed collision metrics so collisions are no longer undercounted when an exact collision event occurred but the sampled value was zero or missing.
  * Collision counts and rates now better reflect actual episode outcomes, while still leaving non-collision episodes unchanged.
  * Improved collision-status availability and source reporting for more consistent summary results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->