### PR TITLE
Issue #3213: add maneuver-authority manifest checker

### DIFF
--- a/scripts/validation/predictive_eval_common.py
+++ b/scripts/validation/predictive_eval_common.py
@@ -10,14 +10,24 @@ from robot_sf.training.scenario_loader import load_scenarios
 
 
 def load_seed_manifest(path: Path) -> dict[str, list[int]]:
-    """Load scenario->seed map from YAML."""
+    """Load and validate scenario->seed map from YAML."""
     payload = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
     if not isinstance(payload, dict):
         raise TypeError(f"Seed manifest must be a mapping: {path}")
     out: dict[str, list[int]] = {}
     for key, value in payload.items():
-        if isinstance(value, list):
-            out[str(key)] = [int(v) for v in value]
+        scenario_id = str(key).strip()
+        if not scenario_id:
+            raise ValueError(f"Seed manifest contains an empty scenario id: {path}")
+        if not isinstance(value, list):
+            raise TypeError(f"Seed manifest entry must be a seed list: {scenario_id}")
+        if not value:
+            raise ValueError(f"Seed manifest entry has no seeds: {scenario_id}")
+
+        seeds = [int(v) for v in value]
+        if len(seeds) != len(set(seeds)):
+            raise ValueError(f"Seed manifest entry contains duplicate seeds: {scenario_id}")
+        out[scenario_id] = seeds
     return out
 
 

