### PR TITLE
Finish docs evidence integrity checks for issue #3476

### DIFF
--- a/.github/workflows/docs-evidence-integrity.yml
+++ b/.github/workflows/docs-evidence-integrity.yml
@@ -1,11 +1,9 @@
 name: Docs & Evidence Integrity
 
 # Lightweight, changed-path-scoped guard for research-facing documentation and
-# evidence surfaces (issue #3476). First rollout is **advisory / warning-only**:
-# it surfaces findings as non-blocking GitHub warning annotations and never fails
-# the PR, so it cannot block unrelated docs fixes. It only inspects files the PR
-# actually touches and is independent of the full Python test suite. A future
-# increment can promote it to blocking once the surfaces are known to be clean.
+# evidence surfaces (issue #3476). The job is blocking but only inspects files
+# the PR actually touches, so it cannot fail on untouched legacy drift and is
+# independent of the full Python test suite.
 
 on:
   pull_request:
@@ -41,8 +39,7 @@ jobs:
       - name: Install PyYAML
         run: python -m pip install --quiet pyyaml
 
-      - name: Docs/evidence integrity (changed-path scoped, advisory)
+      - name: Docs/evidence integrity (changed-path scoped)
         run: |
           python scripts/dev/check_docs_evidence_integrity.py \
-            --base-ref "origin/${{ github.base_ref }}" \
-            --warn-only
+            --base-ref "origin/${{ github.base_ref }}"

--- a/scripts/dev/check_docs_evidence_integrity.py
+++ b/scripts/dev/check_docs_evidence_integrity.py
@@ -2,26 +2,34 @@
 """Lightweight, changed-path-scoped integrity check for docs/evidence surfaces.
 
 This guard treats documentation, compact evidence bundles, schemas, catalogues,
-issue templates, and governance files as first-class research-facing state. It is
-intentionally **changed-path scoped**: it only inspects files a change actually
-touches, so it can be mandatory in CI without failing on pre-existing legacy drift
-in untouched files (issue #3476).
+issue templates, and governance files as first-class research-facing state. It
+is intentionally changed-path scoped: only files a change actually touches are
+inspected, so it can be mandatory in CI without failing on pre-existing legacy
+drift in untouched files (issue #3476).
 
-Checks performed on each changed file:
+Checks performed:
 
-- ``.json`` files must parse as JSON.
-- ``.yaml`` / ``.yml`` files must parse as YAML (multi-document allowed).
-- Markdown files: every *explicit* repository-local relative link (a target that
-  starts with ``./`` or ``../``) must resolve to an existing path. This is the
-  conservative subset of link checking that cannot produce false positives on
-  external URLs, anchors, or ambiguous bare references.
+- ``.json`` files parse JSON.
+- ``.yaml`` / ``.yml`` files parse YAML (multi-document allowed).
+- Markdown files: every explicit repository-local relative link (a target that
+  starts ``./`` or ``../``) must resolve to an existing path.
+- Changed ``docs/context/evidence`` files must be registered in
+  ``docs/context/catalog.yaml``.
+- Changed catalog rows must point at existing files and use valid status /
+  freshness vocabulary values.
+- Changed checksum manifests, and changed files covered by a local checksum
+  manifest, must match current file contents.
+- Evidence ``README.md`` classification fields cannot disagree with adjacent
+  machine-readable ``summary.json`` fields.
+- Cited script/config paths in changed docs or evidence files must exist.
 
-The check is independent of the full Python test suite.
+The check is independent from the full Python test suite.
 """
 
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import re
 import subprocess
@@ -34,14 +42,43 @@ import yaml
 if TYPE_CHECKING:
     from collections.abc import Iterable, Sequence
 
-# Markdown inline link target: capture the URL portion, ignoring an optional title.
+_CATALOG_PATH = Path("docs/context/catalog.yaml")
+_EVIDENCE_DIR = Path("docs/context/evidence")
+_CHECKSUM_FILENAMES = {"SHA256SUMS", "checksums.sha256", "manifest.sha256"}
+_SUMMARY_FILENAME = "summary.json"
+_README_FILENAME = "README.md"
+_VALID_CATALOG_STATUSES = {
+    "current",
+    "historical",
+    "superseded",
+    "evidence",
+    "proposal",
+}
+_VALID_CATALOG_FRESHNESS = {"maintained", "dated", "policy", "evidence"}
+_CLASSIFICATION_KEYS = {
+    "benchmark_promotion",
+    "claim_boundary",
+    "diagnostic_only",
+    "evidence_grade",
+    "evidence_tier",
+    "paper_facing",
+    "result_classification",
+    "schema",
+    "schema_version",
+    "status",
+}
+
 _MD_LINK = re.compile(r"\]\(\s*<?([^)\s>]+)>?(?:\s+\"[^\"]*\")?\s*\)")
