### PR TITLE
Fix issue #3662 absolute-path lint tracked scan

### DIFF
--- a/hooks/check_config_abs_paths.py
+++ b/hooks/check_config_abs_paths.py
@@ -46,14 +46,19 @@ def _iter_config_files(files: list[str]) -> list[Path]:
 
 
 def _iter_tracked_config_files() -> list[str]:
-    """Return Git-tracked files under ``configs/`` for ``--all`` checks."""
+    """Return Git-tracked files under ``configs/`` for ``--all`` checks.
+
+    Uses ``git ls-files -z`` so paths containing spaces or other special
+    characters survive verbatim (default output C-quotes such paths, which
+    would no longer match a real file and could be silently skipped).
+    """
     result = subprocess.run(
-        ["git", "ls-files", "--", str(CONFIG_ROOT)],
+        ["git", "ls-files", "-z", "--", str(CONFIG_ROOT)],
         check=True,
         capture_output=True,
         text=True,
     )
-    return [line for line in result.stdout.splitlines() if Path(line).is_file()]
+    return [name for name in result.stdout.split("\0") if name and Path(name).is_file()]
 
 
 def find_abs_path_violations(files: list[str]) -> dict:

--- a/hooks/check_config_abs_paths.py
+++ b/hooks/check_config_abs_paths.py
@@ -13,6 +13,7 @@ See issue #3605.
 import argparse
 import logging
 import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -42,6 +43,17 @@ def _iter_config_files(files: list[str]) -> list[Path]:
         if CONFIG_ROOT.name in path.parts and path.is_file():
             selected.append(path)
     return selected
+
+
+def _iter_tracked_config_files() -> list[str]:
+    """Return Git-tracked files under ``configs/`` for ``--all`` checks."""
+    result = subprocess.run(
+        ["git", "ls-files", "--", str(CONFIG_ROOT)],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if Path(line).is_file()]
 
 
 def find_abs_path_violations(files: list[str]) -> dict:
@@ -116,7 +128,7 @@ def main() -> None:
     args = parser.parse_args()
 
     if args.all:
-        files = [str(p) for p in CONFIG_ROOT.rglob("*") if p.is_file()]
+        files = _iter_tracked_config_files()
     else:
         files = args.files
 

--- a/tests/integration/test_check_config_abs_paths.py
+++ b/tests/integration/test_check_config_abs_paths.py
@@ -122,3 +122,42 @@ class TestCheckConfigAbsPaths:
             main()
 
         assert exc_info.value.code == 0
+
+    def test_all_checks_tracked_path_with_spaces(self, tmp_path, monkeypatch):
+        """``--all`` still inspects tracked configs whose path contains spaces.
+
+        ``git ls-files`` C-quotes such paths in its default output, so the
+        scan must use the null-delimited (``-z``) listing to see them.
+        """
+        monkeypatch.chdir(tmp_path)
+        rel = "configs/my run/leaky.yaml"
+        _write(tmp_path, rel, "script: /home/dev/cache/run.sh\n")
+
+        subprocess.run(["git", "init"], check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["git", "add", rel],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Test User",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                "track spaced config",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        monkeypatch.setattr("sys.argv", ["check_config_abs_paths.py", "--all"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 1

--- a/tests/integration/test_check_config_abs_paths.py
+++ b/tests/integration/test_check_config_abs_paths.py
@@ -6,9 +6,12 @@ Covers the reject path (an unannotated `/home/...` leak), the allowlist path
 outside `configs/` are ignored.
 """
 
+import subprocess
 from pathlib import Path
 
-from hooks.check_config_abs_paths import find_abs_path_violations
+import pytest
+
+from hooks.check_config_abs_paths import find_abs_path_violations, main
 
 
 def _write(base: Path, rel: str, content: str) -> str:
@@ -77,9 +80,45 @@ class TestCheckConfigAbsPaths:
         assert result["status"] == "pass"
         assert "nothing to check" in result["message"].lower()
 
-    def test_repo_baseline_is_clean(self):
-        """The real configs/ tree must already pass (only annotated paths)."""
-        configs = Path("configs")
-        files = [str(p) for p in configs.rglob("*") if p.is_file()]
-        result = find_abs_path_violations(files)
-        assert result["status"] == "pass", result["message"]
+    def test_repo_baseline_is_clean(self, monkeypatch):
+        """The real tracked configs/ tree must already pass ``--all``."""
+        monkeypatch.setattr("sys.argv", ["check_config_abs_paths.py", "--all"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 0
+
+    def test_all_ignores_untracked_config_files(self, tmp_path, monkeypatch):
+        """``--all`` scans Git-tracked configs, not local untracked outputs."""
+        monkeypatch.chdir(tmp_path)
+        _write(tmp_path, "configs/training/clean.yaml", "script: scripts/run.sh\n")
+        _write(tmp_path, "configs/local/leaky.yaml", "script: /home/dev/cache/run.sh\n")
+
+        subprocess.run(["git", "init"], check=True, capture_output=True, text=True)
+        subprocess.run(
+            ["git", "add", "configs/training/clean.yaml"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        subprocess.run(
+            [
+                "git",
+                "-c",
+                "user.name=Test User",
+                "-c",
+                "user.email=test@example.com",
+                "commit",
+                "-m",
+                "track clean config",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+
+        monkeypatch.setattr("sys.argv", ["check_config_abs_paths.py", "--all"])
+        with pytest.raises(SystemExit) as exc_info:
+            main()
+
+        assert exc_info.value.code == 0


### PR DESCRIPTION
## Issue

Fixes https://github.com/ll7/robot_sf_ll7/issues/3662

## Scope Summary

- Changed `hooks/check_config_abs_paths.py --all` to enumerate Git-tracked files under `configs/` via `git ls-files -- configs` instead of scanning every local file under `configs/`.
- Updated the repository baseline test to exercise the real `--all` path.
- Added a focused regression where a leaky untracked config file is ignored while tracked config files remain checked.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/integration/test_check_config_abs_paths.py -q` - passed, 7 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check hooks/check_config_abs_paths.py tests/integration/test_check_config_abs_paths.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check hooks/check_config_abs_paths.py tests/integration/test_check_config_abs_paths.py` - passed, 2 files already formatted.
- Dirty-worktree reproduction: created temporary untracked `configs/issue_3662_tmp/leaky.yaml` containing `/home/...`, reran `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/integration/test_check_config_abs_paths.py -q`, removed the temporary file - passed, 7 passed.
- `git diff --check` - passed.

## Out Of Scope

- No benchmark campaign.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No allow-list mechanism or path-format redesign.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the full-check mode to evaluate only tracked configuration files, preventing untracked files from affecting results.
  * Better handled configuration paths with spaces or special characters during checks.
  * Expanded end-to-end test coverage for full-scope checks, including clean baselines, ignored untracked files, and detected violations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->