### PR TITLE
refactor: extract camera-ready scenario kinematics helper for #3385

### DIFF
--- a/robot_sf/benchmark/camera_ready/_config.py
+++ b/robot_sf/benchmark/camera_ready/_config.py
@@ -139,6 +139,28 @@ def _campaign_scenario_id(scenario: dict[str, Any]) -> str:
     return "unknown"
 
 
+def _scenario_with_kinematics(
+    scenario: dict[str, Any],
+    *,
+    kinematics: str,
+    holonomic_command_mode: str,
+) -> dict[str, Any]:
+    """Return a scenario copy patched for one robot kinematics mode.
+
+    Returns:
+        dict[str, Any]: Scenario payload with ``robot_config.type`` set.
+    """
+    patched = dict(scenario)
+    robot_cfg = (
+        dict(scenario.get("robot_config")) if isinstance(scenario.get("robot_config"), dict) else {}
+    )
+    robot_cfg["type"] = kinematics
+    if kinematics == "holonomic":
+        robot_cfg.setdefault("command_mode", holonomic_command_mode)
+    patched["robot_config"] = robot_cfg
+    return patched
+
+
 def _load_scenario_horizon_schedule(path: Path) -> dict[str, dict[str, Any]]:
     """Load and validate a scenario-horizon schedule sidecar.
 

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -50,6 +50,7 @@ from robot_sf.benchmark.camera_ready._config import (  # noqa: F401 - re-exporte
     _sanitize_name,
     _scenario_horizon_summary,
     _scenario_name_key,
+    _scenario_with_kinematics,
     _validate_scenario_amv_override_keys,
 )
 from robot_sf.benchmark.camera_ready._preflight import (
@@ -1869,28 +1870,6 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
     kinematics_matrix = _kinematics_matrix_or_default(cfg.kinematics_matrix)
     stop_requested = False
 
-    def _scenario_with_kinematics(
-        scenario: dict[str, Any],
-        *,
-        kinematics: str,
-    ) -> dict[str, Any]:
-        """Return a scenario copy patched for one robot kinematics mode.
-
-        Returns:
-            dict[str, Any]: Scenario payload with ``robot_config.type`` set.
-        """
-        patched = dict(scenario)
-        robot_cfg = (
-            dict(scenario.get("robot_config"))
-            if isinstance(scenario.get("robot_config"), dict)
-            else {}
-        )
-        robot_cfg["type"] = kinematics
-        if kinematics == "holonomic":
-            robot_cfg.setdefault("command_mode", cfg.holonomic_command_mode)
-        patched["robot_config"] = robot_cfg
-        return patched
-
     for planner in cfg.planners:
         if not planner.enabled:
             continue
@@ -1924,7 +1903,12 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
             summary: dict[str, Any]
             aggregates: dict[str, Any] | None = None
             scoped_scenarios = [
-                _scenario_with_kinematics(sc, kinematics=kinematics) for sc in scenarios
+                _scenario_with_kinematics(
+                    sc,
+                    kinematics=kinematics,
+                    holonomic_command_mode=cfg.holonomic_command_mode,
+                )
+                for sc in scenarios
             ]
 
             try:

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -47,6 +47,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     _sanitize_csv_cell,
     _sanitize_git_remote,
     _sanitize_name,
+    _scenario_with_kinematics,
     _sha256_file,
     load_campaign_config,
     prepare_campaign_preflight,
@@ -66,6 +67,50 @@ from robot_sf.benchmark.synthetic_actuation import (
     validate_synthetic_actuation_variability_distribution,
 )
 from robot_sf.common.artifact_paths import get_repository_root
+
+
+def test_scenario_with_kinematics_patches_copy_without_mutating_input() -> None:
+    """Scenario kinematics patching preserves unrelated fields and leaves input untouched."""
+    scenario = {
+        "name": "sample",
+        "robot_config": {"radius": 0.3, "type": "differential"},
+        "metadata": {"group": "smoke"},
+    }
+
+    patched = _scenario_with_kinematics(
+        scenario,
+        kinematics="unicycle",
+        holonomic_command_mode="vx_vy",
+    )
+
+    assert patched == {
+        "name": "sample",
+        "robot_config": {"radius": 0.3, "type": "unicycle"},
+        "metadata": {"group": "smoke"},
+    }
+    assert scenario["robot_config"] == {"radius": 0.3, "type": "differential"}
+    assert patched is not scenario
+    assert patched["robot_config"] is not scenario["robot_config"]
+
+
+def test_scenario_with_kinematics_sets_holonomic_command_mode_default() -> None:
+    """Holonomic scenarios get the campaign default command mode only when missing."""
+    patched = _scenario_with_kinematics(
+        {"name": "sample"},
+        kinematics="holonomic",
+        holonomic_command_mode="vx_vy",
+    )
+    preserved = _scenario_with_kinematics(
+        {"name": "sample", "robot_config": {"command_mode": "speed_heading"}},
+        kinematics="holonomic",
+        holonomic_command_mode="vx_vy",
+    )
+
+    assert patched["robot_config"] == {"type": "holonomic", "command_mode": "vx_vy"}
+    assert preserved["robot_config"] == {
+        "command_mode": "speed_heading",
+        "type": "holonomic",
+    }
 
 
 def test_load_campaign_config_resolves_relative_paths(tmp_path: Path):


### PR DESCRIPTION
## Summary

Issue: #3385 / https://github.com/ll7/robot_sf_ll7/issues/3385

- Extracts the scenario kinematics patcher from `run_campaign` into the existing `robot_sf.benchmark.camera_ready._config` package helper area.
- Keeps `robot_sf.benchmark.camera_ready_campaign` as the compatibility import surface.
- Adds focused characterization tests for the extracted helper's copy semantics, robot kinematics patching, and holonomic command-mode defaulting.

## Validation

- `uv run pytest tests/benchmark/test_camera_ready_campaign.py -k scenario_with_kinematics -q` - passed (`2 passed, 121 deselected`).
- `uv run pytest tests/benchmark/test_camera_ready_campaign.py::test_run_campaign_writes_core_artifacts -q` - passed (`1 passed`).
- `uv run ruff check robot_sf/benchmark/camera_ready/_config.py robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_camera_ready_campaign.py` - passed.
- `uv run ruff format --check robot_sf/benchmark/camera_ready/_config.py robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_camera_ready_campaign.py` - passed.
- `uv run python -m py_compile robot_sf/benchmark/camera_ready/_config.py robot_sf/benchmark/camera_ready_campaign.py tests/benchmark/test_camera_ready_campaign.py` - passed.
- `git diff --check origin/main...HEAD` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue3385_pr_body.md scripts/dev/pr_ready_check.sh` - passed; freshness stamp recorded for head `2b8c331dc4ab953a7434eca0f5aa4b7776a8afa6`.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` - passed (`fresh: true`, `tree_state: clean`).

## Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No campaign output format changes.

## Artifact classification

- No generated benchmark artifacts were promoted or committed.
- Ignored readiness/coverage outputs under `output/validation/` and `output/coverage/` were generated by local validation and remain disposable.
