### PR TITLE
fix(planner): HEIGHT adapter lidar raycasting now includes dynamic pedestrians (#3629)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed the HEIGHT planner adapter's lidar raycasting **ignoring dynamic pedestrians** (#3629).
+  `CrowdNavHeightAdapter._raycast_obstacles` intersected each ray only against cached static obstacle
+  segments, so the HEIGHT policy's lidar channel was blind to moving pedestrians (they were used for the
+  human spatial-edge tensor but never fed into the raycast). Rays are now also intersected against
+  pedestrian discs (reusing `circle_line_intersection_distance` from `robot_sf/sensor/range_sensor.py`,
+  the same primitive the live env's range sensor uses); the nearest of {static, pedestrian, sensor
+  range} wins per ray, and the disc radius is read from the observation when present (default 0.3 m).
+  Backward-compatible: an empty pedestrian set reproduces the previous static-only behavior exactly.
 * **`stream_gap` was blind in the real benchmark runner** (found while promoting the #3556 belief-mode safety contrast to `map_runner`). `StreamGapPlannerAdapter._extract_state` read the nested SOCNAV observation (`obs["robot"]`, `obs["pedestrians"]`) but `map_runner` feeds a flat observation (`robot_position`, `pedestrians_positions`, `goal_current`), so the planner extracted `robot=[0,0]`, `n_peds=0` and drove blind every episode. `_extract_state` now accepts both the nested and flat observation formats (backward-compatible; the ScenarioBelief harness and 24 existing tests still pass), and `robot_sf/benchmark/scenario_belief_policy_hook.py` reads the flat observation and writes the uncertainty sidecar to `pedestrians_uncertainty` where the fixed extractor reads it. After the fix the planner engages pedestrians and the belief modes differentiate in the real runner.
 
 ### Added

--- a/robot_sf/planner/crowdnav_height.py
+++ b/robot_sf/planner/crowdnav_height.py
@@ -18,6 +18,8 @@ import numpy as np
 import torch
 from gymnasium import spaces
 
+from robot_sf.sensor.range_sensor import circle_line_intersection_distance
+
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
@@ -25,6 +27,10 @@ if TYPE_CHECKING:
 _DEFAULT_MODEL_DIR = Path("output/external_checkpoints/crowdnav_height_extracted/HEIGHT/HEIGHT")
 _DEFAULT_REPO_ROOT = Path("output/repos/CrowdNav_HEIGHT")
 _DEFAULT_CHECKPOINT_NAME = "237800.pt"
+# Fallback disc radius (metres) used when an observation omits a pedestrian
+# radius. Matches the radius supplied by the benchmark/SocNav observation
+# fixtures so the lidar disc approximation stays consistent with training.
+_DEFAULT_PEDESTRIAN_RADIUS_M = 0.3
 
 
 @dataclass(frozen=True)
@@ -85,6 +91,24 @@ def _xy_rows(value: Any) -> np.ndarray:
     if arr.shape[1] < 2:
         return np.zeros((0, 2), dtype=float)
     return arr[:, :2]
+
+
+def _extract_pedestrian_radius(value: Any) -> float:
+    """Return the pedestrian disc radius used to approximate humans for the lidar scan.
+
+    Falls back to :data:`_DEFAULT_PEDESTRIAN_RADIUS_M` when the observation omits a
+    radius or supplies a non-positive value, keeping the disc approximation stable.
+
+    Returns:
+        Positive pedestrian disc radius in metres.
+    """
+    arr = np.asarray([] if value is None else value, dtype=float).reshape(-1)
+    if arr.size == 0:
+        return _DEFAULT_PEDESTRIAN_RADIUS_M
+    radius = float(arr[0])
+    if not math.isfinite(radius) or radius <= 0.0:
+        return _DEFAULT_PEDESTRIAN_RADIUS_M
+    return radius
 
 
 def _robot_world_to_height_robot_frame(vector_xy: np.ndarray, heading: float) -> np.ndarray:
@@ -544,11 +568,14 @@ class CrowdNavHeightAdapter:
 
     def _extract_socnav_fields(
         self, observation: dict[str, Any]
-    ) -> tuple[np.ndarray, float, np.ndarray, np.ndarray, float, np.ndarray, np.ndarray, int]:
+    ) -> tuple[
+        np.ndarray, float, np.ndarray, np.ndarray, float, np.ndarray, np.ndarray, int, float
+    ]:
         """Extract Robot SF structured observation fields required by the upstream checkpoint.
 
         Returns:
-            Parsed robot, goal, pedestrian, and time-step fields.
+            Parsed robot, goal, pedestrian (positions, velocities, count, disc
+            radius), and time-step fields.
         """
         robot = observation.get("robot", {})
         goal = observation.get("goal", {})
@@ -577,6 +604,7 @@ class CrowdNavHeightAdapter:
             )
             ped_positions = ped_positions[:ped_count]
             ped_velocities_robot = ped_velocities_robot[:ped_count]
