### PR TITLE
Issue #3207: add fidelity manifest checker

### DIFF
--- a/robot_sf/benchmark/fidelity_sweep_manifest.py
+++ b/robot_sf/benchmark/fidelity_sweep_manifest.py
@@ -9,14 +9,12 @@ from __future__ import annotations
 
 import copy
 import json
+from collections.abc import Mapping
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from robot_sf.benchmark.fidelity_sensitivity import validate_fidelity_sensitivity_config
-
-if TYPE_CHECKING:
-    from collections.abc import Mapping
 
 FIDELITY_SWEEP_MANIFEST_SCHEMA = "fidelity-sweep-manifest.v1"
 FIDELITY_SWEEP_MANIFEST_CHECK_SCHEMA = "fidelity-sweep-manifest-check.v1"
@@ -102,6 +100,8 @@ def check_fidelity_sweep_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]
     Returns:
         JSON-serializable checker payload with coverage counts and boundary violations.
     """
+    if not isinstance(manifest, Mapping):
+        raise ValueError("fidelity sweep manifest must be a mapping")
     axes = manifest.get("axes")
     if not isinstance(axes, list):
         raise ValueError("fidelity sweep manifest must contain axes list")
@@ -184,11 +184,15 @@ def _check_manifest_axis(
     axis_payload_kinds: dict[str, int] = {}
     baseline_variants = 0
     unresolved_runtime_bindings = 0
+    actual_baseline_key = None
     for variant in variants:
         if not isinstance(variant, dict):
             raise ValueError("fidelity sweep manifest variant must be mapping")
-        baseline_variants += int(bool(variant.get("baseline", False)))
-        payload_kind = str(variant.get("payload_kind", "missing"))
+        if variant.get("baseline", False):
+            baseline_variants += 1
+            actual_baseline_key = variant.get("key")
+        payload_kind_value = variant.get("payload_kind")
+        payload_kind = str(payload_kind_value) if payload_kind_value is not None else "missing"
         payload_kind_counts[payload_kind] = payload_kind_counts.get(payload_kind, 0) + 1
         axis_payload_kinds[payload_kind] = axis_payload_kinds.get(payload_kind, 0) + 1
         if variant.get("runtime_binding_status") == UNRESOLVED_RUNTIME_BINDING:
@@ -201,6 +205,11 @@ def _check_manifest_axis(
 
     if baseline_variants != 1:
         violations.append(f"axis {axis.get('key')!r} must have exactly one baseline variant")
+    elif axis.get("baseline_variant") != actual_baseline_key:
+        violations.append(
+            f"axis {axis.get('key')!r} baseline_variant {axis.get('baseline_variant')!r} "
+            f"does not match baseline variant key {actual_baseline_key!r}"
+        )
     return {
         "variant_count": len(variants),
         "unresolved_runtime_binding_count": unresolved_runtime_bindings,

--- a/robot_sf/benchmark/fidelity_sweep_manifest.py
+++ b/robot_sf/benchmark/fidelity_sweep_manifest.py
@@ -174,7 +174,7 @@ def _check_manifest_axis(
     Returns:
         Axis summary plus per-axis counts used by the top-level checker.
     """
-    if not isinstance(axis, dict):
+    if not isinstance(axis, Mapping):
         raise ValueError("fidelity sweep manifest axis must be mapping")
     variants = axis.get("variants")
     if not isinstance(variants, list) or not variants:
