### PR TITLE
#3384 refactor: extract map-runner policy registry dispatch

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -118,6 +118,7 @@ from robot_sf.benchmark.map_runner_observations import (
 from robot_sf.benchmark.map_runner_observations import obs_to_ppo_format as _obs_to_ppo_format
 from robot_sf.benchmark.map_runner_policies import adapters as _adapter_policy_builders
 from robot_sf.benchmark.map_runner_policies import goal as _goal_policy_builder
+from robot_sf.benchmark.map_runner_policies import registry as _policy_builder_registry
 from robot_sf.benchmark.map_runner_policies import safety_barrier as _safety_barrier_builder
 from robot_sf.benchmark.map_runner_policy_common import (
     build_adapter_policy as _build_adapter_policy,
@@ -886,7 +887,7 @@ def _update_adapter_impact_metrics(
 # Registry of migrated per-algorithm policy builders (#3384). Consulted before the
 # inline dispatch in _build_policy; families not yet migrated fall through to the
 # existing if/elif chain.
-_POLICY_BUILDERS: dict[str, Any] = {
+_POLICY_BUILDERS: dict[str, _policy_builder_registry.PolicyBuilder] = {
     **dict.fromkeys(_goal_policy_builder.GOAL_ALGO_KEYS, _goal_policy_builder.build),
     **dict.fromkeys(
         _adapter_policy_builders.RISK_SURFACE_DWA_KEYS,
@@ -924,14 +925,15 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
     """
     algo_key = algo.lower().strip()
     meta: dict[str, Any] = {"algorithm": algo_key}
-    registered_builder = _POLICY_BUILDERS.get(algo_key)
-    if registered_builder is not None:
-        return registered_builder(
-            algo_key,
-            algo_config,
-            robot_kinematics=robot_kinematics,
-            robot_command_mode=robot_command_mode,
-        )
+    registered_policy = _policy_builder_registry.build_registered_policy(
+        algo_key,
+        algo_config,
+        builders=_POLICY_BUILDERS,
+        robot_kinematics=robot_kinematics,
+        robot_command_mode=robot_command_mode,
+    )
+    if registered_policy is not None:
+        return registered_policy
 
     normalized_robot_command_mode = (
         str(robot_command_mode).strip().lower() if robot_command_mode is not None else None

--- a/robot_sf/benchmark/map_runner_policies/registry.py
+++ b/robot_sf/benchmark/map_runner_policies/registry.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import Any, Protocol
 
-type PolicyCallable = Callable[[dict[str, Any]], tuple[float, float]]
+# Policies return a unicycle ``(linear, angular)`` tuple, or a structured payload
+# (e.g. holonomic world-velocity commands from ORCA/HRVO) once those families are
+# migrated into the registry; keep both shapes in the contract.
+type PolicyCallable = Callable[[dict[str, Any]], tuple[float, float] | dict[str, Any]]
 type PolicyBuildResult = tuple[PolicyCallable, dict[str, Any]]
 
 

--- a/robot_sf/benchmark/map_runner_policies/registry.py
+++ b/robot_sf/benchmark/map_runner_policies/registry.py
@@ -1,0 +1,53 @@
+"""Registry dispatch helpers for map-runner policy builders."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Any, Protocol
+
+type PolicyCallable = Callable[[dict[str, Any]], tuple[float, float]]
+type PolicyBuildResult = tuple[PolicyCallable, dict[str, Any]]
+
+
+class PolicyBuilder(Protocol):
+    """Callable contract for per-family map-runner policy builders."""
+
+    def __call__(
+        self,
+        algo_key: str,
+        algo_config: dict[str, Any],
+        *,
+        robot_kinematics: str | None = None,
+        robot_command_mode: str | None = None,
+    ) -> PolicyBuildResult:
+        """Build a policy callable and metadata for ``algo_key``."""
+
+
+def build_registered_policy(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    builders: Mapping[str, PolicyBuilder],
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+) -> PolicyBuildResult | None:
+    """Build a policy from the migrated registry, or return ``None``.
+
+    The legacy ``map_runner._build_policy`` dispatcher still owns families not
+    migrated to ``map_runner_policies``. This helper keeps the registry lookup
+    testable while preserving the fall-through behavior for unmigrated keys.
+
+    Returns:
+        Built policy and metadata when ``algo_key`` is registered, otherwise
+        ``None`` so the caller can continue legacy dispatch.
+    """
+
+    builder = builders.get(algo_key)
+    if builder is None:
+        return None
+    return builder(
+        algo_key,
+        algo_config,
+        robot_kinematics=robot_kinematics,
+        robot_command_mode=robot_command_mode,
+    )

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -9,6 +9,7 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pytest
@@ -61,6 +62,7 @@ from robot_sf.benchmark.map_runner_metrics import (
     summarize_collision_metrics,
 )
 from robot_sf.benchmark.map_runner_policies import safety_barrier as safety_barrier_policy_builder
+from robot_sf.benchmark.map_runner_policies.registry import build_registered_policy
 from robot_sf.benchmark.policy_builders import build_registered_adapter_policy_spec
 from robot_sf.common.types import Rect
 from robot_sf.nav.global_route import GlobalRoute
@@ -562,6 +564,64 @@ def test_build_policy_routes_planner_selector_v2_with_diagnostics() -> None:
     assert (
         stats["last_decision"]["trigger_reason"] == "predeclared_seed_sensitive_low_progress_risk"
     )
+
+
+def test_policy_builder_registry_returns_none_for_unmigrated_key() -> None:
+    """Unregistered keys must keep falling through to map-runner legacy branches."""
+    assert build_registered_policy("unmigrated", {}, builders={}) is None
+
+
+def test_policy_builder_registry_forwards_builder_context() -> None:
+    """Registry dispatch preserves the policy-builder call contract."""
+    calls: list[tuple[str, dict[str, Any], str | None, str | None]] = []
+
+    def _builder(
+        algo_key: str,
+        algo_config: dict[str, Any],
+        *,
+        robot_kinematics: str | None = None,
+        robot_command_mode: str | None = None,
+    ) -> tuple[Any, dict[str, Any]]:
+        calls.append((algo_key, algo_config, robot_kinematics, robot_command_mode))
+
+        def _policy(_obs: dict[str, Any]) -> tuple[float, float]:
+            return (0.0, 0.0)
+
+        return _policy, {"algorithm": algo_key}
+
+    policy, meta = build_registered_policy(
+        "demo",
+        {"gain": 2.0},
+        builders={"demo": _builder},
+        robot_kinematics="holonomic",
+        robot_command_mode="vxy",
+    )
+
+    assert policy({}) == (0.0, 0.0)
+    assert meta == {"algorithm": "demo"}
+    assert calls == [("demo", {"gain": 2.0}, "holonomic", "vxy")]
+
+
+def test_build_policy_simple_alias_still_uses_registered_goal_builder() -> None:
+    """Characterize an existing registry-routed alias before larger migrations."""
+    policy, meta = _build_policy(
+        "simple_policy",
+        {"max_speed": 0.4},
+        robot_kinematics="holonomic",
+        robot_command_mode="vxy",
+    )
+
+    linear, angular = policy(
+        {
+            "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+            "goal": {"current": [1.0, 0.0]},
+        }
+    )
+
+    assert linear == pytest.approx(0.4)
+    assert angular == pytest.approx(0.0)
+    assert meta["algorithm"] == "simple_policy"
+    assert meta["planner_kinematics"]["planner_command_space"] == "unicycle_vw"
 
 
 def test_goal_policy_supports_flat_map_runner_observation() -> None:


### PR DESCRIPTION
## Summary
Extracted the migrated policy-builder registry lookup from `map_runner._build_policy` into `robot_sf.benchmark.map_runner_policies.registry`, keeping unmigrated policy families on the existing inline fall-through path.

## Linked Issues
- Relates `#3384`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none; this branch starts from `origin/main` after the prior #3384 slices landed
- Stack follow-up issues: remaining #3384 migration children, if still desired
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `build_registered_policy(...)` and a `PolicyBuilder` protocol for registry dispatch.
- Replaced the inline `_POLICY_BUILDERS.get(...)` forwarding block in `_build_policy` with the helper.
- Added characterization tests for registry fall-through, builder-context forwarding, and the existing `simple_policy` registered goal alias.

## Why Matters
- Added value: lowers risk for future policy-builder package migration by making the registry dispatch seam directly testable.
- Expected impact: behavior-preserving refactor; no benchmark semantics intended to change.
- Why this worth merging now: it is a small, reviewable slice that stops before migrating another planner family.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support refactor for policy-builder maintainability only.
- Comparator baseline, applicable: NA
- Evidence tier: NA
- Result classification: NA
- Decision stop rule, applicable: NA
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3384 remains the parent tracking surface
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper only

## Domain-Aware Approval
- Required PR: yes - template evidence labels are present, but this is a support refactor with no benchmark, metric, paper-facing, or evidence-classification claim.
- Domains reviewed: benchmark policy construction refactor scope only.
- Status: waived - no domain approval needed before review because no benchmark semantics or evidence interpretation changed.
- Approver/review source waiver: self-review waiver for support refactor; reviewer can confirm no benchmark, metric, paper-facing, or evidence-classification semantics changed.
- Validity checklist: completed for support-refactor claim boundary.
- Target claim/hypothesis: behavior-preserving policy-builder registry dispatch extraction only.
- Comparator split/evidence validity: no comparator, scenario split, or benchmark-result validity claim is made.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution used as evidence.
- Claim boundary: behavior-preserving refactor only; no research or benchmark conclusion.
- Implementation integrity vs experimental validity: focused tests cover registry dispatch behavior; no experimental validity claim.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - support refactor
- Did intervention change command source, selected command, trajectory, route progress? No intended behavior change
- Did scenario actually contain targeted failure mode? NA
- Result route: continue #3384 migration in later small slices
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this helper extraction
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue future registry migration separately
- Proposed child issue existing follow-up: #3384 tracks remaining broad migration scope

## Validation / Proof
- `uv sync --all-extras` - passed
- `uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policies/registry.py tests/benchmark/test_map_runner_utils.py` - passed
- `uv run ruff format robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policies/registry.py tests/benchmark/test_map_runner_utils.py --check` - passed
- `uv run python -m py_compile robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policies/registry.py tests/benchmark/test_map_runner_utils.py` - passed
- `uv run pytest tests/benchmark/test_map_runner_utils.py -k 'policy_builder_registry or simple_alias_still_uses_registered_goal_builder or build_policy_trivial_reference_adapter_exposes_template_contract or build_policy_risk_dwa_routes_through_registered_adapter_builder'` - passed, 5 selected
- `uv run pytest tests/benchmark/test_map_runner_utils.py` - passed, 129 tests
- `git diff --check` - passed
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr_3384_body.md scripts/dev/pr_ready_check.sh` - passed; freshness stamp recorded for `58929688dc55317139fe9d7dab5e5521c4d8c7e1`

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: low; `_build_policy` still accepts the same inputs and falls through to legacy branches when a key is not registered.
- Failure modes: future builders must keep the same callable contract; new tests cover the forwarding contract.
- Rollback fallback plan: revert this helper extraction to restore direct dictionary lookup.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: issue #3384 and prior comments noting #3402/#3404 foundational slices
- Any assumptions need to preserved: remaining planner-family migrations should stay in later small PRs

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - PR links issue #3384; no issue comment authorized
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA - no generated registry/index
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark, metric, claim-map, paper-facing, or artifact propagation change

## Follow-Up Issues
- Deferred work: broad registry migration for the remaining policy families in #3384
- Issues opened follow-up: none

## Reviewer Notes
- Anything reviewer should verify closely: `build_registered_policy` returns `None` for unmigrated keys so `_build_policy` legacy dispatch is preserved.
- Any known limitations: this intentionally does not move another policy family out of `map_runner.py`.
