### PR TITLE
Benchmark: reconcile issue 3810 h600 launch packet

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -2,8 +2,9 @@
 #
 # This is a no-submit decision packet, not benchmark evidence. It converts the
 # live issue decisions into a reviewable Slurm launch, analysis, and retention
-# contract. Do not submit from this packet until the private Slurm decision
-# packet is marked go and job 13175 has been reconciled.
+# contract. Do not submit from this packet on a non-Slurm machine. A
+# Slurm-capable submit host must refresh live queue state, duplicate status,
+# and worktree cleanliness before invoking the private submit wrapper.
 schema_version: research-campaign-manifest.v0.1
 campaign:
   id: issue_3810_comprehensive_h600_snqi_recalibration
@@ -213,11 +214,39 @@ validation:
   dry_run: required
 
 launch_packet:
-  decision: blocked_until_private_slurm_go
+  decision: ready_after_live_queue_and_duplicate_check
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  blocking_jobs:
-    - 13175
+  blocking_jobs: []
+  ledger_reconciliation:
+    checked_date: "2026-06-29"
+    source: private_ops_jobs_and_queue_read_only
+    job_13175_state: analyzed
+    job_13175_campaign: 2026-06-issue1554-s20-h500-l40s-mem180
+    job_13175_relevance: >
+      Completed and analyzed #1554 lane; not a #3810 blocker after read-only
+      private-ops reconciliation.
+    running_related_jobs:
+      - job_id: 13198
+        state: running
+        campaign: 2026-06-issue1554-s20-h500-split-mem180-run
+        relevance: >
+          Separate #1554 evidence-yield lane, not a #3810 duplicate. A
+          Slurm-capable submit host must still refresh live queue pressure
+          before any #3810 submission.
+    issue_3810_duplicate_status: none_found
+  go_no_go:
+    recommendation: go_after_submit_host_live_checks
+    local_submission_status: no_submit_current_machine
+    exact_local_decision_command: >-
+      uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+      --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+      --json
+    slurm_command_status: >
+      Not safe to freeze in this public packet without live submit-host queue
+      pressure, duplicate check, clean-worktree proof, and private route
+      selection. Use the private submit wrapper named below only after those
+      checks return go.
   route:
     private_ops_repo: /home/luttkule/git/robot_sf_ll7-private-ops  # allow-abs-path: private-ops routing (machine-local, non-portable)
     queue_summary_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh  # allow-abs-path: private-ops routing (machine-local, non-portable)
@@ -242,8 +271,9 @@ launch_packet:
       --output output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
     no_submit_guard: >
       Private preflight and route checks may run read-only. The submit wrapper
-      must not be invoked until issue #3810 has an explicit go decision and job
-      13175 has been reconciled.
+      must not be invoked from this machine. It may be invoked only on a
+      Slurm-capable host after live queue, duplicate, branch, commit, and
+      cleanliness checks return go.
   materialized_config:
     # The runnable h600 campaign config does not exist yet and is intentionally
     # not added by this launch-packet PR. It is generated downstream by applying

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -146,8 +146,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
 
     _require(
-        launch_packet.get("decision") == "blocked_until_private_slurm_go",
-        "decision must block submit",
+        launch_packet.get("decision") == "ready_after_live_queue_and_duplicate_check",
+        "decision must require live queue and duplicate checks",
     )
     _require(
         launch_packet.get("compute_submit_authorized") is False, "compute submit must be false"
@@ -155,7 +155,43 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
     )
