### PR TITLE
feat(training): fail-closed campaign-readiness gate for learned-risk v1 Slurm run (#1472)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **fail-closed campaign-readiness gate for the learned-risk model v1 Slurm campaign**
+  (#1472). New module `robot_sf/training/learned_risk_campaign_readiness.py` exposes
+  `evaluate_campaign_readiness`, which aggregates the two existing canonical owners — the
+  launch-packet validator (`validate_launch_packet`) and the durable trace-manifest validator
+  (`validate_trace_manifest`) — into a single campaign launch decision. The decision is
+  `campaign_launch_ready` only when **both** gates pass; an invalid launch packet, a structurally
+  invalid manifest, or unresolved durable artifact pointers all fold into a fail-closed
+  `campaign_blocked` result with the underlying per-gate blockers surfaced. A new CLI
+  `scripts/validation/check_learned_risk_campaign_readiness.py` defaults to the checked-in #1472
+  inputs and reports decision-coded exit status (`0` ready, `2` input file missing, `3` blocked).
+  This is **readiness/preflight only**: it submits no SLURM job, trains nothing, fetches nothing,
+  and promotes no artifacts — a ready decision means the checked-in contract is locally complete.
+  Against current `main` the campaign correctly reports `campaign_blocked` (the launch packet is
+  valid; the durable trace/baseline artifacts are still `:pending`).
+
 * Added a **durable learned-risk training trace manifest contract and fail-closed validator**
   (#2312, parent #1472). New module `robot_sf/training/learned_risk_trace_manifest.py` exposes
   `validate_trace_manifest`, which checks a `learned-risk-trace-manifest.v1` YAML (durable baseline

--- a/robot_sf/training/learned_risk_campaign_readiness.py
+++ b/robot_sf/training/learned_risk_campaign_readiness.py
@@ -1,0 +1,206 @@
+"""Fail-closed campaign-readiness aggregator for the learned-risk model v1 Slurm run.
+
+Issue #1472 ("research: run learned risk model v1 Slurm campaign") is blocked until
+its prerequisites are mechanically satisfied. Two canonical owners already validate
+the separate halves of those prerequisites:
+
+- :mod:`robot_sf.training.learned_risk_launch_packet` proves the *launch packet*:
+  trace input contract against a tracked fixture, baseline packet, safety policy,
+  and execution boundary (config/route metadata).
+- :mod:`robot_sf.training.learned_risk_trace_manifest` proves the *durable trace
+  manifest*: whether the durable trace + baseline artifact pointers are resolvable
+  or training must fail closed.
+
+This module owns neither contract. It is the thin *campaign-level* aggregator that
+runs both owners and folds their results into one fail-closed launch decision so
+#1472 has a single mechanical gate ("is the campaign launch-ready, or blocked, and
+on what?") instead of two separate exit codes that a caller has to reconcile.
+
+Decision boundary:
+
+- Missing/unreadable config *files* raise :class:`LearnedRiskCampaignReadinessError`
+  (operator error: nothing to evaluate).
+- Every other failure -- an invalid launch packet, a structurally invalid manifest,
+  or a well-formed-but-unresolved manifest -- is folded into a fail-closed
+  ``campaign_blocked`` decision with the underlying blockers surfaced per gate. The
+  decision is ``campaign_launch_ready`` only when *both* owners report ready.
+
+It performs no Slurm submission, no training, no network fetch, and no artifact
+promotion; a ready decision means "locally contract-complete", not "job launched".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from robot_sf.training.learned_risk_launch_packet import (
+    LearnedRiskLaunchPacketError,
+    validate_launch_packet,
+)
+from robot_sf.training.learned_risk_trace_manifest import (
+    DECISION_READY,
+    LearnedRiskTraceManifestError,
+    validate_trace_manifest,
+)
+
+# Default checked-in campaign inputs for the #1472 learned-risk model v1 run.
+DEFAULT_LAUNCH_PACKET = "configs/training/learned_risk_model_issue_1395_launch_packet.yaml"
+DEFAULT_TRACE_MANIFEST = "configs/training/learned_risk_trace_manifest_issue_2312.yaml"
+
+# Campaign decision vocabulary. ``campaign_blocked`` is fail-closed: it is the
+# decision for any non-ready gate so an unresolved or invalid input can never be
+# mistaken for a launchable campaign.
+CAMPAIGN_READY = "campaign_launch_ready"
+CAMPAIGN_BLOCKED = "campaign_blocked"
+
+_GATE_PASSED = "passed"
+_GATE_BLOCKED = "blocked"
+
+
+class LearnedRiskCampaignReadinessError(ValueError):
+    """Raised when a campaign-readiness input file is missing or unreadable.
+
+    This is reserved for operator error (a config path that does not point at a
+    file). Contract failures inside an existing file are reported as fail-closed
+    blocked gates, not raised, so the campaign decision stays evaluable.
+    """
+
+
+def evaluate_campaign_readiness(
+    launch_packet_path: Path | str = DEFAULT_LAUNCH_PACKET,
+    trace_manifest_path: Path | str = DEFAULT_TRACE_MANIFEST,
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Aggregate the launch-packet and trace-manifest owners into one launch gate.
+
+    Args:
+        launch_packet_path: Learned-risk launch-packet YAML path (config metadata).
+        trace_manifest_path: Durable trace-manifest YAML path (artifact metadata).
+        repo_root: Repository root for resolving relative paths.
+
+    Returns:
+        Compact report with a per-gate breakdown, the aggregated
+        ``campaign_state`` (``campaign_launch_ready`` only when both gates pass),
+        the list of ``blocking_gates``, and the flattened ``blockers``.
+
+    Raises:
+        LearnedRiskCampaignReadinessError: If either config path is not a file, so
+            the campaign cannot be evaluated at all.
+    """
+    root = (repo_root or Path.cwd()).resolve()
+    launch_packet_path = _resolve_existing(launch_packet_path, root, "launch packet")
+    trace_manifest_path = _resolve_existing(trace_manifest_path, root, "trace manifest")
+
+    gates = [
+        _evaluate_launch_packet_gate(launch_packet_path, root),
+        _evaluate_trace_manifest_gate(trace_manifest_path, root),
+    ]
+
+    blocking_gates = [gate["name"] for gate in gates if gate["status"] != _GATE_PASSED]
+    blockers = [
+        f"{gate['name']}: {blocker}" for gate in gates for blocker in gate.get("blockers", [])
+    ]
+    campaign_state = CAMPAIGN_BLOCKED if blocking_gates else CAMPAIGN_READY
+    return {
+        "status": "ok",
+        "candidate_id": "learned_risk_model_v1",
+        "issue": 1472,
+        "launch_packet": str(launch_packet_path),
+        "trace_manifest": str(trace_manifest_path),
+        "gates": gates,
+        "campaign_ready": not blocking_gates,
+        "campaign_state": campaign_state,
+        "blocking_gates": blocking_gates,
+        "blockers": blockers,
+    }
+
+
+def _resolve_existing(path: Path | str, repo_root: Path, label: str) -> Path:
+    """Resolve a config path and require that it points at an existing file.
+
+    Returns:
+        The resolved absolute path.
+
+    Raises:
+        LearnedRiskCampaignReadinessError: If the resolved path is not a file.
+    """
+    candidate = Path(path)
+    resolved = candidate.resolve() if candidate.is_absolute() else (repo_root / candidate).resolve()
+    if not resolved.is_file():
+        raise LearnedRiskCampaignReadinessError(f"{label} is not a file: {path}")
+    return resolved
+
+
+def _evaluate_launch_packet_gate(launch_packet_path: Path, root: Path) -> dict[str, Any]:
+    """Run the launch-packet owner and fold its result into a campaign gate.
+
+    Returns:
+        A gate mapping with ``name``, ``status``, ``summary``, and ``blockers``.
+    """
+    try:
+        report = validate_launch_packet(launch_packet_path, repo_root=root)
+    except LearnedRiskLaunchPacketError as exc:
+        return {
+            "name": "launch_packet",
+            "status": _GATE_BLOCKED,
+            "summary": "launch packet failed validation",
+            "blockers": _split_error(exc),
+        }
+    return {
+        "name": "launch_packet",
+        "status": _GATE_PASSED,
+        "summary": f"launch packet valid for {report['candidate_id']}",
+        "blockers": [],
+    }
+
+
+def _evaluate_trace_manifest_gate(trace_manifest_path: Path, root: Path) -> dict[str, Any]:
+    """Run the trace-manifest owner and fold its result into a campaign gate.
+
+    A structurally invalid manifest (which the owner raises on) is treated as a
+    fail-closed blocker at the campaign level rather than re-raised, so a single
+    bad input never masks the other gate's status.
+
+    Returns:
+        A gate mapping with ``name``, ``status``, ``summary``, and ``blockers``.
+    """
+    try:
+        report = validate_trace_manifest(trace_manifest_path, repo_root=root)
+    except LearnedRiskTraceManifestError as exc:
+        return {
+            "name": "trace_manifest",
+            "status": _GATE_BLOCKED,
+            "summary": "trace manifest is structurally invalid",
+            "blockers": _split_error(exc),
+        }
+    decision = report["training_readiness_decision"]
+    status = _GATE_PASSED if decision == DECISION_READY else _GATE_BLOCKED
+    return {
+        "name": "trace_manifest",
+        "status": status,
+        "summary": f"trace manifest decision: {decision}",
+        "blockers": list(report.get("blockers", [])),
+    }
+
+
+def _split_error(exc: Exception) -> list[str]:
+    """Split a multi-line validation error into a flat list of blocker lines.
+
+    Returns:
+        Non-empty, bullet-stripped lines from the exception message.
+    """
+    text = str(exc)
+    lines = [line.strip(" -") for line in text.splitlines()]
+    return [line for line in lines if line]
+
+
+__all__ = [
+    "CAMPAIGN_BLOCKED",
+    "CAMPAIGN_READY",
+    "DEFAULT_LAUNCH_PACKET",
+    "DEFAULT_TRACE_MANIFEST",
+    "LearnedRiskCampaignReadinessError",
+    "evaluate_campaign_readiness",
+]

--- a/scripts/validation/check_learned_risk_campaign_readiness.py
+++ b/scripts/validation/check_learned_risk_campaign_readiness.py
@@ -1,0 +1,86 @@
+"""Check learned-risk model v1 Slurm campaign readiness (issue #1472, fail-closed).
+
+This is the single campaign-level gate for #1472. It aggregates the launch-packet
+validator and the durable trace-manifest validator into one decision so the
+campaign can be launched only when *both* canonical owners report ready. It submits
+nothing, trains nothing, and fetches nothing; a ready decision means the checked-in
+contract is locally complete, not that a job has run.
+
+Exit codes are distinct so callers can branch mechanically:
+
+- ``0`` -- both gates pass: ``campaign_launch_ready``.
+- ``2`` -- an input config file is missing/unreadable (cannot be evaluated).
+- ``3`` -- a gate is blocked: ``campaign_blocked`` (fail-closed; never launch-ready).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.training.learned_risk_campaign_readiness import (
+    CAMPAIGN_BLOCKED,
+    DEFAULT_LAUNCH_PACKET,
+    DEFAULT_TRACE_MANIFEST,
+    LearnedRiskCampaignReadinessError,
+    evaluate_campaign_readiness,
+)
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    """Build the command-line parser."""
+    parser = argparse.ArgumentParser(
+        description="Check learned-risk model v1 Slurm campaign readiness (fail-closed)."
+    )
+    parser.add_argument(
+        "--launch-packet",
+        default=DEFAULT_LAUNCH_PACKET,
+        type=Path,
+        help="Learned-risk launch-packet YAML path.",
+    )
+    parser.add_argument(
+        "--trace-manifest",
+        default=DEFAULT_TRACE_MANIFEST,
+        type=Path,
+        help="Durable learned-risk trace-manifest YAML path.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=Path.cwd(),
+        type=Path,
+        help="Repository root used to resolve relative paths.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit a JSON readiness report.")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Evaluate campaign readiness and return a decision-coded exit status."""
+    args = build_arg_parser().parse_args(argv)
+    try:
+        report = evaluate_campaign_readiness(
+            args.launch_packet,
+            args.trace_manifest,
+            repo_root=args.repo_root,
+        )
+    except LearnedRiskCampaignReadinessError as exc:
+        if args.json:
+            print(json.dumps({"status": "invalid", "error": str(exc)}, indent=2, sort_keys=True))
+        else:
+            print(str(exc))
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"learned-risk campaign decision: {report['campaign_state']}")
+        for gate in report["gates"]:
+            print(f"  - {gate['name']}: {gate['status']} ({gate['summary']})")
+        for blocker in report["blockers"]:
+            print(f"    blocker: {blocker}")
+    return 3 if report["campaign_state"] == CAMPAIGN_BLOCKED else 0
+
+
+if __name__ == "__main__":  # pragma: no cover - CLI guard
+    raise SystemExit(main())

--- a/tests/training/test_learned_risk_campaign_readiness.py
+++ b/tests/training/test_learned_risk_campaign_readiness.py
@@ -1,0 +1,271 @@
+"""Tests for the learned-risk model v1 campaign-readiness aggregator (issue #1472).
+
+These tests exercise the fail-closed campaign gate: it aggregates the launch-packet
+and durable trace-manifest owners and decides ``campaign_launch_ready`` only when
+both pass. Synthetic inputs cover ready, each-half-blocked, structurally invalid,
+and missing-file cases; one test pins the honest current blocked state of the
+checked-in #1472 campaign inputs.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.training.learned_risk_campaign_readiness import (
+    CAMPAIGN_BLOCKED,
+    CAMPAIGN_READY,
+    DEFAULT_LAUNCH_PACKET,
+    DEFAULT_TRACE_MANIFEST,
+    LearnedRiskCampaignReadinessError,
+    evaluate_campaign_readiness,
+)
+from scripts.validation.check_learned_risk_campaign_readiness import main as readiness_cli_main
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _write_yaml(path: Path, payload: dict[str, object]) -> Path:
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _valid_launch_packet(tmp_path: Path) -> Path:
+    """Write a launch packet that passes the launch-packet owner.
+
+    Repo-relative metadata paths (candidate config, source report, slurm handoff)
+    resolve against ``_REPO_ROOT``; the trace/baseline fixtures are absolute tmp
+    files so checksums match regardless of the resolved repo root.
+    """
+    trace = tmp_path / "trace.jsonl"
+    trace.write_text(
+        '{"scenario_id":"demo","seed":1,"candidate_id":"baseline",'
+        '"termination_reason":"success","metrics":{},'
+        '"trajectory_features":{},"labels":{"collision":false,'
+        '"near_miss":false,"low_progress":false}}\n',
+        encoding="utf-8",
+    )
+    baseline = tmp_path / "baseline.json"
+    baseline.write_text('{"candidate_id":"hybrid_rule_v3_static_margin0_waypoint2"}\n')
+    packet = {
+        "schema_version": "learned-risk-launch-packet.v1",
+        "candidate_id": "learned_risk_model_v1",
+        "generating_commit": "e14e2f8bc2058d9f0e071219629915dd5b5dd5a8",
+        "slurm_handoff": "docs/context/policy_search/SLURM/001_learned_risk_model_v1.md",
+        "trace_input_contract": {
+            "required_episode_fields": [
+                "scenario_id",
+                "seed",
+                "termination_reason",
+                "metrics",
+                "trajectory_features",
+                "labels",
+            ],
+            "feature_inputs": ["metrics.min_distance"],
+            "label_targets": ["collision", "near_miss", "low_progress"],
+            "missing_required_fields_behavior": "fail_closed",
+            "trace_fixture_paths": [str(trace)],
+            "checksums": {str(trace): hashlib.sha256(trace.read_bytes()).hexdigest()},
+        },
+        "baseline_comparison": {
+            "candidate_id": "hybrid_rule_v3_static_margin0_waypoint2",
+            "candidate_config": "configs/policy_search/candidates/"
+            "hybrid_rule_v3_static_margin0_waypoint2.yaml",
+            "scenario_slices": ["stress_slice", "full_matrix"],
+            "seeds": [111, 112, 113],
+            "summary_artifacts": [
+                str(baseline),
+                "wandb-artifact://robot-sf/policy-search/baseline:v7",
+            ],
+            "source_report": "docs/context/policy_search/reports/"
+            "2026-04-30_best_non_learning_local_policy_report.md",
+            "checksums": {str(baseline): hashlib.sha256(baseline.read_bytes()).hexdigest()},
+        },
+        "safety_policy": {
+            "hard_guards_authoritative": True,
+            "learned_output_role": "auxiliary_cost_only",
+            "required_diagnostics": [
+                "learned_risk_score",
+                "hard_guard_decision",
+                "auxiliary_cost_weight",
+            ],
+        },
+        "execution_boundary": {
+            "full_training_in_this_issue": False,
+            "submit_slurm_from_this_issue": False,
+            "local_preflight_command": "uv run python scripts/validation/"
+            "validate_learned_risk_launch_packet.py --config packet.yaml --json",
+            "slurm_command_shape": "submit follow-up only",
+        },
+    }
+    return _write_yaml(tmp_path / "launch_packet.yaml", packet)
+
+
+def _ready_trace_manifest(tmp_path: Path) -> Path:
+    """Write a contract-complete durable trace manifest (decides ready)."""
+    stress = "wandb-artifact://robot-sf/learned-risk/traces_stress_slice:v3"
+    full = "wandb-artifact://robot-sf/learned-risk/traces_full_matrix:v3"
+    baseline = "wandb-artifact://robot-sf/policy-search/baseline:v7"
+    manifest = {
+        "schema_version": "learned-risk-trace-manifest.v1",
+        "source_issue": 2312,
+        "parent_issue": 1472,
+        "candidate_id": "learned_risk_model_v1",
+        "trace_schema_version": "mechanism_trace.v1",
+        "baseline_artifact_uri": baseline,
+        "trace_artifacts": [stress, full],
+        "split_ids": ["stress_slice", "full_matrix"],
+        "required_episode_fields": [
+            "scenario_id",
+            "seed",
+            "candidate_id",
+            "termination_reason",
+            "metrics",
+            "trajectory_features",
+            "labels",
+        ],
+        "label_availability": {
+            "collision": "present",
+            "near_miss": "present",
+            "low_progress": "present",
+        },
+        "checksums": {stress: "a" * 64, full: "b" * 64, baseline: "c" * 64},
+        "retrieval_status": "available",
+    }
+    return _write_yaml(tmp_path / "trace_manifest.yaml", manifest)
+
+
+def _gate(report: dict[str, object], name: str) -> dict[str, object]:
+    return next(gate for gate in report["gates"] if gate["name"] == name)
+
+
+def test_checked_in_campaign_reports_blocked() -> None:
+    """The committed #1472 inputs are valid but honestly blocked (fail-closed)."""
+    report = evaluate_campaign_readiness(
+        DEFAULT_LAUNCH_PACKET,
+        DEFAULT_TRACE_MANIFEST,
+        repo_root=_REPO_ROOT,
+    )
+
+    assert report["campaign_state"] == CAMPAIGN_BLOCKED
+    assert report["campaign_ready"] is False
+    assert report["issue"] == 1472
+    # The launch packet is internally valid; the campaign is blocked on the
+    # unresolved durable trace/baseline artifacts only.
+    assert _gate(report, "launch_packet")["status"] == "passed"
+    assert _gate(report, "trace_manifest")["status"] == "blocked"
+    assert report["blocking_gates"] == ["trace_manifest"]
+    assert any("trace_manifest" in blocker for blocker in report["blockers"])
+
+
+def test_ready_campaign_decides_ready(tmp_path: Path) -> None:
+    """Both gates passing yields a single campaign_launch_ready decision."""
+    report = evaluate_campaign_readiness(
+        _valid_launch_packet(tmp_path),
+        _ready_trace_manifest(tmp_path),
+        repo_root=_REPO_ROOT,
+    )
+
+    assert report["campaign_state"] == CAMPAIGN_READY
+    assert report["campaign_ready"] is True
+    assert report["blocking_gates"] == []
+    assert report["blockers"] == []
+
+
+def test_blocked_trace_manifest_blocks_campaign(tmp_path: Path) -> None:
+    """A valid launch packet cannot unblock a pending durable trace manifest."""
+    report = evaluate_campaign_readiness(
+        _valid_launch_packet(tmp_path),
+        DEFAULT_TRACE_MANIFEST,
+        repo_root=_REPO_ROOT,
+    )
+
+    assert report["campaign_state"] == CAMPAIGN_BLOCKED
+    assert _gate(report, "launch_packet")["status"] == "passed"
+    assert report["blocking_gates"] == ["trace_manifest"]
+
+
+def test_invalid_launch_packet_blocks_campaign(tmp_path: Path) -> None:
+    """A launch packet that weakens hard guards fails closed at the campaign gate."""
+    packet_path = _valid_launch_packet(tmp_path)
+    packet = yaml.safe_load(packet_path.read_text(encoding="utf-8"))
+    broken = copy.deepcopy(packet)
+    broken["safety_policy"]["hard_guards_authoritative"] = False
+    _write_yaml(packet_path, broken)
+
+    report = evaluate_campaign_readiness(
+        packet_path,
+        _ready_trace_manifest(tmp_path),
+        repo_root=_REPO_ROOT,
+    )
+
+    assert report["campaign_state"] == CAMPAIGN_BLOCKED
+    assert _gate(report, "launch_packet")["status"] == "blocked"
+    assert "launch_packet" in report["blocking_gates"]
+    assert any("hard_guards_authoritative" in blocker for blocker in report["blockers"])
+
+
+def test_structurally_invalid_manifest_blocks_without_raising(tmp_path: Path) -> None:
+    """A malformed manifest is a fail-closed blocked gate, not an aggregator crash."""
+    bad_manifest = _write_yaml(tmp_path / "bad_manifest.yaml", {"schema_version": "wrong"})
+
+    report = evaluate_campaign_readiness(
+        _valid_launch_packet(tmp_path),
+        bad_manifest,
+        repo_root=_REPO_ROOT,
+    )
+
+    assert report["campaign_state"] == CAMPAIGN_BLOCKED
+    assert _gate(report, "trace_manifest")["status"] == "blocked"
+    assert _gate(report, "trace_manifest")["blockers"]
+
+
+def test_missing_config_file_raises(tmp_path: Path) -> None:
+    """A config path that is not a file is an operator error, not a blocked gate."""
+    with pytest.raises(LearnedRiskCampaignReadinessError, match="trace manifest is not a file"):
+        evaluate_campaign_readiness(
+            _valid_launch_packet(tmp_path),
+            tmp_path / "does_not_exist.yaml",
+            repo_root=_REPO_ROOT,
+        )
+
+
+def test_cli_blocked_exit_code() -> None:
+    """The CLI returns exit 3 for the checked-in (blocked) campaign state."""
+    exit_code = readiness_cli_main(["--repo-root", str(_REPO_ROOT)])
+    assert exit_code == 3
+
+
+def test_cli_ready_exit_code(tmp_path: Path) -> None:
+    """The CLI returns exit 0 when both gates pass."""
+    exit_code = readiness_cli_main(
+        [
+            "--launch-packet",
+            str(_valid_launch_packet(tmp_path)),
+            "--trace-manifest",
+            str(_ready_trace_manifest(tmp_path)),
+            "--repo-root",
+            str(_REPO_ROOT),
+            "--json",
+        ]
+    )
+    assert exit_code == 0
+
+
+def test_cli_missing_file_exit_code(tmp_path: Path) -> None:
+    """The CLI returns exit 2 when an input file is missing."""
+    exit_code = readiness_cli_main(
+        [
+            "--launch-packet",
+            str(_valid_launch_packet(tmp_path)),
+            "--trace-manifest",
+            str(tmp_path / "missing.yaml"),
+            "--repo-root",
+            str(_REPO_ROOT),
+        ]
+    )
+    assert exit_code == 2


### PR DESCRIPTION
## Summary

Closes the local, agent-executable readiness slice of **issue #1472** ("research: run learned risk model v1 Slurm campaign"): https://github.com/ll7/robot_sf_ll7/issues/1472

#1472 is blocked until its prerequisites are mechanically satisfied. Two canonical owners already validate the separate halves:

- `robot_sf/training/learned_risk_launch_packet.py` — the **launch packet** (trace input contract vs. a tracked fixture, baseline packet, safety policy, execution boundary).
- `robot_sf/training/learned_risk_trace_manifest.py` (added by #2312) — the **durable trace manifest** (are the durable trace/baseline pointers resolvable, or must training fail closed?).

Until now there was **no single #1472-level gate**: a caller had to run two validators and reconcile two exit codes by hand. This PR adds the thin campaign-level aggregator that folds both into one fail-closed launch decision. It owns neither contract — it **reuses both canonical owners** rather than forking them (per the AGENTS.md Canonical Owner Check).

## Scope

In scope (delivered):

- `robot_sf/training/learned_risk_campaign_readiness.py` — `evaluate_campaign_readiness()` returns `campaign_launch_ready` **only when both** gates pass. An invalid launch packet, a structurally invalid manifest, or unresolved durable artifact pointers all fold into a fail-closed `campaign_blocked` result with the underlying per-gate blockers surfaced. Missing/unreadable config *files* raise `LearnedRiskCampaignReadinessError` (operator error, distinct from a blocked campaign).
- `scripts/validation/check_learned_risk_campaign_readiness.py` — CLI defaulting to the checked-in #1472 inputs, with decision-coded exit status: `0` ready, `2` input file missing, `3` blocked.
- `tests/training/test_learned_risk_campaign_readiness.py` — synthetic ready / each-half-blocked / structurally-invalid / missing-file coverage, plus a pin on the honest current blocked state of the checked-in #1472 inputs.

Explicitly **out of scope** (unchanged): no full benchmark campaign run, no SLURM/GPU submission, no training, no trace materialization, no artifact promotion, and no paper/dissertation claim edits. A `campaign_launch_ready` decision means "checked-in contract is locally complete", not "job launched".

## Validation

All run from the worktree via `scripts/dev/run_worktree_shared_venv.sh`:

| Command | Exit | Result |
| --- | --- | --- |
| `python -m pytest tests/training/test_learned_risk_campaign_readiness.py -q` | 0 | 9 passed |
| `python -m pytest tests/training/ tests/test_ci_driver_contract.py tests/test_semantic_boundaries_issue_2728.py tests/visuals/test_schema_validation_dependency_policy.py -q` | 0 | 452 passed (no contract regressions from the new validation script) |
| `ruff check` + `ruff format --check` (3 changed files) | 0 | all checks passed / already formatted |
| `python scripts/validation/check_learned_risk_campaign_readiness.py --json` | 3 | `campaign_blocked` — launch_packet gate **passed**, trace_manifest gate **blocked** on `:pending` baseline/trace aliases, `pending` labels, and `retrieval_status: blocked` |

First use on tracked input: the CLI was run against the checked-in #1472 launch packet + #2312 manifest and correctly reports the honest current **blocked** state (the launch packet is valid; the durable trace/baseline artifacts remain `:pending`). This is the mechanical campaign gate the #1472 triage comments asked for ("Continue only when readiness is explicitly manifested").

## Downstream Propagation

- Parent issue #1472: this delivers the local readiness gate; the campaign stays blocked on the durable trace/baseline materialization tracked by #2312 / #2407 (SLURM-only). No status flip is claimed here.
- `CHANGELOG.md`: updated under `[Unreleased] > Added`.
- Claim map / leaderboard / registry: NA — no benchmark result or metric is produced; this is preflight tooling only.

## Research Result Guidance

`NA - support/readiness helper`. This PR produces no research claim, metric, or benchmark evidence; it adds a fail-closed preflight gate. The gate's first use (above) reports `campaign_blocked`, which is a contract-completeness check, not a learned-risk-model result.

## Residual Risks

- The gate proves **local contract completeness** only; it performs no network fetch, so `campaign_launch_ready` would still require the durable artifacts to actually resolve at submit time (inherited from the trace-manifest owner).
- The #1472 Unblock Checklist item "Slurm command/wrapper and expected output/log paths are recorded" is **not** asserted by this gate (neither input config declares those fields yet); it remains a manual pre-submit step. Calling it out rather than inventing config fields keeps this PR minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
