### PR TITLE
fix: handle invalid SNQI config reader inputs (#3669)

### DIFF
--- a/robot_sf/training/snqi_utils.py
+++ b/robot_sf/training/snqi_utils.py
@@ -7,6 +7,8 @@ import math
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, cast
 
+from loguru import logger
+
 from robot_sf.benchmark.snqi import WEIGHT_NAMES, compute_snqi
 from robot_sf.benchmark.snqi.weights_validation import validate_weights_mapping
 
@@ -125,6 +127,61 @@ def default_training_snqi_context() -> TrainingSNQIContext:
     )
 
 
+def _resolve_snqi_weights(weights_path: Path | None) -> tuple[dict[str, float], str]:
+    """Load SNQI weights from JSON, falling back to defaults on invalid input.
+
+    Returns:
+        Resolved weights and the source label.
+    """
+    if weights_path is None:
+        return dict(_DEFAULT_SNQI_WEIGHTS), "default"
+
+    try:
+        raw_weights = json.loads(weights_path.read_text(encoding="utf-8"))
+        weights_mapping = _extract_weights_mapping(raw_weights)
+        return validate_weights_mapping(weights_mapping), str(weights_path)
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        logger.warning(
+            "Failed to load SNQI weights from {}; using default weights: {}",
+            weights_path,
+            exc,
+        )
+        return dict(_DEFAULT_SNQI_WEIGHTS), "default"
+
+
+def _resolve_snqi_baseline(
+    baseline_path: Path | None,
+) -> tuple[dict[str, dict[str, float]], str, tuple[str, ...]]:
+    """Load SNQI baseline stats from JSON, falling back to defaults on invalid input.
+
+    Returns:
+        Resolved baseline stats, source label, and fallback keys.
+    """
+    if baseline_path is None:
+        return (
+            {key: dict(value) for key, value in _DEFAULT_SNQI_BASELINE.items()},
+            "default",
+            (),
+        )
+
+    try:
+        raw_baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+        baseline_mapping = _extract_baseline_mapping(raw_baseline)
+        baseline_stats, baseline_fallback_keys = _normalize_baseline_mapping(baseline_mapping)
+        return baseline_stats, str(baseline_path), baseline_fallback_keys
+    except (OSError, json.JSONDecodeError, ValueError) as exc:
+        logger.warning(
+            "Failed to load SNQI baseline stats from {}; using default baseline stats: {}",
+            baseline_path,
+            exc,
+        )
+        return (
+            {key: dict(value) for key, value in _DEFAULT_SNQI_BASELINE.items()},
+            "default",
+            (),
+        )
+
+
 def resolve_training_snqi_context(
     *,
     weights_path: Path | None = None,
@@ -135,24 +192,8 @@ def resolve_training_snqi_context(
     Returns:
         Fully resolved context with sources and any required baseline key fallbacks.
     """
-    if weights_path is None:
-        weights = dict(_DEFAULT_SNQI_WEIGHTS)
-        weights_source = "default"
-    else:
-        raw_weights = json.loads(weights_path.read_text(encoding="utf-8"))
-        weights_mapping = _extract_weights_mapping(raw_weights)
-        weights = validate_weights_mapping(weights_mapping)
-        weights_source = str(weights_path)
-
-    if baseline_path is None:
-        baseline_stats = {key: dict(value) for key, value in _DEFAULT_SNQI_BASELINE.items()}
-        baseline_source = "default"
-        baseline_fallback_keys: tuple[str, ...] = ()
-    else:
-        raw_baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
-        baseline_mapping = _extract_baseline_mapping(raw_baseline)
-        baseline_stats, baseline_fallback_keys = _normalize_baseline_mapping(baseline_mapping)
-        baseline_source = str(baseline_path)
+    weights, weights_source = _resolve_snqi_weights(weights_path)
+    baseline_stats, baseline_source, baseline_fallback_keys = _resolve_snqi_baseline(baseline_path)
 
     return TrainingSNQIContext(
         weights=weights,

--- a/tests/training/test_snqi_utils.py
+++ b/tests/training/test_snqi_utils.py
@@ -5,7 +5,10 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pytest
+
 from robot_sf.benchmark.snqi import compute_snqi
+from robot_sf.training import snqi_utils
 from robot_sf.training.snqi_utils import (
     compute_training_snqi,
     default_training_snqi_context,
@@ -14,6 +17,16 @@ from robot_sf.training.snqi_utils import (
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+
+class _WarningRecorder:
+    """Capture loguru-style warning calls without depending on global logger sinks."""
+
+    def __init__(self) -> None:
+        self.messages: list[str] = []
+
+    def warning(self, message: str, *args: object) -> None:
+        self.messages.append(message.format(*args))
 
 
 def test_default_training_snqi_context_has_collision_penalty_baseline():
@@ -56,6 +69,52 @@ def test_resolve_training_snqi_context_supports_nested_weight_payload(tmp_path: 
     assert context.weights["w_success"] == 1.2
     assert "near_misses" in context.baseline_stats
     assert "near_misses" in context.baseline_fallback_keys
+
+
+@pytest.mark.parametrize(
+    ("payload", "expected_message"),
+    [
+        ("{not-json", "Failed to load SNQI weights"),
+        (json.dumps({"weights": {"w_success": 1.0}}), "Missing weight keys"),
+    ],
+)
+def test_resolve_training_snqi_context_invalid_weights_falls_back_to_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    payload: str,
+    expected_message: str,
+):
+    """Malformed or structurally invalid weights should not crash config resolution."""
+    recorder = _WarningRecorder()
+    monkeypatch.setattr(snqi_utils, "logger", recorder)
+    weights_file = tmp_path / "weights.json"
+    weights_file.write_text(payload, encoding="utf-8")
+
+    context = resolve_training_snqi_context(weights_path=weights_file)
+    default_context = default_training_snqi_context()
+
+    assert context.weights == default_context.weights
+    assert context.weights_source == "default"
+    assert context.baseline_source == "default"
+    assert any(expected_message in message for message in recorder.messages)
+
+
+def test_resolve_training_snqi_context_missing_baseline_falls_back_to_default(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Unreadable baseline paths should not crash config resolution."""
+    recorder = _WarningRecorder()
+    monkeypatch.setattr(snqi_utils, "logger", recorder)
+
+    context = resolve_training_snqi_context(baseline_path=tmp_path / "missing-baseline.json")
+    default_context = default_training_snqi_context()
+
+    assert context.weights == default_context.weights
+    assert context.baseline_stats == default_context.baseline_stats
+    assert context.baseline_source == "default"
+    assert context.baseline_fallback_keys == ()
+    assert any("Failed to load SNQI baseline stats" in message for message in recorder.messages)
 
 
 def test_compute_training_snqi_matches_canonical_benchmark_formula():


### PR DESCRIPTION
## Summary

Fixes the training-side Social Navigation Quality Index (SNQI) config reader so missing, unreadable, malformed, or structurally invalid weights/baseline JSON files log warnings and fall back to the default training SNQI context instead of crashing config resolution.

## Linked Issues

- Closes #3669
- Issue: https://github.com/ll7/robot_sf_ll7/issues/3669

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed

- Added bounded exception handling around SNQI weights and baseline file reads/parsing/validation in `robot_sf/training/snqi_utils.py`.
- Preserved existing valid config behavior and source labels.
- Added focused regression tests for malformed weights JSON, structurally invalid weights JSON, and missing baseline files in `tests/training/test_snqi_utils.py`.

## Why Matters

- Added value: training config resolution no longer crashes when optional SNQI config paths are broken.
- Expected impact: callers receive default SNQI settings with an actionable warning.
- Why worth merging now: directly fixes the bug report with a small, tested change.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - support bug fix, no research claim.
- Comparator or baseline, applicable: NA
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision stop rule, applicable: focused regression tests pass for invalid SNQI config inputs.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3669 only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool.

## Domain-Aware Approval

- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: NA - no benchmark, metric, or paper-facing claim change.
- Validity checklist: NA
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: NA
- Claim boundary: no benchmark evidence claimed.
- Implementation integrity vs experimental validity: implementation-only bug fix.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action

- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: stop; issue scope covered.
- Proposed child issue existing follow-up: none

## Validation / Proof

- `python -m py_compile robot_sf/training/snqi_utils.py tests/training/test_snqi_utils.py` - passed
- `uv run pytest tests/training/test_snqi_utils.py` - passed, 6 tests
- `uv run ruff check robot_sf/training/snqi_utils.py tests/training/test_snqi_utils.py` - passed
- `uv run ruff format --check robot_sf/training/snqi_utils.py tests/training/test_snqi_utils.py` - passed, already formatted
- `git diff --check` - passed

## Performance / Runtime Impact

- Baseline runtime: NA - no runtime performance claim.
- Changed runtime: NA - no runtime performance claim.
- Representative command: `uv run pytest tests/training/test_snqi_utils.py`
- Hot-path call count profile anchor: NA - config resolution only.
- Cache-hit reuse counter: NA
- Rollback failure criterion: revert if valid SNQI config files stop resolving or invalid config paths crash again.

## Risks / Rollout

- Compatibility risks: invalid weights or baseline files now fall back independently to defaults instead of raising.
- Failure modes: callers that relied on immediate exceptions for broken optional SNQI config files will now need to inspect warning logs/source labels.
- Rollback fallback plan: revert this PR.

## Docs / Provenance

- Updated docs: none
- Relevant design provenance notes: issue #3669
- Any assumptions need to preserved: SNQI config paths are optional training inputs and should not crash resolution when invalid.

## Downstream Propagation

- Parent issue updated (yes/no/NA): NA - PR links and closes #3669.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no benchmark/registry/claim-map behavior changed.

## Follow-Up Issues

- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes

- Please verify the fallback behavior is acceptable for structurally invalid weight files as well as missing/malformed files.
- Known limitations: this PR does not restructure the SNQI mapping schema.
