### PR TITLE
Issue #3810: add long-horizon SNQI launch packet

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -1,0 +1,301 @@
+# Issue #3810 long-horizon Social Navigation Quality Index (SNQI) launch packet.
+#
+# This is a no-submit decision packet, not benchmark evidence. It converts the
+# live issue decisions into a reviewable Slurm launch, analysis, and retention
+# contract. Do not submit from this packet until the private Slurm decision
+# packet is marked go and job 13175 has been reconciled.
+schema_version: research-campaign-manifest.v0.1
+campaign:
+  id: issue_3810_comprehensive_h600_snqi_recalibration
+  parent_issue: 3810
+  purpose: >
+    Prepare a comprehensive 600-step long-horizon benchmark campaign with
+    Social Navigation Quality Index recalibration and an interaction-exposure
+    diagnostic guard for wait-it-out successes.
+  evidence_tier: launch-packet-only
+  claim_boundary: >
+    Launch packet only. This packet defines a fail-closed campaign and analysis
+    contract for a future comprehensive h600 run. It does not run a benchmark,
+    submit Slurm work, recalibrate SNQI weights, change paper/dissertation
+    claims, or establish horizon sensitivity. The eventual report must frame the
+    comparison as prior scoped short-horizon versus new comprehensive
+    long-horizon, because scenario scope, seed budget, planner roster, and
+    horizon all change.
+
+scenario_suite:
+  matrix_path: configs/scenarios/classic_interactions_francis2023.yaml
+  scope: all_scenarios_in_matrix
+  scenario_ids:
+    - all_from_configs/scenarios/classic_interactions_francis2023.yaml
+  max_episode_steps: 600
+  suite_hash_policy: record_sha256_before_run
+  comparison_boundary: >
+    New comprehensive h600 surface supersedes the old scoped h100 release
+    comparison target. Reports must not describe ranking movement as caused by
+    horizon alone.
+
+planners:
+  inclusion_policy: >
+    Include every planner row available to the canonical benchmark runner from
+    the public config and readiness registry. Candidate, dependency-gated,
+    adapter, fallback, degraded, failed, and unavailable rows remain visible but
+    cannot count as benchmark-strength success evidence.
+  inventory_sources:
+    - configs/benchmarks/camera_ready_all_planners_strict_socnav.yaml
+    - robot_sf/benchmark/algorithm_readiness.py
+  rows:
+    - planner_id: prediction_planner
+      adapter_mode: native
+      config_path: configs/algos/prediction_planner_camera_ready.yaml
+      benchmark_profile: experimental
+      expected_availability: preflight_required
+    - planner_id: goal
+      adapter_mode: native
+      config_path: null
+      benchmark_profile: baseline-safe
+      expected_availability: available
+    - planner_id: social_force
+      adapter_mode: native
+      config_path: null
+      benchmark_profile: baseline-safe
+      expected_availability: available
+    - planner_id: orca
+      adapter_mode: adapter
+      config_path: null
+      benchmark_profile: baseline-safe
+      expected_availability: dependency_gated
+    - planner_id: ppo
+      adapter_mode: native
+      config_path: configs/baselines/ppo_15m_grid_socnav.yaml
+      benchmark_profile: experimental
+      expected_availability: model_preflight_required
+    - planner_id: socnav_sampling
+      adapter_mode: adapter
+      config_path: null
+      benchmark_profile: experimental
+      expected_availability: dependency_gated
+    - planner_id: sacadrl
+      adapter_mode: adapter
+      config_path: null
+      benchmark_profile: experimental
+      expected_availability: dependency_gated
+    - planner_id: socnav_bench
+      adapter_mode: adapter
+      config_path: null
+      benchmark_profile: experimental
+      expected_availability: dependency_gated
+    - planner_id: guarded_ppo
+      adapter_mode: native
+      config_path: configs/baselines/ppo_15m_grid_socnav.yaml
+      benchmark_profile: experimental
+      expected_availability: diagnostic_only_candidate
+    - planner_id: predictive_mppi
+      adapter_mode: native
+      config_path: configs/algos/predictive_mppi_camera_ready.yaml
+      benchmark_profile: experimental
+      expected_availability: diagnostic_only_candidate
+    - planner_id: risk_dwa
+      adapter_mode: native
+      config_path: configs/algos/risk_dwa_camera_ready.yaml
+      benchmark_profile: experimental
+      expected_availability: diagnostic_only_candidate
+
+seed_policy:
+  mode: fixed-list
+  seed_set: paper_eval_s30
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+  seeds:
+    - 111
+    - 112
+    - 113
+    - 114
+    - 115
+    - 116
+    - 117
+    - 118
+    - 119
+    - 120
+    - 121
+    - 122
+    - 123
+    - 124
+    - 125
+    - 126
+    - 127
+    - 128
+    - 129
+    - 130
+    - 131
+    - 132
+    - 133
+    - 134
+    - 135
+    - 136
+    - 137
+    - 138
+    - 139
+    - 140
+  repeat_policy: every_planner_scenario_pair
+
+metrics:
+  ids:
+    - success_rate
+    - collision_rate
+    - near_miss_rate
+    - timeout_rate
+    - max_steps_share
+    - time_to_goal_norm
+    - snqi
+    - interaction_exposure_share
+  denominator_policy: report_per_planner_scenario_seed_denominators
+  baseline_or_weights: recompute_long_horizon_bundle_before_claim
+
+row_status_policy:
+  allowed_values:
+    - successful_evidence
+    - diagnostic_only
+    - fallback
+    - degraded
+    - not_available
+    - failed
+    - blocked
+  success_values:
+    - successful_evidence
+  fail_closed_values:
+    - not_available
+    - failed
+    - blocked
+  fallback_policy: >
+    Fallback, degraded, adapter-unavailable, candidate diagnostic-only, failed,
+    and blocked rows stay visible in denominators and reports but cannot count
+    as successful benchmark-strength evidence.
+
+outputs:
+  local_root: output/benchmarks/issue_3810_comprehensive_h600_snqi
+  disposable: true
+  required_paths:
+    - campaign_manifest.json
+    - manifest.json
+    - run_meta.json
+    - preflight/validate_config.json
+    - preflight/preview_scenarios.json
+    - preflight/planner_availability.json
+    - preflight/private_ops_route_dry_run.json
+    - reports/campaign_summary.json
+    - reports/campaign_table.csv
+    - reports/campaign_table.md
+    - reports/snqi_recalibration_inputs.json
+    - reports/snqi_recalibration_bundle.json
+    - reports/horizon_sensitivity_report.json
+    - reports/horizon_sensitivity_report.md
+    - reports/interaction_exposure_diagnostics.json
+    - reports/interaction_exposure_diagnostics.md
+
+durable_evidence:
+  plan:
+    kind: tracked_context_evidence_plus_external_pointer
+    path: docs/context/evidence/issue_3810_long_horizon_snqi/
+    required_before_claim: true
+  retention_paths:
+    compact_review_bundle: docs/context/evidence/issue_3810_long_horizon_snqi/
+    external_artifact_pointer: wandb-or-release-artifact-required-before-claim
+    private_ops_ledger: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/jobs.yaml
+  local_output_boundary: >
+    Keep raw episode JSONL, videos, Slurm logs, model caches, and checkpoints out
+    of git. Promote only compact summaries, checksums, and durable artifact
+    pointers after run completion and artifact classification.
+
+validation:
+  commands:
+    - uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi
+    - uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json
+    - uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q
+  dry_run: required
+
+launch_packet:
+  decision: blocked_until_private_slurm_go
+  compute_submit_authorized: false
+  slurm_job_id: not_submitted
+  blocking_jobs:
+    - 13175
+  route:
+    private_ops_repo: /home/luttkule/git/robot_sf_ll7-private-ops
+    queue_summary_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh
+    route_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh
+    submit_wrapper: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh
+    submit_policy: no_submit_until_decision_packet_go
+  preflight:
+    public_manifest_check: >
+      uv run python scripts/validation/run_research_campaign_manifest.py
+      configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+      --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi
+    public_packet_check: >
+      uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+      --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+      --json
+    private_ops_dry_run: >
+      ROBOT_SF_PRIVATE_OPS=/home/luttkule/git/robot_sf_ll7-private-ops
+      /home/luttkule/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh
+      --cluster licca
+      --route-id decision-packet-only
+      --public-repo "$PWD"
+      --output output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
+    no_submit_guard: >
+      Private preflight and route checks may run read-only. The submit wrapper
+      must not be invoked until issue #3810 has an explicit go decision and job
+      13175 has been reconciled.
+  campaign_command: >
+    uv run python scripts/tools/run_camera_ready_benchmark.py
+    --config configs/benchmarks/issue_3810_comprehensive_h600_snqi.yaml
+    --campaign-id issue_3810_comprehensive_h600_snqi
+    --output-root output/benchmarks/issue_3810_comprehensive_h600_snqi
+  config_patch:
+    base_config: configs/benchmarks/camera_ready_all_planners_strict_socnav.yaml
+    required_overrides:
+      horizon: 600
+      scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+      seed_set: paper_eval_s30
+      stop_on_failure: false
+      snqi_weights: output/benchmarks/issue_3810_comprehensive_h600_snqi/recalibration/snqi_weights_h600.json
+      snqi_baseline: output/benchmarks/issue_3810_comprehensive_h600_snqi/recalibration/snqi_baseline_h600.json
+  snqi_recalibration:
+    inputs:
+      campaign_table: output/benchmarks/issue_3810_comprehensive_h600_snqi/reports/campaign_table.csv
+      episode_records: output/benchmarks/issue_3810_comprehensive_h600_snqi/episodes/
+      source_scripts:
+        - scripts/recompute_snqi_weights.py
+        - scripts/snqi_sensitivity_analysis.py
+        - scripts/validate_snqi_scripts.py
+    required_outputs:
+      - output/benchmarks/issue_3810_comprehensive_h600_snqi/recalibration/snqi_weights_h600.json
+      - output/benchmarks/issue_3810_comprehensive_h600_snqi/recalibration/snqi_baseline_h600.json
+      - output/benchmarks/issue_3810_comprehensive_h600_snqi/recalibration/checksums.sha256
+    checksum_policy: checksum_pin_before_claim
+    comparison_rule: within_regime_only_no_cross_regime_absolute_snqi_claim
+  horizon_sensitivity_report:
+    command: >
+      uv run python scripts/benchmark/build_horizon_timestep_denominator_report.py
+      --long-campaign output/benchmarks/issue_3810_comprehensive_h600_snqi
+      --short-campaign-reference docs/context/evidence/prior_scoped_h100_reference
+      --output-dir output/benchmarks/issue_3810_comprehensive_h600_snqi/reports
+    required_fields:
+      - timeout_rate
+      - max_steps_share
+      - success_ranking
+      - snqi_ranking
+      - rank_inversion_persistence
+      - comparison_scope_caveat
+    required_caveat: prior_scoped_short_horizon_vs_new_comprehensive_long_horizon_not_horizon_only
+  wait_it_out_guard:
+    diagnostic_name: interaction_exposure
+    required_episode_fields:
+      - interaction_exposure_share
+      - robot_motion_share_before_first_clearance
+      - first_clearance_step
+      - low_exposure_success
+    low_exposure_success_status: diagnostic_only
+    diagnostic_contract: >
+      A successful episode with low interaction exposure is not counted as
+      benchmark-strength success until the report shows the scenario required
+      meaningful interaction. The diagnostic guards wait-it-out behavior; the
+      sustained-flow structural fix remains follow-up issue #3813.