-# Only validate unambiguously repo-local relative links.
+_README_FIELD = re.compile(r"`(?P<key>[A-Za-z0-9_-]+)`\s*:\s*`(?P<value>[^`]+)`")
+_CONFIG_FLAG = re.compile(r"--[A-Za-z0-9_-]*config(?:=|\s+)(?P<path>[A-Za-z0-9_./:-]+)")
+_CITED_REPO_PATH = re.compile(
+    r"(?<![\w./-])(?P<path>(?:scripts|configs)/[A-Za-z0-9_./:-]+\.(?:py|sh|ya?ml))"
+)
 _RELATIVE_PREFIXES = ("./", "../")
 
 
 def _repo_root() -> Path:
-    """Return the Git repository root."""
+    """Return Git repository root."""
     out = subprocess.run(
         ["git", "rev-parse", "--show-toplevel"],
         check=True,
@@ -61,6 +98,21 @@ def changed_files(base_ref: str, *, root: Path) -> list[str]:
         cwd=root,
     )
     return [line for line in out.stdout.splitlines() if line.strip()]
+
+
+def _repo_rel(path: Path, *, root: Path) -> Path:
+    """Return a repository-relative path for display and catalog matching."""
+    return path.resolve().relative_to(root.resolve())
+
+
+def _looks_dynamic(path: str) -> bool:
+    """Return whether a cited path contains shell/template expansion."""
+    return any(token in path for token in ("$", "{", "}", "<", ">", "*"))
+
+
+def _clean_cited_path(path: str) -> str:
+    """Remove common trailing shell and Markdown punctuation from cited paths."""
+    return path.strip().rstrip(".,;:)`'\"")
 
 
 def _check_json(path: Path) -> list[str]:
@@ -88,33 +140,355 @@ def _check_markdown_links(path: Path, *, root: Path) -> list[str]:
         text = path.read_text(encoding="utf-8")
     except OSError as exc:
         return [f"{path}: unreadable Markdown: {exc}"]
+
     for raw_target in _MD_LINK.findall(text):
         target = raw_target.strip()
         if not target.startswith(_RELATIVE_PREFIXES):
             continue
-        # Drop any anchor fragment; the file existence is what we verify.
+
         file_part = target.split("#", 1)[0]
         if not file_part:
             continue
+
         resolved = (path.parent / file_part).resolve()
         try:
             resolved.relative_to(root.resolve())
         except ValueError:
-            problems.append(f"{path}: relative link escapes the repository: {target}")
+            problems.append(f"{path}: relative link escapes repository: {target}")
             continue
         if not resolved.exists():
             problems.append(f"{path}: broken repo-local link: {target}")
     return problems
 
 
