### PR TITLE
Fix HEIGHT adapter action state clipping for issue #3626

### DIFF
--- a/robot_sf/planner/crowdnav_height.py
+++ b/robot_sf/planner/crowdnav_height.py
@@ -879,34 +879,50 @@ class CrowdNavHeightAdapter:
             raise ValueError(f"Unexpected CrowdNav_HEIGHT discrete action index: {action_idx}")
         delta_v, delta_theta = self._action_table[action_idx]
         robot_cfg = self._checkpoint_config.robot
-        linear_min = max(float(robot_cfg.v_min), -self.config.max_linear_speed)
-        linear_max = min(float(robot_cfg.v_max), self.config.max_linear_speed)
-        angular_min = max(float(robot_cfg.w_min), -self.config.max_angular_speed)
-        angular_max = min(float(robot_cfg.w_max), self.config.max_angular_speed)
-        if linear_min > linear_max or angular_min > angular_max:
+        source_linear_min = float(robot_cfg.v_min)
+        source_linear_max = float(robot_cfg.v_max)
+        source_angular_min = float(robot_cfg.w_min)
+        source_angular_max = float(robot_cfg.w_max)
+        if source_linear_min > source_linear_max or source_angular_min > source_angular_max:
             raise ValueError(
                 "CrowdNav_HEIGHT projection limits are inconsistent with the checkpoint robot limits"
             )
         self._desired_velocity[0] = float(
             np.clip(
                 self._desired_velocity[self._LINEAR_VELOCITY_INDEX] + delta_v,
-                linear_min,
-                linear_max,
+                source_linear_min,
+                source_linear_max,
             )
         )
         self._desired_velocity[1] = float(
             np.clip(
                 self._desired_velocity[self._ANGULAR_VELOCITY_INDEX] + delta_theta,
-                angular_min,
-                angular_max,
+                source_angular_min,
+                source_angular_max,
             )
         )
