### PR TITLE
Issue #3213: add maneuver-authority sweep manifest preflight

### DIFF
--- a/configs/benchmarks/maneuver_authority_sweep_manifest_issue_3213.yaml
+++ b/configs/benchmarks/maneuver_authority_sweep_manifest_issue_3213.yaml
@@ -1,0 +1,117 @@
+schema_version: maneuver-authority-sweep-manifest.v1
+issue: 3213
+benchmark_grid: configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml
+hard_seed_manifest: configs/benchmarks/predictive_hard_seeds_v1.yaml
+default_output_root: output/benchmarks/issue_3213_maneuver_authority
+scope_note: >
+  Metadata-only preflight for the bounded maneuver-authority sweep slice. This
+  manifest declares sweep arms and expected output locations only; it does not
+  run the campaign, submit Slurm/GPU work, or interpret success changes.
+arms:
+  - name: baseline
+    grid_variant: baseline
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_baseline.yaml
+    action_lattice:
+      candidate_speed_count: 5
+      heading_delta_count: 7
+      near_field_speed_count: 4
+      near_field_heading_delta_count: 8
+    turn_authority:
+      max_angular_speed: 1.2
+      heading_delta_count: 7
+      near_field_heading_delta_count: 8
+    kinematic_adapter:
+      command_space: unicycle_vw
+      robot_kinematics: differential_drive
+      execution_mode: adapter
+      planner_family: prediction_planner
+    expected_outputs:
+      campaign_root: output/benchmarks/issue_3213_maneuver_authority/baseline
+      campaign_summary: output/benchmarks/issue_3213_maneuver_authority/baseline/campaign_summary.json
+      campaign_report: output/benchmarks/issue_3213_maneuver_authority/baseline/campaign_report.md
+  - name: high_angular
+    grid_variant: high_angular
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_high_angular.yaml
+    action_lattice:
+      candidate_speed_count: 5
+      heading_delta_count: 9
+      near_field_speed_count: 4
+      near_field_heading_delta_count: 8
+    turn_authority:
+      max_angular_speed: 1.8
+      heading_delta_count: 9
+      near_field_heading_delta_count: 8
+    kinematic_adapter:
+      command_space: unicycle_vw
+      robot_kinematics: differential_drive
+      execution_mode: adapter
+      planner_family: prediction_planner
+    expected_outputs:
+      campaign_root: output/benchmarks/issue_3213_maneuver_authority/high_angular
+      campaign_summary: output/benchmarks/issue_3213_maneuver_authority/high_angular/campaign_summary.json
+      campaign_report: output/benchmarks/issue_3213_maneuver_authority/high_angular/campaign_report.md
+  - name: dense_lattice
+    grid_variant: dense_lattice
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_dense_lattice.yaml
+    action_lattice:
+      candidate_speed_count: 7
+      heading_delta_count: 9
+      near_field_speed_count: 4
+      near_field_heading_delta_count: 8
+    turn_authority:
+      max_angular_speed: 1.2
+      heading_delta_count: 9
+      near_field_heading_delta_count: 8
+    kinematic_adapter:
+      command_space: unicycle_vw
+      robot_kinematics: differential_drive
+      execution_mode: adapter
+      planner_family: prediction_planner
+    expected_outputs:
+      campaign_root: output/benchmarks/issue_3213_maneuver_authority/dense_lattice
+      campaign_summary: output/benchmarks/issue_3213_maneuver_authority/dense_lattice/campaign_summary.json
+      campaign_report: output/benchmarks/issue_3213_maneuver_authority/dense_lattice/campaign_report.md
+  - name: nearfield_turn
+    grid_variant: nearfield_turn
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_nearfield_turn.yaml
+    action_lattice:
+      candidate_speed_count: 5
+      heading_delta_count: 7
+      near_field_speed_count: 4
+      near_field_heading_delta_count: 11
+    turn_authority:
+      max_angular_speed: 1.2
+      heading_delta_count: 7
+      near_field_heading_delta_count: 11
+      near_field_speed_cap: 0.8
+    kinematic_adapter:
+      command_space: unicycle_vw
+      robot_kinematics: differential_drive
+      execution_mode: adapter
+      planner_family: prediction_planner
+    expected_outputs:
+      campaign_root: output/benchmarks/issue_3213_maneuver_authority/nearfield_turn
+      campaign_summary: output/benchmarks/issue_3213_maneuver_authority/nearfield_turn/campaign_summary.json
+      campaign_report: output/benchmarks/issue_3213_maneuver_authority/nearfield_turn/campaign_report.md
+  - name: combined_max_authority
+    grid_variant: combined_max_authority
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_combined_max_authority.yaml
+    action_lattice:
+      candidate_speed_count: 7
+      heading_delta_count: 9
+      near_field_speed_count: 4
+      near_field_heading_delta_count: 11
+    turn_authority:
+      max_angular_speed: 1.8
+      heading_delta_count: 9
+      near_field_heading_delta_count: 11
+      near_field_speed_cap: 0.8
+    kinematic_adapter:
+      command_space: unicycle_vw
+      robot_kinematics: differential_drive
+      execution_mode: adapter
+      planner_family: prediction_planner
+    expected_outputs:
+      campaign_root: output/benchmarks/issue_3213_maneuver_authority/combined_max_authority
+      campaign_summary: output/benchmarks/issue_3213_maneuver_authority/combined_max_authority/campaign_summary.json
+      campaign_report: output/benchmarks/issue_3213_maneuver_authority/combined_max_authority/campaign_report.md

