### PR TITLE
Fix #3683 rollover proxy bicycle yaw-rate plumbing

### DIFF
--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -807,9 +807,13 @@ class RobotEnv(BaseEnv):
     def _rollover_proxy_record(self) -> dict[str, Any] | None:
         """Return opt-in rollover proxy telemetry for the executed robot state.
 
-        Reads ``robot.current_yaw_rate`` when available; otherwise it assumes
-        ``robot.current_speed`` is ``(linear_velocity, yaw_rate)``. The fallback
-        remains for drive models that do not expose an explicit yaw-rate value.
+        Reads ``robot.current_yaw_rate`` when the robot exposes it (e.g.
+        ``BicycleDriveRobot``); otherwise it assumes ``robot.current_speed`` is
+        ``(linear_velocity, yaw_rate)``. The fallback is reserved for drive models
+        that do not expose an explicit yaw-rate accessor at all. When a drive does
+        expose ``current_yaw_rate`` but it is non-finite, the proxy fails closed
+        rather than silently falling back to ``current_speed[1]`` (which is the
+        heading angle for bicycle drive, the original #3683 mis-read).
         """
         if not getattr(self.env_config, "rollover_proxy_enabled", False):
             return None
@@ -820,7 +824,6 @@ class RobotEnv(BaseEnv):
         explicit_yaw_rate = (
             explicit_yaw_rate() if callable(explicit_yaw_rate) else explicit_yaw_rate
         )
-        yaw_rate = _coerce_finite_float(explicit_yaw_rate)
         try:
             linear_velocity = float(current_speed[0])
         except (TypeError, ValueError, IndexError) as exc:
@@ -828,7 +831,16 @@ class RobotEnv(BaseEnv):
                 "rollover_proxy_enabled requires robot.current_speed as "
                 "(linear_velocity, yaw_rate)."
             ) from exc
-        if yaw_rate is None:
+        if explicit_yaw_rate is not None:
+            # The drive exposes a dedicated yaw-rate accessor: trust it as the
+            # sole source. Fail closed on a non-finite value instead of falling
+            # back to the heading-bearing ``current_speed[1]``.
+            yaw_rate = _coerce_finite_float(explicit_yaw_rate)
+            if yaw_rate is None:
+                raise RuntimeError(
+                    "rollover_proxy_enabled requires a finite robot.current_yaw_rate."
+                )
+        else:
             try:
                 yaw_rate = float(current_speed[1])
             except (TypeError, ValueError, IndexError) as exc:

--- a/robot_sf/gym_env/robot_env.py
+++ b/robot_sf/gym_env/robot_env.py
@@ -807,25 +807,35 @@ class RobotEnv(BaseEnv):
     def _rollover_proxy_record(self) -> dict[str, Any] | None:
         """Return opt-in rollover proxy telemetry for the executed robot state.
 
-        Assumes ``robot.current_speed`` is ``(linear_velocity, yaw_rate)``. This
-        holds for ``DifferentialDriveRobot`` and ``HolonomicDriveRobot``. It does
-        NOT hold for ``BicycleDriveRobot``, whose ``current_speed`` second element
-        is the heading angle, not the yaw rate; enabling the proxy with that drive
-        would mis-feed the margin. Tracked as follow-up rather than a default-path
-        concern because the proxy is opt-in and disabled by default (issue #3479).
+        Reads ``robot.current_yaw_rate`` when available; otherwise it assumes
+        ``robot.current_speed`` is ``(linear_velocity, yaw_rate)``. The fallback
+        remains for drive models that do not expose an explicit yaw-rate value.
         """
         if not getattr(self.env_config, "rollover_proxy_enabled", False):
             return None
-        current_speed = getattr(self.simulator.robots[0], "current_speed", None)
+        robot = self.simulator.robots[0]
+        current_speed = getattr(robot, "current_speed", None)
         current_speed = current_speed() if callable(current_speed) else current_speed
