### PR TITLE
Issue #3663: stabilize progress tracker test mtimes

### DIFF
--- a/tests/dev/test_summarize_campaign_progress.py
+++ b/tests/dev/test_summarize_campaign_progress.py
@@ -9,7 +9,9 @@ from pathlib import Path  # noqa: TC003
 
 from scripts.dev.summarize_campaign_progress import main, summarize_campaign_progress
 
-_MTIME_EPOCHS = count(1_700_000_000)
+# Step by 10s so distinct writes stay strictly ordered even on filesystems with
+# coarse mtime resolution (e.g. FAT/exFAT round to 2-second granularity).
+_MTIME_EPOCHS = count(1_700_000_000, 10)
 
 
 def _write_lines(path: Path, count: int) -> None:

--- a/tests/dev/test_summarize_campaign_progress.py
+++ b/tests/dev/test_summarize_campaign_progress.py
@@ -3,9 +3,13 @@
 from __future__ import annotations
 
 import json
+import os
+from itertools import count
 from pathlib import Path  # noqa: TC003
 
 from scripts.dev.summarize_campaign_progress import main, summarize_campaign_progress
+
+_MTIME_EPOCHS = count(1_700_000_000)
 
 
 def _write_lines(path: Path, count: int) -> None:
@@ -14,6 +18,8 @@ def _write_lines(path: Path, count: int) -> None:
     path.write_text(
         "".join(f'{{"episode": {index}}}\n' for index in range(count)), encoding="utf-8"
     )
+    mtime_epoch = next(_MTIME_EPOCHS)
+    os.utime(path, (mtime_epoch, mtime_epoch))
 
 
 def test_summarize_campaign_progress_reports_active_variant(tmp_path: Path) -> None:


### PR DESCRIPTION
## Issue

Refs https://github.com/ll7/robot_sf_ll7/issues/3663

## Scope Summary

- Stabilizes `tests/dev/test_summarize_campaign_progress.py` by making the JSONL fixture writer assign deterministic, strictly increasing file modification times after each write.
- Keeps the progress summarizer implementation unchanged; this PR only removes the test's dependency on filesystem timestamp resolution during rapid writes.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/dev/test_summarize_campaign_progress.py -q` - passed, 5 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/dev/test_summarize_campaign_progress.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/dev/test_summarize_campaign_progress.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- bash -lc 'for i in $(seq 1 100); do uv run pytest tests/dev/test_summarize_campaign_progress.py -q >/tmp/issue3663-pytest-repeat.log || { cat /tmp/issue3663-pytest-repeat.log; echo failed iteration $i; exit 1; }; done; cat /tmp/issue3663-pytest-repeat.log; echo repeated 100 passes'` - passed, 100 repeated runs.

## Out of Scope

- No benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No production progress-tracker behavior rewrite.

## Artifact / Downstream Notes

- Generated validation output remained local and disposable.
- No benchmark, registry, leaderboard, claim map, or paper-facing propagation is applicable.