--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -199,7 +199,7 @@ durable_evidence:
   retention_paths:
     compact_review_bundle: docs/context/evidence/issue_3810_long_horizon_snqi/
     external_artifact_pointer: wandb-or-release-artifact-required-before-claim
-    private_ops_ledger: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/jobs.yaml
+    private_ops_ledger: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/jobs.yaml  # allow-abs-path: private-ops routing
   local_output_boundary: >
     Keep raw episode JSONL, videos, Slurm logs, model caches, and checkpoints out
     of git. Promote only compact summaries, checksums, and durable artifact
@@ -219,10 +219,10 @@ launch_packet:
   blocking_jobs:
     - 13175
   route:
-    private_ops_repo: /home/luttkule/git/robot_sf_ll7-private-ops
-    queue_summary_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh
-    route_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh
-    submit_wrapper: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh
+    private_ops_repo: /home/luttkule/git/robot_sf_ll7-private-ops  # allow-abs-path: private-ops routing
+    queue_summary_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh  # allow-abs-path: private-ops routing
+    route_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh  # allow-abs-path: private-ops routing
+    submit_wrapper: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh  # allow-abs-path: private-ops routing
     submit_policy: no_submit_until_decision_packet_go
   preflight:
     public_manifest_check: >
@@ -234,8 +234,8 @@ launch_packet:
       --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
       --json
     private_ops_dry_run: >
