### PR TITLE
Fix CARLA bridge handedness alignment (#3632)

### DIFF
--- a/robot_sf_carla_bridge/live_replay.py
+++ b/robot_sf_carla_bridge/live_replay.py
@@ -31,6 +31,66 @@ class _Actor(Protocol):
         """Remove the actor from the live CARLA world."""
 
 
+def robot_sf_planar_vector_to_carla(vector: dict[str, Any]) -> dict[str, float]:
+    """Mirror a Robot-SF planar vector into CARLA's left-handed x/y frame.
+
+    Returns:
+        Converted ``{"x", "y"}`` vector in CARLA coordinates.
+    """
+
+    return {"x": float(vector["x"]), "y": -float(vector["y"])}
+
+
+def carla_planar_vector_to_robot_sf(vector: dict[str, Any]) -> dict[str, float]:
+    """Mirror a CARLA planar vector back into Robot-SF's right-handed x/y frame.
+
+    Returns:
+        Converted ``{"x", "y"}`` vector in Robot-SF coordinates.
+    """
+
+    return {"x": float(vector["x"]), "y": -float(vector["y"])}
+
+
+def robot_sf_yaw_to_carla_degrees(theta_rad: float) -> float:
+    """Convert Robot-SF counter-clockwise yaw radians to CARLA yaw degrees.
+
+    Returns:
+        CARLA yaw angle in degrees.
+    """
+
+    return -math.degrees(float(theta_rad))
+
+
+def carla_yaw_degrees_to_robot_sf(yaw_degrees: float) -> float:
+    """Convert CARLA yaw degrees back to Robot-SF counter-clockwise yaw radians.
+
+    Returns:
+        Robot-SF yaw angle in radians.
+    """
+
+    return -math.radians(float(yaw_degrees))
+
+
+def robot_sf_angular_velocity_to_carla_radps(omega_radps: float) -> float:
+    """Convert Robot-SF yaw rate to CARLA yaw rate across handedness boundary.
+
+    Returns:
+        CARLA yaw rate in radians per second.
+    """
+
+    return -float(omega_radps)
+
+
+def carla_angular_velocity_to_robot_sf_radps(omega_radps: float) -> float:
+    """Convert CARLA yaw rate back to Robot-SF yaw rate across handedness boundary.
+
+    Returns:
+        Robot-SF yaw rate in radians per second.
+    """
+
+    return -float(omega_radps)
+
+
 def robot_sf_pose_to_carla_transform(
     carla_module: Any,
     pose: dict[str, Any],
@@ -48,9 +108,10 @@ def robot_sf_pose_to_carla_transform(
     """
 
     theta = float(pose.get("theta") or 0.0)
+    location = robot_sf_planar_vector_to_carla(pose)
     return carla_module.Transform(
-        carla_module.Location(x=float(pose["x"]), y=-float(pose["y"]), z=float(z)),
-        carla_module.Rotation(yaw=-math.degrees(theta)),
+        carla_module.Location(x=location["x"], y=location["y"], z=float(z)),
+        carla_module.Rotation(yaw=robot_sf_yaw_to_carla_degrees(theta)),
     )
 
 
@@ -318,8 +379,9 @@ def _spawn_static_obstacle_actors(
 def _static_obstacle_transform(carla_module: Any, bounds: dict[str, float]) -> Any:
     center_x = (bounds["min_x"] + bounds["max_x"]) / 2.0
     center_y = (bounds["min_y"] + bounds["max_y"]) / 2.0
+    center = robot_sf_planar_vector_to_carla({"x": center_x, "y": center_y})
     return carla_module.Transform(
-        carla_module.Location(x=center_x, y=-center_y, z=_DEFAULT_ACTOR_Z),
+        carla_module.Location(x=center["x"], y=center["y"], z=_DEFAULT_ACTOR_Z),
         carla_module.Rotation(yaw=0.0),
     )
 

--- a/tests/carla_bridge/test_t1_live_replay.py
+++ b/tests/carla_bridge/test_t1_live_replay.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from types import SimpleNamespace
 from typing import TYPE_CHECKING
 
@@ -659,3 +660,30 @@ def test_live_replay_uses_carla_coordinate_boundary() -> None:
     assert transform.location.y == pytest.approx(-2.0)
     assert transform.location.z == pytest.approx(0.1)
     assert transform.rotation.yaw == pytest.approx(-90.0)
+
+
+def test_live_replay_coordinate_helpers_pin_handedness_contract() -> None:
+    """CARLA bridge helpers should mirror vector, yaw, and yaw-rate signs."""
+    from robot_sf_carla_bridge.live_replay import (
+        carla_angular_velocity_to_robot_sf_radps,
+        carla_planar_vector_to_robot_sf,
+        carla_yaw_degrees_to_robot_sf,
+        robot_sf_angular_velocity_to_carla_radps,
+        robot_sf_planar_vector_to_carla,
+        robot_sf_yaw_to_carla_degrees,
+    )
+
+    carla_vector = robot_sf_planar_vector_to_carla({"x": -3.0, "y": 4.5})
+    assert carla_vector == {"x": pytest.approx(-3.0), "y": pytest.approx(-4.5)}
+    assert carla_planar_vector_to_robot_sf(carla_vector) == {
+        "x": pytest.approx(-3.0),
+        "y": pytest.approx(4.5),
+    }
+
+    carla_yaw = robot_sf_yaw_to_carla_degrees(-0.25)
+    assert carla_yaw == pytest.approx(math.degrees(0.25))
+    assert carla_yaw_degrees_to_robot_sf(carla_yaw) == pytest.approx(-0.25)
+
+    carla_omega = robot_sf_angular_velocity_to_carla_radps(0.75)
+    assert carla_omega == pytest.approx(-0.75)
+    assert carla_angular_velocity_to_robot_sf_radps(carla_omega) == pytest.approx(0.75)


### PR DESCRIPTION
## Summary
Fixes the CARLA bridge handedness conversion contract by routing Robot-SF to CARLA pose/static-obstacle math through explicit frame helpers and adding deterministic tests for vector, yaw, and angular-velocity sign conversion.

## Linked Issues
- Fixes `#3632`
- Issue: https://github.com/ll7/robot_sf_ll7/issues/3632

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added explicit Robot-SF/CARLA planar vector, yaw, and angular-velocity conversion helpers in `robot_sf_carla_bridge.live_replay`.
- Reused the helpers for live replay pose and static obstacle placement so the existing Y/yaw mirroring has one adapter-level owner.
- Added CARLA-free fixture tests that pin handedness, inverse conversion, and angular velocity inversion.

## Why Matters
- Added value: closes the adapter math slice for issue #3632 without requiring live CARLA.
- Expected impact: reduces risk of coordinate-frame drift or yaw-rate sign inversion at the bridge boundary.
- Why worth merging now: deterministic tests guard a high-value infrastructure contract with a small diff.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support adapter bugfix for linked issue only.
- Comparator or baseline, applicable: previous inline Y/yaw mirroring without explicit angular-velocity conversion helper/tests.
- Evidence tier: NA - support adapter bugfix with deterministic tests
- Result classification: NA - no research result or benchmark claim
- Decision stop rule, applicable: deterministic CARLA-free bridge tests pass for vector, yaw, and angular-velocity conversion.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3632 only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - adapter helper only.

## Domain-Aware Approval
- Approver/review source waiver: not required; targeted adapter bugfix only.
- Validity checklist: deterministic fixture-level tests only, no benchmark interpretation.
- Target claim/hypothesis: handedness conversion math is explicit and tested at bridge boundary.
- Comparator split/evidence validity: previous code had implicit position/yaw mirroring; new tests validate the explicit contract.
- Fallback/degraded exclusions: no fallback/degraded benchmark evidence claimed.
- Claim boundary: adapter math/test fix only.
- Implementation integrity vs experimental validity: implementation proof is unit-level; no experimental validity claim.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, helpers are used by pose/static obstacle conversion and tested directly.
- Did intervention change command source, selected command, trajectory, route progress? no live CARLA or planner execution performed.
- Did scenario actually contain targeted failure mode? deterministic conversion fixture targets the coordinate-frame failure mode.
- Result route: stop
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this adapter slice.
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: stop for issue #3632 code/test slice; Claude Code owns full PR gate and improvement cycle after PR open.
- Proposed child issue existing follow-up: none

## Validation / Proof
- `uv run pytest tests/carla_bridge/test_t1_live_replay.py -q` - passed, 15 tests.
- `uv run pytest tests/carla_bridge -q` - passed, 104 tests.
- `uv run python -m py_compile robot_sf_carla_bridge/live_replay.py tests/carla_bridge/test_t1_live_replay.py` - passed.
- `uv run ruff check robot_sf_carla_bridge/live_replay.py tests/carla_bridge/test_t1_live_replay.py` - passed.
- `git diff --check` - passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; wrote clean-head freshness stamp for bc85a30e7420c314662ba409bb89bab3229cd62c.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Notes
- Baseline runtime: NA, no performance claim.
- Changed runtime: NA, no performance claim.
- Representative command: `uv run pytest tests/carla_bridge -q`
- Hot-path call count profile anchor: NA, no performance claim.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: coordinate helper tests fail or bridge transform fixture no longer mirrors Y/yaw/yaw-rate as specified.

## Risks / Rollout
- Compatibility risks: low; existing pose/static obstacle output remains equivalent for covered cases while adding explicit helper names.
- Failure modes: future CARLA control code must call the angular-velocity helper when mapping yaw-rate commands.
- Rollback fallback plan: revert this small adapter/test commit.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3632 and existing `docs/context/issue_1444_carla_coordinate_alignment_contract.md`.
- Any assumptions need to preserved: Robot-SF uses right-handed 2D x/y/yaw; CARLA boundary mirrors Y and yaw-rate sign.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark, registry, claim-map, artifact, or paper-facing changes.

## Follow-Up Issues
- Deferred work: none.
- Issues opened follow-up: none

## Reviewer Notes
- Anything reviewer verify closely: confirm angular velocity sign convention is the intended CARLA boundary contract.
- Any known limitations: no live CARLA, full benchmark campaign, Slurm/GPU submission, or paper/dissertation claim edits were performed.
