### PR TITLE
benchmark: fail closed issue #1554 archive readiness boundaries

### DIFF
--- a/scripts/validation/check_s20_s30_archive_readiness.py
+++ b/scripts/validation/check_s20_s30_archive_readiness.py
@@ -135,6 +135,7 @@ def build_report(
     primary_seeds, escalation_seeds = _load_seed_tiers(contract)
 
     diagnostics: list[str] = []
+    diagnostics.extend(_execution_boundary_diagnostics(contract))
     result_store_files = _result_store_file_status(contract)
     missing_files = [path for path, present in result_store_files.items() if not present]
     if missing_files:
@@ -300,6 +301,21 @@ def _coverage_diagnostics(
     }
     if invalid_statuses:
         diagnostics.append(f"fail-closed/non-promotable row statuses present: {invalid_statuses}")
+    return diagnostics
+
+
+def _execution_boundary_diagnostics(contract: PacketContract) -> list[str]:
+    """Return fail-closed diagnostics for packet boundaries outside this issue slice."""
+
+    diagnostics: list[str] = []
+    if contract.full_campaign_in_this_issue:
+        diagnostics.append(
+            "execution_boundary.full_campaign_in_this_issue must be false for archive-readiness"
+        )
+    if contract.submit_slurm_from_this_issue:
+        diagnostics.append(
+            "execution_boundary.submit_slurm_from_this_issue must be false for archive-readiness"
+        )
     return diagnostics
 
 

--- a/tests/validation/test_check_s20_s30_archive_readiness.py
+++ b/tests/validation/test_check_s20_s30_archive_readiness.py
@@ -31,6 +31,7 @@ def _write_packet(
     result_store: str = "store",
     seed_sets_path: str | None = None,
     full_campaign_in_this_issue: object = False,
+    submit_slurm_from_this_issue: object = False,
 ) -> Path:
     seed_sets = _write_seed_sets(repo_root / "seed_sets.yaml")
     payload = {
@@ -79,7 +80,7 @@ def _write_packet(
         },
         "execution_boundary": {
             "full_campaign_in_this_issue": full_campaign_in_this_issue,
-            "submit_slurm_from_this_issue": False,
+            "submit_slurm_from_this_issue": submit_slurm_from_this_issue,
             "bundle_status_until_run": "blocked_until_run",
         },
     }
@@ -308,6 +309,50 @@ def test_execution_boundary_requires_actual_booleans(tmp_path: Path) -> None:
     packet = _write_packet(repo / "packet.yaml", repo, full_campaign_in_this_issue="false")
 
     assert readiness.main(["--packet", str(packet), "--repo-root", str(repo)]) == 2
+
+
+def test_full_campaign_boundary_blocks_complete_archive_readiness(tmp_path: Path) -> None:
+    """Archive readiness cannot pass when packet moves campaign execution into this issue."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    packet = _write_packet(repo / "packet.yaml", repo, full_campaign_in_this_issue=True)
+    write_result_store(
+        repo / "store",
+        _complete_rows(),
+        study_id="issue_1554_test",
+        command="uv run python scripts/tools/run_camera_ready_benchmark.py ...",
+    )
+
+    report = readiness.build_report(packet, repo)
+
+    assert report["status"] == readiness.BLOCKED
+    assert (
+        "execution_boundary.full_campaign_in_this_issue must be false for archive-readiness"
+        in report["missing_artifact_diagnostics"]
+    )
+
+
+def test_slurm_submission_boundary_blocks_complete_archive_readiness(tmp_path: Path) -> None:
+    """Archive readiness cannot pass when packet authorizes Slurm submission in this issue."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    packet = _write_packet(repo / "packet.yaml", repo, submit_slurm_from_this_issue=True)
+    write_result_store(
+        repo / "store",
+        _complete_rows(),
+        study_id="issue_1554_test",
+        command="uv run python scripts/tools/run_camera_ready_benchmark.py ...",
+    )
+
+    report = readiness.build_report(packet, repo)
+
+    assert report["status"] == readiness.BLOCKED
+    assert (
+        "execution_boundary.submit_slurm_from_this_issue must be false for archive-readiness"
+        in report["missing_artifact_diagnostics"]
+    )
 
 
 def test_seed_tiers_must_be_unique_integers(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Tightens the issue #1554 S20/S30 archive-readiness checker so launch packets fail closed when they try to move full benchmark execution or Slurm submission into this archive-readiness slice.

## Linked Issues
- Relates to #1554

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added execution-boundary diagnostics to `scripts/validation/check_s20_s30_archive_readiness.py`.
- Added fixture coverage proving complete synthetic artifact stores still block when `full_campaign_in_this_issue` or `submit_slurm_from_this_issue` is true.

## Why Matters
- Added value: preserves the issue #1554 archive-readiness boundary as fail-closed behavior.
- Expected impact: readiness reports cannot accidentally treat compute execution or Slurm submission as part of this local archive slice.
- Why worth merging now: issue #1554 is a paper-facing evidence lane and should not blur readiness tooling with campaign execution.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for issue #1554 archive-readiness checks; no S20/S30 evidence claim.
- Comparator or baseline, applicable: current checker could report ready for otherwise complete synthetic stores even when execution-boundary flags were true.
- Evidence tier: NA - support checker hardening, no research evidence claim
- Result classification: NA - support checker hardening, no research result claim
- Decision stop rule, applicable: complete synthetic stores with forbidden execution-boundary flags must return `blocked`.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #1554; no claim-map or paper-facing claim update.
- New research/benchmark/metric/paper-facing analysis tool, any: no new tool; narrow hardening of existing support checker.

## Domain-Aware Approval
Required PR: required for archive-readiness boundary hardening.
Domains reviewed: benchmark archive-readiness.
Status: blocked - real S20/S30 evidence remains absent and #1554 stays blocked until artifacts exist.
Approver/review source waiver: blocked on #1554 real S20/S30 artifacts; this PR only hardens local readiness failure modes.
Approval or blocker note: #1554 remains blocked on real S20/S30 artifacts; this PR only hardens local readiness failure modes.
- Validity checklist: fail-closed boundary preserved; no benchmark rows interpreted; no fallback/degraded rows counted.
Target claim/hypothesis: no paper/dissertation claim established.
Comparator or split/evidence validity: fixture-only checker behavior; no benchmark comparison interpreted.
Fallback/degraded exclusions: unchanged and still fail-closed.
Claim boundary: archive-readiness only.
Implementation integrity vs experimental validity: implementation adds guard diagnostics only; experimental validity remains blocked until real S20/S30 artifacts exist.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, fixture tests cover both forbidden boundary flags.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, complete synthetic result stores isolate the forbidden boundary flags.
- Result route: continue with local readiness support; do not claim S20/S30 evidence.
- Follow-up question issue weak, negative, non-transfer results: none opened.

## Next Empirical Action
- Rerun needed: no for this PR; yes for issue #1554 evidence generation outside this PR.
- Extractor analysis tool needed: no new extractor in this PR.
- Artifact missing unavailable: real S20/S30 result store remains absent; checker correctly reports blocked.
- Stop / revise / continue decision: continue to downstream Slurm/evidence work outside this PR.
- Proposed child issue existing follow-up: issue #1554 remains the parent evidence lane.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/validation/check_s20_s30_archive_readiness.py tests/validation/test_check_s20_s30_archive_readiness.py` -> passed, 2 files left unchanged.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_s20_s30_archive_readiness.py tests/validation/test_check_s20_s30_archive_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_s20_s30_archive_readiness.py -q` -> passed, 13 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_s20_s30_archive_readiness.py --json` -> exited 1 as expected with fail-closed missing S20/S30 result-store diagnostics.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Runtime
- Baseline runtime: NA, support-checker behavior only.
- Changed runtime: focused validation completed in seconds.
- Representative command: `uv run pytest tests/validation/test_check_s20_s30_archive_readiness.py -q`.
- Hot-path call count profile anchor: NA, no benchmark runtime path changed.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: readiness checker reports ready when execution-boundary flags authorize in-issue campaign execution or Slurm submission.

## Risks / Rollout
- Compatibility risks: low; adds diagnostics that only block invalid launch-packet boundaries.
- Failure modes: overly strict boundary if a future issue intentionally owns compute submission; that future issue should use a different packet contract.
- Rollback fallback plan: revert this commit to restore prior checker behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #1554 launch packet and `docs/context/issue_1554_s20_s30_seed_budget.md` already define this as blocked until run.
- Any assumptions need to preserved: S20/S30 real evidence remains unavailable in this PR.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): no, no claim change.
- Leaderboard / artifact catalog updated (yes/no/NA): no.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): no.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is fail-closed readiness hardening only; downstream evidence propagation remains blocked on real S20/S30 artifacts.

## Follow-Up Issues
- Deferred work: #1554 tracks running or archiving real S20/S30 campaign artifacts outside this PR.
- Issues opened follow-up: none; existing follow-up lane is #1554.

## Reviewer Notes
- Verify the new diagnostics stay in `missing_artifact_diagnostics` because that is the existing machine-readable blocker surface.
- Known limitation: this PR does not create or promote S20/S30 artifacts.