-    _require(13175 in (launch_packet.get("blocking_jobs") or []), "job 13175 blocker missing")
+    blocking_jobs = launch_packet.get("blocking_jobs")
+    _require(isinstance(blocking_jobs, list), "blocking_jobs must be a list")
+    _require(13175 not in blocking_jobs, "analyzed job 13175 must not remain blocking")
+
+    ledger = _require_mapping(launch_packet, "ledger_reconciliation")
+    _require(
+        ledger.get("job_13175_state") == "analyzed",
+        "job 13175 reconciliation must be analyzed",
+    )
+    _require(
+        ledger.get("issue_3810_duplicate_status") == "none_found",
+        "issue #3810 duplicate status must be none_found",
+    )
+    running_related_jobs = ledger.get("running_related_jobs")
+    _require(
+        isinstance(running_related_jobs, list),
+        "running_related_jobs must be listed",
+    )
+
+    go_no_go = _require_mapping(launch_packet, "go_no_go")
+    _require(
+        go_no_go.get("recommendation") == "go_after_submit_host_live_checks",
+        "go/no-go recommendation must require submit-host live checks",
+    )
+    _require(
+        go_no_go.get("local_submission_status") == "no_submit_current_machine",
+        "local submission status must remain no-submit",
+    )
+    _require(
+        "check_issue_3810_long_horizon_launch_packet.py"
+        in str(go_no_go.get("exact_local_decision_command", "")),
+        "exact local decision command missing",
+    )
+    _require(
+        "Not safe to freeze" in str(go_no_go.get("slurm_command_status", "")),
+        "slurm command status must explain why final submit command is not frozen",
+    )
 
     route = _require_mapping(launch_packet, "route")
     _require(
@@ -217,7 +253,10 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "planner_count": len(planner_rows),
         "compute_submit_authorized": launch_packet["compute_submit_authorized"],
         "slurm_job_id": launch_packet["slurm_job_id"],
-        "blocking_jobs": launch_packet["blocking_jobs"],
+        "blocking_jobs": blocking_jobs,
+        "job_13175_state": ledger["job_13175_state"],
+        "issue_3810_duplicate_status": ledger["issue_3810_duplicate_status"],
+        "go_no_go": go_no_go["recommendation"],
     }
 
 

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -183,13 +183,15 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         go_no_go.get("local_submission_status") == "no_submit_current_machine",
         "local submission status must remain no-submit",
     )
+    exact_cmd = go_no_go.get("exact_local_decision_command")
     _require(
         "check_issue_3810_long_horizon_launch_packet.py"
-        in str(go_no_go.get("exact_local_decision_command", "")),
+        in (str(exact_cmd) if exact_cmd is not None else ""),
         "exact local decision command missing",
     )
+    slurm_status = go_no_go.get("slurm_command_status")
     _require(
-        "Not safe to freeze" in str(go_no_go.get("slurm_command_status", "")),
+        "Not safe to freeze" in (str(slurm_status) if slurm_status is not None else ""),
         "slurm command status must explain why final submit command is not frozen",
     )
 

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -79,6 +79,19 @@ def test_issue_3810_packet_rejects_missing_go_no_go_status() -> None:
         raise AssertionError("packet should require go/no-go status")
 
 
+def test_issue_3810_packet_rejects_null_go_no_go_command() -> None:
+    """An explicit null decision command must fail closed, not coerce to 'None'."""
+    packet = _load_packet()
+    packet["launch_packet"]["go_no_go"]["exact_local_decision_command"] = None
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "exact local decision command missing" in str(exc)
+    else:
+        raise AssertionError("packet should reject a null local decision command")
+
+
 def test_issue_3810_packet_rejects_horizon_only_claim_boundary() -> None:
     """The packet keeps the multi-factor comparison caveat mandatory."""
     packet = _load_packet()

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -34,7 +34,10 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert 13175 in summary["blocking_jobs"]
+    assert summary["blocking_jobs"] == []
+    assert summary["job_13175_state"] == "analyzed"
+    assert summary["issue_3810_duplicate_status"] == "none_found"
+    assert summary["go_no_go"] == "go_after_submit_host_live_checks"
 
 
 def test_issue_3810_packet_rejects_authorized_submit() -> None:
@@ -48,6 +51,32 @@ def test_issue_3810_packet_rejects_authorized_submit() -> None:
         assert "compute submit must be false" in str(exc)
     else:
         raise AssertionError("packet should reject compute submission authorization")
