### PR TITLE
feat: wire occlusion visibility telemetry (#3636)

### DIFF
--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import math
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
@@ -46,6 +47,7 @@ from robot_sf.benchmark.map_runner_metrics import (
 from robot_sf.benchmark.map_runner_metrics import (
     normalize_pedestrian_impact_controls as _normalize_pedestrian_impact_controls,
 )
+from robot_sf.benchmark.map_runner_observations import normalize_xy_rows as _normalize_xy_rows
 from robot_sf.benchmark.map_runner_policy_metadata import (
     finalize_feasibility_metadata as _finalize_feasibility_metadata,
 )
@@ -128,6 +130,16 @@ if TYPE_CHECKING:
 PolicyBuilder = Callable[..., tuple[Any, dict[str, Any]]]
 
 
+@dataclass(frozen=True, slots=True)
+class VisibilityEvidenceTrace:
+    """Episode-level visibility evidence arrays consumed by safety predicates."""
+
+    visibility: np.ndarray | None = None
+    track_confidence: np.ndarray | None = None
+    status: str = "unavailable"
+    reason: str | None = None
+
+
 def _nearest_hazard_distances(
     robot_pos_arr: np.ndarray,
     ped_pos_arr: np.ndarray,
@@ -143,6 +155,143 @@ def _nearest_hazard_distances(
     return np.min(np.linalg.norm(peds - robot, axis=2), axis=1)
 
 
+def _observed_pedestrian_positions(obs: Any) -> np.ndarray | None:
+    """Return planner-facing pedestrian positions when the observation exposes them."""
+    if not isinstance(obs, Mapping):
+        return None
+    pedestrians = obs.get("pedestrians")
+    if isinstance(pedestrians, Mapping) and "positions" in pedestrians:
+        return _normalize_xy_rows(pedestrians.get("positions"))
+    if "pedestrian_positions" in obs:
+        return _normalize_xy_rows(obs.get("pedestrian_positions"))
+    if "ped_positions" in obs:
+        return _normalize_xy_rows(obs.get("ped_positions"))
+    return None
+
+
+def _visibility_evidence_for_step(
+    *,
+    peds: np.ndarray,
+    obs: Any,
+    config: Any,
+) -> tuple[np.ndarray | None, np.ndarray | None, str, str | None]:
+    """Match simulator pedestrians to planner-facing observations for trace labels.
+
+    Returns:
+        Tuple of visible mask, track-confidence values, evidence status, and reason.
+    """
+    peds = (
+        np.asarray(peds, dtype=float).reshape(-1, 2) if np.asarray(peds).size else np.zeros((0, 2))
+    )
+    if peds.shape[0] == 0:
+        return (
+            np.zeros((0,), dtype=bool),
+            np.zeros((0,), dtype=float),
+            "not_applicable",
+            "no_pedestrians",
+        )
+
+    settings = getattr(config, "observation_visibility", None)
+    if settings is None or not bool(getattr(settings, "enabled", False)):
+        return None, None, "not_applicable", "observation_visibility_disabled"
+
+    observed = _observed_pedestrian_positions(obs)
+    if observed is None:
+        return None, None, "unavailable", "planner_observation_missing_pedestrian_positions"
+
+    visible = np.zeros((peds.shape[0],), dtype=bool)
+    if observed.shape[0] > 0:
+        noise_std = float(getattr(settings, "tracking_noise_std_m", 0.0) or 0.0)
+        match_tolerance_m = max(1.0e-4, 3.0 * noise_std + 1.0e-3)
+        distances = np.linalg.norm(peds[:, np.newaxis, :] - observed[np.newaxis, :, :], axis=2)
+        visible = np.min(distances, axis=1) <= match_tolerance_m
+    confidence = visible.astype(float)
+    return visible, confidence, "available", None
+
+
+def _annotate_trace_visibility(
+    pedestrians: list[dict[str, Any]],
+    *,
+    visible: np.ndarray | None,
+    track_confidence: np.ndarray | None,
+    evidence_status: str,
+    evidence_reason: str | None,
+) -> list[dict[str, Any]]:
+    """Attach per-pedestrian visibility labels to trace frames.
+
+    Returns:
+        The same frame list with visibility fields attached to each pedestrian.
+    """
+    for idx, frame in enumerate(pedestrians):
+        if visible is None or track_confidence is None:
+            frame["visibility_state"] = evidence_status
+            frame["track_confidence"] = None
+        else:
+            is_visible = bool(visible[idx]) if idx < visible.shape[0] else False
+            frame["visibility_state"] = "visible" if is_visible else "occluded"
+            frame["track_confidence"] = (
+                float(track_confidence[idx]) if idx < track_confidence.shape[0] else 0.0
+            )
+        frame["visibility_evidence_status"] = evidence_status
+        frame["visibility_evidence_reason"] = evidence_reason
+    return pedestrians
+
+
+def _stack_visibility_values(
+    values: list[np.ndarray | None],
+    *,
+    fill_value: float,
+    dtype: Any,
+) -> np.ndarray | None:
+    """Stack per-step pedestrian scalar labels, preserving missing-evidence state.
+
+    Returns:
+        ``(steps, pedestrians)`` array, or ``None`` when any step lacks evidence.
+    """
+    if not values or any(value is None for value in values):
+        return None
+    width = max((int(np.asarray(value).reshape(-1).shape[0]) for value in values), default=0)
+    stacked = np.full((len(values), width), fill_value, dtype=dtype)
+    for row_idx, value in enumerate(values):
+        arr = np.asarray(value, dtype=dtype).reshape(-1)
+        stacked[row_idx, : arr.shape[0]] = arr
+    return stacked
+
+
+def _nearest_hazard_visibility_signals(
+    *,
+    robot_pos_arr: np.ndarray,
+    ped_pos_arr: np.ndarray,
+    visibility_arr: np.ndarray | None,
+    track_confidence_arr: np.ndarray | None,
+) -> tuple[np.ndarray | None, np.ndarray | None]:
+    """Return nearest-pedestrian visibility/confidence signals for the predicate.
+
+    Returns:
+        Tuple of per-step nearest-hazard visibility and confidence arrays.
+    """
+    if visibility_arr is None or track_confidence_arr is None:
+        return None, None
+    step_count = min(int(robot_pos_arr.shape[0]), int(ped_pos_arr.shape[0]))
+    if step_count == 0 or ped_pos_arr.ndim < 3 or ped_pos_arr.shape[1] == 0:
+        return np.zeros((step_count,), dtype=bool), np.zeros((step_count,), dtype=float)
+    peds = np.asarray(ped_pos_arr[:step_count], dtype=float)
+    robot = np.asarray(robot_pos_arr[:step_count], dtype=float)[:, np.newaxis, :]
+    distances = np.linalg.norm(peds - robot, axis=2)
+    distances[~np.isfinite(distances)] = np.inf
+    nearest = np.argmin(distances, axis=1)
+    visible = np.zeros((step_count,), dtype=bool)
+    confidence = np.zeros((step_count,), dtype=float)
+    for step_idx, ped_idx in enumerate(nearest):
+        if not np.isfinite(distances[step_idx, ped_idx]):
+            continue
+        if step_idx < visibility_arr.shape[0] and ped_idx < visibility_arr.shape[1]:
+            visible[step_idx] = bool(visibility_arr[step_idx, ped_idx])
+        if step_idx < track_confidence_arr.shape[0] and ped_idx < track_confidence_arr.shape[1]:
+            confidence[step_idx] = float(track_confidence_arr[step_idx, ped_idx])
+    return visible, confidence
+
+
 def _safety_predicates_for_episode(
     *,
     robot_pos_arr: np.ndarray,
@@ -150,6 +299,7 @@ def _safety_predicates_for_episode(
     robot_headings: list[float],
     ped_pos_arr: np.ndarray,
     dt: float,
+    visibility_evidence: VisibilityEvidenceTrace | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Build diagnostic safety predicate records for a completed episode.
 
@@ -166,11 +316,13 @@ def _safety_predicates_for_episode(
     speeds = np.linalg.norm(velocities, axis=1) if velocities.size else np.zeros(step_count)
     hazard_distances = _nearest_hazard_distances(positions, ped_pos_arr)[:step_count]
 
-    # Map-runner currently has simulator full-state traces, not per-step occlusion labels.
-    # Treat actors as visible with full track confidence and let the predicate emit false
-    # unless future visibility evidence shows an occluded actor emerging near a miss.
-    hazard_visible = np.ones(step_count, dtype=bool)
-    track_confidence = np.ones(step_count, dtype=float)
+    visibility_evidence = visibility_evidence or VisibilityEvidenceTrace()
+    hazard_visible, track_confidence = _nearest_hazard_visibility_signals(
+        robot_pos_arr=positions,
+        ped_pos_arr=ped_pos_arr[:step_count],
+        visibility_arr=visibility_evidence.visibility,
+        track_confidence_arr=visibility_evidence.track_confidence,
+    )
 
     return {
         "oscillatory_control_predicate": oscillatory_control_predicate(
@@ -191,6 +343,8 @@ def _safety_predicates_for_episode(
             track_confidence,
             speeds,
             dt=dt,
+            visibility_evidence_status=visibility_evidence.status,
+            visibility_evidence_reason=visibility_evidence.reason,
         ),
     }
 
@@ -359,6 +513,10 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     synthetic_actuation_trace: list[dict[str, Any]] = []
     planner_decision_trace: list[dict[str, Any]] = []
     simulation_step_trace: list[dict[str, Any]] = []
+    visibility_trace: list[np.ndarray | None] = []
+    track_confidence_trace: list[np.ndarray | None] = []
+    visibility_evidence_statuses: list[str] = []
+    visibility_evidence_reasons: list[str | None] = []
     single_pedestrian_intent_metadata = _single_pedestrian_intent_metadata(scenario)
     single_pedestrian_vru_metadata = _single_pedestrian_vru_metadata(scenario)
 
@@ -472,6 +630,16 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 ped_forces.append(forces_arr)
             heading = _observation_heading(obs, default=previous_trace_heading)
             robot_headings.append(float(heading))
+            (
+                step_visible,
+                step_confidence,
+                step_visibility_status,
+                step_visibility_reason,
+            ) = _visibility_evidence_for_step(peds=peds, obs=obs, config=config)
+            visibility_trace.append(step_visible)
+            track_confidence_trace.append(step_confidence)
+            visibility_evidence_statuses.append(step_visibility_status)
+            visibility_evidence_reasons.append(step_visibility_reason)
             if record_simulation_step_trace:
                 dt_seconds = float(config.sim_config.time_per_step_in_secs)
                 robot_velocity = (
@@ -498,6 +666,21 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                             [float(force[0]), float(force[1])] for force in forces_arr
                         ]
                     }
+                trace_pedestrians = _annotate_trace_visibility(
+                    _trace_pedestrians(
+                        peds,
+                        previous_trace_ped_pos,
+                        dt_seconds,
+                        single_pedestrian_intent_metadata,
+                        single_pedestrian_vru_metadata,
+                        robot_pos,
+                        robot_velocity,
+                    ),
+                    visible=step_visible,
+                    track_confidence=step_confidence,
+                    evidence_status=step_visibility_status,
+                    evidence_reason=step_visibility_reason,
+                )
                 simulation_step_trace.append(
                     {
                         "step": int(step_idx),
@@ -507,15 +690,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                             "heading": float(heading),
                             "velocity": [float(robot_velocity[0]), float(robot_velocity[1])],
                         },
-                        "pedestrians": _trace_pedestrians(
-                            peds,
-                            previous_trace_ped_pos,
-                            dt_seconds,
-                            single_pedestrian_intent_metadata,
-                            single_pedestrian_vru_metadata,
-                            robot_pos,
-                            robot_velocity,
-                        ),
+                        "pedestrians": trace_pedestrians,
                         "planner": planner_payload,
                     }
                 )
@@ -658,12 +833,40 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         if record_forces
         else np.zeros_like(ped_pos_arr, dtype=float)
     )
+    visibility_arr = _stack_visibility_values(
+        visibility_trace,
+        fill_value=False,
+        dtype=bool,
+    )
+    track_confidence_arr = _stack_visibility_values(
+        track_confidence_trace,
+        fill_value=0.0,
+        dtype=float,
+    )
+    if "unavailable" in visibility_evidence_statuses:
+        visibility_evidence_status = "unavailable"
+    elif visibility_evidence_statuses and all(
+        status == "not_applicable" for status in visibility_evidence_statuses
+    ):
+        visibility_evidence_status = "not_applicable"
+    else:
+        visibility_evidence_status = "available"
+    visibility_evidence_reason = next(
+        (reason for reason in visibility_evidence_reasons if reason),
+        None,
+    )
     safety_predicates = _safety_predicates_for_episode(
         robot_pos_arr=robot_pos_arr,
         robot_vel_arr=robot_vel_arr,
         robot_headings=robot_headings,
         ped_pos_arr=ped_pos_arr,
         dt=float(config.sim_config.time_per_step_in_secs),
+        visibility_evidence=VisibilityEvidenceTrace(
+            visibility=visibility_arr,
+            track_confidence=track_confidence_arr,
+            status=visibility_evidence_status,
+            reason=visibility_evidence_reason,
+        ),
     )
 
     obstacles = (

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -324,6 +324,15 @@ def _safety_predicates_for_episode(
         track_confidence_arr=visibility_evidence.track_confidence,
     )
 
+    # The late-evasive diagnostic measures latency from first hazard visibility and
+    # always requires a concrete per-step visibility signal. When per-step occlusion
+    # evidence is unavailable (the default map-runner path), retain the prior
+    # all-visible assumption so this predicate keeps computing; only the
+    # occlusion-near-miss predicate distinguishes unavailable visibility evidence.
+    late_evasive_visible = (
+        hazard_visible if hazard_visible is not None else np.ones(step_count, dtype=bool)
+    )
+
     return {
         "oscillatory_control_predicate": oscillatory_control_predicate(
             positions,
@@ -333,7 +342,7 @@ def _safety_predicates_for_episode(
         ),
         "late_evasive_predicate": late_evasive_predicate(
             hazard_distances,
-            hazard_visible,
+            late_evasive_visible,
             speeds,
             dt=dt,
         ),

--- a/robot_sf/benchmark/safety_predicates.py
+++ b/robot_sf/benchmark/safety_predicates.py
@@ -265,15 +265,17 @@ class OcclusionNearMissParams:
     decel_threshold_m_s2: float = 0.5
 
 
-def occlusion_near_miss_predicate(
+def occlusion_near_miss_predicate(  # noqa: PLR0913
     hazard_distances: NDArray[np.floating] | object,
-    visible: NDArray[np.bool_] | object,
-    track_confidence: NDArray[np.floating] | object,
+    visible: NDArray[np.bool_] | object | None,
+    track_confidence: NDArray[np.floating] | object | None,
     speeds: NDArray[np.floating] | object,
     *,
     dt: float,
     params: OcclusionNearMissParams | None = None,
     predicted_minimum_separation_m: float | None = None,
+    visibility_evidence_status: str = "available",
+    visibility_evidence_reason: str | None = None,
 ) -> dict[str, Any]:
     """Produce the occlusion-triggered-near-miss predicate fields for one episode.
 
@@ -289,6 +291,8 @@ def occlusion_near_miss_predicate(
         dt: Per-step timestep (s, > 0).
         params: Tunable thresholds; defaults to :class:`OcclusionNearMissParams`.
         predicted_minimum_separation_m: Optional predicted min separation under occlusion.
+        visibility_evidence_status: Evidence availability state for visibility inputs.
+        visibility_evidence_reason: Optional reason for unavailable visibility evidence.
 
     Returns:
         dict[str, Any]: Versioned record with the motivated fields and the diagnostic
@@ -298,16 +302,13 @@ def occlusion_near_miss_predicate(
         raise ValueError(f"dt must be > 0, got {dt!r}")
     params = params or OcclusionNearMissParams()
     dist = np.asarray(hazard_distances, dtype=np.float64).reshape(-1)
-    vis = np.asarray(visible, dtype=bool).reshape(-1)
-    conf = np.asarray(track_confidence, dtype=np.float64).reshape(-1)
     speed = np.asarray(speeds, dtype=np.float64).reshape(-1)
     n = dist.shape[0]
-    if not (vis.shape[0] == n == conf.shape[0] == speed.shape[0]):
-        raise ValueError("all per-step signals must share length N")
+    if speed.shape[0] != n:
+        raise ValueError("hazard_distances and speeds must share length N")
     if n < 2:
         raise ValueError("at least two steps are required")
     require_finite_array("hazard_distances", dist)
-    require_finite_array("track_confidence", conf)
     require_finite_array("speeds", speed)
     if predicted_minimum_separation_m is not None:
         predicted_minimum_separation_m = require_finite_scalar(
@@ -317,6 +318,45 @@ def occlusion_near_miss_predicate(
     min_sep_step = int(np.argmin(dist))
     actual_minimum_separation = float(dist[min_sep_step])
     near_miss = actual_minimum_separation <= params.near_miss_radius_m
+
+    missing_visibility = visible is None or track_confidence is None
+    if missing_visibility:
+        status = (
+            "not_applicable" if visibility_evidence_status == "not_applicable" else "unavailable"
+        )
+        status_reason = visibility_evidence_reason or "missing_visibility_evidence"
+        return {
+            "schema_version": OCCLUSION_NEAR_MISS_PREDICATE_SCHEMA,
+            "predicate": "occlusion_near_miss",
+            "evidence_kind": "diagnostic_proxy",
+            "occlusion_near_miss": False,
+            "status": status,
+            "status_reason": status_reason,
+            "fields": {
+                "was_occluded_before_min": None,
+                "emergence_step": None,
+                "first_detection_step": None,
+                "first_response_step": None,
+                "min_separation_step": min_sep_step,
+                "actual_minimum_separation_m": actual_minimum_separation,
+                "predicted_minimum_separation_m": predicted_minimum_separation_m,
+                "near_miss": near_miss,
+                "visibility_evidence_status": status,
+                "visibility_evidence_reason": status_reason,
+                "n_steps": n,
+            },
+            "thresholds": {
+                "near_miss_radius_m": params.near_miss_radius_m,
+                "detection_confidence_threshold": params.detection_confidence_threshold,
+                "decel_threshold_m_s2": params.decel_threshold_m_s2,
+            },
+        }
+
+    vis = np.asarray(visible, dtype=bool).reshape(-1)
+    conf = np.asarray(track_confidence, dtype=np.float64).reshape(-1)
+    if not (vis.shape[0] == n == conf.shape[0]):
+        raise ValueError("all per-step signals must share length N")
+    require_finite_array("track_confidence", conf)
 
     # The actor was occluded at some point up to (and including) the closest approach.
     was_occluded_before_min = bool(np.any(~vis[: min_sep_step + 1]))
@@ -339,6 +379,8 @@ def occlusion_near_miss_predicate(
         "predicate": "occlusion_near_miss",
         "evidence_kind": "diagnostic_proxy",
         "occlusion_near_miss": occlusion_near_miss,
+        "status": "true" if occlusion_near_miss else "false",
+        "status_reason": None,
         "fields": {
             "was_occluded_before_min": was_occluded_before_min,
             "emergence_step": emergence_step,
@@ -348,6 +390,8 @@ def occlusion_near_miss_predicate(
             "actual_minimum_separation_m": actual_minimum_separation,
             "predicted_minimum_separation_m": predicted_minimum_separation_m,
             "near_miss": near_miss,
+            "visibility_evidence_status": "available",
+            "visibility_evidence_reason": visibility_evidence_reason,
             "n_steps": n,
         },
         "thresholds": {

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -5135,3 +5135,126 @@ def test_holonomic_social_force_diagnosis_config_contains_expected_planners() ->
     assert data.get("holonomic_command_mode") == "vx_vy", (
         "Diagnosis config must use holonomic vx_vy command mode"
     )
+
+
+class _OcclusionVisibilitySim:
+    """Simulator stub with one pedestrian hidden, then revealed during a near miss."""
+
+    def __init__(self, map_def: MapDefinition) -> None:
+        self.robot_pos = [np.array([0.0, 0.0], dtype=float)]
+        self.goal_pos = [np.array([2.0, 0.0], dtype=float)]
+        self.map_def = map_def
+        self.last_ped_forces = np.zeros((1, 2), dtype=float)
+        self._pedestrian_positions = [
+            np.array([[2.0, 0.0]], dtype=float),
+            np.array([[1.5, 0.0]], dtype=float),
+            np.array([[0.3, 0.0]], dtype=float),
+            np.array([[1.0, 0.0]], dtype=float),
+        ]
+        self.ped_pos = self._pedestrian_positions[0].copy()
+
+
+class _OcclusionVisibilityEnv:
+    """Environment stub exposing planner-facing visibility through observations."""
+
+    def __init__(self, map_def: MapDefinition) -> None:
+        self.simulator = _OcclusionVisibilitySim(map_def)
+        self.action_space = None
+        self._step = 0
+
+    def _observation(self, *, visible: bool) -> dict[str, object]:
+        positions = self.simulator.ped_pos if visible else np.zeros((0, 2), dtype=np.float32)
+        return {
+            "robot": {
+                "position": np.array([0.0, 0.0], dtype=np.float32),
+                "heading": np.array([0.0], dtype=np.float32),
+                "speed": np.array([0.0], dtype=np.float32),
+                "radius": np.array([0.5], dtype=np.float32),
+            },
+            "goal": {"current": np.array([2.0, 0.0], dtype=np.float32)},
+            "pedestrians": {
+                "positions": np.asarray(positions, dtype=np.float32),
+                "velocities": np.zeros((positions.shape[0], 2), dtype=np.float32),
+                "radius": np.array([0.4], dtype=np.float32),
+                "count": np.array([float(positions.shape[0])], dtype=np.float32),
+            },
+        }
+
+    def reset(self, seed: int | None = None):
+        """Return an initially occluded planner observation."""
+        del seed
+        self._step = 0
+        self.simulator.ped_pos = self.simulator._pedestrian_positions[0].copy()
+        return self._observation(visible=False), {}
+
+    def step(self, action):
+        """Advance one synthetic step, revealing the pedestrian at step two."""
+        del action
+        self.simulator.ped_pos = self.simulator._pedestrian_positions[self._step].copy()
+        visible = self._step >= 2
+        obs = self._observation(visible=visible)
+        self._step += 1
+        terminated = self._step >= 4
+        return obs, 0.0, terminated, False, {"success": False}
+
+    def close(self) -> None:
+        """No resources to release."""
+
+
+def test_map_episode_visibility_trace_feeds_occlusion_near_miss_predicate(monkeypatch) -> None:
+    """Per-step visibility labels must feed occlusion-near-miss evidence."""
+    from robot_sf.gym_env.unified_config import ObservationVisibilitySettings
+
+    dummy_config = SimpleNamespace(
+        sim_config=SimpleNamespace(time_per_step_in_secs=0.1),
+        robot_config=HolonomicDriveSettings(max_speed=1.0, max_angular_speed=1.0),
+        observation_visibility=ObservationVisibilitySettings(enabled=True),
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._build_env_config",
+        lambda scenario, scenario_path: dummy_config,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.make_robot_env",
+        lambda config, seed, debug: _OcclusionVisibilityEnv(_minimal_map_def()),
+    )
+    monkeypatch.setattr("robot_sf.benchmark.map_runner.sample_obstacle_points", lambda *args: None)
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_shortest_path_length",
+        lambda *args: 1.0,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.compute_all_metrics",
+        lambda *args, **kwargs: {"success": 0.0, "collisions": 0.0},
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner.post_process_metrics",
+        lambda metrics, **kwargs: metrics,
+    )
+    monkeypatch.setattr(
+        "robot_sf.benchmark.map_runner._policy_command_to_env_action",
+        lambda env, config, command: np.asarray(command, dtype=np.float32),
+    )
+
+    record = _run_map_episode(
+        {"name": "occlusion-visibility", "simulation_config": {"max_episode_steps": 4}},
+        seed=1,
+        horizon=None,
+        dt=0.1,
+        record_forces=False,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo="goal",
+        algo_config_path=None,
+        scenario_path=Path("."),
+        record_simulation_step_trace=True,
+    )
+
+    trace = record["algorithm_metadata"]["simulation_step_trace"]
+    labels = [step["pedestrians"][0]["visibility_state"] for step in trace["steps"]]
+    confidences = [step["pedestrians"][0]["track_confidence"] for step in trace["steps"]]
+    assert labels == ["occluded", "occluded", "visible", "visible"]
+    assert confidences == pytest.approx([0.0, 0.0, 1.0, 1.0])
+    predicate = record["safety_predicates"]["occlusion_near_miss_predicate"]
+    assert predicate["status"] == "true"
+    assert predicate["occlusion_near_miss"] is True

--- a/tests/benchmark/test_safety_predicates.py
+++ b/tests/benchmark/test_safety_predicates.py
@@ -327,3 +327,20 @@ def test_occlusion_rejects_non_finite_predicted_separation() -> None:
             dt=_DT,
             predicted_minimum_separation_m=np.inf,
         )
+
+
+def test_occlusion_missing_visibility_evidence_is_unavailable() -> None:
+    """Missing visibility telemetry must not be reported as a real false predicate."""
+    from robot_sf.benchmark.safety_predicates import occlusion_near_miss_predicate
+
+    result = occlusion_near_miss_predicate(
+        np.array([5.0, 2.0, 0.3]),
+        None,
+        None,
+        np.ones(3),
+        dt=_DT,
+    )
+
+    assert result["occlusion_near_miss"] is False
+    assert result["status"] == "unavailable"
+    assert result["status_reason"] == "missing_visibility_evidence"


### PR DESCRIPTION
## Summary
Wires per-step planner-facing visibility labels into map-runner simulation traces and feeds those labels into the occlusion-near-miss safety predicate.

Missing visibility or track-confidence evidence now produces an explicit `unavailable`/`not_applicable` predicate status instead of a silent false predicate.

## Linked Issues
- Closes `#3636`
- Relates to `#3615`
- Relates to `#3619`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added map-runner episode helpers that derive per-step pedestrian `visibility_state`, `track_confidence`, and evidence status from planner-facing observations.
- Annotated `algorithm_metadata.simulation_step_trace.steps[].pedestrians[]` with visibility labels when simulation step traces are requested.
- Passed nearest-hazard visibility and confidence into `occlusion_near_miss_predicate`.
- Added predicate status fields so unavailable/not-applicable visibility evidence is distinct from a real false predicate.
- Added regression tests for missing visibility evidence and map-runner trace-to-predicate wiring.

## Why Matters
- Added value: prevents missing occlusion visibility telemetry from being interpreted as a true negative.
- Expected impact: occlusion-near-miss evidence tables can distinguish false, unavailable, and not-applicable states.
- Why worth merging now: closes the follow-up risk left after #3615/#3619 without changing broader predicate semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: implementation blocker for usable occlusion-near-miss telemetry.
- Comparator or baseline, applicable: NA.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision stop rule, applicable: missing visibility evidence is explicit and focused reconciliation tests pass.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3636 closed by this PR.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support wiring; no research-result interpretation.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required.
- Approver/review source waiver: implementation-only telemetry wiring; no benchmark interpretation or paper-facing claim.
- Validity checklist: NA.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: unavailable/not-applicable states remain caveats, not success evidence.
- Claim boundary: targeted smoke proof only.
- Implementation integrity vs experimental validity: implementation integrity only.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, in focused synthetic map-runner test.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, synthetic pedestrian hidden then revealed during a near miss.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no.
- Stop / revise / continue decision: continue.
- Proposed child issue existing follow-up: NA.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_safety_predicates.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_map_runner_utils.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_event_ledger.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/safety_predicates.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_safety_predicates.py tests/benchmark/test_map_runner_utils.py`
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/benchmark/safety_predicates.py robot_sf/benchmark/map_runner_episode.py tests/benchmark/test_safety_predicates.py tests/benchmark/test_map_runner_utils.py`

Full `pr_ready_check` not run: delegated imech036 scope requested lightweight focused validation only; no GPU-heavy, Slurm, or long benchmark jobs.

## Cache / Runtime Impact
- Baseline runtime: NA, no runtime-performance claim.
- Changed runtime: NA, no runtime-performance claim.
- Representative command: focused pytest and Ruff commands above.
- Hot-path call count profile anchor: NA, no hot-path performance claim.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: predicate status regresses so missing visibility evidence is emitted as a silent false.

## Risks / Rollout
- Compatibility risks: predicate boolean field is preserved; new status fields are additive.
- Failure modes: planner observation formats without pedestrian positions produce explicit unavailable status.
- Rollback fallback plan: revert this PR to restore previous predicate wiring.

## Docs / Provenance
- Updated docs: NA.
- Relevant design provenance notes: issue #3636, follow-up to #3615/#3619.
- Any assumptions need to preserved: planner-facing observation positions are the source for trace visibility labels.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, PR closes #3636.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: implementation-only telemetry wiring; no benchmark or paper-facing result.

## Follow-Up Issues
- Deferred work: fail-closed degenerate-planner-view guard remains out of scope as stated in #3636.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely: nearest-hazard visibility selection and unavailable/not-applicable status behavior.
- Any known limitations: visibility labels are matched from planner-facing pedestrian positions; noisy tracking uses a tolerance based on configured tracking noise.
