### PR TITLE
feat(benchmark): plan-level preflight for paper-grade reactivity-vs-replay rank study (#3637)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **plan-level preflight for the paper-grade reactivity-vs-replay rank study** (#3637,
+  split from #3573). The new pure checker
+  [`robot_sf/benchmark/reactivity_replay_preflight.py`](robot_sf/benchmark/reactivity_replay_preflight.py)
+  (`reactivity_replay_rank_study_preflight.v1`) verifies a proposed run plan's **preconditions**
+  before any compute is spent: ≥3 planners, exactly the reactive/replay arms with **paired** seeds
+  (common random numbers), a seed budget at/above the S20 rank-stability floor and above the #3573
+  diagnostic matrix, a contrast-registering horizon, and that the **replay limitation** is stated
+  (`'replay' = robot→pedestrian force-off in a live sim, NOT trajectory playback`). The limitation
+  constants now live in the canonical owner `robot_sf/benchmark/reactivity_ablation.py`
+  (`REPLAY_LIMITATION`, `REPLAY_IS_TRAJECTORY_PLAYBACK`, `REACTIVITY_ARMS`) and are imported, not
+  duplicated. Thin CPU-only CLI
+  [`scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py`](scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py)
+  emits a `ready`/`blocked` manifest from the launch packet
+  [`configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml`](configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml).
+  This is an evidence-control layer only: it does **not** run the benchmark, interpret rank
+  stability, or make any paper-facing claim (sufficiency stays with
+  `scripts/tools/seed_sufficiency_gate.py` post-run).
 * Added a **context-note archival-sweep planner** (#3190):
   [`scripts/tools/plan_context_note_archival.py`](scripts/tools/plan_context_note_archival.py)
   consumes the existing freshness checker plus `docs/context/catalog.yaml` and proposes which notes

--- a/configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml
+++ b/configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml
@@ -1,0 +1,102 @@
+# Issue #3637 — Paper-grade reactivity-vs-replay rank study LAUNCH PACKET
+#
+# Purpose: make the seed-sufficient reactivity-vs-replay ablation (split from #3573) concrete
+# enough to preflight-check BEFORE any compute is spent. The #3573 diagnostic landed (quantifier
+# #3594, paired runs + open-loop-replay mode #3612) on a small matrix (2 scenarios, goal + orca,
+# 4 seeds). #3637 carries the paper-grade extension: the same ablation across >= 3 planners at a
+# seed budget sufficient for rank stability, with the replay limitation stated explicitly.
+#
+# This is a LAUNCH PACKET + preflight contract, NOT a runnable campaign config and NOT a result.
+# The paper-grade run itself is out of scope here (no benchmark run, no Slurm/GPU submission, no
+# rank-stability interpretation, no paper/dissertation claim edits).
+#
+# Preflight it with the canonical pure checker (CPU-only, no compute):
+#   uv run python scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py \
+#     --packet configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml
+#
+# Honesty boundary: NO paper-facing reactivity-rank claim may be made until this run executes at
+# the declared seed budget AND the post-run seed-sufficiency gate
+# (scripts/tools/seed_sufficiency_gate.py) plus claim-card review classify the bundle. The preflight
+# only confirms the PLAN is well-formed and honestly labeled; it does not prove sufficiency.
+
+schema_version: reactivity_replay_rank_study_preflight.v1
+issue: 3637
+
+# >= 3 planners (Definition of Done). Canonical non-learning baselines from
+# robot_sf/benchmark/algorithm_readiness.py; the diagnostic used goal + orca, social_force is the
+# third. Planner identity is a run-design choice the maintainer may revise; the preflight only
+# enforces the >= 3 count and that the arms/seeds are well-formed.
+planners:
+  - goal
+  - orca
+  - social_force
+
+scenario_set: configs/scenarios/sets/classic_crossing_subset.yaml
+scenario_set_sha256: a5baf5cd4b6aebd333a30f76e319646dd3f3451406db1678ef55d5ea3b972db6
+
+# Horizon long enough for the robot to reach the crossing; below ~150 the contrast is near-null on
+# this family (#3573). Matches the campaign-runner default.
+horizon: 300
+
+# Paired seed budget: BOTH the reactive and replay arms run this identical seed set (common random
+# numbers), the property that makes the per-planner contrast attributable to reactivity. 20 seeds
+# aligns with the S20 rank-stability schedule used elsewhere. This is a precondition floor, not a
+# sufficiency proof — actual sufficiency is decided post-run by the seed-sufficiency gate.
+seeds:
+  - 101
+  - 102
+  - 103
+  - 104
+  - 105
+  - 106
+  - 107
+  - 108
+  - 109
+  - 110
+  - 111
+  - 112
+  - 113
+  - 114
+  - 115
+  - 116
+  - 117
+  - 118
+  - 119
+  - 120
+
+replay:
+  # MUST be false: "replay" here is a live social-force sim with the robot->pedestrian force
+  # disabled (peds_have_robot_repulsion=false), NOT pre-recorded trajectory playback.
+  is_trajectory_playback: false
+  # Defaults to robot_sf.benchmark.reactivity_ablation.REPLAY_LIMITATION when omitted; stated here
+  # so the limitation travels with the packet artifact.
+  limitation: >-
+    'replay' = robot->pedestrian social-force term disabled in a live social-force sim
+    (peds_have_robot_repulsion=false); NOT pre-recorded trajectory playback. Pedestrians still
+    follow social-force dynamics among themselves but do not yield to the robot, so disabling
+    reactivity tends to reveal intrusion hazard rather than hide it.
+
+# Preconditions enforced by the preflight checker (overrides of the module defaults if present).
+min_planners: 3
+min_seeds: 20
+
+# After preflight passes, the run + post-run analysis (OUT OF SCOPE for #3637 implementation slice):
+run_command: |
+  # Paired reactive-vs-replay campaign across the declared planners + seeds (real runner).
+  uv run python scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py \
+    --scenario-set configs/scenarios/sets/classic_crossing_subset.yaml \
+    --planners goal orca social_force \
+    --seeds 101 102 103 104 105 106 107 108 109 110 \
+            111 112 113 114 115 116 117 118 119 120 \
+    --horizon 300 \
+    --report-json output/issue_3637_reactivity_rank_study/report.json
+
+post_run_gate: |
+  # Sufficiency is decided here, NOT by this packet. Rank-flip / CI half-width drive the decision.
+  uv run python scripts/tools/seed_sufficiency_gate.py --input-json <frozen_gate_input.json>
+
+validation:
+  - "Re-verify scenario_set_sha256 before launch (drift guard): sha256sum the scenario set."
+  - "Preflight must report status=ready before any compute is spent."
+  - "No paper-facing reactivity-rank claim until the post-run seed-sufficiency gate + claim-card
+    review classify the bundle; 'replay' is force-off, not trajectory playback."

--- a/docs/context/issue_3637_reactivity_replay_rank_study_preflight.md
+++ b/docs/context/issue_3637_reactivity_replay_rank_study_preflight.md
@@ -1,0 +1,54 @@
+# Issue #3637 — Paper-grade reactivity-vs-replay rank study: preflight control layer
+
+**Status:** evidence-control layer (no campaign run). **Evidence grade:** plan-preflight only — no
+benchmark evidence, no rank-stability interpretation, no paper-facing claim.
+
+Split from #3573 (closed diagnostic-complete). The diagnostic landed the quantifier (#3594) and the
+paired-run + open-loop-replay pedestrian mode (#3612) on a small matrix (2 scenarios, goal + orca,
+4 seeds). #3637 carries the **paper-grade** extension: the same ablation across ≥3 planners at a seed
+budget sufficient for rank stability, with the replay limitation stated explicitly. See
+[issue_3573_reactivity_ablation.md](issue_3573_reactivity_ablation.md) for the quantifier.
+
+## What this slice adds
+
+The **next evidence-control layer**: a plan-level preflight that gates the (not-yet-run) paper-grade
+campaign so under-powered or mislabeled runs are caught **before** any compute is spent. It does
+**not** run the benchmark, measure/interpret rank stability, or edit any paper/dissertation claim.
+
+- `robot_sf/benchmark/reactivity_replay_preflight.py` — pure, side-effect-free checker
+  (`reactivity_replay_rank_study_preflight.v1`). `build_preflight_manifest(plan)` returns a manifest
+  with `status: ready|blocked`. Checks (all plan-level **preconditions**, not run output):
+  - `planner_count` — ≥ `MIN_PLANNERS` (3) distinct planners;
+  - `arms_present` — exactly the `reactive`/`replay` arms;
+  - `paired_seeds` — both arms use the identical seed set (common random numbers);
+  - `seed_budget` — ≥ `MIN_RANK_STABILITY_SEEDS` (20, the S20 floor) and > the #3573 diagnostic
+    matrix (4 seeds);
+  - `horizon` — ≥ 150 steps (the contrast is near-null below this on the diagnostic family);
+  - `replay_limitation` — present, and `is_trajectory_playback` is `False`.
+- `scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py` — thin CPU-only CLI over
+  the checker. Exit `0` ready / `1` blocked / `2` usage error.
+- `configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml` — the proposed run
+  plan (planners, paired S20 seeds, scenario set + sha256, horizon, replay limitation) + the
+  out-of-scope run/post-run commands.
+
+## Replay limitation (canonical, must travel with every artifact)
+
+`REPLAY_LIMITATION` / `REPLAY_IS_TRAJECTORY_PLAYBACK` now live in the canonical owner
+`robot_sf/benchmark/reactivity_ablation.py` and are imported by the preflight (no second copy):
+
+> "replay" = robot→pedestrian social-force term disabled in a **live** social-force sim
+> (`peds_have_robot_repulsion=false`); **NOT** pre-recorded trajectory playback. Pedestrians still
+> follow social-force dynamics among themselves but do not yield to the robot, so disabling
+> reactivity tends to *reveal* intrusion hazard rather than hide it.
+
+## Boundary
+
+The preflight checks the **plan**, not sufficiency. Actual seed *sufficiency* (CI half-width /
+rank-flip) is decided **post-run** by `scripts/tools/seed_sufficiency_gate.py`; no reactivity-rank
+claim may be promoted until that gate plus claim-card review classify the executed bundle.
+
+## Tests
+
+`tests/benchmark/test_reactivity_replay_preflight_issue_3637.py` (18 tests): each precondition
+pass/block path, the packet loader (shared vs per-arm seeds, malformed rejection), the shipped
+packet (ready + scenario-set sha256 drift guard), and the CLI exit codes.

--- a/robot_sf/benchmark/reactivity_ablation.py
+++ b/robot_sf/benchmark/reactivity_ablation.py
@@ -23,6 +23,28 @@ from robot_sf.benchmark.finite_checks import require_finite_fields
 
 REACTIVITY_ABLATION_SCHEMA = "reactivity_ablation.v1"
 
+#: The two paired pedestrian-reactivity conditions (arm tags). ``reactive`` keeps
+#: ``peds_have_robot_repulsion=True`` (pedestrians yield to the robot); ``replay`` disables that
+#: robot->pedestrian force. Common random numbers (identical scenarios + seeds) make the per-planner
+#: contrast attributable to reactivity.
+REACTIVITY_ARMS: tuple[str, str] = ("reactive", "replay")
+
+#: Whether the ``replay`` arm is pre-recorded trajectory playback. It is **not**: this benchmark's
+#: "replay" is a live social-force sim with the robot->pedestrian force disabled (see
+#: :data:`REPLAY_LIMITATION`). Kept as an exported flag so artifacts and preflight checkers assert it.
+REPLAY_IS_TRAJECTORY_PLAYBACK = False
+
+#: Canonical operationalization limitation for the reactivity-vs-replay ablation. Any artifact,
+#: preflight manifest, or paper-facing claim built on this ablation must state this explicitly so the
+#: "replay" framing is not over-read as grounded trajectory playback (#3573 diagnostic / #3637
+#: paper-grade extension).
+REPLAY_LIMITATION = (
+    "'replay' = robot->pedestrian social-force term disabled in a live social-force sim "
+    "(peds_have_robot_repulsion=false); NOT pre-recorded trajectory playback. Pedestrians still "
+    "follow social-force dynamics among themselves but do not yield to the robot, so disabling "
+    "reactivity tends to reveal intrusion hazard rather than hide it."
+)
+
 _CONTRAST_METRIC_FIELDS = (
     "reactive_collision_rate",
     "replay_collision_rate",
@@ -128,6 +150,9 @@ def assess_reactivity_ablation(contrasts: list[ReactivityContrast]) -> dict[str,
 
 __all__ = [
     "REACTIVITY_ABLATION_SCHEMA",
+    "REACTIVITY_ARMS",
+    "REPLAY_IS_TRAJECTORY_PLAYBACK",
+    "REPLAY_LIMITATION",
     "ReactivityContrast",
     "assess_reactivity_ablation",
     "reactivity_delta",

--- a/robot_sf/benchmark/reactivity_replay_preflight.py
+++ b/robot_sf/benchmark/reactivity_replay_preflight.py
@@ -1,0 +1,405 @@
+"""Plan-level preflight checker for the paper-grade reactivity-vs-replay rank study (issue #3637).
+
+Issue #3573 landed the *diagnostic*: the pure quantifier
+``robot_sf.benchmark.reactivity_ablation.assess_reactivity_ablation`` (#3594) and the paired-run +
+open-loop-replay pedestrian mode (#3612), on a small matrix (2 scenarios, goal + orca, 4 seeds).
+Issue #3637 carries the **paper-grade** extension: the same ablation across >=3 planners at a seed
+budget sufficient for rank stability, with the replay limitation stated explicitly.
+
+This module is the *next evidence-control layer* for that extension. It is a **pure, side-effect
+free** checker (mirroring the quantifier in
+:mod:`robot_sf.benchmark.reactivity_ablation`): given a proposed run plan, it verifies the
+**plan-level preconditions** required before the paper-grade campaign is launched, and emits a
+manifest that bakes in the canonical replay limitation.
+
+What it checks (preconditions, declared by the plan — not the run output):
+
+* at least :data:`MIN_PLANNERS` planners (the paper-grade ablation needs >=3);
+* exactly the two reactive/replay arms (:data:`~robot_sf.benchmark.reactivity_ablation.REACTIVITY_ARMS`);
+* **paired seeds** — both arms use the identical seed set (common random numbers), the property that
+  makes the per-planner contrast attributable to reactivity;
+* a seed budget at or above the rank-stability floor and strictly above the #3573 diagnostic matrix;
+* the **replay-limitation metadata** is present and correct: "replay" is robot->ped force-off in a
+  live sim, **not** trajectory playback.
+
+What it deliberately does **not** do (out of scope for #3637's implementation slice): run the
+benchmark, compute or interpret rank stability, or make any paper-facing claim. Actual seed
+*sufficiency* (CI half-width / rank-flip) is decided **post-run** by
+``scripts/tools/seed_sufficiency_gate.py``; this preflight only gates that the *plan* is well-formed
+and honestly labeled before any compute is spent.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from robot_sf.benchmark.reactivity_ablation import (
+    REACTIVITY_ARMS,
+    REPLAY_IS_TRAJECTORY_PLAYBACK,
+    REPLAY_LIMITATION,
+)
+
+PREFLIGHT_SCHEMA = "reactivity_replay_rank_study_preflight.v1"
+ISSUE = 3637
+
+#: Paper-grade ablation requires at least this many planners (issue #3637 Definition of Done).
+MIN_PLANNERS = 3
+
+#: Seed-count floor for a rank-stability-capable plan. This is a *precondition* floor aligned with
+#: the S20 schedule used elsewhere (``scripts/tools/seed_sufficiency_gate.py``), **not** a proof of
+#: sufficiency: actual sufficiency is decided post-run from CI half-width / rank-flip evidence.
+MIN_RANK_STABILITY_SEEDS = 20
+
+#: The #3573 diagnostic small matrix used 4 seeds; a paper-grade plan must strictly exceed it.
+DIAGNOSTIC_SEED_COUNT = 4
+
+
+@dataclass(frozen=True, slots=True)
+class ReactivityReplayRunPlan:
+    """A proposed paper-grade reactivity-vs-replay run plan to be preflight-checked.
+
+    This is the declared *intent* of the run, not its result. ``arm_seeds`` maps each reactivity arm
+    to its seed list; the checker verifies the two arms are paired (identical seeds).
+
+    Attributes:
+        planners: Planner / algo names to compare (canonical names from
+            ``robot_sf.benchmark.algorithm_readiness``).
+        arm_seeds: Mapping of arm tag -> seed list. Must contain exactly the reactive/replay arms.
+        scenario_set: Path to the scenario set the campaign will run over.
+        horizon: Episode horizon (steps); the contrast is near-null below ~150 on the diagnostic
+            family, so the plan must declare a horizon long enough for the robot to reach pedestrians.
+        replay_is_trajectory_playback: Whether the replay arm is pre-recorded trajectory playback.
+            Must be ``False`` for this ablation (live force-off, not playback).
+        replay_limitation: Human-readable limitation note that must accompany every artifact.
+        min_planners: Override for the planner-count floor (defaults to :data:`MIN_PLANNERS`).
+        min_seeds: Override for the seed-count floor (defaults to :data:`MIN_RANK_STABILITY_SEEDS`).
+    """
+
+    planners: tuple[str, ...]
+    arm_seeds: dict[str, tuple[int, ...]]
+    scenario_set: str
+    horizon: int
+    replay_is_trajectory_playback: bool = REPLAY_IS_TRAJECTORY_PLAYBACK
+    replay_limitation: str = REPLAY_LIMITATION
+    min_planners: int = MIN_PLANNERS
+    min_seeds: int = MIN_RANK_STABILITY_SEEDS
+    #: Minimum horizon for the contrast to register (diagnostic family observation, #3573).
+    min_horizon: int = field(default=150)
+
+
+@dataclass(frozen=True, slots=True)
+class CheckResult:
+    """Outcome of a single preflight check.
+
+    Attributes:
+        name: Stable check identifier.
+        passed: Whether the precondition holds.
+        detail: Human-readable explanation (the blocking reason when ``passed`` is False).
+    """
+
+    name: str
+    passed: bool
+    detail: str
+
+
+def _check_planner_count(plan: ReactivityReplayRunPlan) -> CheckResult:
+    """At least ``min_planners`` distinct planners are declared.
+
+    Returns:
+        CheckResult: The ``planner_count`` check outcome.
+    """
+    distinct = sorted(set(plan.planners))
+    ok = len(distinct) >= plan.min_planners
+    return CheckResult(
+        name="planner_count",
+        passed=ok,
+        detail=(
+            f"{len(distinct)} distinct planners ({', '.join(distinct) or 'none'}); "
+            f"need >= {plan.min_planners}"
+        ),
+    )
+
+
+def _check_arms(plan: ReactivityReplayRunPlan) -> CheckResult:
+    """Exactly the two canonical reactive/replay arms are present.
+
+    Returns:
+        CheckResult: The ``arms_present`` check outcome.
+    """
+    arms = set(plan.arm_seeds)
+    expected = set(REACTIVITY_ARMS)
+    ok = arms == expected
+    return CheckResult(
+        name="arms_present",
+        passed=ok,
+        detail=(
+            f"arms {sorted(arms)}; need exactly {sorted(expected)}"
+            if not ok
+            else f"both arms present: {sorted(expected)}"
+        ),
+    )
+
+
+def _check_paired_seeds(plan: ReactivityReplayRunPlan) -> CheckResult:
+    """Both arms use the identical seed set (common random numbers).
+
+    Returns:
+        CheckResult: The ``paired_seeds`` check outcome.
+    """
+    seed_sets = {arm: tuple(seeds) for arm, seeds in plan.arm_seeds.items()}
+    if set(seed_sets) != set(REACTIVITY_ARMS):
+        return CheckResult(
+            name="paired_seeds",
+            passed=False,
+            detail="cannot verify pairing until both reactive/replay arms are present",
+        )
+    reactive_seeds = sorted(seed_sets[REACTIVITY_ARMS[0]])
+    replay_seeds = sorted(seed_sets[REACTIVITY_ARMS[1]])
+    ok = bool(reactive_seeds) and reactive_seeds == replay_seeds
+    return CheckResult(
+        name="paired_seeds",
+        passed=ok,
+        detail=(
+            f"arms share identical {len(reactive_seeds)} seeds (common random numbers)"
+            if ok
+            else "reactive and replay arms must use the identical non-empty seed set"
+        ),
+    )
+
+
+def _check_seed_budget(plan: ReactivityReplayRunPlan) -> CheckResult:
+    """Seed count meets the rank-stability floor and exceeds the diagnostic matrix.
+
+    Returns:
+        CheckResult: The ``seed_budget`` check outcome.
+    """
+    counts = {arm: len(set(seeds)) for arm, seeds in plan.arm_seeds.items()}
+    min_count = min(counts.values()) if counts else 0
+    ok = min_count >= plan.min_seeds and min_count > DIAGNOSTIC_SEED_COUNT
+    return CheckResult(
+        name="seed_budget",
+        passed=ok,
+        detail=(
+            f"min distinct seeds across arms = {min_count}; need >= {plan.min_seeds} "
+            f"and > {DIAGNOSTIC_SEED_COUNT} (the #3573 diagnostic matrix). "
+            "Precondition floor only; sufficiency is decided post-run by the seed-sufficiency gate."
+        ),
+    )
+
+
+def _check_horizon(plan: ReactivityReplayRunPlan) -> CheckResult:
+    """Horizon is long enough for the robot to reach pedestrians (contrast registers).
+
+    Returns:
+        CheckResult: The ``horizon`` check outcome.
+    """
+    ok = plan.horizon >= plan.min_horizon
+    return CheckResult(
+        name="horizon",
+        passed=ok,
+        detail=(
+            f"horizon {plan.horizon} >= {plan.min_horizon} (contrast is near-null below this on the "
+            "diagnostic family, #3573)"
+            if ok
+            else f"horizon {plan.horizon} below the {plan.min_horizon}-step floor; contrast may be "
+            "near-null because the robot never reaches the crossing"
+        ),
+    )
+
+
+def _check_replay_limitation(plan: ReactivityReplayRunPlan) -> CheckResult:
+    """Replay is force-off (not trajectory playback) and the limitation note is present.
+
+    Returns:
+        CheckResult: The ``replay_limitation`` check outcome.
+    """
+    note = (plan.replay_limitation or "").strip()
+    ok = (plan.replay_is_trajectory_playback is False) and bool(note)
+    if plan.replay_is_trajectory_playback is not False:
+        detail = (
+            "replay_is_trajectory_playback must be False: this ablation disables the robot->ped force "
+            "in a live sim, it is not pre-recorded trajectory playback"
+        )
+    elif not note:
+        detail = "replay_limitation note must be present in the manifest and accompanying artifacts"
+    else:
+        detail = "replay limitation stated: live force-off, not trajectory playback"
+    return CheckResult(name="replay_limitation", passed=ok, detail=detail)
+
+
+_CHECKS = (
+    _check_planner_count,
+    _check_arms,
+    _check_paired_seeds,
+    _check_seed_budget,
+    _check_horizon,
+    _check_replay_limitation,
+)
+
+
+def check_run_plan(plan: ReactivityReplayRunPlan) -> list[CheckResult]:
+    """Run every plan-level precondition check and return the results in declaration order.
+
+    Returns:
+        list[CheckResult]: One result per check, in declaration order.
+    """
+    return [check(plan) for check in _CHECKS]
+
+
+def build_preflight_manifest(plan: ReactivityReplayRunPlan) -> dict[str, Any]:
+    """Build the versioned preflight manifest for a proposed run plan.
+
+    The manifest is deterministic and side-effect free (provenance such as git HEAD / timestamps is
+    added by the CLI wrapper). It carries the replay limitation so the constraint travels with the
+    artifact.
+
+    Returns:
+        dict[str, Any]: ``status`` is ``"ready"`` when every precondition passes, else ``"blocked"``
+        with the blocking reasons. Always carries the replay-limitation metadata and a conservative
+        claim boundary.
+    """
+    checks = check_run_plan(plan)
+    blocking = [f"{c.name}: {c.detail}" for c in checks if not c.passed]
+    status = "ready" if not blocking else "blocked"
+    return {
+        "schema_version": PREFLIGHT_SCHEMA,
+        "issue": ISSUE,
+        "status": status,
+        "evidence_tier": "plan_preflight",
+        "plan": {
+            "planners": list(plan.planners),
+            "arms": {arm: list(seeds) for arm, seeds in plan.arm_seeds.items()},
+            "scenario_set": plan.scenario_set,
+            "horizon": plan.horizon,
+            "min_planners": plan.min_planners,
+            "min_seeds": plan.min_seeds,
+        },
+        "replay_limitation": {
+            "note": plan.replay_limitation,
+            "is_trajectory_playback": plan.replay_is_trajectory_playback,
+            "mechanism": "peds_have_robot_repulsion=false (live social-force, robot->ped force off)",
+        },
+        "checks": [{"name": c.name, "passed": c.passed, "detail": c.detail} for c in checks],
+        "blocking_issues": blocking,
+        "claim_boundary": (
+            "Plan-level preflight only: verifies the proposed reactivity-vs-replay run is well-formed "
+            "(>=3 planners, paired seeds, both arms, seed-budget floor, replay limitation stated) "
+            "before any compute is spent. It does NOT run the benchmark, measure or interpret rank "
+            "stability, or make any paper-facing claim. Actual seed sufficiency is decided post-run "
+            "by scripts/tools/seed_sufficiency_gate.py; 'replay' is live force-off, not trajectory "
+            "playback."
+        ),
+    }
+
+
+def run_plan_from_packet(packet: dict[str, Any]) -> ReactivityReplayRunPlan:
+    """Build a :class:`ReactivityReplayRunPlan` from a launch-packet mapping (e.g. parsed YAML).
+
+    Expected shape (only the listed keys are read; extras are ignored)::
+
+        planners: [goal, orca, social_force]
+        scenario_set: configs/scenarios/sets/classic_crossing_subset.yaml
+        horizon: 300
+        seeds: [101, 102, ...]            # paired seed set used by BOTH arms
+        # optional per-arm override (rarely needed; defaults to the shared `seeds`):
+        arm_seeds: {reactive: [...], replay: [...]}
+        replay:
+          is_trajectory_playback: false
+          limitation: "..."              # defaults to the canonical REPLAY_LIMITATION
+        min_planners: 3                  # optional override
+        min_seeds: 20                    # optional override
+
+    Returns:
+        ReactivityReplayRunPlan: The parsed run plan.
+
+    Raises:
+        ValueError: If required keys are missing or malformed.
+    """
+    if not isinstance(packet, dict):
+        raise ValueError("packet must be a mapping")
+
+    planners = packet.get("planners")
+    if not isinstance(planners, list) or not all(isinstance(p, str) for p in planners):
+        raise ValueError("packet 'planners' must be a list of planner-name strings")
+
+    scenario_set = packet.get("scenario_set")
+    if not isinstance(scenario_set, str) or not scenario_set.strip():
+        raise ValueError("packet 'scenario_set' must be a non-empty string")
+
+    horizon = packet.get("horizon")
+    if not isinstance(horizon, int) or isinstance(horizon, bool):
+        raise ValueError("packet 'horizon' must be an integer")
+
+    arm_seeds = _resolve_arm_seeds(packet)
+
+    replay = packet.get("replay", {})
+    if not isinstance(replay, dict):
+        raise ValueError("packet 'replay' must be a mapping when present")
+    is_playback = replay.get("is_trajectory_playback", REPLAY_IS_TRAJECTORY_PLAYBACK)
+    if not isinstance(is_playback, bool):
+        raise ValueError("packet 'replay.is_trajectory_playback' must be a boolean")
+    limitation = replay.get("limitation", REPLAY_LIMITATION)
+    if not isinstance(limitation, str):
+        raise ValueError("packet 'replay.limitation' must be a string")
+
+    overrides: dict[str, Any] = {}
+    if "min_planners" in packet:
+        overrides["min_planners"] = int(packet["min_planners"])
+    if "min_seeds" in packet:
+        overrides["min_seeds"] = int(packet["min_seeds"])
+
+    return ReactivityReplayRunPlan(
+        planners=tuple(planners),
+        arm_seeds=arm_seeds,
+        scenario_set=scenario_set,
+        horizon=horizon,
+        replay_is_trajectory_playback=is_playback,
+        replay_limitation=limitation,
+        **overrides,
+    )
+
+
+def _resolve_arm_seeds(packet: dict[str, Any]) -> dict[str, tuple[int, ...]]:
+    """Resolve per-arm seed lists from an explicit ``arm_seeds`` or a shared ``seeds`` key.
+
+    Returns:
+        dict[str, tuple[int, ...]]: Arm tag -> seed tuple (both arms share the seed set when
+        resolved from a shared ``seeds`` key).
+    """
+
+    def _as_seed_tuple(value: Any, where: str) -> tuple[int, ...]:
+        if not isinstance(value, list) or not all(
+            isinstance(s, int) and not isinstance(s, bool) for s in value
+        ):
+            raise ValueError(f"{where} must be a list of integer seeds")
+        return tuple(value)
+
+    explicit = packet.get("arm_seeds")
+    if explicit is not None:
+        if not isinstance(explicit, dict):
+            raise ValueError("packet 'arm_seeds' must be a mapping of arm -> seed list")
+        return {
+            arm: _as_seed_tuple(seeds, f"arm_seeds[{arm!r}]") for arm, seeds in explicit.items()
+        }
+
+    shared = packet.get("seeds")
+    if shared is None:
+        raise ValueError("packet must provide either 'seeds' (shared) or 'arm_seeds' (per-arm)")
+    seeds = _as_seed_tuple(shared, "packet 'seeds'")
+    # Paired by construction: both arms run the identical seed set (common random numbers).
+    return dict.fromkeys(REACTIVITY_ARMS, seeds)
+
+
+__all__ = [
+    "DIAGNOSTIC_SEED_COUNT",
+    "ISSUE",
+    "MIN_PLANNERS",
+    "MIN_RANK_STABILITY_SEEDS",
+    "PREFLIGHT_SCHEMA",
+    "CheckResult",
+    "ReactivityReplayRunPlan",
+    "build_preflight_manifest",
+    "check_run_plan",
+    "run_plan_from_packet",
+]

--- a/scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py
+++ b/scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py
@@ -1,0 +1,156 @@
+#!/usr/bin/env python3
+"""CPU-only preflight for the paper-grade reactivity-vs-replay rank study (issue #3637).
+
+Reads a launch-packet YAML describing the *proposed* paper-grade run (planners, paired seeds,
+scenario set, horizon, replay-limitation metadata) and checks the **plan-level preconditions**
+before any compute is spent:
+
+* >= 3 planners;
+* exactly the reactive/replay arms with **paired** (identical) seeds — common random numbers;
+* a seed budget at/above the rank-stability floor and above the #3573 diagnostic matrix;
+* the replay limitation is stated and ``replay`` is force-off, not trajectory playback.
+
+It is a thin orchestrator over the canonical pure checker
+``robot_sf.benchmark.reactivity_replay_preflight``; it never re-implements the checks. It does
+**not** run the benchmark, measure or interpret rank stability, submit Slurm/GPU jobs, or make any
+paper-facing claim. Exit 0 = plan is ready to launch; exit 1 = plan is blocked (fix the packet);
+exit 2 = usage/IO error.
+
+Usage::
+
+    preflight_reactivity_replay_rank_study_issue_3637.py \
+        [--packet configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml] \
+        [--output-json output/issue_3637/preflight.json] [--json]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Make the repo root importable when run as a bare script.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from robot_sf.benchmark.reactivity_replay_preflight import (  # noqa: E402
+    build_preflight_manifest,
+    run_plan_from_packet,
+)
+
+DEFAULT_PACKET = Path(
+    "configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml"
+)
+
+
+def _git_head() -> str | None:
+    """Read the current git HEAD SHA for provenance, or ``None`` if unavailable."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=_REPO_ROOT,
+        )
+    except (OSError, subprocess.CalledProcessError):
+        return None
+    return result.stdout.strip() or None
+
+
+def _load_packet(path: Path) -> dict[str, Any]:
+    """Load and minimally validate the launch-packet YAML mapping."""
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected a YAML mapping at the top level")
+    return payload
+
+
+def _render_human(manifest: dict[str, Any]) -> str:
+    """Render a human-readable summary of the preflight manifest."""
+    lines = [
+        f"reactivity-vs-replay preflight (issue #{manifest['issue']})",
+        f"git HEAD: {manifest.get('provenance', {}).get('git_head') or 'unknown'}",
+        f"packet: {manifest.get('provenance', {}).get('packet') or 'unknown'}",
+        f"status: {manifest['status'].upper()}",
+        "checks:",
+    ]
+    for check in manifest["checks"]:
+        mark = "PASS" if check["passed"] else "FAIL"
+        lines.append(f"  [{mark}] {check['name']}: {check['detail']}")
+    lines.append(f"replay limitation: {manifest['replay_limitation']['note']}")
+    if manifest["blocking_issues"]:
+        lines.append("blocking issues:")
+        lines.extend(f"  - {issue}" for issue in manifest["blocking_issues"])
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--packet",
+        type=Path,
+        default=DEFAULT_PACKET,
+        help="Launch-packet YAML describing the proposed run plan.",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Optional path to write the preflight manifest JSON.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the machine-readable JSON manifest to stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the preflight. Returns 0 (ready), 1 (blocked), or 2 (usage/IO error)."""
+    args = _parse_args(argv)
+    try:
+        packet = _load_packet(args.packet)
+        plan = run_plan_from_packet(packet)
+        manifest = build_preflight_manifest(plan)
+    except (OSError, yaml.YAMLError, ValueError) as exc:
+        message = f"preflight failed for {args.packet}: {exc}"
+        if args.json:
+            print(json.dumps({"error": message}))
+        else:
+            print(f"error: {message}", file=sys.stderr)
+        return 2
+
+    manifest["provenance"] = {
+        "git_head": _git_head(),
+        "packet": str(args.packet),
+        "generated_at_utc": datetime.now(UTC).isoformat(),
+    }
+
+    if args.json:
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+    else:
+        print(_render_human(manifest))
+
+    if args.output_json is not None:
+        args.output_json.parent.mkdir(parents=True, exist_ok=True)
+        args.output_json.write_text(
+            json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+        )
+        if not args.json:
+            print(f"\nwrote {args.output_json}")
+
+    return 0 if manifest["status"] == "ready" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
+++ b/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
@@ -1,0 +1,231 @@
+"""Tests for the reactivity-vs-replay rank-study preflight (issue #3637).
+
+Covers the pure checker, the packet loader, the canonical shipped launch packet (regression guard),
+and the thin CLI. No benchmark execution, no rank-stability interpretation.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.reactivity_ablation import REACTIVITY_ARMS, REPLAY_LIMITATION
+from robot_sf.benchmark.reactivity_replay_preflight import (
+    DIAGNOSTIC_SEED_COUNT,
+    MIN_RANK_STABILITY_SEEDS,
+    PREFLIGHT_SCHEMA,
+    ReactivityReplayRunPlan,
+    build_preflight_manifest,
+    check_run_plan,
+    run_plan_from_packet,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SHIPPED_PACKET = (
+    REPO_ROOT / "configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml"
+)
+
+# scripts/benchmark/ has no package __init__; load the CLI module by path (repo convention).
+_CLI_PATH = (
+    REPO_ROOT / "scripts" / "benchmark" / "preflight_reactivity_replay_rank_study_issue_3637.py"
+)
+_SPEC = importlib.util.spec_from_file_location("_issue_3637_preflight_cli", _CLI_PATH)
+assert _SPEC is not None and _SPEC.loader is not None
+_CLI = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_CLI)
+cli_main = _CLI.main
+
+
+def _ready_seeds() -> tuple[int, ...]:
+    """A paired seed set that meets the rank-stability floor."""
+    return tuple(range(101, 101 + MIN_RANK_STABILITY_SEEDS))
+
+
+def _ready_plan(**overrides) -> ReactivityReplayRunPlan:
+    """A plan that passes every precondition unless overridden."""
+    seeds = _ready_seeds()
+    base = {
+        "planners": ("goal", "orca", "social_force"),
+        "arm_seeds": dict.fromkeys(REACTIVITY_ARMS, seeds),
+        "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
+        "horizon": 300,
+    }
+    base.update(overrides)
+    return ReactivityReplayRunPlan(**base)
+
+
+def _checks_by_name(plan: ReactivityReplayRunPlan) -> dict[str, bool]:
+    return {c.name: c.passed for c in check_run_plan(plan)}
+
+
+def test_ready_plan_passes_and_manifest_is_ready():
+    """A well-formed plan passes all checks and yields a ready manifest."""
+    manifest = build_preflight_manifest(_ready_plan())
+    assert manifest["status"] == "ready"
+    assert manifest["schema_version"] == PREFLIGHT_SCHEMA
+    assert manifest["issue"] == 3637
+    assert manifest["blocking_issues"] == []
+    assert all(c["passed"] for c in manifest["checks"])
+
+
+def test_manifest_always_carries_replay_limitation():
+    """The replay limitation travels with the manifest, even when blocked."""
+    manifest = build_preflight_manifest(_ready_plan(planners=("goal",)))
+    assert manifest["status"] == "blocked"
+    limitation = manifest["replay_limitation"]
+    assert limitation["is_trajectory_playback"] is False
+    assert "not pre-recorded trajectory playback" in limitation["note"].lower()
+    assert "rank stability" in manifest["claim_boundary"].lower()
+
+
+def test_too_few_planners_blocks():
+    """Fewer than three planners fails the planner-count check."""
+    assert _checks_by_name(_ready_plan(planners=("goal", "orca")))["planner_count"] is False
+
+
+def test_duplicate_planners_do_not_inflate_count():
+    """Distinct-count, not raw length, drives the planner check."""
+    plan = _ready_plan(planners=("goal", "goal", "goal"))
+    assert _checks_by_name(plan)["planner_count"] is False
+
+
+def test_unpaired_seeds_block():
+    """Differing seed sets across arms fail the paired-seeds check."""
+    seeds = _ready_seeds()
+    plan = _ready_plan(
+        arm_seeds={REACTIVITY_ARMS[0]: seeds, REACTIVITY_ARMS[1]: seeds[:-1] + (999,)}
+    )
+    checks = _checks_by_name(plan)
+    assert checks["paired_seeds"] is False
+
+
+def test_missing_arm_blocks_arms_and_pairing():
+    """A plan missing the replay arm fails both the arms and pairing checks."""
+    plan = _ready_plan(arm_seeds={REACTIVITY_ARMS[0]: _ready_seeds()})
+    checks = _checks_by_name(plan)
+    assert checks["arms_present"] is False
+    assert checks["paired_seeds"] is False
+
+
+def test_seed_budget_floor_enforced():
+    """A paired seed set below the floor (but above the diagnostic) still blocks on budget."""
+    small = tuple(range(101, 101 + DIAGNOSTIC_SEED_COUNT + 1))  # 5 seeds: > diagnostic, < floor
+    plan = _ready_plan(arm_seeds=dict.fromkeys(REACTIVITY_ARMS, small))
+    checks = _checks_by_name(plan)
+    assert checks["paired_seeds"] is True
+    assert checks["seed_budget"] is False
+
+
+def test_trajectory_playback_blocks():
+    """Declaring replay as trajectory playback is a hard block (mislabeled mechanism)."""
+    plan = _ready_plan(replay_is_trajectory_playback=True)
+    assert _checks_by_name(plan)["replay_limitation"] is False
+
+
+def test_missing_limitation_note_blocks():
+    """An empty limitation note blocks even when the playback flag is correct."""
+    plan = _ready_plan(replay_limitation="   ")
+    assert _checks_by_name(plan)["replay_limitation"] is False
+
+
+def test_short_horizon_blocks():
+    """A horizon below the contrast-registration floor blocks."""
+    assert _checks_by_name(_ready_plan(horizon=50))["horizon"] is False
+
+
+def test_run_plan_from_packet_shared_seeds_are_paired():
+    """A shared 'seeds' key fans out to identical paired arms."""
+    packet = {
+        "planners": ["goal", "orca", "social_force"],
+        "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
+        "horizon": 300,
+        "seeds": list(range(101, 121)),
+    }
+    plan = run_plan_from_packet(packet)
+    assert set(plan.arm_seeds) == set(REACTIVITY_ARMS)
+    assert plan.arm_seeds[REACTIVITY_ARMS[0]] == plan.arm_seeds[REACTIVITY_ARMS[1]]
+    assert plan.replay_limitation == REPLAY_LIMITATION
+    assert build_preflight_manifest(plan)["status"] == "ready"
+
+
+def test_run_plan_from_packet_explicit_arm_seeds():
+    """Explicit per-arm seeds are honored verbatim."""
+    seeds = list(range(101, 121))
+    packet = {
+        "planners": ["goal", "orca", "social_force"],
+        "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
+        "horizon": 300,
+        "arm_seeds": {"reactive": seeds, "replay": seeds},
+    }
+    plan = run_plan_from_packet(packet)
+    assert plan.arm_seeds["reactive"] == tuple(seeds)
+
+
+@pytest.mark.parametrize(
+    "packet",
+    [
+        {"scenario_set": "x", "horizon": 1, "seeds": [1]},  # missing planners
+        {"planners": ["a"], "horizon": 1, "seeds": [1]},  # missing scenario_set
+        {"planners": ["a"], "scenario_set": "x", "seeds": [1]},  # missing horizon
+        {"planners": ["a"], "scenario_set": "x", "horizon": 1},  # missing seeds/arm_seeds
+        {"planners": ["a"], "scenario_set": "x", "horizon": 1, "seeds": ["bad"]},  # bad seeds
+        {"planners": ["a"], "scenario_set": "x", "horizon": True, "seeds": [1]},  # bool horizon
+    ],
+)
+def test_run_plan_from_packet_rejects_malformed(packet):
+    """Malformed packets raise ValueError rather than silently passing."""
+    with pytest.raises(ValueError):
+        run_plan_from_packet(packet)
+
+
+def test_shipped_packet_preflights_ready():
+    """Regression guard: the canonical shipped launch packet must preflight as ready."""
+    packet = yaml.safe_load(SHIPPED_PACKET.read_text(encoding="utf-8"))
+    manifest = build_preflight_manifest(run_plan_from_packet(packet))
+    assert manifest["status"] == "ready", manifest["blocking_issues"]
+
+
+def test_shipped_packet_checksum_matches_scenario_set():
+    """The packet's recorded scenario-set sha256 must match the file (drift guard)."""
+    import hashlib
+
+    packet = yaml.safe_load(SHIPPED_PACKET.read_text(encoding="utf-8"))
+    scenario_path = REPO_ROOT / packet["scenario_set"]
+    actual = hashlib.sha256(scenario_path.read_bytes()).hexdigest()
+    assert actual == packet["scenario_set_sha256"]
+
+
+def test_cli_ready_packet_exit_zero(tmp_path):
+    """The CLI returns 0 and writes a manifest for the ready shipped packet."""
+    out = tmp_path / "preflight.json"
+    code = cli_main(["--packet", str(SHIPPED_PACKET), "--output-json", str(out), "--json"])
+    assert code == 0
+    manifest = json.loads(out.read_text(encoding="utf-8"))
+    assert manifest["status"] == "ready"
+    assert manifest["provenance"]["packet"] == str(SHIPPED_PACKET)
+
+
+def test_cli_blocked_packet_exit_one(tmp_path):
+    """A packet that violates a precondition makes the CLI exit 1."""
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(
+        yaml.safe_dump(
+            {
+                "planners": ["goal", "orca"],  # only 2 planners
+                "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
+                "horizon": 300,
+                "seeds": list(range(101, 121)),
+            }
+        ),
+        encoding="utf-8",
+    )
+    assert cli_main(["--packet", str(bad)]) == 1
+
+
+def test_cli_unreadable_packet_exit_two(tmp_path):
+    """A missing packet path makes the CLI exit 2 (usage/IO error)."""
+    assert cli_main(["--packet", str(tmp_path / "does_not_exist.yaml")]) == 2


### PR DESCRIPTION
## Summary

Implements the scoped slice of #3637: the **plan-level preflight / run-manifest checker** for the
paper-grade seed-sufficient reactivity-vs-replay rank study (split from #3573). It is the next
evidence-control layer — it gates the (not-yet-run) paper-grade campaign so under-powered or
mislabeled runs are caught **before** any compute is spent, and it bakes the replay limitation into
the manifest.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3637

## Scope

- `robot_sf/benchmark/reactivity_replay_preflight.py` — **pure, side-effect-free** checker
  (`reactivity_replay_rank_study_preflight.v1`). `build_preflight_manifest(plan)` returns a
  `ready`/`blocked` manifest after verifying plan-level **preconditions**:
  - `planner_count` ≥ 3 distinct planners;
  - `arms_present` — exactly the `reactive`/`replay` arms;
  - `paired_seeds` — both arms use the identical seed set (common random numbers);
  - `seed_budget` ≥ S20 floor (20) and > the #3573 diagnostic matrix (4);
  - `horizon` ≥ 150 (contrast is near-null below this on the diagnostic family);
  - `replay_limitation` present and `is_trajectory_playback = false`.
- `robot_sf/benchmark/reactivity_ablation.py` — centralizes `REPLAY_LIMITATION`,
  `REPLAY_IS_TRAJECTORY_PLAYBACK`, `REACTIVITY_ARMS` in the **canonical owner**; the preflight
  imports them (no duplicate copy), per the canonical-owner rule.
- `scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py` — thin CPU-only CLI
  (exit `0` ready / `1` blocked / `2` usage error).
- `configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml` — the proposed run
  plan (planners, paired S20 seeds, scenario set + sha256, horizon, replay limitation) plus the
  out-of-scope run / post-run commands.
- `docs/context/issue_3637_reactivity_replay_rank_study_preflight.md` + CHANGELOG entry.

## Replay limitation (stated in the artifact, per #3637 DoD)

> "replay" = robot→pedestrian social-force term disabled in a **live** social-force sim
> (`peds_have_robot_repulsion=false`); **NOT** pre-recorded trajectory playback.

## Validation

All commands run from the worktree via the shared venv on `imech039`:

| Command | Exit | Result |
| --- | --- | --- |
| `ruff check` (4 changed files) | 0 | All checks passed |
| `ruff format --check` (4 changed files) | 0 | 4 files already formatted |
| `pytest tests/benchmark/test_reactivity_replay_preflight_issue_3637.py test_reactivity_ablation.py test_run_reactivity_ablation_campaign_issue_3573.py -q` | 0 | **38 passed** |
| `python scripts/tools/sync_ai_config.py --check` | 0 | 7 symlinks validated |
| CLI on shipped packet | 0 | `status: READY` (all 6 checks PASS) |

The preflight test file covers each precondition pass/block path, the packet loader (shared vs
per-arm seeds, malformed rejection), the shipped packet (ready + scenario-set sha256 drift guard),
and the CLI exit codes.

## Out of scope (explicit)

- **No full benchmark campaign run** — this only checks the *plan*.
- **No Slurm/GPU submission.**
- **No rank-stability interpretation** — actual seed *sufficiency* is decided post-run by
  `scripts/tools/seed_sufficiency_gate.py`.
- **No paper/dissertation claim edits.**

## Downstream Propagation

- Parent issue #3637: this lands the bounded preflight slice; the paper-grade run itself remains
  the deferred follow-up (launch packet records the run/post-run commands).
- Context note added; the #3573 note is linked. No leaderboard/registry/catalog change (the #3573
  markdown note is likewise un-cataloged precedent).

## Research Result Guidance

- **Target claim/blocker:** evidence-control precondition layer for the reactivity-rank claim — not a
  claim itself.
- **Evidence tier:** `plan_preflight` (no benchmark evidence).
- **Result classification:** tooling/control layer; no rank-stability result produced.
- **Decision/stop rule:** preflight `ready` is necessary-not-sufficient; promotion still requires the
  post-run seed-sufficiency gate + claim-card review.
- **Synthesis surface:** `docs/context/issue_3637_reactivity_replay_rank_study_preflight.md`.

## Residual risk

- Planner identity in the packet (`goal`, `orca`, `social_force`) is a run-design choice the
  maintainer may revise; the preflight enforces the ≥3 **count** and well-formed arms/seeds, not the
  specific planner set.
- The S20 seed floor is a **precondition** aligned with the existing schedule, not a proof of
  sufficiency — that remains a post-run decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new preflight check for the reactivity-vs-replay rank study to validate run plans before execution.
  * Added a launch-packet format and command-line tool to produce ready/blocked readiness reports.
  * Added clearer replay-setup metadata to distinguish the replay arm from true trajectory playback.

* **Bug Fixes**
  * Enforced stricter checks for planner count, paired seeds, seed thresholds, and minimum horizon.
  * Added validation to block incomplete or inconsistent study plans early.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->