### PR TITLE
feat(benchmark): add scenario denominator manifest audit

### DIFF
--- a/docs/benchmark_campaign_manifest.md
+++ b/docs/benchmark_campaign_manifest.md
@@ -122,3 +122,36 @@ measurements and the durable evidence plan is satisfied.
 For a concrete campaign, also run the loader, dry-run, or schema command named
 in that campaign manifest. If the manifest only defines a proposal, record that
 status in `campaign.evidence_tier` and do not treat it as run evidence.
+
+## Scenario Denominator Manifest
+
+Use the scenario denominator manifest when a report needs one config-derived source for scenario
+families, scenario cells, densities, seeds, and per-family x planner episode denominators. It is an
+audit artifact, not benchmark evidence: it expands canonical benchmark configs and seed policies
+before runtime exclusions, fallback rows, or planner failures.
+
+Generate the JSON manifest and a downstream-checkable CSV table from the canonical all-planners
+paper matrix with:
+
+```bash
+uv run python scripts/benchmark/build_scenario_denominator_manifest.py \
+  --config configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml \
+  --output output/benchmarks/scenario_denominator_manifest.json \
+  --table output/benchmarks/scenario_denominator_table.csv
+```
+
+Fail closed when a checked-in manifest or report table drifts from the canonical configs:
+
+```bash
+uv run python scripts/benchmark/build_scenario_denominator_manifest.py \
+  --config configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml \
+  --check-manifest docs/context/evidence/<issue>/scenario_denominator_manifest.json
+
+uv run python scripts/benchmark/build_scenario_denominator_manifest.py \
+  --config configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml \
+  --check-table docs/context/evidence/<issue>/scenario_denominator_table.csv
+```
+
+The table contract is one row per `(config_name, family, planner)` with scenario count, cell count,
+unique seed count, denominator episodes, kinematics count, kinematics-expanded denominator
+episodes, and densities. Markdown tables may also be checked when they expose the same column names.