--- a/scripts/validation/run_predictive_success_campaign.py
+++ b/scripts/validation/run_predictive_success_campaign.py
@@ -78,7 +78,15 @@ class MissingCampaignArtifactError(RuntimeError):
 def parse_args() -> argparse.Namespace:
     """Parse campaign CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("--checkpoints", nargs="+", required=True)
+    parser.add_argument("--checkpoints", nargs="+")
+    parser.add_argument(
+        "--check-only",
+        action="store_true",
+        help=(
+            "Validate the scenario matrix, hard-seed manifest, and planner grid, then exit "
+            "without requiring checkpoints or running evaluation."
+        ),
+    )
     parser.add_argument(
         "--scenario-matrix",
         type=Path,
@@ -144,13 +152,19 @@ def _load_planner_variants(path: Path) -> list[dict]:
     if not isinstance(variants, list):
         raise TypeError(f"planner grid variants must be a list: {path}")
     out = []
-    for item in variants:
+    names: set[str] = set()
+    for index, item in enumerate(variants, start=1):
         if not isinstance(item, dict):
-            continue
-        name = str(item.get("name", "unnamed"))
+            raise TypeError(f"planner grid variant #{index} must be a mapping: {path}")
+        name = str(item.get("name", "")).strip()
+        if not name:
+            raise ValueError(f"planner grid variant #{index} has no name: {path}")
+        if name in names:
+            raise ValueError(f"planner grid contains duplicate variant name: {name}")
+        names.add(name)
         params = item.get("params", {})
         if not isinstance(params, dict):
-            params = {}
+            raise TypeError(f"planner grid variant params must be a mapping: {name}")
         out.append({"name": name, "params": params})
     if not out:
         raise RuntimeError(f"No planner variants found in {path}")
@@ -532,6 +546,34 @@ def main() -> int:
         raise RuntimeError("Hard-case manifest did not match any scenarios.")
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    if getattr(args, "check_only", False):
+        summary = {
+            "contract_version": _CONTRACT_VERSION,
+            "training_family": _TRAINING_FAMILY,
+            "artifact_role": "predictive_success_campaign_manifest_check",
+            "status": "checked_no_evaluation_run",
+            "generated_at": datetime.now(UTC).isoformat(),
+            "scenario_matrix": str(args.scenario_matrix),
+            "hard_seed_manifest": str(args.hard_seed_manifest),
+            "planner_grid": str(args.planner_grid),
+            "hard_manifest_entries": len(hard_manifest),
+            "matched_hard_scenarios": len(hard_scenarios),
+            "planner_variants": [str(variant["name"]) for variant in variants],
+            "num_planner_variants": len(variants),
+            "scope_note": (
+                "Structural manifest/grid check only; no checkpoint evaluation, benchmark run, "
+                "or maneuver-authority success interpretation was performed."
+            ),
+        }
+        json_path = args.output_dir / "manifest_check_summary.json"
+        json_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+        print(f"Wrote manifest check summary: {json_path}")
+        return 0
+
+    if not getattr(args, "checkpoints", None):
+        raise SystemExit("--checkpoints is required unless --check-only is set")
+
     results: list[dict] = []
 
     try:

--- a/tests/validation/test_predictive_eval_common.py
+++ b/tests/validation/test_predictive_eval_common.py
@@ -7,7 +7,7 @@ from pathlib import Path
 import pytest
 import yaml
 
-from scripts.validation.predictive_eval_common import make_subset_scenarios
+from scripts.validation.predictive_eval_common import load_seed_manifest, make_subset_scenarios
 
 
 def _write_matrix(tmp_path: Path) -> Path:
@@ -65,3 +65,19 @@ def test_make_subset_scenarios_rejects_empty_selection(tmp_path: Path) -> None:
 
     with pytest.raises(ValueError, match="selected no scenarios"):
         make_subset_scenarios(matrix, {})
+
+
+def test_load_seed_manifest_rejects_invalid_entries(tmp_path: Path) -> None:
+    """Hard-case seed manifests fail closed before campaign execution."""
+    manifest = tmp_path / "hard.yaml"
+    manifest.write_text(
+        yaml.safe_dump({"planner_sanity_simple": [101, 101]}),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate seeds"):
+        load_seed_manifest(manifest)
+
+    manifest.write_text(yaml.safe_dump({"planner_sanity_simple": []}), encoding="utf-8")
+    with pytest.raises(ValueError, match="no seeds"):
+        load_seed_manifest(manifest)

--- a/tests/validation/test_predictive_success_campaign_tags.py
+++ b/tests/validation/test_predictive_success_campaign_tags.py
@@ -21,6 +21,85 @@ def test_checkpoint_token_is_path_sensitive() -> None:
     assert b.startswith("predictive_model_")
 
 
+def test_load_planner_variants_rejects_duplicate_names(tmp_path: Path) -> None:
+    """Authority grids should not silently collapse duplicate variant names."""
+    grid = tmp_path / "grid.yaml"
+    grid.write_text(
+        yaml.safe_dump(
+            {
+                "variants": [
+                    {"name": "baseline", "params": {}},
+                    {"name": "baseline", "params": {"max_angular_speed": 1.8}},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="duplicate variant name"):
+        campaign._load_planner_variants(grid)
+
+
+def test_main_check_only_writes_manifest_summary(monkeypatch, tmp_path: Path) -> None:
+    """Check-only mode validates toy manifests without checkpoint evaluation."""
+    matrix = tmp_path / "matrix.yaml"
+    map_path = tmp_path / "maps" / "open.svg"
+    map_path.parent.mkdir()
+    map_path.write_text("<svg />", encoding="utf-8")
+    matrix.write_text(
+        yaml.safe_dump(
+            {
+                "scenarios": [
+                    {
+                        "name": "classic_cross_trap_high",
+                        "map_file": "maps/open.svg",
+                        "seeds": [1],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    hard_manifest = tmp_path / "hard.yaml"
+    hard_manifest.write_text(
+        yaml.safe_dump({"classic_cross_trap_high": [101, 102]}),
+        encoding="utf-8",
+    )
+    grid = tmp_path / "grid.yaml"
+    grid.write_text(
+        yaml.safe_dump(
+            {
+                "variants": [
+                    {"name": "baseline", "params": {}},
+                    {"name": "high_angular", "params": {"max_angular_speed": 1.8}},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "out"
+
+    monkeypatch.setattr(
+        campaign,
+        "parse_args",
+        lambda: campaign.argparse.Namespace(
+            checkpoints=None,
+            check_only=True,
+            scenario_matrix=matrix,
+            hard_seed_manifest=hard_manifest,
+            planner_grid=grid,
+            output_dir=output_dir,
+        ),
+    )
+
+    assert campaign.main() == 0
+    summary = json.loads((output_dir / "manifest_check_summary.json").read_text(encoding="utf-8"))
+    assert summary["status"] == "checked_no_evaluation_run"
+    assert summary["matched_hard_scenarios"] == 1
+    assert summary["planner_variants"] == ["baseline", "high_angular"]
+    assert "no checkpoint evaluation" in summary["scope_note"]
+
+
 def test_rank_key_prefers_global_success_before_clearance_when_hard_tied() -> None:
     """Campaign ranking should not pick the safest failure over the more successful variant."""
     hard_a = campaign.EvalResult(


### PR DESCRIPTION
## Summary

- Adds `--check-only` to `scripts/validation/run_predictive_success_campaign.py` so the hard-case seed manifest and maneuver-authority planner grid can be validated without requiring checkpoints or launching evaluation.
- Tightens hard-seed manifest and planner-grid parsing so empty seed lists, duplicate seeds, unnamed variants, duplicate variant names, and non-mapping variant payloads fail closed.
- Adds toy-fixture tests for the checker path and malformed manifest/grid cases.

Issue: #3213

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_predictive_eval_common.py tests/validation/test_predictive_success_campaign_tags.py -q` — passed (`16 passed`).
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/predictive_eval_common.py scripts/validation/run_predictive_success_campaign.py tests/validation/test_predictive_eval_common.py tests/validation/test_predictive_success_campaign_tags.py` — passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_predictive_success_campaign.py --check-only --scenario-matrix configs/scenarios/classic_interactions.yaml --hard-seed-manifest configs/benchmarks/predictive_hard_seeds_v1.yaml --planner-grid configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml --output-dir output/validation/issue_3213_manifest_check` — passed; wrote `manifest_check_summary.json` with `status=checked_no_evaluation_run`, 4 matched hard scenarios, and 5 planner variants.

## Out of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No maneuver-authority success interpretation or winning-config promotion.
