### PR TITLE
bench: distinguish marker spawn density placeholders

### DIFF
--- a/configs/scenarios/archetypes/classic_bottleneck.yaml
+++ b/configs/scenarios/archetypes/classic_bottleneck.yaml
@@ -8,6 +8,7 @@ scenarios:
   metadata:
     archetype: bottleneck
     density: low
+    spawn_mode: markers
     density_advisory: zero_baseline_route_spawn
     flow: bi
     groups: 0.0
@@ -37,6 +38,7 @@ scenarios:
   metadata:
     archetype: bottleneck
     density: medium
+    spawn_mode: markers
     density_advisory: zero_baseline_route_spawn
     flow: bi
     groups: 0.0
@@ -66,6 +68,7 @@ scenarios:
   metadata:
     archetype: bottleneck
     density: high
+    spawn_mode: markers
     density_advisory: zero_baseline_route_spawn
     flow: bi
     groups: 0.0

--- a/configs/scenarios/archetypes/classic_realworld_bottleneck.yaml
+++ b/configs/scenarios/archetypes/classic_realworld_bottleneck.yaml
@@ -9,6 +9,7 @@ scenarios:
     archetype: bottleneck
     label: real-world-inspired double sequential bottleneck
     density: high
+    spawn_mode: markers
     density_advisory: zero_baseline_route_spawn
     flow: bi
     groups: 0.0

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -1275,6 +1275,10 @@ def _collect_scenario_warnings(  # noqa: PLR0912,PLR0915
                     "/simulation_config/max_episode_steps",
                 )
 
+        metadata = scenario.get("metadata")
+        if not isinstance(metadata, Mapping):
+            metadata = {}
+        spawn_mode = metadata.get("spawn_mode")
         density = sim_cfg.get("ped_density")
         if density is not None:
             try:
@@ -1286,14 +1290,15 @@ def _collect_scenario_warnings(  # noqa: PLR0912,PLR0915
                         f"ped_density must be >= 0 (got {density_val})",
                         "/simulation_config/ped_density",
                     )
-                if density_val == 0:
+                marker_placeholder_density = density_val == 0 and spawn_mode == "markers"
+                if density_val == 0 and not marker_placeholder_density:
                     warn(
                         idx,
                         scenario_id,
                         "ped_density=0.0 means no pedestrians spawn",
                         "/simulation_config/ped_density",
                     )
