### PR TITLE
bench: compare frozen trace event ledgers

### DIFF
--- a/robot_sf/benchmark/frozen_trace_reconciliation.py
+++ b/robot_sf/benchmark/frozen_trace_reconciliation.py
@@ -137,9 +137,17 @@ def _changed_and_unchanged_rows(
     return changed_rows, unchanged_rows
 
 
+def _event_field_names(events: Mapping[str, bool]) -> list[str]:
+    """Return sorted event field names present on one frozen ledger row."""
+
+    return sorted(events)
+
+
 def _affected_artifacts(
     artifact_manifest: Iterable[Mapping[str, Any]],
     changed_rows: Iterable[Mapping[str, Any]],
+    added_rows: Iterable[Mapping[str, Any]],
+    removed_rows: Iterable[Mapping[str, Any]],
 ) -> list[dict[str, Any]]:
     """Classify declared claim/table/figure artifacts by changed consumed event fields.
 
@@ -152,20 +160,41 @@ def _affected_artifacts(
         for row in changed_rows
         if isinstance(row.get("changed_event_fields"), list)
     ]
-    all_changed_fields = set().union(*changed_fields_by_row) if changed_fields_by_row else set()
+    added_fields_by_row = [
+        set(row.get("event_fields", ()))
+        for row in added_rows
+        if isinstance(row.get("event_fields"), list)
+    ]
+    removed_fields_by_row = [
+        set(row.get("event_fields", ()))
+        for row in removed_rows
+        if isinstance(row.get("event_fields"), list)
+    ]
+    all_delta_fields = set().union(
+        *changed_fields_by_row,
+        *added_fields_by_row,
+        *removed_fields_by_row,
+    )
+    has_row_delta = bool(changed_fields_by_row or added_fields_by_row or removed_fields_by_row)
     statuses: list[dict[str, Any]] = []
     for artifact in artifact_manifest:
         consumed = artifact.get("consumes_event_fields", ())
         consumed_fields = (
             {str(field) for field in consumed} if isinstance(consumed, list) else set()
         )
-        affected_fields = sorted(consumed_fields & all_changed_fields)
+        affected_fields = sorted(consumed_fields & all_delta_fields)
         affected_row_count = sum(
             1 for row_fields in changed_fields_by_row if row_fields & consumed_fields
         )
+        affected_added_row_count = sum(
+            1 for row_fields in added_fields_by_row if row_fields & consumed_fields
+        )
+        affected_removed_row_count = sum(
+            1 for row_fields in removed_fields_by_row if row_fields & consumed_fields
+        )
         if affected_fields:
             status = "affected_reconciliation_required"
-        elif all_changed_fields:
+        elif has_row_delta:
             status = "unchanged_by_event_delta"
         else:
             status = "unchanged"
@@ -177,6 +206,8 @@ def _affected_artifacts(
                 "consumes_event_fields": sorted(consumed_fields),
                 "affected_event_fields": affected_fields,
                 "affected_changed_row_count": affected_row_count,
+                "affected_added_row_count": affected_added_row_count,
+                "affected_removed_row_count": affected_removed_row_count,
             }
         )
     return statuses
@@ -201,6 +232,14 @@ def build_frozen_trace_reconciliation_report(
     changed_rows, unchanged_rows = _changed_and_unchanged_rows(old_index, new_index)
     added_keys = sorted(set(new_index) - set(old_index))
     removed_keys = sorted(set(old_index) - set(new_index))
+    added_rows = [
+        {"episode_key": key, "event_fields": _event_field_names(new_index[key])}
+        for key in added_keys
+    ]
+    removed_rows = [
+        {"episode_key": key, "event_fields": _event_field_names(old_index[key])}
+        for key in removed_keys
+    ]
     return {
         "schema_version": FROZEN_TRACE_RECONCILIATION_SCHEMA,
         "summary": {
@@ -217,9 +256,14 @@ def build_frozen_trace_reconciliation_report(
         "new_event_counts": _event_counts(new_index),
         "changed_rows": changed_rows,
         "unchanged_rows": unchanged_rows,
-        "added_rows": [{"episode_key": key} for key in added_keys],
-        "removed_rows": [{"episode_key": key} for key in removed_keys],
-        "affected_artifacts": _affected_artifacts(artifact_manifest, changed_rows),
+        "added_rows": added_rows,
+        "removed_rows": removed_rows,
+        "affected_artifacts": _affected_artifacts(
+            artifact_manifest,
+            changed_rows,
+            added_rows,
+            removed_rows,
+        ),
         "semantics": {
             "input_contract": "existing EpisodeEventLedger.v1 rows only",
             "benchmark_semantics_changed": False,

--- a/robot_sf/benchmark/frozen_trace_reconciliation.py
+++ b/robot_sf/benchmark/frozen_trace_reconciliation.py
@@ -18,6 +18,24 @@ FROZEN_TRACE_RECONCILIATION_SCHEMA = "frozen_trace_event_reconciliation.v1"
 _EVENT_BLOCKS = ("exact_events", "surrogate_events")
 
 
+def _coerce_identifier(value: Any, *, default: str = "unknown") -> str:
+    """Return a stable string identifier while preserving valid falsy values."""
+
+    if value is None:
+        return default
+    text = str(value)
+    return text if text else default
+
+
+def _first_present_identifier(*values: Any, default: str = "unknown") -> str:
+    """Return the first non-``None`` identifier candidate as a stable string."""
+
+    for value in values:
+        if value is not None:
+            return _coerce_identifier(value, default=default)
+    return default
+
+
 def _ledger_from_row(row: Mapping[str, Any]) -> Mapping[str, Any]:
     """Return the existing event ledger carried by a frozen row."""
 
@@ -40,15 +58,14 @@ def _episode_key(row: Mapping[str, Any], ledger: Mapping[str, Any]) -> str:
         Pipe-delimited episode identity string.
     """
 
-    scenario_id = ledger.get("scenario_id") or row.get("scenario_id") or "unknown"
-    concrete_case_id = (
-        ledger.get("concrete_case_id")
-        or row.get("concrete_case_id")
-        or row.get("episode_id")
-        or "unknown"
+    scenario_id = _first_present_identifier(ledger.get("scenario_id"), row.get("scenario_id"))
+    concrete_case_id = _first_present_identifier(
+        ledger.get("concrete_case_id"), row.get("concrete_case_id"), row.get("episode_id")
     )
-    seed = ledger.get("seed") if ledger.get("seed") is not None else row.get("seed", "unknown")
-    planner = ledger.get("planner") or row.get("planner") or row.get("algo") or "unknown"
+    seed = _coerce_identifier(
+        ledger.get("seed") if ledger.get("seed") is not None else row.get("seed")
+    )
+    planner = _first_present_identifier(ledger.get("planner"), row.get("planner"), row.get("algo"))
     return f"{scenario_id}|{concrete_case_id}|{seed}|{planner}"
 
 

--- a/robot_sf/benchmark/frozen_trace_reconciliation.py
+++ b/robot_sf/benchmark/frozen_trace_reconciliation.py
@@ -1,0 +1,234 @@
+"""Frozen-trace before/after reconciliation for episode event ledgers.
+
+This module compares already-materialized ``EpisodeEventLedger.v1`` rows from two frozen
+analyzer outputs. It does not rebuild ledgers, rerun benchmarks, or choose metric semantics; it
+only reports event-count deltas, changed and unchanged episode rows, and which declared
+claim/table/figure artifacts consume changed event fields.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping
+from typing import Any
+
+from robot_sf.benchmark.event_ledger import EPISODE_EVENT_LEDGER_SCHEMA_VERSION
+
+FROZEN_TRACE_RECONCILIATION_SCHEMA = "frozen_trace_event_reconciliation.v1"
+
+_EVENT_BLOCKS = ("exact_events", "surrogate_events")
+
+
+def _ledger_from_row(row: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Return the existing event ledger carried by a frozen row."""
+
+    ledger = (
+        row
+        if row.get("schema_version") == EPISODE_EVENT_LEDGER_SCHEMA_VERSION
+        else row.get("event_ledger")
+    )
+    if not isinstance(ledger, Mapping):
+        raise ValueError("frozen reconciliation rows must contain event_ledger")
+    if ledger.get("schema_version") != EPISODE_EVENT_LEDGER_SCHEMA_VERSION:
+        raise ValueError("frozen reconciliation rows must contain EpisodeEventLedger.v1 payloads")
+    return ledger
+
+
+def _episode_key(row: Mapping[str, Any], ledger: Mapping[str, Any]) -> str:
+    """Build a stable key for pairing frozen before/after rows.
+
+    Returns:
+        Pipe-delimited episode identity string.
+    """
+
+    scenario_id = ledger.get("scenario_id") or row.get("scenario_id") or "unknown"
+    concrete_case_id = (
+        ledger.get("concrete_case_id")
+        or row.get("concrete_case_id")
+        or row.get("episode_id")
+        or "unknown"
+    )
+    seed = ledger.get("seed") if ledger.get("seed") is not None else row.get("seed", "unknown")
+    planner = ledger.get("planner") or row.get("planner") or row.get("algo") or "unknown"
+    return f"{scenario_id}|{concrete_case_id}|{seed}|{planner}"
+
+
+def _event_values(ledger: Mapping[str, Any]) -> dict[str, bool]:
+    """Flatten boolean exact and surrogate event fields from a ledger.
+
+    Returns:
+        Mapping of event field paths to boolean values.
+    """
+
+    values: dict[str, bool] = {}
+    for block_name in _EVENT_BLOCKS:
+        block = ledger.get(block_name)
+        if not isinstance(block, Mapping):
+            continue
+        for field, value in block.items():
+            if isinstance(value, bool):
+                values[f"{block_name}.{field}"] = value
+    return values
+
+
+def _index_rows(rows: Iterable[Mapping[str, Any]]) -> dict[str, dict[str, bool]]:
+    """Index frozen rows by episode key with flattened event values.
+
+    Returns:
+        Episode-keyed event value mapping.
+    """
+
+    indexed: dict[str, dict[str, bool]] = {}
+    for row in rows:
+        ledger = _ledger_from_row(row)
+        key = _episode_key(row, ledger)
+        if key in indexed:
+            raise ValueError(f"duplicate frozen reconciliation row for episode key: {key}")
+        indexed[key] = _event_values(ledger)
+    return indexed
+
+
+def _event_counts(indexed_rows: Mapping[str, Mapping[str, bool]]) -> dict[str, int]:
+    """Count true event values across indexed frozen rows.
+
+    Returns:
+        Event field counts sorted by field path.
+    """
+
+    counts: dict[str, int] = {}
+    for events in indexed_rows.values():
+        for field, value in events.items():
+            counts.setdefault(field, 0)
+            if value:
+                counts[field] += 1
+    return dict(sorted(counts.items()))
+
+
+def _changed_and_unchanged_rows(
+    old_index: Mapping[str, Mapping[str, bool]],
+    new_index: Mapping[str, Mapping[str, bool]],
+) -> tuple[list[dict[str, Any]], list[dict[str, str]]]:
+    """Classify paired episode rows by changed or unchanged event fields.
+
+    Returns:
+        Changed row details and unchanged row identities.
+    """
+
+    changed_rows: list[dict[str, Any]] = []
+    unchanged_rows: list[dict[str, str]] = []
+    for key in sorted(set(old_index) & set(new_index)):
+        old_events = old_index[key]
+        new_events = new_index[key]
+        changed_fields = [
+            field
+            for field in sorted(set(old_events) | set(new_events))
+            if old_events.get(field, False) != new_events.get(field, False)
+        ]
+        if not changed_fields:
+            unchanged_rows.append({"episode_key": key})
+            continue
+        changed_rows.append(
+            {
+                "episode_key": key,
+                "changed_event_fields": changed_fields,
+                "old_events": {field: old_events.get(field, False) for field in changed_fields},
+                "new_events": {field: new_events.get(field, False) for field in changed_fields},
+            }
+        )
+    return changed_rows, unchanged_rows
+
+
+def _affected_artifacts(
+    artifact_manifest: Iterable[Mapping[str, Any]],
+    changed_rows: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Classify declared claim/table/figure artifacts by changed consumed event fields.
+
+    Returns:
+        Manifest entries annotated with reconciliation status.
+    """
+
+    changed_fields_by_row = [
+        set(row.get("changed_event_fields", ()))
+        for row in changed_rows
+        if isinstance(row.get("changed_event_fields"), list)
+    ]
+    all_changed_fields = set().union(*changed_fields_by_row) if changed_fields_by_row else set()
+    statuses: list[dict[str, Any]] = []
+    for artifact in artifact_manifest:
+        consumed = artifact.get("consumes_event_fields", ())
+        consumed_fields = (
+            {str(field) for field in consumed} if isinstance(consumed, list) else set()
+        )
+        affected_fields = sorted(consumed_fields & all_changed_fields)
+        affected_row_count = sum(
+            1 for row_fields in changed_fields_by_row if row_fields & consumed_fields
+        )
+        if affected_fields:
+            status = "affected_reconciliation_required"
+        elif all_changed_fields:
+            status = "unchanged_by_event_delta"
+        else:
+            status = "unchanged"
+        statuses.append(
+            {
+                "artifact_id": str(artifact.get("artifact_id", "unknown")),
+                "artifact_type": str(artifact.get("artifact_type", "unknown")),
+                "status": status,
+                "consumes_event_fields": sorted(consumed_fields),
+                "affected_event_fields": affected_fields,
+                "affected_changed_row_count": affected_row_count,
+            }
+        )
+    return statuses
+
+
+def build_frozen_trace_reconciliation_report(
+    old_rows: Iterable[Mapping[str, Any]],
+    new_rows: Iterable[Mapping[str, Any]],
+    *,
+    artifact_manifest: Iterable[Mapping[str, Any]] = (),
+    old_label: str = "old",
+    new_label: str = "new",
+) -> dict[str, Any]:
+    """Compare frozen old/new event-ledger rows and return a reviewable report.
+
+    Returns:
+        JSON-serializable before/after reconciliation report.
+    """
+
+    old_index = _index_rows(old_rows)
+    new_index = _index_rows(new_rows)
+    changed_rows, unchanged_rows = _changed_and_unchanged_rows(old_index, new_index)
+    added_keys = sorted(set(new_index) - set(old_index))
+    removed_keys = sorted(set(old_index) - set(new_index))
+    return {
+        "schema_version": FROZEN_TRACE_RECONCILIATION_SCHEMA,
+        "summary": {
+            "old_label": old_label,
+            "new_label": new_label,
+            "old_row_count": len(old_index),
+            "new_row_count": len(new_index),
+            "changed_row_count": len(changed_rows),
+            "unchanged_row_count": len(unchanged_rows),
+            "added_row_count": len(added_keys),
+            "removed_row_count": len(removed_keys),
+        },
+        "old_event_counts": _event_counts(old_index),
+        "new_event_counts": _event_counts(new_index),
+        "changed_rows": changed_rows,
+        "unchanged_rows": unchanged_rows,
+        "added_rows": [{"episode_key": key} for key in added_keys],
+        "removed_rows": [{"episode_key": key} for key in removed_keys],
+        "affected_artifacts": _affected_artifacts(artifact_manifest, changed_rows),
+        "semantics": {
+            "input_contract": "existing EpisodeEventLedger.v1 rows only",
+            "benchmark_semantics_changed": False,
+            "claim_promotion": "none",
+        },
+    }
+
+
+__all__ = [
+    "FROZEN_TRACE_RECONCILIATION_SCHEMA",
+    "build_frozen_trace_reconciliation_report",
+]

--- a/scripts/benchmark/compare_frozen_trace_event_ledgers.py
+++ b/scripts/benchmark/compare_frozen_trace_event_ledgers.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Compare frozen before/after EpisodeEventLedger.v1 JSONL exports."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.frozen_trace_reconciliation import (
+    build_frozen_trace_reconciliation_report,
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--old-ledgers",
+        required=True,
+        type=Path,
+        help="Frozen before JSONL rows containing EpisodeEventLedger.v1 payloads.",
+    )
+    parser.add_argument(
+        "--new-ledgers",
+        required=True,
+        type=Path,
+        help="Frozen after JSONL rows containing EpisodeEventLedger.v1 payloads.",
+    )
+    parser.add_argument(
+        "--artifact-manifest",
+        type=Path,
+        help=(
+            "Optional JSON list, or object with an artifacts list, declaring claim/table/figure "
+            "consumes_event_fields entries."
+        ),
+    )
+    parser.add_argument("--old-label", default="old", help="Label for the old frozen input.")
+    parser.add_argument("--new-label", default="new", help="Label for the new frozen input.")
+    parser.add_argument(
+        "--out", required=True, type=Path, help="Output reconciliation report JSON."
+    )
+    return parser.parse_args(argv)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    """Read non-empty JSON object lines from ``path``."""
+
+    rows: list[dict[str, Any]] = []
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            if not line.strip():
+                continue
+            payload = json.loads(line)
+            if not isinstance(payload, dict):
+                raise ValueError(f"{path}:{line_number}: expected JSON object")
+            rows.append(payload)
+    return rows
+
+
+def _read_artifact_manifest(path: Path | None) -> list[dict[str, Any]]:
+    """Read an optional affected artifact manifest."""
+
+    if path is None:
+        return []
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    artifacts = payload.get("artifacts") if isinstance(payload, dict) else payload
+    if not isinstance(artifacts, list):
+        raise ValueError("artifact manifest must be a JSON list or object with an artifacts list")
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            raise ValueError(f"artifact manifest entry {index} must be a JSON object")
+    return artifacts
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+
+    args = _parse_args(argv)
+    report = build_frozen_trace_reconciliation_report(
+        _read_jsonl(args.old_ledgers),
+        _read_jsonl(args.new_ledgers),
+        artifact_manifest=_read_artifact_manifest(args.artifact_manifest),
+        old_label=args.old_label,
+        new_label=args.new_label,
+    )
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    summary = report["summary"]
+    print(
+        "wrote frozen event-ledger reconciliation report "
+        f"{args.out} ({summary['changed_row_count']} changed rows, "
+        f"{summary['unchanged_row_count']} unchanged rows)"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/benchmark/compare_frozen_trace_event_ledgers.py
+++ b/scripts/benchmark/compare_frozen_trace_event_ledgers.py
@@ -54,7 +54,10 @@ def _read_jsonl(path: Path) -> list[dict[str, Any]]:
         for line_number, line in enumerate(handle, start=1):
             if not line.strip():
                 continue
-            payload = json.loads(line)
+            try:
+                payload = json.loads(line)
+            except json.JSONDecodeError as err:
+                raise ValueError(f"{path}:{line_number}: invalid JSON: {err}") from err
             if not isinstance(payload, dict):
                 raise ValueError(f"{path}:{line_number}: expected JSON object")
             rows.append(payload)
@@ -66,7 +69,10 @@ def _read_artifact_manifest(path: Path | None) -> list[dict[str, Any]]:
 
     if path is None:
         return []
-    payload = json.loads(path.read_text(encoding="utf-8"))
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as err:
+        raise ValueError(f"invalid JSON in artifact manifest {path}: {err}") from err
     artifacts = payload.get("artifacts") if isinstance(payload, dict) else payload
     if not isinstance(artifacts, list):
         raise ValueError("artifact manifest must be a JSON list or object with an artifacts list")

--- a/tests/benchmark/test_frozen_trace_reconciliation.py
+++ b/tests/benchmark/test_frozen_trace_reconciliation.py
@@ -140,8 +140,77 @@ def test_report_counts_event_deltas_and_affected_artifact_status() -> None:
 
     statuses = {row["artifact_id"]: row for row in report["affected_artifacts"]}
     assert statuses["claim:collision-free"]["status"] == "affected_reconciliation_required"
+    assert statuses["claim:collision-free"]["affected_changed_row_count"] == 1
+    assert statuses["claim:collision-free"]["affected_added_row_count"] == 0
+    assert statuses["claim:collision-free"]["affected_removed_row_count"] == 0
     assert statuses["table:safety-summary"]["status"] == "affected_reconciliation_required"
     assert statuses["figure:near-miss"]["status"] == "unchanged_by_event_delta"
+
+
+def test_added_and_removed_rows_mark_consuming_artifacts_affected() -> None:
+    """Added or removed frozen rows still require artifact reconciliation."""
+
+    report = build_frozen_trace_reconciliation_report(
+        [_ledger_row("removed-episode", collision=True)],
+        [_ledger_row("added-episode", collision=True)],
+        artifact_manifest=[
+            {
+                "artifact_id": "claim:collision-count",
+                "artifact_type": "claim",
+                "consumes_event_fields": ["exact_events.collision"],
+            }
+        ],
+    )
+
+    assert report["summary"]["changed_row_count"] == 0
+    assert report["summary"]["added_row_count"] == 1
+    assert report["summary"]["removed_row_count"] == 1
+    assert report["added_rows"] == [
+        {
+            "episode_key": "scenario-a|added-episode|7|demo",
+            "event_fields": [
+                "exact_events.collision",
+                "exact_events.goal_reached",
+                "exact_events.invalid_run",
+                "exact_events.timeout",
+                "surrogate_events.clearance_breach",
+                "surrogate_events.late_evasive",
+                "surrogate_events.near_miss",
+                "surrogate_events.occlusion_near_miss",
+                "surrogate_events.oscillation",
+                "surrogate_events.ttc_breach",
+            ],
+        }
+    ]
+    assert report["removed_rows"] == [
+        {
+            "episode_key": "scenario-a|removed-episode|7|demo",
+            "event_fields": [
+                "exact_events.collision",
+                "exact_events.goal_reached",
+                "exact_events.invalid_run",
+                "exact_events.timeout",
+                "surrogate_events.clearance_breach",
+                "surrogate_events.late_evasive",
+                "surrogate_events.near_miss",
+                "surrogate_events.occlusion_near_miss",
+                "surrogate_events.oscillation",
+                "surrogate_events.ttc_breach",
+            ],
+        }
+    ]
+    assert report["affected_artifacts"] == [
+        {
+            "artifact_id": "claim:collision-count",
+            "artifact_type": "claim",
+            "status": "affected_reconciliation_required",
+            "consumes_event_fields": ["exact_events.collision"],
+            "affected_event_fields": ["exact_events.collision"],
+            "affected_changed_row_count": 0,
+            "affected_added_row_count": 1,
+            "affected_removed_row_count": 1,
+        }
+    ]
 
 
 def test_cli_writes_frozen_reconciliation_report(tmp_path: Path) -> None:

--- a/tests/benchmark/test_frozen_trace_reconciliation.py
+++ b/tests/benchmark/test_frozen_trace_reconciliation.py
@@ -1,0 +1,195 @@
+"""Tests for frozen-trace before/after event-ledger reconciliation reports."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.frozen_trace_reconciliation import (
+    FROZEN_TRACE_RECONCILIATION_SCHEMA,
+    build_frozen_trace_reconciliation_report,
+)
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "benchmark"
+    / "compare_frozen_trace_event_ledgers.py"
+)
+_SPEC = importlib.util.spec_from_file_location("compare_frozen_trace_event_ledgers", SCRIPT_PATH)
+assert _SPEC is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_MODULE)
+
+
+def _ledger_row(
+    episode_id: str,
+    *,
+    collision: bool = False,
+    near_miss: bool = False,
+    planner: str = "demo",
+) -> dict:
+    """Build a frozen episode row carrying an already-materialized event ledger."""
+
+    return {
+        "episode_id": episode_id,
+        "scenario_id": "scenario-a",
+        "concrete_case_id": episode_id,
+        "seed": 7,
+        "planner": planner,
+        "event_ledger": {
+            "schema_version": "EpisodeEventLedger.v1",
+            "scenario_id": "scenario-a",
+            "concrete_case_id": episode_id,
+            "seed": 7,
+            "planner": planner,
+            "software_commit": "abc123",
+            "exact_events": {
+                "collision": collision,
+                "goal_reached": not collision,
+                "timeout": False,
+                "invalid_run": False,
+            },
+            "surrogate_events": {
+                "near_miss": near_miss,
+                "clearance_breach": False,
+                "ttc_breach": False,
+                "oscillation": False,
+                "late_evasive": False,
+                "occlusion_near_miss": False,
+            },
+            "metric_definitions": {},
+            "reconciliation": {"audit_result": "pass"},
+            "provenance": {"source": "fixture"},
+        },
+    }
+
+
+def test_report_counts_event_deltas_and_affected_artifact_status() -> None:
+    """Report old/new event counts, row deltas, and claim/table/figure impact status."""
+
+    old_rows = [
+        _ledger_row("episode-1", collision=False, near_miss=True),
+        _ledger_row("episode-2", collision=False, near_miss=False),
+    ]
+    new_rows = [
+        _ledger_row("episode-1", collision=True, near_miss=True),
+        _ledger_row("episode-2", collision=False, near_miss=False),
+    ]
+    artifact_manifest = [
+        {
+            "artifact_id": "claim:collision-free",
+            "artifact_type": "claim",
+            "consumes_event_fields": ["exact_events.collision"],
+        },
+        {
+            "artifact_id": "table:safety-summary",
+            "artifact_type": "table",
+            "consumes_event_fields": ["exact_events.collision", "surrogate_events.near_miss"],
+        },
+        {
+            "artifact_id": "figure:near-miss",
+            "artifact_type": "figure",
+            "consumes_event_fields": ["surrogate_events.near_miss"],
+        },
+    ]
+
+    report = build_frozen_trace_reconciliation_report(
+        old_rows,
+        new_rows,
+        artifact_manifest=artifact_manifest,
+        old_label="0.0.2-before",
+        new_label="0.0.2-after",
+    )
+
+    assert report["schema_version"] == FROZEN_TRACE_RECONCILIATION_SCHEMA
+    assert report["summary"] == {
+        "old_label": "0.0.2-before",
+        "new_label": "0.0.2-after",
+        "old_row_count": 2,
+        "new_row_count": 2,
+        "changed_row_count": 1,
+        "unchanged_row_count": 1,
+        "added_row_count": 0,
+        "removed_row_count": 0,
+    }
+    assert report["old_event_counts"]["exact_events.collision"] == 0
+    assert report["new_event_counts"]["exact_events.collision"] == 1
+    assert report["old_event_counts"]["surrogate_events.near_miss"] == 1
+    assert report["new_event_counts"]["surrogate_events.near_miss"] == 1
+
+    assert report["changed_rows"] == [
+        {
+            "episode_key": "scenario-a|episode-1|7|demo",
+            "changed_event_fields": ["exact_events.collision", "exact_events.goal_reached"],
+            "old_events": {
+                "exact_events.collision": False,
+                "exact_events.goal_reached": True,
+            },
+            "new_events": {
+                "exact_events.collision": True,
+                "exact_events.goal_reached": False,
+            },
+        }
+    ]
+    assert report["unchanged_rows"] == [{"episode_key": "scenario-a|episode-2|7|demo"}]
+
+    statuses = {row["artifact_id"]: row for row in report["affected_artifacts"]}
+    assert statuses["claim:collision-free"]["status"] == "affected_reconciliation_required"
+    assert statuses["table:safety-summary"]["status"] == "affected_reconciliation_required"
+    assert statuses["figure:near-miss"]["status"] == "unchanged_by_event_delta"
+
+
+def test_cli_writes_frozen_reconciliation_report(tmp_path: Path) -> None:
+    """CLI should write the same pure comparison report without running benchmarks."""
+
+    old_path = tmp_path / "old.jsonl"
+    new_path = tmp_path / "new.jsonl"
+    manifest_path = tmp_path / "artifacts.json"
+    out_path = tmp_path / "report.json"
+    old_path.write_text(
+        json.dumps(_ledger_row("episode-1", collision=False)) + "\n", encoding="utf-8"
+    )
+    new_path.write_text(
+        json.dumps(_ledger_row("episode-1", collision=True)) + "\n", encoding="utf-8"
+    )
+    manifest_path.write_text(
+        json.dumps(
+            [
+                {
+                    "artifact_id": "table:safety-summary",
+                    "artifact_type": "table",
+                    "consumes_event_fields": ["exact_events.collision"],
+                }
+            ]
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--old-ledgers",
+            str(old_path),
+            "--new-ledgers",
+            str(new_path),
+            "--artifact-manifest",
+            str(manifest_path),
+            "--out",
+            str(out_path),
+        ],
+        check=False,
+        cwd=SCRIPT_PATH.parents[2],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(out_path.read_text(encoding="utf-8"))
+    assert report["summary"]["changed_row_count"] == 1
+    assert report["affected_artifacts"][0]["status"] == "affected_reconciliation_required"

--- a/tests/benchmark/test_frozen_trace_reconciliation.py
+++ b/tests/benchmark/test_frozen_trace_reconciliation.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import pytest
+
 from robot_sf.benchmark.frozen_trace_reconciliation import (
     FROZEN_TRACE_RECONCILIATION_SCHEMA,
     build_frozen_trace_reconciliation_report,
@@ -211,6 +213,41 @@ def test_added_and_removed_rows_mark_consuming_artifacts_affected() -> None:
             "affected_removed_row_count": 1,
         }
     ]
