### PR TITLE
Add issue #3557 uncertainty-source readiness inventory

### DIFF
--- a/robot_sf/benchmark/uncertainty_source_readiness.py
+++ b/robot_sf/benchmark/uncertainty_source_readiness.py
@@ -1,0 +1,196 @@
+"""Readiness inventory for issue #3557 uncertainty-source episode runs.
+
+This module is intentionally a preflight inventory only. It does not run the
+#3471 episode harness, compute new metrics, or decide whether the uncertainty
+drop safety effect generalizes. It answers the smaller question needed before
+those runs: which uncertainty sources already have the builders, scenario hooks,
+and surrogate output fields required for a per-source episode-level contrast?
+"""
+
+from __future__ import annotations
+
+import importlib
+from dataclasses import dataclass
+from typing import Any
+
+UNCERTAINTY_SOURCE_READINESS_SCHEMA = "uncertainty_source_readiness.v1"
+
+_GENERALIZATION_SURROGATE_OUTPUTS = frozenset(
+    {
+        "source",
+        "retained_unsafe_commit_rate",
+        "dropped_unsafe_commit_rate",
+        "min_separation_delta_m",
+        "n_episodes",
+    }
+)
+
+
+@dataclass(frozen=True, slots=True)
+class UncertaintySourceRunSpec:
+    """Inventory contract for one candidate uncertainty source."""
+
+    source: str
+    condition_builder: str | None
+    scenario_hook: str | None
+    expected_surrogate_outputs: tuple[str, ...] = tuple(sorted(_GENERALIZATION_SURROGATE_OUTPUTS))
+
+
+DEFAULT_UNCERTAINTY_SOURCE_SPECS: tuple[UncertaintySourceRunSpec, ...] = (
+    UncertaintySourceRunSpec(
+        source="existence_degraded",
+        condition_builder="_condition_existence_degraded",
+        scenario_hook="build_belief_for_mode",
+    ),
+    UncertaintySourceRunSpec(
+        source="visibility_limited",
+        condition_builder="_condition_visibility_limited",
+        scenario_hook=None,
+    ),
+    UncertaintySourceRunSpec(
+        source="covariance_inflated",
+        condition_builder="_condition_covariance_inflated",
+        scenario_hook=None,
+    ),
+    UncertaintySourceRunSpec(
+        source="class_probability",
+        condition_builder="_condition_class_probability",
+        scenario_hook=None,
+    ),
+    UncertaintySourceRunSpec(
+        source="tracking_noise",
+        condition_builder=None,
+        scenario_hook=None,
+    ),
+)
+
+
+def _missing_expected_outputs(spec: UncertaintySourceRunSpec) -> list[str]:
+    """Return required surrogate fields absent from ``spec``."""
+
+    declared = set(spec.expected_surrogate_outputs)
+    return sorted(_GENERALIZATION_SURROGATE_OUTPUTS - declared)
+
+
+def _discover_condition_builders() -> frozenset[str]:
+    """Return condition-builder symbols present in the #2546 diagnostic owner."""
+
+    module = importlib.import_module(
+        "scripts.analysis.run_scenario_belief_uncertainty_diagnostic_issue_2546"
+    )
+    return frozenset(name for name in dir(module) if name.startswith("_condition_"))
+
+
+def _discover_scenario_hooks() -> frozenset[str]:
+    """Return episode scenario hook symbols present in the #3471 runner owner."""
+
+    module = importlib.import_module(
+        "scripts.validation.run_scenario_belief_episode_safety_issue_3471"
+    )
+    return frozenset(
+        {"build_belief_for_mode"} if hasattr(module, "build_belief_for_mode") else set()
+    )
+
+
+def classify_uncertainty_source_readiness(
+    spec: UncertaintySourceRunSpec,
+    *,
+    known_condition_builders: set[str] | frozenset[str] | None = None,
+    known_scenario_hooks: set[str] | frozenset[str] | None = None,
+) -> dict[str, Any]:
+    """Classify one source as ready or blocked for a future episode run.
+
+    The result is a static inventory row. A source is ``ready`` only when it has
+    an existing condition builder, an existing scenario hook, and the surrogate
+    outputs needed by the already-landed #3557 decision layer.
+
+    Returns:
+        dict[str, Any]: Source readiness row with status and missing contract parts.
+    """
+
+    known_condition_builders = (
+        _discover_condition_builders()
+        if known_condition_builders is None
+        else known_condition_builders
+    )
+    known_scenario_hooks = (
+        _discover_scenario_hooks() if known_scenario_hooks is None else known_scenario_hooks
+    )
+    missing: list[str] = []
+
+    if spec.condition_builder is None:
+        missing.append("condition_builder")
+        condition_builder_present = False
+    else:
+        condition_builder_present = spec.condition_builder in known_condition_builders
+        if not condition_builder_present:
+            missing.append("condition_builder")
+
+    if spec.scenario_hook is None:
+        missing.append("scenario_hook")
+        scenario_hook_present = False
+    else:
+        scenario_hook_present = spec.scenario_hook in known_scenario_hooks
+        if not scenario_hook_present:
+            missing.append("scenario_hook")
+
+    missing_outputs = _missing_expected_outputs(spec)
+    expected_surrogate_outputs_present = not missing_outputs
+    if missing_outputs:
+        missing.append("expected_surrogate_outputs")
+
+    return {
+        "source": spec.source,
+        "status": "ready" if not missing else "blocked",
+        "missing": sorted(set(missing)),
+        "condition_builder": spec.condition_builder,
+        "condition_builder_present": condition_builder_present,
+        "scenario_hook": spec.scenario_hook,
+        "scenario_hook_present": scenario_hook_present,
+        "expected_surrogate_outputs": list(spec.expected_surrogate_outputs),
+        "expected_surrogate_outputs_present": expected_surrogate_outputs_present,
+        "missing_expected_surrogate_outputs": missing_outputs,
+    }
+
+
+def build_uncertainty_source_readiness_inventory(
+    specs: tuple[UncertaintySourceRunSpec, ...] | list[UncertaintySourceRunSpec] = (
+        DEFAULT_UNCERTAINTY_SOURCE_SPECS
+    ),
+) -> dict[str, Any]:
+    """Build a versioned readiness inventory for issue #3557.
+
+    Returns:
+        dict[str, Any]: Diagnostic readiness report only. ``ready_sources`` names sources
+        that can be wired into an episode-level contrast with current hooks;
+        ``blocked_sources`` names sources that still need builder/hook/output work.
+    """
+
+    if not specs:
+        raise ValueError("at least one uncertainty source spec is required")
+
+    rows = [classify_uncertainty_source_readiness(spec) for spec in specs]
+    ready_sources = sorted(row["source"] for row in rows if row["status"] == "ready")
+    blocked_sources = sorted(row["source"] for row in rows if row["status"] == "blocked")
+
+    return {
+        "schema_version": UNCERTAINTY_SOURCE_READINESS_SCHEMA,
+        "issue": 3557,
+        "claim_boundary": "readiness_inventory_only",
+        "not_benchmark_evidence": True,
+        "runs_executed": False,
+        "surrogate_semantics_changed": False,
+        "sources": rows,
+        "ready_sources": ready_sources,
+        "blocked_sources": blocked_sources,
+        "all_sources_ready": not blocked_sources,
+    }
+
+
+__all__ = [
+    "DEFAULT_UNCERTAINTY_SOURCE_SPECS",
+    "UNCERTAINTY_SOURCE_READINESS_SCHEMA",
+    "UncertaintySourceRunSpec",
+    "build_uncertainty_source_readiness_inventory",
+    "classify_uncertainty_source_readiness",
+]

