### PR TITLE
Add frozen trace missing-export diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added a **diagnostic missing-export blocker report** for frozen-trace `EpisodeEventLedger.v1`
+  before/after reconciliation (#3482). New `build_missing_frozen_trace_export_report`
+  (`robot_sf/benchmark/frozen_trace_reconciliation.py`) emits a
+  `frozen_trace_event_export_blocker.v1` report with null comparison counts and per-artifact
+  `not_evaluable_missing_event_ledger_export` statuses, and the comparator CLI
+  (`scripts/benchmark/compare_frozen_trace_event_ledgers.py`) gains `--diagnose-missing-exports`
+  to write that report when one or both durable exports are absent. The reconciliation guard was
+  also tightened so a metric-semantics export that only names `EpisodeEventLedger.v1` (without the
+  durable exact/surrogate event payload) fails closed instead of being treated as comparable. This
+  is **diagnostic-only**: it promotes no benchmark claim and invents no old/new event counts; the
+  durable frozen 0.0.2 before/after rerun/backfill remains the open blocker under #3482.
 * Added a read-only **readiness preflight for proxy-based predictive-planner checkpoint selection**
   (#3204). New config `configs/research/predictive_checkpoint_proxy_v1.yaml` declares the inputs the
   merged proxy-vs-ADE analyzer (`scripts/research/analyze_predictive_checkpoint_proxy.py`, #3307)

--- a/robot_sf/benchmark/frozen_trace_reconciliation.py
+++ b/robot_sf/benchmark/frozen_trace_reconciliation.py
@@ -14,6 +14,7 @@ from typing import Any
 from robot_sf.benchmark.event_ledger import EPISODE_EVENT_LEDGER_SCHEMA_VERSION
 
 FROZEN_TRACE_RECONCILIATION_SCHEMA = "frozen_trace_event_reconciliation.v1"
+FROZEN_TRACE_MISSING_EXPORT_SCHEMA = "frozen_trace_event_export_blocker.v1"
 
 _EVENT_BLOCKS = ("exact_events", "surrogate_events")
 
@@ -50,6 +51,12 @@ def _ledger_from_row(row: Mapping[str, Any]) -> Mapping[str, Any]:
         else row.get("event_ledger")
     )
     if not isinstance(ledger, Mapping):
+        if row.get("event_ledger_schema_version") == EPISODE_EVENT_LEDGER_SCHEMA_VERSION:
+            raise ValueError(
+                "frozen reconciliation rows must carry event_ledger exact/surrogate event "
+                "values; metric-semantics exports only name EpisodeEventLedger.v1 and cannot "
+                "be compared without the durable ledger payload"
+            )
         raise ValueError("frozen reconciliation rows must contain event_ledger")
     if ledger.get("schema_version") != EPISODE_EVENT_LEDGER_SCHEMA_VERSION:
         raise ValueError("frozen reconciliation rows must contain EpisodeEventLedger.v1 payloads")
@@ -265,6 +272,72 @@ def _affected_artifact_summary(
     }
 
 
+def _missing_export_artifacts(
+    artifact_manifest: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return artifact statuses when no durable event-ledger export can be compared."""
+
+    statuses: list[dict[str, Any]] = []
+    for artifact in artifact_manifest:
+        consumed = artifact.get("consumes_event_fields", ())
+        consumed_fields = (
+            {str(field) for field in consumed} if isinstance(consumed, list) else set()
+        )
+        statuses.append(
+            {
+                "artifact_id": _coerce_optional_field(artifact.get("artifact_id")),
+                "artifact_type": _coerce_optional_field(artifact.get("artifact_type")),
+                "status": "not_evaluable_missing_event_ledger_export",
+                "consumes_event_fields": sorted(consumed_fields),
+                "affected_event_fields": [],
+                "affected_changed_row_count": None,
+                "affected_added_row_count": None,
+                "affected_removed_row_count": None,
+            }
+        )
+    return statuses
+
+
+def build_missing_frozen_trace_export_report(
+    *,
+    missing_exports: Iterable[Mapping[str, Any]],
+    artifact_manifest: Iterable[Mapping[str, Any]] = (),
+    old_label: str = "old",
+    new_label: str = "new",
+) -> dict[str, Any]:
+    """Build a diagnostic report when durable event-ledger exports are unavailable.
+
+    Returns:
+        JSON-serializable blocker report with null comparison counts.
+    """
+
+    missing_export_rows = [dict(export) for export in missing_exports]
+    affected_artifacts = _missing_export_artifacts(artifact_manifest)
+    return {
+        "schema_version": FROZEN_TRACE_MISSING_EXPORT_SCHEMA,
+        "status": "blocked_missing_durable_event_ledger_exports",
+        "summary": {
+            "old_label": old_label,
+            "new_label": new_label,
+            "old_row_count": None,
+            "new_row_count": None,
+            "changed_row_count": None,
+            "unchanged_row_count": None,
+            "added_row_count": None,
+            "removed_row_count": None,
+            "missing_export_count": len(missing_export_rows),
+        },
+        "missing_exports": missing_export_rows,
+        "affected_artifacts": affected_artifacts,
+        "affected_artifact_summary": _affected_artifact_summary(affected_artifacts),
+        "semantics": {
+            "input_contract": "durable EpisodeEventLedger.v1 rows with exact/surrogate events",
+            "benchmark_semantics_changed": False,
+            "claim_promotion": "none",
+        },
+    }
+
+
 def build_frozen_trace_reconciliation_report(
     old_rows: Iterable[Mapping[str, Any]],
     new_rows: Iterable[Mapping[str, Any]],
@@ -327,6 +400,8 @@ def build_frozen_trace_reconciliation_report(
 
 
 __all__ = [
+    "FROZEN_TRACE_MISSING_EXPORT_SCHEMA",
     "FROZEN_TRACE_RECONCILIATION_SCHEMA",
     "build_frozen_trace_reconciliation_report",
+    "build_missing_frozen_trace_export_report",
 ]

--- a/scripts/benchmark/compare_frozen_trace_event_ledgers.py
+++ b/scripts/benchmark/compare_frozen_trace_event_ledgers.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from robot_sf.benchmark.frozen_trace_reconciliation import (
     build_frozen_trace_reconciliation_report,
+    build_missing_frozen_trace_export_report,
 )
 
 
@@ -42,6 +43,14 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--new-label", default="new", help="Label for the new frozen input.")
     parser.add_argument(
         "--out", required=True, type=Path, help="Output reconciliation report JSON."
+    )
+    parser.add_argument(
+        "--diagnose-missing-exports",
+        action="store_true",
+        help=(
+            "Write a diagnostic blocker report instead of reading inputs when one or both "
+            "expected durable event-ledger exports are absent."
+        ),
     )
     return parser.parse_args(argv)
 
@@ -82,10 +91,48 @@ def _read_artifact_manifest(path: Path | None) -> list[dict[str, Any]]:
     return artifacts
 
 
+def _missing_export_inputs(args: argparse.Namespace) -> list[dict[str, str]]:
+    """Return missing old/new durable export inputs for diagnostic reporting."""
+
+    missing: list[dict[str, str]] = []
+    for label, path in (
+        (args.old_label, args.old_ledgers),
+        (args.new_label, args.new_ledgers),
+    ):
+        if not path.exists():
+            missing.append(
+                {
+                    "label": str(label),
+                    "path": str(path),
+                    "required_contract": (
+                        "JSONL rows carrying EpisodeEventLedger.v1 exact_events and "
+                        "surrogate_events"
+                    ),
+                }
+            )
+    return missing
+
+
 def main(argv: list[str] | None = None) -> int:
     """CLI entry point."""
 
     args = _parse_args(argv)
+    missing_exports = _missing_export_inputs(args)
+    if args.diagnose_missing_exports and missing_exports:
+        report = build_missing_frozen_trace_export_report(
+            missing_exports=missing_exports,
+            artifact_manifest=_read_artifact_manifest(args.artifact_manifest),
+            old_label=args.old_label,
+            new_label=args.new_label,
+        )
+        args.out.parent.mkdir(parents=True, exist_ok=True)
+        args.out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+        print(
+            "wrote frozen event-ledger missing-export diagnostic "
+            f"{args.out} ({len(missing_exports)} missing exports)"
+        )
+        return 0
+
     report = build_frozen_trace_reconciliation_report(
         _read_jsonl(args.old_ledgers),
         _read_jsonl(args.new_ledgers),

--- a/tests/benchmark/test_frozen_trace_reconciliation.py
+++ b/tests/benchmark/test_frozen_trace_reconciliation.py
@@ -11,8 +11,10 @@ from pathlib import Path
 import pytest
 
 from robot_sf.benchmark.frozen_trace_reconciliation import (
+    FROZEN_TRACE_MISSING_EXPORT_SCHEMA,
     FROZEN_TRACE_RECONCILIATION_SCHEMA,
     build_frozen_trace_reconciliation_report,
+    build_missing_frozen_trace_export_report,
 )
 
 SCRIPT_PATH = (
@@ -69,6 +71,12 @@ def _ledger_row(
             "provenance": {"source": "fixture"},
         },
     }
+
+
+def _raw_ledger_row(episode_id: str, *, collision: bool = False) -> dict:
+    """Build a raw durable EpisodeEventLedger.v1 row."""
+
+    return _ledger_row(episode_id, collision=collision)["event_ledger"]
 
 
 def test_report_counts_event_deltas_and_affected_artifact_status() -> None:
@@ -159,6 +167,99 @@ def test_report_counts_event_deltas_and_affected_artifact_status() -> None:
             "unchanged_by_event_delta": 1,
         },
     }
+
+
+def test_raw_durable_event_ledger_rows_are_comparable() -> None:
+    """Frozen durable exports can carry raw EpisodeEventLedger.v1 rows."""
+
+    report = build_frozen_trace_reconciliation_report(
+        [_raw_ledger_row("episode-1")],
+        [_raw_ledger_row("episode-1", collision=True)],
+    )
+
+    assert report["summary"]["old_row_count"] == 1
+    assert report["summary"]["new_row_count"] == 1
+    assert report["summary"]["changed_row_count"] == 1
+    assert report["old_event_counts"]["exact_events.collision"] == 0
+    assert report["new_event_counts"]["exact_events.collision"] == 1
+
+
+def test_metric_semantics_export_without_ledger_payload_is_not_comparable() -> None:
+    """Metric-semantics exports name the ledger but do not carry event booleans."""
+
+    semantics_export = {
+        "schema_version": "event_ledger_reconciliation_export.v1",
+        "episode_id": "episode-1",
+        "scenario_id": "scenario-a",
+        "seed": 7,
+        "planner": "demo",
+        "software_commit": "abc123",
+        "event_ledger_schema_version": "EpisodeEventLedger.v1",
+        "reconciliation_table": {"rows": []},
+    }
+
+    with pytest.raises(ValueError, match="metric-semantics exports"):
+        build_frozen_trace_reconciliation_report([semantics_export], [semantics_export])
+
+
+def test_missing_export_report_marks_artifacts_not_evaluable() -> None:
+    """Missing durable exports produce a blocker report without inventing row counts."""
+
+    report = build_missing_frozen_trace_export_report(
+        missing_exports=[
+            {
+                "label": "0.0.2-before",
+                "path": "docs/context/evidence/missing-before.jsonl",
+                "required_contract": "EpisodeEventLedger.v1 exact/surrogate event JSONL",
+            },
+            {
+                "label": "0.0.2-after",
+                "path": "docs/context/evidence/missing-after.jsonl",
+                "required_contract": "EpisodeEventLedger.v1 exact/surrogate event JSONL",
+            },
+        ],
+        artifact_manifest=[
+            {
+                "artifact_id": "table:safety-summary",
+                "artifact_type": "table",
+                "consumes_event_fields": ["exact_events.collision"],
+            }
+        ],
+        old_label="0.0.2-before",
+        new_label="0.0.2-after",
+    )
+
+    assert report["schema_version"] == FROZEN_TRACE_MISSING_EXPORT_SCHEMA
+    assert report["status"] == "blocked_missing_durable_event_ledger_exports"
+    assert report["summary"] == {
+        "old_label": "0.0.2-before",
+        "new_label": "0.0.2-after",
+        "old_row_count": None,
+        "new_row_count": None,
+        "changed_row_count": None,
+        "unchanged_row_count": None,
+        "added_row_count": None,
+        "removed_row_count": None,
+        "missing_export_count": 2,
+    }
+    assert report["affected_artifacts"] == [
+        {
+            "artifact_id": "table:safety-summary",
+            "artifact_type": "table",
+            "status": "not_evaluable_missing_event_ledger_export",
+            "consumes_event_fields": ["exact_events.collision"],
+            "affected_event_fields": [],
+            "affected_changed_row_count": None,
+            "affected_added_row_count": None,
+            "affected_removed_row_count": None,
+        }
+    ]
+    assert report["affected_artifact_summary"] == {
+        "total_artifacts": 1,
+        "by_type": {"table": {"not_evaluable_missing_event_ledger_export": 1}},
+        "by_status": {"not_evaluable_missing_event_ledger_export": 1},
+    }
+    assert report["semantics"]["claim_promotion"] == "none"
 
 
 def test_added_and_removed_rows_mark_consuming_artifacts_affected() -> None:
@@ -350,3 +451,59 @@ def test_cli_writes_frozen_reconciliation_report(tmp_path: Path) -> None:
     report = json.loads(out_path.read_text(encoding="utf-8"))
     assert report["summary"]["changed_row_count"] == 1
     assert report["affected_artifacts"][0]["status"] == "affected_reconciliation_required"
+
+
+def test_cli_can_write_missing_export_diagnostic(tmp_path: Path) -> None:
+    """CLI can document missing durable frozen exports without fabricating comparison data."""
+
+    manifest_path = tmp_path / "artifact_manifest.json"
+    out_path = tmp_path / "missing_export_report.json"
+    manifest_path.write_text(
+        json.dumps(
+            {
+                "artifacts": [
+                    {
+                        "artifact_id": "claim:collision-count",
+                        "artifact_type": "claim",
+                        "consumes_event_fields": ["exact_events.collision"],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT_PATH),
+            "--old-ledgers",
+            str(tmp_path / "missing-before.jsonl"),
+            "--new-ledgers",
+            str(tmp_path / "missing-after.jsonl"),
+            "--artifact-manifest",
+            str(manifest_path),
+            "--out",
+            str(out_path),
+            "--old-label",
+            "0.0.2-before",
+            "--new-label",
+            "0.0.2-after",
+            "--diagnose-missing-exports",
+        ],
+        check=False,
+        cwd=SCRIPT_PATH.parents[2],
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(out_path.read_text(encoding="utf-8"))
+    assert report["schema_version"] == FROZEN_TRACE_MISSING_EXPORT_SCHEMA
+    assert report["status"] == "blocked_missing_durable_event_ledger_exports"
+    assert report["summary"]["missing_export_count"] == 2
+    assert report["affected_artifact_summary"] == {
+        "total_artifacts": 1,
+        "by_type": {"claim": {"not_evaluable_missing_event_ledger_export": 1}},
+        "by_status": {"not_evaluable_missing_event_ledger_export": 1},
+    }


### PR DESCRIPTION
## Summary
Adds a diagnostic-only missing-export report path for frozen-trace `EpisodeEventLedger.v1` before/after comparison. The existing comparator still handles durable ledger rows when present; this adds explicit blocker output when the expected durable exports are absent.

## Linked Issues
- Relates `#3482`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: `#3660`, `#3778`
- Stack follow-up issues: existing `#3482`
- Safe review independently: yes
- Review dependency reason, any: builds on the existing frozen-trace comparator/reporting surface from prior merged slices.

## What Changed
- Added `frozen_trace_event_export_blocker.v1` report generation for missing durable before/after event-ledger exports.
- Added `--diagnose-missing-exports` to `scripts/benchmark/compare_frozen_trace_event_ledgers.py` so future runs can produce a structured blocker report without fabricating data.
- Tightened the error for metric-semantics exports that name `EpisodeEventLedger.v1` but do not carry exact/surrogate event booleans.
- Added focused tests for raw ledger rows, non-comparable semantics exports, missing-export reports, and the CLI diagnostic path.

## Why Matters
- Added value: records the current blocker in machine-readable form while keeping the existing comparator ready for durable exports.
- Expected impact: downstream claim/table/figure consumers get `not_evaluable_missing_event_ledger_export` instead of silent omission or invented counts.
- Why worth merging now: #3482 remains blocked on durable frozen before/after exports; this slice makes that blocker explicit and reusable.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3482 frozen-trace before/after reconciliation remains blocked until durable `EpisodeEventLedger.v1` exports exist.
- Comparator or baseline, applicable: existing frozen-trace old/new event-ledger comparator.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only / blocker-resolution
- Decision stop rule, applicable: durable before/after exports not found in allowed in-repo paths, so no old/new event counts are claimed.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3482 remains open.
- New research/benchmark/metric/paper-facing analysis tool, any: diagnostic helper only; representative durable-input application is deferred until durable exports exist under #3482.

## Domain-Aware Approval
- Approver/review source waiver: pending reviewer judgment
- Validity checklist:
- Target claim/hypothesis: no benchmark or paper claim promoted.
- Comparator split/evidence validity: comparator path unchanged; missing-export path returns null comparison counts.
- Fallback/degraded exclusions: missing exports are reported as blocked, not evidence.
- Claim boundary: diagnostic-only; no old/new event count result claimed.
- Implementation integrity vs experimental validity: implementation tested on fixtures; empirical validity still blocked on durable exports.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, for fixture-level missing-export and non-comparable-export cases.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? fixture covers missing durable exports and semantics export without event payload.
- Result route: continue #3482 once durable exports are available.
- Follow-up question issue weak, negative, non-transfer results: existing #3482 tracks the remaining application/backfill slice.

## Next Empirical Action
- Rerun needed: yes, once durable frozen before/after event-ledger exports are available.
- Extractor analysis tool needed: no new extractor in this PR.
- Artifact missing unavailable: durable frozen before/after `EpisodeEventLedger.v1` exports.
- Stop / revise / continue decision: continue under #3482 after artifacts are available.
- Proposed child issue existing follow-up: #3482.

## Validation / Proof
- `uv run pytest tests/benchmark/test_frozen_trace_reconciliation.py -q`
- `uv run pytest tests/benchmark/test_event_ledger.py tests/benchmark/test_frozen_trace_reconciliation.py -q`
- `uv run ruff check robot_sf/benchmark/frozen_trace_reconciliation.py scripts/benchmark/compare_frozen_trace_event_ledgers.py tests/benchmark/test_frozen_trace_reconciliation.py`
- `uv run ruff format --check robot_sf/benchmark/frozen_trace_reconciliation.py scripts/benchmark/compare_frozen_trace_event_ledgers.py tests/benchmark/test_frozen_trace_reconciliation.py`
- `git diff --check`
- Durable export search in allowed paths found only unrelated `docs/context/evidence/issue_2760_dissertation_evidence_ledger/ledger.json`; no frozen before/after `EpisodeEventLedger.v1` exports were present.

## Risks / Rollout
- Compatibility risks: existing CLI behavior remains strict unless `--diagnose-missing-exports` is passed.
- Failure modes: callers may still pass non-ledger exports; the comparator now reports the metric-semantics export mismatch explicitly.
- Rollback fallback plan: remove the diagnostic flag/report helper; existing comparator behavior remains otherwise unchanged.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3482, #3660, #3778.
- Any assumptions need to preserved: missing-export report is diagnostic-only and must not be treated as benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized for this run.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): no.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): no.
- Follow-up issue opened deferred propagation (yes/no/NA): no, existing #3482 remains open.
- Not applicable because: this PR is a diagnostic helper and does not promote benchmark, paper-facing, or leaderboard claims.

## Follow-Up Issues
- Deferred work: apply comparator to durable frozen before/after `EpisodeEventLedger.v1` exports once available; reconcile affected claim/table/figure artifacts.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that `not_evaluable_missing_event_ledger_export` cannot be mistaken for a changed/unchanged artifact result.
- Known limitation: no durable frozen before/after exports are included or generated by this PR.
