### PR TITLE
#3480 tracking-precision run spec and speed-contract fixtures

### DIFF
--- a/robot_sf/benchmark/tracking_precision_contract.py
+++ b/robot_sf/benchmark/tracking_precision_contract.py
@@ -29,6 +29,8 @@ opt-in follow-up.
 
 from __future__ import annotations
 
+import hashlib
+import json
 import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
@@ -39,8 +41,157 @@ if TYPE_CHECKING:
     from numpy.typing import NDArray
 
 TRACKING_PRECISION_SCHEMA = "tracking_precision_contract.v1"
+TRACKING_PRECISION_INTERPRETATION = (
+    "internal_non_hardware_tracking_precision_proxy_not_a_real_sensor_model"
+)
+TRACKING_PRECISION_MODES = frozenset({"diagnostic", "clamp"})
+
+_DEFAULT_SPEED_CONTRACT_SPEC: dict[str, Any] = {
+    "threshold_m": 2.5,
+    "default_speed": 2.0,
+    "defensive_speed": 0.5,
+    "mode": "diagnostic",
+}
+
+_DEFAULT_SPEC: dict[str, Any] = {
+    "enabled": False,
+    "target_motp_m": 0.0,
+    "speed_contract": _DEFAULT_SPEED_CONTRACT_SPEC,
+    "seed_salt": 0,
+    "schema_version": TRACKING_PRECISION_SCHEMA,
+    "interpretation": TRACKING_PRECISION_INTERPRETATION,
+}
 # Rayleigh mean factor: mean Euclidean error = per-axis sigma * sqrt(pi/2).
 _RAYLEIGH_MEAN_FACTOR = math.sqrt(math.pi / 2.0)
