### PR TITLE
Fix #3665 unicycle angular velocity update

### DIFF
--- a/robot_sf/common/types.py
+++ b/robot_sf/common/types.py
@@ -60,7 +60,7 @@ and a float (orientation)
 
 # Pedestrian types
 PedPose = tuple[Vec2D, float]
-UnicycleAction = tuple[float, float]  # (acceleration, steering angle)
+UnicycleAction = tuple[float, float]  # (acceleration, angular velocity)
 PedState = np.ndarray
 PedGrouping = set[int]
 ZoneAssignments = dict[int, int]

--- a/robot_sf/ped_ego/unicycle_drive.py
+++ b/robot_sf/ped_ego/unicycle_drive.py
@@ -128,7 +128,7 @@ class UnicycleDrivePedestrian:
         """Action-independent observation bounds for the unicycle pedestrian.
 
         Returns:
-            spaces.Box: 2D continuous box for speed and steering-angle constraints.
+            spaces.Box: 2D continuous box for speed and angular-velocity constraints.
         """
         high = np.array([self.config.max_velocity, self.config.max_steer], dtype=np.float32)
         low = np.array([self.config.min_velocity, -self.config.max_steer], dtype=np.float32)
@@ -139,7 +139,7 @@ class UnicycleDrivePedestrian:
         """Action bounds accepted by the unicycle pedestrian.
 
         Returns:
-            spaces.Box: 2D continuous box with acceleration and steering limits.
+            spaces.Box: 2D continuous box with acceleration and angular-velocity limits.
         """
         high = np.array([self.config.max_accel, self.config.max_steer], dtype=np.float32)
         low = np.array([-self.config.max_accel, -self.config.max_steer], dtype=np.float32)
@@ -164,7 +164,7 @@ class UnicycleDrivePedestrian:
         """Integrate one control command for the configured time step.
 
         Args:
-            action: Unicycle control tuple ``(acceleration, steering)``.
+            action: Unicycle control tuple ``(acceleration, angular velocity)``.
             d_t: Integration duration in seconds.
         """
         self.movement.move(self.state, action, d_t)
@@ -181,7 +181,7 @@ class UnicycleDrivePedestrian:
         """Convert a 2-element action array to the unicycle action tuple.
 
         Args:
-            action: Array-like with ``[acceleration, steering]``.
+            action: Array-like with ``[acceleration, angular velocity]``.
 
         Returns:
             UnicycleAction: Parsed acceleration and angular velocity command tuple.

--- a/robot_sf/ped_ego/unicycle_drive.py
+++ b/robot_sf/ped_ego/unicycle_drive.py
@@ -1,7 +1,7 @@
 """This module describes a unicycle drive pedestrian model."""
 
 from dataclasses import dataclass, field
-from math import cos, sin, tan
+from math import cos, sin
 
 import numpy as np
 from gymnasium import spaces
@@ -17,7 +17,7 @@ class UnicycleDriveSettings:
     """
 
     radius: float = 0.4  # Collision radius, not relevant for kinematics
-    max_steer: float = 0.78  # Maximum steering angle (45 degrees in radians)
+    max_steer: float = 0.78  # Maximum angular velocity command, kept for compatibility
     max_velocity: float = 3.0  # Maximum forward velocity
 
     max_accel: float = 1.0  # Maximum acceleration
@@ -75,13 +75,13 @@ class UnicycleMotion:
 
         Args:
             state (UnicycleDriveState): The current unicycle state (mutated in place).
-            action (UnicycleAction): Tuple with acceleration and steering commands.
+            action (UnicycleAction): Tuple with acceleration and angular velocity commands.
             d_t (float): Duration in seconds for which the action is applied.
 
         Notes:
             This method mutates ``state`` directly and does not return a value.
         """
-        acceleration, steering_angle = action
+        acceleration, angular_velocity = action
         (x, y), orient = state.pose
         velocity = state.velocity
 
@@ -90,11 +90,12 @@ class UnicycleMotion:
         new_velocity = velocity + d_t * acceleration
         new_velocity = clip_scalar(new_velocity, self.config.min_velocity, self.config.max_velocity)
 
-        # Apply limits to the steering angle
-        steering_angle = clip_scalar(steering_angle, -self.config.max_steer, self.config.max_steer)
-
-        # Calculate angular velocity based on velocity and steering angle
-        angular_velocity = new_velocity * tan(steering_angle)
+        # Apply limits to the angular velocity command.
+        angular_velocity = clip_scalar(
+            angular_velocity,
+            -self.config.max_steer,
+            self.config.max_steer,
+        )
 
         # Normalize new orientation to ensure it stays within the valid range
         new_orient = normalize_angle_atan2(orient + angular_velocity * d_t)
@@ -183,6 +184,6 @@ class UnicycleDrivePedestrian:
             action: Array-like with ``[acceleration, steering]``.
 
         Returns:
-            UnicycleAction: Parsed acceleration and steering command tuple.
+            UnicycleAction: Parsed acceleration and angular velocity command tuple.
         """
         return (action[0], action[1])

