### PR TITLE
feat(benchmark): fail-closed scenario-horizon Results readiness check (#3266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Added a fail-closed readiness check for scenario-horizon Results evidence (#3266). New module
+  `robot_sf/benchmark/scenario_horizon_readiness.py` and CLI
+  `scripts/validation/check_scenario_horizon_results_readiness.py` read a re-exported scenario-horizon
+  campaign artifact (the dissertation `campaign_table.md` from PR #3263 / issue #3203, or an equivalent
+  campaign-summary JSON) and classify it as `valid`, `diagnostic_only`, or `blocked`. The check is
+  diagnostic-only — it never reruns a campaign or promotes evidence — and fails closed: a missing or
+  unparseable artifact is `blocked`, any non-benchmark-success planner row (e.g. the PPO
+  `partial-failure` recorded for #3266) caps the verdict at `diagnostic_only`, and an unasserted SNQI
+  contract status keeps the evidence diagnostic-only rather than assuming it passed. Per-row status
+  normalization reuses the canonical `fallback_policy.classify_planner_row_status` owner. Run against
+  the real #3203 bundle, the check reports `diagnostic_only` (exit 2), confirming those tables remain
+  diagnostic/provenance evidence only.
+
 ### Fixed
 
 * Fixed the HEIGHT planner adapter's lidar raycasting **ignoring dynamic pedestrians** (#3629).

--- a/robot_sf/benchmark/scenario_horizon_readiness.py
+++ b/robot_sf/benchmark/scenario_horizon_readiness.py
@@ -1,0 +1,278 @@
+"""Fail-closed readiness classification for scenario-horizon Results evidence.
+
+This module answers one diagnostic-only question for the scenario-horizon
+campaign tables (the dissertation tables re-exported by PR #3263 / issue #3203):
+
+    *Is the re-exported scenario-horizon campaign evidence valid benchmark
+    evidence, diagnostic-only, or blocked by a missing artifact?*
+
+It does **not** rerun any campaign and does **not** promote evidence. It reads a
+campaign-table artifact (the re-exported Markdown ``campaign_table.md`` or an
+equivalent campaign-summary JSON with ``planner_rows``) and classifies whether
+the evidence is allowed to support benchmark/Results wording.
+
+The classification is fail-closed (see ``docs/context/issue_691_benchmark_fallback_policy.md``):
+
+- a missing or unparseable artifact is ``blocked`` (never silently "valid");
+- any planner row that did not run as benchmark-success -- in particular the PPO
+  ``partial-failure`` recorded for issue #3266 -- caps the evidence at
+  ``diagnostic_only``;
+- the SNQI contract status must be explicitly asserted as ``pass`` in the
+  artifact. When the artifact carries no SNQI contract status (the re-exported
+  Markdown tables do not), the SNQI caveat is treated as unresolved and the
+  evidence is capped at ``diagnostic_only`` rather than assumed valid.
+
+Per-row status normalization reuses the canonical
+``robot_sf.benchmark.fallback_policy.classify_planner_row_status`` owner instead
+of re-implementing the status taxonomy.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.fallback_policy import classify_planner_row_status
+
+#: Overall readiness verdicts, fail-closed from strongest to weakest.
+VALID = "valid"
+DIAGNOSTIC_ONLY = "diagnostic_only"
+BLOCKED = "blocked"
+
+#: Row-status column names that may carry the per-planner execution status.
+_ROW_STATUS_KEYS = ("status", "readiness_status", "availability_status")
+#: Column names that may carry the SNQI contract pass/warn/fail status.
+_SNQI_CONTRACT_KEYS = ("snqi_contract_status", "snqi_status", "snqi_contract")
+#: SNQI contract statuses other than these block a ``valid`` verdict.
+_SNQI_PASS_STATUSES = {"pass", "ok", "passed"}
+
+
+@dataclass(frozen=True)
+class ScenarioHorizonReadiness:
+    """Diagnostic-only readiness verdict for a scenario-horizon evidence artifact.
+
+    Attributes:
+        status: One of ``valid``, ``diagnostic_only``, or ``blocked``.
+        artifact: Repository-relative or absolute path to the inspected artifact.
+        planner_rows: Number of planner rows parsed from the artifact.
+        ppo_status: Normalized PPO row outcome, or ``None`` when no PPO row exists.
+        snqi_contract_status: SNQI contract status asserted by the artifact, or
+            ``None`` when the artifact does not assert one.
+        blockers: Human-readable reasons the evidence is not ``valid``.
+    """
+
+    status: str
+    artifact: str
+    planner_rows: int = 0
+    ppo_status: str | None = None
+    snqi_contract_status: str | None = None
+    blockers: list[str] = field(default_factory=list)
+
+    @property
+    def is_valid(self) -> bool:
+        """Return whether the artifact is valid benchmark evidence."""
+        return self.status == VALID
+
+    @property
+    def is_blocked(self) -> bool:
+        """Return whether the artifact is blocked by a missing/unreadable source."""
+        return self.status == BLOCKED
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable summary of the readiness verdict.
+
+        Returns:
+            Mapping with the verdict, inspected artifact, and blocker reasons.
+        """
+        return {
+            "schema_version": "scenario_horizon_readiness.v1",
+            "status": self.status,
+            "artifact": self.artifact,
+            "planner_rows": self.planner_rows,
+            "ppo_status": self.ppo_status,
+            "snqi_contract_status": self.snqi_contract_status,
+            "blockers": list(self.blockers),
+        }
+
+
+def _parse_markdown_table(text: str) -> list[dict[str, str]]:
+    """Parse a single pipe-delimited Markdown table into row dictionaries.
+
+    Only the first table found in the text is parsed. The header row supplies the
+    column keys; the separator row (cells of only ``-`` and ``:``) is skipped.
+
+    Returns:
+        One dictionary per data row, keyed by lowercased header column name.
+        Returns an empty list when no pipe table is present.
+    """
+    header: list[str] | None = None
+    rows: list[dict[str, str]] = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            # End the table once a non-table line follows the header.
+            if header is not None:
+                break
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if header is None:
+            header = [cell.lower() for cell in cells]
+            continue
+        if all(set(cell) <= {"-", ":"} and cell for cell in cells):
+            continue
+        # Tolerate ragged rows: zip stops at the shorter of header/cells.
+        rows.append(dict(zip(header, cells, strict=False)))
+    return rows
+
+
+def _rows_from_artifact(path: Path) -> list[dict[str, Any]]:
+    """Read planner rows from a Markdown table or a campaign-summary JSON.
+
+    JSON artifacts are expected to expose a ``planner_rows`` list. Markdown
+    artifacts are parsed as a single pipe-delimited table.
+
+    Returns:
+        Planner-row dictionaries.
+
+    Raises:
+        ValueError: When the artifact cannot be parsed into planner rows.
+    """
+    text = path.read_text(encoding="utf-8")
+    if path.suffix.lower() == ".json":
+        payload = json.loads(text)
+        rows = payload.get("planner_rows") if isinstance(payload, dict) else None
+        if not isinstance(rows, list):
+            raise ValueError("campaign-summary JSON must contain a 'planner_rows' list")
+        return [row for row in rows if isinstance(row, dict)]
+    rows = _parse_markdown_table(text)
+    if not rows:
+        raise ValueError("no Markdown campaign table found in artifact")
+    return rows
+
+
+def _row_status(row: dict[str, Any]) -> str:
+    """Return the most specific per-row execution status available.
+
+    Returns:
+        The first non-empty value among the known status columns, else "".
+    """
+    for key in _ROW_STATUS_KEYS:
+        value = str(row.get(key, "")).strip()
+        if value:
+            return value
+    return ""
+
+
+def _planner_label(row: dict[str, Any]) -> str:
+    """Return a stable planner identifier for a row.
+
+    Returns:
+        The planner key/algo label, or "<unknown>" when none is present.
+    """
+    for key in ("planner_key", "algo", "planner", "planner_id"):
+        value = str(row.get(key, "")).strip()
+        if value:
+            return value
+    return "<unknown>"
+
+
+def _snqi_contract_status(rows: list[dict[str, Any]]) -> str | None:
+    """Extract the SNQI contract status asserted anywhere in the rows.
+
+    Returns:
+        The first non-empty SNQI contract status found, else ``None``.
+    """
+    for row in rows:
+        for key in _SNQI_CONTRACT_KEYS:
+            value = str(row.get(key, "")).strip()
+            if value:
+                return value.lower()
+    return None
+
+
+def classify_scenario_horizon_readiness(artifact: str | Path) -> ScenarioHorizonReadiness:
+    """Classify whether a scenario-horizon evidence artifact is benchmark-valid.
+
+    The verdict is fail-closed: a missing/unparseable artifact is ``blocked``;
+    any non-benchmark-success planner row or an unresolved SNQI contract caveat
+    caps the verdict at ``diagnostic_only``.
+
+    Args:
+        artifact: Path to a re-exported ``campaign_table.md`` or a campaign-summary
+            JSON exposing ``planner_rows``.
+
+    Returns:
+        A :class:`ScenarioHorizonReadiness` verdict.
+    """
+    path = Path(artifact)
+    artifact_str = str(artifact)
+
+    if not path.exists():
+        return ScenarioHorizonReadiness(
+            status=BLOCKED,
+            artifact=artifact_str,
+            blockers=[f"artifact not found: {artifact_str}"],
+        )
+    if not path.is_file():
+        return ScenarioHorizonReadiness(
+            status=BLOCKED,
+            artifact=artifact_str,
+            blockers=[f"artifact is not a file: {artifact_str}"],
+        )
+
+    try:
+        rows = _rows_from_artifact(path)
+    except (ValueError, OSError) as exc:
+        return ScenarioHorizonReadiness(
+            status=BLOCKED,
+            artifact=artifact_str,
+            blockers=[f"could not parse artifact: {exc}"],
+        )
+    if not rows:
+        return ScenarioHorizonReadiness(
+            status=BLOCKED,
+            artifact=artifact_str,
+            blockers=["artifact contains no planner rows"],
+        )
+
+    blockers: list[str] = []
+    ppo_status: str | None = None
+    for row in rows:
+        label = _planner_label(row)
+        outcome = classify_planner_row_status(_row_status(row))
+        if label.lower() == "ppo":
+            ppo_status = outcome
+        if outcome == "unexpected_failure":
+            reason = str(row.get("most_likely_failure_reason", "")).strip()
+            detail = f" ({reason})" if reason else ""
+            blockers.append(f"planner '{label}' did not run as benchmark-success{detail}")
+
+    snqi_contract_status = _snqi_contract_status(rows)
+    if snqi_contract_status is None:
+        blockers.append(
+            "SNQI contract status not asserted by artifact; caveat unresolved "
+            "(re-exported tables carry no SNQI pass/warn/fail status)"
+        )
+    elif snqi_contract_status not in _SNQI_PASS_STATUSES:
+        blockers.append(f"SNQI contract status is '{snqi_contract_status}', not pass")
+
+    status = DIAGNOSTIC_ONLY if blockers else VALID
+    return ScenarioHorizonReadiness(
+        status=status,
+        artifact=artifact_str,
+        planner_rows=len(rows),
+        ppo_status=ppo_status,
+        snqi_contract_status=snqi_contract_status,
+        blockers=blockers,
+    )
+
+
+__all__ = [
+    "BLOCKED",
+    "DIAGNOSTIC_ONLY",
+    "VALID",
+    "ScenarioHorizonReadiness",
+    "classify_scenario_horizon_readiness",
+]

--- a/scripts/validation/check_scenario_horizon_results_readiness.py
+++ b/scripts/validation/check_scenario_horizon_results_readiness.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Fail-closed readiness check for scenario-horizon Results evidence (issue #3266).
+
+Reports whether a re-exported scenario-horizon campaign artifact is valid
+benchmark evidence, diagnostic-only, or blocked by a missing artifact. This is a
+diagnostic-only status check: it never reruns a campaign and never promotes
+evidence.
+
+Exit codes:
+
+- ``0`` -- artifact is valid benchmark evidence.
+- ``2`` -- artifact is diagnostic-only (non-success rows or unresolved SNQI caveat).
+- ``3`` -- artifact is blocked (missing or unparseable).
+
+Example::
+
+    uv run python scripts/validation/check_scenario_horizon_results_readiness.py \
+        docs/context/evidence/issue_3203_scenario_horizon_reexport_2026-06-20/reports/campaign_table.md
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from robot_sf.benchmark.scenario_horizon_readiness import (
+    BLOCKED,
+    VALID,
+    classify_scenario_horizon_readiness,
+)
+
+#: Map readiness verdicts to canonical fail-closed exit codes.
+_EXIT_CODES = {VALID: 0, BLOCKED: 3}
+_DIAGNOSTIC_EXIT_CODE = 2
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Return the CLI argument parser.
+
+    Returns:
+        Configured argument parser.
+    """
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument(
+        "artifact",
+        help="Path to a re-exported campaign_table.md or campaign-summary JSON.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the verdict as JSON instead of human-readable text.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the readiness check and return a fail-closed exit code.
+
+    Returns:
+        ``0`` for valid, ``2`` for diagnostic-only, ``3`` for blocked.
+    """
+    args = _build_parser().parse_args(argv)
+    readiness = classify_scenario_horizon_readiness(args.artifact)
+
+    if args.json:
+        print(json.dumps(readiness.to_payload(), indent=2, sort_keys=True))
+    else:
+        print(f"scenario-horizon Results readiness: {readiness.status}")
+        print(f"  artifact: {readiness.artifact}")
+        print(f"  planner_rows: {readiness.planner_rows}")
+        print(f"  ppo_status: {readiness.ppo_status}")
+        print(f"  snqi_contract_status: {readiness.snqi_contract_status}")
+        if readiness.blockers:
+            print("  blockers:")
+            for blocker in readiness.blockers:
+                print(f"    - {blocker}")
+
+    return _EXIT_CODES.get(readiness.status, _DIAGNOSTIC_EXIT_CODE)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/test_scenario_horizon_readiness_issue_3266.py
+++ b/tests/benchmark/test_scenario_horizon_readiness_issue_3266.py
@@ -1,0 +1,160 @@
+"""Fail-closed readiness tests for scenario-horizon Results evidence (issue #3266).
+
+These tests use small Markdown/JSON fixtures plus the real re-exported
+scenario-horizon bundle (issue #3203, PR #3263) to prove the readiness check
+reports valid / diagnostic-only / blocked without rerunning any campaign.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.scenario_horizon_readiness import (
+    BLOCKED,
+    DIAGNOSTIC_ONLY,
+    VALID,
+    classify_scenario_horizon_readiness,
+)
+from robot_sf.common.artifact_paths import get_repository_root
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+# A minimal two-column table is enough to exercise status + SNQI classification.
+_VALID_TABLE = (
+    "| planner_key | status | benchmark_success | snqi_contract_status |\n"
+    "|---|---|---|---|\n"
+    "| goal | ok | true | pass |\n"
+    "| ppo | ok | true | pass |\n"
+)
+
+_PPO_PARTIAL_FAILURE_TABLE = (
+    "| planner_key | status | most_likely_failure_reason | snqi_contract_status |\n"
+    "|---|---|---|---|\n"
+    "| goal | ok |  | pass |\n"
+    "| ppo | partial-failure | Missing required dict observation keys | pass |\n"
+)
+
+_NO_SNQI_STATUS_TABLE = "| planner_key | status |\n|---|---|\n| goal | ok |\n| ppo | ok |\n"
+
+
+def _write(tmp_path: Path, name: str, text: str) -> Path:
+    """Write fixture text to a temp file and return its path.
+
+    Returns:
+        Path to the written fixture.
+    """
+    path = tmp_path / name
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+def test_valid_table_is_benchmark_valid(tmp_path: Path) -> None:
+    """All-ok rows with an asserted SNQI pass status classify as valid."""
+    artifact = _write(tmp_path, "campaign_table.md", _VALID_TABLE)
+    readiness = classify_scenario_horizon_readiness(artifact)
+    assert readiness.status == VALID
+    assert readiness.is_valid
+    assert readiness.ppo_status == "ok"
+    assert readiness.snqi_contract_status == "pass"
+    assert readiness.blockers == []
+
+
+def test_ppo_partial_failure_is_diagnostic_only(tmp_path: Path) -> None:
+    """A PPO partial-failure row caps the verdict at diagnostic-only."""
+    artifact = _write(tmp_path, "campaign_table.md", _PPO_PARTIAL_FAILURE_TABLE)
+    readiness = classify_scenario_horizon_readiness(artifact)
+    assert readiness.status == DIAGNOSTIC_ONLY
+    assert not readiness.is_valid
+    assert readiness.ppo_status == "unexpected_failure"
+    assert any("ppo" in blocker.lower() for blocker in readiness.blockers)
+    # The failure reason is surfaced for the diagnostic.
+    assert any("Missing required dict observation keys" in b for b in readiness.blockers)
+
+
+def test_missing_snqi_contract_status_blocks_valid(tmp_path: Path) -> None:
+    """An artifact that asserts no SNQI contract status cannot be valid (fail-closed)."""
+    artifact = _write(tmp_path, "campaign_table.md", _NO_SNQI_STATUS_TABLE)
+    readiness = classify_scenario_horizon_readiness(artifact)
+    assert readiness.status == DIAGNOSTIC_ONLY
+    assert readiness.snqi_contract_status is None
+    assert any("snqi" in blocker.lower() for blocker in readiness.blockers)
+
+
+def test_failing_snqi_contract_status_is_diagnostic_only(tmp_path: Path) -> None:
+    """An explicit SNQI fail status caps the verdict at diagnostic-only."""
+    table = _VALID_TABLE.replace(
+        "| pass |\n| ppo | ok | true | pass |", "| fail |\n| ppo | ok | true | fail |"
+    )
+    artifact = _write(tmp_path, "campaign_table.md", table)
+    readiness = classify_scenario_horizon_readiness(artifact)
+    assert readiness.status == DIAGNOSTIC_ONLY
+    assert readiness.snqi_contract_status == "fail"
+    assert any("not pass" in blocker.lower() for blocker in readiness.blockers)
+
+
+def test_missing_artifact_is_blocked(tmp_path: Path) -> None:
+    """A non-existent artifact path is blocked, never silently valid."""
+    readiness = classify_scenario_horizon_readiness(tmp_path / "does_not_exist.md")
+    assert readiness.status == BLOCKED
+    assert readiness.is_blocked
+    assert any("not found" in blocker.lower() for blocker in readiness.blockers)
+
+
+def test_unparseable_artifact_is_blocked(tmp_path: Path) -> None:
+    """An artifact with no campaign table is blocked."""
+    artifact = _write(tmp_path, "campaign_table.md", "# Heading\n\nNo table here.\n")
+    readiness = classify_scenario_horizon_readiness(artifact)
+    assert readiness.status == BLOCKED
+    assert any(
+        "planner rows" in b.lower() or "campaign table" in b.lower() for b in readiness.blockers
+    )
+
+
+def test_json_summary_artifact_is_supported(tmp_path: Path) -> None:
+    """A campaign-summary JSON with planner_rows is parsed like the Markdown table."""
+    payload = {
+        "planner_rows": [
+            {"planner_key": "goal", "status": "ok", "snqi_contract_status": "pass"},
+            {"planner_key": "ppo", "status": "partial-failure", "snqi_contract_status": "pass"},
+        ]
+    }
+    artifact = _write(tmp_path, "summary.json", json.dumps(payload))
+    readiness = classify_scenario_horizon_readiness(artifact)
+    assert readiness.status == DIAGNOSTIC_ONLY
+    assert readiness.ppo_status == "unexpected_failure"
+
+
+def test_to_payload_is_json_serializable(tmp_path: Path) -> None:
+    """The verdict payload round-trips through JSON."""
+    artifact = _write(tmp_path, "campaign_table.md", _VALID_TABLE)
+    readiness = classify_scenario_horizon_readiness(artifact)
+    payload = readiness.to_payload()
+    assert payload["status"] == VALID
+    assert json.loads(json.dumps(payload))["schema_version"] == "scenario_horizon_readiness.v1"
+
+
+def test_real_scenario_horizon_bundle_is_diagnostic_only() -> None:
+    """The real re-exported issue #3203 bundle is diagnostic-only, not benchmark-valid.
+
+    PPO partial-failed (missing dict observation keys) and the re-exported Markdown
+    carries no SNQI contract status, so the evidence must not be promotable to
+    Results wording. This anchors the check on durable on-disk evidence.
+    """
+    artifact = (
+        get_repository_root()
+        / "docs/context/evidence/issue_3203_scenario_horizon_reexport_2026-06-20"
+        / "reports/campaign_table.md"
+    )
+    if not artifact.exists():
+        pytest.skip("issue #3203 scenario-horizon re-export bundle not present in this checkout")
+    readiness = classify_scenario_horizon_readiness(artifact)
+    assert readiness.status == DIAGNOSTIC_ONLY
+    assert readiness.ppo_status == "unexpected_failure"
+    assert readiness.planner_rows >= 1
+    # Both the PPO failure and the absent SNQI contract status are recorded.
+    assert any("ppo" in b.lower() for b in readiness.blockers)
+    assert any("snqi" in b.lower() for b in readiness.blockers)


### PR DESCRIPTION
## Summary

Resolves the **readiness-validation slice** of #3266. Adds a **fail-closed, diagnostic-only readiness check** that reports whether the re-exported scenario-horizon campaign evidence (the dissertation tables from PR #3263 / issue #3203) is **valid** benchmark evidence, **diagnostic-only**, or **blocked** by a missing artifact.

This does **not** attempt the full PPO observation-contract repair or the campaign rerun from the parent issue — those need GPU/SLURM and a real campaign run. This is the safe slice the ready-queue scoped: status/readiness validation only.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3266

## What changed

- **`robot_sf/benchmark/scenario_horizon_readiness.py`** — new module. `classify_scenario_horizon_readiness(artifact)` reads a re-exported `campaign_table.md` (or an equivalent campaign-summary JSON with `planner_rows`) and returns a `ScenarioHorizonReadiness` verdict in `{valid, diagnostic_only, blocked}`. Fail-closed:
  - missing / unparseable artifact → `blocked` (never silently valid);
  - any planner row that did not run as benchmark-success — in particular the PPO `partial-failure` recorded for #3266 — caps the verdict at `diagnostic_only`;
  - an **unasserted** SNQI contract status keeps the evidence `diagnostic_only` rather than assuming it passed (the re-exported Markdown tables carry no SNQI pass/warn/fail status).
  - Per-row status normalization **reuses the canonical `fallback_policy.classify_planner_row_status` owner** instead of re-implementing the status taxonomy.
- **`scripts/validation/check_scenario_horizon_results_readiness.py`** — thin CLI with fail-closed exit codes (`0` valid / `2` diagnostic_only / `3` blocked) and `--json`.
- **`tests/benchmark/test_scenario_horizon_readiness_issue_3266.py`** — 9 tests over small Markdown/JSON fixtures plus the real #3203 bundle.
- **`CHANGELOG.md`** — Added entry.

## Tool used once on durable input

Run against the real #3203 bundle (durable, tracked under `docs/context/evidence/`):

```
$ uv run python scripts/validation/check_scenario_horizon_results_readiness.py \
    docs/context/evidence/issue_3203_scenario_horizon_reexport_2026-06-20/reports/campaign_table.md --json
{
  "status": "diagnostic_only",
  "planner_rows": 9,
  "ppo_status": "unexpected_failure",
  "snqi_contract_status": null,
  "blockers": [
    "planner 'ppo' did not run as benchmark-success (ValueError('Missing required dict observation keys: ...'))",
    "SNQI contract status not asserted by artifact; caveat unresolved (re-exported tables carry no SNQI pass/warn/fail status)"
  ]
}
# exit code: 2
```

This confirms — programmatically and fail-closed — that the PR #3263 scenario-horizon tables remain **diagnostic/provenance evidence only**, matching the parent issue's maintainer note.

## Validation

| Command | Exit | Result |
| --- | --- | --- |
| `uv run pytest tests/benchmark/test_scenario_horizon_readiness_issue_3266.py -q` | 0 | 9 passed |
| `uv run pytest tests/benchmark/ -k "fallback_policy or row_status or scenario_horizon_readiness" -q` | 0 | 31 passed, 1947 deselected (reused classifier contract intact) |
| `uv run ruff check` + `ruff format` (3 new files) | 0 | All checks passed |
| `uv run python -c "import robot_sf.baselines.ppo; import robot_sf.gym_env.snqi_proxy; import robot_sf.benchmark.scenario_horizon_readiness"` | 0 | imports OK |
| CLI on real #3203 bundle | 2 | `diagnostic_only` (see above) |

(Validation run via `scripts/dev/run_worktree_shared_venv.sh` from a sibling worktree on `origin/main`.)

## Evidence grade

`diagnostic-only` tooling. This PR adds and proves a **status/readiness check**; it does not compute or change any benchmark metric and does not promote any evidence. The change is purely additive — no existing module is modified.

## Downstream Propagation

- **Parent issue #3266**: this closes the readiness-validation slice; the PPO observation-contract repair + smallest-valid rerun remain open for a GPU/SLURM-capable follow-up.
- Claim map / leaderboard / registry: NA — no metric or claim changes.
- Context note / memory: NA for this slice.

## Research Result Guidance

- Target: provide a fail-closed gate that prevents the #3203 scenario-horizon tables being read as benchmark/Results evidence.
- Comparator/baseline: NA (status check, not a measurement).
- Evidence tier: diagnostic-only tooling.
- Result classification: the #3203 bundle is confirmed `diagnostic_only` (PPO partial-failure + unasserted SNQI contract).
- Decision/stop rule: evidence may not be promoted to Results until the check returns `valid` after a real rerun.
- Synthesis surface: parent issue #3266.

## Out of scope (explicit)

- **No full benchmark campaign run** and **no scenario-horizon rerun**.
- **No Slurm/GPU submission.**
- **No paper/dissertation claim edits** and **no Results promotion** — the dissertation ledger / gap-report wording is intentionally untouched.
- **No PPO observation-contract repair** — deferred to a compute-capable follow-up on #3266.

## Residual risk

- The Markdown parser is generic (first pipe table; header supplies keys). If a future re-export changes column names for the per-row status (`status` / `readiness_status` / `availability_status`) or the SNQI contract column, the check degrades fail-closed (treats unknown status as `unexpected_failure` and absent SNQI as unasserted), i.e. toward `diagnostic_only` / `blocked`, never toward a false `valid`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
