### PR TITLE
Issue #1491: Add CARLA parity readiness manifest

### DIFF
--- a/robot_sf_carla_bridge/__init__.py
+++ b/robot_sf_carla_bridge/__init__.py
@@ -71,6 +71,8 @@ from robot_sf_carla_bridge.parity import (
 )
 from robot_sf_carla_bridge.parity_bundle_preflight import (
     PREFLIGHT_SCHEMA_VERSION,
+    READINESS_MANIFEST_SCHEMA_VERSION,
+    check_native_aligned_bundle_manifest_readiness,
     check_parity_bundle_readiness,
     evaluate_payload_metadata,
 )
@@ -97,6 +99,7 @@ __all__ = [
     "EXPORT_MANIFEST_SCHEMA_VERSION",
     "EXPORT_SCHEMA_VERSION",
     "PREFLIGHT_SCHEMA_VERSION",
+    "READINESS_MANIFEST_SCHEMA_VERSION",
     "SCHEMA_CATALOG_VERSION",
     "T1_ORACLE_LIVE_REPLAY_SCHEMA_VERSION",
     "T1_ORACLE_REPLAY_SMOKE_SCHEMA_VERSION",
@@ -121,6 +124,7 @@ __all__ = [
     "build_t1_oracle_replay_smoke_setup",
     "carla_planar_twist_to_robot_sf",
     "check_carla_availability",
+    "check_native_aligned_bundle_manifest_readiness",
     "check_parity_bundle_readiness",
     "compare_oracle_replay_metrics",
     "docker_runtime",

--- a/robot_sf_carla_bridge/cli.py
+++ b/robot_sf_carla_bridge/cli.py
@@ -30,7 +30,10 @@ from robot_sf_carla_bridge.export import (
     resolve_export_manifest_payload_paths,
     write_export_records,
 )
-from robot_sf_carla_bridge.parity_bundle_preflight import check_parity_bundle_readiness
+from robot_sf_carla_bridge.parity_bundle_preflight import (
+    check_native_aligned_bundle_manifest_readiness,
+    check_parity_bundle_readiness,
+)
 from robot_sf_carla_bridge.replay_smoke import (
     T1_ORACLE_REPLAY_SMOKE_SCHEMA_VERSION,
     build_t1_oracle_replay_smoke_setup,
@@ -430,16 +433,32 @@ def preflight_carla_parity_bundle_main(argv: list[str] | None = None) -> int:
         help="T0 export manifest JSON path; repeat for multiple candidate scenarios.",
     )
     parser.add_argument(
+        "--readiness-manifest",
+        metavar="PATH",
+        help=(
+            "Issue #1491 native/aligned readiness manifest declaring the intended scenario "
+            "export manifests."
+        ),
+    )
+    parser.add_argument(
         "--output-dir",
         help="Intended parity-bundle output directory (checked for safety; never created).",
     )
     parser.add_argument("--json", action="store_true", help="Print a machine-readable report.")
     args = parser.parse_args(argv)
 
-    if not args.manifest:
-        parser.error("at least one --manifest is required")
+    if args.readiness_manifest and args.manifest:
+        parser.error("--readiness-manifest cannot be combined with --manifest")
+    if not args.readiness_manifest and not args.manifest:
+        parser.error("at least one --manifest or --readiness-manifest is required")
 
-    report = check_parity_bundle_readiness(args.manifest, output_dir=args.output_dir)
+    if args.readiness_manifest:
+        report = check_native_aligned_bundle_manifest_readiness(
+            args.readiness_manifest,
+            output_dir=args.output_dir,
+        )
+    else:
+        report = check_parity_bundle_readiness(args.manifest, output_dir=args.output_dir)
     exit_code = 0 if report["status"] == "ready" else 1
     if args.json:
         sys.stdout.write(f"{json.dumps(report, sort_keys=True)}\n")

--- a/robot_sf_carla_bridge/parity_bundle_preflight.py
+++ b/robot_sf_carla_bridge/parity_bundle_preflight.py
@@ -45,6 +45,12 @@ if TYPE_CHECKING:
 PREFLIGHT_SCHEMA_VERSION = "carla-parity-bundle-preflight.v1"
 """Version tag for the readiness report emitted by :func:`check_parity_bundle_readiness`."""
 
+READINESS_MANIFEST_SCHEMA_VERSION = "carla-parity-readiness-manifest.v1"
+"""Version tag for issue #1491 native/aligned bundle readiness manifests."""
+
+READINESS_MANIFEST_MODES = frozenset({"native", "aligned"})
+"""Replay modes that must both be declared before the issue #1491 bundle is ready."""
+
 # Certificate statuses the scenario certifier may stamp on a certified fixture. Mirrors the
 # ``status`` enum in ``schemas/carla_replay_export.v1.json``; kept here so a scenario whose
 # certificate is structurally valid but not certified still fails the readiness gate explicitly.
@@ -112,6 +118,108 @@ def check_parity_bundle_readiness(
             "capable CARLA host."
         ),
     }
+
+
+def check_native_aligned_bundle_manifest_readiness(  # noqa: C901
+    readiness_manifest_path: str | Path,
+    *,
+    output_dir: str | Path | None = None,
+    metric_names: Iterable[str] = DEFAULT_PARITY_METRICS,
+) -> dict[str, Any]:
+    """Check a declared issue #1491 native/aligned multi-scenario bundle manifest.
+
+    The manifest is intentionally local and static: it names the intended native/aligned
+    scenario export manifests, then this checker reuses the existing T0 export preflight for
+    fixture certificate and provenance checks. It never imports CARLA, starts a simulator, or
+    treats readiness as replay parity evidence.
+
+    Returns:
+        JSON-safe readiness report with explicit blockers and claim boundary.
+    """
+
+    metric_list = list(metric_names)
+    manifest_path = Path(readiness_manifest_path)
+    manifest_label = manifest_path.as_posix()
+    try:
+        readiness_manifest = _read_readiness_manifest(manifest_path)
+    except FileNotFoundError:
+        return _blocked_readiness_manifest_report(
+            manifest_label,
+            output_dir=output_dir,
+            metric_names=metric_list,
+            reason="readiness manifest file not found",
+        )
+    except (ValueError, OSError, json.JSONDecodeError) as exc:
+        return _blocked_readiness_manifest_report(
+            manifest_label,
+            output_dir=output_dir,
+            metric_names=metric_list,
+            reason=f"invalid readiness manifest: {exc}",
+        )
+
+    manifest_dir = manifest_path.parent
+    entries = _readiness_entries(readiness_manifest)
+    scenario_rows: list[dict[str, Any]] = []
+    manifest_blockers: list[str] = []
+
+    if not entries:
+        manifest_blockers.append("readiness manifest declares no scenarios")
+
+    declared_modes: set[str] = set()
+    for index, entry in enumerate(entries):
+        label = _readiness_entry_label(entry, index)
+        mode = entry.get("mode")
+        if isinstance(mode, str):
+            mode = mode.strip().lower()
+        if mode not in READINESS_MANIFEST_MODES:
+            scenario_rows.append(
+                _blocked_manifest_row(
+                    label,
+                    f"readiness entry mode must be one of {sorted(READINESS_MANIFEST_MODES)}",
+                )
+            )
+            continue
+        declared_modes.add(mode)
+
+        export_manifest_value = entry.get("manifest")
+        if not isinstance(export_manifest_value, str) or not export_manifest_value.strip():
+            scenario_rows.append(
+                _blocked_manifest_row(label, "readiness entry manifest is missing")
+            )
+            continue
+        export_manifest_path = _resolve_manifest_reference(manifest_dir, export_manifest_value)
+        rows = _rows_for_manifest(export_manifest_path, metric_list)
+        for row in rows:
+            row["readiness_manifest"] = manifest_label
+            row["readiness_mode"] = mode
+            expected_scenario_id = entry.get("scenario_id")
+            if (
+                row["status"] == "ready"
+                and isinstance(expected_scenario_id, str)
+                and expected_scenario_id.strip()
+                and row.get("scenario_id") != expected_scenario_id
+            ):
+                row["status"] = "blocked"
+                row["reasons"].append(
+                    "readiness entry scenario_id does not match export manifest payload"
+                )
+            scenario_rows.append(row)
+
+    missing_modes = sorted(READINESS_MANIFEST_MODES - declared_modes)
+    if missing_modes:
+        manifest_blockers.append(
+            f"readiness manifest missing mode coverage: {', '.join(missing_modes)}"
+        )
+
+    return _build_readiness_report(
+        scenario_rows,
+        output_dir=output_dir,
+        metric_names=metric_list,
+        extra_blockers=manifest_blockers,
+        readiness_manifest=manifest_label,
+        bundle_id=readiness_manifest.get("bundle_id"),
+        issue=readiness_manifest.get("issue"),
+    )
 
 
 def _rows_for_manifest(manifest_path: Path, metric_names: list[str]) -> list[dict[str, Any]]:
@@ -288,6 +396,135 @@ def _check_output_location(output_dir: str | Path | None) -> dict[str, Any]:
         "status": "ready",
         "reason": "output directory is empty or absent and can be created by the bundle run",
     }
