### PR TITLE
Issue #1585: add AMV calibration source manifest checker

### DIFF
--- a/configs/benchmarks/issue_1585_amv_calibration_source_manifest.yaml
+++ b/configs/benchmarks/issue_1585_amv_calibration_source_manifest.yaml
@@ -1,0 +1,40 @@
+schema_version: amv_calibration_source_manifest.v1
+manifest_id: issue_1585_amv_calibration_source_provenance
+issue: 1585
+source_status: blocked-external-input
+source_type: unknown
+source_uri: https://github.com/ll7/robot_sf_ll7/issues/1585
+license: unavailable
+license_status: unknown
+claim_boundary: hardware-calibrated
+blocked_reason: >-
+  No accepted hardware command-response trace, official platform/controller specification,
+  or maintainer-reviewed source is available for calibrated AMV actuation evidence.
+blocker_issues:
+  - 1585
+  - 2000
+calibration_fields:
+  - name: max_linear_accel_m_s2
+    support_status: missing
+    units: m/s^2
+    reason: No hardware-calibrated or official-spec source has been accepted.
+  - name: max_linear_decel_m_s2
+    support_status: missing
+    units: m/s^2
+    reason: No hardware-calibrated or official-spec source has been accepted.
+  - name: max_yaw_rate_rad_s
+    support_status: missing
+    units: rad/s
+    reason: No hardware-calibrated or official-spec source has been accepted.
+  - name: max_angular_accel_rad_s2
+    support_status: missing
+    units: rad/s^2
+    reason: No hardware-calibrated or official-spec source has been accepted.
+  - name: latency_mode
+    support_status: missing
+    units: mode
+    reason: No measured command-response latency source has been accepted.
+  - name: update_mode
+    support_status: missing
+    units: mode
+    reason: No measured controller update-rate source has been accepted.

--- a/robot_sf/benchmark/amv_calibration_source_manifest.py
+++ b/robot_sf/benchmark/amv_calibration_source_manifest.py
@@ -271,6 +271,17 @@ def _blocked_state_blockers(manifest: Mapping[str, Any], source_status: str) -> 
     return blockers
 
 