@@ -186,7 +186,7 @@ def _check_manifest_axis(
     unresolved_runtime_bindings = 0
     actual_baseline_key = None
     for variant in variants:
-        if not isinstance(variant, dict):
+        if not isinstance(variant, Mapping):
             raise ValueError("fidelity sweep manifest variant must be mapping")
         if variant.get("baseline", False):
             baseline_variants += 1
@@ -226,6 +226,8 @@ def _append_manifest_boundary_violations(
     manifest: Mapping[str, Any], violations: list[str]
 ) -> None:
     """Append dry-run and no-evidence boundary violations in-place."""
+    if manifest.get("schema_version") != FIDELITY_SWEEP_MANIFEST_SCHEMA:
+        violations.append(f"manifest schema_version must remain {FIDELITY_SWEEP_MANIFEST_SCHEMA!r}")
     if manifest.get("dry_run") is not True:
         violations.append("manifest must remain dry_run=true")
     if manifest.get("status") != "manifest_dry_run_only":

--- a/robot_sf/benchmark/fidelity_sweep_manifest.py
+++ b/robot_sf/benchmark/fidelity_sweep_manifest.py
@@ -19,6 +19,7 @@ if TYPE_CHECKING:
     from collections.abc import Mapping
 
 FIDELITY_SWEEP_MANIFEST_SCHEMA = "fidelity-sweep-manifest.v1"
+FIDELITY_SWEEP_MANIFEST_CHECK_SCHEMA = "fidelity-sweep-manifest-check.v1"
 UNRESOLVED_RUNTIME_BINDING = "unresolved_runtime_binding"
 DRY_RUN_CLAIM_BOUNDARY = (
     "dry-run manifest only: enumerates the fixed issue #3207 fidelity sensitivity scope; "
@@ -95,6 +96,144 @@ def write_fidelity_sweep_manifest(manifest: Mapping[str, Any], output_dir: str |
     return manifest_path
 
 
+def check_fidelity_sweep_manifest(manifest: Mapping[str, Any]) -> dict[str, Any]:
+    """Summarize manifest factor coverage without upgrading evidence status.
+
+    Returns:
+        JSON-serializable checker payload with coverage counts and boundary violations.
+    """
+    axes = manifest.get("axes")
+    if not isinstance(axes, list):
+        raise ValueError("fidelity sweep manifest must contain axes list")
+
+    payload_kind_counts: dict[str, int] = {}
+    unresolved_runtime_bindings = 0
+    total_variants = 0
+    axis_summaries: list[dict[str, Any]] = []
+    violations: list[str] = []
+
+    for axis in axes:
+        axis_summary = _check_manifest_axis(
+            axis,
+            payload_kind_counts=payload_kind_counts,
+            violations=violations,
+        )
+        total_variants += int(axis_summary["variant_count"])
+        unresolved_runtime_bindings += int(axis_summary["unresolved_runtime_binding_count"])
+        axis_summaries.append(axis_summary["axis_summary"])
+
+    _append_manifest_boundary_violations(manifest, violations)
+
+    return {
+        "schema_version": FIDELITY_SWEEP_MANIFEST_CHECK_SCHEMA,
+        "status": "manifest_check_only",
+        "evidence_status": "not_benchmark_evidence",
+        "claim_boundary": (
+            "checker summary only: reviews dry-run fidelity factor coverage and "
+            "no-evidence boundaries; does not run sensitivity studies or establish "
+            "simulator-dependence conclusions."
+        ),
+        "manifest_schema_version": manifest.get("schema_version"),
+        "manifest_status": manifest.get("status"),
+        "axis_count": len(axes),
+        "variant_count": total_variants,
+        "payload_kind_counts": dict(sorted(payload_kind_counts.items())),
+        "unresolved_runtime_binding_count": unresolved_runtime_bindings,
+        "axis_summaries": axis_summaries,
+        "violations": violations,
+        "passes": not violations,
+    }
+
+
+def write_fidelity_sweep_manifest_check(
+    check_summary: Mapping[str, Any], output_dir: str | Path
+) -> Path:
+    """Write deterministic JSON fidelity sweep manifest checker summary.
+
+    Returns:
+        Path written JSON checker summary.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    check_path = out / "fidelity_sweep_manifest_check.json"
+    check_path.write_text(
+        json.dumps(check_summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return check_path
+
+
+def _check_manifest_axis(
+    axis: Any,
+    *,
+    payload_kind_counts: dict[str, int],
+    violations: list[str],
+) -> dict[str, Any]:
+    """Check one axis and update shared coverage counters.
+
+    Returns:
+        Axis summary plus per-axis counts used by the top-level checker.
+    """
+    if not isinstance(axis, dict):
+        raise ValueError("fidelity sweep manifest axis must be mapping")
+    variants = axis.get("variants")
+    if not isinstance(variants, list) or not variants:
+        violations.append(f"axis {axis.get('key')!r} has no variants")
+        variants = []
+
+    axis_payload_kinds: dict[str, int] = {}
+    baseline_variants = 0
+    unresolved_runtime_bindings = 0
+    for variant in variants:
+        if not isinstance(variant, dict):
+            raise ValueError("fidelity sweep manifest variant must be mapping")
+        baseline_variants += int(bool(variant.get("baseline", False)))
+        payload_kind = str(variant.get("payload_kind", "missing"))
+        payload_kind_counts[payload_kind] = payload_kind_counts.get(payload_kind, 0) + 1
+        axis_payload_kinds[payload_kind] = axis_payload_kinds.get(payload_kind, 0) + 1
+        if variant.get("runtime_binding_status") == UNRESOLVED_RUNTIME_BINDING:
+            unresolved_runtime_bindings += 1
+        else:
+            violations.append(
+                f"axis {axis.get('key')!r} variant {variant.get('key')!r} "
+                "does not preserve unresolved runtime binding status"
+            )
+
+    if baseline_variants != 1:
+        violations.append(f"axis {axis.get('key')!r} must have exactly one baseline variant")
+    return {
+        "variant_count": len(variants),
+        "unresolved_runtime_binding_count": unresolved_runtime_bindings,
+        "axis_summary": {
+            "key": str(axis.get("key", "")),
+            "variant_count": len(variants),
+            "baseline_variant": axis.get("baseline_variant"),
+            "payload_kind_counts": dict(sorted(axis_payload_kinds.items())),
+        },
+    }
+
+
+def _append_manifest_boundary_violations(
+    manifest: Mapping[str, Any], violations: list[str]
+) -> None:
+    """Append dry-run and no-evidence boundary violations in-place."""
+    if manifest.get("dry_run") is not True:
+        violations.append("manifest must remain dry_run=true")
+    if manifest.get("status") != "manifest_dry_run_only":
+        violations.append("manifest status must remain manifest_dry_run_only")
+    if manifest.get("evidence_status") != "not_benchmark_evidence":
+        violations.append("manifest evidence_status must remain not_benchmark_evidence")
+    claim_boundary = str(manifest.get("claim_boundary", ""))
+    for required_phrase in (
+        "not benchmark evidence",
+        "not simulator-realism evidence",
+        "not sim-to-real evidence",
+        "not paper-facing evidence",
+    ):
+        if required_phrase not in claim_boundary:
+            violations.append(f"claim_boundary must include {required_phrase!r}")
+
+
 def _axis_manifest(axis: Mapping[str, Any]) -> dict[str, Any]:
     """Normalize one canonical axis while preserving source variant order.
 
@@ -165,9 +304,12 @@ def _surface_relationship(config: Mapping[str, Any]) -> dict[str, Any]:
 
 __all__ = [
     "DRY_RUN_CLAIM_BOUNDARY",
+    "FIDELITY_SWEEP_MANIFEST_CHECK_SCHEMA",
     "FIDELITY_SWEEP_MANIFEST_SCHEMA",
     "UNRESOLVED_RUNTIME_BINDING",
     "ManifestOptions",
     "build_fidelity_sweep_manifest",
+    "check_fidelity_sweep_manifest",
     "write_fidelity_sweep_manifest",
+    "write_fidelity_sweep_manifest_check",
 ]

--- a/scripts/benchmark/build_fidelity_sweep_manifest.py
+++ b/scripts/benchmark/build_fidelity_sweep_manifest.py
@@ -11,7 +11,9 @@ from robot_sf.benchmark.fidelity_sensitivity import load_fidelity_sensitivity_co
 from robot_sf.benchmark.fidelity_sweep_manifest import (
     ManifestOptions,
     build_fidelity_sweep_manifest,
+    check_fidelity_sweep_manifest,
     write_fidelity_sweep_manifest,
+    write_fidelity_sweep_manifest_check,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -30,6 +32,14 @@ def _git_head() -> str:
     except (FileNotFoundError, subprocess.SubprocessError):
         return "unknown"
     return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def _display_path(path: Path) -> Path:
+    """Return repo-relative path when possible, otherwise the original path."""
+    try:
+        return path.relative_to(REPO_ROOT)
+    except ValueError:
+        return path
 
 
 def parse_args() -> argparse.Namespace:
@@ -51,6 +61,11 @@ def parse_args() -> argparse.Namespace:
         required=True,
         help="Required acknowledgement that this only builds a manifest and runs no sweep.",
     )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Also write opt-in fidelity_sweep_manifest_check.json summary.",
+    )
     return parser.parse_args()
 
 
@@ -67,7 +82,11 @@ def main() -> int:
         ),
     )
     manifest_path = write_fidelity_sweep_manifest(manifest, REPO_ROOT / args.out)
