### PR TITLE
feat(tools): context-note archival-sweep planner (#3190)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **context-note archival-sweep planner** (#3190):
+  [`scripts/tools/plan_context_note_archival.py`](scripts/tools/plan_context_note_archival.py)
+  consumes the existing freshness checker plus `docs/context/catalog.yaml` and proposes which notes
+  should move to `docs/context/archive/`. It classifies **high-confidence** candidates (catalog rows
+  marked `status: superseded` that already name a valid, existing replacement) and **review**
+  candidates (notes flagged stale by `check_context_note_freshness`), computes per-note archive
+  targets, and detects blocking conflicts (basename collisions or a pre-existing target). The planner
+  is **plan-only** — it never moves, writes, or deletes a note (`--json-output` emits a
+  maintainer-reviewable plan) — so the actual archival sweep stays a separate, review-gated PR per
+  issue #3190. It reuses (does not duplicate) the checker's catalog parsing and stale-note rules.
 * Added an **opt-in three-wheeled rollover proxy** runtime hook in `RobotEnv.step()` (#3479). When
   `rollover_proxy_enabled` is set, the env feeds the executed robot `current_speed`
   `(linear_velocity, yaw_rate)` into the existing `rollover_proxy.v1` closed-form stability margin,

--- a/scripts/tools/plan_context_note_archival.py
+++ b/scripts/tools/plan_context_note_archival.py
@@ -1,0 +1,344 @@
+#!/usr/bin/env python3
+"""Plan a maintainer-reviewed archival sweep for stale/superseded context notes.
+
+This is the *planning* half of the issue #3190 archival sweep. It consumes the
+existing freshness checker (``check_context_note_freshness``) plus the context
+catalog and proposes which notes should move to ``docs/context/archive/`` so a
+maintainer can review the list before any bulk content move happens.
+
+The planner is intentionally **plan-only**: it never moves, writes, or deletes a
+context note. Provenance must be preserved (archive, don't delete), and the
+issue requires the actual sweep to be a separate, maintainer-reviewed PR. This
+tool produces that reviewable plan; applying it stays a human-gated step.
+
+Candidate categories:
+
+* ``superseded`` — catalog entries with ``status: superseded`` that already name
+  a valid, existing replacement. These are high-confidence archive candidates:
+  provenance is preserved by the named replacement, so the source note can be
+  relocated under ``docs/context/archive/`` without losing the trail.
+* ``stale`` — notes flagged by the checker's ``stale_current_dated`` rule (old,
+  date-scoped, no inbound references). These are lower-confidence review
+  candidates; a maintainer decides whether each is genuinely retired.
+
+Conflicts (two candidates mapping to the same archive target, or a target that
+already exists) are reported separately and force a non-zero exit so a plan that
+cannot be applied as-is is never silently accepted.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from scripts.tools import check_context_note_freshness as checker
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+SCHEMA_VERSION = "context_note_archival_plan.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class PlannedMove:
+    """One proposed archival move (source note -> archive target)."""
+
+    category: str
+    confidence: str
+    source: str
+    target: str
+    reason: str
+    replacement: str | None = None
+    last_touched_at: str | None = None
+    age_days: int | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class PlanConflict:
+    """A reason a planned move cannot be applied as-is."""
+
+    kind: str
+    target: str
+    message: str
+    sources: tuple[str, ...]
+
+
+def _archive_target(source: Path, *, archive_dir: Path) -> Path:
+    """Return the archive destination path for a source note.
+
+    The note keeps its file name under ``archive_dir`` so existing references can
+    be repointed mechanically during the (separate) sweep PR.
+    """
+
+    return archive_dir / source.name
+
+
+def _superseded_candidates(
+    entries: list[dict[str, Any]],
+    *,
+    repo_root: Path,
+    archive_dir: Path,
+) -> list[PlannedMove]:
+    """Return high-confidence archive candidates from valid superseded entries.
+
+    Only entries whose named replacement exists in the repository qualify;
+    superseded entries with missing/invalid replacements are integrity errors
+    owned by the checker (Rule A) and are intentionally left for it to flag.
+    """
+
+    moves: list[PlannedMove] = []
+    for entry in entries:
+        if entry.get("status") != "superseded":
+            continue
+        source = checker._safe_repo_path(entry.get("path"))
+        replacement = checker._safe_repo_path(entry.get("replacement"))
+        if source is None or replacement is None:
+            continue
+        if not (repo_root / replacement).exists():
+            continue
+        if not (repo_root / source).is_file():
+            continue
+        # Already archived: nothing to plan.
+        if archive_dir in source.parents:
+            continue
+        moves.append(
+            PlannedMove(
+                category="superseded",
+                confidence="high",
+                source=source.as_posix(),
+                target=_archive_target(source, archive_dir=archive_dir).as_posix(),
+                reason="superseded note with a named, existing replacement",
+                replacement=replacement.as_posix(),
+            )
+        )
+    return moves
+
+
+def _stale_candidates(
+    findings: list[checker.Finding],
+    *,
+    archive_dir: Path,
+) -> list[PlannedMove]:
+    """Return lower-confidence archive candidates from stale-note warnings."""
+
+    moves: list[PlannedMove] = []
+    for finding in findings:
+        if finding.rule != "stale_current_dated":
+            continue
+        source = Path(finding.path)
+        if archive_dir in source.parents:
+            continue
+        moves.append(
+            PlannedMove(
+                category="stale",
+                confidence="review",
+                source=finding.path,
+                target=_archive_target(source, archive_dir=archive_dir).as_posix(),
+                reason=finding.message,
+                last_touched_at=finding.last_touched_at,
+                age_days=finding.age_days,
+            )
+        )
+    return moves
+
+
+def _detect_conflicts(moves: list[PlannedMove], *, repo_root: Path) -> list[PlanConflict]:
+    """Return conflicts that block applying the plan as-is.
+
+    Two conflict kinds are surfaced:
+
+    * ``duplicate_target`` — distinct source notes that would collide at the same
+      archive path.
+    * ``target_exists`` — an archive destination that already exists on disk, so
+      an unconditional move would clobber a file.
+    """
+
+    by_target: dict[str, list[str]] = {}
+    for move in moves:
+        by_target.setdefault(move.target, []).append(move.source)
+
+    conflicts: list[PlanConflict] = []
+    for target, sources in sorted(by_target.items()):
+        unique_sources = sorted(set(sources))
+        if len(unique_sources) > 1:
+            conflicts.append(
+                PlanConflict(
+                    kind="duplicate_target",
+                    target=target,
+                    message="multiple source notes map to the same archive target",
+                    sources=tuple(unique_sources),
+                )
+            )
+        elif (repo_root / Path(target)).exists():
+            conflicts.append(
+                PlanConflict(
+                    kind="target_exists",
+                    target=target,
+                    message="archive target already exists; choose a distinct destination",
+                    sources=tuple(unique_sources),
+                )
+            )
+    return conflicts
+
+
+def plan_archival(
+    *,
+    repo_root: Path,
+    catalog_path: Path = checker.CATALOG_PATH,
+    context_dir: Path = checker.CONTEXT_DIR,
+    index_path: Path = checker.INDEX_PATH,
+    archive_dir: Path = checker.ARCHIVE_DIR,
+    max_age_days: int = 180,
+    include_stale: bool = True,
+    now: datetime | None = None,
+) -> tuple[list[PlannedMove], list[PlanConflict]]:
+    """Return the proposed archival moves and any blocking conflicts.
+
+    No files are moved or written; the result is a maintainer-reviewable plan.
+    """
+
+    entries = checker._catalog_entries(repo_root / catalog_path)
+    moves = _superseded_candidates(entries, repo_root=repo_root, archive_dir=archive_dir)
+
+    if include_stale:
+        findings = checker.check_freshness(
+            repo_root=repo_root,
+            catalog_path=catalog_path,
+            context_dir=context_dir,
+            index_path=index_path,
+            max_age_days=max_age_days,
+            now=now,
+        )
+        moves.extend(_stale_candidates(findings, archive_dir=archive_dir))
+
+    moves.sort(key=lambda move: (move.category, move.source))
+    conflicts = _detect_conflicts(moves, repo_root=repo_root)
+    return moves, conflicts
+
+
+def _summary(
+    moves: list[PlannedMove], conflicts: list[PlanConflict], *, archive_dir: Path
+) -> dict[str, Any]:
+    """Return a compact JSON-ready plan summary."""
+
+    counts: dict[str, int] = {}
+    for move in moves:
+        counts[move.category] = counts.get(move.category, 0) + 1
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "archive_dir": archive_dir.as_posix(),
+        "counts": counts,
+        "conflict_count": len(conflicts),
+        "exit_code": 1 if conflicts else 0,
+        "moves": [asdict(move) for move in moves],
+        "conflicts": [asdict(conflict) for conflict in conflicts],
+        "note": "plan-only: no notes were moved or deleted; apply via a maintainer-reviewed sweep PR",
+    }
+
+
+def _print_human_report(
+    moves: list[PlannedMove],
+    conflicts: list[PlanConflict],
+    *,
+    archive_dir: Path,
+    max_moves: int,
+) -> None:
+    """Print a grouped, bounded, human-readable archival plan."""
+
+    if not moves and not conflicts:
+        print("OK no archival candidates found")
+        return
+
+    print(
+        f"Archival sweep plan (target: {archive_dir.as_posix()}/) -- plan-only, review before applying"
+    )
+    grouped: dict[str, list[PlannedMove]] = {}
+    for move in moves:
+        grouped.setdefault(move.category, []).append(move)
+    for category, group in sorted(grouped.items()):
+        print(f"{category}: {len(group)} candidate(s)")
+        for move in group[:max_moves]:
+            print(f"  [{move.confidence}] {move.source} -> {move.target}")
+            print(f"      reason: {move.reason}")
+        omitted = len(group) - max_moves
+        if omitted > 0:
+            print(f"  ... {omitted} more; use --json-output for full detail")
+
+    if conflicts:
+        print(f"conflicts: {len(conflicts)} (plan cannot be applied as-is)")
+        for conflict in conflicts:
+            print(f"  {conflict.kind} {conflict.target}: {conflict.message}")
+
+
+def _parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(
+        description=(
+            "Plan a maintainer-reviewed archival sweep for stale/superseded "
+            "docs/context notes. Plan-only: never moves or deletes notes."
+        )
+    )
+    parser.add_argument("--max-age-days", type=int, default=180)
+    parser.add_argument(
+        "--no-stale",
+        action="store_true",
+        help="Plan only high-confidence superseded candidates; skip stale-note review candidates.",
+    )
+    parser.add_argument(
+        "--json-output",
+        type=Path,
+        help="Write a JSON plan to this path. Use '-' to print JSON to stdout.",
+    )
+    parser.add_argument("--catalog", type=Path, default=checker.CATALOG_PATH)
+    parser.add_argument("--context-dir", type=Path, default=checker.CONTEXT_DIR)
+    parser.add_argument("--index", type=Path, default=checker.INDEX_PATH)
+    parser.add_argument("--archive-dir", type=Path, default=checker.ARCHIVE_DIR)
+    parser.add_argument(
+        "--max-human-moves",
+        type=int,
+        default=50,
+        help="Maximum moves to print per category in human-readable output.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the context-note archival-sweep planner."""
+
+    args = _parse_args()
+    repo_root = checker._repo_root()
+    moves, conflicts = plan_archival(
+        repo_root=repo_root,
+        catalog_path=args.catalog,
+        context_dir=args.context_dir,
+        index_path=args.index,
+        archive_dir=args.archive_dir,
+        max_age_days=args.max_age_days,
+        include_stale=not args.no_stale,
+    )
+    payload = _summary(moves, conflicts, archive_dir=args.archive_dir)
+    if args.json_output:
+        text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        if str(args.json_output) == "-":
+            print(text, end="")
+        else:
+            output_path = repo_root / args.json_output
+            output_path.parent.mkdir(parents=True, exist_ok=True)
+            output_path.write_text(text, encoding="utf-8")
+    else:
+        _print_human_report(
+            moves,
+            conflicts,
+            archive_dir=args.archive_dir,
+            max_moves=max(0, int(args.max_human_moves)),
+        )
+    return int(payload["exit_code"])
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/tools/test_plan_context_note_archival.py
+++ b/tests/tools/test_plan_context_note_archival.py
@@ -1,0 +1,286 @@
+"""Tests for the context-note archival-sweep planner."""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.tools import plan_context_note_archival as planner
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _run(repo: Path, *args: str, env: dict[str, str] | None = None) -> None:
+    subprocess.run(list(args), cwd=repo, env=env, check=True, capture_output=True, text=True)
+
+
+def _write(repo: Path, path: str, text: str) -> None:
+    full_path = repo / path
+    full_path.parent.mkdir(parents=True, exist_ok=True)
+    full_path.write_text(text, encoding="utf-8")
+
+
+def _commit(repo: Path, message: str, *, iso_date: str) -> None:
+    env = {
+        "GIT_AUTHOR_DATE": iso_date,
+        "GIT_COMMITTER_DATE": iso_date,
+        "GIT_AUTHOR_NAME": "Test Author",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "Test Author",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+    _run(repo, "git", "add", ".")
+    _run(repo, "git", "commit", "-m", message, env=env)
+
+
+def _repo(tmp_path: Path) -> Path:
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(repo, "git", "init")
+    _run(repo, "git", "config", "user.name", "Test Author")
+    _run(repo, "git", "config", "user.email", "test@example.com")
+    _write(repo, "docs/context/INDEX.md", "# Index\n")
+    _write(repo, "docs/context/README.md", "# Context\n")
+    _commit(repo, "base", iso_date="2026-01-01T00:00:00+00:00")
+    return repo
+
+
+def _write_catalog(repo: Path, entries: list[dict[str, object]]) -> None:
+    base_entries = [
+        {"path": "docs/context/README.md", "status": "current", "freshness": "maintained"},
+        {"path": "docs/context/INDEX.md", "status": "current", "freshness": "maintained"},
+    ]
+    _write(
+        repo,
+        "docs/context/catalog.yaml",
+        yaml.safe_dump({"version": 1, "entries": [*base_entries, *entries]}, sort_keys=False),
+    )
+
+
+def test_superseded_with_existing_replacement_is_high_confidence_candidate(tmp_path: Path) -> None:
+    """Superseded notes whose replacement exists are high-confidence archive moves."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old\n")
+    _write(repo, "docs/context/new.md", "# New\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            }
+        ],
+    )
+    _commit(repo, "superseded with replacement", iso_date="2026-01-02T00:00:00+00:00")
+
+    moves, conflicts = planner.plan_archival(repo_root=repo)
+
+    assert conflicts == []
+    assert len(moves) == 1
+    move = moves[0]
+    assert move.category == "superseded"
+    assert move.confidence == "high"
+    assert move.source == "docs/context/old.md"
+    assert move.target == "docs/context/archive/old.md"
+    assert move.replacement == "docs/context/new.md"
+
+
+def test_superseded_without_valid_replacement_is_not_planned(tmp_path: Path) -> None:
+    """Integrity violations stay with the checker (Rule A); the planner skips them."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old\n")
+    _write_catalog(
+        repo,
+        [
+            # Missing replacement -> checker error, not an archive candidate.
+            {"path": "docs/context/old.md", "status": "superseded", "freshness": "dated"},
+            # Replacement points at a nonexistent file -> not safe to archive.
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/missing.md",
+            },
+        ],
+    )
+    _commit(repo, "superseded without valid replacement", iso_date="2026-01-02T00:00:00+00:00")
+
+    moves, conflicts = planner.plan_archival(repo_root=repo)
+
+    assert moves == []
+    assert conflicts == []
+
+
+def test_stale_current_dated_note_is_review_candidate(tmp_path: Path) -> None:
+    """Stale dated notes surface as lower-confidence review candidates."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/dated.md", "# Dated\n")
+    _write_catalog(
+        repo,
+        [{"path": "docs/context/dated.md", "status": "current", "freshness": "dated"}],
+    )
+    _commit(repo, "dated note", iso_date="2025-01-01T00:00:00+00:00")
+
+    moves, conflicts = planner.plan_archival(
+        repo_root=repo, max_age_days=180, now=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+
+    assert conflicts == []
+    assert len(moves) == 1
+    move = moves[0]
+    assert move.category == "stale"
+    assert move.confidence == "review"
+    assert move.source == "docs/context/dated.md"
+    assert move.target == "docs/context/archive/dated.md"
+    assert move.age_days == 365
+
+
+def test_no_stale_flag_excludes_review_candidates(tmp_path: Path) -> None:
+    """include_stale=False plans only high-confidence superseded candidates."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/dated.md", "# Dated\n")
+    _write_catalog(
+        repo,
+        [{"path": "docs/context/dated.md", "status": "current", "freshness": "dated"}],
+    )
+    _commit(repo, "dated note", iso_date="2025-01-01T00:00:00+00:00")
+
+    moves, conflicts = planner.plan_archival(
+        repo_root=repo,
+        max_age_days=180,
+        include_stale=False,
+        now=datetime(2026, 1, 1, tzinfo=UTC),
+    )
+
+    assert moves == []
+    assert conflicts == []
+
+
+def test_duplicate_archive_target_is_conflict(tmp_path: Path) -> None:
+    """Two notes with the same basename collide at one archive target."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old A\n")
+    _write(repo, "docs/context/sub/old.md", "# Old B\n")
+    _write(repo, "docs/context/new.md", "# New\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            },
+            {
+                "path": "docs/context/sub/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            },
+        ],
+    )
+    _commit(repo, "two old notes same basename", iso_date="2026-01-02T00:00:00+00:00")
+
+    moves, conflicts = planner.plan_archival(repo_root=repo)
+
+    assert len(moves) == 2
+    assert len(conflicts) == 1
+    conflict = conflicts[0]
+    assert conflict.kind == "duplicate_target"
+    assert conflict.target == "docs/context/archive/old.md"
+    assert set(conflict.sources) == {"docs/context/old.md", "docs/context/sub/old.md"}
+
+    summary = planner._summary(moves, conflicts, archive_dir=planner.checker.ARCHIVE_DIR)
+    assert summary["exit_code"] == 1
+
+
+def test_existing_archive_target_is_conflict(tmp_path: Path) -> None:
+    """An archive destination that already exists blocks an unconditional move."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old\n")
+    _write(repo, "docs/context/new.md", "# New\n")
+    _write(repo, "docs/context/archive/old.md", "# Pre-existing archive\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            }
+        ],
+    )
+    _commit(repo, "pre-existing archive target", iso_date="2026-01-02T00:00:00+00:00")
+
+    moves, conflicts = planner.plan_archival(repo_root=repo)
+
+    assert len(moves) == 1
+    assert [c.kind for c in conflicts] == ["target_exists"]
+    assert conflicts[0].target == "docs/context/archive/old.md"
+
+
+def test_already_archived_note_is_not_replanned(tmp_path: Path) -> None:
+    """Notes already under the archive dir are not re-proposed for moving."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/archive/old.md", "# Already archived\n")
+    _write(repo, "docs/context/new.md", "# New\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/archive/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            }
+        ],
+    )
+    _commit(repo, "already archived note", iso_date="2026-01-02T00:00:00+00:00")
+
+    moves, conflicts = planner.plan_archival(repo_root=repo)
+
+    assert moves == []
+    assert conflicts == []
+
+
+def test_summary_reports_counts_and_plan_only_note(tmp_path: Path) -> None:
+    """The JSON summary carries category counts, a clean exit, and the plan-only note."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old\n")
+    _write(repo, "docs/context/new.md", "# New\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            }
+        ],
+    )
+    _commit(repo, "superseded", iso_date="2026-01-02T00:00:00+00:00")
+
+    moves, conflicts = planner.plan_archival(repo_root=repo)
+    summary = planner._summary(moves, conflicts, archive_dir=planner.checker.ARCHIVE_DIR)
+
+    assert summary["schema_version"] == "context_note_archival_plan.v1"
+    assert summary["counts"] == {"superseded": 1}
+    assert summary["exit_code"] == 0
+    assert summary["archive_dir"] == "docs/context/archive"
+    assert "plan-only" in summary["note"]


