### PR TITLE
Fix issue #3670: parse comma-separated SVG viewBox values

### DIFF
--- a/robot_sf/benchmark/visualization.py
+++ b/robot_sf/benchmark/visualization.py
@@ -17,6 +17,7 @@ import importlib.util
 import json
 import multiprocessing as mp
 import os
+import re
 import tempfile
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
@@ -62,7 +63,7 @@ def frame_shape_from_map(map_svg_path: str) -> tuple[int, int]:
 
     viewbox = root.get("viewBox") or root.get("viewbox")
     if viewbox:
-        parts = viewbox.strip().split()
+        parts = [part for part in re.split(r"[\s,]+", viewbox.strip()) if part]
         if len(parts) == 4:
             try:
                 _, _, w, h = parts

--- a/tests/unit/benchmark/test_contract_frame_shape.py
+++ b/tests/unit/benchmark/test_contract_frame_shape.py
@@ -43,6 +43,21 @@ def test_frame_shape_from_map_viewbox():
     assert (w, h) == (1024, 768)
 
 
+@pytest.mark.parametrize(
+    ("viewbox", "expected"),
+    [
+        ("0,0,100,200", (100, 200)),
+        ("0, 0, 1024, 768", (1024, 768)),
+    ],
+)
+def test_frame_shape_from_map_viewbox_with_commas(viewbox: str, expected: tuple[int, int]):
+    """Parse comma-separated SVG viewBox dimensions."""
+    svg = f"""<svg viewBox="{viewbox}" xmlns="http://www.w3.org/2000/svg"></svg>"""
+    p = make_svg(svg)
+    w, h = frame_shape_from_map(str(p))
+    assert (w, h) == expected
+
+
 def test_frame_shape_from_map_invalid():
     """TODO docstring. Document this function."""
     svg = """<svg></svg>"""


### PR DESCRIPTION
## Summary
Allow `frame_shape_from_map` to parse standard SVG `viewBox` values separated by commas as well as whitespace.

## Linked Issues
- Addresses https://github.com/ll7/robot_sf_ll7/issues/3670

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: none

## What Changed
- Split SVG `viewBox` values on whitespace or commas in `robot_sf/benchmark/visualization.py`.
- Added focused regression coverage for `0,0,100,200` and `0, 0, 1024, 768` viewBox values.

## Why Matters
- Added value: standard comma-separated SVG viewBox attributes no longer fail frame-size parsing.
- Expected impact: fixes the parser failure reported in issue #3670 without changing advanced SVG geometry behavior.
- Why worth merging now: small bug fix with direct regression coverage.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - parser bug fix only.
- Comparator or baseline, applicable: current whitespace-only viewBox parser.
- Evidence tier: NA - parser bug fix with unit-test proof, not research evidence.
- Result classification: NA - no research result classification.
- Decision stop rule, applicable: NA - issue scope is covered when the focused unit test passes.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3670 only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no research interpretation tool.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: NA - no benchmark, metric, or paper-facing claim.
- Validity checklist: NA - parser bug fix only.
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA - no experimental comparator or split.
- Fallback/degraded exclusions: NA
- Claim boundary: NA
- Implementation integrity vs experimental validity: NA

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? yes, focused unit test fails before the parser change.
- Result route: stop
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: stop; issue scope is covered.
- Proposed child issue existing follow-up: none

## Validation / Proof
- `uv run pytest tests/unit/benchmark/test_contract_frame_shape.py` - exit 1 before fix, new comma-separated viewBox cases failed with `ValueError`.
- `uv run pytest tests/unit/benchmark/test_contract_frame_shape.py` - exit 0, 5 passed.
- `uv run ruff check robot_sf/benchmark/visualization.py tests/unit/benchmark/test_contract_frame_shape.py` - exit 0, all checks passed.
- `uv run ruff format --check robot_sf/benchmark/visualization.py tests/unit/benchmark/test_contract_frame_shape.py` - exit 0, 2 files already formatted.
- `git diff --check` - exit 0.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/validation/pr_ready/issue-3670-pr-body.md scripts/dev/pr_ready_check.sh` - exit 0 via compact wrapper; core and optional readiness lanes passed.

## Runtime / Performance
- Baseline runtime: NA - no runtime performance claim.
- Changed runtime: NA - no runtime performance claim.
- Representative command: `uv run pytest tests/unit/benchmark/test_contract_frame_shape.py`
- Hot-path call count profile anchor: NA - parser bug fix only.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: comma-separated `viewBox` values fail `frame_shape_from_map` again.

## Risks / Rollout
- Compatibility risks: low; whitespace-only viewBox parsing remains covered.
- Failure modes: malformed viewBox values still raise `ValueError`.
- Rollback fallback plan: revert this parser/test commit.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: issue #3670
- Any assumptions need to preserved: advanced SVG geometry parsing remains out of scope.
- Artifact classification: readiness generated ignored local `output/coverage/` reports, `output/validation/pr_ready/` freshness/body files, and hydrated `output/model_cache/` cache entries; none are committed or required as durable artifacts.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes
- Anything reviewer verify closely: tokenizer behavior for comma and mixed comma/space viewBox values.
- Any known limitations: advanced SVG geometry parsing remains out of scope.
