### PR TITLE
Tighten Package B runner schema preflight for issue #3079

### DIFF
--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -186,17 +186,14 @@ def _output_dir_is_directory_or_future(output_dir: Path | None) -> bool:
     return not output_dir.exists() or output_dir.is_dir()
 
 
-def _runner_row_fields(runner_path: Path | None) -> tuple[frozenset[str], str | None]:
+def _runner_row_fields(runner_path: Path | None) -> frozenset[str]:
     """Return static SamplerComparisonRow fields without importing or running runner."""
     if runner_path is None:
-        return frozenset(), "runner output schema target is not declared"
+        raise FileNotFoundError("runner output schema target is not declared")
     if not runner_path.is_file():
-        return frozenset(), f"runner output schema target is missing: {runner_path}"
+        raise FileNotFoundError(f"runner output schema target is missing: {runner_path}")
 
-    try:
-        module = ast.parse(runner_path.read_text(encoding="utf-8"), filename=str(runner_path))
-    except (OSError, SyntaxError) as exc:
-        return frozenset(), f"runner output schema could not be parsed: {exc}"
+    module = ast.parse(runner_path.read_text(encoding="utf-8"), filename=str(runner_path))
 
     for node in module.body:
         if isinstance(node, ast.ClassDef) and node.name == "SamplerComparisonRow":
@@ -205,9 +202,9 @@ def _runner_row_fields(runner_path: Path | None) -> tuple[frozenset[str], str | 
                 for item in node.body
                 if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name)
             }
-            return frozenset(fields), None
+            return frozenset(fields)
 
-    return frozenset(), "runner output schema missing SamplerComparisonRow dataclass"
+    raise ValueError("runner output schema missing SamplerComparisonRow dataclass")
 
 
 def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
@@ -297,9 +294,11 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     if missing_reporting:
         blockers.append(f"reporting_contract missing required fields: {missing_reporting}")
 
-    runner_row_fields, runner_schema_warning = _runner_row_fields(runner_path)
-    if runner_schema_warning:
-        warnings.append(runner_schema_warning)
+    try:
+        runner_row_fields = _runner_row_fields(runner_path)
+    except (OSError, SyntaxError, ValueError) as exc:
+        runner_row_fields = frozenset()
+        warnings.append(f"runner output schema could not be parsed: {exc}")
     missing_runner_fields = sorted(reporting_contract - runner_row_fields)
     checks["runner_emits_reporting_contract"] = not missing_runner_fields
     if missing_runner_fields:

--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -7,6 +7,7 @@ submits jobs, or interprets falsification yield.
 
 from __future__ import annotations
 
+import ast
 import json
 import shlex
 from dataclasses import dataclass
@@ -185,6 +186,28 @@ def _output_dir_is_directory_or_future(output_dir: Path | None) -> bool:
     return not output_dir.exists() or output_dir.is_dir()
 
 
+def _runner_row_fields(runner_path: Path | None) -> tuple[frozenset[str], str | None]:
+    """Return static SamplerComparisonRow fields without importing or running runner."""
+    if runner_path is None or not runner_path.is_file():
+        return frozenset(), None
+
+    try:
+        module = ast.parse(runner_path.read_text(encoding="utf-8"), filename=str(runner_path))
+    except (OSError, SyntaxError) as exc:
+        return frozenset(), f"runner output schema could not be parsed: {exc}"
+
+    for node in module.body:
+        if isinstance(node, ast.ClassDef) and node.name == "SamplerComparisonRow":
+            fields = {
+                item.target.id
+                for item in node.body
+                if isinstance(item, ast.AnnAssign) and isinstance(item.target, ast.Name)
+            }
+            return frozenset(fields), None
+
+    return frozenset(), "runner output schema missing SamplerComparisonRow dataclass"
+
+
 def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     manifest_path: Path = Path("configs/adversarial/issue_3079_package_b_budget_matched.yaml"),
     *,
@@ -271,6 +294,17 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     checks["reporting_contract"] = not missing_reporting
     if missing_reporting:
         blockers.append(f"reporting_contract missing required fields: {missing_reporting}")
+
+    runner_row_fields, runner_schema_warning = _runner_row_fields(runner_path)
+    if runner_schema_warning:
+        warnings.append(runner_schema_warning)
+    missing_runner_fields = sorted(reporting_contract - runner_row_fields)
+    checks["runner_emits_reporting_contract"] = not missing_runner_fields
+    if missing_runner_fields:
+        blockers.append(
+            "runner SamplerComparisonRow missing reporting_contract fields: "
+            f"{missing_runner_fields}"
+        )
 
     exclusions = payload.get("explicit_exclusions")
     checks["explicit_exclusions_mapping"] = isinstance(exclusions, dict)
@@ -400,6 +434,7 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
         "example_command_repeated_seeds": list(command_seeds),
         "samplers": list(samplers),
         "runner": _repo_relative(runner_path, root) if runner_path else None,
