### PR TITLE
perf(ci): single-pass uv cache sizing in ci_uv_sync_diag.sh (#3703)

### DIFF
--- a/scripts/dev/ci_uv_sync_diag.sh
+++ b/scripts/dev/ci_uv_sync_diag.sh
@@ -49,12 +49,24 @@ fi
 
 if [[ -d "$cache_dir" ]]; then
     echo "  cache_dir=${cache_dir}"
-    du -sh "$cache_dir" 2>/dev/null | awk '{print "  cache_total_size="$1}' || true
-    for sub in archive-v0 wheels-v6 wheels-v5 sdists-v9 sdists-v8 simple-v21 simple-v20 builds-v0 environments-v2 environments-v1 interpreter-v4 git-v0; do
-        if [[ -d "$cache_dir/$sub" ]]; then
-            du -sh "$cache_dir/$sub" 2>/dev/null | awk -v s="$sub" '{print "  cache_"s"_size="$1}' || true
-        fi
-    done
+    # Single-pass cache sizing (issue #3703): `du -h -d 1` walks the cache tree
+    # once and emits the size of every immediate subdirectory plus the cache
+    # total. The previous loop re-ran `du` per subdirectory, re-traversing the
+    # tree up to a dozen times and risking preflight timeouts on large caches.
+    # The captured output is then parsed in a single awk pass (pure in-memory,
+    # no further disk I/O), preserving the curated key names and ordering.
+    cache_du="$(du -h -d 1 "$cache_dir" 2>/dev/null || true)"
+    printf '%s\n' "$cache_du" | awk -F'\t' -v dir="$cache_dir" '
+        { size[$2] = $1 }
+        END {
+            if (dir in size) print "  cache_total_size=" size[dir]
+            n = split("archive-v0 wheels-v6 wheels-v5 sdists-v9 sdists-v8 simple-v21 simple-v20 builds-v0 environments-v2 environments-v1 interpreter-v4 git-v0", subs, " ")
+            for (i = 1; i <= n; i++) {
+                p = dir "/" subs[i]
+                if (p in size) print "  cache_" subs[i] "_size=" size[p]
+            }
+        }
+    '
 else
     echo "  cache_dir=${cache_dir} (does not exist)"
 fi

--- a/tests/dev/test_ci_uv_sync_diag.py
+++ b/tests/dev/test_ci_uv_sync_diag.py
@@ -78,6 +78,69 @@ def test_ci_uv_sync_diag_reports_runner_and_uv_state() -> None:
         assert "uv_version=uv " in output
 
 
+def test_ci_uv_sync_diag_cache_sizing_is_single_pass(tmp_path: Path) -> None:
+    """Cache sizing must traverse the cache exactly once (issue #3703).
+
+    The probe previously ran ``du`` once for the whole cache and then again per
+    curated subdirectory, re-walking the tree up to a dozen times. This test
+    pins the optimized contract: a single ``du`` invocation over the cache tree
+    while the curated per-subdirectory keys and the total are still emitted.
+    """
+    script = _script_path()
+    bash_path = shutil.which("bash")
+    assert bash_path, "bash is required for this test"
+
+    # Build a fake uv cache populated with a few curated subdirectories.
+    cache_dir = tmp_path / "uv-cache"
+    for sub in ("archive-v0", "wheels-v6", "git-v0"):
+        (cache_dir / sub).mkdir(parents=True)
+        (cache_dir / sub / "blob").write_bytes(b"x" * 1024)
+
+    # Fake ``du`` that records every invocation and emits ``du -h -d 1`` style
+    # tab-separated output (one line per immediate subdir plus the cache root).
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    du_calls = tmp_path / "du_calls.log"
+    du_shim = fake_bin / "du"
+    du_shim.write_text(
+        "#!/usr/bin/env bash\n"
+        f'printf "%s\\n" "$*" >> "{du_calls}"\n'
+        'target="${@: -1}"\n'
+        'for d in "$target"/*/; do\n'
+        '  [ -d "$d" ] && printf "1.0K\\t%s\\n" "${d%/}"\n'
+        "done\n"
+        'printf "16K\\t%s\\n" "$target"\n'
+    )
+    du_shim.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{fake_bin}{os.pathsep}{env['PATH']}"
+    env["UV_CACHE_DIR"] = str(cache_dir)
+
+    result = subprocess.run(
+        [bash_path, str(script), "single-pass-test"],
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        cwd=tmp_path,  # no .venv here, so du is only invoked for the cache
+        timeout=30,
+    )
+    assert result.returncode == 0, f"stderr: {result.stderr}"
+
+    # The cache tree must be walked by exactly one du invocation (single pass).
+    invocations = du_calls.read_text().splitlines() if du_calls.exists() else []
+    cache_invocations = [line for line in invocations if str(cache_dir) in line]
+    assert len(cache_invocations) == 1, f"expected single du pass, got: {cache_invocations}"
+
+    # Curated per-subdirectory keys and the total are preserved.
+    output = result.stdout
+    assert "cache_total_size=16K" in output
+    assert "cache_archive-v0_size=1.0K" in output
+    assert "cache_wheels-v6_size=1.0K" in output
+    assert "cache_git-v0_size=1.0K" in output
+
+
 def test_workflow_uv_cache_paths_match_setup_uv_cache_dir() -> None:
     """Workflow uv caching must match the UV_CACHE_DIR configured by setup-uv."""
     inline_cache_workflows = [


### PR DESCRIPTION
## Summary

Fixes #3703.

`scripts/dev/ci_uv_sync_diag.sh` sized the uv cache by running `du -sh` once
over the whole cache and then **again per curated subdirectory** in a 12-entry
loop. That re-walked the cache tree up to a dozen times. On large caches the
redundant I/O risks slowing the CI preflight diagnostic (issue scenario:
20GB+ caches; reproduced locally on an 18GB cache).

## Change

- Replace the per-subdirectory `du` loop with a **single `du -h -d 1`
  traversal**. That one pass emits the size of every immediate subdirectory
  plus the cache total. The captured output is parsed in a single in-memory
  `awk` pass (no further disk I/O), preserving the curated `cache_*_size` key
  names, the whitelist ordering, and `cache_total_size`.
- Add `test_ci_uv_sync_diag_cache_sizing_is_single_pass` pinning the optimized
  contract via a fake `du` shim: **exactly one `du` invocation** over the cache
  tree, and the curated per-subdirectory keys + total are still emitted. The
  test fails against the old loop (which invoked `du` 4× for a 3-subdir cache).

Output format is unchanged — verified on the real local 18GB cache:
`cache_total_size=18G`, `cache_archive-v0_size=18G`, etc.

## Validation

| Command | Result |
| --- | --- |
| `bash -n scripts/dev/ci_uv_sync_diag.sh` | exit 0 |
| `shellcheck scripts/dev/ci_uv_sync_diag.sh` | clean |
| `bash scripts/dev/ci_uv_sync_diag.sh` (real 18GB cache) | keys/total preserved, exit 0 |
| `uv run pytest tests/dev/test_ci_uv_sync_diag.py -q` | 6 passed |
| `uv run ruff check / format` (test file) | clean |

## Scope / out of scope

- In scope: remove redundant cache traversal in the diagnostic script;
  behavior-preserving focused test.
- Out of scope: no change to `uv sync` diagnostics logic, dependency policy, or
  broader CI behavior. No full benchmark campaign run, no Slurm/GPU submission,
  no paper/dissertation claim edits.

## Downstream Propagation

Internal CI tooling only; no parent claim map, leaderboard, registry, or memory
note to update. `Research Result Guidance`: NA — support/tooling change with no
research claim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