-                if not 0.02 <= density_val <= 0.08:
+                if not marker_placeholder_density and not 0.02 <= density_val <= 0.08:
                     warn(
                         idx,
                         scenario_id,

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -1276,9 +1276,7 @@ def _collect_scenario_warnings(  # noqa: PLR0912,PLR0915
                 )
 
         metadata = scenario.get("metadata")
-        if not isinstance(metadata, Mapping):
-            metadata = {}
-        spawn_mode = metadata.get("spawn_mode")
+        spawn_mode = metadata.get("spawn_mode") if isinstance(metadata, Mapping) else None
         density = sim_cfg.get("ped_density")
         if density is not None:
             try:

--- a/tests/test_classic_archetype_density_index.py
+++ b/tests/test_classic_archetype_density_index.py
@@ -54,9 +54,14 @@ def _derive_spawn_mode(scenario: dict) -> str:
     metadata = scenario.get("metadata", {}) or {}
     density = sim_cfg.get("ped_density")
     advisory = metadata.get("density_advisory")
+    explicit_spawn_mode = metadata.get("spawn_mode")
+    if explicit_spawn_mode == "markers":
+        return "markers"
     has_scripted = bool(scenario.get("single_pedestrians"))
     if density == 0.0 and advisory == ZERO_DENSITY_ADVISORY:
-        return "markers"
+        raise AssertionError(
+            f"{scenario['name']}: marker spawning must use metadata.spawn_mode=markers"
+        )
     if has_scripted and density:
         return "scripted_and_route_density"
     return "route_density"
@@ -152,9 +157,11 @@ def test_in_matrix_flag_matches_includes() -> None:
 def test_marker_spawn_density_zero_semantics() -> None:
     """Every ``markers`` tier encodes the overloaded ped_density=0.0 placeholder."""
     marker_tiers = 0
-    for entry in _index_entries_by_config().values():
+    config_facts = {path.name: _derive_config_facts(path) for path in _classic_config_paths()}
+    for config_name, entry in _index_entries_by_config().items():
         if entry["spawn_mode"] != "markers":
             continue
+        assert config_facts[config_name]["spawn_mode"] == "markers", config_name
         for tier in entry["tiers"]:
             assert tier["ped_density"] == 0.0, entry["config"]
             assert tier["density_advisory"] == ZERO_DENSITY_ADVISORY, entry["config"]

--- a/tests/test_classic_archetype_density_index.py
+++ b/tests/test_classic_archetype_density_index.py
@@ -166,7 +166,7 @@ def test_marker_spawn_density_zero_semantics() -> None:
             assert tier["ped_density"] == 0.0, entry["config"]
             assert tier["density_advisory"] == ZERO_DENSITY_ADVISORY, entry["config"]
             marker_tiers += 1
-    assert marker_tiers > 0, "expected at least one marker-spawn tier"
+    assert marker_tiers > 0, "expected at least one marker-spawn tier in the density index"
 
 
 def test_summary_counts_match_recomputation() -> None:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -6,6 +6,7 @@ import json
 from typing import TYPE_CHECKING
 
 import pytest
+import yaml
 
 from robot_sf.benchmark import baseline_stats
 from robot_sf.benchmark import cli as benchmark_cli
@@ -240,6 +241,35 @@ def test_cli_validate_config_success(tmp_path: Path, capsys):
     report = json.loads(captured.out)
     assert report["num_scenarios"] == 2
     assert report["errors"] == []
+
+
+def test_cli_validate_config_marker_spawn_zero_density_is_not_empty_scene(tmp_path: Path, capsys):
+    """Marker-spawned zero-density scenarios must not validate as empty scenes."""
+    matrix_path = tmp_path / "matrix.yaml"
+    scenarios = [
+        {
+            "name": "marker_spawn",
+            "map_file": "marker.svg",
+            "simulation_config": {"max_episode_steps": 100, "ped_density": 0.0},
+            "metadata": {
+                "archetype": "bottleneck",
+                "density": "low",
+                "spawn_mode": "markers",
+                "density_advisory": "zero_baseline_route_spawn",
+            },
+        }
+    ]
+    with matrix_path.open("w", encoding="utf-8") as f:
+        yaml.safe_dump({"scenarios": scenarios}, f)
+
+    rc = cli_main(["validate-config", "--matrix", str(matrix_path)])
+    captured = capsys.readouterr()
+
+    assert rc == 0
+    report = json.loads(captured.out)
+    warning_messages = [warning["warning"] for warning in report["warnings"]]
+    assert "ped_density=0.0 means no pedestrians spawn" not in warning_messages
+    assert not any("ped_density outside recommended" in msg for msg in warning_messages)
 
 
 def test_cli_validate_config_errors(tmp_path: Path, capsys):


### PR DESCRIPTION
## Summary
Make marker-spawned classic bottleneck scenarios explicit with `metadata.spawn_mode: markers`, and keep `validate-config` from reporting their `ped_density: 0.0` placeholder as an empty-scene denominator.

## Linked Issues
- Closes `#3725`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `metadata.spawn_mode: markers` to the classic bottleneck and real-world bottleneck marker-spawn scenario rows.
- Tightened `tests/test_classic_archetype_density_index.py` so marker spawning must be explicit instead of inferred from `ped_density: 0.0`.
- Updated `robot_sf_bench validate-config` warning logic so marker placeholder density does not emit empty-scene or density-band warnings.
- Added a focused CLI regression test for marker-spawned zero-density scenarios.

## Why Matters
- Added value: scenario denominator reporting can distinguish density-route spawning from fixed-marker spawning.
- Expected impact: avoids silently treating `ped_density: 0.0` marker scenarios as truthful zero-density denominator rows.
- Why worth merging now: small reversible cleanup that removes an active benchmark-matrix interpretation hazard.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for truthful scenario denominator reporting.
- Comparator or baseline, applicable: previous config/CLI behavior inferred marker mode from `ped_density: 0.0` plus advisory and warned that zero density meant no pedestrians.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision stop rule, applicable: focused tests prove marker configs declare marker mode explicitly and CLI validation no longer reports marker zero-density as empty scene.
- Parent issue, claim map, registry, context note, synthesis surface update: issue `#3725`
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool and no benchmark result claim.

## Domain-Aware Approval
This approval concerns: not required
- Approver/review source waiver: bounded config/validation semantics cleanup; no benchmark result, ranking, or paper-facing claim.
- Validity checklist:
- Target claim/hypothesis: denominator metadata clarity only.
- Comparator split/evidence validity: NA - no benchmark comparison.
- Fallback/degraded exclusions: NA - no benchmark execution.
- Claim boundary: config and validation semantics only.
- Implementation integrity vs experimental validity: focused tests plus PR readiness.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - focused tests fail without explicit `metadata.spawn_mode: markers`.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes - classic marker bottlenecks use `ped_density: 0.0`.
- Result route: stop
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: stop for this bounded PR; broader tier uniformity remains out of scope.
- Proposed child issue existing follow-up: none opened.

## Validation / Proof
- `uv run pytest tests/test_classic_archetype_density_index.py -q` with config patch temporarily reversed: failed for missing `metadata.spawn_mode=markers` as intended.
- `uv run pytest tests/test_classic_archetype_density_index.py tests/test_cli.py::test_cli_validate_config_marker_spawn_zero_density_is_not_empty_scene -q`
- `scripts/dev/ruff_fix_format.sh robot_sf/benchmark/cli.py tests/test_cli.py tests/test_classic_archetype_density_index.py`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`

## Runtime Performance
- Baseline runtime: NA - no runtime performance claim.
- Changed runtime: NA - no runtime performance claim.
- Representative command: `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- Hot-path call count profile anchor: NA - no hot-path change claimed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: marker-spawned `ped_density: 0.0` scenarios again validate/report as empty route-density scenes.

## Risks / Rollout
- Compatibility risks: low; `spawn_mode` is metadata and existing advisory fields remain.
- Failure modes: downstream readers that only inspect `ped_density` may still miscount until they consume `spawn_mode` or the density-tier index.
- Rollback fallback plan: revert the commit; old advisory behavior remains available.

## Docs / Provenance
- Updated docs: NA - no human-facing docs changed in this bounded PR.
- Relevant design provenance notes: issue `#3725`; existing `configs/scenarios/archetypes/classic_density_tier_index.yaml`.
- Any assumptions need to preserved: marker-spawned classic bottleneck rows intentionally use `ped_density: 0.0` as a route-spawn placeholder, not as an empty-scene claim.

## Downstream Propagation
- Parent issue updated: no
- Claim map / benchmark report updated: NA
- Leaderboard / artifact catalog updated: NA
- Registry or config index updated: existing density-tier index test coverage updated; index data already represented marker rows.
- Context index / memory note updated: NA
- Follow-up issue opened deferred propagation: no
- Not applicable because: this PR does not publish benchmark results or paper-facing claims.

## Follow-Up Issues
- Deferred work: tier uniformity and broader scenario-matrix denominator reporting surfaces, if maintainers want more than explicit marker-mode cleanup.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that `validate-config` should suppress both empty-scene and recommended-density warnings for `spawn_mode: markers` with `ped_density: 0.0`.
- Known limitation: this does not rename `ped_density` or make tier coverage uniform.