### PR TITLE
Issue #3653: add SNQI sensitivity readiness preflight

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -23,7 +23,19 @@ if TYPE_CHECKING:
     from pathlib import Path
 
 SCALARIZATION_SENSITIVITY_SCHEMA = "snqi_scalarization_sensitivity.v1"
+SCALARIZATION_SENSITIVITY_PREFLIGHT_SCHEMA = "snqi_scalarization_sensitivity_preflight.v1"
 DEFAULT_SWEEP_FACTORS: tuple[float, ...] = (0.0, 0.25, 0.5, 1.0, 1.5, 2.0)
+SENSITIVITY_PREFLIGHT_READY = "ready"
+SENSITIVITY_PREFLIGHT_BLOCKED = "blocked"
+SENSITIVITY_PREFLIGHT_MALFORMED = "malformed"
+REQUIRED_SENSITIVITY_METRICS = (
+    "success",
+    "time_to_goal_norm",
+    "collisions",
+    "near_misses",
+    "comfort_exposure",
+)
+OPTIONAL_SENSITIVITY_METRICS = ("force_exceed_events", "jerk_mean")
 
 
 @dataclass(frozen=True, slots=True)
@@ -34,6 +46,320 @@ class DiagnosticArtifacts:
     csv_path: Path
     markdown_path: Path
     svg_path: Path