--- a/tests/unicycle_drive_test.py
+++ b/tests/unicycle_drive_test.py
@@ -1,6 +1,6 @@
 """TODO docstring. Document this module."""
 
-from math import pi
+from math import isclose, pi
 
 from robot_sf.ped_ego.unicycle_drive import (
     UnicycleAction,
@@ -145,6 +145,26 @@ def test_unicycle_over_limit_negative_steering_clipped():
     motion.move(state, (0.0, -100.0), 1.0)
     pos_after, _ = state.pose
     assert pos_after[0] > 0.0
+
+
+def test_unicycle_turn_command_is_direct_angular_velocity():
+    """Unicycle turn command updates heading as omega, not v * tan(steer)."""
+    motion = UnicycleMotion(UnicycleDriveSettings(max_steer=1.0))
+    state = UnicycleDriveState(((0.0, 0.0), 0.0), 2.0)
+
+    motion.move(state, (0.0, 0.5), 1.0)
+
+    assert isclose(state.pose[1], 0.5)
+
+
+def test_unicycle_turn_command_clips_direct_angular_velocity():
+    """Unicycle turn command clipping applies to omega before integration."""
+    motion = UnicycleMotion(UnicycleDriveSettings(max_steer=0.3))
+    state = UnicycleDriveState(((0.0, 0.0), 0.0), 2.0)
+
+    motion.move(state, (0.0, 10.0), 1.0)
+
+    assert isclose(state.pose[1], 0.3)
 
 
 def test_default_unicycle_state_can_move():


### PR DESCRIPTION
## Summary
Fixes the kinematic unicycle update so the second unicycle action component is applied as angular velocity instead of using the bicycle/simple-car `v * tan(steer)` equation.

## Linked Issues
- Fixes https://github.com/ll7/robot_sf_ll7/issues/3665

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Removed the bicycle-style tangent transform from `UnicycleMotion.move()`.
- Clarified `UnicycleAction` as `(acceleration, angular velocity)`.
- Added focused regression tests for direct angular-rate heading updates and angular-rate clipping.

## Why Matters
- Added value: restores the unicycle model contract for issue #3665.
- Expected impact: unicycle actions now turn by the commanded angular rate regardless of forward speed.
- Why worth merging now: narrow bug fix with focused regression coverage.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - implementation bug fix only.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - implementation proof only, no research or benchmark evidence claim.
- Result classification: NA - no research result or benchmark interpretation.
- Decision stop rule, applicable: focused regression tests pass for direct angular velocity and clipping.
- Parent issue, claim map, registry, context note, synthesis surface update: #3665.
- New research/benchmark/metric/paper-facing analysis tool, any: none.

## Domain-Aware Approval
- approval concerns experimental validity waived / pending / blocked / not required: not required
- Approver/review source waiver: implementation-only kinematics fix; no benchmark or paper-facing claim.
- Validity checklist:
  - Target claim/hypothesis: NA - no research claim or hypothesis.
  - Comparator split/evidence validity: NA - no comparator or benchmark split.
  - Fallback/degraded exclusions: NA - no benchmark execution.
  - Claim boundary: implementation-only unicycle kinematics contract for issue #3665.
  - Implementation integrity vs experimental validity: focused unit tests cover implementation integrity; experimental validity not claimed.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: NA
- Proposed child issue existing follow-up: none

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/unicycle_drive_test.py -q` - passed, 11 tests.
- `git diff --check` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/ped_ego/unicycle_drive.py robot_sf/common/types.py tests/unicycle_drive_test.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/ped_ego/unicycle_drive.py robot_sf/common/types.py tests/unicycle_drive_test.py` - passed.
- `uv sync --all-extras` - passed; bootstrapped fresh isolated worktree dependencies.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/validation/pr_body_issue_3665.md scripts/dev/pr_ready_check.sh` - passed.

## Performance & Scalability
- Baseline runtime: NA - no performance claim.
- Changed runtime: NA - no performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/unicycle_drive_test.py -q`
- Hot-path call count profile anchor: NA - no profiling claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if unicycle action no longer integrates heading by commanded angular velocity.

## Risks / Rollout
- Compatibility risks: the public `max_steer` setting name remains for compatibility, but it now bounds angular velocity for unicycle actions as the issue requires.
- Failure modes: callers that relied on the incorrect bicycle-style tangent behavior will turn differently.
- Rollback fallback plan: revert this commit.

## Docs / Provenance
- Updated docs: inline type/comment clarification only.
- Relevant design provenance notes: issue #3665.
- Any assumptions need to preserved: unicycle action remains a two-float `(acceleration, angular velocity)` tuple.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark, registry, claim-map, or paper-facing changes.

## Follow-Up Issues
- Deferred work: full benchmark campaign run, Slurm/GPU submission, and paper/dissertation claim edits are explicitly out of scope.
- Issues opened follow-up: none

## Reviewer Notes
- Anything reviewer verify closely: `UnicycleMotion.move()` now applies the second action component directly as angular velocity after clipping.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
