### PR TITLE
fix(benchmark): fail-closed guard on negative route clearance (#3628)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prefix), so single-segment extension-less placeholders are treated as prose — while genuinely broken
   path references (e.g. `docs/does_not_exist.md`, `SLURM/missing/template.sl`) are still caught. The
   offending SKILL.md was left untouched; the fix is in the validator.
+* Added a **fail-closed route-clearance guard** to the camera-ready benchmark (#3628). The
+  originally-reported `0.0 m` centerline clearances in `classic_merging_*` / `classic_station_platform_*`
+  were already re-routed to positive margins on `main` (now +0.56 m and +2.5 m), but the preflight
+  only emitted *informational* warnings, so a route with a **negative** margin (centerline-to-obstacle
+  distance < robot radius = guaranteed collision) would still run silently. `prepare_campaign_preflight`
+  / `run_campaign` now raise `RouteClearanceError` on any `min_clearance_margin_m < 0` (certification
+  cannot excuse hard geometric infeasibility; tangent/positive-narrow geometry stays a warning), so
+  both `--mode preflight` and `--mode run` fail closed. Also corrected the stale
+  `route_clearance_certifications_v1.yaml` entries for the 3 repaired scenarios (`negative clearance` →
+  `repaired_geometry`). User-facing: the benchmark can no longer silently run a geometrically-impossible
+  route.
 * **`stream_gap` was blind in the real benchmark runner** (found while promoting the #3556 belief-mode safety contrast to `map_runner`). `StreamGapPlannerAdapter._extract_state` read the nested SOCNAV observation (`obs["robot"]`, `obs["pedestrians"]`) but `map_runner` feeds a flat observation (`robot_position`, `pedestrians_positions`, `goal_current`), so the planner extracted `robot=[0,0]`, `n_peds=0` and drove blind every episode. `_extract_state` now accepts both the nested and flat observation formats (backward-compatible; the ScenarioBelief harness and 24 existing tests still pass), and `robot_sf/benchmark/scenario_belief_policy_hook.py` reads the flat observation and writes the uncertainty sidecar to `pedestrians_uncertainty` where the fixed extractor reads it. After the fix the planner engages pedestrians and the belief modes differentiate in the real runner.
 
 ### Added

--- a/configs/benchmarks/route_clearance_certifications_v1.yaml
+++ b/configs/benchmarks/route_clearance_certifications_v1.yaml
@@ -46,19 +46,19 @@ certifications:
     reviewed_by: ll7
     issue: "1105"
   classic_merging_low:
-    status: excluded_from_planner_attribution
-    claim_scope: benchmark row may run, but failures are not planner-mechanism evidence until geometry is repaired
-    rationale: Preflight reports negative clearance because the route centerline overlaps obstacle geometry.
-    reviewed_on: "2026-05-09"
+    status: repaired_geometry
+    claim_scope: benchmark-ready; route geometry repaired to a positive robot-radius clearance margin
+    rationale: Route centerline was re-routed off the obstacle; preflight now reports a positive margin (~0.56 m) above the warning threshold.
+    reviewed_on: "2026-06-26"
     reviewed_by: ll7
-    issue: "1105"
+    issue: "3628"
   classic_merging_medium:
-    status: excluded_from_planner_attribution
-    claim_scope: benchmark row may run, but failures are not planner-mechanism evidence until geometry is repaired
-    rationale: Preflight reports negative clearance because the route centerline overlaps obstacle geometry.
-    reviewed_on: "2026-05-09"
+    status: repaired_geometry
+    claim_scope: benchmark-ready; route geometry repaired to a positive robot-radius clearance margin
+    rationale: Route centerline was re-routed off the obstacle; preflight now reports a positive margin (~0.56 m) above the warning threshold.
+    reviewed_on: "2026-06-26"
     reviewed_by: ll7
-    issue: "1105"
+    issue: "3628"
   classic_overtaking_low:
     status: certified_stress_geometry
     claim_scope: benchmark-ready stress geometry; planner-attribution claims require caveat
@@ -74,12 +74,12 @@ certifications:
     reviewed_by: ll7
     issue: "1105"
   classic_station_platform_medium:
-    status: excluded_from_planner_attribution
-    claim_scope: benchmark row may run, but failures are not planner-mechanism evidence until geometry is repaired
-    rationale: Preflight reports negative clearance because the route centerline overlaps station obstacle geometry.
-    reviewed_on: "2026-05-09"
+    status: repaired_geometry
+    claim_scope: benchmark-ready; route geometry repaired to a positive robot-radius clearance margin
+    rationale: Route centerline was re-routed off the station obstacle; preflight now reports a positive margin (~2.5 m) above the warning threshold.
+    reviewed_on: "2026-06-26"
     reviewed_by: ll7
-    issue: "1105"
+    issue: "3628"
   classic_t_intersection_low:
     status: certified_stress_geometry
     claim_scope: benchmark-ready stress geometry; planner-attribution claims require caveat

--- a/robot_sf/benchmark/camera_ready/_route_clearance.py
+++ b/robot_sf/benchmark/camera_ready/_route_clearance.py
@@ -14,11 +14,27 @@ from robot_sf.common.artifact_paths import get_repository_root
 from robot_sf.nav.svg_map_parser import convert_map
 
 _ROUTE_CLEARANCE_WARN_THRESHOLD_M = 0.5
+# A route whose centerline-to-obstacle margin is below this bound has its centerline closer to a
+# static obstacle than the robot's physical radius, so the footprint necessarily overlaps the
+# obstacle and the route is geometrically impossible to follow without collision. Such routes must
+# fail closed rather than run silently (see issue #3628).
+_ROUTE_CLEARANCE_FAIL_MARGIN_M = 0.0
 _ROUTE_CLEARANCE_CERTIFICATION_STATUSES = {
     "certified_stress_geometry",
     "excluded_from_planner_attribution",
     "repaired_geometry",
 }
+
+
+class RouteClearanceError(RuntimeError):
+    """Raised when a scenario route is geometrically impossible for the robot footprint.
+
+    This signals a fail-closed condition: at least one route centerline lies closer to a static
+    obstacle than the robot's physical radius, guaranteeing a collision. The benchmark must not
+    silently run such routes, and no clearance certification can excuse a negative margin because
+    it is a hard geometric infeasibility rather than intentional narrow-but-positive stress
+    geometry.
+    """
 
 
 def _route_clearance_scenario_id(scenario: dict[str, Any]) -> str:
@@ -284,3 +300,54 @@ def _build_route_clearance_warnings(
         warnings.append(warning)
     warnings.sort(key=lambda item: (item.get("scenario", ""), item.get("map_file", "")))
     return warnings
+
+
+def _assert_route_clearance_feasible(
+    warnings: list[dict[str, Any]],
+    *,
+    fail_margin_threshold_m: float = _ROUTE_CLEARANCE_FAIL_MARGIN_M,
+) -> None:
+    """Fail closed when any route is geometrically impossible for the robot footprint.
+
+    Scans the informational route-clearance warning rows and raises when any scenario reports a
+    centerline-to-obstacle margin below ``fail_margin_threshold_m`` (default ``0.0``), i.e. the
+    route centerline is closer to a static obstacle than the robot's physical radius. Such a route
+    guarantees a collision, so the benchmark must not run it silently (issue #3628). The check is
+    certification-independent: a negative margin is a hard geometric infeasibility, and clearance
+    certifications only document intentional narrow-but-positive stress geometry.
+
+    Raises:
+        RouteClearanceError: When at least one scenario has a sub-radius (negative) clearance
+            margin.
+    """
+    infeasible: list[dict[str, Any]] = []
+    for warning in warnings:
+        margin = warning.get("min_clearance_margin_m")
+        try:
+            margin_value = float(margin)
+        except (TypeError, ValueError):
+            continue
+        if not math.isfinite(margin_value):
+            continue
+        if margin_value < float(fail_margin_threshold_m):
+            infeasible.append(warning)
+    if not infeasible:
+        return
+    details = "; ".join(
+        "{scenario} (map={map_file}, margin={margin:.4f} m, "
+        "center_distance={center:.4f} m, robot_radius={radius:.4f} m)".format(
+            scenario=str(item.get("scenario", "unknown")),
+            map_file=str(item.get("map_file", "")),
+            margin=float(item.get("min_clearance_margin_m", float("nan"))),
+            center=float(item.get("min_center_distance_m", float("nan"))),
+            radius=float(item.get("robot_radius_m", float("nan"))),
+        )
+        for item in infeasible
+    )
+    raise RouteClearanceError(
+        "Route-clearance preflight failed closed: "
+        f"{len(infeasible)} scenario(s) have a route centerline closer to a static obstacle "
+        f"than the robot radius (margin < {float(fail_margin_threshold_m):.4f} m), making the "
+        f"route geometrically impossible to follow without collision: {details}. "
+        "Repair the route geometry before running the benchmark."
+    )

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -74,7 +74,10 @@ from robot_sf.benchmark.camera_ready._reporting import (  # noqa: F401 - re-expo
 )
 from robot_sf.benchmark.camera_ready._route_clearance import (  # noqa: F401 - re-exported for back-compat
     _ROUTE_CLEARANCE_CERTIFICATION_STATUSES,
+    _ROUTE_CLEARANCE_FAIL_MARGIN_M,
     _ROUTE_CLEARANCE_WARN_THRESHOLD_M,
+    RouteClearanceError,
+    _assert_route_clearance_feasible,
     _load_route_clearance_certifications,
     _map_route_clearance_center_min_m,
     _resolve_map_path_for_scenario,
@@ -1289,6 +1292,9 @@ def prepare_campaign_preflight(
     Raises:
         OrcaRvo2PreflightError: When enabled ORCA-dependent planners require ``rvo2`` but it is
             not importable.
+        RouteClearanceError: When any scenario route centerline lies closer to a static obstacle
+            than the robot radius, making the route geometrically impossible to follow without
+            collision.
     """
     _validate_campaign_config(cfg)
     check_orca_rvo2_preflight(cfg)
@@ -1314,6 +1320,11 @@ def prepare_campaign_preflight(
         scenarios,
         certifications=route_clearance_certifications,
     )
+    # Fail closed before producing any preflight artifact: a route whose centerline is closer to a
+    # static obstacle than the robot radius is geometrically impossible to follow without
+    # collision, so the benchmark must refuse to run it rather than emit a silent warning
+    # (issue #3628).
+    _assert_route_clearance_feasible(route_clearance_warnings)
     route_clearance_warning_summary = _route_clearance_warning_summary(route_clearance_warnings)
     resolved_seeds = _resolved_seed_inventory(scenarios)
     scenario_hash = _hash_payload(scenarios)
@@ -1810,6 +1821,9 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
     Raises:
         OrcaRvo2PreflightError: When enabled ORCA-dependent planners require ``rvo2`` but it is
             not importable.
+        RouteClearanceError: When any scenario route centerline lies closer to a static obstacle
+            than the robot radius, making the route geometrically impossible to follow without
+            collision.
     """
     start = time.perf_counter()
     prepared = prepare_campaign_preflight(
@@ -2970,6 +2984,7 @@ __all__ = [
     "AmvProfileConfig",
     "CampaignConfig",
     "PlannerSpec",
+    "RouteClearanceError",
     "SeedPolicy",
     "SnqiContractConfig",
     "load_campaign_config",

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -4642,9 +4642,12 @@ def test_prepare_campaign_preflight_emits_route_clearance_warnings(
     )
 
     # Force a deterministic low-clearance condition independent of map geometry.
+    # Positive-but-sub-threshold margin: center distance 1.0 with robot radius 0.8 -> +0.2 m
+    # (below the 0.5 m warn threshold so a warning is still emitted, but above the 0.0 m
+    # fail-closed bound so it does not trip RouteClearanceError; see issue #3628).
     fake_map_def = SimpleNamespace(
-        robot_routes=[SimpleNamespace(waypoints=[(0.0, 0.0), (1.0, 0.0)])],
-        obstacles=[SimpleNamespace(vertices=[(1.0, -0.1), (2.0, -0.1), (2.0, 0.1), (1.0, 0.1)])],
+        robot_routes=[SimpleNamespace(waypoints=[(-1.0, 0.0), (0.0, 0.0)])],
+        obstacles=[SimpleNamespace(vertices=[(1.0, -1.0), (2.0, -1.0), (2.0, 1.0), (1.0, 1.0)])],
     )
     monkeypatch.setattr(
         "robot_sf.benchmark.camera_ready_campaign.convert_map",
@@ -4800,9 +4803,12 @@ def test_prepare_campaign_preflight_attaches_route_clearance_certifications(
         encoding="utf-8",
     )
 
+    # Positive-but-sub-threshold margin: center distance 1.0 with robot radius 0.8 -> +0.2 m
+    # (below the 0.5 m warn threshold so a warning is still emitted, but above the 0.0 m
+    # fail-closed bound so it does not trip RouteClearanceError; see issue #3628).
     fake_map_def = SimpleNamespace(
-        robot_routes=[SimpleNamespace(waypoints=[(0.0, 0.0), (1.0, 0.0)])],
-        obstacles=[SimpleNamespace(vertices=[(1.0, -0.1), (2.0, -0.1), (2.0, 0.1), (1.0, 0.1)])],
+        robot_routes=[SimpleNamespace(waypoints=[(-1.0, 0.0), (0.0, 0.0)])],
+        obstacles=[SimpleNamespace(vertices=[(1.0, -1.0), (2.0, -1.0), (2.0, 1.0), (1.0, 1.0)])],
     )
     monkeypatch.setattr(
         "robot_sf.benchmark.camera_ready_campaign.convert_map",

--- a/tests/benchmark/test_route_clearance_fail_closed.py
+++ b/tests/benchmark/test_route_clearance_fail_closed.py
@@ -1,0 +1,165 @@
+"""Fail-closed contract for geometrically-impossible route clearance (issue #3628).
+
+These tests pin the behaviour that the camera-ready benchmark must refuse to run a scenario whose
+route centerline lies closer to a static obstacle than the robot's physical radius (a negative
+clearance margin = guaranteed collision), while still allowing positive-but-narrow stress
+geometry to pass with only an informational warning.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from robot_sf.benchmark.camera_ready_campaign import (
+    RouteClearanceError,
+    load_campaign_config,
+    prepare_campaign_preflight,
+)
+
+
+def _write_campaign(
+    tmp_path: Path,
+    *,
+    robot_radius: float,
+    certification: bool = False,
+) -> Path:
+    """Write a minimal single-scenario campaign config and return its path.
+
+    Returns:
+        Path to the campaign config file.
+    """
+    map_path = (tmp_path / "scenario_map.svg").resolve()
+    # Content is irrelevant: ``convert_map`` is monkeypatched per test to return fixed geometry.
+    map_path.write_text("<svg></svg>\n", encoding="utf-8")
+
+    scenario_lines = [
+        "- name: clearance_case",
+        f"  map_file: {map_path.as_posix()}",
+        "  seeds: [111]",
+        "  robot_config:",
+        f"    radius: {robot_radius}",
+    ]
+    scenario_path = tmp_path / "scenarios.yaml"
+    scenario_path.write_text("\n".join(scenario_lines) + "\n", encoding="utf-8")
+
+    config_lines = [
+        "name: clearance_fail_closed",
+        f"scenario_matrix: {scenario_path.as_posix()}",
+        "planners:",
+        "  - key: goal",
+        "    algo: goal",
+        "    planner_group: core",
+    ]
+    if certification:
+        cert_lines = [
+            "schema_version: route-clearance-certifications.v1",
+            "certifications:",
+            "  clearance_case:",
+            "    status: certified_stress_geometry",
+            "    claim_scope: stress geometry; planner-attribution claims require caveat",
+            "    rationale: Narrow obstacle margin is intentional stress geometry.",
+        ]
+        cert_path = tmp_path / "certifications.yaml"
+        cert_path.write_text("\n".join(cert_lines) + "\n", encoding="utf-8")
+        config_lines.append(f"route_clearance_certifications: {cert_path.as_posix()}")
+
+    config_path = tmp_path / "campaign.yaml"
+    config_path.write_text("\n".join(config_lines) + "\n", encoding="utf-8")
+    return config_path
+
+
+def _patch_geometry(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    obstacle_x_min: float,
+) -> None:
+    """Patch ``convert_map`` so the centerline-to-obstacle distance equals ``obstacle_x_min``.
+
+    The robot route is a segment ending at the origin (``(-1, 0) -> (0, 0)``). The obstacle is a
+    box spanning the route's y-level (``y in [-1, 1]``) whose left edge is at ``x = obstacle_x_min``
+    and whose x-range stays to the right of the segment, so the nearest approach is the horizontal
+    gap from the origin to that left edge. Combined with the scenario robot radius this controls
+    the sign of the clearance margin deterministically.
+    """
+    fake_map_def = SimpleNamespace(
+        robot_routes=[SimpleNamespace(waypoints=[(-1.0, 0.0), (0.0, 0.0)])],
+        obstacles=[
+            SimpleNamespace(
+                vertices=[
+                    (obstacle_x_min, -1.0),
+                    (obstacle_x_min + 1.0, -1.0),
+                    (obstacle_x_min + 1.0, 1.0),
+                    (obstacle_x_min, 1.0),
+                ]
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.camera_ready_campaign.convert_map",
+        lambda _path: fake_map_def,
+    )
+
+
+def test_preflight_fails_closed_on_subradius_clearance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A centerline closer than the robot radius must fail closed with RouteClearanceError."""
+    # Obstacle edge at distance 0.5 from the centerline, robot radius 1.0 -> margin -0.5 (< 0).
+    _patch_geometry(monkeypatch, obstacle_x_min=0.5)
+    config_path = _write_campaign(tmp_path, robot_radius=1.0)
+    cfg = load_campaign_config(config_path)
+
+    with pytest.raises(RouteClearanceError) as excinfo:
+        prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="fail")
+    message = str(excinfo.value)
+    assert "clearance_case" in message
+    assert "geometrically impossible" in message
+
+
+def test_preflight_fails_closed_even_with_certification(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A clearance certification must not excuse a negative (impossible) margin."""
+    _patch_geometry(monkeypatch, obstacle_x_min=0.5)
+    config_path = _write_campaign(tmp_path, robot_radius=1.0, certification=True)
+    cfg = load_campaign_config(config_path)
+
+    with pytest.raises(RouteClearanceError):
+        prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="fail-cert")
+
+
+def test_preflight_passes_with_adequate_clearance(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A route with margin above the warning threshold passes with no clearance warning."""
+    # Obstacle edge at distance 2.0, robot radius 1.0 -> margin +1.0 (>= 0.5 warn threshold).
+    _patch_geometry(monkeypatch, obstacle_x_min=2.0)
+    config_path = _write_campaign(tmp_path, robot_radius=1.0)
+    cfg = load_campaign_config(config_path)
+
+    prepared = prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="ok")
+    payload = json.loads(Path(prepared["validate_config_path"]).read_text(encoding="utf-8"))
+    assert payload["route_clearance_warning_count"] == 0
+    assert payload["route_clearance_warnings"] == []
+
+
+def test_preflight_warns_but_does_not_fail_on_narrow_positive_margin(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A positive-but-narrow margin emits an informational warning without failing closed."""
+    # Obstacle edge at distance 1.2, robot radius 1.0 -> margin +0.2 (>0 but < 0.5 warn threshold).
+    _patch_geometry(monkeypatch, obstacle_x_min=1.2)
+    config_path = _write_campaign(tmp_path, robot_radius=1.0)
+    cfg = load_campaign_config(config_path)
+
+    prepared = prepare_campaign_preflight(cfg, output_root=tmp_path / "out", label="warn")
+    payload = json.loads(Path(prepared["validate_config_path"]).read_text(encoding="utf-8"))
+    assert payload["route_clearance_warning_count"] == 1
+    warning = payload["route_clearance_warnings"][0]
+    assert warning["scenario"] == "clearance_case"
+    assert warning["min_clearance_margin_m"] == pytest.approx(0.2)
+    assert warning["min_clearance_margin_m"] > 0.0


### PR DESCRIPTION
## Summary

The `0.0 m` route clearances reported for `classic_merging_*` / `classic_station_platform_*` (margin `-1.0 m` for a `1.0 m` robot) **were already re-routed to positive margins on `main`** (now **+0.56 m** and **+2.5 m**, asserted by `tests/maps/test_route_clearance_maps.py`). Two real residual defects remained, which this fixes:

1. **No fail-closed guard** — `prepare_campaign_preflight` only emitted *informational* warnings, so a route with a **negative** margin (centerline-to-obstacle distance < robot radius ⇒ guaranteed collision) would still run silently. That's exactly what the issue says must not happen.
2. **Stale certifications** — `route_clearance_certifications_v1.yaml` still excluded the 3 repaired scenarios with a now-false "negative clearance" rationale.

## Fix
- `camera_ready/_route_clearance.py`: `RouteClearanceError` + `_assert_route_clearance_feasible()` raises when any scenario `min_clearance_margin_m < 0.0` (certification-independent — hard geometric infeasibility can't be excused; tangent / positive-but-narrow geometry stays an informational warning).
- `camera_ready_campaign.py`: guard wired into `prepare_campaign_preflight`, so **both** `--mode preflight` and `--mode run` fail closed.
- `route_clearance_certifications_v1.yaml`: the 3 repaired scenarios → `repaired_geometry` with a truthful rationale.

## Validation
- ruff clean; new fail-closed tests + map regression + 2 existing preflight tests: **8 passed**; full `test_camera_ready_campaign.py`: **121 passed** (no regression).
- Issue-reproduction preflight on the full paper matrix: succeeds, **zero negative-clearance warnings**, no `RouteClearanceError`, target scenarios absent — satisfies the DoD.

**User-facing:** preflight/run now fail closed on geometrically-impossible routes (CHANGELOG updated).

Closes #3628. Part of the goal-driven implementation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