-        linear = float(self._desired_velocity[self._LINEAR_VELOCITY_INDEX])
-        angular = float(self._desired_velocity[self._ANGULAR_VELOCITY_INDEX])
+        linear = float(
+            np.clip(
+                self._desired_velocity[self._LINEAR_VELOCITY_INDEX],
+                -self.config.max_linear_speed,
+                self.config.max_linear_speed,
+            )
+        )
+        angular = float(
+            np.clip(
+                self._desired_velocity[self._ANGULAR_VELOCITY_INDEX],
+                -self.config.max_angular_speed,
+                self.config.max_angular_speed,
+            )
+        )
         meta.update(
             {
                 "action_index": action_idx,
                 "upstream_delta_command": [float(delta_v), float(delta_theta)],
+                "upstream_desired_command": [
+                    float(self._desired_velocity[self._LINEAR_VELOCITY_INDEX]),
+                    float(self._desired_velocity[self._ANGULAR_VELOCITY_INDEX]),
+                ],
                 "projected_command_vw": [linear, angular],
                 "projection_policy": self.projection_policy,
             }

--- a/tests/planner/test_crowdnav_height.py
+++ b/tests/planner/test_crowdnav_height.py
@@ -44,14 +44,24 @@ class Policy(nn.Module):
         del obs_shape, action_space, base
         self.base = _Base()
         self.weight = nn.Parameter(torch.zeros(1))
-        self._action_index = int(base_kwargs.testing.action_index)
+        testing_config = base_kwargs.testing
+        self._action_sequence = [
+            int(index) for index in getattr(testing_config, "action_sequence", [])
+        ]
+        self._action_index = int(testing_config.action_index)
+        self._cursor = 0
 
     def act(self, inputs, rnn_hxs, masks, deterministic=False):
         del deterministic
         global LAST_INPUTS
         LAST_INPUTS = {key: value.detach().cpu().clone() for key, value in inputs.items()}
         LAST_INPUTS["masks"] = masks.detach().cpu().clone()
-        action = torch.tensor([[self._action_index]], dtype=torch.long, device=self.weight.device)
+        if self._cursor < len(self._action_sequence):
+            action_index = self._action_sequence[self._cursor]
+        else:
+            action_index = self._action_index
+        self._cursor += 1
+        action = torch.tensor([[action_index]], dtype=torch.long, device=self.weight.device)
         return (
             torch.zeros((1, 1), dtype=torch.float32, device=self.weight.device),
             action,
@@ -62,7 +72,9 @@ class Policy(nn.Module):
     )
 
 
-def _write_fake_checkpoint_dir(model_dir: Path, *, action_index: int) -> None:
+def _write_fake_checkpoint_dir(
+    model_dir: Path, *, action_index: int, action_sequence: list[int] | None = None
+) -> None:
     """Create a fake checkpoint directory with configurable discrete action output."""
     _write(model_dir / "configs" / "__init__.py", "")
     _write(
@@ -98,8 +110,10 @@ class Config:
     ppo = BaseConfig()
     ppo.num_steps = 1
     ppo.num_mini_batch = 1
-    testing = BaseConfig()
-    testing.action_index = {action_index}
+testing = BaseConfig()
+testing.action_index = {action_index}
+testing.action_sequence = {list(action_sequence or [])!r}
+Config.testing = testing
 """,
     )
     checkpoint_path = model_dir / "checkpoints" / "fake.pt"
@@ -208,6 +222,55 @@ def test_adapter_rebuilds_height_observation_and_accumulates_stateful_command(
     command_3, turn_3 = adapter.plan(obs)
     assert command_3 == pytest.approx(0.05)
     assert turn_3 == pytest.approx(0.1)
+
+
+def test_adapter_preserves_upstream_desired_state_when_projecting_limited_command(
+    tmp_path: Path,
+) -> None:
+    """Adapter command limits must not overwrite upstream HEIGHT delta-action state."""
+    repo_root = tmp_path / "repo"
+    model_dir = tmp_path / "model"
+    _write_fake_upstream_repo(repo_root)
+    # Two accelerate actions followed by a decelerate action distinguish source-state
+    # preservation from clipping the adapter's internal desired velocity to output limits.
+    _write_fake_checkpoint_dir(model_dir, action_index=4, action_sequence=[0, 0, 7])
+    adapter = CrowdNavHeightAdapter(
+        build_crowdnav_height_config(
+            {
+                "repo_root": str(repo_root),
+                "model_dir": str(model_dir),
+                "checkpoint_name": "fake.pt",
+                "max_linear_speed": 0.05,
+                "max_angular_speed": 0.1,
+            }
+        )
+    )
+    adapter.bind_obstacle_segments([[5.0, -1.0, 5.0, 1.0]])
+    obs = {
+        "robot": {
+            "position": [0.0, 0.0],
+            "heading": [0.0],
+            "velocity_xy": [0.0, 0.0],
+            "radius": [0.3],
+        },
+        "goal": {"current": [4.0, 0.0]},
+        "pedestrians": {"positions": [], "velocities": [], "count": [0], "radius": [0.3]},
+        "sim": {"timestep": [0.1]},
+    }
+
+    command_1, turn_1, meta_1 = adapter.act(obs, time_step=0.1)
+    command_2, turn_2, meta_2 = adapter.act(obs, time_step=0.1)
+    command_3, turn_3, meta_3 = adapter.act(obs, time_step=0.1)
+
+    assert (command_1, turn_1) == pytest.approx((0.05, 0.1))
+    assert (command_2, turn_2) == pytest.approx((0.05, 0.1))
+    assert (command_3, turn_3) == pytest.approx((0.05, 0.1))
+    assert meta_1["upstream_desired_command"] == [pytest.approx(0.05), pytest.approx(0.1)]
+    assert meta_2["upstream_desired_command"] == [pytest.approx(0.1), pytest.approx(0.2)]
+    assert meta_2["projected_command_vw"] == [pytest.approx(0.05), pytest.approx(0.1)]
+    assert meta_3["upstream_delta_command"] == [pytest.approx(-0.05), pytest.approx(0.0)]
+    assert meta_3["upstream_desired_command"] == [pytest.approx(0.05), pytest.approx(0.2)]
+    assert meta_3["projected_command_vw"] == [pytest.approx(0.05), pytest.approx(0.1)]
 
 
 def test_adapter_accepts_flat_benchmark_observation_schema(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Fixes https://github.com/ll7/robot_sf_ll7/issues/3626.

- Preserve the HEIGHT adapter's upstream desired `(v, w)` state under checkpoint robot limits.
- Apply Robot SF adapter command limits only to the emitted projected command.
- Add a regression test where adapter output limits are lower than upstream limits, proving a later upstream deceleration starts from the preserved source desired state.

## Validation

- `uv run pytest tests/planner/test_crowdnav_height.py -q` - passed, 10 passed, 3 skipped.
- `uv run ruff check robot_sf/planner/crowdnav_height.py tests/planner/test_crowdnav_height.py` - passed.
- `uv run ruff format --check robot_sf/planner/crowdnav_height.py tests/planner/test_crowdnav_height.py` - passed.
- `python3 -m py_compile robot_sf/planner/crowdnav_height.py tests/planner/test_crowdnav_height.py` - passed.
- `git diff --check` - passed.
- `env -u PR_READY_PR_BODY_FILE uv run pytest tests/dev/test_check_perf_evidence.py::test_cli_requires_body_when_perf_change_and_no_body -q` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue3626_pr_body.md scripts/dev/pr_ready_check.sh` - failed in `tests/dev/test_check_perf_evidence.py::test_cli_requires_body_when_perf_change_and_no_body` because the wrapper-required `PR_READY_PR_BODY_FILE` environment variable is inherited by that self-test and changes its expected missing-body error. The same self-test passes when that environment variable is unset.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Downstream Propagation

NA - scoped planner adapter bugfix with focused regression coverage; no benchmark interpretation or dissertation-facing claim text changed.

## Research Result Guidance

NA - this PR fixes adapter action projection behavior and does not establish benchmark, metric, model-provenance, or paper-facing claims.

## Residual Risk

- Full readiness did not complete because of the `PR_READY_PR_BODY_FILE` environment leak described above; focused adapter tests, lint, format, py_compile, and diff checks passed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command handling so robot motion is constrained correctly at both the robot limit level and the adapter’s configured speed limits.
  - Preserved upstream “desired” motion data in debug metadata even when the final command is clipped, making runtime behavior easier to inspect.
  - Ensured repeated planning calls keep showing consistent desired-state information while still respecting tighter output limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->