+def _missing_calibration_fields_report() -> tuple[AmvCalibrationFieldReport, ...]:
+    """Return the fail-closed report for an absent or malformed ``calibration_fields`` list."""
+    return (
+        AmvCalibrationFieldReport(
+            name="<manifest>",
+            support_status=FIELD_STATUS_MISSING,
+            blockers=("calibration_fields must be a non-empty list",),
+        ),
+    )
+
+
 def _check_calibration_fields(
     raw_fields: Any,
     allowed_fields: set[str],
@@ -280,22 +291,12 @@ def _check_calibration_fields(
     Returns:
         Per-field support reports.
     """
-    if not isinstance(raw_fields, Sequence) or isinstance(raw_fields, (str, bytes)):
-        return (
-            AmvCalibrationFieldReport(
-                name="<manifest>",
-                support_status=FIELD_STATUS_MISSING,
-                blockers=("calibration_fields must be a non-empty list",),
-            ),
-        )
-    if not raw_fields:
-        return (
-            AmvCalibrationFieldReport(
-                name="<manifest>",
-                support_status=FIELD_STATUS_MISSING,
-                blockers=("calibration_fields must be a non-empty list",),
-            ),
-        )
+    if (
+        not isinstance(raw_fields, Sequence)
+        or isinstance(raw_fields, (str, bytes))
+        or not raw_fields
+    ):
+        return _missing_calibration_fields_report()
 
     reports: list[AmvCalibrationFieldReport] = []
     seen: set[str] = set()

--- a/robot_sf/benchmark/amv_calibration_source_manifest.py
+++ b/robot_sf/benchmark/amv_calibration_source_manifest.py
@@ -1,0 +1,423 @@
+"""Metadata-only AMV actuation calibration source provenance manifest.
+
+Issue #1585 is blocked on an accepted source for calibrated autonomous
+micromobility vehicle (AMV) actuation evidence. This module checks the local
+manifest contract for source identification only. It does not collect data,
+ingest traces, calibrate actuation values, or update benchmark claims.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+import yaml
+
+from robot_sf.benchmark.synthetic_actuation import actuation_variability_fields
+
+AMV_CALIBRATION_SOURCE_MANIFEST_SCHEMA_VERSION = "amv_calibration_source_manifest.v1"
+AMV_CALIBRATION_SOURCE_EVIDENCE_BOUNDARY = (
+    "source_identification_only_no_data_collection_no_calibration_no_claim_update"
+)
+
+SOURCE_STATUS_READY = "ready"
+SOURCE_STATUS_BLOCKED_EXTERNAL = "blocked-external-input"
+SOURCE_STATUS_MISSING = "missing"
+
+SOURCE_TYPE_HARDWARE_TRACE = "hardware_trace"
+SOURCE_TYPE_OFFICIAL_SPEC = "official_spec"
+SOURCE_TYPE_PLATFORM_CLASS_PROXY = "platform_class_proxy"
+SOURCE_TYPE_UNKNOWN = "unknown"
+
+LICENSE_STATUS_ACCEPTED = "accepted"
+LICENSE_STATUS_MANUAL_REVIEW_REQUIRED = "manual_license_review_required"
+LICENSE_STATUS_BLOCKED = "blocked"
+LICENSE_STATUS_UNKNOWN = "unknown"
+
+FIELD_STATUS_SUPPORTED = "supported"
+FIELD_STATUS_MISSING = "missing"
+FIELD_STATUS_UNSUPPORTED = "unsupported"
+
+_SOURCE_STATUSES = {
+    SOURCE_STATUS_READY,
+    SOURCE_STATUS_BLOCKED_EXTERNAL,
+    SOURCE_STATUS_MISSING,
+}
+_SOURCE_TYPES = {
+    SOURCE_TYPE_HARDWARE_TRACE,
+    SOURCE_TYPE_OFFICIAL_SPEC,
+    SOURCE_TYPE_PLATFORM_CLASS_PROXY,
+    SOURCE_TYPE_UNKNOWN,
+}
+_LICENSE_STATUSES = {
+    LICENSE_STATUS_ACCEPTED,
+    LICENSE_STATUS_MANUAL_REVIEW_REQUIRED,
+    LICENSE_STATUS_BLOCKED,
+    LICENSE_STATUS_UNKNOWN,
+}
+_FIELD_STATUSES = {
+    FIELD_STATUS_SUPPORTED,
+    FIELD_STATUS_MISSING,
+    FIELD_STATUS_UNSUPPORTED,
+}
+
+
+class AmvCalibrationSourceManifestError(ValueError):
+    """Raised when an AMV calibration source manifest cannot be parsed."""
+
+
+@dataclass(frozen=True)
+class AmvCalibrationFieldReport:
+    """Per-field source-support status."""
+
+    name: str
+    support_status: str
+    units: str | None = None
+    blockers: tuple[str, ...] = field(default_factory=tuple)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe report payload."""
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class AmvCalibrationSourceReport:
+    """Checked AMV calibration source-identification manifest.
+
+    ``source_status == "ready"`` means only that a source candidate is identified for the
+    declared boundary. ``hardware_calibration_claim_allowed`` is stricter and remains false for
+    platform-class proxy sources.
+    """
+
+    schema_version: str
+    manifest_id: str | None
+    issue: int | None
+    source_status: str
+    source_type: str
+    source_uri: str | None
+    license_status: str | None
+    claim_boundary: str | None
+    evidence_boundary: str
+    hardware_calibration_claim_allowed: bool
+    fields: tuple[AmvCalibrationFieldReport, ...] = field(default_factory=tuple)
+    blockers: tuple[str, ...] = field(default_factory=tuple)
+
+    @property
+    def is_ready(self) -> bool:
+        """Whether the manifest has a usable source candidate for its boundary."""
+        return self.source_status == SOURCE_STATUS_READY and not self.blockers
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe report payload."""
+        payload = asdict(self)
+        payload["fields"] = [field_report.to_dict() for field_report in self.fields]
+        return payload
+
+
+def load_amv_calibration_source_manifest(path: str | Path) -> dict[str, Any]:
+    """Load an AMV calibration source manifest from YAML or JSON.
+
+    Returns:
+        Parsed manifest mapping.
+    """
+    manifest_path = Path(path)
+    if not manifest_path.is_file():
+        raise AmvCalibrationSourceManifestError(f"manifest file not found: {manifest_path}")
+    try:
+        payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise AmvCalibrationSourceManifestError(f"invalid YAML/JSON: {exc}") from exc
+    if not isinstance(payload, Mapping):
+        raise AmvCalibrationSourceManifestError("manifest must be a mapping")
+    return dict(payload)
+
+
+def check_amv_calibration_source_manifest(
+    manifest: Mapping[str, Any],
+    *,
+    allowed_calibration_fields: set[str] | None = None,
+) -> AmvCalibrationSourceReport:
+    """Check source-identification readiness for AMV actuation calibration.
+
+    The checker is fail-closed: incomplete metadata, license review blockers,
+    missing supported fields, or source URIs that only point at tracking issues
+    keep the manifest out of the ready state.
+
+    Returns:
+        Structured source-readiness report.
+    """
+    allowed_fields = allowed_calibration_fields or set(actuation_variability_fields())
+    metadata, blockers = _extract_manifest_metadata(manifest)
+    blockers.extend(_source_metadata_blockers(metadata))
+    blockers.extend(_blocked_state_blockers(manifest, metadata["source_status"]))
+
+    field_reports = _check_calibration_fields(manifest.get("calibration_fields"), allowed_fields)
+    blockers.extend(_field_blockers(field_reports))
+    if metadata["source_status"] == SOURCE_STATUS_READY and not _supported_fields(field_reports):
+        blockers.append("ready source requires at least one supported calibration field")
+
+    resolved_status = _resolve_source_status(metadata["source_status"], blockers)
+    return AmvCalibrationSourceReport(
+        schema_version=AMV_CALIBRATION_SOURCE_MANIFEST_SCHEMA_VERSION,
+        manifest_id=metadata["manifest_id"],
+        issue=metadata["issue"],
+        source_status=resolved_status,
+        source_type=metadata["source_type"],
+        source_uri=metadata["source_uri"],
+        license_status=metadata["license_status"],
+        claim_boundary=metadata["claim_boundary"],
+        evidence_boundary=AMV_CALIBRATION_SOURCE_EVIDENCE_BOUNDARY,
+        hardware_calibration_claim_allowed=_hardware_claim_allowed(
+            metadata,
+            resolved_status,
+            blockers,
+        ),
+        fields=tuple(field_reports),
+        blockers=tuple(blockers),
+    )
+
+
+def _extract_manifest_metadata(manifest: Mapping[str, Any]) -> tuple[dict[str, Any], list[str]]:
+    """Extract top-level manifest metadata and structural blockers.
+
+    Returns:
+        Metadata dictionary plus blocker messages.
+    """
+    blockers: list[str] = []
+    schema_version = _optional_text(manifest.get("schema_version"))
+    if schema_version != AMV_CALIBRATION_SOURCE_MANIFEST_SCHEMA_VERSION:
+        blockers.append(
+            f"schema_version must be {AMV_CALIBRATION_SOURCE_MANIFEST_SCHEMA_VERSION!r}"
+        )
+
+    manifest_id = _optional_text(manifest.get("manifest_id"))
+    if manifest_id is None:
+        blockers.append("manifest_id is required")
+
+    issue = manifest.get("issue")
+    if not isinstance(issue, int):
+        blockers.append("issue must be an integer")
+        issue = None
+
+    metadata = {
+        "manifest_id": manifest_id,
+        "issue": issue,
+        "source_status": _optional_text(manifest.get("source_status")) or SOURCE_STATUS_MISSING,
+        "source_type": _optional_text(manifest.get("source_type")) or SOURCE_TYPE_UNKNOWN,
+        "source_uri": _optional_text(manifest.get("source_uri")),
+        "license_status": _optional_text(manifest.get("license_status")),
+        "license": _optional_text(manifest.get("license")),
+        "claim_boundary": _optional_text(manifest.get("claim_boundary")),
+    }
+    return metadata, blockers
+
+
+def _source_metadata_blockers(metadata: Mapping[str, Any]) -> list[str]:
+    """Return blockers for source URI, type, and license metadata."""
+    blockers: list[str] = []
+    source_status = metadata["source_status"]
+    source_type = metadata["source_type"]
+    source_uri = metadata["source_uri"]
+
+    if source_status not in _SOURCE_STATUSES:
+        blockers.append(f"source_status must be one of {sorted(_SOURCE_STATUSES)}")
+    if source_type not in _SOURCE_TYPES:
+        blockers.append(f"source_type must be one of {sorted(_SOURCE_TYPES)}")
+    if source_status == SOURCE_STATUS_READY and source_uri is None:
+        blockers.append("ready source requires source_uri")
+    if source_status == SOURCE_STATUS_READY and _source_uri_is_tracking_issue(source_uri):
+        blockers.append("ready source_uri must point at a source artifact, not a tracking issue")
+    if source_status == SOURCE_STATUS_READY and source_type == SOURCE_TYPE_UNKNOWN:
+        blockers.append("ready source requires source_type other than unknown")
+    blockers.extend(_license_blockers(metadata))
+    return blockers
+
+
+def _license_blockers(metadata: Mapping[str, Any]) -> list[str]:
+    """Return blockers for license and access status."""
+    source_status = metadata["source_status"]
+    license_status = metadata["license_status"]
+    blockers: list[str] = []
+    if source_status == SOURCE_STATUS_READY and license_status != LICENSE_STATUS_ACCEPTED:
+        blockers.append("ready source requires license_status accepted")
+    if license_status is None:
+        blockers.append("license_status is required")
+    elif license_status not in _LICENSE_STATUSES:
+        blockers.append(f"license_status must be one of {sorted(_LICENSE_STATUSES)}")
+    if source_status == SOURCE_STATUS_READY and metadata["license"] is None:
+        blockers.append("ready source requires license")
+    if license_status == LICENSE_STATUS_MANUAL_REVIEW_REQUIRED:
+        blockers.append("license requires maintainer review before source can be ready")
+    if license_status == LICENSE_STATUS_BLOCKED:
+        blockers.append("license/access blocks use of this source")
+    return blockers
+
+
+def _blocked_state_blockers(manifest: Mapping[str, Any], source_status: str) -> list[str]:
+    """Return blockers for explicit blocked-external-input manifests."""
+    if source_status != SOURCE_STATUS_BLOCKED_EXTERNAL:
+        return []
+    blockers: list[str] = []
+    if not _sequence_of_ints(manifest.get("blocker_issues", [])):
+        blockers.append("blocked-external-input source requires blocker_issues")
+    if _optional_text(manifest.get("blocked_reason")) is None:
+        blockers.append("blocked-external-input source requires blocked_reason")
+    return blockers
+
+
+def _check_calibration_fields(
+    raw_fields: Any,
+    allowed_fields: set[str],
+) -> tuple[AmvCalibrationFieldReport, ...]:
+    """Validate declared source support for actuation calibration fields.
+
+    Returns:
+        Per-field support reports.
+    """
+    if not isinstance(raw_fields, Sequence) or isinstance(raw_fields, (str, bytes)):
+        return (
+            AmvCalibrationFieldReport(
+                name="<manifest>",
+                support_status=FIELD_STATUS_MISSING,
+                blockers=("calibration_fields must be a non-empty list",),
+            ),
+        )
+    if not raw_fields:
+        return (
+            AmvCalibrationFieldReport(
+                name="<manifest>",
+                support_status=FIELD_STATUS_MISSING,
+                blockers=("calibration_fields must be a non-empty list",),
+            ),
+        )
+
+    reports: list[AmvCalibrationFieldReport] = []
+    seen: set[str] = set()
+    for index, raw_field in enumerate(raw_fields):
+        reports.append(_check_calibration_field(index, raw_field, allowed_fields, seen))
+    return tuple(reports)
+
+
+def _check_calibration_field(
+    index: int,
+    raw_field: Any,
+    allowed_fields: set[str],
+    seen: set[str],
+) -> AmvCalibrationFieldReport:
+    """Validate one calibration-field entry.
+
+    Returns:
+        Field support report.
+    """
+    if not isinstance(raw_field, Mapping):
+        return AmvCalibrationFieldReport(
+            name=f"<index:{index}>",
+            support_status=FIELD_STATUS_MISSING,
+            blockers=("field entry must be a mapping",),
+        )
+
+    name = _optional_text(raw_field.get("name")) or f"<index:{index}>"
+    support_status = _optional_text(raw_field.get("support_status")) or FIELD_STATUS_MISSING
+    units = _optional_text(raw_field.get("units"))
+    blockers = _calibration_field_blockers(name, support_status, units, raw_field, seen)
+    if name not in allowed_fields:
+        blockers.append("not a canonical synthetic-actuation calibration field")
+    return AmvCalibrationFieldReport(
+        name=name,
+        support_status=support_status,
+        units=units,
+        blockers=tuple(blockers),
+    )
+
+
+def _calibration_field_blockers(
+    name: str,
+    support_status: str,
+    units: str | None,
+    raw_field: Mapping[str, Any],
+    seen: set[str],
+) -> list[str]:
+    """Return blockers for one calibration field."""
+    blockers: list[str] = []
+    if name in seen:
+        blockers.append("duplicate calibration field")
+    seen.add(name)
+    if support_status not in _FIELD_STATUSES:
+        blockers.append(f"support_status must be one of {sorted(_FIELD_STATUSES)}")
+    if support_status == FIELD_STATUS_SUPPORTED and units is None:
+        blockers.append("supported field requires units")
+    if support_status != FIELD_STATUS_SUPPORTED and _optional_text(raw_field.get("reason")) is None:
+        blockers.append("missing/unsupported field requires reason")
+    return blockers
+
+
+def _field_blockers(field_reports: Sequence[AmvCalibrationFieldReport]) -> list[str]:
+    """Return field blockers with field names prefixed."""
+    return [
+        f"calibration_fields[{field_report.name}]: {field_blocker}"
+        for field_report in field_reports
+        for field_blocker in field_report.blockers
+    ]
+
+
+def _supported_fields(
+    field_reports: Sequence[AmvCalibrationFieldReport],
+) -> list[AmvCalibrationFieldReport]:
+    """Return supported calibration fields without field-level blockers."""
+    return [
+        field_report
+        for field_report in field_reports
+        if field_report.support_status == FIELD_STATUS_SUPPORTED and not field_report.blockers
+    ]
+
+
+def _resolve_source_status(source_status: str, blockers: Sequence[str]) -> str:
+    """Return final manifest status after blockers are applied."""
+    if blockers and source_status == SOURCE_STATUS_READY:
+        return SOURCE_STATUS_BLOCKED_EXTERNAL
+    return source_status
+
+
+def _hardware_claim_allowed(
+    metadata: Mapping[str, Any],
+    resolved_status: str,
+    blockers: Sequence[str],
+) -> bool:
+    """Return whether metadata permits a hardware-calibrated claim boundary."""
+    return (
+        resolved_status == SOURCE_STATUS_READY
+        and not blockers
+        and metadata["source_type"] in {SOURCE_TYPE_HARDWARE_TRACE, SOURCE_TYPE_OFFICIAL_SPEC}
+        and metadata["claim_boundary"] == "hardware-calibrated"
+    )
+
+
+def _optional_text(value: Any) -> str | None:
+    """Return stripped non-empty string, otherwise ``None``."""
+    if not isinstance(value, str):
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _sequence_of_ints(value: Any) -> bool:
+    """Return whether value is a non-empty sequence of integers."""
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, (str, bytes))
+        and bool(value)
+        and all(isinstance(item, int) for item in value)
+    )
+
+
+def _source_uri_is_tracking_issue(source_uri: str | None) -> bool:
+    """Return whether a URI points at a GitHub issue instead of a source artifact."""
+    if source_uri is None:
+        return False
+    parsed = urlparse(source_uri.strip().lower())
+    host = parsed.netloc.rsplit("@", 1)[-1].split(":", 1)[0]
+    is_github = host == "github.com" or host.endswith(".github.com")
+    return is_github and "/issues/" in parsed.path

