### PR TITLE
process: add PR-generator guardrails (#3607)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,6 +18,13 @@ It is everyones guide on how to use this repository effectively.
 - Make everything honest, transparent, and reproducible.
 - In benchmark work, use the canonical fail-closed fallback policy in
   `docs/context/issue_691_benchmark_fallback_policy.md`.
+- Before generating PRs, apply these authoring guardrails:
+  - Diagnostic producers that return floats must reject non-finite input and fail closed; use
+    `robot_sf/benchmark/counterfactual_pair.py` as the local example.
+  - Do not add absolute home-directory paths under `configs/**` unless the path is explicitly
+    annotated as machine-local and not portable.
+  - When cloning a config, update the provenance or issue comment so the copied config points at
+    the correct issue, source, and intended run context.
 - For GitHub issue batches and Project #5 writes, follow the batch-first workflow in
   `docs/context/issue_713_batch_first_issue_workflow.md`: clean up issues first, route project
   metadata second, run derived score sync last, use REST/local `git` for non-project state, reserve


### PR DESCRIPTION
## Summary
Adds concise PR-authoring guardrails to `.github/copilot-instructions.md` so PR-generating agents see the repo's fail-closed, portability, and config-provenance expectations before review or CI catches violations.

## Linked Issues
- Closes #3607
- Issue: https://github.com/ll7/robot_sf_ll7/issues/3607

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added a Copilot-facing guardrail block for non-finite diagnostic float handling, portable `configs/**` paths, and config-clone provenance comments.
- Cited `robot_sf/benchmark/counterfactual_pair.py` as the local fail-closed example.

## Why Matters
- Added value: moves recurring review/CI defects into PR-generation guidance.
- Expected impact: earlier authoring-time prevention for fail-open diagnostics, absolute home-dir config paths, and stale config provenance.
- Why worth merging now: low-risk docs/process change that complements existing enforcement without changing benchmark behavior.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - docs/process guidance only.
- Comparator or baseline, applicable: NA
- Evidence tier: docs-only
- Result classification: NA
- Decision stop rule, applicable: NA
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3607
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no research analysis tool added.

## Domain-Aware Approval
- Approver/review source waiver: not required - docs-only process guidance.
- Validity checklist: NA
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: NA
- Claim boundary: no benchmark, metric, schema, model-provenance, paper-facing, or dissertation claim is changed.
- Implementation integrity vs experimental validity: NA

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor analysis tool needed: NA
- Artifact missing unavailable: NA
- Stop / revise / continue decision: NA
- Proposed child issue existing follow-up: NA

## Validation / Proof
- `git fetch --prune origin` - exit 0
- `gh issue view 3607 --repo ll7/robot_sf_ll7 --comments` - exit 1 due GitHub Projects Classic GraphQL deprecation on `repository.issue.projectCards`; fell back to REST issue/comment reads.
- `gh api repos/ll7/robot_sf_ll7/issues/3607` and `gh api repos/ll7/robot_sf_ll7/issues/3607/comments --paginate` - exit 0; issue open, no comments.
- `gh pr list --repo ll7/robot_sf_ll7 --state open --search "3607 OR fail-closed portability provenance PR-generator guidance" --json number,title,headRefName,url --limit 30` - exit 0; no open matching PRs.
- `uv sync --all-extras` - exit 0 in fresh linked worktree.
- `uv run python scripts/tools/sync_ai_config.py --check` - exit 0; AI config links validated.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` - exit 0; docs/proof consistency passed for 1 changed file.
- `uv run python scripts/dev/check_docs_evidence_integrity.py --files .github/copilot-instructions.md` - exit 0; docs/evidence integrity passed for 1 changed file.
- `git diff --check` - exit 0.
- Touched Python files: none; ruff/py_compile for touched Python files is not applicable.
- Full `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` intentionally not run: docs-only low-risk instruction branch, using the cheaper official path from `AGENTS.md` and `docs/ai/ai-workflow.md`.

## Risks / Rollout
- Compatibility risks: low; guidance-only change to Copilot-facing pointer file.
- Failure modes: future PR-generation systems that do not read `.github/copilot-instructions.md` may not inherit the rules.
- Rollback fallback plan: revert the single docs commit.

## Docs / Provenance
- Updated docs: `.github/copilot-instructions.md`
- Relevant design provenance notes: issue #3607 requested surfacing fail-closed, portability, and provenance rules in PR-generator guidance.
- Any assumptions need to preserved: `.github/copilot-instructions.md` is the in-repo Copilot-facing owner; external generator configs, if any, are outside this PR.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA - linked by PR body only.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: docs-only PR-generator guidance; no benchmark, registry, claim-map, artifact, or paper-facing surface changes.

## Follow-Up Issues
- Deferred work: external PR-generator configuration, if separate from `.github/copilot-instructions.md`, remains outside this repository-local slice.
- Issues opened follow-up: none

## Reviewer Notes
- Please verify the guardrail wording is prominent enough for Copilot/PR-generator use while staying compact.
- Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added new pre-PR guidance for contributors on safer handling of generated values, config paths, and copied config metadata.
  * Clarified that certain paths should remain machine-local unless explicitly marked non-portable.
  * Improved instructions for keeping issue and source references accurate when duplicating configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->