### PR TITLE
feat(benchmark): presence-only publication-prerequisites preflight for v0.1 (#2910)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   uniform. New test `tests/test_classic_archetype_density_index.py` re-derives the same facts from the
   `classic_*.yaml` configs and `classic_interactions.yaml` and fails closed on drift or missing
   config/tier coverage. The scenario zoo index links the new file for discoverability.
+* Added a **presence-only publication-prerequisites preflight** for the v0.1 validation/falsification
+  benchmark package (epic #2910). A declarative checklist
+  (`configs/benchmarks/releases/benchmark_v0_1_publication_prerequisites.yaml`) enumerates the
+  canonical prerequisite owners a v0.1 package must be built on — ODD/scenario contracts, scenario
+  certification, benchmark/row claim metadata, ODD/hazard coverage matrix, the release protocol and
+  pinned v0.1 release manifest, the seed schedule, the release checklist doc, and citation metadata.
+  The companion checker `scripts/validation/check_benchmark_v0_1_publication_prerequisites.py`
+  verifies every referenced path exists and fails closed (exit `1`) when a required prerequisite is
+  missing. It is deliberately presence-only: it does **not** release, tag, upload artifacts, run a
+  benchmark/falsification campaign, judge scenario certification, or declare the benchmark "ready" —
+  every report carries an explicit `claim_boundary` to that effect. Run with
+  `uv run python scripts/validation/check_benchmark_v0_1_publication_prerequisites.py`.
 * Recorded metric-affecting run configuration in benchmark result provenance so result artifacts are
   self-describing (#3701). New pure module `robot_sf/benchmark/run_config_provenance.py` exposes
   `metric_affecting_run_config(config)`, which serializes the two run-config toggles that change *what*

--- a/configs/benchmarks/releases/benchmark_v0_1_publication_prerequisites.yaml
+++ b/configs/benchmarks/releases/benchmark_v0_1_publication_prerequisites.yaml
@@ -1,0 +1,98 @@
+# Publication prerequisites checklist for the Robot SF validation/falsification
+# benchmark v0.1 package (epic #2910).
+#
+# IMPORTANT — scope and limits:
+# This file is a *presence* checklist of the canonical prerequisite artifacts a
+# v0.1 benchmark package must be built on. The companion preflight
+# (`scripts/validation/check_benchmark_v0_1_publication_prerequisites.py`) only
+# verifies that the referenced owners exist on disk. It does NOT release, tag,
+# upload artifacts, run a benchmark campaign, judge scenario certification, or
+# declare the benchmark "ready". A passing preflight means the prerequisite
+# owners are present, not that any benchmark/falsification claim is established.
+#
+# Extend `prerequisites` as new canonical owners are frozen for the v0.1 package.
+schema_version: benchmark-v0_1-publication-prerequisites.v1
+release_target: paper-benchmark-v0.1.0
+epic: 2910
+
+prerequisites:
+  - id: odd_contract
+    category: contract
+    required: true
+    epic_acceptance: "ODD bounds for included scenarios"
+    description: "Canonical Operational Design Domain (ODD) contract owner."
+    paths:
+      - robot_sf/benchmark/odd_contract.py
+
+  - id: scenario_contract
+    category: contract
+    required: true
+    epic_acceptance: "All included scenarios have scenario contracts"
+    description: "Canonical scenario-contract owner for benchmark suites."
+    paths:
+      - robot_sf/benchmark/scenario_contract.py
+
+  - id: scenario_certification
+    category: certification
+    required: true
+    epic_acceptance: "All included scenarios have certification status"
+    description: "Scenario certification v1 owner that records certification status."
+    paths:
+      - robot_sf/scenario_certification/v1.py
+
+  - id: benchmark_claim_metadata
+    category: claim_matrix
+    required: true
+    epic_acceptance: "Planner rows fail-closed; claims classified"
+    description: "Benchmark and per-row claim-metadata owners for the claim matrix."
+    paths:
+      - robot_sf/benchmark/benchmark_claim.py
+      - robot_sf/benchmark/benchmark_row_claim.py
+
+  - id: odd_hazard_coverage_matrix
+    category: coverage
+    required: true
+    epic_acceptance: "ODD/hazard coverage matrix"
+    description: "ODD/hazard coverage-matrix owner used to position suite coverage."
+    paths:
+      - robot_sf/benchmark/odd_hazard_coverage_matrix.py
+
+  - id: release_protocol
+    category: release
+    required: true
+    epic_acceptance: "Release summary states what is/is not supported"
+    description: "Release-protocol owner that builds and validates release manifests."
+    paths:
+      - robot_sf/benchmark/release_protocol.py
+
+  - id: release_manifest_v0_1
+    category: release
+    required: true
+    epic_acceptance: "All claims link to durable artifacts (manifest)"
+    description: "Versioned v0.1 release manifest pinning configs, seeds, and hashes."
+    paths:
+      - configs/benchmarks/releases/paper_experiment_matrix_v1_release_v0_1.yaml
+
+  - id: seed_schedule
+    category: seed
+    required: true
+    epic_acceptance: "Seed schedule for every suite"
+    description: "Canonical seed-set schedule referenced by the release manifest."
+    paths:
+      - configs/benchmarks/seed_sets_v1.yaml
+
+  - id: release_checklist_doc
+    category: release
+    required: true
+    epic_acceptance: "Release summary states what is/is not supported"
+    description: "Human release checklist describing the publication steps."
+    paths:
+      - docs/RELEASE.md
+
+  - id: citation
+    category: provenance
+    required: true
+    epic_acceptance: "All claims link to durable artifacts (provenance)"
+    description: "Citation metadata for the published benchmark package."
+    paths:
+      - CITATION.cff

--- a/scripts/validation/check_benchmark_v0_1_publication_prerequisites.py
+++ b/scripts/validation/check_benchmark_v0_1_publication_prerequisites.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Presence-only preflight for the v0.1 benchmark publication prerequisites (epic #2910).
+
+This checker reads a declarative prerequisites checklist (default:
+``configs/benchmarks/releases/benchmark_v0_1_publication_prerequisites.yaml``) and
+verifies that every referenced canonical-owner path exists on disk.
+
+Scope and limits (deliberate):
+
+- This is a *presence* preflight. It only confirms that the prerequisite owners a
+  v0.1 benchmark package must be built on are present.
+- It does NOT release, tag, upload artifacts, run a benchmark/falsification
+  campaign, evaluate scenario certification, or declare the benchmark "ready".
+- A passing run means the prerequisite artifacts exist, NOT that any
+  benchmark/falsification claim is established.
+
+Exit code is ``0`` when no *required* prerequisite is missing, otherwise ``1`` so
+the check can fail closed in CI or local preflight without asserting readiness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+SCHEMA_VERSION = "benchmark-v0_1-publication-prerequisites.v1"
+DEFAULT_CHECKLIST_PATH = Path(
+    "configs/benchmarks/releases/benchmark_v0_1_publication_prerequisites.yaml"
+)
+# Explicit boundary string surfaced in every report so the output cannot be
+# mistaken for a benchmark-readiness or claim declaration.
+CLAIM_BOUNDARY = (
+    "presence-only preflight; existing prerequisites do NOT imply benchmark "
+    "readiness or any established claim"
+)
+
+
+def get_repository_root() -> Path:
+    """Return the repository root for resolving relative checklist paths."""
+    return Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True)
+class PrerequisiteResult:
+    """Resolved presence status for a single checklist prerequisite."""
+
+    item_id: str
+    category: str
+    required: bool
+    description: str
+    present: bool
+    missing_paths: tuple[str, ...]
+
+    @property
+    def status(self) -> str:
+        """Return ``present`` when every referenced path exists, else ``missing``."""
+        return "present" if self.present else "missing"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view of this result."""
+        return {
+            "id": self.item_id,
+            "category": self.category,
+            "required": self.required,
+            "description": self.description,
+            "status": self.status,
+            "missing_paths": list(self.missing_paths),
+        }
+
+
+def _load_checklist(path: Path) -> dict[str, Any]:
+    """Load and minimally validate the checklist mapping.
+
+    Raises:
+        ValueError: When the payload is not a mapping, the schema version is
+            unexpected, or the ``prerequisites`` list is missing/empty.
+    """
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"Checklist {path} must be a mapping")
+    schema = payload.get("schema_version")
+    if schema != SCHEMA_VERSION:
+        raise ValueError(
+            f"Checklist {path} has schema_version {schema!r}, expected {SCHEMA_VERSION!r}"
+        )
+    prerequisites = payload.get("prerequisites")
+    if not isinstance(prerequisites, list) or not prerequisites:
+        raise ValueError(f"Checklist {path} must define a non-empty 'prerequisites' list")
+    return payload
+
+
+def evaluate_prerequisite(item: dict[str, Any], repo_root: Path) -> PrerequisiteResult:
+    """Evaluate one checklist item against the filesystem.
+
+    Args:
+        item: One ``prerequisites`` entry; must carry ``id`` and a non-empty
+            ``paths`` list of repository-relative paths.
+        repo_root: Root used to resolve relative paths.
+
+    Returns:
+        The resolved :class:`PrerequisiteResult`.
+
+    Raises:
+        ValueError: When the item lacks an ``id`` or any usable ``paths``.
+    """
+    item_id = item.get("id")
+    if not item_id:
+        raise ValueError(f"Prerequisite entry missing 'id': {item!r}")
+    raw_paths = item.get("paths") or []
+    if not isinstance(raw_paths, list) or not raw_paths:
+        raise ValueError(f"Prerequisite {item_id!r} must list at least one path")
+    missing = tuple(str(p) for p in raw_paths if not (repo_root / str(p)).exists())
+    return PrerequisiteResult(
+        item_id=str(item_id),
+        category=str(item.get("category", "uncategorized")),
+        required=bool(item.get("required", True)),
+        description=str(item.get("description", "")),
+        present=not missing,
+        missing_paths=missing,
+    )
+
+
+def build_report(checklist_path: Path, repo_root: Path) -> dict[str, Any]:
+    """Evaluate every prerequisite and assemble a deterministic report payload."""
+    payload = _load_checklist(checklist_path)
+    results = [evaluate_prerequisite(item, repo_root) for item in payload["prerequisites"]]
+    required_missing = [r.item_id for r in results if r.required and not r.present]
+    optional_missing = [r.item_id for r in results if not r.required and not r.present]
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "claim_boundary": CLAIM_BOUNDARY,
+        "release_target": payload.get("release_target"),
+        "epic": payload.get("epic"),
+        "checklist_path": str(checklist_path),
+        "total": len(results),
+        "present": sum(1 for r in results if r.present),
+        "required_missing": required_missing,
+        "optional_missing": optional_missing,
+        # Prerequisites *present* is necessary but not sufficient for readiness.
+        "prerequisites_satisfied": not required_missing,
+        "prerequisites": [r.to_dict() for r in results],
+    }
+
+
+def _render_text(report: dict[str, Any]) -> str:
+    """Render a compact human-readable summary of the report."""
+    lines = [
+        f"Benchmark v0.1 publication prerequisites ({report['checklist_path']})",
+        f"Boundary: {report['claim_boundary']}",
+        f"Present: {report['present']}/{report['total']}",
+        "",
+    ]
+    for item in report["prerequisites"]:
+        marker = "ok  " if item["status"] == "present" else "MISS"
+        req = "required" if item["required"] else "optional"
+        lines.append(f"  [{marker}] {item['id']} ({item['category']}, {req})")
+        for missing in item["missing_paths"]:
+            lines.append(f"         missing: {missing}")
+    lines.append("")
+    if report["required_missing"]:
+        lines.append(f"FAIL: required prerequisites missing: {report['required_missing']}")
+    else:
+        lines.append("PASS: all required prerequisite owners present (presence-only).")
+    if report["optional_missing"]:
+        lines.append(f"Note: optional prerequisites missing: {report['optional_missing']}")
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """CLI entry point. Returns ``0`` when no required prerequisite is missing."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--checklist",
+        type=Path,
+        default=None,
+        help="Path to the prerequisites checklist YAML (default: repo v0.1 checklist).",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root used to resolve relative paths (default: inferred).",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON instead of text.")
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root.resolve() if args.repo_root else get_repository_root()
+    checklist_path = args.checklist if args.checklist else repo_root / DEFAULT_CHECKLIST_PATH
+
+    try:
+        report = build_report(checklist_path, repo_root)
+    except (OSError, ValueError, yaml.YAMLError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(_render_text(report))
+    return 0 if report["prerequisites_satisfied"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/test_check_benchmark_v0_1_publication_prerequisites.py
+++ b/tests/validation/test_check_benchmark_v0_1_publication_prerequisites.py
@@ -1,0 +1,178 @@
+"""Tests for the v0.1 benchmark publication prerequisites preflight (epic #2910)."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pytest
+import yaml
+
+from scripts.validation import check_benchmark_v0_1_publication_prerequisites as preflight
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+SCHEMA = preflight.SCHEMA_VERSION
+
+
+def _write_checklist(path: Path, prerequisites: list[dict]) -> Path:
+    """Write a synthetic checklist YAML and return its path."""
+    payload = {
+        "schema_version": SCHEMA,
+        "release_target": "paper-benchmark-v0.1.0",
+        "epic": 2910,
+        "prerequisites": prerequisites,
+    }
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _touch(repo_root: Path, rel: str) -> None:
+    """Create an empty file (and parents) under the synthetic repo root."""
+    target = repo_root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("", encoding="utf-8")
+
+
+def test_all_present_passes(tmp_path: Path) -> None:
+    """When every required path exists the report is satisfied and main returns 0."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _touch(repo, "a/present.py")
+    checklist = _write_checklist(
+        tmp_path / "checklist.yaml",
+        [{"id": "a", "category": "contract", "required": True, "paths": ["a/present.py"]}],
+    )
+    report = preflight.build_report(checklist, repo)
+
+    assert report["prerequisites_satisfied"] is True
+    assert report["required_missing"] == []
+    assert report["present"] == report["total"] == 1
+    assert preflight.main(["--checklist", str(checklist), "--repo-root", str(repo)]) == 0
+
+
+def test_missing_required_fails_closed(tmp_path: Path) -> None:
+    """A missing required path reports the id, is unsatisfied, and main returns 1."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    checklist = _write_checklist(
+        tmp_path / "checklist.yaml",
+        [{"id": "gone", "category": "release", "required": True, "paths": ["nope.yaml"]}],
+    )
+    report = preflight.build_report(checklist, repo)
+
+    assert report["prerequisites_satisfied"] is False
+    assert report["required_missing"] == ["gone"]
+    assert report["prerequisites"][0]["missing_paths"] == ["nope.yaml"]
+    assert preflight.main(["--checklist", str(checklist), "--repo-root", str(repo)]) == 1
+
+
+def test_missing_optional_does_not_fail(tmp_path: Path) -> None:
+    """A missing optional prerequisite is reported but does not fail the preflight."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    checklist = _write_checklist(
+        tmp_path / "checklist.yaml",
+        [{"id": "opt", "category": "seed", "required": False, "paths": ["maybe.yaml"]}],
+    )
+    report = preflight.build_report(checklist, repo)
+
+    assert report["prerequisites_satisfied"] is True
+    assert report["optional_missing"] == ["opt"]
+    assert preflight.main(["--checklist", str(checklist), "--repo-root", str(repo)]) == 0
+
+
+def test_multi_path_requires_all(tmp_path: Path) -> None:
+    """An item with multiple paths is present only when every path exists."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _touch(repo, "one.py")
+    checklist = _write_checklist(
+        tmp_path / "checklist.yaml",
+        [
+            {
+                "id": "pair",
+                "category": "claim_matrix",
+                "required": True,
+                "paths": ["one.py", "two.py"],
+            }
+        ],
+    )
+    report = preflight.build_report(checklist, repo)
+
+    assert report["prerequisites_satisfied"] is False
+    assert report["prerequisites"][0]["missing_paths"] == ["two.py"]
+
+
+def test_report_always_carries_claim_boundary(tmp_path: Path) -> None:
+    """The report surfaces an explicit presence-only boundary string."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _touch(repo, "x.py")
+    checklist = _write_checklist(
+        tmp_path / "checklist.yaml",
+        [{"id": "x", "category": "contract", "required": True, "paths": ["x.py"]}],
+    )
+    report = preflight.build_report(checklist, repo)
+    assert "presence-only" in report["claim_boundary"]
+    assert "readiness" in report["claim_boundary"]
+
+
+@pytest.mark.parametrize(
+    "bad_payload",
+    [
+        "not a mapping\n",
+        "schema_version: wrong\nprerequisites: []\n",
+        f"schema_version: {SCHEMA}\nprerequisites: []\n",
+    ],
+)
+def test_invalid_checklist_raises(tmp_path: Path, bad_payload: str) -> None:
+    """Malformed checklists raise ValueError (surfaced as exit code 2 in main)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    checklist = tmp_path / "bad.yaml"
+    checklist.write_text(bad_payload, encoding="utf-8")
+    with pytest.raises(ValueError):
+        preflight.build_report(checklist, repo)
+    assert preflight.main(["--checklist", str(checklist), "--repo-root", str(repo)]) == 2
+
+
+def test_entry_without_paths_raises(tmp_path: Path) -> None:
+    """A prerequisite entry without paths is rejected."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    checklist = _write_checklist(
+        tmp_path / "checklist.yaml",
+        [{"id": "nopaths", "category": "contract", "required": True}],
+    )
+    with pytest.raises(ValueError):
+        preflight.build_report(checklist, repo)
+
+
+def test_json_output_is_valid(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """The --json flag emits parseable JSON with the schema version."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _touch(repo, "x.py")
+    checklist = _write_checklist(
+        tmp_path / "checklist.yaml",
+        [{"id": "x", "category": "contract", "required": True, "paths": ["x.py"]}],
+    )
+    preflight.main(["--checklist", str(checklist), "--repo-root", str(repo), "--json"])
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["schema_version"] == SCHEMA
+    assert payload["prerequisites_satisfied"] is True
+
+
+def test_repo_checklist_resolves_against_real_tree() -> None:
+    """The committed v0.1 checklist references only paths that exist on this branch.
+
+    This keeps the checklist honest: every declared prerequisite owner must be a
+    real canonical path so the preflight cannot silently drift from the repo.
+    """
+    repo_root = preflight.get_repository_root()
+    checklist = repo_root / preflight.DEFAULT_CHECKLIST_PATH
+    report = preflight.build_report(checklist, repo_root)
+    assert report["required_missing"] == [], report["required_missing"]
+    assert report["prerequisites_satisfied"] is True


### PR DESCRIPTION
## Summary

Implements the safe, smallest publication-readiness slice of epic **#2910** (publish Robot SF
validation/falsification benchmark v0.1): a **presence-only machine-checkable preflight** plus a
declarative checklist for the v0.1 benchmark *package prerequisites*.

Issue: https://github.com/ll7/robot_sf_ll7/issues/2910

## Scope

- `configs/benchmarks/releases/benchmark_v0_1_publication_prerequisites.yaml` — declarative checklist
  enumerating the canonical prerequisite owners a v0.1 package must be built on, each traced to an
  epic acceptance area: ODD contract, scenario contract, scenario certification, benchmark/row claim
  metadata, ODD/hazard coverage matrix, release protocol, the pinned v0.1 release manifest, the seed
  schedule, the release checklist doc, and citation metadata.
- `scripts/validation/check_benchmark_v0_1_publication_prerequisites.py` — checker that verifies
  every referenced path exists and **fails closed** (exit `1`) when a required prerequisite is
  missing; exit `0` otherwise, exit `2` on a malformed checklist. Supports `--checklist`,
  `--repo-root`, and `--json`.
- `tests/validation/test_check_benchmark_v0_1_publication_prerequisites.py` — 11 focused tests on
  synthetic metadata (pass/fail-closed/optional/multi-path/invalid-schema/JSON) plus one honesty
  test asserting the committed checklist resolves against the real tree.
- `CHANGELOG.md` — Unreleased/Added entry.

This reuses existing canonical owners rather than re-deriving them; it does not duplicate the
single-campaign release manifest (`run_benchmark_release.py`) or `check_claim_readiness.py`, which
cover different concerns (campaign hash validation and claim-text evidence fields respectively).

## Validation

| Command | Result |
| --- | --- |
| `uv run ruff check <script> <test>` | All checks passed |
| `uv run ruff format --check <script> <test>` | Formatted (applied) |
| `uv run pytest tests/validation/test_check_benchmark_v0_1_publication_prerequisites.py -q` | 11 passed |
| `uv run python scripts/validation/check_benchmark_v0_1_publication_prerequisites.py` | 10/10 present, exit 0, PASS |

## Out of scope / guardrails

- **No** full benchmark campaign run, **no** Slurm/GPU submission, **no** release/tag/artifact upload.
- **No** paper/dissertation or benchmark claim edits.
- This is **presence-only**: a passing preflight means the prerequisite owners exist, **not** that
  the benchmark is "ready" or that any benchmark/falsification claim is established. Every report
  emits an explicit `claim_boundary` to that effect.

## Residual risk

The checklist asserts *existence*, not *semantic completeness* (e.g. it does not verify that every
suite is frozen, certified, or that planner rows actually fail closed at run time). Tightening any
item to a content/semantic check is deliberately left to follow-up child issues under the epic.

## Downstream Propagation

Parent epic #2910 (remaining suite-freeze + claim-matrix work stays open). No leaderboard, registry,
or claim-map changes — this is a support/preflight helper. `Research Result Guidance`: `NA - support
helper` (presence-only preflight, no research claim).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
