### PR TITLE
training: add issue #3254 predictive retrain provenance preflight

### DIFF
--- a/configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
+++ b/configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
@@ -18,6 +18,12 @@ claim_boundary: >
 output:
   root: output/tmp/predictive_planner/pipeline
 
+provenance:
+  status: expected_missing_until_training
+  checkpoint_path: output/tmp/predictive_planner/pipeline/training/predictive_crossing_conflict_weighted_issue_3254_xl_ego/predictive_model.pt
+  checkpoint_provenance_path: output/tmp/predictive_planner/pipeline/training/predictive_crossing_conflict_weighted_issue_3254_xl_ego/checkpoint_provenance.json
+  hard_seed_evaluation_summary: output/tmp/predictive_planner/pipeline/evaluation/predictive_crossing_conflict_weighted_issue_3254_xl_ego_hard_seeds/summary.json
+
 scenarios:
   scenario_matrix: ../../scenarios/classic_interactions.yaml
   hard_seed_manifest: ../../benchmarks/predictive_hard_seeds_v1.yaml
@@ -79,6 +85,8 @@ wandb:
     - prepare-only
 
 evaluation:
+  baseline_model_id: predictive_proxy_selected_v1
+  baseline_algo_config: ../../algos/gap_prediction_camera_ready.yaml
   workers: 1
   campaign_workers: 2
   horizon: 120