-def check_files(files: Iterable[str], *, root: Path) -> list[str]:
-    """Run the integrity checks over the given repo-relative files."""
+def _load_catalog(root: Path) -> tuple[object | None, list[str]]:
+    """Load the context catalog, returning payload and parse diagnostics."""
+    catalog = root / _CATALOG_PATH
+    if not catalog.is_file():
+        return None, [f"{_CATALOG_PATH}: missing context catalog"]
+    try:
+        return yaml.safe_load(catalog.read_text(encoding="utf-8")), []
+    except yaml.YAMLError as exc:
+        return None, [f"{_CATALOG_PATH}: invalid YAML: {exc}"]
+
+
+def _catalog_entries(payload: object) -> list[dict[object, object]]:
+    """Return mapping entries from a catalog payload."""
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _catalog_path_value(value: object) -> Path | None:
+    """Return a normalized catalog path value when it is repository-relative."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    path = Path(value.strip())
+    if path.is_absolute() or ".." in path.parts:
+        return None
+    return path
+
+
+def _catalog_registered_paths(payload: object) -> set[Path]:
+    """Return repository-relative paths registered in the catalog."""
+    paths: set[Path] = set()
+    for entry in _catalog_entries(payload):
+        path = _catalog_path_value(entry.get("path"))
+        if path is not None:
+            paths.add(path)
+    return paths
+
+
+def _catalog_validation_problems(payload: object, *, root: Path) -> list[str]:  # noqa: C901, PLR0912
+    """Return registration and metadata problems in docs/context/catalog.yaml."""
     problems: list[str] = []
+    if not isinstance(payload, dict):
+        return [f"{_CATALOG_PATH}: context catalog must be a YAML mapping"]
+    if payload.get("version") != 1:
+        problems.append(f"{_CATALOG_PATH}: version must be 1")
+
+    status_values = set(_VALID_CATALOG_STATUSES)
+    raw_status_values = payload.get("status_values")
+    if isinstance(raw_status_values, dict):
+        status_values.update(str(key) for key in raw_status_values)
+
+    freshness_values = set(_VALID_CATALOG_FRESHNESS)
+    raw_freshness_values = payload.get("freshness_values")
+    if isinstance(raw_freshness_values, dict):
+        freshness_values.update(str(key) for key in raw_freshness_values)
+
+    entries = payload.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return [f"{_CATALOG_PATH}: entries must be a non-empty list"]
+
+    seen: set[Path] = set()
+    for index, raw_entry in enumerate(entries):
+        entry_path = f"entries[{index}]"
+        if not isinstance(raw_entry, dict):
+            problems.append(f"{_CATALOG_PATH}: {entry_path} must be a mapping")
+            continue
+
+        path = _catalog_path_value(raw_entry.get("path"))
+        if path is None:
+            problems.append(f"{_CATALOG_PATH}: {entry_path}.path must be repo-relative")
+        else:
+            if path in seen:
+                problems.append(f"{_CATALOG_PATH}: {entry_path}.path duplicates {path}")
+            seen.add(path)
+            if not (root / path).is_file():
+                problems.append(f"{_CATALOG_PATH}: {entry_path}.path does not exist: {path}")
+
+        status = raw_entry.get("status")
+        if status not in status_values:
+            problems.append(f"{_CATALOG_PATH}: {entry_path}.status invalid: {status!r}")
+
+        freshness = raw_entry.get("freshness")
+        if freshness not in freshness_values:
+            problems.append(f"{_CATALOG_PATH}: {entry_path}.freshness invalid: {freshness!r}")
+
+        if status == "superseded":
+            replacement = _catalog_path_value(raw_entry.get("replacement"))
+            if replacement is None:
+                problems.append(f"{_CATALOG_PATH}: {entry_path}.replacement required")
+            elif not (root / replacement).exists():
+                problems.append(
+                    f"{_CATALOG_PATH}: {entry_path}.replacement does not exist: {replacement}"
+                )
+
+    return problems
+
+
+def _checksum_manifest_paths(path: Path, *, root: Path) -> list[Path]:
+    """Return checksum manifests adjacent to a changed evidence file."""
+    try:
+        rel = _repo_rel(path, root=root)
+    except ValueError:
+        return []
+    if _EVIDENCE_DIR not in rel.parents:
+        return []
+    parent = path.parent
+    return [parent / name for name in sorted(_CHECKSUM_FILENAMES) if (parent / name).is_file()]
+
+
+def _parse_checksum_line(line: str, *, manifest: Path, root: Path) -> tuple[str, Path] | None:
+    """Parse a sha256sum-style manifest line."""
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return None
+    match = re.match(r"^(?P<hash>[0-9a-fA-F]{64})\s+\*?(?P<path>.+)$", stripped)
+    if match is None:
+        return None
+
+    raw_path = match.group("path").strip().lstrip("./")
+    candidate = Path(raw_path)
+    if candidate.is_absolute() or ".." in candidate.parts:
+        return None
+
+    root_candidate = root / candidate
+    if root_candidate.exists():
+        return match.group("hash").lower(), root_candidate
+    return match.group("hash").lower(), manifest.parent / candidate
+
+
+def _sha256(path: Path) -> str:
+    """Return sha256 digest for a file."""
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def _checksum_problems_for_manifest(manifest: Path, *, root: Path) -> list[str]:
+    """Return checksum mismatches inside one manifest."""
+    problems: list[str] = []
+    try:
+        lines = manifest.read_text(encoding="utf-8").splitlines()
+    except UnicodeDecodeError:
+        return []
+
+    for line_no, line in enumerate(lines, start=1):
+        parsed = _parse_checksum_line(line, manifest=manifest, root=root)
+        if parsed is None:
+            continue
+        expected, target = parsed
+        if not target.is_file():
+            problems.append(f"{manifest}: line {line_no} target missing: {target}")
+            continue
+        actual = _sha256(target)
+        if actual != expected:
+            problems.append(f"{manifest}: line {line_no} checksum mismatch for {target}")
+    return problems
+
+
+def _checksum_problems_for_changed_file(path: Path, *, root: Path) -> list[str]:
+    """Return checksum mismatch if a changed evidence file has an adjacent manifest."""
+    if path.name in _CHECKSUM_FILENAMES:
+        return _checksum_problems_for_manifest(path, root=root)
+
+    problems: list[str] = []
+    for manifest in _checksum_manifest_paths(path, root=root):
+        found = False
+        try:
+            lines = manifest.read_text(encoding="utf-8").splitlines()
+        except UnicodeDecodeError:
+            continue
+        for line_no, line in enumerate(lines, start=1):
+            parsed = _parse_checksum_line(line, manifest=manifest, root=root)
+            if parsed is None:
+                continue
+            expected, target = parsed
+            if target.resolve() != path.resolve():
+                continue
+            found = True
+            actual = _sha256(path)
+            if actual != expected:
+                problems.append(
+                    f"{manifest}: line {line_no} checksum mismatch for changed file {path}"
+                )
+        if found:
+            break
+    return problems
+
+
+def _evidence_registration_problems(files: Iterable[Path], *, root: Path) -> list[str]:
+    """Return catalog-registration and checksum problems for changed evidence files."""
+    evidence_files = []
+    for path in files:
+        try:
+            rel = _repo_rel(path, root=root)
+        except ValueError:
+            continue
+        if rel == _CATALOG_PATH or _EVIDENCE_DIR in rel.parents:
+            evidence_files.append(path)
+
+    if not evidence_files:
+        return []
+
+    payload, load_problems = _load_catalog(root)
+    if load_problems:
+        return load_problems
+
+    problems: list[str] = []
+    registered = _catalog_registered_paths(payload)
+    if any(_repo_rel(path, root=root) == _CATALOG_PATH for path in evidence_files):
+        problems.extend(_catalog_validation_problems(payload, root=root))
+
+    for path in evidence_files:
+        rel = _repo_rel(path, root=root)
+        if rel == _CATALOG_PATH:
+            continue
+        if rel not in registered:
+            problems.append(f"{rel}: evidence file is not registered in {_CATALOG_PATH}")
+        problems.extend(_checksum_problems_for_changed_file(path, root=root))
+
+    return problems
+
+
+def _read_json_object(path: Path) -> dict[str, object] | None:
+    """Read a JSON object, returning None for invalid or non-object payloads."""
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _normalize_value(value: object) -> str:
+    """Normalize values for README-vs-summary comparisons."""
+    if isinstance(value, bool):
+        return str(value).lower()
+    return str(value).strip().lower().replace("_", "-")
+
+
+def _readme_summary_drift_problems(path: Path, *, root: Path) -> list[str]:  # noqa: C901
+    """Return classification drift between evidence README.md and summary.json."""
+    if path.name not in {_README_FILENAME, _SUMMARY_FILENAME}:
+        return []
+    try:
+        rel = _repo_rel(path, root=root)
+    except ValueError:
+        return []
+    if _EVIDENCE_DIR not in rel.parents:
+        return []
+
+    readme = path.parent / _README_FILENAME
+    summary = path.parent / _SUMMARY_FILENAME
+    if not readme.is_file() or not summary.is_file():
+        return []
+
+    summary_payload = _read_json_object(summary)
+    if summary_payload is None:
+        return []
+
+    try:
+        declared = {
+            match.group("key").replace("-", "_").lower(): match.group("value")
+            for match in _README_FIELD.finditer(readme.read_text(encoding="utf-8"))
+        }
+    except OSError:
+        return []
+
+    problems: list[str] = []
+    for key, readme_value in sorted(declared.items()):
+        if key not in _CLASSIFICATION_KEYS:
+            continue
+        summary_key = key
+        if summary_key not in summary_payload and key == "schema":
+            summary_key = "schema_version"
+        if summary_key not in summary_payload:
+            continue
+        if _normalize_value(readme_value) != _normalize_value(summary_payload[summary_key]):
+            problems.append(
+                f"{readme}: `{key}` disagrees with {summary.name} "
+                f"({readme_value!r} != {summary_payload[summary_key]!r})"
+            )
+    return problems
+
+
+def _extract_cited_paths(text: str) -> set[str]:
+    """Return script and config paths cited by changed text."""
+    paths: set[str] = set()
+    for match in _CONFIG_FLAG.finditer(text):
+        paths.add(_clean_cited_path(match.group("path")))
+    for match in _CITED_REPO_PATH.finditer(text):
+        paths.add(_clean_cited_path(match.group("path")))
+    return {path for path in paths if path and not _looks_dynamic(path)}
+
+
+def _cited_path_problems(path: Path, *, root: Path) -> list[str]:
+    """Return missing cited command/config path diagnostics."""
+    if path.suffix.lower() not in {".md", ".json", ".yaml", ".yml"}:
+        return []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except UnicodeDecodeError:
+        return []
+
+    problems: list[str] = []
+    for cited in sorted(_extract_cited_paths(text)):
+        candidate = Path(cited)
+        if candidate.is_absolute() or ".." in candidate.parts:
+            continue
+        if not (root / candidate).exists():
+            problems.append(f"{path}: cited command/config path does not exist: {cited}")
+    return problems
+
+
+def check_files(files: Iterable[str], *, root: Path) -> list[str]:
+    """Run integrity checks over repository-relative files."""
+    problems: list[str] = []
+    existing_paths: list[Path] = []
+
     for rel in files:
         path = (root / rel).resolve()
         if not path.is_file():
-            # Deleted/renamed-away paths are not our concern (filtered upstream).
             continue
+        existing_paths.append(path)
+
         suffix = path.suffix.lower()
         if suffix == ".json":
             problems.extend(_check_json(path))
@@ -122,31 +496,37 @@ def check_files(files: Iterable[str], *, root: Path) -> list[str]:
             problems.extend(_check_yaml(path))
         elif suffix in {".md", ".markdown"}:
             problems.extend(_check_markdown_links(path, root=root))
+
+        problems.extend(_readme_summary_drift_problems(path, root=root))
+        problems.extend(_cited_path_problems(path, root=root))
+
+    problems.extend(_evidence_registration_problems(existing_paths, root=root))
     return problems
 
 
 def _build_parser() -> argparse.ArgumentParser:
-    """Build the CLI parser."""
-    parser = argparse.ArgumentParser(description=__doc__)
+    """Build CLI parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Changed-path docs/evidence integrity check for JSON/YAML parseability, "
+            "repo-local Markdown links, evidence catalog registration/checksums, "
+            "README-vs-summary drift, and cited command/config paths."
+        )
+    )
     parser.add_argument(
         "--base-ref",
         default="origin/main",
-        help="Git ref to diff against for changed-file scoping (default: origin/main).",
+        help="Base ref for changed-file discovery (default: origin/main).",
     )
     parser.add_argument(
         "--files",
-        nargs="*",
-        default=None,
-        help="Explicit repo-relative files to check, bypassing git diff (mainly for tests).",
+        nargs="+",
+        help="Explicit repository-relative files to check instead of git diff.",
     )
     parser.add_argument(
         "--warn-only",
         action="store_true",
-        help=(
-            "Advisory mode: emit findings as non-blocking GitHub warning annotations "
-            "and always exit 0. This is the first-rollout default for CI so the check "
-            "surfaces problems without blocking unrelated docs fixes."
-        ),
+        help="Emit GitHub warnings but exit 0. Prefer blocking mode for CI.",
     )
     return parser
 
