### PR TITLE
feat(research): dataset-backed scenario-prior staging contract checker (#3161)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a metadata-only staging-contract checker for dataset-backed scenario priors (#3161). New
+  module `robot_sf/research/scenario_prior_staging_contract.py` exposes
+  `check_scenario_prior_staging_contract`, which validates a `scenario_prior_staging_contract.v1`
+  contract (per-dataset provenance/license, the canonical scenario-prior distribution fields a
+  dataset-backed prior would expose, and the explicit external-data blocker) for the Stanford Drone
+  Dataset, SocNavBench ETH, and AMV candidates. Declared distribution fields are checked against the
+  live `PARAMETER_GROUPS` vocabulary of the #2919 comparison harness so the contract cannot drift
+  from what the comparison can compute, and a dataset declared `staged` is reconciled against a live
+  `manage_external_data.check_asset` presence probe (fail-closed). The checker **ingests no dataset,
+  stores no raw trajectories, runs no comparison, and makes no real-world realism claim**; with no
+  dataset staged it reports `blocked-external-input`. Example contract
+  `configs/research/scenario_prior_staging_contract_issue_3161.yaml`, CLI
+  `scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py`, context note
+  `docs/context/issue_3161_scenario_prior_staging_contract.md`.
 * Added a metadata-only measurement/intake-manifest checker for autonomous micromobility vehicle
   (AMV) actuation latency and rider-coupling response (#3283). New module
   `robot_sf/benchmark/actuation_latency_measurement_manifest.py` exposes

--- a/configs/research/scenario_prior_staging_contract_issue_3161.yaml
+++ b/configs/research/scenario_prior_staging_contract_issue_3161.yaml
@@ -1,0 +1,91 @@
+# Dataset-backed scenario-prior staging contract -- Issue #3161
+#
+# Issue #3161 asks whether real-data scenario priors (Stanford Drone Dataset, SocNavBench ETH, AMV)
+# change the scenario space enough to matter relative to the authored + trace-derived baseline from
+# #2919. That comparison is BLOCKED on external data: no licensed dataset is staged, and Robot SF
+# never ingests or redistributes raw trajectories.
+#
+# This file is the metadata-only staging CONTRACT for the local, buildable half. It declares, per
+# candidate dataset, the provenance/license, the canonical scenario-prior distribution fields a
+# dataset-backed prior would expose, and the explicit external-data blocker, so that once a dataset
+# is staged (via scripts/tools/manage_external_data.py) the #2919 comparison can ingest it without
+# guesswork. It is checked by:
+#   uv run python scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py
+#
+# This contract neither ingests datasets nor stores raw trajectories, and makes NO realism claim.
+
+schema_version: scenario_prior_staging_contract.v1
+contract_id: scenario_prior_staging_contract_issue_3161
+issue: 3161
+
+claim_boundary: >-
+  Staging-contract metadata only. Declares how dataset-backed scenario priors would be staged and
+  compared; it does not stage data, ingest trajectories, run the comparison, infer planner ranking,
+  or claim real-world realism. A dataset-backed comparison is permitted only after a dataset is
+  staged and validated through scripts/tools/manage_external_data.py.
+
+# Authored baseline (ScenarioPrior.v1 cards) and the comparison harness this contract feeds.
+authored_baseline: configs/research/scenario_prior_cards_issue_2917.yaml
+comparison_harness: scripts/analysis/compare_scenario_priors_issue_2919.py
+
+# distribution_fields below are canonical comparison parameter groups from the #2919 harness
+# (PARAMETER_GROUPS). The checker fails closed if a field is not in that vocabulary, so the contract
+# cannot drift from what the comparison can actually compute.
+datasets:
+  - dataset_id: sdd
+    asset_id: sdd
+    title: Stanford Drone Dataset annotations
+    staging_status: blocked-external-input
+    redistribution: none
+    blocker_issues: [1497, 2657]
+    provenance:
+      source_url: https://cvgl.stanford.edu/projects/uav_data/
+      license: Creative Commons Attribution-NonCommercial-ShareAlike 3.0
+      license_status: license-gated
+      citation: >-
+        A. Robicquet, A. Sadeghian, A. Alahi, S. Savarese. "Learning Social Etiquette: Human
+        Trajectory Understanding in Crowded Scenes." ECCV 2016.
+    distribution_fields:
+      - pedestrian_density
+      - pedestrian_speed
+      - spatial_offset_m
+      - route_coordinate_m
+      - clearance_distance_m
+
+  - dataset_id: socnavbench_eth
+    asset_id: socnavbench-s3dis-eth
+    title: SocNavBench ETH pedestrian traversible assets
+    staging_status: blocked-external-input
+    redistribution: none
+    blocker_issues: [1498]
+    provenance:
+      source_url: https://github.com/CMU-TBD/SocNavBench
+      license: SocNavBench/S3DIS external data; access terms apply, not redistributed
+      license_status: license-gated
+      citation: >-
+        A. Biswas et al. "SocNavBench: A Grounded Simulation Testing Framework for Evaluating
+        Social Navigation." ACM THRI 2022. ETH pedestrian source: S. Pellegrini et al. "You'll
+        Never Walk Alone: Modeling Social Behavior for Multi-target Tracking." ICCV 2009.
+    distribution_fields:
+      - pedestrian_speed
+      - spatial_offset_m
+      - route_coordinate_m
+      - clearance_distance_m
+
+  - dataset_id: amv
+    asset_id: amv-calibration
+    title: AMV calibration source provenance
+    staging_status: blocked-external-input
+    redistribution: none
+    blocker_issues: [2000, 1585]
+    provenance:
+      source_url: https://github.com/ll7/robot_sf_ll7/issues/1585
+      license: Access and redistribution depend on the selected source; private traces stay local
+      license_status: unknown
+      citation: >-
+        AMV actuation calibration source to be identified via #1585/#2000 (official platform or
+        controller specification, or an accepted command-response trace bundle). No public citation
+        is pinned until the source class is accepted.
+    distribution_fields:
+      - pedestrian_speed
+      - timing_offset_s

--- a/docs/context/issue_3161_scenario_prior_staging_contract.md
+++ b/docs/context/issue_3161_scenario_prior_staging_contract.md
@@ -1,0 +1,84 @@
+# Issue #3161 dataset-backed scenario-prior staging contract (2026-06-27)
+
+This note records the local, buildable half of issue #3161. The full comparison the issue asks for
+-- do real-data scenario priors (Stanford Drone Dataset, SocNavBench ETH, AMV) change the scenario
+space relative to the authored + trace-derived baseline from #2919 -- is **blocked on external
+data**: no licensed dataset is staged in the repository, and Robot SF never ingests or
+redistributes raw trajectories.
+
+What ships here is a **metadata-only staging contract and checker**, so that when a dataset is later
+staged the #2919 comparison can ingest a dataset-backed prior without guesswork.
+
+> Evidence tier: `analysis_only` staging contract. This is **not** a staged dataset, an executed
+> comparison, or a real-world realism claim. Every report stamps
+> `evidence_boundary = staging_contract_only_no_dataset_ingest_no_comparison_run_no_realism_claim`.
+
+## What was added
+
+- Contract schema: `robot_sf/research/schemas/scenario_prior_staging_contract.v1.json`
+- Checker module: `robot_sf/research/scenario_prior_staging_contract.py`
+  (`load_scenario_prior_staging_contract`, `check_scenario_prior_staging_contract`).
+- Example contract: `configs/research/scenario_prior_staging_contract_issue_3161.yaml`
+  (SDD, SocNavBench ETH, AMV; all `blocked-external-input` today).
+- CLI: `scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py`.
+- Tests: `tests/research/test_scenario_prior_staging_contract.py`.
+
+## What the contract declares per dataset
+
+- **Provenance / license** -- source URL, license, `license_status`
+  (`license-gated` | `open` | `unknown`), and citation.
+- **Distribution fields** -- the canonical scenario-prior parameter groups a dataset-backed prior
+  would expose (`pedestrian_density`, `pedestrian_speed`, `timing_offset_s`, `spatial_offset_m`,
+  `route_coordinate_m`, `clearance_distance_m`, ...). These are validated against the **live**
+  `PARAMETER_GROUPS` vocabulary of the #2919 comparison harness
+  (`scripts/analysis/compare_scenario_priors_issue_2919.py`), so the contract cannot silently drift
+  from what the comparison can actually compute.
+- **Explicit external-data blocker** -- a `blocked-external-input` dataset must name the staging
+  issue(s) holding it (SDD #1497/#2657, SocNavBench ETH #1498, AMV #2000/#1585).
+- **Redistribution** -- pinned to `none`; raw external data is never redistributed.
+
+## Fail-closed behavior
+
+- A declared `staged` dataset is reconciled against a live
+  `manage_external_data.check_asset` presence probe (`--probe-live-staging`). If the files are not
+  actually present, the dataset fails closed (`effective_staged = false`) so a comparison can never
+  run on nothing.
+- An unknown distribution field, a blocked dataset with no blocker issue, or a declared-vs-live
+  mismatch makes the contract `invalid`.
+- With no staged dataset (the state today), the contract resolves to `blocked-external-input` rather
+  than substituting a synthetic stand-in -- matching the issue's acceptance / stop rule.
+
+## Reproducibility commands
+
+```bash
+# Plan/check only -- no dataset ingest, no download:
+uv run python scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py
+
+# Reconcile declared staging against live asset presence (no download):
+uv run python scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py \
+    --probe-live-staging --require-ready
+
+# Tests:
+uv run python -m pytest tests/research/test_scenario_prior_staging_contract.py -q
+uv run python -m pytest tests/ -k "scenario and prior" -q
+```
+
+## Status and next action
+
+- Contract status today: `blocked-external-input` (no dataset staged). This is the expected,
+  honest state.
+- Next action: when SDD (#1497), SocNavBench ETH (#1498), or AMV (#2000) reaches `state:ready` and a
+  dataset is staged via `scripts/tools/manage_external_data.py`, flip that dataset's
+  `staging_status` to `staged`, run the checker with `--probe-live-staging`, and extend the #2919
+  comparison harness to ingest the dataset-backed prior using the declared distribution fields.
+- This PR does **not** run a benchmark campaign, submit any Slurm/GPU job, or edit paper/dissertation
+  claims.
+
+## Related
+
+- Parent / sibling: #3057, #2919 (authored vs trace-derived comparison), #3192 (divergence metrics),
+  #2918 (SDD/ETH/AMV extraction).
+- Staging owners: `scripts/tools/manage_external_data.py` (`sdd`, `socnavbench-s3dis-eth`,
+  `amv-calibration` AssetSpecs), `configs/data/sdd_staging_manifest.yaml`,
+  `docs/context/issue_2657_sdd_staging.md`.
+- Authored baseline registry: `configs/research/scenario_prior_cards_issue_2917.yaml`.

--- a/robot_sf/research/scenario_prior_staging_contract.py
+++ b/robot_sf/research/scenario_prior_staging_contract.py
@@ -1,0 +1,342 @@
+"""Staging-contract checker for dataset-backed scenario priors (issue #3161).
+
+Issue #3161 asks whether real-data scenario priors (Stanford Drone Dataset,
+SocNavBench ETH, AMV) change the scenario space relative to the authored and
+trace-derived baseline from #2919. That comparison is **blocked on external
+data**: no licensed dataset is staged in the repository, and the repo never
+ingests or redistributes raw trajectories.
+
+This module fills the *local, buildable* half: a metadata-only contract that
+declares, per candidate dataset, what staging would have to look like before the
+#2919 comparison harness can ingest a dataset-backed prior. It checks:
+
+* **provenance / license** -- source URL, license, license status, citation;
+* **distribution fields** -- the canonical scenario-prior parameter groups a
+  dataset-backed prior would expose, validated against the comparison harness's
+  own parameter vocabulary so the contract cannot silently drift from #2919;
+* **explicit external-data blockers** -- a ``blocked-external-input`` dataset
+  must name the staging issue(s) blocking it;
+* **declared-vs-live staging reconciliation** -- when a live staging probe is
+  supplied (e.g. ``manage_external_data.check_asset``), a dataset declared
+  ``staged`` whose files are not actually present fails closed.
+
+It deliberately does **not** ingest any dataset, read raw trajectories, run the
+comparison, or assert real-world realism. ``evidence_boundary`` on every report
+is :data:`STAGING_CONTRACT_EVIDENCE_BOUNDARY`, and a dataset-backed comparison is
+only permitted once at least one dataset is staged and contract-clean.
+
+The canonical distribution-field vocabulary lives with the comparison harness
+(``scripts/analysis/compare_scenario_priors_issue_2919.py`` ``PARAMETER_GROUPS``).
+Callers pass it in via ``allowed_distribution_groups`` so this module stays free
+of a ``scripts`` import; the CLI wires the two together.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import asdict, dataclass, field
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+import yaml
+from jsonschema import Draft202012Validator
+
+from robot_sf.common.json_pointer import json_pointer
+
+SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_VERSION = "scenario_prior_staging_contract.v1"
+SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_FILE = (
+    Path(__file__).with_name("schemas") / "scenario_prior_staging_contract.v1.json"
+)
+
+#: Explicit boundary stamped on every report so a passing staging-contract check
+#: is never mistaken for a staged dataset, an executed comparison, or a
+#: real-world realism claim.
+STAGING_CONTRACT_EVIDENCE_BOUNDARY = (
+    "staging_contract_only_no_dataset_ingest_no_comparison_run_no_realism_claim"
+)
+
+# Declared per-dataset staging states (must match the JSON schema enum).
+STAGING_STATUS_STAGED = "staged"
+STAGING_STATUS_MISSING = "missing"
+STAGING_STATUS_BLOCKED = "blocked-external-input"
+
+# Resolved overall contract states.
+CONTRACT_STATUS_READY = "ready"
+CONTRACT_STATUS_BLOCKED_EXTERNAL = "blocked-external-input"
+CONTRACT_STATUS_INVALID = "invalid"
+
+#: Live staging-probe statuses that count as "the declared files are actually
+#: present" (matches ``manage_external_data.check_asset`` ``status`` values).
+_LIVE_AVAILABLE_STATUSES = frozenset({"available", "staged"})
+
+
+class ScenarioPriorStagingContractError(ValueError):
+    """Raised when a scenario-prior staging contract fails schema checks."""
+
+    def __init__(self, errors: list[str], *, source: str | Path | None = None):
+        """Build an actionable validation error from schema messages."""
+        self.errors = tuple(errors)
+        self.source = str(source) if source is not None else None
+        prefix = f"{self.source}: " if self.source else ""
+        super().__init__(prefix + "; ".join(errors))
+
+
+@dataclass(frozen=True, slots=True)
+class DatasetStagingReport:
+    """Per-dataset result of checking one scenario-prior staging entry."""
+
+    dataset_id: str
+    asset_id: str | None
+    declared_staging_status: str
+    live_staging_status: str | None
+    effective_staged: bool
+    comparison_ready: bool
+    distribution_fields: list[str]
+    unknown_distribution_fields: list[str]
+    blockers: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dictionary representation."""
+        return asdict(self)
+
+
+@dataclass(frozen=True, slots=True)
+class ScenarioPriorStagingContractReport:
+    """Aggregate result of checking a scenario-prior staging contract."""
+
+    schema_version: str
+    contract_id: str
+    issue: int
+    evidence_boundary: str
+    contract_status: str
+    dataset_backed_comparison_allowed: bool
+    comparison_ready_datasets: list[str]
+    datasets: list[DatasetStagingReport] = field(default_factory=list)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-safe dictionary representation."""
+        return {
+            "schema_version": self.schema_version,
+            "contract_id": self.contract_id,
+            "issue": self.issue,
+            "evidence_boundary": self.evidence_boundary,
+            "contract_status": self.contract_status,
+            "dataset_backed_comparison_allowed": self.dataset_backed_comparison_allowed,
+            "comparison_ready_datasets": list(self.comparison_ready_datasets),
+            "datasets": [dataset.to_dict() for dataset in self.datasets],
+        }
+
+    @property
+    def blockers(self) -> list[str]:
+        """Return all per-dataset blockers, dataset-prefixed and sorted."""
+        return sorted(
+            f"{dataset.dataset_id}: {blocker}"
+            for dataset in self.datasets
+            for blocker in dataset.blockers
+        )
+
+
+@lru_cache(maxsize=1)
+def load_scenario_prior_staging_contract_schema() -> dict[str, Any]:
+    """Load the staging-contract JSON schema.
+
+    Returns:
+        Parsed JSON Schema dictionary.
+    """
+    return json.loads(SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_FILE.read_text(encoding="utf-8"))
+
+
+@lru_cache(maxsize=1)
+def _contract_validator() -> Draft202012Validator:
+    """Return a cached schema validator (schema compilation is reused)."""
+    return Draft202012Validator(load_scenario_prior_staging_contract_schema())
+
+
+def _raise_on_schema_errors(payload: Mapping[str, Any], *, source: str | Path | None) -> None:
+    """Raise :class:`ScenarioPriorStagingContractError` if the payload is invalid."""
+    validator = _contract_validator()
+    errors = [
+        f"{json_pointer(error.absolute_path)}: {error.message}"
+        for error in sorted(validator.iter_errors(payload), key=lambda err: list(err.absolute_path))
+    ]
+    if errors:
+        raise ScenarioPriorStagingContractError(errors, source=source)
+
+
+def load_scenario_prior_staging_contract(path: str | Path) -> dict[str, Any]:
+    """Load and schema-validate a staging contract from JSON or YAML.
+
+    Returns:
+        The validated contract mapping.
+
+    Raises:
+        ScenarioPriorStagingContractError: when the file is missing or invalid.
+    """
+    contract_path = Path(path)
+    if not contract_path.is_file():
+        raise ScenarioPriorStagingContractError(["contract file not found"], source=contract_path)
+    text = contract_path.read_text(encoding="utf-8")
+    try:
+        payload = yaml.safe_load(text)
+    except yaml.YAMLError as exc:  # pragma: no cover - defensive
+        raise ScenarioPriorStagingContractError(
+            [f"invalid YAML/JSON: {exc}"], source=contract_path
+        ) from exc
+    if not isinstance(payload, Mapping):
+        raise ScenarioPriorStagingContractError(
+            ["expected a mapping payload"], source=contract_path
+        )
+    _raise_on_schema_errors(payload, source=contract_path)
+    return dict(payload)
+
+
+def check_scenario_prior_staging_contract(
+    contract: Mapping[str, Any],
+    *,
+    allowed_distribution_groups: set[str] | None = None,
+    live_staging_status: Mapping[str, str] | None = None,
+    source: str | Path | None = None,
+) -> ScenarioPriorStagingContractReport:
+    """Check a dataset-backed scenario-prior staging contract.
+
+    Args:
+        contract: A ``scenario_prior_staging_contract.v1`` mapping. Schema-validated here.
+        allowed_distribution_groups: Canonical scenario-prior parameter-group names
+            the comparison harness understands (e.g.
+            ``set(compare_scenario_priors_issue_2919.PARAMETER_GROUPS)``). When
+            provided, any declared distribution field outside this set is a
+            fail-closed blocker so the contract cannot drift from the harness.
+            When ``None``, the distribution-field vocabulary check is skipped.
+        live_staging_status: Optional mapping of ``asset_id`` to a live staging
+            status (e.g. ``manage_external_data.check_asset(...)["status"]``).
+            Used to reconcile a declared ``staged`` dataset against whether its
+            files are actually present.
+        source: Optional source path for error messages.
+
+    Returns:
+        A structured contract report. The report never asserts a staged dataset,
+        an executed comparison, or real-world realism;
+        ``dataset_backed_comparison_allowed`` is only True when at least one
+        dataset is staged (declared and, if probed, live) and contract-clean.
+
+    Raises:
+        ScenarioPriorStagingContractError: when the contract violates the schema.
+    """
+    _raise_on_schema_errors(contract, source=source)
+
+    dataset_reports = [
+        _check_dataset(
+            dataset,
+            allowed_distribution_groups=allowed_distribution_groups,
+            live_staging_status=live_staging_status,
+        )
+        for dataset in contract["datasets"]
+    ]
+
+    comparison_ready = sorted(d.dataset_id for d in dataset_reports if d.comparison_ready)
+    any_blockers = any(d.blockers for d in dataset_reports)
+    if any_blockers:
+        contract_status = CONTRACT_STATUS_INVALID
+        comparison_allowed = False
+    elif comparison_ready:
+        contract_status = CONTRACT_STATUS_READY
+        comparison_allowed = True
+    else:
+        # A well-formed contract with no staged dataset is the expected state for
+        # #3161 today: report blocked-external-input rather than substituting a
+        # synthetic stand-in (acceptance / stop rule).
+        contract_status = CONTRACT_STATUS_BLOCKED_EXTERNAL
+        comparison_allowed = False
+
+    return ScenarioPriorStagingContractReport(
+        schema_version=SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_VERSION,
+        contract_id=str(contract["contract_id"]),
+        issue=int(contract["issue"]),
+        evidence_boundary=STAGING_CONTRACT_EVIDENCE_BOUNDARY,
+        contract_status=contract_status,
+        dataset_backed_comparison_allowed=comparison_allowed,
+        comparison_ready_datasets=comparison_ready,
+        datasets=dataset_reports,
+    )
+
+
+def _check_dataset(
+    dataset: Mapping[str, Any],
+    *,
+    allowed_distribution_groups: set[str] | None,
+    live_staging_status: Mapping[str, str] | None,
+) -> DatasetStagingReport:
+    """Check one dataset staging entry and return its report.
+
+    Returns:
+        A :class:`DatasetStagingReport`. ``comparison_ready`` is True only for a
+        blocker-free dataset that is declared ``staged`` and (when probed) live
+        present.
+    """
+    dataset_id = str(dataset["dataset_id"])
+    asset_id = dataset.get("asset_id")
+    declared_status = str(dataset["staging_status"])
+    declared_fields = [str(value) for value in dataset["distribution_fields"]]
+    blockers: list[str] = []
+
+    unknown_fields = _unknown_distribution_fields(declared_fields, allowed_distribution_groups)
+    for unknown in unknown_fields:
+        blockers.append(
+            f"distribution field {unknown!r} is not a canonical comparison parameter group"
+        )
+
+    # An explicit external-data blocker must name the staging issue(s) holding it.
+    if declared_status == STAGING_STATUS_BLOCKED and not dataset.get("blocker_issues"):
+        blockers.append(
+            "blocked-external-input dataset must name at least one blocker issue in blocker_issues"
+        )
+
+    live_status = _resolve_live_status(asset_id, live_staging_status)
+    effective_staged = declared_status == STAGING_STATUS_STAGED
+    if effective_staged and live_status is not None and live_status not in _LIVE_AVAILABLE_STATUSES:
+        # Fail closed: a contract that claims staged but whose files are absent
+        # would let a dataset-backed comparison run on nothing.
+        blockers.append(
+            f"declared staging_status 'staged' but live probe reports {live_status!r}; "
+            "stage and validate the asset before claiming staged"
+        )
+        effective_staged = False
+
+    comparison_ready = effective_staged and not blockers
+
+    return DatasetStagingReport(
+        dataset_id=dataset_id,
+        asset_id=str(asset_id) if asset_id is not None else None,
+        declared_staging_status=declared_status,
+        live_staging_status=live_status,
+        effective_staged=effective_staged,
+        comparison_ready=comparison_ready,
+        distribution_fields=declared_fields,
+        unknown_distribution_fields=unknown_fields,
+        blockers=sorted(blockers),
+    )
+
+
+def _unknown_distribution_fields(
+    declared_fields: list[str], allowed_distribution_groups: set[str] | None
+) -> list[str]:
+    """Return declared distribution fields outside the canonical comparison vocabulary.
+
+    Returns:
+        Sorted unknown field names, or an empty list when no vocabulary is supplied.
+    """
+    if allowed_distribution_groups is None:
+        return []
+    return sorted({f for f in declared_fields if f not in allowed_distribution_groups})
+
+
+def _resolve_live_status(
+    asset_id: Any, live_staging_status: Mapping[str, str] | None
+) -> str | None:
+    """Return the live staging status for an asset id, or ``None`` when not probed."""
+    if live_staging_status is None or asset_id is None:
+        return None
+    status = live_staging_status.get(str(asset_id))
+    return str(status) if status is not None else None

--- a/robot_sf/research/schemas/scenario_prior_staging_contract.v1.json
+++ b/robot_sf/research/schemas/scenario_prior_staging_contract.v1.json
@@ -1,0 +1,126 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://robot-sf/schemas/scenario_prior_staging_contract.v1.json",
+  "title": "Scenario-prior dataset staging contract (v1)",
+  "description": "Metadata-only staging contract for dataset-backed scenario-prior comparison (issue #3161). Declares, per candidate external dataset, the provenance, license/status, the canonical distribution fields a dataset-backed prior would expose, and the explicit external-data blocker. It describes staging intent only; it neither ingests datasets nor stores raw trajectories.",
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "schema_version",
+    "contract_id",
+    "issue",
+    "claim_boundary",
+    "authored_baseline",
+    "comparison_harness",
+    "datasets"
+  ],
+  "properties": {
+    "schema_version": {
+      "const": "scenario_prior_staging_contract.v1"
+    },
+    "contract_id": {
+      "type": "string",
+      "minLength": 1
+    },
+    "issue": {
+      "type": "integer"
+    },
+    "claim_boundary": {
+      "type": "string",
+      "minLength": 1
+    },
+    "authored_baseline": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the authored ScenarioPrior.v1 card registry used as the comparison baseline."
+    },
+    "comparison_harness": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Path to the comparison harness (#2919) this contract feeds once a dataset is staged."
+    },
+    "datasets": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "$ref": "#/$defs/dataset"
+      }
+    }
+  },
+  "$defs": {
+    "dataset": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": [
+        "dataset_id",
+        "title",
+        "staging_status",
+        "redistribution",
+        "blocker_issues",
+        "provenance",
+        "distribution_fields"
+      ],
+      "properties": {
+        "dataset_id": {
+          "type": "string",
+          "minLength": 1
+        },
+        "asset_id": {
+          "type": ["string", "null"],
+          "description": "External-data AssetSpec id in scripts/tools/manage_external_data.py, or null when no asset spec is wired yet."
+        },
+        "title": {
+          "type": "string",
+          "minLength": 1
+        },
+        "staging_status": {
+          "type": "string",
+          "enum": ["blocked-external-input", "missing", "staged"]
+        },
+        "redistribution": {
+          "type": "string",
+          "enum": ["none"],
+          "description": "Raw external data is never redistributed by this repository."
+        },
+        "blocker_issues": {
+          "type": "array",
+          "items": {
+            "type": "integer"
+          }
+        },
+        "provenance": {
+          "type": "object",
+          "additionalProperties": false,
+          "required": ["source_url", "license", "license_status", "citation"],
+          "properties": {
+            "source_url": {
+              "type": "string",
+              "minLength": 1
+            },
+            "license": {
+              "type": "string",
+              "minLength": 1
+            },
+            "license_status": {
+              "type": "string",
+              "enum": ["license-gated", "open", "unknown"]
+            },
+            "citation": {
+              "type": "string",
+              "minLength": 1
+            }
+          }
+        },
+        "distribution_fields": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "minLength": 1
+          },
+          "description": "Canonical scenario-prior parameter-group names the dataset-backed prior would extract for comparison."
+        }
+      }
+    }
+  }
+}

--- a/scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py
+++ b/scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py
@@ -1,0 +1,137 @@
+"""CLI for the dataset-backed scenario-prior staging-contract checker (issue #3161).
+
+Checks the metadata-only staging contract that declares how dataset-backed
+scenario priors (SDD / SocNavBench ETH / AMV) would be staged and compared
+against the authored + trace-derived baseline from #2919. It validates
+provenance/license, the declared distribution fields (against the #2919
+comparison parameter vocabulary), and the explicit external-data blockers, and
+-- when ``--probe-live-staging`` is passed -- reconciles each dataset's declared
+staging status against a live ``manage_external_data`` presence probe.
+
+It does NOT ingest any dataset, read raw trajectories, run the comparison, or
+make a realism claim. A dataset-backed comparison is reported as allowed only
+once at least one dataset is staged and contract-clean.
+
+Examples:
+    uv run python scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py
+    uv run python scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py \
+        --probe-live-staging --require-ready
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.research.scenario_prior_staging_contract import (
+    CONTRACT_STATUS_READY,
+    ScenarioPriorStagingContractError,
+    check_scenario_prior_staging_contract,
+    load_scenario_prior_staging_contract,
+)
+from scripts.analysis.compare_scenario_priors_issue_2919 import PARAMETER_GROUPS
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_CONTRACT = (
+    REPO_ROOT / "configs" / "research" / "scenario_prior_staging_contract_issue_3161.yaml"
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments.
+
+    Returns:
+        Parsed namespace.
+    """
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=DEFAULT_CONTRACT,
+        help="Path to a scenario_prior_staging_contract.v1 file (JSON or YAML).",
+    )
+    parser.add_argument(
+        "--probe-live-staging",
+        action="store_true",
+        help=(
+            "Reconcile each dataset's declared staging status against a live "
+            "manage_external_data.check_asset presence probe (no download)."
+        ),
+    )
+    parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Exit non-zero unless the contract status is 'ready' (a dataset is staged and clean).",
+    )
+    return parser.parse_args(argv)
+
+
+def _probe_live_staging_status(asset_ids: set[str]) -> dict[str, str]:
+    """Probe live staging presence for the given asset ids (no network access).
+
+    Imported lazily so the contract check works even if the external-data
+    subsystem is unavailable; any per-asset probe failure is recorded as an
+    ``error:<reason>`` status rather than aborting the whole check.
+
+    Returns:
+        Mapping of asset id to a live staging status string.
+    """
+    from scripts.tools.manage_external_data import ExternalDataError, check_asset
+
+    statuses: dict[str, str] = {}
+    for asset_id in sorted(asset_ids):
+        try:
+            statuses[asset_id] = str(check_asset(asset_id)["status"])
+        except ExternalDataError as exc:
+            statuses[asset_id] = f"error:{exc}"
+    return statuses
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the staging-contract check and print a JSON report.
+
+    Returns:
+        Process exit code (0 on success, 2 on contract error, 1 when
+        ``--require-ready`` is set and the contract is not ready).
+    """
+    args = _parse_args(argv)
+    try:
+        contract = load_scenario_prior_staging_contract(args.contract)
+    except (ScenarioPriorStagingContractError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    live_status: dict[str, str] | None = None
+    if args.probe_live_staging:
+        asset_ids = {
+            str(dataset["asset_id"])
+            for dataset in contract["datasets"]
+            if dataset.get("asset_id") is not None
+        }
+        live_status = _probe_live_staging_status(asset_ids)
+
+    try:
+        report = check_scenario_prior_staging_contract(
+            contract,
+            allowed_distribution_groups=set(PARAMETER_GROUPS),
+            live_staging_status=live_status,
+            source=args.contract,
+        )
+    except (ScenarioPriorStagingContractError, ValueError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    print(json.dumps(report.to_dict(), indent=2, sort_keys=True))
+    if args.require_ready and report.contract_status != CONTRACT_STATUS_READY:
+        print(
+            f"contract status is {report.contract_status!r}, expected 'ready'",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/research/test_scenario_prior_staging_contract.py
+++ b/tests/research/test_scenario_prior_staging_contract.py
@@ -1,0 +1,265 @@
+"""Tests for the dataset-backed scenario-prior staging-contract checker (issue #3161)."""
+
+from __future__ import annotations
+
+import copy
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.research.scenario_prior_staging_contract import (
+    CONTRACT_STATUS_BLOCKED_EXTERNAL,
+    CONTRACT_STATUS_INVALID,
+    CONTRACT_STATUS_READY,
+    SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_VERSION,
+    STAGING_CONTRACT_EVIDENCE_BOUNDARY,
+    ScenarioPriorStagingContractError,
+    check_scenario_prior_staging_contract,
+    load_scenario_prior_staging_contract,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+EXAMPLE_CONTRACT_PATH = (
+    REPO_ROOT / "configs" / "research" / "scenario_prior_staging_contract_issue_3161.yaml"
+)
+
+# Canonical comparison parameter groups used as the allowed distribution-field vocabulary in tests.
+ALLOWED_GROUPS = {
+    "pedestrian_density",
+    "pedestrian_speed",
+    "timing_offset_s",
+    "spatial_offset_m",
+    "route_coordinate_m",
+    "clearance_distance_m",
+    "episode_horizon_steps",
+}
+
+
+def _dataset(staging_status: str = "blocked-external-input", **overrides: object) -> dict:
+    """Return one valid dataset staging entry, overridable per-test."""
+    dataset = {
+        "dataset_id": "sdd",
+        "asset_id": "sdd",
+        "title": "Stanford Drone Dataset annotations",
+        "staging_status": staging_status,
+        "redistribution": "none",
+        "blocker_issues": [1497],
+        "provenance": {
+            "source_url": "https://cvgl.stanford.edu/projects/uav_data/",
+            "license": "CC BY-NC-SA 3.0",
+            "license_status": "license-gated",
+            "citation": "Robicquet et al., ECCV 2016.",
+        },
+        "distribution_fields": ["pedestrian_density", "pedestrian_speed"],
+    }
+    dataset.update(overrides)
+    return dataset
+
+
+def _contract(datasets: list[dict] | None = None) -> dict:
+    """Return a minimal valid staging contract."""
+    return {
+        "schema_version": SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_VERSION,
+        "contract_id": "test_contract",
+        "issue": 3161,
+        "claim_boundary": "staging contract metadata only",
+        "authored_baseline": "configs/research/scenario_prior_cards_issue_2917.yaml",
+        "comparison_harness": "scripts/analysis/compare_scenario_priors_issue_2919.py",
+        "datasets": datasets if datasets is not None else [_dataset()],
+    }
+
+
+def test_blocked_external_input_contract_is_blocked_not_ready() -> None:
+    """A well-formed contract with no staged dataset reports blocked-external-input."""
+    report = check_scenario_prior_staging_contract(
+        _contract(), allowed_distribution_groups=ALLOWED_GROUPS
+    )
+    assert report.contract_status == CONTRACT_STATUS_BLOCKED_EXTERNAL
+    assert report.dataset_backed_comparison_allowed is False
+    assert report.comparison_ready_datasets == []
+    assert report.evidence_boundary == STAGING_CONTRACT_EVIDENCE_BOUNDARY
+    assert report.blockers == []
+
+
+def test_staged_clean_dataset_unlocks_comparison() -> None:
+    """A staged, blocker-free dataset makes the contract ready and comparison-allowed."""
+    report = check_scenario_prior_staging_contract(
+        _contract([_dataset(staging_status="staged")]),
+        allowed_distribution_groups=ALLOWED_GROUPS,
+    )
+    assert report.contract_status == CONTRACT_STATUS_READY
+    assert report.dataset_backed_comparison_allowed is True
+    assert report.comparison_ready_datasets == ["sdd"]
+
+
+def test_missing_dataset_is_not_comparison_ready() -> None:
+    """A 'missing' dataset is well-formed but not comparison-ready."""
+    report = check_scenario_prior_staging_contract(
+        _contract([_dataset(staging_status="missing")]),
+        allowed_distribution_groups=ALLOWED_GROUPS,
+    )
+    assert report.contract_status == CONTRACT_STATUS_BLOCKED_EXTERNAL
+    assert report.comparison_ready_datasets == []
+    dataset = report.datasets[0]
+    assert dataset.effective_staged is False
+    assert dataset.blockers == []
+
+
+def test_unknown_distribution_field_fails_closed() -> None:
+    """A distribution field outside the comparison vocabulary is an invalid-contract blocker."""
+    report = check_scenario_prior_staging_contract(
+        _contract([_dataset(distribution_fields=["pedestrian_speed", "not_a_real_group"])]),
+        allowed_distribution_groups=ALLOWED_GROUPS,
+    )
+    assert report.contract_status == CONTRACT_STATUS_INVALID
+    assert report.datasets[0].unknown_distribution_fields == ["not_a_real_group"]
+    assert any("not_a_real_group" in blocker for blocker in report.blockers)
+
+
+def test_distribution_field_check_skipped_without_vocabulary() -> None:
+    """Without a vocabulary, unknown fields are tolerated (no drift check)."""
+    report = check_scenario_prior_staging_contract(
+        _contract([_dataset(distribution_fields=["anything_goes"])]),
+        allowed_distribution_groups=None,
+    )
+    assert report.datasets[0].unknown_distribution_fields == []
+    assert report.contract_status == CONTRACT_STATUS_BLOCKED_EXTERNAL
+
+
+def test_blocked_dataset_without_blocker_issue_is_invalid() -> None:
+    """A blocked-external-input dataset must name at least one blocker issue."""
+    report = check_scenario_prior_staging_contract(
+        _contract([_dataset(blocker_issues=[])]),
+        allowed_distribution_groups=ALLOWED_GROUPS,
+    )
+    assert report.contract_status == CONTRACT_STATUS_INVALID
+    assert any("blocker_issues" in blocker for blocker in report.blockers)
+
+
+def test_declared_staged_but_live_missing_fails_closed() -> None:
+    """A dataset declared 'staged' whose live probe is missing fails closed."""
+    report = check_scenario_prior_staging_contract(
+        _contract([_dataset(staging_status="staged")]),
+        allowed_distribution_groups=ALLOWED_GROUPS,
+        live_staging_status={"sdd": "missing"},
+    )
+    assert report.contract_status == CONTRACT_STATUS_INVALID
+    dataset = report.datasets[0]
+    assert dataset.effective_staged is False
+    assert dataset.comparison_ready is False
+    assert any("live probe" in blocker for blocker in report.blockers)
+
+
+def test_declared_staged_and_live_available_is_ready() -> None:
+    """A dataset declared 'staged' and live-available reconciles to comparison-ready."""
+    report = check_scenario_prior_staging_contract(
+        _contract([_dataset(staging_status="staged")]),
+        allowed_distribution_groups=ALLOWED_GROUPS,
+        live_staging_status={"sdd": "available"},
+    )
+    assert report.contract_status == CONTRACT_STATUS_READY
+    assert report.datasets[0].live_staging_status == "available"
+    assert report.comparison_ready_datasets == ["sdd"]
+
+
+def test_schema_violation_raises() -> None:
+    """An invalid payload (bad enum) raises a schema error."""
+    bad = _contract([_dataset(staging_status="totally-invalid")])
+    with pytest.raises(ScenarioPriorStagingContractError):
+        check_scenario_prior_staging_contract(bad, allowed_distribution_groups=ALLOWED_GROUPS)
+
+
+def test_missing_required_field_raises() -> None:
+    """A dataset missing a required provenance field raises a schema error."""
+    bad = _contract()
+    del bad["datasets"][0]["provenance"]["citation"]
+    with pytest.raises(ScenarioPriorStagingContractError):
+        check_scenario_prior_staging_contract(bad, allowed_distribution_groups=ALLOWED_GROUPS)
+
+
+def test_report_to_dict_is_json_serializable() -> None:
+    """The report serializes to JSON (CLI contract)."""
+    report = check_scenario_prior_staging_contract(
+        _contract(), allowed_distribution_groups=ALLOWED_GROUPS
+    )
+    payload = json.loads(json.dumps(report.to_dict()))
+    assert payload["schema_version"] == SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_VERSION
+    assert payload["datasets"][0]["dataset_id"] == "sdd"
+
+
+def test_load_missing_file_raises(tmp_path: Path) -> None:
+    """Loading a non-existent contract path raises an actionable error."""
+    with pytest.raises(ScenarioPriorStagingContractError):
+        load_scenario_prior_staging_contract(tmp_path / "nope.yaml")
+
+
+def test_load_roundtrip(tmp_path: Path) -> None:
+    """A contract written to disk loads and validates."""
+    path = tmp_path / "contract.yaml"
+    path.write_text(yaml.safe_dump(_contract(), sort_keys=False), encoding="utf-8")
+    loaded = load_scenario_prior_staging_contract(path)
+    assert loaded["contract_id"] == "test_contract"
+
+
+def test_repo_example_contract_is_valid_and_blocked() -> None:
+    """The shipped #3161 example contract validates and is blocked-external-input today."""
+    contract = load_scenario_prior_staging_contract(EXAMPLE_CONTRACT_PATH)
+    report = check_scenario_prior_staging_contract(
+        contract, allowed_distribution_groups=ALLOWED_GROUPS
+    )
+    assert report.contract_status == CONTRACT_STATUS_BLOCKED_EXTERNAL
+    assert report.dataset_backed_comparison_allowed is False
+    assert report.blockers == []
+    assert {d.dataset_id for d in report.datasets} == {"sdd", "socnavbench_eth", "amv"}
+
+
+def test_repo_example_distribution_fields_match_live_harness_vocabulary() -> None:
+    """Every example distribution field is a real #2919 comparison parameter group.
+
+    This guards against the example contract drifting from the comparison harness
+    it feeds; it imports the live PARAMETER_GROUPS rather than the test constant.
+    """
+    from scripts.analysis.compare_scenario_priors_issue_2919 import PARAMETER_GROUPS
+
+    contract = load_scenario_prior_staging_contract(EXAMPLE_CONTRACT_PATH)
+    report = check_scenario_prior_staging_contract(
+        contract, allowed_distribution_groups=set(PARAMETER_GROUPS)
+    )
+    for dataset in report.datasets:
+        assert dataset.unknown_distribution_fields == []
+
+
+def test_example_contract_matches_repo_path() -> None:
+    """The example contract ships at the path the CLI defaults to."""
+    assert EXAMPLE_CONTRACT_PATH.is_file()
+    payload = yaml.safe_load(EXAMPLE_CONTRACT_PATH.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == SCENARIO_PRIOR_STAGING_CONTRACT_SCHEMA_VERSION
+
+
+def test_multiple_datasets_one_staged_is_ready() -> None:
+    """With several datasets, one staged-and-clean entry unlocks the comparison."""
+    datasets = [
+        _dataset(dataset_id="sdd", asset_id="sdd", staging_status="staged"),
+        _dataset(
+            dataset_id="amv",
+            asset_id="amv-calibration",
+            staging_status="blocked-external-input",
+            blocker_issues=[2000],
+            distribution_fields=["pedestrian_speed", "timing_offset_s"],
+        ),
+    ]
+    report = check_scenario_prior_staging_contract(
+        _contract(datasets), allowed_distribution_groups=ALLOWED_GROUPS
+    )
+    assert report.contract_status == CONTRACT_STATUS_READY
+    assert report.comparison_ready_datasets == ["sdd"]
+
+
+def test_copy_independence() -> None:
+    """The checker does not mutate the input contract mapping."""
+    contract = _contract()
+    snapshot = copy.deepcopy(contract)
+    check_scenario_prior_staging_contract(contract, allowed_distribution_groups=ALLOWED_GROUPS)
+    assert contract == snapshot


### PR DESCRIPTION
## Issue

Closes part of #3161 (`analysis: compare dataset-backed and authored scenario priors after external staging`).

This implements the **local, buildable half** of #3161. The full comparison the issue asks for is
**blocked on external data** (`state:blocked-external-input`, `resource:external-data`): no licensed
dataset (SDD / SocNavBench ETH / AMV) is staged, and Robot SF never ingests or redistributes raw
trajectories. What ships here is the metadata-only **staging contract + checker** so a dataset-backed
prior can be wired into the #2919 comparison without guesswork once a dataset is staged.

## Scope summary

Scoped objective: *a manifest/contract checker for dataset-backed scenario-prior staging, including
provenance, license/status, extracted distribution fields, and explicit external-data blockers.*

Added:
- `robot_sf/research/scenario_prior_staging_contract.py` — `check_scenario_prior_staging_contract`
  (+ loader) and `scenario_prior_staging_contract.v1` JSON schema.
- `configs/research/scenario_prior_staging_contract_issue_3161.yaml` — example contract for SDD,
  SocNavBench ETH, and AMV (all `blocked-external-input` today).
- `scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py` — CLI.
- `tests/research/test_scenario_prior_staging_contract.py` — 18 focused tests.
- `docs/context/issue_3161_scenario_prior_staging_contract.md`, CHANGELOG entry.

What the checker enforces:
- **provenance / license** per dataset (source URL, license, `license_status`, citation);
- **distribution fields** validated against the **live** `PARAMETER_GROUPS` of the #2919 comparison
  harness, so the contract cannot silently drift from what the comparison can compute;
- **explicit external-data blocker** — a `blocked-external-input` dataset must name its blocker
  issue(s) (#1497/#2657 SDD, #1498 ETH, #2000/#1585 AMV);
- **fail-closed declared-vs-live reconciliation** — a dataset declared `staged` is checked against a
  live `manage_external_data.check_asset` presence probe (`--probe-live-staging`); if files are
  absent it fails closed so a comparison can never run on nothing;
- with no dataset staged, the contract resolves to `blocked-external-input` (not a synthetic
  stand-in), matching the issue's acceptance / stop rule.

Reuses canonical owners (no forks): `manage_external_data.check_asset` AssetSpecs and the #2919
`PARAMETER_GROUPS` vocabulary.

## Evidence boundary

`analysis_only` staging contract. **No dataset ingest, no raw trajectories, no comparison run, no
real-world realism claim.** Every report stamps
`evidence_boundary = staging_contract_only_no_dataset_ingest_no_comparison_run_no_realism_claim`.

## Validation

All run via `scripts/dev/run_worktree_shared_venv.sh` against the shared `.venv`.

| Command | Result |
| --- | --- |
| `python -m pytest tests/research/test_scenario_prior_staging_contract.py -q` | **18 passed** |
| `python -m pytest tests/ -k "scenario and prior" -q` | **55 passed, 8937 deselected** |
| `python scripts/analysis/check_scenario_prior_staging_contract_issue_3161.py` | exit 0; `contract_status: blocked-external-input` |
| `... --probe-live-staging --require-ready` | exit 1 (correct: no dataset staged; live probe reports `missing`/`incomplete`) |
| `ruff check` (3 new py files) | All checks passed |
| `ruff format` | clean |

## Downstream Propagation

- Parent/sibling issues: feeds #2919/#3192; unblocks the dataset-backed comparison once #1497/#1498/#2000 stage data.
- Context note added (`docs/context/issue_3161_scenario_prior_staging_contract.md`); discoverable by issue number and via CHANGELOG. `docs/context/INDEX.md` not edited (single large curated cell; deferred to avoid a fragile edit).
- No leaderboard/registry/benchmark-report update (no benchmark result produced).

## Research Result Guidance

- Target: unblock dataset-backed prior comparison for #3161 by pinning the staging contract.
- Comparator/baseline: authored + trace-derived priors from #2919.
- Evidence tier: `analysis_only` (staging contract); **not** benchmark evidence.
- Decision/stop rule: with no dataset staged → `blocked-external-input` (this PR's state); flip a dataset to `staged` + extend #2919 harness when staging lands.
- Synthesis surface: `docs/context/issue_3161_scenario_prior_staging_contract.md`.

## Out of scope (explicit)

- **No** full benchmark campaign run.
- **No** Slurm/GPU submission.
- **No** paper/dissertation claim edits.
- **No** external dataset ingest or raw-trajectory storage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