--- a/robot_sf/benchmark/uncertainty_source_readiness.py
+++ b/robot_sf/benchmark/uncertainty_source_readiness.py
@@ -82,7 +82,7 @@ def _discover_condition_builders() -> frozenset[str]:
         module = importlib.import_module(
             "scripts.analysis.run_scenario_belief_uncertainty_diagnostic_issue_2546"
         )
-    except Exception:
+    except (ImportError, SyntaxError):
         logger.exception("Failed to import uncertainty diagnostic owner for readiness discovery")
         return frozenset()
     return frozenset(name for name in dir(module) if name.startswith("_condition_"))
@@ -95,7 +95,7 @@ def _discover_scenario_hooks() -> frozenset[str]:
         module = importlib.import_module(
             "scripts.validation.run_scenario_belief_episode_safety_issue_3471"
         )
-    except Exception:
+    except (ImportError, SyntaxError):
         logger.exception("Failed to import episode safety owner for readiness discovery")
         return frozenset()
     return frozenset(

--- a/robot_sf/benchmark/uncertainty_source_readiness.py
+++ b/robot_sf/benchmark/uncertainty_source_readiness.py
@@ -10,10 +10,13 @@ and surrogate output fields required for a per-source episode-level contrast?
 from __future__ import annotations
 
 import importlib
+import logging
 from dataclasses import dataclass
 from typing import Any
 
 UNCERTAINTY_SOURCE_READINESS_SCHEMA = "uncertainty_source_readiness.v1"
+
+logger = logging.getLogger(__name__)
 
 _GENERALIZATION_SURROGATE_OUTPUTS = frozenset(
     {
@@ -75,18 +78,26 @@ def _missing_expected_outputs(spec: UncertaintySourceRunSpec) -> list[str]:
 def _discover_condition_builders() -> frozenset[str]:
     """Return condition-builder symbols present in the #2546 diagnostic owner."""
 
-    module = importlib.import_module(
-        "scripts.analysis.run_scenario_belief_uncertainty_diagnostic_issue_2546"
-    )
+    try:
+        module = importlib.import_module(
+            "scripts.analysis.run_scenario_belief_uncertainty_diagnostic_issue_2546"
+        )
+    except Exception:
+        logger.exception("Failed to import uncertainty diagnostic owner for readiness discovery")
+        return frozenset()
     return frozenset(name for name in dir(module) if name.startswith("_condition_"))
 
 
 def _discover_scenario_hooks() -> frozenset[str]:
     """Return episode scenario hook symbols present in the #3471 runner owner."""
 
-    module = importlib.import_module(
-        "scripts.validation.run_scenario_belief_episode_safety_issue_3471"
-    )
+    try:
+        module = importlib.import_module(
+            "scripts.validation.run_scenario_belief_episode_safety_issue_3471"
+        )
+    except Exception:
+        logger.exception("Failed to import episode safety owner for readiness discovery")
+        return frozenset()
     return frozenset(
         {"build_belief_for_mode"} if hasattr(module, "build_belief_for_mode") else set()
     )
@@ -169,7 +180,16 @@ def build_uncertainty_source_readiness_inventory(
     if not specs:
         raise ValueError("at least one uncertainty source spec is required")
 
-    rows = [classify_uncertainty_source_readiness(spec) for spec in specs]
+    known_condition_builders = _discover_condition_builders()
+    known_scenario_hooks = _discover_scenario_hooks()
+    rows = [
+        classify_uncertainty_source_readiness(
+            spec,
+            known_condition_builders=known_condition_builders,
+            known_scenario_hooks=known_scenario_hooks,
+        )
+        for spec in specs
+    ]
     ready_sources = sorted(row["source"] for row in rows if row["status"] == "ready")
     blocked_sources = sorted(row["source"] for row in rows if row["status"] == "blocked")
 

--- a/scripts/validation/check_uncertainty_source_readiness_issue_3557.py
+++ b/scripts/validation/check_uncertainty_source_readiness_issue_3557.py
@@ -1,0 +1,41 @@
+#!/usr/bin/env python3
+"""Print issue #3557 uncertainty-source episode-run readiness inventory."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from robot_sf.benchmark.uncertainty_source_readiness import (  # noqa: E402
+    build_uncertainty_source_readiness_inventory,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the readiness inventory CLI.
+
+    Returns:
+        int: ``1`` only when ``--fail-on-blocked`` is set and some source is blocked.
+    """
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fail-on-blocked",
+        action="store_true",
+        help="Exit 1 when any uncertainty source is not ready for episode-level runs.",
+    )
+    args = parser.parse_args(argv)
+
+    report = build_uncertainty_source_readiness_inventory()
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return int(bool(args.fail_on_blocked and report["blocked_sources"]))
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised through CLI tests when needed.
+    raise SystemExit(main())

--- a/tests/benchmark/test_uncertainty_source_readiness.py
+++ b/tests/benchmark/test_uncertainty_source_readiness.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import pytest
 
+import robot_sf.benchmark.uncertainty_source_readiness as readiness
 from robot_sf.benchmark.uncertainty_source_readiness import (
     UNCERTAINTY_SOURCE_READINESS_SCHEMA,
     UncertaintySourceRunSpec,
@@ -134,6 +135,58 @@ def test_inventory_requires_at_least_one_source() -> None:
 
     with pytest.raises(ValueError, match="at least one uncertainty source"):
         build_uncertainty_source_readiness_inventory([])
+
+
+def test_inventory_reuses_discovered_symbols_once(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Inventory discovery should happen once per report, not once per source."""
+
+    calls = {"builders": 0, "hooks": 0}
+
+    def discover_builders() -> frozenset[str]:
+        calls["builders"] += 1
+        return frozenset(
+            {
+                "_condition_existence_degraded",
+                "_condition_visibility_limited",
+                "_condition_covariance_inflated",
+                "_condition_class_probability",
+            }
+        )
+
+    def discover_hooks() -> frozenset[str]:
+        calls["hooks"] += 1
+        return frozenset({"build_belief_for_mode"})
+
+    monkeypatch.setattr(readiness, "_discover_condition_builders", discover_builders)
+    monkeypatch.setattr(readiness, "_discover_scenario_hooks", discover_hooks)
+
+    report = build_uncertainty_source_readiness_inventory()
+
+    assert report["ready_sources"] == ["existence_degraded"]
+    assert calls == {"builders": 1, "hooks": 1}
+
+
+def test_owner_import_failures_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Broken owner modules should make sources blocked, not crash the inventory CLI."""
+
+    def broken_import_module(module_name: str) -> object:
+        raise RuntimeError(f"{module_name} unavailable")
+
+    monkeypatch.setattr(readiness.importlib, "import_module", broken_import_module)
+
+    report = build_uncertainty_source_readiness_inventory(
+        [
+            UncertaintySourceRunSpec(
+                source="synthetic",
+                condition_builder="_condition_existence_degraded",
+                scenario_hook="build_belief_for_mode",
+            )
+        ]
+    )
+
+    assert report["all_sources_ready"] is False
+    assert report["blocked_sources"] == ["synthetic"]
+    assert report["sources"][0]["missing"] == ["condition_builder", "scenario_hook"]
 
 
 def test_cli_reports_inventory_and_can_fail_on_blocked(capsys: pytest.CaptureFixture[str]) -> None:

--- a/tests/benchmark/test_uncertainty_source_readiness.py
+++ b/tests/benchmark/test_uncertainty_source_readiness.py
@@ -170,7 +170,7 @@ def test_owner_import_failures_fail_closed(monkeypatch: pytest.MonkeyPatch) -> N
     """Broken owner modules should make sources blocked, not crash the inventory CLI."""
 
     def broken_import_module(module_name: str) -> object:
-        raise RuntimeError(f"{module_name} unavailable")
+        raise ImportError(f"{module_name} unavailable")
 
     monkeypatch.setattr(readiness.importlib, "import_module", broken_import_module)
 

--- a/tests/benchmark/test_uncertainty_source_readiness.py
+++ b/tests/benchmark/test_uncertainty_source_readiness.py
@@ -1,0 +1,147 @@
+"""Tests for issue #3557 uncertainty-source readiness inventory."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.uncertainty_source_readiness import (
+    UNCERTAINTY_SOURCE_READINESS_SCHEMA,
+    UncertaintySourceRunSpec,
+    build_uncertainty_source_readiness_inventory,
+    classify_uncertainty_source_readiness,
+)
+
+_SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "validation"
+    / "check_uncertainty_source_readiness_issue_3557.py"
+)
+_SPEC = importlib.util.spec_from_file_location("_issue_3557_readiness", _SCRIPT_PATH)
+assert _SPEC is not None
+_SCRIPT = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+_SPEC.loader.exec_module(_SCRIPT)
+
+
+def test_default_inventory_reports_readiness_without_running_benchmarks() -> None:
+    """Default inventory labels current hooks without executing episode runs."""
+
+    report = build_uncertainty_source_readiness_inventory()
+
+    assert report["schema_version"] == UNCERTAINTY_SOURCE_READINESS_SCHEMA
+    assert report["issue"] == 3557
+    assert report["claim_boundary"] == "readiness_inventory_only"
+    assert report["not_benchmark_evidence"] is True
+    assert report["runs_executed"] is False
+    assert report["surrogate_semantics_changed"] is False
+    assert report["all_sources_ready"] is False
+
+    by_source = {row["source"]: row for row in report["sources"]}
+    assert set(by_source) == {
+        "existence_degraded",
+        "visibility_limited",
+        "covariance_inflated",
+        "class_probability",
+        "tracking_noise",
+    }
+
+    assert by_source["existence_degraded"]["status"] == "ready"
+    assert by_source["existence_degraded"]["missing"] == []
+    assert by_source["visibility_limited"]["missing"] == ["scenario_hook"]
+    assert by_source["covariance_inflated"]["missing"] == ["scenario_hook"]
+    assert by_source["class_probability"]["missing"] == ["scenario_hook"]
+    assert by_source["tracking_noise"]["missing"] == ["condition_builder", "scenario_hook"]
+
+
+def test_supported_source_with_all_surrogate_outputs_is_ready() -> None:
+    """A source with known builder, hook, and output fields is runnable-ready."""
+
+    row = classify_uncertainty_source_readiness(
+        UncertaintySourceRunSpec(
+            source="synthetic",
+            condition_builder="_condition_existence_degraded",
+            scenario_hook="build_belief_for_mode",
+        )
+    )
+
+    assert row["status"] == "ready"
+    assert row["condition_builder_present"] is True
+    assert row["scenario_hook_present"] is True
+    assert row["expected_surrogate_outputs_present"] is True
+
+
+def test_unknown_condition_builder_fails_closed() -> None:
+    """A misspelled or not-yet-written builder blocks the source."""
+
+    row = classify_uncertainty_source_readiness(
+        UncertaintySourceRunSpec(
+            source="tracking_noise",
+            condition_builder="_condition_tracking_noise",
+            scenario_hook="build_belief_for_mode",
+        )
+    )
+
+    assert row["status"] == "blocked"
+    assert row["missing"] == ["condition_builder"]
+    assert row["condition_builder_present"] is False
+
+
+def test_missing_scenario_hook_fails_closed() -> None:
+    """Single-step condition builders alone are not episode-run readiness."""
+
+    row = classify_uncertainty_source_readiness(
+        UncertaintySourceRunSpec(
+            source="visibility_limited",
+            condition_builder="_condition_visibility_limited",
+            scenario_hook=None,
+        )
+    )
+
+    assert row["status"] == "blocked"
+    assert row["missing"] == ["scenario_hook"]
+    assert row["scenario_hook_present"] is False
+
+
+def test_missing_expected_surrogate_output_fails_closed() -> None:
+    """Future run specs must expose all fields consumed by the decision layer."""
+
+    row = classify_uncertainty_source_readiness(
+        UncertaintySourceRunSpec(
+            source="existence_degraded",
+            condition_builder="_condition_existence_degraded",
+            scenario_hook="build_belief_for_mode",
+            expected_surrogate_outputs=(
+                "source",
+                "retained_unsafe_commit_rate",
+                "dropped_unsafe_commit_rate",
+                "n_episodes",
+            ),
+        )
+    )
+
+    assert row["status"] == "blocked"
+    assert row["missing"] == ["expected_surrogate_outputs"]
+    assert row["missing_expected_surrogate_outputs"] == ["min_separation_delta_m"]
+
+
+def test_inventory_requires_at_least_one_source() -> None:
+    """An empty inventory would hide readiness gaps."""
+
+    with pytest.raises(ValueError, match="at least one uncertainty source"):
+        build_uncertainty_source_readiness_inventory([])
+
+
+def test_cli_reports_inventory_and_can_fail_on_blocked(capsys: pytest.CaptureFixture[str]) -> None:
+    """CLI prints JSON by default and can fail closed when blocked sources remain."""
+
+    assert _SCRIPT.main([]) == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["schema_version"] == UNCERTAINTY_SOURCE_READINESS_SCHEMA
+    assert "tracking_noise" in report["blocked_sources"]
+
+    assert _SCRIPT.main(["--fail-on-blocked"]) == 1


### PR DESCRIPTION
## Summary
Adds a diagnostic-only readiness inventory for issue #3557 uncertainty-source episode-level runs. The checker reports which requested sources currently have condition builders, episode scenario hooks, and surrogate output fields before any benchmark campaign is attempted.

## Linked Issues
- Relates to #3557
- Follow-up to #3471

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #3557 remains open for the actual parameterized runs
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `robot_sf.benchmark.uncertainty_source_readiness` with a versioned `uncertainty_source_readiness.v1` inventory and fail-closed source classification.
- Added `scripts/validation/check_uncertainty_source_readiness_issue_3557.py` to print the inventory as JSON, with optional `--fail-on-blocked` behavior.
- Added focused tests for supported and missing condition builders, scenario hooks, surrogate outputs, and CLI exit behavior.

## Why Matters
- Added value: unblocks #3557 planning by making current per-source readiness explicit.
- Expected impact: avoids burning benchmark or Slurm time on sources without episode-run hooks.
- Why worth merging now: it is a small readiness slice and does not claim uncertainty-source generalization.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution only; identifies current readiness gaps for #3557 per-source episode runs.
- Comparator or baseline, applicable: NA - no run comparison performed.
- Evidence tier: NA - support helper; no evidence-producing run or benchmark interpretation.
- Result classification: NA - support helper; readiness gaps are inventory output, not research evidence.
- Decision stop rule, applicable: sources are ready only when builder, hook, and surrogate outputs are present.
- Parent issue, claim map, registry, context note, synthesis surface update: #3557 PR description records this readiness boundary.
- New research/benchmark/metric/paper-facing analysis tool, any: support helper only; no metric semantics or benchmark interpretation added.

## Domain-Aware Approval
Required PR: yes - waived because this is a readiness support helper with no benchmark result or metric-semantics claim.
Domains reviewed: uncertainty-source readiness inventory, benchmark fallback/degraded exclusion boundary.
Status: waived for readiness-only PR body; Claude Code owns full PR gate after open per task authorization.
Approver/review source waiver: maintainer task scope explicitly requests readiness inventory only and forbids full benchmark/generalization claims in this slice.
Approval or blocker note: waiver for readiness-only support helper; no benchmark campaign, metric semantics, or generalization claim is introduced.
Target claim/hypothesis: no uncertainty-source generalization claim; only inventory whether source builders, hooks, and expected outputs exist.
Comparator or split/evidence validity: no comparator split analyzed; checker reports readiness gaps before any retained-vs-dropped run.
Fallback/degraded exclusions: no fallback or degraded benchmark execution is counted as evidence; no benchmark run executed.
Claim boundary: readiness inventory only, not benchmark evidence, not paper/dissertation evidence.
Implementation integrity vs experimental validity: implementation verifies static contracts and CLI JSON; experimental validity remains deferred to future #3557 runs.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no benchmark mechanism run.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3557 remains the follow-up for actual parameterized runs.

## Next Empirical Action
- Rerun needed: yes, but deferred to #3557 follow-up work after missing episode hooks/builders are filled.
- Extractor analysis tool needed: no
- Artifact missing unavailable: no durable run artifact expected from this PR.
- Stop / revise / continue decision: continue readiness work before benchmark execution.
- Proposed child issue existing follow-up: #3557

## Validation / Proof
- `uv run pytest tests/benchmark/test_uncertainty_source_readiness.py` -> 7 passed.
- `uv run ruff check robot_sf/benchmark/uncertainty_source_readiness.py tests/benchmark/test_uncertainty_source_readiness.py scripts/validation/check_uncertainty_source_readiness_issue_3557.py` -> passed.
- `uv run ruff format --check robot_sf/benchmark/uncertainty_source_readiness.py tests/benchmark/test_uncertainty_source_readiness.py scripts/validation/check_uncertainty_source_readiness_issue_3557.py` -> passed after formatting.
- `uv run python scripts/validation/check_uncertainty_source_readiness_issue_3557.py | python -m json.tool >/tmp/issue3557_readiness.json` -> valid JSON; `ready_sources=[existence_degraded]`, `blocked_sources=[class_probability,covariance_inflated,tracking_noise,visibility_limited]`, `runs_executed=False`, `claim_boundary=readiness_inventory_only`.
- `PR_READY_PR_BODY_FILE=/tmp/issue3557_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> pending at PR open time.

Explicit out-of-scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Runtime / Performance
- Baseline runtime: NA - no runtime/performance claim.
- Changed runtime: NA - no runtime/performance claim.
- Representative command: `uv run python scripts/validation/check_uncertainty_source_readiness_issue_3557.py`
- Hot-path call count profile anchor: NA - static readiness inventory helper.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_uncertainty_source_readiness_issue_3557.py` emitted readiness JSON: ready `existence_degraded`; blocked `class_probability`, `covariance_inflated`, `tracking_noise`, `visibility_limited`.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_uncertainty_source_readiness_issue_3557.py --fail-on-blocked` exited 1 as expected.
- Local PR body contract check passed via `scripts/dev/check_pr_followups.py` with #3557 as the linked deferred issue.
- `uv run python scripts/validation/check_broad_exceptions.py` passed after narrowing owner discovery failure handling to import/syntax failures.
- Cache-hit reuse counter: NA when no caching claimed.
- Rollback failure criterion: revert if checker misclassifies missing builders/hooks or starts executing benchmark episodes.

## Risks / Rollout
- Compatibility risks: low; new helper and validation script only.
- Failure modes: static inventory may need updates as #3557 adds new hooks.
- Rollback fallback plan: remove helper/script/tests.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3557, #3471, #3450/#2546 diagnostic condition builders.
- Any assumptions need to preserved: readiness is diagnostic inventory only, not benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; issue comments not authorized in this task.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR does not add benchmark results, registry entries, paper-facing claims, or durable artifacts.

## Follow-Up Issues
- Deferred work: implement missing episode scenario hooks/builders, then run the parameterized per-source #3557 episode evidence path.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that the checker remains import/static inventory only and does not run #3471 or benchmark episodes.
- Known limitation: only `existence_degraded` is currently ready; this is intentionally reported as a blocker, not fixed here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a readiness inventory report for uncertainty-source runs, showing which sources are ready or blocked.
  * Added a command-line check that prints the inventory as JSON and can fail when blocked sources are found.

* **Bug Fixes**
  * Improved validation by clearly reporting missing builders, hooks, and required outputs for each source.
  * Added safeguards for empty source lists and invalid readiness configurations.

* **Tests**
  * Added coverage for report structure, readiness outcomes, blocking scenarios, and CLI exit behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