+
+
+def test_issue_3810_packet_rejects_stale_analyzed_job_blocker() -> None:
+    """A reconciled analyzed job must not stay as a submission blocker."""
+    packet = _load_packet()
+    packet["launch_packet"]["blocking_jobs"] = [13175]
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "13175" in str(exc)
+    else:
+        raise AssertionError("packet should reject stale job 13175 blocker")
+
+
+def test_issue_3810_packet_rejects_missing_go_no_go_status() -> None:
+    """The packet must say what local decision command is safe to run."""
+    packet = _load_packet()
+    packet["launch_packet"].pop("go_no_go")
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "go_no_go" in str(exc)
+    else:
+        raise AssertionError("packet should require go/no-go status")
 
 
 def test_issue_3810_packet_rejects_horizon_only_claim_boundary() -> None:


### PR DESCRIPTION
## Summary
Reconciles the issue #3810 long-horizon Social Navigation Quality Index (SNQI) launch packet with current private-ops ledger state. The packet is now decision-ready for a Slurm-capable submit host after live queue, duplicate, branch, commit, and clean-worktree checks.

## Linked Issues
- Refs `#3810`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3813` for sustained-flow scenario variants
- Safe review independently: yes
- Review dependency reason, any: This PR only updates the no-submit decision packet and its validator.

## What Changed
- Updated `configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml` from stale `blocked_until_private_slurm_go` to `ready_after_live_queue_and_duplicate_check`.
- Recorded public-safe private-ops reconciliation: job `13175` is analyzed and no longer a #3810 blocker; job `13198` is a separate running #1554 lane; no #3810 duplicate was found in read-only ledger/queue inspection.
- Added explicit go/no-go fields and kept `compute_submit_authorized: false`, `slurm_job_id: not_submitted`, and `blocking_jobs: []`.
- Tightened `scripts/validation/check_issue_3810_long_horizon_launch_packet.py` and tests so stale analyzed blockers or missing go/no-go status fail closed.

## Why Matters
- Added value: Converts #3810 from stale blocked packet to a reversible, locally validated Slurm decision packet.
- Expected impact: A Slurm-capable host can use the packet to decide submission without rediscovering job `13175` state.
- Why worth merging now: It reduces the risk of submitting from stale private-ops state or treating low-exposure wait-it-out successes as benchmark-strength evidence.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3810 launch readiness for h600 comprehensive rerun, SNQI recalibration, and interaction-exposure wait-it-out guard.
- Comparator or baseline, applicable: Prior scoped short-horizon h100 surface versus future comprehensive h600 surface; packet explicitly forbids horizon-only causal wording.
- Evidence tier: launch packet
- Result classification: blocker-resolution
- Decision stop rule, applicable: Stop before Slurm submission unless live submit-host queue, duplicate, branch, commit, and cleanliness checks return go.
- Parent issue, claim map, registry, context note, synthesis surface update: #3810 issue packet only; no claim map or benchmark report promoted.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support validator and manifest packet only.

## Domain-Aware Approval
- Required PR: domain-aware evidence-validity review required for the launch packet and blocker-resolution classification
- Domains reviewed: evidence classification, benchmark launch boundary, Slurm no-submit gate
- Status: blocked until domain-aware review confirms the launch packet boundary and no-submit gate
- Approver/review source waiver: blocker is unresolved domain-aware review for issue #3810 launch packet validity.
- Validity checklist:
- Target claim/hypothesis: launch readiness only; no benchmark result claim.
- Comparator split/evidence validity: future report must say prior scoped short-horizon versus new comprehensive long-horizon, not horizon-only; this remains the named domain-review blocker.
- Fallback/degraded exclusions: fallback/degraded/candidate diagnostic rows remain excluded from successful benchmark-strength evidence.
- Claim boundary: no benchmark evidence, no Slurm submission, no paper/dissertation claim promotion; reviewer must confirm before merge.
- Implementation integrity vs experimental validity: validator proves packet fields; actual experiment remains unrun.

## Falsification / Non-Transfer Check
- Did mechanism activate? unknown - no campaign run.
- Did intervention change command source, selected command, trajectory, route progress? NA - launch packet only.
- Did scenario actually contain targeted failure mode? unknown until h600 campaign runs.
- Result route: continue as launch-packet-only, then submit only after live host checks.
- Follow-up question issue weak, negative, non-transfer results: #3813 covers sustained-flow structural scenario variants.

## Next Empirical Action
- Rerun needed: yes, on Slurm-capable host after live checks.
- Extractor analysis tool needed: yes, campaign must emit SNQI recalibration bundle, horizon sensitivity report, and interaction-exposure diagnostics.
- Artifact missing unavailable: All benchmark artifacts are missing by design; this PR generated only ignored local packet output.
- Stop / revise / continue decision: continue to Slurm-capable submit-host decision; do not submit from this machine.
- Proposed child issue existing follow-up: #3813 for sustained-flow variants.

## Slurm Unblock Status
- Local status: no-go for actual submission on this machine; `local.machine.md` has `allow_slurm_submission: false`.
- Ledger reconciliation: read-only private-ops inspection found job `13175` analyzed for #1554 and not a #3810 blocker; job `13198` is a separate running #1554 lane; no #3810 duplicate was found.
- Recommendation: go only after a Slurm-capable submit host refreshes live queue pressure, duplicate state, branch/commit, and clean-worktree proof.
- Exact safe local go/no-go command:

```bash
uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py \
  --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml \
  --json