@@ -154,22 +534,23 @@ def _build_parser() -> argparse.ArgumentParser:
 def _emit_warnings(problems: list[str]) -> None:
     """Emit findings as GitHub Actions warning annotations (non-blocking)."""
     for problem in problems:
-        # `::warning::` annotations surface in the PR/run UI but do not fail the job.
         sys.stdout.write(f"::warning::docs/evidence integrity: {problem}\n")
 
 
 def main(argv: Sequence[str] | None = None) -> int:
-    """Run the docs/evidence integrity check and return a shell exit code."""
+    """Run docs/evidence integrity check and return a shell exit code."""
     args = _build_parser().parse_args(argv)
     root = _repo_root()
     files = list(args.files) if args.files is not None else changed_files(args.base_ref, root=root)
     if not files:
         print("docs/evidence integrity: no changed docs/evidence files to check.")
         return 0
+
     problems = check_files(files, root=root)
     if not problems:
         print(f"docs/evidence integrity: {len(files)} changed file(s) passed.")
         return 0
+
     if args.warn_only:
         _emit_warnings(problems)
         print(
@@ -177,6 +558,7 @@ def main(argv: Sequence[str] | None = None) -> int:
             "(warning-only, not blocking)."
         )
         return 0
+
     sys.stderr.write("docs/evidence integrity check failed:\n")
     sys.stderr.write("\n".join(f"  {problem}" for problem in problems) + "\n")
     return 1

