### PR TITLE
benchmark: prepare #3216 seed analysis for Slurm outputs

### DIFF
--- a/scripts/tools/analyze_seed_sufficiency.py
+++ b/scripts/tools/analyze_seed_sufficiency.py
@@ -166,7 +166,7 @@ def _discover_campaign_roots(output_root: Path, *, campaign_ids: list[str]) -> l
         candidates = [
             root
             for root in candidates
-            if any(campaign_id in str(root) for campaign_id in campaign_ids)
+            if any(campaign_id in root.name for campaign_id in campaign_ids)
         ]
     if not candidates:
         id_note = f" matching campaign id(s) {campaign_ids}" if campaign_ids else ""
@@ -186,12 +186,12 @@ def _has_seed_reports(root: Path) -> bool:
 
 
 def _dedupe_paths(paths: list[Path]) -> list[Path]:
-    """Deduplicate paths while preserving deterministic order."""
+    """Deduplicate equivalent paths while preserving deterministic order."""
 
-    seen: set[str] = set()
+    seen: set[Path] = set()
     unique: list[Path] = []
     for path in sorted(paths, key=str):
-        key = str(path)
+        key = path.resolve()
         if key in seen:
             continue
         seen.add(key)
@@ -860,14 +860,14 @@ def _build_parser() -> argparse.ArgumentParser:
         "--campaign-root",
         type=Path,
         action="append",
