### PR TITLE
Issue #3699: add SNQI normalization inventory preflight

### DIFF
--- a/scripts/validation/check_snqi_normalization_inventory.py
+++ b/scripts/validation/check_snqi_normalization_inventory.py
@@ -1,0 +1,167 @@
+#!/usr/bin/env python3
+"""Fail-closed SNQI term-normalization inventory for issue #3699.
+
+This checker is diagnostic only. It reports the current Social Navigation
+Quality Index (SNQI) term scaling basis and fails when penalty terms mix raw
+and baseline-normalized inputs. It does not change SNQI scoring, weights, or
+normalization behavior.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any
+
+os.environ.setdefault("TF_CPP_MIN_LOG_LEVEL", "2")
+
+from robot_sf.benchmark.snqi.exit_codes import (
+    EXIT_INPUT_ERROR,
+    EXIT_SUCCESS,
+    EXIT_VALIDATION_ERROR,
+)
+from robot_sf.benchmark.snqi.normalization_inventory import (
+    build_snqi_normalization_inventory,
+)
+
+CLAIM_BOUNDARY = (
+    "secondary_diagnostic_only: reports issue #3699 SNQI term-normalization "
+    "status. It does not normalize raw terms, alter weights, change "
+    "compute_snqi output, or promote SNQI to a primary safety ranking."
+)
+
+
+def _load_baseline_stats(path: Path | None) -> dict[str, dict[str, float]] | None:
+    """Load optional baseline stats for normalized-term coverage diagnostics."""
+    if path is None:
+        return None
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise ValueError(f"could not read baseline stats {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"could not parse baseline stats {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError(f"baseline stats must be a JSON object: {path}")
+    return raw
+
+
+def build_normalization_preflight_report(
+    baseline_stats: dict[str, dict[str, float]] | None = None,
+) -> dict[str, Any]:
+    """Build the issue #3699 normalization inventory preflight payload."""
+    inventory = build_snqi_normalization_inventory(baseline_stats)
+    blockers: list[dict[str, Any]] = []
+
+    if inventory.mixed_scale:
+        blockers.append(
+            {
+                "issue": 3699,
+                "kind": "mixed_normalization_basis",
+                "detail": (
+                    "SNQI penalty terms mix raw inputs with baseline-normalized "
+                    "inputs, so weights are not comparable relative priorities."
+                ),
+                "raw_penalty_terms": [term.term for term in inventory.raw_penalty_terms],
+                "normalized_penalty_terms": [
+                    term.term for term in inventory.normalized_penalty_terms
+                ],
+            }
+        )
+
+    if baseline_stats is not None and inventory.missing_baseline_coverage:
+        blockers.append(
+            {
+                "issue": 3699,
+                "kind": "missing_baseline_coverage",
+                "detail": (
+                    "At least one baseline-normalized SNQI term lacks median/p95 "
+                    "coverage and would be silently zeroed by normalize_metric."
+                ),
+                "metrics": [term.metric_key for term in inventory.missing_baseline_coverage],
+            }
+        )
+
+    return {
+        "schema_version": "snqi_normalization_inventory_preflight.v1",
+        "claim_boundary": CLAIM_BOUNDARY,
+        "status": "failed" if blockers else "passed",
+        "blockers": blockers,
+        "normalization": inventory.to_dict(),
+    }
+
+
+def _print_text_report(report: dict[str, Any]) -> None:
+    """Print a compact human-readable preflight report."""
+    print(CLAIM_BOUNDARY)
+    print(f"SNQI normalization inventory status: {report['status']}")
+    if report["blockers"]:
+        print("Blocking diagnostics:")
+        for blocker in report["blockers"]:
+            print(f" - issue #{blocker['issue']} {blocker['kind']}: {blocker['detail']}")
+    else:
+        print("No blocking SNQI normalization diagnostics detected.")
+
+    normalization = report["normalization"]
+    print(
+        "Normalization basis: "
+        f"mixed_scale={normalization['mixed_scale']}; "
+        f"raw_penalty_terms={', '.join(normalization['raw_penalty_terms']) or 'none'}; "
+        "baseline_normalized_penalty_terms="
+        f"{', '.join(normalization['normalized_penalty_terms']) or 'none'}"
+    )
+    print("Term normalization status:")
+    for term in normalization["terms"]:
+        role = "penalty" if term["is_penalty"] else "reward"
+        print(
+            f" - {term['term']} ({term['metric_key']}, {term['weight_name']}): "
+            f"{term['normalization_status']}; role={role}; note={term['note']}"
+        )
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--baseline-stats",
+        type=Path,
+        help="Optional baseline-stats JSON for normalized-term coverage checks.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON to stdout.")
+    parser.add_argument("--json-out", type=Path, help="Write JSON report to this path.")
+    parser.add_argument(
+        "--allow-mixed-basis",
+        action="store_true",
+        help="Exit 0 after reporting current mixed-basis diagnostics.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the issue #3699 normalization inventory preflight."""
+    args = _build_parser().parse_args(argv)
+    try:
+        baseline_stats = _load_baseline_stats(args.baseline_stats)
+        report = build_normalization_preflight_report(baseline_stats)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        _print_text_report(report)
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(report, indent=2, sort_keys=True), encoding="utf-8")
+
+    if report["blockers"] and not args.allow_mixed_basis:
+        return EXIT_VALIDATION_ERROR
+    return EXIT_SUCCESS
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/benchmark/test_snqi_normalization_inventory_preflight.py
+++ b/tests/benchmark/test_snqi_normalization_inventory_preflight.py
@@ -1,0 +1,107 @@
+"""Tests for the issue #3699 SNQI normalization-inventory preflight."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from robot_sf.benchmark.snqi.compute import compute_snqi
+from scripts.validation.check_snqi_normalization_inventory import (
+    build_normalization_preflight_report,
+    main,
+)
+
+_BASELINE_STATS = {
+    "collisions": {"med": 1.0, "p95": 5.0},
+    "near_misses": {"med": 2.0, "p95": 8.0},
+    "force_exceed_events": {"med": 0.0, "p95": 4.0},
+    "jerk_mean": {"med": 0.1, "p95": 1.0},
+}
+
+_WEIGHTS = {
+    "w_success": 1.0,
+    "w_time": 0.8,
+    "w_collisions": 2.0,
+    "w_near": 1.0,
+    "w_comfort": 0.5,
+    "w_force_exceed": 1.5,
+    "w_jerk": 0.3,
+}
+
+_MIXED_BASIS_FIXTURE = {
+    "success": 1.0,
+    "time_to_goal_norm": 4.0,
+    "collisions": 4.0,
+    "near_misses": 9.0,
+    "comfort_exposure": 12.5,
+    "force_exceed_events": 5.0,
+    "jerk_mean": 2.0,
+}
+
+
+def test_preflight_reports_mixed_basis_without_changing_snqi_output() -> None:
+    """Synthetic mixed-basis fixture fails closed while scoring remains unchanged."""
+    before = compute_snqi(_MIXED_BASIS_FIXTURE, _WEIGHTS, _BASELINE_STATS)
+    report = build_normalization_preflight_report(_BASELINE_STATS)
+    after = compute_snqi(_MIXED_BASIS_FIXTURE, _WEIGHTS, _BASELINE_STATS)
+
+    assert before == pytest.approx(after)
+    assert report["status"] == "failed"
+    assert [blocker["kind"] for blocker in report["blockers"]] == ["mixed_normalization_basis"]
+    blocker = report["blockers"][0]
+    assert blocker["raw_penalty_terms"] == ["time", "comfort"]
+    assert blocker["normalized_penalty_terms"] == [
+        "collisions",
+        "near",
+        "force_exceed",
+        "jerk",
+    ]
+    status_by_term = {
+        term["term"]: term["normalization_status"] for term in report["normalization"]["terms"]
+    }
+    assert status_by_term["time"] == "raw_unbounded"
+    assert status_by_term["comfort"] == "raw_unbounded"
+    assert status_by_term["collisions"] == "baseline_normalized_bounded"
+
+
+def test_preflight_main_fails_closed_but_allows_inspection(tmp_path) -> None:
+    """Default command fails closed; explicit inspection mode exits successfully."""
+    json_out = tmp_path / "snqi_normalization_inventory.json"
+
+    assert main(["--json-out", str(json_out)]) == 2
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "snqi_normalization_inventory_preflight.v1"
+    assert payload["status"] == "failed"
+    assert payload["blockers"][0]["kind"] == "mixed_normalization_basis"
+
+    assert main(["--json", "--allow-mixed-basis"]) == 0
+
+
+def test_preflight_text_lists_each_term_status(capsys: pytest.CaptureFixture[str]) -> None:
+    """Human output names each term's normalization status."""
+    assert main(["--allow-mixed-basis"]) == 0
+    out = capsys.readouterr().out
+
+    assert "Term normalization status:" in out
+    assert "time (time_to_goal_norm, w_time): raw_unbounded" in out
+    assert "comfort (comfort_exposure, w_comfort): raw_unbounded" in out
+    assert "collisions (collisions, w_collisions): baseline_normalized_bounded" in out
+    assert "jerk (jerk_mean, w_jerk): baseline_normalized_bounded" in out
+
+
+def test_preflight_reports_optional_missing_baseline_coverage(tmp_path) -> None:
+    """Supplying incomplete baseline stats surfaces normalized-term coverage gaps."""
+    baseline_stats = {
+        "collisions": {"med": 0.0, "p95": 1.0},
+        "near_misses": {"med": 0.0, "p95": 1.0},
+    }
+    path = tmp_path / "baseline_stats.json"
+    path.write_text(json.dumps(baseline_stats), encoding="utf-8")
+
+    assert main(["--baseline-stats", str(path)]) == 2
+    report = build_normalization_preflight_report(baseline_stats)
+    missing = [b for b in report["blockers"] if b["kind"] == "missing_baseline_coverage"]
+
+    assert missing
+    assert set(missing[0]["metrics"]) == {"force_exceed_events", "jerk_mean"}


