### PR TITLE
Issue #3798: keep post-13175 S20/S30 packet reproducible

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -2584,3 +2584,7 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence

--- a/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
+++ b/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": "s20-s30-evidence-gap-packet.v1",
+  "job_id": "13175",
+  "status": "diagnostic_only",
+  "claim_boundary": "diagnostic-only evidence-gap packet; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no S20/S30 claim promotion",
+  "artifact_root": "/home/luttkule/git/robot_sf_ll7/output/issue1554-s20-h500-l40s-mem180/13175",
+  "retrieved_artifacts": {
+    "file_count": 56,
+    "total_bytes": 185111675,
+    "missing_required_metadata_files": []
+  },
+  "campaign": {
+    "campaign_id": "issue1554_s20_h500_l40s_mem180_20260628",
+    "config_name": "paper_experiment_matrix_v1_scenario_horizons_h500_s20",
+    "started_at_utc": "2026-06-28T18:25:45.459248Z",
+    "finished_at_utc": "2026-06-28T20:03:01.128441Z",
+    "git_commit": "38f921fe374bc954ccc8932bfb055fc021c5b528",
+    "git_branch": "slurm-issue-1554-s20-h500-l40s-mem180-20260628",
+    "seed_set": "paper_eval_s20",
+    "resolved_seed_count": 20,
+    "scenario_matrix": "configs/scenarios/classic_interactions_francis2023.yaml",
+    "scenario_matrix_hash": "8609d0192098"
+  },
+  "coverage_snapshot": {
+    "planner_rows": [],
+    "planner_count": 9,
+    "episode_rows": 8640,
+    "seed_count": 20,
+    "seeds": [
+      111,
+      112,
+      113,
+      114,
+      115,
+      116,
+      117,
+      118,
+      119,
+      120,
+      121,
+      122,
+      123,
+      124,
+      125,
+      126,
+      127,
+      128,
+      129,
+      130
+    ],
+    "planners": [
+      "goal",
+      "hybrid_rule_v3_fast_progress_static_escape",
+      "orca",
+      "ppo",
+      "prediction_planner",
+      "sacadrl",
+      "scenario_adaptive_hybrid_orca_v1",
+      "social_force",
+      "socnav_sampling"
+    ]
+  },
+  "promotable_review_files": [
+    {
+      "path": "campaign_manifest.json",
+      "bytes": 20775,
+      "sha256": "0dda7ab427c798a2fb018c5c196be698efddc6934fd9c32e7c92ab806ebe44bb",
+      "promotion_scope": "small metadata/report surface only; diagnostic evidence, not a claim upgrade"
+    },
+    {
+      "path": "run_meta.json",
+      "bytes": 4469,
+      "sha256": "69b40d3e29d3617c4ac1a04abcd0c9819658b3ee41c196f6612fc5ec2a352c96",
+      "promotion_scope": "small metadata/report surface only; diagnostic evidence, not a claim upgrade"
+    },
+    {
+      "path": "reports/campaign_table.csv",
+      "bytes": 2745,
+      "sha256": "8382e741fdfae6e7835eaf2f6e8a4ec56d1d4e5ae17cdd070409cecf08841368",
+      "promotion_scope": "small metadata/report surface only; diagnostic evidence, not a claim upgrade"
+    },
+    {
+      "path": "reports/campaign_table_core.md",
+      "bytes": 742,
+      "sha256": "8dc9ab25142a0d8e6b796f14793caf2fd33463070729e6bb0ba773002a62b2f0",
+      "promotion_scope": "small metadata/report surface only; diagnostic evidence, not a claim upgrade"
+    },
+    {
+      "path": "reports/campaign_table_experimental.md",
+      "bytes": 1323,
+      "sha256": "54fe6c5cf3ba4e579b1e02ccdf118d2f839f5483974988b04a50032ca4f11383",
+      "promotion_scope": "small metadata/report surface only; diagnostic evidence, not a claim upgrade"
+    },
+    {
+      "path": "reports/snqi_diagnostics.md",
+      "bytes": 2495,
+      "sha256": "6a7fae8df44ecc2c2b36a5206e741cfb7ab8ec876e29b08f6e31f7545b6c5fc0",
+      "promotion_scope": "small metadata/report surface only; diagnostic evidence, not a claim upgrade"
+    },
+    {
+      "path": "reports/statistical_sufficiency.json",
+      "bytes": 421732,
+      "sha256": "f9ee5c46121dc39a8fa0e647240258e575a2dcad15e712b2695b60b713652385",
+      "promotion_scope": "small metadata/report surface only; diagnostic evidence, not a claim upgrade"
+    }
+  ],
+  "claim_blockers": [
+    "The retrieved job is S20 only; S30 remains an escalation path, not executed evidence.",
+    "Artifacts live under ignored worktree output and are not yet a canonical campaign result store.",
+    "Archive-readiness still depends on the fail-closed result-store checker before any claim promotion.",
+    "No dissertation, paper, ranking, safety, or significance claim is edited by this packet."
+  ],
+  "validation_commands": [
+    {
+      "command": "uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --packet-fixture docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json --markdown",
+      "purpose": "Print this diagnostic packet from tracked metadata without submitting Slurm, requiring ignored output, or editing claims."
+    },
+    {
+      "command": "uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py",
+      "purpose": "Fixture proof for present, missing, and tracked packet metadata."
+    },
+    {
+      "command": "uv run python scripts/validation/check_s20_s30_archive_readiness.py --json",
+      "purpose": "Fail-closed archive-readiness check; remains the claim gate for a canonical result store."
+    }
+  ]
+}

