### PR TITLE
Add SocNavBench ETH provenance readiness check for issue #1498

### DIFF
--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -540,6 +540,85 @@ def stage_asset(
     return manifest
 
 
+def _manifest_text_field(manifest: dict[str, Any], field: str) -> str | None:
+    """Return non-empty manifest text field or ``None``."""
+    value = manifest.get(field)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    return value.strip()
+
+
+def _missing_provenance_metadata(asset: AssetSpec, manifest: dict[str, Any]) -> list[str]:
+    """Return missing required provenance metadata fields."""
+    missing: list[str] = []
+    if manifest.get("asset_id") != asset.asset_id:
+        missing.append("asset_id")
+    for field in ("source_url", "license_note", "tree_sha256"):
+        if not _manifest_text_field(manifest, field):
+            missing.append(field)
+
+    sample_files = manifest.get("sample_files")
+    has_sample_checksum = isinstance(sample_files, list) and any(
+        isinstance(sample, dict) and _manifest_text_field(sample, "sha256")
+        for sample in sample_files
+    )
+    if not has_sample_checksum:
+        missing.append("sample_files[].sha256")
+
+    required_paths = manifest.get("matched_required_paths")
+    if not isinstance(required_paths, list) or not required_paths:
+        missing.append("matched_required_paths")
+    return missing
+
+
+def check_provenance_manifest(asset_id: str, manifest_path: Path) -> dict[str, Any]:
+    """Validate bounded provenance metadata for a staged external asset manifest."""
+    asset = _get_asset(asset_id)
+    path = manifest_path.expanduser().resolve()
+    report: dict[str, Any] = {
+        "schema": "robot_sf_external_data_provenance_readiness.v1",
+        "asset_id": asset.asset_id,
+        "manifest_path": str(path),
+        "ok": False,
+        "status": "missing_manifest",
+        "missing_metadata": [],
+    }
+    if not path.is_file():
+        report["action"] = (
+            "Manifest file missing; run stage after official local asset acquisition."
+        )
+        return report
+
+    try:
+        manifest = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        report["status"] = "invalid_json"
+        report["action"] = f"Manifest JSON invalid: {exc}"
+        return report
+
+    missing = _missing_provenance_metadata(asset, manifest)
+
+    report["missing_metadata"] = missing
+    report["source_url"] = manifest.get("source_url")
+    report["license_note"] = manifest.get("license_note")
+    report["tree_sha256"] = manifest.get("tree_sha256")
+    report["matched_required_paths"] = manifest.get("matched_required_paths", [])
+    if missing:
+        report["status"] = "incomplete_metadata"
+        report["action"] = (
+            "Provenance manifest is not ready: fill official source URI, license boundary, "
+            "aggregate checksum, sample file checksum, and matched asset paths."
+        )
+        return report
+
+    report["ok"] = True
+    report["status"] = "ready"
+    report["action"] = (
+        "Provenance manifest has required source, license, checksum, and path metadata."
+    )
+    return report
+
+
 def download_asset(asset_id: str) -> None:
     """Download an asset only when the registry declares an allowed direct download path."""
     asset = _get_asset(asset_id)
@@ -1333,6 +1412,17 @@ def parse_args() -> argparse.Namespace:
     )
     stage_parser.add_argument("--manifest-out", type=Path)
 
+    provenance_parser = subparsers.add_parser(
+        "provenance-check", help="Check staged asset provenance manifest metadata."
+    )
+    provenance_parser.add_argument("asset_id")
+    provenance_parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=None,
+        help="Manifest path. Defaults to output/external_data/manifests/<asset>.provenance.json.",
+    )
+
     download_parser = subparsers.add_parser(
         "download", help="Download only approved direct assets."
     )
@@ -1448,6 +1538,22 @@ def _handle_stage(args: argparse.Namespace) -> int:
     return 0
 
 
+def _handle_provenance_check(args: argparse.Namespace) -> int:
+    """Handle provenance-check subcommand."""
+    manifest_path = args.manifest or DEFAULT_MANIFEST_DIR / f"{args.asset_id}.provenance.json"
+    payload = check_provenance_manifest(args.asset_id, manifest_path)
+    if args.json:
+        _print_json(payload)
+    else:
+        print(f"{payload['asset_id']}: provenance {payload['status']}")
+        print(f" action: {payload['action']}")
+        if payload["missing_metadata"]:
+            print(" missing metadata:")
+            for field in payload["missing_metadata"]:
+                print(f" - {field}")
+    return 0 if payload["ok"] else 2
+
+
 def _handle_download(args: argparse.Namespace) -> int:
     """Handle the download subcommand."""
     download_asset(args.asset_id)
