### PR TITLE
Issue #3484: add feasibility diagnostic evidence schema

### DIFF
--- a/robot_sf/scenario_certification/failure_cause.py
+++ b/robot_sf/scenario_certification/failure_cause.py
@@ -37,19 +37,16 @@ REQUIRED_DIAGNOSTIC_LANES = (
     "oracle_or_scripted_controller",
 )
 
+# Keys are stored in canonical underscore form; ``normalize_diagnostic_lane`` folds
+# whitespace and hyphens to underscores before lookup, so hyphenated aliases such as
+# ``route-clearance`` resolve here without separate entries.
 _DIAGNOSTIC_LANE_ALIASES = {
-    "route-clearance": "route_clearance",
     "route_clearance": "route_clearance",
-    "actor-free": "actor_free_run",
-    "actor-free-run": "actor_free_run",
     "actor_free": "actor_free_run",
     "actor_free_run": "actor_free_run",
-    "extended-time": "extended_time_run",
-    "extended-time-run": "extended_time_run",
     "extended_time": "extended_time_run",
     "extended_time_run": "extended_time_run",
     "oracle": "oracle_or_scripted_controller",
-    "oracle-trajectory": "oracle_or_scripted_controller",
     "oracle_trajectory": "oracle_or_scripted_controller",
     "oracle_or_scripted_controller": "oracle_or_scripted_controller",
     "scripted_controller": "oracle_or_scripted_controller",
@@ -249,7 +246,8 @@ def feasibility_diagnostic_row_to_dict(row: FeasibilityDiagnosticRow) -> dict[st
 def normalize_diagnostic_lane(lane: str) -> str:
     """Return canonical diagnostic lane name or raise for unsupported lanes."""
 
-    normalized = _DIAGNOSTIC_LANE_ALIASES.get(str(lane).strip().lower().replace(" ", "_"))
+    key = str(lane).strip().lower().replace(" ", "_").replace("-", "_")
+    normalized = _DIAGNOSTIC_LANE_ALIASES.get(key)
     if normalized is None:
         expected = ", ".join(REQUIRED_DIAGNOSTIC_LANES)
         raise ValueError(

--- a/robot_sf/scenario_certification/failure_cause.py
+++ b/robot_sf/scenario_certification/failure_cause.py
@@ -23,9 +23,12 @@ from typing import Any
 
 FAILURE_CAUSE_SCHEMA = "scenario_failure_cause.v1"
 FEASIBILITY_DIAGNOSTIC_MANIFEST_SCHEMA = "scenario_feasibility_diagnostic_manifest.v1"
+FEASIBILITY_DIAGNOSTIC_EVIDENCE_SCHEMA = "scenario_feasibility_diagnostic_evidence.v1"
 
 DIAGNOSTIC_STATUS_NOT_RUN = "not_run"
 DIAGNOSTIC_STATUS_NEEDS_EVIDENCE = "needs_evidence"
+DIAGNOSTIC_STATUS_PASSED = "passed"
+DIAGNOSTIC_STATUS_FAILED = "failed"
 
 REQUIRED_DIAGNOSTIC_LANES = (
     "route_clearance",
@@ -33,6 +36,31 @@ REQUIRED_DIAGNOSTIC_LANES = (
     "extended_time_run",
     "oracle_or_scripted_controller",
 )
+
+_DIAGNOSTIC_LANE_ALIASES = {
+    "route-clearance": "route_clearance",
+    "route_clearance": "route_clearance",
+    "actor-free": "actor_free_run",
+    "actor-free-run": "actor_free_run",
+    "actor_free": "actor_free_run",
+    "actor_free_run": "actor_free_run",
+    "extended-time": "extended_time_run",
+    "extended-time-run": "extended_time_run",
+    "extended_time": "extended_time_run",
+    "extended_time_run": "extended_time_run",
+    "oracle": "oracle_or_scripted_controller",
+    "oracle-trajectory": "oracle_or_scripted_controller",
+    "oracle_trajectory": "oracle_or_scripted_controller",
+    "oracle_or_scripted_controller": "oracle_or_scripted_controller",
+    "scripted_controller": "oracle_or_scripted_controller",
+}
+
+_DIAGNOSTIC_LANE_TO_INPUT = {
+    "route_clearance": "route_feasible",
+    "actor_free_run": "actor_free_solved",
+    "extended_time_run": "extended_time_solved",
+    "oracle_or_scripted_controller": "oracle_solved",
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -74,6 +102,24 @@ class FeasibilityDiagnosticRow:
     evidence_status: str = DIAGNOSTIC_STATUS_NEEDS_EVIDENCE
     required_diagnostics: tuple[str, ...] = REQUIRED_DIAGNOSTIC_LANES
     notes: str = "Dry-run planning row only; no feasibility diagnostic was executed."
+
+
+@dataclass(frozen=True, slots=True)
+class DiagnosticLaneEvidence:
+    """Observed outcome for one offline feasibility diagnostic lane.
+
+    Rows are intentionally small and synthetic-testable. They describe already-observed
+    route-clearance, actor-free, extended-time, or oracle/scripted-controller outcomes
+    without running a simulator, benchmark campaign, or planner.
+    """
+
+    family_id: str
+    lane: str
+    passed: bool | None
+    source: str
+    scenario_id: str | None = None
+    evidence_ref: str | None = None
+    notes: str = ""
 
 
 # Stable verdict vocabulary.
@@ -200,6 +246,127 @@ def feasibility_diagnostic_row_to_dict(row: FeasibilityDiagnosticRow) -> dict[st
     }
 
 
+def normalize_diagnostic_lane(lane: str) -> str:
+    """Return canonical diagnostic lane name or raise for unsupported lanes."""
+
+    normalized = _DIAGNOSTIC_LANE_ALIASES.get(str(lane).strip().lower().replace(" ", "_"))
+    if normalized is None:
+        expected = ", ".join(REQUIRED_DIAGNOSTIC_LANES)
+        raise ValueError(
+            f"Unsupported feasibility diagnostic lane '{lane}'. Expected one of: {expected}"
+        )
+    return normalized
+
+
+def diagnostic_lane_evidence_to_dict(row: DiagnosticLaneEvidence) -> dict[str, Any]:
+    """Convert an offline diagnostic lane observation to the report schema.
+
+    Returns:
+        JSON-safe diagnostic lane evidence row.
+    """
+
+    lane = normalize_diagnostic_lane(row.lane)
+    return {
+        "schema_version": FEASIBILITY_DIAGNOSTIC_EVIDENCE_SCHEMA,
+        "family_id": row.family_id,
+        "scenario_id": row.scenario_id,
+        "lane": lane,
+        "status": _diagnostic_status_from_passed(row.passed),
+        "passed": row.passed,
+        "source": row.source,
+        "evidence_ref": row.evidence_ref,
+        "notes": row.notes,
+    }
+
+
+def family_diagnostics_from_lane_evidence(
+    rows: Iterable[DiagnosticLaneEvidence],
+    *,
+    any_planner_succeeded: bool = False,
+) -> FamilyDiagnostics:
+    """Aggregate offline lane observations into the classifier input model.
+
+    Conflicting pass/fail values for the same diagnostic lane are rejected because
+    silently choosing one would make the failure-cause verdict non-reproducible.
+    Missing lanes remain ``None`` and therefore classify as ``indeterminate``.
+
+    Returns:
+        Aggregated classifier input model.
+    """
+
+    values: dict[str, bool | None] = {
+        "route_feasible": None,
+        "actor_free_solved": None,
+        "extended_time_solved": None,
+        "oracle_solved": None,
+    }
+    seen: dict[str, bool] = {}
+    for row in rows:
+        lane = normalize_diagnostic_lane(row.lane)
+        input_name = _DIAGNOSTIC_LANE_TO_INPUT[lane]
+        if row.passed is None:
+            continue
+        previous = seen.get(input_name)
+        if previous is not None and previous != row.passed:
+            raise ValueError(
+                f"Conflicting feasibility diagnostic evidence for lane '{lane}': "
+                f"{previous!r} vs {row.passed!r}"
+            )
+        seen[input_name] = row.passed
+        values[input_name] = row.passed
+    return FamilyDiagnostics(
+        any_planner_succeeded=any_planner_succeeded,
+        route_feasible=values["route_feasible"],
+        actor_free_solved=values["actor_free_solved"],
+        extended_time_solved=values["extended_time_solved"],
+        oracle_solved=values["oracle_solved"],
+    )
+
+
+def build_feasibility_diagnostic_evidence_report(
+    rows: Iterable[DiagnosticLaneEvidence],
+    *,
+    source: str,
+    any_planner_succeeded_by_family: Mapping[str, bool] | None = None,
+) -> dict[str, Any]:
+    """Build a diagnostic-only evidence report and per-family failure-cause verdicts.
+
+    Returns:
+        Versioned diagnostic-only evidence report.
+    """
+
+    planner_success = any_planner_succeeded_by_family or {}
+    grouped: dict[str, list[DiagnosticLaneEvidence]] = {}
+    rendered_rows: list[dict[str, Any]] = []
+    for row in rows:
+        rendered_rows.append(diagnostic_lane_evidence_to_dict(row))
+        grouped.setdefault(row.family_id, []).append(row)
+
+    verdicts = []
+    for family_id in sorted(grouped):
+        diagnostics = family_diagnostics_from_lane_evidence(
+            grouped[family_id],
+            any_planner_succeeded=bool(planner_success.get(family_id, False)),
+        )
+        verdicts.append(
+            {
+                "family_id": family_id,
+                "failure_cause_verdict": classify_failure_cause(diagnostics),
+            }
+        )
+
+    return {
+        "schema_version": FEASIBILITY_DIAGNOSTIC_EVIDENCE_SCHEMA,
+        "issue": "3484",
+        "evidence_kind": "diagnostic_observation",
+        "claim_boundary": "diagnostic_only_not_benchmark_evidence",
+        "source": source,
+        "row_count": len(rendered_rows),
+        "rows": rendered_rows,
+        "family_verdicts": verdicts,
+    }
+
+
 def _scenario_family_id(scenario: Mapping[str, Any]) -> str:
     """Return the best available scenario-family identifier."""
 
@@ -266,11 +433,28 @@ def _decide(d: FamilyDiagnostics) -> tuple[str, str]:
     )
 
 
+def _diagnostic_status_from_passed(passed: bool | None) -> str:
+    """Convert tri-state pass/fail evidence into stable report status.
+
+    Returns:
+        Stable diagnostic status string.
+    """
+
+    if passed is True:
+        return DIAGNOSTIC_STATUS_PASSED
+    if passed is False:
+        return DIAGNOSTIC_STATUS_FAILED
+    return DIAGNOSTIC_STATUS_NOT_RUN
+
+
 __all__ = [
+    "DIAGNOSTIC_STATUS_FAILED",
     "DIAGNOSTIC_STATUS_NEEDS_EVIDENCE",
     "DIAGNOSTIC_STATUS_NOT_RUN",
+    "DIAGNOSTIC_STATUS_PASSED",
     "DYNAMIC_BLOCKING_OR_DEADLOCK",
     "FAILURE_CAUSE_SCHEMA",
+    "FEASIBILITY_DIAGNOSTIC_EVIDENCE_SCHEMA",
     "FEASIBILITY_DIAGNOSTIC_MANIFEST_SCHEMA",
     "INDETERMINATE",
     "INFEASIBLE_ROUTE",
@@ -279,9 +463,14 @@ __all__ = [
     "REQUIRED_DIAGNOSTIC_LANES",
     "TIME_LIMITED",
     "VEHICLE_INFEASIBLE",
+    "DiagnosticLaneEvidence",
     "FamilyDiagnostics",
     "FeasibilityDiagnosticRow",
+    "build_feasibility_diagnostic_evidence_report",
     "build_feasibility_diagnostic_manifest",
     "classify_failure_cause",
+    "diagnostic_lane_evidence_to_dict",
+    "family_diagnostics_from_lane_evidence",
     "feasibility_diagnostic_row_to_dict",
+    "normalize_diagnostic_lane",
 ]

--- a/tests/scenario_certification/test_failure_cause.py
+++ b/tests/scenario_certification/test_failure_cause.py
@@ -2,17 +2,24 @@
 
 from __future__ import annotations
 
+import pytest
+
 from robot_sf.scenario_certification.failure_cause import (
     DYNAMIC_BLOCKING_OR_DEADLOCK,
     FAILURE_CAUSE_SCHEMA,
+    FEASIBILITY_DIAGNOSTIC_EVIDENCE_SCHEMA,
     INDETERMINATE,
     INFEASIBLE_ROUTE,
     NOT_UNIVERSALLY_FAILING,
     PLANNER_LIMITED,
     TIME_LIMITED,
     VEHICLE_INFEASIBLE,
+    DiagnosticLaneEvidence,
     FamilyDiagnostics,
+    build_feasibility_diagnostic_evidence_report,
     classify_failure_cause,
+    diagnostic_lane_evidence_to_dict,
+    family_diagnostics_from_lane_evidence,
 )
 
 
@@ -98,3 +105,72 @@ def test_verdict_is_schema_tagged_and_echoes_inputs() -> None:
     assert verdict["evidence_kind"] == "diagnostic_proxy"
     assert verdict["inputs"]["route_feasible"] is False
     assert isinstance(verdict["rationale"], str) and verdict["rationale"]
+
+
+def test_diagnostic_lane_evidence_row_normalizes_oracle_trajectory_alias() -> None:
+    """Oracle-trajectory observations serialize without running any simulator work."""
+    row = diagnostic_lane_evidence_to_dict(
+        DiagnosticLaneEvidence(
+            family_id="head_on_corridor",
+            lane="oracle_trajectory",
+            passed=True,
+            source="synthetic-fixture",
+            scenario_id="head_on_corridor_tight",
+            evidence_ref="fixture://oracle-success",
+        )
+    )
+
+    assert row["schema_version"] == FEASIBILITY_DIAGNOSTIC_EVIDENCE_SCHEMA
+    assert row["lane"] == "oracle_or_scripted_controller"
+    assert row["status"] == "passed"
+    assert row["passed"] is True
+
+
+def test_family_diagnostics_aggregate_route_actor_time_and_oracle_lanes() -> None:
+    """Synthetic lane observations feed the existing failure-cause classifier."""
+    diagnostics = family_diagnostics_from_lane_evidence(
+        [
+            DiagnosticLaneEvidence("bottleneck", "route_clearance", True, "fixture"),
+            DiagnosticLaneEvidence("bottleneck", "actor_free_run", True, "fixture"),
+            DiagnosticLaneEvidence("bottleneck", "extended_time_run", False, "fixture"),
+            DiagnosticLaneEvidence("bottleneck", "oracle_trajectory", True, "fixture"),
+        ]
+    )
+
+    verdict = classify_failure_cause(diagnostics)
+
+    assert verdict["cause"] == PLANNER_LIMITED
+    assert verdict["evidence_complete"] is True
+    assert verdict["comparable_for_ranking"] is True
+
+
+def test_evidence_report_rejects_conflicting_lane_observations() -> None:
+    """Conflicting lane inputs fail closed instead of producing an arbitrary verdict."""
+    with pytest.raises(ValueError, match="Conflicting feasibility diagnostic evidence"):
+        build_feasibility_diagnostic_evidence_report(
+            [
+                DiagnosticLaneEvidence("cross_trap", "route_clearance", True, "fixture-a"),
+                DiagnosticLaneEvidence("cross_trap", "route-clearance", False, "fixture-b"),
+            ],
+            source="synthetic-fixture",
+        )
+
+
+def test_evidence_report_keeps_claim_boundary_diagnostic_only() -> None:
+    """The report schema must not present offline lane rows as benchmark evidence."""
+    report = build_feasibility_diagnostic_evidence_report(
+        [
+            DiagnosticLaneEvidence("cross_trap", "route_clearance", False, "fixture"),
+            DiagnosticLaneEvidence("bottleneck", "actor-free-run", None, "fixture"),
+        ],
+        source="synthetic-fixture",
+    )
+
+    assert report["schema_version"] == FEASIBILITY_DIAGNOSTIC_EVIDENCE_SCHEMA
+    assert report["claim_boundary"] == "diagnostic_only_not_benchmark_evidence"
+    assert report["row_count"] == 2
+    assert report["rows"][1]["status"] == "not_run"
+    assert report["family_verdicts"][0]["family_id"] == "bottleneck"
+    assert report["family_verdicts"][0]["failure_cause_verdict"]["cause"] == INDETERMINATE
+    assert report["family_verdicts"][1]["family_id"] == "cross_trap"
+    assert report["family_verdicts"][1]["failure_cause_verdict"]["cause"] == INFEASIBLE_ROUTE


### PR DESCRIPTION
## Summary
Adds a versioned, diagnostic-only evidence row/report schema for issue #3484 feasibility lanes and aggregates synthetic route-clearance, actor-free, extended-time, and oracle/scripted-controller observations into the existing failure-cause classifier.

## Linked Issues
- Relates to #3484

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `scenario_feasibility_diagnostic_evidence.v1` rows and reports in `robot_sf/scenario_certification/failure_cause.py`.
- Added lane normalization for route-clearance, actor-free, extended-time, and oracle-trajectory aliases.
- Added aggregation from offline lane evidence into the existing `FamilyDiagnostics` verdict path, with fail-closed rejection of conflicting lane observations.
- Added synthetic fixture tests only; no simulator, benchmark campaign, Slurm job, or GPU-heavy work is introduced.

## Why Matters
- Added value: gives universally-failing scenario-family diagnostics a small, versioned input/report shape before any runner integration.
- Expected impact: downstream tools can record route-clearance/oracle/actor-free observations without treating them as benchmark evidence.
- Why worth merging now: it makes the first diagnostic slice reviewable while preserving issue #3484's broader runner work for later.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3484 blocker, diagnostic-only schema for disambiguating universally-failing scenario families.
- Comparator or baseline, applicable: existing `scenario_failure_cause.v1` classifier and dry-run manifest.
- Evidence tier: NA - support helper; synthetic unit coverage only, no research evidence claim.
- Result classification: NA - no research result or benchmark interpretation.
- Decision stop rule, applicable: schema and aggregation verified on synthetic fixtures; no benchmark interpretation made.
- Parent issue, claim map, registry, context note, synthesis surface update: #3484 remains the parent issue; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: support helper only. No representative benchmark use in this PR; runner integration and durable-input use are deferred under #3484.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: diagnostic-only support schema, no benchmark or paper claim.
- Validity checklist:
- Target claim/hypothesis: no research claim advanced.
- Comparator split/evidence validity: NA - no comparator split or evidence-validity claim; synthetic fixtures only verify code behavior.
- Fallback/degraded exclusions: no fallback or degraded benchmark execution.
- Claim boundary: diagnostic-only, not benchmark evidence.
- Implementation integrity vs experimental validity: tests verify schema and aggregation behavior only.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: continue #3484 runner integration before interpreting real scenario families.

## Next Empirical Action
- Rerun needed: no for this PR
- Extractor analysis tool needed: yes, deferred to #3484 runner integration
- Artifact missing unavailable: no durable diagnostic input artifact in this PR
- Stop / revise / continue decision: continue with opt-in diagnostic runners before any benchmark claim
- Proposed child issue existing follow-up: #3484

## Validation / Proof
- `uv run python -m pytest tests/scenario_certification/test_failure_cause.py tests/scenario_certification/test_feasibility_diagnostic_manifest.py -q` - passed, 14 tests.
- `uv run python -m py_compile robot_sf/scenario_certification/failure_cause.py tests/scenario_certification/test_failure_cause.py` - passed.
- `uv run ruff check robot_sf/scenario_certification/failure_cause.py tests/scenario_certification/test_failure_cause.py` - passed.
- `uv run ruff format --check robot_sf/scenario_certification/failure_cause.py tests/scenario_certification/test_failure_cause.py` - passed.
- `git diff --check` - passed.
- `uv sync --all-extras` - passed; refreshed the fresh worktree environment after broader tests needed `torch`.
- `uv run python -m pytest tests/scenario_certification -q` - passed, 146 tests.
- Full benchmark campaign run: not run, explicitly out of scope.
- Slurm/GPU submission: not run, explicitly forbidden/out of scope.
- Paper/dissertation claim edits: none.

## Performance & Scalability
- Baseline runtime: NA, pure schema/helper code.
- Changed runtime: NA, no hot path or campaign execution.
- Representative command: `uv run python -m pytest tests/scenario_certification -q`
- Hot-path call count profile anchor: NA, no benchmark runtime path changed.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if synthetic schema aggregation or existing failure-cause classification regresses.

## Risks / Rollout
- Compatibility risks: low; new API is additive inside the existing scenario-certification failure-cause module.
- Failure modes: callers could overstate diagnostic rows as benchmark evidence; report schema labels `claim_boundary` as diagnostic-only.
- Rollback fallback plan: revert this commit and keep existing dry-run manifest/classifier behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3484 live contract.
- Any assumptions need to preserved: route/oracle/actor-free observations are diagnostic inputs until validated on durable real inputs.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized in this task.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no, issue comments/new issues not authorized.
- Not applicable because: this PR adds support schema only and makes no benchmark, registry, claim-map, or paper-facing claim.

## Follow-Up Issues
- Deferred work: opt-in route-clearance, oracle/scripted-controller, actor-free, extended-time, and difficulty-ramp runners on durable inputs.
- Issues opened follow-up: none; #3484 remains the existing follow-up surface.

## Reviewer Notes
- Anything reviewer verify closely: lane alias normalization and conflict rejection are intentionally conservative.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no real scenario-family diagnosis in this PR.