-    print(f"wrote dry-run fidelity sweep manifest: {manifest_path.relative_to(REPO_ROOT)}")
+    print(f"wrote dry-run fidelity sweep manifest: {_display_path(manifest_path)}")
+    if args.check:
+        check_summary = check_fidelity_sweep_manifest(manifest)
+        check_path = write_fidelity_sweep_manifest_check(check_summary, REPO_ROOT / args.out)
+        print(f"wrote dry-run fidelity sweep manifest check: {_display_path(check_path)}")
     return 0
 
 

--- a/tests/benchmark/test_fidelity_sweep_manifest_check.py
+++ b/tests/benchmark/test_fidelity_sweep_manifest_check.py
@@ -97,6 +97,17 @@ def test_manifest_checker_flags_baseline_variant_mismatch() -> None:
     )
 
 
+def test_manifest_checker_fails_closed_on_unsupported_manifest_schema() -> None:
+    """Checker fails closed when the manifest schema_version drifts from the known schema."""
+    manifest = _repo_manifest()
+    manifest["schema_version"] = "fidelity-sweep-manifest.v2"
+
+    summary = check_fidelity_sweep_manifest(manifest)
+
+    assert summary["passes"] is False
+    assert any("schema_version must remain" in violation for violation in summary["violations"])
+
+
 def test_manifest_checker_rejects_non_mapping_manifest() -> None:
     """Checker raises a clear error instead of AttributeError on a non-mapping manifest."""
     with pytest.raises(ValueError, match="must be a mapping"):