+
+
+def _read_readiness_manifest(path: Path) -> dict[str, Any]:
+    """Read and minimally validate an issue #1491 readiness manifest.
+
+    Returns:
+        Parsed readiness manifest mapping.
+    """
+
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError("readiness manifest must be a JSON object")
+    schema_version = payload.get("schema_version")
+    if schema_version != READINESS_MANIFEST_SCHEMA_VERSION:
+        raise ValueError(
+            f"readiness manifest schema_version must be {READINESS_MANIFEST_SCHEMA_VERSION!r}"
+        )
+    return payload
+
+
+def _readiness_entries(readiness_manifest: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return object-valued scenario entries from a readiness manifest.
+
+    Returns:
+        Scenario entry mappings; non-object entries are ignored.
+    """
+
+    scenarios = readiness_manifest.get("scenarios")
+    if not isinstance(scenarios, list):
+        return []
+    return [entry for entry in scenarios if isinstance(entry, dict)]
+
+
+def _readiness_entry_label(entry: dict[str, Any], index: int) -> str:
+    """Return a stable label for blocker rows from a readiness manifest entry.
+
+    Returns:
+        Scenario identifier when present, otherwise an index label.
+    """
+
+    scenario_id = entry.get("scenario_id")
+    if isinstance(scenario_id, str) and scenario_id.strip():
+        return scenario_id
+    return f"readiness_entry[{index}]"
+
+
+def _resolve_manifest_reference(manifest_dir: Path, manifest_value: str) -> Path:
+    """Resolve a readiness-manifest export reference relative to the manifest file.
+
+    Returns:
+        Absolute path or manifest-directory-relative path object.
+    """
+
+    path = Path(manifest_value)
+    return path if path.is_absolute() else manifest_dir / path
+
+
+def _build_readiness_report(
+    scenario_rows: list[dict[str, Any]],
+    *,
+    output_dir: str | Path | None,
+    metric_names: list[str],
+    extra_blockers: list[str] | None = None,
+    readiness_manifest: str | None = None,
+    bundle_id: Any = None,
+    issue: Any = None,
+) -> dict[str, Any]:
+    """Build the shared readiness report envelope.
+
+    Returns:
+        JSON-safe readiness report.
+    """
+
+    output_location = _check_output_location(output_dir)
+    ready_rows = [row for row in scenario_rows if row["status"] == "ready"]
+    blocking_reasons: list[str] = list(extra_blockers or [])
+    if not scenario_rows:
+        blocking_reasons.append("no scenario manifests provided")
+    for row in scenario_rows:
+        label = row.get("scenario_id") or row["manifest"]
+        blocking_reasons.extend(f"{label}: {reason}" for reason in row["reasons"])
+    if output_location["status"] == "unsafe":
+        blocking_reasons.append(f"output location: {output_location['reason']}")
+
+    status = "ready" if scenario_rows and not blocking_reasons else "not-ready"
+    report = {
+        "schema_version": PREFLIGHT_SCHEMA_VERSION,
+        "status": status,
+        "scenario_count": len(scenario_rows),
+        "ready_count": len(ready_rows),
+        "metric_names": metric_names,
+        "output_location": output_location,
+        "scenarios": scenario_rows,
+        "blocking_reasons": blocking_reasons,
+        "claim_boundary": (
+            "Readiness checks static T0 export prerequisites only. It does not run CARLA and does "
+            "not assert native↔aligned metric parity; runtime eligibility must be confirmed on a "
+            "capable CARLA host."
+        ),
+    }
+    if readiness_manifest is not None:
+        report["readiness_manifest"] = readiness_manifest
+        report["readiness_manifest_schema_version"] = READINESS_MANIFEST_SCHEMA_VERSION
+    if isinstance(bundle_id, str) and bundle_id.strip():
+        report["bundle_id"] = bundle_id
+    if isinstance(issue, int):
+        report["issue"] = issue
+    return report
+
+
+def _blocked_readiness_manifest_report(
+    readiness_manifest: str,
+    *,
+    output_dir: str | Path | None,
+    metric_names: list[str],
+    reason: str,
+) -> dict[str, Any]:
+    """Return a fail-closed report for an unreadable readiness manifest.
+
+    Returns:
+        Not-ready report containing a manifest-level blocker row.
+    """
+
+    return _build_readiness_report(
+        [_blocked_manifest_row(readiness_manifest, reason)],
+        output_dir=output_dir,
+        metric_names=metric_names,
+        readiness_manifest=readiness_manifest,
+    )
 
 
 def _blocked_manifest_row(manifest_label: str, reason: str) -> dict[str, Any]:

--- a/tests/carla_bridge/test_parity_bundle_preflight.py
+++ b/tests/carla_bridge/test_parity_bundle_preflight.py
@@ -18,6 +18,8 @@ from robot_sf_carla_bridge.cli import preflight_carla_parity_bundle_main
 from robot_sf_carla_bridge.export import write_export_records
 from robot_sf_carla_bridge.parity_bundle_preflight import (
     PREFLIGHT_SCHEMA_VERSION,
+    READINESS_MANIFEST_SCHEMA_VERSION,
+    check_native_aligned_bundle_manifest_readiness,
     check_parity_bundle_readiness,
     evaluate_payload_metadata,
 )
@@ -80,6 +82,24 @@ def _write_manifest(tmp_path: Path, *payloads: dict, subdir: str = "exports") ->
     output_dir = tmp_path / subdir
     write_export_records(records, output_dir)
     return output_dir / "manifest.json"
+
+
+def _write_readiness_manifest(tmp_path: Path, entries: list[dict]) -> Path:
+    """Write issue #1491 readiness manifest beside synthetic export bundles."""
+
+    manifest = tmp_path / "carla_parity_readiness.json"
+    manifest.write_text(
+        json.dumps(
+            {
+                "schema_version": READINESS_MANIFEST_SCHEMA_VERSION,
+                "bundle_id": "issue-1491-unit",
+                "issue": 1491,
+                "scenarios": entries,
+            }
+        ),
+        encoding="utf-8",
+    )
+    return manifest
 
 
 # --- pure metadata checker -------------------------------------------------------------------
@@ -236,6 +256,99 @@ def test_check_parity_bundle_readiness_never_claims_parity(tmp_path: Path) -> No
     assert "does not assert native↔aligned metric parity" in report["claim_boundary"]
 
 
+def test_native_aligned_readiness_manifest_reports_ready(tmp_path: Path) -> None:
+    """Issue #1491 manifest ready only when native and aligned entries pass static checks."""
+
+    native_manifest = _write_manifest(tmp_path, _valid_payload("native_a"), subdir="native")
+    aligned_manifest = _write_manifest(tmp_path, _valid_payload("aligned_a"), subdir="aligned")
+    readiness_manifest = _write_readiness_manifest(
+        tmp_path,
+        [
+            {
+                "scenario_id": "native_a",
+                "mode": "native",
+                "manifest": native_manifest.relative_to(tmp_path).as_posix(),
+            },
+            {
+                "scenario_id": "aligned_a",
+                "mode": "aligned",
+                "manifest": aligned_manifest.relative_to(tmp_path).as_posix(),
+            },
+        ],
+    )
+
+    report = check_native_aligned_bundle_manifest_readiness(
+        readiness_manifest,
+        output_dir=tmp_path / "parity_out",
+    )
+
+    assert report["status"] == "ready"
+    assert report["readiness_manifest_schema_version"] == READINESS_MANIFEST_SCHEMA_VERSION
+    assert report["issue"] == 1491
+    assert report["ready_count"] == 2
+    assert {row["readiness_mode"] for row in report["scenarios"]} == {"native", "aligned"}
+    assert "does not assert native↔aligned metric parity" in report["claim_boundary"]
+
+
+def test_native_aligned_readiness_manifest_blocks_missing_mode(tmp_path: Path) -> None:
+    """A manifest without both native and aligned coverage fails closed."""
+
+    native_manifest = _write_manifest(tmp_path, _valid_payload("native_a"), subdir="native")
+    readiness_manifest = _write_readiness_manifest(
+        tmp_path,
+        [
+            {
+                "scenario_id": "native_a",
+                "mode": "native",
+                "manifest": native_manifest.relative_to(tmp_path).as_posix(),
+            }
+        ],
+    )
+
+    report = check_native_aligned_bundle_manifest_readiness(readiness_manifest)
+
+    assert report["status"] == "not-ready"
+    assert report["ready_count"] == 1
+    assert any("missing mode coverage: aligned" in reason for reason in report["blocking_reasons"])
+
+
+def test_native_aligned_readiness_manifest_blocks_missing_export_manifest(tmp_path: Path) -> None:
+    """Missing declared T0 export manifest is reported as a scenario blocker."""
+
+    native_manifest = _write_manifest(tmp_path, _valid_payload("native_a"), subdir="native")
+    readiness_manifest = _write_readiness_manifest(
+        tmp_path,
+        [
+            {
+                "scenario_id": "native_a",
+                "mode": "native",
+                "manifest": native_manifest.relative_to(tmp_path).as_posix(),
+            },
+            {"scenario_id": "aligned_a", "mode": "aligned", "manifest": "aligned/manifest.json"},
+        ],
+    )
+
+    report = check_native_aligned_bundle_manifest_readiness(readiness_manifest)
+
+    assert report["status"] == "not-ready"
+    assert report["ready_count"] == 1
+    assert any("export manifest file not found" in reason for reason in report["blocking_reasons"])
+
+
+def test_native_aligned_readiness_manifest_blocks_missing_readiness_manifest(
+    tmp_path: Path,
+) -> None:
+    """Absent issue #1491 readiness manifest produces explicit not-ready report."""
+
+    report = check_native_aligned_bundle_manifest_readiness(tmp_path / "missing.json")
+
+    assert report["status"] == "not-ready"
+    assert report["scenario_count"] == 1
+    assert any(
+        "readiness manifest file not found" in reason for reason in report["blocking_reasons"]
+    )
+
+
 # --- CLI -------------------------------------------------------------------------------------
 
 
@@ -247,6 +360,38 @@ def test_cli_reports_ready_and_exits_zero(tmp_path: Path, capsys: pytest.Capture
     )
     assert exit_code == 0
     report = json.loads(capsys.readouterr().out)
+    assert report["status"] == "ready"
+
+
+def test_cli_accepts_native_aligned_readiness_manifest(
+    tmp_path: Path, capsys: pytest.CaptureFixture
+) -> None:
+    """The CLI checks an issue #1491 readiness manifest without CARLA."""
+    native_manifest = _write_manifest(tmp_path, _valid_payload("native_a"), subdir="native")
+    aligned_manifest = _write_manifest(tmp_path, _valid_payload("aligned_a"), subdir="aligned")
+    readiness_manifest = _write_readiness_manifest(
+        tmp_path,
+        [
+            {
+                "scenario_id": "native_a",
+                "mode": "native",
+                "manifest": native_manifest.relative_to(tmp_path).as_posix(),
+            },
+            {
+                "scenario_id": "aligned_a",
+                "mode": "aligned",
+                "manifest": aligned_manifest.relative_to(tmp_path).as_posix(),
+            },
+        ],
+    )
+
+    exit_code = preflight_carla_parity_bundle_main(
+        ["--readiness-manifest", str(readiness_manifest), "--json"]
+    )
+
+    assert exit_code == 0
+    report = json.loads(capsys.readouterr().out)
+    assert report["readiness_manifest_schema_version"] == READINESS_MANIFEST_SCHEMA_VERSION
     assert report["status"] == "ready"
 
 


### PR DESCRIPTION
## Summary

- Adds an issue #1491 native/aligned CARLA parity readiness manifest checker on top of the existing CARLA T0 export preflight.
- Adds `--readiness-manifest` to `robot-sf-carla-parity-bundle-preflight` for static blocker reporting without importing CARLA or running replay.
- Covers ready, missing mode, missing export manifest, missing readiness manifest, and CLI readiness-manifest paths with synthetic CARLA-free tests.

Issue: https://github.com/ll7/robot_sf_ll7/issues/1491

## Validation

- `scripts/dev/ruff_fix_format.sh` - passed
- `uv run pytest tests/carla_bridge/test_parity_bundle_preflight.py -q` - passed
- `uv run pytest tests/carla_bridge -q` - passed

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No CARLA runtime execution.
- No paper/dissertation claim edits.

## Downstream Propagation

Not applicable because this PR adds a local readiness contract and blocker reporter only; it does not produce parity evidence, benchmark results, or paper-facing claims.
