### PR TITLE
Issue #3723: expose SNQI weight inventory alias

### DIFF
--- a/robot_sf/benchmark/snqi/cli.py
+++ b/robot_sf/benchmark/snqi/cli.py
@@ -383,6 +383,7 @@ def create_parser() -> argparse.ArgumentParser:
     # Weight-set provenance inventory subcommand (read-only diagnostic)
     inventory_parser = subparsers.add_parser(
         "inventory",
+        aliases=["weights-inventory"],
         help="Inventory SNQI weight sets and report provenance conflicts (read-only)",
     )
     inventory_parser.add_argument(
@@ -424,7 +425,7 @@ def main() -> int:
         return cmd_recompute_weights(args)
     elif args.command == "ablation":
         return cmd_ablation_analysis(args)
-    elif args.command == "inventory":
+    elif args.command in {"inventory", "weights-inventory"}:
         return cmd_inventory_weights(args)
     else:
         return 1

--- a/tests/benchmark/test_snqi_weight_inventory_cli.py
+++ b/tests/benchmark/test_snqi_weight_inventory_cli.py
@@ -1,0 +1,36 @@
+"""CLI coverage for the SNQI weight-set provenance inventory."""
+
+from __future__ import annotations
+
+import json
+import sys
+
+import pytest
+
+from robot_sf.benchmark.snqi import cli as snqi_cli
+
+
+def test_weights_inventory_alias_reports_conflict_fail_closed(
+    monkeypatch: pytest.MonkeyPatch,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The explicit weight-inventory alias reports #3723 conflicts fail-closed."""
+    monkeypatch.setattr(sys, "argv", ["robot_sf_snqi", "weights-inventory", "--json"])
+
+    assert snqi_cli.main() == 2
+
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["has_blocking_conflict"] is True
+    assert {record["name"] for record in payload["records"]} == {
+        "code_default",
+        "model_canonical_v1",
+        "camera_ready_v1",
+        "camera_ready_v2",
+        "camera_ready_v3",
+    }
+    assert any(
+        conflict["kind"] == "canonical_direction_conflict"
+        and conflict["severity"] == "error"
+        and set(conflict["sources"]) == {"code_default", "model_canonical_v1"}
+        for conflict in payload["conflicts"]
+    )


### PR DESCRIPTION
## Summary

Expose the existing Social Navigation Quality Index (SNQI) weight-set provenance inventory through an explicit `weights-inventory` CLI alias, while keeping the existing `inventory` command intact.

## Linked Issues

- Refs #3723 (bounded slice: discoverability alias only; does not resolve the decision-required canonical-weight-set choice, so the parent issue stays open)

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed

- Added `robot_sf_snqi weights-inventory` as an alias for the existing read-only SNQI weight inventory command.
- Added a focused regression test proving the alias reports all registered weight sources and exits fail-closed on the current code-default vs shipped JSON canonical-direction conflict.

## Why Matters

- Added value: makes the #3723 diagnostic entry point discoverable by name without changing any scoring behavior.
- Expected impact: users can run an explicit weight-set inventory/preflight and see the current provenance conflict.
- Why worth merging now: low-risk usability hardening for an already implemented fail-closed diagnostic.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #3723 blocker visibility only.
- Comparator or baseline, applicable: current `robot_sf_snqi inventory` behavior.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision stop rule, applicable: alias reports the same conflict and returns the fail-closed validation exit code.
- Parent issue, claim map, registry, context note, synthesis surface update: #3723
- New research/benchmark/metric/paper-facing analysis tool, any: NA - this exposes an existing support diagnostic alias and does not interpret new evidence.

## Domain-Aware Approval

- Required for this PR: SNQI provenance preflight CLI surface
- Domains reviewed: SNQI weight provenance diagnostics, CLI fail-closed behavior
- Status: waived
- Approver/review source or waiver: support diagnostic alias only; no metric semantics, benchmark interpretation, paper claim, or canonical weight decision changed.
- Approver/review source waiver: support diagnostic alias only; no metric semantics, benchmark interpretation, paper claim, or canonical weight decision changed.
- Validity checklist: no metric semantics or benchmark interpretation changed.
- Target claim/hypothesis: #3723 provenance conflict is visible through CLI preflight.
- Comparator or split/evidence validity: direct CLI/test comparison to existing inventory behavior; no planner comparator split is introduced.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution involved.
- Claim boundary: diagnostic/preflight only.
- Implementation integrity vs experimental validity: implementation-only alias plus regression test; no experimental validity claim.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? command source only; SNQI scoring unchanged.
- Did scenario actually contain targeted failure mode? yes, repository fixtures include the current canonical-direction conflict.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action

- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue
- Proposed child issue existing follow-up: none

## Validation / Proof

- `pytest tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py tests/benchmark/test_snqi_weight_inventory_cli.py -q` -> 15 passed
- `ruff format robot_sf/benchmark/snqi/cli.py tests/benchmark/test_snqi_weight_inventory_cli.py` -> 2 files left unchanged
- `ruff check robot_sf/benchmark/snqi/cli.py tests/benchmark/test_snqi_weight_inventory_cli.py` -> all checks passed
- `python -m robot_sf.benchmark.snqi.cli weights-inventory --json` -> exit 2 as expected; emitted all registered sources and `canonical_direction_conflict` between `code_default` and `model_canonical_v1`
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance

- Baseline runtime: NA, no runtime benchmark path changed.
- Changed runtime: NA, no runtime benchmark path changed.
- Representative command: `python -m robot_sf.benchmark.snqi.cli weights-inventory --json`
- Hot-path call count profile anchor: NA, CLI alias only.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: alias fails to parse or no longer reports the current blocking conflict fail-closed.

## Risks / Rollout

- Compatibility risks: low; existing `inventory` command remains supported.
- Failure modes: argparse alias dispatch could drift if command names are refactored.
- Rollback fallback plan: remove alias and test; existing `inventory` command remains available.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: existing `robot_sf/benchmark/snqi/weights_inventory.py` issue #3723 diagnostic contract.
- Any assumptions need to preserved: no canonical weight set is selected by this PR.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: this is a support diagnostic CLI alias and test; no benchmark, registry, claim-map, or paper-facing result is changed.

## Follow-Up Issues

- Deferred work: choosing canonical SNQI weights, changing metric semantics, rerunning campaigns, and editing paper/dissertation claims remain out of scope.
- Issues opened follow-up: none

## Reviewer Notes

- Verify closely: `weights-inventory` is intentionally an alias for existing `inventory`, not a new metric implementation.
- Known limitations: current repository still has the reported SNQI weight provenance conflict until maintainers choose and document a canonical set.