-      ROBOT_SF_PRIVATE_OPS=/home/luttkule/git/robot_sf_ll7-private-ops
-      /home/luttkule/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh
+      ROBOT_SF_PRIVATE_OPS="$HOME/git/robot_sf_ll7-private-ops"
+      "$HOME/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh"
       --cluster licca
       --route-id decision-packet-only
       --public-repo "$PWD"

--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -244,9 +244,21 @@ launch_packet:
       Private preflight and route checks may run read-only. The submit wrapper
       must not be invoked until issue #3810 has an explicit go decision and job
       13175 has been reconciled.
+  materialized_config:
+    # The runnable h600 campaign config does not exist yet and is intentionally
+    # not added by this launch-packet PR. It is generated downstream by applying
+    # config_patch (base_config + required_overrides) and written to a disposable
+    # output/ path; promote it into tracked configs/ only when the actual run is
+    # prepared. campaign_command resolves ${MATERIALIZED_H600_CONFIG} to this
+    # generated path, so it deliberately does not cite a tracked config that does
+    # not exist yet.
+    target_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/config/issue_3810_comprehensive_h600_snqi.yaml
+    materialize_policy: generated_from_config_patch_before_run
+    promote_policy: promote_to_tracked_configs_only_at_run_preparation
   campaign_command: >
