### PR TITLE
test(env): regression guard for pygame-free headless execution (#3631)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a regression guard for **pygame-free headless execution** (#3631). A subprocess-probe test
+  (`tests/test_pygame_headless.py::test_headless_step_does_not_import_pygame`) builds and **steps** the
+  env under forced-headless drivers and asserts `pygame` is never imported and no `sim_ui` is created —
+  extending the no-pygame contract from env *construction* (already covered) through a full step, which
+  the issue's reproduction specifically targets. The headless path was verified already pygame-free, so
+  this is a test-only guard (a negative probe with an injected `import pygame` flips it red, confirming
+  it is not vacuous).
 * Began the #3463 corrective engineering for the topology near-parity selector lane (diagnostic-tier,
   no benchmark claim). `TopologyGuidedLocalPolicyConfig` gains two current-behavior-preserving knobs:
   `primary_route_progress_gate_use_monotone_accounting` (default `False`) hardens primary-route

--- a/tests/test_pygame_headless.py
+++ b/tests/test_pygame_headless.py
@@ -3,10 +3,81 @@ Test that pygame windows don't open during tests in headless environments.
 """
 
 import os
+import subprocess
+import sys
+import textwrap
 
 import pygame
 
 from robot_sf.gym_env.environment_factory import make_robot_env
+
+
+def _run_headless_probe(code: str) -> str:
+    """Run an isolated Python probe in a forced-headless subprocess and return stdout.
+
+    A subprocess is required because this very test module imports ``pygame`` at the
+    top level, which would otherwise pollute ``sys.modules`` and make an in-process
+    ``"pygame" in sys.modules`` assertion meaningless. The child process starts with a
+    clean interpreter and headless SDL/matplotlib drivers so the assertion reflects only
+    what the production ``make_robot_env`` code path imports.
+
+    Args:
+        code: Python source executed in the child interpreter via ``-c``.
+
+    Returns:
+        The captured standard output of the child process.
+    """
+    env = os.environ.copy()
+    env.update(
+        {
+            "DISPLAY": "",
+            "MPLBACKEND": "Agg",
+            "SDL_VIDEODRIVER": "dummy",
+            "SDL_AUDIODRIVER": "dummy",
+            "PYGAME_HIDE_SUPPORT_PROMPT": "hide",
+        }
+    )
+    result = subprocess.run(
+        [sys.executable, "-c", textwrap.dedent(code)],
+        check=True,
+        cwd=os.getcwd(),
+        env=env,
+        text=True,
+        capture_output=True,
+    )
+    return result.stdout
+
+
+def test_headless_step_does_not_import_pygame() -> None:
+    """Regression guard: a full reset+step on ``debug=False`` must not import pygame.
+
+    Headless runs (SLURM, minimal CI containers) require that pygame is never imported
+    or display-initialized on the pure-simulation path. ``test_lazy_pygame_init.py`` covers
+    env *construction*; this guard extends the contract through env *execution* by
+    inspecting ``sys.modules`` after a real ``reset()`` and ``step()``, matching the
+    reproduction in issue #3631. If a future change adds a top-level pygame import or a
+    render call on the headless step path, this probe fails.
+    """
+    stdout = _run_headless_probe(
+        """
+        import sys
+
+        from robot_sf.gym_env.environment_factory import make_robot_env
+
+        env = make_robot_env(debug=False)
+        try:
+            env.reset(seed=42)
+            action = env.action_space.sample()
+            env.step(action)
+            print("pygame_after_step", "pygame" in sys.modules)
+            print("sim_ui", getattr(env, "sim_ui", None))
+        finally:
+            env.close()
+        """
+    )
+
+    assert "pygame_after_step False" in stdout, stdout
+    assert "sim_ui None" in stdout, stdout
 
 
 class TestPygameHeadless:


### PR DESCRIPTION
## Summary
The headless path must stay pygame-free **through a full step**, but existing coverage (`test_lazy_pygame_init.py`) only checked env *construction* — the gap the issue's reproduction explicitly targets ("after running a headless step").

## What's here
Added `tests/test_pygame_headless.py::test_headless_step_does_not_import_pygame`: a clean **subprocess** with forced-headless drivers runs `make_robot_env(debug=False)` + `reset(seed=42)` + `step(action)` and asserts `"pygame" not in sys.modules` and `sim_ui is None`. The subprocess probe is necessary because `test_pygame_headless.py` imports pygame at module top level (an in-process `sys.modules` check would be vacuous); it reuses the proven pattern from `test_lazy_pygame_init.py`.

## Findings
- The headless path is **already genuinely pygame-free** after a step (`pygame_after_step=False`, `sim_ui=None`) — so this is a **test-only guard**, no production change (would have been gold-plating).
- **Negative check:** injecting `import pygame` into the probe body flips it to fail — confirming the guard is not vacuous.

## Validation
- ruff clean; `pytest tests/test_pygame_headless.py`: **6 passed**.

Closes #3631. Part of the goal-driven implementation loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)