+        explicit_yaw_rate = getattr(robot, "current_yaw_rate", None)
+        explicit_yaw_rate = (
+            explicit_yaw_rate() if callable(explicit_yaw_rate) else explicit_yaw_rate
+        )
+        yaw_rate = _coerce_finite_float(explicit_yaw_rate)
         try:
             linear_velocity = float(current_speed[0])
-            yaw_rate = float(current_speed[1])
         except (TypeError, ValueError, IndexError) as exc:
             raise RuntimeError(
                 "rollover_proxy_enabled requires robot.current_speed as "
                 "(linear_velocity, yaw_rate)."
             ) from exc
+        if yaw_rate is None:
+            try:
+                yaw_rate = float(current_speed[1])
+            except (TypeError, ValueError, IndexError) as exc:
+                raise RuntimeError(
+                    "rollover_proxy_enabled requires robot.current_yaw_rate "
+                    "or robot.current_speed (linear_velocity, yaw_rate)."
+                ) from exc
         return rollover_proxy_telemetry(
             linear_velocity,
             yaw_rate,

--- a/robot_sf/robot/bicycle_drive.py
+++ b/robot_sf/robot/bicycle_drive.py
@@ -40,6 +40,7 @@ class BicycleDriveState:
 
     pose: RobotPose
     velocity: float = field(default=0)
+    angular_velocity: float = field(default=0)
 
     @property
     def pos(self) -> Vec2D:
@@ -60,6 +61,11 @@ class BicycleDriveState:
     def current_speed(self) -> PolarVec2D:
         """Get the current speed and orientation of the robot."""
         return (self.velocity, self.orient)
+
+    @property
+    def current_yaw_rate(self) -> float:
+        """Return the last executed bicycle yaw rate in radians per second."""
+        return self.angular_velocity
 
 
 @dataclass
@@ -107,6 +113,7 @@ class BicycleMotion:
         # Update state with new pose and velocity
         state.pose = ((new_x, new_y), new_orient)
         state.velocity = new_velocity
+        state.angular_velocity = angular_velocity
 
 
 @dataclass
@@ -173,6 +180,11 @@ class BicycleDriveRobot:
             The current speed/orientation tuple exposed by the drive state.
         """
         return self.state.current_speed
+
+    @property
+    def current_yaw_rate(self) -> float:
+        """Return the last executed bicycle yaw rate in radians per second."""
+        return self.state.current_yaw_rate
 
     def apply_action(self, action: BicycleAction, d_t: float):
         """Apply action and advance simulation by dt.

--- a/tests/test_rollover_proxy.py
+++ b/tests/test_rollover_proxy.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from math import tan
 from types import SimpleNamespace
 
 import numpy as np
@@ -11,6 +12,7 @@ from robot_sf.benchmark.metrics import evaluate_stability_margin
 from robot_sf.gym_env.env_config import EnvSettings
 from robot_sf.gym_env.robot_env import RobotEnv
 from robot_sf.gym_env.unified_config import RobotSimulationConfig
+from robot_sf.robot.bicycle_drive import BicycleDriveRobot, BicycleDriveSettings
 from robot_sf.robot.rollover_proxy import (
     PROXY_SCHEMA_VERSION,
     RolloverProxyParams,
@@ -133,6 +135,19 @@ def test_proxy_agrees_with_benchmark_surface_source_of_truth(v: float, omega: fl
     assert proxy_margin == pytest.approx(benchmark_margin)
 
 
+def test_bicycle_drive_exposes_executed_yaw_rate_for_rollover_proxy() -> None:
+    """Bicycle ``current_speed`` heading stays separate from executed yaw rate."""
+    robot = BicycleDriveRobot(
+        BicycleDriveSettings(wheelbase=2.0, max_accel=4.0, max_velocity=5.0, max_steer=1.0)
+    )
+
+    robot.apply_action((2.0, 0.5), 1.0)
+
+    expected_yaw_rate = robot.current_speed[0] * tan(0.5) / robot.config.wheelbase
+    assert robot.current_speed[1] == pytest.approx(robot.pose[1])
+    assert robot.current_yaw_rate == pytest.approx(expected_yaw_rate)
+
+
 class _StepRobot:
     """Minimal robot double exposing executed ``current_speed``."""
 
@@ -142,6 +157,14 @@ class _StepRobot:
     def parse_action(self, action: np.ndarray) -> tuple[float, float]:
         """Return action as differential-drive ``(v, omega)`` command."""
         return (float(action[0]), float(action[1]))
+
+
+class _BicycleStepRobot(_StepRobot):
+    """Robot double exposing bicycle-drive ``current_speed`` plus yaw rate."""
+
+    def __init__(self) -> None:
+        self.current_speed = (0.0, 0.0)
+        self.current_yaw_rate = 0.0
 
 
 class _StepSimulator:
@@ -155,6 +178,20 @@ class _StepSimulator:
     def step_once(self, actions: list[tuple[float, float]]) -> None:
         """Record the executed command as the robot's current speed."""
         self.robots[0].current_speed = actions[0]
+
+
+class _BicycleStepSimulator(_StepSimulator):
+    """Simulator double whose robot reports heading separately from yaw rate."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.robots = [_BicycleStepRobot()]
+
+    def step_once(self, actions: list[tuple[float, float]]) -> None:
+        """Record bicycle-style speed plus explicit executed yaw rate."""
+        linear_velocity, yaw_rate = actions[0]
+        self.robots[0].current_speed = (linear_velocity, 0.1)
+        self.robots[0].current_yaw_rate = yaw_rate
 
 
 class _StepState:
@@ -190,6 +227,7 @@ def _make_step_env(
     rollover_enabled: bool = True,
     penalty: float = -4.0,
     env_config: object | None = None,
+    simulator: _StepSimulator | None = None,
 ) -> RobotEnv:
     env = RobotEnv.__new__(RobotEnv)
     env.env_config = env_config or EnvSettings(
@@ -198,7 +236,7 @@ def _make_step_env(
     )
     env.config = env.env_config
     env.debug_without_robot_movement = False
-    env.simulator = _StepSimulator()
+    env.simulator = simulator or _StepSimulator()
     env.state = _StepState()
     env.occupancy_grid = None
     env._asymmetric_critic_enabled = False
@@ -223,6 +261,20 @@ def test_runtime_rollover_proxy_keeps_feasible_command_nonterminal() -> None:
     assert info["rollover_critical"] is False
     assert info["rollover_proxy"]["stability_margin"] > 0.0
     assert "termination_reason" not in info
+
+
+def test_runtime_rollover_proxy_uses_explicit_bicycle_yaw_rate() -> None:
+    """Bicycle drive ``current_speed`` heading must not be treated as yaw rate."""
+    env = _make_step_env(penalty=-4.0, simulator=_BicycleStepSimulator())
+
+    _obs, reward, terminated, truncated, info = env.step(np.array([2.0, 2.0]))
+
+    assert reward == pytest.approx(-3.0)
+    assert terminated is True
+    assert truncated is False
+    assert info["termination_reason"] == "ROLLOVER_CRITICAL"
+    assert info["rollover_proxy"]["yaw_rate"] == pytest.approx(2.0)
+    assert info["rollover_proxy"]["rollover_critical"] is True
 
 
 def test_runtime_rollover_proxy_over_yaw_trips_terminal_penalty() -> None:

--- a/tests/unit/test_rollover_proxy_yaw_rate.py
+++ b/tests/unit/test_rollover_proxy_yaw_rate.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from math import nan
 from types import SimpleNamespace
 
 import pytest
@@ -15,6 +16,15 @@ class _CurrentSpeedRobot:
     """Robot double exposing the legacy ``(linear_velocity, yaw_rate)`` speed tuple."""
 
     current_speed = (0.5, 0.5)
+
+
+class _NonFiniteYawRateRobot:
+    """Robot double that exposes ``current_yaw_rate`` but reports a non-finite value."""
+
+    # ``current_speed[1]`` here stands in for the bicycle heading angle; the proxy must
+    # never silently fall back to it when the dedicated accessor is present.
+    current_speed = (0.5, 0.5)
+    current_yaw_rate = nan
 
 
 def _make_env(robot: object) -> RobotEnv:
@@ -46,3 +56,11 @@ def test_rollover_proxy_keeps_current_speed_yaw_rate_fallback() -> None:
     assert record is not None
     assert record["linear_velocity"] == pytest.approx(0.5)
     assert record["yaw_rate"] == pytest.approx(0.5)
+
+
+def test_rollover_proxy_fails_closed_on_non_finite_explicit_yaw_rate() -> None:
+    """A present-but-non-finite ``current_yaw_rate`` must fail closed, not fall back."""
+    env = _make_env(_NonFiniteYawRateRobot())
+
+    with pytest.raises(RuntimeError, match="finite robot.current_yaw_rate"):
+        env._rollover_proxy_record()

--- a/tests/unit/test_rollover_proxy_yaw_rate.py
+++ b/tests/unit/test_rollover_proxy_yaw_rate.py
@@ -1,0 +1,48 @@
+"""Regression tests for rollover proxy yaw-rate plumbing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from robot_sf.gym_env.env_config import EnvSettings
+from robot_sf.gym_env.robot_env import RobotEnv
+from robot_sf.robot.bicycle_drive import BicycleDriveRobot, BicycleDriveSettings
+
+
+class _CurrentSpeedRobot:
+    """Robot double exposing the legacy ``(linear_velocity, yaw_rate)`` speed tuple."""
+
+    current_speed = (0.5, 0.5)
+
+
+def _make_env(robot: object) -> RobotEnv:
+    env = RobotEnv.__new__(RobotEnv)
+    env.env_config = EnvSettings(rollover_proxy_enabled=True)
+    env.simulator = SimpleNamespace(robots=[robot])
+    return env
+
+
+def test_rollover_proxy_uses_bicycle_current_yaw_rate() -> None:
+    """Bicycle heading from ``current_speed`` must not be treated as yaw rate."""
+    robot = BicycleDriveRobot(
+        BicycleDriveSettings(wheelbase=0.5, max_accel=8.0, max_velocity=5.0, max_steer=1.0)
+    )
+    robot.apply_action((2.0, 0.8), 0.25)
+
+    record = _make_env(robot)._rollover_proxy_record()
+
+    assert record is not None
+    assert robot.current_speed[1] != pytest.approx(robot.current_yaw_rate)
+    assert record["linear_velocity"] == pytest.approx(robot.current_speed[0])
+    assert record["yaw_rate"] == pytest.approx(robot.current_yaw_rate)
+
+
+def test_rollover_proxy_keeps_current_speed_yaw_rate_fallback() -> None:
+    """Drive models without explicit yaw rate keep the legacy speed tuple contract."""
+    record = _make_env(_CurrentSpeedRobot())._rollover_proxy_record()
+
+    assert record is not None
+    assert record["linear_velocity"] == pytest.approx(0.5)
+    assert record["yaw_rate"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
- Fixes #3683.
- Adds an explicit executed yaw-rate surface for `BicycleDriveRobot` so the rollover proxy does not read bicycle heading as yaw rate.
- Updates `RobotEnv` rollover telemetry to prefer `current_yaw_rate` when available and keep the existing `current_speed` fallback for other drive models.
- Adds focused rollover regression coverage for actual bicycle yaw-rate exposure, the `RobotEnv` fallback, and runtime proxy behavior.

## Validation
- `uv run pytest tests/test_rollover_proxy.py tests/unit/test_rollover_proxy_yaw_rate.py -q` - passed
- `uv run ruff check robot_sf/gym_env/robot_env.py robot_sf/robot/bicycle_drive.py tests/test_rollover_proxy.py tests/unit/test_rollover_proxy_yaw_rate.py` - passed
- `git diff --check` - passed
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr_body_3683.md scripts/dev/pr_ready_check.sh` - passed: 1621 core tests passed; changed-file coverage `robot_env.py` 80.0% warning, `bicycle_drive.py` 100.0%; final stamp fresh for `fe43b42f`.

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
