### PR TITLE
dev: add local CI signoff wrapper

### DIFF
--- a/docs/dev_guide.md
+++ b/docs/dev_guide.md
@@ -296,6 +296,7 @@ scripts/dev/ruff_fix_format.sh
 scripts/dev/run_tests_parallel.sh
 scripts/dev/run_worktree_shared_venv.sh -- pytest tests/test_ci_script_contract.py -q
 scripts/dev/run_ci_local.sh
+scripts/dev/local_signoff.sh --no-setup lint test
 scripts/dev/check_docs_proof_consistency_diff.sh
 scripts/dev/sbatch_use_max_time.sh --partition <partition> --qos <qos> --sbatch-arg --partition=<partition> --sbatch-arg --qos=<qos> SLURM/templates/gpu_training.sl
 BASE_REF=origin/main scripts/dev/pr_ready_check.sh
@@ -316,6 +317,13 @@ share the same phase definitions (`lint`, `typecheck`, `test`, `examples-smoke`,
 `artifact-policy`). Pass explicit phases to scope a run, for example
 `scripts/dev/run_ci_local.sh lint test`. After dependencies are already current, use
 `scripts/dev/run_ci_local.sh --no-setup lint test` for faster repeat local feedback.
+
+`scripts/dev/local_signoff.sh` is the optional local-CI attestation wrapper. It runs selected
+`run_ci_local.sh` phases, auto-installs the `basecamp/gh-signoff` GitHub CLI extension if missing,
+and posts advisory `signoff/local-*` statuses only after the worktree is clean and `HEAD` is already
+pushed to its push remote. It never calls `gh signoff install` and never changes branch protection.
+Use `scripts/dev/local_signoff.sh --no-setup lint test` for fast repeat local proof, or
+`scripts/dev/local_signoff.sh --full` before a higher-confidence handoff.
 
 Before opening a PR, fetch the latest `origin/main`, integrate it into the feature branch with
 either merge or rebase, and only then run

--- a/docs/dev_runtime_requirements.md
+++ b/docs/dev_runtime_requirements.md
@@ -56,6 +56,8 @@ workflow:
 * `gh` - GitHub issue, PR, checks, and Actions log workflows.
 * `jq` - JSON validation in CI smoke paths and local diagnostics.
 * `ffmpeg` - video/rendering paths and GitHub CI parity.
+* `gh-signoff` - optional advisory local-CI statuses. `scripts/dev/local_signoff.sh`
+  auto-installs `basecamp/gh-signoff` when needed and never changes branch protection.
 
 GitHub Actions currently installs these Ubuntu packages for headless jobs:
 

--- a/scripts/dev/check_runtime_requirements.sh
+++ b/scripts/dev/check_runtime_requirements.sh
@@ -97,6 +97,12 @@ if command -v gh >/dev/null 2>&1 && gh extension list 2>/dev/null | grep -qE "$g
 else
   print_result "optional" "gh-act" "install with: gh extension install https://github.com/nektos/gh-act"
 fi
+if command -v gh >/dev/null 2>&1 && gh extension list 2>/dev/null | grep -qE '(^|[[:space:]])basecamp/gh-signoff([[:space:]]|$)'; then
+  version="$(gh signoff version 2>/dev/null || true)"
+  print_result "ok" "gh-signoff" "${version:-GitHub CLI extension installed}"
+else
+  print_result "optional" "gh-signoff" "advisory local CI statuses; auto-installed by scripts/dev/local_signoff.sh"
+fi
 
 echo
 echo "Container and accelerator capabilities"

