### PR TITLE
bench: summarize frozen trace artifact statuses

### DIFF
--- a/robot_sf/benchmark/frozen_trace_reconciliation.py
+++ b/robot_sf/benchmark/frozen_trace_reconciliation.py
@@ -230,6 +230,36 @@ def _affected_artifacts(
     return statuses
 
 
+def _affected_artifact_summary(
+    affected_artifacts: Iterable[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Summarize affected artifact statuses by artifact type and overall.
+
+    Returns:
+        JSON-serializable status counts for quick review.
+    """
+    by_type: dict[str, dict[str, int]] = {}
+    by_status: dict[str, int] = {}
+    total = 0
+
+    for artifact in affected_artifacts:
+        artifact_type = str(artifact.get("artifact_type", "unknown"))
+        status = str(artifact.get("status", "unknown"))
+        total += 1
+        by_status[status] = by_status.get(status, 0) + 1
+        type_counts = by_type.setdefault(artifact_type, {})
+        type_counts[status] = type_counts.get(status, 0) + 1
+
+    return {
+        "total_artifacts": total,
+        "by_type": {
+            artifact_type: dict(sorted(status_counts.items()))
+            for artifact_type, status_counts in sorted(by_type.items())
+        },
+        "by_status": dict(sorted(by_status.items())),
+    }
+
+
 def build_frozen_trace_reconciliation_report(
     old_rows: Iterable[Mapping[str, Any]],
     new_rows: Iterable[Mapping[str, Any]],
@@ -257,6 +287,12 @@ def build_frozen_trace_reconciliation_report(
         {"episode_key": key, "event_fields": _event_field_names(old_index[key])}
         for key in removed_keys
     ]
+    affected_artifacts = _affected_artifacts(
+        artifact_manifest,
+        changed_rows,
+        added_rows,
+        removed_rows,
+    )
     return {
         "schema_version": FROZEN_TRACE_RECONCILIATION_SCHEMA,
         "summary": {
@@ -275,12 +311,8 @@ def build_frozen_trace_reconciliation_report(
         "unchanged_rows": unchanged_rows,
         "added_rows": added_rows,
         "removed_rows": removed_rows,
-        "affected_artifacts": _affected_artifacts(
-            artifact_manifest,
-            changed_rows,
-            added_rows,
-            removed_rows,
-        ),
+        "affected_artifacts": affected_artifacts,
+        "affected_artifact_summary": _affected_artifact_summary(affected_artifacts),
         "semantics": {
             "input_contract": "existing EpisodeEventLedger.v1 rows only",
             "benchmark_semantics_changed": False,

--- a/robot_sf/benchmark/frozen_trace_reconciliation.py
+++ b/robot_sf/benchmark/frozen_trace_reconciliation.py
@@ -36,6 +36,11 @@ def _first_present_identifier(*values: Any, default: str = "unknown") -> str:
     return default
 
 
+def _coerce_optional_field(value: Any, *, default: str = "unknown") -> str:
+    """Return a stable string while treating only ``None`` as missing."""
+    return str(value) if value is not None else default
+
+
 def _ledger_from_row(row: Mapping[str, Any]) -> Mapping[str, Any]:
     """Return the existing event ledger carried by a frozen row."""
 
@@ -217,8 +222,8 @@ def _affected_artifacts(
             status = "unchanged"
         statuses.append(
             {
-                "artifact_id": str(artifact.get("artifact_id", "unknown")),
-                "artifact_type": str(artifact.get("artifact_type", "unknown")),
+                "artifact_id": _coerce_optional_field(artifact.get("artifact_id")),
+                "artifact_type": _coerce_optional_field(artifact.get("artifact_type")),
                 "status": status,
                 "consumes_event_fields": sorted(consumed_fields),
                 "affected_event_fields": affected_fields,
@@ -243,8 +248,8 @@ def _affected_artifact_summary(
     total = 0
 
     for artifact in affected_artifacts:
-        artifact_type = str(artifact.get("artifact_type", "unknown"))
-        status = str(artifact.get("status", "unknown"))
+        artifact_type = _coerce_optional_field(artifact.get("artifact_type"))
+        status = _coerce_optional_field(artifact.get("status"))
         total += 1
         by_status[status] = by_status.get(status, 0) + 1
         type_counts = by_type.setdefault(artifact_type, {})

--- a/tests/benchmark/test_frozen_trace_reconciliation.py
+++ b/tests/benchmark/test_frozen_trace_reconciliation.py
@@ -232,6 +232,40 @@ def test_added_and_removed_rows_mark_consuming_artifacts_affected() -> None:
     }
 
 
+def test_artifact_summary_treats_none_as_missing_but_preserves_falsy_values() -> None:
+    """Artifact summary coercion preserves valid falsy values while handling missing fields."""
+
+    report = build_frozen_trace_reconciliation_report(
+        [_ledger_row("episode-1")],
+        [_ledger_row("episode-1", collision=True)],
+        artifact_manifest=[
+            {
+                "artifact_id": None,
+                "artifact_type": None,
+                "consumes_event_fields": ["exact_events.collision"],
+            },
+            {
+                "artifact_id": 0,
+                "artifact_type": 0,
+                "consumes_event_fields": ["exact_events.collision"],
+            },
+        ],
+    )
+
+    assert report["affected_artifacts"][0]["artifact_id"] == "unknown"
+    assert report["affected_artifacts"][0]["artifact_type"] == "unknown"
+    assert report["affected_artifacts"][1]["artifact_id"] == "0"
+    assert report["affected_artifacts"][1]["artifact_type"] == "0"
+    assert report["affected_artifact_summary"] == {
+        "total_artifacts": 2,
+        "by_type": {
+            "0": {"affected_reconciliation_required": 1},
+            "unknown": {"affected_reconciliation_required": 1},
+        },
+        "by_status": {"affected_reconciliation_required": 2},
+    }
+
+
 def test_episode_keys_preserve_valid_falsy_identifiers() -> None:
     """Episode pairing keys should preserve valid falsy identifiers like zero."""
 

--- a/tests/benchmark/test_frozen_trace_reconciliation.py
+++ b/tests/benchmark/test_frozen_trace_reconciliation.py
@@ -147,6 +147,18 @@ def test_report_counts_event_deltas_and_affected_artifact_status() -> None:
     assert statuses["claim:collision-free"]["affected_removed_row_count"] == 0
     assert statuses["table:safety-summary"]["status"] == "affected_reconciliation_required"
     assert statuses["figure:near-miss"]["status"] == "unchanged_by_event_delta"
+    assert report["affected_artifact_summary"] == {
+        "total_artifacts": 3,
+        "by_type": {
+            "claim": {"affected_reconciliation_required": 1},
+            "figure": {"unchanged_by_event_delta": 1},
+            "table": {"affected_reconciliation_required": 1},
+        },
+        "by_status": {
+            "affected_reconciliation_required": 2,
+            "unchanged_by_event_delta": 1,
+        },
+    }
 
 
 def test_added_and_removed_rows_mark_consuming_artifacts_affected() -> None:
@@ -213,6 +225,11 @@ def test_added_and_removed_rows_mark_consuming_artifacts_affected() -> None:
             "affected_removed_row_count": 1,
         }
     ]
+    assert report["affected_artifact_summary"] == {
+        "total_artifacts": 1,
+        "by_type": {"claim": {"affected_reconciliation_required": 1}},
+        "by_status": {"affected_reconciliation_required": 1},
+    }
 
 
 def test_episode_keys_preserve_valid_falsy_identifiers() -> None:


### PR DESCRIPTION
## Summary
Adds a compact `affected_artifact_summary` block to frozen-trace event-ledger reconciliation reports so reviewers can see claim/table/figure status counts without manually aggregating every manifest row. This is a diagnostic reporting helper only: it compares already-materialized `EpisodeEventLedger.v1` rows and does not rerun benchmarks, change metric semantics, edit paper claims, or promote any result.

## Linked Issues
- Relates to `#3482`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3482`
- Safe review independently: yes
- Review dependency reason, any: builds on the frozen-trace comparator already merged in PR #3773.

## What Changed
- Added derived `affected_artifact_summary` counts: `total_artifacts`, `by_type`, and `by_status`.
- Kept the summary derived only from existing per-artifact reconciliation status rows.
- Preserved explicit `None` artifact fields as `unknown` while keeping valid falsy values such as `0` distinct.
- Added focused tests for mixed claim/table/figure manifests, added/removed-row reconciliation, and missing/falsy artifact summary fields.

## Why Matters
- Added value: reviewers can quickly audit affected claim/table/figure status totals in frozen before/after reconciliation output.
- Expected impact: easier #3482 backfill review without changing event detection or benchmark outputs.
- Why worth merging now: this is a small additive slice on top of the existing comparator with focused coverage.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3482 reviewability for frozen-trace before/after reconciliation reports.
- Comparator or baseline, applicable: existing `origin/main` comparator output without aggregate artifact-status counts.
- Evidence tier: NA - support helper; no research, benchmark, metric, or paper-facing claim is promoted.
- Result classification: NA - support helper; PR only adds derived report counts.
- Decision stop rule, applicable: stop at reporting existing old/new counts, changed/unchanged rows, and artifact statuses; do not run campaigns.
- Parent issue, claim map, registry, context note, synthesis surface update: #3482 remains open for durable frozen-trace application.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper; the comparator already exists and this PR adds an aggregate report field.

## Domain-Aware Approval
- Status: not required.
- Approver/review source waiver: additive diagnostic report aggregation only.
- Validity checklist: no evidence classification, comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim surface changes.
- Target claim/hypothesis: no research claim promoted.
- Comparator split/evidence validity: existing frozen row comparison contract only; no campaign, split, baseline, or comparator-selection change.
- Fallback/degraded exclusions: no benchmark execution, fallback path, or degraded result included.
- Claim boundary: diagnostic-only reporting helper; no paper-grade or benchmark-strength claim.
- Implementation integrity vs experimental validity: implementation summarizes already-computed artifact statuses and does not interpret validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, focused tests assert summary counts and missing/falsy artifact field coercion.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA, no scenario run.
- Result route: continue #3482 durable frozen-trace application.
- Follow-up question issue weak, negative, non-transfer results: #3482.

## Next Empirical Action
- Rerun needed: yes, outside this PR; apply the comparator to durable frozen 0.0.2 before/after traces.
- Extractor analysis tool needed: no new extractor from this PR.
- Artifact missing unavailable: durable frozen before/after inputs are not included in this PR.
- Stop / revise / continue decision: continue #3482 backfill/application slice.
- Proposed child issue existing follow-up: existing #3482.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_frozen_trace_reconciliation.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_frozen_trace_reconciliation.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/frozen_trace_reconciliation.py tests/benchmark/test_frozen_trace_reconciliation.py`
- `git diff --check`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_followups.py --body-file <(gh pr view 3778 --json body --jq .body) --changed-file robot_sf/benchmark/frozen_trace_reconciliation.py --changed-file tests/benchmark/test_frozen_trace_reconciliation.py`
- Baseline runtime: NA, no runtime/performance claim.
- Changed runtime: NA, no runtime/performance claim.
- Representative command: first pytest command above.
- Hot-path call count profile anchor: NA, no hot-path performance change claimed.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: report schema consumers cannot tolerate additive `affected_artifact_summary`, or focused reconciliation tests fail.

## Risks / Rollout
- Compatibility risks: additive JSON key only; existing fields remain unchanged.
- Failure modes: strict consumers that reject unknown report keys may need to ignore the new summary.
- Rollback fallback plan: remove the summary field/helper; per-artifact rows still provide the same information.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3482 and prior comparator PR #3773.
- Any assumptions need preserved: summary remains diagnostic-only and must not be used as claim promotion.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; issue remains open and this PR body records the partial disposition.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): no.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): no.
- Follow-up issue opened deferred propagation (yes/no/NA): no, existing #3482 remains the follow-up.
- Not applicable because: no benchmark result, claim map, leaderboard, registry, or paper-facing text is changed.

## Follow-Up Issues
- Deferred work: apply the frozen-trace comparator to durable 0.0.2 before/after trace ledgers and reconcile affected paper/report artifacts without promoting claims prematurely.
- Issues opened follow-up: existing open issue #3482.

## Reviewer Notes
- Verify `affected_artifact_summary` is derived only from `affected_artifacts`.
- Known limitation: no durable frozen-trace application was performed in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new summary in reconciliation reports showing affected artifact counts overall, by type, and by status.

* **Bug Fixes**
  * Improved handling of missing artifact identifiers and types so blank values are treated as missing, while other falsy values are preserved.
  * Reconciliation results now more consistently reflect which artifacts were affected in different trace scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->