### PR TITLE
training: add predictive retrain decision packet for issue #3801

### DIFF
--- a/robot_sf/training/predictive_retrain_preflight.py
+++ b/robot_sf/training/predictive_retrain_preflight.py
@@ -42,6 +42,7 @@ _EXPECTED_PROVENANCE_KEYS = (
     "checkpoint_provenance_path",
     "hard_seed_evaluation_summary",
 )
+_PROVENANCE_PRETRAINING_STATUS = "expected_missing_until_training"
 
 
 class PredictiveRetrainPreflightError(ValueError):
@@ -447,8 +448,160 @@ def _validate_output(config: dict[str, Any], errors: list[str]) -> str | None:
     return _require_non_empty_string(output, "root", errors)
 
 
+def build_retrain_decision_packet(
+    config_path: Path | str,
+    *,
+    repo_root: Path | None = None,
+) -> dict[str, Any]:
+    """Summarize no-submit training readiness from static preflight metadata.
+
+    The packet is deliberately read-only: it maps the #3254 preflight to a
+    launch decision, blockers, expected costs, and validation proof without
+    collecting data, training, submitting a job, or asserting model quality.
+
+    Returns:
+        JSON-serializable decision packet for the dry-run CLI.
+    """
+    root = (repo_root or Path.cwd()).resolve()
+    config_path = _resolve_path(config_path, root)
+    try:
+        config = load_pipeline_config(config_path)
+    except PredictiveRetrainPreflightError as exc:
+        return _decision_packet(
+            config_path=config_path,
+            decision="missing_preflight_metadata",
+            preflight_status="missing",
+            blockers=[str(exc)],
+            validation_proof=[],
+        )
+
+    missing_metadata = _missing_preflight_metadata(config)
+    if missing_metadata:
+        return _decision_packet(
+            config_path=config_path,
+            config=config,
+            decision="missing_preflight_metadata",
+            preflight_status="missing",
+            blockers=missing_metadata,
+            validation_proof=[_validation_command(config_path, root)],
+        )
+
+    try:
+        preflight_report = validate_retrain_preflight(config_path, repo_root=root)
+    except PredictiveRetrainPreflightError as exc:
+        return _decision_packet(
+            config_path=config_path,
+            config=config,
+            decision="blocked",
+            preflight_status="invalid",
+            blockers=[str(exc)],
+            validation_proof=[_validation_command(config_path, root)],
+        )
+
+    return _decision_packet(
+        config_path=config_path,
+        config=config,
+        decision="ready",
+        preflight_status="valid",
+        blockers=[],
+        validation_proof=[_validation_command(config_path, root)],
+        preflight_report=preflight_report,
+    )
+
+
+def _missing_preflight_metadata(config: dict[str, Any]) -> list[str]:
+    """Return missing decision-critical metadata without running validation."""
+    blockers: list[str] = []
+    provenance = config.get("provenance")
+    if not isinstance(provenance, dict):
+        return ["provenance metadata block is missing"]
+    for key in _EXPECTED_PROVENANCE_KEYS:
+        value = provenance.get(key)
+        if not isinstance(value, str) or not value.strip():
+            blockers.append(f"provenance.{key} is missing")
+    if provenance.get("status") != _PROVENANCE_PRETRAINING_STATUS:
+        blockers.append(
+            f"provenance.status must be {_PROVENANCE_PRETRAINING_STATUS!r} "
+            "before training evidence exists"
+        )
+    return blockers
+
+
+def _decision_packet(
+    *,
+    config_path: Path,
+    decision: str,
+    preflight_status: str,
+    blockers: list[str],
+    validation_proof: list[str],
+    config: dict[str, Any] | None = None,
+    preflight_report: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build the stable JSON shape used by tests and the dry-run CLI.
+
+    Returns:
+        JSON-serializable packet containing decision, blockers, and proof.
+    """
+    experiment = config.get("experiment", {}) if config else {}
+    training = config.get("training", {}) if config else {}
+    base_collection = config.get("base_collection", {}) if config else {}
+    hardcase_collection = config.get("hardcase_collection", {}) if config else {}
+    mixing = config.get("mixing", {}) if config else {}
+    evaluation = config.get("evaluation", {}) if config else {}
+    output = config.get("output", {}) if config else {}
+
+    packet = {
+        "schema_version": "predictive_retrain_decision_packet.v1",
+        "issue": 3801,
+        "parent_issue": 3254,
+        "parent_pr": 3784,
+        "config_path": str(config_path),
+        "run_id": experiment.get("run_id"),
+        "decision": decision,
+        "preflight_status": preflight_status,
+        "submitted": False,
+        "claim_boundary": config.get("claim_boundary") if config else None,
+        "blockers": blockers,
+        "expected_missing_outputs": (
+            ((preflight_report.get("provenance") or {}).get("missing_artifacts") or [])
+            if preflight_report
+            else []
+        ),
+        "expected_costs": {
+            "training_epochs": training.get("epochs"),
+            "base_seeds_per_scenario": base_collection.get("seeds_per_scenario"),
+            "hardcase_seeds_per_scenario": hardcase_collection.get("seeds_per_scenario"),
+            "hardcase_repeat": (
+                (preflight_report.get("mixing") or {}).get("hardcase_repeat")
+                if preflight_report
+                else mixing.get("hardcase_repeat")
+            ),
+            "evaluation_workers": evaluation.get("workers"),
+            "evaluation_horizon": evaluation.get("horizon"),
+            "output_root": output.get("root"),
+        },
+        "validation_proof": validation_proof,
+        "out_of_scope": [
+            "no full benchmark campaign run",
+            "no Slurm/GPU submission",
+            "no paper/dissertation claim edits",
+        ],
+    }
+    if preflight_report is not None:
+        packet["preflight_report"] = preflight_report
+    return packet
+
+
+def _validation_command(config_path: Path, repo_root: Path) -> str:
+    return (
+        "uv run python scripts/validation/validate_predictive_retrain_preflight.py "
+        f"--config {config_path} --repo-root {repo_root} --json"
+    )
+
+
 __all__ = [
     "PredictiveRetrainPreflightError",
+    "build_retrain_decision_packet",
     "load_pipeline_config",
     "validate_retrain_preflight",
 ]

--- a/scripts/validation/validate_predictive_retrain_preflight.py
+++ b/scripts/validation/validate_predictive_retrain_preflight.py
@@ -14,6 +14,7 @@ from pathlib import Path
 
 from robot_sf.training.predictive_retrain_preflight import (
     PredictiveRetrainPreflightError,
+    build_retrain_decision_packet,
     validate_retrain_preflight,
 )
 
@@ -31,12 +32,22 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Repository root used to resolve relative paths.",
     )
     parser.add_argument("--json", action="store_true", help="Emit a JSON validation report.")
+    parser.add_argument(
+        "--decision-packet",
+        action="store_true",
+        help="Emit the no-submit training readiness decision packet.",
+    )
     return parser
 
 
 def main(argv: list[str] | None = None) -> int:
     """Validate a predictive retraining launch config; return a shell-friendly code."""
     args = build_arg_parser().parse_args(argv)
+    if args.decision_packet:
+        packet = build_retrain_decision_packet(args.config, repo_root=args.repo_root)
+        print(json.dumps(packet, indent=2, sort_keys=True))
+        return 0
+
     try:
         report = validate_retrain_preflight(args.config, repo_root=args.repo_root)
     except PredictiveRetrainPreflightError as exc:

--- a/tests/training/test_predictive_retrain_preflight.py
+++ b/tests/training/test_predictive_retrain_preflight.py
@@ -9,6 +9,7 @@ import yaml
 
 from robot_sf.training.predictive_retrain_preflight import (
     PredictiveRetrainPreflightError,
+    build_retrain_decision_packet,
     validate_retrain_preflight,
 )
 from scripts.validation.validate_predictive_retrain_preflight import main as validate_cli_main
@@ -344,3 +345,65 @@ def test_config_must_be_mapping(tmp_path: Path) -> None:
     path.write_text("- just\n- a\n- list\n", encoding="utf-8")
     with pytest.raises(PredictiveRetrainPreflightError, match="config must be a YAML mapping"):
         validate_retrain_preflight(path, repo_root=tmp_path)
+
+
+def test_decision_packet_ready_from_valid_preflight(tmp_path: Path) -> None:
+    """A valid prepare-only config becomes a no-submit ready packet."""
+    path = _write_config(tmp_path, _base_config(tmp_path))
+
+    packet = build_retrain_decision_packet(path, repo_root=tmp_path)
+
+    assert packet["schema_version"] == "predictive_retrain_decision_packet.v1"
+    assert packet["decision"] == "ready"
+    assert packet["preflight_status"] == "valid"
+    assert packet["submitted"] is False
+    assert packet["blockers"] == []
+    assert len(packet["expected_missing_outputs"]) == 3
+    assert packet["expected_costs"]["training_epochs"] == 400
+    assert packet["expected_costs"]["output_root"] == "output/tmp/predictive_planner/pipeline"
+    assert "no Slurm/GPU submission" in packet["out_of_scope"]
+    assert packet["preflight_report"]["status"] == "valid"
+
+
+def test_decision_packet_blocks_invalid_preflight(tmp_path: Path) -> None:
+    """Invalid static preflight is reported as blocked, not submitted."""
+    config = _base_config(tmp_path)
+    config["scenarios"]["planner_grid"] = "missing.yaml"  # type: ignore[index]
+    path = _write_config(tmp_path, config)
+
+    packet = build_retrain_decision_packet(path, repo_root=tmp_path)
+
+    assert packet["decision"] == "blocked"
+    assert packet["preflight_status"] == "invalid"
+    assert packet["submitted"] is False
+    assert "planner_grid" in packet["blockers"][0]
+
+
+def test_decision_packet_reports_missing_preflight_metadata(tmp_path: Path) -> None:
+    """Missing provenance metadata has its own status before full validation."""
+    config = _base_config(tmp_path)
+    del config["provenance"]
+    path = _write_config(tmp_path, config)
+
+    packet = build_retrain_decision_packet(path, repo_root=tmp_path)
+
+    assert packet["decision"] == "missing_preflight_metadata"
+    assert packet["preflight_status"] == "missing"
+    assert packet["submitted"] is False
+    assert packet["blockers"] == ["provenance metadata block is missing"]
+
+
+def test_decision_packet_cli_is_no_submit_dry_run(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """CLI decision-packet mode emits JSON and keeps submission false."""
+    path = _write_config(tmp_path, _base_config(tmp_path))
+
+    code = validate_cli_main(
+        ["--config", str(path), "--repo-root", str(tmp_path), "--decision-packet"]
+    )
+
+    assert code == 0
+    output = capsys.readouterr().out
+    assert '"decision": "ready"' in output
+    assert '"submitted": false' in output


### PR DESCRIPTION
## Summary
Adds a read-only predictive retrain decision packet for issue #3801, consuming the #3254 preflight metadata into a no-submit go/no-go readiness summary.

## Linked Issues
- Closes #3801
- Relates #3254
- Relates #3784

## Stack / Dependency
- Base dependency: none
- Required prior PRs: #3784 (merged)
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: consumes the merged #3254 preflight owner only.

## What Changed
- Added `build_retrain_decision_packet` in `robot_sf/training/predictive_retrain_preflight.py`.
- Added `--decision-packet` to `scripts/validation/validate_predictive_retrain_preflight.py` for the no-submit dry-run packet command.
- Added fixture coverage for ready, blocked, missing metadata, and CLI no-submit output.

## Why Matters
- Added value: turns predictive retrain preflight evidence into a compact training-readiness packet.
- Expected impact: makes go/no-go state, blockers, expected costs, validation proof, and no-submit boundary explicit before compute is authorized.
- Why worth merging now: #3801 is the bounded hindsight successor to #3784/#3254.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: training-readiness blocker for predictive retrain launch packet; no model-quality claim.
- Comparator or baseline, applicable: current predictive baseline metadata from #3254 preflight.
- Evidence tier: NA - support helper; no benchmark, training, or model-quality evidence is produced.
- Result classification: NA - support helper; it only formats preflight readiness metadata.
- Decision stop rule, applicable: valid static preflight emits ready packet with `submitted: false`; invalid or missing metadata emits blocked/missing status.
- Parent issue, claim map, registry, context note, synthesis surface update: #3801 / #3254.
- New research/benchmark/metric/paper-facing analysis tool, any: no benchmark or paper-facing analysis tool; read-only launch decision packet.

## Domain-Aware Approval
- Required PR: yes - launch packet evidence tier triggers domain-aware review policy.
- Domains reviewed: training launch readiness / predictive retrain preflight metadata.
- Status: waived for merge-readiness because this PR makes no benchmark, model-quality, paper-facing, or dissertation claim.
- Approver/review source waiver: maintainer authorization in #3801 limits scope to no-submit decision packet; Claude Code owns full PR gate after open.
- Approval or blocker note: waiver is limited to implementation readiness; actual compute submission remains separately unauthorized.
- Target claim/hypothesis: no predictive model-quality claim; only read-only launch-readiness packet generation.
- Comparator or split/evidence validity: valid by non-use; the packet does not compare experimental splits or interpret benchmark results.
- Fallback/degraded exclusions: no benchmark run and no fallback/degraded result is classified as success evidence.
- Claim boundary: launch-readiness packet only; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: focused fixture tests and dry-run command prove packet behavior; experimental validity is out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no training or benchmark mechanism executed.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA.
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action
- Rerun needed: no for this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: expected checkpoint/provenance/evaluation outputs remain absent until authorized training.
- Stop / revise / continue decision: continue only after compute submission is separately authorized.
- Proposed child issue existing follow-up: none opened.

## Validation / Proof
- `uv run pytest tests/training/test_predictive_retrain_preflight.py -q` -> passed (28 tests).
- `uv run ruff check robot_sf/training/predictive_retrain_preflight.py scripts/validation/validate_predictive_retrain_preflight.py tests/training/test_predictive_retrain_preflight.py` -> passed.
- `uv run python scripts/validation/validate_predictive_retrain_preflight.py --config configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml --repo-root . --decision-packet` -> passed; packet reported `decision=ready`, `preflight_status=valid`, `submitted=false`, `blockers=0`, `expected_missing_outputs=3`, `hardcase_repeat=8`.

## Performance Impact
- Baseline runtime: NA - no runtime hot path changed.
- Changed runtime: NA - read-only CLI helper only.
- Representative command: `uv run python scripts/validation/validate_predictive_retrain_preflight.py --config configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml --repo-root . --decision-packet`
- Hot-path call count profile anchor: NA - no benchmark/training hot path.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: packet misclassifies ready/blocked/missing metadata or dry-run submits work.

## Risks / Rollout
- Compatibility risks: low; extends existing preflight API/CLI without changing existing validation behavior.
- Failure modes: packet consumers may treat expected missing training outputs as final artifacts; field is explicitly named `expected_missing_outputs`.
- Rollback fallback plan: remove `--decision-packet` and helper, leaving existing preflight unchanged.

## Docs / Provenance
- Updated docs: none; CLI help and tests cover the bounded entry point.
- Relevant design provenance notes: #3801, #3254, #3784.
- Any assumptions need to preserved: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - issue comments were not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a read-only launch-readiness packet, not benchmark, registry, claim-map, or paper-facing evidence.

## Follow-Up Issues
- Deferred work: actual training submission remains out of scope and requires separate authorization.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that `submitted` remains false and expected missing outputs are not treated as blockers for a valid preflight.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
