### PR TITLE
Tighten Package B preflight seed parity for issue #3079

### DIFF
--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -121,6 +121,28 @@ def _extract_output_paths(
     return output_dir, out_json, warnings
 
 
+def _extract_repeated_seed_args(command: str) -> tuple[tuple[int, ...], list[str]]:
+    warnings: list[str] = []
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        warnings.append(f"example_command could not shlex: {exc}")
+        return (), warnings
+
+    seed_args: list[int] = []
+    for index, token in enumerate(tokens):
+        if token != "--seed":
+            continue
+        if index + 1 >= len(tokens):
+            warnings.append("example_command has --seed without value")
+            continue
+        try:
+            seed_args.append(int(tokens[index + 1]))
+        except ValueError:
+            warnings.append(f"example_command has non-integer --seed value: {tokens[index + 1]!r}")
+    return tuple(seed_args), warnings
+
+
 def _under_output_prefix(path: Path | None, repo_root: Path) -> bool:
     if path is None:
         return False
@@ -268,6 +290,15 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
         if not checks[f"example_command_seed_{seed}"]:
             blockers.append(f"example_command missing --seed {seed}")
 
+    command_seeds, seed_warnings = _extract_repeated_seed_args(example_command)
+    warnings.extend(seed_warnings)
+    checks["example_command_repeated_seeds"] = command_seeds == seeds
+    if not checks["example_command_repeated_seeds"]:
+        blockers.append(
+            "example_command --seed values must exactly match repeated_seeds "
+            f"{list(seeds)}, got {list(command_seeds)}"
+        )
+
     output_dir, out_json, output_warnings = _extract_output_paths(example_command, root)
     warnings.extend(output_warnings)
     checks["output_dir_under_issue_path"] = _under_output_prefix(output_dir, root)
@@ -281,6 +312,7 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
         "issue": EXPECTED_ISSUE,
         "budget_grid": list(budgets),
         "repeated_seeds": list(seeds),
+        "example_command_repeated_seeds": list(command_seeds),
         "samplers": list(samplers),
         "runner": _repo_relative(runner_path, root) if runner_path else None,
         "output_dir": _repo_relative(output_dir, root) if output_dir else None,

--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -131,15 +131,20 @@ def _extract_repeated_seed_args(command: str) -> tuple[tuple[int, ...], list[str
 
     seed_args: list[int] = []
     for index, token in enumerate(tokens):
-        if token != "--seed":
+        if token == "--seed":
+            if index + 1 >= len(tokens):
+                warnings.append("example_command has --seed without value")
+                continue
+            seed_value = tokens[index + 1]
+        elif token.startswith("--seed="):
+            seed_value = token.removeprefix("--seed=")
+        else:
             continue
-        if index + 1 >= len(tokens):
-            warnings.append("example_command has --seed without value")
-            continue
+
         try:
-            seed_args.append(int(tokens[index + 1]))
+            seed_args.append(int(seed_value))
         except ValueError:
-            warnings.append(f"example_command has non-integer --seed value: {tokens[index + 1]!r}")
+            warnings.append(f"example_command has non-integer --seed value: {seed_value!r}")
     return tuple(seed_args), warnings
 
 
@@ -286,7 +291,9 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
         blockers.append("example_command must use --package-b-budget-grid")
 
     for seed in seeds:
-        checks[f"example_command_seed_{seed}"] = f"--seed {seed}" in example_command
+        checks[f"example_command_seed_{seed}"] = (
+            f"--seed {seed}" in example_command or f"--seed={seed}" in example_command
+        )
         if not checks[f"example_command_seed_{seed}"]:
             blockers.append(f"example_command missing --seed {seed}")
 

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -125,6 +125,25 @@ def test_preflight_blocks_example_command_seed_drift(tmp_path: Path) -> None:
     assert any("example_command --seed values" in blocker for blocker in result.blockers)
 
 
+def test_preflight_accepts_equals_form_example_command_seed_args(tmp_path: Path) -> None:
+    """The seed parser should mirror argparse's --seed=value spelling."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--package-b-budget-grid --seed=1101 --seed=2202 --seed=3303 "
+        "--output-dir output/adversarial/issue_3079_package_b "
+        "--out-json output/adversarial/issue_3079_package_b/report.json"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is True
+    assert result.checks["example_command_repeated_seeds"] is True
+    assert result.metadata["example_command_repeated_seeds"] == [1101, 2202, 3303]
+
+
 def test_preflight_blocks_example_command_without_package_b_budget_grid(tmp_path: Path) -> None:
     """The example command must opt into the fixed package-B budget grid."""
     manifest = _base_manifest(tmp_path)

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -105,6 +105,66 @@ def test_preflight_fails_closed_for_missing_budget_seed_and_provenance(tmp_path:
     assert any("paper_facing_success_claims" in blocker for blocker in result.blockers)
 
 
+def test_preflight_blocks_example_command_seed_drift(tmp_path: Path) -> None:
+    """The executable seed plan must match manifest repeated_seeds."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--package-b-budget-grid --seed 1101 --seed 2202 --seed 4404 "
+        "--output-dir output/adversarial/issue_3079_package_b "
+        "--out-json output/adversarial/issue_3079_package_b/report.json"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["example_command_repeated_seeds"] is False
+    assert any("example_command --seed values" in blocker for blocker in result.blockers)
+
+
+def test_preflight_blocks_example_command_without_package_b_budget_grid(tmp_path: Path) -> None:
+    """The example command must opt into the fixed package-B budget grid."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--budget 16 --budget 32 --budget 64 --seed 1101 --seed 2202 --seed 3303 "
+        "--output-dir output/adversarial/issue_3079_package_b "
+        "--out-json output/adversarial/issue_3079_package_b/report.json"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["example_command_uses_package_b_grid"] is False
+    assert any("--package-b-budget-grid" in blocker for blocker in result.blockers)
+
+
+def test_preflight_warns_for_malformed_example_command_seed_args(tmp_path: Path) -> None:
+    """Malformed command seed flags are warnings plus fail-closed blockers."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--package-b-budget-grid --seed not-an-int --seed "
+        "--output-dir output/adversarial/issue_3079_package_b "
+        "--out-json output/adversarial/issue_3079_package_b/report.json --seed"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.checks["example_command_repeated_seeds"] is False
+    assert any("non-integer --seed value" in warning for warning in result.warnings)
+    assert any("--seed without value" in warning for warning in result.warnings)
+
+
 def test_preflight_raises_filenotfound_for_missing_manifest(tmp_path: Path) -> None:
     """Missing manifest path raises before producing cascading blockers."""
     manifest = tmp_path / "configs/adversarial/missing_package_b_manifest.yaml"


### PR DESCRIPTION
## Summary
Tightens the issue #3079 Package B preflight so the executable example command must carry the same repeated seed plan declared in the manifest.

## Linked Issues
- Relates `#3079`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added exact parsing of `example_command` `--seed` arguments in `robot_sf/benchmark/adversarial_package_b_preflight.py`.
- Added focused synthetic tests for seed-plan drift and missing Package B budget-grid opt-in.

## Why Matters
- Added value: catches a readiness/provenance mismatch before anyone launches the budget-matched Package B command.
- Expected impact: fail-closed preflight remains a support gate only.
- Why worth merging now: issue #3079 is still open for the actual campaign, and this keeps the readiness contract tighter without running benchmarks.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: readiness/provenance blocker for issue #3079 Package B launch packet.
- Comparator or baseline, applicable: NA - support helper.
- Evidence tier: NA - support/preflight helper; no benchmark result claimed.
- Result classification: NA - no research result.
- Decision stop rule, applicable: NA - no campaign executed.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue remains open for the full campaign.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - preflight checker only; it does not interpret research evidence.

## Domain-Aware Approval
- Approver/review source waiver: not required - no evidence classification, benchmark interpretation, or paper-facing claim changes.
- Validity checklist: NA - support/preflight helper.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: NA - no rows generated.
- Claim boundary: support/preflight only.
- Implementation integrity vs experimental validity: implementation tests prove the fail-closed metadata contract; experimental validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no benchmark mechanism executed.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA - no empirical run in this PR.
- Extractor analysis tool needed: NA.
- Artifact missing unavailable: none for this support slice.
- Stop / revise / continue decision: continue #3079 campaign work after readiness gates pass.
- Proposed child issue existing follow-up: #3079 remains open for full benchmark execution.

## Validation / Proof
- `uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py -q` -> pass, 9 tests.
- `uv run python scripts/tools/preflight_adversarial_package_b.py --manifest configs/adversarial/issue_3079_package_b_budget_matched.yaml --repo-root . --output output/adversarial/issue_3079_package_b/preflight.json` -> pass, `ready=true`.
- `uv run ruff format --check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` -> pass.
- `uv run ruff check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` -> pass.
- Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance
- Baseline runtime: NA - no runtime-performance claim.
- Changed runtime: NA - no runtime-performance claim.
- Representative command: `uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py -q`.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: preflight no longer fails closed on seed-plan drift between `repeated_seeds` and `example_command`.

## Risks / Rollout
- Compatibility risks: low; additive check payload key and stricter preflight failure on inconsistent command seeds.
- Failure modes: manifests with extra, missing, or non-integer `--seed` values now block as intended.
- Rollback fallback plan: revert this PR if a legitimate Package B command needs a different seed expression, then add the alternate parser contract first.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3079 and prior preflight PR #3781.
- Any assumptions need to preserved: `example_command` is the local launch packet command and should exactly match manifest seed metadata.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - issue comments are not authorized for this task.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: no benchmark rows, claim-map updates, leaderboard entries, or paper-facing claims are produced.

## Follow-Up Issues
- Deferred work: run the full budget-matched Package B campaign under #3079 after launch authorization.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the stricter seed parsing remains bounded to preflight and does not execute `compare_adversarial_samplers.py`.
- Known limitations: this PR does not validate falsification yield or replay/certification outputs.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preflight checks to verify command-line seed values against the manifest and block mismatches.
  * Added clearer warnings for malformed seed arguments, including missing or non-numeric values.
  * Readiness metadata now includes the parsed seed values from the example command.
* **Tests**
  * Added coverage for seed drift, missing budget-grid usage, and malformed seed argument handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
