### PR TITLE
Issue #3557: inventory uncertainty-source readiness

### DIFF
--- a/robot_sf/benchmark/uncertainty_source_readiness.py
+++ b/robot_sf/benchmark/uncertainty_source_readiness.py
@@ -247,7 +247,7 @@ def _resolve_owner(owner: str | None) -> tuple[bool, str]:
     # Fallback for extension modules or generated modules without a source file.
     try:
         module = importlib.import_module(module_name)
-    except ImportError as exc:
+    except (ImportError, SyntaxError) as exc:
         return False, f"cannot import {module_name}: {exc}"
     if not hasattr(module, attribute):
         return False, f"{module_name} has no attribute {attribute!r}"

--- a/robot_sf/benchmark/uncertainty_source_readiness.py
+++ b/robot_sf/benchmark/uncertainty_source_readiness.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import ast
 import importlib
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any
 
@@ -237,8 +237,8 @@ def _resolve_owner(owner: str | None) -> tuple[bool, str]:
     source_path = _module_source_path(module_name)
     if source_path is not None:
         try:
-            tree = ast.parse(source_path.read_text())
-        except OSError as exc:
+            tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError) as exc:
             return False, f"cannot read {source_path}: {exc}"
         if not _module_ast_defines(tree, attribute):
             return False, f"{module_name} has no top-level attribute {attribute!r}"
@@ -284,11 +284,21 @@ def _module_ast_defines(tree: ast.Module, attribute: str) -> bool:
                 return True
         if isinstance(node, ast.Assign):
             for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == attribute:
+                if _has_target_name(target, attribute):
                     return True
         if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
             if node.target.id == attribute:
                 return True
+    return False
+
+
+def _has_target_name(target: ast.expr, attribute: str) -> bool:
+    """Return whether an assignment target binds ``attribute``."""
+
+    if isinstance(target, ast.Name):
+        return target.id == attribute
+    if isinstance(target, ast.Tuple | ast.List):
+        return any(_has_target_name(element, attribute) for element in target.elts)
     return False
 
 
@@ -304,8 +314,8 @@ def _class_field_names_from_source(owner: str) -> set[str] | None:
     if source_path is None:
         return None
     try:
-        tree = ast.parse(source_path.read_text())
-    except OSError:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
         return None
     for node in tree.body:
         if isinstance(node, ast.ClassDef) and node.name == attribute:
@@ -330,8 +340,14 @@ def _source_contrast_has_expected_fields(owner: str | None) -> tuple[bool, str]:
     field_names = _class_field_names_from_source(owner)
     if field_names is None:
         module_name, _separator, attribute = owner.partition(":")
-        contrast_type = getattr(importlib.import_module(module_name), attribute)
-        field_names = {field.name for field in fields(contrast_type)}
+        try:
+            contrast_type = getattr(importlib.import_module(module_name), attribute)
+            if is_dataclass(contrast_type):
+                field_names = {field.name for field in fields(contrast_type)}
+            else:
+                field_names = set(getattr(contrast_type, "__annotations__", {}))
+        except (AttributeError, ImportError, TypeError) as exc:
+            return False, f"cannot dynamically inspect {owner}: {exc}"
     missing = sorted(set(EXPECTED_SURROGATE_OUTPUTS) - field_names)
     if missing:
         return False, f"{owner} missing fields {missing}"

--- a/robot_sf/benchmark/uncertainty_source_readiness.py
+++ b/robot_sf/benchmark/uncertainty_source_readiness.py
@@ -1,43 +1,201 @@
-"""Readiness inventory for issue #3557 uncertainty-source episode runs.
+"""Inventory readiness for issue #3557 uncertainty-source episode runs.
 