--- a/robot_sf/training/predictive_retrain_preflight.py
+++ b/robot_sf/training/predictive_retrain_preflight.py
@@ -342,7 +342,13 @@ def _validate_evaluation_algo_config(
     if not path.is_file():
         errors.append(f"evaluation.baseline_algo_config does not exist: {value}")
         return None
-    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    payload = _load_yaml_mapping_for_preflight(
+        path,
+        label=f"evaluation.baseline_algo_config {value}",
+        errors=errors,
+    )
+    if payload is None:
+        return path
     if not isinstance(payload, dict):
         errors.append(f"evaluation.baseline_algo_config must be YAML mapping: {value}")
         return path
@@ -362,13 +368,41 @@ def _validate_registry_model_id(repo_root: Path, model_id: Any, errors: list[str
     if not registry_path.is_file():
         errors.append(f"model registry missing for evaluation baseline: {registry_path}")
         return
-    payload = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    payload = _load_yaml_mapping_for_preflight(
+        registry_path,
+        label="model registry",
+        errors=errors,
+    )
+    if payload is None:
+        return
     models = payload.get("models") if isinstance(payload, dict) else None
     if not isinstance(models, list):
         errors.append(f"model registry missing models list: {registry_path}")
         return
     if not any(isinstance(model, dict) and model.get("model_id") == model_id for model in models):
         errors.append(f"evaluation.baseline_model_id not found in model registry: {model_id}")
+
+
+def _load_yaml_mapping_for_preflight(
+    path: Path,
+    *,
+    label: str,
+    errors: list[str],
+) -> dict[str, Any] | None:
+    """Load referenced YAML mapping while preserving preflight error aggregation.
+
+    Returns:
+        Parsed mapping, or ``None`` when read/parse/type validation fails.
+    """
+    try:
+        payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, yaml.YAMLError) as exc:
+        errors.append(f"{label} is not readable as valid YAML: {exc}")
+        return None
+    if not isinstance(payload, dict):
+        errors.append(f"{label} must be YAML mapping")
+        return None
+    return payload
 
 
 def _validate_provenance(

--- a/robot_sf/training/predictive_retrain_preflight.py
+++ b/robot_sf/training/predictive_retrain_preflight.py
@@ -36,6 +36,12 @@ _REQUIRED_SCENARIO_REFERENCES = (
 
 # Evaluation keys the pipeline reads when wiring final eval / hard-seed campaign.
 _REQUIRED_EVALUATION_KEYS = ("workers", "horizon", "dt")
+_EXPECTED_BASELINE_MODEL_ID = "predictive_proxy_selected_v1"
+_EXPECTED_PROVENANCE_KEYS = (
+    "checkpoint_path",
+    "checkpoint_provenance_path",
+    "hard_seed_evaluation_summary",
+)
 
 
 class PredictiveRetrainPreflightError(ValueError):
@@ -86,7 +92,8 @@ def validate_retrain_preflight(
     feature_contract = _validate_feature_compatibility(config, errors)
     mixing = _validate_mixing(config, config_dir, errors)
     training = _validate_training(config, errors)
-    evaluation = _validate_evaluation(config, errors)
+    evaluation = _validate_evaluation(config, config_dir, root, errors)
+    provenance = _validate_provenance(config, root, errors)
     output_root = _validate_output(config, errors)
 
     if errors:
@@ -105,6 +112,7 @@ def validate_retrain_preflight(
         "mixing": mixing,
         "training": training,
         "evaluation": evaluation,
+        "provenance": provenance,
         "output_root": output_root,
     }
 
@@ -284,14 +292,118 @@ def _validate_training(config: dict[str, Any], errors: list[str]) -> dict[str, A
     return {"model_id": model_id}
 
 
-def _validate_evaluation(config: dict[str, Any], errors: list[str]) -> dict[str, Any] | None:
+def _validate_evaluation(
+    config: dict[str, Any],
+    config_dir: Path,
+    repo_root: Path,
+    errors: list[str],
+) -> dict[str, Any] | None:
     evaluation = _require_mapping(config, "evaluation", errors)
     if evaluation is None:
         return None
     for key in _REQUIRED_EVALUATION_KEYS:
         if key not in evaluation:
-            errors.append(f"evaluation.{key} is required")
-    return {"keys": sorted(k for k in _REQUIRED_EVALUATION_KEYS if k in evaluation)}
+            errors.append(f"evaluation.{key} required")
+
+    baseline_model_id = _require_non_empty_string(evaluation, "baseline_model_id", errors)
+    if baseline_model_id and baseline_model_id != _EXPECTED_BASELINE_MODEL_ID:
+        errors.append(
+            "evaluation.baseline_model_id must be "
+            f"{_EXPECTED_BASELINE_MODEL_ID!r} for issue #3254 lineage"
+        )
+
+    algo_config_path = _validate_evaluation_algo_config(
+        evaluation=evaluation,
+        config_dir=config_dir,
+        expected_model_id=baseline_model_id,
+        errors=errors,
+    )
+    _validate_registry_model_id(repo_root, baseline_model_id, errors)
+
+    return {
+        "keys": sorted(k for k in _REQUIRED_EVALUATION_KEYS if k in evaluation),
+        "baseline_model_id": baseline_model_id,
+        "baseline_algo_config": str(algo_config_path) if algo_config_path is not None else None,
+    }
+
+
+def _validate_evaluation_algo_config(
+    *,
+    evaluation: dict[str, Any],
+    config_dir: Path,
+    expected_model_id: Any,
+    errors: list[str],
+) -> Path | None:
+    value = evaluation.get("baseline_algo_config")
+    if not isinstance(value, str) or not value.strip():
+        errors.append("evaluation.baseline_algo_config must be non-empty path string")
+        return None
+    path = _resolve_path(value, config_dir)
+    if not path.is_file():
+        errors.append(f"evaluation.baseline_algo_config does not exist: {value}")
+        return None
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        errors.append(f"evaluation.baseline_algo_config must be YAML mapping: {value}")
+        return path
+    config_model_id = payload.get("predictive_model_id")
+    if expected_model_id and config_model_id != expected_model_id:
+        errors.append(
+            "evaluation.baseline_algo_config predictive_model_id must match "
+            f"evaluation.baseline_model_id: {config_model_id!r} != {expected_model_id!r}"
+        )
+    return path
+
+
+def _validate_registry_model_id(repo_root: Path, model_id: Any, errors: list[str]) -> None:
+    if not model_id:
+        return
+    registry_path = repo_root / "model" / "registry.yaml"
+    if not registry_path.is_file():
+        errors.append(f"model registry missing for evaluation baseline: {registry_path}")
+        return
+    payload = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    models = payload.get("models") if isinstance(payload, dict) else None
+    if not isinstance(models, list):
+        errors.append(f"model registry missing models list: {registry_path}")
+        return
+    if not any(isinstance(model, dict) and model.get("model_id") == model_id for model in models):
+        errors.append(f"evaluation.baseline_model_id not found in model registry: {model_id}")
+
+
+def _validate_provenance(
+    config: dict[str, Any],
+    repo_root: Path,
+    errors: list[str],
+) -> dict[str, Any] | None:
+    provenance = _require_mapping(config, "provenance", errors)
+    if provenance is None:
+        return None
+
+    resolved: dict[str, str] = {}
+    missing_artifacts: list[str] = []
+    for key in _EXPECTED_PROVENANCE_KEYS:
+        value = provenance.get(key)
+        if not isinstance(value, str) or not value.strip():
+            errors.append(f"provenance.{key} must be non-empty path string")
+            continue
+        path = _resolve_path(value, repo_root)
+        resolved[key] = str(path)
+        if not path.exists():
+            missing_artifacts.append(str(path))
+
+    status = provenance.get("status")
+    if status != "expected_missing_until_training":
+        errors.append(
+            "provenance.status must be 'expected_missing_until_training' for "
+            "prepare-only issue #3254 preflight"
+        )
+
+    return {
+        "status": status,
+        "paths": resolved,
+        "missing_artifacts": missing_artifacts,
+    }
 
 
 def _validate_output(config: dict[str, Any], errors: list[str]) -> str | None:

--- a/tests/training/test_predictive_retrain_preflight.py
+++ b/tests/training/test_predictive_retrain_preflight.py
@@ -232,6 +232,18 @@ def test_baseline_algo_config_must_be_mapping(tmp_path: Path) -> None:
         validate_retrain_preflight(path, repo_root=tmp_path)
 
 
+def test_invalid_baseline_algo_config_yaml_is_collected(tmp_path: Path) -> None:
+    """Invalid baseline algo YAML reported as preflight error."""
+    config = _base_config(tmp_path)
+    (tmp_path / "algo.yaml").write_text("predictive_model_id: [\n", encoding="utf-8")
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError) as exc_info:
+        validate_retrain_preflight(path, repo_root=tmp_path)
+    message = str(exc_info.value)
+    assert "evaluation.baseline_algo_config" in message
+    assert "not readable as valid YAML" in message
+
+
 def test_baseline_registry_must_have_models_list(tmp_path: Path) -> None:
     """Registry has to expose a models list for baseline lineage lookup."""
     config = _base_config(tmp_path)
@@ -239,6 +251,18 @@ def test_baseline_registry_must_have_models_list(tmp_path: Path) -> None:
     path = _write_config(tmp_path, config)
     with pytest.raises(PredictiveRetrainPreflightError, match="models list"):
         validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_invalid_baseline_registry_yaml_is_collected(tmp_path: Path) -> None:
+    """Invalid model registry YAML reported as preflight error."""
+    config = _base_config(tmp_path)
+    (tmp_path / "model" / "registry.yaml").write_text("models: [\n", encoding="utf-8")
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError) as exc_info:
+        validate_retrain_preflight(path, repo_root=tmp_path)
+    message = str(exc_info.value)
+    assert "model registry" in message
+    assert "not readable as valid YAML" in message
 
 
 def test_baseline_registry_must_contain_model_id(tmp_path: Path) -> None:

--- a/tests/training/test_predictive_retrain_preflight.py
+++ b/tests/training/test_predictive_retrain_preflight.py
@@ -32,6 +32,16 @@ def _base_config(tmp_path: Path) -> dict[str, object]:
     (tmp_path / "scenarios.yaml").write_text("- name: a\n", encoding="utf-8")
     (tmp_path / "hard_seeds.yaml").write_text("a: [1, 2]\n", encoding="utf-8")
     (tmp_path / "planner_grid.yaml").write_text("variants: []\n", encoding="utf-8")
+    (tmp_path / "algo.yaml").write_text(
+        "predictive_model_id: predictive_proxy_selected_v1\n",
+        encoding="utf-8",
+    )
+    registry_dir = tmp_path / "model"
+    registry_dir.mkdir()
+    (registry_dir / "registry.yaml").write_text(
+        yaml.safe_dump({"models": [{"model_id": "predictive_proxy_selected_v1"}]}),
+        encoding="utf-8",
+    )
     (tmp_path / "weighting.yaml").write_text(
         yaml.safe_dump(
             {
@@ -49,6 +59,12 @@ def _base_config(tmp_path: Path) -> dict[str, object]:
         "model_family": "predictive_ego_v1",
         "experiment": {"run_id": "demo_crossing_conflict"},
         "output": {"root": "output/tmp/predictive_planner/pipeline"},
+        "provenance": {
+            "status": "expected_missing_until_training",
+            "checkpoint_path": "output/tmp/predictive_planner/pipeline/training/demo/predictive_model.pt",
+            "checkpoint_provenance_path": "output/tmp/predictive_planner/pipeline/training/demo/checkpoint_provenance.json",
+            "hard_seed_evaluation_summary": "output/tmp/predictive_planner/pipeline/evaluation/demo_hard_seeds/summary.json",
+        },
         "scenarios": {
             "scenario_matrix": "scenarios.yaml",
             "hard_seed_manifest": "hard_seeds.yaml",
@@ -63,7 +79,13 @@ def _base_config(tmp_path: Path) -> dict[str, object]:
             "max_val_ade": 1.0,
             "max_val_fde": 1.8,
         },
-        "evaluation": {"workers": 1, "horizon": 120, "dt": 0.1},
+        "evaluation": {
+            "baseline_model_id": "predictive_proxy_selected_v1",
+            "baseline_algo_config": "algo.yaml",
+            "workers": 1,
+            "horizon": 120,
+            "dt": 0.1,
+        },
     }
 
 
@@ -81,6 +103,9 @@ def test_real_crossing_conflict_config_passes() -> None:
     assert report["feature_compatibility"]["ego_conditioning"] is True
     assert report["mixing"]["weighting_rule"] == "repeat_hardcase_rows"
     assert report["mixing"]["hardcase_family"] == "crossing_conflict"
+    assert report["evaluation"]["baseline_model_id"] == "predictive_proxy_selected_v1"
+    assert report["provenance"]["status"] == "expected_missing_until_training"
+    assert len(report["provenance"]["missing_artifacts"]) == 3
 
 
 def test_minimal_config_passes(tmp_path: Path) -> None:
@@ -148,6 +173,101 @@ def test_missing_evaluation_block_fails(tmp_path: Path) -> None:
     path = _write_config(tmp_path, config)
     with pytest.raises(PredictiveRetrainPreflightError, match="evaluation must be a mapping"):
         validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_missing_baseline_algo_config_fails(tmp_path: Path) -> None:
+    """Evaluation must name an explicit algo config; no implicit fallback."""
+    config = _base_config(tmp_path)
+    config["evaluation"]["baseline_algo_config"] = "missing.yaml"  # type: ignore[index]
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError, match="baseline_algo_config"):
+        validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_baseline_algo_config_must_match_lineage(tmp_path: Path) -> None:
+    """Baseline algo config must point at the expected predictive v1 model."""
+    config = _base_config(tmp_path)
+    (tmp_path / "algo.yaml").write_text(
+        "predictive_model_id: predictive_proxy_selected_v2_full\n",
+        encoding="utf-8",
+    )
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError, match="predictive_model_id"):
+        validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_missing_provenance_block_fails(tmp_path: Path) -> None:
+    """Expected checkpoint/provenance paths are required even before training."""
+    config = _base_config(tmp_path)
+    del config["provenance"]
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError, match="provenance must be a mapping"):
+        validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_missing_required_evaluation_key_fails(tmp_path: Path) -> None:
+    """Evaluation block must include runner settings pipeline expects."""
+    config = _base_config(tmp_path)
+    del config["evaluation"]["horizon"]  # type: ignore[index]
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError, match="evaluation.horizon required"):
+        validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_baseline_model_id_must_be_issue_3254_lineage(tmp_path: Path) -> None:
+    """Baseline lineage is pinned to predictive_proxy_selected_v1."""
+    config = _base_config(tmp_path)
+    config["evaluation"]["baseline_model_id"] = "predictive_proxy_selected_v2_full"  # type: ignore[index]
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError, match="baseline_model_id"):
+        validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_baseline_algo_config_must_be_mapping(tmp_path: Path) -> None:
+    """Algo config path must load as a YAML mapping."""
+    config = _base_config(tmp_path)
+    (tmp_path / "algo.yaml").write_text("- not\n- mapping\n", encoding="utf-8")
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError, match="YAML mapping"):
+        validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_baseline_registry_must_have_models_list(tmp_path: Path) -> None:
+    """Registry has to expose a models list for baseline lineage lookup."""
+    config = _base_config(tmp_path)
+    (tmp_path / "model" / "registry.yaml").write_text("version: 1\n", encoding="utf-8")
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError, match="models list"):
+        validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_baseline_registry_must_contain_model_id(tmp_path: Path) -> None:
+    """Baseline model id must be present in the registry."""
+    config = _base_config(tmp_path)
+    (tmp_path / "model" / "registry.yaml").write_text(
+        yaml.safe_dump({"models": [{"model_id": "other"}]}),
+        encoding="utf-8",
+    )
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError, match="not found in model registry"):
+        validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_provenance_fields_and_status_are_required(tmp_path: Path) -> None:
+    """Expected output artifacts are declared and labelled prepare-only."""
+    config = _base_config(tmp_path)
+    config["provenance"] = {
+        "status": "available",
+        "checkpoint_path": "",
+        "checkpoint_provenance_path": "prov.json",
+    }
+    path = _write_config(tmp_path, config)
+    with pytest.raises(PredictiveRetrainPreflightError) as exc_info:
+        validate_retrain_preflight(path, repo_root=tmp_path)
+    message = str(exc_info.value)
+    assert "provenance.checkpoint_path" in message
+    assert "provenance.hard_seed_evaluation_summary" in message
+    assert "expected_missing_until_training" in message
 
 
 def test_missing_output_root_fails(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds a static preflight/provenance check for issue #3254 crossing-conflict weighted predictive retraining readiness. This is a prepare-only PR: it validates the #3214 weighting spec wiring, the expected `predictive_proxy_selected_v1` baseline lineage, the explicit algo config, and expected checkpoint/evaluation artifact paths without running training.

## Linked Issues
- Relates to `#3254`
- Relates to `#3214`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: `#3254` remains open for the authorized SLURM/GPU training/evaluation lane
- Safe to review independently: yes
- Review dependency reason, any: support-tooling slice only; no scheduler or model artifact dependency

## What Changed
- Added explicit issue #3254 provenance fields to `configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml`, including expected missing checkpoint/provenance/evaluation-summary paths.
- Extended `robot_sf.training.predictive_retrain_preflight` to require the `predictive_proxy_selected_v1` evaluation baseline, validate the declared algo config resolves to that model, confirm the baseline exists in `model/registry.yaml`, and report missing expected output artifacts.
- Expanded focused tests with synthetic path fixtures for baseline config presence, baseline lineage mismatch, provenance block presence, and the committed #3254 config report.

## Why Matters
- Added value: catches missing or mismatched retraining launch lineage before any GPU/SLURM budget is used.
- Expected impact: better diagnostics for the next #3254 worker without claiming a retrained model exists.
- Why worth merging now: the issue is blocked on artifact/training readiness; this narrows the next launch packet failure modes.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for #3254 launch provenance preflight only.
- Comparator or baseline, applicable: `predictive_proxy_selected_v1` lineage declared and checked via `configs/algos/gap_prediction_camera_ready.yaml`.
- Evidence tier: NA - support preflight; validation is static contract checking only.
- Result classification: NA - support preflight; no empirical result classification.
- Decision stop rule, applicable: preflight must fail closed when baseline config, registry lineage, or provenance declarations are absent or mismatched.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue remains open; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support preflight; no result interpretation.

## Domain-Aware Approval
Required PR: domain-aware approval required; waived because this PR is static launch preflight only and makes no empirical result claim.
Required: domain-aware approval required; waived because this PR is static launch preflight only and makes no empirical result claim.
Domains reviewed: predictive retraining launch provenance, baseline lineage, artifact policy
Status: waived - no model-improvement, benchmark, metric, or paper/dissertation claim is made in this PR.
Approver/review source waiver: Maintainer task authorization scoped this PR to prepare-only preflight/provenance checks; Claude Code on `imech156-u` owns the full PR gate and any later empirical approval cycle.
- Target claim/hypothesis: launch packet integrity only; no empirical model-performance hypothesis is accepted here.
- Comparator or split/evidence validity: static check that the declared evaluation baseline is `predictive_proxy_selected_v1` and that the explicit algo config resolves to the same model.
- Fallback/degraded exclusions: no benchmark run; fallback/degraded execution is not used as evidence.
- Claim boundary: no checkpoint, hard-seed evaluation result, model improvement, paper-facing claim, or dissertation claim.
- Implementation integrity vs experimental validity: focused tests validate the preflight contract; empirical validity is deferred to compute-authorized #3254 work.


## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no training/evaluation mechanism run.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: #3254 remains the follow-up for actual training and hard-seed evaluation.

## Next Empirical Action
- Rerun needed: yes, but outside this PR: authorized SLURM/GPU training/evaluation under #3254.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: expected retrained checkpoint, checkpoint provenance JSON, and hard-seed evaluation summary are intentionally reported missing until training runs.
- Stop / revise / continue decision: continue to compute-authorized lane after review.
- Proposed child issue existing follow-up: #3254.

## Validation / Proof
- `git diff --check` passed.
- `uv run ruff format robot_sf/training/predictive_retrain_preflight.py tests/training/test_predictive_retrain_preflight.py` passed; 2 files left unchanged.
- `uv run ruff check robot_sf/training/predictive_retrain_preflight.py tests/training/test_predictive_retrain_preflight.py` passed at head `278136230`.
- `uv run pytest tests/training/test_predictive_retrain_preflight.py -q` passed: 24 tests at head `278136230`.
- `uv run python scripts/validation/validate_predictive_retrain_preflight.py --config configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml --repo-root . --json` passed and reported status `valid`, baseline `predictive_proxy_selected_v1`, and three expected missing artifacts.
- `scripts/dev/run_worktree_shared_venv.sh --venv /home/luttkule/git/robot_sf_ll7/.venv -- uv run pytest tests/training -q` passed via shared worktree virtualenv at head `278136230`; direct fresh-worktree `uv run pytest tests/training -q` failed during collection because that local `.venv` lacked optional training extras (`torch`, `stable_baselines3`, `optuna`, `sqlalchemy`).
- `uv run python scripts/dev/check_pr_followups.py --body-file /tmp/pr-3784-body.md --changed-files-file /tmp/pr-3784-files.txt --require-body --require-substantive-body --require-open-issues` passed at head `278136230`.
- No full benchmark campaign run, no SLURM/GPU submission, no paper/dissertation claim edits.

## Runtime / Performance
- Baseline runtime: NA - static preflight only.
- Changed runtime: focused tests completed in about 8 seconds locally via shared worktree venv.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_predictive_retrain_preflight.py -q`.
- Hot-path call count profile anchor: NA - no runtime hot path changed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: preflight blocks a valid declared #3254 launch config or permits mismatched baseline lineage.

## Risks / Rollout
- Compatibility risks: issue-specific expectation pins `predictive_proxy_selected_v1`; update the preflight if #3254 is intentionally re-scoped to a newer baseline.
- Failure modes: future trained artifacts will still be reported missing until the config/provenance status is updated after compute-authorized training.
- Rollback fallback plan: revert this PR and use the prior minimal preflight, with weaker lineage diagnostics.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3254 and #3214 config comments.
- Any assumptions need to preserved: this PR assumes the next lane should validate against `predictive_proxy_selected_v1` exactly, per issue #3254.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comment authorization is false for this task.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): no registry entry changed.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no; #3254 remains open.
- Not applicable because: no benchmark result, model artifact, registry promotion, or paper-facing claim is produced.

## Follow-Up Issues
- Deferred work: compute-authorized #3254 training, checkpoint provenance capture, and hard-seed evaluation.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the static preflight should remain pinned to `predictive_proxy_selected_v1` rather than the newer v2 camera-ready predictive configs.
- Known limitation: expected artifacts are diagnostics only; this PR does not create or validate a retrained checkpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter retraining preflight checks for evaluation baseline lineage and artifact provenance.
  * Retraining configs can now include explicit baseline comparison settings and expected missing-artifact status.

* **Bug Fixes**
  * Improved validation so misconfigured baseline references, missing provenance details, and invalid registry entries are caught before retraining starts.
  * Added clearer safeguards to ensure expected model and evaluation artifacts are correctly linked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


