### PR TITLE
feat(tools): re-export readiness preflight for stale dissertation table bundles (#3203)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a read-only **re-export readiness preflight** for stale dissertation table bundles
+  (`scripts/tools/reexport_readiness_preflight.py`, #3203). It composes the existing
+  `scripts/tools/stale_artifact_detector.py` freshness classifier with a required-input availability
+  check and reduces both signals to a single `fresh` / `stale` / `blocked` state: `fresh` when the
+  payload is present and checksums match (no re-export needed), `stale` when a re-export is needed and
+  all required inputs (campaign config, generation script, source-commit provenance) are present
+  (re-export unblocked), and `blocked` when a re-export is needed but a required input is missing or
+  the provenance cannot be reconstructed. This prevents a stale bundle from being silently cited as
+  current evidence without first checking that the bounded campaign can be reproduced here. The tool
+  never runs the campaign, regenerates a table, or edits dissertation claims.
 * Recorded metric-affecting run configuration in benchmark result provenance so result artifacts are
   self-describing (#3701). New pure module `robot_sf/benchmark/run_config_provenance.py` exposes
   `metric_affecting_run_config(config)`, which serializes the two run-config toggles that change *what*

--- a/docs/context/issue_2542_dissertation_export_bundle.md
+++ b/docs/context/issue_2542_dissertation_export_bundle.md
@@ -67,6 +67,11 @@ payloads, not the local output tree.
 - `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/benchmark_publication_bundle.py dissertation-bundle ...`
 - `uv run python scripts/tools/benchmark_publication_bundle.py validate-dissertation-bundle --bundle-dir docs/context/evidence/issue_2542_dissertation_export_bundle --source-root docs/context/evidence/issue_3203_scenario_horizon_reexport_2026-06-20/reports --expected-source-command "uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500.yaml --output-root <disposable-output-root>/benchmarks/issue_3203 --campaign-id issue3203_scenario_horizons_h500_reexport_2026-06-20 --mode run --log-level INFO" --expected-source-commit 76d84347a40c669fb878b55489a2614917399bda`
 - `uv run python scripts/tools/stale_artifact_detector.py docs/context/evidence/issue_2542_dissertation_export_bundle/artifact_manifest.json --json-out output/issue-3203/stale_artifact_report.json`
+- `uv run python scripts/tools/reexport_readiness_preflight.py docs/context/evidence/issue_2542_dissertation_export_bundle/artifact_manifest.json --repo-root .` —
+  read-only re-export readiness preflight (Issue #3203). Reports `fresh` / `stale` / `blocked` and
+  the required re-export inputs (campaign config, generation script, source-commit provenance) so a
+  stale bundle is never silently cited as current without checking that a bounded campaign can be
+  reproduced here. It does not run the campaign or edit dissertation claims.
 - `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`
 
 ## Boundary

--- a/scripts/tools/reexport_readiness_preflight.py
+++ b/scripts/tools/reexport_readiness_preflight.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Re-export readiness preflight for stale dissertation table bundles.
+
+Issue #3203 motivation: a stale dissertation export bundle (for example the
+scenario-horizon tables) must never be silently treated as current evidence
+just because a manifest exists. Before anyone re-runs the bounded campaign that
+regenerates the tables, an operator needs a conservative, read-only answer to
+two questions:
+
+1. *Does this bundle even need a re-export?* (Is the payload present and do its
+   checksums still match?)
+2. *If a re-export is needed, can it be reproduced here?* (Are the required
+   inputs -- the campaign config and the generation script -- actually present
+   in this checkout, and is the source-commit provenance recorded?)
+
+This preflight composes the existing freshness classifier in
+``scripts/tools/stale_artifact_detector.py`` (the canonical owner for artifact
+freshness) with a *required-input availability* check, and reduces the two
+signals to a single readiness state:
+
+* ``fresh`` -- payload present and checksums match; no re-export needed.
+* ``stale`` -- a re-export is needed and every required input is present, so the
+  bounded campaign can be reproduced here (re-export is unblocked).
+* ``blocked`` -- a re-export is needed but at least one required input is missing
+  or the provenance cannot be reconstructed, so the re-export must be reported
+  as blocked rather than run against unverifiable provenance.
+
+This tool is intentionally read-only. It does **not** run the campaign,
+regenerate any table, or edit dissertation claims. It only reports status and
+the concrete inputs a re-export would require.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import shlex
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from scripts.tools import stale_artifact_detector as detector
+
+try:
+    import yaml
+except ImportError:  # pragma: no cover - dependency is present in repo env
+    yaml = None
+
+SCHEMA_VERSION = "reexport_readiness_preflight.v1"
+
+# Exceptions that mean a manifest could not be loaded/parsed. ``json.JSONDecodeError``
+# is a ``ValueError`` subclass; ``yaml.YAMLError`` is added when PyYAML is available.
+_LOAD_ERRORS: tuple[type[Exception], ...] = (OSError, ValueError)
+if yaml is not None:  # pragma: no branch - PyYAML is present in the repo env
+    _LOAD_ERRORS = (*_LOAD_ERRORS, yaml.YAMLError)
+
+# Freshness states that mean the bundle payload is safe to cite as-is and does
+# not require a re-export. Everything else implies a re-export is needed.
+_FRESH_STATES = frozenset(
+    {
+        detector.ArtifactState.CURRENT,
+        detector.ArtifactState.HISTORICAL_VALID,
+    }
+)
+
+
+class ReexportReadiness(StrEnum):
+    """Operator-facing re-export readiness for a dissertation table bundle."""
+
+    FRESH = "fresh"
+    STALE = "stale"
+    BLOCKED = "blocked"
+
+
+@dataclass(frozen=True, slots=True)
+class RequiredInput:
+    """One input a re-export needs, with its resolved availability."""
+
+    name: str
+    kind: str
+    value: str | None
+    present: bool
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable view."""
+        return {
+            "name": self.name,
+            "kind": self.kind,
+            "value": self.value,
+            "present": self.present,
+            "detail": self.detail,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class BundleReadinessReport:
+    """Readiness assessment for one bundle manifest."""
+
+    manifest_path: str
+    state: ReexportReadiness
+    reexport_needed: bool
+    reasons: list[str]
+    required_inputs: list[RequiredInput]
+    freshness: dict[str, Any]
+    generated_at_utc: str
+    schema: str = SCHEMA_VERSION
+
+    @property
+    def missing_inputs(self) -> list[RequiredInput]:
+        """Return required inputs that are not present in this checkout."""
+        return [item for item in self.required_inputs if not item.present]
+
+    @property
+    def exit_code(self) -> int:
+        """Return non-zero only when a re-export is blocked.
+
+        A ``stale`` bundle is an actionable-but-unblocked state (the operator can
+        re-run the bounded campaign), so it is not treated as a hard failure. A
+        ``blocked`` bundle is a hard failure because the re-export cannot be
+        reproduced from the recorded provenance.
+        """
+        return int(self.state is ReexportReadiness.BLOCKED)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable report."""
+        return {
+            "schema": self.schema,
+            "generated_at_utc": self.generated_at_utc,
+            "manifest_path": self.manifest_path,
+            "state": self.state.value,
+            "reexport_needed": self.reexport_needed,
+            "reasons": self.reasons,
+            "required_inputs": [item.to_dict() for item in self.required_inputs],
+            "missing_inputs": [item.name for item in self.missing_inputs],
+            "freshness": self.freshness,
+        }
+
+
+def _load_raw_payload(manifest_path: Path) -> Any:
+    """Load the raw manifest payload (JSON or YAML) without flattening."""
+    text = manifest_path.read_text(encoding="utf-8")
+    if manifest_path.suffix.lower() == ".json":
+        return json.loads(text)
+    if yaml is None:  # pragma: no cover - dependency is present in repo env
+        raise RuntimeError("PyYAML is required for YAML manifests")
+    return yaml.safe_load(text)
+
+
+def _iter_entries(payload: Any) -> list[dict[str, Any]]:
+    """Return candidate entries from a manifest payload for metadata scraping."""
+    entries: list[dict[str, Any]] = []
+    if isinstance(payload, dict):
+        entries.append(payload)
+        artifacts = payload.get("artifacts")
+        if isinstance(artifacts, list):
+            entries.extend(item for item in artifacts if isinstance(item, dict))
+    elif isinstance(payload, list):
+        entries.extend(item for item in payload if isinstance(item, dict))
+    return entries
+
+
+def _first_field(entries: list[dict[str, Any]], *names: str) -> str | None:
+    """Return the first non-empty string value for any of ``names``."""
+    for entry in entries:
+        for name in names:
+            value = entry.get(name)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+def _extract_option_value(command: str, *flags: str) -> str | None:
+    """Return the value following any of ``flags`` in a shell command string."""
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    for index, token in enumerate(tokens):
+        for flag in flags:
+            if token == flag and index + 1 < len(tokens):
+                return tokens[index + 1]
+            prefix = f"{flag}="
+            if token.startswith(prefix):
+                return token[len(prefix) :]
+    return None
+
+
+def _extract_script_path(command: str) -> str | None:
+    """Return the first ``*.py`` script path token in a command string.
+
+    Handles both direct ``python scripts/foo.py`` and ``python -m pkg.mod``
+    forms; for ``-m`` invocations the module path is returned as a dotted
+    reference rather than a filesystem path.
+    """
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = command.split()
+    for index, token in enumerate(tokens):
+        if token == "-m" and index + 1 < len(tokens):
+            return tokens[index + 1]
+        if token.endswith(".py") and not token.startswith("-"):
+            return token
+    return None
+
+
+def _resolve_under_root(path_text: str, repo_root: Path) -> Path:
+    """Resolve a possibly-relative manifest path against ``repo_root``."""
+    candidate = Path(path_text)
+    if candidate.is_absolute():
+        return candidate
+    return repo_root / candidate
+
+
+_PLACEHOLDER_RE = re.compile(r"<[^>]+>")
+
+
+def _looks_like_placeholder(value: str) -> bool:
+    """Return True when a recorded path is a placeholder, not a real input."""
+    return bool(_PLACEHOLDER_RE.search(value))
+
+
+def _required_inputs(
+    entries: list[dict[str, Any]],
+    *,
+    repo_root: Path,
+) -> list[RequiredInput]:
+    """Derive the concrete inputs a re-export needs and check their presence."""
+    inputs: list[RequiredInput] = []
+
+    command = _first_field(entries, "generation_command")
+    source_commit = _first_field(entries, "source_commit")
+
+    # Campaign config: the bounded campaign cannot be reproduced without it.
+    config_value = _extract_option_value(command, "--config") if command else None
+    if config_value is None:
+        inputs.append(
+            RequiredInput(
+                name="campaign_config",
+                kind="config",
+                value=None,
+                present=False,
+                detail="no --config recorded in generation_command",
+            )
+        )
+    elif _looks_like_placeholder(config_value):
+        inputs.append(
+            RequiredInput(
+                name="campaign_config",
+                kind="config",
+                value=config_value,
+                present=False,
+                detail="recorded config path is a placeholder",
+            )
+        )
+    else:
+        config_path = _resolve_under_root(config_value, repo_root)
+        present = config_path.is_file()
+        inputs.append(
+            RequiredInput(
+                name="campaign_config",
+                kind="config",
+                value=config_value,
+                present=present,
+                detail="config file present" if present else "config file missing",
+            )
+        )
+
+    # Generation script: the entry point that produces the tables.
+    script_value = _extract_script_path(command) if command else None
+    if script_value is None:
+        inputs.append(
+            RequiredInput(
+                name="generation_script",
+                kind="script",
+                value=None,
+                present=False,
+                detail="no generation script found in generation_command",
+            )
+        )
+    elif script_value.endswith(".py"):
+        script_path = _resolve_under_root(script_value, repo_root)
+        present = script_path.is_file()
+        inputs.append(
+            RequiredInput(
+                name="generation_script",
+                kind="script",
+                value=script_value,
+                present=present,
+                detail="script present" if present else "script missing",
+            )
+        )
+    else:
+        # A ``-m`` module reference; treat as present-as-recorded provenance.
+        inputs.append(
+            RequiredInput(
+                name="generation_script",
+                kind="module",
+                value=script_value,
+                present=True,
+                detail="module reference recorded",
+            )
+        )
+
+    # Source commit: provenance anchor for a reproducible re-run.
+    inputs.append(
+        RequiredInput(
+            name="source_commit",
+            kind="provenance",
+            value=source_commit,
+            present=source_commit is not None,
+            detail="source_commit recorded"
+            if source_commit is not None
+            else "no source_commit recorded",
+        )
+    )
+
+    return inputs
+
+
+def assess_bundle(
+    manifest_path: Path,
+    *,
+    repo_root: Path | None = None,
+    current_schema: str = detector.CURRENT_ARTIFACT_SCHEMA,
+) -> BundleReadinessReport:
+    """Assess re-export readiness for one bundle manifest.
+
+    Composes the canonical freshness classifier with a required-input
+    availability check and reduces both to a single readiness state.
+    """
+    repo_root = repo_root or manifest_path.resolve().parent
+    reasons: list[str] = []
+
+    try:
+        payload = _load_raw_payload(manifest_path)
+        entries = _iter_entries(payload)
+    except _LOAD_ERRORS as exc:  # malformed manifest -> cannot reproduce
+        return BundleReadinessReport(
+            manifest_path=str(manifest_path),
+            state=ReexportReadiness.BLOCKED,
+            reexport_needed=True,
+            reasons=[f"cannot load manifest: {exc}"],
+            required_inputs=[],
+            freshness={"error": str(exc)},
+            generated_at_utc=datetime.now(UTC).isoformat(),
+        )
+
+    freshness_report = detector.scan_manifest(manifest_path, current_schema=current_schema)
+    fresh = bool(freshness_report.results) and all(
+        result.state in _FRESH_STATES for result in freshness_report.results
+    )
+    reexport_needed = not fresh
+
+    required_inputs = _required_inputs(entries, repo_root=repo_root)
+    missing = [item for item in required_inputs if not item.present]
+
+    summary_counts = {state.value: 0 for state in detector.ArtifactState}
+    for result in freshness_report.results:
+        summary_counts[result.state.value] += 1
+    freshness_summary = {
+        "summary": summary_counts,
+        "results": [
+            {"artifact_id": result.artifact_id, "state": result.state.value}
+            for result in freshness_report.results
+        ],
+    }
+
+    if not reexport_needed:
+        reasons.append("payload present and checksums match; no re-export needed")
+        state = ReexportReadiness.FRESH
+    elif missing:
+        reasons.append("re-export needed but required inputs are missing")
+        reasons.extend(f"missing {item.name}: {item.detail}" for item in missing)
+        state = ReexportReadiness.BLOCKED
+    else:
+        reasons.append("re-export needed; all required inputs present (re-export unblocked)")
+        state = ReexportReadiness.STALE
+
+    return BundleReadinessReport(
+        manifest_path=str(manifest_path),
+        state=state,
+        reexport_needed=reexport_needed,
+        reasons=reasons,
+        required_inputs=required_inputs,
+        freshness=freshness_summary,
+        generated_at_utc=datetime.now(UTC).isoformat(),
+    )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Read-only re-export readiness preflight for stale dissertation table "
+            "bundles. Reports fresh/stale/blocked status and required re-export inputs; "
+            "never runs the campaign or edits claims."
+        )
+    )
+    parser.add_argument("manifest", type=Path, help="Bundle manifest JSON/YAML file.")
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root used to resolve relative input paths (default: manifest dir).",
+    )
+    parser.add_argument(
+        "--current-schema",
+        default=detector.CURRENT_ARTIFACT_SCHEMA,
+        help="Schema version treated as current for freshness classification.",
+    )
+    parser.add_argument("--json-out", type=Path, help="Optional JSON report output path.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
+    report = assess_bundle(
+        args.manifest,
+        repo_root=args.repo_root,
+        current_schema=args.current_schema,
+    )
+    payload = json.dumps(report.to_dict(), indent=2, sort_keys=True) + "\n"
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(payload, encoding="utf-8")
+    else:
+        print(payload, end="")
+    return report.exit_code
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/tools/test_reexport_readiness_preflight.py
+++ b/tests/tools/test_reexport_readiness_preflight.py
@@ -1,0 +1,206 @@
+"""Tests for the re-export readiness preflight (issue #3203).
+
+Cover the three operator-facing readiness states (``fresh``, ``stale``,
+``blocked``) using small on-disk fixtures so the classification stays
+verifiable without running any benchmark campaign.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+from scripts.tools import reexport_readiness_preflight as preflight
+from scripts.tools.reexport_readiness_preflight import ReexportReadiness
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write(path: Path, content: bytes) -> str:
+    """Write ``content`` to ``path`` and return its sha256 digest."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(content)
+    return hashlib.sha256(content).hexdigest()
+
+
+def _bundle_payload(*, checksum: str, command: str, source_commit: str | None) -> dict:
+    """Build a dissertation-bundle manifest payload for the fixtures."""
+    artifact = {
+        "artifact_id": "tab_scenario_horizon",
+        "output_path": "table.md",
+        "sha256": checksum,
+        "generation_command": command,
+    }
+    if source_commit is not None:
+        artifact["source_commit"] = source_commit
+    payload = {
+        "schema_version": "dissertation_artifact_bundle.v1",
+        "generation_command": command,
+        "artifacts": [artifact],
+    }
+    if source_commit is not None:
+        payload["source_commit"] = source_commit
+    return payload
+
+
+def _make_repo_root(tmp_path: Path, *, with_config: bool, with_script: bool) -> Path:
+    """Create a fake repo root with optional config and generation script."""
+    repo_root = tmp_path / "repo"
+    if with_config:
+        cfg = repo_root / "configs" / "campaign.yaml"
+        cfg.parent.mkdir(parents=True, exist_ok=True)
+        cfg.write_text("name: scenario_horizon\n", encoding="utf-8")
+    if with_script:
+        script = repo_root / "scripts" / "tools" / "run_campaign.py"
+        script.parent.mkdir(parents=True, exist_ok=True)
+        script.write_text("# entry point\n", encoding="utf-8")
+    repo_root.mkdir(parents=True, exist_ok=True)
+    return repo_root
+
+
+_COMMAND = "uv run python scripts/tools/run_campaign.py --config configs/campaign.yaml --mode run"
+
+
+def test_fresh_bundle_with_matching_payload(tmp_path: Path) -> None:
+    """Payload present + matching checksum => fresh, no re-export needed."""
+    bundle = tmp_path / "bundle"
+    digest = _write(bundle / "payload" / "table.md", b"horizon table\n")
+    repo_root = _make_repo_root(tmp_path, with_config=True, with_script=True)
+    manifest = bundle / "artifact_manifest.json"
+    manifest.write_text(
+        json.dumps(_bundle_payload(checksum=digest, command=_COMMAND, source_commit="abc123")),
+        encoding="utf-8",
+    )
+
+    report = preflight.assess_bundle(manifest, repo_root=repo_root)
+
+    assert report.state is ReexportReadiness.FRESH
+    assert report.reexport_needed is False
+    assert report.exit_code == 0
+    assert report.missing_inputs == []
+
+
+def test_stale_bundle_with_inputs_present_is_reexport_ready(tmp_path: Path) -> None:
+    """Missing payload but all inputs present => stale (re-export unblocked)."""
+    bundle = tmp_path / "bundle"
+    # Manifest references a payload file that is never written -> checksum fails.
+    repo_root = _make_repo_root(tmp_path, with_config=True, with_script=True)
+    manifest = bundle / "artifact_manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps(
+            _bundle_payload(checksum="deadbeef" * 8, command=_COMMAND, source_commit="abc123")
+        ),
+        encoding="utf-8",
+    )
+
+    report = preflight.assess_bundle(manifest, repo_root=repo_root)
+
+    assert report.state is ReexportReadiness.STALE
+    assert report.reexport_needed is True
+    # stale is actionable-but-unblocked, so it is not a hard failure.
+    assert report.exit_code == 0
+    assert report.missing_inputs == []
+    assert {item.name for item in report.required_inputs} == {
+        "campaign_config",
+        "generation_script",
+        "source_commit",
+    }
+
+
+def test_blocked_when_config_input_missing(tmp_path: Path) -> None:
+    """Re-export needed but the campaign config is absent => blocked."""
+    bundle = tmp_path / "bundle"
+    repo_root = _make_repo_root(tmp_path, with_config=False, with_script=True)
+    manifest = bundle / "artifact_manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps(
+            _bundle_payload(checksum="deadbeef" * 8, command=_COMMAND, source_commit="abc123")
+        ),
+        encoding="utf-8",
+    )
+
+    report = preflight.assess_bundle(manifest, repo_root=repo_root)
+
+    assert report.state is ReexportReadiness.BLOCKED
+    assert report.reexport_needed is True
+    assert report.exit_code == 1
+    assert [item.name for item in report.missing_inputs] == ["campaign_config"]
+
+
+def test_blocked_when_provenance_commit_missing(tmp_path: Path) -> None:
+    """Re-export needed and no source_commit recorded => blocked on provenance."""
+    bundle = tmp_path / "bundle"
+    repo_root = _make_repo_root(tmp_path, with_config=True, with_script=True)
+    manifest = bundle / "artifact_manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps(_bundle_payload(checksum="deadbeef" * 8, command=_COMMAND, source_commit=None)),
+        encoding="utf-8",
+    )
+
+    report = preflight.assess_bundle(manifest, repo_root=repo_root)
+
+    assert report.state is ReexportReadiness.BLOCKED
+    assert "source_commit" in {item.name for item in report.missing_inputs}
+
+
+def test_placeholder_config_is_treated_as_missing(tmp_path: Path) -> None:
+    """A placeholder config path (e.g. ``<config>``) cannot be reproduced."""
+    bundle = tmp_path / "bundle"
+    repo_root = _make_repo_root(tmp_path, with_config=True, with_script=True)
+    manifest = bundle / "artifact_manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    command = "uv run python scripts/tools/run_campaign.py --config <config> --mode run"
+    manifest.write_text(
+        json.dumps(
+            _bundle_payload(checksum="deadbeef" * 8, command=command, source_commit="abc123")
+        ),
+        encoding="utf-8",
+    )
+
+    report = preflight.assess_bundle(manifest, repo_root=repo_root)
+
+    assert report.state is ReexportReadiness.BLOCKED
+    config_input = next(i for i in report.required_inputs if i.name == "campaign_config")
+    assert config_input.present is False
+    assert "placeholder" in config_input.detail
+
+
+def test_malformed_manifest_is_blocked(tmp_path: Path) -> None:
+    """An unloadable manifest is blocked, not silently fresh."""
+    manifest = tmp_path / "broken.json"
+    manifest.write_text("{not valid json", encoding="utf-8")
+
+    report = preflight.assess_bundle(manifest, repo_root=tmp_path)
+
+    assert report.state is ReexportReadiness.BLOCKED
+    assert report.exit_code == 1
+
+
+def test_cli_writes_json_report(tmp_path: Path) -> None:
+    """The CLI emits a JSON report and a non-zero exit code when blocked."""
+    bundle = tmp_path / "bundle"
+    repo_root = _make_repo_root(tmp_path, with_config=False, with_script=True)
+    manifest = bundle / "artifact_manifest.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        json.dumps(
+            _bundle_payload(checksum="deadbeef" * 8, command=_COMMAND, source_commit="abc123")
+        ),
+        encoding="utf-8",
+    )
+    out = tmp_path / "report.json"
+
+    exit_code = preflight.main(
+        [str(manifest), "--repo-root", str(repo_root), "--json-out", str(out)]
+    )
+
+    assert exit_code == 1
+    report = json.loads(out.read_text(encoding="utf-8"))
+    assert report["state"] == "blocked"
+    assert report["schema"] == preflight.SCHEMA_VERSION
+    assert "campaign_config" in report["missing_inputs"]