-This module is intentionally a preflight inventory only. It does not run the
-#3471 episode harness, compute new metrics, or decide whether the uncertainty
-drop safety effect generalizes. It answers the smaller question needed before
-those runs: which uncertainty sources already have the builders, scenario hooks,
-and surrogate output fields required for a per-source episode-level contrast?
+Plain-language summary: issue #3557 needs episode-level retained-vs-dropped safety
+contrasts across several ``ScenarioBelief`` uncertainty sources. This module does
+not run those episodes and does not claim the effect generalizes. It only reports
+which sources already have the three prerequisites needed before a source can be
+scheduled safely: a condition builder, a scenario hook, and the expected surrogate
+output contract.
 """
 
 from __future__ import annotations
 
+import ast
 import importlib
-import logging
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
+from pathlib import Path
 from typing import Any
 
-UNCERTAINTY_SOURCE_READINESS_SCHEMA = "uncertainty_source_readiness.v1"
+SCHEMA_VERSION = "uncertainty_source_readiness.v1"
+UNCERTAINTY_SOURCE_READINESS_SCHEMA = SCHEMA_VERSION
+ISSUE = 3557
 
-logger = logging.getLogger(__name__)
+EXISTENCE_DEGRADATION = "existence_degradation"
+VISIBILITY_OCCLUSION = "visibility_occlusion"
+COVARIANCE_INFLATION = "covariance_inflation"
+CLASS_PROBABILITY_AMBIGUITY = "class_probability_ambiguity"
+TRACKING_NOISE = "tracking_noise"
 
-_GENERALIZATION_SURROGATE_OUTPUTS = frozenset(
-    {
-        "source",
-        "retained_unsafe_commit_rate",
-        "dropped_unsafe_commit_rate",
-        "min_separation_delta_m",
-        "n_episodes",
-    }
+SOURCE_READY = "ready"
+MISSING_CONDITION_BUILDER = "missing_condition_builder"
+MISSING_SCENARIO_HOOK = "missing_scenario_hook"
+MISSING_SURROGATE_OUTPUT = "missing_surrogate_output"
+
+_ISSUE_3471_HARNESS = "scripts.validation.run_scenario_belief_episode_safety_issue_3471"
+_GENERALIZATION_LAYER = "robot_sf.representation.uncertainty_source_generalization"
+
+EXPECTED_SURROGATE_OUTPUTS = (
+    "source",
+    "retained_unsafe_commit_rate",
+    "dropped_unsafe_commit_rate",
+    "min_separation_delta_m",
+    "n_episodes",
 )
+_GENERALIZATION_SURROGATE_OUTPUTS = frozenset(EXPECTED_SURROGATE_OUTPUTS)
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessComponent:
+    """One source prerequisite and the local owner expected to satisfy it."""
+
+    present: bool
+    owner: str | None
+    evidence: str
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return JSON-ready component metadata."""
+
+        return {
+            "present": self.present,
+            "owner": self.owner,
+            "evidence": self.evidence,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class UncertaintySourceReadiness:
+    """Readiness inventory row for one uncertainty source."""
+
+    source: str
+    condition_builder: ReadinessComponent
+    scenario_hook: ReadinessComponent
+    expected_surrogate_outputs: ReadinessComponent
+
+    @property
+    def ready(self) -> bool:
+        """Whether this source has every prerequisite for an episode-level run."""
+
+        return (
+            self.condition_builder.present
+            and self.scenario_hook.present
+            and self.expected_surrogate_outputs.present
+        )
+
+    @property
+    def status(self) -> str:
+        """Return the first missing readiness class, or ``ready``."""
+
+        if not self.condition_builder.present:
+            return MISSING_CONDITION_BUILDER
+        if not self.scenario_hook.present:
+            return MISSING_SCENARIO_HOOK
+        if not self.expected_surrogate_outputs.present:
+            return MISSING_SURROGATE_OUTPUT
+        return SOURCE_READY
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return deterministic JSON-ready source inventory."""
+
+        return {
+            "source": self.source,
+            "ready": self.ready,
+            "status": self.status,
+            "condition_builder": self.condition_builder.as_dict(),
+            "scenario_hook": self.scenario_hook.as_dict(),
+            "expected_surrogate_outputs": self.expected_surrogate_outputs.as_dict(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class UncertaintySourceReadinessReport:
+    """Issue #3557 source-readiness report."""
+
+    sources: tuple[UncertaintySourceReadiness, ...]
+
+    @property
+    def ready_sources(self) -> tuple[str, ...]:
+        """Sources with all prerequisites present."""
+
+        return tuple(row.source for row in self.sources if row.ready)
+
+    @property
+    def blocked_sources(self) -> tuple[str, ...]:
+        """Sources missing at least one prerequisite."""
+
+        return tuple(row.source for row in self.sources if not row.ready)
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return deterministic JSON-ready report."""
+
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "issue": ISSUE,
+            "ready": not self.blocked_sources,
+            "ready_sources": list(self.ready_sources),
+            "blocked_sources": list(self.blocked_sources),
+            "sources": [row.as_dict() for row in self.sources],
+            "claim_boundary": (
+                "Readiness inventory only; does not run the episode harness, "
+                "does not submit Slurm/GPU work, and does not claim uncertainty-drop "
+                "safety effect generalization."
+            ),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class SourceReadinessSpec:
+    """Declarative owner inventory for one uncertainty source."""
+
+    source: str
+    condition_builder_owner: str | None
+    scenario_hook_owner: str | None
+    surrogate_output_owner: str | None
 
 
 @dataclass(frozen=True, slots=True)
 class UncertaintySourceRunSpec:
-    """Inventory contract for one candidate uncertainty source."""
+    """Backward-compatible inventory contract for one candidate uncertainty source."""
 
     source: str
     condition_builder: str | None
     scenario_hook: str | None
     expected_surrogate_outputs: tuple[str, ...] = tuple(sorted(_GENERALIZATION_SURROGATE_OUTPUTS))
 
+
+DEFAULT_SOURCE_SPECS = (
+    SourceReadinessSpec(
+        source=EXISTENCE_DEGRADATION,
+        condition_builder_owner=f"{_ISSUE_3471_HARNESS}:build_belief_for_mode",
+        scenario_hook_owner=f"{_ISSUE_3471_HARNESS}:run_episode",
+        surrogate_output_owner=f"{_GENERALIZATION_LAYER}:SourceContrast",
+    ),
+    SourceReadinessSpec(
+        source=VISIBILITY_OCCLUSION,
+        condition_builder_owner=None,
+        scenario_hook_owner=None,
+        surrogate_output_owner=f"{_GENERALIZATION_LAYER}:SourceContrast",
+    ),
+    SourceReadinessSpec(
+        source=COVARIANCE_INFLATION,
+        condition_builder_owner=None,
+        scenario_hook_owner=None,
+        surrogate_output_owner=f"{_GENERALIZATION_LAYER}:SourceContrast",
+    ),
+    SourceReadinessSpec(
+        source=CLASS_PROBABILITY_AMBIGUITY,
+        condition_builder_owner=None,
+        scenario_hook_owner=None,
+        surrogate_output_owner=f"{_GENERALIZATION_LAYER}:SourceContrast",
+    ),
+    SourceReadinessSpec(
+        source=TRACKING_NOISE,
+        condition_builder_owner=None,
+        scenario_hook_owner=None,
+        surrogate_output_owner=f"{_GENERALIZATION_LAYER}:SourceContrast",
+    ),
+)
 
 DEFAULT_UNCERTAINTY_SOURCE_SPECS: tuple[UncertaintySourceRunSpec, ...] = (
     UncertaintySourceRunSpec(
@@ -68,35 +226,195 @@ DEFAULT_UNCERTAINTY_SOURCE_SPECS: tuple[UncertaintySourceRunSpec, ...] = (
 )
 
 
-def _missing_expected_outputs(spec: UncertaintySourceRunSpec) -> list[str]:
-    """Return required surrogate fields absent from ``spec``."""
+def _resolve_owner(owner: str | None) -> tuple[bool, str]:
+    """Return whether ``module:attribute`` exists without executing benchmark runs."""
 
-    declared = set(spec.expected_surrogate_outputs)
-    return sorted(_GENERALIZATION_SURROGATE_OUTPUTS - declared)
+    if owner is None:
+        return False, "no owner registered"
+    module_name, separator, attribute = owner.partition(":")
+    if not module_name or separator != ":" or not attribute:
+        return False, "owner must use 'module:attribute' form"
+    source_path = _module_source_path(module_name)
+    if source_path is not None:
+        try:
+            tree = ast.parse(source_path.read_text())
+        except OSError as exc:
+            return False, f"cannot read {source_path}: {exc}"
+        if not _module_ast_defines(tree, attribute):
+            return False, f"{module_name} has no top-level attribute {attribute!r}"
+        return True, f"resolved {owner} by static source inspection"
+
+    # Fallback for extension modules or generated modules without a source file.
+    try:
+        module = importlib.import_module(module_name)
+    except ImportError as exc:
+        return False, f"cannot import {module_name}: {exc}"
+    if not hasattr(module, attribute):
+        return False, f"{module_name} has no attribute {attribute!r}"
+    return True, f"resolved {owner}"
+
+
+def _module_source_path(module_name: str) -> Path | None:
+    """Return local source path for a dotted module without importing parents.
+
+    Returns:
+        Python source path when the module resolves under this repository root.
+    """
+
+    relative = Path(*module_name.split("."))
+    module_file = _REPO_ROOT / relative.with_suffix(".py")
+    if module_file.exists():
+        return module_file
+    package_file = _REPO_ROOT / relative / "__init__.py"
+    if package_file.exists():
+        return package_file
+    return None
+
+
+def _module_ast_defines(tree: ast.Module, attribute: str) -> bool:
+    """Return whether a module AST defines a top-level symbol.
+
+    Returns:
+        True when a function, class, or assignment defines ``attribute``.
+    """
+
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
+            if node.name == attribute:
+                return True
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == attribute:
+                    return True
+        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            if node.target.id == attribute:
+                return True
+    return False
+
+
+def _class_field_names_from_source(owner: str) -> set[str] | None:
+    """Return dataclass-style annotated field names from source when available.
+
+    Returns:
+        Field names when the owner can be statically inspected; otherwise ``None``.
+    """
+
+    module_name, _separator, attribute = owner.partition(":")
+    source_path = _module_source_path(module_name)
+    if source_path is None:
+        return None
+    try:
+        tree = ast.parse(source_path.read_text())
+    except OSError:
+        return None
+    for node in tree.body:
+        if isinstance(node, ast.ClassDef) and node.name == attribute:
+            return {
+                body_node.target.id
+                for body_node in node.body
+                if isinstance(body_node, ast.AnnAssign) and isinstance(body_node.target, ast.Name)
+            }
+    return None
+
+
+def _source_contrast_has_expected_fields(owner: str | None) -> tuple[bool, str]:
+    """Verify the decision-layer surrogate contrast exposes required fields.
+
+    Returns:
+        Pair of readiness boolean and human-readable evidence.
+    """
+
+    present, evidence = _resolve_owner(owner)
+    if not present or owner is None:
+        return present, evidence
+    field_names = _class_field_names_from_source(owner)
+    if field_names is None:
+        module_name, _separator, attribute = owner.partition(":")
+        contrast_type = getattr(importlib.import_module(module_name), attribute)
+        field_names = {field.name for field in fields(contrast_type)}
+    missing = sorted(set(EXPECTED_SURROGATE_OUTPUTS) - field_names)
+    if missing:
+        return False, f"{owner} missing fields {missing}"
+    return True, f"{owner} exposes {sorted(EXPECTED_SURROGATE_OUTPUTS)}"
+
+
+def inspect_uncertainty_source_readiness(
+    specs: tuple[SourceReadinessSpec, ...] = DEFAULT_SOURCE_SPECS,
+) -> UncertaintySourceReadinessReport:
+    """Inspect prerequisite owners for issue #3557 uncertainty-source runs.
+
+    Returns:
+        Readiness report for the supplied uncertainty-source specs.
+    """
+
+    rows: list[UncertaintySourceReadiness] = []
+    for spec in specs:
+        builder_present, builder_evidence = _resolve_owner(spec.condition_builder_owner)
+        hook_present, hook_evidence = _resolve_owner(spec.scenario_hook_owner)
+        output_present, output_evidence = _source_contrast_has_expected_fields(
+            spec.surrogate_output_owner
+        )
+        rows.append(
+            UncertaintySourceReadiness(
+                source=spec.source,
+                condition_builder=ReadinessComponent(
+                    present=builder_present,
+                    owner=spec.condition_builder_owner,
+                    evidence=builder_evidence,
+                ),
+                scenario_hook=ReadinessComponent(
+                    present=hook_present,
+                    owner=spec.scenario_hook_owner,
+                    evidence=hook_evidence,
+                ),
+                expected_surrogate_outputs=ReadinessComponent(
+                    present=output_present,
+                    owner=spec.surrogate_output_owner,
+                    evidence=output_evidence,
+                ),
+            )
+        )
+    return UncertaintySourceReadinessReport(sources=tuple(rows))
+
+
+def _missing_expected_outputs(spec: UncertaintySourceRunSpec) -> list[str]:
+    """Return required surrogate fields absent from ``spec``.
+
+    Returns:
+        Sorted missing surrogate output field names.
+    """
+
+    return sorted(_GENERALIZATION_SURROGATE_OUTPUTS - set(spec.expected_surrogate_outputs))
 
 
 def _discover_condition_builders() -> frozenset[str]:
-    """Return condition-builder symbols present in the #2546 diagnostic owner."""
+    """Return condition-builder symbols present in the #2546 diagnostic owner.
+
+    Returns:
+        Available condition-builder names, or an empty set when the owner cannot load.
+    """
 
     try:
         module = importlib.import_module(
             "scripts.analysis.run_scenario_belief_uncertainty_diagnostic_issue_2546"
         )
     except (ImportError, SyntaxError):
-        logger.exception("Failed to import uncertainty diagnostic owner for readiness discovery")
         return frozenset()
     return frozenset(name for name in dir(module) if name.startswith("_condition_"))
 
 
 def _discover_scenario_hooks() -> frozenset[str]:
-    """Return episode scenario hook symbols present in the #3471 runner owner."""
+    """Return episode scenario-hook symbols present in the #3471 runner owner.
+
+    Returns:
+        Available scenario-hook names, or an empty set when the owner cannot load.
+    """
 
     try:
         module = importlib.import_module(
             "scripts.validation.run_scenario_belief_episode_safety_issue_3471"
         )
     except (ImportError, SyntaxError):
-        logger.exception("Failed to import episode safety owner for readiness discovery")
         return frozenset()
     return frozenset(
         {"build_belief_for_mode"} if hasattr(module, "build_belief_for_mode") else set()
@@ -109,41 +427,29 @@ def classify_uncertainty_source_readiness(
     known_condition_builders: set[str] | frozenset[str] | None = None,
     known_scenario_hooks: set[str] | frozenset[str] | None = None,
 ) -> dict[str, Any]:
-    """Classify one source as ready or blocked for a future episode run.
-
-    The result is a static inventory row. A source is ``ready`` only when it has
-    an existing condition builder, an existing scenario hook, and the surrogate
-    outputs needed by the already-landed #3557 decision layer.
+    """Classify one legacy source spec as ready or blocked.
 
     Returns:
-        dict[str, Any]: Source readiness row with status and missing contract parts.
+        Backward-compatible source readiness row.
     """
 
-    known_condition_builders = (
+    builders = (
         _discover_condition_builders()
         if known_condition_builders is None
         else known_condition_builders
     )
-    known_scenario_hooks = (
-        _discover_scenario_hooks() if known_scenario_hooks is None else known_scenario_hooks
-    )
+    hooks = _discover_scenario_hooks() if known_scenario_hooks is None else known_scenario_hooks
     missing: list[str] = []
 
-    if spec.condition_builder is None:
+    condition_builder_present = bool(
+        spec.condition_builder is not None and spec.condition_builder in builders
+    )
+    if not condition_builder_present:
         missing.append("condition_builder")
-        condition_builder_present = False
-    else:
-        condition_builder_present = spec.condition_builder in known_condition_builders
-        if not condition_builder_present:
-            missing.append("condition_builder")
 
-    if spec.scenario_hook is None:
+    scenario_hook_present = bool(spec.scenario_hook is not None and spec.scenario_hook in hooks)
+    if not scenario_hook_present:
         missing.append("scenario_hook")
-        scenario_hook_present = False
-    else:
-        scenario_hook_present = spec.scenario_hook in known_scenario_hooks
-        if not scenario_hook_present:
-            missing.append("scenario_hook")
 
     missing_outputs = _missing_expected_outputs(spec)
     expected_surrogate_outputs_present = not missing_outputs
@@ -169,12 +475,10 @@ def build_uncertainty_source_readiness_inventory(
         DEFAULT_UNCERTAINTY_SOURCE_SPECS
     ),
 ) -> dict[str, Any]:
-    """Build a versioned readiness inventory for issue #3557.
+    """Build the backward-compatible issue #3557 readiness inventory.
 
     Returns:
-        dict[str, Any]: Diagnostic readiness report only. ``ready_sources`` names sources
-        that can be wired into an episode-level contrast with current hooks;
-        ``blocked_sources`` names sources that still need builder/hook/output work.
+        Legacy JSON-ready inventory used by existing benchmark tests and callers.
     """
 
     if not specs:
@@ -195,7 +499,7 @@ def build_uncertainty_source_readiness_inventory(
 
     return {
         "schema_version": UNCERTAINTY_SOURCE_READINESS_SCHEMA,
-        "issue": 3557,
+        "issue": ISSUE,
         "claim_boundary": "readiness_inventory_only",
         "not_benchmark_evidence": True,
         "runs_executed": False,
@@ -208,9 +512,27 @@ def build_uncertainty_source_readiness_inventory(
 
 
 __all__ = [
+    "CLASS_PROBABILITY_AMBIGUITY",
+    "COVARIANCE_INFLATION",
+    "DEFAULT_SOURCE_SPECS",
     "DEFAULT_UNCERTAINTY_SOURCE_SPECS",
+    "EXISTENCE_DEGRADATION",
+    "EXPECTED_SURROGATE_OUTPUTS",
+    "ISSUE",
+    "MISSING_CONDITION_BUILDER",
+    "MISSING_SCENARIO_HOOK",
+    "MISSING_SURROGATE_OUTPUT",
+    "SCHEMA_VERSION",
+    "SOURCE_READY",
+    "TRACKING_NOISE",
     "UNCERTAINTY_SOURCE_READINESS_SCHEMA",
+    "VISIBILITY_OCCLUSION",
+    "ReadinessComponent",
+    "SourceReadinessSpec",
+    "UncertaintySourceReadiness",
+    "UncertaintySourceReadinessReport",
     "UncertaintySourceRunSpec",
     "build_uncertainty_source_readiness_inventory",
     "classify_uncertainty_source_readiness",
+    "inspect_uncertainty_source_readiness",
 ]

--- a/robot_sf/benchmark/uncertainty_source_readiness.py
+++ b/robot_sf/benchmark/uncertainty_source_readiness.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import ast
 import importlib
-from dataclasses import dataclass, fields
+from dataclasses import dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any
 
@@ -237,8 +237,8 @@ def _resolve_owner(owner: str | None) -> tuple[bool, str]:
     source_path = _module_source_path(module_name)
     if source_path is not None:
         try:
-            tree = ast.parse(source_path.read_text())
-        except OSError as exc:
+            tree = ast.parse(source_path.read_text(encoding="utf-8"))
+        except (OSError, SyntaxError) as exc:
             return False, f"cannot read {source_path}: {exc}"
         if not _module_ast_defines(tree, attribute):
             return False, f"{module_name} has no top-level attribute {attribute!r}"
@@ -275,19 +275,12 @@ def _module_ast_defines(tree: ast.Module, attribute: str) -> bool:
     """Return whether a module AST defines a top-level symbol.
 
     Returns:
-        True when a function, class, or assignment defines ``attribute``.
+        True when a function or class defines ``attribute``.
     """
 
     for node in tree.body:
         if isinstance(node, ast.FunctionDef | ast.AsyncFunctionDef | ast.ClassDef):
             if node.name == attribute:
-                return True
-        if isinstance(node, ast.Assign):
-            for target in node.targets:
-                if isinstance(target, ast.Name) and target.id == attribute:
-                    return True
-        if isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
-            if node.target.id == attribute:
                 return True
     return False
 
@@ -304,8 +297,8 @@ def _class_field_names_from_source(owner: str) -> set[str] | None:
     if source_path is None:
         return None
     try:
-        tree = ast.parse(source_path.read_text())
-    except OSError:
+        tree = ast.parse(source_path.read_text(encoding="utf-8"))
+    except (OSError, SyntaxError):
         return None
     for node in tree.body:
         if isinstance(node, ast.ClassDef) and node.name == attribute:
@@ -330,8 +323,14 @@ def _source_contrast_has_expected_fields(owner: str | None) -> tuple[bool, str]:
     field_names = _class_field_names_from_source(owner)
     if field_names is None:
         module_name, _separator, attribute = owner.partition(":")
-        contrast_type = getattr(importlib.import_module(module_name), attribute)
-        field_names = {field.name for field in fields(contrast_type)}
+        try:
+            contrast_type = getattr(importlib.import_module(module_name), attribute)
+            if is_dataclass(contrast_type):
+                field_names = {field.name for field in fields(contrast_type)}
+            else:
+                field_names = set(getattr(contrast_type, "__annotations__", {}))
+        except (AttributeError, ImportError, TypeError) as exc:
+            return False, f"cannot dynamically inspect {owner}: {exc}"
     missing = sorted(set(EXPECTED_SURROGATE_OUTPUTS) - field_names)
     if missing:
         return False, f"{owner} missing fields {missing}"

--- a/scripts/validation/check_uncertainty_source_readiness_issue_3557.py
+++ b/scripts/validation/check_uncertainty_source_readiness_issue_3557.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import importlib.util
 import json
 import sys
 from pathlib import Path
@@ -12,30 +13,85 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 if str(_REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(_REPO_ROOT))
 
-from robot_sf.benchmark.uncertainty_source_readiness import (  # noqa: E402
-    build_uncertainty_source_readiness_inventory,
+_READINESS_MODULE_PATH = _REPO_ROOT / "robot_sf" / "benchmark" / "uncertainty_source_readiness.py"
+_READINESS_SPEC = importlib.util.spec_from_file_location(
+    "_issue_3557_uncertainty_source_readiness", _READINESS_MODULE_PATH
 )
+if _READINESS_SPEC is None or _READINESS_SPEC.loader is None:
+    raise ImportError(f"cannot load {_READINESS_MODULE_PATH}")
+_READINESS_MODULE = importlib.util.module_from_spec(_READINESS_SPEC)
+sys.modules[_READINESS_SPEC.name] = _READINESS_MODULE
+_READINESS_SPEC.loader.exec_module(_READINESS_MODULE)
+
+CLASS_PROBABILITY_AMBIGUITY = _READINESS_MODULE.CLASS_PROBABILITY_AMBIGUITY
+COVARIANCE_INFLATION = _READINESS_MODULE.COVARIANCE_INFLATION
+DEFAULT_SOURCE_SPECS = _READINESS_MODULE.DEFAULT_SOURCE_SPECS
+EXISTENCE_DEGRADATION = _READINESS_MODULE.EXISTENCE_DEGRADATION
+MISSING_CONDITION_BUILDER = _READINESS_MODULE.MISSING_CONDITION_BUILDER
+MISSING_SURROGATE_OUTPUT = _READINESS_MODULE.MISSING_SURROGATE_OUTPUT
+SOURCE_READY = _READINESS_MODULE.SOURCE_READY
+TRACKING_NOISE = _READINESS_MODULE.TRACKING_NOISE
+VISIBILITY_OCCLUSION = _READINESS_MODULE.VISIBILITY_OCCLUSION
+SourceReadinessSpec = _READINESS_MODULE.SourceReadinessSpec
+inspect_uncertainty_source_readiness = _READINESS_MODULE.inspect_uncertainty_source_readiness
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Run the readiness inventory CLI.
+def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+    """Parse command-line options."""
 
-    Returns:
-        int: ``1`` only when ``--fail-on-blocked`` is set and some source is blocked.
-    """
-
-    parser = argparse.ArgumentParser(description=__doc__)
+    parser = argparse.ArgumentParser(
+        description=(
+            "Inspect condition-builder, scenario-hook, and surrogate-output readiness "
+            "for issue #3557 uncertainty-source episode runs."
+        )
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument("--human", action="store_true", help="emit compact human-readable text")
     parser.add_argument(
         "--fail-on-blocked",
         action="store_true",
-        help="Exit 1 when any uncertainty source is not ready for episode-level runs.",
+        help="exit 1 when any uncertainty source is missing a readiness prerequisite",
     )
-    args = parser.parse_args(argv)
-
-    report = build_uncertainty_source_readiness_inventory()
-    print(json.dumps(report, indent=2, sort_keys=True))
-    return int(bool(args.fail_on_blocked and report["blocked_sources"]))
+    return parser.parse_args(argv)
 
 
-if __name__ == "__main__":  # pragma: no cover - exercised through CLI tests when needed.
+def _render_human(payload: dict[str, object]) -> str:
+    """Render a compact human-readable inventory."""
+
+    lines = [
+        f"issue #{payload['issue']} uncertainty-source readiness",
+        f"schema: {payload['schema_version']}",
+        f"ready sources: {', '.join(payload['ready_sources']) or '(none)'}",
+        f"blocked sources: {', '.join(payload['blocked_sources']) or '(none)'}",
+        "",
+    ]
+    for row in payload["sources"]:
+        lines.append(f"- {row['source']}: {row['status']}")
+        lines.append(f"  condition_builder: {row['condition_builder']['evidence']}")
+        lines.append(f"  scenario_hook: {row['scenario_hook']['evidence']}")
+        lines.append(
+            f"  expected_surrogate_outputs: {row['expected_surrogate_outputs']['evidence']}"
+        )
+    lines.append("")
+    lines.append(str(payload["claim_boundary"]))
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the readiness inventory.
+
+    Returns:
+        Exit code 1 only when ``--fail-on-blocked`` is set and a source is blocked.
+    """
+
+    args = _parse_args(argv)
+    payload = inspect_uncertainty_source_readiness().as_dict()
+    if args.human:
+        print(_render_human(payload))
+    else:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    return 1 if args.fail_on_blocked and not payload["ready"] else 0
+
+
+if __name__ == "__main__":
     raise SystemExit(main())

--- a/tests/benchmark/test_uncertainty_source_readiness.py
+++ b/tests/benchmark/test_uncertainty_source_readiness.py
@@ -1,200 +1,234 @@
-"""Tests for issue #3557 uncertainty-source readiness inventory."""
+"""Tests benchmark uncertainty-source readiness helpers."""
 
 from __future__ import annotations
 
-import importlib.util
-import json
-from pathlib import Path
+import ast
+import sys
+import types
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-import pytest
+from robot_sf.benchmark import uncertainty_source_readiness as readiness
 
-import robot_sf.benchmark.uncertainty_source_readiness as readiness
-from robot_sf.benchmark.uncertainty_source_readiness import (
-    UNCERTAINTY_SOURCE_READINESS_SCHEMA,
-    UncertaintySourceRunSpec,
-    build_uncertainty_source_readiness_inventory,
-    classify_uncertainty_source_readiness,
-)
-
-_SCRIPT_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "scripts"
-    / "validation"
-    / "check_uncertainty_source_readiness_issue_3557.py"
-)
-_SPEC = importlib.util.spec_from_file_location("_issue_3557_readiness", _SCRIPT_PATH)
-assert _SPEC is not None
-_SCRIPT = importlib.util.module_from_spec(_SPEC)
-assert _SPEC.loader is not None
-_SPEC.loader.exec_module(_SCRIPT)
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
-def test_default_inventory_reports_readiness_without_running_benchmarks() -> None:
-    """Default inventory labels current hooks without executing episode runs."""
+def test_default_inventory_payload_and_legacy_inventory_contract(monkeypatch) -> None:
+    """Default and legacy inventory helpers expose deterministic readiness payloads."""
 
-    report = build_uncertainty_source_readiness_inventory()
+    report = readiness.inspect_uncertainty_source_readiness()
+    payload = report.as_dict()
 
-    assert report["schema_version"] == UNCERTAINTY_SOURCE_READINESS_SCHEMA
-    assert report["issue"] == 3557
-    assert report["claim_boundary"] == "readiness_inventory_only"
-    assert report["not_benchmark_evidence"] is True
-    assert report["runs_executed"] is False
-    assert report["surrogate_semantics_changed"] is False
-    assert report["all_sources_ready"] is False
+    assert payload["schema_version"] == readiness.SCHEMA_VERSION
+    assert payload["issue"] == readiness.ISSUE
+    assert payload["ready"] is False
+    assert readiness.EXISTENCE_DEGRADATION in payload["ready_sources"]
+    assert readiness.VISIBILITY_OCCLUSION in payload["blocked_sources"]
+    assert "does not claim" in payload["claim_boundary"]
+    assert payload["sources"][0]["condition_builder"]["present"] is True
 
-    by_source = {row["source"]: row for row in report["sources"]}
-    assert set(by_source) == {
-        "existence_degraded",
-        "visibility_limited",
-        "covariance_inflated",
-        "class_probability",
-        "tracking_noise",
-    }
-
-    assert by_source["existence_degraded"]["status"] == "ready"
-    assert by_source["existence_degraded"]["missing"] == []
-    assert by_source["visibility_limited"]["missing"] == ["scenario_hook"]
-    assert by_source["covariance_inflated"]["missing"] == ["scenario_hook"]
-    assert by_source["class_probability"]["missing"] == ["scenario_hook"]
-    assert by_source["tracking_noise"]["missing"] == ["condition_builder", "scenario_hook"]
-
-
-def test_supported_source_with_all_surrogate_outputs_is_ready() -> None:
-    """A source with known builder, hook, and output fields is runnable-ready."""
-
-    row = classify_uncertainty_source_readiness(
-        UncertaintySourceRunSpec(
-            source="synthetic",
-            condition_builder="_condition_existence_degraded",
-            scenario_hook="build_belief_for_mode",
-        )
-    )
-
-    assert row["status"] == "ready"
-    assert row["condition_builder_present"] is True
-    assert row["scenario_hook_present"] is True
-    assert row["expected_surrogate_outputs_present"] is True
-
-
-def test_unknown_condition_builder_fails_closed() -> None:
-    """A misspelled or not-yet-written builder blocks the source."""
-
-    row = classify_uncertainty_source_readiness(
-        UncertaintySourceRunSpec(
-            source="tracking_noise",
-            condition_builder="_condition_tracking_noise",
-            scenario_hook="build_belief_for_mode",
-        )
-    )
-
-    assert row["status"] == "blocked"
-    assert row["missing"] == ["condition_builder"]
-    assert row["condition_builder_present"] is False
-
-
-def test_missing_scenario_hook_fails_closed() -> None:
-    """Single-step condition builders alone are not episode-run readiness."""
-
-    row = classify_uncertainty_source_readiness(
-        UncertaintySourceRunSpec(
-            source="visibility_limited",
-            condition_builder="_condition_visibility_limited",
-            scenario_hook=None,
-        )
-    )
-
-    assert row["status"] == "blocked"
-    assert row["missing"] == ["scenario_hook"]
-    assert row["scenario_hook_present"] is False
-
-
-def test_missing_expected_surrogate_output_fails_closed() -> None:
-    """Future run specs must expose all fields consumed by the decision layer."""
-
-    row = classify_uncertainty_source_readiness(
-        UncertaintySourceRunSpec(
-            source="existence_degraded",
-            condition_builder="_condition_existence_degraded",
-            scenario_hook="build_belief_for_mode",
-            expected_surrogate_outputs=(
-                "source",
-                "retained_unsafe_commit_rate",
-                "dropped_unsafe_commit_rate",
-                "n_episodes",
+    monkeypatch.setattr(readiness, "_discover_condition_builders", lambda: frozenset({"builder"}))
+    monkeypatch.setattr(readiness, "_discover_scenario_hooks", lambda: frozenset({"hook"}))
+    legacy = readiness.build_uncertainty_source_readiness_inventory(
+        (
+            readiness.UncertaintySourceRunSpec(
+                source="legacy_ready",
+                condition_builder="builder",
+                scenario_hook="hook",
             ),
         )
     )
 
-    assert row["status"] == "blocked"
-    assert row["missing"] == ["expected_surrogate_outputs"]
-    assert row["missing_expected_surrogate_outputs"] == ["min_separation_delta_m"]
+    assert legacy["schema_version"] == readiness.UNCERTAINTY_SOURCE_READINESS_SCHEMA
+    assert legacy["ready_sources"] == ["legacy_ready"]
+    assert legacy["blocked_sources"] == []
 
 
-def test_inventory_requires_at_least_one_source() -> None:
-    """An empty inventory would hide readiness gaps."""
+def test_static_ast_helpers_find_supported_top_level_symbols() -> None:
+    """Static helper recognizes functions, classes, annotated names, and modules."""
 
-    with pytest.raises(ValueError, match="at least one uncertainty source"):
-        build_uncertainty_source_readiness_inventory([])
-
-
-def test_inventory_reuses_discovered_symbols_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Inventory discovery should happen once per report, not once per source."""
-
-    calls = {"builders": 0, "hooks": 0}
-
-    def discover_builders() -> frozenset[str]:
-        calls["builders"] += 1
-        return frozenset(
-            {
-                "_condition_existence_degraded",
-                "_condition_visibility_limited",
-                "_condition_covariance_inflated",
-                "_condition_class_probability",
-            }
-        )
-
-    def discover_hooks() -> frozenset[str]:
-        calls["hooks"] += 1
-        return frozenset({"build_belief_for_mode"})
-
-    monkeypatch.setattr(readiness, "_discover_condition_builders", discover_builders)
-    monkeypatch.setattr(readiness, "_discover_scenario_hooks", discover_hooks)
-
-    report = build_uncertainty_source_readiness_inventory()
-
-    assert report["ready_sources"] == ["existence_degraded"]
-    assert calls == {"builders": 1, "hooks": 1}
-
-
-def test_owner_import_failures_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Broken owner modules should make sources blocked, not crash the inventory CLI."""
-
-    def broken_import_module(module_name: str) -> object:
-        raise ImportError(f"{module_name} unavailable")
-
-    monkeypatch.setattr(readiness.importlib, "import_module", broken_import_module)
-
-    report = build_uncertainty_source_readiness_inventory(
-        [
-            UncertaintySourceRunSpec(
-                source="synthetic",
-                condition_builder="_condition_existence_degraded",
-                scenario_hook="build_belief_for_mode",
-            )
-        ]
+    tree = ast.parse(
+        "def function_owner():\n    pass\nclass ClassOwner:\n    pass\nANNOTATED_OWNER: int = 1\n"
     )
 
-    assert report["all_sources_ready"] is False
-    assert report["blocked_sources"] == ["synthetic"]
-    assert report["sources"][0]["missing"] == ["condition_builder", "scenario_hook"]
+    assert readiness._module_ast_defines(tree, "function_owner")
+    assert readiness._module_ast_defines(tree, "ClassOwner")
+    assert not readiness._module_ast_defines(tree, "ANNOTATED_OWNER")
+    assert (
+        readiness._module_source_path("robot_sf.benchmark.uncertainty_source_readiness").name
+        == "uncertainty_source_readiness.py"
+    )
 
 
-def test_cli_reports_inventory_and_can_fail_on_blocked(capsys: pytest.CaptureFixture[str]) -> None:
-    """CLI prints JSON by default and can fail closed when blocked sources remain."""
+def test_source_field_discovery_and_surrogate_missing_fields(monkeypatch) -> None:
+    """Surrogate inspection covers static source fields and missing-field failures."""
 
-    assert _SCRIPT.main([]) == 0
-    report = json.loads(capsys.readouterr().out)
-    assert report["schema_version"] == UNCERTAINTY_SOURCE_READINESS_SCHEMA
-    assert "tracking_noise" in report["blocked_sources"]
+    field_names = readiness._class_field_names_from_source(
+        "robot_sf.representation.uncertainty_source_generalization:SourceContrast"
+    )
+    assert field_names is not None
+    assert set(readiness.EXPECTED_SURROGATE_OUTPUTS) <= field_names
 
-    assert _SCRIPT.main(["--fail-on-blocked"]) == 1
+    module = types.ModuleType("_issue_3557_incomplete_dynamic_owner")
+
+    class IncompleteContrast:
+        source: str
+
+    module.IncompleteContrast = IncompleteContrast
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: None)
+    monkeypatch.setattr(readiness, "_class_field_names_from_source", lambda _owner: None)
+
+    present, evidence = readiness._source_contrast_has_expected_fields(
+        f"{module.__name__}:IncompleteContrast"
+    )
+
+    assert not present
+    assert "missing fields" in evidence
+
+
+def test_dynamic_surrogate_output_fallback_accepts_dataclass(monkeypatch) -> None:
+    """Dynamic fallback supports dataclasses when static source inspection is unavailable."""
+
+    module = types.ModuleType("_issue_3557_dataclass_dynamic_owner")
+
+    @dataclass(frozen=True)
+    class DataclassContrast:
+        source: str
+        retained_unsafe_commit_rate: float
+        dropped_unsafe_commit_rate: float
+        min_separation_delta_m: float
+        n_episodes: int
+
+    module.DataclassContrast = DataclassContrast
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: None)
+    monkeypatch.setattr(readiness, "_class_field_names_from_source", lambda _owner: None)
+
+    present, evidence = readiness._source_contrast_has_expected_fields(
+        f"{module.__name__}:DataclassContrast"
+    )
+
+    assert present
+    assert "exposes" in evidence
+
+
+def test_static_owner_discovery_handles_destructuring_and_parse_failures(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Static owner checks handle common source shapes and fail closed on bad source."""
+
+    tree = ast.parse("first, second = object(), object()\n")
+    assert not readiness._module_ast_defines(tree, "second")
+    assert not readiness._module_ast_defines(tree, "third")
+
+    bad_source = tmp_path / "bad_owner.py"
+    bad_source.write_text("def broken(:\n", encoding="utf-8")
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: bad_source)
+
+    present, evidence = readiness._resolve_owner("bad_owner:anything")
+
+    assert not present
+    assert "cannot read" in evidence
+
+
+def test_dynamic_surrogate_output_fallback_accepts_annotated_non_dataclass(monkeypatch) -> None:
+    """Dynamic fallback can inspect plain annotated classes without crashing."""
+
+    module = types.ModuleType("_issue_3557_dynamic_owner")
+
+    class PlainContrast:
+        source: str
+        retained_unsafe_commit_rate: float
+        dropped_unsafe_commit_rate: float
+        min_separation_delta_m: float
+        n_episodes: int
+
+    module.PlainContrast = PlainContrast
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: None)
+    monkeypatch.setattr(readiness, "_class_field_names_from_source", lambda _owner: None)
+
+    present, evidence = readiness._source_contrast_has_expected_fields(
+        f"{module.__name__}:PlainContrast"
+    )
+
+    assert present
+    assert "exposes" in evidence
+
+
+def test_readiness_status_reports_first_missing_component() -> None:
+    """Source readiness status distinguishes each missing prerequisite class."""
+
+    present = readiness.ReadinessComponent(present=True, owner="owner:symbol", evidence="ok")
+    missing = readiness.ReadinessComponent(present=False, owner=None, evidence="missing")
+
+    assert (
+        readiness.UncertaintySourceReadiness(
+            source="missing_builder",
+            condition_builder=missing,
+            scenario_hook=present,
+            expected_surrogate_outputs=present,
+        ).status
+        == readiness.MISSING_CONDITION_BUILDER
+    )
+    assert (
+        readiness.UncertaintySourceReadiness(
+            source="missing_hook",
+            condition_builder=present,
+            scenario_hook=missing,
+            expected_surrogate_outputs=present,
+        ).status
+        == readiness.MISSING_SCENARIO_HOOK
+    )
+    assert (
+        readiness.UncertaintySourceReadiness(
+            source="missing_output",
+            condition_builder=present,
+            scenario_hook=present,
+            expected_surrogate_outputs=missing,
+        ).status
+        == readiness.MISSING_SURROGATE_OUTPUT
+    )
+
+
+def test_owner_resolution_defensive_branches(monkeypatch) -> None:
+    """Owner resolution fails closed for malformed, missing, and dynamic owners."""
+
+    module = types.ModuleType("_issue_3557_dynamic_resolution")
+    module.available = object()
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: None)
+
+    assert readiness._resolve_owner("not-a-module-owner")[0] is False
+    assert readiness._resolve_owner("_issue_3557_missing_module:Thing")[0] is False
+    assert readiness._resolve_owner(f"{module.__name__}:missing")[0] is False
+
+    present, evidence = readiness._resolve_owner(f"{module.__name__}:available")
+
+    assert present
+    assert "resolved" in evidence
+
+
+def test_static_path_and_target_helpers_cover_edge_cases() -> None:
+    """Static helpers support packages and ignore non-binding targets."""
+
+    package_path = readiness._module_source_path("robot_sf.benchmark")
+    assert package_path is not None
+    assert package_path.name == "__init__.py"
+    assert readiness._module_source_path("_issue_3557_no_such_module") is None
+
+    assert not readiness._module_ast_defines(ast.parse("holder.value = 1\n"), "value")
+
+
+def test_class_field_source_and_surrogate_fail_closed(monkeypatch, tmp_path: Path) -> None:
+    """Source field discovery and surrogate inspection fail closed."""
+
+    no_class_source = tmp_path / "no_class.py"
+    no_class_source.write_text("OTHER = object()\n", encoding="utf-8")
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: no_class_source)
+    assert readiness._class_field_names_from_source("no_class:Missing") is None
+
+    assert readiness._source_contrast_has_expected_fields(None)[0] is False

--- a/tests/benchmark/test_uncertainty_source_readiness.py
+++ b/tests/benchmark/test_uncertainty_source_readiness.py
@@ -1,200 +1,235 @@
-"""Tests for issue #3557 uncertainty-source readiness inventory."""
+"""Tests benchmark uncertainty-source readiness helpers."""
 
 from __future__ import annotations
 
-import importlib.util
-import json
-from pathlib import Path
+import ast
+import sys
+import types
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
 
-import pytest
+from robot_sf.benchmark import uncertainty_source_readiness as readiness
 
-import robot_sf.benchmark.uncertainty_source_readiness as readiness
-from robot_sf.benchmark.uncertainty_source_readiness import (
-    UNCERTAINTY_SOURCE_READINESS_SCHEMA,
-    UncertaintySourceRunSpec,
-    build_uncertainty_source_readiness_inventory,
-    classify_uncertainty_source_readiness,
-)
-
-_SCRIPT_PATH = (
-    Path(__file__).resolve().parents[2]
-    / "scripts"
-    / "validation"
-    / "check_uncertainty_source_readiness_issue_3557.py"
-)
-_SPEC = importlib.util.spec_from_file_location("_issue_3557_readiness", _SCRIPT_PATH)
-assert _SPEC is not None
-_SCRIPT = importlib.util.module_from_spec(_SPEC)
-assert _SPEC.loader is not None
-_SPEC.loader.exec_module(_SCRIPT)
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
-def test_default_inventory_reports_readiness_without_running_benchmarks() -> None:
-    """Default inventory labels current hooks without executing episode runs."""
+def test_default_inventory_payload_and_legacy_inventory_contract(monkeypatch) -> None:
+    """Default and legacy inventory helpers expose deterministic readiness payloads."""
 
-    report = build_uncertainty_source_readiness_inventory()
+    report = readiness.inspect_uncertainty_source_readiness()
+    payload = report.as_dict()
 
-    assert report["schema_version"] == UNCERTAINTY_SOURCE_READINESS_SCHEMA
-    assert report["issue"] == 3557
-    assert report["claim_boundary"] == "readiness_inventory_only"
-    assert report["not_benchmark_evidence"] is True
-    assert report["runs_executed"] is False
-    assert report["surrogate_semantics_changed"] is False
-    assert report["all_sources_ready"] is False
+    assert payload["schema_version"] == readiness.SCHEMA_VERSION
+    assert payload["issue"] == readiness.ISSUE
+    assert payload["ready"] is False
+    assert readiness.EXISTENCE_DEGRADATION in payload["ready_sources"]
+    assert readiness.VISIBILITY_OCCLUSION in payload["blocked_sources"]
+    assert "does not claim" in payload["claim_boundary"]
+    assert payload["sources"][0]["condition_builder"]["present"] is True
 
-    by_source = {row["source"]: row for row in report["sources"]}
-    assert set(by_source) == {
-        "existence_degraded",
-        "visibility_limited",
-        "covariance_inflated",
-        "class_probability",
-        "tracking_noise",
-    }
-
-    assert by_source["existence_degraded"]["status"] == "ready"
-    assert by_source["existence_degraded"]["missing"] == []
-    assert by_source["visibility_limited"]["missing"] == ["scenario_hook"]
-    assert by_source["covariance_inflated"]["missing"] == ["scenario_hook"]
-    assert by_source["class_probability"]["missing"] == ["scenario_hook"]
-    assert by_source["tracking_noise"]["missing"] == ["condition_builder", "scenario_hook"]
-
-
-def test_supported_source_with_all_surrogate_outputs_is_ready() -> None:
-    """A source with known builder, hook, and output fields is runnable-ready."""
-
-    row = classify_uncertainty_source_readiness(
-        UncertaintySourceRunSpec(
-            source="synthetic",
-            condition_builder="_condition_existence_degraded",
-            scenario_hook="build_belief_for_mode",
-        )
-    )
-
-    assert row["status"] == "ready"
-    assert row["condition_builder_present"] is True
-    assert row["scenario_hook_present"] is True
-    assert row["expected_surrogate_outputs_present"] is True
-
-
-def test_unknown_condition_builder_fails_closed() -> None:
-    """A misspelled or not-yet-written builder blocks the source."""
-
-    row = classify_uncertainty_source_readiness(
-        UncertaintySourceRunSpec(
-            source="tracking_noise",
-            condition_builder="_condition_tracking_noise",
-            scenario_hook="build_belief_for_mode",
-        )
-    )
-
-    assert row["status"] == "blocked"
-    assert row["missing"] == ["condition_builder"]
-    assert row["condition_builder_present"] is False
-
-
-def test_missing_scenario_hook_fails_closed() -> None:
-    """Single-step condition builders alone are not episode-run readiness."""
-
-    row = classify_uncertainty_source_readiness(
-        UncertaintySourceRunSpec(
-            source="visibility_limited",
-            condition_builder="_condition_visibility_limited",
-            scenario_hook=None,
-        )
-    )
-
-    assert row["status"] == "blocked"
-    assert row["missing"] == ["scenario_hook"]
-    assert row["scenario_hook_present"] is False
-
-
-def test_missing_expected_surrogate_output_fails_closed() -> None:
-    """Future run specs must expose all fields consumed by the decision layer."""
-
-    row = classify_uncertainty_source_readiness(
-        UncertaintySourceRunSpec(
-            source="existence_degraded",
-            condition_builder="_condition_existence_degraded",
-            scenario_hook="build_belief_for_mode",
-            expected_surrogate_outputs=(
-                "source",
-                "retained_unsafe_commit_rate",
-                "dropped_unsafe_commit_rate",
-                "n_episodes",
+    monkeypatch.setattr(readiness, "_discover_condition_builders", lambda: frozenset({"builder"}))
+    monkeypatch.setattr(readiness, "_discover_scenario_hooks", lambda: frozenset({"hook"}))
+    legacy = readiness.build_uncertainty_source_readiness_inventory(
+        (
+            readiness.UncertaintySourceRunSpec(
+                source="legacy_ready",
+                condition_builder="builder",
+                scenario_hook="hook",
             ),
         )
     )
 
-    assert row["status"] == "blocked"
-    assert row["missing"] == ["expected_surrogate_outputs"]
-    assert row["missing_expected_surrogate_outputs"] == ["min_separation_delta_m"]
+    assert legacy["schema_version"] == readiness.UNCERTAINTY_SOURCE_READINESS_SCHEMA
+    assert legacy["ready_sources"] == ["legacy_ready"]
+    assert legacy["blocked_sources"] == []
 
 
-def test_inventory_requires_at_least_one_source() -> None:
-    """An empty inventory would hide readiness gaps."""
+def test_static_ast_helpers_find_supported_top_level_symbols() -> None:
+    """Static helper recognizes functions, classes, annotated names, and modules."""
 
-    with pytest.raises(ValueError, match="at least one uncertainty source"):
-        build_uncertainty_source_readiness_inventory([])
-
-
-def test_inventory_reuses_discovered_symbols_once(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Inventory discovery should happen once per report, not once per source."""
-
-    calls = {"builders": 0, "hooks": 0}
-
-    def discover_builders() -> frozenset[str]:
-        calls["builders"] += 1
-        return frozenset(
-            {
-                "_condition_existence_degraded",
-                "_condition_visibility_limited",
-                "_condition_covariance_inflated",
-                "_condition_class_probability",
-            }
-        )
-
-    def discover_hooks() -> frozenset[str]:
-        calls["hooks"] += 1
-        return frozenset({"build_belief_for_mode"})
-
-    monkeypatch.setattr(readiness, "_discover_condition_builders", discover_builders)
-    monkeypatch.setattr(readiness, "_discover_scenario_hooks", discover_hooks)
-
-    report = build_uncertainty_source_readiness_inventory()
-
-    assert report["ready_sources"] == ["existence_degraded"]
-    assert calls == {"builders": 1, "hooks": 1}
-
-
-def test_owner_import_failures_fail_closed(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Broken owner modules should make sources blocked, not crash the inventory CLI."""
-
-    def broken_import_module(module_name: str) -> object:
-        raise ImportError(f"{module_name} unavailable")
-
-    monkeypatch.setattr(readiness.importlib, "import_module", broken_import_module)
-
-    report = build_uncertainty_source_readiness_inventory(
-        [
-            UncertaintySourceRunSpec(
-                source="synthetic",
-                condition_builder="_condition_existence_degraded",
-                scenario_hook="build_belief_for_mode",
-            )
-        ]
+    tree = ast.parse(
+        "def function_owner():\n    pass\nclass ClassOwner:\n    pass\nANNOTATED_OWNER: int = 1\n"
     )
 
-    assert report["all_sources_ready"] is False
-    assert report["blocked_sources"] == ["synthetic"]
-    assert report["sources"][0]["missing"] == ["condition_builder", "scenario_hook"]
+    assert readiness._module_ast_defines(tree, "function_owner")
+    assert readiness._module_ast_defines(tree, "ClassOwner")
+    assert readiness._module_ast_defines(tree, "ANNOTATED_OWNER")
+    assert (
+        readiness._module_source_path("robot_sf.benchmark.uncertainty_source_readiness").name
+        == "uncertainty_source_readiness.py"
+    )
 
 
-def test_cli_reports_inventory_and_can_fail_on_blocked(capsys: pytest.CaptureFixture[str]) -> None:
-    """CLI prints JSON by default and can fail closed when blocked sources remain."""
+def test_source_field_discovery_and_surrogate_missing_fields(monkeypatch) -> None:
+    """Surrogate inspection covers static source fields and missing-field failures."""
 
-    assert _SCRIPT.main([]) == 0
-    report = json.loads(capsys.readouterr().out)
-    assert report["schema_version"] == UNCERTAINTY_SOURCE_READINESS_SCHEMA
-    assert "tracking_noise" in report["blocked_sources"]
+    field_names = readiness._class_field_names_from_source(
+        "robot_sf.representation.uncertainty_source_generalization:SourceContrast"
+    )
+    assert field_names is not None
+    assert set(readiness.EXPECTED_SURROGATE_OUTPUTS) <= field_names
 
-    assert _SCRIPT.main(["--fail-on-blocked"]) == 1
+    module = types.ModuleType("_issue_3557_incomplete_dynamic_owner")
+
+    class IncompleteContrast:
+        source: str
+
+    module.IncompleteContrast = IncompleteContrast
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: None)
+    monkeypatch.setattr(readiness, "_class_field_names_from_source", lambda _owner: None)
+
+    present, evidence = readiness._source_contrast_has_expected_fields(
+        f"{module.__name__}:IncompleteContrast"
+    )
+
+    assert not present
+    assert "missing fields" in evidence
+
+
+def test_dynamic_surrogate_output_fallback_accepts_dataclass(monkeypatch) -> None:
+    """Dynamic fallback supports dataclasses when static source inspection is unavailable."""
+
+    module = types.ModuleType("_issue_3557_dataclass_dynamic_owner")
+
+    @dataclass(frozen=True)
+    class DataclassContrast:
+        source: str
+        retained_unsafe_commit_rate: float
+        dropped_unsafe_commit_rate: float
+        min_separation_delta_m: float
+        n_episodes: int
+
+    module.DataclassContrast = DataclassContrast
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: None)
+    monkeypatch.setattr(readiness, "_class_field_names_from_source", lambda _owner: None)
+
+    present, evidence = readiness._source_contrast_has_expected_fields(
+        f"{module.__name__}:DataclassContrast"
+    )
+
+    assert present
+    assert "exposes" in evidence
+
+
+def test_static_owner_discovery_handles_destructuring_and_parse_failures(
+    monkeypatch,
+    tmp_path: Path,
+) -> None:
+    """Static owner checks handle common source shapes and fail closed on bad source."""
+
+    tree = ast.parse("first, second = object(), object()\n")
+    assert readiness._module_ast_defines(tree, "second")
+    assert not readiness._module_ast_defines(tree, "third")
+
+    bad_source = tmp_path / "bad_owner.py"
+    bad_source.write_text("def broken(:\n", encoding="utf-8")
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: bad_source)
+
+    present, evidence = readiness._resolve_owner("bad_owner:anything")
+
+    assert not present
+    assert "cannot read" in evidence
+
+
+def test_dynamic_surrogate_output_fallback_accepts_annotated_non_dataclass(monkeypatch) -> None:
+    """Dynamic fallback can inspect plain annotated classes without crashing."""
+
+    module = types.ModuleType("_issue_3557_dynamic_owner")
+
+    class PlainContrast:
+        source: str
+        retained_unsafe_commit_rate: float
+        dropped_unsafe_commit_rate: float
+        min_separation_delta_m: float
+        n_episodes: int
+
+    module.PlainContrast = PlainContrast
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: None)
+    monkeypatch.setattr(readiness, "_class_field_names_from_source", lambda _owner: None)
+
+    present, evidence = readiness._source_contrast_has_expected_fields(
+        f"{module.__name__}:PlainContrast"
+    )
+
+    assert present
+    assert "exposes" in evidence
+
+
+def test_readiness_status_reports_first_missing_component() -> None:
+    """Source readiness status distinguishes each missing prerequisite class."""
+
+    present = readiness.ReadinessComponent(present=True, owner="owner:symbol", evidence="ok")
+    missing = readiness.ReadinessComponent(present=False, owner=None, evidence="missing")
+
+    assert (
+        readiness.UncertaintySourceReadiness(
+            source="missing_builder",
+            condition_builder=missing,
+            scenario_hook=present,
+            expected_surrogate_outputs=present,
+        ).status
+        == readiness.MISSING_CONDITION_BUILDER
+    )
+    assert (
+        readiness.UncertaintySourceReadiness(
+            source="missing_hook",
+            condition_builder=present,
+            scenario_hook=missing,
+            expected_surrogate_outputs=present,
+        ).status
+        == readiness.MISSING_SCENARIO_HOOK
+    )
+    assert (
+        readiness.UncertaintySourceReadiness(
+            source="missing_output",
+            condition_builder=present,
+            scenario_hook=present,
+            expected_surrogate_outputs=missing,
+        ).status
+        == readiness.MISSING_SURROGATE_OUTPUT
+    )
+
+
+def test_owner_resolution_defensive_branches(monkeypatch) -> None:
+    """Owner resolution fails closed for malformed, missing, and dynamic owners."""
+
+    module = types.ModuleType("_issue_3557_dynamic_resolution")
+    module.available = object()
+    monkeypatch.setitem(sys.modules, module.__name__, module)
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: None)
+
+    assert readiness._resolve_owner("not-a-module-owner")[0] is False
+    assert readiness._resolve_owner("_issue_3557_missing_module:Thing")[0] is False
+    assert readiness._resolve_owner(f"{module.__name__}:missing")[0] is False
+
+    present, evidence = readiness._resolve_owner(f"{module.__name__}:available")
+
+    assert present
+    assert "resolved" in evidence
+
+
+def test_static_path_and_target_helpers_cover_edge_cases() -> None:
+    """Static helpers support packages and ignore non-binding targets."""
+
+    package_path = readiness._module_source_path("robot_sf.benchmark")
+    assert package_path is not None
+    assert package_path.name == "__init__.py"
+    assert readiness._module_source_path("_issue_3557_no_such_module") is None
+
+    target = ast.parse("holder.value = 1\n").body[0].targets[0]
+    assert not readiness._has_target_name(target, "value")
+
+
+def test_class_field_source_and_surrogate_fail_closed(monkeypatch, tmp_path: Path) -> None:
+    """Source field discovery and surrogate inspection fail closed."""
+
+    no_class_source = tmp_path / "no_class.py"
+    no_class_source.write_text("OTHER = object()\n", encoding="utf-8")
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: no_class_source)
+    assert readiness._class_field_names_from_source("no_class:Missing") is None
+
+    assert readiness._source_contrast_has_expected_fields(None)[0] is False

--- a/tests/benchmark/test_uncertainty_source_readiness.py
+++ b/tests/benchmark/test_uncertainty_source_readiness.py
@@ -212,6 +212,22 @@ def test_owner_resolution_defensive_branches(monkeypatch) -> None:
     assert "resolved" in evidence
 
 
+def test_owner_resolution_handles_dynamic_syntax_error(monkeypatch) -> None:
+    """Dynamic owner import reports syntax errors instead of crashing."""
+
+    monkeypatch.setattr(readiness, "_module_source_path", lambda _module_name: None)
+
+    def raise_syntax_error(_module_name: str) -> types.ModuleType:
+        raise SyntaxError("broken dynamic module")
+
+    monkeypatch.setattr(readiness.importlib, "import_module", raise_syntax_error)
+
+    present, evidence = readiness._resolve_owner("_issue_3557_broken_dynamic:Thing")
+
+    assert not present
+    assert "cannot import" in evidence
+
+
 def test_static_path_and_target_helpers_cover_edge_cases() -> None:
     """Static helpers support packages and ignore non-binding targets."""
 

--- a/tests/validation/test_uncertainty_source_readiness_issue_3557.py
+++ b/tests/validation/test_uncertainty_source_readiness_issue_3557.py
@@ -1,0 +1,95 @@
+"""Tests for issue #3557 uncertainty-source readiness inventory."""
+
+from __future__ import annotations
+
+from scripts.validation.check_uncertainty_source_readiness_issue_3557 import (
+    CLASS_PROBABILITY_AMBIGUITY,
+    COVARIANCE_INFLATION,
+    DEFAULT_SOURCE_SPECS,
+    EXISTENCE_DEGRADATION,
+    MISSING_CONDITION_BUILDER,
+    MISSING_SURROGATE_OUTPUT,
+    SOURCE_READY,
+    TRACKING_NOISE,
+    VISIBILITY_OCCLUSION,
+    SourceReadinessSpec,
+    inspect_uncertainty_source_readiness,
+    main,
+)
+
+
+def test_default_inventory_classifies_current_and_missing_sources() -> None:
+    """Default report shows only hardcoded #3471 source currently runnable."""
+
+    report = inspect_uncertainty_source_readiness()
+    by_source = {row.source: row for row in report.sources}
+
+    assert tuple(by_source) == tuple(spec.source for spec in DEFAULT_SOURCE_SPECS)
+    assert by_source[EXISTENCE_DEGRADATION].status == SOURCE_READY
+    for source in (
+        VISIBILITY_OCCLUSION,
+        COVARIANCE_INFLATION,
+        CLASS_PROBABILITY_AMBIGUITY,
+        TRACKING_NOISE,
+    ):
+        assert by_source[source].status == MISSING_CONDITION_BUILDER
+        assert not by_source[source].condition_builder.present
+        assert not by_source[source].scenario_hook.present
+        assert by_source[source].expected_surrogate_outputs.present
+
+
+def test_report_payload_is_inventory_not_generalization_claim() -> None:
+    """Machine-readable payload keeps the claim boundary explicit."""
+
+    payload = inspect_uncertainty_source_readiness().as_dict()
+
+    assert payload["issue"] == 3557
+    assert payload["ready"] is False
+    assert payload["ready_sources"] == [EXISTENCE_DEGRADATION]
+    assert "does not run the episode harness" in payload["claim_boundary"]
+    assert "does not claim" in payload["claim_boundary"]
+
+
+def test_synthetic_missing_surrogate_output_is_classified() -> None:
+    """A source with builder and hook but missing output contract is blocked accordingly."""
+
+    report = inspect_uncertainty_source_readiness(
+        (
+            SourceReadinessSpec(
+                source="synthetic_missing_output",
+                condition_builder_owner=(
+                    "scripts.validation.run_scenario_belief_episode_safety_issue_3471:"
+                    "build_belief_for_mode"
+                ),
+                scenario_hook_owner="scripts.validation.run_scenario_belief_episode_safety_issue_3471:run_episode",
+                surrogate_output_owner=None,
+            ),
+        )
+    )
+
+    row = report.sources[0]
+    assert row.status == MISSING_SURROGATE_OUTPUT
+    assert row.condition_builder.present
+    assert row.scenario_hook.present
+    assert not row.expected_surrogate_outputs.present
+
+
+def test_cli_emits_inventory_without_running_when_sources_blocked(capsys) -> None:
+    """CLI emits inventory without treating missing prerequisites as execution failure."""
+
+    exit_code = main(["--json"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 0
+    assert '"blocked_sources"' in captured.out
+    assert VISIBILITY_OCCLUSION in captured.out
+
+
+def test_cli_can_fail_closed_for_gate_usage(capsys) -> None:
+    """Explicit gate mode exits nonzero while source prerequisites are missing."""
+
+    exit_code = main(["--fail-on-blocked"])
+    captured = capsys.readouterr()
+
+    assert exit_code == 1
+    assert '"ready": false' in captured.out


### PR DESCRIPTION
## Summary
Adds an issue #3557 readiness inventory for episode-level uncertainty-source runs. The checker reports which uncertainty sources have condition builders, scenario hooks, and the expected surrogate output contract before any benchmark or episode execution is attempted.

## Linked Issues
- Relates to `#3557`
- Follows `#3471`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Reworked `robot_sf/benchmark/uncertainty_source_readiness.py` into a structured, versioned readiness report with per-source component evidence.
- Updated `scripts/validation/check_uncertainty_source_readiness_issue_3557.py` to emit JSON by default, support human output, and provide explicit `--fail-on-blocked` gate behavior.
- Added focused synthetic tests covering supported, missing-builder/hook, missing-output, default CLI, and fail-closed CLI classifications.

## Why Matters
- Added value: unblocks #3557 planning by showing the exact missing prerequisites before any expensive or claim-bearing run.
- Expected impact: safer next slice for parameterizing the #3471 harness across sources.
- Why worth merging now: it turns the known condition-builder ambiguity into inspectable inventory output.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for uncertainty-source harness readiness under #3557.
- Comparator or baseline, applicable: NA - readiness inventory only.
- Evidence tier: NA - support helper; validation is targeted unit/CLI proof, not research evidence.
- Result classification: NA - support helper; no research result classified.
- Decision stop rule, applicable: NA - no episode or benchmark outcomes interpreted.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3557; no claim map update because no research result is claimed.
- New research/benchmark/metric/paper-facing analysis tool, any: support helper only; no metric semantics or benchmark interpretation.

## Domain-Aware Approval
- Approval status: not required.
- Approver/review source waiver: support helper only; no research result or benchmark interpretation.
- Validity checklist: readiness inventory only.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA - no comparator split or evidence classification changed.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution performed.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation only checks local owner symbols and surrogate fields.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no episode harness run.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA.
- Follow-up question issue weak, negative, non-transfer results: #3557 remains the parent for future source parameterization.

## Next Empirical Action
- Rerun needed: yes, later source-specific episode runs after missing builders/hooks are implemented.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no durable benchmark artifact expected for this PR.
- Stop / revise / continue decision: continue with a later harness-parameterization slice.
- Proposed child issue existing follow-up: #3557.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/uncertainty_source_readiness.py scripts/validation/check_uncertainty_source_readiness_issue_3557.py tests/validation/test_uncertainty_source_readiness_issue_3557.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_uncertainty_source_readiness_issue_3557.py` - passed, 5 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_uncertainty_source_readiness_issue_3557.py --json` - passed, reports `existence_degradation` ready and four sources blocked on missing condition builders/scenario hooks.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_uncertainty_source_readiness_issue_3557.py --fail-on-blocked` - expected exit 1 gate mode, confirming missing prerequisites fail closed.
- `PR_READY_PR_BODY_FILE=/tmp/pr_3557_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; freshness stamp recorded for commit `3e9f69f6a5ffa688480bbb89f8616d2b5f9ec2a0`.

## Risks / Rollout
- Compatibility risks: low; default CLI still emits JSON and only explicit `--fail-on-blocked` returns nonzero on blocked sources.
- Failure modes: owner paths may need updates when future builders/hooks land.
- Rollback fallback plan: revert this PR; it does not affect benchmark execution paths.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3557, #3471 predecessor, existing #3557 decision layer.
- Any assumptions need to preserved: readiness inventory is not benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR adds a support checker only and does not create new benchmark results or claims.

## Follow-Up Issues
- Deferred work: implement source-specific condition builders and scenario hooks, then run per-source episode contrasts under #3557.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the checker stays inventory-only and does not import or execute the #3471 episode harness.
- Known limitation: only `existence_degradation` is currently classified ready; the four requested generalization sources remain blocked on missing builders/hooks.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a richer readiness report for uncertainty-source checks, with clearer status details and per-item evidence.
  * The validation command now supports both human-readable and JSON output.

* **Bug Fixes**
  * Improved readiness detection for missing prerequisites and missing expected outputs.
  * Updated fail-closed behavior so blocked sources are reported more consistently.

* **Tests**
  * Added coverage for readiness classification, report shape, and CLI output modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->