### PR TITLE
Fix issue #3667 pygame window exit handling

### DIFF
--- a/robot_sf/render/sim_view.py
+++ b/robot_sf/render/sim_view.py
@@ -399,8 +399,6 @@ class SimulationView:
     def _handle_exit(self):
         """Handle the exit state."""
         pygame.quit()
-        if self.is_abortion_requested:
-            sys.exit()
 
     def _prepare_frame(self, state: VisualizableSimState):
         """Prepare a new frame with the given state."""

--- a/tests/visuals/test_sim_view_coverage_paths.py
+++ b/tests/visuals/test_sim_view_coverage_paths.py
@@ -579,7 +579,7 @@ def test_sim_view_exit_and_telemetry_paths(monkeypatch) -> None:
     view._handle_exit()
 
     exit_calls = []
-    monkeypatch.setattr(sim_view_mod.sys, "exit", lambda: exit_calls.append(True))
+    monkeypatch.setattr(sim_view_mod.sys, "exit", lambda *args, **kwargs: exit_calls.append(True))
     view.is_abortion_requested = True
     view._handle_exit()
     assert exit_calls == []

--- a/tests/visuals/test_sim_view_coverage_paths.py
+++ b/tests/visuals/test_sim_view_coverage_paths.py
@@ -578,11 +578,11 @@ def test_sim_view_exit_and_telemetry_paths(monkeypatch) -> None:
     view.is_abortion_requested = False
     view._handle_exit()
 
-    exit_called = {"value": False}
-    monkeypatch.setattr(sim_view_mod.sys, "exit", lambda: exit_called.__setitem__("value", True))
+    exit_calls = []
+    monkeypatch.setattr(sim_view_mod.sys, "exit", lambda: exit_calls.append(True))
     view.is_abortion_requested = True
     view._handle_exit()
-    assert exit_called["value"] is True
+    assert exit_calls == []
 
     # Telemetry panel: missing method, None surface, and both layouts.
     view.show_telemetry_panel = True


### PR DESCRIPTION
## Issue

Fixes https://github.com/ll7/robot_sf_ll7/issues/3667

## Scope

- Stop `SimulationView._handle_exit()` from calling `sys.exit()` after a pygame window close/quit request.
- Preserve the existing renderer shutdown path: pygame is still quit and the existing exit/abortion flags remain available to callers.
- Update the focused SimulationView exit regression coverage so the test fails if `sys.exit()` is attempted.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/visuals/test_sim_view_coverage_paths.py::test_sim_view_exit_and_telemetry_paths -q` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/visuals/test_sim_view_coverage_paths.py -q` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/render/sim_view.py tests/visuals/test_sim_view_coverage_paths.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/render/sim_view.py tests/visuals/test_sim_view_coverage_paths.py` - passed
- `git diff --check` - passed

## Out Of Scope

- No full benchmark campaign run.
- No Slurm or GPU submission.
- No paper, dissertation, benchmark, metric, schema, or release-claim edits.

## Notes

Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and merge authority per the worker request.