+    MATERIALIZED_H600_CONFIG=output/benchmarks/issue_3810_comprehensive_h600_snqi/config/issue_3810_comprehensive_h600_snqi.yaml
     uv run python scripts/tools/run_camera_ready_benchmark.py
-    --config configs/benchmarks/issue_3810_comprehensive_h600_snqi.yaml
+    --config "${MATERIALIZED_H600_CONFIG}"
     --campaign-id issue_3810_comprehensive_h600_snqi
     --output-root output/benchmarks/issue_3810_comprehensive_h600_snqi
   config_patch:

--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -199,7 +199,7 @@ durable_evidence:
   retention_paths:
     compact_review_bundle: docs/context/evidence/issue_3810_long_horizon_snqi/
     external_artifact_pointer: wandb-or-release-artifact-required-before-claim
-    private_ops_ledger: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/jobs.yaml  # allow-abs-path: private-ops routing
+    private_ops_ledger: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/jobs.yaml  # allow-abs-path: private-ops routing (machine-local, non-portable)
   local_output_boundary: >
     Keep raw episode JSONL, videos, Slurm logs, model caches, and checkpoints out
     of git. Promote only compact summaries, checksums, and durable artifact
@@ -219,10 +219,10 @@ launch_packet:
   blocking_jobs:
     - 13175
   route:
-    private_ops_repo: /home/luttkule/git/robot_sf_ll7-private-ops  # allow-abs-path: private-ops routing
-    queue_summary_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh  # allow-abs-path: private-ops routing
-    route_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh  # allow-abs-path: private-ops routing
-    submit_wrapper: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh  # allow-abs-path: private-ops routing
+    private_ops_repo: /home/luttkule/git/robot_sf_ll7-private-ops  # allow-abs-path: private-ops routing (machine-local, non-portable)
+    queue_summary_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh  # allow-abs-path: private-ops routing (machine-local, non-portable)
+    route_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh  # allow-abs-path: private-ops routing (machine-local, non-portable)
+    submit_wrapper: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh  # allow-abs-path: private-ops routing (machine-local, non-portable)
     submit_policy: no_submit_until_decision_packet_go
   preflight:
     public_manifest_check: >

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -1,0 +1,246 @@
+#!/usr/bin/env python3
+"""Validate the issue #3810 long-horizon SNQI no-submit launch packet."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path, PurePosixPath
+from typing import Any
+
+import yaml
+
+DEFAULT_PACKET = Path("configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml")
+REQUIRED_OUTPUTS = {
+    "preflight/private_ops_route_dry_run.json",
+    "reports/snqi_recalibration_inputs.json",
+    "reports/snqi_recalibration_bundle.json",
+    "reports/horizon_sensitivity_report.json",
+    "reports/interaction_exposure_diagnostics.json",
+}
+REQUIRED_REPORT_FIELDS = {
+    "timeout_rate",
+    "max_steps_share",
+    "success_ranking",
+    "snqi_ranking",
+    "rank_inversion_persistence",
+    "comparison_scope_caveat",
+}
+REQUIRED_EXPOSURE_FIELDS = {
+    "interaction_exposure_share",
+    "robot_motion_share_before_first_clearance",
+    "first_clearance_step",
+    "low_exposure_success",
+}
+
+
+class PacketError(ValueError):
+    """Raised when the launch packet would not fail closed."""
+
+
+def _load_packet(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise PacketError("packet must be a YAML mapping")
+    return payload
+
+
+def _path_is_repo_relative(value: str) -> bool:
+    path = PurePosixPath(value)
+    return not path.is_absolute() and ".." not in path.parts
+
+
+def _require_mapping(payload: dict[str, Any], key: str) -> dict[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise PacketError(f"{key} must be a mapping")
+    return value
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise PacketError(message)
+
+
+def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
+    """Return a compact validation summary for a fail-closed packet."""
+    campaign = _require_mapping(packet, "campaign")
+    scenario_suite = _require_mapping(packet, "scenario_suite")
+    seed_policy = _require_mapping(packet, "seed_policy")
+    planners = _require_mapping(packet, "planners")
+    metrics = _require_mapping(packet, "metrics")
+    row_status_policy = _require_mapping(packet, "row_status_policy")
+    outputs = _require_mapping(packet, "outputs")
+    durable_evidence = _require_mapping(packet, "durable_evidence")
+    launch_packet = _require_mapping(packet, "launch_packet")
+
+    _require(packet.get("schema_version") == "research-campaign-manifest.v0.1", "unexpected schema")
+    _require(campaign.get("parent_issue") == 3810, "campaign.parent_issue must be 3810")
+    _require(
+        campaign.get("evidence_tier") == "launch-packet-only", "evidence tier must be launch-only"
+    )
+    claim_boundary = str(campaign.get("claim_boundary", ""))
+    _require("does not run a benchmark" in claim_boundary, "claim boundary must forbid run claims")
+    _require(
+        "horizon alone" in claim_boundary or "horizon all change" in claim_boundary,
+        "claim boundary must reject horizon-only claims",
+    )
+
+    _require(scenario_suite.get("max_episode_steps") == 600, "max_episode_steps must be 600")
+    _require(scenario_suite.get("scope") == "all_scenarios_in_matrix", "scenario scope must be all")
+    matrix_path = str(scenario_suite.get("matrix_path", ""))
+    _require(_path_is_repo_relative(matrix_path), "scenario matrix must be repo-relative")
+    _require(
+        scenario_suite.get("suite_hash_policy") == "record_sha256_before_run",
+        "suite hash policy must record sha256 before run",
+    )
+
+    _require(seed_policy.get("seed_set") == "paper_eval_s30", "seed_set must be paper_eval_s30")
+    seeds = seed_policy.get("seeds")
+    _require(isinstance(seeds, list) and len(seeds) >= 30, "packet must include all S30 seeds")
+
+    planner_rows = planners.get("rows")
+    _require(isinstance(planner_rows, list) and len(planner_rows) >= 10, "planner roster too small")
+    expected_availability = {
+        str(row.get("expected_availability")) for row in planner_rows if isinstance(row, dict)
+    }
+    _require(
+        "diagnostic_only_candidate" in expected_availability, "candidate rows must be explicit"
+    )
+    _require("dependency_gated" in expected_availability, "dependency-gated rows must be explicit")
+
+    metric_ids = set(metrics.get("ids", []))
+    _require("snqi" in metric_ids, "SNQI metric required")
+    _require("interaction_exposure_share" in metric_ids, "interaction exposure metric required")
+    _require("timeout_rate" in metric_ids, "timeout metric required")
+    _require("max_steps_share" in metric_ids, "max-steps share metric required")
+
+    success_values = set(row_status_policy.get("success_values", []))
+    fail_closed_values = set(row_status_policy.get("fail_closed_values", []))
+    _require(success_values == {"successful_evidence"}, "only successful_evidence may count")
+    _require(
+        {"not_available", "failed", "blocked"} <= fail_closed_values, "fail-closed statuses missing"
+    )
+    fallback_policy = str(row_status_policy.get("fallback_policy", ""))
+    _require("cannot count" in fallback_policy, "fallback policy must exclude weak rows")
+
+    local_root = str(outputs.get("local_root", ""))
+    _require(local_root.startswith("output/"), "outputs.local_root must be under output/")
+    _require(outputs.get("disposable") is True, "outputs must be disposable local output")
+    required_paths = set(outputs.get("required_paths", []))
+    _require(REQUIRED_OUTPUTS <= required_paths, "required outputs missing issue #3810 artifacts")
+
+    durable_plan = _require_mapping(durable_evidence, "plan")
+    durable_path = str(durable_plan.get("path", ""))
+    _require(
+        durable_plan.get("required_before_claim") is True, "durable evidence required before claim"
+    )
+    _require(
+        durable_path.startswith("docs/context/evidence/"), "durable path must be context evidence"
+    )
+
+    _require(
+        launch_packet.get("decision") == "blocked_until_private_slurm_go",
+        "decision must block submit",
+    )
+    _require(
+        launch_packet.get("compute_submit_authorized") is False, "compute submit must be false"
+    )
+    _require(
+        launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
+    )
+    _require(13175 in launch_packet.get("blocking_jobs", []), "job 13175 blocker missing")
+
+    route = _require_mapping(launch_packet, "route")
+    _require(
+        str(route.get("submit_policy")) == "no_submit_until_decision_packet_go",
+        "submit policy missing",
+    )
+    _require(
+        str(route.get("submit_wrapper", "")).endswith("submit_and_record.sh"),
+        "submit wrapper missing",
+    )
+
+    preflight = _require_mapping(launch_packet, "preflight")
+    _require("private_ops_dry_run" in preflight, "private-ops dry-run command missing")
+    _require(
+        "must not be invoked" in str(preflight.get("no_submit_guard", "")),
+        "no-submit guard missing",
+    )
+
+    config_patch = _require_mapping(launch_packet, "config_patch")
+    overrides = _require_mapping(config_patch, "required_overrides")
+    _require(overrides.get("horizon") == 600, "config patch must set horizon 600")
+    _require(overrides.get("stop_on_failure") is False, "long run must keep collecting rows")
+
+    snqi = _require_mapping(launch_packet, "snqi_recalibration")
+    _require(
+        str(snqi.get("checksum_policy")) == "checksum_pin_before_claim",
+        "SNQI checksum policy missing",
+    )
+    _require(
+        str(snqi.get("comparison_rule"))
+        == "within_regime_only_no_cross_regime_absolute_snqi_claim",
+        "SNQI comparison rule must forbid cross-regime absolute claims",
+    )
+
+    report = _require_mapping(launch_packet, "horizon_sensitivity_report")
+    report_fields = set(report.get("required_fields", []))
+    _require(REQUIRED_REPORT_FIELDS <= report_fields, "horizon report fields missing")
+    _require(
+        "not_horizon_only" in str(report.get("required_caveat", "")), "comparison caveat missing"
+    )
+
+    exposure = _require_mapping(launch_packet, "wait_it_out_guard")
+    exposure_fields = set(exposure.get("required_episode_fields", []))
+    _require(REQUIRED_EXPOSURE_FIELDS <= exposure_fields, "interaction exposure fields missing")
+    _require(
+        exposure.get("low_exposure_success_status") == "diagnostic_only",
+        "low exposure must be diagnostic",
+    )
+    _require(
+        "#3813" in str(exposure.get("diagnostic_contract", "")), "sustained-flow follow-up missing"
+    )
+
+    return {
+        "ok": True,
+        "issue": 3810,
+        "campaign_id": campaign["id"],
+        "max_episode_steps": scenario_suite["max_episode_steps"],
+        "seed_count": len(seeds),
+        "planner_count": len(planner_rows),
+        "compute_submit_authorized": launch_packet["compute_submit_authorized"],
+        "slurm_job_id": launch_packet["slurm_job_id"],
+        "blocking_jobs": launch_packet["blocking_jobs"],
+    }
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
+    parser.add_argument("--json", action="store_true", help="Emit JSON summary.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the command-line validator."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        summary = validate_packet(_load_packet(args.packet))
+    except (OSError, PacketError, yaml.YAMLError) as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    if args.json:
+        print(json.dumps(summary, indent=2, sort_keys=True))
+    else:
+        print(
+            "issue #3810 launch packet ok: "
+            f"{summary['planner_count']} planners, {summary['seed_count']} seeds, "
+            f"horizon {summary['max_episode_steps']}, no submit"
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -47,6 +47,10 @@ def _load_packet(path: Path) -> dict[str, Any]:
 
 
 def _path_is_repo_relative(value: str) -> bool:
+    # A blank value normalizes to "." via PurePosixPath, which would wrongly pass
+    # as repo-relative; treat empty/whitespace as not a valid repo path.
+    if not value or not value.strip():
+        return False
     path = PurePosixPath(value)
     return not path.is_absolute() and ".." not in path.parts
 
@@ -77,6 +81,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
 
     _require(packet.get("schema_version") == "research-campaign-manifest.v0.1", "unexpected schema")
     _require(campaign.get("parent_issue") == 3810, "campaign.parent_issue must be 3810")
+    _require(bool(str(campaign.get("id") or "").strip()), "campaign.id required")
     _require(
         campaign.get("evidence_tier") == "launch-packet-only", "evidence tier must be launch-only"
     )
@@ -228,7 +233,9 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
     try:
         summary = validate_packet(_load_packet(args.packet))
-    except (OSError, PacketError, yaml.YAMLError) as exc:
+    except (OSError, PacketError, yaml.YAMLError, KeyError, TypeError, AttributeError) as exc:
+        # KeyError/TypeError/AttributeError backstop: a malformed packet must
+        # always fail closed with a clear error, never an unhandled traceback.
         print(f"error: {exc}", file=sys.stderr)
         return 2
     if args.json:

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -110,14 +110,14 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
     _require("dependency_gated" in expected_availability, "dependency-gated rows must be explicit")
 
-    metric_ids = set(metrics.get("ids", []))
+    metric_ids = set(metrics.get("ids") or [])
     _require("snqi" in metric_ids, "SNQI metric required")
     _require("interaction_exposure_share" in metric_ids, "interaction exposure metric required")
     _require("timeout_rate" in metric_ids, "timeout metric required")
     _require("max_steps_share" in metric_ids, "max-steps share metric required")
 
-    success_values = set(row_status_policy.get("success_values", []))
-    fail_closed_values = set(row_status_policy.get("fail_closed_values", []))
+    success_values = set(row_status_policy.get("success_values") or [])
+    fail_closed_values = set(row_status_policy.get("fail_closed_values") or [])
     _require(success_values == {"successful_evidence"}, "only successful_evidence may count")
     _require(
         {"not_available", "failed", "blocked"} <= fail_closed_values, "fail-closed statuses missing"
@@ -128,7 +128,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     local_root = str(outputs.get("local_root", ""))
     _require(local_root.startswith("output/"), "outputs.local_root must be under output/")
     _require(outputs.get("disposable") is True, "outputs must be disposable local output")
-    required_paths = set(outputs.get("required_paths", []))
+    required_paths = set(outputs.get("required_paths") or [])
     _require(REQUIRED_OUTPUTS <= required_paths, "required outputs missing issue #3810 artifacts")
 
     durable_plan = _require_mapping(durable_evidence, "plan")
@@ -150,7 +150,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
     )
-    _require(13175 in launch_packet.get("blocking_jobs", []), "job 13175 blocker missing")
+    _require(13175 in (launch_packet.get("blocking_jobs") or []), "job 13175 blocker missing")
 
     route = _require_mapping(launch_packet, "route")
     _require(
@@ -186,14 +186,14 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
 
     report = _require_mapping(launch_packet, "horizon_sensitivity_report")
-    report_fields = set(report.get("required_fields", []))
+    report_fields = set(report.get("required_fields") or [])
     _require(REQUIRED_REPORT_FIELDS <= report_fields, "horizon report fields missing")
     _require(
         "not_horizon_only" in str(report.get("required_caveat", "")), "comparison caveat missing"
     )
 
     exposure = _require_mapping(launch_packet, "wait_it_out_guard")
-    exposure_fields = set(exposure.get("required_episode_fields", []))
+    exposure_fields = set(exposure.get("required_episode_fields") or [])
     _require(REQUIRED_EXPOSURE_FIELDS <= exposure_fields, "interaction exposure fields missing")
     _require(
         exposure.get("low_exposure_success_status") == "diagnostic_only",

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -78,6 +78,19 @@ def test_issue_3810_packet_rejects_low_exposure_success_evidence() -> None:
         raise AssertionError("packet should reject low-exposure success evidence")
 
 
+def test_issue_3810_packet_rejects_null_list_fields_cleanly() -> None:
+    """Explicit-null list fields fail closed with PacketError, not TypeError."""
+    packet = _load_packet()
+    packet["metrics"]["ids"] = None
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "SNQI metric required" in str(exc)
+    else:
+        raise AssertionError("packet should reject a null metrics.ids list")
+
+
 def test_issue_3810_packet_cli_json() -> None:
     """The command-line validator emits a compact JSON pass summary."""
     completed = subprocess.run(

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -1,0 +1,93 @@
+"""Tests for the issue #3810 no-submit long-horizon launch packet."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKET = REPO_ROOT / "configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml"
+SCRIPT = REPO_ROOT / "scripts/validation/check_issue_3810_long_horizon_launch_packet.py"
+
+_SPEC = importlib.util.spec_from_file_location("_issue_3810_packet_check", SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def _load_packet() -> dict:
+    return yaml.safe_load(PACKET.read_text(encoding="utf-8"))
+
+
+def test_issue_3810_packet_passes_fail_closed_contract() -> None:
+    """The checked-in packet satisfies the issue #3810 launch contract."""
+    summary = _MODULE.validate_packet(_load_packet())
+
+    assert summary["ok"] is True
+    assert summary["issue"] == 3810
+    assert summary["max_episode_steps"] == 600
+    assert summary["seed_count"] == 30
+    assert summary["planner_count"] >= 10
+    assert summary["compute_submit_authorized"] is False
+    assert summary["slurm_job_id"] == "not_submitted"
+    assert 13175 in summary["blocking_jobs"]
+
+
+def test_issue_3810_packet_rejects_authorized_submit() -> None:
+    """The packet validator rejects any direct compute authorization."""
+    packet = _load_packet()
+    packet["launch_packet"]["compute_submit_authorized"] = True
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "compute submit must be false" in str(exc)
+    else:
+        raise AssertionError("packet should reject compute submission authorization")
+
+
+def test_issue_3810_packet_rejects_horizon_only_claim_boundary() -> None:
+    """The packet keeps the multi-factor comparison caveat mandatory."""
+    packet = _load_packet()
+    packet["campaign"]["claim_boundary"] = "Launch packet only. It does not run a benchmark."
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "horizon-only" in str(exc)
+    else:
+        raise AssertionError("packet should reject missing comparison caveat")
+
+
+def test_issue_3810_packet_rejects_low_exposure_success_evidence() -> None:
+    """Low-exposure successes stay diagnostic instead of success evidence."""
+    packet = _load_packet()
+    packet["launch_packet"]["wait_it_out_guard"]["low_exposure_success_status"] = (
+        "successful_evidence"
+    )
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "low exposure must be diagnostic" in str(exc)
+    else:
+        raise AssertionError("packet should reject low-exposure success evidence")
+
+
+def test_issue_3810_packet_cli_json() -> None:
+    """The command-line validator emits a compact JSON pass summary."""
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--packet", str(PACKET), "--json"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert '"compute_submit_authorized": false' in completed.stdout
+    assert '"max_episode_steps": 600' in completed.stdout

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -91,6 +91,50 @@ def test_issue_3810_packet_rejects_null_list_fields_cleanly() -> None:
         raise AssertionError("packet should reject a null metrics.ids list")
 
 
+def test_issue_3810_packet_rejects_blank_matrix_path() -> None:
+    """A blank scenario matrix path must not pass the repo-relative check."""
+    packet = _load_packet()
+    packet["scenario_suite"]["matrix_path"] = ""
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "scenario matrix must be repo-relative" in str(exc)
+    else:
+        raise AssertionError("packet should reject a blank scenario matrix path")
+
+
+def test_issue_3810_packet_rejects_missing_campaign_id() -> None:
+    """A missing campaign id fails closed instead of escaping as KeyError."""
+    packet = _load_packet()
+    packet["campaign"].pop("id", None)
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "campaign.id required" in str(exc)
+    else:
+        raise AssertionError("packet should reject a missing campaign id")
+
+
+def test_issue_3810_packet_cli_returns_2_on_malformed_packet(tmp_path) -> None:
+    """The CLI converts a malformed packet into a clean exit 2, not a traceback."""
+    bad_packet = tmp_path / "bad_packet.yaml"
+    bad_packet.write_text("schema_version: research-campaign-manifest.v0.1\n", encoding="utf-8")
+
+    completed = subprocess.run(
+        [sys.executable, str(SCRIPT), "--packet", str(bad_packet), "--json"],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 2, completed.stderr
+    assert "error:" in completed.stderr
+    assert "Traceback" not in completed.stderr
+
+
 def test_issue_3810_packet_cli_json() -> None:
     """The command-line validator emits a compact JSON pass summary."""
     completed = subprocess.run(


### PR DESCRIPTION
## Summary
Adds a no-submit launch packet for issue #3810: a comprehensive h600 benchmark campaign contract with Social Navigation Quality Index (SNQI) recalibration inputs, horizon-sensitivity reporting requirements, retention paths, private-ops route/preflight fields, and an interaction-exposure diagnostic guard for wait-it-out successes.

## Linked Issues
- Relates to #3810
- Follow-up retained: #3813 for sustained-flow scenario variants

## Scope
- Adds `configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml` as a fail-closed launch, analysis, and retention packet.
- Adds `scripts/validation/check_issue_3810_long_horizon_launch_packet.py` to validate the #3810-specific packet contract.
- Adds focused tests covering the no-submit guard, h600/S30/planner-roster checks, horizon-only caveat, and interaction-exposure diagnostic classification.

## Claim Boundary
Launch-packet-only. This PR does not run a benchmark, submit Slurm work, recalibrate SNQI weights, update paper/dissertation claims, or establish horizon sensitivity. The packet requires the eventual report to frame the comparison as prior scoped short-horizon versus new comprehensive long-horizon, not horizon-only.

## Validation / Proof
- `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` - passed; reports h600, 30 seeds, 11 planners, `compute_submit_authorized=false`, `slurm_job_id=not_submitted`, blocker `13175`.
- `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q` - passed, 5 tests.
- `uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` - passed.
- `uv run ruff format --check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` - passed.
- `uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` - passed; generated disposable dry-run packet rows under ignored `output/`.
- Private-ops preflight dry-run command exited 0 and wrote ignored local JSON with `submitted=false`; local `sbatch` and W&B online auth were unavailable, so this is route/preflight evidence only, not submission readiness.
- `uv run python -m py_compile scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` - passed.
- `python3` YAML load smoke for the launch packet - passed; campaign id `issue_3810_comprehensive_h600_snqi_recalibration`, horizon 600, 30 seeds, 11 planner rows.
- `git diff --cached --check` - passed before commit.

## Explicit Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Risks / Reviewer Notes
- The packet names a future materialized campaign config via config patch; it deliberately does not add the full runnable campaign config or submit it.
- Private preflight reported `missing_sbatch` and missing W&B online auth on this host; actual Slurm go/no-go remains owned by the downstream Claude Code PR gate on `imech156-u`.
- Candidate/dependency-gated planner rows are explicit and remain diagnostic/fail-closed unless later preflight proves availability.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new benchmark launch packet with built-in checks for campaign settings, required outputs, and gated launch behavior.
  * Added a command-line validator that can verify the packet and return either a brief status or JSON output.

* **Tests**
  * Added coverage for successful validation and for rejection of invalid launch settings, including submit authorization and required evaluation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->