### PR DESCRIPTION
## Summary
Adds a standalone, fail-closed Social Navigation Quality Index (SNQI) normalization-inventory preflight for issue #3699. The checker lists each term's raw or baseline-normalized status and reports mixed penalty-term inputs without changing SNQI scoring.

## Linked Issues
- Relates `#3699`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `scripts/validation/check_snqi_normalization_inventory.py`, a diagnostic-only checker that fails closed on `mixed_normalization_basis` and supports `--allow-mixed-basis` inspection mode.
- Added focused tests covering the synthetic mixed-basis fixture, per-term status output, fail-closed exit behavior, optional baseline coverage checks, and unchanged `compute_snqi` output.

## Why Matters
- Added value: exposes the #3699 raw-vs-baseline-normalized term mismatch through a dedicated preflight not entangled with other SNQI governance blockers.
- Expected impact: reviewers and future redesign work can inspect term normalization status directly while current SNQI values remain unchanged.
- Why worth merging now: this is the reversible diagnostic slice requested in the latest issue comment and preserves the normalize-vs-bound decision for a later semantic PR.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3699 diagnostic blocker visibility only.
- Comparator or baseline, applicable: existing `compute_snqi` output on a synthetic mixed-basis fixture.
- Evidence tier: NA - support checker only; no benchmark result claimed.
- Result classification: NA - diagnostic support surface only.
- Decision stop rule, applicable: checker reports mixed raw/baseline-normalized penalty terms and focused tests prove scoring remains unchanged.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3699 remains open for the normalization redesign decision.
- New research/benchmark/metric/paper-facing analysis tool, any: support checker only; no benchmark interpretation or claim promotion.