### PR DESCRIPTION
## Summary

Implements a focused, first-code slice of issue #3203: a **read-only re-export readiness
preflight** for stale dissertation table bundles (e.g. the scenario-horizon tables). Closes the
issue's stated risk — *"Prevents stale dissertation-supporting tables from being treated as current
evidence without running campaigns"* — by giving operators a conservative, automatable answer
**before** any campaign is run.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3203

## Scope

In scope (this PR):
- `scripts/tools/reexport_readiness_preflight.py` — composes the existing canonical freshness
  classifier `scripts/tools/stale_artifact_detector.py` with a *required-input availability* check
  and reduces both signals to one state:
  - `fresh` — payload present and checksums match; no re-export needed.
  - `stale` — re-export needed and all required inputs present (campaign config, generation script,
    source-commit provenance) → re-export **unblocked** (exit 0; actionable but not a hard failure).
  - `blocked` — re-export needed but a required input is missing or provenance cannot be
    reconstructed → reported as blocked (exit 1).
- `tests/tools/test_reexport_readiness_preflight.py` — fixtures for fresh/stale/blocked
  classification, placeholder configs, malformed manifests, and the CLI JSON report.
- Discoverability pointer in `docs/context/issue_2542_dissertation_export_bundle.md` and a
  `CHANGELOG.md` entry.