### PR DESCRIPTION
## Summary

Implements the **planning half** of issue #3190 (workflow: add context-note freshness-decay check and archival sweep). The freshness-decay **checker** already landed via #3208 (`scripts/tools/check_context_note_freshness.py`); the remaining scope is the **archival sweep** (step 2), which the issue requires to be a *separate, maintainer-reviewed* PR that moves notes (never deletes).

This PR adds the tooling that feeds that gated sweep — a **plan-only** archival-sweep planner — without performing the bulk content move.

Closes part of #3190 (checker-first slice already in #3208; the actual content-move sweep remains a separate review-gated PR). Parent: #3057.

## What changed

- **`scripts/tools/plan_context_note_archival.py`** — reuses the existing freshness checker (`check_context_note_freshness`) and `docs/context/catalog.yaml` to propose which notes should move to `docs/context/archive/`:
  - **`superseded` (high confidence):** catalog rows `status: superseded` that already name a valid, existing replacement (provenance preserved by the named replacement).
  - **`stale` (review):** notes flagged by the checker's `stale_current_dated` rule; lower-confidence, maintainer decides.
  - Computes a per-note archive target, detects blocking **conflicts** (`duplicate_target` basename collisions, `target_exists` pre-existing destination) → non-zero exit so an un-appliable plan is never silently accepted.
  - **Plan-only:** never moves, writes, or deletes a note. `--json-output` (schema `context_note_archival_plan.v1`) emits the maintainer-reviewable plan; `--no-stale` restricts to high-confidence superseded candidates.
  - Reuses (does not duplicate) the checker's catalog parsing and stale-note rules per the AGENTS.md canonical-owner rule.
