### PR TITLE
feat(benchmark): export event ledger reconciliation rows (#3482)

### DIFF
--- a/scripts/benchmark/export_event_ledger_reconciliation.py
+++ b/scripts/benchmark/export_event_ledger_reconciliation.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Export per-episode metric-semantics audit tables from benchmark JSONL records."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.event_ledger import ensure_event_ledger
+from robot_sf.benchmark.event_ledger_reconciliation import build_metric_semantics_table
+
+EXPORT_SCHEMA_VERSION = "event_ledger_reconciliation_export.v1"
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--episodes",
+        required=True,
+        type=Path,
+        help="Input benchmark episode records JSONL.",
+    )
+    parser.add_argument(
+        "--out",
+        required=True,
+        type=Path,
+        help="Output JSONL path for one reconciliation table per episode.",
+    )
+    parser.add_argument(
+        "--fail-on-violations",
+        action="store_true",
+        help="Exit non-zero after export when any episode ledger fails reconciliation.",
+    )
+    return parser.parse_args(argv)
+
+
+def _read_episode_records(path: Path) -> list[dict[str, Any]]:
+    """Read non-empty JSONL episode records from ``path``."""
+
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"{path}:{line_number}: expected JSON object episode record")
+            records.append(payload)
+    return records
+
+
+def build_export_row(record: dict[str, Any]) -> dict[str, Any]:
+    """Build one exported reconciliation row from an episode record."""
+
+    ledger = ensure_event_ledger(record)
+    table = build_metric_semantics_table(ledger)
+    return {
+        "schema_version": EXPORT_SCHEMA_VERSION,
+        "episode_id": record.get("episode_id"),
+        "scenario_id": ledger.get("scenario_id"),
+        "seed": ledger.get("seed"),
+        "planner": ledger.get("planner"),
+        "software_commit": ledger.get("software_commit"),
+        "event_ledger_schema_version": ledger.get("schema_version"),
+        "reconciliation_table": table,
+    }
+
+
+def export_reconciliation_tables(
+    records: list[dict[str, Any]],
+    out_path: Path,
+) -> tuple[int, int]:
+    """Write reconciliation rows and return ``(episode_count, violation_count)``."""
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    violation_count = 0
+    with out_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            row = build_export_row(record)
+            table = row["reconciliation_table"]
+            if not table["reconciles"]:
+                violation_count += 1
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+    return len(records), violation_count
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+
+    args = _parse_args(argv)
+    records = _read_episode_records(args.episodes)
+    episode_count, violation_count = export_reconciliation_tables(records, args.out)
+    print(
+        "wrote "
+        f"{episode_count} event-ledger reconciliation rows to {args.out} "
+        f"({violation_count} violation episodes)"
+    )
+    if args.fail_on_violations and violation_count:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/test_event_ledger_reconciliation_export.py
+++ b/tests/benchmark/test_event_ledger_reconciliation_export.py
@@ -1,0 +1,129 @@
+"""Tests for exporting event-ledger reconciliation audit tables."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "benchmark"
+    / "export_event_ledger_reconciliation.py"
+)
+_SPEC = importlib.util.spec_from_file_location("export_event_ledger_reconciliation", SCRIPT_PATH)
+assert _SPEC is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MODULE)
+
+EXPORT_SCHEMA_VERSION = _MODULE.EXPORT_SCHEMA_VERSION
+build_export_row = _MODULE.build_export_row
+
+
+def _record(*, collision_event: bool = False, collisions: float = 0.0) -> dict:
+    """Build a minimal benchmark episode record."""
+
+    return {
+        "episode_id": "episode-1",
+        "scenario_id": "scenario-1",
+        "seed": 7,
+        "algo": "goal",
+        "git_hash": "abc123",
+        "metrics": {
+            "success": 0.0 if collision_event else 1.0,
+            "collisions": collisions,
+        },
+        "termination_reason": "collision" if collision_event else "success",
+        "outcome": {
+            "route_complete": not collision_event,
+            "collision_event": collision_event,
+        },
+    }
+
+
+def test_build_export_row_wraps_episode_identity_and_audit_table() -> None:
+    """Export rows should preserve episode identity around the canonical audit table."""
+
+    row = build_export_row(_record(collision_event=True, collisions=1.0))
+
+    assert row["schema_version"] == EXPORT_SCHEMA_VERSION
+    assert row["episode_id"] == "episode-1"
+    assert row["scenario_id"] == "scenario-1"
+    assert row["seed"] == 7
+    assert row["planner"] == "goal"
+    assert row["software_commit"] == "abc123"
+    assert row["event_ledger_schema_version"] == "EpisodeEventLedger.v1"
+    assert row["reconciliation_table"]["reconciles"] is True
+    assert {entry["field"] for entry in row["reconciliation_table"]["rows"]} >= {
+        "collision_count",
+        "near_miss",
+        "clearance_breach",
+        "ttc_breach",
+    }
+
+
+def test_cli_exports_disagreement_without_silently_resolving_it(tmp_path: Path) -> None:
+    """Exact-vs-derived disagreements should stay visible in exported rows."""
+
+    episodes = tmp_path / "episodes.jsonl"
+    out = tmp_path / "event_ledger_reconciliation.jsonl"
+    episodes.write_text(
+        json.dumps(_record(collision_event=True, collisions=0.0)) + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--episodes",
+            str(episodes),
+            "--out",
+            str(out),
+        ],
+        check=False,
+        cwd=SCRIPT_PATH.parents[2],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    exported = [json.loads(line) for line in out.read_text(encoding="utf-8").splitlines()]
+    assert len(exported) == 1
+    table = exported[0]["reconciliation_table"]
+    assert table["reconciles"] is False
+    assert any("collision" in violation for violation in table["violations"])
+
+
+def test_cli_can_fail_closed_on_exported_reconciliation_violations(tmp_path: Path) -> None:
+    """Pipelines can opt into a non-zero exit when exported rows contain violations."""
+
+    episodes = tmp_path / "episodes.jsonl"
+    out = tmp_path / "event_ledger_reconciliation.jsonl"
+    episodes.write_text(
+        json.dumps(_record(collision_event=True, collisions=0.0)) + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--episodes",
+            str(episodes),
+            "--out",
+            str(out),
+            "--fail-on-violations",
+        ],
+        check=False,
+        cwd=SCRIPT_PATH.parents[2],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 1
+    assert out.exists()


### PR DESCRIPTION
## Summary
Adds a bounded JSONL export helper for `EpisodeEventLedger.v1` metric-semantics reconciliation tables. The helper turns existing episode records into one per-episode audit row and keeps exact/derived disagreements visible instead of resolving them.

## Linked Issues
- Relates `#3482`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `scripts/benchmark/export_event_ledger_reconciliation.py`, a standalone exporter over existing episode JSONL records.
- Export rows include episode identity, `EpisodeEventLedger.v1` provenance, and the existing `event_ledger_reconciliation.v1` table.
- Added focused tests for identity/provenance wrapping, visible exact collision versus zero collision metric disagreement, and optional fail-closed exit behavior.

## Why Matters
- Added value: Provides a reviewable per-episode audit/export surface for the ledger reconciliation table without rerunning traces.
- Expected impact: Downstream paper-facing table backfill can consume explicit audit rows instead of re-deriving ledger semantics.
- Why worth merging now: It closes a remaining audit/export gap while keeping frozen-trace rerun and before/after diff work out of this PR.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Infrastructure for issue #3482 ledger auditability; no empirical result claim.
- Comparator or baseline, applicable: NA
- Evidence tier: NA - support helper; focused tests validate exporter behavior only.
- Result classification: NA - support helper; no benchmark result or empirical claim.
- Decision stop rule, applicable: Exporter must emit one audit row per episode and surface reconciliation violations.
- Parent issue, claim map, registry, context note, synthesis surface update: Parent issue #3482 remains open for frozen-trace rerun/backfill.
- New research/benchmark/metric/paper-facing analysis tool, any: Support helper only; validation uses synthetic unit-test records and does not interpret benchmark results.

## Domain-Aware Approval
- Approver/review source waiver: not required; no benchmark interpretation or paper claim changes.
- Validity checklist: no full benchmark campaign, no fallback/degraded execution treated as evidence.
- Target claim/hypothesis: NA - support helper.
- Comparator split/evidence validity: NA - no comparator, split, benchmark result, or empirical evidence claim.
- Fallback/degraded exclusions: No benchmark runs performed.
- Claim boundary: Export/audit infrastructure only.
- Implementation integrity vs experimental validity: Tests cover exporter behavior; empirical validity remains deferred to issue #3482 backfill.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? synthetic unit records cover exact collision with zero collision metric disagreement.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: Existing issue #3482 tracks frozen-trace rerun/backfill.

## Next Empirical Action
- Rerun needed: no for this PR; yes for the remaining parent issue backfill.
- Extractor analysis tool needed: no
- Artifact missing unavailable: frozen 0.0.2 trace artifacts remain outside this PR scope.
- Stop / revise / continue decision: continue with review of bounded export helper.
- Proposed child issue existing follow-up: #3482 remains open.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_event_ledger_reconciliation_export.py tests/benchmark/test_event_ledger_reconciliation.py tests/benchmark/test_event_ledger.py` - passed, 18 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/export_event_ledger_reconciliation.py tests/benchmark/test_event_ledger_reconciliation_export.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m py_compile scripts/benchmark/export_event_ledger_reconciliation.py tests/benchmark/test_event_ledger_reconciliation_export.py` - passed.
- `git diff --check` - passed.
- Full benchmark campaign run: not run.
- Slurm/GPU submission: not run.
- Paper/dissertation claim edits: none.

## Performance Considerations
- Baseline runtime: NA - JSONL support helper, no runtime-performance claim.
- Changed runtime: NA - JSONL support helper, no runtime-performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_event_ledger_reconciliation_export.py tests/benchmark/test_event_ledger_reconciliation.py tests/benchmark/test_event_ledger.py`
- Hot-path call count profile anchor: NA - no campaign hot path changed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: exporter fails to emit one row per episode or hides reconciliation violations.

## Risks / Rollout
- Compatibility risks: Low; adds a new standalone script and tests only.
- Failure modes: Malformed non-object JSONL records raise `ValueError`; `--fail-on-violations` returns non-zero after still writing the audit rows.
- Rollback fallback plan: Revert this commit; existing in-process reconciliation table remains unchanged.

## Docs / Provenance
- Updated docs: none; PR body documents the entry point and scope.
- Relevant design provenance notes: issue #3482 and existing `docs/context/issue_3482_metric_semantics_reconciliation.md`.
- Any assumptions need to preserved: Export uses existing ledger semantics and does not change event definitions.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: This PR adds support/audit export infrastructure only; frozen-trace rerun/backfill remains tracked by #3482.

## Follow-Up Issues
- Deferred work: no full benchmark campaign run, no frozen trace rerun/backfill, no before/after numerical diff, no Slurm/GPU submission, no paper/dissertation claim edits.
- Issues opened follow-up: none; #3482 remains open for deferred work.

## Reviewer Notes
- Verify that the exporter wraps the existing `build_metric_semantics_table` result rather than redefining event semantics.
- Known limitations: The exporter is an audit surface over existing JSONL records; it does not locate, hydrate, or rerun frozen trace artifacts.