--- a/scripts/dev/check_docs_evidence_integrity.py
+++ b/scripts/dev/check_docs_evidence_integrity.py
@@ -238,7 +238,9 @@ def _catalog_validation_problems(payload: object, *, root: Path) -> list[str]:  
             if path in seen:
                 problems.append(f"{_CATALOG_PATH}: {entry_path}.path duplicates {path}")
             seen.add(path)
-            if not (root / path).is_file():
+            # Evidence bundles may be registered either as a single file or as a
+            # directory, so accept both rather than requiring a regular file.
+            if not (root / path).exists():
                 problems.append(f"{_CATALOG_PATH}: {entry_path}.path does not exist: {path}")
 
         status = raw_entry.get("status")
@@ -381,7 +383,9 @@ def _evidence_registration_problems(files: Iterable[Path], *, root: Path) -> lis
         rel = _repo_rel(path, root=root)
         if rel == _CATALOG_PATH:
             continue
-        if rel not in registered:
+        # A file is registered if its exact path is listed, or if an ancestor
+        # directory is registered as an evidence bundle.
+        if rel not in registered and not any(parent in registered for parent in rel.parents):
             problems.append(f"{rel}: evidence file is not registered in {_CATALOG_PATH}")
         problems.extend(_checksum_problems_for_changed_file(path, root=root))
 

