### PR TITLE
Tighten Package B registry preflight issue #3079

### DIFF
--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -35,6 +35,7 @@ EXPECTED_REPORTING_FIELDS = frozenset(
     }
 )
 EXPECTED_OUTPUT_PREFIX = Path("output/adversarial/issue_3079_package_b")
+RESEARCH_PACKAGE_REGISTRY = Path("configs/research/research_package_registry_issue_3057.yaml")
 FORBIDDEN_COMMAND_TOKENS = frozenset({"sbatch", "srun", "slurm", "wandb", "paper", "dissertation"})
 
 
@@ -207,6 +208,31 @@ def _runner_row_fields(runner_path: Path | None) -> frozenset[str]:
     raise ValueError("runner output schema missing SamplerComparisonRow dataclass")
 
 
+def _registry_includes_package_b_manifest(
+    registry_path: Path, manifest_path: Path, repo_root: Path
+) -> bool:
+    """Return true when the research package registry points at this manifest."""
+    if not registry_path.is_file():
+        return False
+
+    payload = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        return False
+
+    expected_manifest = _repo_relative(manifest_path, repo_root)
+    for package in payload.get("packages", []):
+        if not isinstance(package, dict):
+            continue
+        if package.get("id") != "package_b_adversarial":
+            continue
+        if package.get("issue") != EXPECTED_ISSUE:
+            return False
+        artifacts = _as_str_tuple(package.get("required_artifacts"))
+        return expected_manifest in artifacts
+
+    return False
+
+
 def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     manifest_path: Path = Path("configs/adversarial/issue_3079_package_b_budget_matched.yaml"),
     *,
@@ -246,6 +272,15 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     checks["issue"] = payload.get("issue") == EXPECTED_ISSUE
     if not checks["issue"]:
         blockers.append(f"issue must be {EXPECTED_ISSUE}")
+
+    registry_path = root / RESEARCH_PACKAGE_REGISTRY
+    checks["research_package_registry_includes_manifest"] = _registry_includes_package_b_manifest(
+        registry_path, manifest_path, root
+    )
+    if not checks["research_package_registry_includes_manifest"]:
+        blockers.append(
+            "research package registry must list the Package B manifest as a required artifact"
+        )
 
     runner_path = _resolve_repo_path(root, payload.get("runner"))
     checks["runner_exists"] = bool(runner_path and runner_path.is_file())
@@ -434,6 +469,7 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
         "repeated_seeds": list(seeds),
         "example_command_repeated_seeds": list(command_seeds),
         "samplers": list(samplers),
+        "research_package_registry": _repo_relative(registry_path, root),
         "runner": _repo_relative(runner_path, root) if runner_path else None,
         "runner_reporting_fields": sorted(runner_row_fields),
         "output_dir": _repo_relative(output_dir, root) if output_dir else None,