--- a/robot_sf/benchmark/maneuver_authority_sweep_manifest.py
+++ b/robot_sf/benchmark/maneuver_authority_sweep_manifest.py
@@ -1,0 +1,443 @@
+"""Fail-closed checker for issue #3213 maneuver-authority sweep manifests."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_VERSION = "maneuver-authority-sweep-manifest.v1"
+MANIFEST_STATUS_READY = "ready"
+MANIFEST_STATUS_MISSING = "missing"
+MANIFEST_STATUS_MALFORMED = "malformed"
+EXPECTED_OUTPUT_PREFIX = "output/benchmarks/issue_3213_maneuver_authority"
+
+_REQUIRED_ARM_METADATA = (
+    "action_lattice",
+    "turn_authority",
+    "kinematic_adapter",
+    "expected_outputs",
+)
+_REQUIRED_ADAPTER_FIELDS = ("command_space", "robot_kinematics", "execution_mode")
+_REQUIRED_OUTPUT_FIELDS = ("campaign_root", "campaign_summary", "campaign_report")
+_MALFORMED_CODES = {
+    "duplicate_arm_name",
+    "invalid_action_lattice_metadata",
+    "invalid_arm",
+    "invalid_expected_output_path",
+    "invalid_expected_output_root",
+    "invalid_issue",
+    "invalid_kinematic_adapter_metadata",
+    "invalid_path",
+    "invalid_schema_version",
+    "invalid_turn_authority_metadata",
+    "manifest_not_mapping",
+    "missing_arm_metadata",
+    "missing_arm_name",
+    "missing_arms",
+    "missing_grid_variant",
+    "unknown_grid_variant",
+}
+
+
+def _load_yaml(path: Path) -> Any:
+    """Load a YAML document.
+
+    Returns:
+        Parsed YAML content, or an empty mapping for an empty document.
+    """
+    with path.open("r", encoding="utf-8") as handle:
+        return yaml.safe_load(handle) or {}
+
+
+def _relative_path(value: Any) -> str | None:
+    """Return ``value`` when it is a non-empty relative string path."""
+    if not isinstance(value, str) or not value:
+        return None
+    if Path(value).is_absolute():
+        return None
+    return value
+
+
+def _diagnostic(code: str, **details: Any) -> dict[str, Any]:
+    """Build a compact structured diagnostic.
+
+    Returns:
+        Diagnostic dictionary with a stable ``code`` field plus caller details.
+    """
+    return {"code": code, **details}
+
+
+def _missing_report(manifest_path: str | Path) -> dict[str, Any]:
+    """Return a fail-closed missing-manifest report."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": MANIFEST_STATUS_MISSING,
+        "issue": 3213,
+        "manifest": str(manifest_path),
+        "arms": [],
+        "diagnostics": [_diagnostic("missing_manifest", path=str(manifest_path))],
+    }
+
+
+def _malformed_report(manifest_path: str | Path, code: str) -> dict[str, Any]:
+    """Return a fail-closed malformed-manifest report."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": MANIFEST_STATUS_MALFORMED,
+        "issue": 3213,
+        "manifest": str(manifest_path),
+        "arms": [],
+        "diagnostics": [_diagnostic(code)],
+    }
+
+
+def _validate_repo_path(
+    *,
+    repo_root: Path,
+    path_value: Any,
+    field: str,
+    code: str,
+    diagnostics: list[dict[str, Any]],
+    arm: str | None = None,
+) -> str | None:
+    """Validate a required manifest path and report diagnostics.
+
+    Returns:
+        The relative path string when syntactically valid; otherwise ``None``.
+    """
+    relative = _relative_path(path_value)
+    if relative is None:
+        diagnostics.append(_diagnostic("invalid_path", field=field, arm=arm))
+        return None
+    if not (repo_root / relative).exists():
+        diagnostics.append(_diagnostic(code, field=field, path=relative, arm=arm))
+    return relative
+
+
+def _grid_variant_names(repo_root: Path, grid_path: str | None) -> set[str]:
+    """Return declared grid variant names, or an empty set when unavailable."""
+    if grid_path is None:
+        return set()
+    path = repo_root / grid_path
+    if not path.exists():
+        return set()
+    payload = _load_yaml(path)
+    variants = payload.get("variants", []) if isinstance(payload, dict) else []
+    return {
+        str(variant.get("name"))
+        for variant in variants
+        if isinstance(variant, dict) and variant.get("name")
+    }
+
+
+def _require_metadata_dicts(
+    arm: dict[str, Any],
+    arm_name: str,
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Report missing top-level arm metadata dictionaries."""
+    for field in _REQUIRED_ARM_METADATA:
+        if not isinstance(arm.get(field), dict):
+            diagnostics.append(_diagnostic("missing_arm_metadata", arm=arm_name, field=field))
+
+
+def _validate_action_lattice(
+    arm: dict[str, Any],
+    arm_name: str,
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Validate action-lattice metadata fields."""
+    action_lattice = arm.get("action_lattice", {})
+    if not isinstance(action_lattice, dict):
+        return
+    for field in ("candidate_speed_count", "heading_delta_count"):
+        if not isinstance(action_lattice.get(field), int) or action_lattice[field] < 1:
+            diagnostics.append(
+                _diagnostic("invalid_action_lattice_metadata", arm=arm_name, field=field)
+            )
+
+
+def _validate_turn_authority(
+    arm: dict[str, Any],
+    arm_name: str,
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Validate turn-authority metadata fields."""
+    turn_authority = arm.get("turn_authority", {})
+    if not isinstance(turn_authority, dict):
+        return
+    if not isinstance(turn_authority.get("max_angular_speed"), int | float):
+        diagnostics.append(
+            _diagnostic(
+                "invalid_turn_authority_metadata",
+                arm=arm_name,
+                field="max_angular_speed",
+            )
+        )
+    if not isinstance(turn_authority.get("heading_delta_count"), int):
+        diagnostics.append(
+            _diagnostic(
+                "invalid_turn_authority_metadata",
+                arm=arm_name,
+                field="heading_delta_count",
+            )
+        )
+
+
+def _validate_adapter(
+    arm: dict[str, Any],
+    arm_name: str,
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Validate kinematic-adapter metadata fields."""
+    adapter = arm.get("kinematic_adapter", {})
+    if not isinstance(adapter, dict):
+        return
+    for field in _REQUIRED_ADAPTER_FIELDS:
+        if not isinstance(adapter.get(field), str) or not adapter[field]:
+            diagnostics.append(
+                _diagnostic("invalid_kinematic_adapter_metadata", arm=arm_name, field=field)
+            )
+
+
+def _validate_expected_outputs(
+    *,
+    arm: dict[str, Any],
+    arm_name: str,
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Validate declared output locations without requiring generated outputs."""
+    outputs = arm.get("expected_outputs", {})
+    if not isinstance(outputs, dict):
+        return
+    allowed_prefixes = (EXPECTED_OUTPUT_PREFIX, f"{EXPECTED_OUTPUT_PREFIX}/")
+    for field in _REQUIRED_OUTPUT_FIELDS:
+        relative = _relative_path(outputs.get(field))
+        if relative is None:
+            diagnostics.append(
+                _diagnostic("invalid_expected_output_path", arm=arm_name, field=field)
+            )
+        elif not relative.startswith(allowed_prefixes):
+            diagnostics.append(
+                _diagnostic(
+                    "invalid_expected_output_root",
+                    arm=arm_name,
+                    field=field,
+                    path=relative,
+                    expected_prefix=EXPECTED_OUTPUT_PREFIX,
+                )
+            )
+
+
+def _validate_arm_metadata(
+    arm: dict[str, Any],
+    arm_name: str,
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Validate all per-arm metadata blocks."""
+    _require_metadata_dicts(arm, arm_name, diagnostics)
+    _validate_action_lattice(arm, arm_name, diagnostics)
+    _validate_turn_authority(arm, arm_name, diagnostics)
+    _validate_adapter(arm, arm_name, diagnostics)
+    _validate_expected_outputs(arm=arm, arm_name=arm_name, diagnostics=diagnostics)
+
+
+def _validate_header(
+    payload: dict[str, Any],
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Validate manifest header identity fields."""
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        diagnostics.append(
+            _diagnostic(
+                "invalid_schema_version",
+                expected=SCHEMA_VERSION,
+                actual=payload.get("schema_version"),
+            )
+        )
+    if payload.get("issue") != 3213:
+        diagnostics.append(_diagnostic("invalid_issue", expected=3213, actual=payload.get("issue")))
+
+
+def _validate_shared_paths(
+    payload: dict[str, Any],
+    repo_root: Path,
+    diagnostics: list[dict[str, Any]],
+) -> set[str]:
+    """Validate shared manifest paths.
+
+    Returns:
+        Known variant names from the referenced benchmark grid, or an empty set.
+    """
+    grid_path = _validate_repo_path(
+        repo_root=repo_root,
+        path_value=payload.get("benchmark_grid"),
+        field="benchmark_grid",
+        code="missing_benchmark_grid",
+        diagnostics=diagnostics,
+    )
+    _validate_repo_path(
+        repo_root=repo_root,
+        path_value=payload.get("hard_seed_manifest"),
+        field="hard_seed_manifest",
+        code="missing_hard_seed_manifest",
+        diagnostics=diagnostics,
+    )
+    return _grid_variant_names(repo_root, grid_path)
+
+
+def _validate_arm_identity(
+    *,
+    arm: dict[str, Any],
+    seen_names: set[str],
+    diagnostics: list[dict[str, Any]],
+) -> str | None:
+    """Validate a sweep arm name.
+
+    Returns:
+        The arm name when valid; otherwise ``None``.
+    """
+    arm_name = arm.get("name")
+    if not isinstance(arm_name, str) or not arm_name:
+        diagnostics.append(_diagnostic("missing_arm_name"))
+        return None
+    if arm_name in seen_names:
+        diagnostics.append(_diagnostic("duplicate_arm_name", arm=arm_name))
+    seen_names.add(arm_name)
+    return arm_name
+
+
+def _validate_grid_variant(
+    *,
+    arm: dict[str, Any],
+    arm_name: str,
+    grid_variants: set[str],
+    diagnostics: list[dict[str, Any]],
+) -> Any:
+    """Validate the declared grid variant.
+
+    Returns:
+        The raw grid variant value from the arm payload.
+    """
+    grid_variant = arm.get("grid_variant")
+    if not isinstance(grid_variant, str) or not grid_variant:
+        diagnostics.append(_diagnostic("missing_grid_variant", arm=arm_name))
+    elif grid_variants and grid_variant not in grid_variants:
+        diagnostics.append(
+            _diagnostic("unknown_grid_variant", arm=arm_name, grid_variant=grid_variant)
+        )
+    return grid_variant
+
+
+def _report_arm(arm: dict[str, Any], arm_name: str, grid_variant: Any) -> dict[str, Any]:
+    """Return the normalized arm payload used in checker reports."""
+    return {
+        "name": arm_name,
+        "grid_variant": grid_variant,
+        "algo_config": arm.get("algo_config"),
+        "action_lattice": arm.get("action_lattice"),
+        "turn_authority": arm.get("turn_authority"),
+        "kinematic_adapter": arm.get("kinematic_adapter"),
+        "expected_outputs": arm.get("expected_outputs"),
+    }
+
+
+def _validate_arms(
+    payload: dict[str, Any],
+    repo_root: Path,
+    grid_variants: set[str],
+    diagnostics: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    """Validate all sweep arms.
+
+    Returns:
+        Normalized arm entries used by the checker report.
+    """
+    arms = payload.get("arms")
+    if not isinstance(arms, list) or not arms:
+        diagnostics.append(_diagnostic("missing_arms"))
+        return []
+
+    seen_names: set[str] = set()
+    report_arms: list[dict[str, Any]] = []
+    for arm in arms:
+        if not isinstance(arm, dict):
+            diagnostics.append(_diagnostic("invalid_arm"))
+            continue
+        arm_name = _validate_arm_identity(
+            arm=arm,
+            seen_names=seen_names,
+            diagnostics=diagnostics,
+        )
+        if arm_name is None:
+            continue
+        _validate_repo_path(
+            repo_root=repo_root,
+            path_value=arm.get("algo_config"),
+            field="algo_config",
+            code="missing_algo_config",
+            diagnostics=diagnostics,
+            arm=arm_name,
+        )
+        grid_variant = _validate_grid_variant(
+            arm=arm,
+            arm_name=arm_name,
+            grid_variants=grid_variants,
+            diagnostics=diagnostics,
+        )
+        _validate_arm_metadata(arm, arm_name, diagnostics)
+        report_arms.append(_report_arm(arm, arm_name, grid_variant))
+    return report_arms
+
+
+def _status_for_diagnostics(diagnostics: list[dict[str, Any]]) -> str:
+    """Return the fail-closed status implied by diagnostics."""
+    if any(diagnostic["code"] in _MALFORMED_CODES for diagnostic in diagnostics):
+        return MANIFEST_STATUS_MALFORMED
+    if diagnostics:
+        return MANIFEST_STATUS_MISSING
+    return MANIFEST_STATUS_READY
+
+
+def check_maneuver_authority_sweep_manifest(
+    manifest_path: str | Path,
+    *,
+    repo_root: str | Path | None = None,
+) -> dict[str, Any]:
+    """Return a fail-closed readiness report for a maneuver-authority sweep manifest.
+
+    The checker validates only preflight metadata and repository-local inputs. It does not
+    execute a sweep, inspect generated results, or promote any benchmark interpretation.
+    """
+    root = Path.cwd() if repo_root is None else Path(repo_root)
+    root = root.resolve()
+    manifest = Path(manifest_path)
+    resolved_manifest = manifest if manifest.is_absolute() else root / manifest
+    if not resolved_manifest.exists():
+        return _missing_report(manifest_path)
+
+    payload = _load_yaml(resolved_manifest)
+    if not isinstance(payload, dict):
+        return _malformed_report(manifest_path, "manifest_not_mapping")
+
+    diagnostics: list[dict[str, Any]] = []
+    _validate_header(payload, diagnostics)
+    grid_variants = _validate_shared_paths(payload, root, diagnostics)
+    report_arms = _validate_arms(payload, root, grid_variants, diagnostics)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": _status_for_diagnostics(diagnostics),
+        "issue": payload.get("issue"),
+        "manifest": str(manifest_path),
+        "benchmark_grid": payload.get("benchmark_grid"),
+        "hard_seed_manifest": payload.get("hard_seed_manifest"),
+        "default_output_root": payload.get("default_output_root"),
+        "arms": report_arms,
+        "diagnostics": diagnostics,
+        "scope_note": (
+            "Metadata-only preflight; no benchmark campaign execution or success interpretation."
+        ),
+    }

--- a/scripts/tools/check_maneuver_authority_sweep_manifest.py
+++ b/scripts/tools/check_maneuver_authority_sweep_manifest.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""CLI for the issue #3213 maneuver-authority sweep manifest checker."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.maneuver_authority_sweep_manifest import (
+    MANIFEST_STATUS_READY,
+    check_maneuver_authority_sweep_manifest,
+)
+
+DEFAULT_MANIFEST = (
+    Path(__file__).resolve().parents[2]
+    / "configs"
+    / "benchmarks"
+    / "maneuver_authority_sweep_manifest_issue_3213.yaml"
+)
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=DEFAULT_MANIFEST,
+        help="Path to maneuver-authority-sweep-manifest.v1 YAML.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=Path.cwd(),
+        help="Repository root used to resolve relative manifest paths.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the checker and print a structured JSON report."""
+    args = _parse_args(argv)
+    report = check_maneuver_authority_sweep_manifest(
+        args.manifest,
+        repo_root=args.repo_root,
+    )
+    print(json.dumps(report, indent=2, sort_keys=True))
+    return 0 if report["status"] == MANIFEST_STATUS_READY else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_maneuver_authority_sweep_manifest.py
+++ b/tests/benchmark/test_maneuver_authority_sweep_manifest.py
@@ -1,0 +1,101 @@
+"""Tests for the issue #3213 maneuver-authority sweep manifest checker."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.maneuver_authority_sweep_manifest import (
+    MANIFEST_STATUS_MALFORMED,
+    MANIFEST_STATUS_MISSING,
+    MANIFEST_STATUS_READY,
+    check_maneuver_authority_sweep_manifest,
+)
+from scripts.tools.check_maneuver_authority_sweep_manifest import main as cli_main
+
+CANONICAL_MANIFEST = Path("configs/benchmarks/maneuver_authority_sweep_manifest_issue_3213.yaml")
+
+
+def _load_manifest(repo_root: Path) -> dict:
+    return yaml.safe_load((repo_root / CANONICAL_MANIFEST).read_text(encoding="utf-8"))
+
+
+def _write_manifest(tmp_path: Path, payload: dict) -> Path:
+    path = tmp_path / "manifest.yaml"
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def test_canonical_manifest_is_ready_and_declares_sweep_arm_metadata() -> None:
+    """The committed issue #3213 manifest should be a ready preflight contract."""
+    repo_root = Path.cwd()
+
+    report = check_maneuver_authority_sweep_manifest(CANONICAL_MANIFEST, repo_root=repo_root)
+
+    assert report["status"] == MANIFEST_STATUS_READY
+    assert report["issue"] == 3213
+    assert {arm["name"] for arm in report["arms"]} >= {
+        "baseline",
+        "high_angular",
+        "dense_lattice",
+        "nearfield_turn",
+        "combined_max_authority",
+    }
+    dense_lattice = next(arm for arm in report["arms"] if arm["name"] == "dense_lattice")
+    assert dense_lattice["action_lattice"]["candidate_speed_count"] == 7
+    assert dense_lattice["turn_authority"]["heading_delta_count"] == 9
+    assert dense_lattice["kinematic_adapter"]["command_space"] == "unicycle_vw"
+    assert dense_lattice["expected_outputs"]["campaign_root"].startswith(
+        "output/benchmarks/issue_3213_maneuver_authority"
+    )
+
+
+def test_missing_arm_config_fails_closed_with_path_diagnostic(tmp_path: Path) -> None:
+    """Missing ordinary inputs should be diagnosed instead of treated as runnable."""
+    repo_root = Path.cwd()
+    payload = _load_manifest(repo_root)
+    payload["arms"][0]["algo_config"] = "configs/algos/hardcase_authority/absent.yaml"
+    manifest = _write_manifest(tmp_path, payload)
+
+    report = check_maneuver_authority_sweep_manifest(manifest, repo_root=repo_root)
+
+    assert report["status"] == MANIFEST_STATUS_MISSING
+    assert report["diagnostics"][0]["arm"] == "baseline"
+    assert report["diagnostics"][0]["code"] == "missing_algo_config"
+    assert report["diagnostics"][0]["path"] == "configs/algos/hardcase_authority/absent.yaml"
+
+
+def test_malformed_arm_metadata_fails_closed(tmp_path: Path) -> None:
+    """Sweep arms without action/turn/adapter metadata should fail closed."""
+    repo_root = Path.cwd()
+    payload = _load_manifest(repo_root)
+    payload["arms"][1].pop("kinematic_adapter")
+    manifest = _write_manifest(tmp_path, payload)
+
+    report = check_maneuver_authority_sweep_manifest(manifest, repo_root=repo_root)
+
+    assert report["status"] == MANIFEST_STATUS_MALFORMED
+    assert {
+        "arm": "high_angular",
+        "code": "missing_arm_metadata",
+        "field": "kinematic_adapter",
+    } in report["diagnostics"]
+
+
+def test_cli_exits_nonzero_for_fail_closed_manifest(tmp_path: Path, capsys) -> None:
+    """The command-line checker should gate malformed manifests with exit code 2."""
+    repo_root = Path.cwd()
+    payload = _load_manifest(repo_root)
+    payload["arms"][0]["expected_outputs"]["campaign_root"] = "tmp/not-durable"
+    manifest = _write_manifest(tmp_path, payload)
+
+    exit_code = cli_main(["--manifest", str(manifest), "--repo-root", str(repo_root)])
+
+    assert exit_code == 2
+    report = json.loads(capsys.readouterr().out)
+    assert report["status"] == MANIFEST_STATUS_MALFORMED
+    assert any(
+        diagnostic["code"] == "invalid_expected_output_root" for diagnostic in report["diagnostics"]
+    )


### PR DESCRIPTION
## Summary
Adds a metadata-only maneuver-authority sweep manifest and fail-closed checker for issue #3213.

## Linked Issues
- Relates `#3213`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `configs/benchmarks/maneuver_authority_sweep_manifest_issue_3213.yaml` declaring the bounded authority sweep arms, action-lattice metadata, turn-authority metadata, kinematic-adapter metadata, and expected output locations.
- Added `robot_sf.benchmark.maneuver_authority_sweep_manifest` plus `scripts/tools/check_maneuver_authority_sweep_manifest.py` for fail-closed manifest preflight diagnostics.
- Added focused tests for valid canonical metadata, missing arm config diagnostics, malformed metadata diagnostics, and CLI non-zero gating.

## Why Matters
- Added value: turns the #3213 safe slice into a reviewable manifest/checker contract without running or interpreting a benchmark campaign.
- Expected impact: future sweep launches can fail closed on missing configs or malformed sweep-arm metadata before spending compute.
- Why worth merging now: it is a bounded preflight improvement for the ready-queue issue and does not change planner behavior.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3213 maneuver-authority sweep launch readiness metadata only.
- Comparator or baseline, applicable: current `baseline` authority arm is declared as metadata; no result comparison is made.
- Evidence tier: NA - support helper only.
- Result classification: NA - no research claim.
- Decision stop rule, applicable: no benchmark decision made in this PR.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3213 linked; no claim map or benchmark report update because this PR adds no result interpretation.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper; representative use is the canonical manifest preflight command in Validation / Proof.

## Domain-Aware Approval
approval concerns experimental validity waived / not required
- Approver/review source waiver: not required; this PR does not change benchmark semantics, evidence classification, comparison methodology, figure eligibility, or claim boundaries.
- Validity checklist:
- Target claim/hypothesis: NA - metadata preflight only.
- Comparator split/evidence validity: NA - no benchmark rows or comparisons produced.
- Fallback/degraded exclusions: checker reports fail-closed diagnostics and does not treat missing/malformed inputs as success.
- Claim boundary: manifest/checker readiness only.
- Implementation integrity vs experimental validity: targeted tests and CLI preflight prove implementation integrity; no experimental-validity claim.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no benchmark mechanism executed.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: NA - support helper only.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: NA - no benchmark campaign run in this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none for manifest preflight; generated benchmark outputs remain out of scope.
- Stop / revise / continue decision: continue only through separate benchmark/execution work, not this PR.
- Proposed child issue existing follow-up: #3213 remains the linked parent.

## Validation / Proof
- `uv run ruff check robot_sf/benchmark/maneuver_authority_sweep_manifest.py scripts/tools/check_maneuver_authority_sweep_manifest.py tests/benchmark/test_maneuver_authority_sweep_manifest.py && uv run ruff format --check robot_sf/benchmark/maneuver_authority_sweep_manifest.py scripts/tools/check_maneuver_authority_sweep_manifest.py tests/benchmark/test_maneuver_authority_sweep_manifest.py` - passed.
- `uv run pytest tests/benchmark/test_maneuver_authority_sweep_manifest.py -q` - passed, 4 tests.
- `uv run python scripts/tools/check_maneuver_authority_sweep_manifest.py --manifest configs/benchmarks/maneuver_authority_sweep_manifest_issue_3213.yaml` - passed, status `ready`, 5 arms, diagnostics `[]`.
- `CUDA_VISIBLE_DEVICES= PR_READY_PR_BODY_FILE=/tmp/issue3213_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed.

Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Performance / Runtime Impact:
- Baseline runtime: NA - no runtime behavior changed.
- Changed runtime: NA - no runtime behavior changed.
- Representative command: `uv run python scripts/tools/check_maneuver_authority_sweep_manifest.py --manifest configs/benchmarks/maneuver_authority_sweep_manifest_issue_3213.yaml`.
- Hot-path call count profile anchor: NA - not a benchmark hot path.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if checker blocks the committed canonical manifest incorrectly or stops reporting missing/malformed inputs fail-closed.

## Risks / Rollout
- Compatibility risks: low; new manifest/checker/test files only.
- Failure modes: metadata drift if future authority arms change without updating the manifest.
- Rollback fallback plan: remove the manifest/checker and continue using existing authority grid/configs.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3213, existing `configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml`, existing `configs/algos/hardcase_authority/*.yaml`.
- Any assumptions need to preserved: per-arm expected output locations are declared for preflight/reviewability only; they are not required to exist before execution.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - authorization disallows issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA - no claim or result interpretation.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA - standalone manifest path is explicit.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR is a metadata/checker preflight and explicitly does not produce benchmark results or paper-facing claims.

## Follow-Up Issues
- Deferred work: broader full campaign execution, success interpretation, or planner tuning remains tracked by #3213 and outside this PR.
- Issues opened follow-up: #3213.

## Reviewer Notes
- Verify the checker stays metadata-only and does not require generated `output/` files to exist.
- Known limitation: metadata values are declared and path-checked; the checker does not execute the planner grid or validate campaign result quality.
