### PR TITLE
fix(dev): pr_ready_check resolves missing BASE_REF instead of crashing (#3702)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Fixed **`scripts/dev/pr_ready_check.sh` mishandling a missing `BASE_REF`** on fresh checkouts
+  (#3702). When the default `origin/main` (or any configured `BASE_REF`) was not present locally, the
+  `git diff "$BASE_REF...HEAD"` comparison emitted a raw `fatal: ambiguous argument` error; because the
+  command runs inside a process substitution, `set -e` silently swallowed the failure and the script
+  proceeded with an empty changed-file set while still passing the unresolved ref to the downstream
+  coverage, perf-evidence, and freshness checks. The script now resolves `BASE_REF` once up front via a
+  new `resolve_base_ref` helper: a resolvable ref is used unchanged, a remote-tracking ref (e.g.
+  `origin/main`) triggers a best-effort `git fetch`, and an otherwise-unresolvable ref falls back to
+  `HEAD` with a clear message instead of crashing. Regression coverage lives in
+  `tests/dev/test_pr_ready_preflight.py`. This is a developer-tooling fix only — it changes no test
+  lane coverage semantics, coverage thresholds, or CI policy.
 * Fixed the **SAC baseline velocity action space ignoring `action_semantics`** when converting model
   output to benchmark commands (#3705). In `robot_sf/baselines/sac.py`, `_action_vec_to_dict` always
   scaled the `velocity` (`vx`, `vy`) output vector to `v_max`, even when `action_semantics="delta"`.

--- a/scripts/dev/pr_ready_check.sh
+++ b/scripts/dev/pr_ready_check.sh
@@ -88,6 +88,44 @@ print_compact_worktree_status() {
   fi
 }
 
+resolve_base_ref() {
+  # Ensure BASE_REF resolves to a real commit before any `git diff
+  # "$BASE_REF...HEAD"` comparison or downstream consumer (perf/coverage/
+  # freshness checks) uses it. On fresh checkouts where the default
+  # origin/main has not been fetched, the unresolved ref otherwise leaks a
+  # raw `fatal: ambiguous argument` from git: the comparison sits inside a
+  # process substitution, so `set -e` silently swallows the failure and the
+  # script proceeds with an empty changed-file set and an invalid base ref.
+  if git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+    return 0
+  fi
+
+  printf 'BASE_REF %q does not resolve to a local commit.\n' "$BASE_REF" >&2
+
+  # Best-effort fetch for remote-tracking refs (e.g. origin/main) so a network
+  # checkout can still compare against the intended base before falling back.
+  if [[ "$BASE_REF" == */* ]]; then
+    local remote="${BASE_REF%%/*}"
+    local branch="${BASE_REF#*/}"
+    if git remote get-url "$remote" >/dev/null 2>&1; then
+      printf 'Attempting git fetch --quiet %q %q to resolve BASE_REF.\n' "$remote" "$branch" >&2
+      if git fetch --quiet "$remote" "$branch" >/dev/null 2>&1 \
+        && git rev-parse --verify --quiet "${BASE_REF}^{commit}" >/dev/null 2>&1; then
+        printf 'Resolved BASE_REF %q after fetch.\n' "$BASE_REF" >&2
+        return 0
+      fi
+    fi
+  fi
+
+  # Fall back to HEAD so readiness gates still run instead of crashing. On a
+  # fresh checkout this yields an empty changed-file set rather than a fatal
+  # git error, and keeps a valid ref flowing to the coverage/perf/freshness
+  # checks that also consume BASE_REF.
+  printf 'Falling back to BASE_REF=HEAD; changed-file gates will compare against HEAD.\n' >&2
+  BASE_REF="HEAD"
+  export BASE_REF
+}
+
 is_optional_readiness_path() {
   case "$1" in
     robot_sf/benchmark/*|\
@@ -164,6 +202,8 @@ fi
 if [[ "$pr_ready_final" == "1" ]]; then
   preflight_check_test_deps
 fi
+
+resolve_base_ref
 
 changed_files=()
 core_changed_files=()

--- a/tests/dev/test_pr_ready_preflight.py
+++ b/tests/dev/test_pr_ready_preflight.py
@@ -292,6 +292,58 @@ def test_optional_lane_collection_hook_skips_core_paths(monkeypatch: pytest.Monk
     )
 
 
+def test_missing_base_ref_falls_back_to_head_without_crashing(preflight_repo: Path) -> None:
+    """A BASE_REF that does not resolve must fall back to HEAD, not leak a git fatal.
+
+    Regression for issue #3702: on fresh checkouts the default origin/main is not
+    always present. The unresolved ref previously leaked a raw
+    ``fatal: ambiguous argument`` from the ``git diff "$BASE_REF...HEAD"`` call
+    (silently swallowed by ``set -e`` inside the process substitution) and left an
+    invalid base ref flowing to the downstream coverage/perf/freshness checks.
+    """
+    _make_fake_bin(preflight_repo, fail=True)
+    result = _run_pr_ready(
+        preflight_repo,
+        help_flag=False,
+        env_overrides={
+            "BASE_REF": "non_existent_branch",
+            "PR_READY_MODE": "interim",
+        },
+    )
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+    assert "Falling back to BASE_REF=HEAD" in result.stderr
+    # The raw git error must not leak; the missing ref is handled gracefully.
+    assert "fatal" not in result.stderr.lower()
+    assert "unknown revision" not in result.stderr.lower()
+
+
+def test_valid_base_ref_is_used_unchanged(preflight_repo: Path) -> None:
+    """A BASE_REF that resolves must be used as-is, with no fallback or fetch.
+
+    Guards against the issue #3702 fix degrading the normal path: a valid ref
+    (here HEAD~1) should never trigger the HEAD fallback or a fetch attempt.
+    """
+    _make_fake_bin(preflight_repo, fail=True)
+    extra = preflight_repo / "tests" / "unit" / "test_valid_base_ref.py"
+    extra.parent.mkdir(parents=True, exist_ok=True)
+    extra.write_text("print('valid base ref')\n", encoding="utf-8")
+    _git(preflight_repo, "add", "-A")
+    _git(preflight_repo, "commit", "-q", "-m", "valid base ref change")
+
+    result = _run_pr_ready(
+        preflight_repo,
+        help_flag=False,
+        env_overrides={
+            "BASE_REF": "HEAD~1",
+            "PR_READY_MODE": "interim",
+        },
+    )
+    assert result.returncode == 0, f"Script failed: {result.stderr}"
+    assert "Falling back to BASE_REF=HEAD" not in result.stderr
+    assert "does not resolve to a local commit" not in result.stderr
+    assert "Attempting git fetch" not in result.stderr
+
+
 def test_preflight_passes_when_modules_available(preflight_repo: Path) -> None:
     """Preflight should pass silently when python reports no missing modules."""
     _make_fake_bin(preflight_repo, fail=False)


### PR DESCRIPTION
## Summary

Fixes #3702. `scripts/dev/pr_ready_check.sh` no longer mishandles a missing `BASE_REF` on fresh checkouts.

When the default `origin/main` (or any configured `BASE_REF`) was not present locally, `git diff "$BASE_REF...HEAD"` emitted a raw `fatal: ambiguous argument`. Because that command runs inside a process substitution, `set -e` **silently swallowed** the failure: the script proceeded with an empty changed-file set and still passed the unresolved ref to the downstream coverage, perf-evidence, and freshness checks.

## Change (scope)

A new `resolve_base_ref` helper runs once, before `BASE_REF` is consumed:

- a resolvable ref is used unchanged;
- a remote-tracking ref (e.g. `origin/main`) triggers a best-effort `git fetch` of that branch, then re-checks;
- an otherwise-unresolvable ref falls back to `HEAD` with a clear message instead of crashing.

This keeps a valid ref flowing to the `git diff` comparison and to the `check_perf_evidence.py` / `check_changed_coverage.sh` / `pr_ready_freshness.py` consumers that also read `BASE_REF`.

**In scope:** graceful missing-`BASE_REF` handling + focused regression coverage.
**Out of scope (unchanged):** test lane coverage semantics, coverage thresholds, and CI policy.

## Files

- `scripts/dev/pr_ready_check.sh` — add `resolve_base_ref`, call it before the changed-files computation.
- `tests/dev/test_pr_ready_preflight.py` — regression tests for the missing-ref fallback and the valid-ref pass-through.
- `CHANGELOG.md` — `Fixed` entry under `[Unreleased]`.

## Validation

| Command | Result |
| --- | --- |
| `bash -n scripts/dev/pr_ready_check.sh` | syntax OK |
| `shellcheck scripts/dev/pr_ready_check.sh` | only pre-existing info findings (SC1091/SC2016); none from this change |
| `uv run pytest tests/dev/test_pr_ready_preflight.py -q` | 12 passed (incl. 2 new) |
| `uv run pytest tests/test_ci_script_contract.py -q` | 56 passed |
| `uv run ruff format/check tests/dev/test_pr_ready_preflight.py` | clean |
| real-git exercise of `resolve_base_ref` | bogus ref → HEAD fallback; `origin/main` → unchanged; `git diff HEAD...HEAD` exit 0 (no fatal) |

## Definition of Done (issue #3702)

- [x] Bug fixed and no longer reproducible (`BASE_REF=non_existent_branch` no longer leaks a git fatal).
- [x] Root cause addressed (unresolved ref + `set -e`-swallowed process substitution).
- [x] Regression tests verify the check succeeds when the origin ref is missing.

## Downstream Propagation

NA — developer-tooling fix; no parent claim map, benchmark report, leaderboard, registry, or memory note affected.

## Out-of-scope note

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks when the comparison base reference is missing or invalid on fresh checkouts.
  * The check now falls back to a safe default instead of failing with unclear git errors, keeping downstream validation running.
  * Better messaging now explains when the fallback is used.
* **Tests**
  * Added regression coverage for missing and valid base-reference scenarios to ensure the new behavior stays reliable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->