### PR TITLE
fix(issue-audit): recognize "Scope / non-goals" heading variant

### DIFF
--- a/scripts/tools/issue_template_audit.py
+++ b/scripts/tools/issue_template_audit.py
@@ -52,6 +52,7 @@ SECTION_ALIASES: dict[str, str] = {
     # YAML issue forms (epic/execution-run/test-debt/blocked-external-artifact) name this
     # "Scope and non-goals"; treat it as the canonical Scope section.
     "scope and non-goals": "Scope",
+    "scope / non-goals": "Scope",
     "scope / out of scope": "Scope",
     "out of scope": "Scope",
     "scope / decision needed": "Scope",
@@ -94,6 +95,7 @@ SECTION_ALIASES: dict[str, str] = {
 LEANER_TEMPLATE_SIGNATURES: frozenset[str] = frozenset(
     {
         "scope and non-goals",
+        "scope / non-goals",
         "scope / out of scope",
         "non-goals",
         "acceptance criteria",

--- a/tests/tools/test_issue_template_audit.py
+++ b/tests/tools/test_issue_template_audit.py
@@ -53,6 +53,39 @@ Ship the thing.
     assert result.missing_sections == ()
 
 
+def test_scope_non_goals_heading_is_recognized() -> None:
+    """Verify the ``Scope / non-goals`` heading variant is credited and signals the leaner core.
+
+    This matters because agent-authored analysis/research bodies write ``## Scope / non-goals``
+    (slash variant) where the YAML forms write ``Scope and non-goals``; without the alias the
+    audit reported a false "missing Scope" and held the body to the full markdown contract.
+    """
+
+    body = """## Goal / Problem
+
+Investigate the thing.
+
+## Scope / non-goals
+
+- In scope: the analysis.
+- Out of scope: implementation.
+
+## Definition of Done
+
+- [ ] Analysis complete.
+
+## Validation / Testing
+
+- [ ] Run the analysis script.
+"""
+
+    assert normalize_section_title("Scope / non-goals") == "Scope"
+    assert select_required_sections(body) == CORE_SECTION_ORDER
+    result = audit_issue_body(body)
+    assert "Scope" not in result.missing_sections
+    assert result.missing_sections == ()
+
+
 def test_agent_exec_spec_h3_content_counts_as_present() -> None:
     """Verify contract content carried as ``###`` headings in the agent-exec-spec is credited.
 


### PR DESCRIPTION
## Goal / Problem

The issue-template audit (`scripts/tools/issue_template_audit.py`) recognized
`Scope and non-goals` (YAML issue forms) but not the slash variant
`Scope / non-goals` that agent-authored analysis/research bodies use. That
produced a false "missing Scope" report and held those bodies to the full
markdown contract instead of the leaner agent-ready core — e.g. issue #3574,
which has a `## Scope / non-goals` section, was flagged for 11 missing sections.

## Scope

- In scope: add `scope / non-goals` to `SECTION_ALIASES` (→ `Scope`) and to
  `LEANER_TEMPLATE_SIGNATURES`, consistent with the existing `scope and non-goals`
  and `non-goals` entries; add a regression test.
- Out of scope: any other alias/vocabulary changes; issue-body edits.

## Validation / Testing

- [x] `uv run ruff check` / `ruff format` — clean.
- [x] `uv run pytest tests/tools/test_issue_template_audit.py` — 19 passed
      (incl. new `test_scope_non_goals_heading_is_recognized`).

## Definition of Done

- [x] `normalize_section_title("Scope / non-goals") == "Scope"`.
- [x] A body using `## Scope / non-goals` selects `CORE_SECTION_ORDER` and audits clean.
- [x] Regression test added.

## Notes

Found while sweeping open-issue contract health: this was the one true tooling
false-positive among the flagged issues. Evidence grade: diagnostic/tooling —
deterministic parser change with a unit test; no benchmark semantics touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
