### PR TITLE
feat(benchmark): hybrid-learning prerequisite/status matrix helper (#1489)

### DIFF
--- a/robot_sf/benchmark/hybrid_evidence_matrix.py
+++ b/robot_sf/benchmark/hybrid_evidence_matrix.py
@@ -30,6 +30,16 @@ VERDICTS = frozenset({"continue", "revise", "stop", "insufficient_evidence", "pe
 SUCCESS_LIKE_TIERS = frozenset({"smoke_only", "nominal_only", "stress", "full_matrix"})
 SYNTHESIS_TIERS = frozenset({"stress", "full_matrix"})
 SYNTHESIS_VERDICTS = frozenset({"continue", "revise"})
+# Campaign-lifecycle states for the #1489 prerequisite/status matrix, ordered by
+# escalating readiness. Only ``complete`` lanes count toward unblocking synthesis.
+COMPONENT_CAMPAIGN_STATES = ("missing", "blocked", "ready", "complete")
+# Evidence tiers that represent a pre-runtime or non-comparable lane: the campaign
+# has not produced durable runtime evidence yet, so the lane stays ``blocked``.
+PRE_RUNTIME_TIERS = frozenset({"launch_packet", "failed", "not_available"})
+# Default number of ``complete`` (synthesis-eligible) lanes required before the
+# #1489 synthesis gate opens. The umbrella contract requires at least two
+# component campaigns with durable comparable outputs.
+DEFAULT_SYNTHESIS_PREREQUISITE_COUNT = 2
 ROW_REQUIRED_FIELDS = frozenset(
     {
         "component",
@@ -162,6 +172,190 @@ def validate_hybrid_evidence_rows(
         "invalid_row_count": invalid_row_count,
         "rows": row_reports,
     }
+
+
+def classify_component_campaign_state(row_report: dict[str, Any]) -> str:
+    """Classify one validated evidence row into a campaign-lifecycle state.
+
+    The lifecycle escalates ``missing -> blocked -> ready -> complete``:
+
+    - ``complete``: the row is synthesis-eligible — a durable comparable output
+      (``stress``/``full_matrix`` tier with a ``continue``/``revise`` verdict and
+      no validation errors). Only ``complete`` lanes count toward the #1489
+      synthesis prerequisite, so no single pre-result lane can unblock synthesis.
+    - ``ready``: the campaign executed and produced runtime evidence that is not
+      yet synthesis-grade (smoke/nominal/degraded/fallback tiers, or a terminal
+      tier with a non-synthesis verdict such as ``stop``).
+    - ``blocked``: the row is pre-runtime or non-comparable — a launch packet, a
+      ``not_run`` slice, a failed/unavailable tier, or an invalid row.
+
+    ``missing`` is assigned by :func:`build_hybrid_prerequisite_matrix` for
+    expected components that have no row; it is never returned here.
+
+    Args:
+        row_report: A per-row entry produced by :func:`validate_hybrid_evidence_rows`.
+
+    Returns:
+        One of ``"blocked"``, ``"ready"``, or ``"complete"``.
+    """
+    if row_report.get("synthesis_eligible"):
+        return "complete"
+    if row_report.get("status") == "invalid":
+        return "blocked"
+    if row_report.get("evaluation_slice") == "not_run":
+        return "blocked"
+    if row_report.get("evidence_tier") in PRE_RUNTIME_TIERS:
+        return "blocked"
+    return "ready"
+
+
+def build_hybrid_prerequisite_matrix(
+    rows: list[dict[str, Any]],
+    *,
+    expected_components: list[str] | None = None,
+    repo_root: Path | None = None,
+    check_git_history: bool = False,
+    prerequisite_count: int = DEFAULT_SYNTHESIS_PREREQUISITE_COUNT,
+) -> dict[str, Any]:
+    """Build the #1489 prerequisite/status matrix for hybrid-learning lanes.
+
+    Validates every row, classifies each into a campaign-lifecycle state, marks
+    expected-but-absent components as ``missing``, and decides whether the
+    synthesis prerequisite (at least ``prerequisite_count`` ``complete`` lanes)
+    is met. The gate is intentionally conservative: a lane counts only when the
+    row validator already marked it synthesis-eligible, so launch packets, smoke
+    runs, fallback/degraded rows, and invalid rows never open the gate.
+
+    Args:
+        rows: Evidence-matrix row mappings, as accepted by the row validator.
+        expected_components: Optional component names that should have a row.
+            Each name with no matching row becomes a ``missing`` lane.
+        repo_root: Repository root for provenance-path resolution.
+        check_git_history: Forwarded to the row validator to verify git SHAs.
+        prerequisite_count: Minimum ``complete`` lanes that open the gate.
+
+    Returns:
+        Structured report with the gate decision, per-state counts, and per-lane
+        classification details.
+    """
+    if prerequisite_count < 1:
+        raise HybridEvidenceMatrixValidationError("prerequisite_count must be >= 1")
+    validation = validate_hybrid_evidence_rows(
+        rows, repo_root=repo_root, check_git_history=check_git_history
+    )
+    lanes: list[dict[str, Any]] = []
+    seen_components: set[str] = set()
+    for row_report in validation["rows"]:
+        component = row_report.get("component")
+        if isinstance(component, str):
+            seen_components.add(component)
+        lanes.append(
+            {
+                "component": component,
+                "source_issue": row_report.get("source_issue"),
+                "state": classify_component_campaign_state(row_report),
+                "evaluation_slice": row_report.get("evaluation_slice"),
+                "evidence_tier": row_report.get("evidence_tier"),
+                "verdict": row_report.get("verdict"),
+                "row_status": row_report.get("status"),
+                "synthesis_eligible": bool(row_report.get("synthesis_eligible")),
+                "row_index": row_report.get("index"),
+            }
+        )
+    for component in _missing_components(expected_components, seen_components):
+        lanes.append(
+            {
+                "component": component,
+                "source_issue": None,
+                "state": "missing",
+                "evaluation_slice": None,
+                "evidence_tier": None,
+                "verdict": None,
+                "row_status": None,
+                "synthesis_eligible": False,
+                "row_index": None,
+            }
+        )
+    state_counts = dict.fromkeys(COMPONENT_CAMPAIGN_STATES, 0)
+    for lane in lanes:
+        state_counts[lane["state"]] += 1
+    complete_count = state_counts["complete"]
+    prerequisite_met = complete_count >= prerequisite_count
+    return {
+        "gate": "ready_for_synthesis" if prerequisite_met else "blocked",
+        "prerequisite_met": prerequisite_met,
+        "prerequisite_count": prerequisite_count,
+        "complete_count": complete_count,
+        "lane_count": len(lanes),
+        "state_counts": state_counts,
+        "rows_valid": validation["status"] == "valid",
+        "invalid_row_count": validation["invalid_row_count"],
+        "provenance_validation": validation["provenance_validation"],
+        "lanes": lanes,
+    }
+
+
+def build_hybrid_prerequisite_matrix_file(
+    path: Path,
+    *,
+    expected_components: list[str] | None = None,
+    repo_root: Path | None = None,
+    check_git_history: bool = False,
+    prerequisite_count: int = DEFAULT_SYNTHESIS_PREREQUISITE_COUNT,
+) -> dict[str, Any]:
+    """Load a matrix file and build its #1489 prerequisite/status report.
+
+    Args:
+        path: YAML/JSON evidence-matrix file accepted by
+            :func:`load_hybrid_evidence_input`.
+        expected_components: Optional expected component names (see
+            :func:`build_hybrid_prerequisite_matrix`).
+        repo_root: Repository root for provenance-path resolution.
+        check_git_history: Forwarded to the row validator to verify git SHAs.
+        prerequisite_count: Minimum ``complete`` lanes that open the gate.
+
+    Returns:
+        The prerequisite-matrix report with the input format and path attached.
+    """
+    input_format, rows = load_hybrid_evidence_input(path)
+    report = build_hybrid_prerequisite_matrix(
+        rows,
+        expected_components=expected_components,
+        repo_root=repo_root,
+        check_git_history=check_git_history,
+        prerequisite_count=prerequisite_count,
+    )
+    report["input_format"] = input_format
+    report["input_path"] = _repo_relative_or_absolute(
+        path.resolve(), root=(repo_root or get_repository_root())
+    )
+    return report
+
+
+def _missing_components(
+    expected_components: list[str] | None,
+    seen_components: set[str],
+) -> list[str]:
+    """Return expected component names that have no row, preserving input order.
+
+    Returns:
+        The de-duplicated list of expected names absent from ``seen_components``.
+    """
+    if not expected_components:
+        return []
+    seen_normalized = {
+        component.strip() for component in seen_components if isinstance(component, str)
+    }
+    missing: list[str] = []
+    for component in expected_components:
+        if not isinstance(component, str) or not component.strip():
+            raise HybridEvidenceMatrixValidationError(
+                "expected_components entries must be non-empty strings"
+            )
+        normalized = component.strip()
+        if normalized not in seen_normalized and normalized not in missing:
+            missing.append(normalized)
+    return missing
 
 
 def _validate_row(
@@ -803,7 +997,13 @@ def _repo_relative_or_absolute(path: Path, *, root: Path) -> str:
 
 
 __all__ = [
+    "COMPONENT_CAMPAIGN_STATES",
+    "DEFAULT_SYNTHESIS_PREREQUISITE_COUNT",
+    "PRE_RUNTIME_TIERS",
     "HybridEvidenceMatrixValidationError",
+    "build_hybrid_prerequisite_matrix",
+    "build_hybrid_prerequisite_matrix_file",
+    "classify_component_campaign_state",
     "load_hybrid_evidence_input",
     "validate_hybrid_evidence_file",
     "validate_hybrid_evidence_rows",

--- a/robot_sf/benchmark/hybrid_evidence_matrix.py
+++ b/robot_sf/benchmark/hybrid_evidence_matrix.py
@@ -343,6 +343,10 @@ def _missing_components(
     """
     if not expected_components:
         return []
+    if isinstance(expected_components, str):
+        raise HybridEvidenceMatrixValidationError(
+            "expected_components must be a list of strings, not a single string"
+        )
     seen_normalized = {
         component.strip() for component in seen_components if isinstance(component, str)
     }

--- a/scripts/validation/validate_hybrid_evidence_matrix.py
+++ b/scripts/validation/validate_hybrid_evidence_matrix.py
@@ -8,7 +8,9 @@ import json
 from pathlib import Path
 
 from robot_sf.benchmark.hybrid_evidence_matrix import (
+    DEFAULT_SYNTHESIS_PREREQUISITE_COUNT,
     HybridEvidenceMatrixValidationError,
+    build_hybrid_prerequisite_matrix_file,
     validate_hybrid_evidence_file,
 )
 from robot_sf.common.artifact_paths import get_repository_root
@@ -36,6 +38,35 @@ def build_arg_parser() -> argparse.ArgumentParser:
             "local repository history. Default validation remains format-only."
         ),
     )
+    parser.add_argument(
+        "--prerequisite-matrix",
+        action="store_true",
+        help=(
+            "Emit the #1489 prerequisite/status matrix instead of the row-validation report: "
+            "classify each component lane as missing, blocked, ready, or complete and decide "
+            "whether the synthesis gate is open."
+        ),
+    )
+    parser.add_argument(
+        "--expected-component",
+        action="append",
+        default=None,
+        dest="expected_components",
+        metavar="NAME",
+        help=(
+            "Component name expected to have a row (repeatable). Expected components with no "
+            "matching row are reported as 'missing'. Only used with --prerequisite-matrix."
+        ),
+    )
+    parser.add_argument(
+        "--prerequisite-count",
+        type=int,
+        default=DEFAULT_SYNTHESIS_PREREQUISITE_COUNT,
+        help=(
+            "Minimum number of 'complete' (synthesis-eligible) lanes that open the synthesis "
+            "gate. Only used with --prerequisite-matrix."
+        ),
+    )
     return parser
 
 
@@ -43,6 +74,16 @@ def main(argv: list[str] | None = None) -> int:
     """Validate a matrix file and return a shell-friendly exit code."""
     args = build_arg_parser().parse_args(argv)
     try:
+        if args.prerequisite_matrix:
+            report = build_hybrid_prerequisite_matrix_file(
+                args.input,
+                expected_components=args.expected_components,
+                repo_root=args.repo_root,
+                check_git_history=args.check_git_history,
+                prerequisite_count=args.prerequisite_count,
+            )
+            print(json.dumps(report, indent=2, sort_keys=True))
+            return 0 if report["rows_valid"] else 2
         report = validate_hybrid_evidence_file(
             args.input,
             repo_root=args.repo_root,

--- a/tests/benchmark/test_hybrid_prerequisite_matrix.py
+++ b/tests/benchmark/test_hybrid_prerequisite_matrix.py
@@ -1,0 +1,217 @@
+"""Tests for the #1489 hybrid-learning prerequisite/status matrix helper.
+
+These tests exercise the campaign-lifecycle classification (missing, blocked,
+ready, complete) and the conservative synthesis gate that consumes it. Rows are
+built from the shared evidence-matrix fixtures and mutated synthetically so each
+lifecycle state has a focused, deterministic case.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.hybrid_evidence_matrix import (
+    DEFAULT_SYNTHESIS_PREREQUISITE_COUNT,
+    HybridEvidenceMatrixValidationError,
+    build_hybrid_prerequisite_matrix,
+    build_hybrid_prerequisite_matrix_file,
+    classify_component_campaign_state,
+    load_hybrid_evidence_input,
+)
+from scripts.validation.validate_hybrid_evidence_matrix import main as validate_cli_main
+
+FIXTURE_ROOT = Path("tests/fixtures/hybrid_evidence_matrix/v1")
+
+
+def _complete_row() -> dict:
+    """Return a deep copy of the synthesis-eligible stress-slice fixture row."""
+    _input_format, rows = load_hybrid_evidence_input(FIXTURE_ROOT / "valid_rows.yaml")
+    return copy.deepcopy(rows[0])
+
+
+def _blocked_launch_packet_row() -> dict:
+    """Return a deep copy of the not-run launch-packet fixture row."""
+    _input_format, rows = load_hybrid_evidence_input(FIXTURE_ROOT / "valid_rows.yaml")
+    return copy.deepcopy(rows[1])
+
+
+def _ready_smoke_row() -> dict:
+    """Build an executed smoke-only row that is valid but not synthesis-grade."""
+    row = _complete_row()
+    row["component"] = "shielded_ppo_repair_v1"
+    row["source_issue"] = "#1474"
+    row["evaluation_slice"] = "smoke"
+    row["evidence_tier"] = "smoke_only"
+    return row
+
+
+def test_classify_component_campaign_state_maps_each_state() -> None:
+    """The row-level classifier maps eligibility/tier/slice to the lifecycle state."""
+    assert classify_component_campaign_state({"synthesis_eligible": True, "status": "valid"}) == (
+        "complete"
+    )
+    assert classify_component_campaign_state({"status": "invalid"}) == "blocked"
+    assert (
+        classify_component_campaign_state({"status": "valid", "evaluation_slice": "not_run"})
+        == "blocked"
+    )
+    assert (
+        classify_component_campaign_state({"status": "valid", "evidence_tier": "failed"})
+        == "blocked"
+    )
+    assert (
+        classify_component_campaign_state(
+            {"status": "valid", "evaluation_slice": "smoke", "evidence_tier": "smoke_only"}
+        )
+        == "ready"
+    )
+
+
+def test_complete_row_classifies_as_complete() -> None:
+    """A synthesis-eligible stress row is the only state that feeds synthesis."""
+    matrix = build_hybrid_prerequisite_matrix([_complete_row()])
+
+    assert matrix["lanes"][0]["state"] == "complete"
+    assert matrix["lanes"][0]["synthesis_eligible"] is True
+    assert matrix["state_counts"]["complete"] == 1
+
+
+def test_blocked_launch_packet_row_classifies_as_blocked() -> None:
+    """A not-run launch packet is pre-runtime evidence and must stay blocked."""
+    matrix = build_hybrid_prerequisite_matrix([_blocked_launch_packet_row()])
+
+    assert matrix["lanes"][0]["state"] == "blocked"
+    assert matrix["state_counts"]["blocked"] == 1
+
+
+def test_ready_smoke_row_classifies_as_ready() -> None:
+    """An executed smoke-only row produced runtime evidence but is not synthesis-grade."""
+    matrix = build_hybrid_prerequisite_matrix([_ready_smoke_row()])
+
+    assert matrix["lanes"][0]["state"] == "ready"
+    assert matrix["lanes"][0]["synthesis_eligible"] is False
+    assert matrix["state_counts"]["ready"] == 1
+
+
+def test_invalid_row_classifies_as_blocked() -> None:
+    """An invalid row cannot be trusted, so it is blocked rather than ready/complete."""
+    row = _complete_row()
+    row["source_issue"] = "not-an-issue-ref"
+
+    matrix = build_hybrid_prerequisite_matrix([row])
+
+    assert matrix["rows_valid"] is False
+    assert matrix["invalid_row_count"] == 1
+    assert matrix["lanes"][0]["state"] == "blocked"
+
+
+def test_expected_component_without_row_is_missing() -> None:
+    """Expected components with no row should surface as a 'missing' lane."""
+    matrix = build_hybrid_prerequisite_matrix(
+        [_complete_row()],
+        expected_components=["learned_risk_model_v1", "orca_residual_bc_v1"],
+    )
+
+    states = {lane["component"]: lane["state"] for lane in matrix["lanes"]}
+    assert states["learned_risk_model_v1"] == "complete"
+    assert states["orca_residual_bc_v1"] == "missing"
+    assert matrix["state_counts"]["missing"] == 1
+
+
+def test_gate_blocked_with_single_complete_lane() -> None:
+    """One synthesis-eligible lane is below the default prerequisite of two."""
+    matrix = build_hybrid_prerequisite_matrix(
+        [_complete_row(), _ready_smoke_row(), _blocked_launch_packet_row()]
+    )
+
+    assert matrix["prerequisite_count"] == DEFAULT_SYNTHESIS_PREREQUISITE_COUNT
+    assert matrix["complete_count"] == 1
+    assert matrix["prerequisite_met"] is False
+    assert matrix["gate"] == "blocked"
+
+
+def test_gate_opens_only_when_two_lanes_are_complete() -> None:
+    """The gate opens at exactly two durable comparable (complete) lanes."""
+    first = _complete_row()
+    second = _complete_row()
+    second["component"] = "orca_residual_learned_v1"
+    second["source_issue"] = "#1358"
+
+    matrix = build_hybrid_prerequisite_matrix([first, second])
+
+    assert matrix["complete_count"] == 2
+    assert matrix["prerequisite_met"] is True
+    assert matrix["gate"] == "ready_for_synthesis"
+
+
+def test_ready_lanes_never_open_the_gate() -> None:
+    """Even many executed-but-not-synthesis-grade lanes cannot open the gate."""
+    rows = [_ready_smoke_row() for _ in range(3)]
+
+    matrix = build_hybrid_prerequisite_matrix(rows)
+
+    assert matrix["state_counts"]["ready"] == 3
+    assert matrix["complete_count"] == 0
+    assert matrix["gate"] == "blocked"
+
+
+def test_custom_prerequisite_count_changes_gate() -> None:
+    """A prerequisite of one opens the gate on a single complete lane."""
+    matrix = build_hybrid_prerequisite_matrix([_complete_row()], prerequisite_count=1)
+
+    assert matrix["prerequisite_count"] == 1
+    assert matrix["gate"] == "ready_for_synthesis"
+
+
+def test_invalid_prerequisite_count_is_rejected() -> None:
+    """A non-positive prerequisite count is a usage error, not a silent default."""
+    try:
+        build_hybrid_prerequisite_matrix([_complete_row()], prerequisite_count=0)
+    except HybridEvidenceMatrixValidationError as exc:
+        assert "prerequisite_count" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected HybridEvidenceMatrixValidationError")
+
+
+def test_blank_expected_component_is_rejected() -> None:
+    """Expected-component entries must be non-empty strings."""
+    try:
+        build_hybrid_prerequisite_matrix([_complete_row()], expected_components=["  "])
+    except HybridEvidenceMatrixValidationError as exc:
+        assert "expected_components" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected HybridEvidenceMatrixValidationError")
+
+
+def test_file_helper_attaches_input_metadata() -> None:
+    """The file helper should classify fixture rows and record the input path."""
+    report = build_hybrid_prerequisite_matrix_file(FIXTURE_ROOT / "valid_rows.yaml")
+
+    assert report["input_format"] == "rows"
+    assert report["input_path"].endswith("valid_rows.yaml")
+    assert report["lane_count"] == 2
+    states = sorted(lane["state"] for lane in report["lanes"])
+    assert states == ["blocked", "complete"]
+
+
+def test_cli_prerequisite_matrix_emits_gate_decision(capsys) -> None:
+    """The CLI prerequisite mode should emit the gate JSON and a clean exit code."""
+    exit_code = validate_cli_main(
+        [
+            "--input",
+            str(FIXTURE_ROOT / "valid_rows.yaml"),
+            "--prerequisite-matrix",
+            "--expected-component",
+            "learned_risk_model_v1",
+            "--expected-component",
+            "shielded_ppo_repair_v1",
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["gate"] == "blocked"
+    assert payload["complete_count"] == 1
+    assert payload["state_counts"]["missing"] == 1

--- a/tests/benchmark/test_hybrid_prerequisite_matrix.py
+++ b/tests/benchmark/test_hybrid_prerequisite_matrix.py
@@ -185,6 +185,18 @@ def test_blank_expected_component_is_rejected() -> None:
         raise AssertionError("expected HybridEvidenceMatrixValidationError")
 
 
+def test_single_string_expected_components_is_rejected() -> None:
+    """A bare string must not be iterated character-by-character into lanes."""
+    try:
+        build_hybrid_prerequisite_matrix(
+            [_complete_row()], expected_components="learned_risk_model_v1"
+        )
+    except HybridEvidenceMatrixValidationError as exc:
+        assert "expected_components" in str(exc)
+    else:  # pragma: no cover - defensive
+        raise AssertionError("expected HybridEvidenceMatrixValidationError")
+
+
 def test_file_helper_attaches_input_metadata() -> None:
     """The file helper should classify fixture rows and record the input path."""
     report = build_hybrid_prerequisite_matrix_file(FIXTURE_ROOT / "valid_rows.yaml")


### PR DESCRIPTION
## Summary

Adds a **prerequisite/status matrix helper** for the hard-guarded hybrid-learning
synthesis umbrella, issue #1489. The umbrella is blocked until at least two
component campaigns produce durable comparable outputs; today that readiness
judgment is maintained by hand in markdown (e.g. `docs/context/issue_2410_*`).
This PR makes the gate machine-checkable so the synthesis cannot be started on
pre-result lanes.

Closes the scoped slice of #1489: <https://github.com/ll7/robot_sf_ll7/issues/1489>
(prerequisite matrix only — not the synthesis itself).

## Scope

- **In scope:** a campaign-lifecycle classifier and synthesis gate built on top
  of the existing canonical owner `robot_sf/benchmark/hybrid_evidence_matrix.py`
  (extended, not forked), plus a CLI mode and focused synthetic tests.
- **Out of scope (unchanged):** no child-campaign execution, no Slurm/GPU
  submission, no synthesis output, no paper/dissertation claim edits.

### What it does

`build_hybrid_prerequisite_matrix(rows, expected_components=…, prerequisite_count=2)`
validates every row through the existing row validator, then classifies each
component lane into an escalating lifecycle state:

| State | Meaning |
| --- | --- |
| `missing` | An expected component has no evidence row. |
| `blocked` | Pre-runtime or non-comparable: launch packet, `not_run`, failed/unavailable tier, or an invalid row. |
| `ready` | Executed runtime evidence that is not yet synthesis-grade (smoke/nominal/degraded/fallback, or a terminal tier with a non-synthesis verdict such as `stop`). |
| `complete` | Synthesis-eligible durable comparable output (`stress`/`full_matrix` tier + `continue`/`revise` verdict, no validation errors). |

The gate opens (`ready_for_synthesis`) only when at least `prerequisite_count`
(default 2) lanes are `complete`. This is conservative by construction: launch
packets, smoke/nominal/degraded/fallback rows, and invalid rows never count, so
no single pre-result lane can drive a premature comparative claim — exactly the
overclaim risk #1489 calls out.

The `scripts/validation/validate_hybrid_evidence_matrix.py` CLI gains a
`--prerequisite-matrix` mode with `--expected-component` (repeatable) and
`--prerequisite-count` flags.

## Validation

All run from the worktree via `scripts/dev/run_worktree_shared_venv.sh`.

```
uv run pytest tests/benchmark/test_hybrid_prerequisite_matrix.py \
              tests/benchmark/test_hybrid_evidence_matrix.py -q
# -> 24 passed in 2.21s (14 new + 10 existing regression)

uv run ruff check  <changed files>   # -> All checks passed!
uv run ruff format --check <changed files>   # -> 3 files already formatted
git diff --check    # -> clean
```

**First use on durable tracked input** (satisfies the AGENTS.md new-tool rule).
Run against the tracked `#2410` readiness matrix:

```
uv run python scripts/validation/validate_hybrid_evidence_matrix.py \
  --input docs/context/evidence/issue_2410_hybrid_component_readiness_refresh_2026-06-06/matrix.yaml \
  --prerequisite-matrix
# gate: blocked | complete_count: 0
# state_counts: {blocked: 4, complete: 0, missing: 0, ready: 1} | lane_count: 5 | exit 0
```

This reproduces the maintainer's hand-written conclusion ("Issue #1489 remains
blocked from comparative hybrid-learning synthesis … No component has stress or
full-matrix evidence") automatically.

## Research Result Guidance

- **Target/blocker:** the #1489 synthesis prerequisite (≥2 component campaigns
  with durable comparable outputs) was a manual judgment; this makes it a
  reproducible gate.
- **Evidence tier:** support/tooling. No new benchmark claim is asserted.
- **Result classification:** the helper *confirms* the current blocked status; it
  does not change any component verdict.
- **Synthesis surface to update:** `docs/context/issue_2410_*` readiness refreshes
  can cite `--prerequisite-matrix` output in future passes (follow-up, not this PR).

## Downstream Propagation

- Parent issue #1489: prerequisite-matrix slice; umbrella stays blocked.
- Claim map / leaderboard / registry: NA — no metric or claim change.
- Context index / memory: NA — no new durable note added in this PR (helper is
  self-documenting via docstrings, CLI `--help`, and tests).

## Residual risk

`complete` is defined as synthesis-eligible per the existing row validator; a
terminal-but-negative `stop` row is classified `ready`, not `complete`, so it
correctly does not open the gate but is not visually distinguished from
in-progress lanes. If maintainers later want a distinct `terminal_negative`
state, that is a small follow-up.

## Out-of-scope confirmation

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation
claim edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