- **`tests/tools/test_plan_context_note_archival.py`** — fixtures covering each category, the `--no-stale` gate, both conflict kinds, already-archived skipping, and the JSON summary.
- **`CHANGELOG.md`** — one `Added` entry under `[Unreleased]`.

## Scope

- **In scope:** bounded archival-sweep *helper* (planning only) + focused tests, complementing the #3208 checker. Kept separate from the content move exactly as the issue specifies ("Keep the checker and the sweep in separate PRs").
- **Out of scope (deliberately not done here):** the maintainer-gated bulk note move to `docs/context/archive/`, creating the archive dir, editing `docs/context/README.md`/`INDEX.md`/`catalog.yaml` paths, deleting notes. No auto-archiving without review.

## Validation

All run from the issue worktree via the shared-venv helper.

| Command | Exit | Result |
| --- | --- | --- |
| `uv run pytest tests/tools/test_plan_context_note_archival.py tests/tools/test_check_context_note_freshness.py -q` | 0 | 20 passed (8 new + 12 existing checker regression) |
| `uv run ruff check scripts/tools/plan_context_note_archival.py tests/tools/test_plan_context_note_archival.py` | 0 | All checks passed |
| `uv run ruff format --check ...` | 0 | 2 files already formatted |
| `uv run python scripts/tools/plan_context_note_archival.py --json-output -` | 0 | Real repo: 5 high-confidence `superseded` candidates, 0 conflicts |