@@ -1520,6 +1626,7 @@ def main() -> int:
         "explain": _handle_explain,
         "check": _handle_check,
         "stage": _handle_stage,
+        "provenance-check": _handle_provenance_check,
         "download": _handle_download,
         "sdd-plan": _handle_sdd_plan,
         "sdd-preflight": _handle_sdd_preflight,

--- a/scripts/tools/manage_external_data.py
+++ b/scripts/tools/manage_external_data.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import argparse
 import datetime as dt
+import fnmatch
 import hashlib
 import json
 import os
@@ -540,12 +541,46 @@ def stage_asset(
     return manifest
 
 
+def _pattern_is_literal(pattern: str) -> bool:
+    """Return whether a required-path pattern has no glob magic characters."""
+    return not any(char in pattern for char in ("*", "?", "["))
+
+
 def _manifest_text_field(manifest: dict[str, Any], field: str) -> str | None:
     """Return non-empty manifest text field or ``None``."""
     value = manifest.get(field)
     if not isinstance(value, str) or not value.strip():
         return None
     return value.strip()
+
+
+def _provenance_paths_cover_requirements(asset: AssetSpec, matched_paths: list[Any]) -> bool:
+    """Return whether manifest matched paths satisfy every required path group.
+
+    A manifest is only ready when each required group has at least one matched path that
+    actually corresponds to a declared pattern, so an unrelated or partial non-empty list
+    cannot pass the fail-closed gate. Literal patterns require an exact (or path-prefixed)
+    match; glob patterns fall back to ``fnmatch`` coverage since the concrete matched path
+    cannot be reversed back to the pattern reliably.
+    """
+    candidates = {path for path in matched_paths if isinstance(path, str) and path.strip()}
+    if not candidates:
+        return False
+    for requirements in _required_groups(asset).values():
+        literal_patterns = [r.pattern for r in requirements if _pattern_is_literal(r.pattern)]
+        glob_patterns = [r.pattern for r in requirements if not _pattern_is_literal(r.pattern)]
+        satisfied = any(
+            candidate == pattern or candidate.startswith(f"{pattern}/")
+            for candidate in candidates
+            for pattern in literal_patterns
+        ) or any(
+            fnmatch.fnmatch(candidate, pattern)
+            for candidate in candidates
+            for pattern in glob_patterns
+        )
+        if not satisfied:
+            return False
+    return True
 
 
 def _missing_provenance_metadata(asset: AssetSpec, manifest: dict[str, Any]) -> list[str]:
@@ -565,8 +600,10 @@ def _missing_provenance_metadata(asset: AssetSpec, manifest: dict[str, Any]) -> 
     if not has_sample_checksum:
         missing.append("sample_files[].sha256")
 
-    required_paths = manifest.get("matched_required_paths")
-    if not isinstance(required_paths, list) or not required_paths:
+    matched_paths = manifest.get("matched_required_paths")
+    if not isinstance(matched_paths, list) or not _provenance_paths_cover_requirements(
+        asset, matched_paths
+    ):
         missing.append("matched_required_paths")
     return missing
 
@@ -594,6 +631,10 @@ def check_provenance_manifest(asset_id: str, manifest_path: Path) -> dict[str, A
     except json.JSONDecodeError as exc:
         report["status"] = "invalid_json"
         report["action"] = f"Manifest JSON invalid: {exc}"
+        return report
+    if not isinstance(manifest, dict):
+        report["status"] = "invalid_json"
+        report["action"] = "Manifest JSON invalid: root value must be a JSON object."
         return report
 
     missing = _missing_provenance_metadata(asset, manifest)

--- a/tests/tools/test_manage_external_data.py
+++ b/tests/tools/test_manage_external_data.py
@@ -31,6 +31,16 @@ def _write_sdd_fixture(path: Path) -> None:
     )
 
 
+def _write_socnavbench_eth_fixture(path: Path) -> None:
+    """Create a minimal SocNavBench ETH layout fixture for metadata-only tests."""
+    mesh_dir = path / "sd3dis" / "stanford_building_parser_dataset" / "mesh" / "ETH"
+    traversible_dir = path / "sd3dis" / "stanford_building_parser_dataset" / "traversibles" / "ETH"
+    mesh_dir.mkdir(parents=True, exist_ok=True)
+    traversible_dir.mkdir(parents=True, exist_ok=True)
+    (mesh_dir / "mesh.obj").write_text("# synthetic fixture, not official data\n", encoding="utf-8")
+    (traversible_dir / "data.pkl").write_bytes(b"synthetic fixture, not official data")
+
+
 def test_registry_covers_initial_required_asset_groups() -> None:
     """The first slice should cover SDD, SocNavBench, and AMV provenance assets."""
     asset_ids = {asset.asset_id for asset in manage_external_data.list_assets()}
@@ -217,6 +227,102 @@ def test_stage_writes_small_manifest_for_ignored_sdd_path(tmp_path: Path) -> Non
     assert payload["validation_command"].endswith(f"check sdd --source {source_root.resolve()}")
     assert payload["sample_files"][0]["path"] == "annotations.txt"
     assert "Pedestrian" not in json.dumps(payload)
+
+
+def test_socnavbench_eth_provenance_check_accepts_staged_manifest(tmp_path: Path) -> None:
+    """ETH provenance readiness requires source, license, checksum, and path metadata."""
+    _init_git_repo(tmp_path, gitignore="external/socnavbench/\n")
+    source_root = tmp_path / "external" / "socnavbench"
+    _write_socnavbench_eth_fixture(source_root)
+    manifest_path = tmp_path / "manifests" / "socnavbench-s3dis-eth.provenance.json"
+
+    manage_external_data.stage_asset(
+        "socnavbench-s3dis-eth",
+        source_path=source_root,
+        manifest_out=manifest_path,
+        repo_root=tmp_path,
+    )
+    report = manage_external_data.check_provenance_manifest("socnavbench-s3dis-eth", manifest_path)
+
+    assert report["ok"] is True
+    assert report["status"] == "ready"
+    assert report["missing_metadata"] == []
+    assert report["tree_sha256"]
+
+
+@pytest.mark.parametrize(
+    ("field", "expected_missing"),
+    [
+        ("source_url", "source_url"),
+        ("license_note", "license_note"),
+        ("tree_sha256", "tree_sha256"),
+        ("sample_files", "sample_files[].sha256"),
+    ],
+)
+def test_socnavbench_eth_provenance_check_fails_missing_metadata(
+    tmp_path: Path, field: str, expected_missing: str
+) -> None:
+    """ETH provenance readiness fails closed for missing URI/license/checksum metadata."""
+    manifest_path = tmp_path / "socnavbench-s3dis-eth.provenance.json"
+    manifest = {
+        "schema": "robot_sf_external_data_manifest.v1",
+        "asset_id": "socnavbench-s3dis-eth",
+        "source_url": "https://github.com/CMU-TBD/SocNavBench",
+        "license_note": "External licensed data not redistributed by Robot SF.",
+        "tree_sha256": "0" * 64,
+        "sample_files": [{"path": "sd3dis/example", "sha256": "1" * 64}],
+        "matched_required_paths": [
+            "sd3dis/stanford_building_parser_dataset/mesh/ETH",
+            "sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl",
+        ],
+    }
+    manifest.pop(field)
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = manage_external_data.check_provenance_manifest("socnavbench-s3dis-eth", manifest_path)
+
+    assert report["ok"] is False
+    assert report["status"] == "incomplete_metadata"
+    assert expected_missing in report["missing_metadata"]
+
+
+def test_cli_provenance_check_reports_missing_socnavbench_eth_metadata(tmp_path: Path) -> None:
+    """CLI provenance-check reports incomplete ETH metadata with nonzero exit."""
+    manifest_path = tmp_path / "socnavbench-s3dis-eth.provenance.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "schema": "robot_sf_external_data_manifest.v1",
+                "asset_id": "socnavbench-s3dis-eth",
+                "license_note": "External licensed data not redistributed by Robot SF.",
+                "matched_required_paths": [
+                    "sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl"
+                ],
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/tools/manage_external_data.py",
+            "--json",
+            "provenance-check",
+            "socnavbench-s3dis-eth",
+            "--manifest",
+            str(manifest_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    payload = json.loads(result.stdout)
+    assert payload["status"] == "incomplete_metadata"
+    assert "source_url" in payload["missing_metadata"]
+    assert "tree_sha256" in payload["missing_metadata"]
 
 
 def test_socnavbench_control_check_accepts_wayptnav_layout(tmp_path: Path) -> None:

--- a/tests/tools/test_manage_external_data.py
+++ b/tests/tools/test_manage_external_data.py
@@ -286,6 +286,62 @@ def test_socnavbench_eth_provenance_check_fails_missing_metadata(
     assert expected_missing in report["missing_metadata"]
 
 
+def test_provenance_check_fails_closed_on_non_dict_json(tmp_path: Path) -> None:
+    """A manifest whose JSON root is not an object must fail closed, not crash."""
+    manifest_path = tmp_path / "socnavbench-s3dis-eth.provenance.json"
+    manifest_path.write_text(json.dumps(["not", "a", "dict"]), encoding="utf-8")
+
+    report = manage_external_data.check_provenance_manifest("socnavbench-s3dis-eth", manifest_path)
+
+    assert report["ok"] is False
+    assert report["status"] == "invalid_json"
+
+
+def test_provenance_check_rejects_incomplete_path_coverage(tmp_path: Path) -> None:
+    """A non-empty matched-path list that misses a required group must not pass."""
+    manifest_path = tmp_path / "socnavbench-s3dis-eth.provenance.json"
+    manifest = {
+        "schema": "robot_sf_external_data_manifest.v1",
+        "asset_id": "socnavbench-s3dis-eth",
+        "source_url": "https://github.com/CMU-TBD/SocNavBench",
+        "license_note": "External licensed data not redistributed by Robot SF.",
+        "tree_sha256": "0" * 64,
+        "sample_files": [{"path": "sd3dis/example", "sha256": "1" * 64}],
+        # Only the traversible group is present; the required ETH mesh group is missing.
+        "matched_required_paths": [
+            "sd3dis/stanford_building_parser_dataset/traversibles/ETH/data.pkl"
+        ],
+    }
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = manage_external_data.check_provenance_manifest("socnavbench-s3dis-eth", manifest_path)
+
+    assert report["ok"] is False
+    assert report["status"] == "incomplete_metadata"
+    assert "matched_required_paths" in report["missing_metadata"]
+
+
+def test_provenance_check_rejects_unrelated_matched_paths(tmp_path: Path) -> None:
+    """An unrelated non-empty matched-path list must not satisfy the readiness gate."""
+    manifest_path = tmp_path / "socnavbench-s3dis-eth.provenance.json"
+    manifest = {
+        "schema": "robot_sf_external_data_manifest.v1",
+        "asset_id": "socnavbench-s3dis-eth",
+        "source_url": "https://github.com/CMU-TBD/SocNavBench",
+        "license_note": "External licensed data not redistributed by Robot SF.",
+        "tree_sha256": "0" * 64,
+        "sample_files": [{"path": "sd3dis/example", "sha256": "1" * 64}],
+        "matched_required_paths": ["totally/unrelated/path"],
+    }
+    manifest_path.write_text(json.dumps(manifest), encoding="utf-8")
+
+    report = manage_external_data.check_provenance_manifest("socnavbench-s3dis-eth", manifest_path)
+
+    assert report["ok"] is False
+    assert report["status"] == "incomplete_metadata"
+    assert "matched_required_paths" in report["missing_metadata"]
+
+
 def test_cli_provenance_check_reports_missing_socnavbench_eth_metadata(tmp_path: Path) -> None:
     """CLI provenance-check reports incomplete ETH metadata with nonzero exit."""
     manifest_path = tmp_path / "socnavbench-s3dis-eth.provenance.json"


### PR DESCRIPTION
## Summary
- Adds `manage_external_data.py provenance-check` for staged external-data provenance manifests.
- Validates SocNavBench/S3DIS ETH manifest readiness for required source URI, license boundary, aggregate checksum, sample checksum, and matched asset paths.
- Keeps raw external assets local and license-gated; no download or conversion path is added.

## Issue
Refs #1498 (provenance-readiness slice only — issue stays `blocked-external-input` until a maintainer stages the official ETH `data.pkl` and the existing `eth_first` validator passes; see repeated maintainer triage notes on #1498). Closing keyword intentionally omitted so merging this tooling slice does not auto-close the blocked-external tracking issue.
Issue: https://github.com/ll7/robot_sf_ll7/issues/1498

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/tools/manage_external_data.py tests/tools/test_manage_external_data.py` -> exit 0
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/manage_external_data.py tests/tools/test_manage_external_data.py` -> exit 0
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/tools/test_manage_external_data.py` -> exit 0, 20 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/manage_external_data.py --json provenance-check socnavbench-s3dis-eth --manifest /tmp/nonexistent-socnavbench-eth-provenance.json` -> exit 2 as expected, missing manifest fails closed
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/robot_sf_issue_1498_pr_body.md scripts/dev/pr_ready_check.sh` -> exit 0
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> exit 0, fresh clean-tree stamp for `7e2e7787fc4c91b20f7a290006b49ba52f40ce6f`

## Out of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No SocNavBench/S3DIS asset download, raw external data copy, map conversion, or benchmark claim.

## Artifact Decision
- No generated benchmark artifacts or raw external data are committed.
- Worktree-local readiness outputs under `output/` remain disposable validation metadata.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new provenance check for staged external assets, with both JSON and human-readable output.
  * Expanded the command-line tool with a new `provenance-check` option and configurable manifest path.

* **Bug Fixes**
  * Improved validation to flag missing or incomplete metadata clearly, including required source, license, checksum, and file-hash details.
  * The check now returns a nonzero exit status when provenance data is not ready.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
