### PR TITLE
fix(osm-converter): parse comma-separated SVG viewBox values (#3708)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed **OSM SVG `viewBox` parsing failing on comma-separated values** in
+  `fast-pysf/pysocialforce/map_osm_converter.py` (#3708). The converter parsed the `viewBox`
+  attribute with bare `str.split()`, which only handles whitespace separators, so SVG exports using
+  the equally valid comma-delimited form (e.g. `"0,0,488.48,458.33"`) raised
+  `ValueError: could not convert string to float`. A new `parse_viewbox` helper splits on any run of
+  commas and/or whitespace per the SVG spec, and both call sites (`extract_buildings_as_obstacle` and
+  `add_scale_bar_to_root`) now use it. Whitespace-separated viewBoxes are unaffected.
 * Fixed the **SAC baseline velocity action space ignoring `action_semantics`** when converting model
   output to benchmark commands (#3705). In `robot_sf/baselines/sac.py`, `_action_vec_to_dict` always
   scaled the `velocity` (`vx`, `vy`) output vector to `v_max`, even when `action_semantics="delta"`.

--- a/fast-pysf/pysocialforce/map_osm_converter.py
+++ b/fast-pysf/pysocialforce/map_osm_converter.py
@@ -18,6 +18,26 @@ OSM_REFERENCE_SCALE = 1350  # Reference scale denominator from OSM export
 OSM_COORDINATE_ADJUSTMENT = 4.08  # Coordinate system scaling factor
 
 
+def parse_viewbox(viewbox_str: str) -> list[float]:
+    """Parse an SVG ``viewBox`` attribute into a list of floats.
+
+    Per the SVG specification, the four ``viewBox`` values (min-x, min-y, width,
+    height) may be separated by whitespace and/or commas, e.g. ``"0 0 488 458"``,
+    ``"0,0,488,458"``, or ``"0, 0, 488, 458"``. A plain ``str.split()`` only
+    handles whitespace, so comma-delimited exports raise ``ValueError`` on float
+    conversion. Splitting on any run of commas/whitespace handles every valid
+    form (see issue #3708).
+
+    Args:
+        viewbox_str (str): The raw ``viewBox`` attribute value.
+
+    Returns:
+        list[float]: The parsed numeric viewBox components.
+    """
+    tokens = re.split(r"[\s,]+", viewbox_str.strip())
+    return [float(token) for token in tokens if token]
+
+
 def extract_buildings_as_obstacle(
     map_full_name,
     building_rgb_color_str: str = "rgb(85.098039%,81.568627%,78.823529%)",
@@ -76,7 +96,7 @@ def extract_buildings_as_obstacle(
     # Copy viewBox attribute from the original root to the new root
 
     if "viewBox" in root.attrib:
-        viewbox = list(map(float, root.attrib["viewBox"].split()))
+        viewbox = parse_viewbox(root.attrib["viewBox"])
         logger.debug("Old viewBox: {}", viewbox)
         viewbox[2] *= scale_factor  # Scale the width
         viewbox[3] *= scale_factor  # Scale the height
@@ -123,7 +143,7 @@ def add_scale_bar_to_root(root: ET.Element, line_length: int = 100):
         ET.Element: The modified root element with the scale bar added.
     """
     # Get the width of the image
-    viewbox = list(map(float, root.attrib["viewBox"].split()))
+    viewbox = parse_viewbox(root.attrib["viewBox"])
     image_width = viewbox[2]
 
     # Add an alternating black and white line over the whole image width

--- a/fast-pysf/tests/test_map_osm_converter.py
+++ b/fast-pysf/tests/test_map_osm_converter.py
@@ -1,0 +1,63 @@
+"""Regression tests for OSM SVG viewBox parsing in ``map_osm_converter``.
+
+Covers issue #3708: comma-delimited (and mixed comma/whitespace) ``viewBox``
+attributes from OSM SVG exports must parse without raising ``ValueError``.
+"""
+
+import xml.etree.ElementTree as ET
+
+import pytest
+from pysocialforce.map_osm_converter import (
+    add_scale_bar_to_root,
+    extract_buildings_as_obstacle,
+    parse_viewbox,
+)
+
+
+@pytest.mark.parametrize(
+    "viewbox_str",
+    [
+        "0 0 488.48 458.33",  # whitespace separated
+        "0,0,488.48,458.33",  # comma separated (issue #3708)
+        "0, 0, 488.48, 458.33",  # mixed comma + whitespace
+        "  0 0 488.48 458.33  ",  # surrounding whitespace
+    ],
+)
+def test_parse_viewbox_separator_variants(viewbox_str):
+    """All valid SVG viewBox separator styles parse to the same floats."""
+    assert parse_viewbox(viewbox_str) == [0.0, 0.0, 488.48, 458.33]
+
+
+def _building_svg(viewbox_str: str) -> str:
+    """Minimal OSM-style SVG with one building path and a given viewBox."""
+    color = "rgb(85.098039%,81.568627%,78.823529%)"
+    return (
+        f'<svg xmlns="http://www.w3.org/2000/svg" viewBox="{viewbox_str}">'
+        f'<path style="fill:{color};" d="M 1 1 L 2 2 Z"/>'
+        "</svg>"
+    )
+
+
+@pytest.mark.parametrize(
+    "viewbox_str",
+    ["0 0 488.48 458.33", "0,0,488.48,458.33", "0, 0, 488.48, 458.33"],
+)
+def test_extract_buildings_handles_comma_viewbox(tmp_path, viewbox_str):
+    """extract_buildings_as_obstacle parses comma/whitespace viewBoxes alike."""
+    svg_path = tmp_path / "map.svg"
+    svg_path.write_text(_building_svg(viewbox_str))
+
+    new_root = extract_buildings_as_obstacle(str(svg_path))
+
+    # viewBox is scaled by the composite factor; verify it parsed and re-emitted
+    # four numeric components rather than raising on float conversion.
+    assert "viewBox" in new_root.attrib
+    assert len(parse_viewbox(new_root.attrib["viewBox"])) == 4
+
+
+def test_add_scale_bar_handles_comma_viewbox():
+    """add_scale_bar_to_root reads a comma-separated viewBox without error."""
+    root = ET.Element("svg", attrib={"viewBox": "0,0,300,200"})
+    add_scale_bar_to_root(root, line_length=100)
+    # Scale bar lines were added across the parsed image width (300).
+    assert any(child.tag == "line" for child in root)


### PR DESCRIPTION
## Summary

Fixes #3708. `fast-pysf/pysocialforce/map_osm_converter.py` parsed the SVG `viewBox`
attribute with bare `str.split()`, which only handles whitespace separators. Valid
comma-delimited viewBoxes (e.g. `"0,0,488.48,458.33"`) — an equally legal SVG form —
therefore raised `ValueError: could not convert string to float`, blocking import of
otherwise-valid OSM SVG maps.

## Changes

- Add a `parse_viewbox(viewbox_str)` helper that splits on any run of commas and/or
  whitespace per the SVG spec (`re.split(r"[\s,]+", ...)`), handling comma, whitespace,
  and mixed forms.
- Route both call sites through it: `extract_buildings_as_obstacle` and `add_scale_bar_to_root`.
- Add focused regression tests (`fast-pysf/tests/test_map_osm_converter.py`) covering the
  helper and both call sites across separator variants.
- CHANGELOG `### Fixed` entry.

## Scope

In scope: viewBox parsing in `map_osm_converter.py` + regression tests, per the issue.
Out of scope (untouched): other SVG parsing helpers in `robot_sf`.

## Validation

Run from the worktree against the local `fast-pysf` source (shared venv):

- New regression tests: `python -m pytest fast-pysf/tests/test_map_osm_converter.py -v`
  → **8 passed**.
- Full fast-pysf suite (regression check): `python -m pytest fast-pysf/tests -q`
  → **24 passed**.
- `ruff check` + `ruff format --check` on both changed files → **clean**.
- Bug reproduction on `origin/main` source confirmed the comma viewBox raised
  `ValueError: could not convert string to float: '0,0,488.48,458.33'`; the patched code
  parses it successfully (test fails-for-the-right-reason demonstrated before the fix).

## Definition of Done (issue #3708)

- [x] Parser splits by commas and/or whitespace.
- [x] Comma-separated SVG viewBoxes parse successfully.

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim
edits were performed. This is a bounded parser correctness fix validated with focused
unit/smoke tests only (smoke evidence tier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