## Domain-Aware Approval
- Required PR: no - support checker only; no benchmark result or claim promoted.
- Domains reviewed: NA - no domain-aware approval required.
- Status: not applicable - no domain-sensitive evidence claim.
- Approver/review source waiver: NA - diagnostic support checker only.
- Validity checklist: no benchmark result or paper-facing claim is promoted.
- Target claim/hypothesis: issue #3699 diagnostic visibility only.
- Comparator or split/evidence validity: synthetic fixture verifies unchanged scoring.
- Fallback/degraded exclusions: no fallback or degraded benchmark execution involved.
- Claim boundary: secondary diagnostic only; no normalization redesign.
- Implementation integrity vs experimental validity: implementation integrity covered by focused tests; experimental validity not claimed.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, checker exits 2 on current mixed-basis inventory.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, synthetic fixture and current inventory include raw `time`/`comfort` penalty terms and baseline-normalized count/jerk penalty terms.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: #3699 still needs normalize-vs-bound redesign decision.

## Next Empirical Action
- Rerun needed: no for this diagnostic slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with later #3699 semantic decision PR.
- Proposed child issue existing follow-up: #3699 remains the follow-up surface.

## Validation / Proof
- `uv run ruff check scripts/validation/check_snqi_normalization_inventory.py tests/benchmark/test_snqi_normalization_inventory_preflight.py` -> passed.
- `uv run pytest tests/benchmark/test_snqi_normalization_inventory_preflight.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py -q` -> 19 passed.
- `uv run python scripts/validation/check_snqi_normalization_inventory.py --json` -> exit 2 with #3699 `mixed_normalization_basis`; raw penalty terms `time`, `comfort`; normalized penalty terms `collisions`, `near`, `force_exceed`, `jerk`.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed after `uv sync --all-extras`.
- Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: low; new checker and tests only.
- Failure modes: future SNQI term changes could require updating the canonical inventory used by this checker.
- Rollback fallback plan: remove the standalone checker/tests; existing SNQI scoring is untouched.

## Docs / Provenance
- Updated docs: none; checker has CLI help and JSON schema version.
- Relevant design provenance notes: issue #3699 latest comment requested a reversible fail-closed inventory.
- Any assumptions need to preserved: normalize-vs-bound semantic decision remains out of scope.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: diagnostic support checker only; no benchmark results, registry changes, claim-map changes, or paper-facing claims.

## Follow-Up Issues
- Deferred work: #3699 normalize raw terms vs document bounded asymmetry decision and semantic implementation.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer verify closely: ensure this remains diagnostic-only and does not change `compute_snqi`, weights, or `normalize_metric`.
- Any known limitations: the checker reports the current mixed basis; it does not resolve it.