+
+
+def tracking_precision_hash(spec: dict[str, Any]) -> str:
+    """Return stable short hash for a normalized tracking-precision spec."""
+
+    encoded = json.dumps(spec, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha1(encoded).hexdigest()[:12]
+
+
+def _normalize_speed_contract_spec(speed_contract: Any) -> dict[str, Any]:
+    """Validate the nested speed-contract block.
+
+    Returns:
+        Canonical speed-contract spec.
+    """
+
+    normalized = dict(_DEFAULT_SPEED_CONTRACT_SPEC)
+    if speed_contract is None:
+        return normalized
+    if not isinstance(speed_contract, dict):
+        raise TypeError("tracking_precision.speed_contract must be a mapping")
+
+    aliases = {
+        "precision_threshold_m": "threshold_m",
+        "defensive_speed_cap": "defensive_speed",
+        "default_speed_cap": "default_speed",
+    }
+    for key, value in speed_contract.items():
+        canonical_key = aliases.get(key, key)
+        if canonical_key not in normalized:
+            raise ValueError(f"unknown tracking_precision.speed_contract key: {key}")
+        normalized[canonical_key] = value
+
+    normalized["threshold_m"] = float(normalized["threshold_m"])
+    normalized["default_speed"] = float(normalized["default_speed"])
+    normalized["defensive_speed"] = float(normalized["defensive_speed"])
+    normalized["mode"] = str(normalized["mode"])
+    if normalized["mode"] not in TRACKING_PRECISION_MODES:
+        raise ValueError(
+            "tracking_precision.speed_contract.mode must be one of "
+            f"{sorted(TRACKING_PRECISION_MODES)}"
+        )
+    TrackingPrecisionContract(
+        precision_threshold_m=normalized["threshold_m"],
+        default_speed_cap=normalized["default_speed"],
+        defensive_speed_cap=normalized["defensive_speed"],
+    )
+    return normalized
+
+
+def normalize_tracking_precision_spec(spec: dict[str, Any] | None) -> dict[str, Any]:
+    """Validate and normalize the default-off tracking-precision run spec.
+
+    The normalized shape mirrors the benchmark observation-noise spec style while
+    preserving issue #3480's speed-contract names: ``threshold_m``,
+    ``default_speed``, ``defensive_speed``, and ``mode``.
+
+    Returns:
+        Canonical tracking-precision run spec.
+    """
+
+    normalized = {
+        **_DEFAULT_SPEC,
+        "speed_contract": dict(_DEFAULT_SPEED_CONTRACT_SPEC),
+    }
+    if spec is None:
+        return normalized
+    if not isinstance(spec, dict):
+        raise TypeError("tracking_precision spec must be a mapping or None")
+
+    speed_contract = spec.get("speed_contract")
+    for key, value in spec.items():
+        if key == "speed_contract":
+            continue
+        if key not in normalized:
+            raise ValueError(f"unknown tracking_precision key: {key}")
+        normalized[key] = value
+
+    normalized["target_motp_m"] = float(normalized["target_motp_m"])
+    if normalized["target_motp_m"] < 0.0:
+        raise ValueError("tracking_precision.target_motp_m must be >= 0")
+
+    normalized["enabled"] = bool(normalized.get("enabled", False)) or (
+        normalized["target_motp_m"] > 0.0
+    )
+    normalized["seed_salt"] = int(normalized["seed_salt"])
+    if normalized["seed_salt"] < 0:
+        raise ValueError("tracking_precision.seed_salt must be >= 0")
+
+    normalized["speed_contract"] = _normalize_speed_contract_spec(speed_contract)
+    normalized["schema_version"] = TRACKING_PRECISION_SCHEMA
+    normalized["interpretation"] = TRACKING_PRECISION_INTERPRETATION
+    return normalized
+
+
+def tracking_precision_contract_from_spec(
+    spec: dict[str, Any] | None,
+) -> TrackingPrecisionContract:
+    """Return the operational contract encoded by a normalized run spec."""
+
+    normalized = normalize_tracking_precision_spec(spec)
+    contract = normalized["speed_contract"]
+    return TrackingPrecisionContract(
+        precision_threshold_m=contract["threshold_m"],
+        default_speed_cap=contract["default_speed"],
+        defensive_speed_cap=contract["defensive_speed"],
+    )
+
+
+def make_tracking_precision_rng(
+    spec: dict[str, Any], *, seed: int, scenario_id: str
+) -> np.random.Generator:
+    """Create deterministic per-episode RNG for tracking-drift corruption.
+
+    Returns:
+        NumPy generator scoped to the normalized spec, scenario, and seed.
+    """
+
+    normalized = normalize_tracking_precision_spec(spec)
+    material = {
+        "episode_seed": int(seed),
+        "scenario_id": str(scenario_id),
+        "spec_hash": tracking_precision_hash(normalized),
+        "seed_salt": normalized["seed_salt"],
+    }
+    digest = hashlib.sha256(
+        json.dumps(material, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).digest()
+    return np.random.default_rng(int.from_bytes(digest[:8], "big", signed=False))
 
 
 def drift_std_for_motp(motp_m: float) -> float:
@@ -170,13 +321,72 @@ def tracking_precision_telemetry(
     }
 
 
+def apply_tracking_precision_spec(
+    positions: NDArray[np.floating] | object,
+    spec: dict[str, Any] | None,
+    rng: np.random.Generator,
+) -> NDArray[np.float64]:
+    """Apply the normalized tracking-drift mask to tracked actor positions.
+
+    Returns:
+        Position array copied or corrupted according to the normalized spec.
+    """
+
+    normalized = normalize_tracking_precision_spec(spec)
+    if not normalized["enabled"]:
+        return np.asarray(positions, dtype=np.float64).copy()
+    return apply_tracking_drift(positions, normalized["target_motp_m"], rng)
+
+
+def apply_speed_contract(
+    linear_speed: float,
+    motp_m: float,
+    spec: dict[str, Any] | None,
+) -> tuple[float, dict[str, Any]]:
+    """Apply or diagnose the precision-to-speed cap for one linear command.
+
+    ``mode == "clamp"`` returns ``min(linear_speed, contracted_cap)``.
+    ``mode == "diagnostic"`` leaves the command unchanged and records whether
+    the command would have honored the operational contract.
+
+    Returns:
+        Tuple of applied linear speed and schema-tagged contract telemetry.
+    """
+
+    normalized = normalize_tracking_precision_spec(spec)
+    contract = tracking_precision_contract_from_spec(normalized)
+    mode = normalized["speed_contract"]["mode"]
+    requested = float(linear_speed)
+    contracted_cap = speed_cap_for_precision(motp_m, contract)
+    applied = (
+        min(requested, contracted_cap) if normalized["enabled"] and mode == "clamp" else requested
+    )
+    telemetry = tracking_precision_telemetry(motp_m, applied, contract)
+    telemetry.update(
+        {
+            "contract_mode": mode,
+            "commanded_linear_speed": requested,
+            "tracking_precision_enabled": normalized["enabled"],
+        }
+    )
+    return applied, telemetry
+
+
 __all__ = [
+    "TRACKING_PRECISION_INTERPRETATION",
+    "TRACKING_PRECISION_MODES",
     "TRACKING_PRECISION_SCHEMA",
     "TrackingPrecisionContract",
+    "apply_speed_contract",
     "apply_tracking_drift",
+    "apply_tracking_precision_spec",
     "drift_std_for_motp",
     "is_contract_honored",
+    "make_tracking_precision_rng",
     "minimum_separation",
+    "normalize_tracking_precision_spec",
     "speed_cap_for_precision",
+    "tracking_precision_contract_from_spec",
+    "tracking_precision_hash",
     "tracking_precision_telemetry",
 ]

--- a/tests/benchmark/test_tracking_precision_contract.py
+++ b/tests/benchmark/test_tracking_precision_contract.py
@@ -10,11 +10,16 @@ import pytest
 from robot_sf.benchmark.tracking_precision_contract import (
     TRACKING_PRECISION_SCHEMA,
     TrackingPrecisionContract,
+    apply_speed_contract,
     apply_tracking_drift,
+    apply_tracking_precision_spec,
     drift_std_for_motp,
     is_contract_honored,
+    make_tracking_precision_rng,
     minimum_separation,
+    normalize_tracking_precision_spec,
     speed_cap_for_precision,
+    tracking_precision_hash,
     tracking_precision_telemetry,
 )
 
@@ -118,3 +123,126 @@ def test_telemetry_is_schema_tagged() -> None:
     assert record["defensive_regime"] is True
     assert record["contracted_speed_cap"] == TrackingPrecisionContract().defensive_speed_cap
     assert record["contract_honored"] is False  # applied 2.0 > defensive ceiling
+
+
+def test_normalized_spec_is_default_off_and_hash_stable() -> None:
+    """Absent spec preserves current behavior and hashes canonically."""
+    normalized = normalize_tracking_precision_spec(None)
+
+    assert normalized["enabled"] is False
+    assert normalized["target_motp_m"] == 0.0
+    assert normalized["speed_contract"]["mode"] == "diagnostic"
+    assert tracking_precision_hash(normalized) == tracking_precision_hash(
+        normalize_tracking_precision_spec(dict(reversed(list(normalized.items()))))
+    )
+
+
+def test_normalized_spec_accepts_issue_aliases() -> None:
+    """Issue #3480 speed-contract aliases normalize to one operational contract."""
+    normalized = normalize_tracking_precision_spec(
+        {
+            "target_motp_m": 3.0,
+            "speed_contract": {
+                "precision_threshold_m": 2.0,
+                "default_speed_cap": 1.4,
+                "defensive_speed_cap": 0.4,
+                "mode": "clamp",
+            },
+            "seed_salt": 17,
+        }
+    )
+
+    assert normalized["enabled"] is True
+    assert normalized["speed_contract"] == {
+        "threshold_m": 2.0,
+        "default_speed": 1.4,
+        "defensive_speed": 0.4,
+        "mode": "clamp",
+    }
+    assert normalized["seed_salt"] == 17
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {"speed_contract": {"mode": "unknown"}},
+        {"target_motp_m": -0.1},
+        {"seed_salt": -1},
+        {"unexpected": True},
+        {"speed_contract": {"unexpected": True}},
+    ],
+)
+def test_invalid_spec_is_rejected(spec: dict[str, object]) -> None:
+    """Malformed run specs fail before they can enter benchmark provenance."""
+    with pytest.raises((TypeError, ValueError)):
+        normalize_tracking_precision_spec(spec)
+
+
+def test_tracking_precision_rng_is_episode_deterministic() -> None:
+    """Spec, scenario, and seed produce stable but distinct drift streams."""
+    spec = normalize_tracking_precision_spec({"target_motp_m": 2.5, "seed_salt": 4})
+    positions = np.zeros((3, 2))
+
+    rng_a = make_tracking_precision_rng(spec, seed=12, scenario_id="map-a")
+    rng_b = make_tracking_precision_rng(spec, seed=12, scenario_id="map-a")
+    rng_c = make_tracking_precision_rng(spec, seed=12, scenario_id="map-b")
+
+    drift_a = apply_tracking_precision_spec(positions, spec, rng_a)
+    drift_b = apply_tracking_precision_spec(positions, spec, rng_b)
+    drift_c = apply_tracking_precision_spec(positions, spec, rng_c)
+
+    assert np.array_equal(drift_a, drift_b)
+    assert not np.array_equal(drift_a, drift_c)
+
+
+def test_tracking_precision_spec_zero_or_disabled_passes_through() -> None:
+    """Default-off specs do not corrupt observations before explicit opt-in."""
+    rng = np.random.default_rng(42)
+    positions = np.array([[1.0, 2.0], [3.0, 4.0]])
+
+    disabled = apply_tracking_precision_spec(positions, None, rng)
+    zero_motp = apply_tracking_precision_spec(
+        positions,
+        {"enabled": True, "target_motp_m": 0.0},
+        rng,
+    )
+
+    assert np.array_equal(disabled, positions)
+    assert np.array_equal(zero_motp, positions)
+    assert disabled is not positions
+    assert zero_motp is not positions
+
+
+def test_speed_contract_diagnostic_mode_records_without_clamping() -> None:
+    """Diagnostic mode preserves command speed and marks contract violation."""
+    applied, record = apply_speed_contract(
+        1.5,
+        3.0,
+        {
+            "enabled": True,
+            "target_motp_m": 3.0,
+            "speed_contract": {"defensive_speed": 0.5, "mode": "diagnostic"},
+        },
+    )
+
+    assert applied == 1.5
+    assert record["contract_mode"] == "diagnostic"
+    assert record["tracking_precision_enabled"] is True
+    assert record["contract_honored"] is False
+
+
+def test_speed_contract_clamp_mode_applies_defensive_ceiling() -> None:
+    """Clamp mode applies the defensive cap once MOTP crosses the threshold."""
+    applied, record = apply_speed_contract(
+        1.5,
+        3.0,
+        {
+            "enabled": True,
+            "target_motp_m": 3.0,
+            "speed_contract": {"defensive_speed": 0.5, "mode": "clamp"},
+        },
+    )
+
+    assert applied == 0.5
+    assert record["contract_mode"] == "clamp"
+    assert record["contract_honored"] is True


