### PR TITLE
feat(tools): presence-only tournament-readiness checker for predictive hard-case portfolio (#3215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **presence-only tournament-readiness helper** for the predictive hard-case breakthrough
+  portfolio (#3215). `scripts/tools/predictive_tournament_readiness.py` inventories the local
+  prerequisites (expected configs, harness scripts, and output path) for the three concurrent
+  tournament arms — Selection (#3204), Authority (#3213), and Model (#3214) — plus the shared
+  `predictive_hard_seeds_v1` benchmark protocol, and classifies each as `ready` or `blocked` with the
+  missing paths named as blockers. The check is deliberately fail-closed and **never** asserts run
+  authorization: `run_authorized` is always `False` and the standing `run_gates` (open child bets,
+  maintainer-set overnight SLURM/GPU budget, Autonomous Usage Stop Guard) are reported so a
+  "prerequisites ready" result is not mistaken for "authorized to launch". It does not submit Slurm
+  jobs, run the tournament, rank arms, or edit any claim. Text and `--json` reports; exit code 0 when
+  local prerequisites are ready, 1 when blocked.
 * Recorded metric-affecting run configuration in benchmark result provenance so result artifacts are
   self-describing (#3701). New pure module `robot_sf/benchmark/run_config_provenance.py` exposes
   `metric_affecting_run_config(config)`, which serializes the two run-config toggles that change *what*

--- a/scripts/tools/predictive_tournament_readiness.py
+++ b/scripts/tools/predictive_tournament_readiness.py
@@ -1,0 +1,301 @@
+#!/usr/bin/env python3
+"""Report local prerequisite readiness for the predictive hard-case tournament (#3215).
+
+The epic #3215 runs three hard-case levers concurrently as a tournament -- Selection
+(#3204), Authority (#3213), and Model (#3214) -- under a shared benchmark protocol, then
+synthesizes a single decision. The full campaign is SLURM/GPU-gated and needs maintainer
+budget pre-authorization, so this helper deliberately does **not** submit jobs, run the
+tournament, or rank arms.
+
+Instead it answers a narrow, repeatable question: *are the local prerequisites in place to
+launch each arm?* For every arm and for the shared protocol it inventories the expected
+configs, harness scripts, and output path, then classifies the arm as ``ready`` (all local
+prerequisites present) or ``blocked`` (one or more missing). The report is presence-only and
+fail-closed: it never marks the tournament itself authorized to run, because that remains
+gated on the open child issues and the maintainer-set overnight SLURM budget.
+
+Example:
+    uv run python scripts/tools/predictive_tournament_readiness.py
+    uv run python scripts/tools/predictive_tournament_readiness.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+# Shared-protocol prerequisites every arm depends on. Frozen by the launch packet in #3215:
+# fixed seed fixture, the campaign harness, the compact result store, the no-fallback algo
+# config builder, and the portfolio scenario set used as the map-runner gate.
+SHARED_PROTOCOL_PATHS: tuple[Path, ...] = (
+    Path("configs/benchmarks/predictive_hard_seeds_v1.yaml"),
+    Path("scripts/validation/run_predictive_success_campaign.py"),
+    Path("scripts/tools/campaign_result_store.py"),
+    Path("robot_sf/benchmark/predictive_planner_config.py"),
+    Path("configs/scenarios/sets/predictive_hardcase_portfolio_v1.yaml"),
+)
+
+# The tournament run is gated on more than local files: the three child bets must be ready
+# and the maintainer must pre-authorize a bounded overnight SLURM/GPU budget. These are
+# standing run blockers recorded so a "prerequisites ready" report is never mistaken for
+# "authorized to launch".
+RUN_GATES: tuple[str, ...] = (
+    "child bets #3204 / #3213 / #3214 must reach their own decision rules",
+    "maintainer must pre-authorize a bounded overnight SLURM/GPU budget (#3144 capacity policy)",
+    "Autonomous Usage Stop Guard must permit unattended execution",
+)
+
+
+@dataclass(frozen=True)
+class ArmSpec:
+    """Static definition of one tournament arm and its local prerequisites."""
+
+    arm_id: str
+    display_name: str
+    child_issue: int
+    description: str
+    # Configs and harness scripts that must exist locally before the arm can be staged.
+    required_paths: tuple[Path, ...]
+    # Where this arm's campaign results are expected to be written (informational; the path
+    # need not exist yet -- the run that creates it is SLURM-gated and out of scope here).
+    expected_output_path: Path
+    notes: str = ""
+
+
+ARMS: tuple[ArmSpec, ...] = (
+    ArmSpec(
+        arm_id="selection",
+        display_name="Selection (proxy-based checkpoint selection)",
+        child_issue=3204,
+        description=(
+            "Proxy-based checkpoint selection vs hard-set success: pick the checkpoint whose "
+            "cheap proxy best predicts hard-case success."
+        ),
+        required_paths=(
+            Path("scripts/research/analyze_predictive_checkpoint_proxy.py"),
+            Path("configs/benchmarks/predictive_hard_seeds_v1.yaml"),
+        ),
+        expected_output_path=Path("output/tmp/predictive_planner/campaigns/tournament_selection"),
+        notes="Proxy analysis is local; the success comparison it selects against is SLURM-gated.",
+    ),
+    ArmSpec(
+        arm_id="authority",
+        display_name="Authority (maneuver-authority / action-lattice sweep)",
+        child_issue=3213,
+        description=(
+            "Maneuver-authority / action-lattice / kinematic sweep over the hard-case seeds "
+            "to test whether more action authority closes the plateau."
+        ),
+        required_paths=(
+            Path("configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml"),
+            Path("configs/algos/hardcase_authority"),
+        ),
+        expected_output_path=Path("output/tmp/predictive_planner/campaigns/tournament_authority"),
+        notes="Algo dir provides the fully-specified --algo-config variants (no implicit fallback).",
+    ),
+    ArmSpec(
+        arm_id="model",
+        display_name="Model (hard-case-focused retraining)",
+        child_issue=3214,
+        description=(
+            "Hard-case-focused retraining with crossing-conflict augmentation, then evaluated "
+            "under the shared protocol."
+        ),
+        required_paths=(
+            Path(
+                "configs/training/predictive/"
+                "predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml"
+            ),
+        ),
+        expected_output_path=Path("output/tmp/predictive_planner/campaigns/tournament_model"),
+        notes="Retraining itself consumes the overnight GPU budget; only the config is checked here.",
+    ),
+)
+
+
+@dataclass
+class PathStatus:
+    """Presence record for a single expected prerequisite path."""
+
+    path: str
+    exists: bool
+
+
+@dataclass
+class ComponentReadiness:
+    """Readiness classification for one arm or for the shared protocol."""
+
+    component_id: str
+    display_name: str
+    status: str  # "ready" | "blocked"
+    paths: list[PathStatus]
+    missing_paths: list[str] = field(default_factory=list)
+    child_issue: int | None = None
+    description: str = ""
+    expected_output_path: str | None = None
+    notes: str = ""
+
+
+def _classify_paths(repo_root: Path, paths: tuple[Path, ...]) -> tuple[list[PathStatus], list[str]]:
+    """Return per-path presence records and the list of missing relative paths.
+
+    A path counts as present if the file or directory exists. Directories are valid
+    prerequisites (e.g. the authority algo-config family lives in a directory).
+    """
+    statuses: list[PathStatus] = []
+    missing: list[str] = []
+    for rel in paths:
+        exists = (repo_root / rel).exists()
+        statuses.append(PathStatus(path=rel.as_posix(), exists=exists))
+        if not exists:
+            missing.append(rel.as_posix())
+    return statuses, missing
+
+
+def evaluate_shared_protocol(repo_root: Path) -> ComponentReadiness:
+    """Classify the shared-protocol prerequisites that every arm depends on."""
+    statuses, missing = _classify_paths(repo_root, SHARED_PROTOCOL_PATHS)
+    return ComponentReadiness(
+        component_id="shared_protocol",
+        display_name="Shared benchmark protocol (predictive_hard_seeds_v1)",
+        status="ready" if not missing else "blocked",
+        paths=statuses,
+        missing_paths=missing,
+        description=(
+            "Fixed seed fixture, campaign harness, result store, no-fallback algo-config "
+            "builder, and portfolio scenario set shared across all three arms."
+        ),
+    )
+
+
+def evaluate_arm(repo_root: Path, arm: ArmSpec) -> ComponentReadiness:
+    """Classify a single tournament arm as ready or blocked on local prerequisites."""
+    statuses, missing = _classify_paths(repo_root, arm.required_paths)
+    return ComponentReadiness(
+        component_id=arm.arm_id,
+        display_name=arm.display_name,
+        status="ready" if not missing else "blocked",
+        paths=statuses,
+        missing_paths=missing,
+        child_issue=arm.child_issue,
+        description=arm.description,
+        expected_output_path=arm.expected_output_path.as_posix(),
+        notes=arm.notes,
+    )
+
+
+def evaluate_readiness(repo_root: Path = REPO_ROOT) -> dict:
+    """Build the full presence-only readiness report for the #3215 tournament.
+
+    The returned payload separates *local prerequisite* readiness (which this helper can
+    verify) from *run authorization* (which it cannot and must never assert): ``run_authorized``
+    is always ``False`` and ``run_gates`` lists the standing blockers to actually launching.
+    """
+    shared = evaluate_shared_protocol(repo_root)
+    arms = [evaluate_arm(repo_root, arm) for arm in ARMS]
+
+    components_ready = shared.status == "ready" and all(a.status == "ready" for a in arms)
+    prerequisites_status = "ready" if components_ready else "blocked"
+
+    return {
+        "issue": 3215,
+        "report": "predictive-tournament-readiness",
+        "scope": "presence-only local prerequisite check; does not submit, run, or rank",
+        "prerequisites_status": prerequisites_status,
+        "run_authorized": False,
+        "run_gates": list(RUN_GATES),
+        "shared_protocol": _component_to_dict(shared),
+        "arms": [_component_to_dict(a) for a in arms],
+    }
+
+
+def _component_to_dict(component: ComponentReadiness) -> dict:
+    """Serialize a ComponentReadiness to a plain JSON-friendly dict."""
+    payload: dict = {
+        "id": component.component_id,
+        "display_name": component.display_name,
+        "status": component.status,
+        "paths": [{"path": p.path, "exists": p.exists} for p in component.paths],
+        "missing_paths": component.missing_paths,
+        "description": component.description,
+    }
+    if component.child_issue is not None:
+        payload["child_issue"] = component.child_issue
+    if component.expected_output_path is not None:
+        payload["expected_output_path"] = component.expected_output_path
+    if component.notes:
+        payload["notes"] = component.notes
+    return payload
+
+
+def render_text(report: dict) -> str:
+    """Render a compact human-readable readiness summary."""
+    lines: list[str] = []
+    lines.append("Predictive hard-case tournament readiness (#3215)")
+    lines.append(f"  scope: {report['scope']}")
+    lines.append(f"  local prerequisites: {report['prerequisites_status'].upper()}")
+    lines.append(f"  run authorized: {report['run_authorized']} (presence-only check)")
+    lines.append("")
+
+    shared = report["shared_protocol"]
+    lines.append(f"[shared protocol] {shared['display_name']}: {shared['status'].upper()}")
+    for path in shared["paths"]:
+        mark = "ok " if path["exists"] else "MISS"
+        lines.append(f"    [{mark}] {path['path']}")
+    lines.append("")
+
+    for arm in report["arms"]:
+        header = f"[arm:{arm['id']}] {arm['display_name']} (child #{arm['child_issue']})"
+        lines.append(f"{header}: {arm['status'].upper()}")
+        for path in arm["paths"]:
+            mark = "ok " if path["exists"] else "MISS"
+            lines.append(f"    [{mark}] {path['path']}")
+        lines.append(f"    expected output: {arm['expected_output_path']}")
+        if arm["missing_paths"]:
+            lines.append(f"    blockers: {', '.join(arm['missing_paths'])}")
+        lines.append("")
+
+    lines.append("Run gates (must clear before launching; out of scope for this helper):")
+    for gate in report["run_gates"]:
+        lines.append(f"  - {gate}")
+    return "\n".join(lines)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit the machine-readable JSON report instead of the text summary.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=REPO_ROOT,
+        help="Repository root to evaluate prerequisites against (defaults to this checkout).",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Print the readiness report; exit 0 when local prerequisites are ready, else 1.
+
+    The non-zero exit on blocked prerequisites is a fail-closed signal for callers staging the
+    tournament. It says nothing about run authorization, which stays gated on ``run_gates``.
+    """
+    args = _parse_args(argv)
+    report = evaluate_readiness(args.repo_root)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(render_text(report))
+    return 0 if report["prerequisites_status"] == "ready" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_predictive_tournament_readiness.py
+++ b/tests/test_predictive_tournament_readiness.py
@@ -1,0 +1,150 @@
+"""Fixture tests for the predictive hard-case tournament readiness helper (#3215).
+
+These tests exercise the presence-only classifier against synthetic repository roots so the
+ready / blocked / missing-path logic is covered without depending on the real checkout layout
+or any SLURM/GPU execution.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+
+from scripts.tools.predictive_tournament_readiness import (
+    ARMS,
+    RUN_GATES,
+    SHARED_PROTOCOL_PATHS,
+    evaluate_arm,
+    evaluate_readiness,
+    main,
+    render_text,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _touch(repo_root: Path, rel: Path) -> None:
+    """Create an empty file (and parents) at ``rel`` under ``repo_root``."""
+    target = repo_root / rel
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("", encoding="utf-8")
+
+
+def _stage_all_prerequisites(repo_root: Path) -> None:
+    """Materialize every shared-protocol and per-arm prerequisite path."""
+    for rel in SHARED_PROTOCOL_PATHS:
+        _touch(repo_root, rel)
+    for arm in ARMS:
+        for rel in arm.required_paths:
+            # The authority arm requires a directory; create a dir for any path without a suffix.
+            if rel.suffix:
+                _touch(repo_root, rel)
+            else:
+                (repo_root / rel).mkdir(parents=True, exist_ok=True)
+
+
+def test_all_present_reports_ready(tmp_path: Path) -> None:
+    """When every prerequisite exists, all components classify as ready."""
+    _stage_all_prerequisites(tmp_path)
+    report = evaluate_readiness(tmp_path)
+
+    assert report["prerequisites_status"] == "ready"
+    assert report["shared_protocol"]["status"] == "ready"
+    assert all(arm["status"] == "ready" for arm in report["arms"])
+    assert all(not arm["missing_paths"] for arm in report["arms"])
+
+
+def test_run_is_never_authorized_even_when_ready(tmp_path: Path) -> None:
+    """The helper is presence-only: prerequisites ready must not imply run authorization."""
+    _stage_all_prerequisites(tmp_path)
+    report = evaluate_readiness(tmp_path)
+
+    assert report["run_authorized"] is False
+    assert report["run_gates"] == list(RUN_GATES)
+    assert report["run_gates"], "standing run gates must be reported"
+
+
+def test_missing_arm_path_reports_blocked_with_blockers(tmp_path: Path) -> None:
+    """A missing arm prerequisite yields a blocked arm that names the missing path."""
+    _stage_all_prerequisites(tmp_path)
+    model_arm = next(arm for arm in ARMS if arm.arm_id == "model")
+    missing = model_arm.required_paths[0]
+    (tmp_path / missing).unlink()
+
+    report = evaluate_readiness(tmp_path)
+    model = next(arm for arm in report["arms"] if arm["id"] == "model")
+
+    assert report["prerequisites_status"] == "blocked"
+    assert model["status"] == "blocked"
+    assert missing.as_posix() in model["missing_paths"]
+
+
+def test_missing_shared_protocol_blocks_overall(tmp_path: Path) -> None:
+    """A missing shared-protocol file blocks the portfolio even if all arms are ready."""
+    _stage_all_prerequisites(tmp_path)
+    (tmp_path / SHARED_PROTOCOL_PATHS[0]).unlink()
+
+    report = evaluate_readiness(tmp_path)
+
+    assert report["shared_protocol"]["status"] == "blocked"
+    assert report["prerequisites_status"] == "blocked"
+    assert SHARED_PROTOCOL_PATHS[0].as_posix() in report["shared_protocol"]["missing_paths"]
+
+
+def test_empty_repo_reports_all_paths_missing(tmp_path: Path) -> None:
+    """Against an empty root, every expected path is recorded as missing (not crashing)."""
+    report = evaluate_readiness(tmp_path)
+
+    assert report["prerequisites_status"] == "blocked"
+    for arm in report["arms"]:
+        assert arm["status"] == "blocked"
+        assert arm["missing_paths"] == [p["path"] for p in arm["paths"]]
+        assert all(p["exists"] is False for p in arm["paths"])
+
+
+def test_authority_directory_prerequisite_is_satisfied_by_directory(tmp_path: Path) -> None:
+    """The authority algo-config directory counts as present when the directory exists."""
+    authority = next(arm for arm in ARMS if arm.arm_id == "authority")
+    dir_prereq = next(p for p in authority.required_paths if not p.suffix)
+    (tmp_path / dir_prereq).mkdir(parents=True, exist_ok=True)
+
+    component = evaluate_arm(tmp_path, authority)
+    dir_status = next(p for p in component.paths if p.path == dir_prereq.as_posix())
+
+    assert dir_status.exists is True
+
+
+def test_arms_cover_the_three_named_bets() -> None:
+    """The portfolio must expose exactly the selection / authority / model bets."""
+    assert {arm.arm_id for arm in ARMS} == {"selection", "authority", "model"}
+    assert {arm.child_issue for arm in ARMS} == {3204, 3213, 3214}
+
+
+def test_render_text_runs_and_mentions_status(tmp_path: Path) -> None:
+    """The text renderer produces output and surfaces the prerequisite status."""
+    _stage_all_prerequisites(tmp_path)
+    text = render_text(evaluate_readiness(tmp_path))
+
+    assert "tournament readiness" in text.lower()
+    assert "READY" in text
+
+
+def test_main_exit_code_reflects_prerequisite_status(tmp_path: Path, capsys) -> None:
+    """main() exits 0 when ready and 1 when blocked, in both text and JSON modes."""
+    _stage_all_prerequisites(tmp_path)
+    assert main(["--repo-root", str(tmp_path), "--json"]) == 0
+    capsys.readouterr()
+
+    (tmp_path / SHARED_PROTOCOL_PATHS[0]).unlink()
+    assert main(["--repo-root", str(tmp_path)]) == 1
+
+
+@pytest.mark.parametrize("flag", [[], ["--json"]])
+def test_main_against_real_checkout_does_not_crash(flag: list[str], capsys) -> None:
+    """Running against the real repository root produces a report without raising."""
+    rc = main(flag)
+    out = capsys.readouterr().out
+    assert rc in (0, 1)
+    assert out.strip()


### PR DESCRIPTION
## Summary

Closes a small, agent-executable slice of the #3215 epic: a **presence-only tournament-readiness
helper** that reports whether the local prerequisites for the predictive hard-case portfolio are in
place, without launching or ranking anything.

`scripts/tools/predictive_tournament_readiness.py` inventories, for each of the three concurrent
tournament arms and for the shared benchmark protocol, the expected configs/harness scripts and the
expected output path, then classifies each as `ready` or `blocked` (missing paths named as blockers):

| Component | Child issue | Key prerequisites |
| --- | --- | --- |
| Shared protocol | — | `predictive_hard_seeds_v1.yaml`, `run_predictive_success_campaign.py`, `campaign_result_store.py`, `predictive_planner_config.py`, `predictive_hardcase_portfolio_v1.yaml` |
| Selection | #3204 | `analyze_predictive_checkpoint_proxy.py`, seed fixture |
| Authority | #3213 | `predictive_hardcase_authority_grid_issue_3213.yaml`, `configs/algos/hardcase_authority/` |
| Model | #3214 | `predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml` |

The check is **fail-closed and never asserts run authorization**: `run_authorized` is always `False`,
and the standing `run_gates` (open child bets, maintainer-set overnight SLURM/GPU budget, Autonomous
Usage Stop Guard) are reported separately so a "prerequisites ready" result is never mistaken for
"authorized to launch". Text and `--json` output; exit code `0` when local prerequisites are ready, `1`
when blocked.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3215

## Scope

- **In scope:** a small readiness helper reporting prerequisite status (configs, output paths,
  blockers) for the selection / authority / model arms and the shared protocol; focused fixture tests.
- **Narrowing:** #3215 is a SLURM/GPU-gated synthesis epic. This PR implements only the local,
  presence-only readiness slice named in the issue's "Agent-executable slice" — it is **not** the
  cross-bet synthesis harness or any campaign run.

## Validation

All run from the worktree via the shared venv (`scripts/dev/run_worktree_shared_venv.sh`):

```
$ ruff check scripts/tools/predictive_tournament_readiness.py tests/test_predictive_tournament_readiness.py
All checks passed!

$ ruff format --check <same files>
2 files already formatted

$ python -m pytest tests/test_predictive_tournament_readiness.py -q
11 passed in 0.53s

$ python scripts/tools/predictive_tournament_readiness.py
... local prerequisites: READY ; run authorized: False (all 3 arms + shared protocol present)
```

The fixture tests cover the validation hint directly: ready (all present), blocked (missing arm
prerequisite), missing (empty repo → every path missing), shared-protocol blocking, the
directory-prerequisite case, and the never-authorized invariant.

## Out of scope (explicit)

- **No full benchmark campaign run.**
- **No Slurm/GPU submission** — the helper only checks file presence; `run_authorized` is hard-coded
  `False`.
- **No paper/dissertation claim edits**, no arm ranking, no synthesis decision.

## Downstream Propagation

- Parent issue #3215: this PR satisfies the "local prerequisites … validated (dry-run)" readiness step
  only; the synthesis harness and SLURM budget remain open.
- Claim map / leaderboard / registry: NA — presence-only support helper, produces no benchmark
  evidence or metric.
- Context index / memory: NA — no durable evidence artifact produced.

## Research Result Guidance

`NA - support helper.` This is a readiness/preflight tool that coordinates prerequisites; it makes no
research claim, comparator, or evidence-tier assertion. First use is in this PR (the helper is run in
the validation block above against the real checkout). Its role in the #3215 epic is to gate, not to
measure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