--- a/tests/dev/test_check_docs_evidence_integrity.py
+++ b/tests/dev/test_check_docs_evidence_integrity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import hashlib
+import json
 from typing import TYPE_CHECKING
 
 from scripts.dev.check_docs_evidence_integrity import check_files, main
@@ -9,14 +11,40 @@ from scripts.dev.check_docs_evidence_integrity import check_files, main
 if TYPE_CHECKING:
     from pathlib import Path
 
+    from pytest import MonkeyPatch
+
+
+def _write_catalog(root: Path, paths: list[str]) -> None:
+    """Write a minimal context catalog registering evidence paths."""
+    catalog = root / "docs/context/catalog.yaml"
+    catalog.parent.mkdir(parents=True, exist_ok=True)
+    entries = "\n".join(
+        f"  - path: {path}\n    status: evidence\n    freshness: evidence" for path in paths
+    )
+    catalog.write_text(
+        "version: 1\n"
+        "status_values:\n"
+        "  evidence: Evidence pointer or manifest.\n"
+        "freshness_values:\n"
+        "  evidence: Evidence pointer.\n"
+        "entries:\n"
+        f"{entries}\n",
+        encoding="utf-8",
+    )
+
+
+def _sha256(path: Path) -> str:
+    """Return sha256 digest for a test fixture file."""
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
 
 def test_valid_files_pass(tmp_path: Path) -> None:
-    """Well-formed JSON/YAML and a resolvable relative link must produce no problems."""
+    """Well-formed JSON/YAML/resolvable relative link produce no problems."""
     (tmp_path / "target.md").write_text("# target\n", encoding="utf-8")
     (tmp_path / "data.json").write_text('{"ok": true}\n', encoding="utf-8")
     (tmp_path / "data.yaml").write_text("schema_version: 1\nitems: [a, b]\n", encoding="utf-8")
     (tmp_path / "note.md").write_text(
-        "See [target](./target.md) and [home](https://example.com) and [anchor](#section).\n",
+        "See [target](./target.md) [home](https://example.com) and [anchor](#section).\n",
         encoding="utf-8",
     )
 
@@ -46,51 +74,150 @@ def test_invalid_yaml_is_reported(tmp_path: Path) -> None:
 
 
 def test_broken_relative_link_is_reported(tmp_path: Path) -> None:
-    """A repo-local relative link to a missing file must be flagged."""
-    (tmp_path / "note.md").write_text("See [gone](./missing.md).\n", encoding="utf-8")
+    """Explicit relative links must resolve."""
+    (tmp_path / "note.md").write_text("[missing](./missing.md)\n", encoding="utf-8")
 
     problems = check_files(["note.md"], root=tmp_path)
 
     assert len(problems) == 1
     assert "broken repo-local link" in problems[0]
-    assert "./missing.md" in problems[0]
 
 
-def test_external_and_anchor_links_are_not_flagged(tmp_path: Path) -> None:
-    """External URLs, mailto, and pure anchors must never be treated as broken paths."""
-    (tmp_path / "note.md").write_text(
-        "[web](https://example.com/x) [mail](mailto:a@b.c) [top](#top) [bare](some/other.md)\n",
-        encoding="utf-8",
-    )
-
-    problems = check_files(["note.md"], root=tmp_path)
-
-    assert problems == []
-
-
-def test_relative_link_escaping_repo_is_reported(tmp_path: Path) -> None:
-    """A relative link resolving outside the repository root must be flagged."""
+def test_relative_link_cannot_escape_repo(tmp_path: Path) -> None:
+    """Relative Markdown links cannot escape the checkout."""
     root = tmp_path / "repo"
-    (root / "docs").mkdir(parents=True)
-    (tmp_path / "outside.md").write_text("# outside\n", encoding="utf-8")
-    (root / "docs" / "note.md").write_text("[up](../../outside.md)\n", encoding="utf-8")
+    root.mkdir()
+    (root / "docs").mkdir()
+    (root / "docs/note.md").write_text("[escape](../../outside.md)\n", encoding="utf-8")
 
     problems = check_files(["docs/note.md"], root=root)
 
     assert len(problems) == 1
-    assert "escapes the repository" in problems[0]
+    assert "escapes repository" in problems[0]
 
 
 def test_link_with_anchor_fragment_resolves_to_file(tmp_path: Path) -> None:
-    """A relative link with an anchor fragment must validate the file part only."""
+    """Only the file part of an anchor link is validated."""
     (tmp_path / "target.md").write_text("# target\n", encoding="utf-8")
     (tmp_path / "note.md").write_text("[sec](./target.md#section)\n", encoding="utf-8")
 
     assert check_files(["note.md"], root=tmp_path) == []
 
 
