### PR TITLE
analysis: export SNQI scalarization sensitivity diagnostics (#3653)

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -1,0 +1,687 @@
+"""Social Navigation Quality Index (SNQI) scalarization diagnostics.
+
+This module exports post-hoc analysis artifacts only. It recomputes SNQI rankings
+from existing episode records under weight-zero and weight-sweep variants, then
+compares those scalar rankings with a constraints-first diagnostic ordering. It
+does not change SNQI definitions, benchmark metrics, or claim status.
+"""
+
+from __future__ import annotations
+
+import csv
+import html
+import json
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.rank_metrics import kendall_tau, spearman_from_order
+from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES, compute_snqi, normalize_metric
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SCALARIZATION_SENSITIVITY_SCHEMA = "snqi_scalarization_sensitivity.v1"
+DEFAULT_SWEEP_FACTORS: tuple[float, ...] = (0.0, 0.25, 0.5, 1.0, 1.5, 2.0)
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticArtifacts:
+    """Paths written by ``write_diagnostic_artifacts``."""
+
+    json_path: Path
+    csv_path: Path
+    markdown_path: Path
+    svg_path: Path
+
+
+def build_scalarization_sensitivity_report(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    weights: Mapping[str, float],
+    baseline: Mapping[str, Mapping[str, float]],
+    planner_key: str = "planner_key",
+    fallback_planner_key: str = "planner",
+    sweep_factors: Sequence[float] = DEFAULT_SWEEP_FACTORS,
+) -> dict[str, Any]:
+    """Build a SNQI scalarization-sensitivity and Pareto-front report.
+
+    Returns:
+        Versioned report payload with rank disagreement, weight variants, term
+        dominance, and Pareto-front rows.
+    """
+
+    grouped = _group_records(records, planner_key, fallback_planner_key)
+    if len(grouped) < 2:
+        raise ValueError("at least two planners are required for rank-sensitivity diagnostics")
+
+    clean_weights = {name: float(weights.get(name, 1.0)) for name in WEIGHT_NAMES}
+    base_scores = _planner_snqi_scores(grouped, clean_weights, baseline)
+    base_order = _rank_order(base_scores, higher_is_better=True)
+    constraints = {
+        planner: _constraints_first_endpoint(episodes)
+        for planner, episodes in sorted(grouped.items(), key=lambda item: item[0])
+    }
+    constraints_scores = {
+        planner: float(endpoint["constraints_first_score"])
+        for planner, endpoint in constraints.items()
+    }
+    constraints_order = _rank_order(constraints_scores, higher_is_better=True)
+    disagreement = _rank_disagreement(base_order, constraints_order)
+    planner_rows = _planner_rows(base_scores, constraints, base_order, constraints_order)
+    pareto_points = _pareto_points(planner_rows)
+
+    weight_zero: dict[str, Any] = {}
+    weight_sweep: dict[str, Any] = {}
+    for weight_name in WEIGHT_NAMES:
+        if weight_name not in clean_weights:
+            continue
+        zero_weights = dict(clean_weights)
+        zero_weights[weight_name] = 0.0
+        zero_order = _rank_order(
+            _planner_snqi_scores(grouped, zero_weights, baseline),
+            higher_is_better=True,
+        )
+        weight_zero[weight_name] = _variant_summary(base_order, zero_order)
+
+        variants = []
+        for factor in sweep_factors:
+            sweep_weights = dict(clean_weights)
+            sweep_weights[weight_name] = clean_weights[weight_name] * float(factor)
+            sweep_scores = _planner_snqi_scores(grouped, sweep_weights, baseline)
+            sweep_order = _rank_order(sweep_scores, higher_is_better=True)
+            variants.append(
+                {
+                    "factor": float(factor),
+                    "weight_value": float(sweep_weights[weight_name]),
+                    "order": sweep_order,
+                    **_variant_summary(base_order, sweep_order),
+                }
+            )
+        weight_sweep[weight_name] = variants
+
+    dominance = _term_dominance(grouped, clean_weights, baseline)
+    max_disagreement_rate = max(
+        [
+            float(row["pairwise_disagreement_rate_vs_base"])
+            for rows in weight_sweep.values()
+            for row in rows
+        ],
+        default=0.0,
+    )
+    max_zero_reversals = max(
+        [int(row["pairwise_reversal_count_vs_base"]) for row in weight_zero.values()],
+        default=0,
+    )
+
+    return {
+        "schema_version": SCALARIZATION_SENSITIVITY_SCHEMA,
+        "evidence_kind": "analysis_artifact_only",
+        "claim_boundary": (
+            "Diagnostic export for inspecting SNQI scalarization sensitivity; "
+            "not benchmark evidence and not a primary-index claim."
+        ),
+        "inputs": {
+            "planner_key": planner_key,
+            "fallback_planner_key": fallback_planner_key,
+            "planners": len(grouped),
+            "episodes": sum(len(rows) for rows in grouped.values()),
+            "sweep_factors": [float(factor) for factor in sweep_factors],
+        },
+        "base_snqi_order": base_order,
+        "constraints_first_order": constraints_order,
+        "decision_disagreement": disagreement,
+        "planner_rows": planner_rows,
+        "term_dominance": dominance,
+        "weight_zero_ablation": weight_zero,
+        "weight_sweep": weight_sweep,
+        "pareto_front": {
+            "x": "constraints_first_score",
+            "y": "snqi_mean",
+            "points": pareto_points,
+        },
+        "summary": {
+            "decision_disagreement_rate": disagreement["pairwise_disagreement_rate"],
+            "max_weight_sweep_disagreement_rate_vs_base": max_disagreement_rate,
+            "max_weight_zero_pairwise_reversal_count_vs_base": max_zero_reversals,
+            "top_term_by_mean_abs_contribution": dominance[0]["component"] if dominance else None,
+        },
+    }
+
+
+def write_diagnostic_artifacts(
+    report: Mapping[str, Any],
+    output_dir: Path,
+    *,
+    stem: str = "snqi_scalarization_sensitivity",
+) -> DiagnosticArtifacts:
+    """Write JSON, CSV, Markdown, and SVG diagnostic artifacts.
+
+    Returns:
+        Paths for the written diagnostic artifact files.
+    """
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    json_path = output_dir / f"{stem}.json"
+    csv_path = output_dir / f"{stem}_planner_rows.csv"
+    markdown_path = output_dir / f"{stem}.md"
+    svg_path = output_dir / f"{stem}_pareto.svg"
+
+    json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    _write_planner_csv(csv_path, report)
+    markdown_path.write_text(format_markdown(report), encoding="utf-8")
+    svg_path.write_text(format_pareto_svg(report), encoding="utf-8")
+    return DiagnosticArtifacts(json_path, csv_path, markdown_path, svg_path)
+
+
+def load_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Load episode records from JSON Lines.
+
+    Returns:
+        Episode records as dictionaries.
+    """
+
+    records: list[dict[str, Any]] = []
+    for line_number, line in enumerate(path.read_text(encoding="utf-8").splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        record = json.loads(stripped)
+        if not isinstance(record, dict):
+            raise ValueError(f"{path}:{line_number}: expected a JSON object")
+        records.append(record)
+    return records
+
+
+def load_weight_mapping(path: Path | None) -> dict[str, float]:
+    """Load SNQI weight mapping, accepting either raw or nested ``weights`` JSON.
+
+    Returns:
+        Complete SNQI weight mapping.
+    """
+
+    if path is None:
+        return dict.fromkeys(WEIGHT_NAMES, 1.0)
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("weights file must contain a JSON object")
+    source = raw.get("weights", raw)
+    if not isinstance(source, Mapping):
+        raise ValueError("weights file 'weights' field must be a JSON object")
+    return {name: float(source.get(name, 1.0)) for name in WEIGHT_NAMES}
+
+
+def load_baseline_mapping(path: Path | None) -> dict[str, dict[str, float]]:
+    """Load SNQI baseline normalization stats.
+
+    Returns:
+        Baseline mapping keyed by metric name.
+    """
+
+    if path is None:
+        return {}
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(raw, Mapping):
+        raise ValueError("baseline file must contain a JSON object")
+    baseline: dict[str, dict[str, float]] = {}
+    for metric, entry in raw.items():
+        if not isinstance(entry, Mapping):
+            continue
+        baseline[str(metric)] = {
+            "med": float(entry.get("med", 0.0)),
+            "p95": float(entry.get("p95", entry.get("med", 1.0))),
+        }
+    return baseline
+
+
+def format_markdown(report: Mapping[str, Any]) -> str:
+    """Render the report as Markdown.
+
+    Returns:
+        Markdown report text.
+    """
+
+    summary = report.get("summary", {})
+    disagreement = report.get("decision_disagreement", {})
+    lines = [
+        "# SNQI Scalarization Sensitivity Diagnostic",
+        "",
+        "This is a diagnostic export for Social Navigation Quality Index (SNQI) "
+        "scalarization sensitivity; it is not benchmark evidence and does not "
+        "establish SNQI as a primary index.",
+        "",
+        "## Summary",
+        "",
+        f"- Decision disagreement rate: `{float(disagreement.get('pairwise_disagreement_rate', 0.0)):.6f}`",
+        "- Max weight-sweep disagreement rate vs base: "
+        f"`{float(summary.get('max_weight_sweep_disagreement_rate_vs_base', 0.0)):.6f}`",
+        "- Max weight-zero pairwise reversals vs base: "
+        f"`{int(summary.get('max_weight_zero_pairwise_reversal_count_vs_base', 0))}`",
+        f"- Top term by mean absolute contribution: `{summary.get('top_term_by_mean_abs_contribution')}`",
+        "",
+        "## Planner Rows",
+        "",
+        "| Planner | SNQI rank | Constraints-first rank | Rank delta | SNQI mean | Constraints-first score | Pareto front |",
+        "|---|---:|---:|---:|---:|---:|:---:|",
+    ]
+    for row in report.get("planner_rows", []):
+        lines.append(
+            "| {planner} | {snqi_rank} | {constraints_rank} | {rank_delta:+d} | "
+            "{snqi_mean:.6f} | {constraints_first_score:.6f} | {front} |".format(
+                planner=str(row.get("planner", "unknown")),
+                snqi_rank=int(row.get("snqi_rank", 0)),
+                constraints_rank=int(row.get("constraints_first_rank", 0)),
+                rank_delta=int(row.get("rank_delta", 0)),
+                snqi_mean=float(row.get("snqi_mean", 0.0)),
+                constraints_first_score=float(row.get("constraints_first_score", 0.0)),
+                front="yes" if bool(row.get("pareto_front")) else "no",
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Term Dominance",
+            "",
+            "| Component | Mean abs contribution | Share |",
+            "|---|---:|---:|",
+        ]
+    )
+    for row in report.get("term_dominance", []):
+        lines.append(
+            "| {component} | {mean_abs:.6f} | {share:.6f} |".format(
+                component=str(row.get("component", "unknown")),
+                mean_abs=float(row.get("mean_abs_contribution", 0.0)),
+                share=float(row.get("mean_abs_share", 0.0)),
+            )
+        )
+
+    lines.extend(
+        [
+            "",
+            "## Out Of Scope",
+            "",
+            "- No full benchmark campaign run.",
+            "- No Slurm or GPU submission.",
+            "- No paper or dissertation claim edits.",
+        ]
+    )
+    return "\n".join(lines) + "\n"
+
+
+def format_pareto_svg(report: Mapping[str, Any], *, width: int = 900, height: int = 560) -> str:
+    """Render a dependency-free SVG Pareto figure.
+
+    Returns:
+        SVG figure text.
+    """
+
+    rows = [dict(row) for row in report.get("planner_rows", []) if isinstance(row, Mapping)]
+    margin_left = 90
+    margin_right = 30
+    margin_top = 40
+    margin_bottom = 90
+    plot_width = width - margin_left - margin_right
+    plot_height = height - margin_top - margin_bottom
+    xs = [float(row.get("constraints_first_score", 0.0)) for row in rows] or [0.0]
+    ys = [float(row.get("snqi_mean", 0.0)) for row in rows] or [0.0]
+    x_min, x_max = _padded_domain(xs)
+    y_min, y_max = _padded_domain(ys)
+
+    def x_pos(value: float) -> float:
+        return margin_left + ((value - x_min) / (x_max - x_min)) * plot_width
+
+    def y_pos(value: float) -> float:
+        return margin_top + (1.0 - ((value - y_min) / (y_max - y_min))) * plot_height
+
+    front = [
+        row
+        for row in sorted(rows, key=lambda item: float(item.get("constraints_first_score", 0.0)))
+        if bool(row.get("pareto_front"))
+    ]
+    polyline = " ".join(
+        f"{x_pos(float(row.get('constraints_first_score', 0.0))):.1f},"
+        f"{y_pos(float(row.get('snqi_mean', 0.0))):.1f}"
+        for row in front
+    )
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}" role="img">',
+        "<title>SNQI scalarization sensitivity Pareto diagnostic</title>",
+        '<rect width="100%" height="100%" fill="#ffffff"/>',
+        f'<line x1="{margin_left}" y1="{height - margin_bottom}" x2="{width - margin_right}" y2="{height - margin_bottom}" stroke="#333"/>',
+        f'<line x1="{margin_left}" y1="{margin_top}" x2="{margin_left}" y2="{height - margin_bottom}" stroke="#333"/>',
+        f'<text x="{width / 2:.1f}" y="{height - 24}" text-anchor="middle" font-family="sans-serif" font-size="15">Constraints-first score (higher is better)</text>',
+        f'<text x="24" y="{height / 2:.1f}" text-anchor="middle" transform="rotate(-90 24 {height / 2:.1f})" font-family="sans-serif" font-size="15">SNQI mean (higher is better)</text>',
+    ]
+    if polyline:
+        parts.append(
+            f'<polyline points="{polyline}" fill="none" stroke="#1f77b4" stroke-width="2.5"/>'
+        )
+    for row in rows:
+        cx = x_pos(float(row.get("constraints_first_score", 0.0)))
+        cy = y_pos(float(row.get("snqi_mean", 0.0)))
+        color = "#1f77b4" if bool(row.get("pareto_front")) else "#777777"
+        planner = html.escape(str(row.get("planner", "unknown")))
+        parts.extend(
+            [
+                f'<circle cx="{cx:.1f}" cy="{cy:.1f}" r="5" fill="{color}"/>',
+                f'<text x="{cx + 8:.1f}" y="{cy - 8:.1f}" font-family="sans-serif" font-size="12">{planner}</text>',
+            ]
+        )
+    parts.append("</svg>")
+    return "\n".join(parts) + "\n"
+
+
+def _group_records(
+    records: Iterable[Mapping[str, Any]], planner_key: str, fallback_planner_key: str
+) -> dict[str, list[Mapping[str, Any]]]:
+    grouped: dict[str, list[Mapping[str, Any]]] = {}
+    for index, record in enumerate(records, start=1):
+        planner = _get_nested(record, planner_key)
+        if planner in (None, ""):
+            planner = _get_nested(record, fallback_planner_key)
+        if planner in (None, ""):
+            planner = _get_nested(record, "scenario_params.algo")
+        if planner in (None, ""):
+            raise ValueError(f"record {index} missing planner key {planner_key!r}")
+        grouped.setdefault(str(planner), []).append(record)
+    return grouped
+
+
+def _planner_snqi_scores(
+    grouped: Mapping[str, Sequence[Mapping[str, Any]]],
+    weights: Mapping[str, float],
+    baseline: Mapping[str, Mapping[str, float]],
+) -> dict[str, float]:
+    scores: dict[str, float] = {}
+    for planner, rows in grouped.items():
+        episode_scores = [compute_snqi(_metrics(row), weights, baseline) for row in rows]
+        scores[planner] = _mean(episode_scores)
+    return scores
+
+
+def _constraints_first_endpoint(rows: Sequence[Mapping[str, Any]]) -> dict[str, float | int]:
+    n = len(rows)
+    if n == 0:
+        raise ValueError("planner must have at least one episode")
+    metrics = [_metrics(row) for row in rows]
+    success_rate = _mean(_metric_float(row, "success", 0.0) for row in metrics)
+    collision_rate = _mean(
+        1.0 if _metric_float(row, "collisions", 0.0) > 0.0 else 0.0 for row in metrics
+    )
+    near_miss_rate = _mean(
+        1.0 if _metric_float(row, "near_misses", 0.0) > 0.0 else 0.0 for row in metrics
+    )
+    timeout_rate = _mean(
+        1.0 if _metric_float(row, "timeout", 0.0) > 0.0 else 0.0 for row in metrics
+    )
+    deadlock_rate = _mean(
+        1.0 if _metric_float(row, "deadlock", 0.0) > 0.0 else 0.0 for row in metrics
+    )
+    time_mean = _mean(_metric_float(row, "time_to_goal_norm", 1.0) for row in metrics)
+    constraints_first_score = (
+        success_rate
+        - collision_rate
+        - (0.5 * near_miss_rate)
+        - (0.25 * timeout_rate)
+        - (0.25 * deadlock_rate)
+        - (0.01 * time_mean)
+    )
+    return {
+        "episodes": n,
+        "success_rate": success_rate,
+        "collision_event_rate": collision_rate,
+        "near_miss_event_rate": near_miss_rate,
+        "timeout_rate": timeout_rate,
+        "deadlock_rate": deadlock_rate,
+        "time_to_goal_norm_mean": time_mean,
+        "constraints_first_score": constraints_first_score,
+    }
+
+
+def _planner_rows(
+    snqi_scores: Mapping[str, float],
+    constraints: Mapping[str, Mapping[str, float | int]],
+    snqi_order: Sequence[str],
+    constraints_order: Sequence[str],
+) -> list[dict[str, Any]]:
+    snqi_ranks = {planner: index + 1 for index, planner in enumerate(snqi_order)}
+    constraints_ranks = {planner: index + 1 for index, planner in enumerate(constraints_order)}
+    rows: list[dict[str, Any]] = []
+    for planner in snqi_order:
+        endpoint = constraints[planner]
+        rows.append(
+            {
+                "planner": planner,
+                "snqi_rank": snqi_ranks[planner],
+                "constraints_first_rank": constraints_ranks[planner],
+                "rank_delta": constraints_ranks[planner] - snqi_ranks[planner],
+                "snqi_mean": float(snqi_scores[planner]),
+                **endpoint,
+            }
+        )
+    front_names = {row["planner"] for row in _pareto_points(rows)}
+    for row in rows:
+        row["pareto_front"] = row["planner"] in front_names
+    return rows
+
+
+def _pareto_points(rows: Sequence[Mapping[str, Any]]) -> list[dict[str, Any]]:
+    points: list[dict[str, Any]] = []
+    for row in rows:
+        x = float(row.get("constraints_first_score", 0.0))
+        y = float(row.get("snqi_mean", 0.0))
+        dominated = False
+        for other in rows:
+            if other is row:
+                continue
+            ox = float(other.get("constraints_first_score", 0.0))
+            oy = float(other.get("snqi_mean", 0.0))
+            if ox >= x and oy >= y and (ox > x or oy > y):
+                dominated = True
+                break
+        if not dominated:
+            points.append(
+                {
+                    "planner": str(row.get("planner", "unknown")),
+                    "constraints_first_score": x,
+                    "snqi_mean": y,
+                }
+            )
+    return sorted(points, key=lambda item: (item["constraints_first_score"], item["snqi_mean"]))
+
+
+def _variant_summary(base_order: Sequence[str], variant_order: Sequence[str]) -> dict[str, Any]:
+    return {
+        "order": list(variant_order),
+        "winner_changed": bool(base_order and variant_order and base_order[0] != variant_order[0]),
+        "pairwise_reversal_count_vs_base": _pairwise_reversal_count(base_order, variant_order),
+        "pairwise_disagreement_rate_vs_base": _pairwise_disagreement_rate(
+            base_order, variant_order
+        ),
+        "kendall_tau_vs_base": kendall_tau(base_order, variant_order, degenerate=0.0),
+        "spearman_rho_vs_base": spearman_from_order(base_order, variant_order, degenerate=0.0),
+    }
+
+
+def _rank_disagreement(
+    snqi_order: Sequence[str], constraints_order: Sequence[str]
+) -> dict[str, Any]:
+    return {
+        "pairwise_reversal_count": _pairwise_reversal_count(snqi_order, constraints_order),
+        "pairwise_disagreement_rate": _pairwise_disagreement_rate(snqi_order, constraints_order),
+        "kendall_tau": kendall_tau(snqi_order, constraints_order, degenerate=0.0),
+        "spearman_rho": spearman_from_order(snqi_order, constraints_order, degenerate=0.0),
+        "snqi_winner": snqi_order[0] if snqi_order else None,
+        "constraints_first_winner": constraints_order[0] if constraints_order else None,
+        "winner_disagreement": bool(
+            snqi_order and constraints_order and snqi_order[0] != constraints_order[0]
+        ),
+    }
+
+
+def _pairwise_reversal_count(left_order: Sequence[str], right_order: Sequence[str]) -> int:
+    if set(left_order) != set(right_order):
+        raise ValueError("rank orders must contain the same planners")
+    right_pos = {planner: index for index, planner in enumerate(right_order)}
+    reversals = 0
+    for left_index, planner in enumerate(left_order):
+        for other in left_order[left_index + 1 :]:
+            if right_pos[planner] > right_pos[other]:
+                reversals += 1
+    return reversals
+
+
+def _pairwise_disagreement_rate(left_order: Sequence[str], right_order: Sequence[str]) -> float:
+    possible = len(left_order) * (len(left_order) - 1) / 2
+    if possible <= 0:
+        return 0.0
+    return float(_pairwise_reversal_count(left_order, right_order) / possible)
+
+
+def _term_dominance(
+    grouped: Mapping[str, Sequence[Mapping[str, Any]]],
+    weights: Mapping[str, float],
+    baseline: Mapping[str, Mapping[str, float]],
+) -> list[dict[str, Any]]:
+    contributions: dict[str, list[float]] = {name: [] for name in WEIGHT_NAMES}
+    for rows in grouped.values():
+        for row in rows:
+            metrics = _metrics(row)
+            contributions["w_success"].append(
+                weights.get("w_success", 1.0) * _metric_float(metrics, "success", 0.0)
+            )
+            contributions["w_time"].append(
+                -weights.get("w_time", 1.0) * _metric_float(metrics, "time_to_goal_norm", 1.0)
+            )
+            contributions["w_collisions"].append(
+                -weights.get("w_collisions", 1.0)
+                * normalize_metric(
+                    "collisions", _metric_float(metrics, "collisions", 0.0), baseline
+                )
+            )
+            contributions["w_near"].append(
+                -weights.get("w_near", 1.0)
+                * normalize_metric(
+                    "near_misses", _metric_float(metrics, "near_misses", 0.0), baseline
+                )
+            )
+            contributions["w_comfort"].append(
+                -weights.get("w_comfort", 1.0) * _metric_float(metrics, "comfort_exposure", 0.0)
+            )
+            contributions["w_force_exceed"].append(
+                -weights.get("w_force_exceed", 1.0)
+                * normalize_metric(
+                    "force_exceed_events",
+                    _metric_float(metrics, "force_exceed_events", 0.0),
+                    baseline,
+                )
+            )
+            contributions["w_jerk"].append(
+                -weights.get("w_jerk", 1.0)
+                * normalize_metric("jerk_mean", _metric_float(metrics, "jerk_mean", 0.0), baseline)
+            )
+    mean_abs = {
+        name: _mean(abs(value) for value in values) if values else 0.0
+        for name, values in contributions.items()
+    }
+    total = sum(mean_abs.values())
+    rows = [
+        {
+            "component": name,
+            "mean_abs_contribution": value,
+            "mean_abs_share": value / total if total > 0.0 else 0.0,
+        }
+        for name, value in mean_abs.items()
+    ]
+    return sorted(rows, key=lambda row: (-row["mean_abs_contribution"], row["component"]))
+
+
+def _write_planner_csv(path: Path, report: Mapping[str, Any]) -> None:
+    headers = [
+        "planner",
+        "snqi_rank",
+        "constraints_first_rank",
+        "rank_delta",
+        "snqi_mean",
+        "constraints_first_score",
+        "success_rate",
+        "collision_event_rate",
+        "near_miss_event_rate",
+        "pareto_front",
+    ]
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=headers)
+        writer.writeheader()
+        for row in report.get("planner_rows", []):
+            writer.writerow({header: row.get(header, "") for header in headers})
+
+
+def _rank_order(scores: Mapping[str, float], *, higher_is_better: bool) -> list[str]:
+    return [
+        key
+        for key, _value in sorted(
+            scores.items(),
+            key=lambda item: (
+                -float(item[1]) if higher_is_better else float(item[1]),
+                str(item[0]),
+            ),
+        )
+    ]
+
+
+def _metrics(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    metrics = record.get("metrics")
+    return metrics if isinstance(metrics, Mapping) else record
+
+
+def _metric_float(metrics: Mapping[str, Any], key: str, default: float) -> float:
+    value = metrics.get(key, default)
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return default
+    return number if math.isfinite(number) else default
+
+
+def _mean(values: Iterable[float]) -> float:
+    clean = [float(value) for value in values if math.isfinite(float(value))]
+    if not clean:
+        return 0.0
+    return float(sum(clean) / len(clean))
+
+
+def _get_nested(record: Mapping[str, Any], dotted_key: str) -> Any:
+    current: Any = record
+    for part in dotted_key.split("."):
+        if not isinstance(current, Mapping) or part not in current:
+            return None
+        current = current[part]
+    return current
+
+
+def _padded_domain(values: Sequence[float]) -> tuple[float, float]:
+    low = min(values)
+    high = max(values)
+    if math.isclose(low, high):
+        pad = max(abs(low) * 0.05, 1.0)
+    else:
+        pad = (high - low) * 0.08
+    return low - pad, high + pad
+
+
+__all__ = [
+    "DEFAULT_SWEEP_FACTORS",
+    "SCALARIZATION_SENSITIVITY_SCHEMA",
+    "DiagnosticArtifacts",
+    "build_scalarization_sensitivity_report",
+    "format_markdown",
+    "format_pareto_svg",
+    "load_baseline_mapping",
+    "load_jsonl",
+    "load_weight_mapping",
+    "write_diagnostic_artifacts",
+]

--- a/scripts/tools/analyze_snqi_scalarization_sensitivity.py
+++ b/scripts/tools/analyze_snqi_scalarization_sensitivity.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Export SNQI scalarization-sensitivity diagnostics from episode JSONL.
+
+The outputs are analysis artifacts only. They expose weight-zero/sweep rank
+reversals, term dominance, decision disagreement against a constraints-first
+ordering, and a Pareto SVG without changing benchmark metrics or claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.snqi_scalarization_sensitivity import (
+    DEFAULT_SWEEP_FACTORS,
+    build_scalarization_sensitivity_report,
+    load_baseline_mapping,
+    load_jsonl,
+    load_weight_mapping,
+    write_diagnostic_artifacts,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--episodes", type=Path, required=True, help="Episode JSONL input.")
+    parser.add_argument("--weights", type=Path, default=None, help="Optional SNQI weights JSON.")
+    parser.add_argument("--baseline", type=Path, default=None, help="Optional SNQI baseline JSON.")
+    parser.add_argument("--output-dir", type=Path, required=True, help="Directory for artifacts.")
+    parser.add_argument("--planner-key", default="planner_key", help="Dotted planner key.")
+    parser.add_argument(
+        "--fallback-planner-key", default="planner", help="Fallback dotted planner key."
+    )
+    parser.add_argument(
+        "--sweep-factors",
+        nargs="+",
+        type=float,
+        default=list(DEFAULT_SWEEP_FACTORS),
+        help="Multipliers applied one SNQI weight at a time.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run scalarization-sensitivity export.
+
+    Returns:
+        Process exit code.
+    """
+
+    args = _parse_args(argv)
+    report = build_scalarization_sensitivity_report(
+        load_jsonl(args.episodes),
+        weights=load_weight_mapping(args.weights),
+        baseline=load_baseline_mapping(args.baseline),
+        planner_key=args.planner_key,
+        fallback_planner_key=args.fallback_planner_key,
+        sweep_factors=args.sweep_factors,
+    )
+    artifacts = write_diagnostic_artifacts(report, args.output_dir)
+    print(
+        json.dumps(
+            {
+                "json": str(artifacts.json_path),
+                "csv": str(artifacts.csv_path),
+                "markdown": str(artifacts.markdown_path),
+                "svg": str(artifacts.svg_path),
+                "decision_disagreement_rate": report["summary"]["decision_disagreement_rate"],
+            },
+            indent=2,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -1,0 +1,216 @@
+"""Tests for SNQI scalarization-sensitivity diagnostics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.snqi_scalarization_sensitivity import (
+    SCALARIZATION_SENSITIVITY_SCHEMA,
+    build_scalarization_sensitivity_report,
+    format_pareto_svg,
+    load_jsonl,
+    write_diagnostic_artifacts,
+)
+from scripts.tools.analyze_snqi_scalarization_sensitivity import main as scalarization_cli_main
+
+
+def _episodes() -> list[dict]:
+    return [
+        {
+            "planner_key": "fast-risky",
+            "metrics": {
+                "success": 1,
+                "time_to_goal_norm": 0.05,
+                "collisions": 1,
+                "near_misses": 0,
+                "comfort_exposure": 0.0,
+            },
+        },
+        {
+            "planner_key": "fast-risky",
+            "metrics": {
+                "success": 1,
+                "time_to_goal_norm": 0.05,
+                "collisions": 1,
+                "near_misses": 0,
+                "comfort_exposure": 0.0,
+            },
+        },
+        {
+            "planner_key": "safe-slow",
+            "metrics": {
+                "success": 1,
+                "time_to_goal_norm": 0.8,
+                "collisions": 0,
+                "near_misses": 0,
+                "comfort_exposure": 0.1,
+            },
+        },
+        {
+            "planner_key": "safe-slow",
+            "metrics": {
+                "success": 1,
+                "time_to_goal_norm": 0.8,
+                "collisions": 0,
+                "near_misses": 0,
+                "comfort_exposure": 0.1,
+            },
+        },
+        {
+            "planner_key": "middle",
+            "metrics": {
+                "success": 1,
+                "time_to_goal_norm": 0.9,
+                "collisions": 0,
+                "near_misses": 0,
+                "comfort_exposure": 0.2,
+            },
+        },
+        {
+            "planner_key": "middle",
+            "metrics": {
+                "success": 1,
+                "time_to_goal_norm": 0.9,
+                "collisions": 0,
+                "near_misses": 0,
+                "comfort_exposure": 0.2,
+            },
+        },
+    ]
+
+
+def _weights() -> dict[str, float]:
+    return {
+        "w_success": 0.2,
+        "w_time": 1.0,
+        "w_collisions": 0.1,
+        "w_near": 0.1,
+        "w_comfort": 0.0,
+        "w_force_exceed": 0.0,
+        "w_jerk": 0.0,
+    }
+
+
+def _baseline() -> dict[str, dict[str, float]]:
+    return {
+        "collisions": {"med": 0.0, "p95": 1.0},
+        "near_misses": {"med": 0.0, "p95": 1.0},
+        "force_exceed_events": {"med": 0.0, "p95": 1.0},
+        "jerk_mean": {"med": 0.0, "p95": 1.0},
+    }
+
+
+def test_report_exports_decision_disagreement_and_weight_reversals() -> None:
+    """Sensitivity report exposes rank disagreement and scalarization reversals."""
+
+    report = build_scalarization_sensitivity_report(
+        _episodes(),
+        weights=_weights(),
+        baseline=_baseline(),
+        sweep_factors=[0.0, 1.0, 10.0],
+    )
+
+    assert report["schema_version"] == SCALARIZATION_SENSITIVITY_SCHEMA
+    assert report["evidence_kind"] == "analysis_artifact_only"
+    assert report["base_snqi_order"][0] == "fast-risky"
+    assert report["constraints_first_order"][0] == "safe-slow"
+    assert report["decision_disagreement"]["winner_disagreement"] is True
+    assert report["summary"]["decision_disagreement_rate"] > 0.0
+    assert report["weight_sweep"]["w_collisions"][-1]["winner_changed"] is True
+    assert report["weight_zero_ablation"]["w_time"]["pairwise_reversal_count_vs_base"] > 0
+    assert report["term_dominance"][0]["component"] == "w_time"
+    assert {point["planner"] for point in report["pareto_front"]["points"]} == {
+        "fast-risky",
+        "safe-slow",
+    }
+
+
+def test_artifact_writer_creates_report_ready_files(tmp_path: Path) -> None:
+    """Artifact writer emits report-ready JSON, CSV, Markdown, and SVG."""
+
+    report = build_scalarization_sensitivity_report(
+        _episodes(),
+        weights=_weights(),
+        baseline=_baseline(),
+        sweep_factors=[0.0, 1.0],
+    )
+
+    artifacts = write_diagnostic_artifacts(report, tmp_path)
+
+    assert json.loads(artifacts.json_path.read_text(encoding="utf-8"))["schema_version"]
+    csv_text = artifacts.csv_path.read_text(encoding="utf-8")
+    assert "planner,snqi_rank,constraints_first_rank" in csv_text
+    markdown = artifacts.markdown_path.read_text(encoding="utf-8")
+    assert "not benchmark evidence" in markdown
+    svg = artifacts.svg_path.read_text(encoding="utf-8")
+    assert svg.startswith("<svg")
+    assert "safe-slow" in svg
+
+
+def test_load_jsonl_rejects_non_object_records(tmp_path: Path) -> None:
+    """JSONL loader fails closed on non-object records."""
+
+    path = tmp_path / "episodes.jsonl"
+    path.write_text(json.dumps(_episodes()[0]) + "\n[]\n", encoding="utf-8")
+
+    try:
+        load_jsonl(path)
+    except ValueError as exc:
+        assert "expected a JSON object" in str(exc)
+    else:
+        raise AssertionError("expected non-object JSONL records to fail closed")
+
+
+def test_svg_renderer_marks_pareto_points() -> None:
+    """SVG renderer includes a title and front styling."""
+
+    report = build_scalarization_sensitivity_report(
+        _episodes(),
+        weights=_weights(),
+        baseline=_baseline(),
+        sweep_factors=[1.0],
+    )
+
+    svg = format_pareto_svg(report)
+
+    assert "<title>SNQI scalarization sensitivity Pareto diagnostic</title>" in svg
+    assert "#1f77b4" in svg
+
+
+def test_cli_writes_scalarization_artifacts(tmp_path: Path, capsys) -> None:
+    """CLI writes the same report-ready artifact family."""
+
+    episodes_path = tmp_path / "episodes.jsonl"
+    episodes_path.write_text(
+        "\n".join(json.dumps(record) for record in _episodes()) + "\n",
+        encoding="utf-8",
+    )
+    weights_path = tmp_path / "weights.json"
+    weights_path.write_text(json.dumps(_weights()), encoding="utf-8")
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(_baseline()), encoding="utf-8")
+    output_dir = tmp_path / "out"
+
+    exit_code = scalarization_cli_main(
+        [
+            "--episodes",
+            str(episodes_path),
+            "--weights",
+            str(weights_path),
+            "--baseline",
+            str(baseline_path),
+            "--output-dir",
+            str(output_dir),
+            "--sweep-factors",
+            "0",
+            "1",
+        ]
+    )
+
+    assert exit_code == 0
+    stdout = json.loads(capsys.readouterr().out)
+    assert Path(stdout["json"]).exists()
+    assert Path(stdout["csv"]).exists()
+    assert Path(stdout["markdown"]).exists()
+    assert Path(stdout["svg"]).exists()


### PR DESCRIPTION
## Summary
Adds a Social Navigation Quality Index (SNQI) scalarization-sensitivity diagnostic exporter for inspecting rank reversals, term dominance, decision disagreement, and a Pareto-front SVG from existing episode JSONL records.

This is analysis/export tooling only; it does not change SNQI metric definitions, benchmark results, or paper/dissertation claims.

## Linked Issues
- Closes `#3653`
- Depends on `#3266` for valid real campaign inputs before interpreting report outputs as evidence.

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none for tool/test code
- Stack follow-up issues: `#3266` for valid input campaign readiness
- Safe to review independently: yes
- Review dependency reason, any: Real-input interpretation remains blocked on #3266, but this PR only adds export logic and synthetic contract tests.

## What Changed
- Added `robot_sf.benchmark.snqi_scalarization_sensitivity` to compute base SNQI order, constraints-first diagnostic order, decision-disagreement rates, weight-zero ablation reversals, weight-sweep reversals, term-dominance rows, and Pareto-front points.
- Added `scripts/tools/analyze_snqi_scalarization_sensitivity.py` to write JSON, planner-row CSV, Markdown, and SVG artifacts from episode JSONL.
- Added focused synthetic tests covering disagreement detection, weight-sweep/zero reversals, Pareto-front export, JSONL fail-closed behavior, and the CLI artifact path.

## Why Matters
- Added value: Makes SNQI scalarization sensitivity inspectable as a diagnostic artifact instead of hiding decision reversals behind one scalar.
- Expected impact: Reviewers can audit whether scalar ranking disagrees with constraints-first ordering once valid inputs are available.
- Why worth merging now: The code/test slice is bounded and unblocks later evidence inspection without running campaigns.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Diagnostic visibility for SNQI scalarization sensitivity and decision disagreement.
- Comparator or baseline, applicable: Base SNQI ranking versus constraints-first diagnostic ordering and one-weight-at-a-time variants.
- Evidence tier: NA - support tooling only; synthetic contract tests verify code behavior but produce no research evidence.
- Result classification: NA - no research result produced.
- Decision stop rule, applicable: Do not interpret generated reports as benchmark evidence until #3266 clears valid inputs and a durable/versioned input run is used.
- Parent issue, claim map, registry, context note, synthesis surface update: #3653; no claim-map update because no real evidence artifact is produced here.
- New research/benchmark/metric/paper-facing analysis tool, any: Yes. Representative real-input use is deferred until #3266 resolves input validity. This PR proves the logic and CLI with focused synthetic tests only.

## Domain-Aware Approval
- approval concerns experimental validity claim: not required for merge of support tooling; required later before interpreting real outputs as evidence.
- Approver/review source waiver: No benchmark or paper-facing claim is made.
- Validity checklist: Synthetic logic tests only; no full benchmark campaign.
- Target claim/hypothesis: Diagnostic export can expose scalarization-driven rank reversals.
- Comparator split/evidence validity: Real input interpretation deferred to #3266.
- Fallback/degraded exclusions: No fallback/degraded benchmark execution used.
- Scope boundary: Analysis artifact only; not benchmark evidence.
- Implementation integrity vs experimental validity: Implementation is tested; experimental validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes in synthetic tests.
- Did intervention change command source, selected command, trajectory, route progress? NA; no planner run.
- Did scenario actually contain targeted failure mode? yes in synthetic fixture only.
- Result route: continue after #3266 for real-input diagnostic run.
- Follow-up question issue weak, negative, non-transfer results: #3266 remains the validity gate.

## Next Empirical Action
- Rerun needed: yes, after #3266 clears valid inputs.
- Extractor analysis tool needed: no; this PR adds the extractor/exporter.
- Artifact missing unavailable: Durable/versioned real input artifact for #3653 interpretation.
- Stop / revise / continue decision: continue with real-input diagnostic use after #3266.
- Proposed child issue existing follow-up: #3266.

## Validation / Proof
- `uv sync --all-extras` passed in fresh worktree.
- `python -m py_compile robot_sf/benchmark/snqi_scalarization_sensitivity.py scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` passed.
- `pytest tests/benchmark/test_snqi_scalarization_sensitivity.py -q` passed: 5 passed.
- `pytest tests/test_snqi -q` passed.
- `ruff check robot_sf/benchmark/snqi_scalarization_sensitivity.py scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` passed.
- `ruff format --check robot_sf/benchmark/snqi_scalarization_sensitivity.py scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` passed.
- `git diff --check` passed.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue3653_pr_body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed and wrote freshness stamp for `07fcb300`.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Impact
- Baseline runtime: NA; no runtime benchmark claimed.
- Changed runtime: NA; no runtime benchmark claimed.
- Representative command: `pytest tests/benchmark/test_snqi_scalarization_sensitivity.py -q`
- Hot-path call count profile anchor: NA; post-hoc export helper only.
- Cache-hit reuse counter: NA; no caching claimed.
- Rollback failure criterion: Revert if diagnostic export produces incorrect rank disagreement, malformed artifacts, or breaks existing SNQI tests.

## Risks / Rollout
- Compatibility risks: New script expects episode JSONL with `metrics` plus a planner key; missing planner keys fail closed.
- Failure modes: Real report interpretation can be invalid if #3266 input blockers remain unresolved.
- Rollback fallback plan: Remove the new module, CLI wrapper, and tests.

## Docs / Provenance
- Updated docs: NA; CLI docstring and PR body document usage boundary.
- Relevant design provenance notes: Issue #3653.
- Any assumptions need to preserved: Outputs are diagnostic analysis artifacts only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, issue comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark evidence produced.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no; existing #3266 covers input-validity blocker.
- Not applicable because: This PR adds support tooling and synthetic tests only; downstream evidence propagation waits for a valid real-input diagnostic run.

## Follow-Up Issues
- Deferred work: Run on valid durable/versioned inputs after #3266 clears blockers and publish the resulting artifacts/provenance through the appropriate synthesis surface.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that the report stays analysis-only and does not alter SNQI computation or benchmark claims.
- Known limitation: The constraints-first score in this exporter is a diagnostic endpoint for disagreement inspection, not a replacement benchmark metric.
