### PR TITLE
feat(benchmark): fail-closed readiness gate for ScenarioBelief drop-vs-retain runner (#3556)

### DIFF
--- a/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
+++ b/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
@@ -12,6 +12,14 @@ result (``revise`` / ``retention_dominates`` / ``inconclusive`` / ``inconclusive
 The three modes differ only in the ``belief_mode`` algo-config knob; everything else is identical so
 the contrast is attributable to dropping vs retaining out-of-FOV agents.
 
+Before any episode is rolled, a CPU-only fail-closed readiness gate
+(:func:`check_campaign_readiness`, also runnable via ``--preflight-only``) verifies the campaign's
+own inputs and contracts (modes pinned, seed matrix pinned, scenario set present, run geometry
+positive, the uncertainty-consuming planner key, and the oracle-near-safety screening
+precondition). A failed gate aborts with no compute burned. This gate guards *this* real runner;
+the controlled-scenario predecessor (#3471) is gated separately by
+``scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py``.
+
 Evidence boundary: real-benchmark-runner evidence on a bounded crossing family. The FOV uncertainty
 source is a configurable rule, not a calibrated perception model; no paper-grade claim until the
 predeclared matrix is run at the seed-sufficiency budget and reviewed via a claim card.
@@ -29,6 +37,7 @@ import numpy as np
 import yaml
 
 from robot_sf.benchmark.map_runner import run_map_batch
+from robot_sf.planner.scenario_belief_adapter import SUPPORTED_UNCERTAINTY_PLANNER_KEYS
 from robot_sf.training.scenario_loader import load_scenarios
 
 SCHEMA_VERSION = "belief-mode-safety-campaign.v1"
@@ -37,6 +46,12 @@ SCHEMA_PATH = "robot_sf/benchmark/schemas/episode.schema.v1.json"
 
 #: Belief modes -> planner uncertainty gate (oracle/retained keep agents; dropped drops them).
 MODES = ("oracle", "uncertain_retained", "uncertain_dropped")
+#: The planner algo the campaign drives; it must be the uncertainty-consuming one.
+CAMPAIGN_ALGO = "stream_gap"
+#: Contrast pair plus near-safe oracle baseline; each is individually load-bearing.
+REQUIRED_MODES = ("oracle", "uncertain_retained", "uncertain_dropped")
+#: A planner key guaranteed not to consume the uncertainty sidecar, used to prove fail-closed.
+_UNSUPPORTED_PROBE_KEY = "campaign_preflight_unsupported_probe"
 DEFAULT_SCENARIO_SET = "configs/scenarios/sets/classic_crossing_subset.yaml"
 DEFAULT_SEEDS = list(range(101, 113))
 DEFAULT_FOV = 120.0
@@ -63,7 +78,7 @@ def load_campaign_scenarios(set_path: Path, seeds: list[int]) -> list[dict[str, 
 def write_algo_config(mode: str, out_dir: Path, *, fov_degrees: float) -> Path:
     """Write the stream_gap algo config for a belief mode; return its path."""
     config = {
-        "algo": "stream_gap",
+        "algo": CAMPAIGN_ALGO,
         "allow_testing_algorithms": True,
         "belief_mode": mode,
         "belief_fov_degrees": fov_degrees,
@@ -92,7 +107,7 @@ def run_mode(
         scenarios,
         episodes_path,
         schema_path=Path(SCHEMA_PATH),
-        algo="stream_gap",
+        algo=CAMPAIGN_ALGO,
         algo_config_path=str(algo_path),
         horizon=horizon,
         dt=dt,
@@ -239,6 +254,143 @@ def classify_screened_decision(by_mode: dict[str, dict[str, Any]]) -> dict[str, 
     }
 
 
+def check_campaign_readiness(
+    set_path: Path,
+    seeds: list[int],
+    *,
+    fov_degrees: float,
+    horizon: int,
+    dt: float,
+    workers: int,
+) -> dict[str, Any]:
+    """Fail-closed CPU-only readiness gate for the REAL belief-mode campaign inputs.
+
+    This gates the campaign that this module actually runs (``run_map_batch`` over the three
+    belief modes) -- not a predecessor controlled-scenario runner. It verifies the campaign's own
+    inputs and contracts so a real run never burns compute on an unpinned matrix or a planner that
+    cannot consume the uncertainty sidecar. It does **not** roll episodes or interpret outcomes.
+
+    Checks (all must pass for ``ready``):
+
+    * the three belief modes the drop-vs-retain contrast + near-safe oracle baseline need are
+      pinned (``MODES``);
+    * the seed matrix is a non-empty list of unique integers (not a silent fallback);
+    * the scenario set file exists;
+    * the controlled run geometry (fov / horizon / dt / workers) is strictly positive;
+    * the campaign algo is the uncertainty-consuming planner key and an unsupported key is *not*
+      in the supported set (the adapter's fail-closed guarantee);
+    * the oracle-near-safety precondition holds as a contract: ``NEAR_SAFE_ORACLE_COLLISION_RATE``
+      is a probability and ``classify_screened_decision`` refuses to interpret an unsafe-oracle
+      matrix (synthetic input, no episode roll).
+
+    Returns:
+        A JSON-serializable report ``{"ready": bool, "checks": [...], "failed_checks": [...]}``.
+    """
+    checks: list[dict[str, Any]] = []
+
+    def add(name: str, passed: bool, detail: str) -> None:
+        checks.append({"name": name, "passed": bool(passed), "detail": detail})
+
+    # 1. Belief modes pinned: exactly the contrast pair + oracle baseline.
+    mode_set = set(MODES)
+    missing_modes = [m for m in REQUIRED_MODES if m not in mode_set]
+    add(
+        "belief_modes_pinned",
+        not missing_modes and mode_set == set(REQUIRED_MODES),
+        f"pinned exactly {sorted(REQUIRED_MODES)}"
+        if not missing_modes and mode_set == set(REQUIRED_MODES)
+        else f"MODES must equal {sorted(REQUIRED_MODES)} (got {sorted(mode_set)})",
+    )
+
+    # 2. Seed matrix explicitly pinned: non-empty, integer, unique.
+    seeds_ok = (
+        isinstance(seeds, list)
+        and len(seeds) > 0
+        and all(isinstance(s, int) and not isinstance(s, bool) for s in seeds)
+        and len(set(seeds)) == len(seeds)
+    )
+    add(
+        "seeds_pinned",
+        seeds_ok,
+        f"{len(seeds)} unique integer seeds pinned"
+        if seeds_ok
+        else "seeds must be a non-empty list of unique integers",
+    )
+
+    # 3. Scenario set exists.
+    add(
+        "scenario_set_exists",
+        set_path.exists(),
+        f"scenario set present at {set_path}"
+        if set_path.exists()
+        else f"scenario set not found: {set_path}",
+    )
+
+    # 4. Controlled run geometry strictly positive.
+    geometry = {"fov_degrees": fov_degrees, "horizon": horizon, "dt": dt, "workers": workers}
+    bad_geometry = [f"{k}={v} must be > 0" for k, v in geometry.items() if not v > 0]
+    add(
+        "run_geometry_positive",
+        not bad_geometry,
+        "fov/horizon/dt/workers all > 0" if not bad_geometry else "; ".join(bad_geometry),
+    )
+
+    # 5. Planner uncertainty contract: the campaign algo consumes uncertainty; an unsupported key
+    #    is provably outside the supported set (the adapter fails closed on it).
+    planner_ok = (
+        CAMPAIGN_ALGO in SUPPORTED_UNCERTAINTY_PLANNER_KEYS
+        and _UNSUPPORTED_PROBE_KEY not in SUPPORTED_UNCERTAINTY_PLANNER_KEYS
+    )
+    add(
+        "uncertainty_planner_contract",
+        planner_ok,
+        f"campaign algo {CAMPAIGN_ALGO!r} consumes uncertainty; unsupported keys fail closed"
+        if planner_ok
+        else f"campaign algo {CAMPAIGN_ALGO!r} is not in supported set "
+        f"{sorted(SUPPORTED_UNCERTAINTY_PLANNER_KEYS)}",
+    )
+
+    # 6. Oracle-near-safety precondition contract (synthetic; no episode roll). The threshold must
+    #    be a probability, and the screening classifier must refuse to interpret an unsafe-oracle
+    #    matrix even when the dropped mode looks worse.
+    threshold_ok = 0.0 < NEAR_SAFE_ORACLE_COLLISION_RATE < 1.0
+    unsafe_rate = min(1.0, NEAR_SAFE_ORACLE_COLLISION_RATE + 0.5)
+    synthetic_unsafe = {
+        "oracle": {"episodes": 3, "collision_rate": unsafe_rate, "total_near_misses": 0},
+        "uncertain_retained": {"episodes": 3, "collision_rate": 0.0, "total_near_misses": 0},
+        "uncertain_dropped": {"episodes": 3, "collision_rate": 1.0, "total_near_misses": 5},
+    }
+    screened = classify_screened_decision(synthetic_unsafe)
+    contract_ok = (
+        threshold_ok
+        and screened.get("decision") == "inconclusive_oracle_unsafe"
+        and screened.get("oracle_near_safe") is False
+    )
+    add(
+        "oracle_near_safety_contract",
+        contract_ok,
+        f"unsafe oracle (rate {unsafe_rate}) blocks interpretation at threshold "
+        f"{NEAR_SAFE_ORACLE_COLLISION_RATE}"
+        if contract_ok
+        else f"oracle-near-safety contract violated: threshold_ok={threshold_ok}, "
+        f"decision={screened.get('decision')}",
+    )
+
+    failed = [c["name"] for c in checks if not c["passed"]]
+    return {
+        "schema_version": "belief-mode-campaign-readiness.v1",
+        "issue": ISSUE,
+        "campaign_algo": CAMPAIGN_ALGO,
+        "ready": not failed,
+        "checks": checks,
+        "failed_checks": failed,
+        "claim_boundary": (
+            "Input-pinning and fail-closed readiness gate for the real campaign runner; does not "
+            "run the benchmark matrix, roll episodes, or interpret drop-vs-retain outcomes."
+        ),
+    }
+
+
 def run_campaign(
     set_path: Path,
     seeds: list[int],
@@ -249,7 +401,24 @@ def run_campaign(
     dt: float,
     workers: int,
 ) -> dict[str, Any]:
-    """Run all three belief modes through the real runner and assemble the classified report."""
+    """Run all three belief modes through the real runner and assemble the classified report.
+
+    Fails closed: if the campaign inputs/contracts are not ready, raises ``RuntimeError`` before
+    any episode is rolled so no compute is burned on an invalid matrix.
+    """
+    readiness = check_campaign_readiness(
+        set_path,
+        seeds,
+        fov_degrees=fov_degrees,
+        horizon=horizon,
+        dt=dt,
+        workers=workers,
+    )
+    if not readiness["ready"]:
+        raise RuntimeError(
+            "campaign readiness gate failed (no episodes rolled); "
+            f"failed checks: {readiness['failed_checks']}"
+        )
     out_dir.mkdir(parents=True, exist_ok=True)
     scenarios = load_campaign_scenarios(set_path, seeds)
     by_mode: dict[str, dict[str, Any]] = {}
@@ -297,12 +466,36 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--dt", type=float, default=0.1)
     parser.add_argument("--workers", type=int, default=4)
     parser.add_argument("--report-json", type=Path, default=None)
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help=(
+            "Run only the CPU-only fail-closed readiness gate over the campaign inputs and exit "
+            "(0 = ready, 1 = a readiness check failed). Rolls no episodes."
+        ),
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point: run the real-runner belief-mode safety campaign and emit the report."""
+    """CLI entry point: gate inputs, then run the real-runner belief-mode safety campaign.
+
+    Returns ``1`` (and rolls no episodes) when the fail-closed readiness gate fails, otherwise
+    ``0`` after the campaign report is emitted. ``--preflight-only`` stops after the gate.
+    """
     args = parse_args(argv)
+    readiness = check_campaign_readiness(
+        args.scenario_set,
+        args.seeds,
+        fov_degrees=args.fov_degrees,
+        horizon=args.horizon,
+        dt=args.dt,
+        workers=args.workers,
+    )
+    if args.preflight_only or not readiness["ready"]:
+        print(json.dumps(readiness, indent=2, sort_keys=True))
+        return 0 if readiness["ready"] else 1
+
     report = run_campaign(
         args.scenario_set,
         args.seeds,
@@ -312,6 +505,7 @@ def main(argv: list[str] | None = None) -> int:
         dt=args.dt,
         workers=args.workers,
     )
+    report["readiness"] = readiness
     report["generated_at_utc"] = datetime.now(UTC).isoformat()
     print(json.dumps(report, indent=2, sort_keys=True))
     if args.report_json is not None:

--- a/scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py
+++ b/scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py
@@ -347,10 +347,24 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
 
 def main(argv: list[str] | None = None) -> int:
     """Run the readiness gate. Returns the process exit code (0 ready, 1 not ready, 2 error)."""
+    import yaml
+
     args = _parse_args(argv)
+    # Narrow fail-closed surface: catch the input/parse/contract errors the readiness
+    # evaluation can realistically raise (missing or malformed config, bad YAML, type/value
+    # mismatches while pinning the matrix or building the probe belief) and report exit 2.
+    # Genuinely unexpected errors are intentionally *not* swallowed so they surface as a crash.
     try:
         report = check_runner_readiness(args.config)
-    except Exception as exc:  # noqa: BLE001 - surface any evaluation failure as a fail-closed error
+    except (
+        OSError,
+        ValueError,
+        TypeError,
+        KeyError,
+        AttributeError,
+        ImportError,
+        yaml.YAMLError,
+    ) as exc:
         message = f"readiness evaluation failed for {args.config}: {exc}"
         if args.json:
             print(json.dumps({"issue": ISSUE, "ready": False, "error": message}, indent=2))

--- a/scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py
+++ b/scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py
@@ -1,16 +1,24 @@
 #!/usr/bin/env python3
-"""Fail-closed readiness gate for the ScenarioBelief drop-vs-retain runner (#3556).
+"""Fail-closed readiness gate for the #3471 controlled-scenario ScenarioBelief runner (#3556).
+
+Scope note: this gate validates the *controlled-scenario diagnostic predecessor*
+(``run_scenario_belief_episode_safety_issue_3471``) whose finding #3556 promotes -- it does **not**
+gate the real benchmark campaign. The real campaign runner
+(``scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py``) carries its own fail-closed
+readiness gate over its own inputs (``run_belief_mode_safety_campaign_issue_3556.check_campaign_readiness``,
+or ``--preflight-only``). Keep the two distinct: this script pins the #3471 controlled-episode
+inputs; that one pins the real ``run_map_batch`` campaign inputs.
 
 Plain-language summary: issue #3471 (PR #3553) produced a *diagnostic*-tier finding that
 **dropping** uncertain agents raises unsafe commitment while **retaining** them stays near an
-oracle baseline. Issue #3556 wants to promote that contrast toward nominal benchmark evidence by
-running the same three belief modes through the real benchmark runner. Before any such real run
-burns compute, the runner *inputs* must be pinned and the planner's uncertainty contract must
-**fail closed** on unsupported paths -- otherwise a real campaign can silently run a planner that
-ignores the uncertainty sidecar and the drop-vs-retain contrast becomes meaningless.
+oracle baseline. Issue #3556 promotes that contrast toward nominal benchmark evidence by running
+the three belief modes through the real benchmark runner. Before that promotion is trustworthy, the
+*controlled-scenario inputs* the finding rests on must be pinned and the planner's uncertainty
+contract must **fail closed** on unsupported paths -- otherwise the diagnostic itself could run a
+planner that ignores the uncertainty sidecar and the drop-vs-retain contrast becomes meaningless.
 
-This is the cheap CPU-only pre-run gate. It does **not** execute the benchmark matrix, roll
-episodes, or interpret outcomes. It only verifies that:
+This is the cheap CPU-only gate for those controlled-scenario inputs. It does **not** execute the
+benchmark matrix, roll episodes, or interpret outcomes. It only verifies that:
 
 * the predeclared config pins the exact three belief modes (oracle / uncertain_retained /
   uncertain_dropped) needed for the drop-vs-retain contrast plus the near-safe oracle baseline;
@@ -26,9 +34,9 @@ It is a thin orchestrator: it **composes** the canonical runner
 (``robot_sf.planner.scenario_belief_adapter``); it never redefines the mode set, the parameter
 schema, or the fail-closed semantics.
 
-Exit code ``0`` means the runner inputs are pinned and the fail-closed contract holds (safe to
-proceed to a real run). Exit ``1`` means at least one readiness check failed (do not run). Exit
-``2`` means the check itself could not be evaluated (e.g. missing/unparseable config).
+Exit code ``0`` means the #3471 controlled-scenario inputs are pinned and the fail-closed contract
+holds. Exit ``1`` means at least one readiness check failed. Exit ``2`` means the check itself could
+not be evaluated (e.g. missing/unparseable config).
 """
 
 from __future__ import annotations

--- a/scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py
+++ b/scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Fail-closed readiness gate for the ScenarioBelief drop-vs-retain runner (#3556).
+
+Plain-language summary: issue #3471 (PR #3553) produced a *diagnostic*-tier finding that
+**dropping** uncertain agents raises unsafe commitment while **retaining** them stays near an
+oracle baseline. Issue #3556 wants to promote that contrast toward nominal benchmark evidence by
+running the same three belief modes through the real benchmark runner. Before any such real run
+burns compute, the runner *inputs* must be pinned and the planner's uncertainty contract must
+**fail closed** on unsupported paths -- otherwise a real campaign can silently run a planner that
+ignores the uncertainty sidecar and the drop-vs-retain contrast becomes meaningless.
+
+This is the cheap CPU-only pre-run gate. It does **not** execute the benchmark matrix, roll
+episodes, or interpret outcomes. It only verifies that:
+
+* the predeclared config pins the exact three belief modes (oracle / uncertain_retained /
+  uncertain_dropped) needed for the drop-vs-retain contrast plus the near-safe oracle baseline;
+* the seed matrix is explicitly pinned (a non-empty list of unique integers), not silently
+  defaulted by the runner's fallback;
+* every controlled episode parameter is pinned in the config and geometrically valid;
+* the uncertainty-consuming planner key (``stream_gap``) is supported and actually consumes the
+  uncertainty sidecar for the dropped mode;
+* an unsupported planner key **fails closed** (no uncertainty consumed).
+
+It is a thin orchestrator: it **composes** the canonical runner
+(``run_scenario_belief_episode_safety_issue_3471``) and the planner-projection contract owner
+(``robot_sf.planner.scenario_belief_adapter``); it never redefines the mode set, the parameter
+schema, or the fail-closed semantics.
+
+Exit code ``0`` means the runner inputs are pinned and the fail-closed contract holds (safe to
+proceed to a real run). Exit ``1`` means at least one readiness check failed (do not run). Exit
+``2`` means the check itself could not be evaluated (e.g. missing/unparseable config).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+# Make the repo root importable when run as a bare script.
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+# Canonical contract owners: the planner-projection fail-closed semantics live here.
+from robot_sf.planner.scenario_belief_adapter import (  # noqa: E402
+    SUPPORTED_UNCERTAINTY_PLANNER_KEYS,
+    project_scenario_belief_for_planner,
+)
+
+# Canonical runner owner: the mode set, parameter schema, and belief construction live here.
+from scripts.validation.run_scenario_belief_episode_safety_issue_3471 import (  # noqa: E402
+    ISSUE as RUNNER_ISSUE,
+)
+from scripts.validation.run_scenario_belief_episode_safety_issue_3471 import (  # noqa: E402
+    MODES,
+    PLANNER_KEY,
+    EpisodeParams,
+    build_belief_for_mode,
+    build_initial_state,
+    load_config,
+)
+
+SCHEMA_VERSION = "scenario-belief-runner-readiness.v1"
+ISSUE = 3556
+
+#: Default predeclared config promoted toward the real runner by #3556.
+DEFAULT_CONFIG = (
+    _REPO_ROOT / "configs" / "benchmarks" / "scenario_belief_episode_safety_issue_3471.yaml"
+)
+
+#: The two modes whose contrast is the entire point of the study; both must be pinned.
+REQUIRED_CONTRAST_MODES = ("uncertain_retained", "uncertain_dropped")
+
+#: A planner key guaranteed not to consume the uncertainty sidecar, used to prove fail-closed.
+_UNSUPPORTED_PROBE_KEY = "preflight_unsupported_probe"
+
+#: Episode-parameter fields that must be strictly positive for a valid controlled crossing.
+_POSITIVE_PARAM_FIELDS = (
+    "max_steps",
+    "dt",
+    "robot_radius",
+    "ped_radius",
+    "near_miss_margin",
+    "ped_cross_speed",
+)
+
+
+@dataclass
+class ReadinessCheck:
+    """One named readiness assertion and its outcome."""
+
+    name: str
+    passed: bool
+    detail: str
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view of the check."""
+        return {"name": self.name, "passed": self.passed, "detail": self.detail}
+
+
+@dataclass
+class ReadinessReport:
+    """Aggregate readiness verdict for the drop-vs-retain runner inputs."""
+
+    checks: list[ReadinessCheck] = field(default_factory=list)
+
+    def add(self, name: str, passed: bool, detail: str) -> bool:
+        """Record one check and return its pass/fail so callers can short-circuit."""
+        self.checks.append(ReadinessCheck(name=name, passed=passed, detail=detail))
+        return passed
+
+    @property
+    def ready(self) -> bool:
+        """True only when every recorded check passed."""
+        return all(c.passed for c in self.checks)
+
+    @property
+    def failures(self) -> list[ReadinessCheck]:
+        """Return the failed checks (empty when ready)."""
+        return [c for c in self.checks if not c.passed]
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return the structured, JSON-serializable readiness report."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "issue": ISSUE,
+            "runner_issue": RUNNER_ISSUE,
+            "planner_key": PLANNER_KEY,
+            "ready": self.ready,
+            "checks": [c.as_dict() for c in self.checks],
+            "failed_checks": [c.name for c in self.failures],
+            "claim_boundary": (
+                "Input-pinning and fail-closed readiness gate only; does not run the benchmark "
+                "matrix, roll episodes, or interpret drop-vs-retain outcomes."
+            ),
+        }
+
+
+def _check_belief_modes(report: ReadinessReport, raw: dict[str, Any]) -> None:
+    """Verify the config pins exactly the three modes the drop-vs-retain contrast needs."""
+    declared = raw.get("belief_modes")
+    if not isinstance(declared, list) or not declared:
+        report.add(
+            "belief_modes_pinned",
+            False,
+            "config is missing a non-empty 'belief_modes' list",
+        )
+        return
+    declared_set = set(declared)
+    unknown = declared_set - set(MODES)
+    missing = set(MODES) - declared_set
+    if unknown or missing:
+        report.add(
+            "belief_modes_pinned",
+            False,
+            f"belief_modes must equal {sorted(MODES)}; unknown={sorted(unknown)} "
+            f"missing={sorted(missing)}",
+        )
+    else:
+        report.add(
+            "belief_modes_pinned",
+            True,
+            f"pinned exactly {sorted(MODES)}",
+        )
+    # The contrast pair plus the near-safe oracle baseline are individually load-bearing.
+    contrast_missing = [m for m in (*REQUIRED_CONTRAST_MODES, "oracle") if m not in declared_set]
+    report.add(
+        "contrast_modes_present",
+        not contrast_missing,
+        "drop-vs-retain contrast + oracle baseline all pinned"
+        if not contrast_missing
+        else f"missing required modes: {contrast_missing}",
+    )
+
+
+def _check_seeds(report: ReadinessReport, raw: dict[str, Any]) -> None:
+    """Verify the seed matrix is explicitly pinned, not left to the runner's fallback."""
+    seeds = raw.get("seeds")
+    if not isinstance(seeds, list) or not seeds:
+        report.add(
+            "seeds_pinned",
+            False,
+            "config must pin a non-empty 'seeds' list (runner fallback is not a pinned matrix)",
+        )
+        return
+    if not all(isinstance(s, int) and not isinstance(s, bool) for s in seeds):
+        report.add("seeds_pinned", False, "all seeds must be integers")
+        return
+    if len(set(seeds)) != len(seeds):
+        report.add("seeds_pinned", False, "seed matrix contains duplicates")
+        return
+    report.add("seeds_pinned", True, f"{len(seeds)} unique integer seeds pinned")
+
+
+def _check_params(report: ReadinessReport, raw: dict[str, Any], params: EpisodeParams) -> None:
+    """Verify every episode parameter is pinned in the config and geometrically valid."""
+    declared = raw.get("params")
+    if not isinstance(declared, dict):
+        report.add("params_pinned", False, "config is missing a 'params' mapping")
+        return
+    field_names = {f.name for f in EpisodeParams.__dataclass_fields__.values()}
+    unpinned = sorted(field_names - set(declared))
+    if unpinned:
+        report.add(
+            "params_pinned",
+            False,
+            f"these episode params rely on runner defaults instead of being pinned: {unpinned}",
+        )
+    else:
+        report.add("params_pinned", True, f"all {len(field_names)} episode params pinned")
+
+    # Geometric validity: strictly-positive fields, an achievable goal, and a contested corridor.
+    problems: list[str] = []
+    for name in _POSITIVE_PARAM_FIELDS:
+        if getattr(params, name) <= 0:
+            problems.append(f"{name} must be > 0 (got {getattr(params, name)})")
+    if params.goal_x <= params.start_x:
+        problems.append(f"goal_x ({params.goal_x}) must be > start_x ({params.start_x})")
+    if not params.start_x < params.corridor_x < params.goal_x:
+        problems.append(
+            f"corridor_x ({params.corridor_x}) must lie between start_x ({params.start_x}) "
+            f"and goal_x ({params.goal_x}) so the crosser actually contests the path"
+        )
+    report.add(
+        "params_valid",
+        not problems,
+        "controlled-crossing geometry is valid" if not problems else "; ".join(problems),
+    )
+
+
+def _check_planner_contract(report: ReadinessReport, params: EpisodeParams) -> None:
+    """Verify the planner key is supported, consumes uncertainty, and fails closed otherwise.
+
+    Builds a single synthetic ``uncertain_dropped`` belief (one step, no episode roll) and
+    projects it twice: once under the real planner key (must be ``compatible`` and consume the
+    sidecar) and once under an unsupported key (must ``fail_closed`` and consume nothing). This is
+    the core "fail closed before real runs" guarantee.
+    """
+    report.add(
+        "planner_supported",
+        PLANNER_KEY in SUPPORTED_UNCERTAINTY_PLANNER_KEYS,
+        f"runner planner key {PLANNER_KEY!r} in supported set {sorted(SUPPORTED_UNCERTAINTY_PLANNER_KEYS)}"
+        if PLANNER_KEY in SUPPORTED_UNCERTAINTY_PLANNER_KEYS
+        else f"runner planner key {PLANNER_KEY!r} is not in {sorted(SUPPORTED_UNCERTAINTY_PLANNER_KEYS)}",
+    )
+
+    state = build_initial_state(seed=101, params=params)
+    belief = build_belief_for_mode(state, "uncertain_dropped", params)
+
+    supported = project_scenario_belief_for_planner(belief, planner_key=PLANNER_KEY)
+    consumes = (
+        supported.compatibility.get("status") == "compatible"
+        and supported.compatibility.get("uncertainty_consumed") is True
+    )
+    report.add(
+        "dropped_mode_consumes_uncertainty",
+        consumes,
+        "dropped mode consumes the uncertainty sidecar (gate is exercised)"
+        if consumes
+        else f"dropped mode did not consume uncertainty: {supported.compatibility}",
+    )
+
+    unsupported = project_scenario_belief_for_planner(belief, planner_key=_UNSUPPORTED_PROBE_KEY)
+    fails_closed = (
+        unsupported.compatibility.get("status") == "fail_closed"
+        and unsupported.compatibility.get("uncertainty_consumed") is False
+    )
+    report.add(
+        "unsupported_planner_fails_closed",
+        fails_closed,
+        "unsupported planner key fails closed (no uncertainty consumed)"
+        if fails_closed
+        else f"unsupported planner key did not fail closed: {unsupported.compatibility}",
+    )
+
+
+def check_runner_readiness(config_path: Path) -> ReadinessReport:
+    """Evaluate all drop-vs-retain runner-readiness checks for ``config_path``.
+
+    Raises:
+        FileNotFoundError: if the config file does not exist.
+        ValueError / yaml.YAMLError: if the config cannot be parsed into the expected shape.
+    """
+    import yaml
+
+    if not config_path.exists():
+        raise FileNotFoundError(f"config not found: {config_path}")
+    raw = yaml.safe_load(config_path.read_text()) or {}
+    if not isinstance(raw, dict):
+        raise ValueError(f"{config_path}: expected a YAML mapping at the top level")
+
+    # Resolve the pinned matrix/params through the canonical runner loader so the readiness
+    # check evaluates exactly what the real run would consume.
+    _seeds, params = load_config(config_path)
+
+    report = ReadinessReport()
+    _check_belief_modes(report, raw)
+    _check_seeds(report, raw)
+    _check_params(report, raw, params)
+    _check_planner_contract(report, params)
+    return report
+
+
+def _render_human(report: ReadinessReport, config_path: Path) -> str:
+    """Render a human-readable readiness report block."""
+    lines = [
+        f"readiness gate: ScenarioBelief drop-vs-retain runner (issue #{ISSUE})",
+        f"config: {config_path}",
+    ]
+    for check in report.checks:
+        marker = "PASS" if check.passed else "FAIL"
+        lines.append(f"  [{marker}] {check.name}: {check.detail}")
+    if report.ready:
+        lines.append("result: READY — inputs pinned and fail-closed contract holds.")
+    else:
+        failed = ", ".join(c.name for c in report.failures)
+        lines.append(f"result: NOT READY — failed checks: {failed}")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="preflight_scenario_belief_runner_readiness_issue_3556.py",
+        description=(
+            "CPU-only fail-closed readiness gate for the ScenarioBelief drop-vs-retain runner. "
+            "Exit 0 = inputs pinned and fail-closed contract holds; 1 = a readiness check failed; "
+            "2 = the check could not be evaluated. Does not run the benchmark matrix."
+        ),
+    )
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=DEFAULT_CONFIG,
+        help="Predeclared scenario/seed config to gate (defaults to the #3471 pinned config).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the machine-readable JSON report to stdout.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the readiness gate. Returns the process exit code (0 ready, 1 not ready, 2 error)."""
+    args = _parse_args(argv)
+    try:
+        report = check_runner_readiness(args.config)
+    except Exception as exc:  # noqa: BLE001 - surface any evaluation failure as a fail-closed error
+        message = f"readiness evaluation failed for {args.config}: {exc}"
+        if args.json:
+            print(json.dumps({"issue": ISSUE, "ready": False, "error": message}, indent=2))
+        else:
+            print(f"error: {message}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report.as_dict(), indent=2, sort_keys=True))
+    else:
+        print(_render_human(report, args.config))
+    return 0 if report.ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py
+++ b/scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py
@@ -36,7 +36,7 @@ from __future__ import annotations
 import argparse
 import json
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, fields
 from pathlib import Path
 from typing import Any
 
@@ -202,7 +202,7 @@ def _check_params(report: ReadinessReport, raw: dict[str, Any], params: EpisodeP
     if not isinstance(declared, dict):
         report.add("params_pinned", False, "config is missing a 'params' mapping")
         return
-    field_names = {f.name for f in EpisodeParams.__dataclass_fields__.values()}
+    field_names = {f.name for f in fields(EpisodeParams)}
     unpinned = sorted(field_names - set(declared))
     if unpinned:
         report.add(

--- a/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
+++ b/tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
+
 _MODULE_PATH = (
     Path(__file__).resolve().parents[2]
     / "scripts"
@@ -17,6 +19,21 @@ _MODULE = importlib.util.module_from_spec(_SPEC)
 assert _SPEC.loader is not None
 _SPEC.loader.exec_module(_MODULE)
 classify_screened_decision = _MODULE.classify_screened_decision
+check_campaign_readiness = _MODULE.check_campaign_readiness
+run_campaign = _MODULE.run_campaign
+main = _MODULE.main
+
+
+def _ready_kwargs() -> dict[str, float | int]:
+    """Valid, strictly-positive campaign run geometry for readiness checks."""
+    return {"fov_degrees": 120.0, "horizon": 300, "dt": 0.1, "workers": 4}
+
+
+def _scenario_set(tmp_path) -> Path:
+    """Create a placeholder scenario-set file so the existence check passes."""
+    path = tmp_path / "scenario_set.yaml"
+    path.write_text("scenarios: []\n")
+    return path
 
 
 def _mode(collision_rate: float, near_misses: int) -> dict[str, float | int]:
@@ -74,3 +91,75 @@ def test_near_safe_discriminating_matrix_recommends_revise() -> None:
     assert decision["screening_status"] == "near_safe_discriminating"
     assert decision["oracle_near_safe"] is True
     assert decision["mode_is_discriminating"] is True
+
+
+def test_campaign_readiness_ready_with_valid_inputs(tmp_path) -> None:
+    """Valid pinned inputs pass every fail-closed readiness check for the real campaign."""
+    report = check_campaign_readiness(_scenario_set(tmp_path), [101, 102, 103], **_ready_kwargs())
+
+    assert report["ready"] is True
+    assert report["failed_checks"] == []
+    names = {c["name"] for c in report["checks"]}
+    # The gate must actually exercise the oracle-near-safety + planner contracts, not just inputs.
+    assert {"oracle_near_safety_contract", "uncertainty_planner_contract"} <= names
+
+
+def test_campaign_readiness_missing_scenario_set(tmp_path) -> None:
+    """A missing scenario set fails closed before any compute."""
+    report = check_campaign_readiness(tmp_path / "absent.yaml", [101, 102], **_ready_kwargs())
+
+    assert report["ready"] is False
+    assert "scenario_set_exists" in report["failed_checks"]
+
+
+def test_campaign_readiness_duplicate_seeds_block(tmp_path) -> None:
+    """A seed matrix with duplicates is not a valid pinned matrix."""
+    report = check_campaign_readiness(_scenario_set(tmp_path), [101, 101, 102], **_ready_kwargs())
+
+    assert report["ready"] is False
+    assert "seeds_pinned" in report["failed_checks"]
+
+
+def test_campaign_readiness_nonpositive_geometry(tmp_path) -> None:
+    """Zero/negative run geometry fails closed."""
+    kwargs = _ready_kwargs()
+    kwargs["dt"] = 0.0
+    report = check_campaign_readiness(_scenario_set(tmp_path), [101], **kwargs)
+
+    assert report["ready"] is False
+    assert "run_geometry_positive" in report["failed_checks"]
+
+
+def test_run_campaign_fails_closed_on_bad_inputs(tmp_path) -> None:
+    """run_campaign aborts (rolling no episodes) when the readiness gate fails."""
+    out_dir = tmp_path / "out"
+    with pytest.raises(RuntimeError, match="readiness gate failed"):
+        run_campaign(
+            _scenario_set(tmp_path),
+            [101, 101],  # duplicate -> not ready
+            out_dir,
+            **_ready_kwargs(),
+        )
+    # Fail-closed means nothing was written.
+    assert not out_dir.exists()
+
+
+def test_main_preflight_only_exit_codes(tmp_path) -> None:
+    """--preflight-only returns 0 when ready and 1 when a check fails; rolls no episodes."""
+    scenario_set = _scenario_set(tmp_path)
+    ready_code = main(
+        ["--preflight-only", "--scenario-set", str(scenario_set), "--seeds", "101", "102"]
+    )
+    assert ready_code == 0
+
+    not_ready_code = main(
+        [
+            "--preflight-only",
+            "--scenario-set",
+            str(tmp_path / "absent.yaml"),
+            "--seeds",
+            "101",
+            "102",
+        ]
+    )
+    assert not_ready_code == 1

--- a/tests/validation/test_preflight_scenario_belief_runner_readiness_issue_3556.py
+++ b/tests/validation/test_preflight_scenario_belief_runner_readiness_issue_3556.py
@@ -139,7 +139,7 @@ def test_report_schema_shape(tmp_path):
     assert payload["failed_checks"] == []
 
 
-def test_cli_exit_codes(tmp_path, capsys):
+def test_cli_exit_codes(tmp_path):
     """The CLI returns 0 when ready, 1 when not ready, and 2 on an unevaluable config."""
     ready_cfg = _write(tmp_path, _VALID_CONFIG)
     assert main(["--config", str(ready_cfg), "--json"]) == 0

--- a/tests/validation/test_preflight_scenario_belief_runner_readiness_issue_3556.py
+++ b/tests/validation/test_preflight_scenario_belief_runner_readiness_issue_3556.py
@@ -1,0 +1,152 @@
+"""Tests for the ScenarioBelief drop-vs-retain runner-readiness gate (#3556).
+
+These exercise the fail-closed readiness contract with synthetic YAML fixtures only; they never
+run the benchmark matrix or roll episodes.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.validation.preflight_scenario_belief_runner_readiness_issue_3556 import (
+    DEFAULT_CONFIG,
+    ISSUE,
+    SCHEMA_VERSION,
+    check_runner_readiness,
+    main,
+)
+
+# A minimal, fully-pinned config that should pass every readiness check.
+_VALID_CONFIG: dict = {
+    "schema_version": "scenario-belief-episode-safety-config.v1",
+    "issue": 3471,
+    "belief_modes": ["oracle", "uncertain_retained", "uncertain_dropped"],
+    "seeds": [101, 102, 103],
+    "params": {
+        "max_steps": 40,
+        "dt": 0.1,
+        "start_x": 2.0,
+        "path_y": 5.0,
+        "goal_x": 9.0,
+        "corridor_x": 5.0,
+        "robot_radius": 0.4,
+        "ped_radius": 0.3,
+        "near_miss_margin": 0.6,
+        "ped_cross_speed": 0.7,
+    },
+}
+
+
+def _write(tmp_path: Path, data: dict) -> Path:
+    """Write a YAML config fixture and return its path."""
+    path = tmp_path / "config.yaml"
+    path.write_text(yaml.safe_dump(data))
+    return path
+
+
+def test_committed_default_config_is_ready():
+    """The committed #3471 config the runner promotes must already pass the readiness gate."""
+    report = check_runner_readiness(DEFAULT_CONFIG)
+    assert report.ready, [c.as_dict() for c in report.failures]
+
+
+def test_valid_synthetic_config_is_ready(tmp_path):
+    """A fully-pinned synthetic config passes every check."""
+    report = check_runner_readiness(_write(tmp_path, _VALID_CONFIG))
+    assert report.ready
+    # The fail-closed planner contract checks are present and passing.
+    names = {c.name for c in report.checks}
+    assert {"dropped_mode_consumes_uncertainty", "unsupported_planner_fails_closed"} <= names
+
+
+def test_missing_mode_blocks_readiness(tmp_path):
+    """Dropping a required contrast mode makes the gate fail closed."""
+    data = {**_VALID_CONFIG, "belief_modes": ["oracle", "uncertain_retained"]}
+    report = check_runner_readiness(_write(tmp_path, data))
+    assert not report.ready
+    failed = {c.name for c in report.failures}
+    assert "belief_modes_pinned" in failed
+    assert "contrast_modes_present" in failed
+
+
+def test_unknown_mode_blocks_readiness(tmp_path):
+    """An unknown belief mode is rejected rather than silently accepted."""
+    data = {**_VALID_CONFIG, "belief_modes": [*_VALID_CONFIG["belief_modes"], "made_up_mode"]}
+    report = check_runner_readiness(_write(tmp_path, data))
+    assert not report.ready
+    assert "belief_modes_pinned" in {c.name for c in report.failures}
+
+
+def test_missing_seeds_blocks_readiness(tmp_path):
+    """Seeds must be explicitly pinned; an absent matrix fails closed."""
+    data = {k: v for k, v in _VALID_CONFIG.items() if k != "seeds"}
+    report = check_runner_readiness(_write(tmp_path, data))
+    assert not report.ready
+    assert "seeds_pinned" in {c.name for c in report.failures}
+
+
+def test_duplicate_seeds_block_readiness(tmp_path):
+    """A seed matrix with duplicates is not a valid pinned matrix."""
+    data = {**_VALID_CONFIG, "seeds": [101, 101, 102]}
+    report = check_runner_readiness(_write(tmp_path, data))
+    assert not report.ready
+    assert "seeds_pinned" in {c.name for c in report.failures}
+
+
+def test_unpinned_param_blocks_readiness(tmp_path):
+    """Leaving an episode parameter to the runner default fails the pinning check."""
+    params = {k: v for k, v in _VALID_CONFIG["params"].items() if k != "near_miss_margin"}
+    data = {**_VALID_CONFIG, "params": params}
+    report = check_runner_readiness(_write(tmp_path, data))
+    assert not report.ready
+    assert "params_pinned" in {c.name for c in report.failures}
+
+
+def test_invalid_geometry_blocks_readiness(tmp_path):
+    """A corridor outside the start->goal span cannot contest the path and is rejected."""
+    params = {**_VALID_CONFIG["params"], "corridor_x": 20.0}
+    data = {**_VALID_CONFIG, "params": params}
+    report = check_runner_readiness(_write(tmp_path, data))
+    assert not report.ready
+    assert "params_valid" in {c.name for c in report.failures}
+
+
+def test_nonpositive_radius_blocks_readiness(tmp_path):
+    """A non-positive robot radius is geometrically invalid."""
+    params = {**_VALID_CONFIG["params"], "robot_radius": 0.0}
+    data = {**_VALID_CONFIG, "params": params}
+    report = check_runner_readiness(_write(tmp_path, data))
+    assert not report.ready
+    assert "params_valid" in {c.name for c in report.failures}
+
+
+def test_missing_config_raises():
+    """A missing config path raises (CLI maps this to the exit-2 error path)."""
+    with pytest.raises(FileNotFoundError):
+        check_runner_readiness(Path("/nonexistent/config.yaml"))
+
+
+def test_report_schema_shape(tmp_path):
+    """The structured report carries the schema/issue metadata and a claim boundary."""
+    report = check_runner_readiness(_write(tmp_path, _VALID_CONFIG))
+    payload = report.as_dict()
+    assert payload["schema_version"] == SCHEMA_VERSION
+    assert payload["issue"] == ISSUE
+    assert "does not run the benchmark matrix" in payload["claim_boundary"]
+    assert payload["failed_checks"] == []
+
+
+def test_cli_exit_codes(tmp_path, capsys):
+    """The CLI returns 0 when ready, 1 when not ready, and 2 on an unevaluable config."""
+    ready_cfg = _write(tmp_path, _VALID_CONFIG)
+    assert main(["--config", str(ready_cfg), "--json"]) == 0
+
+    bad = {**_VALID_CONFIG, "seeds": []}
+    not_ready_cfg = tmp_path / "bad.yaml"
+    not_ready_cfg.write_text(yaml.safe_dump(bad))
+    assert main(["--config", str(not_ready_cfg)]) == 1
+
+    assert main(["--config", str(tmp_path / "missing.yaml"), "--json"]) == 2


### PR DESCRIPTION
## Summary

Closes part of #3556 (runner-readiness slice). Issue #3556 promotes the #3471 (PR #3553)
`diagnostic`-tier drop-vs-retain ScenarioBelief safety contrast toward nominal benchmark
evidence by running the three belief modes through the **real** benchmark runner
(`run_map_batch`). This PR adds the **cheap, CPU-only fail-closed readiness gate** that must
pass before any such real run burns compute. It does **not** run the benchmark matrix or
interpret outcomes.

## What changed (after Claude PR gate request_changes)

The gate flagged that the standalone preflight composed the **#3471 controlled-scenario
diagnostic runner** (`run_scenario_belief_episode_safety_issue_3471`) and its config — so it did
**not** actually gate the real #3556 campaign runner, despite the framing. Per the preferred fix,
the readiness value is now **folded into the canonical real campaign owner**:

- `scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py` now carries its own fail-closed
  readiness gate over **its own** inputs:
  - `check_campaign_readiness()` verifies: the three belief modes are pinned; the seed matrix is a
    non-empty list of unique integers; the scenario set exists; run geometry (fov / horizon / dt /
    workers) is strictly positive; the campaign algo is the uncertainty-consuming planner key and
    an unsupported key is provably outside the adapter's supported set (fail-closed guarantee);
    and the **oracle-near-safety precondition** holds as a contract self-check — a synthetic
    unsafe-oracle matrix must classify `inconclusive_oracle_unsafe` (no episode roll).
  - `--preflight-only` runs only the gate and exits `0` (ready) / `1` (not ready).
  - `run_campaign()` now **fails closed** (raises, rolls no episodes) when inputs are not ready;
    `main()` embeds the readiness report in the campaign output.
- `scripts/validation/preflight_scenario_belief_runner_readiness_issue_3556.py` — docstring
  **rescoped** to state honestly that it gates the **#3471 controlled-scenario diagnostic
  predecessor** (the input source #3556 promotes), not the real campaign. Its behavior and tests
  are unchanged.

## Validation

| Command | Exit | Result |
| --- | --- | --- |
| `pytest tests/benchmark/test_run_belief_mode_safety_campaign_issue_3556.py tests/validation/test_preflight_scenario_belief_runner_readiness_issue_3556.py -q` | 0 | 21 passed |
| `ruff check` (3 touched files) | 0 | All checks passed |
| `ruff format --check` (3 touched files) | 0 | clean |
| `scripts/validation/check_broad_exceptions.py` | 0 | 283 entries (no increase) |
| `run_belief_mode_safety_campaign_issue_3556.py --preflight-only` (default config) | 0 | READY |
| `... --preflight-only --scenario-set <absent>` / `--seeds 1 1 2` | 1 | fails closed |

(Run from the sibling worktree via `scripts/dev/run_worktree_shared_venv.sh`.)

## Research Result Guidance

`NA — support/tooling`. This PR adds a pre-run readiness gate with no research claim, comparator,
or evidence tier of its own. It guards a future real run; it does not produce benchmark evidence.

## Out of scope (explicit)

- **No full benchmark campaign run** — the matrix is not executed and no episodes are rolled.
- **No Slurm/GPU submission.**
- **No paper/dissertation claim edits.**
- No promotion of the #3471 diagnostic finding to nominal/paper-grade evidence.

## Residual risk

The gate validates *input pinning* and *interface-level* contracts (planner uncertainty key,
oracle-near-safety screening); it does not prove the real benchmark environment reproduces the
controlled-scenario contrast. That remains the core open work of #3556.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
