### PR TITLE
Fix #3479: add opt-in runtime three-wheeled rollover proxy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added an **opt-in three-wheeled rollover proxy** runtime hook in `RobotEnv.step()` (#3479). When
+  `rollover_proxy_enabled` is set, the env feeds the executed robot `current_speed`
+  `(linear_velocity, yaw_rate)` into the existing `rollover_proxy.v1` closed-form stability margin,
+  surfaces rollover telemetry in step info / telemetry-analyzer metrics, emits a `ROLLOVER_CRITICAL`
+  termination reason, terminates the step, and applies a configured non-positive
+  `rollover_proxy_penalty` when the internal proxy trips. **Disabled by default**, so existing
+  benchmark/training runs keep identical episode semantics; config validation rejects a non-typed
+  `rollover_proxy_params` and a non-finite or positive penalty. This remains an explicit
+  **internal non-hardware proxy** (governance gate #2416/#2417), not a hardware-calibrated AMV
+  stability claim. The `(linear_velocity, yaw_rate)` assumption holds for differential/holonomic
+  drives but not bicycle drive (tracked follow-up #3683).
 * Added a regression guard for **pygame-free headless execution** (#3631). A subprocess-probe test
   (`tests/test_pygame_headless.py::test_headless_step_does_not_import_pygame`) builds and **steps** the
   env under forced-headless drivers and asserts `pygame` is never imported and no `sim_ui` is created —

--- a/robot_sf/gym_env/env_config.py
+++ b/robot_sf/gym_env/env_config.py
@@ -17,6 +17,7 @@ alternatives for gradual migration.
 All configuration classes validate required fields during initialization and inherit
 telemetry configuration support from `TelemetryConfigMixin`."""
 
+import math
 from dataclasses import dataclass, field
 
 from robot_sf.common.forecast_variants import FORECAST_VARIANT_CHOICES
@@ -104,8 +105,13 @@ class BaseEnvSettings(TelemetryConfigMixin):
                 f"forecast_variant must be one of {list(FORECAST_VARIANT_CHOICES)}; "
                 f"got {self.forecast_variant!r}"
             )
-        if self.rollover_proxy_penalty > 0.0:
-            raise ValueError("rollover_proxy_penalty must be non-positive.")
+        if not isinstance(self.rollover_proxy_params, RolloverProxyParams):
+            raise TypeError(
+                "rollover_proxy_params must be a RolloverProxyParams instance; "
+                f"got {type(self.rollover_proxy_params)!r}"
+            )
+        if not math.isfinite(self.rollover_proxy_penalty) or self.rollover_proxy_penalty > 0.0:
+            raise ValueError("rollover_proxy_penalty must be a finite non-positive value.")
 
         sync_observation_stack_settings(self)
         self._validate_telemetry()

--- a/robot_sf/gym_env/env_config.py
+++ b/robot_sf/gym_env/env_config.py
@@ -38,6 +38,7 @@ from robot_sf.robot.differential_drive import (
     DifferentialDriveSettings,
 )
 from robot_sf.robot.holonomic_drive import HolonomicDriveRobot, HolonomicDriveSettings
+from robot_sf.robot.rollover_proxy import RolloverProxyParams
 from robot_sf.sensor.image_sensor import ImageSensorSettings
 from robot_sf.sensor.range_sensor import LidarScannerSettings
 from robot_sf.sim.sim_config import SimulationSettings
@@ -78,6 +79,11 @@ class BaseEnvSettings(TelemetryConfigMixin):
     grid_config: GridConfig | None = None
     include_grid_in_observation: bool = False
     show_occupancy_grid: bool = False
+    # Internal non-hardware three-wheeled rollover proxy. Disabled by default so
+    # existing benchmark/training runs keep identical episode semantics.
+    rollover_proxy_enabled: bool = False
+    rollover_proxy_params: RolloverProxyParams = field(default_factory=RolloverProxyParams)
+    rollover_proxy_penalty: float = 0.0
     # Forecast variant selection for planners that consume ProbabilisticPredictor baselines.
     # "none" disables baseline forecast consumption and uses the planner's default behavior.
     forecast_variant: str = field(default="none")
@@ -98,6 +104,9 @@ class BaseEnvSettings(TelemetryConfigMixin):
                 f"forecast_variant must be one of {list(FORECAST_VARIANT_CHOICES)}; "
                 f"got {self.forecast_variant!r}"
             )
+        if self.rollover_proxy_penalty > 0.0:
+            raise ValueError("rollover_proxy_penalty must be non-positive.")
+
         sync_observation_stack_settings(self)
         self._validate_telemetry()
 

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -45,7 +45,7 @@ from robot_sf.nav.occupancy_grid import OccupancyGrid
 from robot_sf.render.lidar_visual import render_lidar
 from robot_sf.render.sim_state import VisualizableAction, VisualizableSimState
 from robot_sf.robot.robot_state import RobotState
-from robot_sf.robot.rollover_proxy import rollover_proxy_telemetry
+from robot_sf.robot.rollover_proxy import RolloverProxyParams, rollover_proxy_telemetry
 from robot_sf.sensor.range_sensor import lidar_ray_scan
 from robot_sf.sensor.sensor_fusion import OBS_IMAGE, SensorFusion
 from robot_sf.sensor.socnav_observation import (
@@ -806,7 +806,7 @@ class RobotEnv(BaseEnv):
 
     def _rollover_proxy_record(self) -> dict[str, Any] | None:
         """Return opt-in rollover proxy telemetry for the executed robot state."""
-        if not self.env_config.rollover_proxy_enabled:
+        if not getattr(self.env_config, "rollover_proxy_enabled", False):
             return None
         current_speed = getattr(self.simulator.robots[0], "current_speed", None)
         current_speed = current_speed() if callable(current_speed) else current_speed
@@ -821,7 +821,7 @@ class RobotEnv(BaseEnv):
         return rollover_proxy_telemetry(
             linear_velocity,
             yaw_rate,
-            params=self.env_config.rollover_proxy_params,
+            params=getattr(self.env_config, "rollover_proxy_params", RolloverProxyParams()),
         )
 
     def _apply_rollover_proxy_metadata(self, reward_dict: dict[str, Any]) -> bool:
@@ -859,7 +859,7 @@ class RobotEnv(BaseEnv):
         """
         if not rollover_critical:
             return reward
-        penalty = float(self.env_config.rollover_proxy_penalty)
+        penalty = float(getattr(self.env_config, "rollover_proxy_penalty", 0.0))
         reward_dict["reward_terms"]["rollover_proxy_penalty"] = penalty
         return reward + penalty
 

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -805,7 +805,15 @@ class RobotEnv(BaseEnv):
             self.sim_ui.telemetry_session = self._telemetry_session
 
     def _rollover_proxy_record(self) -> dict[str, Any] | None:
-        """Return opt-in rollover proxy telemetry for the executed robot state."""
+        """Return opt-in rollover proxy telemetry for the executed robot state.
+
+        Assumes ``robot.current_speed`` is ``(linear_velocity, yaw_rate)``. This
+        holds for ``DifferentialDriveRobot`` and ``HolonomicDriveRobot``. It does
+        NOT hold for ``BicycleDriveRobot``, whose ``current_speed`` second element
+        is the heading angle, not the yaw rate; enabling the proxy with that drive
+        would mis-feed the margin. Tracked as follow-up rather than a default-path
+        concern because the proxy is opt-in and disabled by default (issue #3479).
+        """
         if not getattr(self.env_config, "rollover_proxy_enabled", False):
             return None
         current_speed = getattr(self.simulator.robots[0], "current_speed", None)
@@ -860,7 +868,14 @@ class RobotEnv(BaseEnv):
         if not rollover_critical:
             return reward
         penalty = float(getattr(self.env_config, "rollover_proxy_penalty", 0.0))
-        reward_dict["reward_terms"]["rollover_proxy_penalty"] = penalty
+        # Defensively normalize reward_terms before assignment: custom reward
+        # functions may leave it absent or set it to a non-dict value, mirroring
+        # the guard in `_extract_reward_terms`.
+        reward_terms = reward_dict.get("reward_terms")
+        if not isinstance(reward_terms, dict):
+            reward_terms = {}
+            reward_dict["reward_terms"] = reward_terms
+        reward_terms["rollover_proxy_penalty"] = penalty
         return reward + penalty
 
     def step(self, action):

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -45,6 +45,7 @@ from robot_sf.nav.occupancy_grid import OccupancyGrid
 from robot_sf.render.lidar_visual import render_lidar
 from robot_sf.render.sim_state import VisualizableAction, VisualizableSimState
 from robot_sf.robot.robot_state import RobotState
+from robot_sf.robot.rollover_proxy import rollover_proxy_telemetry
 from robot_sf.sensor.range_sensor import lidar_ray_scan
 from robot_sf.sensor.sensor_fusion import OBS_IMAGE, SensorFusion
 from robot_sf.sensor.socnav_observation import (
@@ -66,6 +67,9 @@ _TELEMETRY_ANALYZER_STEP_METRIC_KEYS: tuple[str, ...] = (
     "force_exceed_events",
     "comfort_exposure",
     "jerk_mean",
+    "rollover_stability_margin",
+    "rollover_lateral_acceleration",
+    "rollover_critical_lateral_acceleration",
 )
 _ASYMMETRIC_CRITIC_STATE_KEY = "critic_privileged_state"
 _GridObstacleCacheKey = tuple[int, int, int]
@@ -311,13 +315,19 @@ def _build_step_info(meta: dict[str, Any]) -> dict[str, Any]:
         or meta.get("is_robot_collision")
     )
     success = bool(meta.get("is_route_complete"))
-    return {
+    info = {
         "step": meta.get("step"),
         "meta": meta,
         "collision": collision,
         "success": success,
         "is_success": success,
     }
+    if "termination_reason" in meta:
+        info["termination_reason"] = meta["termination_reason"]
+    if "rollover_proxy" in meta:
+        info["rollover_proxy"] = meta["rollover_proxy"]
+        info["rollover_critical"] = bool(meta.get("rollover_critical", False))
+    return info
 
 
 def _coerce_finite_float(value: Any) -> float | None:
@@ -794,6 +804,65 @@ class RobotEnv(BaseEnv):
         if self.sim_ui:
             self.sim_ui.telemetry_session = self._telemetry_session
 
+    def _rollover_proxy_record(self) -> dict[str, Any] | None:
+        """Return opt-in rollover proxy telemetry for the executed robot state."""
+        if not self.env_config.rollover_proxy_enabled:
+            return None
+        current_speed = getattr(self.simulator.robots[0], "current_speed", None)
+        current_speed = current_speed() if callable(current_speed) else current_speed
+        try:
+            linear_velocity = float(current_speed[0])
+            yaw_rate = float(current_speed[1])
+        except (TypeError, ValueError, IndexError) as exc:
+            raise RuntimeError(
+                "rollover_proxy_enabled requires robot.current_speed as "
+                "(linear_velocity, yaw_rate)."
+            ) from exc
+        return rollover_proxy_telemetry(
+            linear_velocity,
+            yaw_rate,
+            params=self.env_config.rollover_proxy_params,
+        )
+
+    def _apply_rollover_proxy_metadata(self, reward_dict: dict[str, Any]) -> bool:
+        """Add opt-in rollover proxy step metadata.
+
+        Returns:
+            True when the proxy classified this step as ``ROLLOVER_CRITICAL``.
+        """
+        rollover_record = self._rollover_proxy_record()
+        if rollover_record is None:
+            return False
+        reward_dict["rollover_proxy"] = rollover_record
+        reward_dict["rollover_stability_margin"] = rollover_record["stability_margin"]
+        reward_dict["rollover_lateral_acceleration"] = rollover_record["lateral_acceleration"]
+        reward_dict["rollover_critical_lateral_acceleration"] = rollover_record[
+            "critical_lateral_acceleration"
+        ]
+        rollover_critical = bool(rollover_record["rollover_critical"])
+        reward_dict["rollover_critical"] = rollover_critical
+        if rollover_critical:
+            reward_dict["termination_reason"] = "ROLLOVER_CRITICAL"
+        return rollover_critical
+
+    def _apply_rollover_proxy_reward(
+        self,
+        reward: float,
+        reward_dict: dict[str, Any],
+        *,
+        rollover_critical: bool,
+    ) -> float:
+        """Apply configured rollover penalty when the opt-in proxy trips.
+
+        Returns:
+            Reward with the configured rollover penalty applied when critical.
+        """
+        if not rollover_critical:
+            return reward
+        penalty = float(self.env_config.rollover_proxy_penalty)
+        reward_dict["reward_terms"]["rollover_proxy_penalty"] = penalty
+        return reward + penalty
+
     def step(self, action):
         """Execute one environment step.
 
@@ -861,6 +930,7 @@ class RobotEnv(BaseEnv):
             )
         )
         # add the action space to dict
+        rollover_critical = self._apply_rollover_proxy_metadata(reward_dict)
         reward_dict["action_space"] = self.action_space
         # add action to dict
         reward_dict["action"] = action
@@ -869,9 +939,15 @@ class RobotEnv(BaseEnv):
         # Determine if the episode has reached terminal state
         term = self.state.is_terminal
         # Compute the reward using the provided reward function
+        term = term or rollover_critical
         reward = self.reward_func(reward_dict)
         if "reward_terms" not in reward_dict:
             reward_dict["reward_terms"] = {"scalar_reward": float(reward)}
+        reward = self._apply_rollover_proxy_reward(
+            reward,
+            reward_dict,
+            rollover_critical=rollover_critical,
+        )
         reward_dict["reward_total"] = float(reward)
         # Update last_action for next step
         self.last_action = action

--- a/robot_sf/gym_env/unified_config.py
+++ b/robot_sf/gym_env/unified_config.py
@@ -6,6 +6,7 @@ duplication and provides clear separation of concerns.
 """
 
 import importlib
+import math
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -225,8 +226,13 @@ class RobotSimulationConfig(BaseSimulationConfig):
 
     def _validate_rollover_proxy(self) -> None:
         """Validate opt-in rollover proxy reward settings."""
-        if self.rollover_proxy_penalty > 0.0:
-            raise ValueError("rollover_proxy_penalty must be non-positive.")
+        if not isinstance(self.rollover_proxy_params, RolloverProxyParams):
+            raise TypeError(
+                "rollover_proxy_params must be a RolloverProxyParams instance; "
+                f"got {type(self.rollover_proxy_params)!r}"
+            )
+        if not math.isfinite(self.rollover_proxy_penalty) or self.rollover_proxy_penalty > 0.0:
+            raise ValueError("rollover_proxy_penalty must be a finite non-positive value.")
 
     def _validate_forecast_variant(self) -> None:
         """Validate the forecast variant selector when configured."""

--- a/robot_sf/gym_env/unified_config.py
+++ b/robot_sf/gym_env/unified_config.py
@@ -32,6 +32,7 @@ from robot_sf.robot.differential_drive import (
     DifferentialDriveSettings,
 )
 from robot_sf.robot.holonomic_drive import HolonomicDriveRobot, HolonomicDriveSettings
+from robot_sf.robot.rollover_proxy import RolloverProxyParams
 from robot_sf.sensor.image_sensor import ImageSensorSettings
 from robot_sf.sensor.range_sensor import LidarScannerSettings
 from robot_sf.sim.sim_config import SimulationSettings
@@ -157,6 +158,11 @@ class RobotSimulationConfig(BaseSimulationConfig):
     )
     # Environment behavior flags
     use_image_obs: bool = field(default=False)
+    # Internal non-hardware three-wheeled rollover proxy. Disabled by default so
+    # existing benchmark/training runs keep identical episode semantics.
+    rollover_proxy_enabled: bool = field(default=False)
+    rollover_proxy_params: RolloverProxyParams = field(default_factory=RolloverProxyParams)
+    rollover_proxy_penalty: float = field(default=0.0)
     # Explicit force flags (new API).
     peds_have_static_obstacle_forces: bool = field(default=True)
     peds_have_robot_repulsion: bool | None = field(default=None)
@@ -213,8 +219,14 @@ class RobotSimulationConfig(BaseSimulationConfig):
         self._validate_grid_visualization()
         self._validate_planner_config()
         self._validate_global_sampling()
+        self._validate_rollover_proxy()
         self._validate_forecast_variant()
         self._validate_predictive_foresight()
+
+    def _validate_rollover_proxy(self) -> None:
+        """Validate opt-in rollover proxy reward settings."""
+        if self.rollover_proxy_penalty > 0.0:
+            raise ValueError("rollover_proxy_penalty must be non-positive.")
 
     def _validate_forecast_variant(self) -> None:
         """Validate the forecast variant selector when configured."""

--- a/tests/test_rollover_proxy.py
+++ b/tests/test_rollover_proxy.py
@@ -240,6 +240,24 @@ def test_runtime_rollover_proxy_over_yaw_trips_terminal_penalty() -> None:
     assert info["meta"]["reward_terms"]["rollover_proxy_penalty"] == pytest.approx(-4.0)
 
 
+def test_runtime_rollover_proxy_penalty_handles_non_dict_reward_terms() -> None:
+    """Penalty assignment is robust when a reward function clobbers reward_terms."""
+    env = _make_step_env(penalty=-4.0)
+
+    def _reward_func(meta: dict) -> float:
+        # Custom reward functions may leave reward_terms as a non-dict value.
+        meta["reward_terms"] = None
+        return 1.0
+
+    env.reward_func = _reward_func
+
+    _obs, reward, terminated, _truncated, info = env.step(np.array([2.0, 2.0]))
+
+    assert reward == pytest.approx(-3.0)
+    assert terminated is True
+    assert info["meta"]["reward_terms"]["rollover_proxy_penalty"] == pytest.approx(-4.0)
+
+
 def test_runtime_rollover_proxy_disabled_by_default_keeps_step_semantics() -> None:
     """Disabled proxy leaves even over-yaw toy command nonterminal."""
     env = _make_step_env(rollover_enabled=False, penalty=-4.0)

--- a/tests/test_rollover_proxy.py
+++ b/tests/test_rollover_proxy.py
@@ -2,9 +2,14 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
+import numpy as np
 import pytest
 
 from robot_sf.benchmark.metrics import evaluate_stability_margin
+from robot_sf.gym_env.env_config import EnvSettings
+from robot_sf.gym_env.robot_env import RobotEnv
 from robot_sf.robot.rollover_proxy import (
     PROXY_SCHEMA_VERSION,
     RolloverProxyParams,
@@ -125,3 +130,124 @@ def test_proxy_agrees_with_benchmark_surface_source_of_truth(v: float, omega: fl
     )
 
     assert proxy_margin == pytest.approx(benchmark_margin)
+
+
+class _StepRobot:
+    """Minimal robot double exposing executed ``current_speed``."""
+
+    def __init__(self) -> None:
+        self.current_speed = (0.0, 0.0)
+
+    def parse_action(self, action: np.ndarray) -> tuple[float, float]:
+        """Return action as differential-drive ``(v, omega)`` command."""
+        return (float(action[0]), float(action[1]))
+
+
+class _StepSimulator:
+    """Minimal simulator double for ``RobotEnv.step`` rollover fixtures."""
+
+    def __init__(self) -> None:
+        self.robots = [_StepRobot()]
+        self.robot_poses = [((0.0, 0.0), 0.0)]
+        self.ped_pos = np.zeros((0, 2), dtype=float)
+
+    def step_once(self, actions: list[tuple[float, float]]) -> None:
+        """Record the executed command as the robot's current speed."""
+        self.robots[0].current_speed = actions[0]
+
+
+class _StepState:
+    """Minimal state double for ``RobotEnv.step`` rollover fixtures."""
+
+    d_t = 0.25
+    is_terminal = False
+
+    def step(self) -> np.ndarray:
+        """Return a deterministic observation."""
+        return np.zeros(1, dtype=np.float32)
+
+    def meta_dict(self) -> dict:
+        """Return nonterminal state metadata."""
+        return {
+            "step": 1,
+            "episode": 1,
+            "step_of_episode": 1,
+            "is_pedestrian_collision": False,
+            "is_robot_collision": False,
+            "is_obstacle_collision": False,
+            "is_waypoint_complete": False,
+            "is_route_complete": False,
+            "distance_to_goal": 1.0,
+            "prev_distance_to_goal": 1.2,
+            "is_timesteps_exceeded": False,
+            "max_sim_steps": 100,
+        }
+
+
+def _make_step_env(*, rollover_enabled: bool = True, penalty: float = -4.0) -> RobotEnv:
+    env = RobotEnv.__new__(RobotEnv)
+    env.env_config = EnvSettings(
+        rollover_proxy_enabled=rollover_enabled,
+        rollover_proxy_penalty=penalty,
+    )
+    env.config = env.env_config
+    env.debug_without_robot_movement = False
+    env.simulator = _StepSimulator()
+    env.state = _StepState()
+    env.occupancy_grid = None
+    env._asymmetric_critic_enabled = False
+    env._snqi_proxy = SimpleNamespace(compute_step_metrics=lambda *args, **kwargs: {})
+    env.action_space = SimpleNamespace()
+    env.last_action = None
+    env.reward_func = lambda _meta: 1.0
+    env._telemetry_session = None
+    env.recording_enabled = False
+    return env
+
+
+def test_runtime_rollover_proxy_keeps_feasible_command_nonterminal() -> None:
+    """Opt-in runtime proxy surfaces stable telemetry without terminating."""
+    env = _make_step_env()
+
+    _obs, reward, terminated, truncated, info = env.step(np.array([0.5, 0.5]))
+
+    assert reward == pytest.approx(1.0)
+    assert terminated is False
+    assert truncated is False
+    assert info["rollover_critical"] is False
+    assert info["rollover_proxy"]["stability_margin"] > 0.0
+    assert "termination_reason" not in info
+
+
+def test_runtime_rollover_proxy_over_yaw_trips_terminal_penalty() -> None:
+    """Opt-in runtime proxy trips ``ROLLOVER_CRITICAL`` on over-yaw command."""
+    env = _make_step_env(penalty=-4.0)
+
+    _obs, reward, terminated, truncated, info = env.step(np.array([2.0, 2.0]))
+
+    assert reward == pytest.approx(-3.0)
+    assert terminated is True
+    assert truncated is False
+    assert info["termination_reason"] == "ROLLOVER_CRITICAL"
+    assert info["rollover_critical"] is True
+    assert info["rollover_proxy"]["rollover_critical"] is True
+    assert info["meta"]["reward_terms"]["rollover_proxy_penalty"] == pytest.approx(-4.0)
+
+
+def test_runtime_rollover_proxy_disabled_by_default_keeps_step_semantics() -> None:
+    """Disabled proxy leaves even over-yaw toy command nonterminal."""
+    env = _make_step_env(rollover_enabled=False, penalty=-4.0)
+
+    _obs, reward, terminated, truncated, info = env.step(np.array([2.0, 2.0]))
+
+    assert reward == pytest.approx(1.0)
+    assert terminated is False
+    assert truncated is False
+    assert "rollover_proxy" not in info
+    assert "termination_reason" not in info
+
+
+def test_rollover_proxy_penalty_must_not_be_positive() -> None:
+    """Configured rollover penalty must not accidentally reward rollover."""
+    with pytest.raises(ValueError, match="rollover_proxy_penalty"):
+        EnvSettings(rollover_proxy_penalty=0.1)

--- a/tests/test_rollover_proxy.py
+++ b/tests/test_rollover_proxy.py
@@ -10,6 +10,7 @@ import pytest
 from robot_sf.benchmark.metrics import evaluate_stability_margin
 from robot_sf.gym_env.env_config import EnvSettings
 from robot_sf.gym_env.robot_env import RobotEnv
+from robot_sf.gym_env.unified_config import RobotSimulationConfig
 from robot_sf.robot.rollover_proxy import (
     PROXY_SCHEMA_VERSION,
     RolloverProxyParams,
@@ -184,9 +185,14 @@ class _StepState:
         }
 
 
-def _make_step_env(*, rollover_enabled: bool = True, penalty: float = -4.0) -> RobotEnv:
+def _make_step_env(
+    *,
+    rollover_enabled: bool = True,
+    penalty: float = -4.0,
+    env_config: object | None = None,
+) -> RobotEnv:
     env = RobotEnv.__new__(RobotEnv)
-    env.env_config = EnvSettings(
+    env.env_config = env_config or EnvSettings(
         rollover_proxy_enabled=rollover_enabled,
         rollover_proxy_penalty=penalty,
     )
@@ -237,6 +243,32 @@ def test_runtime_rollover_proxy_over_yaw_trips_terminal_penalty() -> None:
 def test_runtime_rollover_proxy_disabled_by_default_keeps_step_semantics() -> None:
     """Disabled proxy leaves even over-yaw toy command nonterminal."""
     env = _make_step_env(rollover_enabled=False, penalty=-4.0)
+
+    _obs, reward, terminated, truncated, info = env.step(np.array([2.0, 2.0]))
+
+    assert reward == pytest.approx(1.0)
+    assert terminated is False
+    assert truncated is False
+    assert "rollover_proxy" not in info
+    assert "termination_reason" not in info
+
+
+def test_robot_simulation_config_rollover_proxy_default_keeps_step_semantics() -> None:
+    """Unified robot configs keep the rollover proxy disabled by default."""
+    env = _make_step_env(env_config=RobotSimulationConfig())
+
+    _obs, reward, terminated, truncated, info = env.step(np.array([2.0, 2.0]))
+
+    assert reward == pytest.approx(1.0)
+    assert terminated is False
+    assert truncated is False
+    assert "rollover_proxy" not in info
+    assert "termination_reason" not in info
+
+
+def test_missing_rollover_config_attributes_keep_proxy_disabled() -> None:
+    """Older/minimal config objects without rollover attributes stay compatible."""
+    env = _make_step_env(env_config=SimpleNamespace())
 
     _obs, reward, terminated, truncated, info = env.step(np.array([2.0, 2.0]))
 

--- a/tests/test_rollover_proxy.py
+++ b/tests/test_rollover_proxy.py
@@ -283,3 +283,20 @@ def test_rollover_proxy_penalty_must_not_be_positive() -> None:
     """Configured rollover penalty must not accidentally reward rollover."""
     with pytest.raises(ValueError, match="rollover_proxy_penalty"):
         EnvSettings(rollover_proxy_penalty=0.1)
+
+
+@pytest.mark.parametrize("bad_penalty", [float("nan"), float("inf"), float("-inf")])
+def test_rollover_proxy_penalty_must_be_finite(bad_penalty: float) -> None:
+    """Non-finite penalties must fail closed in both config paths."""
+    with pytest.raises(ValueError, match="rollover_proxy_penalty"):
+        EnvSettings(rollover_proxy_penalty=bad_penalty)
+    with pytest.raises(ValueError, match="rollover_proxy_penalty"):
+        RobotSimulationConfig(rollover_proxy_penalty=bad_penalty)
+
+
+def test_rollover_proxy_params_must_be_typed() -> None:
+    """A non-RolloverProxyParams value must be rejected in both config paths."""
+    with pytest.raises(TypeError, match="rollover_proxy_params"):
+        EnvSettings(rollover_proxy_params={"track_width_m": 0.8})
+    with pytest.raises(TypeError, match="rollover_proxy_params"):
+        RobotSimulationConfig(rollover_proxy_params={"track_width_m": 0.8})


### PR DESCRIPTION
## Summary

Implements the remaining runtime slice for issue #3479: an opt-in three-wheeled rollover proxy hook in `RobotEnv.step()` that surfaces rollover telemetry, emits `ROLLOVER_CRITICAL`, terminates the step, and applies a configured non-positive reward penalty when the internal proxy trips.

## Linked Issues

- Closes #3479

## Scope Summary

- Adds disabled-by-default `EnvSettings` controls for the internal non-hardware rollover proxy: enable flag, versioned proxy params, and reward penalty.
- Wires the existing `rollover_proxy.v1` telemetry into `RobotEnv.step()` using the executed robot `current_speed` `(linear_velocity, yaw_rate)`.
- Surfaces rollover diagnostics in step metadata/info and telemetry analyzer metrics when enabled.
- Adds toy runtime fixtures proving a feasible command stays nonterminal, an over-yaw command trips `ROLLOVER_CRITICAL` and receives the configured penalty, and disabled-default semantics do not change.

## Validation / Proof

- `uv run python -m py_compile robot_sf/gym_env/env_config.py robot_sf/gym_env/robot_env.py tests/test_rollover_proxy.py` -> exit 0
- `uv run ruff check robot_sf/gym_env/env_config.py robot_sf/gym_env/robot_env.py tests/test_rollover_proxy.py` -> exit 0
- `uv run ruff format robot_sf/gym_env/env_config.py robot_sf/gym_env/robot_env.py tests/test_rollover_proxy.py --check` -> exit 0
- `uv run pytest tests/test_rollover_proxy.py -q` -> exit 0, 25 passed
- `uv run pytest tests/test_env_util_helpers.py tests/test_rollover_proxy.py -q` -> exit 0, 30 passed
- `git diff --check` -> exit 0
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> exit 1, clean tree but missing full `pr_ready_check` stamp; full PR gate explicitly deferred to Claude Code per issue handoff.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No hardware-calibrated AMV stability claim; this remains an internal non-hardware proxy.

## Risks / Rollout

- Compatibility risk is low because the runtime hook is disabled by default.
- Enabling the proxy changes episode termination and reward semantics by design; callers must opt in and set the penalty consciously.
- Full PR gate, broader improvement cycle, and merge authority are delegated to Claude Code on `imech156-u` after PR open.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional rollover-proxy support in robot simulation settings.
  * Exposed rollover-related telemetry and step info, including stability margin and critical rollover status.
  * When rollover conditions are detected, episodes now terminate and apply a configurable penalty.

* **Bug Fixes**
  * Added validation to prevent invalid rollover penalty values.
  * Improved handling so rollover info only appears when the feature is enabled.

* **Tests**
  * Added coverage for enabled/disabled rollover behavior, termination, penalties, and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->