+
+
+def test_episode_keys_preserve_valid_falsy_identifiers() -> None:
+    """Episode pairing keys should preserve valid falsy identifiers like zero."""
+
+    row = _ledger_row("unused")
+    ledger = row["event_ledger"]
+    ledger["scenario_id"] = 0
+    ledger["concrete_case_id"] = 0
+    ledger["seed"] = 0
+    ledger["planner"] = 0
+
+    report = build_frozen_trace_reconciliation_report([row], [row])
+
+    assert report["unchanged_rows"] == [{"episode_key": "0|0|0|0"}]
+
+
+def test_cli_jsonl_parse_error_names_path_and_line(tmp_path: Path) -> None:
+    """Malformed JSONL input errors should identify the path and line."""
+
+    path = tmp_path / "bad.jsonl"
+    path.write_text('{"ok": true}\n{"broken":\n', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"bad\.jsonl:2: invalid JSON"):
+        _MODULE._read_jsonl(path)
+
+
+def test_cli_manifest_parse_error_names_path(tmp_path: Path) -> None:
+    """Malformed artifact manifests should identify the path."""
+
+    path = tmp_path / "bad_manifest.json"
+    path.write_text('{"artifacts": [', encoding="utf-8")
+
+    with pytest.raises(ValueError, match=r"invalid JSON in artifact manifest .*bad_manifest\.json"):
+        _MODULE._read_artifact_manifest(path)
 
 
 def test_cli_writes_frozen_reconciliation_report(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds a frozen-trace before/after reconciliation report for existing `EpisodeEventLedger.v1` rows. The report is diagnostic-only: it counts old/new events, lists changed and unchanged episode rows, and marks declared claim/table/figure artifacts as affected or unchanged without rerunning benchmarks or changing metric semantics.

## Linked Issues
- Relates to `#3482`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: `NA`

## What Changed
- Added `robot_sf.benchmark.frozen_trace_reconciliation` to compare two frozen JSONL inputs that already contain `EpisodeEventLedger.v1`.
- Added `scripts/benchmark/compare_frozen_trace_event_ledgers.py` CLI for writing a JSON reconciliation report.
- Added focused tests for event counts, changed rows, unchanged rows, and affected claim/table/figure status.

## Why Matters
- Added value: turns issue #3482 follow-up work into a reviewable frozen-trace reconciliation artifact.
- Expected impact: supports before/after audit reporting without promoting claims or mutating benchmark semantics.
- Why worth merging now: closes a bounded tooling gap left after the canonical ledger guard landed.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: `#3482` frozen-trace before/after reconciliation blocker.
- Comparator or baseline, applicable: old vs new frozen `EpisodeEventLedger.v1` JSONL inputs supplied by caller.
- Evidence tier: NA - support helper; no benchmark result or claim promoted.
- Result classification: NA - diagnostic comparator only, with behavior covered by focused tests.
- Decision stop rule, applicable: report only; any affected artifact remains reconciliation-required until reviewed separately.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue `#3482`; no issue comment by authorization.
- New research/benchmark/metric/paper-facing analysis tool, any: diagnostic comparator only; representative use covered by committed test fixture and CLI test. Real frozen `0.0.2` trace use remains a follow-up because compute campaign/rerun and claim propagation were out of scope.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: diagnostic-only tool, no claim promotion.
- Validity checklist:
- Target claim/hypothesis: no claim promoted.
- Comparator split/evidence validity: NA - no experimental comparison result promoted; caller-provided frozen before/after ledgers only.
- Fallback/degraded exclusions: no benchmark execution.
- Claim boundary: report marks affected artifacts as requiring reconciliation.
- Implementation integrity vs experimental validity: implementation tested locally; experimental validity remains downstream review.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - diagnostic report helper.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: run on durable frozen trace inputs and reconcile affected artifact statuses.

## Next Empirical Action
- Rerun needed: yes, outside this PR scope on durable frozen trace inputs.
- Extractor analysis tool needed: no
- Artifact missing unavailable: durable old/new frozen `EpisodeEventLedger.v1` JSONL inputs.
- Stop / revise / continue decision: continue with frozen trace application.
- Proposed child issue existing follow-up: continue under `#3482`.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_frozen_trace_reconciliation.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_event_ledger_reconciliation.py tests/benchmark/test_event_ledger_reconciliation_export.py tests/benchmark/test_frozen_trace_reconciliation.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check --fix robot_sf/benchmark/frozen_trace_reconciliation.py scripts/benchmark/compare_frozen_trace_event_ledgers.py tests/benchmark/test_frozen_trace_reconciliation.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/frozen_trace_reconciliation.py scripts/benchmark/compare_frozen_trace_event_ledgers.py tests/benchmark/test_frozen_trace_reconciliation.py`
- Final readiness: pending in this PR body draft; rerun with `PR_READY_PR_BODY_FILE`.

## Performance / Resource Impact
- Baseline runtime: `NA - no benchmark runtime path changed`
- Changed runtime: `NA - no benchmark runtime path changed`
- Representative command: `python scripts/benchmark/compare_frozen_trace_event_ledgers.py --old-ledgers <old.jsonl> --new-ledgers <new.jsonl> --artifact-manifest <artifacts.json> --out <report.json>`
- Hot-path call count profile anchor: `NA - offline JSON comparator only`
- Cache-hit reuse counter: `NA - no caching claimed`
- Rollback failure criterion: comparator misreports event deltas or affected-artifact status.

## Risks / Rollout
- Compatibility risks: input rows must already contain `EpisodeEventLedger.v1`.
- Failure modes: duplicate episode keys or missing ledger payloads fail closed with `ValueError`.
- Rollback fallback plan: remove the comparator module/script and tests.

## Docs / Provenance
- Updated docs: none; CLI help and PR body document the diagnostic contract.
- Relevant design provenance notes: issue `#3482`, prior PR `#3498`.
- Any assumptions need to preserved: no benchmark campaigns, no claim promotion, no dissertation/paper edits.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, not authorized.
- Claim map / benchmark report updated (yes/no/NA): no
- Leaderboard / artifact catalog updated (yes/no/NA): no
- Registry or config index updated (yes/no/NA): no
- Context index / memory note updated (yes/no/NA): no
- Follow-up issue opened deferred propagation (yes/no/NA): no, not authorized.
- Not applicable because: this PR only adds a diagnostic comparator; applying it to frozen traces and reconciling claim/table/figure artifacts remains under `#3482`.

## Follow-Up Issues
- Deferred work: run the comparator on durable old/new frozen trace ledgers and use affected artifact statuses to decide claim/table/figure propagation under `#3482`.
- Issues opened follow-up: `#3482`.

## Reviewer Notes
- Verify that the comparator never calls `ensure_event_ledger`, analyzers, or benchmark runners.
- Any known limitations: affected artifact status depends on a caller-supplied manifest of consumed event fields.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a reconciliation report for comparing frozen trace outputs before and after analysis runs.
  * Added a command-line tool to generate a JSON report from two ledger exports.
  * Report now includes summary counts, changed/unchanged rows, added/removed entries, and affected artifact status.

* **Tests**
  * Added coverage for report counts, change detection, artifact impact, and CLI output generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Codex PR Gate Update - 2026-06-28
- Head reviewed: `0a1035ffc9fbe2ead487cd911464c4fbbdf92dc0`.
- Contract finding: satisfies the bounded frozen-trace reconciliation tooling slice for `#3482` by reporting old/new event counts, changed and unchanged paired rows, added and removed rows, and claim/table/figure artifact statuses. This does not close `#3482`; applying the tool to durable frozen `0.0.2` before/after traces and reconciling paper-facing artifacts remains open.
- Gate fixes added: artifact status now accounts for added and removed frozen episode rows, valid falsy episode identifiers are preserved in pairing keys, and malformed JSON/JSONL CLI inputs report path-aware errors.
- Additional validation:
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/frozen_trace_reconciliation.py scripts/benchmark/compare_frozen_trace_event_ledgers.py tests/benchmark/test_frozen_trace_reconciliation.py`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_frozen_trace_reconciliation.py -q`
  - `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_event_ledger_reconciliation.py tests/benchmark/test_event_ledger_reconciliation_export.py tests/benchmark/test_frozen_trace_reconciliation.py -q`

