### PR TITLE
Issue #3699: surface SNQI term normalization statuses

### DIFF
--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -73,6 +73,15 @@ class TermScaling:
         """Whether this term subtracts from the SNQI composite."""
         return self.sign < 0
 
+    @property
+    def normalization_status(self) -> str:
+        """Compact diagnostic status for preflight reports."""
+        if self.scaling == SCALING_BASELINE_NORMALIZED:
+            return (
+                "baseline_normalized_bounded" if self.bounded else "baseline_normalized_unbounded"
+            )
+        return "raw_bounded" if self.bounded else "raw_unbounded"
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable view of this term."""
         return {
@@ -80,6 +89,7 @@ class TermScaling:
             "weight_name": self.weight_name,
             "metric_key": self.metric_key,
             "scaling": self.scaling,
+            "normalization_status": self.normalization_status,
             "sign": self.sign,
             "is_penalty": self.is_penalty,
             "bounded": self.bounded,

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -132,6 +132,13 @@ def _print_text_report(report: dict[str, Any]) -> None:
         f"raw_penalty_terms={', '.join(normalization['raw_penalty_terms']) or 'none'}; "
         f"unbounded_terms={', '.join(normalization['unbounded_terms']) or 'none'}"
     )
+    print("Term normalization status:")
+    for term in normalization["terms"]:
+        role = "penalty" if term["is_penalty"] else "reward"
+        print(
+            f"  - {term['term']} ({term['metric_key']}, {term['weight_name']}): "
+            f"{term['normalization_status']}; role={role}; note={term['note']}"
+        )
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from scripts.validation.check_snqi_governance import build_governance_report, main
 
 REPO_ROOT = Path(__file__).parents[2]
@@ -42,6 +44,20 @@ def test_governance_main_fails_closed_but_allows_inspection(tmp_path: Path) -> N
         )
         == 0
     )
+
+
+def test_governance_text_lists_per_term_normalization_status(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """Human preflight output lists raw and baseline-normalized term statuses."""
+    assert main(["--repo-root", str(REPO_ROOT), "--allow-current-blockers"]) == 0
+
+    out = capsys.readouterr().out
+    assert "Term normalization status:" in out
+    assert "time (time_to_goal_norm, w_time): raw_unbounded" in out
+    assert "comfort (comfort_exposure, w_comfort): raw_unbounded" in out
+    assert "collisions (collisions, w_collisions): baseline_normalized_bounded" in out
+    assert "jerk (jerk_mean, w_jerk): baseline_normalized_bounded" in out
 
 
 def test_governance_report_checks_optional_baseline_coverage(tmp_path: Path) -> None:

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -155,6 +155,11 @@ def test_to_dict_is_json_serializable_and_self_consistent():
     assert encoded["mixed_scale"] is True
     assert set(encoded["raw_penalty_terms"]) == {"time", "comfort"}
     assert encoded["is_consistent"] is False
+    status_by_term = {term["term"]: term["normalization_status"] for term in encoded["terms"]}
+    assert status_by_term["success"] == "raw_bounded"
+    assert status_by_term["time"] == "raw_unbounded"
+    assert status_by_term["comfort"] == "raw_unbounded"
+    assert status_by_term["collisions"] == "baseline_normalized_bounded"
 
 
 def test_format_report_is_human_readable():


### PR DESCRIPTION
## Summary
- Adds an explicit `normalization_status` field to each SNQI term in the existing diagnostic normalization inventory.
- Extends the SNQI governance preflight text output to list every term's metric key, weight, raw/baseline-normalized status, role, and note.
- Keeps `compute_snqi()` scoring, weights, and normalization behavior unchanged.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3699

## Scope
This is a bounded diagnostic/preflight slice for issue #3699. It surfaces the current mixed raw and baseline-normalized SNQI term basis more directly in machine-readable JSON and human preflight output.

Out of scope: no SNQI metric redesign, no weight changes, no scoring behavior changes, no full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py -q` -> 15 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --json-out /tmp/snqi_governance_3699.json` -> exit 2 as expected; fail-closed report still includes #3699 `mixed_normalization_basis` and now includes per-term `normalization_status` values.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --allow-current-blockers | rg -n 'Term normalization status|raw_unbounded|baseline_normalized_bounded'` -> exit 0; text output lists raw-unbounded `time`/`comfort` and baseline-normalized bounded penalty terms.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi/normalization_inventory.py scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py` -> passed.
- `PR_READY_PR_BODY_FILE=/tmp/pr_3699_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; freshness stamp recorded for `fbceb3934dec9597d1bd9e8fa5f2cf56014627e5`.

## Artifact / Campaign Decision
No generated benchmark artifacts are promoted. Routine ignored validation outputs remain under `output/` only.

## Downstream Propagation
SNQI remains a secondary diagnostic index. This PR only improves visibility of the existing unresolved mixed-normalization blocker; it does not clear the semantic decision required to normalize raw terms or document a bounded raw-term asymmetry.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-term normalization status details to the governance text report.
  * Included a normalization status field in exported term metadata for easier inspection.

* **Bug Fixes**
  * Improved visibility into which terms are treated as raw, normalized, or bounded in report output.

* **Tests**
  * Expanded coverage to verify the new normalization status values in exported data and CLI output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->