--- a/robot_sf/benchmark/amv_calibration_source_manifest.py
+++ b/robot_sf/benchmark/amv_calibration_source_manifest.py
@@ -229,7 +229,10 @@ def _source_metadata_blockers(metadata: Mapping[str, Any]) -> list[str]:
     if source_status == SOURCE_STATUS_READY and source_uri is None:
         blockers.append("ready source requires source_uri")
     if source_status == SOURCE_STATUS_READY and _source_uri_is_tracking_issue(source_uri):
-        blockers.append("ready source_uri must point at a source artifact, not a tracking issue")
+        blockers.append(
+            "ready source_uri must point at a source artifact, "
+            "not a tracking issue, pull request, or discussion"
+        )
     if source_status == SOURCE_STATUS_READY and source_type == SOURCE_TYPE_UNKNOWN:
         blockers.append("ready source requires source_type other than unknown")
     blockers.extend(_license_blockers(metadata))
@@ -413,11 +416,19 @@ def _sequence_of_ints(value: Any) -> bool:
     )
 
 
+_GITHUB_TRACKING_PATH_SEGMENTS = ("/issues/", "/pull/", "/pulls/", "/discussions/")
+
+
 def _source_uri_is_tracking_issue(source_uri: str | None) -> bool:
-    """Return whether a URI points at a GitHub issue instead of a source artifact."""
+    """Return whether a URI points at a GitHub tracking thread, not a source artifact.
+
+    GitHub issue, pull request, and discussion URLs all reference tracking
+    conversations rather than a durable calibration source, so none of them may
+    back a ``ready`` source.
+    """
     if source_uri is None:
         return False
     parsed = urlparse(source_uri.strip().lower())
     host = parsed.netloc.rsplit("@", 1)[-1].split(":", 1)[0]
     is_github = host == "github.com" or host.endswith(".github.com")