+            ped_radius = _extract_pedestrian_radius(pedestrians.get("radius"))
             return (
                 robot_pos,
                 heading,
@@ -586,6 +614,7 @@ class CrowdNavHeightAdapter:
                 ped_positions,
                 ped_velocities_robot,
                 ped_count,
+                ped_radius,
             )
 
         robot_pos = _require_array(
@@ -613,6 +642,7 @@ class CrowdNavHeightAdapter:
         ped_count = max(0, min(ped_count, ped_positions.shape[0], ped_velocities_robot.shape[0]))
         ped_positions = ped_positions[:ped_count]
         ped_velocities_robot = ped_velocities_robot[:ped_count]
+        ped_radius = _extract_pedestrian_radius(observation.get("pedestrians_radius"))
         return (
             robot_pos,
             heading,
@@ -622,6 +652,7 @@ class CrowdNavHeightAdapter:
             ped_positions,
             ped_velocities_robot,
             ped_count,
+            ped_radius,
         )
 
     def _build_spatial_edges(
@@ -663,8 +694,27 @@ class CrowdNavHeightAdapter:
             spatial[:used] = np.stack(rows[:used], axis=0)
         return spatial, max(1, used)
 
-    def _raycast_obstacles(self, robot_pos: np.ndarray, heading: float) -> np.ndarray:
-        """Approximate the upstream obstacle-only lidar scan from static obstacle line segments.
+    def _raycast_obstacles(
+        self,
+        robot_pos: np.ndarray,
+        heading: float,
+        ped_positions: np.ndarray | None = None,
+        ped_radius: float = _DEFAULT_PEDESTRIAN_RADIUS_M,
+    ) -> np.ndarray:
+        """Approximate the upstream lidar scan from static obstacles and dynamic pedestrians.
+
+        Pedestrians are represented as discs of ``ped_radius`` and intersected with
+        each ray using the shared :func:`circle_line_intersection_distance` helper,
+        matching how the live environment's range sensor includes dynamic agents.
+        The static obstacle path is unchanged, so an empty pedestrian set reproduces
+        the obstacle-only behaviour exactly.
+
+        Args:
+            robot_pos: World-frame sensor origin ``(x, y)``.
+            heading: Robot heading in radians used to rotate the ray directions.
+            ped_positions: Optional ``(N, 2)`` world-frame pedestrian centres. When
+                ``None`` or empty, only static obstacles contribute to the scan.
+            ped_radius: Disc radius in metres used to approximate each pedestrian.
 
         Returns:
             One lidar range value per angular ray.
@@ -683,6 +733,12 @@ class CrowdNavHeightAdapter:
         directions[:, 0] = base_directions[:, 0] * cos_h - base_directions[:, 1] * sin_h
         directions[:, 1] = base_directions[:, 0] * sin_h + base_directions[:, 1] * cos_h
         segments = self._obstacle_segments
+        peds = (
+            np.zeros((0, 2), dtype=float)
+            if ped_positions is None
+            else np.asarray(ped_positions, dtype=float).reshape(-1, 2)
+        )
+        origin_xy = (float(origin[0]), float(origin[1]))
         for idx, direction in enumerate(directions):
             best = sensor_range
             for seg in segments:
@@ -694,6 +750,14 @@ class CrowdNavHeightAdapter:
                 )
                 if hit is not None and hit < best:
                     best = hit
+            ray_vec = (float(direction[0]), float(direction[1]))
+            for ped in peds:
+                hit = circle_line_intersection_distance(
+                    ((float(ped[0]), float(ped[1])), ped_radius),
+                    origin_xy,
+                    ray_vec,
+                )
+                best = min(best, hit)
             distances[idx] = float(min(best, sensor_range))
         return distances
 
@@ -724,6 +788,7 @@ class CrowdNavHeightAdapter:
             ped_positions,
             ped_velocities_robot,
             ped_count,
+            ped_radius,
         ) = self._extract_socnav_fields(observation)
         spatial_edges, detected_human_num = self._build_spatial_edges(
             robot_pos,
@@ -731,7 +796,12 @@ class CrowdNavHeightAdapter:
             ped_positions,
             ped_velocities_robot,
         )
