### PR TITLE
Add package B adversarial preflight for issue #3079

### DIFF
--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -147,11 +147,11 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     warnings: list[str] = []
     checks: dict[str, bool] = {}
 
+    if not manifest_path.is_file():
+        raise FileNotFoundError(f"Manifest file not found: {_repo_relative(manifest_path, root)}")
+
     try:
         payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        payload = None
-        blockers.append(f"manifest missing: {_repo_relative(manifest_path, root)}")
     except yaml.YAMLError as exc:
         payload = None
         blockers.append(f"manifest YAML could not be parsed: {exc}")

--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -1,0 +1,314 @@
+"""Fail-closed preflight for the issue #3079 package-B comparison manifest.
+
+The checker validates only local readiness metadata for the budget-matched
+adversarial falsification package-B plan. It never runs sampler comparisons,
+submits jobs, or interprets falsification yield.
+"""
+
+from __future__ import annotations
+
+import json
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_VERSION = "adversarial-package-b-preflight.v1"
+MANIFEST_SCHEMA_VERSION = "adversarial-package-b-comparison.v1"
+EXPECTED_ISSUE = 3079
+EXPECTED_BUDGETS = (16, 32, 64)
+EXPECTED_SAMPLERS = ("random", "coordinate", "optuna")
+EXPECTED_REPORTING_FIELDS = frozenset(
+    {
+        "first_failure_iteration",
+        "best_valid_objective",
+        "invalid_candidate_rate",
+        "replay_success_rate",
+        "certified_valid_failure_count",
+        "replayable_valid_failure_count",
+        "fallback_candidate_count",
+        "degraded_candidate_count",
+        "held_out_family_yield",
+    }
+)
+EXPECTED_OUTPUT_PREFIX = Path("output/adversarial/issue_3079_package_b")
+FORBIDDEN_COMMAND_TOKENS = frozenset({"sbatch", "srun", "slurm", "wandb", "paper", "dissertation"})
+
+
+@dataclass(frozen=True)
+class PackageBPreflightResult:
+    """Structured package-B readiness result."""
+
+    manifest_path: str
+    ready: bool
+    blocked: bool
+    checks: dict[str, bool]
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    metadata: dict[str, Any]
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a stable JSON payload for CLI and tests."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "manifest_path": self.manifest_path,
+            "ready": self.ready,
+            "blocked": self.blocked,
+            "checks": self.checks,
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "metadata": self.metadata,
+        }
+
+
+def _repo_relative(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _as_int_tuple(value: Any) -> tuple[int, ...]:
+    if not isinstance(value, list):
+        return ()
+    values: list[int] = []
+    for item in value:
+        if isinstance(item, bool) or not isinstance(item, int):
+            return ()
+        values.append(item)
+    return tuple(values)
+
+
+def _as_str_tuple(value: Any) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        return ()
+    values: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not item.strip():
+            return ()
+        values.append(item.strip())
+    return tuple(values)
+
+
+def _resolve_repo_path(repo_root: Path, value: Any) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    path = Path(value)
+    if path.is_absolute():
+        return path
+    return repo_root / path
+
+
+def _extract_output_paths(
+    command: str, repo_root: Path
+) -> tuple[Path | None, Path | None, list[str]]:
+    warnings: list[str] = []
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        warnings.append(f"example_command could not be parsed with shlex: {exc}")
+        return None, None, warnings
+
+    output_dir: Path | None = None
+    out_json: Path | None = None
+    for index, token in enumerate(tokens):
+        if token == "--output-dir" and index + 1 < len(tokens):
+            output_dir = _resolve_repo_path(repo_root, tokens[index + 1])
+        if token == "--out-json" and index + 1 < len(tokens):
+            out_json = _resolve_repo_path(repo_root, tokens[index + 1])
+    return output_dir, out_json, warnings
+
+
+def _under_output_prefix(path: Path | None, repo_root: Path) -> bool:
+    if path is None:
+        return False
+    try:
+        rel = path.resolve().relative_to((repo_root / EXPECTED_OUTPUT_PREFIX).resolve())
+    except ValueError:
+        return False
+    return rel == Path(".") or bool(rel.parts)
+
+
+def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
+    manifest_path: Path = Path("configs/adversarial/issue_3079_package_b_budget_matched.yaml"),
+    *,
+    repo_root: Path | None = None,
+) -> PackageBPreflightResult:
+    """Validate the package-B manifest readiness contract without executing it.
+
+    Returns:
+        Fail-closed readiness result with per-check booleans and blockers.
+    """
+    root = (repo_root or Path.cwd()).resolve()
+    manifest_path = manifest_path if manifest_path.is_absolute() else root / manifest_path
+    blockers: list[str] = []
+    warnings: list[str] = []
+    checks: dict[str, bool] = {}
+
+    try:
+        payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        payload = None
+        blockers.append(f"manifest missing: {_repo_relative(manifest_path, root)}")
+    except yaml.YAMLError as exc:
+        payload = None
+        blockers.append(f"manifest YAML could not be parsed: {exc}")
+
+    if not isinstance(payload, dict):
+        blockers.append("manifest payload must be a mapping")
+        payload = {}
+
+    checks["schema_version"] = payload.get("schema_version") == MANIFEST_SCHEMA_VERSION
+    if not checks["schema_version"]:
+        blockers.append(
+            f"schema_version must be {MANIFEST_SCHEMA_VERSION!r}, "
+            f"got {payload.get('schema_version')!r}"
+        )
+
+    checks["issue"] = payload.get("issue") == EXPECTED_ISSUE
+    if not checks["issue"]:
+        blockers.append(f"issue must be {EXPECTED_ISSUE}")
+
+    runner_path = _resolve_repo_path(root, payload.get("runner"))
+    checks["runner_exists"] = bool(runner_path and runner_path.is_file())
+    if not checks["runner_exists"]:
+        blockers.append("runner must point at an existing repository file")
+
+    base_config = payload.get("base_config")
+    checks["base_config_mapping"] = isinstance(base_config, dict)
+    if not isinstance(base_config, dict):
+        blockers.append("base_config must be a mapping")
+        base_config = {}
+
+    for key in ("scenario_template", "search_space"):
+        path = _resolve_repo_path(root, base_config.get(key))
+        checks[f"{key}_exists"] = bool(path and path.is_file())
+        if not checks[f"{key}_exists"]:
+            blockers.append(f"base_config.{key} must point at an existing repository file")
+
+    for key in ("policy", "objective"):
+        checks[f"{key}_declared"] = isinstance(base_config.get(key), str) and bool(
+            base_config.get(key).strip()
+        )
+        if not checks[f"{key}_declared"]:
+            blockers.append(f"base_config.{key} must be a non-empty string")
+
+    budgets = _as_int_tuple(payload.get("budget_grid"))
+    checks["budget_grid"] = budgets == EXPECTED_BUDGETS
+    if not checks["budget_grid"]:
+        blockers.append(f"budget_grid must exactly match {list(EXPECTED_BUDGETS)}")
+
+    seeds = _as_int_tuple(payload.get("repeated_seeds"))
+    checks["repeated_seeds"] = (
+        bool(seeds) and len(set(seeds)) == len(seeds) and all(seed >= 0 for seed in seeds)
+    )
+    if not checks["repeated_seeds"]:
+        blockers.append("repeated_seeds must be non-empty, unique, non-negative integers")
+
+    samplers = _as_str_tuple(payload.get("samplers"))
+    checks["samplers"] = samplers == EXPECTED_SAMPLERS
+    if not checks["samplers"]:
+        blockers.append(f"samplers must exactly match {list(EXPECTED_SAMPLERS)}")
+
+    reporting_contract = frozenset(_as_str_tuple(payload.get("reporting_contract")))
+    missing_reporting = sorted(EXPECTED_REPORTING_FIELDS - reporting_contract)
+    checks["reporting_contract"] = not missing_reporting
+    if missing_reporting:
+        blockers.append(f"reporting_contract missing required fields: {missing_reporting}")
+
+    exclusions = payload.get("explicit_exclusions")
+    checks["explicit_exclusions_mapping"] = isinstance(exclusions, dict)
+    if not isinstance(exclusions, dict):
+        blockers.append("explicit_exclusions must be a mapping")
+        exclusions = {}
+
+    exclusion_checks = {
+        "learned_failure_proposal_issue_2921": "stretch_out_of_scope",
+        "held_out_family_yield": "not_evaluated",
+        "paper_facing_success_claims": "forbidden",
+    }
+    for key, required_fragment in exclusion_checks.items():
+        value = str(exclusions.get(key, ""))
+        checks[f"exclusion_{key}"] = required_fragment in value
+        if not checks[f"exclusion_{key}"]:
+            blockers.append(f"explicit_exclusions.{key} must include {required_fragment!r} caveat")
+
+    checks["claim_scope_not_paper_facing"] = (
+        payload.get("claim_scope") == "not_paper_facing_benchmark_evidence"
+    )
+    if not checks["claim_scope_not_paper_facing"]:
+        blockers.append("claim_scope must stay not_paper_facing_benchmark_evidence")
+
+    checks["status_diagnostic"] = payload.get("status") == "diagnostic_local_nominal"
+    if not checks["status_diagnostic"]:
+        blockers.append("status must stay diagnostic_local_nominal")
+
+    example_command = payload.get("example_command")
+    checks["example_command_declared"] = isinstance(example_command, str) and bool(
+        example_command.strip()
+    )
+    if not checks["example_command_declared"]:
+        blockers.append("example_command must be a non-empty string")
+        example_command = ""
+
+    lower_command = example_command.lower()
+    forbidden_hits = sorted(token for token in FORBIDDEN_COMMAND_TOKENS if token in lower_command)
+    checks["example_command_no_forbidden_actions"] = not forbidden_hits
+    if forbidden_hits:
+        blockers.append(f"example_command includes forbidden action tokens: {forbidden_hits}")
+
+    checks["example_command_uses_package_b_grid"] = "--package-b-budget-grid" in example_command
+    if not checks["example_command_uses_package_b_grid"]:
+        blockers.append("example_command must use --package-b-budget-grid")
+
+    for seed in seeds:
+        checks[f"example_command_seed_{seed}"] = f"--seed {seed}" in example_command
+        if not checks[f"example_command_seed_{seed}"]:
+            blockers.append(f"example_command missing --seed {seed}")
+
+    output_dir, out_json, output_warnings = _extract_output_paths(example_command, root)
+    warnings.extend(output_warnings)
+    checks["output_dir_under_issue_path"] = _under_output_prefix(output_dir, root)
+    if not checks["output_dir_under_issue_path"]:
+        blockers.append(f"--output-dir must stay under {EXPECTED_OUTPUT_PREFIX.as_posix()}")
+    checks["out_json_under_issue_path"] = _under_output_prefix(out_json, root)
+    if not checks["out_json_under_issue_path"]:
+        blockers.append(f"--out-json must stay under {EXPECTED_OUTPUT_PREFIX.as_posix()}")
+
+    metadata = {
+        "issue": EXPECTED_ISSUE,
+        "budget_grid": list(budgets),
+        "repeated_seeds": list(seeds),
+        "samplers": list(samplers),
+        "runner": _repo_relative(runner_path, root) if runner_path else None,
+        "output_dir": _repo_relative(output_dir, root) if output_dir else None,
+        "out_json": _repo_relative(out_json, root) if out_json else None,
+        "claim_scope": payload.get("claim_scope"),
+        "status": payload.get("status"),
+        "does_not_execute_benchmark": True,
+        "does_not_submit_slurm_or_gpu": True,
+        "does_not_edit_paper_claims": True,
+    }
+    ready = not blockers
+    return PackageBPreflightResult(
+        manifest_path=_repo_relative(manifest_path, root),
+        ready=ready,
+        blocked=not ready,
+        checks=checks,
+        blockers=tuple(blockers),
+        warnings=tuple(warnings),
+        metadata=metadata,
+    )
+
+
+def dump_preflight_payload(result: PackageBPreflightResult, output: Path | None) -> None:
+    """Write preflight payload to disk when requested."""
+    if output is None:
+        return
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text(
+        json.dumps(result.to_payload(), indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )

--- a/scripts/tools/preflight_adversarial_package_b.py
+++ b/scripts/tools/preflight_adversarial_package_b.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Run the fail-closed package-B manifest preflight for issue #3079."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.adversarial_package_b_preflight import (
+    dump_preflight_payload,
+    preflight_package_b_manifest,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse package-B preflight CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("configs/adversarial/issue_3079_package_b_budget_matched.yaml"),
+        help="Package-B budget-matched comparison manifest to preflight.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root for resolving relative manifest paths.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional JSON path for the preflight report.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run preflight and return non-zero when blockers are present."""
+    args = parse_args(argv)
+    result = preflight_package_b_manifest(args.manifest, repo_root=args.repo_root)
+    dump_preflight_payload(result, args.output)
+    print(json.dumps(result.to_payload(), sort_keys=True))
+    return 0 if result.ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import pytest
 import yaml
 
 from robot_sf.benchmark.adversarial_package_b_preflight import preflight_package_b_manifest
@@ -102,6 +103,14 @@ def test_preflight_fails_closed_for_missing_budget_seed_and_provenance(tmp_path:
     assert any("budget_grid" in blocker for blocker in result.blockers)
     assert any("repeated_seeds" in blocker for blocker in result.blockers)
     assert any("paper_facing_success_claims" in blocker for blocker in result.blockers)
+
+
+def test_preflight_raises_filenotfound_for_missing_manifest(tmp_path: Path) -> None:
+    """Missing manifest path raises before producing cascading blockers."""
+    manifest = tmp_path / "configs/adversarial/missing_package_b_manifest.yaml"
+
+    with pytest.raises(FileNotFoundError, match="Manifest file not found"):
+        preflight_package_b_manifest(manifest, repo_root=tmp_path)
 
 
 def test_preflight_blocks_missing_inputs_and_output_paths(tmp_path: Path) -> None:

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -1,0 +1,151 @@
+"""Tests for the issue #3079 package-B readiness preflight."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import yaml
+
+from robot_sf.benchmark.adversarial_package_b_preflight import preflight_package_b_manifest
+from scripts.tools import preflight_adversarial_package_b
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_file(path: Path, text: str = "placeholder\n") -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _base_manifest(repo_root: Path) -> Path:
+    _write_file(repo_root / "configs/scenarios/templates/crossing_ttc.yaml")
+    _write_file(repo_root / "configs/adversarial/crossing_ttc_space.yaml")
+    _write_file(repo_root / "scripts/tools/compare_adversarial_samplers.py")
+    manifest = repo_root / "configs/adversarial/issue_3079_package_b_budget_matched.yaml"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "adversarial-package-b-comparison.v1",
+                "issue": 3079,
+                "status": "diagnostic_local_nominal",
+                "claim_scope": "not_paper_facing_benchmark_evidence",
+                "runner": "scripts/tools/compare_adversarial_samplers.py",
+                "base_config": {
+                    "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+                    "search_space": "configs/adversarial/crossing_ttc_space.yaml",
+                    "policy": "goal",
+                    "objective": "worst_case_snqi",
+                },
+                "budget_grid": [16, 32, 64],
+                "repeated_seeds": [1101, 2202, 3303],
+                "samplers": ["random", "coordinate", "optuna"],
+                "reporting_contract": [
+                    "first_failure_iteration",
+                    "best_valid_objective",
+                    "invalid_candidate_rate",
+                    "replay_success_rate",
+                    "certified_valid_failure_count",
+                    "replayable_valid_failure_count",
+                    "fallback_candidate_count",
+                    "degraded_candidate_count",
+                    "held_out_family_yield",
+                ],
+                "explicit_exclusions": {
+                    "learned_failure_proposal_issue_2921": "stretch_out_of_scope",
+                    "held_out_family_yield": "not_evaluated_narrow_archive_caveat",
+                    "paper_facing_success_claims": "forbidden",
+                },
+                "example_command": (
+                    "uv run python scripts/tools/compare_adversarial_samplers.py "
+                    "--package-b-budget-grid --seed 1101 --seed 2202 --seed 3303 "
+                    "--output-dir output/adversarial/issue_3079_package_b "
+                    "--out-json output/adversarial/issue_3079_package_b/report.json"
+                ),
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return manifest
+
+
+def test_committed_package_b_manifest_preflights_without_running_benchmark() -> None:
+    """The checked-in manifest has complete readiness metadata."""
+    result = preflight_package_b_manifest()
+
+    assert result.ready is True
+    assert result.blocked is False
+    assert result.metadata["budget_grid"] == [16, 32, 64]
+    assert result.metadata["repeated_seeds"] == [1101, 2202, 3303]
+    assert result.metadata["does_not_execute_benchmark"] is True
+    assert result.metadata["does_not_submit_slurm_or_gpu"] is True
+
+
+def test_preflight_fails_closed_for_missing_budget_seed_and_provenance(tmp_path: Path) -> None:
+    """Missing package-B readiness metadata blocks before any benchmark run."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    del payload["budget_grid"]
+    payload["repeated_seeds"] = []
+    payload["explicit_exclusions"] = {}
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["budget_grid"] is False
+    assert result.checks["repeated_seeds"] is False
+    assert any("budget_grid" in blocker for blocker in result.blockers)
+    assert any("repeated_seeds" in blocker for blocker in result.blockers)
+    assert any("paper_facing_success_claims" in blocker for blocker in result.blockers)
+
+
+def test_preflight_blocks_missing_inputs_and_output_paths(tmp_path: Path) -> None:
+    """Missing local inputs or wrong output roots cannot pass readiness."""
+    manifest = _base_manifest(tmp_path)
+    (tmp_path / "configs/adversarial/crossing_ttc_space.yaml").unlink()
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--package-b-budget-grid --seed 1101 --seed 2202 --seed 3303 "
+        "--output-dir /tmp/package_b --out-json /tmp/package_b/report.json"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.checks["search_space_exists"] is False
+    assert result.checks["output_dir_under_issue_path"] is False
+    assert result.checks["out_json_under_issue_path"] is False
+
+
+def test_package_b_preflight_cli_writes_report_and_returns_nonzero_on_blocker(
+    tmp_path: Path,
+) -> None:
+    """CLI exits non-zero with a structured blocked report."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["samplers"] = ["random", "coordinate"]
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    report_path = tmp_path / "preflight.json"
+
+    exit_code = preflight_adversarial_package_b.main(
+        [
+            "--manifest",
+            str(manifest),
+            "--repo-root",
+            str(tmp_path),
+            "--output",
+            str(report_path),
+        ]
+    )
+
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert exit_code == 1
+    assert report["blocked"] is True
+    assert report["checks"]["samplers"] is False

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -104,6 +104,18 @@ def test_preflight_fails_closed_for_missing_budget_seed_and_provenance(tmp_path:
     assert any("paper_facing_success_claims" in blocker for blocker in result.blockers)
 
 
+def test_preflight_fails_closed_for_missing_manifest(tmp_path: Path) -> None:
+    """Missing manifest path returns a structured blocker instead of running anything."""
+    manifest = tmp_path / "configs/adversarial/missing_package_b_manifest.yaml"
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["schema_version"] is False
+    assert any("manifest missing" in blocker for blocker in result.blockers)
+
+
 def test_preflight_blocks_missing_inputs_and_output_paths(tmp_path: Path) -> None:
     """Missing local inputs or wrong output roots cannot pass readiness."""
     manifest = _base_manifest(tmp_path)


### PR DESCRIPTION
## Summary
Adds a fail-closed readiness/preflight checker for the issue #3079 package-B budget-matched adversarial comparison manifest. The checker validates local inputs, budget/seed/sampler metadata, reporting/provenance caveats, and output paths without running a benchmark.

## Linked Issues
- Relates to `#3079`
- Issue URL: https://github.com/ll7/robot_sf_ll7/issues/3079

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## Changed
- Added `robot_sf.benchmark.adversarial_package_b_preflight` structured package-B readiness checks.
- Added `scripts/tools/preflight_adversarial_package_b.py` thin CLI that exits non-zero when blockers exist.
- Added focused synthetic tests for ready metadata, missing manifest, missing budget/seed/provenance fields, missing input paths, invalid output roots, and CLI blocked reports.

## Why Matters
- Added value: package-B campaign prerequisites now fail closed before expensive execution.
- Expected impact: safer handoff for later benchmark execution by catching incomplete metadata and path mistakes early.
- Why worth merging now: issue #3079 is ready-queue work, but this authorized slice is readiness/provenance gating only.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support preflight only; no benchmark result or research claim.
- Comparator or baseline, applicable: NA - support preflight only.
- Evidence tier: NA - support preflight only.
- Result classification: NA - support preflight only.
- Decision stop rule, applicable: preflight returns ready only when manifest metadata and referenced local inputs are complete.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3079 remains open; no claim-map update because no benchmark result was produced.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support-only preflight.

## Domain-Aware Approval
- Approval concerns experimental validity and waived / pending / blocked / not required: not required - no evidence classification, comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim changes.
- Approver/review source waiver: PR gate review on #3781.
- Validity checklist: NA - support preflight only.
- Target claim/hypothesis: NA - no research claim.
- Comparator split/evidence validity: NA - no comparison run.
- Fallback/degraded exclusions: manifest caveats required by preflight; fallback/degraded counts are reporting fields only.
- Claim boundary: not paper-facing benchmark evidence.
- Implementation integrity vs experimental validity: implementation checks prerequisites; later campaign validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no benchmark mechanism run.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this PR; yes for the later actual package-B campaign outside this scope.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no durable benchmark artifact expected here.
- Stop / revise / continue decision: continue later authorized benchmark execution review under #3079 or a successor if scope splits.
- Proposed child issue existing follow-up: #3079 remains the parent benchmark issue.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py -q` passed, 5 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/adversarial_package_b_preflight.py scripts/tools/preflight_adversarial_package_b.py tests/benchmark/test_adversarial_package_b_preflight.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/preflight_adversarial_package_b.py --output output/validation/issue_3079_package_b_preflight_gate_raise_missing.json` passed; ready true, blockers empty. Output remains ignored local validation output.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py tests/test_ci_script_contract.py -q` passed, 61 tests.

## Performance / Hot Path
- Baseline runtime: NA - not a hot-path/runtime optimization.
- Changed runtime: NA - not a hot-path/runtime optimization.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/preflight_adversarial_package_b.py --output output/validation/issue_3079_package_b_preflight_gate_raise_missing.json`.
- Hot-path call count profile anchor: NA - not a hot-path/runtime optimization.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: preflight incorrectly reports ready when budget, seed, provenance, input path, output path, or missing manifest prerequisites are incomplete.

## Risks / Rollout
- Compatibility risks: low; adds a new checker CLI without changing benchmark runner behavior.
- Failure modes: overly strict manifest expectations could block a legitimate future package-B plan until the preflight contract is intentionally updated.
- Rollback fallback plan: remove checker/CLI/tests; existing package-B manifest comparison runner is unchanged.

## Docs / Provenance
- Updated docs: none; CLI/module docstrings document the local contract.
- Relevant design provenance notes: issue #3079 ready-queue scope.
- Any assumptions need preserved: PR is readiness/provenance gating, not benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - #3079 remains open because this PR is only a support preflight slice.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark result.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: support preflight produces no benchmark, registry, claim-map, paper-facing result.

## Follow-Up Issues
- Deferred work: actual package-B campaign execution, yield reporting, and interpretation remain under issue #3079 or later authorized work.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the checker remains fail-closed and does not import/run the sampler comparison campaign.
- Known limitation: expected package-B budgets/samplers are intentionally fixed to the current issue contract.

