### PR TITLE
training: complete #3807 #3068 launch-packet route preflight

### DIFF
--- a/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+++ b/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
@@ -183,36 +183,61 @@ validation_command: >
   uv run python -c "import yaml; d=yaml.safe_load(open('configs/training/ppo_curriculum_issue_3068_launch_packet.yaml')); assert d['no_training_result_claim'] is True; print('valid', d['campaign_id'])"
 execution_boundary:
   full_training_in_this_issue: false
-  submit_slurm_from_this_issue: true
+  submit_slurm_from_this_issue: false
   local_preflight_command: >
     uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q
   slurm_command_shape: >
-    Submit through private operations only, using public worktree that owns
-    issue-3068 launch branch. First launchable run is a full-surface scout that
-    records training-curve artifacts under issue-3068 PPO curriculum campaign,
-    but does not by itself establish full curriculum-vs-baseline final benchmark
-    claim.
+    No submission is authorized by this packet slice. A future submitter may use
+    the queue_hint route/script/resource/preflight fields below after rerunning
+    the exact validation_commands and replacing pending durable artifact aliases.
 queue_hint:
   public_issue: ll7/robot_sf_ll7#3068
-  state: ready
-  submit_ready: true
+  state: no_submit_preflight_ready
+  submit_ready: false
   review_required: false
   source: issue_3068_launch_packet
   job_class: robot_sf_gpu_training_small
   route_id: imech192:a30
+  cluster: imech192
+  partition: a30
+  qos: a30-gpu
   script: /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl  # allow-abs-path: private-ops SLURM routing target (lives outside this repo)
   config: configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
   campaign: 2026-06-issue3068-ppo-curriculum
-  cpus: 20
-  gpus: 1
-  mem_gb: 120
-  estimated_elapsed_sec: 43200
+  resources:
+    cpus: 20
+    gpus: 1
+    mem_gb: 120
+    estimated_elapsed_sec: 43200
+  preflight_proof:
+    local_only: true
+    requires_private_ops_checkout: true
+    requires_slurm_submit: false
+    required_checks:
+      missing_script:
+        command: test -f /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl
+        expected: script exists on submit host before any future submission
+      missing_config:
+        command: test -f configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml
+        expected: public training config exists in the worktree
+      packet_contract:
+        command: uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q
+        expected: launch-packet contract passes without Slurm submission
   submit_args: >-
     --sbatch-arg --qos=a30-gpu --sbatch-arg --cpus-per-task=20
     --sbatch-arg --mem=120G --sbatch-arg --nice=10000
     --sbatch-arg --export=ALL,ISSUE791_TRAIN_CONFIG=configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml,ISSUE791_WANDB_POLICY=require
-  remote_results: output/slurm/issue3068-ppo-curriculum
-  local_results: output/issue3068-ppo-curriculum
+  expected_outputs:
+    remote_results: output/slurm/issue3068-ppo-curriculum
+    local_results: output/issue3068-ppo-curriculum
+    wandb_group: issue-3068-ppo-curriculum
+    required_files:
+      - train_curve_metrics.csv
+      - checkpoint_manifest.json
+      - run_summary.json
+  validation_commands:
+    - uv run python -c "import yaml; d=yaml.safe_load(open('configs/training/ppo_curriculum_issue_3068_launch_packet.yaml')); assert d['execution_boundary']['submit_slurm_from_this_issue'] is False; assert d['queue_hint']['submit_ready'] is False; print('no-submit', d['campaign_id'])"
+    - uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q
   success_criteria:
     - training wrapper starts with W&B enabled
     - train-curve metrics and checkpoint manifest are written

--- a/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
+++ b/configs/training/ppo_curriculum_issue_3068_launch_packet.yaml
@@ -215,7 +215,7 @@ queue_hint:
     requires_slurm_submit: false
     required_checks:
       missing_script:
-        command: test -f /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl
+        command: test -f /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl  # allow-abs-path: private-ops SLURM routing target (lives outside this repo)
         expected: script exists on submit host before any future submission
       missing_config:
         command: test -f configs/training/ppo/ablations/expert_ppo_issue_3068_curriculum_full_surface_scout_12m_env22.yaml

