### PR TITLE
Tighten Package B output preflight for issue #3079

### DIFF
--- a/configs/adversarial/issue_3079_package_b_budget_matched.yaml
+++ b/configs/adversarial/issue_3079_package_b_budget_matched.yaml
@@ -28,6 +28,9 @@ explicit_exclusions:
   learned_failure_proposal_issue_2921: stretch_out_of_scope_until_base_comparison_succeeds
   held_out_family_yield: not_evaluated_narrow_archive_caveat
   paper_facing_success_claims: forbidden
+output_artifacts:
+  output_dir: output/adversarial/issue_3079_package_b
+  report_json: output/adversarial/issue_3079_package_b/report.json
 example_command: >
   uv run python scripts/tools/compare_adversarial_samplers.py
   --package-b-budget-grid

--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -158,6 +158,13 @@ def _under_output_prefix(path: Path | None, repo_root: Path) -> bool:
     return rel == Path(".") or bool(rel.parts)
 
 
+def _same_resolved_path(left: Path | None, right: Path | None) -> bool:
+    """Return true when both optional paths resolve to the same filesystem path."""
+    if left is None or right is None:
+        return False
+    return left.resolve() == right.resolve()
+
+
 def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     manifest_path: Path = Path("configs/adversarial/issue_3079_package_b_budget_matched.yaml"),
     *,
@@ -272,6 +279,47 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     if not checks["status_diagnostic"]:
         blockers.append("status must stay diagnostic_local_nominal")
 