--- a/scripts/dev/local_signoff.sh
+++ b/scripts/dev/local_signoff.sh
@@ -1,0 +1,193 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'EOF'
+Usage: scripts/dev/local_signoff.sh [options] [<ci-phase> ...]
+
+Run local CI phases on the exact pushed clean HEAD, then post advisory
+gh-signoff commit statuses. This script never installs or changes branch
+protection.
+
+Default phases:
+  lint test
+
+Options:
+  --full                 Run all scripts/dev/run_ci_local.sh phases and sign local-pr-ready.
+  --context <name>       Sign this context after all phases pass. May repeat.
+                         Default: local-<phase> for each selected phase.
+  --no-setup             Pass through to scripts/dev/run_ci_local.sh for faster repeat runs.
+  --no-auto-install      Do not install basecamp/gh-signoff when missing.
+  --dry-run              Run validation and checks, but print instead of signing.
+  -h, --help             Show this help.
+
+Examples:
+  scripts/dev/local_signoff.sh --no-setup lint test
+  scripts/dev/local_signoff.sh --full
+  scripts/dev/local_signoff.sh --context local-pr-ready lint test smoke
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common_setup.sh
+source "$SCRIPT_DIR/common_setup.sh"
+
+auto_install=true
+dry_run=false
+full=false
+run_setup=true
+phases=()
+contexts=()
+
+normalize_context() {
+  printf "%s" "$1" \
+    | tr "[:upper:]_" "[:lower:]-" \
+    | sed -E "s/[^a-z0-9./-]+/-/g; s/^-+//; s/-+$//"
+}
+
+require_clean_pushed_head() {
+  local status
+  status="$(git status --porcelain)"
+  if [[ -n "$status" ]]; then
+    echo "Error: worktree has tracked or untracked changes; refusing to sign HEAD." >&2
+    echo "Commit, stash, or clean changes before local signoff." >&2
+    return 1
+  fi
+
+  local branch
+  branch="$(git symbolic-ref --quiet --short HEAD)" || {
+    echo "Error: detached HEAD; local signoff requires a branch with a push remote." >&2
+    return 1
+  }
+
+  local push_ref
+  push_ref="$(git rev-parse --abbrev-ref --symbolic-full-name "@{push}" 2>/dev/null)" || {
+    echo "Error: branch '$branch' has no push remote configured." >&2
+    echo "Push the branch first, then rerun local signoff." >&2
+    return 1
+  }
+
+  local head_sha push_sha
+  head_sha="$(git rev-parse HEAD)"
+  push_sha="$(git rev-parse "@{push}")"
+  if [[ "$head_sha" != "$push_sha" ]]; then
+    echo "Error: HEAD is not pushed to $push_ref." >&2
+    echo "Local signoff posts a GitHub status for HEAD, so push this exact commit first." >&2
+    return 1
+  fi
+}
+
+ensure_gh_signoff() {
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "Error: gh is required for GitHub signoff." >&2
+    return 1
+  fi
+
+  if gh extension list 2>/dev/null | grep -Eq '(^|[[:space:]])basecamp/gh-signoff([[:space:]]|$)'; then
+    return 0
+  fi
+
+  if [[ "$auto_install" != true ]]; then
+    echo "Error: gh-signoff extension is missing." >&2
+    echo "Install with: gh extension install basecamp/gh-signoff" >&2
+    return 1
+  fi
+
+  echo "Installing gh-signoff extension (advisory statuses only; no branch protection changes)." >&2
+  gh extension install basecamp/gh-signoff
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --full)
+      full=true
+      shift
+      ;;
+    --context)
+      if [[ $# -lt 2 ]]; then
+        echo "Error: --context requires a value." >&2
+        exit 2
+      fi
+      contexts+=("$(normalize_context "$2")")
+      shift 2
+      ;;
+    --no-setup)
+      run_setup=false
+      shift
+      ;;
+    --no-auto-install)
+      auto_install=false
+      shift
+      ;;
+    --dry-run)
+      dry_run=true
+      shift
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    --)
+      shift
+      phases+=("$@")
+      break
+      ;;
+    -*)
+      echo "Error: unknown option '$1'." >&2
+      show_help >&2
+      exit 2
+      ;;
+    *)
+      phases+=("$1")
+      shift
+      ;;
+  esac
+done
+
+if [[ "$full" == true ]]; then
+  if [[ ${#phases[@]} -gt 0 ]]; then
+    echo "Error: --full cannot be combined with explicit phases." >&2
+    exit 2
+  fi
+  mapfile -t phases <("$SCRIPT_DIR/run_ci_local.sh" --list-phases)
+  if [[ ${#contexts[@]} -eq 0 ]]; then
+    contexts=("local-pr-ready")
+  fi
+elif [[ ${#phases[@]} -eq 0 ]]; then
+  phases=("lint" "test")
+fi
+
+if [[ ${#contexts[@]} -eq 0 ]]; then
+  for phase in "${phases[@]}"; do
+    contexts+=("local-$(normalize_context "$phase")")
+  done
+fi
+
+require_clean_pushed_head
+ensure_gh_signoff
+
+run_args=()
+if [[ "$run_setup" != true ]]; then
+  run_args+=(--no-setup)
+fi
+run_args+=("${phases[@]}")
+
+head_before="$(git rev-parse HEAD)"
+echo "Running local validation for ${head_before}: scripts/dev/run_ci_local.sh ${run_args[*]}" >&2
+"$SCRIPT_DIR/run_ci_local.sh" "${run_args[@]}"
+
+require_clean_pushed_head
+head_after="$(git rev-parse HEAD)"
+if [[ "$head_before" != "$head_after" ]]; then
+  echo "Error: HEAD changed during validation; refusing to sign." >&2
+  exit 1
+fi
+
+echo "Validation passed for ${head_after}." >&2
+echo "Signoff contexts: ${contexts[*]}" >&2
+if [[ "$dry_run" == true ]]; then
+  echo "Dry run: gh signoff ${contexts[*]}" >&2
+  exit 0
+fi
+
+gh signoff "${contexts[@]}"

--- a/tests/dev/test_check_perf_evidence.py
+++ b/tests/dev/test_check_perf_evidence.py
@@ -9,6 +9,7 @@ and — when caching is claimed — a cache-hit/reuse counter.
 
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -159,11 +160,14 @@ def test_non_caching_change_does_not_require_cache_counter() -> None:
 
 def _run_cli(args: list[str], tmp_path: Path) -> subprocess.CompletedProcess[str]:
     repo_root = SCRIPT.resolve().parents[2]
+    env = os.environ.copy()
+    env.pop("PR_READY_PR_BODY_FILE", None)
     return subprocess.run(
         [sys.executable, str(SCRIPT), *args],
         capture_output=True,
         text=True,
         cwd=repo_root,
+        env=env,
         check=False,
     )
 

--- a/tests/test_ci_script_contract.py
+++ b/tests/test_ci_script_contract.py
@@ -7,10 +7,10 @@ handle both forms as cheap success paths: exit 0, print usage to stdout,
 and return before sourcing common_setup.sh or invoking heavy dependencies
 (uv, ruff, pytest, gh, etc.).
 
-Covered scripts (9 total):
+Covered scripts (10 total):
   pr_ready_check.sh, gh_comment.sh, run_worktree_shared_venv.sh,
-  run_tests_parallel.sh, run_xdist_race_validation.sh, run_ci_local.sh, ci_driver.sh,
-  check_runtime_requirements.sh, check_carla_runtime.sh
+  run_tests_parallel.sh, run_xdist_race_validation.sh, run_ci_local.sh, local_signoff.sh,
+  ci_driver.sh, check_runtime_requirements.sh, check_carla_runtime.sh
 
 Also covered (in tests/dev/): ci_step_timer.sh
 
@@ -39,6 +39,7 @@ PYPROJECT = ROOT / "pyproject.toml"
 RUN_TESTS_PARALLEL = ROOT / "scripts" / "dev" / "run_tests_parallel.sh"
 RUN_XDIST_RACE_VALIDATION = ROOT / "scripts" / "dev" / "run_xdist_race_validation.sh"
 RUN_CI_LOCAL = ROOT / "scripts" / "dev" / "run_ci_local.sh"
+LOCAL_SIGNOFF = ROOT / "scripts" / "dev" / "local_signoff.sh"
 PR_READY_CHECK = ROOT / "scripts" / "dev" / "pr_ready_check.sh"
 PR_BODY_CONTRACTS_WORKFLOW = ROOT / ".github" / "workflows" / "pr-body-contracts.yml"
 RUN_WORKTREE_SHARED_VENV = ROOT / "scripts" / "dev" / "run_worktree_shared_venv.sh"
@@ -713,6 +714,7 @@ HELP_COVERED_SCRIPTS = [
     RUN_TESTS_PARALLEL,
     RUN_XDIST_RACE_VALIDATION,
     RUN_CI_LOCAL,
+    LOCAL_SIGNOFF,
     CI_DRIVER,
     CHECK_RUNTIME_REQUIREMENTS,
     CHECK_CARLA_RUNTIME,
@@ -826,6 +828,29 @@ def test_ci_driver_help_does_not_invoke_phases(tmp_path: Path) -> None:
     )
     assert result.returncode == 0
     assert "Usage:" in result.stdout
+    assert "uv should not be called" not in result.stderr
+
+
+def test_local_signoff_refuses_dirty_worktree_before_signing(tmp_path: Path) -> None:
+    """local_signoff.sh refuses dirty commits before gh or validation can sign them."""
+    repo, script_dir, env = _make_help_fixture_repo(
+        tmp_path,
+        ("local_signoff.sh", "common_setup.sh"),
+    )
+    (repo / "dirty.txt").write_text("not committed\n", encoding="utf-8")
+
+    result = subprocess.run(
+        [str(script_dir / "local_signoff.sh"), "--dry-run", "--no-setup", "artifact-policy"],
+        cwd=repo,
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert "refusing to sign HEAD" in result.stderr
     assert "uv should not be called" not in result.stderr
 
 


### PR DESCRIPTION
## Summary
Add a repo-local wrapper for advisory local CI signoff statuses without changing GitHub branch protection.

## Linked Issues
- Relates to local CI signoff workflow discussion in this thread.

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `scripts/dev/local_signoff.sh`, which runs selected `run_ci_local.sh` phases and posts `gh-signoff` statuses only for a clean, already-pushed `HEAD`.
- Added `gh-signoff` discovery to `scripts/dev/check_runtime_requirements.sh`.
- Documented the advisory local signoff flow in `docs/dev_guide.md` and `docs/dev_runtime_requirements.md`.
- Added shell-wrapper contract coverage for help output and dirty-worktree refusal.

## Why Matters
- Added value: makes fast local validation visible on PRs without replacing remote CI.
- Expected impact: consistent multi-machine local signoff behavior with guardrails against signing uncommitted or unpushed work.
- Why worth merging now: supports local validation discipline while preserving remote clean-runner checks.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support tooling only.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - support tooling only.
- Result classification: NA - no research result.
- Decision stop rule, applicable: wrapper refuses dirty or unpushed HEAD before validation or signing.
- Parent issue, claim map, registry, context note, synthesis surface update: NA.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper.

## Domain-Aware Approval
- Approver/review source waiver: not required.
- Validity checklist: NA.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: NA.
- Claim boundary: support tooling only.
- Implementation integrity vs experimental validity: implementation integrity covered by shell syntax and contract tests.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor analysis tool needed: NA.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: stop; wrapper scope is complete.
- Proposed child issue existing follow-up: none.

## Validation / Proof
- `bash -n scripts/dev/local_signoff.sh scripts/dev/check_runtime_requirements.sh`
- `uv run pytest tests/test_ci_script_contract.py -q`
- `git diff --check`
- `scripts/dev/check_runtime_requirements.sh` reports `gh-signoff 0.2.1` on this machine after extension install.
- `scripts/dev/local_signoff.sh --dry-run --no-setup artifact-policy` refused this dirty implementation checkout before signing, as intended.

## Performance Impact
- Baseline runtime: NA - no runtime path changed.
- Changed runtime: NA.
- Representative command: `uv run pytest tests/test_ci_script_contract.py -q`
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: local signoff wrapper signs dirty/unpushed work or changes branch protection.

## Risks / Rollout
- Compatibility risks: requires authenticated `gh` for actual signoff; wrapper auto-installs `basecamp/gh-signoff` unless `--no-auto-install` is used.
- Failure modes: missing push remote, dirty worktree, detached HEAD, or missing GitHub CLI all fail closed.
- Rollback fallback plan: remove the wrapper/docs and continue using `scripts/dev/run_ci_local.sh` directly.

## Docs / Provenance
- Updated docs: `docs/dev_guide.md`, `docs/dev_runtime_requirements.md`.
- Relevant design provenance notes: keeps remote CI as clean-runner evidence and uses local statuses only as advisory attestation.
- Any assumptions need to preserved: do not run `gh signoff install` unless branch-protection changes are explicitly desired.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: support tooling PR with no benchmark, registry, claim-map, or paper-facing changes.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that `scripts/dev/local_signoff.sh` never invokes `gh signoff install` and refuses dirty or unpushed heads.
- Known limitations: local signoff remains trust-based advisory status; remote CI remains the clean-room validation path.
