### PR TITLE
feat(benchmark): fail-closed readiness preflight for predictive-v2 same-seed comparison (#1490)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **fail-closed readiness/preflight checker for the predictive planner v2 same-seed
+  comparison** (#1490 umbrella, ego-conditioning child #1504). New module
+  `robot_sf/benchmark/predictive_v2_comparison_readiness.py` exposes
+  `validate_predictive_v2_comparison_readiness`, which validates the committed feature contract
+  `configs/training/predictive/predictive_ego_features_contract_v1.yaml` across four metadata stage
+  gates: variant completeness (baseline / obstacle-only / ego-only / combined with the expected
+  schema and input-dim), provenance (every referenced config and seed/scenario/grid manifest exists),
+  ego-obstacle conditioning metadata (ego variants declare a defined `ego_motion_channel_producer` and
+  share a single comparability key), and same-seed schedule (seed manifests, fixed seed, and forecast
+  vs. navigation metric separation). A fifth gate, `blocked_slurm_gate`, fails **closed**: the
+  four-way expansion (#1505/#1506/#1507) stays `blocked` behind the maintainer-selected revised
+  hypothesis and the same-seed coupling gate #2916, clearing only when an explicit `continue`
+  coupling-gate artifact and the maintainer-hypothesis acknowledgement are both supplied. A new CLI
+  `scripts/validation/validate_predictive_v2_comparison_readiness.py` exposes the check with
+  decision-coded exit status (`0` ready, `2` blocked/incomplete, `1` contract load error). Against the
+  committed contract the preflight reports metadata-complete-but-`blocked`, mirroring the recorded
+  #1490 decision. This is **coordination/preflight readiness only**: it does not train, evaluate, tune
+  planners, run benchmarks, or submit SLURM.
+
 * Added a **durable learned-risk training trace manifest contract and fail-closed validator**
   (#2312, parent #1472). New module `robot_sf/training/learned_risk_trace_manifest.py` exposes
   `validate_trace_manifest`, which checks a `learned-risk-trace-manifest.v1` YAML (durable baseline

--- a/robot_sf/benchmark/predictive_v2_comparison_readiness.py
+++ b/robot_sf/benchmark/predictive_v2_comparison_readiness.py
@@ -1,0 +1,382 @@
+"""Fail-closed readiness/preflight checker for the predictive planner v2 same-seed comparison.
+
+This module is the canonical owner for *preflighting* the same-seed predictive planner v2
+four-way comparison described by issue #1490 (umbrella) and its ego-conditioning child #1504.
+It is a read-only, coordination-only check: it validates that the comparison's prerequisite
+metadata is present and self-consistent, and it surfaces the *blocked* Slurm/maintainer-gate
+state. It never trains, evaluates, submits Slurm, or tunes planners.
+
+The comparison contract validated here is the committed feature contract
+``configs/training/predictive/predictive_ego_features_contract_v1.yaml``, which already declares:
+
+* the four comparison variants (``baseline``, ``obstacle_only``, ``ego_only``,
+  ``ego_obstacle_combined``) under ``row_identifiers``;
+* the ego-obstacle conditioning metadata (``ego_motion_channel_producers`` and per-row
+  ``ego_motion_channel_producer`` references);
+* the same-seed comparability surface (``same_seed_comparability`` manifests/scenarios/grid).
+
+Stage gates (each reported independently so missing metadata is actionable):
+
+1. ``variant_completeness`` — all four variants present with schema name, input dim, and config.
+2. ``provenance`` — every referenced config/manifest path exists on disk.
+3. ``ego_obstacle_conditioning`` — ego variants declare a producer defined in the contract and
+   share a single comparability producer key.
+4. ``same_seed_schedule`` — seed manifests, scenario matrix, planner grid, and the
+   forecast/navigation metric separation are declared.
+5. ``blocked_slurm_gate`` — FAIL-CLOSED. The four-way expansion stays blocked behind the
+   maintainer-selected revised hypothesis and a passing closed-loop coupling gate (#2916).
+   This stage clears only when an explicit coupling-gate clearance artifact (recommendation
+   ``continue``) is supplied together with the maintainer-hypothesis acknowledgement.
+
+The default outcome (no gate clearance supplied) is ``blocked`` even when all metadata is
+complete, mirroring the recorded #1490 maintainer decision. This is intentional: per
+``docs/context/issue_691_benchmark_fallback_policy.md`` and the issue history (#1543 negative,
+#1897 failed the coupling gate), the lane must fail closed, not silently report ready.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+# Stage status vocabulary shared with sibling readiness validators
+# (see scripts/validation/validate_learned_prediction_readiness.py).
+STATUS_PASSED = "passed"
+STATUS_FAILED = "failed"
+STATUS_BLOCKED = "blocked"
+
+DEFAULT_CONTRACT_PATH = Path("configs/training/predictive/predictive_ego_features_contract_v1.yaml")
+
+# The four same-seed comparison variants and their contract-declared schema/width expectations.
+# input_dim values mirror the committed feature contract so a silent width drift is caught here
+# rather than only at training time.
+REQUIRED_VARIANTS: dict[str, dict[str, Any]] = {
+    "baseline": {"schema_name": "predictive_legacy_v1", "input_dim": 4, "ego_conditioned": False},
+    "obstacle_only": {
+        "schema_name": "predictive_obstacle_features_v1",
+        "input_dim": 10,
+        "ego_conditioned": False,
+    },
+    "ego_only": {"schema_name": "predictive_ego_v1", "input_dim": 9, "ego_conditioned": True},
+    "ego_obstacle_combined": {
+        "schema_name": "predictive_obstacle_features_v1",
+        "input_dim": 15,
+        "ego_conditioned": True,
+    },
+}
+
+# Same-seed comparability path fields that must be declared and exist on disk.
+SAME_SEED_PATH_FIELDS = (
+    "seed_manifest",
+    "hard_seed_manifest",
+    "scenario_matrix",
+    "planner_grid",
+)
+
+_GATE_CONTINUE = "continue"
+
+
+class PredictiveV2ComparisonReadinessError(Exception):
+    """Raised when the comparison contract cannot be loaded or parsed."""
+
+
+def _load_yaml(path: Path) -> Any:
+    """Load a YAML document, raising a readiness error on missing/invalid input.
+
+    Returns:
+        The parsed YAML document (typically a mapping).
+    """
+    if not path.exists():
+        raise PredictiveV2ComparisonReadinessError(f"contract file not found: {path}")
+    try:
+        with open(path, encoding="utf-8") as handle:
+            return yaml.safe_load(handle)
+    except (OSError, yaml.YAMLError) as exc:  # pragma: no cover - defensive
+        raise PredictiveV2ComparisonReadinessError(f"could not parse contract {path}: {exc}")
+
+
+def _resolve(repo_root: Path, raw: str) -> Path:
+    """Resolve a contract-declared repository-relative path against the repo root.
+
+    Returns:
+        The absolute path to the referenced file.
+    """
+    candidate = Path(raw)
+    return candidate if candidate.is_absolute() else repo_root / candidate
+
+
+def _check_variant_completeness(contract: dict) -> tuple[str, list[str]]:
+    """Verify all four comparison variants exist with schema name, width, and config.
+
+    Returns:
+        A ``(status, messages)`` tuple; status is ``passed`` or ``failed``.
+    """
+    rows = contract.get("row_identifiers")
+    if not isinstance(rows, dict):
+        return STATUS_FAILED, ["contract missing row_identifiers mapping"]
+
+    errors: list[str] = []
+    for variant, expected in REQUIRED_VARIANTS.items():
+        entry = rows.get(variant)
+        if not isinstance(entry, dict):
+            errors.append(f"row_identifiers missing variant: {variant}")
+            continue
+        schema_name = entry.get("schema_name")
+        if schema_name != expected["schema_name"]:
+            errors.append(
+                f"{variant} schema_name is {schema_name!r}, expected {expected['schema_name']!r}"
+            )
+        input_dim = entry.get("input_dim")
+        if input_dim != expected["input_dim"]:
+            errors.append(f"{variant} input_dim is {input_dim!r}, expected {expected['input_dim']}")
+        if not entry.get("config"):
+            errors.append(f"{variant} missing config provenance path")
+    return (STATUS_FAILED, errors) if errors else (STATUS_PASSED, [])
+
+
+def _check_provenance(contract: dict, repo_root: Path) -> tuple[str, list[str]]:
+    """Verify every per-variant config and same-seed manifest path exists on disk.
+
+    Returns:
+        A ``(status, messages)`` tuple; status is ``passed`` or ``failed``.
+    """
+    errors: list[str] = []
+    rows = contract.get("row_identifiers")
+    if isinstance(rows, dict):
+        for variant in REQUIRED_VARIANTS:
+            entry = rows.get(variant)
+            if not isinstance(entry, dict):
+                continue
+            config = entry.get("config")
+            if config and not _resolve(repo_root, str(config)).exists():
+                errors.append(f"{variant} config path does not exist: {config}")
+
+    comparability = contract.get("same_seed_comparability")
+    if isinstance(comparability, dict):
+        for field in SAME_SEED_PATH_FIELDS:
+            raw = comparability.get(field)
+            if raw and not _resolve(repo_root, str(raw)).exists():
+                errors.append(f"same_seed_comparability.{field} path does not exist: {raw}")
+
+    return (STATUS_FAILED, errors) if errors else (STATUS_PASSED, [])
+
+
+def _check_ego_obstacle_conditioning(contract: dict) -> tuple[str, list[str]]:
+    """Verify ego variants declare a defined producer and share one comparability key.
+
+    Returns:
+        A ``(status, messages)`` tuple; status is ``passed`` or ``failed``.
+    """
+    errors: list[str] = []
+    producers = contract.get("ego_motion_channel_producers")
+    if not isinstance(producers, dict) or not producers:
+        return STATUS_FAILED, ["contract missing ego_motion_channel_producers definitions"]
+
+    rows = contract.get("row_identifiers")
+    if not isinstance(rows, dict):
+        return STATUS_FAILED, ["contract missing row_identifiers mapping"]
+
+    declared_keys: set[str] = set()
+    for variant, expected in REQUIRED_VARIANTS.items():
+        entry = rows.get(variant)
+        if not isinstance(entry, dict):
+            continue
+        producer_key = entry.get("ego_motion_channel_producer")
+        if expected["ego_conditioned"]:
+            if not producer_key:
+                errors.append(f"{variant} missing ego_motion_channel_producer metadata")
+                continue
+            if producer_key not in producers:
+                errors.append(f"{variant} references undefined ego producer: {producer_key}")
+            else:
+                declared_keys.add(producer_key)
+        elif producer_key:
+            errors.append(f"{variant} is not ego-conditioned but declares producer {producer_key}")
+
+    # Mixed producer keys across ego variants are "not_comparable_without_caveat" per the
+    # contract's comparability block; for a same-seed comparison they must match.
+    if len(declared_keys) > 1:
+        errors.append(
+            "ego variants use mixed ego_motion_channel_producer keys "
+            f"({sorted(declared_keys)}); same-seed comparison requires a single producer"
+        )
+
+    return (STATUS_FAILED, errors) if errors else (STATUS_PASSED, [])
+
+
+def _check_same_seed_schedule(contract: dict) -> tuple[str, list[str]]:
+    """Verify same-seed manifests, seed value, and forecast/navigation separation are declared.
+
+    Returns:
+        A ``(status, messages)`` tuple; status is ``passed`` or ``failed``.
+    """
+    errors: list[str] = []
+    comparability = contract.get("same_seed_comparability")
+    if not isinstance(comparability, dict):
+        return STATUS_FAILED, ["contract missing same_seed_comparability block"]
+
+    for field in SAME_SEED_PATH_FIELDS:
+        if not comparability.get(field):
+            errors.append(f"same_seed_comparability missing {field}")
+    if comparability.get("seed") is None:
+        errors.append("same_seed_comparability missing fixed seed")
+
+    separation = contract.get("metric_separation")
+    if not isinstance(separation, dict):
+        errors.append("contract missing metric_separation block")
+    else:
+        if not separation.get("forecast_metrics"):
+            errors.append("metric_separation missing forecast_metrics")
+        if not separation.get("navigation_metrics"):
+            errors.append("metric_separation missing navigation_metrics")
+
+    return (STATUS_FAILED, errors) if errors else (STATUS_PASSED, [])
+
+
+def _coupling_gate_recommendation(path: Path) -> tuple[str | None, str | None]:
+    """Extract a coupling-gate recommendation from a JSON or Markdown artifact.
+
+    Mirrors the JSON/Markdown handling in validate_learned_prediction_readiness.
+
+    Returns:
+        A ``(recommendation, error)`` tuple. Exactly one element is non-None.
+    """
+    if not path.exists():
+        return None, f"coupling-gate clearance artifact not found: {path}"
+
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            return None, f"coupling-gate artifact is malformed JSON: {exc}"
+        if not isinstance(payload, dict):
+            return None, "coupling-gate artifact must be a JSON object"
+        recommendation = payload.get("recommendation")
+        if isinstance(recommendation, dict):
+            recommendation = recommendation.get("decision")
+        if not isinstance(recommendation, str) or not recommendation.strip():
+            return None, "coupling-gate artifact missing recommendation/decision"
+        return recommendation.strip().lower(), None
+
+    if suffix in {".md", ".markdown"}:
+        content = path.read_text(encoding="utf-8")
+        match = re.search(
+            r"(?im)^[-*]?\s*(?:recommendation|decision)\s*:\s*`?([A-Za-z_]+)`?", content
+        )
+        if match is None:
+            return None, "coupling-gate Markdown missing recommendation/decision line"
+        return match.group(1).strip().lower(), None
+
+    return None, "coupling-gate artifact must be JSON or Markdown"
+
+
+def _check_blocked_slurm_gate(
+    coupling_gate_path: Path | None,
+    revised_hypothesis_recorded: bool,
+) -> tuple[str, list[str]]:
+    """Fail-closed gate: blocked unless a passing coupling gate AND maintainer ack are supplied.
+
+    Returns:
+        A ``(status, messages)`` tuple; status is ``passed`` or ``blocked``.
+    """
+    blocked_reasons = [
+        "predictive-v2 four-way expansion (#1505/#1506/#1507) is blocked behind the "
+        "maintainer-selected revised hypothesis and the same-seed coupling gate #2916",
+        "Slurm/GPU submission is out of scope for this preflight (coordination-only)",
+    ]
+
+    if coupling_gate_path is None and not revised_hypothesis_recorded:
+        return STATUS_BLOCKED, blocked_reasons
+
+    errors: list[str] = []
+    if not revised_hypothesis_recorded:
+        errors.append("maintainer revised-hypothesis acknowledgement not provided")
+    if coupling_gate_path is None:
+        errors.append("coupling-gate clearance artifact not provided")
+    else:
+        recommendation, error = _coupling_gate_recommendation(coupling_gate_path)
+        if error is not None:
+            errors.append(error)
+        elif recommendation != _GATE_CONTINUE:
+            errors.append(
+                f"coupling-gate recommendation is {recommendation!r}, expected {_GATE_CONTINUE!r}"
+            )
+
+    if errors:
+        return STATUS_BLOCKED, errors
+    return STATUS_PASSED, []
+
+
+def validate_predictive_v2_comparison_readiness(
+    contract_path: Path,
+    repo_root: Path,
+    coupling_gate_path: Path | None = None,
+    revised_hypothesis_recorded: bool = False,
+) -> dict:
+    """Run all preflight stage gates and return a structured readiness report.
+
+    Args:
+        contract_path: Path to the predictive ego-features comparison contract YAML.
+        repo_root: Repository root for resolving contract-relative provenance paths.
+        coupling_gate_path: Optional coupling-gate clearance artifact (JSON/Markdown).
+        revised_hypothesis_recorded: Explicit maintainer acknowledgement that a revised
+            predictive-v2 hypothesis has been recorded (required to clear the blocked gate).
+
+    Returns:
+        A report dict with an overall ``status`` (``ready``, ``blocked``, or ``incomplete``),
+        the per-stage results, and the inputs that were checked.
+
+    Raises:
+        PredictiveV2ComparisonReadinessError: If the contract cannot be loaded or parsed.
+    """
+    contract = _load_yaml(contract_path)
+    if not isinstance(contract, dict):
+        raise PredictiveV2ComparisonReadinessError(
+            f"contract {contract_path} must be a mapping at the top level"
+        )
+
+    stages: dict[str, tuple[str, list[str]]] = {
+        "variant_completeness": _check_variant_completeness(contract),
+        "provenance": _check_provenance(contract, repo_root),
+        "ego_obstacle_conditioning": _check_ego_obstacle_conditioning(contract),
+        "same_seed_schedule": _check_same_seed_schedule(contract),
+        "blocked_slurm_gate": _check_blocked_slurm_gate(
+            coupling_gate_path, revised_hypothesis_recorded
+        ),
+    }
+
+    stage_report: dict[str, dict[str, Any]] = {}
+    metadata_failed = False
+    gate_blocked = False
+    for name, (status, messages) in stages.items():
+        stage_report[name] = {"status": status, "messages": messages}
+        if name == "blocked_slurm_gate":
+            gate_blocked = status != STATUS_PASSED
+        elif status != STATUS_PASSED:
+            metadata_failed = True
+
+    if metadata_failed:
+        overall = "incomplete"
+    elif gate_blocked:
+        overall = "blocked"
+    else:
+        overall = "ready"
+
+    return {
+        "status": overall,
+        "issue": "#1490",
+        "child_issue": "#1504",
+        "stages": stage_report,
+        "checked": {
+            "contract": str(contract_path),
+            "repo_root": str(repo_root),
+            "coupling_gate": str(coupling_gate_path) if coupling_gate_path else None,
+            "revised_hypothesis_recorded": revised_hypothesis_recorded,
+            "required_variants": sorted(REQUIRED_VARIANTS),
+        },
+    }

--- a/scripts/validation/validate_predictive_v2_comparison_readiness.py
+++ b/scripts/validation/validate_predictive_v2_comparison_readiness.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""CLI for the predictive planner v2 same-seed comparison readiness preflight (#1490).
+
+This is a thin wrapper around
+``robot_sf.benchmark.predictive_v2_comparison_readiness``. It is read-only and
+coordination-only: it never trains, evaluates, submits Slurm, or tunes planners.
+
+Exit codes:
+  0  ready    — metadata complete AND the blocked Slurm/maintainer gate is cleared.
+  2  not ready — metadata complete but blocked (default), or prerequisite metadata incomplete.
+  1  error     — the contract could not be loaded or parsed.
+
+Default invocation (fail-closed, expected ``blocked``)::
+
+    uv run python scripts/validation/validate_predictive_v2_comparison_readiness.py --json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.predictive_v2_comparison_readiness import (
+    DEFAULT_CONTRACT_PATH,
+    PredictiveV2ComparisonReadinessError,
+    validate_predictive_v2_comparison_readiness,
+)
+from robot_sf.common.artifact_paths import get_repository_root
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description=(
+            "Fail-closed readiness preflight for the predictive planner v2 same-seed "
+            "comparison (#1490). Validates variant/conditioning/seed/provenance metadata "
+            "and surfaces the blocked Slurm/maintainer-gate state. Does not run benchmarks."
+        )
+    )
+    parser.add_argument(
+        "--contract",
+        type=Path,
+        default=DEFAULT_CONTRACT_PATH,
+        help="Path to the predictive ego-features comparison contract YAML.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=get_repository_root(),
+        help="Repository root used to resolve contract-relative provenance paths.",
+    )
+    parser.add_argument(
+        "--coupling-gate",
+        type=Path,
+        default=None,
+        help=(
+            "Optional coupling-gate clearance artifact (JSON or Markdown) recording a "
+            "recommendation of 'continue'. Required to clear the blocked Slurm gate."
+        ),
+    )
+    parser.add_argument(
+        "--revised-hypothesis-recorded",
+        action="store_true",
+        help=(
+            "Explicit maintainer acknowledgement that a revised predictive-v2 hypothesis "
+            "has been recorded. Required (with --coupling-gate) to clear the blocked gate."
+        ),
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON readiness report.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the preflight and return a shell-friendly exit code."""
+    args = build_arg_parser().parse_args(argv)
+    repo_root = args.repo_root.resolve()
+    contract_path = args.contract if args.contract.is_absolute() else repo_root / args.contract
+
+    try:
+        report = validate_predictive_v2_comparison_readiness(
+            contract_path=contract_path,
+            repo_root=repo_root,
+            coupling_gate_path=args.coupling_gate,
+            revised_hypothesis_recorded=args.revised_hypothesis_recorded,
+        )
+    except PredictiveV2ComparisonReadinessError as exc:
+        print(json.dumps({"status": "error", "error": str(exc)}, indent=2, sort_keys=True))
+        return 1
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"predictive-v2 same-seed comparison readiness: {report['status'].upper()}")
+        for name, payload in report["stages"].items():
+            print(f" - {name}: {payload['status']}")
+            for message in payload["messages"]:
+                print(f"   * {message}")
+
+    return 0 if report["status"] == "ready" else 2
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/benchmark/test_predictive_v2_comparison_readiness.py
+++ b/tests/benchmark/test_predictive_v2_comparison_readiness.py
@@ -1,0 +1,278 @@
+"""Tests for the predictive planner v2 same-seed comparison readiness preflight (#1490).
+
+These are focused synthetic preflight tests: they assert behavior on missing
+seed/conditioning/provenance metadata and the fail-closed blocked Slurm gate. No
+benchmark, training, or Slurm execution is performed.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from typing import TYPE_CHECKING
+
+import yaml
+
+from robot_sf.benchmark.predictive_v2_comparison_readiness import (
+    DEFAULT_CONTRACT_PATH,
+    PredictiveV2ComparisonReadinessError,
+    validate_predictive_v2_comparison_readiness,
+)
+from robot_sf.common.artifact_paths import get_repository_root
+from scripts.validation.validate_predictive_v2_comparison_readiness import main as cli_main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+REPO_ROOT = get_repository_root()
+
+
+def _write_contract(tmp_path: Path, contract: dict) -> Path:
+    """Write a contract dict to a YAML file and return its path."""
+    path = tmp_path / "contract.yaml"
+    path.write_text(yaml.safe_dump(contract), encoding="utf-8")
+    return path
+
+
+def _minimal_contract(tmp_path: Path) -> dict:
+    """Build a self-consistent contract whose referenced paths all exist under tmp_path."""
+    # Create stand-in config and manifest files so the provenance stage passes.
+    for name in (
+        "baseline.yaml",
+        "obstacle_only.yaml",
+        "ego_only.yaml",
+        "ego_obstacle_combined.yaml",
+        "seed_manifest.yaml",
+        "hard_seeds.yaml",
+        "scenario_matrix.yaml",
+        "planner_grid.yaml",
+    ):
+        (tmp_path / name).write_text("placeholder: true\n", encoding="utf-8")
+
+    return {
+        "ego_motion_channel_producers": {
+            "same_seed_hardcase_runtime_robot_speed_v1": {
+                "producer_key": "same_seed_hardcase_runtime_robot_speed_v1",
+            },
+        },
+        "row_identifiers": {
+            "baseline": {
+                "schema_name": "predictive_legacy_v1",
+                "input_dim": 4,
+                "config": "baseline.yaml",
+            },
+            "obstacle_only": {
+                "schema_name": "predictive_obstacle_features_v1",
+                "input_dim": 10,
+                "config": "obstacle_only.yaml",
+            },
+            "ego_only": {
+                "schema_name": "predictive_ego_v1",
+                "input_dim": 9,
+                "config": "ego_only.yaml",
+                "ego_motion_channel_producer": "same_seed_hardcase_runtime_robot_speed_v1",
+            },
+            "ego_obstacle_combined": {
+                "schema_name": "predictive_obstacle_features_v1",
+                "input_dim": 15,
+                "config": "ego_obstacle_combined.yaml",
+                "ego_motion_channel_producer": "same_seed_hardcase_runtime_robot_speed_v1",
+            },
+        },
+        "same_seed_comparability": {
+            "seed_manifest": "seed_manifest.yaml",
+            "hard_seed_manifest": "hard_seeds.yaml",
+            "scenario_matrix": "scenario_matrix.yaml",
+            "planner_grid": "planner_grid.yaml",
+            "seed": 42,
+        },
+        "metric_separation": {
+            "forecast_metrics": ["ADE", "FDE"],
+            "navigation_metrics": ["success_rate", "collision_rate"],
+        },
+    }
+
+
+def _run(contract_path: Path, repo_root: Path, **kwargs) -> dict:
+    """Convenience wrapper for the validator."""
+    return validate_predictive_v2_comparison_readiness(
+        contract_path=contract_path, repo_root=repo_root, **kwargs
+    )
+
+
+def test_complete_metadata_is_blocked_by_default(tmp_path: Path) -> None:
+    """A metadata-complete contract is still blocked when no gate clearance is supplied."""
+    contract_path = _write_contract(tmp_path, _minimal_contract(tmp_path))
+    report = _run(contract_path, tmp_path)
+
+    assert report["status"] == "blocked"
+    for stage in (
+        "variant_completeness",
+        "provenance",
+        "ego_obstacle_conditioning",
+        "same_seed_schedule",
+    ):
+        assert report["stages"][stage]["status"] == "passed"
+    assert report["stages"]["blocked_slurm_gate"]["status"] == "blocked"
+
+
+def test_gate_clears_only_with_continue_and_hypothesis(tmp_path: Path) -> None:
+    """The blocked gate clears only with a 'continue' coupling gate and maintainer ack."""
+    contract_path = _write_contract(tmp_path, _minimal_contract(tmp_path))
+    gate = tmp_path / "gate.json"
+    gate.write_text(json.dumps({"recommendation": {"decision": "continue"}}), encoding="utf-8")
+
+    ready = _run(contract_path, tmp_path, coupling_gate_path=gate, revised_hypothesis_recorded=True)
+    assert ready["status"] == "ready"
+    assert ready["stages"]["blocked_slurm_gate"]["status"] == "passed"
+
+    # Missing maintainer acknowledgement keeps it blocked.
+    still_blocked = _run(contract_path, tmp_path, coupling_gate_path=gate)
+    assert still_blocked["status"] == "blocked"
+
+
+def test_failing_coupling_gate_stays_blocked(tmp_path: Path) -> None:
+    """A coupling gate recommending stop/revise must not clear the gate (issue #1897 case)."""
+    contract_path = _write_contract(tmp_path, _minimal_contract(tmp_path))
+    gate = tmp_path / "gate.json"
+    gate.write_text(
+        json.dumps({"recommendation": "stop_predictive_v2_expansion"}), encoding="utf-8"
+    )
+
+    report = _run(
+        contract_path, tmp_path, coupling_gate_path=gate, revised_hypothesis_recorded=True
+    )
+    assert report["status"] == "blocked"
+    messages = report["stages"]["blocked_slurm_gate"]["messages"]
+    assert any("expected 'continue'" in m for m in messages)
+
+
+def test_missing_variant_is_incomplete(tmp_path: Path) -> None:
+    """Dropping a required variant reports an incomplete metadata stage."""
+    contract = _minimal_contract(tmp_path)
+    del contract["row_identifiers"]["ego_obstacle_combined"]
+    contract_path = _write_contract(tmp_path, contract)
+
+    report = _run(contract_path, tmp_path)
+    assert report["status"] == "incomplete"
+    assert report["stages"]["variant_completeness"]["status"] == "failed"
+    assert any(
+        "ego_obstacle_combined" in m for m in report["stages"]["variant_completeness"]["messages"]
+    )
+
+
+def test_missing_ego_producer_is_incomplete(tmp_path: Path) -> None:
+    """An ego variant without conditioning metadata fails the conditioning stage."""
+    contract = _minimal_contract(tmp_path)
+    del contract["row_identifiers"]["ego_only"]["ego_motion_channel_producer"]
+    contract_path = _write_contract(tmp_path, contract)
+
+    report = _run(contract_path, tmp_path)
+    assert report["status"] == "incomplete"
+    assert report["stages"]["ego_obstacle_conditioning"]["status"] == "failed"
+
+
+def test_mixed_ego_producers_not_comparable(tmp_path: Path) -> None:
+    """Different ego producers across ego variants break same-seed comparability."""
+    contract = _minimal_contract(tmp_path)
+    contract["ego_motion_channel_producers"]["standalone_rollout_velocity_xy_preferred_v1"] = {
+        "producer_key": "standalone_rollout_velocity_xy_preferred_v1",
+    }
+    contract["row_identifiers"]["ego_obstacle_combined"]["ego_motion_channel_producer"] = (
+        "standalone_rollout_velocity_xy_preferred_v1"
+    )
+    contract_path = _write_contract(tmp_path, contract)
+
+    report = _run(contract_path, tmp_path)
+    assert report["stages"]["ego_obstacle_conditioning"]["status"] == "failed"
+    assert any("mixed" in m for m in report["stages"]["ego_obstacle_conditioning"]["messages"])
+
+
+def test_missing_provenance_path_is_incomplete(tmp_path: Path) -> None:
+    """A config path that does not exist on disk fails the provenance stage."""
+    contract = _minimal_contract(tmp_path)
+    contract["row_identifiers"]["baseline"]["config"] = "does_not_exist.yaml"
+    contract_path = _write_contract(tmp_path, contract)
+
+    report = _run(contract_path, tmp_path)
+    assert report["status"] == "incomplete"
+    assert report["stages"]["provenance"]["status"] == "failed"
+
+
+def test_missing_seed_value_is_incomplete(tmp_path: Path) -> None:
+    """Dropping the fixed seed fails the same-seed schedule stage."""
+    contract = _minimal_contract(tmp_path)
+    del contract["same_seed_comparability"]["seed"]
+    contract_path = _write_contract(tmp_path, contract)
+
+    report = _run(contract_path, tmp_path)
+    assert report["status"] == "incomplete"
+    assert report["stages"]["same_seed_schedule"]["status"] == "failed"
+
+
+def test_missing_contract_raises(tmp_path: Path) -> None:
+    """A non-existent contract path raises a readiness error."""
+    try:
+        _run(tmp_path / "nope.yaml", tmp_path)
+    except PredictiveV2ComparisonReadinessError as exc:
+        assert "not found" in str(exc)
+    else:  # pragma: no cover - explicit failure
+        raise AssertionError("expected PredictiveV2ComparisonReadinessError")
+
+
+def test_committed_contract_is_metadata_complete_but_blocked() -> None:
+    """The real committed contract should be metadata-complete yet blocked by default.
+
+    This is the integration assertion: the same-seed predictive-v2 comparison has all its
+    prerequisite metadata declared, but the lane stays fail-closed behind the maintainer
+    gate (#2916) until a revised hypothesis and passing coupling gate are recorded.
+    """
+    contract_path = REPO_ROOT / DEFAULT_CONTRACT_PATH
+    report = _run(contract_path, REPO_ROOT)
+
+    assert report["status"] == "blocked"
+    assert report["stages"]["variant_completeness"]["status"] == "passed"
+    assert report["stages"]["provenance"]["status"] == "passed"
+    assert report["stages"]["ego_obstacle_conditioning"]["status"] == "passed"
+    assert report["stages"]["same_seed_schedule"]["status"] == "passed"
+    assert report["stages"]["blocked_slurm_gate"]["status"] == "blocked"
+
+
+def test_cli_default_exit_code_is_blocked(capsys) -> None:
+    """The CLI exits 2 (not ready) by default against the committed contract."""
+    exit_code = cli_main(["--json"])
+    assert exit_code == 2
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "blocked"
+
+
+def test_cli_markdown_gate_clears(tmp_path: Path, capsys) -> None:
+    """A Markdown coupling gate recommending continue clears the CLI gate to ready."""
+    contract = _minimal_contract(tmp_path)
+    contract_path = _write_contract(tmp_path, contract)
+    gate = tmp_path / "gate.md"
+    gate.write_text("# Coupling gate\n\n- recommendation: continue\n", encoding="utf-8")
+
+    exit_code = cli_main(
+        [
+            "--contract",
+            str(contract_path),
+            "--repo-root",
+            str(tmp_path),
+            "--coupling-gate",
+            str(gate),
+            "--revised-hypothesis-recorded",
+            "--json",
+        ]
+    )
+    assert exit_code == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["status"] == "ready"
+
+
+# Guard against accidental mutation of the shared REQUIRED_VARIANTS template in tests.
+def test_minimal_contract_is_independent(tmp_path: Path) -> None:
+    """The helper returns an independent contract each call (deepcopy hygiene)."""
+    first = _minimal_contract(tmp_path)
+    second = copy.deepcopy(first)
+    assert first == second


### PR DESCRIPTION
## Summary

Adds a **fail-closed readiness/preflight checker** for the same-seed predictive planner v2
four-way comparison tracked by issue #1490 (umbrella) and its ego-conditioning child #1504.

Issue: https://github.com/ll7/robot_sf_ll7/issues/1490

#1490 is a **blocked umbrella**: the recorded maintainer decision (2026-05-31, reaffirmed
2026-06-21) is to *revise planner coupling/objective before any ego/combined four-way matrix*,
and #1543 (negative) / #1897 (failed coupling gate) mean the four-way expansion
(#1505/#1506/#1507) must not run. This PR delivers only the safe slice named in the scoped
objective: a bounded, read-only readiness checker for comparison prerequisites, ego-obstacle
conditioning metadata, and the blocked Slurm state. It does **not** revise the lane, run anything,
or change any claim.

## What changed

- **`robot_sf/benchmark/predictive_v2_comparison_readiness.py`** (new canonical owner) —
  `validate_predictive_v2_comparison_readiness` validates the committed feature contract
  `configs/training/predictive/predictive_ego_features_contract_v1.yaml` across five stage gates:
  - `variant_completeness` — baseline / obstacle-only / ego-only / combined present with the
    expected schema name and input dim (4 / 10 / 9 / 15);
  - `provenance` — every referenced per-variant config and same-seed manifest (seed manifest,
    hard-seed manifest, scenario matrix, planner grid) exists on disk;
  - `ego_obstacle_conditioning` — ego variants declare a defined `ego_motion_channel_producer`
    and share a **single** comparability producer key (mixed keys are
    `not_comparable_without_caveat`);
  - `same_seed_schedule` — seed manifests, fixed seed, and forecast vs. navigation
    `metric_separation` are declared;
  - `blocked_slurm_gate` — **fail-closed**; stays `blocked` behind the maintainer-selected revised
    hypothesis and the same-seed coupling gate #2916, clearing only when an explicit `continue`
    coupling-gate artifact **and** the maintainer-hypothesis acknowledgement are both supplied.
- **`scripts/validation/validate_predictive_v2_comparison_readiness.py`** (new thin CLI) —
  decision-coded exit status: `0` ready, `2` blocked/incomplete, `1` contract load error.
- **`tests/benchmark/test_predictive_v2_comparison_readiness.py`** — focused synthetic preflight
  tests for missing seed/conditioning/provenance metadata plus the fail-closed gate; one
  integration test asserts the committed contract is metadata-complete-but-`blocked`.
- **`CHANGELOG.md`** — Unreleased/Added entry.

**First use (per AGENTS.md new-tool rule):** exercised in-PR against the committed contract via the
integration test and the CLI run below. Output is coordination/preflight evidence only — not
benchmark-strength or paper-facing evidence.

## Validation

```
$ uv run ruff check robot_sf/benchmark/predictive_v2_comparison_readiness.py \
    scripts/validation/validate_predictive_v2_comparison_readiness.py \
    tests/benchmark/test_predictive_v2_comparison_readiness.py
All checks passed!          # exit 0

$ uv run pytest tests/benchmark/test_predictive_v2_comparison_readiness.py -q
13 passed in 0.55s          # exit 0

$ uv run python scripts/validation/validate_predictive_v2_comparison_readiness.py
predictive-v2 same-seed comparison readiness: BLOCKED
 - variant_completeness: passed
 - provenance: passed
 - ego_obstacle_conditioning: passed
 - same_seed_schedule: passed
 - blocked_slurm_gate: blocked
   * predictive-v2 four-way expansion (#1505/#1506/#1507) is blocked behind the
     maintainer-selected revised hypothesis and the same-seed coupling gate #2916
   * Slurm/GPU submission is out of scope for this preflight (coordination-only)
exit=2
```

## Downstream Propagation

- **Parent issue #1490 / child #1504**: this PR adds the readiness tooling only; it does not change
  the umbrella's blocked lifecycle decision. No status flip is implied.
- **Claim map / benchmark report / leaderboard / registry**: not applicable — no benchmark evidence
  is produced; the preflight is coordination-only and reports `blocked` against the live contract.
- **Context note / memory**: module + CLI docstrings and the CHANGELOG entry document the contract,
  stages, and exit codes; no separate context note added to keep the PR minimal.

## Research Result Guidance

- Target: keep the predictive-v2 same-seed comparison **fail-closed** until a revised closed-loop
  hypothesis and the coupling gate #2916 clear it; make missing prerequisite metadata actionable.
- Comparator/baseline: N/A (no run); the gate mirrors the recorded #1490 decision and #1897 result.
- Evidence tier: `diagnostic-only` / preflight tooling.
- Decision/stop rule: gate clears only with `continue` coupling-gate artifact + maintainer ack.

## Out of scope (explicit)

- **No full benchmark campaign run.**
- **No Slurm/GPU submission.**
- **No planner tuning, training, or evaluation.**
- **No paper/dissertation claim edits.**

## Residual risk

The contract paths and conditioning keys are validated structurally (presence, schema name,
input-dim, file existence, single producer key); the checker does not parse the referenced configs'
internal contents or recompute feature widths from code. Equivalence of the actual training/eval
surface across variants is still established by the downstream same-seed harness, not by this
preflight.

After this PR is open, Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and
merge authority.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readiness check for predictive planner v2 same-seed comparisons, with clear statuses for ready, blocked, and incomplete.
  * Added a command-line tool to run the check and optionally output JSON results.

* **Bug Fixes**
  * Improved validation of required comparison metadata, including variant setup, provenance links, seed separation, and ego-conditioning consistency.
  * Added fail-closed behavior so results stay blocked until required coordination inputs are provided.

* **Tests**
  * Added coverage for blocked, ready, incomplete, and error scenarios, plus CLI exit-code behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->