### PR TITLE
Issue #3808: prepare TTC near-miss diagnostic decision packet

### DIFF
--- a/robot_sf/benchmark/near_miss_ttc.py
+++ b/robot_sf/benchmark/near_miss_ttc.py
@@ -547,8 +547,13 @@ def _json_safe_value(value: object) -> object:
         Value with non-finite floats replaced by ``None``.
     """
 
-    if isinstance(value, float):
-        return value if np.isfinite(value) else None
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (float, np.floating)):
+        float_value = float(value)
+        return float_value if np.isfinite(float_value) else None
+    if isinstance(value, (int, np.integer)):
+        return int(value)
     if isinstance(value, dict):
         return {key: _json_safe_value(item) for key, item in value.items()}
     if isinstance(value, list):

--- a/robot_sf/benchmark/near_miss_ttc.py
+++ b/robot_sf/benchmark/near_miss_ttc.py
@@ -49,7 +49,7 @@ metric so this diagnostic stays consistent with the repository's TTC definition:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -113,6 +113,41 @@ class NearMissTtcReadiness:
     n_steps: int = 0
     n_peds: int = 0
     dt: float = float("nan")
+
+
+@dataclass(frozen=True)
+class NearMissTtcDecisionPacket:
+    """Read-only TTC near-miss diagnostic decision packet.
+
+    The packet summarizes whether the existing opt-in diagnostic can be
+    evaluated for a trajectory and what the result can and cannot support. It
+    intentionally carries no threshold recommendation and does not replace the
+    canonical distance-based near-miss metric.
+    """
+
+    issue: str
+    evidence_status: str
+    diagnostic_status: str
+    available_inputs: tuple[str, ...]
+    unsupported_cases: tuple[str, ...]
+    cannot_claim: tuple[str, ...]
+    readiness: NearMissTtcReadiness
+    diagnostic: dict[str, float | str] = field(default_factory=dict)
+    threshold_s: float = DIAGNOSTIC_TTC_THRESHOLD_S
+
+    def to_dict(self) -> dict[str, object]:
+        """Return JSON-safe packet representation."""
+        return {
+            "issue": self.issue,
+            "evidence_status": self.evidence_status,
+            "diagnostic_status": self.diagnostic_status,
+            "available_inputs": list(self.available_inputs),
+            "unsupported_cases": list(self.unsupported_cases),
+            "cannot_claim": list(self.cannot_claim),
+            "readiness": _json_safe_value(asdict(self.readiness)),
+            "diagnostic": _json_safe_value(dict(self.diagnostic)),
+            "threshold_s": _json_safe_value(self.threshold_s),
+        }
 
 
 def _as_float_array(value: object) -> np.ndarray | None:
@@ -360,10 +395,176 @@ def compute_ttc_near_miss_diagnostic(
     return base_result
 
 
+def build_ttc_near_miss_decision_packet(
+    data: EpisodeData,
+    *,
+    t_thr: float = DIAGNOSTIC_TTC_THRESHOLD_S,
+    issue: str = "#3808",
+) -> NearMissTtcDecisionPacket:
+    """Build a read-only TTC near-miss diagnostic decision packet.
+
+    The packet consumes the issue #3700 diagnostic surface without mutating the
+    trajectory or canonical benchmark metrics. Unsupported inputs are reported
+    fail-closed instead of converted to a zero near-miss result.
+
+    Returns
+    -------
+    NearMissTtcDecisionPacket
+        Structured diagnostic-only packet for review handoff.
+    """
+
+    readiness = near_miss_ttc_input_readiness(data)
+    available_inputs = _describe_available_ttc_inputs(readiness)
+    cannot_claim = (
+        "no canonical near-miss metric replacement",
+        "no calibrated TTC threshold or severity weighting choice",
+        "no planner comparison, benchmark ranking, or paper/dissertation claim",
+    )
+
+    if not readiness.ready:
+        return NearMissTtcDecisionPacket(
+            issue=issue,
+            evidence_status="diagnostic-only",
+            diagnostic_status="unsupported-inputs",
+            available_inputs=available_inputs,
+            unsupported_cases=tuple(readiness.reasons),
+            cannot_claim=cannot_claim,
+            readiness=readiness,
+            threshold_s=t_thr,
+        )
+
+    diagnostic = compute_ttc_near_miss_diagnostic(data, t_thr=t_thr)
+    status = str(diagnostic["near_miss_ttc__status"])
+    unsupported_cases = _describe_unsupported_ttc_cases(status)
+
+    return NearMissTtcDecisionPacket(
+        issue=issue,
+        evidence_status="diagnostic-only",
+        diagnostic_status=status,
+        available_inputs=available_inputs,
+        unsupported_cases=unsupported_cases,
+        cannot_claim=cannot_claim,
+        readiness=readiness,
+        diagnostic=diagnostic,
+        threshold_s=float(diagnostic["near_miss_ttc__threshold_s"]),
+    )
+
+
+def render_ttc_near_miss_decision_packet_markdown(packet: NearMissTtcDecisionPacket) -> str:
+    """Render a compact Markdown decision packet for review or issue handoff.
+
+    Returns
+    -------
+    str
+        Markdown packet text.
+    """
+
+    lines = [
+        "# TTC Near-Miss Diagnostic Decision Packet",
+        "",
+        f"- Issue: `{packet.issue}`",
+        f"- Evidence status: `{packet.evidence_status}`",
+        f"- Diagnostic status: `{packet.diagnostic_status}`",
+        f"- Threshold inspected: `{packet.threshold_s}` seconds",
+        "",
+        "## Available Diagnostic Inputs",
+        *_bullet_lines(packet.available_inputs),
+        "",
+        "## Unsupported Cases",
+        *_bullet_lines(packet.unsupported_cases),
+        "",
+        "## Cannot Claim Before Canonical Metric Change",
+        *_bullet_lines(packet.cannot_claim),
+    ]
+    if packet.diagnostic:
+        lines.extend(["", "## Diagnostic Values"])
+        lines.extend(
+            f"- `{key}`: `{value}`"
+            for key, value in sorted(packet.diagnostic.items(), key=lambda item: item[0])
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _describe_available_ttc_inputs(readiness: NearMissTtcReadiness) -> tuple[str, ...]:
+    """Describe the timing and trajectory inputs visible to the packet.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Human-readable input availability lines.
+    """
+
+    inputs = [
+        f"dt inspected: {readiness.dt}",
+        f"trajectory frames inspected: {readiness.n_steps}",
+        f"pedestrians inspected: {readiness.n_peds}",
+    ]
+    if readiness.ready:
+        inputs.append("robot position, robot velocity, and pedestrian position arrays are usable")
+    return tuple(inputs)
+
+
+def _describe_unsupported_ttc_cases(status: str) -> tuple[str, ...]:
+    """Describe cases this diagnostic cannot support as TTC near-miss evidence.
+
+    Returns
+    -------
+    tuple[str, ...]
+        Human-readable unsupported-case lines.
+    """
+
+    cases = [
+        "static distance-only proximity remains covered only by canonical near_misses",
+        "trajectory-free aggregate metrics cannot be reinterpreted as TTC evidence",
+    ]
+    if status == "no-pedestrians":
+        cases.append("no pedestrian pairs were available for TTC evaluation")
+    elif status == "no-approaching-pairs":
+        cases.append("opening or non-converging pairs do not support TTC near-miss counts")
+    return tuple(cases)
+
+
+def _bullet_lines(items: tuple[str, ...]) -> list[str]:
+    """Format tuple content as Markdown bullets.
+
+    Returns
+    -------
+    list[str]
+        Markdown bullet lines.
+    """
+
+    if not items:
+        return ["- none"]
+    return [f"- {item}" for item in items]
+
+
+def _json_safe_value(value: object) -> object:
+    """Convert packet values to strict JSON-compatible primitives.
+
+    Returns
+    -------
+    object
+        Value with non-finite floats replaced by ``None``.
+    """
+
+    if isinstance(value, float):
+        return value if np.isfinite(value) else None
+    if isinstance(value, dict):
+        return {key: _json_safe_value(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [_json_safe_value(item) for item in value]
+    if isinstance(value, tuple):
+        return [_json_safe_value(item) for item in value]
+    return value
+
+
 __all__ = [
     "DIAGNOSTIC_TTC_THRESHOLD_S",
+    "NearMissTtcDecisionPacket",
     "NearMissTtcInputError",
     "NearMissTtcReadiness",
+    "build_ttc_near_miss_decision_packet",
     "compute_ttc_near_miss_diagnostic",
     "near_miss_ttc_input_readiness",
+    "render_ttc_near_miss_decision_packet_markdown",
 ]

--- a/tests/benchmark/test_near_miss_ttc.py
+++ b/tests/benchmark/test_near_miss_ttc.py
@@ -7,6 +7,8 @@ distance-based ``near_misses`` metric is left untouched (backward compatibility)
 
 from __future__ import annotations
 
+import json
+
 import numpy as np
 import pytest
 
@@ -14,8 +16,10 @@ from robot_sf.benchmark.metrics import EpisodeData
 from robot_sf.benchmark.near_miss_ttc import (
     DIAGNOSTIC_TTC_THRESHOLD_S,
     NearMissTtcInputError,
+    build_ttc_near_miss_decision_packet,
     compute_ttc_near_miss_diagnostic,
     near_miss_ttc_input_readiness,
+    render_ttc_near_miss_decision_packet_markdown,
 )
 
 
@@ -222,3 +226,68 @@ def test_canonical_near_misses_metric_unchanged():
 
     assert before == after
     assert before > 0.0  # sanity: the canonical metric actually fired here
+
+
+# --- Issue #3808 read-only decision packet -------------------------------------
+
+
+def test_decision_packet_summarizes_closing_case():
+    """Closing trajectories produce diagnostic-only packet values, not claims."""
+    data = _fast_head_on_episode()
+    packet = build_ttc_near_miss_decision_packet(data, t_thr=1.0)
+
+    assert packet.evidence_status == "diagnostic-only"
+    assert packet.diagnostic_status == "ok"
+    assert packet.diagnostic["near_miss_ttc__count"] > 0
+    assert any("canonical near-miss metric replacement" in item for item in packet.cannot_claim)
+    assert any("robot position" in item for item in packet.available_inputs)
+
+
+def test_decision_packet_summarizes_opening_case_as_unsupported_for_ttc_counts():
+    """Opening trajectories are available inputs but unsupported TTC count evidence."""
+    data = _slow_opening_episode()
+    packet = build_ttc_near_miss_decision_packet(data, t_thr=5.0)
+
+    assert packet.diagnostic_status == "no-approaching-pairs"
+    assert packet.diagnostic["near_miss_ttc__count"] == 0.0
+    assert any("opening or non-converging pairs" in item for item in packet.unsupported_cases)
+
+
+def test_decision_packet_fails_closed_on_missing_timing():
+    """Missing/invalid timing stays unsupported instead of becoming zero evidence."""
+    data = _fast_head_on_episode()
+    data.dt = float("nan")
+
+    packet = build_ttc_near_miss_decision_packet(data)
+
+    assert packet.diagnostic_status == "unsupported-inputs"
+    assert packet.diagnostic == {}
+    assert any("dt" in item for item in packet.unsupported_cases)
+
+
+def test_decision_packet_fails_closed_on_unsupported_trajectory_shape():
+    """Malformed trajectory arrays are listed as unsupported packet inputs."""
+    data = _fast_head_on_episode()
+    data.peds_pos = np.zeros((data.robot_pos.shape[0], 2))
+
+    packet = build_ttc_near_miss_decision_packet(data)
+
+    assert packet.diagnostic_status == "unsupported-inputs"
+    assert any("peds_pos" in item for item in packet.unsupported_cases)
+
+
+def test_decision_packet_renders_markdown_and_json_safe_dict():
+    """Decision packet can be emitted as generated Markdown/JSON-like payload."""
+    packet = build_ttc_near_miss_decision_packet(_slow_opening_episode(), t_thr=1.0)
+
+    payload = packet.to_dict()
+    markdown = render_ttc_near_miss_decision_packet_markdown(packet)
+
+    json.dumps(payload, allow_nan=False)
+    assert payload["issue"] == "#3808"
+    assert payload["evidence_status"] == "diagnostic-only"
+    assert payload["diagnostic"]["near_miss_ttc__status"] == "no-approaching-pairs"
+    assert payload["diagnostic"]["near_miss_ttc__min_ttc_s"] is None
+    assert "# TTC Near-Miss Diagnostic Decision Packet" in markdown
+    assert "Cannot Claim Before Canonical Metric Change" in markdown
+    assert "no planner comparison, benchmark ranking, or paper/dissertation claim" in markdown

--- a/tests/benchmark/test_near_miss_ttc.py
+++ b/tests/benchmark/test_near_miss_ttc.py
@@ -291,3 +291,20 @@ def test_decision_packet_renders_markdown_and_json_safe_dict():
     assert "# TTC Near-Miss Diagnostic Decision Packet" in markdown
     assert "Cannot Claim Before Canonical Metric Change" in markdown
     assert "no planner comparison, benchmark ranking, or paper/dissertation claim" in markdown
+
+
+def test_decision_packet_json_safe_dict_handles_numpy_scalars():
+    """Decision packet JSON conversion handles NumPy scalar values."""
+    packet = build_ttc_near_miss_decision_packet(_slow_opening_episode(), t_thr=1.0)
+    packet.diagnostic["numpy_nan"] = np.float32(np.nan)
+    packet.diagnostic["numpy_float"] = np.float64(1.25)
+    packet.diagnostic["numpy_int"] = np.int64(3)
+    packet.diagnostic["bool_flag"] = True
+
+    payload = packet.to_dict()
+
+    json.dumps(payload, allow_nan=False)
+    assert payload["diagnostic"]["numpy_nan"] is None
+    assert payload["diagnostic"]["numpy_float"] == 1.25
+    assert payload["diagnostic"]["numpy_int"] == 3
+    assert payload["diagnostic"]["bool_flag"] is True


### PR DESCRIPTION
## Summary
Adds a read-only Time to Collision (TTC) near-miss diagnostic decision packet on top of the existing opt-in issue #3700 diagnostic surface. The packet reports available timing/trajectory inputs, unsupported cases, strict JSON-safe payload output, Markdown rendering, and what cannot be claimed before a canonical metric change.

## Linked Issues
- Relates `#3808`
- Relates `#3700`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: no - PR #3748 is already merged and this PR consumes that diagnostic surface.
- Domains reviewed: evidence classification / benchmark interpretation
- Status: pending reviewer approval
- Approver/review source waiver: none
- Validity checklist:
  - Target claim/hypothesis: a read-only decision packet can summarize TTC/closing-speed diagnostic inputs and unsupported cases without changing canonical near-miss semantics.
  - Comparator split/evidence validity: synthetic trajectory fixtures cover closing, opening, invalid timing, malformed trajectory, and generated Markdown/JSON payload paths.
  - Fallback/degraded exclusions: unsupported inputs fail closed as `unsupported-inputs`; no fallback counts are treated as evidence.
  - Claim boundary: diagnostic-only support/tooling, not benchmark evidence.
  - Implementation integrity vs experimental validity: implementation is additive in `robot_sf/benchmark/near_miss_ttc.py`; tests cover behavior without a benchmark campaign.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - synthetic closing trajectory produces an `ok` packet with positive TTC diagnostic count.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? yes for fixtures only: closing, opening, missing timing, malformed trajectory.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: canonical metric semantics remain in #3700.

## Next Empirical Action
- Rerun needed: no for this bounded packet generator.
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue review; do not promote to benchmark evidence.
- Proposed child issue existing follow-up: #3700 remains the canonical metric semantics question.

## Validation / Proof
- `uv run pytest tests/benchmark/test_near_miss_ttc.py -q`
  - Result: passed, 24 tests.
- `uv run ruff check robot_sf/benchmark/near_miss_ttc.py tests/benchmark/test_near_miss_ttc.py`
  - Result: passed.
- `git diff --check`
  - Result: passed.

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: low; additive exports only, no canonical metric wiring changed.
- Failure modes: downstream users could overread diagnostic-only packets as benchmark evidence; packet text explicitly lists cannot-claim boundaries.
- Rollback fallback plan: revert the additive packet helpers and tests.

## Docs / Provenance
- Updated docs: none; scoped helper/test slice only.
- Relevant design provenance notes: issue #3808 successor packet from PR #3748 / issue #3700.
- Any assumptions need to preserved: TTC threshold remains uncalibrated and diagnostic-only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - user authorization disallows issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: this is a read-only diagnostic packet generator and explicitly does not change benchmark semantics or paper-facing claims.

## Follow-Up Issues
- Deferred work: canonical near-miss metric semantics and threshold calibration remain in #3700.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely: packet payload is strict JSON-safe (`allow_nan=False`) and unsupported inputs fail closed instead of producing zero-count evidence.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