-    return is_github and "/issues/" in parsed.path
+    return is_github and any(segment in parsed.path for segment in _GITHUB_TRACKING_PATH_SEGMENTS)

--- a/scripts/tools/check_amv_calibration_source_manifest.py
+++ b/scripts/tools/check_amv_calibration_source_manifest.py
@@ -1,0 +1,64 @@
+"""CLI checker for the AMV calibration source manifest (issue #1585).
+
+The report is metadata-only. It does not collect external data, ingest traces,
+calibrate AMV actuation values, or update benchmark/paper claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.amv_calibration_source_manifest import (
+    AmvCalibrationSourceManifestError,
+    check_amv_calibration_source_manifest,
+    load_amv_calibration_source_manifest,
+)
+
+DEFAULT_MANIFEST = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "benchmarks"
+    / "issue_1585_amv_calibration_source_manifest.yaml"
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="Path to an amv_calibration_source_manifest.v1 YAML or JSON file.",
+    )
+    parser.add_argument(
+        "--require-ready",
+        action="store_true",
+        help="Exit non-zero unless source_status is ready and blocker-free.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run manifest check and print JSON report."""
+    args = _parse_args(argv)
+    try:
+        manifest = load_amv_calibration_source_manifest(args.manifest)
+        report = check_amv_calibration_source_manifest(manifest)
+    except AmvCalibrationSourceManifestError as exc:
+        print(json.dumps({"ok": False, "error": str(exc)}, indent=2), file=sys.stderr)
+        return 2
+
+    payload = report.to_dict()
+    payload["ok"] = report.is_ready
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    if args.require_ready and not report.is_ready:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_issue_1585_amv_calibration_source_manifest.py
+++ b/tests/benchmark/test_issue_1585_amv_calibration_source_manifest.py
@@ -102,6 +102,21 @@ def test_ready_source_cannot_use_tracking_issue_uri() -> None:
     assert any("tracking issue" in blocker for blocker in report.blockers)
 
 
