### PR TITLE
Issue #3425: fail closed on finalizer issue traceability

### DIFF
--- a/scripts/validation/preflight_slurm_finalizer.py
+++ b/scripts/validation/preflight_slurm_finalizer.py
@@ -337,11 +337,7 @@ def _check_issue_traceability(inputs: LoadedInputs) -> PreflightCheck:
     # an int and drops bools/blanks, keeping this check consistent with
     # ``reconcile_slurm_evidence`` instead of over-blocking string-encoded issues.
     queue_issues = sorted(
-        {
-            coerced
-            for entry in inputs.queue
-            if (coerced := _coerce_seed(entry.issue)) is not None
-        }
+        {coerced for entry in inputs.queue if (coerced := _coerce_seed(entry.issue)) is not None}
     )
     finalizer_issues = sorted(
         {

--- a/scripts/validation/preflight_slurm_finalizer.py
+++ b/scripts/validation/preflight_slurm_finalizer.py
@@ -26,6 +26,8 @@ What it checks (each maps to an acceptance criterion of #3425):
   and carries the expected finalization schema and a job id.
 * ``finalizer_manifest_linkage`` — every finalizer ``job_id`` resolves to a
   submission-manifest job (the "manifest linkage missing" fail-closed case).
+* ``issue_traceability_matches`` — queue/finalizer issue numbers agree for
+  public issue/PR traceability.
 * ``durable_pointer_present`` — every *successful* finalizer carries a durable
   pointer (the "durable pointers missing" fail-closed case).
 * ``claim_boundary_present`` — every finalizer carries a claim boundary so the
@@ -326,6 +328,64 @@ def _check_finalizer_linkage(inputs: LoadedInputs) -> PreflightCheck:
     )
 
 
+def _check_issue_traceability(inputs: LoadedInputs) -> PreflightCheck:
+    """Require queue and finalizer issue numbers to agree when both are present."""
+    queue_issues = sorted(
+        {
+            int(entry.issue)
+            for entry in inputs.queue
+            if isinstance(entry.issue, int) and not isinstance(entry.issue, bool)
+        }
+    )
+    finalizer_issues = sorted(
+        {
+            int(finalizer.issue_number)
+            for finalizer in inputs.finalizers
+            if isinstance(finalizer.issue_number, int)
+            and not isinstance(finalizer.issue_number, bool)
+        }
+    )
+
+    if not inputs.queue or not inputs.finalizers:
+        return PreflightCheck(
+            name="issue_traceability_matches",
+            status=_SKIPPED,
+            severity=_REQUIRED,
+            detail="queue or finalizer records missing",
+            remediation="resolve queue_present and finalizer_manifests_present first",
+        )
+    if not queue_issues:
+        return PreflightCheck(
+            name="issue_traceability_matches",
+            status=_BLOCKED,
+            severity=_REQUIRED,
+            detail="queue entries do not record an issue number",
+            remediation="record issue number in submission queue entries before public handoff",
+        )
+    if not finalizer_issues:
+        return PreflightCheck(
+            name="issue_traceability_matches",
+            status=_BLOCKED,
+            severity=_REQUIRED,
+            detail="finalizer records do not record an issue number",
+            remediation="record issue_number in finalizer manifest before public handoff",
+        )
+    if queue_issues != finalizer_issues:
+        return PreflightCheck(
+            name="issue_traceability_matches",
+            status=_BLOCKED,
+            severity=_REQUIRED,
+            detail=f"queue issue(s) {queue_issues} differ from finalizer issue(s) {finalizer_issues}",
+            remediation="align queue and finalizer issue numbers before claim decision handoff",
+        )
+    return PreflightCheck(
+        name="issue_traceability_matches",
+        status=_READY,
+        severity=_REQUIRED,
+        detail=f"queue/finalizer issue traceability matches issue(s) {queue_issues}",
+    )
+
+
 def _check_durable_pointer(inputs: LoadedInputs) -> PreflightCheck:
     """Require every successful finalizer to carry a durable pointer."""
     successful = [
@@ -456,6 +516,7 @@ def preflight(
         _check_submission_manifests(submission_manifests, inputs),
         _check_finalizer_present(finalizer_manifests, inputs),
         _check_finalizer_linkage(inputs),
+        _check_issue_traceability(inputs),
         _check_durable_pointer(inputs),
         _check_claim_boundary(inputs),
         _check_evidence_root(evidence_root),

--- a/scripts/validation/preflight_slurm_finalizer.py
+++ b/scripts/validation/preflight_slurm_finalizer.py
@@ -67,6 +67,7 @@ from scripts.tools.reconcile_slurm_evidence import (  # noqa: E402
     FinalizerReport,
     ManifestJob,
     QueueEntry,
+    _coerce_seed,
     _load_finalizer_report,
     load_queue,
     load_submission_manifests,
@@ -330,19 +331,23 @@ def _check_finalizer_linkage(inputs: LoadedInputs) -> PreflightCheck:
 
 def _check_issue_traceability(inputs: LoadedInputs) -> PreflightCheck:
     """Require queue and finalizer issue numbers to agree when both are present."""
+    # Normalize via the canonical coercion so the gate reads issue numbers
+    # exactly as the reconciler does. ``QueueEntry.issue`` is ``str | int | None``
+    # (a queue may record ``issue: "3425"``); ``_coerce_seed`` maps both forms to
+    # an int and drops bools/blanks, keeping this check consistent with
+    # ``reconcile_slurm_evidence`` instead of over-blocking string-encoded issues.
     queue_issues = sorted(
         {
-            int(entry.issue)
+            coerced
             for entry in inputs.queue
-            if isinstance(entry.issue, int) and not isinstance(entry.issue, bool)
+            if (coerced := _coerce_seed(entry.issue)) is not None
         }
     )
     finalizer_issues = sorted(
         {
-            int(finalizer.issue_number)
+            coerced
             for finalizer in inputs.finalizers
-            if isinstance(finalizer.issue_number, int)
-            and not isinstance(finalizer.issue_number, bool)
+            if (coerced := _coerce_seed(finalizer.issue_number)) is not None
         }
     )
 

--- a/tests/validation/test_preflight_slurm_finalizer.py
+++ b/tests/validation/test_preflight_slurm_finalizer.py
@@ -161,9 +161,7 @@ def test_ready_when_queue_issue_recorded_as_string(tmp_path: Path) -> None:
     report = gate.preflight(**inputs)
 
     assert report["ready"] is True
-    traceability = next(
-        c for c in report["checks"] if c["name"] == "issue_traceability_matches"
-    )
+    traceability = next(c for c in report["checks"] if c["name"] == "issue_traceability_matches")
     assert traceability["status"] == "ready"
 
 

--- a/tests/validation/test_preflight_slurm_finalizer.py
+++ b/tests/validation/test_preflight_slurm_finalizer.py
@@ -136,6 +136,44 @@ def test_blocks_when_manifest_linkage_missing(tmp_path: Path) -> None:
     assert "finalizer_manifest_linkage" in blocker_names
 
 
+def test_blocks_when_issue_traceability_mismatches(tmp_path: Path) -> None:
+    """Queue/finalizer issue mismatch blocks public issue traceability."""
+    inputs = _ready_inputs(tmp_path)
+    _write_finalizer(tmp_path / "finalizer.json", issue=9999)
+
+    report = gate.preflight(**inputs)
+
+    assert report["ready"] is False
+    blocker = next(b for b in report["blockers"] if b["check"] == "issue_traceability_matches")
+    assert "align queue and finalizer issue numbers" in blocker["remediation"]
+
+
+def test_blocks_when_queue_issue_traceability_missing(tmp_path: Path) -> None:
+    """Missing queue issue metadata blocks public handoff traceability."""
+    queue = tmp_path / "queue.yaml"
+    queue.write_text(
+        yaml.safe_dump(
+            {
+                "entries": [
+                    {"id": "slice_a", "seeds": [101], "status": "completed"},
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    inputs = {
+        "queue_path": queue,
+        "submission_manifests": [_write_manifest(tmp_path / "manifest.yaml")],
+        "finalizer_manifests": [_write_finalizer(tmp_path / "finalizer.json")],
+    }
+
+    report = gate.preflight(**inputs)
+
+    assert report["ready"] is False
+    blocker = next(b for b in report["blockers"] if b["check"] == "issue_traceability_matches")
+    assert "queue entries do not record an issue number" in blocker["detail"]
+
+
 def test_blocks_when_claim_boundary_missing(tmp_path: Path) -> None:
     """A finalizer without a claim boundary fails closed."""
     inputs = _ready_inputs(tmp_path)

--- a/tests/validation/test_preflight_slurm_finalizer.py
+++ b/tests/validation/test_preflight_slurm_finalizer.py
@@ -148,6 +148,25 @@ def test_blocks_when_issue_traceability_mismatches(tmp_path: Path) -> None:
     assert "align queue and finalizer issue numbers" in blocker["remediation"]
 
 
+def test_ready_when_queue_issue_recorded_as_string(tmp_path: Path) -> None:
+    """A string-encoded queue issue (``issue: "3425"``) still matches the finalizer.
+
+    ``QueueEntry.issue`` is ``str | int | None``; the gate must coerce it exactly
+    like ``reconcile_slurm_evidence`` rather than treating a string as a missing
+    issue number and over-blocking.
+    """
+    inputs = _ready_inputs(tmp_path)
+    _write_queue(inputs["queue_path"], issue="3425")  # type: ignore[arg-type]
+
+    report = gate.preflight(**inputs)
+
+    assert report["ready"] is True
+    traceability = next(
+        c for c in report["checks"] if c["name"] == "issue_traceability_matches"
+    )
+    assert traceability["status"] == "ready"
+
+
 def test_blocks_when_queue_issue_traceability_missing(tmp_path: Path) -> None:
     """Missing queue issue metadata blocks public handoff traceability."""
     queue = tmp_path / "queue.yaml"


### PR DESCRIPTION
## Summary

- Adds a fail-closed issue traceability check to the SLURM-to-claim finalizer preflight for issue #3425.
- Blocks readiness when queue issue metadata is missing, finalizer issue metadata is missing, or queue/finalizer issue numbers disagree.
- Extends synthetic finalizer preflight tests for mismatched and missing issue provenance.

Issue: #3425
URL: https://github.com/ll7/robot_sf_ll7/issues/3425

## Scope Summary

This PR stays within the local readiness/preflight checker slice. It strengthens the existing CPU-only finalizer readiness gate and does not run or claim the full SLURM-to-claim vertical slice.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_preflight_slurm_finalizer.py -q` -> passed, 13 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/preflight_slurm_finalizer.py tests/validation/test_preflight_slurm_finalizer.py` -> passed.
- `git diff --check` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- env PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/validation/pr_body/issue_3425_pr_body.md scripts/dev/pr_ready_check.sh` -> passed; freshness stamp recorded for `de599bd898ece3ac733fbf5b290aa2709e31c8fe`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> passed with `fresh: true`.

## Artifact Classification

Generated validation outputs under `output/coverage/` and `output/validation/pr_ready/` are ignored local validation artifacts. No durable benchmark, model, release, or paper artifact was produced or promoted.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No claim promotion or release artifact publication.

## Residual Risk

This is a readiness/preflight slice only. A real SLURM-to-claim finalizer run still requires an approved SLURM-capable route and real finalizer artifacts before issue #3425 can claim end-to-end evidence.