--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -215,12 +215,19 @@ def _registry_includes_package_b_manifest(
     if not registry_path.is_file():
         return False
 
-    payload = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    try:
+        payload = yaml.safe_load(registry_path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return False
     if not isinstance(payload, dict):
         return False
 
     expected_manifest = _repo_relative(manifest_path, repo_root)
-    for package in payload.get("packages", []):
+    packages = payload.get("packages")
+    if not isinstance(packages, list):
+        return False
+
+    for package in packages:
         if not isinstance(package, dict):
             continue
         if package.get("id") != "package_b_adversarial":

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -20,7 +20,28 @@ def _write_file(path: Path, text: str = "placeholder\n") -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def _write_research_package_registry(repo_root: Path) -> None:
+    _write_file(
+        repo_root / "configs/research/research_package_registry_issue_3057.yaml",
+        yaml.safe_dump(
+            {
+                "packages": [
+                    {
+                        "id": "package_b_adversarial",
+                        "issue": 3079,
+                        "required_artifacts": [
+                            "configs/adversarial/issue_3079_package_b_budget_matched.yaml"
+                        ],
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+    )
+
+
 def _base_manifest(repo_root: Path) -> Path:
+    _write_research_package_registry(repo_root)
     _write_file(repo_root / "configs/scenarios/templates/crossing_ttc.yaml")
     _write_file(repo_root / "configs/adversarial/crossing_ttc_space.yaml")
     _write_file(
@@ -104,6 +125,10 @@ def test_committed_package_b_manifest_preflights_without_running_benchmark() -> 
     assert result.metadata["budget_grid"] == [16, 32, 64]
     assert result.metadata["repeated_seeds"] == [1101, 2202, 3303]
     assert "held_out_family_yield" in result.metadata["runner_reporting_fields"]
+    assert (
+        result.metadata["research_package_registry"]
+        == "configs/research/research_package_registry_issue_3057.yaml"
+    )
     assert result.metadata["output_artifacts"] == {
         "output_dir": "output/adversarial/issue_3079_package_b",
         "report_json": "output/adversarial/issue_3079_package_b/report.json",
@@ -132,6 +157,71 @@ def test_preflight_fails_closed_for_missing_budget_seed_and_provenance(tmp_path:
     assert any("repeated_seeds" in blocker for blocker in result.blockers)
     assert any("paper_facing_success_claims" in blocker for blocker in result.blockers)
     assert any("output_artifacts" in blocker for blocker in result.blockers)
+
+
+def test_preflight_fails_closed_when_registry_drops_package_b_manifest(tmp_path: Path) -> None:
+    """Package-B provenance must stay discoverable from the research package registry."""
+    manifest = _base_manifest(tmp_path)
+    registry = tmp_path / "configs/research/research_package_registry_issue_3057.yaml"
+    registry.write_text(
+        yaml.safe_dump(
+            {
+                "packages": [
+                    {
+                        "id": "package_b_adversarial",
+                        "issue": 3079,
+                        "required_artifacts": [],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["research_package_registry_includes_manifest"] is False
+    assert any("research package registry" in blocker for blocker in result.blockers)
+
+
+@pytest.mark.parametrize(
+    "registry_payload",
+    [
+        None,
+        ["not-a-package-map"],
+        {"packages": ["not-a-package-map"]},
+        {
+            "packages": [
+                {
+                    "id": "package_b_adversarial",
+                    "issue": 9999,
+                    "required_artifacts": [
+                        "configs/adversarial/issue_3079_package_b_budget_matched.yaml"
+                    ],
+                }
+            ]
+        },
+    ],
+)
+def test_preflight_fails_closed_for_malformed_registry_provenance(
+    tmp_path: Path, registry_payload: object
+) -> None:
+    """Malformed registry provenance blocks before benchmark execution."""
+    manifest = _base_manifest(tmp_path)
+    registry = tmp_path / "configs/research/research_package_registry_issue_3057.yaml"
+    if registry_payload is None:
+        registry.unlink()
+    else:
+        registry.write_text(yaml.safe_dump(registry_payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["research_package_registry_includes_manifest"] is False
+    assert any("research package registry" in blocker for blocker in result.blockers)
 
 
 def test_preflight_blocks_runner_output_schema_drift(tmp_path: Path) -> None:

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -191,6 +191,7 @@ def test_preflight_fails_closed_when_registry_drops_package_b_manifest(tmp_path:
     [
         None,
         ["not-a-package-map"],
+        {"packages": None},
         {"packages": ["not-a-package-map"]},
         {
             "packages": [
@@ -215,6 +216,20 @@ def test_preflight_fails_closed_for_malformed_registry_provenance(
         registry.unlink()
     else:
         registry.write_text(yaml.safe_dump(registry_payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["research_package_registry_includes_manifest"] is False
+    assert any("research package registry" in blocker for blocker in result.blockers)
+
+
+def test_preflight_fails_closed_for_invalid_registry_yaml(tmp_path: Path) -> None:
+    """Corrupt registry YAML blocks before benchmark execution."""
+    manifest = _base_manifest(tmp_path)
+    registry = tmp_path / "configs/research/research_package_registry_issue_3057.yaml"
+    registry.write_text("packages:\n  - id: [unterminated\n", encoding="utf-8")
 
     result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
 


### PR DESCRIPTION
## Summary

- Tightens the #3079 Package B readiness preflight so it fails closed unless the research package registry still lists the Package B manifest as a required artifact.
- Records the registry provenance path in the preflight metadata payload.
- Adds synthetic coverage for registry drift, malformed registry shapes, and corrupt registry YAML while preserving the checked-in manifest preflight.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3079

## Linked Issues

- Relates #3079

## Issue Disposition

This is a support/preflight slice only. It does not complete issue 3079 because the actual budget-matched adversarial comparison run, certified/replayable failure counting, held-out-family yield reporting, and interpretation remain open under that issue.

## Validation

- `uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py -q` - passed, 23 tests.
- `uv run python scripts/tools/preflight_adversarial_package_b.py` - passed, checked-in manifest ready with no blockers.
- `uv run ruff check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` - passed.
- `git diff --check` - passed.
- Prior author validation: `uv run ruff format --check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` - passed.
- Prior author validation: `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=/tmp/issue_3079_package_b_registry_pr_body.md scripts/dev/pr_ready_check.sh` - passed.

## Out Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No falsification-yield interpretation.
- No paper/dissertation claim edits.

## Follow-Up Issues

- Deferred work: #3079 remains open for the budget-matched adversarial comparison run, certified/replayable failure counting, held-out-family yield reporting, and interpretation.
- Issues opened follow-up: none; the existing issue remains the canonical follow-up.