+def test_ready_source_cannot_use_tracking_pr_or_discussion_uri() -> None:
+    """GitHub PR and discussion URLs are tracking threads, not source artifacts."""
+    for tracking_uri in (
+        "https://github.com/ll7/robot_sf_ll7/pull/3794",
+        "https://github.com/ll7/robot_sf_ll7/discussions/12",
+    ):
+        manifest = _ready_manifest()
+        manifest["source_uri"] = tracking_uri
+
+        report = check_amv_calibration_source_manifest(manifest)
+
+        assert report.source_status == SOURCE_STATUS_BLOCKED_EXTERNAL, tracking_uri
+        assert any("source artifact" in blocker for blocker in report.blockers), tracking_uri
+
+
 def test_proxy_source_ready_does_not_allow_hardware_calibration_claim() -> None:
     """Accepted platform-class proxy source stays outside hardware-calibrated claims."""
     manifest = _ready_manifest()

--- a/tests/benchmark/test_issue_1585_amv_calibration_source_manifest.py
+++ b/tests/benchmark/test_issue_1585_amv_calibration_source_manifest.py
@@ -1,0 +1,126 @@
+"""Tests for the AMV calibration source-identification manifest (#1585)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from robot_sf.benchmark.amv_calibration_source_manifest import (
+    AMV_CALIBRATION_SOURCE_EVIDENCE_BOUNDARY,
+    SOURCE_STATUS_BLOCKED_EXTERNAL,
+    SOURCE_STATUS_MISSING,
+    SOURCE_STATUS_READY,
+    check_amv_calibration_source_manifest,
+    load_amv_calibration_source_manifest,
+)
+
+EXAMPLE_MANIFEST_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "benchmarks"
+    / "issue_1585_amv_calibration_source_manifest.yaml"
+)
+
+
+def _ready_manifest() -> dict:
+    """Return a synthetic, metadata-only accepted hardware-source manifest."""
+    return {
+        "schema_version": "amv_calibration_source_manifest.v1",
+        "manifest_id": "synthetic_ready_source_contract",
+        "issue": 1585,
+        "source_status": "ready",
+        "source_type": "official_spec",
+        "source_uri": "https://example.com/amv/specification-v1.pdf",
+        "license": "redistribution-approved-fixture",
+        "license_status": "accepted",
+        "claim_boundary": "hardware-calibrated",
+        "calibration_fields": [
+            {
+                "name": "max_linear_accel_m_s2",
+                "support_status": "supported",
+                "units": "m/s^2",
+            },
+            {
+                "name": "max_yaw_rate_rad_s",
+                "support_status": "missing",
+                "units": "rad/s",
+                "reason": "Spec excerpt does not identify yaw-rate limits.",
+            },
+        ],
+    }
+
+
+def test_tracked_issue_manifest_is_blocked_external_input() -> None:
+    """The checked-in #1585 manifest records the current blocked source state."""
+    manifest = load_amv_calibration_source_manifest(EXAMPLE_MANIFEST_PATH)
+    report = check_amv_calibration_source_manifest(manifest)
+
+    assert report.source_status == SOURCE_STATUS_BLOCKED_EXTERNAL
+    assert report.evidence_boundary == AMV_CALIBRATION_SOURCE_EVIDENCE_BOUNDARY
+    assert not report.is_ready
+    assert not report.hardware_calibration_claim_allowed
+    assert report.source_uri == "https://github.com/ll7/robot_sf_ll7/issues/1585"
+
+
+def test_ready_manifest_requires_source_uri_license_and_supported_field() -> None:
+    """A complete metadata manifest can be ready without ingesting data."""
+    report = check_amv_calibration_source_manifest(_ready_manifest())
+
+    assert report.source_status == SOURCE_STATUS_READY
+    assert report.is_ready
+    assert report.hardware_calibration_claim_allowed
+    assert report.blockers == ()
+
+
+def test_missing_manifest_state_is_not_ready() -> None:
+    """Missing source identification remains explicit and fail-closed."""
+    manifest = _ready_manifest()
+    manifest.update(
+        {
+            "source_status": "missing",
+            "source_type": "unknown",
+            "source_uri": None,
+            "license": None,
+            "license_status": "unknown",
+        }
+    )
+
+    report = check_amv_calibration_source_manifest(manifest)
+
+    assert report.source_status == SOURCE_STATUS_MISSING
+    assert not report.is_ready
+    assert not report.hardware_calibration_claim_allowed
+
+
+def test_ready_source_cannot_use_tracking_issue_uri() -> None:
+    """A tracking issue URL is a blocker, not a source artifact URI."""
+    manifest = _ready_manifest()
+    manifest["source_uri"] = "https://github.com/ll7/robot_sf_ll7/issues/1585"
+
+    report = check_amv_calibration_source_manifest(manifest)
+
+    assert report.source_status == SOURCE_STATUS_BLOCKED_EXTERNAL
+    assert any("tracking issue" in blocker for blocker in report.blockers)
+
+
+def test_proxy_source_ready_does_not_allow_hardware_calibration_claim() -> None:
+    """Accepted platform-class proxy source stays outside hardware-calibrated claims."""
+    manifest = _ready_manifest()
+    manifest["source_type"] = "platform_class_proxy"
+    manifest["claim_boundary"] = "platform_class_proxy"
+
+    report = check_amv_calibration_source_manifest(manifest)
+
+    assert report.source_status == SOURCE_STATUS_READY
+    assert report.is_ready
+    assert not report.hardware_calibration_claim_allowed
+
+
+def test_unknown_calibration_field_blocks_ready_manifest() -> None:
+    """Calibration fields must stay aligned with synthetic-actuation envelope names."""
+    manifest = _ready_manifest()
+    manifest["calibration_fields"][0]["name"] = "not_a_real_actuation_field"
+
+    report = check_amv_calibration_source_manifest(manifest)
+
+    assert report.source_status == SOURCE_STATUS_BLOCKED_EXTERNAL
+    assert any("canonical synthetic-actuation" in blocker for blocker in report.blockers)


