### PR TITLE
Issue #3799: Prepare Package B post-readiness evidence-gap packet

### DIFF
--- a/robot_sf/benchmark/adversarial_package_b_gap_packet.py
+++ b/robot_sf/benchmark/adversarial_package_b_gap_packet.py
@@ -1,0 +1,146 @@
+"""Post-readiness evidence-gap packet for adversarial Package B.
+
+This module consumes the issue #3079 Package B readiness preflight and maps it
+to the next safe decision. It does not run adversarial sampler comparisons,
+submit Slurm jobs, or interpret benchmark evidence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from robot_sf.benchmark.adversarial_package_b_preflight import (
+    PackageBPreflightResult,
+    preflight_package_b_manifest,
+)
+
+SCHEMA_VERSION = "package-b-post-readiness-gap-packet.v1"
+DEFAULT_MANIFEST = Path("configs/adversarial/issue_3079_package_b_budget_matched.yaml")
+
+
+@dataclass(frozen=True)
+class PackageBGapPacket:
+    """Structured dry-run packet for the Package B readiness-to-evidence gap."""
+
+    manifest_path: str
+    status: str
+    safe_next_decision: str
+    readiness_ready: bool
+    blockers: tuple[str, ...]
+    expected_outputs: tuple[dict[str, str], ...]
+    validation_commands: tuple[str, ...]
+    out_of_scope: tuple[str, ...]
+    source_preflight: dict[str, Any]
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return stable JSON payload for CLI snapshots and downstream review."""
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "manifest_path": self.manifest_path,
+            "status": self.status,
+            "safe_next_decision": self.safe_next_decision,
+            "readiness_ready": self.readiness_ready,
+            "blockers": list(self.blockers),
+            "expected_outputs": list(self.expected_outputs),
+            "validation_commands": list(self.validation_commands),
+            "out_of_scope": list(self.out_of_scope),
+            "source_preflight": self.source_preflight,
+        }
+
+
+def _expected_outputs(preflight: PackageBPreflightResult) -> tuple[dict[str, str], ...]:
+    """Return expected Package B outputs without requiring them to exist yet."""
+    artifacts = preflight.metadata.get("output_artifacts", {})
+    output_dir = artifacts.get("output_dir")
+    report_json = artifacts.get("report_json")
+    outputs: list[dict[str, str]] = []
+
+    if isinstance(output_dir, str) and output_dir:
+        outputs.append(
+            {
+                "path": output_dir,
+                "artifact_class": "worktree_local_campaign_output",
+                "required_before": "local_or_slurm_campaign_execution",
+                "durability": "not_durable_until_promoted_or_manifested",
+            }
+        )
+    if isinstance(report_json, str) and report_json:
+        outputs.append(
+            {
+                "path": report_json,
+                "artifact_class": "package_b_sampler_comparison_report",
+                "required_before": "evidence_review",
+                "durability": "not_durable_until_promoted_or_manifested",
+            }
+        )
+
+    outputs.append(
+        {
+            "path": "output/adversarial/issue_3079_package_b/post_readiness_gap_packet.json",
+            "artifact_class": "dry_run_decision_packet",
+            "required_before": "handoff_to_campaign_operator",
+            "durability": "disposable_unless_copied_to_reviewable_evidence",
+        }
+    )
+    return tuple(outputs)
+
+
+def _validation_commands(manifest_path: str) -> tuple[str, ...]:
+    """Return commands that validate readiness before any campaign launch."""
+    return (
+        "uv run python scripts/tools/preflight_adversarial_package_b.py "
+        f"--manifest {manifest_path}",
+        "uv run python scripts/tools/prepare_package_b_post_readiness_gap_packet.py "
+        f"--manifest {manifest_path} "
+        "--output output/adversarial/issue_3079_package_b/post_readiness_gap_packet.json",
+        "uv run pytest tests/benchmark/test_adversarial_package_b_gap_packet.py",
+    )
+
+
+def _blockers(preflight: PackageBPreflightResult) -> tuple[str, ...]:
+    """Return readiness blockers plus the fixed campaign-submission guard."""
+    blockers = list(preflight.blockers)
+    if preflight.ready:
+        blockers.append(
+            "Slurm/GPU submission remains blocked until a human operator chooses to launch the "
+            "campaign from a clean owning worktree after local dry-run validation."
+        )
+    return tuple(blockers)
+
+
+def build_package_b_gap_packet(
+    manifest_path: Path = DEFAULT_MANIFEST,
+    *,
+    repo_root: Path | None = None,
+) -> PackageBGapPacket:
+    """Build the Package B post-readiness gap packet without executing a campaign.
+
+    Returns:
+        Dry-run packet that maps readiness metadata to the next safe decision.
+    """
+    preflight = preflight_package_b_manifest(manifest_path, repo_root=repo_root)
+    status = "ready_for_local_dry_run_handoff" if preflight.ready else "blocked_on_readiness"
+    decision = (
+        "Run only the listed local validation commands, then decide whether a separate "
+        "Slurm-capable operator should launch Package B."
+        if preflight.ready
+        else "Repair the readiness blockers before any local or Slurm campaign decision."
+    )
+
+    return PackageBGapPacket(
+        manifest_path=preflight.manifest_path,
+        status=status,
+        safe_next_decision=decision,
+        readiness_ready=preflight.ready,
+        blockers=_blockers(preflight),
+        expected_outputs=_expected_outputs(preflight),
+        validation_commands=_validation_commands(preflight.manifest_path),
+        out_of_scope=(
+            "no full benchmark campaign run",
+            "no Slurm/GPU submission",
+            "no paper/dissertation claim edits",
+        ),
+        source_preflight=preflight.to_payload(),
+    )

