### PR TITLE
fix(snqi): fail-closed SNQIWeights config validation (#3710)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed `SNQIWeights.load` / `from_dict` **raising unhandled `KeyError`s on malformed config**
+  (#3710). In `robot_sf/benchmark/snqi/types.py`, reconstructing an `SNQIWeights` from JSON used bare
+  `data["key"]` access (so a missing provenance field surfaced as an opaque `KeyError`) and never
+  validated the weights mapping values. Loading now **fails closed with structured diagnostics**:
+  non-mapping input, missing or non-string required metadata fields, a non-mapping `bootstrap_params`,
+  a non-list `components`, and weight values that are non-numeric, non-finite, or negative each raise a
+  descriptive `ValueError` naming the offending field and the source path. Invalid JSON is also
+  wrapped in a `ValueError` that includes the file path. This is bounded to input validation — SNQI
+  metric definitions, weights, normalization, and benchmark results are unchanged.
 * Fixed differential-drive velocity updates **ignoring timestep scaling** (#3711). In
   `DifferentialDriveMotion._robot_velocity` the commanded acceleration (clipped to
   `max_linear_accel` / `max_angular_accel`, the follow-up to #3666/#3689) was applied directly as a

--- a/robot_sf/benchmark/snqi/types.py
+++ b/robot_sf/benchmark/snqi/types.py
@@ -3,9 +3,68 @@
 from __future__ import annotations
 
 import json
+import math
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
+
+# Provenance metadata fields that must be present (and string-typed) for a
+# weights config to be considered well-formed. These mirror the dataclass
+# fields written by ``SNQIWeights.to_dict`` / the recompute CLI.
+_REQUIRED_META_FIELDS: tuple[str, ...] = (
+    "weights_version",
+    "created_at",
+    "git_sha",
+    "baseline_stats_path",
+    "baseline_stats_hash",
+    "normalization_strategy",
+)
+
+
+def _validate_weight_values(weights: object, *, source: str) -> dict[str, float]:
+    """Validate a weights mapping holds finite, non-negative numeric values.
+
+    The ``SNQIWeights.weights`` container is a generic ``component -> weight``
+    mapping, so this helper deliberately does not require a fixed key set (the
+    canonical ``WEIGHT_NAMES`` completeness check lives in
+    ``robot_sf.benchmark.snqi.weights_validation`` for the recompute path). It
+    only enforces that every supplied value is a usable weight, casting it to
+    ``float`` so downstream consumers never receive a malformed value.
+
+    Args:
+        weights: Candidate weights mapping loaded from untrusted JSON/config.
+        source: Human-readable origin (file path or ``"<dict>"``) used in error
+            messages so failures are diagnosable.
+
+    Returns:
+        A new ``dict[str, float]`` with all values validated and cast to float.
+
+    Raises:
+        ValueError: If ``weights`` is not a mapping or holds a value that is not
+            a finite, non-negative number.
+    """
+    if not isinstance(weights, Mapping):
+        raise ValueError(
+            f"SNQIWeights 'weights' must be a mapping, got {type(weights).__name__} "
+            f"(source: {source})"
+        )
+    validated: dict[str, float] = {}
+    for name, value in weights.items():
+        # Reject bools explicitly: bool is an int subclass and float(True) == 1.0
+        # would silently coerce a clearly malformed value.
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise ValueError(
+                f"SNQIWeights weight '{name}' is not numeric: {value!r} (source: {source})"
+            )
+        fv = float(value)
+        if not math.isfinite(fv) or fv < 0:
+            raise ValueError(
+                f"SNQIWeights weight '{name}' must be finite and non-negative, "
+                f"got {fv} (source: {source})"
+            )
+        validated[name] = fv
+    return validated
 
 
 @dataclass(slots=True)
@@ -61,12 +120,62 @@ class SNQIWeights:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> SNQIWeights:
-        """Create from dict (e.g., loaded from JSON).
+    def from_dict(cls, data: dict[str, Any], *, source: str = "<dict>") -> SNQIWeights:
+        """Create from dict (e.g., loaded from JSON), failing closed on bad input.
+
+        Required provenance metadata must be present and string-typed, and every
+        weight value must be a finite, non-negative number. Malformed input
+        raises a descriptive ``ValueError`` instead of a bare ``KeyError`` or a
+        silently-coerced value, so callers can surface an actionable diagnostic.
+
+        Args:
+            data: Parsed mapping (typically from JSON).
+            source: Human-readable origin (file path or ``"<dict>"``) included in
+                error messages for diagnosability.
 
         Returns:
             SNQIWeights instance reconstructed from dictionary data.
+
+        Raises:
+            ValueError: If ``data`` is not a mapping, a required metadata field is
+                missing or not a string, or any optional field has the wrong type
+                or an invalid weight value.
         """
+        if not isinstance(data, Mapping):
+            raise ValueError(
+                f"SNQIWeights config must be a JSON object/mapping, "
+                f"got {type(data).__name__} (source: {source})"
+            )
+
+        missing = [key for key in _REQUIRED_META_FIELDS if key not in data]
+        if missing:
+            raise ValueError(
+                f"SNQIWeights config is missing required field(s): {missing} (source: {source})"
+            )
+        for key in _REQUIRED_META_FIELDS:
+            value = data[key]
+            if not isinstance(value, str):
+                raise ValueError(
+                    f"SNQIWeights field '{key}' must be a string, "
+                    f"got {type(value).__name__} (source: {source})"
+                )
+
+        bootstrap_params = data.get("bootstrap_params", {})
+        if not isinstance(bootstrap_params, Mapping):
+            raise ValueError(
+                f"SNQIWeights 'bootstrap_params' must be a mapping, "
+                f"got {type(bootstrap_params).__name__} (source: {source})"
+            )
+
+        components = data.get("components", [])
+        if not isinstance(components, list):
+            raise ValueError(
+                f"SNQIWeights 'components' must be a list, "
+                f"got {type(components).__name__} (source: {source})"
+            )
+
+        weights = _validate_weight_values(data.get("weights", {}), source=source)
+
         return cls(
             weights_version=data["weights_version"],
             created_at=data["created_at"],
@@ -74,9 +183,9 @@ class SNQIWeights:
             baseline_stats_path=data["baseline_stats_path"],
             baseline_stats_hash=data["baseline_stats_hash"],
             normalization_strategy=data["normalization_strategy"],
-            bootstrap_params=data.get("bootstrap_params", {}),
-            components=data.get("components", []),
-            weights=data.get("weights", {}),
+            bootstrap_params=dict(bootstrap_params),
+            components=list(components),
+            weights=weights,
         )
 
     def save(self, path: Path | str) -> None:
@@ -89,15 +198,25 @@ class SNQIWeights:
 
     @classmethod
     def load(cls, path: Path | str) -> SNQIWeights:
-        """Load weights from JSON file.
+        """Load weights from JSON file, failing closed on malformed content.
 
         Returns:
             SNQIWeights instance loaded from the JSON file.
+
+        Raises:
+            ValueError: If the file is not valid JSON or the parsed config fails
+                the :meth:`from_dict` validation contract. The originating path is
+                included in the error message for diagnosability.
         """
         path = Path(path)
         with path.open(encoding="utf-8") as f:
-            data = json.load(f)
-        return cls.from_dict(data)
+            try:
+                data = json.load(f)
+            except json.JSONDecodeError as e:
+                raise ValueError(
+                    f"SNQIWeights config is not valid JSON (source: {path}): {e}"
+                ) from e
+        return cls.from_dict(data, source=str(path))
 
 
 __all__ = ["SNQIWeights"]

--- a/tests/benchmark/test_snqi_weights_load_validation.py
+++ b/tests/benchmark/test_snqi_weights_load_validation.py
@@ -1,0 +1,155 @@
+"""Fail-closed validation regressions for ``SNQIWeights`` JSON/config loading.
+
+Covers issue #3710: ``SNQIWeights.load`` / ``from_dict`` previously raised bare
+``KeyError`` on missing provenance metadata and silently accepted malformed
+weight values. These tests pin the descriptive, fail-closed contract.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+
+from robot_sf.benchmark.snqi.types import SNQIWeights
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _valid_payload() -> dict[str, object]:
+    """Return a minimal well-formed SNQIWeights mapping."""
+    return {
+        "weights_version": "v1",
+        "created_at": "2026-01-01T00:00:00",
+        "git_sha": "abc123",
+        "baseline_stats_path": "baseline.json",
+        "baseline_stats_hash": "deadbeef",
+        "normalization_strategy": "median_p95_clamp",
+        "bootstrap_params": {"method": "balanced", "seed": 7},
+        "components": ["w_success", "w_time"],
+        "weights": {"w_success": 1.0, "w_time": 0.8},
+    }
+
+
+def test_from_dict_round_trips_valid_payload() -> None:
+    """A well-formed mapping reconstructs without error and coerces weights to float."""
+    weights = SNQIWeights.from_dict(_valid_payload())
+
+    assert weights.weights_version == "v1"
+    assert weights.bootstrap_params == {"method": "balanced", "seed": 7}
+    assert weights.components == ["w_success", "w_time"]
+    assert weights.weights == {"w_success": 1.0, "w_time": 0.8}
+    assert all(isinstance(v, float) for v in weights.weights.values())
+
+
+def test_from_dict_rejects_non_mapping() -> None:
+    """A JSON array (or any non-mapping) fails closed with a descriptive error."""
+    with pytest.raises(ValueError, match="must be a JSON object/mapping"):
+        SNQIWeights.from_dict(["not", "a", "mapping"])  # type: ignore[arg-type]
+
+
+def test_from_dict_missing_required_metadata_lists_keys() -> None:
+    """Missing provenance metadata raises ValueError naming the absent keys (not KeyError)."""
+    payload = _valid_payload()
+    del payload["git_sha"]
+    del payload["baseline_stats_hash"]
+
+    with pytest.raises(ValueError, match="missing required field") as exc_info:
+        SNQIWeights.from_dict(payload)
+
+    message = str(exc_info.value)
+    assert "git_sha" in message
+    assert "baseline_stats_hash" in message
+
+
+def test_from_dict_rejects_non_string_metadata() -> None:
+    """Non-string provenance metadata fails closed with a descriptive error."""
+    payload = _valid_payload()
+    payload["weights_version"] = 123
+
+    with pytest.raises(ValueError, match="'weights_version' must be a string"):
+        SNQIWeights.from_dict(payload)
+
+
+@pytest.mark.parametrize("bad_weight", [-1.0, float("nan"), float("inf")])
+def test_from_dict_rejects_non_finite_or_negative_weights(bad_weight: float) -> None:
+    """Negative or non-finite weight values fail closed."""
+    payload = _valid_payload()
+    payload["weights"] = {"w_success": bad_weight}
+
+    with pytest.raises(ValueError, match="finite and non-negative"):
+        SNQIWeights.from_dict(payload)
+
+
+@pytest.mark.parametrize("bad_weight", ["1.0", None, True])
+def test_from_dict_rejects_non_numeric_weights(bad_weight: object) -> None:
+    """Non-numeric weight values (including bools) fail closed."""
+    payload = _valid_payload()
+    payload["weights"] = {"w_success": bad_weight}
+
+    with pytest.raises(ValueError, match="is not numeric"):
+        SNQIWeights.from_dict(payload)
+
+
+def test_from_dict_rejects_non_mapping_weights() -> None:
+    """A weights field that is not a mapping fails closed."""
+    payload = _valid_payload()
+    payload["weights"] = ["w_success", 1.0]
+
+    with pytest.raises(ValueError, match="'weights' must be a mapping"):
+        SNQIWeights.from_dict(payload)
+
+
+def test_from_dict_rejects_non_mapping_bootstrap_params() -> None:
+    """A bootstrap_params field that is not a mapping fails closed."""
+    payload = _valid_payload()
+    payload["bootstrap_params"] = ["not", "a", "mapping"]
+
+    with pytest.raises(ValueError, match="'bootstrap_params' must be a mapping"):
+        SNQIWeights.from_dict(payload)
+
+
+def test_from_dict_rejects_non_list_components() -> None:
+    """A components field that is not a list fails closed."""
+    payload = _valid_payload()
+    payload["components"] = "w_success"
+
+    with pytest.raises(ValueError, match="'components' must be a list"):
+        SNQIWeights.from_dict(payload)
+
+
+def test_load_round_trips_saved_file(tmp_path: Path) -> None:
+    """save() output reloads cleanly through load()."""
+    path = tmp_path / "weights.json"
+    SNQIWeights.from_dict(_valid_payload()).save(path)
+
+    reloaded = SNQIWeights.load(path)
+
+    assert reloaded.weights_version == "v1"
+    assert reloaded.weights == {"w_success": 1.0, "w_time": 0.8}
+
+
+def test_load_invalid_json_includes_path(tmp_path: Path) -> None:
+    """Malformed JSON fails closed with the source path in the message."""
+    path = tmp_path / "broken.json"
+    path.write_text("{not valid json", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="not valid JSON") as exc_info:
+        SNQIWeights.load(path)
+
+    assert str(path) in str(exc_info.value)
+
+
+def test_load_malformed_config_includes_path(tmp_path: Path) -> None:
+    """A structurally-invalid config surfaces the originating file path."""
+    path = tmp_path / "missing_keys.json"
+    payload = _valid_payload()
+    del payload["weights_version"]
+    path.write_text(json.dumps(payload), encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required field") as exc_info:
+        SNQIWeights.load(path)
+
+    assert str(path) in str(exc_info.value)


### PR DESCRIPTION
## Summary

Fixes #3710. `SNQIWeights.load` / `from_dict` in `robot_sf/benchmark/snqi/types.py` previously raised opaque `KeyError`s on missing provenance metadata and silently accepted malformed weight values. Loading now **fails closed with structured diagnostics**.

## Scope

In scope (per ready-queue objective — fail-closed input validation only):

- `from_dict` rejects non-mapping config input with a descriptive `ValueError`.
- Missing required provenance metadata (`weights_version`, `created_at`, `git_sha`, `baseline_stats_path`, `baseline_stats_hash`, `normalization_strategy`) raises a `ValueError` listing the absent keys instead of a bare `KeyError`; non-string metadata is also rejected.
- `bootstrap_params` must be a mapping; `components` must be a list.
- Weight values are validated as finite, non-negative numbers and cast to `float`; non-numeric values (including bools) and `NaN`/`inf`/negative values fail closed.
- `load` wraps invalid JSON in a `ValueError` and includes the originating file path in error messages for diagnosability.

Reused the module's existing `ValueError`-with-descriptive-message convention (matching `snqi/schema.py` and `snqi/weights_validation.py`). Per-value validation is local to the generic `SNQIWeights.weights` container and deliberately does **not** impose the `WEIGHT_NAMES` completeness check (that canonical, recompute-path check stays in `weights_validation.py`), preserving subset/`components`-filtered weight maps.

## Out of scope

- No change to SNQI metric definitions, weights, normalization strategy, or benchmark results/claims.
- No full benchmark campaign run, no Slurm/GPU submission.
- No paper/dissertation claim edits.
- The recomputation CLI tools are unchanged (issue marked them out of scope).

## Validation

Run from the issue worktree via the shared venv (`scripts/dev/run_worktree_shared_venv.sh`):

- `pytest tests/benchmark/test_snqi_weights_load_validation.py tests/benchmark/test_snqi_cli_failure_logging.py tests/test_snqi_cli_method_aliases.py -q` → **30 passed** (12 new regression tests + existing SNQI CLI suites unaffected).
- `ruff check robot_sf/benchmark/snqi/types.py tests/benchmark/test_snqi_weights_load_validation.py` → All checks passed.
- `ruff format --check` (same files) → already formatted.
- `python scripts/tools/sync_ai_config.py --check` → 7 symlinks validated (no AI config drift).

Evidence tier: smoke / focused regression (matches the issue's `evidence_tier: smoke`). No benchmark execution required for input-validation hardening.

## Downstream Propagation

- Parent issue: #3710 (this PR).
- `CHANGELOG.md`: updated under `Fixed`.
- No claim map / leaderboard / registry / config index impact (no metric or schema semantics changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