Real-repo plan output (the 5 superseded catalog rows with valid replacements):

```
docs/context/issue_1583_high_risk_root_boundaries.md        -> docs/context/archive/issue_1583_high_risk_root_boundaries.md
docs/context/issue_1598_1599_root_compatibility_decisions.md -> docs/context/archive/issue_1598_1599_root_compatibility_decisions.md
docs/context/issue_1690_root_layout_inventory.md            -> docs/context/archive/issue_1690_root_layout_inventory.md
docs/context/issue_2660_topology_successor_gate.md          -> docs/context/archive/issue_2660_topology_successor_gate.md
docs/context/issue_2903_horizon_denominator_health.md       -> docs/context/archive/issue_2903_horizon_denominator_health.md
```

## Evidence grade

`smoke evidence` + focused unit/CLI tests. This is contributor tooling (workflow/tooling-docs class), not a benchmark/metric/schema/model-provenance change.

## Downstream Propagation

- Parent issue #3057 / issue #3190: the remaining content-move sweep stays a separate maintainer-reviewed PR; this PR provides the plan input for it.
- No claim map, leaderboard, registry, or evidence catalog affected.
- `Research Result Guidance`: `NA - support/tooling helper` (no research claim).

## Out-of-scope confirmation

No full benchmark campaign run; no Slurm/GPU submission; no paper/dissertation claim edits; no note deletions or moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a plan-only archiving report for context notes, with both human-readable and JSON output.
  * The report highlights high-confidence archive candidates, review candidates, and any blocking conflicts before changes are made.
  * Added options to filter stale-note candidates, choose input/output paths, limit displayed results, and write the plan to a file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->