### PR TITLE
feat(adversarial): fail-closed certified-failure-archive readiness checker (#3275)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **fail-closed archive-readiness checker** for the adversarial proposal-vs-random study
+  (#3275). Before the proposal runner consumes a *real* certified failure archive, the archive must
+  carry the fields the downstream disjoint split, overlap provenance, candidate certification, and
+  null tests depend on — otherwise those steps cannot be computed. The new pure checker
+  (`assess_archive_readiness` / `assess_archive_file_readiness` in
+  [`robot_sf/adversarial/disjoint_evaluation.py`](robot_sf/adversarial/disjoint_evaluation.py),
+  composing the existing `scenario_family_key` / `disjoint_family_split`) reports a precise
+  `ready` / `not_ready` verdict over schema, per-entry `archive_id` / `candidate.scenario_seed` /
+  `failure_attribution` presence, derivable scenario families, and whether a disjoint scenario-family
+  split with non-empty fit/eval sides is even possible. Unlike the runner's loader, it **never falls
+  back to a synthetic fixture**: a missing, empty, unreadable, malformed, or under-populated archive
+  is reported `ready=False` with the blocking reasons. A thin CLI
+  [`scripts/tools/check_adversarial_archive_readiness.py`](scripts/tools/check_adversarial_archive_readiness.py)
+  prints the JSON report and exits non-zero when not ready, so it is safe to use as an input gate.
+  This is a readiness/input-hygiene slice only — it runs no proposal-model evaluation, fabricates no
+  archive inputs, and makes no held-out-yield or benchmark claim.
 * Added a **plan-level preflight for the paper-grade reactivity-vs-replay rank study** (#3637,
   split from #3573). The new pure checker
   [`robot_sf/benchmark/reactivity_replay_preflight.py`](robot_sf/benchmark/reactivity_replay_preflight.py)

--- a/robot_sf/adversarial/disjoint_evaluation.py
+++ b/robot_sf/adversarial/disjoint_evaluation.py
@@ -25,7 +25,8 @@ from __future__ import annotations
 import hashlib
 import json
 import random
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -359,3 +360,265 @@ def classify_held_out_evidence(
     if not null_tests_reject_null:
         return "not_available_null_tests_not_rejected"
     return "eligible_held_out_diagnostic"
+
+
+# --- Archive-readiness / fail-closed input checker (issue #3275) ---------------
+#
+# Before the proposal-vs-random runner consumes a *real* certified failure
+# archive, the archive must satisfy structural prerequisites or the downstream
+# disjoint split, overlap provenance, certification, and null tests cannot be
+# computed. The runner historically degraded a missing/malformed archive to a
+# synthetic fixture (``run_proposal_vs_random_issue_2921.py``), which is fine for
+# plumbing but hides whether a real archive is actually usable. These helpers
+# provide a standalone, fail-closed readiness verdict over a real archive input.
+# They never fabricate entries and never fall back to synthetic data: an archive
+# that fails any prerequisite is reported ``ready=False`` with precise reasons.
+
+#: Top-level schema tag emitted by ``robot_sf.adversarial.archive``.
+ARCHIVE_SCHEMA_VERSION = "adversarial_failure_archive.v1"
+
+#: Minimum scenario families required to form a disjoint fit/eval split. A
+#: single family collapses both sides together and can never pass the held-out
+#: disjointness gate (see :func:`classify_held_out_evidence`).
+_MIN_DISJOINT_FAMILIES = 2
+
+
+@dataclass(frozen=True)
+class ArchiveReadinessReport:
+    """Fail-closed readiness verdict for a certified failure-archive input.
+
+    ``ready`` is ``True`` only when the archive can drive a non-circular,
+    held-out proposal-vs-random comparison: it parses, carries entries with the
+    fields the overlap-provenance and certification gates need, and admits a
+    disjoint scenario-family split with non-empty fit/eval sides. Any failing
+    prerequisite leaves ``ready=False`` with a precise entry in
+    ``blocking_reasons``.
+    """
+
+    ready: bool
+    status: str
+    schema_ok: bool
+    entry_count: int
+    distinct_family_count: int
+    disjoint_split_possible: bool
+    overlap_metadata_ready: bool
+    null_test_prerequisites_ready: bool
+    entries_missing_archive_id: int
+    entries_missing_scenario_seed: int
+    entries_missing_failure_attribution: int
+    entries_unknown_family: int
+    archive_sha256: str | None = None
+    blocking_reasons: list[str] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe representation of the readiness report."""
+        return {
+            "ready": self.ready,
+            "status": self.status,
+            "schema_ok": self.schema_ok,
+            "entry_count": self.entry_count,
+            "distinct_family_count": self.distinct_family_count,
+            "disjoint_split_possible": self.disjoint_split_possible,
+            "overlap_metadata_ready": self.overlap_metadata_ready,
+            "null_test_prerequisites_ready": self.null_test_prerequisites_ready,
+            "entries_missing_archive_id": self.entries_missing_archive_id,
+            "entries_missing_scenario_seed": self.entries_missing_scenario_seed,
+            "entries_missing_failure_attribution": self.entries_missing_failure_attribution,
+            "entries_unknown_family": self.entries_unknown_family,
+            "archive_sha256": self.archive_sha256,
+            "blocking_reasons": list(self.blocking_reasons),
+        }
+
+
+def _not_ready(status: str, *reasons: str, **fields: Any) -> ArchiveReadinessReport:
+    """Build a fail-closed ``not_ready`` report with sensible numeric defaults."""
+    defaults: dict[str, Any] = {
+        "schema_ok": False,
+        "entry_count": 0,
+        "distinct_family_count": 0,
+        "disjoint_split_possible": False,
+        "overlap_metadata_ready": False,
+        "null_test_prerequisites_ready": False,
+        "entries_missing_archive_id": 0,
+        "entries_missing_scenario_seed": 0,
+        "entries_missing_failure_attribution": 0,
+        "entries_unknown_family": 0,
+        "archive_sha256": None,
+    }
+    defaults.update(fields)
+    return ArchiveReadinessReport(
+        ready=False, status=status, blocking_reasons=list(reasons), **defaults
+    )
+
+
+def _entry_scenario_seed(entry: dict[str, Any]) -> Any:
+    """Return the nested ``candidate.scenario_seed`` value, or ``None``."""
+    candidate = entry.get("candidate")
+    if isinstance(candidate, dict):
+        return candidate.get("scenario_seed")
+    return None
+
+
+@dataclass(frozen=True)
+class _EntryStats:
+    """Aggregate structural statistics over a list of archive entries."""
+
+    entry_count: int
+    non_dict_count: int
+    missing_archive_id: int
+    missing_seed: int
+    missing_attribution: int
+    unknown_family: int
+    distinct_family_count: int
+    disjoint_split_possible: bool
+
+
+def _collect_entry_stats(
+    entries: list[Any], *, eval_fraction: float, split_seed: int
+) -> _EntryStats:
+    """Compute fail-closed structural statistics over raw archive entries."""
+    dict_entries = [e for e in entries if isinstance(e, dict)]
+    distinct_families = {scenario_family_key(e) for e in dict_entries}
+
+    # A disjoint split must actually produce non-empty fit and eval sides; this
+    # is the prerequisite for overlap provenance and the null tests downstream.
+    disjoint_split_possible = False
+    if len(distinct_families) >= _MIN_DISJOINT_FAMILIES:
+        split = disjoint_family_split(dict_entries, eval_fraction=eval_fraction, seed=split_seed)
+        disjoint_split_possible = split.is_disjoint_split
+
+    return _EntryStats(
+        entry_count=len(dict_entries),
+        non_dict_count=len(entries) - len(dict_entries),
+        missing_archive_id=sum(1 for e in dict_entries if not e.get("archive_id")),
+        missing_seed=sum(1 for e in dict_entries if _entry_scenario_seed(e) is None),
+        missing_attribution=sum(
+            1 for e in dict_entries if not isinstance(e.get("failure_attribution"), dict)
+        ),
+        unknown_family=sum(1 for e in dict_entries if scenario_family_key(e) == "unknown_family"),
+        distinct_family_count=len(distinct_families),
+        disjoint_split_possible=disjoint_split_possible,
+    )
+
+
+def _readiness_blocking_reasons(
+    stats: _EntryStats, *, schema_ok: bool, schema_version: Any, min_entries: int
+) -> list[str]:
+    """Collect precise fail-closed reasons an archive is not ready, in order."""
+    reasons: list[str] = []
+    if not schema_ok:
+        reasons.append(f"unexpected_schema_version:{schema_version!r}")
+    if stats.non_dict_count:
+        reasons.append(f"non_object_entries:{stats.non_dict_count}")
+    if stats.entry_count < min_entries:
+        reasons.append(f"too_few_entries:{stats.entry_count}<{min_entries}")
+    if stats.missing_archive_id:
+        reasons.append(f"entries_missing_archive_id:{stats.missing_archive_id}")
+    if stats.missing_seed:
+        reasons.append(f"entries_missing_scenario_seed:{stats.missing_seed}")
+    if stats.missing_attribution:
+        reasons.append(f"entries_missing_failure_attribution:{stats.missing_attribution}")
+    if stats.unknown_family:
+        reasons.append(f"entries_unknown_family:{stats.unknown_family}")
+    if stats.distinct_family_count < _MIN_DISJOINT_FAMILIES:
+        reasons.append(f"insufficient_scenario_families:{stats.distinct_family_count}")
+    if not stats.disjoint_split_possible:
+        reasons.append("no_disjoint_split_possible")
+    return reasons
+
+
+def assess_archive_readiness(
+    archive_data: Any,
+    *,
+    min_entries: int = _MIN_DISJOINT_FAMILIES,
+    eval_fraction: float = 0.5,
+    split_seed: int = 0,
+) -> ArchiveReadinessReport:
+    """Assess whether a loaded failure archive is ready for held-out evaluation.
+
+    This is a pure, fail-closed structural check over already-parsed archive
+    data. It does not execute planners, fabricate entries, or fall back to
+    synthetic data. It composes :func:`scenario_family_key` and
+    :func:`disjoint_family_split` so its notion of "splittable" matches the
+    machinery the proposal runner actually uses.
+
+    Args:
+        archive_data: Parsed archive payload (expected to be a dict with a
+            ``schema_version`` tag and a non-empty ``entries`` list).
+        min_entries: Minimum number of entries required to attempt a split.
+        eval_fraction: Eval-side family fraction forwarded to the trial split.
+        split_seed: Deterministic seed forwarded to the trial split.
+
+    Returns:
+        An :class:`ArchiveReadinessReport`.
+    """
+    if not isinstance(archive_data, dict):
+        return _not_ready("not_ready", "archive_payload_not_object")
+
+    schema_version = archive_data.get("schema_version")
+    schema_ok = schema_version == ARCHIVE_SCHEMA_VERSION
+    archive_hash = archive_sha256(archive_data)
+
+    entries = archive_data.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return _not_ready(
+            "not_ready",
+            "archive_has_no_entries",
+            schema_ok=schema_ok,
+            archive_sha256=archive_hash,
+        )
+
+    stats = _collect_entry_stats(entries, eval_fraction=eval_fraction, split_seed=split_seed)
+    reasons = _readiness_blocking_reasons(
+        stats, schema_ok=schema_ok, schema_version=schema_version, min_entries=min_entries
+    )
+
+    # Overlap provenance needs disjoint families, unique archive ids, and seeds
+    # to compare. Null tests additionally need a non-empty eval side, which the
+    # disjoint-split check guarantees.
+    overlap_metadata_ready = (
+        stats.disjoint_split_possible and not stats.missing_archive_id and not stats.missing_seed
+    )
+    null_test_prerequisites_ready = stats.disjoint_split_possible and not stats.missing_attribution
+
+    ready = not reasons
+    return ArchiveReadinessReport(
+        ready=ready,
+        status="ready" if ready else "not_ready",
+        schema_ok=schema_ok,
+        entry_count=stats.entry_count,
+        distinct_family_count=stats.distinct_family_count,
+        disjoint_split_possible=stats.disjoint_split_possible,
+        overlap_metadata_ready=overlap_metadata_ready,
+        null_test_prerequisites_ready=null_test_prerequisites_ready,
+        entries_missing_archive_id=stats.missing_archive_id,
+        entries_missing_scenario_seed=stats.missing_seed,
+        entries_missing_failure_attribution=stats.missing_attribution,
+        entries_unknown_family=stats.unknown_family,
+        archive_sha256=archive_hash,
+        blocking_reasons=reasons,
+    )
+
+
+def assess_archive_file_readiness(path: Path | None) -> ArchiveReadinessReport:
+    """Load an archive file fail-closed and assess its readiness.
+
+    Unlike the proposal runner's loader, this never substitutes a synthetic
+    fixture: a missing, empty, unreadable, or malformed input is reported
+    ``ready=False`` with a precise ``not_ready`` reason. A real archive that
+    parses is delegated to :func:`assess_archive_readiness`.
+
+    Returns:
+        An :class:`ArchiveReadinessReport`.
+    """
+    if path is None:
+        return _not_ready("not_ready", "no_archive_path_provided")
+    if not path.exists():
+        return _not_ready("not_ready", f"archive_path_missing:{path}")
+    if path.stat().st_size == 0:
+        return _not_ready("not_ready", f"archive_file_empty:{path}")
+    try:
+        archive_data = json.loads(path.read_text(encoding="utf-8"))
+    except (ValueError, OSError) as exc:
+        return _not_ready("not_ready", f"archive_unreadable:{exc}")
+    return assess_archive_readiness(archive_data)

--- a/scripts/tools/check_adversarial_archive_readiness.py
+++ b/scripts/tools/check_adversarial_archive_readiness.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Fail-closed readiness check for a certified adversarial failure archive.
+
+This is the up-front gate for issue #3275. Before the proposal-vs-random runner
+(``scripts/adversarial/run_proposal_vs_random_issue_2921.py``) consumes a *real*
+certified failure archive, the archive must satisfy structural prerequisites or
+the downstream disjoint split, overlap provenance, candidate certification, and
+null tests cannot be computed.
+
+Unlike the runner — which degrades a missing/malformed archive to a synthetic
+fixture for plumbing — this checker fails closed: it never fabricates entries and
+never falls back to synthetic data. It prints a JSON readiness report and exits
+non-zero when the archive is not ready, so it is safe to use as a gate.
+
+It makes no benchmark or held-out-yield claim; it only reports whether the
+archive *input* is usable for a later held-out comparison.
+
+Example:
+    uv run python scripts/tools/check_adversarial_archive_readiness.py \\
+        --archive output/adversarial/certified_failure_archive.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.adversarial.disjoint_evaluation import assess_archive_file_readiness
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(
+        description="Fail-closed readiness check for a certified failure archive (issue #3275)."
+    )
+    parser.add_argument(
+        "--archive",
+        type=Path,
+        required=True,
+        help="Path to the certified failure archive JSON file.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write the JSON readiness report.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Assess the archive and return 0 when ready, 1 otherwise (fail-closed)."""
+    args = parse_args(argv)
+    report = assess_archive_file_readiness(args.archive)
+    report_str = json.dumps(report.to_dict(), indent=2, sort_keys=True)
+    print(report_str)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(report_str + "\n", encoding="utf-8")
+    return 0 if report.ready else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/adversarial/test_archive_readiness.py
+++ b/tests/adversarial/test_archive_readiness.py
@@ -1,0 +1,249 @@
+"""Tests for the fail-closed certified-failure-archive readiness checker.
+
+These cover the issue #3275 up-front input gate in isolation. The module imports
+no simulation/torch surfaces, so these tests run standalone. Synthetic fixtures
+exercise missing/malformed archives and the overlap-metadata / null-test
+prerequisite checks the proposal-vs-random runner depends on.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.adversarial.disjoint_evaluation import (
+    ARCHIVE_SCHEMA_VERSION,
+    ArchiveReadinessReport,
+    assess_archive_file_readiness,
+    assess_archive_readiness,
+)
+
+_CLI_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "tools"
+    / "check_adversarial_archive_readiness.py"
+)
+
+
+def _load_cli():
+    """Import the standalone CLI checker module from its script path."""
+    spec = importlib.util.spec_from_file_location("check_archive_readiness_cli", _CLI_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _entry(family: str, archive_id: str, seed: int) -> dict:
+    """Build a minimal, readiness-complete archive entry."""
+    return {
+        "archive_id": archive_id,
+        "cluster_key": family,
+        "candidate": {"scenario_seed": seed},
+        "failure_attribution": {"primary_failure": "collision"},
+    }
+
+
+def _archive(entries: list[dict]) -> dict:
+    """Wrap entries in a schema-tagged archive payload."""
+    return {"schema_version": ARCHIVE_SCHEMA_VERSION, "entries": entries}
+
+
+def _ready_archive() -> dict:
+    """A two-family archive that satisfies every readiness prerequisite."""
+    return _archive(
+        [
+            _entry("A", "a0", 1),
+            _entry("A", "a1", 2),
+            _entry("B", "b0", 3),
+            _entry("B", "b1", 4),
+        ]
+    )
+
+
+def test_ready_archive_passes_all_prerequisites() -> None:
+    """A well-formed two-family archive is ready with no blocking reasons."""
+    report = assess_archive_readiness(_ready_archive())
+    assert isinstance(report, ArchiveReadinessReport)
+    assert report.ready is True
+    assert report.status == "ready"
+    assert report.schema_ok is True
+    assert report.entry_count == 4
+    assert report.distinct_family_count == 2
+    assert report.disjoint_split_possible is True
+    assert report.overlap_metadata_ready is True
+    assert report.null_test_prerequisites_ready is True
+    assert report.blocking_reasons == []
+    # The report is JSON-serializable for durable provenance.
+    assert json.loads(json.dumps(report.to_dict()))["ready"] is True
+
+
+def test_non_object_payload_fails_closed() -> None:
+    """A non-dict payload is not ready and never raises."""
+    report = assess_archive_readiness([1, 2, 3])
+    assert report.ready is False
+    assert report.status == "not_ready"
+    assert "archive_payload_not_object" in report.blocking_reasons
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"schema_version": ARCHIVE_SCHEMA_VERSION},
+        {"schema_version": ARCHIVE_SCHEMA_VERSION, "entries": []},
+        {"schema_version": ARCHIVE_SCHEMA_VERSION, "entries": "not-a-list"},
+    ],
+)
+def test_missing_or_empty_entries_fail_closed(payload: dict) -> None:
+    """Missing, empty, or non-list entries fail closed."""
+    report = assess_archive_readiness(payload)
+    assert report.ready is False
+    assert "archive_has_no_entries" in report.blocking_reasons
+
+
+def test_unexpected_schema_version_blocks() -> None:
+    """A mismatched schema tag blocks even when entries are otherwise fine."""
+    payload = _ready_archive()
+    payload["schema_version"] = "some_other_schema.v9"
+    report = assess_archive_readiness(payload)
+    assert report.schema_ok is False
+    assert report.ready is False
+    assert any(r.startswith("unexpected_schema_version") for r in report.blocking_reasons)
+
+
+def test_single_family_cannot_form_disjoint_split() -> None:
+    """One scenario family cannot be split, so overlap metadata is not ready."""
+    report = assess_archive_readiness(_archive([_entry("A", "a0", 1), _entry("A", "a1", 2)]))
+    assert report.ready is False
+    assert report.distinct_family_count == 1
+    assert report.disjoint_split_possible is False
+    assert report.overlap_metadata_ready is False
+    assert report.null_test_prerequisites_ready is False
+    assert any(r.startswith("insufficient_scenario_families") for r in report.blocking_reasons)
+    assert "no_disjoint_split_possible" in report.blocking_reasons
+
+
+def test_missing_archive_id_breaks_overlap_metadata() -> None:
+    """Missing archive ids break the archive-id overlap check prerequisite."""
+    entries = [_entry("A", "a0", 1), _entry("B", "b0", 2)]
+    del entries[1]["archive_id"]
+    report = assess_archive_readiness(_archive(entries))
+    assert report.entries_missing_archive_id == 1
+    assert report.overlap_metadata_ready is False
+    assert report.ready is False
+    assert "entries_missing_archive_id:1" in report.blocking_reasons
+
+
+def test_missing_scenario_seed_breaks_overlap_metadata() -> None:
+    """Missing candidate.scenario_seed breaks the seed-overlap prerequisite."""
+    entries = [_entry("A", "a0", 1), _entry("B", "b0", 2)]
+    entries[0]["candidate"] = {}  # no scenario_seed
+    report = assess_archive_readiness(_archive(entries))
+    assert report.entries_missing_scenario_seed == 1
+    assert report.overlap_metadata_ready is False
+    assert report.ready is False
+    assert "entries_missing_scenario_seed:1" in report.blocking_reasons
+
+
+def test_missing_failure_attribution_breaks_null_test_prereq() -> None:
+    """Missing failure_attribution blocks the null-test prerequisite."""
+    entries = [_entry("A", "a0", 1), _entry("B", "b0", 2)]
+    del entries[1]["failure_attribution"]
+    report = assess_archive_readiness(_archive(entries))
+    assert report.entries_missing_failure_attribution == 1
+    assert report.null_test_prerequisites_ready is False
+    assert report.ready is False
+    assert "entries_missing_failure_attribution:1" in report.blocking_reasons
+
+
+def test_unknown_family_entries_are_counted_and_block() -> None:
+    """Entries with no derivable family fall into the unknown-family bucket."""
+    # Second entry has no cluster_key / failure key / manifest -> unknown_family.
+    entries = [_entry("A", "a0", 1), {"archive_id": "x", "candidate": {"scenario_seed": 2}}]
+    report = assess_archive_readiness(_archive(entries))
+    assert report.entries_unknown_family == 1
+    assert report.ready is False
+    assert "entries_unknown_family:1" in report.blocking_reasons
+
+
+def test_non_object_entries_are_flagged() -> None:
+    """Non-dict entries are counted and block readiness."""
+    payload = _ready_archive()
+    payload["entries"].append("not-an-entry")
+    report = assess_archive_readiness(payload)
+    assert report.ready is False
+    assert any(r.startswith("non_object_entries") for r in report.blocking_reasons)
+
+
+# --- File-loading fail-closed behavior ----------------------------------------
+
+
+def test_file_readiness_none_path_fails_closed() -> None:
+    """A ``None`` path is not ready (no synthetic fallback)."""
+    report = assess_archive_file_readiness(None)
+    assert report.ready is False
+    assert "no_archive_path_provided" in report.blocking_reasons
+
+
+def test_file_readiness_missing_path_fails_closed(tmp_path) -> None:
+    """A missing file path fails closed rather than fabricating data."""
+    report = assess_archive_file_readiness(tmp_path / "absent.json")
+    assert report.ready is False
+    assert any(r.startswith("archive_path_missing") for r in report.blocking_reasons)
+
+
+def test_file_readiness_empty_file_fails_closed(tmp_path) -> None:
+    """An empty file fails closed."""
+    path = tmp_path / "empty.json"
+    path.write_text("", encoding="utf-8")
+    report = assess_archive_file_readiness(path)
+    assert report.ready is False
+    assert any(r.startswith("archive_file_empty") for r in report.blocking_reasons)
+
+
+def test_file_readiness_malformed_json_fails_closed(tmp_path) -> None:
+    """Malformed JSON fails closed with an unreadable reason."""
+    path = tmp_path / "bad.json"
+    path.write_text("{not valid json", encoding="utf-8")
+    report = assess_archive_file_readiness(path)
+    assert report.ready is False
+    assert any(r.startswith("archive_unreadable") for r in report.blocking_reasons)
+
+
+def test_file_readiness_round_trip_ready(tmp_path) -> None:
+    """A real ready archive written to disk loads and assesses as ready."""
+    path = tmp_path / "archive.json"
+    path.write_text(json.dumps(_ready_archive()), encoding="utf-8")
+    report = assess_archive_file_readiness(path)
+    assert report.ready is True
+    assert report.status == "ready"
+
+
+# --- CLI exit-code contract ----------------------------------------------------
+
+
+def test_cli_exits_zero_when_ready(tmp_path, capsys) -> None:
+    """The CLI exits 0 and prints a ready report for a valid archive."""
+    cli = _load_cli()
+    path = tmp_path / "archive.json"
+    path.write_text(json.dumps(_ready_archive()), encoding="utf-8")
+    out_path = tmp_path / "report.json"
+    exit_code = cli.main(["--archive", str(path), "--output", str(out_path)])
+    assert exit_code == 0
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["ready"] is True
+    # The optional output file mirrors the printed report.
+    assert json.loads(out_path.read_text(encoding="utf-8"))["ready"] is True
+
+
+def test_cli_exits_nonzero_when_not_ready(tmp_path, capsys) -> None:
+    """The CLI fails closed (exit 1) for a missing archive input."""
+    cli = _load_cli()
+    exit_code = cli.main(["--archive", str(tmp_path / "absent.json")])
+    assert exit_code == 1
+    printed = json.loads(capsys.readouterr().out)
+    assert printed["ready"] is False


### PR DESCRIPTION
## Summary

Closes part of #3275 (archive-readiness / fail-closed input slice).

Issue #3275 requires a non-circular, held-out proposal-vs-random comparison against a **real certified failure archive**. Batch 1 (PR #3389) added the disjoint scenario-family split, overlap provenance, and null tests; Batch 2 (PR #3437 + follow-ups) added the independent-outcome packet contract and gating. Both are on `main`.

What was still missing is an **up-front, fail-closed check on the real archive input itself**: the proposal runner's loader (`scripts/adversarial/run_proposal_vs_random_issue_2921.py`) silently **degrades a missing/malformed archive to a synthetic fixture**, which hides whether a real archive can actually drive the disjoint split, overlap provenance, certification, and null tests. This PR adds that checker.

## Scope

- **`robot_sf/adversarial/disjoint_evaluation.py`** (canonical owner — composes the existing `scenario_family_key` / `disjoint_family_split`, no parallel implementation):
  - `assess_archive_readiness(archive_data, ...)` — pure, fail-closed structural verdict (`ArchiveReadinessReport`) over: schema tag, per-entry `archive_id` / `candidate.scenario_seed` / `failure_attribution` presence, derivable scenario families, and whether a disjoint scenario-family split with non-empty fit/eval sides is even possible (the prerequisite for overlap provenance + null tests downstream).
  - `assess_archive_file_readiness(path)` — loads the file fail-closed; missing / empty / unreadable / malformed inputs report `ready=False` with precise reasons and **never** substitute synthetic data.
- **`scripts/tools/check_adversarial_archive_readiness.py`** — thin CLI that prints the JSON report and exits non-zero when not ready (safe as an input gate).
- **`tests/adversarial/test_archive_readiness.py`** — synthetic-fixture tests for missing / empty / malformed / non-object archives, missing-field overlap-metadata checks, single-family (no disjoint split), unknown-family, and the CLI exit-code contract.
- **`CHANGELOG.md`** — Unreleased / Added entry.

## Validation

| Command | Result |
| --- | --- |
| `uv run pytest tests/adversarial/test_archive_readiness.py tests/adversarial/test_disjoint_evaluation.py tests/adversarial/test_independent_outcomes.py -q` | 45 passed |
| `uv run pytest tests/adversarial -q` | 226 passed |
| `ruff check` (changed files) | All checks passed |
| `ruff format --check` (changed files) | clean |
| CLI smoke — ready archive | exit 0, `"ready": true` |
| CLI smoke — missing archive | exit 1, `"ready": false`, `archive_path_missing` (no synthetic fallback) |
| `uv run python scripts/tools/sync_ai_config.py --check` | 7 symlinks validated |

(Validation run from a sibling worktree on the shared venv via `scripts/dev/run_worktree_shared_venv.sh`.)

## Downstream Propagation

- Parent issue #3275: this PR addresses the "fail closed when the real search-space/archive input is missing or malformed" and overlap/null-test **prerequisite** surface only. The held-out yield claim and independent planner-execution outcomes remain out of scope.
- No leaderboard / registry / artifact-catalog updates (no benchmark result produced).

## Research Result Guidance

`NA - readiness/input-hygiene helper.` This adds a fail-closed input gate; it does not move a claim boundary, produce benchmark evidence, or assert held-out yield. First-use is exercised in tests + CLI smoke against synthetic archives; durable real-archive use belongs to the deferred independent-outcomes evaluation.

## Out of scope (explicit)

- **No full benchmark campaign run.**
- **No Slurm/GPU submission.**
- **No paper/dissertation claim edits.**
- No proposal-model evaluation, no fabricated archive inputs, no held-out-yield or benchmark-yield report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