-        default=[],
+        default=None,
         help="Campaign root containing reports/seed_* artifacts. Repeat for multiple schedules.",
     )
     parser.add_argument(
         "--campaign-output-root",
         type=Path,
         action="append",
-        default=[],
+        default=None,
         help=(
             "Slurm/output container to scan for campaign roots with reports/"
             "seed_variability_by_scenario.json. Repeatable."
@@ -876,7 +876,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--campaign-id",
         action="append",
-        default=[],
+        default=None,
         help="Optional substring filter for campaign roots discovered under --campaign-output-root.",
     )
     parser.add_argument("--output-dir", type=Path, required=True, help="Output report directory.")

--- a/scripts/tools/analyze_seed_sufficiency.py
+++ b/scripts/tools/analyze_seed_sufficiency.py
@@ -124,6 +124,81 @@ def analyze_seed_sufficiency(
     return payload
 
 
+def resolve_campaign_roots(
+    *,
+    campaign_roots: list[Path] | None = None,
+    campaign_output_roots: list[Path] | None = None,
+    campaign_ids: list[str] | None = None,
+) -> list[Path]:
+    """Resolve direct and container roots into campaign roots with seed reports."""
+
+    roots: list[Path] = []
+    roots.extend(campaign_roots or [])
+    ids = [campaign_id.strip() for campaign_id in (campaign_ids or []) if campaign_id.strip()]
+    for output_root in campaign_output_roots or []:
+        roots.extend(_discover_campaign_roots(output_root, campaign_ids=ids))
+    roots = _dedupe_paths(roots)
+    if not roots:
+        raise FileNotFoundError(
+            "No campaign roots supplied or discovered. Pass --campaign-root for exact roots, "
+            "or --campaign-output-root for a Slurm/output container containing reports/"
+            "seed_variability_by_scenario.json."
+        )
+    return roots
+
+
+def _discover_campaign_roots(output_root: Path, *, campaign_ids: list[str]) -> list[Path]:
+    """Find campaign roots beneath a Slurm/output container, failing closed if absent."""
+
+    if not output_root.exists():
+        raise FileNotFoundError(f"Campaign output root does not exist: {output_root}")
+    if _has_seed_reports(output_root):
+        candidates = [output_root]
+    else:
+        candidates = sorted(
+            {
+                path.parent.parent
+                for path in output_root.rglob("reports/seed_variability_by_scenario.json")
+                if path.is_file()
+            }
+        )
+    if campaign_ids:
+        candidates = [
+            root
+            for root in candidates
+            if any(campaign_id in str(root) for campaign_id in campaign_ids)
+        ]
+    if not candidates:
+        id_note = f" matching campaign id(s) {campaign_ids}" if campaign_ids else ""
+        raise FileNotFoundError(
+            f"No seed-sufficiency campaign reports found under {output_root}{id_note}. "
+            "Expected reports/seed_variability_by_scenario.json and "
+            "reports/seed_episode_rows.csv from the completed S20/S30 campaign."
+        )
+    return candidates
+
+
+def _has_seed_reports(root: Path) -> bool:
+    """Return whether a path already looks like a campaign root."""
+
+    reports = root / "reports"
+    return (reports / "seed_variability_by_scenario.json").is_file()
+
+
+def _dedupe_paths(paths: list[Path]) -> list[Path]:
+    """Deduplicate paths while preserving deterministic order."""
+
+    seen: set[str] = set()
+    unique: list[Path] = []
+    for path in sorted(paths, key=str):
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
 def _load_campaign(root: Path, *, metrics: tuple[str, ...]) -> dict[str, Any]:
     """Load the report artifacts used by the analysis."""
 
@@ -363,6 +438,7 @@ def _build_headline_contract(
         "schema_version": "headline-rank-stability-contract.v1",
         "contract_scope": "headline_rank_stability_ci_preflight",
         "label": labels[0],
+        "claim_status": _headline_claim_status(labels),
         "labels": labels,
         "source_roots": source_roots,
         "seed_counts": [campaign["seed_count"] for campaign in campaigns],
@@ -442,6 +518,18 @@ def _headline_labels(
     if labels:
         return labels
     return ["rank_flip_detected" if rank_flipped else "stable"]
+
+
+def _headline_claim_status(labels: list[str]) -> str:
+    """Map contract labels to paper-facing claim status."""
+
+    if "blocked_pending_s20_s30" in labels:
+        return "blocked_missing_increased_seed_rows"
+    if "row_status_exclusions_present" in labels:
+        return "blocked_non_promotable_rows"
+    if labels[0] == "rank_flip_detected":
+        return "not_statistically_distinguishable_budget"
+    return "paper_grade"
 
 
 def _headline_caveats(
@@ -772,8 +860,24 @@ def _build_parser() -> argparse.ArgumentParser:
         "--campaign-root",
         type=Path,
         action="append",
-        required=True,
+        default=[],
         help="Campaign root containing reports/seed_* artifacts. Repeat for multiple schedules.",
+    )
+    parser.add_argument(
+        "--campaign-output-root",
+        type=Path,
+        action="append",
+        default=[],
+        help=(
+            "Slurm/output container to scan for campaign roots with reports/"
+            "seed_variability_by_scenario.json. Repeatable."
+        ),
+    )
+    parser.add_argument(
+        "--campaign-id",
+        action="append",
+        default=[],
+        help="Optional substring filter for campaign roots discovered under --campaign-output-root.",
     )
     parser.add_argument("--output-dir", type=Path, required=True, help="Output report directory.")
     parser.add_argument(
@@ -814,8 +918,13 @@ def main(argv: list[str] | None = None) -> int:
 
     args = _build_parser().parse_args(argv)
     metrics = tuple(args.metrics) if args.metrics else DEFAULT_METRICS
+    campaign_roots = resolve_campaign_roots(
+        campaign_roots=args.campaign_root,
+        campaign_output_roots=args.campaign_output_root,
+        campaign_ids=args.campaign_id,
+    )
     payload = analyze_seed_sufficiency(
-        args.campaign_root,
+        campaign_roots,
         args.output_dir,
         metrics=metrics,
         rank_metric=args.rank_metric,

--- a/tests/tools/test_analyze_seed_sufficiency.py
+++ b/tests/tools/test_analyze_seed_sufficiency.py
@@ -377,6 +377,43 @@ def test_resolve_campaign_roots_discovers_slurm_output_container(tmp_path: Path)
     assert ignored not in roots
 
 
+def test_resolve_campaign_roots_filters_campaign_id_on_root_name(tmp_path: Path) -> None:
+    """Campaign-id filters should not match unrelated parent directory names."""
+
+    container = tmp_path / "issue1554_parent_only"
+    _campaign(
+        container / "s20_h500",
+        seed_count=20,
+        goal_snqi=0.75,
+        orca_snqi=0.45,
+        ci_half_width=0.03,
+        goal_successes=18,
+        orca_successes=10,
+    )
+
+    with pytest.raises(FileNotFoundError, match="No seed-sufficiency campaign reports"):
+        resolve_campaign_roots(campaign_output_roots=[container], campaign_ids=["issue1554"])
+
+
+def test_resolve_campaign_roots_deduplicates_equivalent_paths(tmp_path: Path) -> None:
+    """Direct roots with different spellings should resolve to one campaign."""
+
+    campaign = _campaign(
+        tmp_path / "issue1554_s20_h500",
+        seed_count=20,
+        goal_snqi=0.75,
+        orca_snqi=0.45,
+        ci_half_width=0.03,
+        goal_successes=18,
+        orca_successes=10,
+    )
+    duplicate = campaign / ".." / campaign.name
+
+    roots = resolve_campaign_roots(campaign_roots=[campaign, duplicate])
+
+    assert roots == [campaign]
+
+
 def test_main_accepts_campaign_output_root(tmp_path: Path) -> None:
     """CLI feeds discovered S20/H500 roots through existing analysis path."""
 

--- a/tests/tools/test_analyze_seed_sufficiency.py
+++ b/tests/tools/test_analyze_seed_sufficiency.py
@@ -6,7 +6,13 @@ import csv
 import json
 from typing import TYPE_CHECKING
 
-from scripts.tools.analyze_seed_sufficiency import analyze_seed_sufficiency, main
+import pytest
+
+from scripts.tools.analyze_seed_sufficiency import (
+    analyze_seed_sufficiency,
+    main,
+    resolve_campaign_roots,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -304,9 +310,11 @@ def test_headline_contract_s20_stable_and_rank_flip_labels(tmp_path: Path) -> No
     stable_contract = stable_payload["headline_rank_stability_contract"]
     flip_contract = flip_payload["headline_rank_stability_contract"]
     assert stable_contract["label"] == "stable"
+    assert stable_contract["claim_status"] == "paper_grade"
     assert stable_contract["promotion_allowed"] is True
     assert stable_contract["pairwise"][0]["rank_label"] == "stable"
     assert flip_contract["label"] == "rank_flip_detected"
+    assert flip_contract["claim_status"] == "not_statistically_distinguishable_budget"
     assert flip_contract["promotion_allowed"] is False
     assert flip_contract["pairwise"][0]["rank_label"] == "rank_flip"
     assert flip_contract["pairwise"][0]["kendall_tau"] == -1.0
@@ -333,7 +341,81 @@ def test_headline_contract_blocks_missing_durable_roots(tmp_path: Path) -> None:
 
     contract = payload["headline_rank_stability_contract"]
     assert contract["label"] == "blocked_pending_s20_s30"
+    assert contract["claim_status"] == "blocked_missing_increased_seed_rows"
     assert contract["missing_durable_roots"] == [str(tmp_path / "missing_s20")]
+
+
+def test_resolve_campaign_roots_discovers_slurm_output_container(tmp_path: Path) -> None:
+    """CLI resolver accepts a Slurm output container and campaign-id filter."""
+
+    container = tmp_path / "2026-06-issue1554-s20-h500-l40s-mem180"
+    ignored = _campaign(
+        container / "old_s10_baseline",
+        seed_count=10,
+        goal_snqi=0.7,
+        orca_snqi=0.4,
+        ci_half_width=0.04,
+        goal_successes=8,
+        orca_successes=5,
+    )
+    target = _campaign(
+        container / "issue1554_s20_h500",
+        seed_count=20,
+        goal_snqi=0.75,
+        orca_snqi=0.45,
+        ci_half_width=0.03,
+        goal_successes=18,
+        orca_successes=10,
+    )
+
+    roots = resolve_campaign_roots(
+        campaign_output_roots=[container],
+        campaign_ids=["issue1554_s20_h500"],
+    )
+
+    assert roots == [target]
+    assert ignored not in roots
+
+
+def test_main_accepts_campaign_output_root(tmp_path: Path) -> None:
+    """CLI feeds discovered S20/H500 roots through existing analysis path."""
+
+    container = tmp_path / "slurm-output"
+    campaign = _campaign(
+        container / "issue1554_s20_h500",
+        seed_count=20,
+        goal_snqi=0.75,
+        orca_snqi=0.45,
+        ci_half_width=0.03,
+        goal_successes=18,
+        orca_successes=10,
+    )
+    exit_code = main(
+        [
+            "--campaign-output-root",
+            str(container),
+            "--campaign-id",
+            "issue1554_s20_h500",
+            "--headline-required-durable-root",
+            str(campaign),
+            "--output-dir",
+            str(tmp_path / "out"),
+        ]
+    )
+
+    assert exit_code == 0
+    payload = json.loads((tmp_path / "out" / "seed_sufficiency_analysis.json").read_text())
+    assert payload["campaigns"][0]["root"] == str(campaign)
+
+
+def test_resolve_campaign_roots_fails_closed_on_empty_output_root(tmp_path: Path) -> None:
+    """Empty Slurm containers fail closed instead of yielding zero-campaign evidence."""
+
+    container = tmp_path / "empty-slurm-output"
+    container.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="No seed-sufficiency campaign reports"):
+        resolve_campaign_roots(campaign_output_roots=[container])
 
 
 def test_main_writes_requested_outputs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Prepare the #3216 seed-sufficiency analysis CLI to consume completed Slurm output containers directly, so active job `13175` / #1554 S20/H500 output can be routed into the existing confidence-interval and rank-stability path without guessing the exact campaign root.

## Linked Issues
- Relates `#3216`
- Relates `#1554`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3216`, `#1554`
- Safe review independently: yes
- Review dependency reason, any: This only extends the existing `analyze_seed_sufficiency.py` input resolver and contract payload.

## What Changed
- Added `--campaign-output-root` and optional `--campaign-id` to discover campaign roots containing `reports/seed_variability_by_scenario.json` under a Slurm/output container.
- Added fail-closed errors when an output container has no seed-sufficiency reports, instead of producing empty evidence.
- Added `claim_status` to the headline rank-stability contract: `paper_grade`, `not_statistically_distinguishable_budget`, `blocked_missing_increased_seed_rows`, or `blocked_non_promotable_rows`.
- Added fixture-backed tests for Slurm output-container discovery, campaign-id filtering, empty-container failure, CLI execution, and claim-status labels.

## Why Matters
- Added value: #3216 can consume the active #1554 S20/H500 Slurm output when job `13175` lands even if the handoff gives the campaign output container rather than an exact nested campaign root.
- Expected impact: Less manual path recovery before confidence-interval and rank-stability analysis.
- Why worth merging now: It unblocks analysis readiness while compute is still running and does not submit jobs or change benchmark/planner semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Blocker-resolution for #3216 consuming increased-seed rows from #1554.
- Comparator or baseline, applicable: Existing direct `--campaign-root` analysis path.
- Evidence tier: NA - support helper; fixture-backed validation is listed below.
- Result classification: NA - support helper; no research or benchmark result is interpreted.
- Decision stop rule, applicable: Synthetic S20/H500-compatible fixture must route through the same analyzer and empty output roots must fail closed.
- Parent issue, claim map, registry, context note, synthesis surface update: #3216 and #1554 remain open for real Slurm evidence.
- New research/benchmark/metric/paper-facing analysis tool, any: No new analysis method; extends the existing seed-sufficiency CLI entry point and contract labels.

## Domain-Aware Approval
- Required PR: yes
- Domains reviewed: benchmark analysis tooling, paper-facing claim boundary
- Status: waived
- Approval or blocker note: Waived because this PR changes only fixture-backed input discovery and status reporting, not planner, metric, scenario, ranking, or benchmark semantics.
- approval concerns experimental validity waived / pending / blocked / not required: waived
- approval_status: waived
- approval_note: Tooling-only readiness; no planner, metric, scenario, ranking, or benchmark semantics changed.
- Approver/review source waiver: Tooling-only readiness; no planner, metric, scenario, ranking, or benchmark semantics changed.
- Target claim/hypothesis: No paper-grade claim made by this PR.
- Comparator or split/evidence validity: Existing direct-root CLI path versus fixture-discovered output-container CLI path; no benchmark comparison is interpreted.
- Fallback/degraded exclusions: Existing row-status exclusion path remains in force; tests cover blocked non-promotable rows already in this test file.
- Claim boundary: CLI reports claim status but does not promote live paper claims.
- Implementation integrity vs experimental validity: This changes input discovery and status reporting only.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? CLI accepts `--campaign-output-root` and discovers a matching fixture campaign root.
- Did scenario actually contain targeted failure mode? yes, empty output-root fixture fails closed.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: none

## Next Empirical Action
- Rerun needed: yes, after Slurm job `13175` finishes.
- Extractor analysis tool needed: no
- Artifact missing unavailable: Real #1554 S20/H500 campaign reports are still pending.
- Stop / revise / continue decision: continue
- Proposed child issue existing follow-up: Continue #3216 / #1554 closeout with real Slurm output.

## Validation / Proof
- `uv run pytest tests/tools/test_analyze_seed_sufficiency.py -q` - passed
- `uv run python scripts/tools/analyze_seed_sufficiency.py --help` - passed
- `uv run ruff format scripts/tools/analyze_seed_sufficiency.py tests/tools/test_analyze_seed_sufficiency.py` - passed, unchanged after final edit
- `uv run ruff check scripts/tools/analyze_seed_sufficiency.py tests/tools/test_analyze_seed_sufficiency.py` - passed
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed before commit with dirty-tree interim stamp
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - pending final rerun with this body

## Performance Evidence
- Performance-sensitive change? no
- Baseline runtime: NA, no runtime-performance claim.
- Changed runtime: NA, no runtime-performance claim.
- Representative command: `uv run pytest tests/tools/test_analyze_seed_sufficiency.py -q`
- Hot-path call count profile anchor: NA
- Cache-hit reuse counter: NA
- Rollback failure criterion: CLI cannot discover a completed output container or silently treats missing S20/S30 reports as evidence.

## Risks / Rollout
- Compatibility risks: Existing `--campaign-root` callers remain supported.
- Failure modes: If multiple campaign roots match a broad output root, all are analyzed unless `--campaign-id` filters them.
- Rollback fallback plan: Revert this PR and pass exact campaign roots manually.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: Active #3216 and #1554 issue context; PR #3256 existing seed-sufficiency tooling.
- Any assumptions need preserved: Slurm job `13175` output will eventually contain camera-ready campaign `reports/seed_variability_by_scenario.json` plus `reports/seed_episode_rows.csv`.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, #3216 remains open because real S20/S30 rows are still pending.
- Claim map / benchmark report updated (yes/no/NA): no, real rows pending.
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: This PR is readiness tooling; #3216/#1554 remain the downstream propagation surfaces after real Slurm output lands.

## Follow-Up Issues
- Deferred work: Run the CLI against Slurm job `13175` output, inspect `claim_status`, row-status exclusions, pairwise rank stability, and confidence intervals in #3216 / #1554.
- Issues opened follow-up: none; existing issues #3216 and #1554 track the deferred real-output analysis.

## Reviewer Notes
- Verify closely: `resolve_campaign_roots` fails closed on empty containers and does not bypass existing row-status exclusions.
- Any known limitations: It does not parse result-store `episodes.parquet`; it discovers completed camera-ready campaign report roots for the existing seed-sufficiency analyzer.