--- a/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.md
+++ b/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.md
@@ -54,9 +54,9 @@ This packet summarizes retrieved S20 (20-seed) job artifacts for issue #1554, ke
 
 ## Validation Commands
 
-- `uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --artifact-root /home/luttkule/git/robot_sf_ll7/output/issue1554-s20-h500-l40s-mem180/13175 --job-id 13175 --markdown`
-  - Print this diagnostic packet from retrieved job metadata without submitting Slurm or editing claims.
+- `uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --packet-fixture docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json --markdown`
+  - Print this diagnostic packet from tracked metadata without submitting Slurm, requiring ignored output, or editing claims.
 - `uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py`
-  - Fixture proof for present and missing retrieved-artifact metadata.
+  - Fixture proof for present, missing, and tracked packet metadata.
 - `uv run python scripts/validation/check_s20_s30_archive_readiness.py --json`
   - Fail-closed archive-readiness check; remains the claim gate for a canonical result store.

--- a/scripts/validation/extract_s20_s30_evidence_gap_packet.py
+++ b/scripts/validation/extract_s20_s30_evidence_gap_packet.py
@@ -17,6 +17,9 @@ from typing import Any
 SCHEMA_VERSION = "s20-s30-evidence-gap-packet.v1"
 DEFAULT_JOB_ID = "13175"
 DEFAULT_ARTIFACT_ROOT = Path("output/issue1554-s20-h500-l40s-mem180/13175")
+DEFAULT_PACKET_FIXTURE = Path(
+    "docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json"
+)
 CLAIM_BOUNDARY = (
     "diagnostic-only evidence-gap packet; no full benchmark campaign run, no "
     "Slurm/GPU submission, no paper/dissertation claim edits, and no S20/S30 "
@@ -105,6 +108,19 @@ def build_packet(artifact_root: Path, *, job_id: str = DEFAULT_JOB_ID) -> dict[s
             },
         ],
     }
