### PR TITLE
fix(baselines): SAC velocity action space honors action_semantics (#3705)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed the **SAC baseline velocity action space ignoring `action_semantics`** when converting model
+  output to benchmark commands (#3705). In `robot_sf/baselines/sac.py`, `_action_vec_to_dict` always
+  scaled the `velocity` (`vx`, `vy`) output vector to `v_max`, even when `action_semantics="delta"`.
+  Deltas are increments the env later accumulates (`new_v = old_v + delta`) and are already bounded by
+  the SAC action space, so scaling them toward `v_max` distorted the accumulated trajectory. The
+  velocity branch now mirrors the existing unicycle contract: the speed cap is applied only for the
+  absolute-velocity contract, while delta increments pass through unchanged. Behavior for the
+  `unicycle` action space (the current benchmark config default) is unchanged; the default
+  `action_semantics="delta"` is intentionally preserved per the canonical training setting.
 * Fixed `SNQIWeights.load` / `from_dict` **raising unhandled `KeyError`s on malformed config**
   (#3710). In `robot_sf/benchmark/snqi/types.py`, reconstructing an `SNQIWeights` from JSON used bare
   `data["key"]` access (so a missing provenance field surfaced as an opaque `KeyError`) and never

--- a/robot_sf/baselines/sac.py
+++ b/robot_sf/baselines/sac.py
@@ -484,11 +484,17 @@ class SACPlanner:
             return {"v": v, "omega": w}
         vx = float(act[0]) if act.size >= 1 else 0.0
         vy = float(act[1]) if act.size >= 2 else 0.0
-        speed = float(np.hypot(vx, vy))
-        if speed > self.config.v_max and speed > self.EPS:
-            scale = self.config.v_max / (speed + self.EPS)
-            vx *= scale
-            vy *= scale
+        # Mirror the unicycle branch: only the absolute-velocity contract is
+        # clamped to the configured speed cap. Delta actions are increments the
+        # env later accumulates (new_v = old_v + delta) and are already bounded
+        # by the SAC action space, so scaling them toward v_max would distort the
+        # accumulated trajectory.
+        if str(self.config.action_semantics).strip().lower() != "delta":
+            speed = float(np.hypot(vx, vy))
+            if speed > self.config.v_max and speed > self.EPS:
+                scale = self.config.v_max / (speed + self.EPS)
+                vx *= scale
+                vy *= scale
         return {"vx": vx, "vy": vy}
 
     def _fallback_action(self, obs: Observation) -> dict[str, float]:

--- a/tests/baselines/test_sac_planner.py
+++ b/tests/baselines/test_sac_planner.py
@@ -235,6 +235,57 @@ def test_step_vector_mode_uses_model_prediction_and_fallback_action(
     assert fallback["omega"] == pytest.approx(0.7853981633974483)
 
 
+def _velocity_planner(action_semantics: str, *, v_max: float = 2.0) -> SACPlanner:
+    """Build a fallback SAC planner in the velocity action space (issue #3705).
+
+    The model is left unloaded; tests exercise ``_action_vec_to_dict`` directly
+    so the conversion contract is checked independently of model inference.
+    """
+    planner = SACPlanner(
+        {
+            "model_path": "model/does_not_exist_sac.zip",
+            "action_space": "velocity",
+            "action_semantics": action_semantics,
+            "v_max": v_max,
+            "fallback_to_goal": True,
+        }
+    )
+    planner._model = None
+    return planner
+
+
+def test_velocity_absolute_semantics_scales_speed_to_v_max() -> None:
+    """Absolute velocity outputs above v_max are scaled to the configured cap (issue #3705)."""
+    planner = _velocity_planner("absolute", v_max=2.0)
+    # Raw speed = hypot(3.0, 4.0) = 5.0 > v_max=2.0, so the vector is scaled to magnitude 2.0.
+    action = planner._action_vec_to_dict(np.array([3.0, 4.0], dtype=float))
+    speed = float(np.hypot(action["vx"], action["vy"]))
+    assert speed == pytest.approx(2.0)
+    # Direction is preserved while only the magnitude is clamped.
+    assert action["vx"] == pytest.approx(3.0 / 5.0 * 2.0)
+    assert action["vy"] == pytest.approx(4.0 / 5.0 * 2.0)
+
+
+def test_velocity_absolute_semantics_passes_through_within_bounds() -> None:
+    """Absolute velocity outputs already within v_max are returned unchanged (issue #3705)."""
+    planner = _velocity_planner("absolute", v_max=2.0)
+    action = planner._action_vec_to_dict(np.array([0.25, -0.5], dtype=float))
+    assert action == {"vx": pytest.approx(0.25), "vy": pytest.approx(-0.5)}
+
+
+def test_velocity_delta_semantics_are_not_scaled() -> None:
+    """Delta velocity increments must not be scaled toward v_max (issue #3705).
+
+    Deltas are increments the env accumulates (``new_v = old_v + delta``) and are
+    already bounded by the SAC action space; scaling them would distort the
+    accumulated trajectory, mirroring the unicycle delta contract.
+    """
+    planner = _velocity_planner("delta", v_max=2.0)
+    # Raw speed = 5.0 > v_max, but delta semantics must leave the increment intact.
+    action = planner._action_vec_to_dict(np.array([3.0, 4.0], dtype=float))
+    assert action == {"vx": pytest.approx(3.0), "vy": pytest.approx(4.0)}
+
+
 def test_step_dict_mode_applies_transform_and_aliases(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## Summary

Fixes #3705. The SAC baseline adapter's `_action_vec_to_dict`
(`robot_sf/baselines/sac.py`) honored `action_semantics` only for the
`unicycle` action space. For the `velocity` action space it **always** scaled
the `(vx, vy)` output vector to `v_max`, ignoring `action_semantics` entirely.

Under `action_semantics="delta"` this is incorrect: delta outputs are
increments the env later accumulates (`new_v = old_v + delta`) and are already
bounded by the SAC action space, so scaling them toward `v_max` distorts the
accumulated trajectory — the same defect the unicycle branch was previously
fixed for. The velocity branch now mirrors the unicycle contract: the speed cap
is applied only for the absolute-velocity contract; delta increments pass
through unchanged.

This directly addresses the issue's Definition of Done — semantics now align
with the action space and clamping is applied only where it is correct — and the
success metric: correct absolute velocities are produced when absolute
semantics are configured.

### Scope

- In scope: the smallest SAC action-conversion/default-semantics fix so
  configured absolute velocity semantics clamp/scale correctly, and delta
  semantics are not corrupted.
- Default `action_semantics="delta"` is **intentionally preserved** — it is the
  canonical training setting (`scripts/training/train_sac_sb3.py`,
  `_DEFAULT_ACTION_SEMANTICS = "delta"`) and the `unicycle` benchmark config
  relies on the native-bypass delta path. Flipping the default would be a broad
  semantic/benchmark change and is out of scope.
- `unicycle` action-space behavior is unchanged.

## Changes

- `robot_sf/baselines/sac.py` — velocity branch of `_action_vec_to_dict` applies
  the `v_max` speed cap only when `action_semantics != "delta"`.
- `tests/baselines/test_sac_planner.py` — three focused unit tests: velocity
  absolute scaling to `v_max`, absolute in-bounds passthrough, delta passthrough
  (no scaling).
- `CHANGELOG.md` — Fixed entry.

## Validation

All run from the issue worktree via the shared-venv helper.

- `uv run pytest tests/baselines/test_sac_planner.py -q` → **16 passed**
- `uv run pytest tests/baselines/ tests/test_map_runner_sac.py -q` →
  **85 passed, 1 skipped**
- `uv run ruff check robot_sf/baselines/sac.py tests/baselines/test_sac_planner.py`
  → **All checks passed**; `ruff format` → no changes.
- Bug demonstrated: `test_velocity_delta_semantics_are_not_scaled` **fails** on
  the pre-fix `sac.py` (deltas scaled to magnitude 2.0) and **passes** after the
  fix.

## Out of scope / not run

- No full benchmark campaign run.
- No Slurm / GPU submission.
- No SAC retuning, training run, or other-baseline changes.
- No paper/dissertation claim edits.

## Downstream Propagation

Bugfix to baseline action conversion; no claim map, leaderboard, registry, or
artifact updates required. Research Result Guidance: `NA` — correctness bugfix,
no research claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
