### PR TITLE
Issue #2921: add failure archive export index

### DIFF
--- a/robot_sf/adversarial/archive.py
+++ b/robot_sf/adversarial/archive.py
@@ -102,6 +102,79 @@ def curate_failure_archive(
     return payload
 
 
+def failure_archive_feature_rows(archive: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return deterministic tabular metadata rows from a failure archive.
+
+    The rows intentionally contain compact archive metadata and scalar candidate
+    fields only. They are suitable for fixture-based proposal-model plumbing and
+    index/export checks, not for training claims on raw traces.
+    """
+    rows: list[dict[str, Any]] = []
+    for entry in _archive_entries(archive):
+        candidate = entry.get("candidate") if isinstance(entry.get("candidate"), dict) else {}
+        start = candidate.get("start") if isinstance(candidate.get("start"), dict) else {}
+        goal = candidate.get("goal") if isinstance(candidate.get("goal"), dict) else {}
+        attribution = (
+            entry.get("failure_attribution")
+            if isinstance(entry.get("failure_attribution"), dict)
+            else {}
+        )
+        details = attribution.get("details") if isinstance(attribution.get("details"), dict) else {}
+        cluster_key = entry.get("cluster_key") if isinstance(entry.get("cluster_key"), dict) else {}
+
+        rows.append(
+            {
+                "archive_id": str(entry.get("archive_id", "")),
+                "cluster_key": _stable_json(cluster_key),
+                "source_manifest": _as_optional_str(entry.get("source_manifest")),
+                "source_candidate_index": entry.get("source_candidate_index"),
+                "bundle_path": _as_optional_str(entry.get("bundle_path")),
+                "scenario_yaml_path": _as_optional_str(entry.get("scenario_yaml_path")),
+                "start_x": _finite_float(start.get("x")),
+                "start_y": _finite_float(start.get("y")),
+                "goal_x": _finite_float(goal.get("x")),
+                "goal_y": _finite_float(goal.get("y")),
+                "spawn_time_s": _finite_float(candidate.get("spawn_time_s")),
+                "pedestrian_speed_mps": _finite_float(candidate.get("pedestrian_speed_mps")),
+                "pedestrian_delay_s": _finite_float(candidate.get("pedestrian_delay_s")),
+                "scenario_seed": _finite_float(candidate.get("scenario_seed")),
+                "objective_value": _finite_float(entry.get("objective_value")),
+                "primary_failure": _as_optional_str(attribution.get("primary_failure")),
+                "termination_reason": _as_optional_str(details.get("termination_reason")),
+                "normalized_perturbation": _finite_float(entry.get("normalized_perturbation")),
+                "replay_command": _as_optional_str(entry.get("replay_command")),
+            }
+        )
+    return sorted(rows, key=lambda row: row["archive_id"])
+
+
+def failure_archive_index(archive: dict[str, Any]) -> dict[str, Any]:
+    """Build stable lookup indexes over archive feature rows."""
+    rows = failure_archive_feature_rows(archive)
+    by_archive_id: dict[str, dict[str, Any]] = {}
+    by_cluster_key: dict[str, list[str]] = defaultdict(list)
+    by_primary_failure: dict[str, list[str]] = defaultdict(list)
+    by_scenario_seed: dict[str, list[str]] = defaultdict(list)
+
+    for row in rows:
+        archive_id = row["archive_id"]
+        by_archive_id[archive_id] = row
+        by_cluster_key[str(row["cluster_key"])].append(archive_id)
+        by_primary_failure[str(row["primary_failure"])].append(archive_id)
+        seed = row.get("scenario_seed")
+        if seed is not None:
+            by_scenario_seed[_stable_number_key(seed)].append(archive_id)
+
+    return {
+        "schema_version": "adversarial_failure_archive_index.v1",
+        "row_count": len(rows),
+        "by_archive_id": by_archive_id,
+        "by_cluster_key": _sorted_list_index(by_cluster_key),
+        "by_primary_failure": _sorted_list_index(by_primary_failure),
+        "by_scenario_seed": _sorted_list_index(by_scenario_seed),
+    }
+
+
 def _load_search_manifest(path: Path) -> dict[str, Any]:
     """Load one adversarial search manifest and validate the schema tag."""
     payload = json.loads(path.read_text(encoding="utf-8"))
@@ -290,4 +363,43 @@ def _as_optional_str(value: Any) -> str | None:
     return str(value)
 
 
-__all__ = ["ARCHIVE_SCHEMA_VERSION", "curate_failure_archive"]
+def _archive_entries(archive: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return archive entries, raising for malformed archive payloads."""
+    if not isinstance(archive, dict):
+        raise ValueError("Failure archive must be a JSON object.")
+    schema = archive.get("schema_version")
+    if schema != ARCHIVE_SCHEMA_VERSION:
+        raise ValueError(
+            f"Unsupported failure archive schema {schema!r}; expected {ARCHIVE_SCHEMA_VERSION!r}"
+        )
+    entries = archive.get("entries")
+    if not isinstance(entries, list):
+        raise ValueError("Failure archive entries must be a list.")
+    if not all(isinstance(entry, dict) for entry in entries):
+        raise ValueError("Failure archive entries must be JSON objects.")
+    return entries
+
+
+def _stable_json(value: Any) -> str:
+    """Return deterministic compact JSON string for index keys."""
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def _stable_number_key(value: float) -> str:
+    """Return stable key for numeric index values."""
+    if float(value).is_integer():
+        return str(int(value))
+    return str(value)
+
+
+def _sorted_list_index(index: dict[str, list[str]]) -> dict[str, list[str]]:
+    """Return deterministic index lists sorted by key and archive id."""
+    return {key: sorted(values) for key, values in sorted(index.items())}
+
+
+__all__ = [
+    "ARCHIVE_SCHEMA_VERSION",
+    "curate_failure_archive",
+    "failure_archive_feature_rows",
+    "failure_archive_index",
+]

--- a/robot_sf/adversarial/proposal_model.py
+++ b/robot_sf/adversarial/proposal_model.py
@@ -6,6 +6,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+from robot_sf.adversarial.archive import failure_archive_feature_rows
 from robot_sf.adversarial.certification import CertificationStatus, certify_candidate
 from robot_sf.adversarial.config import CandidateSpec, SearchSpaceConfig
 from robot_sf.adversarial.scenario_manifest import (
@@ -74,31 +75,9 @@ class FailureArchiveProposalModel:
 
     def get_tabular_view(self) -> list[dict[str, Any]]:
         """Build a tabular feature view from archive entries."""
-        table = []
-        for entry in self.entries:
-            cand = entry.get("candidate", {})
-            start = cand.get("start", {})
-            goal = cand.get("goal", {})
-            attr = entry.get("failure_attribution", {})
-            row = {
-                "archive_id": entry.get("archive_id", ""),
-                "start_x": start.get("x"),
-                "start_y": start.get("y"),
-                "goal_x": goal.get("x"),
-                "goal_y": goal.get("y"),
-                "spawn_time_s": cand.get("spawn_time_s"),
-                "pedestrian_speed_mps": cand.get("pedestrian_speed_mps"),
-                "pedestrian_delay_s": cand.get("pedestrian_delay_s"),
-                "scenario_seed": cand.get("scenario_seed"),
-                "objective_value": entry.get("objective_value"),
-                "primary_failure": attr.get("primary_failure"),
-                "termination_reason": attr.get("details", {}).get("termination_reason")
-                if isinstance(attr.get("details"), dict)
-                else None,
-                "normalized_perturbation": entry.get("normalized_perturbation"),
-            }
-            table.append(row)
-        return table
+        return failure_archive_feature_rows(
+            {"schema_version": "adversarial_failure_archive.v1", "entries": self.entries}
+        )
 
     def _get_candidate_value(self, cand_dict: dict[str, Any], name: str) -> float | None:
         """Helper to safely extract a scalar feature from candidate dict."""

--- a/tests/adversarial/test_failure_archive.py
+++ b/tests/adversarial/test_failure_archive.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 import pytest
 
-from robot_sf.adversarial.archive import curate_failure_archive
+from robot_sf.adversarial.archive import (
+    curate_failure_archive,
+    failure_archive_feature_rows,
+    failure_archive_index,
+)
 from scripts.tools.curate_adversarial_failure_archive import main as archive_cli_main
 
 
@@ -212,6 +216,79 @@ def test_simulation_error_candidates_excluded_from_archive(tmp_path: Path) -> No
     assert archive["summary"]["source_candidate_count"] == 6, (
         "source_candidate_count must still count simulation_error for budget auditing"
     )
+
+
+def test_failure_archive_feature_rows_are_deterministic_export_slice(tmp_path: Path) -> None:
+    """Archive feature rows expose stable scalar metadata for proposal fixtures."""
+    manifest_path = _manifest(tmp_path)
+    archive = curate_failure_archive([manifest_path], output_path=tmp_path / "archive.json")
+
+    rows = failure_archive_feature_rows(archive)
+
+    assert [row["archive_id"] for row in rows] == [
+        "failure_0000",
+        "failure_0001",
+        "failure_0002",
+    ]
+    assert rows[0] == {
+        "archive_id": "failure_0000",
+        "cluster_key": (
+            '{"policy":"goal","primary_failure":"collision",'
+            '"scenario_template":"configs/scenarios/templates/crossing_ttc.yaml",'
+            '"termination_reason":"collision"}'
+        ),
+        "source_manifest": manifest_path.as_posix(),
+        "source_candidate_index": 0,
+        "bundle_path": "output/adversarial/run/candidate_0000",
+        "scenario_yaml_path": "output/adversarial/run/candidate_0000/scenario.yaml",
+        "start_x": 0.25,
+        "start_y": 2.0,
+        "goal_x": 5.0,
+        "goal_y": 2.0,
+        "spawn_time_s": 0.0,
+        "pedestrian_speed_mps": 1.0,
+        "pedestrian_delay_s": 0.0,
+        "scenario_seed": 7.0,
+        "objective_value": 9.0,
+        "primary_failure": "collision",
+        "termination_reason": "collision",
+        "normalized_perturbation": 0.4375,
+        "replay_command": (
+            "uv run robot_sf_bench run --matrix "
+            "output/adversarial/run/candidate_0000/scenario.yaml "
+            "--out output/adversarial/run/candidate_0000/episode_records_replay.jsonl "
+            "--algo goal --no-video"
+        ),
+    }
+
+
+def test_failure_archive_index_groups_export_rows(tmp_path: Path) -> None:
+    """Archive index supports lookup by id, mechanism, failure, and seed."""
+    archive = curate_failure_archive([_manifest(tmp_path)], output_path=tmp_path / "archive.json")
+
+    index = failure_archive_index(archive)
+
+    assert index["schema_version"] == "adversarial_failure_archive_index.v1"
+    assert index["row_count"] == 3
+    assert sorted(index["by_archive_id"]) == ["failure_0000", "failure_0001", "failure_0002"]
+    assert index["by_primary_failure"] == {
+        "collision": ["failure_0000", "failure_0001"],
+        "timeout": ["failure_0002"],
+    }
+    assert index["by_scenario_seed"] == {
+        "7": ["failure_0000"],
+        "8": ["failure_0001"],
+        "9": ["failure_0002"],
+    }
+
+
+def test_failure_archive_feature_rows_reject_malformed_archives() -> None:
+    """Export helpers fail closed for non-archive payloads."""
+    with pytest.raises(ValueError, match="Unsupported failure archive schema"):
+        failure_archive_feature_rows({"schema_version": "unexpected", "entries": []})
+
+    with pytest.raises(ValueError, match="entries must be a list"):
+        failure_archive_index({"schema_version": "adversarial_failure_archive.v1", "entries": {}})
 
 
 def test_curate_failure_archive_cli_writes_summary(


### PR DESCRIPTION
## Issue

Closes/addresses https://github.com/ll7/robot_sf_ll7/issues/2921.

## Scope Summary

This is the narrow `failure_archive_export_slice` for the learned-proposal issue. It adds archive-owned helpers to produce deterministic scalar feature rows and stable lookup indexes from `adversarial_failure_archive.v1` payloads, then routes `FailureArchiveProposalModel.get_tabular_view()` through that canonical export surface.

The fixture coverage verifies row determinism, index grouping by archive ID/failure/seed, malformed archive fail-closed behavior, and existing proposal-model compatibility.

## Validation Command Results

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/adversarial/test_failure_archive.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py -q` exited 0; 21 tests passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/adversarial/archive.py robot_sf/adversarial/proposal_model.py tests/adversarial/test_failure_archive.py` exited 0; all checks passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/adversarial/archive.py robot_sf/adversarial/proposal_model.py tests/adversarial/test_failure_archive.py` exited 0; 3 files left unchanged.
- `git diff --check` exited 0.

## Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. This PR does not claim held-out yield improvement or benchmark-strength learned-proposal evidence.

## Handoff

Per ready-queue instructions, Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and merge authority after this PR is open.
