### PR TITLE
fix(robot): scale differential-drive velocity update by timestep (#3711)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed differential-drive velocity updates **ignoring timestep scaling** (#3711). In
+  `DifferentialDriveMotion._robot_velocity` the commanded acceleration (clipped to
+  `max_linear_accel` / `max_angular_accel`, the follow-up to #3666/#3689) was applied directly as a
+  per-step velocity delta without multiplying by the simulation timestep `d_t`. At the default
+  `d_t = 0.1` this permitted 10× the labeled acceleration per step and made the dynamics
+  timestep-dependent (smaller timesteps inflated the effective acceleration — the unstable velocity
+  spikes reported in the issue). The action is now integrated over `d_t`
+  (`max_delta = max_accel * d_t`), making the velocity update timestep-invariant and consistent with
+  the `bicycle_drive` model. All pre-existing differential-drive tests use `d_t = 1.0`, where
+  `accel * d_t == accel`, so their behavior is unchanged; new regression tests cover `d_t != 1.0`.
+  **Behavioral note:** at the simulator's default `d_t = 0.1` this reduces the realized per-step
+  velocity change for a given action by 10×; differential-drive controllers tuned against the
+  previous (timestep-dependent) integration may need re-tuning. Controller re-tuning and benchmark
+  re-validation are out of scope for this fix.
 * Fixed the HEIGHT planner adapter's lidar raycasting **ignoring dynamic pedestrians** (#3629).
   `CrowdNavHeightAdapter._raycast_obstacles` intersected each ray only against cached static obstacle
   segments, so the HEIGHT policy's lidar channel was blind to moving pedestrians (they were used for the

--- a/robot_sf/robot/differential_drive.py
+++ b/robot_sf/robot/differential_drive.py
@@ -32,9 +32,11 @@ class DifferentialDriveSettings:
     interaxis_length: float = 0.3
     # Whether backwards motion is allowed (enables negative linear speed)
     allow_backwards: bool = False
-    # Maximum linear velocity delta accepted as an action
+    # Maximum linear acceleration (m/s^2) accepted as an action; the per-step
+    # velocity delta is max_linear_accel * d_t (see issue #3711)
     max_linear_accel: float = 1.0
-    # Maximum angular velocity delta accepted as an action
+    # Maximum angular acceleration (rad/s^2) accepted as an action; the per-step
+    # angular velocity delta is max_angular_accel * d_t (see issue #3711)
     max_angular_accel: float = 1.0
 
     def __post_init__(self):
@@ -93,10 +95,10 @@ class DifferentialDriveMotion:
         the action taken and elapsed time.
 
         :param state: The current state of the differential drive.
-        :param action: The desired change in velocity and orientation (dx, dtheta).
+        :param action: The commanded linear/angular acceleration (a_linear, a_angular).
         :param d_t: The time elapsed since the last update in seconds.
         """
-        robot_vel = self._robot_velocity(state.velocity, action)
+        robot_vel = self._robot_velocity(state.velocity, action, d_t)
         new_wheel_speeds = self._resulting_wheel_speeds(robot_vel)
         distance = self._covered_distance(state.wheel_speeds, new_wheel_speeds, d_t)
         new_orient = self._new_orientation(state.pose[1], state.wheel_speeds, new_wheel_speeds, d_t)
@@ -105,26 +107,39 @@ class DifferentialDriveMotion:
         state.wheel_speeds = new_wheel_speeds
         state.velocity = robot_vel
 
-    def _robot_velocity(self, velocity: PolarVec2D, action: PolarVec2D) -> PolarVec2D:
+    def _robot_velocity(self, velocity: PolarVec2D, action: PolarVec2D, d_t: float) -> PolarVec2D:
         """
-        Computes the new polar velocity vector from the current velocity and
-        the action applied.
+        Computes the new polar velocity vector from the current velocity and the
+        commanded acceleration integrated over the timestep.
+
+        The action is interpreted as a commanded acceleration ``(a_linear,
+        a_angular)``. It is first clipped to the configured acceleration limits,
+        then integrated over ``d_t`` to obtain the velocity delta
+        (``max_delta = max_accel * d_t``). Scaling by ``d_t`` keeps the velocity
+        update timestep-invariant: the same acceleration command applied over the
+        same elapsed time produces the same velocity change regardless of how the
+        interval is subdivided. Without this scaling, smaller timesteps inflated
+        the effective acceleration and produced unstable velocity spikes at high
+        update frequencies (see issue #3711).
 
         Args:
             velocity: The current velocity of the robot (linear speed, angular speed).
-            action: The action to apply on the velocity (dV, dTheta).
+            action: The commanded acceleration to apply (a_linear, a_angular).
+            d_t: The time elapsed since the last update in seconds.
 
         Returns:
-            PolarVec2D: The new velocity clipped by configured delta and speed limits.
+            PolarVec2D: The new velocity clipped by configured accel and speed limits.
         """
-        linear_delta = clip_scalar(
+        linear_accel = clip_scalar(
             action[0], -self.config.max_linear_accel, self.config.max_linear_accel
         )
-        angular_delta = clip_scalar(
+        angular_accel = clip_scalar(
             action[1], -self.config.max_angular_accel, self.config.max_angular_accel
         )
-        dot_x = velocity[0] + linear_delta
-        dot_orient = velocity[1] + angular_delta
+        # Integrate the commanded acceleration over the timestep so the per-step
+        # velocity delta scales with d_t (max_delta = max_accel * d_t).
+        dot_x = velocity[0] + linear_accel * d_t
+        dot_orient = velocity[1] + angular_accel * d_t
         dot_x = clip_scalar(dot_x, self.config.min_linear_speed, self.config.max_linear_speed)
         angular_max = self.config.max_angular_speed
         dot_orient = clip_scalar(dot_orient, -angular_max, angular_max)
@@ -266,8 +281,8 @@ class DifferentialDriveRobot:
 
         Returns:
             Box: An instance of gymnasium.spaces.Box representing the continuous
-            action space where each action is a vector containing
-            linear and angular velocity deltas.
+            action space where each action is a vector containing commanded
+            linear and angular accelerations (integrated over d_t per step).
         """
         high = np.array(
             [self.config.max_linear_accel, self.config.max_angular_accel],
@@ -315,8 +330,8 @@ class DifferentialDriveRobot:
         Applies an action to the robot over a time interval.
 
         Args:
-            action: The action to be applied represented by linear and angular
-                    velocities.
+            action: The action to be applied represented by commanded linear and
+                    angular accelerations.
             d_t: The duration in seconds over which to apply the action.
         """
         self.movement.move(self.state, action, d_t)

--- a/tests/differential_drive_test.py
+++ b/tests/differential_drive_test.py
@@ -203,6 +203,74 @@ def test_over_limit_negative_angular_speed_clipped() -> None:
     assert dot_orient == -1.0
 
 
+def test_velocity_delta_scales_with_timestep() -> None:
+    """Per-step velocity delta scales linearly with d_t (issue #3711).
+
+    The action is a commanded acceleration; the realized velocity change over one
+    step must be ``accel * d_t``. Halving the timestep must halve the velocity
+    delta for the same command.
+    """
+    settings = DifferentialDriveSettings(max_linear_speed=10.0, max_linear_accel=5.0)
+
+    state_half = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    DifferentialDriveMotion(settings).move(state_half, (2.0, 0.0), 0.5)
+
+    state_tenth = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    DifferentialDriveMotion(settings).move(state_tenth, (2.0, 0.0), 0.1)
+
+    # delta = accel (2.0) * d_t
+    assert state_half.velocity[0] == pytest.approx(1.0)
+    assert state_tenth.velocity[0] == pytest.approx(0.2)
+    # Halving d_t (0.5 -> 0.1, factor 5) scales the delta by the same factor.
+    assert state_half.velocity[0] == pytest.approx(5.0 * state_tenth.velocity[0])
+
+
+def test_acceleration_clip_then_scaled_by_dt() -> None:
+    """Over-limit accel commands are clipped, then integrated over d_t (issue #3711).
+
+    With ``max_linear_accel=0.4`` and ``d_t=0.1`` the maximum reachable per-step
+    delta is ``0.4 * 0.1 = 0.04`` (contrast the d_t=1.0 case which yields 0.4).
+    """
+    motion = DifferentialDriveMotion(
+        DifferentialDriveSettings(max_linear_speed=10.0, max_linear_accel=0.4)
+    )
+    state = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+
+    motion.move(state, (100.0, 0.0), 0.1)
+
+    assert state.velocity[0] == pytest.approx(0.04)
+
+
+def test_velocity_update_is_timestep_invariant_over_equal_real_time() -> None:
+    """Equal real elapsed time yields the same velocity regardless of step size.
+
+    Integrating a constant acceleration command for 1.0s in a single d_t=1.0 step
+    must match ten d_t=0.1 substeps. Before issue #3711 the finer schedule
+    inflated the velocity tenfold because the delta ignored d_t.
+    """
+    settings = DifferentialDriveSettings(
+        max_linear_speed=10.0,
+        max_angular_speed=10.0,
+        max_linear_accel=5.0,
+        max_angular_accel=5.0,
+    )
+    accel = (1.0, 0.5)
+
+    coarse = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    DifferentialDriveMotion(settings).move(coarse, accel, 1.0)
+
+    fine = DifferentialDriveState(((0.0, 0.0), 0.0), (0.0, 0.0), (0.0, 0.0), (0.0, 0.0))
+    fine_motion = DifferentialDriveMotion(settings)
+    for _ in range(10):
+        fine_motion.move(fine, accel, 0.1)
+
+    assert fine.velocity[0] == pytest.approx(coarse.velocity[0])
+    assert fine.velocity[1] == pytest.approx(coarse.velocity[1])
+    # Sanity: the constant command reaches accel * total_time after 1.0s.
+    assert coarse.velocity[0] == pytest.approx(1.0)
+    assert coarse.velocity[1] == pytest.approx(0.5)
+
+
 def test_in_place_rotation_matches_kinematics() -> None:
     """Verify in-place rotation math to prevent drift in heading updates."""
     motion = DifferentialDriveMotion(


### PR DESCRIPTION
## Summary

Fixes #3711 — differential-drive velocity updates ignored timestep scaling.

`DifferentialDriveMotion._robot_velocity` applied the commanded acceleration
(clipped to `max_linear_accel` / `max_angular_accel`, the bounds introduced for
#3666 in PR #3689) **directly as a per-step velocity delta without scaling by the
simulation timestep `d_t`**:

```python
dot_x = velocity[0] + linear_delta          # before: no d_t
```

At the simulator default `d_t = 0.1` this permitted 10× the labeled acceleration
per step and made the dynamics timestep-dependent — halving the timestep doubled
the effective acceleration, the "unstable spikes at small timesteps" the issue
describes.

The action is now interpreted as a **commanded acceleration** (matching the
`max_*_accel` field names) and integrated over `d_t`:

```python
dot_x = velocity[0] + linear_accel * d_t    # after: max_delta = max_accel * d_t
```

This makes the velocity update timestep-invariant and consistent with the sibling
`bicycle_drive` model (`new_velocity = velocity + d_t * acceleration`). Docstrings
and field comments were updated to acceleration semantics. The `action_space`
bounds remain `[-max_*_accel, max_*_accel]` (now genuinely an acceleration command
space), so `test_action_space_uses_delta_velocity_bounds` still holds.

## Scope

- **In scope:** the smallest timestep-scaling correction in
  `robot_sf/robot/differential_drive.py` plus regression tests.
- **Out of scope:** bicycle/holonomic models, controller re-tuning, benchmark
  campaigns, and any paper/dissertation claim edits.

## Why all existing tests stay green

Every pre-existing differential-drive test uses `d_t = 1.0`, where
`accel * d_t == accel`, so their numeric expectations are unchanged. The fix only
alters the (buggy) `d_t != 1.0` behavior. New tests were confirmed to **fail on
the unfixed source for the right reason** (e.g. the invariance test obtained
`10.0` vs expected `1.0` at `d_t = 0.1`) and pass after the fix.

## Validation

All commands run via `scripts/dev/run_worktree_shared_venv.sh` on the shared venv
(host `imech039`). Evidence tier: **smoke** (focused CPU-only unit tests, matching
the issue's `evidence_tier: smoke`).

| Command | Result |
| --- | --- |
| `uv run pytest tests/differential_drive_test.py -q` | **16 passed** (13 existing + 3 new) |
| New tests vs. **unfixed** source (`-k "scales_with_timestep or clip_then_scaled or timestep_invariant"`) | **3 failed** for the right reason (e.g. 10.0 vs 1.0) — confirms guard |
| `pytest` over dependent tests (`test_types`, `test_manual_control_input_mapping`, `test_compare_holonomic_vs_differential_rollout`, `robot_env_simple_reward_test`) | **55 passed** |
| `pytest` over robot/sim sweep (`test_robot_state_robot_collision`, `test_holonomic_drive`, `test_bicycle_drive`, `unicycle_drive_test`, `test_robot_sf_import_smoke`, `test_ped_robot_force_contract`) | **30 passed** |
| `uv run ruff check` + `ruff format` on changed files | clean |

New regression tests in `tests/differential_drive_test.py`:
- `test_velocity_delta_scales_with_timestep` — per-step delta is `accel * d_t`; halving `d_t` halves the delta.
- `test_acceleration_clip_then_scaled_by_dt` — over-limit accel is clipped, then scaled by `d_t` (`0.4 * 0.1 = 0.04`).
- `test_velocity_update_is_timestep_invariant_over_equal_real_time` — one `d_t=1.0` step matches ten `d_t=0.1` substeps.

## Behavioral note / residual risk

At the simulator default `d_t = 0.1`, this reduces the realized per-step velocity
change for a given action by 10× relative to the previous (timestep-dependent)
integration. **Differential-drive controllers/policies tuned against the old
behavior may need re-tuning, and benchmark results may shift.** That re-tuning and
benchmark re-validation are intentionally **out of scope** here (the issue is
`evidence_tier: smoke` and the launcher scope forbids controller re-tuning and
benchmark campaigns). The PR is a focused, unit-test-validated physics-correctness
fix; downstream re-tuning/benchmark re-validation should be tracked separately if
needed.

## Out-of-scope confirmation

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