--- a/docs/context/issue_3068_ppo_curriculum_launch_packet.md
+++ b/docs/context/issue_3068_ppo_curriculum_launch_packet.md
@@ -83,6 +83,27 @@ uv run python -c "import yaml; d=yaml.safe_load(open('configs/training/ppo_curri
 uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q
 ```
 
+## No-Submit Route And Preflight Fields
+
+Issue #3807 completes the #3068 launch-packet decision surface without submitting a
+SLURM job. The packet now sets `execution_boundary.submit_slurm_from_this_issue:
+false`, `queue_hint.submit_ready: false`, and `queue_hint.state:
+no_submit_preflight_ready`.
+
+Route and resource fields are explicit under `queue_hint`:
+
+- `route_id`: `imech192:a30`
+- `cluster`: `imech192`
+- `partition`: `a30`
+- `qos`: `a30-gpu`
+- `script`: `/home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl`
+- `resources`: 20 CPUs, 1 GPU, 120 GB memory, 43,200 second estimate
+
+The packet also records local-only preflight proof commands for the private script
+path, public training config, and packet contract test. Expected outputs are
+grouped under `queue_hint.expected_outputs`, and exact no-submit validation
+commands are listed under `queue_hint.validation_commands`.
+
 ## Durable Artifact Policy
 
 Checkpoints and raw logs stay in the durable W&B backend, not in git. Before training, the

--- a/tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
+++ b/tests/training/test_ppo_curriculum_launch_packet_issue_3068.py
@@ -63,7 +63,7 @@ def test_no_training_result_claim(packet: dict[str, object]) -> None:
     assert packet["evidence_status"] == "proposal"
     assert "no_claim_statement" in packet
     assert packet["execution_boundary"]["full_training_in_this_issue"] is False
-    assert packet["execution_boundary"]["submit_slurm_from_this_issue"] is True
+    assert packet["execution_boundary"]["submit_slurm_from_this_issue"] is False
 
 
 def test_referenced_configs_exist_and_checksums_match(packet: dict[str, object]) -> None:
@@ -195,11 +195,13 @@ def test_context_doc_links_packet() -> None:
 
 
 def test_queue_hint_points_to_launchable_issue_3068_scout(packet: dict[str, object]) -> None:
-    """Ready queue hint must reference a real #3068 PPO training config."""
+    """Queue hint must reference a real #3068 PPO training config without submitting."""
     hint = packet["queue_hint"]
     config_path = _REPO_ROOT / hint["config"]
     assert hint["public_issue"] == "ll7/robot_sf_ll7#3068"
-    assert hint["submit_ready"] is True
+    assert packet["execution_boundary"]["submit_slurm_from_this_issue"] is False
+    assert hint["submit_ready"] is False
+    assert hint["state"] == "no_submit_preflight_ready"
     assert hint["job_class"] == "robot_sf_gpu_training_small"
     assert config_path.is_file()
 
@@ -209,3 +211,53 @@ def test_queue_hint_points_to_launchable_issue_3068_scout(packet: dict[str, obje
     assert config["total_timesteps"] == 12000000
     assert config["tracking"]["wandb"]["enabled"] is True
     assert "issue-3068" in config["tracking"]["wandb"]["tags"]
+
+
+def test_queue_hint_declares_route_script_preflight_resources_and_outputs(
+    packet: dict[str, object],
+) -> None:
+    """Issue #3807 requires the #3068 route decision surface, not a Slurm submit."""
+    hint = packet["queue_hint"]
+
+    assert hint["route_id"] == "imech192:a30"
+    assert hint["cluster"] == "imech192"
+    assert hint["partition"] == "a30"
+    assert hint["qos"] == "a30-gpu"
+    assert hint["script"].endswith("issue_791_reward_curriculum.sl")
+    assert "ISSUE791_TRAIN_CONFIG=" in hint["submit_args"]
+
+    resources = hint["resources"]
+    assert resources == {
+        "cpus": 20,
+        "gpus": 1,
+        "mem_gb": 120,
+        "estimated_elapsed_sec": 43200,
+    }
+
+    preflight = hint["preflight_proof"]
+    assert preflight["local_only"] is True
+    assert preflight["requires_slurm_submit"] is False
+    required_checks = preflight["required_checks"]
+    assert set(required_checks) == {"missing_script", "missing_config", "packet_contract"}
+    assert required_checks["missing_script"]["command"].startswith("test -f ")
+    assert required_checks["missing_config"]["command"].startswith("test -f configs/training/")
+    assert (
+        required_checks["packet_contract"]["command"]
+        == "uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q"
+    )
+
+    expected_outputs = hint["expected_outputs"]
+    assert expected_outputs["remote_results"] == "output/slurm/issue3068-ppo-curriculum"
+    assert expected_outputs["local_results"] == "output/issue3068-ppo-curriculum"
+    assert expected_outputs["wandb_group"] == "issue-3068-ppo-curriculum"
+    assert set(expected_outputs["required_files"]) == {
+        "train_curve_metrics.csv",
+        "checkpoint_manifest.json",
+        "run_summary.json",
+    }
+
+    validation_commands = hint["validation_commands"]
+    assert validation_commands == [
+        "uv run python -c \"import yaml; d=yaml.safe_load(open('configs/training/ppo_curriculum_issue_3068_launch_packet.yaml')); assert d['execution_boundary']['submit_slurm_from_this_issue'] is False; assert d['queue_hint']['submit_ready'] is False; print('no-submit', d['campaign_id'])\"",
+        "uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q",
+    ]


### PR DESCRIPTION
## Summary
Completes the no-submit launch-packet decision surface for the issue #3068 PPO curriculum entry by making route, script, preflight, resource, expected-output, and exact validation command fields explicit.

## Linked Issues
- Closes #3807
- Relates to #3068

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Updated `configs/training/ppo_curriculum_issue_3068_launch_packet.yaml` so the #3068 queue hint is no-submit (`submit_ready: false`) and includes cluster/partition/qos, private script path, resources, preflight proof checks, expected outputs, and exact validation commands.
- Updated `tests/training/test_ppo_curriculum_launch_packet_issue_3068.py` to fail closed when route/script/preflight/resource/expected-output/validation fields are missing.
- Updated `docs/context/issue_3068_ppo_curriculum_launch_packet.md` with the no-submit route and preflight field summary.

## Why Matters
- Added value: turns the #3068 proposed launch entry into a reviewable packet without authorizing compute submission.
- Expected impact: future submitter can rerun exact preflight commands before any separate authorized Slurm launch.
- Why worth merging now: resolves the explicit PR hindsight successor scope from issue #3807.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: launch-packet route/preflight completeness for issue #3068 only; no training result claim.
- Comparator or baseline, applicable: fixed-difficulty PPO baseline remains packet metadata only.
- Evidence tier: launch packet
- Result classification: blocker-resolution
- Decision stop rule, applicable: packet must expose route/script/preflight/resource/expected-output/exact-command fields and tests must pass without Slurm submission.
- Parent issue, claim map, registry, context note, synthesis surface update: context note updated at `docs/context/issue_3068_ppo_curriculum_launch_packet.md`.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: launch-packet metadata only; no benchmark/training claim.
- Validity checklist: no Slurm/GPU submission; fallback/degraded execution not involved; claim boundary is no-submit packet completeness.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA for this PR
- Extractor analysis tool needed: no
- Artifact missing unavailable: no generated artifacts required
- Stop / revise / continue decision: continue only via separate authorized training issue
- Proposed child issue existing follow-up: #3068 remains the related launch/training context

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q` -> passed, 15 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/training/test_ppo_curriculum_launch_packet_issue_3068.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -c "import yaml; d=yaml.safe_load(open('configs/training/ppo_curriculum_issue_3068_launch_packet.yaml')); assert d['execution_boundary']['submit_slurm_from_this_issue'] is False; assert d['queue_hint']['submit_ready'] is False; print('no-submit', d['campaign_id'])"` -> passed, printed `no-submit issue_3068_ppo_curriculum_v1`.
- `test -f /home/luttkule/git/robot_sf_ll7-private-ops/auxme/SLURM/issue_791_reward_curriculum.sl` -> passed.
- `git diff --check` -> passed.

## Performance / Runtime Impact
- Baseline runtime: NA - metadata/test/doc change only.
- Changed runtime: focused packet test completed in about 9 seconds on imech156-u shared venv.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_ppo_curriculum_launch_packet_issue_3068.py -q`
- Hot-path call count profile anchor: NA - no runtime path changed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if the packet no longer parses or no-submit route/preflight contract test fails.

## Risks / Rollout
- Compatibility risks: future submitters must read nested `queue_hint.resources` / `queue_hint.expected_outputs` instead of legacy flat output/resource fields.
- Failure modes: private script path can drift outside this public repo; preflight explicitly checks it before any future submission.
- Rollback fallback plan: restore prior packet fields and tests if downstream submit tooling requires the old flat shape.

## Docs / Provenance
- Updated docs: `docs/context/issue_3068_ppo_curriculum_launch_packet.md`
- Relevant design provenance notes: issue #3807 and issue #3068
- Any assumptions need to preserved: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA - no issue comment authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): context note updated; index not needed for existing note.
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: this is a no-submit launch-packet metadata completion, not benchmark evidence.

## Follow-Up Issues
- Deferred work: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Issues opened follow-up: none

## Reviewer Notes
- Verify the no-submit boundary: `execution_boundary.submit_slurm_from_this_issue: false` and `queue_hint.submit_ready: false`.
- Known limitations: no compute was submitted; this PR only completes the decision/preflight surface.
