### PR TITLE
Fix #3671 scenario switching bounds refresh

### DIFF
--- a/robot_sf/training/scenario_sampling.py
+++ b/robot_sf/training/scenario_sampling.py
@@ -213,8 +213,6 @@ class ScenarioSwitchingEnv(Env):
 
         env, scenario_id = self._build_env(seed=seed)
         self._activate_env(env, scenario_id)
-        self.observation_space = self._current_env.observation_space
-        self.action_space = self._current_env.action_space
         self.metadata = getattr(self._current_env, "metadata", {})
         self.render_mode = getattr(self._current_env, "render_mode", None)
 
@@ -251,6 +249,8 @@ class ScenarioSwitchingEnv(Env):
         self._scenario_coverage[scenario_id] = self._scenario_coverage.get(scenario_id, 0) + 1
         self._current_env = env
         self._current_scenario_id = scenario_id
+        self.observation_space = env.observation_space
+        self.action_space = env.action_space
 
     def reset(self, *, seed: int | None = None, options: dict | None = None):
         """Reset the current scenario environment, optionally switching scenarios.
@@ -264,8 +264,6 @@ class ScenarioSwitchingEnv(Env):
         if self._current_env is None:
             env, scenario_id = self._build_env(seed=seed)
             self._activate_env(env, scenario_id)
-            self.observation_space = self._current_env.observation_space
-            self.action_space = self._current_env.action_space
         elif self._switch_per_reset and self._has_reset:
             previous_scenario_id = self._current_scenario_id
             new_env, new_scenario_id = self._build_env(seed=seed)
@@ -292,7 +290,7 @@ class ScenarioSwitchingEnv(Env):
             if not obs_strict and not self._warned_obs_bounds:
                 logger.warning(
                     "Scenario switching detected observation-space bound mismatches; "
-                    "using initial bounds for compatibility. previous={} current={}",
+                    "updating wrapper bounds to the active scenario. previous={} current={}",
                     previous_scenario_id,
                     new_scenario_id,
                 )

--- a/tests/training/test_scenario_sampling.py
+++ b/tests/training/test_scenario_sampling.py
@@ -127,6 +127,8 @@ def test_scenario_switching_env_handles_bounds_mismatch() -> None:
     env.reset()
     env.reset()
     assert set(env.scenario_coverage) == {"A", "B"}
+    np.testing.assert_array_equal(env.observation_space.low, np.array([-1.0, -1.0]))
+    np.testing.assert_array_equal(env.observation_space.high, np.array([1.0, 1.0]))
 
     bad_scenarios = [
         {"name": "C", "low": [0.0, 0.0], "high": [1.0, 1.0]},


### PR DESCRIPTION
## Summary

Refresh `ScenarioSwitchingEnv`'s published observation and action spaces whenever an accepted scenario environment becomes active, so reset-time scenario switches do not continue with stale Box bounds.

## Linked Issues

- Closes #3671
- Issue: https://github.com/ll7/robot_sf_ll7/issues/3671

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed

- Moved wrapper `observation_space` and `action_space` refresh into `_activate_env`, covering constructor setup, first reset rebuilds, and reset-time scenario switches.
- Updated the bounds-mismatch warning to reflect that wrapper bounds are refreshed to the active scenario.
- Added regression assertions that a switch to a same-shape, different-bounds scenario updates `env.observation_space.low/high`.

## Why Matters

- Added value: downstream policies and normalizers read bounds from the active scenario instead of stale initial bounds.
- Expected impact: fixes the scenario-switching boundary mismatch without restructuring the wrapper.
- Why worth merging now: issue #3671 describes a narrow correctness bug in existing training scenario switching.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - runtime bug fix, no benchmark or research claim.
- Comparator or baseline, applicable: NA
- Evidence tier: NA - runtime bug fix with targeted tests, no research evidence claim.
- Result classification: NA - runtime bug fix, no research result.
- Decision stop rule, applicable: focused regression and relevant existing scenario-sampling tests pass.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3671 only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no analysis tool added.

## Domain-Aware Approval

- Approver/review source waiver: not required - no benchmark, metric, paper-facing, or evidence-classification change.
- Validity checklist: NA
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA - no comparator split or evidence-validity claim.
- Fallback/degraded exclusions: NA
- Claim boundary: runtime wrapper behavior only.
- Implementation integrity vs experimental validity: implementation integrity covered by focused tests; no experimental validity claim.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes - pre-fix regression failed on stale `observation_space.low`; post-fix tests pass.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? yes - same-shape Box spaces with different bounds.
- Result route: stop
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action

- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: stop after review/CI.
- Proposed child issue existing follow-up: none.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_scenario_sampling.py::test_scenario_switching_env_handles_bounds_mismatch` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_scenario_sampling.py` - 8 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_training_scenario_sampling.py` - 4 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/scenario_sampling.py tests/training/test_scenario_sampling.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/training/scenario_sampling.py tests/training/test_scenario_sampling.py` - 2 files already formatted
- `git diff --check` - passed
- `PR_READY_PR_BODY_FILE=/tmp/issue-3671-pr-body.md scripts/dev/run_worktree_shared_venv.sh -- bash -lc 'PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh'` - passed; stamp `output/validation/pr_ready/issue-3671-scenario-switching-stale-bounds.json`

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Runtime / Performance Budget

- Baseline runtime: NA - no runtime performance claim.
- Changed runtime: NA - no runtime performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_scenario_sampling.py`
- Hot-path call count profile anchor: NA - no hot-path optimization claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: scenario switching again exposes stale `observation_space.low/high` after reset to a different-bounds same-shape scenario.

## Risks / Rollout

- Compatibility risks: downstream code that assumed static wrapper bounds across scenarios will now see active-scenario bounds after a switch.
- Failure modes: dynamically changing bounds may still be incompatible with downstream policies that require static bounds; this PR fixes wrapper state freshness, not policy support.
- Rollback fallback plan: revert this PR and treat bounds-mismatched scenario switching as unsupported.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: issue #3671.
- Any assumptions need to preserved: same-shape Box observation spaces with different bounds remain allowed by existing compatibility rules.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no - worker authorization disallows issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark, registry, claim-map, paper-facing, or artifact propagation change.

## Follow-Up Issues

- Deferred work: none.
- Issues opened follow-up: none.

## Reviewer Notes

- Anything reviewer verify closely: `_activate_env` is now the single owner for wrapper space refresh when an environment becomes active.
- Any known limitations: full benchmark campaigns and Slurm/GPU jobs were intentionally not run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved environment switching so the app now updates its available observation and action ranges as soon as a new environment becomes active.
  * Clarified the warning shown when observation ranges differ during a switch, making the behavior easier to understand.
* **Tests**
  * Added coverage to verify the updated observation range values after resets and environment changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->