-def test_warn_only_mode_does_not_fail_on_problems(tmp_path: Path, capsys, monkeypatch) -> None:
-    """Advisory mode must exit 0 and emit GitHub warning annotations, not block."""
+def test_changed_evidence_file_must_be_catalog_registered(tmp_path: Path) -> None:
+    """A changed evidence file without a catalog entry must fail."""
+    summary = tmp_path / "docs/context/evidence/issue_999_missing/summary.json"
+    summary.parent.mkdir(parents=True)
+    summary.write_text('{"status": "ok"}\n', encoding="utf-8")
+    _write_catalog(tmp_path, [])
+
+    problems = check_files([summary.relative_to(tmp_path).as_posix()], root=tmp_path)
+
+    assert any("not registered" in problem for problem in problems)
+
+
+def test_changed_evidence_file_checksum_must_match(tmp_path: Path) -> None:
+    """A changed evidence file covered by a checksum manifest must match it."""
+    bundle = tmp_path / "docs/context/evidence/issue_999_checksums"
+    bundle.mkdir(parents=True)
+    summary = bundle / "summary.json"
+    summary.write_text('{"status": "ok"}\n', encoding="utf-8")
+    manifest = bundle / "SHA256SUMS"
+    manifest.write_text(
+        f"{'0' * 64}  {summary.relative_to(tmp_path).as_posix()}\n",
+        encoding="utf-8",
+    )
+    _write_catalog(
+        tmp_path,
+        [
+            summary.relative_to(tmp_path).as_posix(),
+            manifest.relative_to(tmp_path).as_posix(),
+        ],
+    )
+
+    problems = check_files([summary.relative_to(tmp_path).as_posix()], root=tmp_path)
+
+    assert any("checksum mismatch" in problem for problem in problems)
+
+
+def test_changed_checksum_manifest_validates_targets(tmp_path: Path) -> None:
+    """A changed checksum manifest validates referenced file checksums."""
+    bundle = tmp_path / "docs/context/evidence/issue_999_manifest"
+    bundle.mkdir(parents=True)
+    summary = bundle / "summary.json"
+    summary.write_text('{"status": "ok"}\n', encoding="utf-8")
+    manifest = bundle / "SHA256SUMS"
+    manifest.write_text(
+        f"{_sha256(summary)}  {summary.relative_to(tmp_path).as_posix()}\n",
+        encoding="utf-8",
+    )
+    _write_catalog(
+        tmp_path,
+        [
+            summary.relative_to(tmp_path).as_posix(),
+            manifest.relative_to(tmp_path).as_posix(),
+        ],
+    )
+
+    problems = check_files([manifest.relative_to(tmp_path).as_posix()], root=tmp_path)
+
+    assert problems == []
+
+
+def test_catalog_change_validates_registered_paths(tmp_path: Path) -> None:
+    """Changing catalog.yaml validates that registered paths exist."""
+    _write_catalog(tmp_path, ["docs/context/evidence/issue_999_missing/summary.json"])
+
+    problems = check_files(["docs/context/catalog.yaml"], root=tmp_path)
+
+    assert any("does not exist" in problem for problem in problems)
+
+
+def test_readme_summary_classification_drift_is_reported(tmp_path: Path) -> None:
+    """README evidence status must not disagree with summary.json fields."""
+    bundle = tmp_path / "docs/context/evidence/issue_999_drift"
+    bundle.mkdir(parents=True)
+    readme = bundle / "README.md"
+    readme.write_text(
+        "# Evidence\n\n## Evidence Status\n- `result_classification`: `positive_result`\n",
+        encoding="utf-8",
+    )
+    summary = bundle / "summary.json"
+    summary.write_text(
+        json.dumps({"result_classification": "negative_result"}) + "\n",
+        encoding="utf-8",
+    )
+    _write_catalog(
+        tmp_path,
+        [
+            readme.relative_to(tmp_path).as_posix(),
+            summary.relative_to(tmp_path).as_posix(),
+        ],
+    )
+
+    problems = check_files([readme.relative_to(tmp_path).as_posix()], root=tmp_path)
+
+    assert any("disagrees" in problem for problem in problems)
+
+
+def test_cited_command_and_config_paths_must_exist(tmp_path: Path) -> None:
+    """Changed docs verify practical script/config paths cited in commands."""
+    note = tmp_path / "docs/context/issue_999.md"
+    note.parent.mkdir(parents=True)
+    note.write_text(
+        "Run `uv run python scripts/missing.py --config configs/missing.yaml`.\n",
+        encoding="utf-8",
+    )
+
+    problems = check_files([note.relative_to(tmp_path).as_posix()], root=tmp_path)
+
+    assert sum("cited command/config path" in problem for problem in problems) == 2
+
+
+def test_warn_only_mode_does_not_fail_on_problems(
+    tmp_path: Path, capsys, monkeypatch: MonkeyPatch
+) -> None:
+    """Advisory mode exits 0 and emits GitHub warnings."""
     monkeypatch.setattr("scripts.dev.check_docs_evidence_integrity._repo_root", lambda: tmp_path)
     (tmp_path / "broken.json").write_text("{not valid}", encoding="utf-8")
 