### PR DESCRIPTION
## Issue

Refs https://github.com/ll7/robot_sf_ll7/issues/3480

## Scope

This PR keeps #3480 in the pure contract layer. It adds a default-off, normalized `tracking_precision` run spec with stable hashing, deterministic per-episode drift RNG, speed-contract alias normalization, and pure helpers for fixture-level observation corruption and `diagnostic` versus `clamp` speed-cap behavior.

No live benchmark-loop, planner, action-path, or campaign behavior changes in this PR.

## Validation

- `python -m py_compile robot_sf/benchmark/tracking_precision_contract.py tests/benchmark/test_tracking_precision_contract.py` - passed
- `uv run pytest tests/benchmark/test_tracking_precision_contract.py -q` - passed, 24 tests
- `uv run ruff check robot_sf/benchmark/tracking_precision_contract.py tests/benchmark/test_tracking_precision_contract.py` - passed
- `uv run ruff format --check robot_sf/benchmark/tracking_precision_contract.py tests/benchmark/test_tracking_precision_contract.py` - passed
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/pr_body_issue_3480.md scripts/dev/pr_ready_check.sh` - passed

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No live perception or action-loop wiring; the safety-vs-precision curve remains a follow-up.

## Artifact Decision

Generated local artifacts are ignored worktree state only (`.venv/`, local machine symlink, and disposable `output/` validation/body files). Nothing under `output/` is required as durable evidence for this PR.
