### PR TITLE
fix(training): recurse Tuple space compatibility under strict type checks (#3709)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed `_spaces_compatible` **rejecting wrapper- or subclass-derived `Tuple` spaces** under strict
+  top-level type checking (#3709). In `robot_sf/training/scenario_sampling.py`, the helper opened with
+  `type(base) is not type(other)`, so a `gymnasium.spaces.Tuple` and a Tuple subclass (as produced by
+  some vectorized-env wrappers/adapters) were reported incompatible even when their element spaces
+  matched. Two `Tuple`-compatible spaces are now compared **structurally on their child spaces** while
+  every other space family keeps the strict type check, so `Box`/`Dict`/`Discrete` comparison
+  semantics are unchanged. The recursive child checks (length, per-element compatibility, Tuple
+  vs. non-Tuple) still reject genuine mismatches.
 * Fixed `SNQIWeights.load` / `from_dict` **raising unhandled `KeyError`s on malformed config**
   (#3710). In `robot_sf/benchmark/snqi/types.py`, reconstructing an `SNQIWeights` from JSON used bare
   `data["key"]` access (so a missing provenance field surfaced as an opaque `KeyError`) and never

--- a/robot_sf/training/scenario_sampling.py
+++ b/robot_sf/training/scenario_sampling.py
@@ -35,7 +35,13 @@ def _spaces_compatible(  # noqa: C901
     allow_box_bounds_mismatch: bool,
 ) -> bool:
     """Return whether two spaces can safely share one vectorized env contract."""
-    if type(base) is not type(other):
+    # Tuple spaces are often re-created by wrappers or subclassed by vectorized-env
+    # adapters, so their concrete type can differ even when the element spaces match.
+    # Compare such Tuple-compatible spaces structurally on their child spaces instead
+    # of rejecting them on strict top-level type identity. All other space families
+    # keep the strict type check so Box/Dict/Discrete semantics are unchanged.
+    both_tuple = isinstance(base, spaces.Tuple) and isinstance(other, spaces.Tuple)
+    if not both_tuple and type(base) is not type(other):
         return False
     if isinstance(base, spaces.Box):
         if base.shape != other.shape or np.dtype(base.dtype) != np.dtype(other.dtype):

--- a/tests/training/test_scenario_sampling.py
+++ b/tests/training/test_scenario_sampling.py
@@ -82,6 +82,46 @@ def test_spaces_compatible_rejects_tuple_length_mismatch() -> None:
     assert _spaces_compatible(base, other, allow_box_bounds_mismatch=True) is False
 
 
+class _WrappedTuple(spaces.Tuple):
+    """Tuple subclass standing in for wrapper/adapter-derived Tuple spaces."""
+
+
+def test_spaces_compatible_tuple_subclass_recurses_on_children() -> None:
+    """Tuple subclasses with matching children should be compatible (issue #3709)."""
+    children = (
+        spaces.Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32),
+        spaces.Discrete(3),
+    )
+    base = spaces.Tuple(children)
+    wrapped = _WrappedTuple(children)
+    # Both directions must hold despite the strict top-level type difference.
+    assert _spaces_compatible(base, wrapped, allow_box_bounds_mismatch=False) is True
+    assert _spaces_compatible(wrapped, base, allow_box_bounds_mismatch=False) is True
+    assert _spaces_compatible(wrapped, wrapped, allow_box_bounds_mismatch=False) is True
+
+
+def test_spaces_compatible_tuple_subclass_still_checks_children() -> None:
+    """Tuple recursion must still reject mismatched child spaces, lengths, and non-Tuples."""
+    base = spaces.Tuple(
+        (spaces.Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32), spaces.Discrete(3))
+    )
+    mismatched_child = _WrappedTuple(
+        (spaces.Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32), spaces.Discrete(4))
+    )
+    shorter = _WrappedTuple((spaces.Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32),))
+    assert _spaces_compatible(base, mismatched_child, allow_box_bounds_mismatch=False) is False
+    assert _spaces_compatible(base, shorter, allow_box_bounds_mismatch=False) is False
+    # A Tuple is never compatible with a non-Tuple space.
+    assert (
+        _spaces_compatible(
+            base,
+            spaces.Box(low=0.0, high=1.0, shape=(2,), dtype=np.float32),
+            allow_box_bounds_mismatch=False,
+        )
+        is False
+    )
+
+
 def test_scenario_sampler_cycles_and_filters() -> None:
     """Sampler should honor include filters and cycle strategy."""
     sampler = ScenarioSampler(


### PR DESCRIPTION
## Summary

Fixes #3709. `_spaces_compatible` in `robot_sf/training/scenario_sampling.py` opened with a strict
`type(base) is not type(other)` gate, so a `gymnasium.spaces.Tuple` and a wrapper-/subclass-derived
Tuple (as produced by some vectorized-env adapters) were reported **incompatible even when their
element spaces matched**. This could block wrapped benchmark/training environments with false
incompatibilities.

Two `Tuple`-compatible spaces are now compared **structurally on their child spaces**; every other
space family keeps the strict top-level type check, so **Box / Dict / Discrete comparison semantics
are unchanged**. The existing recursive child checks (length, per-element compatibility, Tuple
vs. non-Tuple) still reject genuine mismatches.

## Scope

- In scope: relax only the top-level type gate for `Tuple` spaces so matching children recurse.
- Out of scope (unchanged): Box / Dict / Discrete / MultiDiscrete / MultiBinary comparison semantics.
- Change: 1 guard line + comment in `_spaces_compatible`; 2 new focused regression tests; CHANGELOG.

## Definition of Done

- [x] Compatibility check passes for subclass-derived / wrapped Tuple spaces when elements match.

## Validation

All run from the issue worktree against the shared `.venv`:

- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/training/test_scenario_sampling.py -q`
  → **10 passed** (includes 2 new Tuple-subclass tests).
- Right-reason check: with the source fix stashed, `test_spaces_compatible_tuple_subclass_recurses_on_children`
  **fails** (strict type identity rejects the subclass); restored → passes.
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/training/test_train_dreamerv3_rllib_runtime.py -q`
  → **11 passed** (other `_spaces_compatible` consumer, no regression).
- `uv run ruff check` + `ruff format --check` on both changed files → clean.

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream Propagation

- Parent issue: #3709 (this PR).
- Claim map / leaderboard / registry / config index: NA — internal env-contract compatibility helper,
  no metric, schema, or benchmark-evidence change.

## Research Result Guidance

`NA - support helper`: bugfix to an internal space-compatibility check; no research claim, comparator,
or benchmark evidence is asserted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility checks for tuple-based spaces, including tuple wrappers and subclasses, so matching child spaces are now handled correctly.
  * Preserved strict compatibility behavior for other space types.

* **Documentation**
  * Updated the changelog to note the tuple-space compatibility fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->