### PR TITLE
Fix issue #3632 CARLA bridge planar twist handedness

### DIFF
--- a/robot_sf_carla_bridge/__init__.py
+++ b/robot_sf_carla_bridge/__init__.py
@@ -59,6 +59,8 @@ from robot_sf_carla_bridge.export import (
 )
 from robot_sf_carla_bridge.live_replay import (
     T1_ORACLE_LIVE_REPLAY_SCHEMA_VERSION,
+    carla_planar_twist_to_robot_sf,
+    robot_sf_planar_twist_to_carla,
     robot_sf_pose_to_carla_transform,
     run_t1_oracle_live_replay_against_server,
 )
@@ -111,6 +113,7 @@ __all__ = [
     "build_export_payload_from_scenario_entry",
     "build_export_payloads_from_scenario_file",
     "build_t1_oracle_replay_smoke_setup",
+    "carla_planar_twist_to_robot_sf",
     "check_carla_availability",
     "compare_oracle_replay_metrics",
     "docker_runtime",
@@ -126,6 +129,7 @@ __all__ = [
     "read_export_payload",
     "require_carla",
     "resolve_export_manifest_payload_paths",
+    "robot_sf_planar_twist_to_carla",
     "robot_sf_pose_to_carla_transform",
     "run_carla_docker_live_replay",
     "run_carla_docker_preflight",

--- a/robot_sf_carla_bridge/live_replay.py
+++ b/robot_sf_carla_bridge/live_replay.py
@@ -91,6 +91,44 @@ def carla_angular_velocity_to_robot_sf_radps(omega_radps: float) -> float:
     return -float(omega_radps)
 
 
+def robot_sf_planar_twist_to_carla(twist: dict[str, Any]) -> dict[str, float]:
+    """Convert a Robot-SF planar velocity command into CARLA coordinates.
+
+    The handedness boundary mirrors linear ``y`` and yaw rate together. Keeping
+    the two sign changes in one helper prevents CARLA callers from applying the
+    position transform while leaving angular velocity in the Robot-SF frame.
+
+    Returns:
+        CARLA ``{"x", "y", "angular_velocity"}`` twist in meters and radians per second.
+    """
+
+    velocity = robot_sf_planar_vector_to_carla(twist)
+    return {
+        "x": velocity["x"],
+        "y": velocity["y"],
+        "angular_velocity": robot_sf_angular_velocity_to_carla_radps(
+            float(twist["angular_velocity"])
+        ),
+    }
+
+
+def carla_planar_twist_to_robot_sf(twist: dict[str, Any]) -> dict[str, float]:
+    """Convert a CARLA planar velocity command back into Robot-SF coordinates.
+
+    Returns:
+        Robot-SF ``{"x", "y", "angular_velocity"}`` twist in meters and radians per second.
+    """
+
+    velocity = carla_planar_vector_to_robot_sf(twist)
+    return {
+        "x": velocity["x"],
+        "y": velocity["y"],
+        "angular_velocity": carla_angular_velocity_to_robot_sf_radps(
+            float(twist["angular_velocity"])
+        ),
+    }
+
+
 def robot_sf_pose_to_carla_transform(
     carla_module: Any,
     pose: dict[str, Any],

--- a/tests/carla_bridge/test_t1_live_replay.py
+++ b/tests/carla_bridge/test_t1_live_replay.py
@@ -666,9 +666,11 @@ def test_live_replay_coordinate_helpers_pin_handedness_contract() -> None:
     """CARLA bridge helpers should mirror vector, yaw, and yaw-rate signs."""
     from robot_sf_carla_bridge.live_replay import (
         carla_angular_velocity_to_robot_sf_radps,
+        carla_planar_twist_to_robot_sf,
         carla_planar_vector_to_robot_sf,
         carla_yaw_degrees_to_robot_sf,
         robot_sf_angular_velocity_to_carla_radps,
+        robot_sf_planar_twist_to_carla,
         robot_sf_planar_vector_to_carla,
         robot_sf_yaw_to_carla_degrees,
     )
@@ -687,3 +689,35 @@ def test_live_replay_coordinate_helpers_pin_handedness_contract() -> None:
     carla_omega = robot_sf_angular_velocity_to_carla_radps(0.75)
     assert carla_omega == pytest.approx(-0.75)
     assert carla_angular_velocity_to_robot_sf_radps(carla_omega) == pytest.approx(0.75)
+
+    carla_twist = robot_sf_planar_twist_to_carla({"x": 1.25, "y": -0.5, "angular_velocity": 0.75})
+    assert carla_twist == {
+        "x": pytest.approx(1.25),
+        "y": pytest.approx(0.5),
+        "angular_velocity": pytest.approx(-0.75),
+    }
+    assert carla_planar_twist_to_robot_sf(carla_twist) == {
+        "x": pytest.approx(1.25),
+        "y": pytest.approx(-0.5),
+        "angular_velocity": pytest.approx(0.75),
+    }
+
+
+def test_carla_bridge_exports_planar_twist_handedness_contract() -> None:
+    """Package-level adapter API exposes the strict twist handedness transform."""
+    from robot_sf_carla_bridge import (
+        carla_planar_twist_to_robot_sf,
+        robot_sf_planar_twist_to_carla,
+    )
+
+    carla_twist = robot_sf_planar_twist_to_carla({"x": -2.0, "y": 3.0, "angular_velocity": -1.5})
+    assert carla_twist == {
+        "x": pytest.approx(-2.0),
+        "y": pytest.approx(-3.0),
+        "angular_velocity": pytest.approx(1.5),
+    }
+    assert carla_planar_twist_to_robot_sf(carla_twist) == {
+        "x": pytest.approx(-2.0),
+        "y": pytest.approx(3.0),
+        "angular_velocity": pytest.approx(-1.5),
+    }


### PR DESCRIPTION
## Summary
Adds a strict planar twist conversion contract for the CARLA bridge so linear `y` and `angular_velocity` are mirrored together at the Robot-SF/CARLA handedness boundary.

## Linked Issues
- Closes `#3632`
- Issue: https://github.com/ll7/robot_sf_ll7/issues/3632

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `robot_sf_planar_twist_to_carla` and `carla_planar_twist_to_robot_sf` helpers in `robot_sf_carla_bridge/live_replay.py`.
- Exported the helpers from `robot_sf_carla_bridge`.
- Extended CARLA bridge unit tests to pin the handedness contract for planar velocity commands and public imports.

## Why Matters
- Added value: prevents bridge callers from mirroring planar vectors while accidentally leaving yaw-rate commands in the Robot-SF frame.
- Expected impact: fixes the smallest adapter-surface mismatch behind issue #3632 without changing simulator runtime behavior.
- Why worth merging now: CPU-only unit coverage verifies the coordinate contract directly.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - bridge adapter bugfix; no benchmark or paper claim is made.
- Comparator or baseline, applicable: NA
- Evidence tier: NA - unit-level adapter bugfix; validation is listed below and no research evidence claim is made.
- Result classification: NA - bugfix only.
- Decision stop rule, applicable: focused CARLA bridge tests pass and no CARLA runtime is required.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3632 only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no analysis tool added.

## Domain-Aware Approval
- Approver/review source waiver: not required; no benchmark, metric, or paper-facing evidence claim.
- Validity checklist: NA
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: no CARLA runtime or fallback/degraded benchmark mode used.
- Claim boundary: unit-level adapter coordinate handedness only.
- Implementation integrity vs experimental validity: implementation integrity tested by focused CPU-only unit tests.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - unit adapter transform only.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: none

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: stop after review; Claude Code on `imech156-u` owns the full PR gate and merge authority.
- Proposed child issue existing follow-up: none

## Validation / Proof
- `uv run pytest tests/carla_bridge/test_t1_live_replay.py -q` - passed
- `uv run pytest tests/carla_bridge -q` - passed
- `uv run ruff check robot_sf_carla_bridge/live_replay.py robot_sf_carla_bridge/__init__.py tests/carla_bridge/test_t1_live_replay.py` - passed
- `uv run ruff format --check robot_sf_carla_bridge/live_replay.py robot_sf_carla_bridge/__init__.py tests/carla_bridge/test_t1_live_replay.py` - passed
- `git diff --check` - passed
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3632-pr-body.md PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` - passed via compact validation wrapper (`validation-20260626T214734Z-2938674`, exit 0)

## Performance
- Baseline runtime: NA - no runtime performance claim.
- Changed runtime: NA - no runtime performance claim.
- Representative command: `uv run pytest tests/carla_bridge -q`
- Hot-path call count profile anchor: NA - no profiling claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: any regression in CARLA bridge coordinate helper or replay fixture tests.

## Risks / Rollout
- Compatibility risks: low; adds helpers and exports without changing existing replay behavior.
- Failure modes: callers using a different twist key name still need explicit adaptation before calling these helpers.
- Rollback fallback plan: revert this helper/export/test change.

## Docs / Provenance
- Updated docs: none; scoped bugfix with tests.
- Relevant design provenance notes: issue #3632.
- Any assumptions need to preserved: Robot-SF planar frame is right-handed; CARLA bridge mirrors `y` and yaw/yaw-rate signs at the boundary.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - PR links issue; no issue comment authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark, registry, claim-map, paper-facing, or dissertation claim changes.

## Follow-Up Issues
- Deferred work: none in this PR scope.
- Issues opened follow-up: none

## Reviewer Notes
- Verify the twist helpers intentionally require `angular_velocity`; this keeps the transform strict for the bug covered by #3632.
- Out of scope: no full benchmark campaign run, no CARLA runtime run, no Slurm/GPU submission, and no paper/dissertation claim edits.