### PR DESCRIPTION
## Summary
Adds a metadata-only AMV calibration source provenance manifest and checker for issue #1585. The checked-in manifest records the current blocked external-input state and explicitly does not collect data, fabricate measurements, run calibration, or update claims.

## Linked Issues
- Relates to #1585

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `configs/benchmarks/issue_1585_amv_calibration_source_manifest.yaml` with source URI, license/status, blocker issues, and per-field calibration support status.
- Added `robot_sf.benchmark.amv_calibration_source_manifest` to check ready, blocked-external-input, and missing source states fail-closed.
- Added `scripts/tools/check_amv_calibration_source_manifest.py` for local JSON reporting.
- Added focused synthetic tests for ready, blocked, missing, tracking-issue URI, proxy-source, and unknown-field states.

## Why Matters
- Added value: records the AMV actuation source provenance contract locally while the real hardware source remains unavailable.
- Expected impact: future source candidates can be checked before any calibrated AMV actuation claim or profile update.
- Why worth merging now: closes a local readiness slice without depending on external data acquisition.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #1585 source-provenance blocker for calibrated AMV actuation evidence.
- Comparator or baseline, applicable: NA - source manifest/checker only.
- Evidence tier: NA - support helper; validation uses focused tests but makes no research evidence claim
- Result classification: NA - source-provenance support helper only
- Decision stop rule, applicable: manifest remains blocked until accepted source metadata is present; checker must keep missing/proxy/tracking-issue states fail-closed.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #1585; no claim map update because no evidence claim changed.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper only; it reports source provenance readiness and does not interpret benchmark results.