@@ -102,8 +229,8 @@ def test_warn_only_mode_does_not_fail_on_problems(tmp_path: Path, capsys, monkey
     assert "invalid JSON" in out
 
 
-def test_blocking_mode_fails_on_problems(tmp_path: Path, monkeypatch) -> None:
-    """Without --warn-only the same problem must fail closed (exit 1)."""
+def test_blocking_mode_fails_on_problems(tmp_path: Path, monkeypatch: MonkeyPatch) -> None:
+    """Without --warn-only the same problem fails closed."""
     monkeypatch.setattr("scripts.dev.check_docs_evidence_integrity._repo_root", lambda: tmp_path)
     (tmp_path / "broken.json").write_text("{not valid}", encoding="utf-8")
 

--- a/tests/dev/test_check_docs_evidence_integrity.py
+++ b/tests/dev/test_check_docs_evidence_integrity.py
@@ -173,6 +173,31 @@ def test_catalog_change_validates_registered_paths(tmp_path: Path) -> None:
     assert any("does not exist" in problem for problem in problems)
 
 
+def test_catalog_directory_entry_is_accepted(tmp_path: Path) -> None:
+    """An evidence bundle registered as a directory must not be flagged missing."""
+    bundle = tmp_path / "docs/context/evidence/issue_999_bundle"
+    bundle.mkdir(parents=True)
+    (bundle / "summary.json").write_text('{"status": "ok"}\n', encoding="utf-8")
+    _write_catalog(tmp_path, [bundle.relative_to(tmp_path).as_posix()])
+
+    problems = check_files(["docs/context/catalog.yaml"], root=tmp_path)
+
+    assert not any("does not exist" in problem for problem in problems)
+
+
+def test_file_inside_directory_registered_bundle_counts_as_registered(tmp_path: Path) -> None:
+    """A changed file inside a directory-registered bundle is treated as registered."""
+    bundle = tmp_path / "docs/context/evidence/issue_999_bundle"
+    bundle.mkdir(parents=True)
+    summary = bundle / "summary.json"
+    summary.write_text('{"status": "ok"}\n', encoding="utf-8")
+    _write_catalog(tmp_path, [bundle.relative_to(tmp_path).as_posix()])
+
+    problems = check_files([summary.relative_to(tmp_path).as_posix()], root=tmp_path)
+
+    assert not any("not registered" in problem for problem in problems)
+
+
 def test_readme_summary_classification_drift_is_reported(tmp_path: Path) -> None:
     """README evidence status must not disagree with summary.json fields."""
     bundle = tmp_path / "docs/context/evidence/issue_999_drift"


### PR DESCRIPTION
## Issue

Fixes https://github.com/ll7/robot_sf_ll7/issues/3476.

## Scope Summary

- Extends the changed-path `docs-evidence-integrity` check for the remaining #3476 DoD:
  `docs/context/catalog.yaml` registration/checksum validation, evidence README-vs-summary drift
  detection, and cited script/config-path verification.
- Promotes the workflow from warning-only to blocking while keeping it strictly changed-path scoped.
- Adds focused fixture tests for the new validator failure modes.

## Validation

- `uv run --active pytest tests/dev/test_check_docs_evidence_integrity.py -q` - passed, 14 tests.
- `uv run --active ruff check scripts/dev/check_docs_evidence_integrity.py tests/dev/test_check_docs_evidence_integrity.py` - passed.
- `uv run --active ruff format scripts/dev/check_docs_evidence_integrity.py tests/dev/test_check_docs_evidence_integrity.py` - passed.
- `uv run --active python scripts/dev/check_docs_evidence_integrity.py --base-ref origin/main` - passed, 3 changed files checked.
- `uv run --active python - <<'PY' ... yaml.safe_load('.github/workflows/docs-evidence-integrity.yml') ... PY` - passed.
- `git diff --check origin/main...HEAD` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/validation/pr_body_issue_3476.md scripts/dev/pr_ready_check.sh` - passed.

## Out of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Downstream Propagation

- Parent issue updated: no, issue comments are not authorized for this task.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because this is a changed-path workflow/static-validation PR with no benchmark,
  metric, schema, model-provenance, or paper-facing result claim.

## Follow-Up Issues

- Deferred work: none
- Issues opened for follow-up: none


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened the docs/evidence integrity check so it now fails the workflow on problems instead of only warning.
  * Added broader validation for changed documentation and evidence files, including link checks, manifest consistency, catalog registration, and path existence.
  * Improved detection of mismatches between evidence status details and related summary information.

* **Tests**
  * Expanded coverage for broken links, checksum mismatches, catalog issues, and other integrity failures.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->