+    output_artifacts = payload.get("output_artifacts")
+    checks["output_artifacts_mapping"] = isinstance(output_artifacts, dict)
+    if not isinstance(output_artifacts, dict):
+        blockers.append("output_artifacts must be a mapping")
+        output_artifacts = {}
+
+    artifact_output_dir = _resolve_repo_path(root, output_artifacts.get("output_dir"))
+    artifact_report_json = _resolve_repo_path(root, output_artifacts.get("report_json"))
+
+    checks["output_artifacts_output_dir_declared"] = artifact_output_dir is not None
+    if not checks["output_artifacts_output_dir_declared"]:
+        blockers.append("output_artifacts.output_dir must be a non-empty path")
+
+    checks["output_artifacts_report_json_declared"] = artifact_report_json is not None
+    if not checks["output_artifacts_report_json_declared"]:
+        blockers.append("output_artifacts.report_json must be a non-empty path")
+
+    checks["output_artifacts_output_dir_under_issue_path"] = _under_output_prefix(
+        artifact_output_dir, root
+    )
+    if not checks["output_artifacts_output_dir_under_issue_path"]:
+        blockers.append(
+            f"output_artifacts.output_dir must be under {EXPECTED_OUTPUT_PREFIX.as_posix()}"
+        )
+
+    checks["output_artifacts_report_json_under_issue_path"] = _under_output_prefix(
+        artifact_report_json, root
+    )
+    if not checks["output_artifacts_report_json_under_issue_path"]:
+        blockers.append(
+            f"output_artifacts.report_json must be under {EXPECTED_OUTPUT_PREFIX.as_posix()}"
+        )
+
+    checks["output_artifacts_report_json_in_output_dir"] = (
+        artifact_output_dir is not None
+        and artifact_report_json is not None
+        and artifact_report_json.resolve().is_relative_to(artifact_output_dir.resolve())
+    )
+    if not checks["output_artifacts_report_json_in_output_dir"]:
+        blockers.append("output_artifacts.report_json must be inside output_artifacts.output_dir")
+
     example_command = payload.get("example_command")
     checks["example_command_declared"] = isinstance(example_command, str) and bool(
         example_command.strip()
@@ -315,6 +363,12 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     if not checks["out_json_under_issue_path"]:
         blockers.append(f"--out-json must stay under {EXPECTED_OUTPUT_PREFIX.as_posix()}")
 
+    checks["example_command_matches_output_artifacts"] = _same_resolved_path(
+        output_dir, artifact_output_dir
+    ) and _same_resolved_path(out_json, artifact_report_json)
+    if not checks["example_command_matches_output_artifacts"]:
+        blockers.append("example_command output paths must match output_artifacts metadata")
+
     metadata = {
         "issue": EXPECTED_ISSUE,
         "budget_grid": list(budgets),
@@ -324,6 +378,14 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
         "runner": _repo_relative(runner_path, root) if runner_path else None,
         "output_dir": _repo_relative(output_dir, root) if output_dir else None,
         "out_json": _repo_relative(out_json, root) if out_json else None,
+        "output_artifacts": {
+            "output_dir": _repo_relative(artifact_output_dir, root)
+            if artifact_output_dir
+            else None,
+            "report_json": _repo_relative(artifact_report_json, root)
+            if artifact_report_json
+            else None,
+        },
         "claim_scope": payload.get("claim_scope"),
         "status": payload.get("status"),
         "does_not_execute_benchmark": True,

--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -178,6 +178,13 @@ def _report_path_inside_output_dir(report_json: Path | None, output_dir: Path | 
     return resolved_report != resolved_dir and resolved_report.is_relative_to(resolved_dir)
 
 
+def _output_dir_is_directory_or_future(output_dir: Path | None) -> bool:
+    """Return true when output_dir is either absent or an existing directory."""
+    if output_dir is None:
+        return False
+    return not output_dir.exists() or output_dir.is_dir()
+
+
 def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     manifest_path: Path = Path("configs/adversarial/issue_3079_package_b_budget_matched.yaml"),
     *,
@@ -304,6 +311,12 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     checks["output_artifacts_output_dir_declared"] = artifact_output_dir is not None
     if not checks["output_artifacts_output_dir_declared"]:
         blockers.append("output_artifacts.output_dir must be a non-empty path")
+
+    checks["output_artifacts_output_dir_directory_or_future"] = _output_dir_is_directory_or_future(
+        artifact_output_dir
+    )
+    if not checks["output_artifacts_output_dir_directory_or_future"]:
+        blockers.append("output_artifacts.output_dir must be a directory or future path")
 
     checks["output_artifacts_report_json_declared"] = artifact_report_json is not None
     if not checks["output_artifacts_report_json_declared"]:

--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -165,6 +165,19 @@ def _same_resolved_path(left: Path | None, right: Path | None) -> bool:
     return left.resolve() == right.resolve()
 
 
+def _report_path_inside_output_dir(report_json: Path | None, output_dir: Path | None) -> bool:
+    """Return true when report_json is a future or file-valued path inside output_dir."""
+    if report_json is None or output_dir is None:
+        return False
+    if report_json.is_symlink():
+        return False
+    if report_json.exists() and not report_json.is_file():
+        return False
+    resolved_report = report_json.resolve(strict=False)
+    resolved_dir = output_dir.resolve(strict=False)
+    return resolved_report != resolved_dir and resolved_report.is_relative_to(resolved_dir)
+
+
 def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     manifest_path: Path = Path("configs/adversarial/issue_3079_package_b_budget_matched.yaml"),
     *,
@@ -312,10 +325,8 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
             f"output_artifacts.report_json must be under {EXPECTED_OUTPUT_PREFIX.as_posix()}"
         )
 
-    checks["output_artifacts_report_json_in_output_dir"] = (
-        artifact_output_dir is not None
-        and artifact_report_json is not None
-        and artifact_report_json.resolve().is_relative_to(artifact_output_dir.resolve())
+    checks["output_artifacts_report_json_in_output_dir"] = _report_path_inside_output_dir(
+        artifact_report_json, artifact_output_dir
     )
     if not checks["output_artifacts_report_json_in_output_dir"]:
         blockers.append("output_artifacts.report_json must be inside output_artifacts.output_dir")

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -253,7 +253,10 @@ def test_preflight_blocks_directory_valued_output_artifact_report(tmp_path: Path
     assert result.ready is False
     assert result.blocked is True
     assert result.checks["output_artifacts_report_json_in_output_dir"] is False
-    assert any("report_json must be inside output_artifacts.output_dir" in blocker for blocker in result.blockers)
+    assert any(
+        "report_json must be inside output_artifacts.output_dir" in blocker
+        for blocker in result.blockers
+    )
 
 
 def test_preflight_blocks_symlinked_output_artifact_report(tmp_path: Path) -> None:
@@ -270,7 +273,10 @@ def test_preflight_blocks_symlinked_output_artifact_report(tmp_path: Path) -> No
     assert result.ready is False
     assert result.blocked is True
     assert result.checks["output_artifacts_report_json_in_output_dir"] is False
-    assert any("report_json must be inside output_artifacts.output_dir" in blocker for blocker in result.blockers)
+    assert any(
+        "report_json must be inside output_artifacts.output_dir" in blocker
+        for blocker in result.blockers
+    )
 
 
 def test_package_b_preflight_cli_writes_report_and_returns_nonzero_on_blocker(

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -59,6 +59,10 @@ def _base_manifest(repo_root: Path) -> Path:
                     "held_out_family_yield": "not_evaluated_narrow_archive_caveat",
                     "paper_facing_success_claims": "forbidden",
                 },
+                "output_artifacts": {
+                    "output_dir": "output/adversarial/issue_3079_package_b",
+                    "report_json": "output/adversarial/issue_3079_package_b/report.json",
+                },
                 "example_command": (
                     "uv run python scripts/tools/compare_adversarial_samplers.py "
                     "--package-b-budget-grid --seed 1101 --seed 2202 --seed 3303 "
@@ -81,6 +85,10 @@ def test_committed_package_b_manifest_preflights_without_running_benchmark() -> 
     assert result.blocked is False
     assert result.metadata["budget_grid"] == [16, 32, 64]
     assert result.metadata["repeated_seeds"] == [1101, 2202, 3303]
+    assert result.metadata["output_artifacts"] == {
+        "output_dir": "output/adversarial/issue_3079_package_b",
+        "report_json": "output/adversarial/issue_3079_package_b/report.json",
+    }
     assert result.metadata["does_not_execute_benchmark"] is True
     assert result.metadata["does_not_submit_slurm_or_gpu"] is True
 
@@ -92,6 +100,7 @@ def test_preflight_fails_closed_for_missing_budget_seed_and_provenance(tmp_path:
     del payload["budget_grid"]
     payload["repeated_seeds"] = []
     payload["explicit_exclusions"] = {}
+    del payload["output_artifacts"]
     manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
 
     result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
@@ -103,6 +112,7 @@ def test_preflight_fails_closed_for_missing_budget_seed_and_provenance(tmp_path:
     assert any("budget_grid" in blocker for blocker in result.blockers)
     assert any("repeated_seeds" in blocker for blocker in result.blockers)
     assert any("paper_facing_success_claims" in blocker for blocker in result.blockers)
+    assert any("output_artifacts" in blocker for blocker in result.blockers)
 
 
 def test_preflight_blocks_example_command_seed_drift(tmp_path: Path) -> None:
@@ -210,6 +220,26 @@ def test_preflight_blocks_missing_inputs_and_output_paths(tmp_path: Path) -> Non
     assert result.checks["search_space_exists"] is False
     assert result.checks["output_dir_under_issue_path"] is False
     assert result.checks["out_json_under_issue_path"] is False
+
+
+def test_preflight_blocks_output_artifact_command_drift(tmp_path: Path) -> None:
+    """Declared output artifacts must match executable example paths."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["output_artifacts"] = {
+        "output_dir": "output/adversarial/issue_3079_package_b/declared",
+        "report_json": "output/adversarial/issue_3079_package_b/declared/report.json",
+    }
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["output_artifacts_output_dir_under_issue_path"] is True
+    assert result.checks["output_artifacts_report_json_under_issue_path"] is True
+    assert result.checks["example_command_matches_output_artifacts"] is False
+    assert any("output paths must match output_artifacts" in blocker for blocker in result.blockers)
 
 
 def test_package_b_preflight_cli_writes_report_and_returns_nonzero_on_blocker(

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -242,6 +242,37 @@ def test_preflight_blocks_output_artifact_command_drift(tmp_path: Path) -> None:
     assert any("output paths must match output_artifacts" in blocker for blocker in result.blockers)
 
 
+def test_preflight_blocks_directory_valued_output_artifact_report(tmp_path: Path) -> None:
+    """The declared report_json path must not already be an existing directory."""
+    manifest = _base_manifest(tmp_path)
+    report_path = tmp_path / "output/adversarial/issue_3079_package_b/report.json"
+    report_path.mkdir(parents=True)
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["output_artifacts_report_json_in_output_dir"] is False
+    assert any("report_json must be inside output_artifacts.output_dir" in blocker for blocker in result.blockers)
+
+
+def test_preflight_blocks_symlinked_output_artifact_report(tmp_path: Path) -> None:
+    """The declared report_json path must not be a symlink."""
+    manifest = _base_manifest(tmp_path)
+    report_path = tmp_path / "output/adversarial/issue_3079_package_b/report.json"
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+    target = tmp_path / "output/adversarial/issue_3079_package_b/real_report.json"
+    target.write_text("{}", encoding="utf-8")
+    report_path.symlink_to(target)
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["output_artifacts_report_json_in_output_dir"] is False
+    assert any("report_json must be inside output_artifacts.output_dir" in blocker for blocker in result.blockers)
+
+
 def test_package_b_preflight_cli_writes_report_and_returns_nonzero_on_blocker(
     tmp_path: Path,
 ) -> None:

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -259,6 +259,23 @@ def test_preflight_blocks_directory_valued_output_artifact_report(tmp_path: Path
     )
 
 
+def test_preflight_blocks_file_valued_output_artifact_dir(tmp_path: Path) -> None:
+    """The declared output_dir path must not already be an existing file."""
+    manifest = _base_manifest(tmp_path)
+    output_dir = tmp_path / "output/adversarial/issue_3079_package_b"
+    output_dir.parent.mkdir(parents=True, exist_ok=True)
+    output_dir.write_text("not a directory\n", encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["output_artifacts_output_dir_directory_or_future"] is False
+    assert any(
+        "output_dir must be a directory or future path" in blocker for blocker in result.blockers
+    )
+
+
 def test_preflight_blocks_symlinked_output_artifact_report(tmp_path: Path) -> None:
     """The declared report_json path must not be a symlink."""
     manifest = _base_manifest(tmp_path)


### PR DESCRIPTION
## Summary
Tightens the issue #3079 Package B readiness preflight by making output artifacts first-class manifest metadata and requiring the executable example command to match those declared paths.

## Linked Issues
- Relates #3079

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #3079 remains open for the actual benchmark campaign
- Safe review independently: yes
- Review dependency reason, any: Small preflight-only follow-up on top of merged #3781/#3785 support slices.

## What Changed
- Added `output_artifacts.output_dir` and `output_artifacts.report_json` to `configs/adversarial/issue_3079_package_b_budget_matched.yaml`.
- Extended `robot_sf/benchmark/adversarial_package_b_preflight.py` to fail closed when output artifact metadata is missing, outside the issue output root, internally inconsistent, or drifting from the example command.
- Added focused tests for missing output provenance and command/metadata path drift.

## Why Matters
- Added value: prevents Package B launch packets from carrying only implicit output paths in the example command.
- Expected impact: downstream result-store/provenance review can inspect explicit output paths before any campaign run.
- Why worth merging now: closes a bounded readiness gap without executing or interpreting the benchmark.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Readiness/provenance blocker for #3079 Package B output paths.
- Comparator or baseline, applicable: NA - support preflight only.
- Evidence tier: targeted smoke / support preflight.
- Result classification: blocker-resolution; not benchmark evidence.
- Decision stop rule, applicable: Preflight must fail closed on missing or drifting output artifact metadata.
- Parent issue, claim map, registry, context note, synthesis surface update: #3079 issue remains the parent; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper only; no interpretation added.

## Domain-Aware Approval
- Required for this PR: yes - conservative parser gate because this support preflight PR names evidence tier and result classification while making no benchmark claim.
- Domains reviewed: benchmark-readiness metadata, evidence-validity boundary, fallback/degraded exclusions.
- Status: waived
- Approver/review source or waiver: Codex PR gate review waiver for #3787.
- Approval or blocker note: waiver is limited to this metadata preflight slice; #3079 remains open for the actual benchmark campaign and interpretation.
- Target claim/hypothesis: NA - no benchmark result claim.
- Comparator or split/evidence validity: unchanged; this PR only validates manifest output path metadata before future #3079 runs.
- Comparator split/evidence validity: unchanged; this PR only validates manifest output path metadata before future #3079 runs.
- Fallback/degraded exclusions: unchanged; fallback/degraded rows remain excluded from success evidence.
- Claim boundary: not benchmark evidence; does not execute or interpret Package B.
- Implementation integrity vs experimental validity: targeted tests and preflight prove metadata contract only; experimental validity remains deferred to #3079.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no benchmark run.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue #3079 readiness/campaign work separately.
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: yes, for the actual #3079 campaign; not part of this PR.
- Extractor analysis tool needed: NA
- Artifact missing unavailable: NA for this preflight slice.
- Stop / revise / continue decision: continue with campaign execution only after remaining readiness is accepted.
- Proposed child issue existing follow-up: #3079 remains open.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py -q` -> passed, 10 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/preflight_adversarial_package_b.py` -> passed, `ready=true`, `blocked=false`, `example_command_matches_output_artifacts=true`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py scripts/tools/preflight_adversarial_package_b.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python - <<'PY' ... yaml.safe_load(...) ... PY` -> passed, manifest `output_artifacts` parsed as expected.
- `git diff --check` -> passed.
- Note: an initial `ruff check` command that included the YAML file failed because Ruff parsed YAML as Python; rerun above scoped Ruff to Python files only.

## Explicit Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No falsification yield interpretation.
- No paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: manifests omitting `output_artifacts` now fail closed under this package-B preflight, by design.
- Failure modes: callers must keep declared output metadata and example command paths synchronized.
- Rollback fallback plan: revert this PR to restore implicit command-only output path checking.

## Docs / Provenance
- Updated docs: NA
- Relevant design provenance notes: #3079, #3781, #3785.
- Any assumptions need to preserved: output artifacts remain worktree-local `output/` paths, not durable benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized in this task.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this is a support/preflight slice only and does not produce benchmark evidence.

## Follow-Up Issues
- Deferred work: actual budget-matched Package B benchmark campaign, certified/replayable failure counting, held-out-yield reporting, and interpretation remain in #3079.
- Issues opened follow-up: none.

## Reviewer Notes
- Please verify the new `output_artifacts` manifest metadata stays synchronized with `example_command`.
- Known limitation: this does not validate durable artifact publication; it only checks local output path readiness.










<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for declaring output artifact locations in the issue configuration, including the output directory and JSON report path.

* **Bug Fixes**
  * Strengthened preflight checks to ensure declared output paths are valid, consistent, and stay within the expected output area.
  * Improved validation so generated command output matches the configured artifact locations, with clearer blocking for invalid or unsafe paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->