--- a/robot_sf/benchmark/scenario_denominator_manifest.py
+++ b/robot_sf/benchmark/scenario_denominator_manifest.py
@@ -1,0 +1,820 @@
+"""Build scenario denominator manifests from canonical benchmark configs.
+
+The manifest is an audit artifact: it expands tracked campaign YAML, resolves the
+configured seed policy, and reports the intended scenario-family and planner
+episode denominators before any benchmark execution or runtime exclusions.
+"""
+
+from __future__ import annotations
+
+import csv
+import hashlib
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.training.scenario_loader import load_scenarios
+
+SCENARIO_DENOMINATOR_SCHEMA_VERSION = "scenario_denominator_manifest.v1"
+
+_DEFAULT_SEED_SETS_PATH = Path("configs/benchmarks/seed_sets_v1.yaml")
+_UNKNOWN = "unknown"
+_TABLE_COLUMNS = (
+    "config_name",
+    "config_path",
+    "family",
+    "planner",
+    "planner_algo",
+    "scenario_count",
+    "cell_count",
+    "seed_count",
+    "denominator_episodes",
+    "kinematics_count",
+    "denominator_episodes_with_kinematics",
+    "densities",
+)
+_TABLE_INT_COLUMNS = {
+    "scenario_count",
+    "cell_count",
+    "seed_count",
+    "denominator_episodes",
+    "kinematics_count",
+    "denominator_episodes_with_kinematics",
+}
+
+
+class DenominatorManifestError(ValueError):
+    """Raised when configs or consumer tables cannot produce a closed denominator audit."""
+
+
+@dataclass(frozen=True)
+class _Planner:
+    """Normalized planner row from a benchmark campaign config."""
+
+    key: str
+    algo: str
+    enabled: bool
+
+
+def _repo_root() -> Path:
+    """Return the repository root for repo-relative path normalization.
+
+    Returns:
+        Absolute repository root path.
+    """
+
+    return Path(__file__).resolve().parents[2]
+
+
+def _read_yaml_mapping(path: Path, *, label: str) -> dict[str, Any]:
+    """Read a YAML file that must contain a top-level mapping.
+
+    Returns:
+        Parsed YAML mapping.
+    """
+
+    payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise DenominatorManifestError(f"{label} must contain a YAML mapping: {path}")
+    return payload
+
+
+def _resolve_path(raw: Any, *, config_path: Path, repo_root: Path, field: str) -> Path:
+    """Resolve config paths using local-relative first, then repository-relative fallback.
+
+    Returns:
+        Resolved filesystem path.
+    """
+
+    if raw is None:
+        raise DenominatorManifestError(
+            f"Campaign config missing required field '{field}': {config_path}"
+        )
+    candidate = Path(str(raw)).expanduser()
+    if candidate.is_absolute():
+        return candidate.resolve()
+
+    local_candidate = (config_path.parent / candidate).resolve()
+    if local_candidate.exists():
+        return local_candidate
+
+    repo_candidate = (repo_root / candidate).resolve()
+    if repo_candidate.exists():
+        return repo_candidate
+
+    raise FileNotFoundError(
+        f"Could not resolve '{field}' path '{raw}' relative to {config_path.parent} or {repo_root}"
+    )
+
+
+def _repo_relative(path: Path, *, repo_root: Path) -> str:
+    """Return a stable repository-relative path when possible.
+
+    Returns:
+        Repository-relative path when possible, otherwise absolute path.
+    """
+
+    resolved = path.resolve()
+    try:
+        return resolved.relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return resolved.as_posix()
+
+
+def _sha256_file(path: Path) -> str:
+    """Return SHA256 hash for a source config or matrix file.
+
+    Returns:
+        Hex-encoded SHA256 digest.
+    """
+
+    hasher = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
+def _normalize_string_list(raw: Any, *, field: str) -> list[str]:
+    """Normalize scalar or list config values into non-empty stripped strings.
+
+    Returns:
+        Normalized string values.
+    """
+
+    if raw is None:
+        return []
+    if isinstance(raw, (str, int, float)):
+        values = [str(raw)]
+    elif isinstance(raw, list):
+        values = [str(value) for value in raw if isinstance(value, (str, int, float))]
+        if len(values) != len(raw):
+            raise DenominatorManifestError(f"{field} entries must be scalar strings or numbers")
+    else:
+        raise DenominatorManifestError(f"{field} must be a scalar or list")
+
+    normalized = [value.strip() for value in values if value.strip()]
+    if len(normalized) != len(values):
+        raise DenominatorManifestError(f"{field} must not contain empty values")
+    return normalized
+
+
+def _normalize_seed_list(raw: Any, *, field: str) -> list[int]:
+    """Normalize a seed list and fail closed when it is absent or empty.
+
+    Returns:
+        Integer seed list.
+    """
+
+    if not isinstance(raw, list) or not raw:
+        raise DenominatorManifestError(f"{field} must be a non-empty list of integer seeds")
+    seeds: list[int] = []
+    for value in raw:
+        try:
+            seeds.append(int(value))
+        except (TypeError, ValueError) as exc:
+            raise DenominatorManifestError(
+                f"{field} contains a non-integer seed: {value!r}"
+            ) from exc
+    return seeds
+
+
+def _load_seed_sets(path: Path) -> dict[str, list[int]]:
+    """Load named seed sets from the canonical seed-set YAML file.
+
+    Returns:
+        Mapping from seed-set name to integer seeds.
+    """
+
+    payload = _read_yaml_mapping(path, label="seed sets")
+    seed_sets: dict[str, list[int]] = {}
+    for name, raw_seeds in payload.items():
+        seed_sets[str(name)] = _normalize_seed_list(raw_seeds, field=f"seed set {name!r}")
+    return seed_sets
+
+
+def _resolve_seed_override(
+    payload: dict[str, Any], *, config_path: Path, repo_root: Path
+) -> tuple[list[int] | None, dict[str, Any]]:
+    """Resolve the campaign seed policy and return both override and provenance payload.
+
+    Returns:
+        Tuple of optional seed override and manifest seed-policy payload.
+    """
+
+    raw_policy = payload.get("seed_policy") or {}
+    if not isinstance(raw_policy, dict):
+        raise DenominatorManifestError(f"seed_policy must be a mapping: {config_path}")
+
+    mode = str(raw_policy.get("mode", "scenario-default")).strip().lower()
+    policy_payload: dict[str, Any] = {
+        "mode": mode,
+        "seed_set": raw_policy.get("seed_set"),
+        "seeds": [],
+        "resolved_seeds": None,
+        "seed_sets_path": None,
+    }
+
+    if mode == "scenario-default":
+        return None, policy_payload
+
+    if mode == "fixed-list":
+        seeds = _normalize_seed_list(raw_policy.get("seeds"), field="seed_policy.seeds")
+        policy_payload["seeds"] = seeds
+        policy_payload["resolved_seeds"] = seeds
+        return seeds, policy_payload
+
+    if mode == "seed-set":
+        seed_set = str(raw_policy.get("seed_set") or "").strip()
+        if not seed_set:
+            raise DenominatorManifestError(f"seed_policy.seed_set is required: {config_path}")
+        seed_sets_path = _resolve_path(
+            raw_policy.get("seed_sets_path", _DEFAULT_SEED_SETS_PATH),
+            config_path=config_path,
+            repo_root=repo_root,
+            field="seed_policy.seed_sets_path",
+        )
+        seed_sets = _load_seed_sets(seed_sets_path)
+        if seed_set not in seed_sets:
+            known = ", ".join(sorted(seed_sets))
+            raise DenominatorManifestError(f"Unknown seed set {seed_set!r}. Available: {known}")
+        seeds = list(seed_sets[seed_set])
+        policy_payload["seed_set"] = seed_set
+        policy_payload["resolved_seeds"] = seeds
+        policy_payload["seed_sets_path"] = _repo_relative(seed_sets_path, repo_root=repo_root)
+        return seeds, policy_payload
+
+    raise DenominatorManifestError(f"Unsupported seed_policy.mode {mode!r}: {config_path}")
+
+
+def _normalize_kinematics(raw: Any) -> list[str]:
+    """Return normalized campaign kinematics values with camera-ready default.
+
+    Returns:
+        Normalized kinematics labels.
+    """
+
+    values = _normalize_string_list(raw, field="kinematics_matrix")
+    return [value.lower() for value in values] or ["differential_drive"]
+
+
+def _normalize_planners(raw: Any, *, config_path: Path) -> tuple[list[_Planner], list[_Planner]]:
+    """Return enabled and disabled planner rows from campaign config.
+
+    Returns:
+        Tuple of enabled planner rows and disabled planner rows.
+    """
+
+    if not isinstance(raw, list) or not raw:
+        raise DenominatorManifestError(
+            f"Campaign config requires non-empty planners list: {config_path}"
+        )
+
+    enabled: list[_Planner] = []
+    disabled: list[_Planner] = []
+    seen: set[str] = set()
+    for index, entry in enumerate(raw):
+        if not isinstance(entry, dict):
+            raise DenominatorManifestError(
+                f"Planner entry #{index} must be a mapping: {config_path}"
+            )
+        key = str(entry.get("key") or entry.get("algo") or "").strip()
+        algo = str(entry.get("algo") or key).strip()
+        if not key:
+            raise DenominatorManifestError(
+                f"Planner entry #{index} missing key/algo: {config_path}"
+            )
+        if key in seen:
+            raise DenominatorManifestError(f"Duplicate planner key {key!r}: {config_path}")
+        seen.add(key)
+        planner = _Planner(key=key, algo=algo, enabled=bool(entry.get("enabled", True)))
+        if planner.enabled:
+            enabled.append(planner)
+        else:
+            disabled.append(planner)
+
+    if not enabled:
+        raise DenominatorManifestError(f"Campaign config has no enabled planners: {config_path}")
+    return enabled, disabled
+
+
+def _scenario_id(scenario: dict[str, Any], *, index: int, matrix_path: Path) -> str:
+    """Return the stable scenario cell identifier used by benchmark configs.
+
+    Returns:
+        Scenario identifier.
+    """
+
+    for key in ("name", "scenario_id", "id"):
+        value = scenario.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    raise DenominatorManifestError(f"Scenario #{index} missing name/scenario_id/id: {matrix_path}")
+
+
+def _scenario_family(scenario: dict[str, Any]) -> str:
+    """Return scenario family from metadata, falling back to explicit top-level fields.
+
+    Returns:
+        Scenario family label, or ``unknown``.
+    """
+
+    metadata = scenario.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("archetype", "family", "scenario_family"):
+            value = metadata.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    for key in ("archetype", "family", "scenario_family"):
+        value = scenario.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return _UNKNOWN
+
+
+def _scenario_density(scenario: dict[str, Any]) -> str:
+    """Return scenario density from metadata or top-level density-like fields.
+
+    Returns:
+        Scenario density label, or ``unknown``.
+    """
+
+    metadata = scenario.get("metadata")
+    if isinstance(metadata, dict):
+        for key in ("density", "pedestrian_density", "density_label"):
+            value = metadata.get(key)
+            if value is not None and str(value).strip():
+                return str(value).strip()
+    for key in ("density", "pedestrian_density", "ped_density", "density_label"):
+        value = scenario.get(key)
+        if value is not None and str(value).strip():
+            return str(value).strip()
+    return _UNKNOWN
+
+
+def _scenario_seeds(
+    scenario: dict[str, Any],
+    *,
+    seed_override: list[int] | None,
+    scenario_id: str,
+) -> list[int]:
+    """Resolve per-scenario seeds after applying campaign seed overrides.
+
+    Returns:
+        Integer seeds for the scenario cell.
+    """
+
+    if seed_override is not None:
+        return list(seed_override)
+    raw_seeds = scenario.get("seeds")
+    if isinstance(raw_seeds, list) and raw_seeds:
+        return _normalize_seed_list(raw_seeds, field=f"scenario {scenario_id!r} seeds")
+    raw_seed = scenario.get("seed")
+    if raw_seed is not None:
+        try:
+            return [int(raw_seed)]
+        except (TypeError, ValueError) as exc:
+            raise DenominatorManifestError(
+                f"scenario {scenario_id!r} contains a non-integer seed: {raw_seed!r}"
+            ) from exc
+    raise DenominatorManifestError(
+        f"scenario {scenario_id!r} has no seeds and campaign seed_policy is scenario-default"
+    )
+
+
+def _filter_scenario_candidates(
+    scenarios: list[dict[str, Any]],
+    *,
+    candidate_names: list[str],
+    matrix_path: Path,
+    repo_root: Path,
+) -> list[dict[str, Any]]:
+    """Apply campaign scenario candidate selection with missing-name validation.
+
+    Returns:
+        Filtered scenario list, or the original list when no candidates are configured.
+    """
+
+    if not candidate_names:
+        return scenarios
+    counts = dict.fromkeys(candidate_names, 0)
+    filtered: list[dict[str, Any]] = []
+    for index, scenario in enumerate(scenarios):
+        sid = _scenario_id(scenario, index=index, matrix_path=matrix_path)
+        if sid in counts:
+            counts[sid] += 1
+            filtered.append(scenario)
+    missing = [name for name, count in counts.items() if count == 0]
+    if missing:
+        raise DenominatorManifestError(
+            "scenario_candidates did not resolve in "
+            f"{_repo_relative(matrix_path, repo_root=repo_root)}: {', '.join(missing)}"
+        )
+    return filtered
+
+
+def _family_rows(cells: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Summarize scenario cells by family.
+
+    Returns:
+        Family denominator rows.
+    """
+
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for cell in cells:
+        grouped.setdefault(str(cell["family"]), []).append(cell)
+
+    rows: list[dict[str, Any]] = []
+    for family, family_cells in sorted(grouped.items()):
+        densities = sorted({str(cell["density"]) for cell in family_cells})
+        density_counts = {
+            density: sum(1 for cell in family_cells if cell["density"] == density)
+            for density in densities
+        }
+        seeds = sorted({int(seed) for cell in family_cells for seed in cell["seeds"]})
+        rows.append(
+            {
+                "family": family,
+                "scenario_count": len(family_cells),
+                "cell_count": len(family_cells),
+                "density_counts": density_counts,
+                "densities": densities,
+                "scenario_ids": sorted(str(cell["scenario_id"]) for cell in family_cells),
+                "seeds": seeds,
+                "seed_count": len(seeds),
+                "episode_denominator": sum(int(cell["seed_count"]) for cell in family_cells),
+            }
+        )
+    return rows
+
+
+def _per_family_planner_denominators(
+    family_rows: list[dict[str, Any]],
+    *,
+    planners: list[_Planner],
+    kinematics: list[str],
+) -> list[dict[str, Any]]:
+    """Cross family episode denominators with enabled planners.
+
+    Returns:
+        Per-family x planner denominator rows.
+    """
+
+    rows: list[dict[str, Any]] = []
+    for family in family_rows:
+        for planner in planners:
+            denominator = int(family["episode_denominator"])
+            rows.append(
+                {
+                    "family": family["family"],
+                    "planner": planner.key,
+                    "planner_algo": planner.algo,
+                    "scenario_count": int(family["scenario_count"]),
+                    "cell_count": int(family["cell_count"]),
+                    "seed_count": int(family["seed_count"]),
+                    "denominator_episodes": denominator,
+                    "kinematics": list(kinematics),
+                    "kinematics_count": len(kinematics),
+                    "denominator_episodes_with_kinematics": denominator * len(kinematics),
+                    "densities": list(family["densities"]),
+                }
+            )
+    return rows
+
+
+def _build_config_manifest(config_path: Path, *, repo_root: Path) -> dict[str, Any]:
+    """Build one config entry for the scenario denominator manifest.
+
+    Returns:
+        Manifest entry for one benchmark config.
+    """
+
+    config_path = config_path.resolve()
+    payload = _read_yaml_mapping(config_path, label="benchmark config")
+    name = str(payload.get("name") or config_path.stem).strip()
+    scenario_matrix_path = _resolve_path(
+        payload.get("scenario_matrix"),
+        config_path=config_path,
+        repo_root=repo_root,
+        field="scenario_matrix",
+    )
+    candidate_names = _normalize_string_list(
+        payload.get("scenario_candidates"), field="scenario_candidates"
+    )
+    seed_override, seed_policy = _resolve_seed_override(
+        payload, config_path=config_path, repo_root=repo_root
+    )
+    enabled_planners, disabled_planners = _normalize_planners(
+        payload.get("planners"), config_path=config_path
+    )
+    kinematics = _normalize_kinematics(payload.get("kinematics_matrix"))
+
+    loaded_scenarios = load_scenarios(scenario_matrix_path)
+    scenarios = [dict(scenario) for scenario in loaded_scenarios]
+    scenarios = _filter_scenario_candidates(
+        scenarios,
+        candidate_names=candidate_names,
+        matrix_path=scenario_matrix_path,
+        repo_root=repo_root,
+    )
+    if not scenarios:
+        raise DenominatorManifestError(
+            f"Scenario matrix resolved no scenarios: {scenario_matrix_path}"
+        )
+
+    cells: list[dict[str, Any]] = []
+    for index, scenario in enumerate(scenarios):
+        sid = _scenario_id(scenario, index=index, matrix_path=scenario_matrix_path)
+        seeds = _scenario_seeds(scenario, seed_override=seed_override, scenario_id=sid)
+        family = _scenario_family(scenario)
+        density = _scenario_density(scenario)
+        cells.append(
+            {
+                "scenario_id": sid,
+                "cell_id": sid,
+                "family": family,
+                "density": density,
+                "seeds": seeds,
+                "seed_count": len(seeds),
+                "episode_denominator": len(seeds),
+            }
+        )
+
+    families = _family_rows(cells)
+    per_family_planner = _per_family_planner_denominators(
+        families,
+        planners=enabled_planners,
+        kinematics=kinematics,
+    )
+    all_seeds = sorted({int(seed) for cell in cells for seed in cell["seeds"]})
+    densities = sorted({str(cell["density"]) for cell in cells})
+    episode_denominator = sum(int(cell["seed_count"]) for cell in cells)
+
+    return {
+        "name": name,
+        "config_path": _repo_relative(config_path, repo_root=repo_root),
+        "config_sha256": _sha256_file(config_path),
+        "scenario_matrix": _repo_relative(scenario_matrix_path, repo_root=repo_root),
+        "scenario_matrix_sha256": _sha256_file(scenario_matrix_path),
+        "scenario_candidates": candidate_names,
+        "seed_policy": seed_policy,
+        "kinematics_matrix": kinematics,
+        "planners": [
+            {"key": planner.key, "algo": planner.algo, "enabled": True}
+            for planner in enabled_planners
+        ],
+        "disabled_planners": [
+            {"key": planner.key, "algo": planner.algo, "enabled": False}
+            for planner in disabled_planners
+        ],
+        "summary": {
+            "scenario_count": len(cells),
+            "cell_count": len(cells),
+            "family_count": len(families),
+            "density_count": len(densities),
+            "densities": densities,
+            "seed_count": len(all_seeds),
+            "seeds": all_seeds,
+            "planner_count": len(enabled_planners),
+            "kinematics_count": len(kinematics),
+            "episode_denominator_without_planner": episode_denominator,
+            "planner_episode_denominator": episode_denominator * len(enabled_planners),
+            "planner_kinematics_episode_denominator": (
+                episode_denominator * len(enabled_planners) * len(kinematics)
+            ),
+        },
+        "families": families,
+        "cells": sorted(cells, key=lambda cell: str(cell["scenario_id"])),
+        "per_family_planner_denominators": per_family_planner,
+    }
+
+
+def build_scenario_denominator_manifest(
+    config_paths: list[Path], *, repo_root: Path | None = None
+) -> dict[str, Any]:
+    """Build a denominator manifest from one or more canonical benchmark configs.
+
+    Returns:
+        Complete scenario denominator manifest payload.
+    """
+
+    if not config_paths:
+        raise DenominatorManifestError("At least one benchmark config path is required")
+    root = (repo_root or _repo_root()).resolve()
+    configs = [_build_config_manifest(Path(path), repo_root=root) for path in config_paths]
+    total_planner_denominator = sum(
+        int(config["summary"]["planner_episode_denominator"]) for config in configs
+    )
+    total_planner_kinematics_denominator = sum(
+        int(config["summary"]["planner_kinematics_episode_denominator"]) for config in configs
+    )
+    return {
+        "schema_version": SCENARIO_DENOMINATOR_SCHEMA_VERSION,
+        "summary": {
+            "config_count": len(configs),
+            "planner_episode_denominator": total_planner_denominator,
+            "planner_kinematics_episode_denominator": total_planner_kinematics_denominator,
+        },
+        "configs": configs,
+    }
+
+
+def write_manifest(manifest: dict[str, Any], path: Path) -> Path:
+    """Write a deterministic JSON denominator manifest.
+
+    Returns:
+        Path written.
+    """
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+def load_manifest(path: Path) -> dict[str, Any]:
+    """Load a JSON or YAML denominator manifest from disk.
+
+    Returns:
+        Loaded manifest mapping.
+    """
+
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() in {".yaml", ".yml"}:
+        payload = yaml.safe_load(text)
+    else:
+        payload = json.loads(text)
+    if not isinstance(payload, dict):
+        raise DenominatorManifestError(f"Manifest must contain a mapping: {path}")
+    return payload
+
+
+def check_manifest(expected: dict[str, Any], observed_path: Path) -> None:
+    """Fail closed when an observed manifest differs from expected generated content."""
+
+    observed = load_manifest(observed_path)
+    if observed != expected:
+        raise DenominatorManifestError(f"Manifest mismatch: {observed_path}")
+
+
+def denominator_table_rows(manifest: dict[str, Any]) -> list[dict[str, str]]:
+    """Return stable table rows for per-family x planner denominator consumers.
+
+    Returns:
+        Sorted table rows with string values.
+    """
+
+    rows: list[dict[str, str]] = []
+    for config in manifest.get("configs", []):
+        for row in config.get("per_family_planner_denominators", []):
+            rows.append(
+                {
+                    "config_name": str(config["name"]),
+                    "config_path": str(config["config_path"]),
+                    "family": str(row["family"]),
+                    "planner": str(row["planner"]),
+                    "planner_algo": str(row["planner_algo"]),
+                    "scenario_count": str(int(row["scenario_count"])),
+                    "cell_count": str(int(row["cell_count"])),
+                    "seed_count": str(int(row["seed_count"])),
+                    "denominator_episodes": str(int(row["denominator_episodes"])),
+                    "kinematics_count": str(int(row["kinematics_count"])),
+                    "denominator_episodes_with_kinematics": str(
+                        int(row["denominator_episodes_with_kinematics"])
+                    ),
+                    "densities": ";".join(str(value) for value in row["densities"]),
+                }
+            )
+    return sorted(rows, key=lambda item: (item["config_name"], item["family"], item["planner"]))
+
+
+def write_denominator_table(manifest: dict[str, Any], path: Path) -> Path:
+    """Write per-family x planner denominator rows as CSV.
+
+    Returns:
+        Path written.
+    """
+
+    rows = denominator_table_rows(manifest)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=_TABLE_COLUMNS)
+        writer.writeheader()
+        writer.writerows(rows)
+    return path
+
+
+def _normalize_table_row(row: dict[str, Any]) -> dict[str, str]:
+    """Normalize CSV/Markdown/JSON consumer rows for closed comparison.
+
+    Returns:
+        Normalized table row with string values.
+    """
+
+    missing = [column for column in _TABLE_COLUMNS if column not in row]
+    if missing:
+        raise DenominatorManifestError(f"Denominator table row missing columns: {missing}")
+    normalized: dict[str, str] = {}
+    for column in _TABLE_COLUMNS:
+        value = row[column]
+        if column in _TABLE_INT_COLUMNS:
+            try:
+                normalized[column] = str(int(value))
+            except (TypeError, ValueError) as exc:
+                raise DenominatorManifestError(
+                    f"Denominator table column {column!r} must be integer, got {value!r}"
+                ) from exc
+        elif column == "densities":
+            parts = [
+                part.strip()
+                for chunk in str(value).split(";")
+                for part in chunk.split(",")
+                if part.strip()
+            ]
+            normalized[column] = ";".join(sorted(parts))
+        else:
+            normalized[column] = str(value).strip()
+    return normalized
+
+
+def _parse_markdown_table(path: Path) -> list[dict[str, str]]:
+    """Parse a GitHub-style Markdown table containing the required denominator columns.
+
+    Returns:
+        Parsed table rows.
+    """
+
+    lines = path.read_text(encoding="utf-8").splitlines()
+    required = set(_TABLE_COLUMNS)
+    for index, line in enumerate(lines[:-1]):
+        if "|" not in line:
+            continue
+        headers = [cell.strip() for cell in line.strip().strip("|").split("|")]
+        normalized_headers = [header.lower().replace(" ", "_") for header in headers]
+        if not required.issubset(normalized_headers):
+            continue
+        separator = lines[index + 1]
+        if not set(separator.strip()).issubset({"|", "-", ":", " "}):
+            continue
+        rows: list[dict[str, str]] = []
+        header_map = dict(zip(normalized_headers, range(len(headers)), strict=False))
+        for row_line in lines[index + 2 :]:
+            if "|" not in row_line:
+                break
+            cells = [cell.strip() for cell in row_line.strip().strip("|").split("|")]
+            if len(cells) < len(headers):
+                break
+            rows.append({column: cells[header_map[column]] for column in _TABLE_COLUMNS})
+        return rows
+    raise DenominatorManifestError(f"No denominator table with required columns found: {path}")
+
+
+def load_denominator_table(path: Path) -> list[dict[str, str]]:
+    """Load denominator consumer table from CSV, JSON/YAML, or Markdown.
+
+    Returns:
+        Normalized denominator table rows.
+    """
+
+    suffix = path.suffix.lower()
+    if suffix == ".csv":
+        with path.open("r", encoding="utf-8", newline="") as handle:
+            rows = list(csv.DictReader(handle))
+    elif suffix in {".json", ".yaml", ".yml"}:
+        payload = load_manifest(path)
+        raw_rows = payload.get("rows", payload.get("per_family_planner_denominators"))
+        if not isinstance(raw_rows, list):
+            raise DenominatorManifestError(
+                f"JSON/YAML denominator table must contain rows list: {path}"
+            )
+        rows = raw_rows
+    elif suffix == ".md":
+        rows = _parse_markdown_table(path)
+    else:
+        raise DenominatorManifestError(
+            f"Unsupported denominator table format {suffix!r}; use CSV, JSON, YAML, or Markdown"
+        )
+    return [_normalize_table_row(dict(row)) for row in rows]
+
+
+def check_denominator_table(expected_manifest: dict[str, Any], observed_path: Path) -> None:
+    """Fail closed when a consumer table does not match manifest-derived denominators."""
+
+    expected = [_normalize_table_row(row) for row in denominator_table_rows(expected_manifest)]
+    observed = load_denominator_table(observed_path)
+    expected_keys = {tuple(row[column] for column in _TABLE_COLUMNS) for row in expected}
+    observed_keys = {tuple(row[column] for column in _TABLE_COLUMNS) for row in observed}
+    missing = sorted(expected_keys - observed_keys)
+    extra = sorted(observed_keys - expected_keys)
+    if missing or extra:
+        parts = [f"Denominator table mismatch: {observed_path}"]
+        if missing:
+            parts.append(f"missing rows: {len(missing)}")
+        if extra:
+            parts.append(f"extra rows: {len(extra)}")
+        raise DenominatorManifestError("; ".join(parts))

--- a/scripts/benchmark/build_scenario_denominator_manifest.py
+++ b/scripts/benchmark/build_scenario_denominator_manifest.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Build or check scenario denominator manifests from benchmark configs."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.scenario_denominator_manifest import (
+    DenominatorManifestError,
+    build_scenario_denominator_manifest,
+    check_denominator_table,
+    check_manifest,
+    denominator_table_rows,
+    write_denominator_table,
+    write_manifest,
+)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Create the command-line parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        type=Path,
+        action="append",
+        required=True,
+        help="Benchmark campaign config YAML. Repeat to combine multiple canonical configs.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional JSON manifest output path. If omitted without checks, manifest prints to stdout.",
+    )
+    parser.add_argument(
+        "--table",
+        type=Path,
+        default=None,
+        help="Optional CSV per-family x planner denominator table output path.",
+    )
+    parser.add_argument(
+        "--check-manifest",
+        type=Path,
+        default=None,
+        help="Existing manifest to compare with generated config-derived manifest.",
+    )
+    parser.add_argument(
+        "--check-table",
+        type=Path,
+        default=None,
+        help="Existing CSV, JSON, YAML, or Markdown denominator table to compare with manifest rows.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the scenario denominator manifest CLI."""
+
+    args = _build_parser().parse_args(argv)
+    try:
+        manifest = build_scenario_denominator_manifest(args.config)
+        if args.check_manifest is not None:
+            check_manifest(manifest, args.check_manifest)
+        if args.check_table is not None:
+            check_denominator_table(manifest, args.check_table)
+        if args.output is not None:
+            path = write_manifest(manifest, args.output)
+            print(f"wrote scenario denominator manifest: {path}")
+        elif args.check_manifest is None and args.check_table is None:
+            print(json.dumps(manifest, indent=2, sort_keys=True))
+        if args.table is not None:
+            path = write_denominator_table(manifest, args.table)
+            print(f"wrote scenario denominator table: {path}")
+        if args.check_manifest is not None or args.check_table is not None:
+            rows = len(denominator_table_rows(manifest))
+            print(f"scenario denominator checks passed ({rows} family x planner rows)")
+    except (DenominatorManifestError, FileNotFoundError, OSError, ValueError) as exc:
+        print(f"scenario denominator manifest failed: {exc}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_scenario_denominator_manifest.py
+++ b/tests/benchmark/test_scenario_denominator_manifest.py
@@ -1,0 +1,289 @@
+"""Tests for config-derived scenario denominator manifests."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.scenario_denominator_manifest import (
+    DenominatorManifestError,
+    build_scenario_denominator_manifest,
+    check_denominator_table,
+    check_manifest,
+    denominator_table_rows,
+    write_denominator_table,
+    write_manifest,
+)
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "benchmark"
+    / "build_scenario_denominator_manifest.py"
+)
+_SPEC = importlib.util.spec_from_file_location("build_scenario_denominator_manifest", _SCRIPT_PATH)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_SCRIPT = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_SCRIPT)
+
+
+def _write_yaml(path: Path, payload: object) -> None:
+    """Write YAML fixtures with deterministic key order."""
+
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _write_fixture_campaign(tmp_path: Path, *, seed_policy: dict[str, object]) -> Path:
+    """Create a compact campaign config and scenario matrix fixture."""
+
+    scenarios_path = tmp_path / "scenarios.yaml"
+    _write_yaml(
+        scenarios_path,
+        {
+            "scenarios": [
+                {
+                    "name": "crossing_low",
+                    "map_file": "map.svg",
+                    "metadata": {"archetype": "crossing", "density": "low"},
+                    "seeds": [1, 2],
+                },
+                {
+                    "name": "crossing_high",
+                    "map_file": "map.svg",
+                    "metadata": {"archetype": "crossing", "density": "high"},
+                    "seeds": [3],
+                },
+                {
+                    "name": "bottleneck_low",
+                    "map_file": "map.svg",
+                    "metadata": {"archetype": "bottleneck", "density": "low"},
+                    "seeds": [4, 5],
+                },
+            ]
+        },
+    )
+    config_path = tmp_path / "campaign.yaml"
+    _write_yaml(
+        config_path,
+        {
+            "name": "fixture_campaign",
+            "scenario_matrix": "scenarios.yaml",
+            "seed_policy": seed_policy,
+            "kinematics_matrix": ["differential_drive", "holonomic"],
+            "planners": [
+                {"key": "goal", "algo": "goal"},
+                {"key": "social_force", "algo": "social_force"},
+                {"key": "disabled_ppo", "algo": "ppo", "enabled": False},
+            ],
+        },
+    )
+    return config_path
+
+
+def test_manifest_resolves_seed_policy_and_family_planner_denominators(tmp_path: Path) -> None:
+    """Manifest denominators come from scenario cells, resolved seeds, and enabled planners."""
+
+    config_path = _write_fixture_campaign(
+        tmp_path,
+        seed_policy={"mode": "fixed-list", "seeds": [11, 12, 13]},
+    )
+
+    manifest = build_scenario_denominator_manifest([config_path], repo_root=tmp_path)
+
+    config = manifest["configs"][0]
+    assert config["summary"]["scenario_count"] == 3
+    assert config["summary"]["family_count"] == 2
+    assert config["summary"]["seed_count"] == 3
+    assert config["summary"]["planner_count"] == 2
+    assert config["summary"]["kinematics_count"] == 2
+    assert config["summary"]["episode_denominator_without_planner"] == 9
+    assert config["summary"]["planner_episode_denominator"] == 18
+    assert config["summary"]["planner_kinematics_episode_denominator"] == 36
+    assert [planner["key"] for planner in config["disabled_planners"]] == ["disabled_ppo"]
+
+    rows = denominator_table_rows(manifest)
+    crossing_goal = next(
+        row for row in rows if row["family"] == "crossing" and row["planner"] == "goal"
+    )
+    assert crossing_goal["scenario_count"] == "2"
+    assert crossing_goal["seed_count"] == "3"
+    assert crossing_goal["denominator_episodes"] == "6"
+    assert crossing_goal["denominator_episodes_with_kinematics"] == "12"
+    assert crossing_goal["densities"] == "high;low"
+
+
+def test_manifest_uses_scenario_default_seeds_and_candidate_filter(tmp_path: Path) -> None:
+    """Scenario-default seed policy preserves per-cell seeds after candidate filtering."""
+
+    config_path = _write_fixture_campaign(tmp_path, seed_policy={"mode": "scenario-default"})
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    payload["scenario_candidates"] = ["crossing_low", "bottleneck_low"]
+    _write_yaml(config_path, payload)
+
+    manifest = build_scenario_denominator_manifest([config_path], repo_root=tmp_path)
+
+    config = manifest["configs"][0]
+    assert config["summary"]["scenario_count"] == 2
+    assert config["summary"]["seeds"] == [1, 2, 4, 5]
+    assert config["summary"]["episode_denominator_without_planner"] == 4
+    assert {cell["scenario_id"] for cell in config["cells"]} == {
+        "crossing_low",
+        "bottleneck_low",
+    }
+
+
+def test_manifest_check_modes_fail_closed_on_mismatch(tmp_path: Path) -> None:
+    """Manifest and table checks reject drift from config-derived denominators."""
+
+    config_path = _write_fixture_campaign(
+        tmp_path,
+        seed_policy={"mode": "fixed-list", "seeds": [11, 12, 13]},
+    )
+    manifest = build_scenario_denominator_manifest([config_path], repo_root=tmp_path)
+    manifest_path = write_manifest(manifest, tmp_path / "manifest.json")
+    table_path = write_denominator_table(manifest, tmp_path / "denominators.csv")
+
+    check_manifest(manifest, manifest_path)
+    check_denominator_table(manifest, table_path)
+
+    with table_path.open("r", encoding="utf-8", newline="") as handle:
+        rows = list(csv.DictReader(handle))
+    headers = list(rows[0])
+    markdown_path = tmp_path / "denominators.md"
+    markdown_path.write_text(
+        "\n".join(
+            [
+                "| " + " | ".join(headers) + " |",
+                "| " + " | ".join("---" for _ in headers) + " |",
+                *("| " + " | ".join(row[header] for header in headers) + " |" for row in rows),
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    check_denominator_table(manifest, markdown_path)
+
+    rows[0]["denominator_episodes"] = "999"
+    bad_table_path = tmp_path / "bad_denominators.csv"
+    with bad_table_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+
+    with pytest.raises(DenominatorManifestError, match="Denominator table mismatch"):
+        check_denominator_table(manifest, bad_table_path)
+
+
+def test_manifest_fails_closed_on_invalid_config_inputs(tmp_path: Path) -> None:
+    """Malformed canonical config inputs fail before producing denominator counts."""
+
+    bad_mapping = tmp_path / "bad_mapping.yaml"
+    _write_yaml(bad_mapping, ["not", "a", "mapping"])
+    with pytest.raises(DenominatorManifestError, match="YAML mapping"):
+        build_scenario_denominator_manifest([bad_mapping], repo_root=tmp_path)
+
+    config_path = _write_fixture_campaign(tmp_path, seed_policy={"mode": "scenario-default"})
+    scenarios_path = tmp_path / "scenarios.yaml"
+    _write_yaml(
+        scenarios_path,
+        {
+            "scenarios": [
+                {
+                    "name": "seedless",
+                    "map_file": "map.svg",
+                    "metadata": {"archetype": "crossing", "density": "low"},
+                }
+            ]
+        },
+    )
+    with pytest.raises(DenominatorManifestError, match="no seeds"):
+        build_scenario_denominator_manifest([config_path], repo_root=tmp_path)
+
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+    payload["seed_policy"] = {"mode": "fixed-list", "seeds": [11]}
+    payload["scenario_candidates"] = ["missing_scenario"]
+    _write_yaml(config_path, payload)
+    with pytest.raises(DenominatorManifestError, match="scenario_candidates"):
+        build_scenario_denominator_manifest([config_path], repo_root=tmp_path)
+
+    payload["scenario_candidates"] = []
+    payload["seed_policy"] = {"mode": "seed-set", "seed_set": "missing"}
+    seed_sets = tmp_path / "seed_sets.yaml"
+    _write_yaml(seed_sets, {"eval": [1, 2]})
+    payload["seed_policy"]["seed_sets_path"] = "seed_sets.yaml"
+    _write_yaml(config_path, payload)
+    with pytest.raises(DenominatorManifestError, match="Unknown seed set"):
+        build_scenario_denominator_manifest([config_path], repo_root=tmp_path)
+
+
+def test_table_check_fails_closed_on_malformed_consumers(tmp_path: Path) -> None:
+    """Consumer tables must expose complete integer denominator rows."""
+
+    config_path = _write_fixture_campaign(
+        tmp_path,
+        seed_policy={"mode": "fixed-list", "seeds": [11, 12, 13]},
+    )
+    manifest = build_scenario_denominator_manifest([config_path], repo_root=tmp_path)
+    rows = denominator_table_rows(manifest)
+
+    missing_column_path = tmp_path / "missing_column.json"
+    missing_column_path.write_text(
+        json.dumps({"rows": [{"config_name": rows[0]["config_name"]}]}),
+        encoding="utf-8",
+    )
+    with pytest.raises(DenominatorManifestError, match="missing columns"):
+        check_denominator_table(manifest, missing_column_path)
+
+    bad_int_path = tmp_path / "bad_int.csv"
+    bad_rows = [dict(rows[0])]
+    bad_rows[0]["denominator_episodes"] = "not-an-int"
+    with bad_int_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=bad_rows[0].keys())
+        writer.writeheader()
+        writer.writerows(bad_rows)
+    with pytest.raises(DenominatorManifestError, match="must be integer"):
+        check_denominator_table(manifest, bad_int_path)
+
+    no_table_path = tmp_path / "no_table.md"
+    no_table_path.write_text("No denominator table here.\n", encoding="utf-8")
+    with pytest.raises(DenominatorManifestError, match="No denominator table"):
+        check_denominator_table(manifest, no_table_path)
+
+    unsupported_path = tmp_path / "table.txt"
+    unsupported_path.write_text("plain text\n", encoding="utf-8")
+    with pytest.raises(DenominatorManifestError, match="Unsupported denominator table format"):
+        check_denominator_table(manifest, unsupported_path)
+
+
+def test_cli_generates_outputs_and_checks_table(tmp_path: Path) -> None:
+    """Script entry point supports generate and fail-closed check mode."""
+
+    config_path = _write_fixture_campaign(
+        tmp_path,
+        seed_policy={"mode": "fixed-list", "seeds": [11, 12, 13]},
+    )
+    manifest_path = tmp_path / "manifest.json"
+    table_path = tmp_path / "denominators.csv"
+
+    assert (
+        _SCRIPT.main(
+            [
+                "--config",
+                str(config_path),
+                "--output",
+                str(manifest_path),
+                "--table",
+                str(table_path),
+            ]
+        )
+        == 0
+    )
+    assert manifest_path.exists()
+    assert table_path.exists()
+    assert _SCRIPT.main(["--config", str(config_path), "--check-table", str(table_path)]) == 0


### PR DESCRIPTION
## Summary
Adds a config-derived scenario denominator manifest audit for canonical benchmark configs.

## Linked Issues
- Closes #3652

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `robot_sf.benchmark.scenario_denominator_manifest` to expand benchmark campaign configs, scenario matrices, seed policies, enabled planners, and kinematics into a machine-readable denominator manifest.
- Added `scripts/benchmark/build_scenario_denominator_manifest.py` with JSON manifest output, CSV table output, and fail-closed `--check-manifest` / `--check-table` modes for CSV, JSON/YAML, or Markdown tables.
- Added focused tests for seed policies, scenario candidate filtering, disabled planners, CSV/Markdown table checking, and CLI generate/check flow.
- Documented the scenario denominator manifest command and table contract in `docs/benchmark_campaign_manifest.md`.

## Why Matters
- Added value: scenario catalog counts and per-family x planner denominators can now be regenerated from canonical configs instead of maintained by hand.
- Expected impact: downstream reports can fail closed when a denominator table drifts from benchmark configs.
- Why worth merging now: closes a bounded audit gap without rerunning campaigns or changing benchmark scenarios.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: denominator audit/source-of-truth tooling only; no planner or benchmark result claim.
- Comparator or baseline, applicable: NA - support/audit tooling
- Evidence tier: NA - support/audit tooling; validation is a config-loader smoke, not research evidence
- Result classification: NA - support/audit tooling
- Decision stop rule, applicable: NA - support/audit tooling; acceptance validation is listed under Validation / Proof.
- Parent issue, claim map, registry, context note, synthesis surface update: closes #3652; docs updated in `docs/benchmark_campaign_manifest.md`.
- New research/benchmark/metric/paper-facing analysis tool, any: support/audit tool only; representative use run on `configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml` with no benchmark execution.

## Domain-Aware Approval
- Approver/review source waiver: not required - support/audit tooling makes no research, benchmark-result, or paper-facing claim.
- Validity checklist: NA - support/audit tooling.
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA - support/audit tooling.
- Fallback/degraded exclusions: manifest is pre-execution denominator audit; fallback/degraded rows are not counted as success evidence.
- Claim boundary: no campaign rerun, no scenario-set change, no planner-performance claim.
- Implementation integrity vs experimental validity: implementation validates config-derived counts and fail-closed table checks.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - support/audit helper.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: none

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: stop; acceptance criteria covered by manifest generation and check modes.
- Proposed child issue existing follow-up: none

## Validation / Proof
- `uv run pytest tests/benchmark/test_scenario_denominator_manifest.py -q`
- `uv run ruff check robot_sf/benchmark/scenario_denominator_manifest.py scripts/benchmark/build_scenario_denominator_manifest.py tests/benchmark/test_scenario_denominator_manifest.py docs/benchmark_campaign_manifest.md`
- `uv run ruff format --check robot_sf/benchmark/scenario_denominator_manifest.py scripts/benchmark/build_scenario_denominator_manifest.py tests/benchmark/test_scenario_denominator_manifest.py`
- `uv run python scripts/benchmark/build_scenario_denominator_manifest.py --config configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml --output output/benchmarks/issue3652/scenario_denominator_manifest.json --table output/benchmarks/issue3652/scenario_denominator_table.csv`
- `uv run python scripts/benchmark/build_scenario_denominator_manifest.py --config configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml --check-manifest output/benchmarks/issue3652/scenario_denominator_manifest.json --check-table output/benchmarks/issue3652/scenario_denominator_table.csv`
- Final readiness: `GITHUB_EVENT_NAME=pull_request GITHUB_EVENT_PATH=/tmp/issue3652_pr_event.json PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (passed; stamp `output/validation/pr_ready/issue-3652-scenario-denominator-manifest.json`).

## Performance / Runtime Impact
- Baseline runtime: NA - no existing denominator manifest script.
- Changed runtime: ~1.4s for all-planners manifest check on imech039.
- Representative command: `uv run python scripts/benchmark/build_scenario_denominator_manifest.py --config configs/benchmarks/paper_experiment_matrix_all_planners_v1.yaml --check-manifest output/benchmarks/issue3652/scenario_denominator_manifest.json --check-table output/benchmarks/issue3652/scenario_denominator_table.csv`
- Hot-path call count profile anchor: NA - no runtime benchmark path changed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: config-derived counts or table checks disagree with canonical benchmark configs.

## Risks / Rollout
- Compatibility risks: new script/module only; no scenario or benchmark runner behavior changes.
- Failure modes: configs missing families/densities are represented as `unknown`; missing seeds fail closed for scenario-default policy.
- Rollback fallback plan: revert this PR; no generated artifact is durable dependency.

## Docs / Provenance
- Updated docs: `docs/benchmark_campaign_manifest.md`
- Relevant design provenance notes: issue #3652
- Any assumptions need to preserved: `output/benchmarks/issue3652/*` files are local validation artifacts only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, PR closes #3652
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this is support tooling and documentation, not a benchmark-result or paper-facing claim update.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes
- Verify denominator semantics: per-family x planner rows count intended episodes before runtime exclusions; kinematics-expanded denominator is exposed separately.
- Any known limitations: scenario rows without explicit density are surfaced as `unknown` rather than inferred.
