### PR TITLE
feat(benchmark): record metric-affecting run config (scan_noise, collision regime) in result provenance (#3701)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Recorded metric-affecting run configuration in benchmark result provenance so result artifacts are
+  self-describing (#3701). New pure module `robot_sf/benchmark/run_config_provenance.py` exposes
+  `metric_affecting_run_config(config)`, which serializes the two run-config toggles that change *what*
+  the reported safety metrics mean — LiDAR `scan_noise` (noisy default `[0.005, 0.002]` vs deterministic
+  `[0.0, 0.0]`; see `robot_sf/sensor/range_sensor.py`) and the collision-handling regime
+  (`terminate_on_contact` vs `bounce_back`; the robot benchmark env terminates on collision per
+  `RobotState.is_terminal`). The map-runner now embeds this block under
+  `provenance.config_identity.metric_affecting_config` in every batch summary
+  (`robot_sf/benchmark/map_runner.py`), derived once per batch via the fail-soft
+  `representative_metric_affecting_config` helper, so two result sets can be checked for comparability
+  without out-of-band knowledge of each run's config. The helper is descriptive provenance only — it
+  does not redefine metrics, rerun campaigns, or promote benchmark claims, and degrades to a
+  `status: not_available` block rather than ever breaking a run.
 * Added a fail-closed readiness check for scenario-horizon Results evidence (#3266). New module
   `robot_sf/benchmark/scenario_horizon_readiness.py` and CLI
   `scripts/validation/check_scenario_horizon_results_readiness.py` read a re-exported scenario-horizon

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -84,6 +84,9 @@ from robot_sf.benchmark.map_runner_env import (
 )
 from robot_sf.benchmark.map_runner_env import build_env_config as _build_env_config
 from robot_sf.benchmark.map_runner_env import (
+    representative_metric_affecting_config as _representative_metric_affecting_config,
+)
+from robot_sf.benchmark.map_runner_env import (
     validate_sensor_fusion_adapter_config as _validate_sensor_fusion_adapter_config,  # noqa: F401 - compatibility re-export.
 )
 from robot_sf.benchmark.map_runner_episode import run_map_episode as _execute_map_episode
@@ -2285,6 +2288,13 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
             continue
         filtered.append(scenario)
 
+    # Record the metric-affecting run config (scan_noise, collision regime) once so
+    # the emitted result manifest is self-describing about settings that change
+    # metric semantics (issue #3701). Fail-soft: never blocks a run.
+    metric_affecting_config = _representative_metric_affecting_config(
+        filtered, scenario_path=scenario_path
+    )
+
     kinematics_tag, scenario_kinematics = _resolve_batch_kinematics_tag(filtered)
     batch_observation_mode = str(observation_mode).strip() if observation_mode is not None else None
     raw_policy_cfg = _parse_algo_config(algo_config_path)
@@ -2486,6 +2496,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
             total_jobs=len(jobs),
             written=0,
             artifact_pointer_status="not_available",
+            metric_affecting_config=metric_affecting_config,
         )
         summary["benchmark_availability"] = availability_payload(summary)
         return summary
@@ -2654,6 +2665,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         algo_config_path=algo_config_path,
         suite_key=suite_key,
         kinematics_tag=kinematics_tag,
+        metric_affecting_config=metric_affecting_config,
     )
 
 

--- a/robot_sf/benchmark/map_runner_batch_summary.py
+++ b/robot_sf/benchmark/map_runner_batch_summary.py
@@ -215,6 +215,7 @@ def build_completed_batch_summary(  # noqa: PLR0913
     algo_config_path: str | None,
     suite_key: str,
     kinematics_tag: str,
+    metric_affecting_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the final successful batch summary after all map jobs finish.
 
@@ -340,6 +341,7 @@ def build_completed_batch_summary(  # noqa: PLR0913
         total_jobs=total_jobs,
         written=wrote,
         artifact_pointer_status=artifact_pointer_status,
+        metric_affecting_config=metric_affecting_config,
     )
     summary["benchmark_availability"] = availability_payload(summary)
     return summary

--- a/robot_sf/benchmark/map_runner_env.py
+++ b/robot_sf/benchmark/map_runner_env.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any
 
+from loguru import logger
+
+from robot_sf.benchmark.run_config_provenance import metric_affecting_run_config
 from robot_sf.gym_env.observation_mode import ObservationMode
 from robot_sf.nav.occupancy_grid import GridChannel, GridConfig
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario
@@ -44,6 +47,39 @@ def build_env_config(
     )
     apply_pedestrian_reactivity_to_env_config(config, scenario=scenario)
     return config
+
+
+def representative_metric_affecting_config(
+    scenarios: Sequence[Mapping[str, Any]],
+    *,
+    scenario_path: Path,
+) -> dict[str, Any]:
+    """Return the metric-affecting run-config provenance block for a batch (issue #3701).
+
+    Builds a representative environment config from the first scenario and
+    extracts the metric-affecting toggles (LiDAR ``scan_noise`` and the
+    collision-handling regime) so the benchmark run manifest is self-describing.
+    The benchmark uses a uniform sensor configuration across a batch, so the
+    first scenario is representative of the run.
+
+    This helper is *fail-soft*: it returns a ``status: not_available`` block
+    instead of raising, because this is descriptive provenance metadata and must
+    never break an otherwise valid benchmark run. A run that omits the block on
+    error is still honest; a run that crashes while annotating metadata is not.
+
+    Returns:
+        A JSON-safe metric-affecting run-config block, or a
+        ``{"status": "not_available", "reason": ...}`` block when no scenario is
+        available or config construction fails.
+    """
+    if not scenarios:
+        return {"status": "not_available", "reason": "no scenarios"}
+    try:
+        config = build_env_config(dict(scenarios[0]), scenario_path=scenario_path)
+        return metric_affecting_run_config(config)
+    except Exception as exc:  # noqa: BLE001 - provenance must never break a benchmark run.
+        logger.debug("metric-affecting run-config provenance unavailable: {}", exc)
+        return {"status": "not_available", "reason": str(exc)}
 
 
 def apply_pedestrian_reactivity_to_env_config(

--- a/robot_sf/benchmark/map_runner_provenance.py
+++ b/robot_sf/benchmark/map_runner_provenance.py
@@ -26,9 +26,30 @@ def map_result_provenance(  # noqa: PLR0913
     total_jobs: int,
     written: int,
     artifact_pointer_status: str,
+    metric_affecting_config: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
-    """Return self-describing provenance for map-runner summary artifacts."""
+    """Return self-describing provenance for map-runner summary artifacts.
+
+    The optional ``metric_affecting_config`` is the metric-affecting run-config
+    block (LiDAR ``scan_noise`` and the collision-handling regime; see
+    ``robot_sf/benchmark/run_config_provenance.py``). When provided it is embedded
+    under ``config_identity`` so the result artifact is self-describing about the
+    settings that change metric semantics (issue #3701). When ``None`` the field
+    is omitted for backwards compatibility.
+    """
     from robot_sf.benchmark.release_protocol import BENCHMARK_PROTOCOL_VERSION  # noqa: PLC0415
+
+    config_identity: dict[str, Any] = {
+        "schema_path": str(schema_path),
+        "scenario_path": str(scenario_path),
+        "scenario_count": len(scenarios),
+        "scenario_matrix_hash": _config_hash(scenarios),
+        "algo": str(algo),
+        "algo_config_path": str(algo_config_path) if algo_config_path is not None else None,
+        "benchmark_profile": str(benchmark_profile),
+    }
+    if metric_affecting_config is not None:
+        config_identity["metric_affecting_config"] = metric_affecting_config
 
     provenance: dict[str, Any] = {
         "protocol_version": BENCHMARK_PROTOCOL_VERSION,
@@ -36,15 +57,7 @@ def map_result_provenance(  # noqa: PLR0913
         "run_id": uuid.uuid4().hex,
         "python_version": platform.python_version(),
         "artifact_pointer_status": artifact_pointer_status,
-        "config_identity": {
-            "schema_path": str(schema_path),
-            "scenario_path": str(scenario_path),
-            "scenario_count": len(scenarios),
-            "scenario_matrix_hash": _config_hash(scenarios),
-            "algo": str(algo),
-            "algo_config_path": str(algo_config_path) if algo_config_path is not None else None,
-            "benchmark_profile": str(benchmark_profile),
-        },
+        "config_identity": config_identity,
         "seed_identity": {
             "suite_key": suite_key,
             "total_jobs": int(total_jobs),

--- a/robot_sf/benchmark/run_config_provenance.py
+++ b/robot_sf/benchmark/run_config_provenance.py
@@ -1,0 +1,152 @@
+"""Provenance for metric-affecting run configuration (issue #3701).
+
+Some run-configuration toggles change *what the reported benchmark metrics mean*
+rather than just the numbers. Two result sets are only comparable when these
+toggles match, yet they are not part of the emitted results, so a reader of a
+results table cannot tell which setting produced the numbers.
+
+This module provides a small, pure serialization helper that records those
+toggles so each result artifact is self-describing. Two metric-affecting
+settings are captured:
+
+* **LiDAR ``scan_noise``** -- sensor observation noise probabilities
+  ``[loss, corruption]`` (see ``robot_sf/sensor/range_sensor.py``). The default
+  is noisy (``[0.005, 0.002]``); deterministic/reproduction configs set
+  ``[0.0, 0.0]``. Noise-free vs noisy observations change collision and
+  near-miss outcomes.
+* **Collision-handling regime** -- ``terminate_on_contact`` vs ``bounce_back``.
+  The robot benchmark environment ends an episode on collision
+  (``RobotState.is_terminal`` in ``robot_sf/robot/robot_state.py`` includes the
+  collision flags), so a collision is an episode-ending failure rather than a
+  recoverable event. The collision-force toggles
+  (``peds_have_static_obstacle_forces``, ``peds_have_robot_repulsion``) are
+  recorded alongside the regime because they also change collision outcomes.
+
+The output is a JSON-safe dictionary intended for embedding in a benchmark run
+manifest or episode metadata. This module deliberately depends only on the
+standard library so it can be imported without simulator dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+#: Collision-handling regime where any collision ends the episode (the robot
+#: benchmark contract). See ``robot_sf/robot/robot_state.py``.
+COLLISION_REGIME_TERMINATE_ON_CONTACT = "terminate_on_contact"
+#: Collision-handling regime where a collision is recoverable and the episode
+#: continues (e.g. bounce-back / respawn behavior).
+COLLISION_REGIME_BOUNCE_BACK = "bounce_back"
+#: All recognized collision-handling regimes.
+COLLISION_REGIMES = (
+    COLLISION_REGIME_TERMINATE_ON_CONTACT,
+    COLLISION_REGIME_BOUNCE_BACK,
+)
+
+#: Human-readable note clarifying how this block should be interpreted.
+METRIC_AFFECTING_CONFIG_INTERPRETATION = (
+    "metric_affecting_run_config: run settings that change what reported metrics mean; "
+    "two result sets are only directly comparable when these settings match"
+)
+
+#: Schema tag for the emitted block, so downstream readers can version it.
+METRIC_AFFECTING_CONFIG_SCHEMA = "metric_affecting_run_config.v1"
+
+
+def _coerce_scan_noise(value: Any) -> list[float] | None:
+    """Coerce ``value`` into a JSON-safe list of floats.
+
+    Accepts any sequence of numbers (e.g. a list or a read-only numpy array such
+    as ``LidarScannerSettings.scan_noise``).
+
+    Returns:
+        A list of floats, or ``None`` when the value is missing or cannot be
+        interpreted as a sequence of numbers.
+    """
+    if value is None:
+        return None
+    try:
+        items = list(value)
+    except TypeError:
+        return None
+    coerced: list[float] = []
+    for item in items:
+        try:
+            coerced.append(float(item))
+        except (TypeError, ValueError):
+            return None
+    return coerced
+
+
+def _resolve_scan_noise(config: Any) -> list[float] | None:
+    """Resolve the LiDAR ``scan_noise`` probabilities from a config-like object.
+
+    Reads ``config.lidar_config.scan_noise`` via duck typing so the helper works
+    on any environment config exposing that attribute.
+
+    Returns:
+        The scan-noise probabilities as a list of floats, or ``None`` when the
+        attribute chain is absent or unparseable.
+    """
+    lidar_config = getattr(config, "lidar_config", None)
+    if lidar_config is None:
+        return None
+    return _coerce_scan_noise(getattr(lidar_config, "scan_noise", None))
+
+
+def metric_affecting_run_config(
+    config: Any,
+    *,
+    collision_regime: str = COLLISION_REGIME_TERMINATE_ON_CONTACT,
+) -> dict[str, Any]:
+    """Extract a JSON-safe metric-affecting run-config provenance block.
+
+    Args:
+        config: An environment config-like object. The function reads
+            ``config.lidar_config.scan_noise`` and the collision-force toggles
+            (``peds_have_static_obstacle_forces``, ``peds_have_robot_repulsion``)
+            via duck typing, so any object exposing those attributes works.
+            Missing attributes are recorded as ``None`` rather than raising.
+        collision_regime: The collision-handling regime in effect for the run.
+            Defaults to ``terminate_on_contact``, which reflects the robot
+            benchmark environment contract (collisions end the episode).
+
+    Returns:
+        A dictionary describing the metric-affecting settings, suitable for
+        embedding in a benchmark run manifest or episode metadata.
+
+    Raises:
+        ValueError: If ``collision_regime`` is not one of ``COLLISION_REGIMES``.
+    """
+    if collision_regime not in COLLISION_REGIMES:
+        raise ValueError(
+            f"collision_regime must be one of {COLLISION_REGIMES!r} (got {collision_regime!r})"
+        )
+
+    scan_noise = _resolve_scan_noise(config)
+    scan_noise_enabled: bool | None
+    if scan_noise is None:
+        scan_noise_enabled = None
+    else:
+        scan_noise_enabled = any(prob > 0.0 for prob in scan_noise)
+
+    static_obstacle_forces = getattr(config, "peds_have_static_obstacle_forces", None)
+    robot_repulsion = getattr(config, "peds_have_robot_repulsion", None)
+
+    return {
+        "schema": METRIC_AFFECTING_CONFIG_SCHEMA,
+        "sensor_noise": {
+            "scan_noise": scan_noise,
+            "scan_noise_enabled": scan_noise_enabled,
+        },
+        "collision_regime": {
+            "regime": collision_regime,
+            "peds_have_static_obstacle_forces": (
+                None if static_obstacle_forces is None else bool(static_obstacle_forces)
+            ),
+            "peds_have_robot_repulsion": (
+                None if robot_repulsion is None else bool(robot_repulsion)
+            ),
+        },
+        "interpretation": METRIC_AFFECTING_CONFIG_INTERPRETATION,
+    }

--- a/scripts/validation/broad_exception_baseline.json
+++ b/scripts/validation/broad_exception_baseline.json
@@ -19,6 +19,7 @@
       "robot_sf/benchmark/imitation_manifest.py": 1,
       "robot_sf/benchmark/map_runner.py": 2,
       "robot_sf/benchmark/map_runner_batch_runner.py": 3,
+      "robot_sf/benchmark/map_runner_env.py": 1,
       "robot_sf/benchmark/metrics.py": 1,
       "robot_sf/benchmark/orca_preflight.py": 1,
       "robot_sf/benchmark/planner_inclusion.py": 2,
@@ -123,7 +124,7 @@
       "scripts/validation/verify_maps.py": 1,
       "scripts/validation/verify_sf_implementation.py": 4
     },
-    "total": 283
+    "total": 284
   },
   "description": "Broad exception handler baseline for benchmark/script surfaces. Run scripts/validation/check_broad_exceptions.py --write-baseline to refresh after intentionally removing or approving entries.",
   "entries": [
@@ -168,7 +169,7 @@
       "context": "run_campaign",
       "fingerprint": "7d11e1766f0c13ae",
       "handler": "Exception",
-      "lineno": 1954,
+      "lineno": 1952,
       "path": "robot_sf/benchmark/camera_ready_campaign.py",
       "source": "except Exception as exc:"
     },
@@ -177,7 +178,7 @@
       "context": "run_campaign",
       "fingerprint": "7d11e1766f0c13ae",
       "handler": "Exception",
-      "lineno": 2002,
+      "lineno": 2000,
       "path": "robot_sf/benchmark/camera_ready_campaign.py",
       "source": "except Exception as exc:"
     },
@@ -186,7 +187,7 @@
       "context": "run_campaign",
       "fingerprint": "7d11e1766f0c13ae",
       "handler": "Exception",
-      "lineno": 2895,
+      "lineno": 2893,
       "path": "robot_sf/benchmark/camera_ready_campaign.py",
       "source": "except Exception as exc:"
     },
@@ -951,7 +952,7 @@
       "context": "_to_json_ready",
       "fingerprint": "282c0ddbbcb7b444",
       "handler": "Exception",
-      "lineno": 105,
+      "lineno": 136,
       "path": "robot_sf/benchmark/imitation_manifest.py",
       "source": "except Exception:  # pragma: no cover - best effort fallback"
     },
@@ -960,7 +961,7 @@
       "context": "_preflight_policy",
       "fingerprint": "9d6addfc4094f787",
       "handler": "Exception",
-      "lineno": 682,
+      "lineno": 686,
       "path": "robot_sf/benchmark/map_runner.py",
       "source": "except Exception as exc:"
     },
@@ -969,7 +970,7 @@
       "context": "_preflight_policy",
       "fingerprint": "3f6860893c2f6ced",
       "handler": "Exception",
-      "lineno": 712,
+      "lineno": 716,
       "path": "robot_sf/benchmark/map_runner.py",
       "source": "except Exception as fallback_exc:"
     },
@@ -999,6 +1000,15 @@
       "lineno": 211,
       "path": "robot_sf/benchmark/map_runner_batch_runner.py",
       "source": "except Exception as exc:  # pragma: no cover - write/validate path"
+    },
+    {
+      "col_offset": 4,
+      "context": "representative_metric_affecting_config",
+      "fingerprint": "ca3a7028492cbd27",
+      "handler": "Exception",
+      "lineno": 80,
+      "path": "robot_sf/benchmark/map_runner_env.py",
+      "source": "except Exception as exc:  # noqa: BLE001 - provenance must never break a benchmark run."
     },
     {
       "col_offset": 4,
@@ -1293,7 +1303,7 @@
       "context": "frame_shape_from_map",
       "fingerprint": "bba45879be658dd5",
       "handler": "Exception",
-      "lineno": 59,
+      "lineno": 60,
       "path": "robot_sf/benchmark/visualization.py",
       "source": "except Exception:"
     },
@@ -1302,7 +1312,7 @@
       "context": "frame_shape_from_map",
       "fingerprint": "bba45879be658dd5",
       "handler": "Exception",
-      "lineno": 70,
+      "lineno": 71,
       "path": "robot_sf/benchmark/visualization.py",
       "source": "except Exception:"
     },
@@ -1311,7 +1321,7 @@
       "context": "generate_benchmark_plots_from_data",
       "fingerprint": "8f539027d1a9c59a",
       "handler": "Exception",
-      "lineno": 223,
+      "lineno": 224,
       "path": "robot_sf/benchmark/visualization.py",
       "source": "except Exception as e:"
     },
@@ -1320,7 +1330,7 @@
       "context": "generate_benchmark_plots_from_data",
       "fingerprint": "8f539027d1a9c59a",
       "handler": "Exception",
-      "lineno": 245,
+      "lineno": 246,
       "path": "robot_sf/benchmark/visualization.py",
       "source": "except Exception as e:"
     },
@@ -1329,7 +1339,7 @@
       "context": "_plot_subprocess_worker",
       "fingerprint": "bba1e9e83de4d87b",
       "handler": "Exception",
-      "lineno": 400,
+      "lineno": 401,
       "path": "robot_sf/benchmark/visualization.py",
       "source": "except Exception as exc:  # pragma: no cover - defensive fallback"
     },
@@ -1338,7 +1348,7 @@
       "context": "_generate_metrics_plot",
       "fingerprint": "c90db09c9215e774",
       "handler": "Exception",
-      "lineno": 583,
+      "lineno": 584,
       "path": "robot_sf/benchmark/visualization.py",
       "source": "except Exception:"
     },
@@ -1347,7 +1357,7 @@
       "context": "_generate_scenario_comparison_plot",
       "fingerprint": "fe958e2b9ee653e9",
       "handler": "Exception",
-      "lineno": 672,
+      "lineno": 673,
       "path": "robot_sf/benchmark/visualization.py",
       "source": "except Exception:"
     },
@@ -1482,7 +1492,7 @@
       "context": "_git_head",
       "fingerprint": "921b9a3a806e63e6",
       "handler": "Exception",
-      "lineno": 92,
+      "lineno": 100,
       "path": "scripts/benchmark/run_observation_noise_envelope.py",
       "source": "except Exception:"
     },
@@ -1491,7 +1501,7 @@
       "context": "_fixture_contract",
       "fingerprint": "23019bf113bfda33",
       "handler": "Exception",
-      "lineno": 343,
+      "lineno": 358,
       "path": "scripts/benchmark/run_observation_noise_live_replay_issue_2777.py",
       "source": "except Exception as exc:  # pragma: no cover - defensive fail-closed path"
     },
@@ -2166,7 +2176,7 @@
       "context": "run_recipe",
       "fingerprint": "461262047f30f3e3",
       "handler": "Exception",
-      "lineno": 124,
+      "lineno": 159,
       "path": "scripts/tools/run_benchmark_sql_recipe.py",
       "source": "except Exception as exc:"
     },
@@ -2175,7 +2185,7 @@
       "context": "_validate_columns",
       "fingerprint": "ae2c94585588b271",
       "handler": "Exception",
-      "lineno": 266,
+      "lineno": 322,
       "path": "scripts/tools/run_benchmark_sql_recipe.py",
       "source": "except Exception as exc:"
     },
@@ -2589,7 +2599,7 @@
       "context": "main",
       "fingerprint": "ea061efac66ad94e",
       "handler": "(Exception, SystemExit)",
-      "lineno": 543,
+      "lineno": 585,
       "path": "scripts/validation/run_predictive_success_campaign.py",
       "source": "except (Exception, SystemExit) as exc:"
     },

--- a/tests/benchmark/test_map_runner_result_provenance.py
+++ b/tests/benchmark/test_map_runner_result_provenance.py
@@ -47,6 +47,12 @@ def test_run_map_batch_empty_summary_has_result_provenance(
     assert config_identity["algo_config_path"] is None
     assert config_identity["benchmark_profile"] == "experimental"
     assert isinstance(config_identity["scenario_matrix_hash"], str)
+    # With no scenarios the metric-affecting run-config block is fail-soft but
+    # still present, so the manifest is explicit about the missing provenance.
+    assert config_identity["metric_affecting_config"] == {
+        "status": "not_available",
+        "reason": "no scenarios",
+    }
 
     seed_identity = provenance["seed_identity"]
     assert seed_identity["suite_key"] == "default"
@@ -72,6 +78,32 @@ def test_map_result_provenance_preserves_planned_skipped_job_count() -> None:
     assert provenance["seed_identity"]["total_jobs"] == 2
     assert provenance["seed_identity"]["written"] == 0
     assert provenance["artifact_pointer_status"] == "not_available"
+    # Backwards compatible: omitting the optional block leaves config_identity unchanged.
+    assert "metric_affecting_config" not in provenance["config_identity"]
+
+
+def test_map_result_provenance_embeds_metric_affecting_config() -> None:
+    """A provided metric-affecting block is embedded under config_identity (issue #3701)."""
+    block = {
+        "schema": "metric_affecting_run_config.v1",
+        "sensor_noise": {"scan_noise": [0.0, 0.0], "scan_noise_enabled": False},
+        "collision_regime": {"regime": "terminate_on_contact"},
+    }
+    provenance = _map_result_provenance(
+        schema_path="robot_sf/benchmark/schemas/episode.schema.v1.json",
+        scenario_path=Path("configs/example.yaml"),
+        scenarios=[{"name": "one"}],
+        algo="goal",
+        algo_config_path=None,
+        benchmark_profile="experimental",
+        suite_key="default",
+        total_jobs=1,
+        written=1,
+        artifact_pointer_status="local_jsonl_present",
+        metric_affecting_config=block,
+    )
+
+    assert provenance["config_identity"]["metric_affecting_config"] == block
 
 
 def test_map_result_provenance_can_mark_existing_jsonl_available() -> None:

--- a/tests/benchmark/test_run_config_provenance.py
+++ b/tests/benchmark/test_run_config_provenance.py
@@ -1,0 +1,123 @@
+"""Serialization tests for metric-affecting run-config provenance (issue #3701).
+
+These tests use synthetic config fixtures only; they do not start the simulator,
+load maps, or run any benchmark campaign.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.map_runner_env import representative_metric_affecting_config
+from robot_sf.benchmark.run_config_provenance import (
+    COLLISION_REGIME_BOUNCE_BACK,
+    COLLISION_REGIME_TERMINATE_ON_CONTACT,
+    METRIC_AFFECTING_CONFIG_SCHEMA,
+    metric_affecting_run_config,
+)
+
+
+def _fake_config(scan_noise, *, static_forces=True, robot_repulsion=None) -> SimpleNamespace:
+    """Build a minimal duck-typed env config fixture."""
+    return SimpleNamespace(
+        lidar_config=SimpleNamespace(scan_noise=scan_noise),
+        peds_have_static_obstacle_forces=static_forces,
+        peds_have_robot_repulsion=robot_repulsion,
+    )
+
+
+def test_records_default_noisy_sensor_config() -> None:
+    """A default noisy sensor config is recorded as noise-enabled."""
+    block = metric_affecting_run_config(_fake_config([0.005, 0.002]))
+
+    assert block["schema"] == METRIC_AFFECTING_CONFIG_SCHEMA
+    assert block["sensor_noise"]["scan_noise"] == [0.005, 0.002]
+    assert block["sensor_noise"]["scan_noise_enabled"] is True
+    assert block["collision_regime"]["regime"] == COLLISION_REGIME_TERMINATE_ON_CONTACT
+    assert block["collision_regime"]["peds_have_static_obstacle_forces"] is True
+    assert block["collision_regime"]["peds_have_robot_repulsion"] is None
+    assert "interpretation" in block
+
+
+def test_records_deterministic_noise_free_config() -> None:
+    """A deterministic ``[0.0, 0.0]`` sensor config is recorded as noise-disabled."""
+    block = metric_affecting_run_config(_fake_config([0.0, 0.0]))
+
+    assert block["sensor_noise"]["scan_noise"] == [0.0, 0.0]
+    assert block["sensor_noise"]["scan_noise_enabled"] is False
+
+
+def test_noisy_and_deterministic_blocks_differ() -> None:
+    """The recorded provenance distinguishes noisy from noise-free runs."""
+    noisy = metric_affecting_run_config(_fake_config([0.005, 0.002]))
+    deterministic = metric_affecting_run_config(_fake_config([0.0, 0.0]))
+
+    assert noisy["sensor_noise"] != deterministic["sensor_noise"]
+
+
+def test_coerces_numpy_scan_noise_array() -> None:
+    """A read-only numpy ``scan_noise`` array (as LidarScannerSettings exposes) is JSON-safe."""
+    arr = np.array([0.01, 0.0], dtype=np.float64)
+    arr.flags.writeable = False
+    block = metric_affecting_run_config(_fake_config(arr))
+
+    assert block["sensor_noise"]["scan_noise"] == [0.01, 0.0]
+    assert block["sensor_noise"]["scan_noise_enabled"] is True
+    # The block must round-trip through JSON without custom encoders.
+    assert json.loads(json.dumps(block)) == block
+
+
+def test_real_lidar_scanner_settings_default() -> None:
+    """The helper reads ``scan_noise`` from a real LidarScannerSettings object."""
+    from robot_sf.sensor.range_sensor import LidarScannerSettings
+
+    config = SimpleNamespace(lidar_config=LidarScannerSettings())
+    block = metric_affecting_run_config(config)
+
+    assert block["sensor_noise"]["scan_noise"] == [0.005, 0.002]
+    assert block["sensor_noise"]["scan_noise_enabled"] is True
+
+
+def test_bounce_back_regime_is_recorded() -> None:
+    """A bounce-back regime is recorded distinctly from terminate-on-contact."""
+    block = metric_affecting_run_config(
+        _fake_config([0.0, 0.0]),
+        collision_regime=COLLISION_REGIME_BOUNCE_BACK,
+    )
+
+    assert block["collision_regime"]["regime"] == COLLISION_REGIME_BOUNCE_BACK
+
+
+def test_invalid_collision_regime_raises() -> None:
+    """An unknown collision regime is rejected rather than silently recorded."""
+    with pytest.raises(ValueError, match="collision_regime"):
+        metric_affecting_run_config(_fake_config([0.0, 0.0]), collision_regime="warp")
+
+
+def test_missing_lidar_config_records_none() -> None:
+    """A config without a lidar_config records None rather than raising."""
+    block = metric_affecting_run_config(SimpleNamespace())
+
+    assert block["sensor_noise"]["scan_noise"] is None
+    assert block["sensor_noise"]["scan_noise_enabled"] is None
+    assert block["collision_regime"]["peds_have_static_obstacle_forces"] is None
+
+
+def test_unparseable_scan_noise_records_none() -> None:
+    """A non-sequence scan_noise value degrades to None instead of raising."""
+    block = metric_affecting_run_config(_fake_config("noisy"))
+
+    assert block["sensor_noise"]["scan_noise"] is None
+    assert block["sensor_noise"]["scan_noise_enabled"] is None
+
+
+def test_representative_config_without_scenarios_is_not_available() -> None:
+    """The batch helper is fail-soft when there are no scenarios (no simulator needed)."""
+    block = representative_metric_affecting_config([], scenario_path=Path("."))
+
+    assert block == {"status": "not_available", "reason": "no scenarios"}


### PR DESCRIPTION
## Summary

Closes #3701.

Two run-configuration toggles change *what the reported benchmark safety metrics mean*, but were not
surfaced in the per-run results/manifest, so a reader of a results table could not tell which setting
produced the numbers, and two result sets could only be compared with out-of-band knowledge of each
run's config:

1. **LiDAR `scan_noise`** — noisy default `[0.005, 0.002]` (`robot_sf/sensor/range_sensor.py`) vs
   deterministic `[0.0, 0.0]`. Noise-free vs noisy observations change collision/near-miss outcomes.
2. **Collision-handling regime** — `terminate_on_contact` vs `bounce_back`. The robot benchmark env
   ends an episode on collision (`RobotState.is_terminal` in `robot_sf/robot/robot_state.py` includes
   the collision flags), so a collision is an episode-ending failure rather than a recoverable event.

This PR makes each benchmark result artifact self-describing about these settings.

## Scope

- **New pure helper** `robot_sf/benchmark/run_config_provenance.py`:
  `metric_affecting_run_config(config, *, collision_regime=...)` serializes `scan_noise`
  (+ `scan_noise_enabled`) and the collision regime (+ `peds_have_static_obstacle_forces`,
  `peds_have_robot_repulsion`) into a JSON-safe `metric_affecting_run_config.v1` block. Stdlib-only;
  duck-typed; missing attributes record `None` rather than raising; unknown regimes raise `ValueError`.
- **Manifest integration**: the map-runner derives the block once per batch via the fail-soft
  `representative_metric_affecting_config` helper (`robot_sf/benchmark/map_runner_env.py`) and embeds it
  under `provenance.config_identity.metric_affecting_config` in both the completed-batch and
  preflight/early-return summaries (`map_runner.py`, `map_runner_batch_summary.py`,
  `map_runner_provenance.py`). The provenance param is optional and defaults to omitted, so existing
  callers are unchanged.
- Distinct from the existing `observation_noise` block, which is explicitly a non-calibrated benchmark
  *robustness* injection ("not a real sensor model") — the actual sensor `scan_noise` was genuinely not
  captured before this change.

**Why fail-soft:** the block is descriptive provenance metadata, not a benchmark claim. On any error
(or no scenarios) it degrades to a `{"status": "not_available", "reason": ...}` block instead of
breaking an otherwise valid run. A run that omits the block on error is still honest; a run that
crashes while annotating metadata is not.

## Validation

Run with the shared-venv worktree wrapper (`scripts/dev/run_worktree_shared_venv.sh`):

| Command | Result |
| --- | --- |
| `ruff check` (all changed files) | exit 0 — All checks passed |
| `ruff format` (all changed files) | exit 0 — 7 files unchanged |
| `pytest tests/benchmark/test_run_config_provenance.py tests/benchmark/test_map_runner_result_provenance.py` | exit 0 — 17 passed |
| `pytest` over 5 related map-runner files (provenance, reactivity, preflight, utils, run-config) | exit 0 — 165 passed |

Smoke evidence (real config type, no campaign): `metric_affecting_run_config(RobotSimulationConfig())`
returns `scan_noise=[0.005, 0.002]`, `scan_noise_enabled=true`, `regime=terminate_on_contact`,
`peds_have_static_obstacle_forces=true`, `peds_have_robot_repulsion=true` — confirming the manifest is
populated with the real run config, not a placeholder. The `run_map_batch` integration tests (in the
165-passed set) exercise the representative-config path against real scenarios.

## Evidence grade

`smoke evidence` + focused serialization/schema tests. No metric is redefined and no benchmark claim is
promoted — this is provenance/serialization only.

## Downstream Propagation

- **Parent issue**: #3701 (closed by this PR).
- **Claim map / benchmark report / leaderboard / registry**: NA — no metric or claim changes; this only
  adds descriptive provenance to the existing manifest, so downstream evidence surfaces are unaffected.
- **Context index / memory note**: NA — no new durable evidence artifact promoted.
- **Schema**: the block carries an inline `schema: metric_affecting_run_config.v1` tag for future
  readers; no JSON Schema file was added (the manifest already embeds free-form provenance sub-blocks).

## Research Result Guidance

NA — support/provenance change, no research claim. Target is evidence hygiene (self-describing
results), not a new benchmark result.

## Out of scope (explicit)

- **No full benchmark campaign run.**
- **No Slurm/GPU submission.**
- **No paper/dissertation claim edits.**
- No metric redefinition, no normalization changes, no claim promotion.

## Residual risk

- The collision regime defaults to `terminate_on_contact`, which is correct for the current robot
  benchmark env contract (`RobotState.is_terminal`). If a future path adds a true bounce-back/respawn
  benchmark mode, callers must pass `collision_regime=COLLISION_REGIME_BOUNCE_BACK` so the recorded
  regime stays accurate (the constant and `ValueError` guard are already provided).
- `representative_metric_affecting_config` records the first filtered scenario's config as
  representative of the batch (the benchmark uses a uniform sensor config); a future per-scenario
  `scan_noise` override would not be captured per-scenario by this batch-level block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance details to batch summaries so safety-related run settings are recorded alongside results.
  * Introduced clearer reporting for sensor noise and collision-handling settings, with a human-readable interpretation block.

* **Bug Fixes**
  * When provenance details can’t be determined, runs now continue with a `not_available` status instead of failing.
  * Improved handling of missing or unparseable configuration values so summaries remain usable.

* **Tests**
  * Added coverage for provenance recording, fallback behavior, and JSON-safe configuration handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->