### PR TITLE
Fix issue #3668: tuple space compatibility strictness

### DIFF
--- a/robot_sf/training/scenario_sampling.py
+++ b/robot_sf/training/scenario_sampling.py
@@ -69,7 +69,7 @@ def _spaces_compatible(  # noqa: C901
                 other_space,
                 allow_box_bounds_mismatch=allow_box_bounds_mismatch,
             )
-            for base_space, other_space in zip(base.spaces, other.spaces, strict=False)
+            for base_space, other_space in zip(base.spaces, other.spaces, strict=True)
         )
     return base == other
 

--- a/tests/training/test_scenario_sampling.py
+++ b/tests/training/test_scenario_sampling.py
@@ -69,6 +69,19 @@ def test_spaces_compatible_allows_bounds_mismatch() -> None:
     assert _spaces_compatible(base, other, allow_box_bounds_mismatch=True) is True
 
 
+def test_spaces_compatible_rejects_tuple_length_mismatch() -> None:
+    """Tuple compatibility rejects mismatched child-space counts."""
+    base = spaces.Tuple(
+        (
+            spaces.Discrete(2),
+            spaces.Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32),
+        )
+    )
+    other = spaces.Tuple((spaces.Discrete(2),))
+
+    assert _spaces_compatible(base, other, allow_box_bounds_mismatch=True) is False
+
+
 def test_scenario_sampler_cycles_and_filters() -> None:
     """Sampler should honor include filters and cycle strategy."""
     sampler = ScenarioSampler(


### PR DESCRIPTION
## Summary

Fixes #3668: https://github.com/ll7/robot_sf_ll7/issues/3668 by making the Tuple-space compatibility check zip child spaces with `strict=True`.

## Scope

- Tightened `_spaces_compatible()` Tuple child-space iteration in `robot_sf/training/scenario_sampling.py`.
- Added focused regression coverage for Tuple child-space count mismatches in `tests/training/test_scenario_sampling.py`.
- Preserved existing Box bound-mismatch compatibility behavior.

## Validation

- `uv run pytest tests/training/test_scenario_sampling.py` - passed, 8 tests.
- `uv run ruff check robot_sf/training/scenario_sampling.py tests/training/test_scenario_sampling.py` - passed.
- `uv run ruff format --check robot_sf/training/scenario_sampling.py tests/training/test_scenario_sampling.py` - passed.
- `git diff --check` - passed.
- `PR_READY_PR_BODY_FILE=output/validation/pr_body_issue_3668.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed.

## Out Of Scope

- No benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No Gym space representation changes.

## Artifact / Downstream Notes

Generated validation files under `output/` are local ignored artifacts only. No benchmark, registry, leaderboard, claim map, or paper-facing propagation is applicable.