## Domain-Aware Approval
- Approver/review source waiver: not required because this PR is a metadata-only support helper and promotes no research, benchmark, metric, or paper-facing claim.
- Validity checklist: no benchmark result, metric value, scenario comparison, or paper claim changes; checker reports only source metadata readiness.
- Target claim/hypothesis: none changed; #1585 remains blocked for calibrated AMV actuation evidence.
- Comparator split/evidence validity: no comparator split is introduced; focused tests exercise ready, blocked, missing, proxy, tracking-issue, and invalid-field metadata states only.
- Fallback/degraded exclusions: no planner or benchmark execution path is touched.
- Claim boundary: `source_identification_only_no_data_collection_no_calibration_no_claim_update`.
- Implementation integrity vs experimental validity: focused unit tests and CLI run cover the checker contract; experimental validity remains blocked on external source.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no planner or benchmark mechanism.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA.
- Result route: stop - this slice stops at manifest/checker readiness.
- Follow-up question issue weak, negative, non-transfer results: existing #2000 hardware trace/source path remains the unblock condition.

## Next Empirical Action
- Rerun needed: no.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: accepted calibrated AMV actuation source remains unavailable.
- Stop / revise / continue decision: stop this slice; continue only when a real source candidate appears.
- Proposed child issue existing follow-up: #2000.