--- a/tests/benchmark/test_fidelity_sweep_manifest_check.py
+++ b/tests/benchmark/test_fidelity_sweep_manifest_check.py
@@ -1,0 +1,127 @@
+"""Tests for issue #3207 dry-run fidelity manifest checker summaries."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.fidelity_sensitivity import load_fidelity_sensitivity_config
+from robot_sf.benchmark.fidelity_sweep_manifest import (
+    FIDELITY_SWEEP_MANIFEST_CHECK_SCHEMA,
+    ManifestOptions,
+    build_fidelity_sweep_manifest,
+    check_fidelity_sweep_manifest,
+    write_fidelity_sweep_manifest,
+    write_fidelity_sweep_manifest_check,
+)
+
+if TYPE_CHECKING:
+    from types import ModuleType
+
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_CONFIG_PATH = "configs/research/fidelity_sensitivity_v1.yaml"
+
+
+def _repo_manifest() -> dict[str, object]:
+    config = load_fidelity_sensitivity_config(_CONFIG_PATH)
+    return build_fidelity_sweep_manifest(
+        config,
+        options=ManifestOptions(config_path=_CONFIG_PATH, git_head="abc1234"),
+    )
+
+
+def _load_manifest_builder() -> ModuleType:
+    module_path = _REPO_ROOT / "scripts" / "benchmark" / "build_fidelity_sweep_manifest.py"
+    spec = importlib.util.spec_from_file_location("build_fidelity_sweep_manifest", module_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not load builder module from {module_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules["build_fidelity_sweep_manifest"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_manifest_checker_summarizes_factor_coverage_without_evidence_upgrade() -> None:
+    """Checker reports factor coverage while preserving no-claim boundaries."""
+    manifest = _repo_manifest()
+
+    summary = check_fidelity_sweep_manifest(manifest)
+
+    assert summary["schema_version"] == FIDELITY_SWEEP_MANIFEST_CHECK_SCHEMA
+    assert summary["status"] == "manifest_check_only"
+    assert summary["evidence_status"] == "not_benchmark_evidence"
+    assert "does not run sensitivity studies" in summary["claim_boundary"]
+    assert summary["passes"] is True
+    assert summary["violations"] == []
+    assert summary["axis_count"] == len(manifest["axes"])
+    assert summary["variant_count"] == sum(len(axis["variants"]) for axis in manifest["axes"])
+    assert summary["unresolved_runtime_binding_count"] == summary["variant_count"]
+    assert summary["payload_kind_counts"]["patch"] >= 1
+    assert summary["payload_kind_counts"]["observation_noise"] >= 1
+    assert [axis["key"] for axis in summary["axis_summaries"]] == [
+        axis["key"] for axis in manifest["axes"]
+    ]
+
+
+def test_manifest_checker_fails_closed_on_evidence_boundary_violation() -> None:
+    """Checker surfaces evidence-boundary regressions instead of silently passing."""
+    manifest = _repo_manifest()
+    manifest["evidence_status"] = "benchmark_evidence"
+    manifest["claim_boundary"] = "benchmark evidence"
+    manifest["axes"][0]["variants"][0]["runtime_binding_status"] = "bound_runtime_patch"
+
+    summary = check_fidelity_sweep_manifest(manifest)
+
+    assert summary["passes"] is False
+    assert "manifest evidence_status must remain not_benchmark_evidence" in summary["violations"]
+    assert any("not benchmark evidence" in violation for violation in summary["violations"])
+    assert any("unresolved runtime binding" in violation for violation in summary["violations"])
+
+
+def test_manifest_checker_json_output_is_deterministic(tmp_path: Path) -> None:
+    """Checker JSON writes deterministically alongside dry-run manifest output."""
+    manifest = _repo_manifest()
+    summary = check_fidelity_sweep_manifest(manifest)
+
+    manifest_path = write_fidelity_sweep_manifest(manifest, tmp_path)
+    check_path = write_fidelity_sweep_manifest_check(summary, tmp_path)
+    reloaded_summary = json.loads(check_path.read_text(encoding="utf-8"))
+
+    assert manifest_path.name == "fidelity_sweep_manifest.json"
+    assert check_path.name == "fidelity_sweep_manifest_check.json"
+    assert reloaded_summary == summary
+    assert check_path.read_text(encoding="utf-8") == (
+        json.dumps(summary, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def test_manifest_builder_cli_writes_check_summary_when_requested(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """CLI check mode writes a checker summary without changing dry-run behavior."""
+    builder = _load_manifest_builder()
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "build_fidelity_sweep_manifest.py",
+            "--dry-run",
+            "--check",
+            "--out",
+            str(tmp_path),
+        ],
+    )
+
+    assert builder.main() == 0
+    manifest_path = tmp_path / "fidelity_sweep_manifest.json"
+    check_path = tmp_path / "fidelity_sweep_manifest_check.json"
+    check_summary = json.loads(check_path.read_text(encoding="utf-8"))
+
+    assert manifest_path.exists()
+    assert check_summary["schema_version"] == FIDELITY_SWEEP_MANIFEST_CHECK_SCHEMA
+    assert check_summary["status"] == "manifest_check_only"
+    assert check_summary["passes"] is True

--- a/tests/benchmark/test_fidelity_sweep_manifest_check.py
+++ b/tests/benchmark/test_fidelity_sweep_manifest_check.py
@@ -8,6 +8,8 @@ import sys
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pytest
+
 from robot_sf.benchmark.fidelity_sensitivity import load_fidelity_sensitivity_config
 from robot_sf.benchmark.fidelity_sweep_manifest import (
     FIDELITY_SWEEP_MANIFEST_CHECK_SCHEMA,
@@ -80,6 +82,25 @@ def test_manifest_checker_fails_closed_on_evidence_boundary_violation() -> None:
     assert "manifest evidence_status must remain not_benchmark_evidence" in summary["violations"]
     assert any("not benchmark evidence" in violation for violation in summary["violations"])
     assert any("unresolved runtime binding" in violation for violation in summary["violations"])
+
+
+def test_manifest_checker_flags_baseline_variant_mismatch() -> None:
+    """Checker fails closed when axis baseline_variant no longer matches its baseline key."""
+    manifest = _repo_manifest()
+    manifest["axes"][0]["baseline_variant"] = "not-a-real-variant-key"
+
+    summary = check_fidelity_sweep_manifest(manifest)
+
+    assert summary["passes"] is False
+    assert any(
+        "does not match baseline variant key" in violation for violation in summary["violations"]
+    )
+
+
+def test_manifest_checker_rejects_non_mapping_manifest() -> None:
+    """Checker raises a clear error instead of AttributeError on a non-mapping manifest."""
+    with pytest.raises(ValueError, match="must be a mapping"):
+        check_fidelity_sweep_manifest(None)  # type: ignore[arg-type]
 
 
 def test_manifest_checker_json_output_is_deterministic(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds an opt-in dry-run checker for the existing issue #3207 fidelity sweep manifest. The checker summarizes fidelity-factor coverage, unresolved runtime bindings, and no-evidence boundary violations without running any sensitivity study.

## Linked Issues
- Relates #3207

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `check_fidelity_sweep_manifest()` and `write_fidelity_sweep_manifest_check()` to the existing dry-run manifest module.
- Added `--check` to `scripts/benchmark/build_fidelity_sweep_manifest.py` to write `fidelity_sweep_manifest_check.json` only when requested.
- Added unit tests for checker summaries, fail-closed boundary violations, deterministic JSON, and the CLI check path.

## Why Matters
- Added value: reviewers can inspect the planned fidelity-factor surface and evidence-boundary status before any study execution.
- Expected impact: reduces risk of accidentally treating dry-run manifests as benchmark or simulator-dependence evidence.
- Why worth merging now: it is a small support slice for #3207 and does not broaden the research claim boundary.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support checker only; no study result or validity-boundary conclusion.
- Comparator or baseline, applicable: NA
- Evidence tier: NA - support helper exercised on tracked config path only
- Result classification: NA - no research result
- Decision stop rule, applicable: NA
- Parent issue, claim map, registry, context note, synthesis surface update: #3207 remains open; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper that checks dry-run manifest coverage and boundaries without interpreting benchmark evidence.

## Domain-Aware Approval
approval concerns experimental validity waived / pending / blocked / not required
- Approver/review source waiver: not required; this PR does not produce or interpret experimental evidence.
- Validity checklist: no benchmark campaign run, no degraded/fallback success claim, no simulator-realism conclusion.
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: no benchmark execution.
- Claim boundary: checker summary only; not benchmark evidence, not simulator-realism evidence, not sim-to-real evidence, not paper-facing evidence.
- Implementation integrity vs experimental validity: implementation only validates manifest structure and boundary metadata.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA for this support PR
- Extractor analysis tool needed: no
- Artifact missing unavailable: none for the checker slice
- Stop / revise / continue decision: continue #3207 only through separately authorized study execution.
- Proposed child issue existing follow-up: #3207 remains the parent scope.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- python -m py_compile robot_sf/benchmark/fidelity_sweep_manifest.py scripts/benchmark/build_fidelity_sweep_manifest.py tests/benchmark/test_fidelity_sweep_manifest_check.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_fidelity_sweep_manifest.py tests/benchmark/test_fidelity_sweep_manifest_check.py` - passed, 9 tests
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/fidelity_sweep_manifest.py scripts/benchmark/build_fidelity_sweep_manifest.py tests/benchmark/test_fidelity_sweep_manifest.py tests/benchmark/test_fidelity_sweep_manifest_check.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check robot_sf/benchmark/fidelity_sweep_manifest.py scripts/benchmark/build_fidelity_sweep_manifest.py tests/benchmark/test_fidelity_sweep_manifest.py tests/benchmark/test_fidelity_sweep_manifest_check.py` - passed
- `git diff --check` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/benchmark/build_fidelity_sweep_manifest.py --dry-run --check --out output/issue_3207_manifest_check_validation` - passed; generated ignored local validation files and then removed them.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance and Scalability
- Baseline runtime: NA - no runtime/performance behavior changed.
- Changed runtime: NA - no runtime/performance behavior changed.
- Representative command: `python scripts/benchmark/build_fidelity_sweep_manifest.py --dry-run --check --out output/issue_3207_manifest_check_validation`
- Hot-path call count profile anchor: NA - no hot path touched.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: checker emits false passing status for benchmark-evidence or runtime-binding boundary violations.

## Risks / Rollout
- Compatibility risks: low; existing manifest output remains unchanged unless `--check` is provided.
- Failure modes: checker could under-report a future manifest field until tests are updated.
- Rollback fallback plan: remove `--check` flag and helper exports.

## Docs / Provenance
- Updated docs: NA
- Relevant design provenance notes: issue #3207 and prior merged manifest path.
- Any assumptions need to preserved: dry-run manifest/checker output is not benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - user requested no issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this is a support checker only and does not produce benchmark, registry, claim-map, paper-facing, or durable evidence changes.

## Follow-Up Issues
- Deferred work: actual sensitivity studies and conclusions remain out of scope for this PR and remain tracked by #3207.
- Issues opened follow-up: none

## Reviewer Notes
- Verify closely that the checker preserves `not_benchmark_evidence` and unresolved runtime-binding boundaries.
- Any known limitations: checker summarizes manifest metadata only; it does not prove runtime patch binding or simulator fidelity behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional manifest check output for benchmark runs.
  * The command-line manifest builder can now generate a separate JSON summary when requested.

* **Bug Fixes**
  * Improved validation of manifest structure and coverage counts.
  * Added safeguards to reject invalid manifests and boundary mismatches.
  * Ensured the generated check summary is written deterministically.

* **Tests**
  * Added coverage for manifest validation, error handling, JSON output consistency, and the new CLI behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->