### PR TITLE
feat(maps): fail-closed SocNavBench ETH map-conversion readiness preflight (#1134)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **fail-closed SocNavBench map-conversion readiness preflight** for the ETH import batch
+  (#1134, parent #334). The batch validator
+  (`scripts/tools/validate_socnav_map_batch.py`) gains a `conversion_readiness()` function and a
+  `--preflight` CLI mode that layer a conversion *decision* on top of the existing raw
+  asset-existence report. Conversion is reported `ready` only when every `required_for_conversion`
+  source asset is staged; while the ETH traversible `data.pkl` (or mesh dir) is missing the verdict
+  is `blocked_pending_source_assets` with `conversion_ready: false`, a `next_action` naming the
+  missing source paths, and a non-zero exit code. When blocked, any pre-existing planned map
+  *artifact* (`map_svg`, `scenario_config`) is surfaced as `placeholder_risk` so a hand-authored or
+  inferred ETH-like SVG cannot be silently mistaken for an official conversion; the provenance note
+  is intentionally excluded because it is expected to exist during the blocked phase. This is
+  **preflight/readiness only**: it does not download assets, stage data, convert maps, run
+  simulations, or assert any benchmark result. Against the current repo state the preflight reports
+  `blocked_pending_source_assets`, matching the issue's blocked status.
+
 * Added a **durable learned-risk training trace manifest contract and fail-closed validator**
   (#2312, parent #1472). New module `robot_sf/training/learned_risk_trace_manifest.py` exposes
   `validate_trace_manifest`, which checks a `learned-risk-trace-manifest.v1` YAML (durable baseline

--- a/scripts/tools/validate_socnav_map_batch.py
+++ b/scripts/tools/validate_socnav_map_batch.py
@@ -122,6 +122,121 @@ def validate_batch(
     }
 
 
+# Conversion-readiness statuses returned by ``conversion_readiness``. ``ready``
+# means every conversion-required source asset is staged and conversion may
+# proceed. ``blocked_pending_source_assets`` means at least one required asset
+# (notably the ETH traversible ``data.pkl``) is missing, so conversion must fail
+# closed instead of fabricating a placeholder map.
+READY = "ready"
+BLOCKED = "blocked_pending_source_assets"
+
+# Planned-output keys that name a generated *map artifact* (the conversion's
+# product). These are the outputs forbidden while the batch is blocked, because
+# a pre-existing copy may be a hand-authored or inferred placeholder. Other
+# planned outputs such as the provenance note are documentation that is expected
+# to exist during the blocked phase, so they are not treated as placeholder risk.
+CONVERSION_ARTIFACT_OUTPUT_KEYS = frozenset({"map_svg", "scenario_config"})
+
+
+def _existing_planned_outputs(
+    map_reports: list[dict[str, Any]],
+    repo_root: Path,
+) -> list[dict[str, str]]:
+    """Return planned map artifacts that already exist on disk while blocked.
+
+    The map-conversion issue (#1134) explicitly forbids committing a
+    hand-authored or inferred ETH-like SVG while the official source assets are
+    not staged. When the batch is blocked, a pre-existing conversion *artifact*
+    (for example ``maps/svg_maps/socnavbench/socnavbench_eth.svg`` or the smoke
+    scenario) is a provenance risk: it may be a placeholder masquerading as an
+    official conversion. Only artifact outputs in
+    :data:`CONVERSION_ARTIFACT_OUTPUT_KEYS` are flagged; the provenance note and
+    other documentation outputs are expected to exist during the blocked phase.
+    """
+    found: list[dict[str, str]] = []
+    for map_report in map_reports:
+        planned = map_report.get("planned_outputs")
+        if not isinstance(planned, dict):
+            continue
+        for output_key, rel in planned.items():
+            if str(output_key) not in CONVERSION_ARTIFACT_OUTPUT_KEYS:
+                continue
+            if not isinstance(rel, str) or not rel.strip():
+                continue
+            candidate = repo_root / rel.strip()
+            if candidate.exists():
+                found.append(
+                    {
+                        "map_id": str(map_report.get("map_id", "")),
+                        "output_key": str(output_key),
+                        "relative_path": rel.strip(),
+                        "path": str(candidate),
+                    }
+                )
+    return found
+
+
+def conversion_readiness(
+    *,
+    manifest_path: Path,
+    socnav_root: Path,
+    batch_id: str,
+    repo_root: Path = REPO_ROOT,
+) -> dict[str, Any]:
+    """Decide whether SocNavBench map conversion may begin for one batch.
+
+    This is a fail-closed preflight gate layered on top of :func:`validate_batch`.
+    The underlying validator reports raw source-asset existence; this function
+    narrows that to the conversion decision:
+
+    - ``conversion_ready`` is ``True`` only when every asset marked
+      ``required_for_conversion`` is staged. Any missing required asset (the ETH
+      traversible ``data.pkl`` in particular) yields ``status`` ``blocked`` and
+      ``conversion_ready`` ``False``.
+    - When blocked, planned outputs that already exist are reported as
+      ``placeholder_risk`` so a hand-authored or inferred map cannot be silently
+      mistaken for an official conversion.
+    - ``next_action`` names the smallest concrete step toward unblocking.
+
+    The function never converts assets, downloads data, or writes maps; it only
+    inspects staged state and returns a verdict.
+    """
+    report = validate_batch(
+        manifest_path=manifest_path,
+        socnav_root=socnav_root,
+        batch_id=batch_id,
+    )
+    missing = report["missing_required"]
+    ready = not missing
+    placeholder_risk = [] if ready else _existing_planned_outputs(report["maps"], repo_root)
+
+    if ready:
+        next_action = (
+            "Conversion-required source assets are staged. Record source "
+            "checksums/provenance, then run the official conversion."
+        )
+    else:
+        missing_paths = ", ".join(sorted(item["relative_path"] for item in missing))
+        next_action = (
+            "Stage the official SocNavBench source assets under the socnav root "
+            f"({missing_paths}), then re-run this preflight. Do not author a "
+            "placeholder map while blocked."
+        )
+
+    return {
+        "manifest": report["manifest"],
+        "socnav_root": report["socnav_root"],
+        "repo_root": str(repo_root),
+        "batch_id": report["batch_id"],
+        "batch_status": report["batch_status"],
+        "conversion_ready": ready,
+        "status": READY if ready else BLOCKED,
+        "missing_required": missing,
+        "placeholder_risk": placeholder_risk,
+        "next_action": next_action,
+    }
+
+
 def parse_args() -> argparse.Namespace:
     """Parse CLI arguments."""
     parser = argparse.ArgumentParser(description=__doc__)
@@ -129,22 +244,40 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--socnav-root", type=Path, default=DEFAULT_SOCNAV_ROOT)
     parser.add_argument("--batch-id", default="eth_first")
     parser.add_argument("--report-json", type=Path)
+    parser.add_argument(
+        "--preflight",
+        action="store_true",
+        help=(
+            "Emit a fail-closed map-conversion readiness verdict instead of the "
+            "raw asset-existence report. Exits non-zero while conversion is "
+            "blocked on missing source assets."
+        ),
+    )
     return parser.parse_args()
 
 
 def main() -> int:
-    """Validate one SocNavBench import batch and return a process exit code."""
+    """Validate or preflight one SocNavBench import batch and return an exit code."""
     args = parse_args()
-    report = validate_batch(
-        manifest_path=args.manifest.resolve(),
-        socnav_root=args.socnav_root.resolve(),
-        batch_id=str(args.batch_id),
-    )
+    if args.preflight:
+        report = conversion_readiness(
+            manifest_path=args.manifest.resolve(),
+            socnav_root=args.socnav_root.resolve(),
+            batch_id=str(args.batch_id),
+        )
+        ok = bool(report["conversion_ready"])
+    else:
+        report = validate_batch(
+            manifest_path=args.manifest.resolve(),
+            socnav_root=args.socnav_root.resolve(),
+            batch_id=str(args.batch_id),
+        )
+        ok = bool(report["ok"])
     if args.report_json is not None:
         args.report_json.parent.mkdir(parents=True, exist_ok=True)
         args.report_json.write_text(json.dumps(report, indent=2), encoding="utf-8")
     print(json.dumps(report, indent=2))
-    return 0 if report["ok"] else 2
+    return 0 if ok else 2
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_validate_socnav_map_batch.py
+++ b/tests/tools/test_validate_socnav_map_batch.py
@@ -7,10 +7,17 @@ from typing import TYPE_CHECKING
 import pytest
 import yaml
 
-from scripts.tools.validate_socnav_map_batch import validate_batch
+from scripts.tools.validate_socnav_map_batch import (
+    BLOCKED,
+    READY,
+    conversion_readiness,
+    validate_batch,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
+
+PLANNED_MAP_SVG = "maps/svg_maps/socnavbench/socnavbench_eth.svg"
 
 
 def _write_manifest(path: Path) -> None:
@@ -44,12 +51,22 @@ def _write_manifest(path: Path) -> None:
                                 "required_for_conversion": True,
                             },
                         ],
+                        "planned_outputs": {"map_svg": PLANNED_MAP_SVG},
                     }
                 ],
             }
         ],
     }
     path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _stage_eth_assets(root: Path) -> None:
+    """Stage the exact ETH mesh dir and traversible pickle under ``root``."""
+    base = root / "sd3dis" / "stanford_building_parser_dataset"
+    (base / "mesh" / "ETH").mkdir(parents=True)
+    traversible = base / "traversibles" / "ETH" / "data.pkl"
+    traversible.parent.mkdir(parents=True)
+    traversible.write_bytes(b"fixture")
 
 
 def test_validate_batch_reports_missing_required_assets(tmp_path: Path) -> None:
@@ -75,12 +92,7 @@ def test_validate_batch_accepts_staged_eth_assets(tmp_path: Path) -> None:
     manifest = tmp_path / "manifest.yaml"
     _write_manifest(manifest)
     root = tmp_path / "socnavbench"
-    (root / "sd3dis" / "stanford_building_parser_dataset" / "mesh" / "ETH").mkdir(parents=True)
-    traversible = (
-        root / "sd3dis" / "stanford_building_parser_dataset" / "traversibles" / "ETH" / "data.pkl"
-    )
-    traversible.parent.mkdir(parents=True)
-    traversible.write_bytes(b"fixture")
+    _stage_eth_assets(root)
 
     report = validate_batch(
         manifest_path=manifest,
@@ -123,6 +135,69 @@ def test_validate_batch_rejects_parent_relative_path(tmp_path: Path) -> None:
             socnav_root=tmp_path / "socnavbench",
             batch_id="eth_first",
         )