## Validation / Proof
- `uv run ruff format robot_sf/benchmark/amv_calibration_source_manifest.py scripts/tools/check_amv_calibration_source_manifest.py tests/benchmark/test_issue_1585_amv_calibration_source_manifest.py` - exit 0, 3 files left unchanged after formatting.
- `uv run ruff check robot_sf/benchmark/amv_calibration_source_manifest.py scripts/tools/check_amv_calibration_source_manifest.py tests/benchmark/test_issue_1585_amv_calibration_source_manifest.py` - exit 0, all checks passed.
- `uv run pytest tests/benchmark/test_issue_1585_amv_calibration_source_manifest.py -q` - exit 0, 6 passed.
- `uv run python scripts/tools/check_amv_calibration_source_manifest.py` - exit 0, reports `source_status=blocked-external-input`, `ok=false`, and `hardware_calibration_claim_allowed=false`.

Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Scaling
- Representative dataset size: one small YAML manifest plus synthetic in-test dictionaries.
- Baseline runtime: NA - no existing checker.
- Changed runtime: targeted pytest completed in about 4 seconds locally.
- Representative command: `uv run pytest tests/benchmark/test_issue_1585_amv_calibration_source_manifest.py -q`.
- Hot-path call count profile anchor: NA - metadata checker only, not runtime hot path.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: checker permits tracking-issue URI, missing source, or proxy source to enable hardware-calibrated claims.

## Risks / Rollout
- Compatibility risks: low; new files only.
- Failure modes: future users may misread source `ready` as hardware claim readiness, so report separates `is_ready` from `hardware_calibration_claim_allowed`.
- Rollback fallback plan: revert this PR if the manifest contract conflicts with a later accepted source-staging design.

## Docs / Provenance
- Updated docs: NA - tracked manifest and CLI docstring document this small contract.
- Relevant design provenance notes: issue #1585 live discussion and #2000 hardware-source dependency.
- Any assumptions need to preserved: no source data is collected or redistributed; current state remains blocked external input.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - authorization forbids issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a local source-provenance manifest/checker and changes no benchmark result, claim map, leaderboard, or paper-facing statement.

## Follow-Up Issues
- Deferred work: accept and stage a real hardware trace, official specification, or maintainer-approved proxy source when available.
- Issues opened follow-up: none; #2000 already tracks hardware trace acquisition.

## Reviewer Notes
- Verify that blocked and missing states remain fail-closed and that proxy sources do not set `hardware_calibration_claim_allowed`.
- Known limitation: the checked-in manifest intentionally records the current blocked state; it is not evidence for calibrated AMV actuation.
