### PR TITLE
benchmark: add deferred vulnerable-user proxy pack scaffold (#3654)

### DIFF
--- a/configs/scenarios/README.md
+++ b/configs/scenarios/README.md
@@ -16,6 +16,10 @@ This directory supports a mix of **per-scenario**, **per-archetype**, and
 - `sets/`: manifest files that include other scenario files.
 - `perturbations/`: perturbation manifests for validity preflight before paired criticality pilots.
 
+`sets/vulnerable_user_proxy_pack_v0_deferred_issue3654.yaml` is a deferred vulnerable-user proxy
+scaffold. It is disabled from default benchmark campaigns and records only synthetic proxy intent,
+not real-world user-group evidence or paper-facing results.
+
 ## Plausibility tracking
 
 Scenario metadata includes a `plausibility` block used to record verification

--- a/configs/scenarios/sets/vulnerable_user_proxy_pack_v0_deferred_issue3654.yaml
+++ b/configs/scenarios/sets/vulnerable_user_proxy_pack_v0_deferred_issue3654.yaml
@@ -1,0 +1,83 @@
+# Issue #3654 vulnerable-user proxy scenario pack v0.
+#
+# This pack is a deferred scaffold only. It is intentionally excluded from default
+# benchmark campaign configs until a later issue defines certification, metrics,
+# and claim boundaries for any executable benchmark use.
+schema_version: robot_sf.scenario_matrix.v1
+scenarios:
+  - name: vulnerable_user_proxy_slow_crossing_low
+    map_id: classic_crossing
+    simulation_config:
+      max_episode_steps: 650
+      ped_density: 0.02
+    robot_config: {}
+    metadata:
+      archetype: vulnerable_user_proxy
+      pack_id: issue_3654_vulnerable_user_proxy_v0
+      status: deferred
+      enabled_by_default: false
+      benchmark_evidence: false
+      claim_boundary: Synthetic slow-crossing proxy only; not a real-world user-group claim.
+      proxy_dimension: reduced_pedestrian_speed
+      label: vulnerable-user proxy slow crossing low density
+      density: low
+      flow: crossing
+      intended_use: future opt-in validation scaffold
+      requires_before_benchmark_use:
+        - scenario certification
+        - explicit metric contract
+        - opt-in benchmark config
+    seeds: [365401, 365402, 365403]
+
+  - name: vulnerable_user_proxy_waiting_dwell_medium
+    map_id: classic_merging
+    simulation_config:
+      max_episode_steps: 700
+      ped_density: 0.05
+    robot_config: {}
+    metadata:
+      archetype: vulnerable_user_proxy
+      pack_id: issue_3654_vulnerable_user_proxy_v0
+      status: deferred
+      enabled_by_default: false
+      benchmark_evidence: false
+      claim_boundary: Synthetic dwell-and-wait proxy only; not a real-world user-group claim.
+      proxy_dimension: intermittent_pedestrian_dwell
+      label: vulnerable-user proxy waiting dwell medium density
+      density: medium
+      flow: merging_with_dwell
+      intended_use: future opt-in validation scaffold
+      requires_before_benchmark_use:
+        - scenario certification
+        - explicit metric contract
+        - opt-in benchmark config
+    seeds: [365411, 365412, 365413]
+
+  - name: vulnerable_user_proxy_occluded_emergence_low
+    map_id: classic_urban_crossing
+    simulation_config:
+      max_episode_steps: 700
+      ped_density: 0.03
+    observation_visibility:
+      static_occlusion: true
+      dynamic_occlusion: false
+      max_range_m: 9.0
+      fov_degrees: 160
+    robot_config: {}
+    metadata:
+      archetype: vulnerable_user_proxy
+      pack_id: issue_3654_vulnerable_user_proxy_v0
+      status: deferred
+      enabled_by_default: false
+      benchmark_evidence: false
+      claim_boundary: Synthetic occluded-emergence proxy only; not a real-world user-group claim.
+      proxy_dimension: visibility_limited_emergence
+      label: vulnerable-user proxy occluded emergence low density
+      density: low
+      flow: crossing
+      intended_use: future opt-in validation scaffold
+      requires_before_benchmark_use:
+        - scenario certification
+        - explicit metric contract
+        - opt-in benchmark config
+    seeds: [365421, 365422, 365423]

--- a/tests/benchmark/test_issue_3654_vulnerable_user_proxy_pack.py
+++ b/tests/benchmark/test_issue_3654_vulnerable_user_proxy_pack.py
@@ -1,0 +1,71 @@
+"""Issue #3654 vulnerable-user proxy scenario-pack scaffold tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.cli import cli_main
+from robot_sf.training.scenario_loader import load_scenarios
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACK_PATH = (
+    REPO_ROOT / "configs/scenarios/sets/vulnerable_user_proxy_pack_v0_deferred_issue3654.yaml"
+)
+
+
+def test_vulnerable_user_proxy_pack_loads_as_deferred_manifest(capsys) -> None:
+    """The pack is structurally valid but explicitly deferred from benchmark use."""
+    rc = cli_main(["validate-config", "--matrix", str(PACK_PATH)])
+    report = json.loads(capsys.readouterr().out)
+
+    assert rc == 0
+    assert report["num_scenarios"] == 3
+    assert report["source"]["schema_version"] == "robot_sf.scenario_matrix.v1"
+
+    scenarios = load_scenarios(PACK_PATH)
+    assert [scenario["name"] for scenario in scenarios] == [
+        "vulnerable_user_proxy_slow_crossing_low",
+        "vulnerable_user_proxy_waiting_dwell_medium",
+        "vulnerable_user_proxy_occluded_emergence_low",
+    ]
+
+    for scenario in scenarios:
+        metadata = scenario["metadata"]
+        assert metadata["pack_id"] == "issue_3654_vulnerable_user_proxy_v0"
+        assert metadata["status"] == "deferred"
+        assert metadata["enabled_by_default"] is False
+        assert metadata["benchmark_evidence"] is False
+        assert "not a real-world user-group claim" in metadata["claim_boundary"]
+        assert "opt-in benchmark config" in metadata["requires_before_benchmark_use"]
+
+
+def test_vulnerable_user_proxy_pack_is_not_referenced_by_default_benchmarks() -> None:
+    """Default benchmark configs must not pick up the deferred pack implicitly."""
+    pack_name = PACK_PATH.name
+    benchmark_configs = sorted((REPO_ROOT / "configs/benchmarks").rglob("*.yaml"))
+
+    referencing_configs = []
+    for path in benchmark_configs:
+        text = path.read_text(encoding="utf-8")
+        if pack_name in text or "issue_3654_vulnerable_user_proxy_v0" in text:
+            referencing_configs.append(path)
+
+    assert referencing_configs == []
+
+
+def test_vulnerable_user_proxy_pack_avoids_accessibility_claim_text() -> None:
+    """The deferred scaffold must not make accessibility or paper-facing claims."""
+    payload = yaml.safe_load(PACK_PATH.read_text(encoding="utf-8"))
+    serialized = yaml.safe_dump(payload, sort_keys=True).lower()
+
+    forbidden_terms = [
+        "accessibility",
+        "disabled user",
+        "paper claim",
+        "dissertation claim",
+        "benchmark evidence true",
+    ]
+    assert not any(term in serialized for term in forbidden_terms)


### PR DESCRIPTION
## Issue

Part of https://github.com/ll7/robot_sf_ll7/issues/3654 (deferred v0 scaffold).

Note: this PR delivers only the smallest deferred scaffold, so it intentionally does **not** use a `Closes` keyword. Issue #3654 stays open as the deferred (P2) tracker for the full mobility-class proxy axis and #3206 composability, which require certification, a metric contract, and an opt-in benchmark config before any executable/benchmark use.

## Scope Summary

This PR adds the smallest deferred vulnerable-user proxy scenario-pack scaffold for issue #3654:

- adds `configs/scenarios/sets/vulnerable_user_proxy_pack_v0_deferred_issue3654.yaml` as a `robot_sf.scenario_matrix.v1` manifest with three synthetic proxy entries;
- marks every entry `status: deferred`, `enabled_by_default: false`, and `benchmark_evidence: false`;
- documents the deferred pack in `configs/scenarios/README.md`;
- adds focused tests that prove the manifest validates/loads, is not referenced by default benchmark configs, and avoids accessibility or paper-facing claim wording.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3654_vulnerable_user_proxy_pack.py` - passed, 3 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/benchmark/test_issue_3654_vulnerable_user_proxy_pack.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m py_compile tests/benchmark/test_issue_3654_vulnerable_user_proxy_pack.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m robot_sf.benchmark.cli validate-config --matrix configs/scenarios/sets/vulnerable_user_proxy_pack_v0_deferred_issue3654.yaml` - passed.
- `git diff --check` - passed.

## Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits. This PR does not enable the pack in default benchmark campaigns and does not claim accessibility, safety, or real-world vulnerable-user validity.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new deferred scenario pack with multiple pedestrian-traffic scenarios and visibility constraints for one scenario.
  * Marked the pack as disabled by default and not intended for benchmark evidence.

* **Documentation**
  * Updated scenario documentation to include the new deferred pack entry.

* **Tests**
  * Added validation coverage to ensure the pack loads correctly, stays out of default benchmark setups, and avoids restricted wording.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
