### PR TITLE
Fix issue #3630 false-positive observation replay

### DIFF
--- a/scripts/benchmark/run_observation_noise_envelope.py
+++ b/scripts/benchmark/run_observation_noise_envelope.py
@@ -51,6 +51,14 @@ CONDITIONS: dict[str, dict[str, Any]] = {
         "description": "Single pedestrian fully missed (probability=1.0).",
         "spec_kw": {"missed_detection_probability": 1.0, "seed": 2755},
     },
+    "false_positive_only": {
+        "description": "One observed-only pedestrian injected into the replay observation.",
+        "spec_kw": {
+            "false_positive_positions": [[26.0, 7.0]],
+            "false_positive_velocities": [[0.0, 0.0]],
+            "false_positive_ids": ["false_positive_0"],
+        },
+    },
     "occlusion_only": {
         "description": "Single pedestrian position/velocity zeroed by occlusion mask.",
         "spec_kw": {"occlusion_mask": np.array([True])},
@@ -187,6 +195,7 @@ def evaluate_condition(
     response_delay_steps: int | None = None
     missed_counts: list[int] = []
     occluded_counts: list[int] = []
+    false_positive_counts: list[int] = []
     closest_distances: list[float] = []
     action_proxies: list[dict[str, Any]] = []
     observed_steps: list[int] = []
@@ -232,6 +241,7 @@ def evaluate_condition(
 
         missed_counts.append(meta["missed_actor_count"])
         occluded_counts.append(meta["occluded_actor_count"])
+        false_positive_counts.append(meta["false_positive_actor_count"])
         closest_distances.append(closest_dist)
         action_proxies.append(action_proxy)
 
@@ -258,6 +268,7 @@ def evaluate_condition(
         "perturbed_observed_steps": perturbed_observed_steps,
         "missed_actor_observations_total": sum(missed_counts),
         "occluded_actor_observations_total": sum(occluded_counts),
+        "false_positive_actor_observations_total": sum(false_positive_counts),
         "delay_steps_configured": spec.delay_steps,
         "closest_distance_m": round(min(closest_distances), 4) if closest_distances else None,
         "stop_yield_feasibility": {
@@ -286,6 +297,7 @@ def _spec_summary(spec: ObservationPerturbationSpec) -> dict[str, Any]:
         "position_noise_bound_m": spec.position_noise_bound_m,
         "missed_detection_probability": spec.missed_detection_probability,
         "has_occlusion_mask": spec.occlusion_mask is not None,
+        "false_positive_actor_count": spec.false_positive_actor_count,
         "delay_steps": spec.delay_steps,
         "noise_profile": spec.noise_profile,
         "is_noop": spec.is_noop,
@@ -308,7 +320,7 @@ def _observation_quality_group(spec: ObservationPerturbationSpec) -> dict[str, A
         range_limit_m=None,
         angular_noise_std_rad=0.0,
         false_negative_rate=float(spec.missed_detection_probability),
-        false_positive_rate=0.0,
+        false_positive_rate=1.0 if spec.false_positive_actor_count > 0 else 0.0,
         notes=(
             "Diagnostic simulator observation-quality metadata only; "
             "not hardware-calibrated sensor realism."
@@ -406,6 +418,7 @@ def _safety_effect_summary(result: dict[str, Any]) -> dict[str, Any]:
 
     missed_total = int(result["missed_actor_observations_total"])
     occluded_total = int(result["occluded_actor_observations_total"])
+    false_positive_total = int(result["false_positive_actor_observations_total"])
     delay_steps = result["response_delay_steps"]
     if result["first_observed_step"] is None and (missed_total > 0 or occluded_total > 0):
         false_negative_effect = "full_miss_or_occlusion"
@@ -432,10 +445,12 @@ def _safety_effect_summary(result: dict[str, Any]) -> dict[str, Any]:
             "rationale": false_negative_rationale,
         },
         "false_positive": {
-            "effect": "not_modeled",
+            "effect": "actor_injected" if false_positive_total > 0 else "none_observed",
+            "false_positive_actor_observations_total": false_positive_total,
             "rationale": (
-                "This perturbation path does not inject false-positive actors; false-positive "
-                "effects are explicitly not available from this diagnostic report."
+                "Observed-only actors were injected into the perturbation replay."
+                if false_positive_total > 0
+                else "No false-positive actor observations were recorded."
             ),
         },
     }
@@ -557,7 +572,6 @@ def _generate_markdown(
             "",
             "- Single deterministic fixture (seed=111), single scenario family.",
             "- No live planner replay; action proxies are from the stored trace, not re-executed.",
-            "- False-positive actors are not injected by this diagnostic perturbation path.",
             "- Stop/yield feasibility is from fixture metadata, not re-derived.",
             "- Not paper-facing benchmark evidence.",
         ]

--- a/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
+++ b/scripts/benchmark/run_observation_noise_live_replay_issue_2777.py
@@ -35,6 +35,7 @@ REQUIRED_CONDITIONS = (
     "low_noise",
     "medium_noise",
     "missed_detection_only",
+    "false_positive_only",
     "occlusion_only",
     "delay_only",
     "combined",
@@ -116,6 +117,20 @@ CONDITIONS = (
         "missed_detection_only",
         "All live pedestrians removed from planner input by missed-detection probability 1.0.",
         ("--missed-detection-probability", "1.0", "--observation-perturbation-seed", "2755"),
+    ),
+    Condition(
+        "false_positive_only",
+        "One deterministic observed-only pedestrian injected into planner input.",
+        (
+            "--false-positive-actor-count",
+            "1",
+            "--false-positive-offset-x-m",
+            "1.0",
+            "--false-positive-offset-y-m",
+            "0.0",
+            "--observation-perturbation-seed",
+            "2755",
+        ),
     ),
     Condition(
         "occlusion_only",
@@ -491,6 +506,7 @@ def _observation_totals(trace: dict[str, Any]) -> dict[str, Any]:
         "missed_actor_observations_total": 0,
         "occluded_actor_observations_total": 0,
         "visibility_hidden_actor_observations_total": 0,
+        "false_positive_actor_observations_total": 0,
         "min_observed_actor_count": None,
         "max_observed_actor_count": None,
         "noise_profiles": set(),
@@ -502,6 +518,9 @@ def _observation_totals(trace: dict[str, Any]) -> dict[str, Any]:
         totals["occluded_actor_observations_total"] += int(meta.get("occluded_actor_count", 0) or 0)
         totals["visibility_hidden_actor_observations_total"] += int(
             meta.get("visibility_hidden_actor_count", 0) or 0
+        )
+        totals["false_positive_actor_observations_total"] += int(
+            meta.get("false_positive_actor_count", 0) or 0
         )
         observed_counts.append(int(meta.get("observed_actor_count", 0) or 0))
         profile = meta.get("noise_profile")

--- a/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
+++ b/tests/benchmark/test_issue_2777_observation_noise_live_replay.py
@@ -33,7 +33,7 @@ def _load_script():
 
 
 def test_condition_set_matches_issue_2755_contract() -> None:
-    """The wrapper should preserve the seven perturbation family names."""
+    """The wrapper should preserve the default perturbation family names."""
     mod = _load_script()
 
     assert tuple(condition.name for condition in mod.CONDITIONS) == mod.REQUIRED_CONDITIONS
@@ -41,10 +41,23 @@ def test_condition_set_matches_issue_2755_contract() -> None:
     delay = next(condition for condition in mod.CONDITIONS if condition.name == "delay_only")
     assert "--observation-delay-steps" in delay.flags
     assert "2" in delay.flags
+    false_positive = next(
+        condition for condition in mod.CONDITIONS if condition.name == "false_positive_only"
+    )
+    assert false_positive.flags == (
+        "--false-positive-actor-count",
+        "1",
+        "--false-positive-offset-x-m",
+        "1.0",
+        "--false-positive-offset-y-m",
+        "0.0",
+        "--observation-perturbation-seed",
+        "2755",
+    )
 
 
 def test_issue_3328_behavior_probe_condition_set_is_opt_in() -> None:
-    """The #3328 probe should not mutate the default seven-condition run."""
+    """The #3328 probe should not mutate the default condition run."""
     mod = _load_script()
 
     probe_conditions = mod.CONDITION_SETS[mod.ISSUE_3328_CONDITION_SET]
@@ -128,7 +141,7 @@ def test_default_strict_mode_fails_closed_without_occluded_fixture(tmp_path: Pat
     assert report["status"] == "fail_closed"
     assert report["classification"]["label"] == "blocked"
     assert report["fixture_contract"]["satisfied"] is False
-    assert len(report["conditions"]) == 7
+    assert len(report["conditions"]) == len(mod.REQUIRED_CONDITIONS)
     assert {condition["status"] for condition in report["conditions"]} == {"blocked"}
 
 
@@ -402,8 +415,8 @@ def test_live_condition_timeout_becomes_fail_closed_blocker(
         funnel_config=funnel,
     )
 
-    assert len(conditions) == 7
-    assert len(blockers) == 7
+    assert len(conditions) == len(mod.REQUIRED_CONDITIONS)
+    assert len(blockers) == len(mod.REQUIRED_CONDITIONS)
     assert all(condition["status"] == "blocked" for condition in conditions)
     assert "timed out" in blockers[0]
 
@@ -415,6 +428,7 @@ def _write_trace(
     observed_count: int,
     closest: float,
     seed: int = 111,
+    false_positive_count: int = 0,
 ) -> None:
     payload = {
         "candidate": "risk_surface_dwa_v0",
@@ -440,6 +454,7 @@ def _write_trace(
                     "noise_profile": "bounded_gaussian",
                     "missed_actor_count": 0,
                     "occluded_actor_count": 0,
+                    "false_positive_actor_count": false_positive_count,
                     "observed_actor_count": observed_count,
                 },
             }
@@ -833,6 +848,25 @@ def test_trace_comparison_names_scenario_seed_planner_and_policy_insensitive(
     assert comparison["seed"]["same"] is True
     assert comparison["planner_mode"]["candidate"] == "risk_surface_dwa_v0"
     assert comparison["classification"]["label"] == "policy_insensitive"
+
+
+def test_observation_totals_report_false_positive_actor_injection(tmp_path: Path) -> None:
+    """Comparison metadata should expose observed-only actor injection counts."""
+    mod = _load_script()
+    trace = tmp_path / "false_positive.json"
+    _write_trace(
+        trace,
+        command=[1.0, 0.0],
+        observed_count=2,
+        closest=1.5,
+        false_positive_count=1,
+    )
+    payload = json.loads(trace.read_text(encoding="utf-8"))
+
+    totals = mod._observation_totals(payload)
+
+    assert totals["false_positive_actor_observations_total"] == 1
+    assert totals["max_observed_actor_count"] == 2
 
 
 def test_trace_comparison_reports_behavior_change_dimensions(tmp_path: Path) -> None:

--- a/tests/benchmark/test_observation_noise_envelope.py
+++ b/tests/benchmark/test_observation_noise_envelope.py
@@ -44,6 +44,7 @@ EXPECTED_CONDITIONS = [
     "low_noise",
     "medium_noise",
     "missed_detection_only",
+    "false_positive_only",
     "occlusion_only",
     "delay_only",
     "combined",
@@ -76,12 +77,12 @@ def test_report_has_required_top_level_keys() -> None:
     assert report["issue"] == 2755
     assert "claim_boundary" in report
     assert "conditions" in report
-    assert len(report["conditions"]) == 7
+    assert len(report["conditions"]) == len(EXPECTED_CONDITIONS)
     assert "summary" in report
     assert "safety_effects" in report["summary"]
     assert (
         report["summary"]["safety_effects"]["missed_detection_only"]["false_positive"]["effect"]
-        == "not_modeled"
+        == "none_observed"
     )
 
 
@@ -173,7 +174,27 @@ def test_missed_detection_never_observed() -> None:
     assert result["first_observed_step"] is None
     assert result["classification"]["label"] == "scenario_too_weak"
     assert result["safety_effects"]["false_negative"]["effect"] == "full_miss_or_occlusion"
-    assert result["safety_effects"]["false_positive"]["effect"] == "not_modeled"
+    assert result["safety_effects"]["false_positive"]["effect"] == "none_observed"
+
+
+def test_false_positive_condition_injects_observed_only_actor() -> None:
+    """False-positive condition injects a ghost actor into replay observations."""
+    mod = _load_script()
+    trace = _load_fixture_for_test()
+    frames = trace["frames"]
+    first_visible = trace["occlusion"]["first_visible_step"]
+
+    result = mod.evaluate_condition(
+        "false_positive_only", mod.CONDITIONS["false_positive_only"], frames, first_visible
+    )
+
+    assert result["false_positive_actor_observations_total"] > 0
+    assert result["spec"]["false_positive_actor_count"] == 1
+    assert result["safety_effects"]["false_positive"]["effect"] == "actor_injected"
+    assert (
+        result["safety_effects"]["false_positive"]["false_positive_actor_observations_total"]
+        == result["false_positive_actor_observations_total"]
+    )
 
 
 def test_occlusion_only_never_observed() -> None:
@@ -302,7 +323,7 @@ def test_markdown_report_contains_caveats() -> None:
     assert "Diagnostic" in md
     assert "False-negative safety effect" in md
     assert "False-positive safety effect" in md
-    assert "False-positive actors are not injected" in md
+    assert "False-positive actors are not injected" not in md
 
 
 def test_spec_summary_fields() -> None:


### PR DESCRIPTION
## Summary
- Fixes https://github.com/ll7/robot_sf_ll7/issues/3630.
- Adds a `false_positive_only` actor-injection condition to the trace-derived observation-noise envelope.
- Adds the same false-positive replay condition to the live replay wrapper and surfaces false-positive actor observation totals in comparison metadata.
- Updates focused replay/envelope tests for the new condition and aggregate counters.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_observation_noise_envelope.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py` PASS (47 tests)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/run_observation_noise_envelope.py scripts/benchmark/run_observation_noise_live_replay_issue_2777.py tests/benchmark/test_observation_noise_envelope.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py` PASS
- `python3 -m py_compile scripts/benchmark/run_observation_noise_envelope.py scripts/benchmark/run_observation_noise_live_replay_issue_2777.py tests/benchmark/test_observation_noise_envelope.py tests/benchmark/test_issue_2777_observation_noise_live_replay.py` PASS
- `git diff --check` PASS

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