```

- Exact Slurm submission command: not safe to freeze in this public packet before submit-host live queue and route selection. The packet names the private submit wrapper and records that it may be invoked only after those checks return go.

## Retention / Analysis Plan
- Local raw output root remains disposable: `output/benchmarks/issue_3810_comprehensive_h600_snqi`.
- Compact review bundle path before any claim: `docs/context/evidence/issue_3810_long_horizon_snqi/`.
- External durable pointer required before claim: W&B or release artifact pointer.
- Required analysis artifacts include campaign summary/table, SNQI recalibration inputs and checksum-pinned bundle, horizon-sensitivity JSON/Markdown, and interaction-exposure diagnostics JSON/Markdown.
- Raw episode JSONL, videos, Slurm logs, model caches, and checkpoints stay out of git.

## Validation / Proof
- `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json`
- `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q`
- `uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi`
- `uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py`
- `uv run ruff format --check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py`
- `git diff --check`
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` initially failed because the fresh worktree lacked analytics extras; after `uv sync --all-extras` and body drafting, it stops on `pending_domain_approval`, which is the declared draft blocker for this benchmark launch packet.

## Performance / Caching
- Performance-critical path changed: no
- Baseline runtime: NA - launch packet/validator only
- Changed runtime: NA - launch packet/validator only
- Representative command: `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q`
- Hot-path call count profile anchor: NA - no benchmark runtime path changed
- Cache-hit reuse counter: NA
- Rollback failure criterion: Revert if packet validator accepts stale analyzed blockers, direct compute authorization, missing h600/S30 scope, or low-exposure success as benchmark evidence.

## Risks / Rollout
- Compatibility risks: Low; validator contract changed for the #3810 packet only.
- Failure modes: Submit host may still find live queue pressure, dirty worktree, missing materialized config, or private route constraints.
- Rollback fallback plan: Revert this commit to restore the previous blocked packet state.

## Docs / Provenance
- Updated docs: NA - config packet and validator only.
- Relevant design provenance notes: #3810 and #3813.
- Any assumptions need to preserved: Future h600 report is multi-factor scope change, not horizon-only sensitivity.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes, claimed before branch work; PR will link #3810.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark evidence.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no benchmark evidence.
- Registry or config index updated (yes/no/NA): NA - existing packet path retained.
- Context index / memory note updated (yes/no/NA): NA - no durable result note.
- Follow-up issue opened deferred propagation (yes/no/NA): existing #3813.
- Not applicable because: This is a launch-packet readiness PR; downstream benchmark/report propagation waits for actual h600 campaign artifacts.

## Follow-Up Issues
- Deferred work: Actual Slurm submission, SNQI recalibration, horizon sensitivity report, durable artifact promotion, and #3813 sustained-flow variants.
- Issues opened follow-up: none; existing #3813 covers structural wait-it-out scenario variants.

## Reviewer Notes
- Verify closely: The final Slurm command is intentionally not frozen because live queue and submit-host state are required immediately before submission.
- Known limitations: No Slurm job was submitted, no h600 benchmark ran, and no SNQI or dissertation/paper claim is promoted.
