### PR TITLE
fix(baselines): PPO dict observation backfills missing keys instead of crashing (#3704)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed the PPO baseline adapter **crashing on partial dict observations** instead of backfilling
+  missing keys (#3704). In `robot_sf/baselines/ppo.py`, `_align_model_obs_dict` previously raised
+  `ValueError: Missing required dict observation keys` whenever a runner emitted a subset of the keys
+  a checkpoint's `Dict` observation space declares (after flattening, prefix-expansion, and alias
+  resolution); this failed all 144/144 serial-worker jobs in the #3203 campaign. Missing keys are now
+  backfilled with an in-bounds default derived from the target subspace via the new
+  `_default_for_space` helper: nested `Dict` subspaces recurse so each declared leaf is materialized,
+  and leaf `Box` subspaces yield zeros **clipped to the declared low/high bounds** so a non-zero
+  lower bound (e.g. counts/radii) stays in range. The backfill is logged at debug level so the
+  substitution stays visible. Genuine shape mismatches and non-Dict payloads for nested keys still
+  raise. This keeps PPO evaluation running on partial observations; heavily backfilled runs should be
+  treated as degraded rather than faithful evidence. Gym wrapper observation spaces are unchanged.
 * Fixed `_spaces_compatible` **rejecting wrapper- or subclass-derived `Tuple` spaces** under strict
   top-level type checking (#3709). In `robot_sf/training/scenario_sampling.py`, the helper opened with
   `type(base) is not type(other)`, so a `gymnasium.spaces.Tuple` and a Tuple subclass (as produced by

--- a/robot_sf/baselines/ppo.py
+++ b/robot_sf/baselines/ppo.py
@@ -454,12 +454,20 @@ class PPOPlanner:
     ) -> dict[str, Any]:
         """Align source observation fields to a model-declared Dict space.
 
+        Keys declared by the model space but absent from ``source_obs`` (after
+        flattening, expansion, and alias resolution) are backfilled with an
+        in-bounds default derived from the target subspace rather than raising.
+        This keeps PPO evaluation running when a runner emits a subset of the
+        keys a checkpoint declares (see issue #3704); the backfill is logged so
+        the substitution stays visible, and callers should treat heavily
+        backfilled runs as degraded rather than faithful evidence.
+
         Returns:
             Dict payload shaped and typed to match the model-declared subspaces.
         """
 
         converted: dict[str, Any] = {}
-        missing: list[str] = []
+        backfilled: list[str] = []
         aliases: dict[str, tuple[str, ...]] = {
             "robot_speed": ("robot_velocity_xy",),
             "robot_velocity_xy": ("robot_speed",),
@@ -467,7 +475,8 @@ class PPOPlanner:
         for key, sub_space in spaces.items():
             source = self._resolve_dict_observation_source(source_obs, str(key), aliases)
             if source is None:
-                missing.append(str(key))
+                converted[key] = self._default_for_space(sub_space)
+                backfilled.append(str(key))
                 continue
             sub_spaces = getattr(sub_space, "spaces", None)
             if isinstance(sub_spaces, dict):
@@ -490,10 +499,42 @@ class PPOPlanner:
                     )
                 arr = arr.reshape(target_shape)
             converted[key] = arr
-        if missing:
-            missing_preview = ", ".join(missing[:6])
-            raise ValueError(f"Missing required dict observation keys: {missing_preview}")
+        if backfilled:
+            logger.debug(
+                "PPO dict observation backfilled {} missing key(s) with space defaults: {}",
+                len(backfilled),
+                ", ".join(backfilled[:6]),
+            )
         return converted
+
+    @classmethod
+    def _default_for_space(cls, sub_space: Any) -> Any:
+        """Build an in-bounds default payload for a missing model observation key.
+
+        Nested Dict subspaces recurse so each declared leaf is materialized;
+        leaf Box subspaces yield zeros clipped to the (finite) box bounds, so the
+        default never falls outside a declared low/high range. Unknown subspace
+        types fall back to a zero array matching the declared shape.
+
+        Returns:
+            A nested dict, or an ``np.ndarray`` default for the subspace.
+        """
+
+        sub_spaces = getattr(sub_space, "spaces", None)
+        if isinstance(sub_spaces, dict):
+            return {str(key): cls._default_for_space(leaf) for key, leaf in sub_spaces.items()}
+
+        target_shape = getattr(sub_space, "shape", None)
+        target_dtype = getattr(sub_space, "dtype", None) or np.float32
+        shape = tuple(target_shape) if target_shape is not None else ()
+        default = np.zeros(shape, dtype=target_dtype)
+        low = getattr(sub_space, "low", None)
+        high = getattr(sub_space, "high", None)
+        if low is not None and high is not None:
+            # Clip the zero default into the declared range so a non-zero lower
+            # bound (e.g. counts/radii bounded away from 0) stays in-bounds.
+            default = np.clip(default, low, high).astype(target_dtype)
+        return default
 
     @staticmethod
     def _resolve_dict_observation_source(

--- a/tests/baselines/test_ppo_planner.py
+++ b/tests/baselines/test_ppo_planner.py
@@ -195,16 +195,22 @@ def test_bind_env_rejects_flat_box_checkpoint_shape_mismatch() -> None:
         )
 
 
-def test_build_model_obs_dict_raises_on_missing_key():
-    """Planner should fail when required dict keys are missing."""
+def test_build_model_obs_dict_backfills_missing_key():
+    """Planner should backfill missing dict keys with space defaults, not crash (#3704)."""
     planner = PPOPlanner(_planner_config(obs_mode="dict"))
     planner._model = SimpleNamespace(
         observation_space=SimpleNamespace(
             spaces={"required": SimpleNamespace(shape=(1,), dtype=np.float32)},
         ),
     )
-    with pytest.raises(ValueError, match="Missing required dict observation keys"):
-        planner._build_model_obs_dict({"other": [1.0]})
+
+    converted = planner._build_model_obs_dict({"other": [1.0]})
+
+    # The declared key is materialized with an in-bounds (zero) default instead
+    # of raising ValueError, so PPO evaluation keeps running on partial obs.
+    assert "required" in converted
+    np.testing.assert_allclose(converted["required"], [0.0])
+    assert converted["required"].shape == (1,)
 
 
 def test_build_model_obs_dict_backfills_predictive_features(monkeypatch):

--- a/tests/test_baseline_ppo_observation_keys.py
+++ b/tests/test_baseline_ppo_observation_keys.py
@@ -34,6 +34,11 @@ def _box(shape: tuple[int, ...]) -> gym_spaces.Box:
     return gym_spaces.Box(low=-np.inf, high=np.inf, shape=shape, dtype=np.float32)
 
 
+def _bounded_box(shape: tuple[int, ...], low: float, high: float) -> gym_spaces.Box:
+    """Return a float32 Box leaf with explicit finite bounds for backfill tests."""
+    return gym_spaces.Box(low=low, high=high, shape=shape, dtype=np.float32)
+
+
 def _planner_with_model(model: _FakePPOModel) -> PPOPlanner:
     """Build a PPOPlanner with a fake loaded model and no checkpoint IO."""
     planner = PPOPlanner.__new__(PPOPlanner)
@@ -127,3 +132,102 @@ def test_ppo_dict_obs_keeps_nested_env_obs_compatible_with_flat_model_space() ->
     }
     np.testing.assert_allclose(model.last_obs["robot_position"], [1.0, 2.0])
     np.testing.assert_allclose(model.last_obs["goal_current"], [4.0, 5.0])
+
+
+def test_ppo_dict_obs_backfills_missing_leaf_key_with_space_default() -> None:
+    """A missing leaf inside a nested block is backfilled instead of crashing (#3704)."""
+    model = _FakePPOModel(
+        gym_spaces.Dict(
+            {
+                "robot": gym_spaces.Dict(
+                    {
+                        "position": _box((2,)),
+                        "velocity": _box((2,)),
+                    }
+                ),
+                "goal": gym_spaces.Dict({"current": _box((2,))}),
+            }
+        )
+    )
+    planner = _planner_with_model(model)
+    # Runner only emits robot_position and goal_current; robot_velocity is absent.
+    partial_obs = {
+        "robot_position": np.array([1.0, 2.0], dtype=np.float32),
+        "goal_current": np.array([4.0, 5.0], dtype=np.float32),
+    }
+
+    action = planner.step(partial_obs)
+
+    assert action == {"vx": pytest.approx(0.4), "vy": pytest.approx(-0.2)}
+    assert model.last_obs is not None
+    np.testing.assert_allclose(model.last_obs["robot"]["position"], [1.0, 2.0])
+    # Missing leaf backfilled with an in-bounds (zero) default for the (2,) Box.
+    np.testing.assert_allclose(model.last_obs["robot"]["velocity"], [0.0, 0.0])
+    assert model.last_obs["robot"]["velocity"].shape == (2,)
+
+
+def test_ppo_dict_obs_backfills_entire_missing_nested_block() -> None:
+    """A nested Dict block absent from the runner obs is recursively backfilled (#3704)."""
+    model = _FakePPOModel(
+        gym_spaces.Dict(
+            {
+                "robot": gym_spaces.Dict({"position": _box((2,))}),
+                "pedestrians": gym_spaces.Dict(
+                    {
+                        "positions": _box((2, 2)),
+                        "count": _box((1,)),
+                    }
+                ),
+            }
+        )
+    )
+    planner = _planner_with_model(model)
+    # The entire pedestrians block is missing from the runner observation.
+    partial_obs = {"robot_position": np.array([1.0, 2.0], dtype=np.float32)}
+
+    action = planner.step(partial_obs)
+
+    assert action == {"vx": pytest.approx(0.4), "vy": pytest.approx(-0.2)}
+    assert model.last_obs is not None
+    np.testing.assert_allclose(model.last_obs["robot"]["position"], [1.0, 2.0])
+    np.testing.assert_allclose(model.last_obs["pedestrians"]["positions"], np.zeros((2, 2)))
+    np.testing.assert_allclose(model.last_obs["pedestrians"]["count"], [0.0])
+    assert model.last_obs["pedestrians"]["positions"].shape == (2, 2)
+
+
+def test_ppo_dict_obs_backfill_respects_nonzero_lower_bound() -> None:
+    """Backfill clips the zero default into the declared box bounds (#3704)."""
+    model = _FakePPOModel(
+        gym_spaces.Dict(
+            {
+                "robot_position": _box((2,)),
+                # Lower bound above zero: a raw zero fill would be out of bounds.
+                "pedestrians_radius": _bounded_box((1,), low=0.5, high=2.0),
+            }
+        )
+    )
+    planner = _planner_with_model(model)
+    partial_obs = {"robot_position": np.array([1.0, 2.0], dtype=np.float32)}
+
+    action = planner.step(partial_obs)
+
+    assert action == {"vx": pytest.approx(0.4), "vy": pytest.approx(-0.2)}
+    assert model.last_obs is not None
+    # Clipped to the declared lower bound rather than left at an out-of-bounds 0.0.
+    np.testing.assert_allclose(model.last_obs["pedestrians_radius"], [0.5])
+
+
+def test_align_model_obs_dict_default_for_space_is_in_bounds() -> None:
+    """`_default_for_space` returns in-bounds defaults for nested and bounded spaces (#3704)."""
+    planner = _planner_with_model(_FakePPOModel(gym_spaces.Dict({"x": _box((1,))})))
+
+    nested_default = planner._default_for_space(
+        gym_spaces.Dict({"a": _box((2,)), "b": _bounded_box((1,), low=1.0, high=3.0)})
+    )
+    assert set(nested_default) == {"a", "b"}
+    np.testing.assert_allclose(nested_default["a"], [0.0, 0.0])
+    np.testing.assert_allclose(nested_default["b"], [1.0])
+
+    box_default = planner._default_for_space(_bounded_box((3,), low=-2.0, high=-0.5))
+    # Zero is above the upper bound here, so the default clips down to -0.5.
+    np.testing.assert_allclose(box_default, [-0.5, -0.5, -0.5])


### PR DESCRIPTION
## Summary

Fixes #3704. The PPO baseline adapter crashed on partial dict observations instead of backfilling missing keys.

`robot_sf/baselines/ppo.py::_align_model_obs_dict` raised `ValueError: Missing required dict observation keys` whenever a runner emitted a subset of the keys a checkpoint's `Dict` observation space declares (after flattening, prefix-expansion, and alias resolution). Per the issue, this failed **144/144** serial-worker jobs in the #3203 campaign.

## Scope

In scope (matches the issue's "In scope: Safe backfilling of missing keys in `_align_model_obs_dict`"):

- Missing keys are now backfilled with an in-bounds default derived from the target subspace, via the new `_default_for_space` helper:
  - nested `Dict` subspaces **recurse** so each declared leaf is materialized;
  - leaf `Box` subspaces yield zeros **clipped to the declared `low`/`high` bounds**, so a non-zero lower bound (e.g. pedestrian counts/radii) stays in range;
  - unknown subspace types fall back to a zero array of the declared shape.
- The backfill is **logged at debug level** so the substitution stays visible.
- Genuine shape mismatches and non-`Dict` payloads for nested keys still raise — only the missing-key path changed.

Out of scope (unchanged): Gym wrapper observation spaces; SAC adapter; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Changed files

- `robot_sf/baselines/ppo.py` — backfill missing keys in `_align_model_obs_dict`; add `_default_for_space`.
- `tests/test_baseline_ppo_observation_keys.py` — 4 new regression tests (missing-leaf backfill, whole missing nested-block backfill, non-zero lower-bound clipping, `_default_for_space` direct unit test).
- `tests/baselines/test_ppo_planner.py` — updated the prior `test_build_model_obs_dict_raises_on_missing_key` to assert the new backfill contract (renamed to `..._backfills_missing_key`).
- `CHANGELOG.md` — `Unreleased / Fixed` entry.

## Validation

All run from the issue worktree via the shared venv wrapper:

| Command | Result |
| --- | --- |
| `uv run pytest tests/test_baseline_ppo_observation_keys.py -q` | 6 passed |
| `uv run pytest tests/baselines/test_ppo_planner.py tests/test_baseline_ppo_observation_keys.py tests/test_baseline_ppo_smoke.py tests/test_map_runner_ppo.py -q` | 41 passed (pre-update) → 46 passed (post-update) |
| `uv run pytest tests/test_baseline_ppo_observation_keys.py tests/baselines/test_ppo_planner.py tests/benchmark/test_ppo_baseline_contract.py tests/benchmark/test_scenario_horizon_readiness_issue_3266.py -q` | 42 passed |
| `uv run ruff check robot_sf/baselines/ppo.py tests/test_baseline_ppo_observation_keys.py tests/baselines/test_ppo_planner.py` | All checks passed |

**Fail-without-fix check (test catches the regression):** the 4 new tests were run against the unmodified `origin/main` `ppo.py` and all 4 failed (3 with the old `ValueError`, 1 with `AttributeError` on the missing `_default_for_space`); they pass with the fix.

## Definition of Done

- [x] Mappings backfill missing keys safely.
- [x] No `ValueError` raised on partial observations.
- [x] Regression tests replicating the mismatch added.

## Residual risk

- Zero/clipped backfill keeps evaluation running but is **degraded, not faithful**: a checkpoint that genuinely depends on a missing feature will run on a default value. The new docstring/CHANGELOG state this, and a heavily backfilled run should not be treated as faithful benchmark evidence. No campaign was re-run here (out of scope); end-to-end campaign confirmation of #3203 is downstream.

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