+        "runner_reporting_fields": sorted(runner_row_fields),
         "output_dir": _repo_relative(output_dir, root) if output_dir else None,
         "out_json": _repo_relative(out_json, root) if out_json else None,
         "output_artifacts": {

--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -188,8 +188,10 @@ def _output_dir_is_directory_or_future(output_dir: Path | None) -> bool:
 
 def _runner_row_fields(runner_path: Path | None) -> tuple[frozenset[str], str | None]:
     """Return static SamplerComparisonRow fields without importing or running runner."""
-    if runner_path is None or not runner_path.is_file():
-        return frozenset(), None
+    if runner_path is None:
+        return frozenset(), "runner output schema target is not declared"
+    if not runner_path.is_file():
+        return frozenset(), f"runner output schema target is missing: {runner_path}"
 
     try:
         module = ast.parse(runner_path.read_text(encoding="utf-8"), filename=str(runner_path))

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -158,6 +158,23 @@ class SamplerComparisonRow:
     assert any("SamplerComparisonRow missing" in blocker for blocker in result.blockers)
 
 
+def test_preflight_blocks_missing_runner_output_schema_target(tmp_path: Path) -> None:
+    """Missing runner files block both path existence and static schema checks."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["runner"] = "scripts/tools/missing_compare_adversarial_samplers.py"
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["runner_exists"] is False
+    assert result.checks["runner_emits_reporting_contract"] is False
+    assert any("runner must point" in blocker for blocker in result.blockers)
+    assert any("schema target is missing" in warning for warning in result.warnings)
+
+
 def test_preflight_blocks_unparseable_runner_output_schema(tmp_path: Path) -> None:
     """Runner schema parse failures block readiness without importing runner."""
     manifest = _base_manifest(tmp_path)

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -23,7 +23,25 @@ def _write_file(path: Path, text: str = "placeholder\n") -> None:
 def _base_manifest(repo_root: Path) -> Path:
     _write_file(repo_root / "configs/scenarios/templates/crossing_ttc.yaml")
     _write_file(repo_root / "configs/adversarial/crossing_ttc_space.yaml")
-    _write_file(repo_root / "scripts/tools/compare_adversarial_samplers.py")
+    _write_file(
+        repo_root / "scripts/tools/compare_adversarial_samplers.py",
+        """
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SamplerComparisonRow:
+    first_failure_iteration: int | None
+    best_valid_objective: float | None
+    invalid_candidate_rate: float
+    replay_success_rate: float | None
+    certified_valid_failure_count: int
+    replayable_valid_failure_count: int
+    fallback_candidate_count: int
+    degraded_candidate_count: int
+    held_out_family_yield: float | None
+""",
+    )
     manifest = repo_root / "configs/adversarial/issue_3079_package_b_budget_matched.yaml"
     manifest.parent.mkdir(parents=True, exist_ok=True)
     manifest.write_text(
@@ -85,6 +103,7 @@ def test_committed_package_b_manifest_preflights_without_running_benchmark() -> 
     assert result.blocked is False
     assert result.metadata["budget_grid"] == [16, 32, 64]
     assert result.metadata["repeated_seeds"] == [1101, 2202, 3303]
+    assert "held_out_family_yield" in result.metadata["runner_reporting_fields"]
     assert result.metadata["output_artifacts"] == {
         "output_dir": "output/adversarial/issue_3079_package_b",
         "report_json": "output/adversarial/issue_3079_package_b/report.json",
@@ -113,6 +132,46 @@ def test_preflight_fails_closed_for_missing_budget_seed_and_provenance(tmp_path:
     assert any("repeated_seeds" in blocker for blocker in result.blockers)
     assert any("paper_facing_success_claims" in blocker for blocker in result.blockers)
     assert any("output_artifacts" in blocker for blocker in result.blockers)
+
+
+def test_preflight_blocks_runner_output_schema_drift(tmp_path: Path) -> None:
+    """Manifest reporting fields must be emitted by runner row schema."""
+    manifest = _base_manifest(tmp_path)
+    (tmp_path / "scripts/tools/compare_adversarial_samplers.py").write_text(
+        """
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SamplerComparisonRow:
+    first_failure_iteration: int | None
+    best_valid_objective: float | None
+""",
+        encoding="utf-8",
+    )
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["runner_emits_reporting_contract"] is False
+    assert any("SamplerComparisonRow missing" in blocker for blocker in result.blockers)
+
+
+def test_preflight_blocks_unparseable_runner_output_schema(tmp_path: Path) -> None:
+    """Runner schema parse failures block readiness without importing runner."""
+    manifest = _base_manifest(tmp_path)
+    (tmp_path / "scripts/tools/compare_adversarial_samplers.py").write_text(
+        "def broken(:\n",
+        encoding="utf-8",
+    )
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["runner_emits_reporting_contract"] is False
+    assert any("could not be parsed" in warning for warning in result.warnings)
 
 
 def test_preflight_blocks_example_command_seed_drift(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Issue: #3079. This PR covers only a bounded readiness slice.

- Adds a fail-closed Package B preflight check that statically parses the configured runner and verifies `SamplerComparisonRow` emits every field declared by the manifest `reporting_contract`.
- Tightens missing-runner handling so the static schema check records a fail-closed missing-target diagnostic instead of returning an empty schema silently.
- Records runner reporting fields in preflight metadata so reviewer-visible output can prove manifest-to-runner parity.
- Adds synthetic preflight coverage for runner output schema drift and missing runner targets without running a benchmark campaign.

## Validation

- `uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py -q` - passed
- `uv run python scripts/tools/preflight_adversarial_package_b.py --output output/validation/issue_3079_package_b_preflight.json` - passed
- `uv run ruff format --check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` - passed
- `uv run ruff check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` - passed
- `git diff --check` - passed
- `PR_READY_PR_BODY_FILE=output/validation/issue_3079_pr_body.md PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` - passed

## Out Scope

- No full benchmark campaign run.
- No Slurm or GPU submission.
- No falsification-yield interpretation.
- No paper or dissertation claim edits.

## Artifact Classification

- `output/validation/issue_3079_package_b_preflight.json` is local validation evidence only and is not committed.
- No benchmark outputs, model artifacts, or durable research artifacts added.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preflight checks now verify that runner-generated reporting includes all required fields before allowing readiness.
  * Added fail-closed handling for missing, incomplete, or unreadable runner definitions, with clear warnings and blockers when validation cannot be completed.

* **Tests**
  * Expanded coverage for reporting-schema drift, missing runner targets, and unparseable runner files.
  * Updated test data to include additional reporting fields and confirm they are detected correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->