--- a/robot_sf/benchmark/adversarial_package_b_gap_packet.py
+++ b/robot_sf/benchmark/adversarial_package_b_gap_packet.py
@@ -7,6 +7,7 @@ submit Slurm jobs, or interpret benchmark evidence.
 
 from __future__ import annotations
 
+import shlex
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -88,12 +89,17 @@ def _expected_outputs(preflight: PackageBPreflightResult) -> tuple[dict[str, str
 
 
 def _validation_commands(manifest_path: str) -> tuple[str, ...]:
-    """Return commands that validate readiness before any campaign launch."""
+    """Return commands that validate readiness before any campaign launch.
+
+    The manifest path is shell-quoted so the emitted copy-paste commands stay
+    correct even if the path contains spaces or shell metacharacters.
+    """
+    quoted_path = shlex.quote(manifest_path)
     return (
         "uv run python scripts/tools/preflight_adversarial_package_b.py "
-        f"--manifest {manifest_path}",
+        f"--manifest {quoted_path}",
         "uv run python scripts/tools/prepare_package_b_post_readiness_gap_packet.py "
-        f"--manifest {manifest_path} "
+        f"--manifest {quoted_path} "
         "--output output/adversarial/issue_3079_package_b/post_readiness_gap_packet.json",
         "uv run pytest tests/benchmark/test_adversarial_package_b_gap_packet.py",
     )

--- a/robot_sf/benchmark/adversarial_package_b_gap_packet.py
+++ b/robot_sf/benchmark/adversarial_package_b_gap_packet.py
@@ -96,8 +96,7 @@ def _validation_commands(manifest_path: str) -> tuple[str, ...]:
     """
     quoted_path = shlex.quote(manifest_path)
     return (
-        "uv run python scripts/tools/preflight_adversarial_package_b.py "
-        f"--manifest {quoted_path}",
+        f"uv run python scripts/tools/preflight_adversarial_package_b.py --manifest {quoted_path}",
         "uv run python scripts/tools/prepare_package_b_post_readiness_gap_packet.py "
         f"--manifest {quoted_path} "
         "--output output/adversarial/issue_3079_package_b/post_readiness_gap_packet.json",

--- a/scripts/tools/prepare_package_b_post_readiness_gap_packet.py
+++ b/scripts/tools/prepare_package_b_post_readiness_gap_packet.py
@@ -1,0 +1,54 @@
+#!/usr/bin/env python3
+"""Emit the dry-run Package B post-readiness evidence-gap packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.adversarial_package_b_gap_packet import (
+    DEFAULT_MANIFEST,
+    build_package_b_gap_packet,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse Package B gap-packet CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="Package B readiness manifest to consume.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root for resolving relative manifest paths.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional JSON output path for the dry-run packet.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Build the gap packet and return non-zero while readiness blockers remain."""
+    args = parse_args(argv)
+    packet = build_package_b_gap_packet(args.manifest, repo_root=args.repo_root)
+    payload = packet.to_payload()
+    text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0 if packet.readiness_ready else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_adversarial_package_b_gap_packet.py
+++ b/tests/benchmark/test_adversarial_package_b_gap_packet.py
@@ -1,0 +1,246 @@
+"""Tests for the issue #3799 Package B post-readiness gap packet."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.benchmark.adversarial_package_b_gap_packet import build_package_b_gap_packet
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/tools/prepare_package_b_post_readiness_gap_packet.py"
+SHIPPED_MANIFEST = REPO_ROOT / "configs/adversarial/issue_3079_package_b_budget_matched.yaml"
+
+
+def _write_file(path: Path, text: str = "placeholder\n") -> None:
+    """Write a fixture file and create parents."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _write_registry(repo_root: Path, *, include_manifest: bool = True) -> None:
+    """Write the minimum research package registry fixture."""
+    required = (
+        ["configs/adversarial/issue_3079_package_b_budget_matched.yaml"] if include_manifest else []
+    )
+    _write_file(
+        repo_root / "configs/research/research_package_registry_issue_3057.yaml",
+        yaml.safe_dump(
+            {
+                "packages": [
+                    {
+                        "id": "package_b_adversarial",
+                        "issue": 3079,
+                        "required_artifacts": required,
+                    }
+                ]
+            },
+            sort_keys=False,
+        ),
+    )
+
+
+def _write_complete_manifest(repo_root: Path) -> Path:
+    """Write a self-contained complete Package B readiness fixture."""
+    _write_registry(repo_root)
+    _write_file(repo_root / "configs/scenarios/templates/crossing_ttc.yaml")
+    _write_file(repo_root / "configs/adversarial/crossing_ttc_space.yaml")
+    _write_file(
+        repo_root / "scripts/tools/compare_adversarial_samplers.py",
+        """
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class SamplerComparisonRow:
+    first_failure_iteration: int | None
+    best_valid_objective: float | None
+    invalid_candidate_rate: float
+    replay_success_rate: float | None
+    certified_valid_failure_count: int
+    replayable_valid_failure_count: int
+    fallback_candidate_count: int
+    degraded_candidate_count: int
+    held_out_family_yield: float | None
+""",
+    )
+    manifest = repo_root / "configs/adversarial/issue_3079_package_b_budget_matched.yaml"
+    _write_file(
+        manifest,
+        yaml.safe_dump(
+            {
+                "schema_version": "adversarial-package-b-comparison.v1",
+                "issue": 3079,
+                "status": "diagnostic_local_nominal",
+                "claim_scope": "not_paper_facing_benchmark_evidence",
+                "runner": "scripts/tools/compare_adversarial_samplers.py",
+                "base_config": {
+                    "scenario_template": "configs/scenarios/templates/crossing_ttc.yaml",
+                    "search_space": "configs/adversarial/crossing_ttc_space.yaml",
+                    "policy": "goal",
+                    "objective": "worst_case_snqi",
+                },
+                "budget_grid": [16, 32, 64],
+                "repeated_seeds": [1101, 2202, 3303],
+                "samplers": ["random", "coordinate", "optuna"],
+                "reporting_contract": [
+                    "first_failure_iteration",
+                    "best_valid_objective",
+                    "invalid_candidate_rate",
+                    "replay_success_rate",
+                    "certified_valid_failure_count",
+                    "replayable_valid_failure_count",
+                    "fallback_candidate_count",
+                    "degraded_candidate_count",
+                    "held_out_family_yield",
+                ],
+                "explicit_exclusions": {
+                    "learned_failure_proposal_issue_2921": "stretch_out_of_scope",
+                    "held_out_family_yield": "not_evaluated_narrow_archive_caveat",
+                    "paper_facing_success_claims": "forbidden",
+                },
+                "output_artifacts": {
+                    "output_dir": "output/adversarial/issue_3079_package_b",
+                    "report_json": "output/adversarial/issue_3079_package_b/report.json",
+                },
+                "example_command": (
+                    "uv run python scripts/tools/compare_adversarial_samplers.py "
+                    "--package-b-budget-grid --seed 1101 --seed 2202 --seed 3303 "
+                    "--output-dir output/adversarial/issue_3079_package_b "
+                    "--out-json output/adversarial/issue_3079_package_b/report.json"
+                ),
+            },
+            sort_keys=False,
+        ),
+    )
+    return manifest
+
+
+def test_shipped_manifest_builds_ready_gap_packet() -> None:
+    """The checked-in Package B readiness artifacts map to a local handoff packet."""
+    packet = build_package_b_gap_packet(SHIPPED_MANIFEST, repo_root=REPO_ROOT).to_payload()
+
+    assert packet["schema_version"] == "package-b-post-readiness-gap-packet.v1"
+    assert packet["status"] == "ready_for_local_dry_run_handoff"
+    assert packet["readiness_ready"] is True
+    assert "no full benchmark campaign run" in packet["out_of_scope"]
+    assert "no Slurm/GPU submission" in packet["out_of_scope"]
+    assert "no paper/dissertation claim edits" in packet["out_of_scope"]
+    assert any(
+        output["path"] == "output/adversarial/issue_3079_package_b/report.json"
+        for output in packet["expected_outputs"]
+    )
+    assert any(
+        "prepare_package_b_post_readiness_gap_packet.py" in command
+        for command in packet["validation_commands"]
+    )
+    assert packet["source_preflight"]["metadata"]["does_not_execute_benchmark"] is True
+
+
+def test_gap_packet_fails_closed_when_readiness_metadata_is_incomplete(tmp_path: Path) -> None:
+    """Incomplete readiness metadata blocks both local and Slurm campaign decisions."""
+    manifest = _write_complete_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    del payload["output_artifacts"]
+    payload["repeated_seeds"] = []
+    manifest.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    packet = build_package_b_gap_packet(manifest, repo_root=tmp_path).to_payload()
+
+    assert packet["status"] == "blocked_on_readiness"
+    assert packet["readiness_ready"] is False
+    assert packet["source_preflight"]["blocked"] is True
+    assert any("output_artifacts" in blocker for blocker in packet["blockers"])
+    assert any("repeated_seeds" in blocker for blocker in packet["blockers"])
+    assert "Repair the readiness blockers" in packet["safe_next_decision"]
+
+
+def test_gap_packet_cli_emits_stable_dry_run_snapshot(tmp_path: Path) -> None:
+    """The CLI writes and prints the same dry-run packet without launching a campaign."""
+    manifest = _write_complete_manifest(tmp_path)
+    output = tmp_path / "packet.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--manifest",
+            str(manifest),
+            "--repo-root",
+            str(tmp_path),
+            "--output",
+            str(output),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    stdout_payload = json.loads(completed.stdout)
+    file_payload = json.loads(output.read_text(encoding="utf-8"))
+    assert stdout_payload == file_payload
+    assert stdout_payload["safe_next_decision"].startswith("Run only the listed local validation")
+    assert stdout_payload["expected_outputs"] == [
+        {
+            "artifact_class": "worktree_local_campaign_output",
+            "durability": "not_durable_until_promoted_or_manifested",
+            "path": "output/adversarial/issue_3079_package_b",
+            "required_before": "local_or_slurm_campaign_execution",
+        },
+        {
+            "artifact_class": "package_b_sampler_comparison_report",
+            "durability": "not_durable_until_promoted_or_manifested",
+            "path": "output/adversarial/issue_3079_package_b/report.json",
+            "required_before": "evidence_review",
+        },
+        {
+            "artifact_class": "dry_run_decision_packet",
+            "durability": "disposable_unless_copied_to_reviewable_evidence",
+            "path": "output/adversarial/issue_3079_package_b/post_readiness_gap_packet.json",
+            "required_before": "handoff_to_campaign_operator",
+        },
+    ]
+    assert all("sbatch" not in command for command in stdout_payload["validation_commands"])
+
+
+def test_gap_packet_cli_returns_nonzero_for_incomplete_readiness(tmp_path: Path) -> None:
+    """CLI exit code stays fail-closed when readiness preflight is blocked."""
+    manifest = _write_complete_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["budget_grid"] = [16]
+    manifest.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--manifest",
+            str(manifest),
+            "--repo-root",
+            str(tmp_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1
+    payload = json.loads(completed.stdout)
+    assert payload["status"] == "blocked_on_readiness"
+    assert any("budget_grid" in blocker for blocker in payload["blockers"])
+
+
+@pytest.mark.parametrize("forbidden", ["sbatch", "srun", "wandb"])
+def test_gap_packet_validation_commands_stay_dry_run_only(forbidden: str) -> None:
+    """The shipped packet validation commands do not include submission surfaces."""
+    packet = build_package_b_gap_packet(SHIPPED_MANIFEST, repo_root=REPO_ROOT).to_payload()
+    command_text = "\n".join(packet["validation_commands"]).lower()
+    assert forbidden not in command_text


### PR DESCRIPTION
## Issue

Closes #3799

## Scope Summary

Adds a dry-run Package B post-readiness evidence-gap packet that consumes the existing issue #3079 fail-closed readiness preflight and maps the readiness artifacts to the next safe local/Slurm decision.

The packet reports:
- readiness status and blockers from `preflight_adversarial_package_b.py`
- expected Package B outputs and durability caveats
- local validation commands for preflight and packet generation
- fixed out-of-scope boundaries for campaign launch and claims work

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/adversarial_package_b_gap_packet.py scripts/tools/prepare_package_b_post_readiness_gap_packet.py tests/benchmark/test_adversarial_package_b_gap_packet.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_adversarial_package_b_gap_packet.py` - passed, 7 tests
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_gap_packet.py` - passed, 30 tests
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/preflight_adversarial_package_b.py --manifest configs/adversarial/issue_3079_package_b_budget_matched.yaml` - passed, readiness `ready: true`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/prepare_package_b_post_readiness_gap_packet.py --manifest configs/adversarial/issue_3079_package_b_budget_matched.yaml --output output/adversarial/issue_3079_package_b/post_readiness_gap_packet.json` - passed, status `ready_for_local_dry_run_handoff`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed after `uv sync --all-extras`; final stamp `output/validation/pr_ready/issue-3799-benchmark-prepare-package-b-post-readiness-evidence-gap-packet.json`, clean tree, head `95260dc3f4b54d097953616628c8af58f86d0137`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` - passed, fresh clean-tree stamp

## Artifact Classification

Generated outputs are ignored local validation artifacts only:
- `output/adversarial/` contains the dry-run packet snapshot
- `output/coverage/` contains readiness coverage output
- `output/model_cache/` is local cache state
- `output/validation/` contains PR readiness stamps/logs

No generated artifact is committed as durable benchmark evidence.

## Explicit Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
