### PR TITLE
feat(benchmark): control-trace per-archetype metric harness (#3574)

### DIFF
--- a/robot_sf/benchmark/heterogeneous_population_metrics.py
+++ b/robot_sf/benchmark/heterogeneous_population_metrics.py
@@ -243,9 +243,12 @@ def per_archetype_metrics_from_control_trace(
         Versioned per-archetype metric report with trace provenance fields.
     """
 
+    # Record the same normalized key used for lookup so the provenance field never
+    # disagrees with the metric actually extracted (e.g. a padded " speed_m_s ").
+    normalized_metric_key = str(metric_key).strip()
     observations = pedestrian_metric_observations_from_control_trace(
         control_trace,
-        metric_key,
+        normalized_metric_key,
         reducer=reducer,
     )
     report = per_archetype_metrics(
@@ -254,7 +257,7 @@ def per_archetype_metrics_from_control_trace(
         cvar_alpha=cvar_alpha,
     )
     report["source"] = "pedestrian_control_trace"
-    report["metric_key"] = metric_key
+    report["metric_key"] = normalized_metric_key
     report["pedestrian_metric_reducer"] = reducer
     return report
 

--- a/robot_sf/benchmark/heterogeneous_population_metrics.py
+++ b/robot_sf/benchmark/heterogeneous_population_metrics.py
@@ -20,17 +20,17 @@ analysis layers in this run (#3484, #3558, #3557, #3573).
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 import numpy as np
 
 from robot_sf.benchmark.finite_checks import require_finite_array, require_finite_scalar
 
-if TYPE_CHECKING:
-    from collections.abc import Sequence
-
 HETEROGENEOUS_POPULATION_METRICS_SCHEMA = "heterogeneous_population_metrics.v1"
+
+_CONTROL_TRACE_REDUCERS = frozenset({"mean", "min", "max", "final"})
 
 
 def _require_finite(name: str, value: float) -> None:
@@ -123,6 +123,128 @@ def per_archetype_metrics(
     }
 
 
+def pedestrian_metric_observations_from_control_trace(
+    control_trace: Mapping[str, Any],
+    metric_key: str,
+    *,
+    reducer: str = "mean",
+) -> list[PedestrianMetric]:
+    """Extract per-pedestrian metric observations from a control trace.
+
+    The input is the ``pedestrian_control_trace`` payload attached to episode
+    metadata. This is intentionally a pure trace-to-observation bridge so later
+    ablation code can reuse the per-archetype harness without running benchmark
+    campaigns inside the metric layer.
+
+    Returns:
+        Per-pedestrian observations tagged by archetype.
+    """
+
+    metric_key = str(metric_key).strip()
+    if not metric_key:
+        raise ValueError("metric_key must be non-empty")
+    if reducer not in _CONTROL_TRACE_REDUCERS:
+        raise ValueError(f"reducer must be one of {sorted(_CONTROL_TRACE_REDUCERS)}")
+
+    observations: list[PedestrianMetric] = []
+    for pedestrian_index, pedestrian in enumerate(_control_trace_pedestrians(control_trace)):
+        archetype = _control_trace_archetype(pedestrian, pedestrian_index)
+        arr = _control_trace_metric_values(pedestrian, pedestrian_index, metric_key)
+        value = _reduce_control_trace_metric(arr, reducer)
+        observations.append(PedestrianMetric(archetype=archetype, value=value))
+
+    return observations
+
+
+def _control_trace_pedestrians(control_trace: Mapping[str, Any]) -> Sequence[Any]:
+    pedestrians = control_trace.get("pedestrians")
+    if not isinstance(pedestrians, Sequence) or isinstance(pedestrians, str):
+        raise ValueError("control_trace.pedestrians must be a sequence")
+    if not pedestrians:
+        raise ValueError("control_trace.pedestrians must be non-empty")
+    return pedestrians
+
+
+def _control_trace_archetype(pedestrian: Any, pedestrian_index: int) -> str:
+    if not isinstance(pedestrian, Mapping):
+        raise ValueError(f"control_trace.pedestrians[{pedestrian_index}] must be a mapping")
+    archetype = str(pedestrian.get("archetype", "")).strip()
+    if not archetype:
+        raise ValueError(
+            f"control_trace.pedestrians[{pedestrian_index}].archetype must be non-empty"
+        )
+    return archetype
+
+
+def _control_trace_metric_values(
+    pedestrian: Mapping[str, Any],
+    pedestrian_index: int,
+    metric_key: str,
+) -> np.ndarray:
+    steps = pedestrian.get("steps")
+    if not isinstance(steps, Sequence) or isinstance(steps, str) or not steps:
+        raise ValueError(f"control_trace.pedestrians[{pedestrian_index}].steps must be non-empty")
+
+    values: list[float] = []
+    for step_index, step in enumerate(steps):
+        if not isinstance(step, Mapping):
+            raise ValueError(
+                "control_trace.pedestrians"
+                f"[{pedestrian_index}].steps[{step_index}] must be a mapping"
+            )
+        if metric_key not in step:
+            raise ValueError(
+                "control_trace.pedestrians"
+                f"[{pedestrian_index}].steps[{step_index}] missing {metric_key!r}"
+            )
+        values.append(float(step[metric_key]))
+
+    return require_finite_array(
+        f"control_trace.pedestrians[{pedestrian_index}].steps.{metric_key}",
+        values,
+    )
+
+
+def _reduce_control_trace_metric(values: np.ndarray, reducer: str) -> float:
+    if reducer == "mean":
+        return float(np.mean(values))
+    if reducer == "min":
+        return float(np.min(values))
+    if reducer == "max":
+        return float(np.max(values))
+    return float(values[-1])
+
+
+def per_archetype_metrics_from_control_trace(
+    control_trace: Mapping[str, Any],
+    metric_key: str,
+    *,
+    higher_is_safer: bool = True,
+    cvar_alpha: float = 0.1,
+    reducer: str = "mean",
+) -> dict[str, Any]:
+    """Build a per-archetype metric report from a pedestrian control trace.
+
+    Returns:
+        Versioned per-archetype metric report with trace provenance fields.
+    """
+
+    observations = pedestrian_metric_observations_from_control_trace(
+        control_trace,
+        metric_key,
+        reducer=reducer,
+    )
+    report = per_archetype_metrics(
+        observations,
+        higher_is_safer=higher_is_safer,
+        cvar_alpha=cvar_alpha,
+    )
+    report["source"] = "pedestrian_control_trace"
+    report["metric_key"] = metric_key
+    report["pedestrian_metric_reducer"] = reducer
+    return report
+
+
 def mean_matched_heterogeneity_effect(
     homogeneous_mean: float,
     heterogeneous_mean: float,
@@ -157,5 +279,7 @@ __all__ = [
     "PedestrianMetric",
     "cvar",
     "mean_matched_heterogeneity_effect",
+    "pedestrian_metric_observations_from_control_trace",
     "per_archetype_metrics",
+    "per_archetype_metrics_from_control_trace",
 ]

--- a/robot_sf/benchmark/heterogeneous_population_metrics.py
+++ b/robot_sf/benchmark/heterogeneous_population_metrics.py
@@ -157,6 +157,7 @@ def pedestrian_metric_observations_from_control_trace(
 
 
 def _control_trace_pedestrians(control_trace: Mapping[str, Any]) -> Sequence[Any]:
+    """Return the non-empty ``pedestrians`` sequence, failing closed on bad shapes."""
     if not isinstance(control_trace, Mapping):
         raise ValueError("control_trace must be a mapping")
     pedestrians = control_trace.get("pedestrians")
@@ -168,6 +169,7 @@ def _control_trace_pedestrians(control_trace: Mapping[str, Any]) -> Sequence[Any
 
 
 def _control_trace_archetype(pedestrian: Any, pedestrian_index: int) -> str:
+    """Return a non-empty archetype label, rejecting null/blank values fail-closed."""
     if not isinstance(pedestrian, Mapping):
         raise ValueError(f"control_trace.pedestrians[{pedestrian_index}] must be a mapping")
     archetype_value = pedestrian.get("archetype")
@@ -187,6 +189,14 @@ def _control_trace_metric_values(
     pedestrian_index: int,
     metric_key: str,
 ) -> np.ndarray:
+    """Collect the per-step ``metric_key`` values as a finite array, failing closed.
+
+    Missing keys, null values, non-mapping steps, and non-finite values each raise a
+    descriptive ``ValueError`` instead of silently degrading the extracted support.
+
+    Returns:
+        Finite per-step values for ``metric_key`` as a 1-D array.
+    """
     steps = pedestrian.get("steps")
     if not isinstance(steps, Sequence) or isinstance(steps, str) or not steps:
         raise ValueError(f"control_trace.pedestrians[{pedestrian_index}].steps must be non-empty")
@@ -220,6 +230,11 @@ def _control_trace_metric_values(
 
 
 def _reduce_control_trace_metric(values: np.ndarray, reducer: str) -> float:
+    """Reduce a per-step value array to one scalar per the validated reducer name.
+
+    Returns:
+        The reduced scalar value.
+    """
     if reducer == "mean":
         return float(np.mean(values))
     if reducer == "min":

--- a/robot_sf/benchmark/heterogeneous_population_metrics.py
+++ b/robot_sf/benchmark/heterogeneous_population_metrics.py
@@ -157,6 +157,8 @@ def pedestrian_metric_observations_from_control_trace(
 
 
 def _control_trace_pedestrians(control_trace: Mapping[str, Any]) -> Sequence[Any]:
+    if not isinstance(control_trace, Mapping):
+        raise ValueError("control_trace must be a mapping")
     pedestrians = control_trace.get("pedestrians")
     if not isinstance(pedestrians, Sequence) or isinstance(pedestrians, str):
         raise ValueError("control_trace.pedestrians must be a sequence")
@@ -168,7 +170,11 @@ def _control_trace_pedestrians(control_trace: Mapping[str, Any]) -> Sequence[Any
 def _control_trace_archetype(pedestrian: Any, pedestrian_index: int) -> str:
     if not isinstance(pedestrian, Mapping):
         raise ValueError(f"control_trace.pedestrians[{pedestrian_index}] must be a mapping")
-    archetype = str(pedestrian.get("archetype", "")).strip()
+    archetype_value = pedestrian.get("archetype")
+    # Guard against an explicit ``archetype: null`` payload: ``str(None)`` would
+    # coerce to the truthy string ``"None"`` and silently group pedestrians under
+    # a fake archetype, defeating the fail-closed contract of this helper.
+    archetype = str(archetype_value).strip() if archetype_value is not None else ""
     if not archetype:
         raise ValueError(
             f"control_trace.pedestrians[{pedestrian_index}].archetype must be non-empty"
@@ -197,7 +203,15 @@ def _control_trace_metric_values(
                 "control_trace.pedestrians"
                 f"[{pedestrian_index}].steps[{step_index}] missing {metric_key!r}"
             )
-        values.append(float(step[metric_key]))
+        raw_value = step[metric_key]
+        # A null trace value would raise a bare ``TypeError`` from ``float(None)``;
+        # raise a descriptive ``ValueError`` instead so the offending field is named.
+        if raw_value is None:
+            raise ValueError(
+                "control_trace.pedestrians"
+                f"[{pedestrian_index}].steps[{step_index}].{metric_key} must not be null"
+            )
+        values.append(float(raw_value))
 
     return require_finite_array(
         f"control_trace.pedestrians[{pedestrian_index}].steps.{metric_key}",

--- a/tests/benchmark/test_heterogeneous_population_metrics.py
+++ b/tests/benchmark/test_heterogeneous_population_metrics.py
@@ -11,7 +11,9 @@ from robot_sf.benchmark.heterogeneous_population_metrics import (
     PedestrianMetric,
     cvar,
     mean_matched_heterogeneity_effect,
+    pedestrian_metric_observations_from_control_trace,
     per_archetype_metrics,
+    per_archetype_metrics_from_control_trace,
 )
 
 
@@ -69,6 +71,108 @@ def test_per_archetype_rejects_empty() -> None:
     """An empty observation set cannot be aggregated."""
     with pytest.raises(ValueError):
         per_archetype_metrics([])
+
+
+def _control_trace() -> dict[str, object]:
+    return {
+        "schema_version": "pedestrian-control-trace.v1",
+        "pedestrians": [
+            {
+                "id": "ped_cautious_a",
+                "archetype": "cautious",
+                "steps": [
+                    {"step": 0, "speed_m_s": 0.0, "force_norm": 0.0},
+                    {"step": 1, "speed_m_s": 0.4, "force_norm": 0.2},
+                    {"step": 2, "speed_m_s": 0.6, "force_norm": 0.1},
+                ],
+            },
+            {
+                "id": "ped_cautious_b",
+                "archetype": "cautious",
+                "steps": [
+                    {"step": 0, "speed_m_s": 0.0, "force_norm": 0.0},
+                    {"step": 1, "speed_m_s": 0.2, "force_norm": 0.3},
+                    {"step": 2, "speed_m_s": 0.4, "force_norm": 0.4},
+                ],
+            },
+            {
+                "id": "ped_hurried",
+                "archetype": "hurried",
+                "steps": [
+                    {"step": 0, "speed_m_s": 0.0, "force_norm": 0.0},
+                    {"step": 1, "speed_m_s": 1.0, "force_norm": 0.5},
+                    {"step": 2, "speed_m_s": 1.4, "force_norm": 0.7},
+                ],
+            },
+        ],
+    }
+
+
+def test_control_trace_extraction_builds_per_pedestrian_observations() -> None:
+    """Control-trace rows can feed the per-archetype metric harness directly."""
+
+    observations = pedestrian_metric_observations_from_control_trace(
+        _control_trace(),
+        "speed_m_s",
+        reducer="mean",
+    )
+
+    assert observations == [
+        PedestrianMetric("cautious", pytest.approx(1.0 / 3.0)),
+        PedestrianMetric("cautious", pytest.approx(0.2)),
+        PedestrianMetric("hurried", pytest.approx(0.8)),
+    ]
+
+
+def test_per_archetype_metrics_from_control_trace_keeps_trace_provenance() -> None:
+    """Trace-derived report records source, metric, reducer, and per-archetype stats."""
+
+    report = per_archetype_metrics_from_control_trace(
+        _control_trace(),
+        "force_norm",
+        higher_is_safer=False,
+        cvar_alpha=0.5,
+        reducer="max",
+    )
+
+    assert report["schema_version"] == HETEROGENEOUS_POPULATION_METRICS_SCHEMA
+    assert report["source"] == "pedestrian_control_trace"
+    assert report["metric_key"] == "force_norm"
+    assert report["pedestrian_metric_reducer"] == "max"
+    assert report["worst_archetype_by_mean"] == "hurried"
+    assert report["per_archetype"]["cautious"]["n"] == 2
+    assert report["per_archetype"]["cautious"]["mean"] == pytest.approx(0.3)
+    assert report["per_archetype"]["hurried"]["mean"] == pytest.approx(0.7)
+
+
+def test_control_trace_extraction_supports_final_step_reducer() -> None:
+    """Final-step extraction supports endpoint-style per-pedestrian metrics."""
+
+    observations = pedestrian_metric_observations_from_control_trace(
+        _control_trace(),
+        "speed_m_s",
+        reducer="final",
+    )
+
+    assert [observation.value for observation in observations] == pytest.approx([0.6, 0.4, 1.4])
+
+
+def test_control_trace_extraction_rejects_missing_metric_key() -> None:
+    """Missing trace metric keys fail closed rather than silently changing support."""
+
+    trace = _control_trace()
+    with pytest.raises(ValueError, match="missing 'clearance_m'"):
+        pedestrian_metric_observations_from_control_trace(trace, "clearance_m")
+
+
+def test_control_trace_extraction_rejects_non_finite_metric_value() -> None:
+    """Non-finite trace metrics fail before per-archetype aggregation."""
+
+    trace = _control_trace()
+    trace["pedestrians"][0]["steps"][1]["speed_m_s"] = math.nan
+
+    with pytest.raises(ValueError, match="finite"):
+        pedestrian_metric_observations_from_control_trace(trace, "speed_m_s")
 
 
 def test_mean_matched_effect_is_isolated_when_baseline_is_mean_matched() -> None:

--- a/tests/benchmark/test_heterogeneous_population_metrics.py
+++ b/tests/benchmark/test_heterogeneous_population_metrics.py
@@ -175,6 +175,33 @@ def test_control_trace_extraction_rejects_non_finite_metric_value() -> None:
         pedestrian_metric_observations_from_control_trace(trace, "speed_m_s")
 
 
+def test_control_trace_extraction_rejects_null_archetype() -> None:
+    """An explicit null archetype fails closed instead of grouping under 'None'."""
+
+    trace = _control_trace()
+    trace["pedestrians"][0]["archetype"] = None
+
+    with pytest.raises(ValueError, match="archetype must be non-empty"):
+        pedestrian_metric_observations_from_control_trace(trace, "speed_m_s")
+
+
+def test_control_trace_extraction_rejects_null_metric_value() -> None:
+    """A null trace metric value fails closed with a descriptive error, not float(None)."""
+
+    trace = _control_trace()
+    trace["pedestrians"][0]["steps"][1]["speed_m_s"] = None
+
+    with pytest.raises(ValueError, match="must not be null"):
+        pedestrian_metric_observations_from_control_trace(trace, "speed_m_s")
+
+
+def test_control_trace_extraction_rejects_non_mapping_trace() -> None:
+    """A non-mapping control trace fails closed instead of raising a bare AttributeError."""
+
+    with pytest.raises(ValueError, match="control_trace must be a mapping"):
+        pedestrian_metric_observations_from_control_trace([], "speed_m_s")  # type: ignore[arg-type]
+
+
 def test_mean_matched_effect_is_isolated_when_baseline_is_mean_matched() -> None:
     """A mean-matched homogeneous baseline yields an isolated heterogeneity effect."""
     report = mean_matched_heterogeneity_effect(0.50, 0.62, homogeneous_is_mean_matched=True)

--- a/tests/benchmark/test_heterogeneous_population_metrics.py
+++ b/tests/benchmark/test_heterogeneous_population_metrics.py
@@ -145,6 +145,17 @@ def test_per_archetype_metrics_from_control_trace_keeps_trace_provenance() -> No
     assert report["per_archetype"]["hurried"]["mean"] == pytest.approx(0.7)
 
 
+def test_per_archetype_metrics_from_control_trace_normalizes_metric_key_provenance() -> None:
+    """A padded metric key is normalized for lookup and recorded normalized in provenance."""
+
+    report = per_archetype_metrics_from_control_trace(
+        _control_trace(),
+        "  speed_m_s  ",
+    )
+
+    assert report["metric_key"] == "speed_m_s"
+
+
 def test_control_trace_extraction_supports_final_step_reducer() -> None:
     """Final-step extraction supports endpoint-style per-pedestrian metrics."""
 


### PR DESCRIPTION
## Summary
Adds a bounded control-trace extraction hook for issue #3574 so existing `pedestrian_control_trace` payloads can feed the per-archetype metric harness without running mean-matched experiments.

## Linked Issues
- Relates to `#3574`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3574`
- Safe to review independently: yes
- Review dependency reason, any: Uses surfaces already merged on `origin/main`.

## What Changed
- Added `pedestrian_metric_observations_from_control_trace()` to convert per-pedestrian trace steps into finite `PedestrianMetric` observations.
- Added `per_archetype_metrics_from_control_trace()` to build the existing versioned per-archetype metric report with trace provenance fields.
- Added synthetic CPU-only unit tests covering mean/final/max reducers, provenance fields, missing metric keys, and non-finite values.

## Why Matters
- Added value: Provides the trace/metric plumbing needed before any later heterogeneous-population ablation can be interpreted by archetype.
- Expected impact: Later analysis can reuse a pure, tested helper instead of duplicating trace parsing in experiment scripts.
- Why worth merging now: This is the first useful slice from #3574 and does not require benchmark or GPU work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Blocks later #3574 per-archetype analysis plumbing; does not evaluate the ablation claim.
- Comparator or baseline, applicable: NA - no experiment or comparator run.
- Evidence tier: NA - support helper validated by focused unit tests only.
- Result classification: NA - no research result or benchmark result.
- Decision stop rule, applicable: Stop at pure trace extraction and synthetic unit tests; defer benchmark interpretation to later work.
- Parent issue, claim map, registry, context note, synthesis surface update: Parent issue #3574 remains open for full ablation/harness application.
- New research/benchmark/metric/paper-facing analysis tool, any: Support helper only; representative use is synthetic committed unit tests, with full benchmark use deferred to #3574.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: No experiment result or paper-facing claim is introduced.
- Validity checklist: Pure extraction helper only; no benchmark rows classified.
- Target claim/hypothesis: NA - no claim movement.
- Comparator split/evidence validity: NA - no comparator or experimental-validity claim.
- Fallback/degraded exclusions: Missing/non-finite trace metric values fail closed.
- Claim boundary: Trace/metric plumbing only.
- Implementation integrity vs experimental validity: Unit tests cover implementation integrity; experimental validity remains deferred.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3574 owns later empirical interpretation.

## Next Empirical Action
- Rerun needed: NA for this PR
- Extractor analysis tool needed: no
- Artifact missing unavailable: Full mean-matched campaign artifacts are intentionally out of scope.
- Stop / revise / continue decision: Continue with later #3574 ablation work after this plumbing lands.
- Proposed child issue existing follow-up: #3574

## Validation / Proof
- `uv run python -m py_compile robot_sf/benchmark/heterogeneous_population_metrics.py tests/benchmark/test_heterogeneous_population_metrics.py` - passed
- `uv run pytest tests/benchmark/test_heterogeneous_population_metrics.py` - passed, 20 tests
- `uv run ruff check robot_sf/benchmark/heterogeneous_population_metrics.py tests/benchmark/test_heterogeneous_population_metrics.py` - passed
- `uv run ruff format --check robot_sf/benchmark/heterogeneous_population_metrics.py tests/benchmark/test_heterogeneous_population_metrics.py` - passed
- `git diff --check` - passed
- `PR_READY_PR_BODY_FILE=output/validation/pr_body_issue_3574.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - pending at PR open time

## Performance
- Baseline runtime: NA - no runtime or benchmark performance claim.
- Changed runtime: NA - no runtime or benchmark performance claim.
- Representative command: `uv run pytest tests/benchmark/test_heterogeneous_population_metrics.py`
- Hot-path call count profile anchor: NA - pure helper, no hot-path claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: Revert if trace extraction changes support silently, accepts non-finite metric values, or breaks the existing per-archetype report contract.

## Risks / Rollout
- Compatibility risks: Low; new helper functions are additive and reuse the existing report schema.
- Failure modes: Callers must choose a metric key/reducer that matches the control trace payload.
- Rollback fallback plan: Remove the additive helper functions and tests.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: Issue #3574 and existing `pedestrian_control_trace`/`heterogeneous_population_metrics` modules.
- Any assumptions need to preserved: This PR does not run or interpret mean-matched experiments.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: This is a support helper for #3574, not a benchmark result, registry update, or paper-facing claim.

## Follow-Up Issues
- Deferred work: Full benchmark campaign run, Slurm/GPU submission, mean-matched ablation interpretation, and paper/dissertation claim edits remain out of scope and stay tracked by existing issue #3574.
- Issues opened follow-up: none - existing issue #3574 remains the follow-up tracker.

## Reviewer Notes
- Please verify that the helper stays fail-closed for missing/non-finite trace values and does not imply benchmark evidence.
- Known limitations: No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for generating per-pedestrian metric observations from control trace data.
  * Added a per-archetype metrics report that includes trace provenance details and supports multiple reduction options, including final value.

* **Bug Fixes**
  * Improved validation for malformed trace inputs and missing or invalid metric fields.
  * Added safeguards to fail cleanly when trace data is not in the expected format.

* **Tests**
  * Expanded test coverage for metric extraction, aggregation, reducer behavior, and invalid input handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->