+
+
+@dataclass(frozen=True, slots=True)
+class SensitivityPreflightIssue:
+    """One fail-closed readiness issue for scalarization-sensitivity inputs."""
+
+    code: str
+    severity: str
+    message: str
+
+    def as_dict(self) -> dict[str, str]:
+        """Return a JSON-ready issue row."""
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "message": self.message,
+        }
+
+
+@dataclass(slots=True)
+class _SensitivityPreflightState:
+    issues: list[SensitivityPreflightIssue]
+    malformed: bool
+    grouped: dict[str, list[Mapping[str, Any]]]
+    coverage: dict[str, set[tuple[str, str]]]
+    scenario_horizons: set[tuple[str, str]]
+
+    @classmethod
+    def empty(cls) -> _SensitivityPreflightState:
+        return cls(
+            issues=[],
+            malformed=False,
+            grouped={},
+            coverage={},
+            scenario_horizons=set(),
+        )
+
+    def add_issue(self, code: str, severity: str, message: str) -> None:
+        self.issues.append(SensitivityPreflightIssue(code, severity, message))
+        if severity == SENSITIVITY_PREFLIGHT_MALFORMED:
+            self.malformed = True
+
+
+def classify_scalarization_sensitivity_inputs(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    weights: Mapping[str, float],
+    baseline: Mapping[str, Mapping[str, float]],
+    planner_key: str = "planner_key",
+    fallback_planner_key: str = "planner",
+    scenario_key: str = "scenario_id",
+    horizon_key: str = "horizon",
+    min_planners: int = 2,
+) -> dict[str, Any]:
+    """Classify whether SNQI scalarization-sensitivity inputs are ready.
+
+    This is a blocker/readiness preflight only. It intentionally avoids exporting
+    sensitivity artifacts or making decision-reversal claims.
+
+    Returns:
+        JSON-ready readiness report with ``ready``, ``blocked``, or ``malformed`` status.
+    """
+
+    state = _SensitivityPreflightState.empty()
+    records = _validate_preflight_inputs(state, records, weights, baseline)
+    _collect_preflight_records(
+        state, records, planner_key, fallback_planner_key, scenario_key, horizon_key
+    )
+    missing_cells = _add_global_preflight_issues(state, records, min_planners)
+    _add_pareto_preflight_issues(state, weights, baseline, min_planners)
+    return _format_preflight_report(state, records, missing_cells)
+
+
+def _validate_preflight_inputs(
+    state: _SensitivityPreflightState,
+    records: Sequence[Mapping[str, Any]],
+    weights: Mapping[str, float],
+    baseline: Mapping[str, Mapping[str, float]],
+) -> Sequence[Mapping[str, Any]]:
+    if not isinstance(records, Sequence) or isinstance(records, (str, bytes)):
+        state.add_issue(
+            "records_not_sequence",
+            SENSITIVITY_PREFLIGHT_MALFORMED,
+            "records must be a sequence of mapping objects",
+        )
+        records = []
+    if not isinstance(weights, Mapping):
+        state.add_issue(
+            "weights_not_mapping",
+            SENSITIVITY_PREFLIGHT_MALFORMED,
+            "weights must be a mapping keyed by SNQI component",
+        )
+    if not isinstance(baseline, Mapping):
+        state.add_issue(
+            "baseline_not_mapping",
+            SENSITIVITY_PREFLIGHT_MALFORMED,
+            "baseline must be a mapping keyed by normalized metric",
+        )
+
+    if isinstance(weights, Mapping):
+        missing_weights = [name for name in WEIGHT_NAMES if name not in weights]
+        if missing_weights:
+            state.add_issue(
+                "missing_snqi_weights",
+                SENSITIVITY_PREFLIGHT_MALFORMED,
+                "missing SNQI weights: " + ", ".join(missing_weights),
+            )
+    return records
+
+
+def _collect_preflight_records(
+    state: _SensitivityPreflightState,
+    records: Sequence[Mapping[str, Any]],
+    planner_key: str,
+    fallback_planner_key: str,
+    scenario_key: str,
+    horizon_key: str,
+) -> None:
+    for index, record in enumerate(records, start=1):
+        if not isinstance(record, Mapping):
+            state.add_issue(
+                "record_not_mapping",
+                SENSITIVITY_PREFLIGHT_MALFORMED,
+                f"record {index} must be a mapping",
+            )
+            continue
+        _collect_preflight_record(
+            state,
+            index,
+            record,
+            planner_key,
+            fallback_planner_key,
+            scenario_key,
+            horizon_key,
+        )
+
+
+def _collect_preflight_record(
+    state: _SensitivityPreflightState,
+    index: int,
+    record: Mapping[str, Any],
+    planner_key: str,
+    fallback_planner_key: str,
+    scenario_key: str,
+    horizon_key: str,
+) -> None:
+    planner = _preflight_planner(record, planner_key, fallback_planner_key)
+    if planner in (None, ""):
+        state.add_issue(
+            "missing_planner",
+            SENSITIVITY_PREFLIGHT_MALFORMED,
+            f"record {index} is missing planner identity",
+        )
+        return
+
+    scenario = _get_nested(record, scenario_key)
+    horizon = _get_nested(record, horizon_key)
+    if horizon in (None, ""):
+        horizon = _get_nested(record, "scenario_horizon")
+    if scenario in (None, "") or horizon in (None, ""):
+        state.add_issue(
+            "missing_scenario_horizon",
+            SENSITIVITY_PREFLIGHT_BLOCKED,
+            f"record {index} lacks scenario-horizon evidence",
+        )
+        return
+
+    _add_metric_preflight_issues(state, index, _metrics(record))
+    planner_name = str(planner)
+    scenario_horizon = (str(scenario), str(horizon))
+    state.grouped.setdefault(planner_name, []).append(record)
+    state.scenario_horizons.add(scenario_horizon)
+    state.coverage.setdefault(planner_name, set()).add(scenario_horizon)
+
+
+def _preflight_planner(
+    record: Mapping[str, Any], planner_key: str, fallback_planner_key: str
+) -> Any:
+    planner = _get_nested(record, planner_key)
+    if planner in (None, ""):
+        planner = _get_nested(record, fallback_planner_key)
+    if planner in (None, ""):
+        planner = _get_nested(record, "scenario_params.algo")
+    return planner
+
+
+def _add_metric_preflight_issues(
+    state: _SensitivityPreflightState, index: int, metrics: Mapping[str, Any]
+) -> None:
+    for metric in REQUIRED_SENSITIVITY_METRICS:
+        if metric not in metrics:
+            state.add_issue(
+                "missing_required_term",
+                SENSITIVITY_PREFLIGHT_BLOCKED,
+                f"record {index} is missing SNQI term {metric!r}",
+            )
+        elif not _is_finite_metric(metrics.get(metric)):
+            state.add_issue(
+                "non_finite_required_term",
+                SENSITIVITY_PREFLIGHT_MALFORMED,
+                f"record {index} has non-finite SNQI term {metric!r}",
+            )
+
+    for metric in OPTIONAL_SENSITIVITY_METRICS:
+        if metric in metrics and not _is_finite_metric(metrics.get(metric)):
+            state.add_issue(
+                "non_finite_optional_term",
+                SENSITIVITY_PREFLIGHT_MALFORMED,
+                f"record {index} has non-finite SNQI term {metric!r}",
+            )
+
+
+def _add_global_preflight_issues(
+    state: _SensitivityPreflightState,
+    records: Sequence[Mapping[str, Any]],
+    min_planners: int,
+) -> dict[str, list[tuple[str, str]]]:
+    if not records:
+        state.add_issue(
+            "no_records",
+            SENSITIVITY_PREFLIGHT_BLOCKED,
+            "no episode records available for scalarization-sensitivity preflight",
+        )
+    if len(state.grouped) < min_planners:
+        state.add_issue(
+            "insufficient_planners",
+            SENSITIVITY_PREFLIGHT_BLOCKED,
+            f"at least {min_planners} planners are required for rank and Pareto diagnostics",
+        )
+
+    missing_cells = {
+        planner: sorted(state.scenario_horizons - seen)
+        for planner, seen in sorted(state.coverage.items())
+        if state.scenario_horizons - seen
+    }
+    if missing_cells:
+        state.add_issue(
+            "non_rectangular_planner_table",
+            SENSITIVITY_PREFLIGHT_BLOCKED,
+            "planner table must cover the same scenario-horizon cells for every planner",
+        )
+    if not state.scenario_horizons:
+        state.add_issue(
+            "no_valid_scenario_horizon",
+            SENSITIVITY_PREFLIGHT_BLOCKED,
+            "no valid scenario-horizon evidence was found",
+        )
+    return missing_cells
+
+
+def _add_pareto_preflight_issues(
+    state: _SensitivityPreflightState,
+    weights: Mapping[str, float],
+    baseline: Mapping[str, Mapping[str, float]],
+    min_planners: int,
+) -> None:
+    if len(state.grouped) < min_planners or state.malformed:
+        return
+    try:
+        snqi_scores = _planner_snqi_scores(state.grouped, weights, baseline)
+        constraints = {
+            planner: _constraints_first_endpoint(rows) for planner, rows in state.grouped.items()
+        }
+        rows = _planner_rows(
+            snqi_scores,
+            constraints,
+            _rank_order(snqi_scores, higher_is_better=True),
+            _rank_order(
+                {
+                    planner: endpoint["constraints_first_score"]
+                    for planner, endpoint in constraints.items()
+                },
+                higher_is_better=True,
+            ),
+        )
+        _pareto_points(rows)
+    except (TypeError, ValueError, KeyError) as exc:
+        state.add_issue(
+            "pareto_prerequisite_error",
+            SENSITIVITY_PREFLIGHT_MALFORMED,
+            f"could not derive Pareto prerequisites: {exc}",
+        )
+
+
+def _format_preflight_report(
+    state: _SensitivityPreflightState,
+    records: Sequence[Mapping[str, Any]],
+    missing_cells: Mapping[str, Sequence[tuple[str, str]]],
+) -> dict[str, Any]:
+    status = SENSITIVITY_PREFLIGHT_READY
+    if state.malformed:
+        status = SENSITIVITY_PREFLIGHT_MALFORMED
+    elif state.issues:
+        status = SENSITIVITY_PREFLIGHT_BLOCKED
+
+    return {
+        "schema_version": SCALARIZATION_SENSITIVITY_PREFLIGHT_SCHEMA,
+        "issue": 3653,
+        "status": status,
+        "ready": status == SENSITIVITY_PREFLIGHT_READY,
+        "planners": sorted(state.grouped),
+        "planner_count": len(state.grouped),
+        "record_count": len(records),
+        "scenario_horizon_count": len(state.scenario_horizons),
+        "missing_planner_cells": {
+            planner: [{"scenario": cell[0], "horizon": cell[1]} for cell in cells]
+            for planner, cells in missing_cells.items()
+        },
+        "issues": [issue.as_dict() for issue in state.issues],
+        "claim_boundary": (
+            "Readiness preflight only; no SNQI weight changes, no scalarization export, "
+            "no benchmark campaign run, and no decision-reversal claim."
+        ),
+    }
 
 
 def build_scalarization_sensitivity_report(
@@ -647,6 +973,15 @@ def _metric_float(metrics: Mapping[str, Any], key: str, default: float) -> float
     return number if math.isfinite(number) else default
 
 
+def _is_finite_metric(value: Any) -> bool:
+    if isinstance(value, bool):
+        return True
+    try:
+        return math.isfinite(float(value))
+    except (TypeError, ValueError):
+        return False
+
+
 def _mean(values: Iterable[float]) -> float:
     clean = [float(value) for value in values if math.isfinite(float(value))]
     if not clean:
@@ -675,9 +1010,17 @@ def _padded_domain(values: Sequence[float]) -> tuple[float, float]:
 
 __all__ = [
     "DEFAULT_SWEEP_FACTORS",
+    "OPTIONAL_SENSITIVITY_METRICS",
+    "REQUIRED_SENSITIVITY_METRICS",
+    "SCALARIZATION_SENSITIVITY_PREFLIGHT_SCHEMA",
     "SCALARIZATION_SENSITIVITY_SCHEMA",
+    "SENSITIVITY_PREFLIGHT_BLOCKED",
+    "SENSITIVITY_PREFLIGHT_MALFORMED",
+    "SENSITIVITY_PREFLIGHT_READY",
     "DiagnosticArtifacts",
+    "SensitivityPreflightIssue",
     "build_scalarization_sensitivity_report",
+    "classify_scalarization_sensitivity_inputs",
     "format_markdown",
     "format_pareto_svg",
     "load_baseline_mapping",

--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -322,7 +322,7 @@ def _add_pareto_preflight_issues(
             ),
         )
         _pareto_points(rows)
-    except (TypeError, ValueError, KeyError) as exc:
+    except (AttributeError, TypeError, ValueError, KeyError) as exc:
         state.add_issue(
             "pareto_prerequisite_error",
             SENSITIVITY_PREFLIGHT_MALFORMED,

--- a/scripts/tools/analyze_snqi_scalarization_sensitivity.py
+++ b/scripts/tools/analyze_snqi_scalarization_sensitivity.py
@@ -15,7 +15,9 @@ from pathlib import Path
 
 from robot_sf.benchmark.snqi_scalarization_sensitivity import (
     DEFAULT_SWEEP_FACTORS,
+    SENSITIVITY_PREFLIGHT_READY,
     build_scalarization_sensitivity_report,
+    classify_scalarization_sensitivity_inputs,
     load_baseline_mapping,
     load_jsonl,
     load_weight_mapping,
@@ -28,7 +30,17 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--episodes", type=Path, required=True, help="Episode JSONL input.")
     parser.add_argument("--weights", type=Path, default=None, help="Optional SNQI weights JSON.")
     parser.add_argument("--baseline", type=Path, default=None, help="Optional SNQI baseline JSON.")
-    parser.add_argument("--output-dir", type=Path, required=True, help="Directory for artifacts.")
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=None,
+        help="Directory for artifacts. Required unless --preflight-only is set.",
+    )
+    parser.add_argument(
+        "--preflight-only",
+        action="store_true",
+        help="Classify input readiness without writing scalarization artifacts.",
+    )
     parser.add_argument("--planner-key", default="planner_key", help="Dotted planner key.")
     parser.add_argument(
         "--fallback-planner-key", default="planner", help="Fallback dotted planner key."
@@ -49,12 +61,29 @@ def main(argv: list[str] | None = None) -> int:
     Returns:
         Process exit code.
     """
-
     args = _parse_args(argv)
+    records = load_jsonl(args.episodes)
+    weights = load_weight_mapping(args.weights)
+    baseline = load_baseline_mapping(args.baseline)
+
+    if args.preflight_only:
+        preflight = classify_scalarization_sensitivity_inputs(
+            records,
+            weights=weights,
+            baseline=baseline,
+            planner_key=args.planner_key,
+            fallback_planner_key=args.fallback_planner_key,
+        )
+        print(json.dumps(preflight, indent=2))
+        return 0 if preflight["status"] == SENSITIVITY_PREFLIGHT_READY else 2
+
+    if args.output_dir is None:
+        raise SystemExit("--output-dir is required unless --preflight-only is set")
+
     report = build_scalarization_sensitivity_report(
-        load_jsonl(args.episodes),
-        weights=load_weight_mapping(args.weights),
-        baseline=load_baseline_mapping(args.baseline),
+        records,
+        weights=weights,
+        baseline=baseline,
         planner_key=args.planner_key,
         fallback_planner_key=args.fallback_planner_key,
         sweep_factors=args.sweep_factors,

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -199,6 +199,21 @@ def test_preflight_malformed_for_non_finite_term() -> None:
     assert any(issue["code"] == "non_finite_required_term" for issue in report["issues"])
 
 
+def test_preflight_malformed_for_non_mapping_baseline_value() -> None:
+    """A baseline metric value that is not a mapping is classified malformed, not crashed."""
+    baseline = _baseline()
+    baseline["collisions"] = 1.0  # scalar instead of {"med": ..., "p95": ...}
+
+    report = classify_scalarization_sensitivity_inputs(
+        _preflight_episodes(),
+        weights=_weights(),
+        baseline=baseline,
+    )
+
+    assert report["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
+    assert any(issue["code"] == "pareto_prerequisite_error" for issue in report["issues"])
+
+
 def test_report_exports_decision_disagreement_and_weight_reversals() -> None:
     """Sensitivity report exposes rank disagreement and scalarization reversals."""
 

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -7,7 +7,11 @@ from pathlib import Path
 
 from robot_sf.benchmark.snqi_scalarization_sensitivity import (
     SCALARIZATION_SENSITIVITY_SCHEMA,
+    SENSITIVITY_PREFLIGHT_BLOCKED,
+    SENSITIVITY_PREFLIGHT_MALFORMED,
+    SENSITIVITY_PREFLIGHT_READY,
     build_scalarization_sensitivity_report,
+    classify_scalarization_sensitivity_inputs,
     format_pareto_svg,
     load_jsonl,
     write_diagnostic_artifacts,
@@ -99,6 +103,100 @@ def _baseline() -> dict[str, dict[str, float]]:
         "force_exceed_events": {"med": 0.0, "p95": 1.0},
         "jerk_mean": {"med": 0.0, "p95": 1.0},
     }
+
+
+def _preflight_episodes() -> list[dict]:
+    records = []
+    for horizon in (500, 600):
+        records.extend(
+            [
+                {
+                    "scenario_id": "crossing",
+                    "horizon": horizon,
+                    "planner_key": "fast-risky",
+                    "metrics": {
+                        "success": 1,
+                        "time_to_goal_norm": 0.1,
+                        "collisions": 1,
+                        "near_misses": 0,
+                        "comfort_exposure": 0.0,
+                    },
+                },
+                {
+                    "scenario_id": "crossing",
+                    "horizon": horizon,
+                    "planner_key": "safe-slow",
+                    "metrics": {
+                        "success": 1,
+                        "time_to_goal_norm": 0.8,
+                        "collisions": 0,
+                        "near_misses": 0,
+                        "comfort_exposure": 0.1,
+                    },
+                },
+                {
+                    "scenario_id": "crossing",
+                    "horizon": horizon,
+                    "planner_key": "middle",
+                    "metrics": {
+                        "success": 1,
+                        "time_to_goal_norm": 0.5,
+                        "collisions": 0,
+                        "near_misses": 1,
+                        "comfort_exposure": 0.2,
+                    },
+                },
+            ]
+        )
+    return records
+
+
+def test_preflight_ready_for_rectangular_scenario_horizon_terms() -> None:
+    """Ready input has planners, complete scenario-horizon cells, and SNQI terms."""
+    report = classify_scalarization_sensitivity_inputs(
+        _preflight_episodes(),
+        weights=_weights(),
+        baseline=_baseline(),
+    )
+
+    assert report["status"] == SENSITIVITY_PREFLIGHT_READY
+    assert report["ready"] is True
+    assert report["planner_count"] == 3
+    assert report["scenario_horizon_count"] == 2
+    assert report["issues"] == []
+
+
+def test_preflight_blocks_missing_scenario_horizon_and_non_rectangular_table() -> None:
+    """Missing scenario-horizon evidence and table cells block sensitivity export."""
+    records = _preflight_episodes()
+    records[0].pop("horizon")
+    records = records[:-1]
+
+    report = classify_scalarization_sensitivity_inputs(
+        records,
+        weights=_weights(),
+        baseline=_baseline(),
+    )
+
+    assert report["status"] == SENSITIVITY_PREFLIGHT_BLOCKED
+    codes = {issue["code"] for issue in report["issues"]}
+    assert "missing_scenario_horizon" in codes
+    assert "non_rectangular_planner_table" in codes
+
+
+def test_preflight_malformed_for_non_finite_term() -> None:
+    """Non-finite required SNQI terms are malformed rather than merely blocked."""
+    records = _preflight_episodes()
+    records[0]["metrics"]["time_to_goal_norm"] = "nan"
+
+    report = classify_scalarization_sensitivity_inputs(
+        records,
+        weights=_weights(),
+        baseline=_baseline(),
+    )
+
+    assert report["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
+    assert any(issue["code"] == "non_finite_required_term" for issue in report["issues"])
 
 
 def test_report_exports_decision_disagreement_and_weight_reversals() -> None:
@@ -214,3 +312,35 @@ def test_cli_writes_scalarization_artifacts(tmp_path: Path, capsys) -> None:
     assert Path(stdout["csv"]).exists()
     assert Path(stdout["markdown"]).exists()
     assert Path(stdout["svg"]).exists()
+
+
+def test_cli_preflight_only_blocks_invalid_inputs(tmp_path: Path, capsys) -> None:
+    """Preflight mode reports blocked inputs without writing diagnostic artifacts."""
+    records = _preflight_episodes()
+    records[0].pop("scenario_id")
+    episodes_path = tmp_path / "episodes.jsonl"
+    episodes_path.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    weights_path = tmp_path / "weights.json"
+    weights_path.write_text(json.dumps(_weights()), encoding="utf-8")
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(_baseline()), encoding="utf-8")
+
+    exit_code = scalarization_cli_main(
+        [
+            "--episodes",
+            str(episodes_path),
+            "--weights",
+            str(weights_path),
+            "--baseline",
+            str(baseline_path),
+            "--preflight-only",
+        ]
+    )
+
+    assert exit_code == 2
+    stdout = json.loads(capsys.readouterr().out)
+    assert stdout["status"] == SENSITIVITY_PREFLIGHT_BLOCKED
+    assert any(issue["code"] == "missing_scenario_horizon" for issue in stdout["issues"])


### PR DESCRIPTION
## Summary
Adds a fail-closed readiness preflight for issue #3653 Social Navigation Quality Index (SNQI) scalarization-sensitivity inputs before the existing diagnostic exporter is treated as usable.

## Linked Issues
- Relates to https://github.com/ll7/robot_sf_ll7/issues/3653

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Safe review independently: yes

## What Changed
- Added `classify_scalarization_sensitivity_inputs(...)` to the existing SNQI scalarization-sensitivity owner.
- The preflight classifies inputs as `ready`, `blocked`, or `malformed` for scenario-horizon evidence, required SNQI terms, planner table shape, complete weights, and Pareto-row derivability.
- Added `--preflight-only` to `scripts/tools/analyze_snqi_scalarization_sensitivity.py`; it prints the readiness report and exits `0` only when ready, `2` otherwise.
- Added synthetic focused tests for ready, blocked, malformed, and CLI blocked states.

## Scope Summary
This is a blocker/readiness checker slice only. It does not change SNQI weights, compute new scalarization results, run a benchmark campaign, or make decision-reversal claims.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker preflight for issue #3653 input readiness.
- Comparator or baseline, applicable: NA - support checker only.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision stop rule, applicable: inputs remain blocked/malformed until the preflight reports `ready` on valid scenario-horizon planner records.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3653 remains open for full analysis/export closure.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - readiness preflight only; it does not interpret research evidence.

## Domain-Aware Approval
- Approval concerns: not required for this support-only preflight slice.
- Fallback/degraded exclusions: fallback/degraded execution is not classified as benchmark evidence by this PR.
- Claim boundary: readiness preflight only; no SNQI sensitivity or decision-reversal claim.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py -q` -> passed, 9 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_plots_pareto.py -q` -> passed, 3 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi_scalarization_sensitivity.py scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/snqi_scalarization_sensitivity.py scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` -> passed, 3 files already formatted.
- `git diff --check` -> passed.

## Explicit Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No SNQI weight changes.
- No new scalarization result export or decision-reversal claim.

## Risks / Rollout
- Compatibility risks: low; existing artifact export remains the default unless `--preflight-only` is passed.
- Failure modes: real archived inputs may use different scenario or horizon field names; the checker exposes configurable `scenario_key` and `horizon_key` in the API, with `scenario_horizon` as a fallback horizon field.
- Rollback fallback plan: revert the checker and CLI flag without touching existing exporter behavior.

## Downstream Propagation
- Parent issue updated: no, per task authorization `comment_issue_or_pr: false`.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: this PR is a preflight helper and deliberately avoids benchmark, claim-map, and paper-facing result updates.

## Follow-Up Issues
- Deferred work: run the full Pareto-front export and decision-disagreement table on durable valid inputs after the checker reports ready.
- Issues opened follow-up: none.

## Reviewer Notes
- Please verify the fail-closed status boundaries: malformed structural inputs should not be reported as merely blocked, and blocked ordinary missing inputs should not stop the CLI with an exception.