The tool reuses the canonical owner (`stale_artifact_detector`) rather than re-implementing
freshness, per the `AGENTS.md` canonical-owner rule.

## Explicitly out of scope (deferred to the full issue / `imech156-u` gate)
- **No full benchmark campaign run** — this PR does not run the bounded scenario-horizon campaign.
- **No Slurm/GPU submission.**
- **No result-table regeneration** and **no paper/dissertation claim edits** — the ledger row,
  caption claims, and evidence catalog are untouched. The preflight only *reports* status and the
  inputs a re-export would require.

## Validation

All run from the worktree via `scripts/dev/run_worktree_shared_venv.sh`:

- `uv run pytest tests/tools/test_reexport_readiness_preflight.py -q` → **7 passed**
- `uv run pytest tests/tools/test_stale_artifact_detector.py -q` (regression on reused owner) →
  passed (23 passed combined)
- `scripts/dev/ruff_fix_format.sh` → **All checks passed**
- `BASE_REF=origin/main scripts/dev/check_docstring_todos_diff.sh` → no TODO docstrings
- Smoke against the real on-main bundle:
  `uv run python scripts/tools/reexport_readiness_preflight.py docs/context/evidence/issue_2542_dissertation_export_bundle/artifact_manifest.json --repo-root .`
  → `state: fresh`, `reexport_needed: false`, exit 0 (payload present + checksums match; all required
  inputs resolvable).

## Evidence grade

`smoke evidence` / tooling. This is read-only reproducibility/maintenance tooling; it makes no
benchmark, metric, or paper claim and does not upgrade the tier of any restored table.

## Downstream Propagation

- Parent issue (#3203): partially addressed — preflight slice only; full re-export + ledger
  reclassification remains the issue's broader scope.
- Claim map / leaderboard / registry: **Not applicable** — no claim or metric changes.
- Context note: updated `docs/context/issue_2542_dissertation_export_bundle.md` validation list.

## Research Result Guidance

`NA - support tooling.` No research claim; the preflight is a provenance/readiness guard, not
evidence movement.

## Residual risk

The full issue (re-running the bounded campaign, regenerating payload-complete tables, reclassifying
the ledger row from `non-claimable`) is intentionally left to the compute-authorized lane. This PR
narrows to a first code/test slice and adds no benchmark claim.