+
+
+def test_conversion_readiness_blocks_when_traversible_missing(tmp_path: Path) -> None:
+    """Preflight must fail closed and name the missing traversible while blocked."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+
+    report = conversion_readiness(
+        manifest_path=manifest,
+        socnav_root=tmp_path / "socnavbench",
+        batch_id="eth_first",
+        repo_root=tmp_path / "repo",
+    )
+
+    assert report["conversion_ready"] is False
+    assert report["status"] == BLOCKED
+    missing_keys = {item["asset_key"] for item in report["missing_required"]}
+    assert "eth_traversible_pickle" in missing_keys
+    # The next-action hint must point at staging the missing traversible path.
+    assert "traversibles/ETH/data.pkl" in report["next_action"]
+    # Nothing was staged, so there is no placeholder masquerading as a conversion.
+    assert report["placeholder_risk"] == []
+
+
+def test_conversion_readiness_ready_when_assets_staged(tmp_path: Path) -> None:
+    """Preflight should clear conversion only once every required asset is staged."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+    root = tmp_path / "socnavbench"
+    _stage_eth_assets(root)
+
+    report = conversion_readiness(
+        manifest_path=manifest,
+        socnav_root=root,
+        batch_id="eth_first",
+        repo_root=tmp_path / "repo",
+    )
+
+    assert report["conversion_ready"] is True
+    assert report["status"] == READY
+    assert report["missing_required"] == []
+    assert report["placeholder_risk"] == []
+
+
+def test_conversion_readiness_flags_placeholder_when_blocked(tmp_path: Path) -> None:
+    """A pre-existing planned SVG while blocked is a provenance/placeholder risk."""
+    manifest = tmp_path / "manifest.yaml"
+    _write_manifest(manifest)
+    repo_root = tmp_path / "repo"
+    placeholder = repo_root / PLANNED_MAP_SVG
+    placeholder.parent.mkdir(parents=True)
+    placeholder.write_text("<svg></svg>", encoding="utf-8")
+
+    report = conversion_readiness(
+        manifest_path=manifest,
+        socnav_root=tmp_path / "socnavbench",
+        batch_id="eth_first",
+        repo_root=repo_root,
+    )
+
+    assert report["conversion_ready"] is False
+    assert [risk["relative_path"] for risk in report["placeholder_risk"]] == [PLANNED_MAP_SVG]
+    assert report["placeholder_risk"][0]["output_key"] == "map_svg"
 
 
 def test_validate_batch_rejects_absolute_relative_path(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Adds the safe, bounded **map-conversion readiness slice** for issue #1134 (parent #334). The issue
is **blocked**: SocNavBench ETH map conversion must not proceed until the official ETH traversible
`data.pkl` and mesh directory are staged locally with provenance. This PR does **not** unblock it —
it implements the fail-closed preflight that decides whether conversion may begin and refuses to let
a placeholder masquerade as an official conversion.

Closes part of #1134 (the local, fixture-testable converter-preflight slice from the issue's agent
execution spec). The asset-staging gate (#1498) and the actual SVG conversion remain out of scope.

## What changed

Extends the canonical validator `scripts/tools/validate_socnav_map_batch.py` (no per-issue fork):

- **`conversion_readiness()`** layers a conversion *decision* on top of the existing raw
  asset-existence report (`validate_batch`). Conversion is `ready` only when every
  `required_for_conversion` source asset is staged. While the ETH traversible `data.pkl` (or mesh
  dir) is missing, the verdict is `blocked_pending_source_assets` with `conversion_ready: false` and
  a `next_action` naming the exact missing source paths.
- **`--preflight` CLI mode** emits that verdict and exits non-zero while blocked (fail-closed).
- **`placeholder_risk`**: when blocked, any pre-existing planned map *artifact* (`map_svg`,
  `scenario_config`) is surfaced so a hand-authored or inferred ETH-like SVG cannot be silently
  mistaken for an official conversion. The provenance note is intentionally excluded — it is expected
  to exist during the blocked phase.
- Focused synthetic tests for the blocked-traversible case, the staged-ready case, and the
  placeholder-risk case.

## Validation

| Command | Exit | Result |
| --- | --- | --- |
| `ruff check` (changed files) | 0 | All checks passed |
| `ruff format --check` (changed files) | 0 | 2 files already formatted |
| `python -m pytest tests/tools/test_validate_socnav_map_batch.py -q` | 0 | 8 passed |
| `python scripts/tools/validate_socnav_map_batch.py --batch-id eth_first --preflight` | 2 | `status: blocked_pending_source_assets`, `conversion_ready: false`, `placeholder_risk: []` (correct: provenance note not flagged) |
| `python scripts/tools/prepare_socnav_assets.py --help` (issue cmd) | 0 | runs |
| `python -m pytest tests/maps/ -k "socnav or eth or traversible" -q` (issue cmd) | 0 | 29 deselected (matching tests live under `tests/tools/`) |

The real-repo preflight reporting `blocked_pending_source_assets` is the expected, honest state for
this issue.

## Scope

- **In scope:** fail-closed conversion-readiness/preflight checker + tests.
- **Out of scope (explicit):** no asset download/staging, no map conversion, no SVG authoring, no
  simulation run, **no full benchmark campaign run, no Slurm/GPU submission, and no
  paper/dissertation claim edits.**

## Downstream Propagation

- Parent #334 / blocker #1498 unchanged (still gate real conversion). Map artifact, leaderboard, and
  benchmark report: NA — no benchmark result asserted.
- Context note `docs/context/issue_334_socnavbench_eth_import.md` unchanged; provenance recording
  belongs to the staging/conversion step once unblocked.

## Research Result Guidance

NA — support/tooling preflight, no research claim. Evidence tier: smoke/diagnostic (the tool's own
fail-closed behavior is fixture-proven; it asserts no benchmark or map-quality result).

Issue: #1134