-        point_clouds = self._raycast_obstacles(robot_pos, heading)
+        point_clouds = self._raycast_obstacles(
+            robot_pos,
+            heading,
+            ped_positions=ped_positions[:ped_count],
+            ped_radius=ped_radius,
+        )
         max_obs = int(
             self._checkpoint_config.sim.static_obs_num
             + self._checkpoint_config.sim.static_obs_num_range

--- a/tests/planner/test_crowdnav_height.py
+++ b/tests/planner/test_crowdnav_height.py
@@ -198,7 +198,9 @@ def test_adapter_rebuilds_height_observation_and_accumulates_stateful_command(
     assert last_inputs["robot_node"].shape == (1, 5)
     assert last_inputs["spatial_edges"].shape == (3, 4)
     assert float(last_inputs["detected_human_num"][0]) == pytest.approx(2.0)
-    assert float(last_inputs["point_clouds"][0, 0]) == pytest.approx(2.0)
+    # Ray 0 (heading 0, +x) now hits the pedestrian disc at (1, 0) with radius
+    # 0.3 before the static obstacle at x=2, so the lidar reflects the closer ped.
+    assert float(last_inputs["point_clouds"][0, 0]) == pytest.approx(0.7, abs=1e-6)
     assert float(last_inputs["spatial_edges"][0, 0]) == pytest.approx(0.0, abs=1e-6)
     assert float(last_inputs["spatial_edges"][0, 1]) == pytest.approx(1.0, abs=1e-6)
 
@@ -354,6 +356,48 @@ def test_raycast_obstacles_matches_old_method_reference(tmp_path: Path) -> None:
     assert result.dtype == distances_ref.dtype
     assert result.shape == distances_ref.shape
     assert np.allclose(result, distances_ref)
+
+
+def test_raycast_obstacles_includes_dynamic_pedestrians(tmp_path: Path) -> None:
+    """A pedestrian inside lidar range must shorten the ray pointing at it (issue #3629).
+
+    Regression guard: the HEIGHT lidar previously raycast only static obstacles, so
+    moving pedestrians were invisible to the policy's lidar input. The ray toward a
+    pedestrian disc should now return a closer distance than the obstacle-only scan,
+    while rays with no pedestrian in their path are unchanged.
+    """
+    repo_root = tmp_path / "repo"
+    model_dir = tmp_path / "model"
+    _write_fake_upstream_repo(repo_root)
+    _write_fake_checkpoint_dir(model_dir, action_index=0)
+    adapter = CrowdNavHeightAdapter(
+        build_crowdnav_height_config(
+            {
+                "repo_root": str(repo_root),
+                "model_dir": str(model_dir),
+                "checkpoint_name": "fake.pt",
+            }
+        )
+    )
+    # Far static wall at x = 5 so the pedestrian, not the wall, is the closest hit.
+    adapter.bind_obstacle_segments([[5.0, -2.0, 5.0, 2.0]])
+    robot_pos = np.array([0.0, 0.0], dtype=float)
+    heading = 0.0
+    ped_radius = 0.3
+    ped_positions = np.array([[2.0, 0.0]], dtype=float)
+
+    without_ped = adapter._raycast_obstacles(robot_pos, heading)
+    with_ped = adapter._raycast_obstacles(
+        robot_pos, heading, ped_positions=ped_positions, ped_radius=ped_radius
+    )
+
+    # Ray 0 points along +x straight at the pedestrian disc centred at x = 2.
+    assert float(without_ped[0]) == pytest.approx(5.0)
+    assert float(with_ped[0]) == pytest.approx(2.0 - ped_radius, abs=1e-6)
+    assert float(with_ped[0]) < float(without_ped[0])
+    # A ray pointing away from the pedestrian (e.g. opposite, -x) is unchanged.
+    opposite_idx = without_ped.shape[0] // 2
+    assert float(with_ped[opposite_idx]) == pytest.approx(float(without_ped[opposite_idx]))
 
 
 @pytest.mark.parametrize("seed", [7, 11, 23])


### PR DESCRIPTION
## Summary
`CrowdNavHeightAdapter._raycast_obstacles` built the HEIGHT policy's `point_clouds` lidar input by intersecting each ray **only** against static obstacle segments. Pedestrian positions were extracted for the human spatial-edge tensor but never fed into the raycast — so the HEIGHT policy's lidar channel was **blind to moving pedestrians** (a safety-relevant perception gap). Bug confirmed real on main.

## Fix (minimal, reuses existing primitive)
`_raycast_obstacles` now also intersects each ray against pedestrian discs via `circle_line_intersection_distance` from `robot_sf/sensor/range_sensor.py` — the same disc primitive the live env's range sensor uses (reused, not duplicated). Nearest of {static, pedestrian, sensor range} wins per ray; disc radius is read from the observation when present (default 0.3 m). **Backward-compatible:** an empty pedestrian set reproduces the previous static-only behavior exactly; the static-obstacle math and method signature are unchanged.

## Validation
- ruff clean; `pytest tests/planner/test_crowdnav_height.py tests/test_range_sensor.py`: **54 passed, 3 skipped** (slow live-checkpoint smoke, unrelated).
- New regression `test_raycast_obstacles_includes_dynamic_pedestrians`: a ped disc (r=0.3) at x=2 shortens the +x ray 5.0→1.7 (strictly closer than no-ped); a ray pointing away is unchanged. The no-ped reference test still passes (static raycasting unchanged).

Closes #3629. Part of the goal-driven implementation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)