+    return packet
+
+
+def load_packet_fixture(packet_fixture: Path) -> dict[str, Any]:
+    """Load a compact tracked packet fixture for hosts without raw output artifacts."""
+
+    packet = _load_json(packet_fixture)
+    if packet.get("schema_version") != SCHEMA_VERSION:
+        raise ValueError(f"{packet_fixture} schema_version must be {SCHEMA_VERSION!r}")
+    if packet.get("job_id") != DEFAULT_JOB_ID:
+        raise ValueError(f"{packet_fixture} job_id must be {DEFAULT_JOB_ID!r}")
+    if packet.get("claim_boundary") != CLAIM_BOUNDARY:
+        raise ValueError(f"{packet_fixture} claim boundary drifted")
     return packet
 
 
@@ -296,6 +312,11 @@ def _sha256(path: Path) -> str:
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--artifact-root", type=Path, default=DEFAULT_ARTIFACT_ROOT)
+    parser.add_argument(
+        "--packet-fixture",
+        type=Path,
+        help="Tracked compact packet JSON used when ignored raw artifacts are unavailable.",
+    )
     parser.add_argument("--job-id", default=DEFAULT_JOB_ID)
     parser.add_argument("--markdown", action="store_true", help="Print a Markdown packet.")
     parser.add_argument("--json", action="store_true", help="Print the packet JSON.")
@@ -307,7 +328,11 @@ def main(argv: list[str] | None = None) -> int:
     """Run the diagnostic packet extractor CLI."""
 
     args = _parse_args(argv)
-    packet = build_packet(args.artifact_root, job_id=args.job_id)
+    packet = (
+        load_packet_fixture(args.packet_fixture)
+        if args.packet_fixture is not None
+        else build_packet(args.artifact_root, job_id=args.job_id)
+    )
     rendered = (
         json.dumps(packet, indent=2, sort_keys=True) if args.json else render_markdown(packet)
     )

--- a/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
+++ b/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
@@ -135,3 +135,22 @@ def test_dry_run_command_prints_markdown_packet(tmp_path: Path, capsys) -> None:
     assert (
         "uv run python scripts/validation/check_s20_s30_archive_readiness.py --json" in captured.out
     )
+
+
+def test_tracked_packet_fixture_renders_without_raw_artifacts(capsys) -> None:
+    """Tracked packet fixture keeps public proof independent of ignored output."""
+
+    exit_code = extractor.main(
+        [
+            "--packet-fixture",
+            "docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json",
+            "--markdown",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Status: `diagnostic_only`" in captured.out
+    assert "File count: 56" in captured.out
+    assert "requiring ignored output" in captured.out
+    assert "no paper/dissertation claim edits" in captured.out


### PR DESCRIPTION
## Issue

Refs https://github.com/ll7/robot_sf_ll7/issues/3798

## Scope Summary

This is a narrow follow-up to the already-merged packet work in PR #3806. It makes the public post-13175 S20/S30 evidence-gap packet reproducible on hosts where the ignored raw `output/issue1554-s20-h500-l40s-mem180/13175` directory is no longer present.

Changes:
- add a compact tracked JSON fixture for the job 13175 packet metadata and hashes;
- add `--packet-fixture` to the read-only extractor/checker with schema, job-id, and claim-boundary guards;
- regenerate the public Markdown packet so its currentness command uses tracked metadata;
- add fixture coverage for present, missing, and tracked packet metadata.

## Validation

- `uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py` -> passed, 4 tests.
- `uv run ruff check scripts/validation/extract_s20_s30_evidence_gap_packet.py tests/validation/test_extract_s20_s30_evidence_gap_packet.py` -> passed.
- `uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --packet-fixture docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json --markdown` -> passed; prints the diagnostic-only packet from tracked metadata.
- `uv run python scripts/validation/check_s20_s30_archive_readiness.py --json` -> exits 1 by design in this worktree because the canonical result store is absent; this is the fail-closed claim gate, not a claim promotion.
- `uv run python - <<'PY' ... yaml.safe_load('docs/context/catalog.yaml') ... PY` -> passed; catalog parses with 639 entries.
- `git diff --check` -> passed.

## Out of Scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits. This PR does not promote job 13175 into dissertation, paper, ranking, safety, or significance evidence; it only preserves a compact diagnostic packet/checker surface.
