### PR TITLE
feat(benchmark): opt-in safety-wrapper factorial-ablation manifest + checker (#3501)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added an **opt-in factorial-ablation manifest + checker** for the merged planner-agnostic safety
+  wrapper (#3501). `robot_sf/benchmark/safety_wrapper_ablation_manifest.py` enumerates the
+  `planner × {wrapper off, wrapper on}` ablation cells from a tracked config
+  (`configs/research/safety_wrapper_ablation_v1.yaml`) and **checks** the design so later runs can
+  compare the wrapper on/off consistently: exactly the two `{wrapper_off, wrapper_on}` arms with one
+  baseline (off), the off arm disabled and the on arm enabled, the on-arm thresholds validated as a
+  real `SafetyWrapperConfig` (predeclared, no per-planner tuning), every planner present in both
+  arms, and paired seeds shared identically across arms. The manifest records provenance fields
+  (`schema_version`, `safety_wrapper_schema`, `config_path`, `git_head`, `claim_boundary`,
+  `evidence_status`) and a `factorial_check` summary; a thin runner
+  (`scripts/benchmark/build_safety_wrapper_ablation_manifest.py --dry-run`) writes it. This is a
+  **dry-run design contract only** — it binds no runtime objects, runs no benchmark episodes, tunes
+  no thresholds, and makes no mitigation-effectiveness claim (the factorial campaign run is the
+  deferred downstream follow-up tracked by #3501).
+
 ### Fixed
 
 * Fixed the HEIGHT planner adapter's lidar raycasting **ignoring dynamic pedestrians** (#3629).

--- a/configs/research/safety_wrapper_ablation_v1.yaml
+++ b/configs/research/safety_wrapper_ablation_v1.yaml
@@ -1,0 +1,78 @@
+# Planner-agnostic safety-wrapper factorial ablation contract (bounded #3501 slice).
+#
+# This file declares the `planner x {wrapper off, wrapper on}` factorial design that
+# later runs use to compare the merged planner-agnostic safety wrapper
+# (robot_sf.robot.safety_wrapper, landed in #3591) consistently with and without
+# the mitigation lever, under paired seeds applied identically to both arms.
+#
+# It is a DESIGN/MANIFEST contract only. It binds no runtime objects, runs no
+# benchmark episodes, tunes no thresholds, and makes no mitigation-effectiveness
+# claim. The wrapper-on thresholds are the FIXED, PREDECLARED modeling choices that
+# match robot_sf.robot.safety_wrapper.SafetyWrapperConfig defaults (no per-planner
+# tuning). Quantifying the effect is a downstream benchmark/SLURM run, split out
+# when the bounded local result motivates it.
+schema_version: safety-wrapper-ablation.v1
+issue: 3501
+study_id: issue_3501_safety_wrapper_ablation_v1
+status: launch_packet
+
+claim_boundary: >
+  Factorial-design and provenance contract only. This config enumerates the fixed
+  planner x {wrapper off, wrapper on} ablation cells and paired seeds required before
+  any with/without mitigation comparison can be run. It is not benchmark evidence,
+  not a mitigation-effectiveness result, and not paper-facing evidence until the
+  ablation is run and promoted through a compact evidence bundle.
+
+fixed_scope:
+  # Scenario distribution the ablation runs over (verify against tree before running).
+  scenario_set: configs/benchmarks/paper_experiment_matrix_v1.yaml
+  # Paired seeds: the SAME seed list is applied identically to both wrapper arms so
+  # the only difference between the two arms is the wrapper itself.
+  seeds: [111, 112, 113]
+  planner_groups:
+    - orca
+    - default_social_force
+    - hybrid_rule_v0_minimal
+
+# The single factor under test: the planner-agnostic safety wrapper, off vs on.
+# Exactly two arms; the off arm is the baseline. Thresholds are predeclared and
+# fixed (no per-planner tuning); they mirror SafetyWrapperConfig defaults.
+wrapper_arms:
+  - key: wrapper_off
+    baseline: true
+    enabled: false
+  - key: wrapper_on
+    baseline: false
+    enabled: true
+    config:
+      pedestrian_caution_radius_m: 2.0
+      capped_speed_m_s: 0.5
+      ttc_veto_threshold_s: 1.0
+      clearance_veto_m: 0.3
+
+# Primary outcomes reported per cell (positive AND negative/transfer effects).
+primary_outcomes:
+  - exact_collision_probability
+  - near_miss_probability
+  - min_predicted_separation
+  - completion_probability
+  - progress_at_timeout
+  - false_positive_stop_rate
+  - stop_yield_latency
+  - wrapper_intervention_rate
+
+# Per-episode safety-event ledger the ablation emits into (issue #3482).
+event_ledger_target: 3482
+
+result_contract:
+  required_outputs:
+    - planner
+    - wrapper_arm
+    - seed
+    - scenario_id
+    - metric_values
+    - wrapper_intervention_rate
+  caveat_rule: >
+    Report both positive and negative/transfer-poorly effects. Any effect must be
+    reported as diagnostic until durable, paired-seed evidence over the full scenario
+    distribution is collected; a single arm or unpaired seed is not a valid contrast.

--- a/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
+++ b/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
@@ -108,6 +108,8 @@ def _validate_wrapper_arms(arms: Any) -> None:
     """Require exactly the {off, on} factorial arms with one baseline and valid thresholds."""
     if not isinstance(arms, Sequence) or isinstance(arms, (str, bytes)):
         raise ValueError("wrapper_arms must be a list")
+    if not all(isinstance(arm, Mapping) for arm in arms):
+        raise ValueError("each entry in wrapper_arms must be a mapping")
     keys = [str(arm.get("key")) for arm in arms if isinstance(arm, Mapping)]
     if keys != [WRAPPER_OFF_ARM, WRAPPER_ON_ARM] and sorted(keys) != sorted(
         [WRAPPER_OFF_ARM, WRAPPER_ON_ARM]

--- a/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
+++ b/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
@@ -1,0 +1,326 @@
+"""Dry-run factorial-ablation manifest + checker for the safety wrapper (issue #3501).
+
+The merged planner-agnostic safety wrapper (``robot_sf.robot.safety_wrapper``, landed in
+#3591) is the mitigation lever. The strongest available thesis result is causal: *the
+framework identifies a mitigation lever and quantifies its effect*. Quantifying that effect
+requires a ``planner x {wrapper off, wrapper on}`` factorial run, with paired seeds applied
+identically to both arms, so the only difference between the two arms is the wrapper.
+
+This module is the **opt-in design/manifest slice** of that work: it enumerates the factorial
+cells and **checks** that the configured ablation is well formed (exactly two wrapper arms
+{off, on}, one baseline, predeclared wrapper thresholds that match the merged
+``SafetyWrapperConfig`` contract, every planner present in both arms, paired seeds shared
+identically across arms). It binds no runtime objects, runs no benchmark episodes, tunes no
+thresholds, and makes no mitigation-effectiveness claim. The ablation campaign and live wiring
+are deliberate downstream follow-ups.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.robot.safety_wrapper import SAFETY_WRAPPER_SCHEMA, SafetyWrapperConfig
+
+SAFETY_WRAPPER_ABLATION_SCHEMA = "safety-wrapper-ablation-manifest.v1"
+CONFIG_SCHEMA_VERSION = "safety-wrapper-ablation.v1"
+
+WRAPPER_OFF_ARM = "wrapper_off"
+WRAPPER_ON_ARM = "wrapper_on"
+
+DRY_RUN_CLAIM_BOUNDARY = (
+    "dry-run factorial-ablation manifest only: enumerates the fixed issue #3501 "
+    "planner x {wrapper off, wrapper on} cells and paired seeds; not benchmark evidence, "
+    "not a mitigation-effectiveness result, and not paper-facing evidence."
+)
+
+
+@dataclass(frozen=True)
+class ManifestOptions:
+    """Stable metadata for a dry-run manifest build."""
+
+    config_path: str
+    git_head: str = "unknown"
+    dry_run: bool = True
+
+
+def load_safety_wrapper_ablation_config(path: str | Path) -> dict[str, Any]:
+    """Load and validate a safety-wrapper ablation YAML config.
+
+    Returns:
+        Validated config mapping.
+    """
+    config_path = Path(path)
+    payload = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+    if not isinstance(payload, dict):
+        raise ValueError(f"safety-wrapper ablation config must be a mapping: {config_path}")
+    return validate_safety_wrapper_ablation_config(payload)
+
+
+def validate_safety_wrapper_ablation_config(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate the issue #3501 factorial-ablation design contract.
+
+    Checks the wrapper on/off factorization and provenance the manifest depends on:
+    exactly two arms keyed ``wrapper_off``/``wrapper_on``, exactly one baseline (the off
+    arm), the off arm disabled and the on arm enabled, and the on-arm thresholds usable as
+    a real ``SafetyWrapperConfig`` (predeclared, no per-planner tuning).
+
+    Returns:
+        Shallow-normalized dictionary with the original config values.
+    """
+    normalized = dict(config)
+    if normalized.get("schema_version") != CONFIG_SCHEMA_VERSION:
+        raise ValueError(f"schema_version must be {CONFIG_SCHEMA_VERSION!r}")
+    _validate_fixed_scope(normalized.get("fixed_scope"))
+    _validate_wrapper_arms(normalized.get("wrapper_arms"))
+    return normalized
+
+
+def _validate_fixed_scope(fixed_scope: Any) -> None:
+    """Require a scenario set, a non-empty paired-seed list, and >=1 planner group."""
+    if not isinstance(fixed_scope, Mapping):
+        raise ValueError("fixed_scope must be a mapping")
+    if not fixed_scope.get("scenario_set"):
+        raise ValueError("fixed_scope.scenario_set is required")
+    seeds = fixed_scope.get("seeds")
+    if not isinstance(seeds, Sequence) or isinstance(seeds, (str, bytes)) or len(seeds) == 0:
+        raise ValueError("fixed_scope.seeds must be a non-empty list")
+    if len(set(seeds)) != len(seeds):
+        raise ValueError("fixed_scope.seeds must be unique (paired seeds applied to both arms)")
+    planner_groups = fixed_scope.get("planner_groups")
+    if (
+        not isinstance(planner_groups, Sequence)
+        or isinstance(planner_groups, (str, bytes))
+        or len(planner_groups) == 0
+    ):
+        raise ValueError("fixed_scope.planner_groups must be a non-empty list")
+    if len(set(planner_groups)) != len(planner_groups):
+        raise ValueError("fixed_scope.planner_groups must be unique")
+
+
+def _validate_wrapper_arms(arms: Any) -> None:
+    """Require exactly the {off, on} factorial arms with one baseline and valid thresholds."""
+    if not isinstance(arms, Sequence) or isinstance(arms, (str, bytes)):
+        raise ValueError("wrapper_arms must be a list")
+    keys = [str(arm.get("key")) for arm in arms if isinstance(arm, Mapping)]
+    if keys != [WRAPPER_OFF_ARM, WRAPPER_ON_ARM] and sorted(keys) != sorted(
+        [WRAPPER_OFF_ARM, WRAPPER_ON_ARM]
+    ):
+        raise ValueError(
+            f"wrapper_arms must be exactly [{WRAPPER_OFF_ARM!r}, {WRAPPER_ON_ARM!r}], got {keys!r}"
+        )
+    by_key = {str(arm["key"]): arm for arm in arms}
+    baselines = [key for key, arm in by_key.items() if bool(arm.get("baseline", False))]
+    if baselines != [WRAPPER_OFF_ARM]:
+        raise ValueError(
+            f"exactly one baseline arm is required and it must be {WRAPPER_OFF_ARM!r}, "
+            f"got {baselines!r}"
+        )
+    if bool(by_key[WRAPPER_OFF_ARM].get("enabled", False)):
+        raise ValueError(f"{WRAPPER_OFF_ARM!r} arm must have enabled: false")
+    if not bool(by_key[WRAPPER_ON_ARM].get("enabled", False)):
+        raise ValueError(f"{WRAPPER_ON_ARM!r} arm must have enabled: true")
+    # The on-arm thresholds must construct a real SafetyWrapperConfig: this ties the manifest
+    # to the merged wrapper contract and rejects unusable (non-positive) thresholds.
+    _wrapper_config_from_arm(by_key[WRAPPER_ON_ARM])
+
+
+def _wrapper_config_from_arm(arm: Mapping[str, Any]) -> SafetyWrapperConfig:
+    """Build the merged ``SafetyWrapperConfig`` for an arm (validates thresholds).
+
+    Returns:
+        The constructed, threshold-validated wrapper config for the arm.
+    """
+    raw = arm.get("config") or {}
+    if not isinstance(raw, Mapping):
+        raise ValueError("wrapper_on arm config must be a mapping")
+    allowed = {
+        "pedestrian_caution_radius_m",
+        "capped_speed_m_s",
+        "ttc_veto_threshold_s",
+        "clearance_veto_m",
+    }
+    unknown = set(raw) - allowed
+    if unknown:
+        raise ValueError(f"wrapper_on arm config has unknown threshold keys: {sorted(unknown)}")
+    return SafetyWrapperConfig(enabled=True, **{key: float(raw[key]) for key in raw})
+
+
+def build_safety_wrapper_ablation_manifest(
+    config: Mapping[str, Any],
+    *,
+    options: ManifestOptions,
+) -> dict[str, Any]:
+    """Build a deterministic dry-run factorial-ablation manifest.
+
+    Enumerates one cell per ``(planner, wrapper_arm)`` pair, each carrying the shared paired
+    seeds, and records provenance fields that tie the design back to the merged wrapper.
+
+    Returns:
+        JSON-serializable manifest payload.
+    """
+    if not options.dry_run:
+        raise ValueError("safety-wrapper ablation manifest builder only supports dry-run manifests")
+
+    validated = validate_safety_wrapper_ablation_config(config)
+    fixed_scope = validated["fixed_scope"]
+    seeds = list(fixed_scope["seeds"])
+    planner_groups = list(fixed_scope["planner_groups"])
+    arms = [_arm_manifest(arm) for arm in validated["wrapper_arms"]]
+    cells = _enumerate_cells(planner_groups, arms, seeds)
+    return {
+        "schema_version": SAFETY_WRAPPER_ABLATION_SCHEMA,
+        "safety_wrapper_schema": SAFETY_WRAPPER_SCHEMA,
+        "issue": int(validated.get("issue", 3501)),
+        "study_id": str(validated["study_id"]),
+        "status": "manifest_dry_run_only",
+        "dry_run": True,
+        "evidence_status": "not_benchmark_evidence",
+        "claim_boundary": DRY_RUN_CLAIM_BOUNDARY,
+        "config_path": options.config_path,
+        "git_head": options.git_head,
+        "fixed_scope": copy.deepcopy(fixed_scope),
+        "seeds": seeds,
+        "planner_groups": planner_groups,
+        "wrapper_arms": arms,
+        "primary_outcomes": copy.deepcopy(validated.get("primary_outcomes", [])),
+        "event_ledger_target": validated.get("event_ledger_target"),
+        "result_contract": copy.deepcopy(validated.get("result_contract")),
+        "cell_count": len(cells),
+        "cells": cells,
+        "factorial_check": check_factorial_ablation(planner_groups, arms, seeds),
+    }
+
+
+def _arm_manifest(arm: Mapping[str, Any]) -> dict[str, Any]:
+    """Normalize one wrapper arm and echo its predeclared thresholds.
+
+    Returns:
+        JSON-serializable arm manifest.
+    """
+    enabled = bool(arm.get("enabled", False))
+    wrapper_config: dict[str, Any] | None = None
+    if enabled:
+        cfg = _wrapper_config_from_arm(arm)
+        wrapper_config = {
+            "pedestrian_caution_radius_m": cfg.pedestrian_caution_radius_m,
+            "capped_speed_m_s": cfg.capped_speed_m_s,
+            "ttc_veto_threshold_s": cfg.ttc_veto_threshold_s,
+            "clearance_veto_m": cfg.clearance_veto_m,
+        }
+    return {
+        "key": str(arm["key"]),
+        "baseline": bool(arm.get("baseline", False)),
+        "enabled": enabled,
+        "wrapper_config": wrapper_config,
+        "thresholds_source": "predeclared_fixed_no_per_planner_tuning",
+        "runtime_binding_status": "unresolved_runtime_binding",
+        "runtime_binding_note": (
+            "Arm config copied for manifest review only; no runtime wrapper binding or "
+            "benchmark execution was performed."
+        ),
+    }
+
+
+def _enumerate_cells(
+    planner_groups: Sequence[str],
+    arms: Sequence[Mapping[str, Any]],
+    seeds: Sequence[int],
+) -> list[dict[str, Any]]:
+    """Enumerate one factorial cell per ``(planner, arm)`` with the shared paired seeds.
+
+    Returns:
+        Deterministic list of cell descriptors ordered planner-major, arm-minor.
+    """
+    cells: list[dict[str, Any]] = []
+    for planner in planner_groups:
+        for arm in arms:
+            cells.append(
+                {
+                    "planner": str(planner),
+                    "wrapper_arm": str(arm["key"]),
+                    "wrapper_enabled": bool(arm["enabled"]),
+                    "baseline": bool(arm["baseline"]),
+                    "seeds": list(seeds),
+                }
+            )
+    return cells
+
+
+def check_factorial_ablation(
+    planner_groups: Sequence[str],
+    arms: Sequence[Mapping[str, Any]],
+    seeds: Sequence[int],
+) -> dict[str, Any]:
+    """Check wrapper on/off factorization and paired-seed completeness.
+
+    Verifies every planner appears in both the off and on arm, that the two arms are the
+    expected {off, on} pair, and that the paired seeds are shared identically across arms.
+
+    Returns:
+        Structured check report with ``complete`` plus per-condition booleans and counts.
+    """
+    arm_keys = sorted(str(arm["key"]) for arm in arms)
+    arms_are_off_on = arm_keys == sorted([WRAPPER_OFF_ARM, WRAPPER_ON_ARM])
+    enabled_by_key = {str(arm["key"]): bool(arm["enabled"]) for arm in arms}
+    off_on_enabled = (
+        enabled_by_key.get(WRAPPER_OFF_ARM) is False and enabled_by_key.get(WRAPPER_ON_ARM) is True
+    )
+    seeds_paired = len(seeds) > 0 and len(set(seeds)) == len(seeds)
+    expected_cells = len(planner_groups) * 2
+    complete = (
+        arms_are_off_on
+        and off_on_enabled
+        and seeds_paired
+        and len(planner_groups) > 0
+        and len(set(planner_groups)) == len(planner_groups)
+    )
+    return {
+        "complete": bool(complete),
+        "arms_are_off_on": bool(arms_are_off_on),
+        "off_on_enabled": bool(off_on_enabled),
+        "seeds_paired_across_arms": bool(seeds_paired),
+        "planner_count": len(planner_groups),
+        "expected_cell_count": expected_cells,
+        "seeds_per_cell": len(seeds),
+    }
+
+
+def write_safety_wrapper_ablation_manifest(
+    manifest: Mapping[str, Any],
+    output_dir: str | Path,
+) -> Path:
+    """Write a deterministic JSON dry-run manifest.
+
+    Returns:
+        Path to the written JSON manifest.
+    """
+    out = Path(output_dir)
+    out.mkdir(parents=True, exist_ok=True)
+    manifest_path = out / "safety_wrapper_ablation_manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    return manifest_path
+
+
+__all__ = [
+    "CONFIG_SCHEMA_VERSION",
+    "DRY_RUN_CLAIM_BOUNDARY",
+    "SAFETY_WRAPPER_ABLATION_SCHEMA",
+    "WRAPPER_OFF_ARM",
+    "WRAPPER_ON_ARM",
+    "ManifestOptions",
+    "build_safety_wrapper_ablation_manifest",
+    "check_factorial_ablation",
+    "load_safety_wrapper_ablation_config",
+    "validate_safety_wrapper_ablation_config",
+    "write_safety_wrapper_ablation_manifest",
+]

--- a/scripts/benchmark/build_safety_wrapper_ablation_manifest.py
+++ b/scripts/benchmark/build_safety_wrapper_ablation_manifest.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Build an issue #3501 dry-run safety-wrapper factorial-ablation manifest.
+
+This only enumerates and checks the ``planner x {wrapper off, wrapper on}`` design; it runs
+no benchmark episodes, tunes no thresholds, and makes no mitigation-effectiveness claim.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+from pathlib import Path
+
+from robot_sf.benchmark.safety_wrapper_ablation_manifest import (
+    ManifestOptions,
+    build_safety_wrapper_ablation_manifest,
+    load_safety_wrapper_ablation_config,
+    write_safety_wrapper_ablation_manifest,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _git_head() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=REPO_ROOT,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+    except (FileNotFoundError, subprocess.SubprocessError):
+        return "unknown"
+    return result.stdout.strip() if result.returncode == 0 else "unknown"
+
+
+def _display_path(path: Path) -> Path:
+    """Return repo-relative path when possible, otherwise the original path.
+
+    Returns:
+        Repo-relative path or the original path.
+    """
+    try:
+        return path.relative_to(REPO_ROOT)
+    except ValueError:
+        return path
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed argument namespace.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--config",
+        default="configs/research/safety_wrapper_ablation_v1.yaml",
+        help="Tracked safety-wrapper ablation config path.",
+    )
+    parser.add_argument(
+        "--out",
+        default="output/safety_wrapper_ablation_manifest",
+        help="Output directory for safety_wrapper_ablation_manifest.json.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        required=True,
+        help="Required acknowledgement that this only builds a manifest and runs no ablation.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """CLI entry point.
+
+    Returns:
+        Process exit code.
+    """
+    args = parse_args()
+    config = load_safety_wrapper_ablation_config(REPO_ROOT / args.config)
+    manifest = build_safety_wrapper_ablation_manifest(
+        config,
+        options=ManifestOptions(
+            config_path=args.config,
+            git_head=_git_head(),
+            dry_run=args.dry_run,
+        ),
+    )
+    manifest_path = write_safety_wrapper_ablation_manifest(manifest, REPO_ROOT / args.out)
+    check = manifest["factorial_check"]
+    print(f"wrote dry-run safety-wrapper ablation manifest: {_display_path(manifest_path)}")
+    print(
+        f"factorial check: complete={check['complete']} "
+        f"cells={manifest['cell_count']} seeds_per_cell={check['seeds_per_cell']}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_safety_wrapper_ablation_manifest.py
+++ b/tests/benchmark/test_safety_wrapper_ablation_manifest.py
@@ -129,6 +129,15 @@ def test_config_rejects_unpaired_seeds() -> None:
         build_safety_wrapper_ablation_manifest(config, options=_options())
 
 
+def test_config_rejects_non_mapping_wrapper_arm() -> None:
+    """A non-mapping entry in wrapper_arms is rejected cleanly (no raw TypeError)."""
+    config = _repo_config()
+    config["wrapper_arms"].append("not-a-mapping")
+
+    with pytest.raises(ValueError, match="each entry in wrapper_arms must be a mapping"):
+        build_safety_wrapper_ablation_manifest(config, options=_options())
+
+
 def test_check_factorial_ablation_flags_missing_arm() -> None:
     """The checker reports incomplete factorization when an arm is missing."""
     only_off = [{"key": WRAPPER_OFF_ARM, "enabled": False, "baseline": True}]

--- a/tests/benchmark/test_safety_wrapper_ablation_manifest.py
+++ b/tests/benchmark/test_safety_wrapper_ablation_manifest.py
@@ -1,0 +1,157 @@
+"""Tests for the dry-run safety-wrapper factorial-ablation manifest (issue #3501)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.safety_wrapper_ablation_manifest import (
+    SAFETY_WRAPPER_ABLATION_SCHEMA,
+    WRAPPER_OFF_ARM,
+    WRAPPER_ON_ARM,
+    ManifestOptions,
+    build_safety_wrapper_ablation_manifest,
+    check_factorial_ablation,
+    load_safety_wrapper_ablation_config,
+    write_safety_wrapper_ablation_manifest,
+)
+from robot_sf.robot.safety_wrapper import SAFETY_WRAPPER_SCHEMA
+
+_CONFIG_PATH = "configs/research/safety_wrapper_ablation_v1.yaml"
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _repo_config() -> dict[str, object]:
+    return load_safety_wrapper_ablation_config(_CONFIG_PATH)
+
+
+def _options() -> ManifestOptions:
+    return ManifestOptions(config_path=_CONFIG_PATH, git_head="abc1234")
+
+
+def test_manifest_factorizes_planners_over_wrapper_off_on() -> None:
+    """Every planner gets exactly the off and on arm; cells carry the shared paired seeds."""
+    config = _repo_config()
+    manifest = build_safety_wrapper_ablation_manifest(config, options=_options())
+
+    assert manifest["schema_version"] == SAFETY_WRAPPER_ABLATION_SCHEMA
+    assert manifest["safety_wrapper_schema"] == SAFETY_WRAPPER_SCHEMA
+    assert manifest["status"] == "manifest_dry_run_only"
+    assert manifest["evidence_status"] == "not_benchmark_evidence"
+
+    planners = manifest["planner_groups"]
+    assert manifest["cell_count"] == len(planners) * 2
+    # Each planner appears once per arm.
+    for planner in planners:
+        arms_for_planner = sorted(
+            cell["wrapper_arm"] for cell in manifest["cells"] if cell["planner"] == planner
+        )
+        assert arms_for_planner == sorted([WRAPPER_OFF_ARM, WRAPPER_ON_ARM])
+    # Paired seeds are applied identically to every cell.
+    for cell in manifest["cells"]:
+        assert cell["seeds"] == manifest["seeds"]
+
+    check = manifest["factorial_check"]
+    assert check["complete"] is True
+    assert check["arms_are_off_on"] is True
+    assert check["off_on_enabled"] is True
+    assert check["seeds_paired_across_arms"] is True
+    assert check["expected_cell_count"] == len(planners) * 2
+
+
+def test_manifest_echoes_predeclared_wrapper_thresholds_as_provenance() -> None:
+    """The on arm echoes the fixed, predeclared SafetyWrapperConfig thresholds."""
+    manifest = build_safety_wrapper_ablation_manifest(_repo_config(), options=_options())
+
+    arms = {arm["key"]: arm for arm in manifest["wrapper_arms"]}
+    off_arm = arms[WRAPPER_OFF_ARM]
+    on_arm = arms[WRAPPER_ON_ARM]
+
+    assert off_arm["enabled"] is False
+    assert off_arm["baseline"] is True
+    assert off_arm["wrapper_config"] is None
+
+    assert on_arm["enabled"] is True
+    assert on_arm["baseline"] is False
+    assert on_arm["thresholds_source"] == "predeclared_fixed_no_per_planner_tuning"
+    assert on_arm["wrapper_config"] == {
+        "pedestrian_caution_radius_m": 2.0,
+        "capped_speed_m_s": 0.5,
+        "ttc_veto_threshold_s": 1.0,
+        "clearance_veto_m": 0.3,
+    }
+    assert on_arm["runtime_binding_status"] == "unresolved_runtime_binding"
+    assert manifest["event_ledger_target"] == 3482
+
+
+def test_manifest_claim_boundary_prevents_benchmark_or_paper_claims() -> None:
+    """The dry-run manifest must not be worded as evidence."""
+    manifest = build_safety_wrapper_ablation_manifest(_repo_config(), options=_options())
+
+    claim_boundary = manifest["claim_boundary"]
+    assert "dry-run factorial-ablation manifest only" in claim_boundary
+    assert "not benchmark evidence" in claim_boundary
+    assert "not a mitigation-effectiveness result" in claim_boundary
+    assert "not paper-facing evidence" in claim_boundary
+    assert manifest["dry_run"] is True
+
+
+def test_config_rejects_arm_that_breaks_off_on_factorization() -> None:
+    """An enabled off arm breaks the wrapper off/on contrast and must be rejected."""
+    config = _repo_config()
+    arms = {arm["key"]: arm for arm in config["wrapper_arms"]}
+    arms[WRAPPER_OFF_ARM]["enabled"] = True
+
+    with pytest.raises(ValueError, match="wrapper_off.*enabled: false"):
+        build_safety_wrapper_ablation_manifest(config, options=_options())
+
+
+def test_config_rejects_non_positive_wrapper_threshold() -> None:
+    """On-arm thresholds must construct a real SafetyWrapperConfig (positive thresholds)."""
+    config = _repo_config()
+    arms = {arm["key"]: arm for arm in config["wrapper_arms"]}
+    arms[WRAPPER_ON_ARM]["config"]["capped_speed_m_s"] = 0.0
+
+    with pytest.raises(ValueError, match="capped_speed_m_s must be > 0"):
+        build_safety_wrapper_ablation_manifest(config, options=_options())
+
+
+def test_config_rejects_unpaired_seeds() -> None:
+    """Duplicate seeds break the paired-seed contract across arms."""
+    config = _repo_config()
+    config["fixed_scope"]["seeds"] = [111, 111, 112]
+
+    with pytest.raises(ValueError, match="seeds must be unique"):
+        build_safety_wrapper_ablation_manifest(config, options=_options())
+
+
+def test_check_factorial_ablation_flags_missing_arm() -> None:
+    """The checker reports incomplete factorization when an arm is missing."""
+    only_off = [{"key": WRAPPER_OFF_ARM, "enabled": False, "baseline": True}]
+    report = check_factorial_ablation(["orca"], only_off, [111, 112])
+
+    assert report["complete"] is False
+    assert report["arms_are_off_on"] is False
+
+
+def test_manifest_json_output_is_deterministic(tmp_path: Path) -> None:
+    """Repeated builds and writes with the same inputs produce byte-identical JSON."""
+    config = _repo_config()
+    options = _options()
+
+    first = build_safety_wrapper_ablation_manifest(config, options=options)
+    second = build_safety_wrapper_ablation_manifest(config, options=options)
+
+    assert first == second
+    assert json.dumps(first, indent=2, sort_keys=True) == json.dumps(
+        second, indent=2, sort_keys=True
+    )
+
+    first_path = write_safety_wrapper_ablation_manifest(first, tmp_path / "first")
+    second_path = write_safety_wrapper_ablation_manifest(second, tmp_path / "second")
+
+    assert first_path.read_text(encoding="utf-8") == second_path.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

Closes the **manifest/checker slice** of issue #3501 (https://github.com/ll7/robot_sf_ll7/issues/3501).

The planner-agnostic safety-wrapper *core* landed in #3591. This PR adds the **opt-in factorial-ablation manifest + checker** around it so later runs can compare the wrapper **on vs off** consistently. It is a **dry-run design contract only** — no thresholds tuned, no campaign run, no mitigation-effectiveness claim.

## Scope

- **In scope:** an opt-in `planner × {wrapper off, wrapper on}` factorial-ablation manifest + checker with provenance fields, mirroring the existing `fidelity_sweep_manifest` dry-run pattern.
- **Out of scope (deferred):** the factorial campaign run, threshold tuning, live wiring into action adapters, and any mitigation-effectiveness / paper-facing claim.

## Changes

| Path | Reason |
| --- | --- |
| `robot_sf/benchmark/safety_wrapper_ablation_manifest.py` | Config validator + dry-run manifest builder + `check_factorial_ablation` checker. Validates wrapper on/off factorization (exactly `{wrapper_off, wrapper_on}` arms, one baseline=off, off disabled / on enabled, on-arm thresholds construct a real `SafetyWrapperConfig`), paired-seed uniqueness; emits provenance (`schema_version`, `safety_wrapper_schema`, `config_path`, `git_head`, `claim_boundary`, `evidence_status`) + `factorial_check`. |
| `configs/research/safety_wrapper_ablation_v1.yaml` | Tracked design contract: predeclared wrapper-on thresholds (match `SafetyWrapperConfig` defaults, no per-planner tuning), paired seeds, planner groups, primary outcomes, #3482 ledger target. |
| `scripts/benchmark/build_safety_wrapper_ablation_manifest.py` | Thin `--dry-run` runner (canonical first-use path; mirrors `build_fidelity_sweep_manifest.py`). |
| `tests/benchmark/test_safety_wrapper_ablation_manifest.py` | Focused tests for factorization, provenance, claim boundary, rejection cases, determinism. |
| `CHANGELOG.md` | `Added` entry. |

## Validation

```
$ scripts/dev/run_worktree_shared_venv.sh -- ruff check <new files>
All checks passed!     # exit 0

$ scripts/dev/run_worktree_shared_venv.sh -- ruff format --check <new files>
already formatted      # exit 0

$ scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_safety_wrapper_ablation_manifest.py tests/test_safety_wrapper.py -q
21 passed in 2.10s     # exit 0

$ scripts/dev/run_worktree_shared_venv.sh -- python scripts/benchmark/build_safety_wrapper_ablation_manifest.py --dry-run
wrote dry-run safety-wrapper ablation manifest: output/safety_wrapper_ablation_manifest/safety_wrapper_ablation_manifest.json
factorial check: complete=True cells=6 seeds_per_cell=3     # exit 0
```

First-use output (3 planners × 2 arms = 6 cells, paired seeds, `complete=True`) confirms the checker. The generated manifest lands under git-ignored `output/` (disposable; regenerable via the runner above).

## Downstream Propagation

- **Parent issue #3501:** remains open; this delivers the deferred manifest/checker slice. The factorial **campaign run** (every planner × hard families × seed budget, SLURM) is the concrete downstream follow-up tracked by #3501.
- **Safety-event ledger #3482:** recorded as `event_ledger_target` in the config (emit target for the future run); no emission here.
- **Claim map / leaderboard / registry:** N/A — dry-run design contract, `evidence_status: not_benchmark_evidence`, no benchmark numbers produced.

## Research Result Guidance

- **Target:** wiring only — enable a consistent with/without wrapper contrast later. No claim moved.
- **Evidence tier:** `diagnostic-only` / design contract; not benchmark evidence.
- **Decision/stop rule:** the manifest checker must report `complete=True` before any ablation run is launched.

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits were made in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
