### PR TITLE
analysis: guard S20/S30 packet go-no-go (#3798)

### DIFF
--- a/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
+++ b/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
@@ -123,5 +123,13 @@
       "command": "uv run python scripts/validation/check_s20_s30_archive_readiness.py --json",
       "purpose": "Fail-closed archive-readiness check; remains the claim gate for a canonical result store."
     }
-  ]
+  ],
+  "next_slurm_go_no_go": {
+    "claim_promotion": "no_go",
+    "s20_archive_readiness": "run_fail_closed_checker_before_claim",
+    "s30_submission_from_issue_3798": "not_authorized_here",
+    "s30_escalation_status": "defer_until_claim_owner_authorizes_escalation",
+    "compute_submission": "not_authorized",
+    "next_valid_step": "run archive-readiness checker and decide S30 only in a separately authorized lane"
+  }
 }

--- a/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.md
+++ b/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.md
@@ -7,6 +7,15 @@ This packet summarizes retrieved S20 (20-seed) job artifacts for issue #1554, ke
 - Status: `diagnostic_only`
 - Boundary: diagnostic-only evidence-gap packet; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no S20/S30 claim promotion
 
+## Next Slurm Go/No-Go
+
+- claim_promotion: `no_go`
+- s20_archive_readiness: `run_fail_closed_checker_before_claim`
+- s30_submission_from_issue_3798: `not_authorized_here`
+- s30_escalation_status: `defer_until_claim_owner_authorizes_escalation`
+- compute_submission: `not_authorized`
+- next_valid_step: `run archive-readiness checker and decide S30 only in a separately authorized lane`
+
 ## Retrieved Artifacts
 
 - Artifact root: `/home/luttkule/git/robot_sf_ll7/output/issue1554-s20-h500-l40s-mem180/13175`

--- a/scripts/validation/extract_s20_s30_evidence_gap_packet.py
+++ b/scripts/validation/extract_s20_s30_evidence_gap_packet.py
@@ -90,6 +90,10 @@ def build_packet(artifact_root: Path, *, job_id: str = DEFAULT_JOB_ID) -> dict[s
             "planners": seed_episode_rows["planners"],
         },
         "claim_blockers": _claim_blockers(campaign_rows, seed_episode_rows, missing_files),
+        "next_slurm_go_no_go": _next_slurm_go_no_go(
+            missing_files=missing_files,
+            seed_count=len(seed_episode_rows["seeds"]),
+        ),
         "validation_commands": [
             {
                 "command": (
@@ -121,6 +125,11 @@ def load_packet_fixture(packet_fixture: Path) -> dict[str, Any]:
         raise ValueError(f"{packet_fixture} job_id must be {DEFAULT_JOB_ID!r}")
     if packet.get("claim_boundary") != CLAIM_BOUNDARY:
         raise ValueError(f"{packet_fixture} claim boundary drifted")
+    go_no_go = packet.get("next_slurm_go_no_go", {})
+    if go_no_go.get("claim_promotion") != "no_go":
+        raise ValueError(f"{packet_fixture} claim_promotion must remain no_go")
+    if go_no_go.get("s30_submission_from_issue_3798") != "not_authorized_here":
+        raise ValueError(f"{packet_fixture} must not authorize S30 submission from issue #3798")
     return packet
 
 
@@ -141,16 +150,29 @@ def render_markdown(packet: dict[str, Any]) -> str:
         f"- Status: `{packet['status']}`",
         f"- Boundary: {packet['claim_boundary']}",
         "",
-        "## Retrieved Artifacts",
-        "",
-        f"- Artifact root: `{packet['artifact_root']}`",
-        f"- File count: {packet['retrieved_artifacts']['file_count']}",
-        f"- Total bytes: {packet['retrieved_artifacts']['total_bytes']}",
-        f"- Missing required metadata files: {packet['retrieved_artifacts']['missing_required_metadata_files'] or 'none'}",
-        "",
-        "## Campaign Metadata",
+        "## Next Slurm Go/No-Go",
         "",
     ]
+    for key, value in packet["next_slurm_go_no_go"].items():
+        lines.append(f"- {key}: `{value}`")
+    lines.extend(
+        [
+            "",
+            "## Retrieved Artifacts",
+            "",
+            f"- Artifact root: `{packet['artifact_root']}`",
+            f"- File count: {packet['retrieved_artifacts']['file_count']}",
+            f"- Total bytes: {packet['retrieved_artifacts']['total_bytes']}",
+            (
+                "- Missing required metadata files: "
+                f"{packet['retrieved_artifacts']['missing_required_metadata_files'] or 'none'}"
+            ),
+            "",
+            "## Campaign Metadata",
+            "",
+        ]
+    )
+
     for key, value in packet["campaign"].items():
         lines.append(f"- {key}: `{value}`")
     lines.extend(
@@ -238,6 +260,34 @@ def _claim_blockers(
             "At least one campaign table row is not `ok`; row status needs fail-closed review."
         )
     return blockers
+
+
+def _next_slurm_go_no_go(*, missing_files: list[str], seed_count: int) -> dict[str, str]:
+    """Return the diagnostic-only next-action decision for the packet."""
+
+    if missing_files:
+        archive_readiness = "blocked_missing_retrieved_metadata"
+        s30_status = "not_ready_missing_s20_metadata"
+        next_step = "recover required retrieved metadata before considering any escalation"
+    elif seed_count < 20:
+        archive_readiness = "blocked_incomplete_s20_seed_coverage"
+        s30_status = "not_ready_incomplete_s20"
+        next_step = "reconcile S20 seed coverage before considering any escalation"
+    else:
+        archive_readiness = "run_fail_closed_checker_before_claim"
+        s30_status = "defer_until_claim_owner_authorizes_escalation"
+        next_step = (
+            "run archive-readiness checker and decide S30 only in a separately authorized lane"
+        )
+
+    return {
+        "claim_promotion": "no_go",
+        "s20_archive_readiness": archive_readiness,
+        "s30_submission_from_issue_3798": "not_authorized_here",
+        "s30_escalation_status": s30_status,
+        "compute_submission": "not_authorized",
+        "next_valid_step": next_step,
+    }
 
 
 def _read_campaign_table(path: Path) -> list[dict[str, str]]:

--- a/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
+++ b/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
@@ -101,6 +101,9 @@ def test_present_job_artifact_metadata_builds_diagnostic_packet(tmp_path: Path) 
     assert packet["coverage_snapshot"]["seed_count"] == 2
     assert packet["coverage_snapshot"]["planners"] == ["goal", "orca"]
     assert packet["retrieved_artifacts"]["missing_required_metadata_files"] == []
+    assert packet["next_slurm_go_no_go"]["claim_promotion"] == "no_go"
+    assert packet["next_slurm_go_no_go"]["s30_submission_from_issue_3798"] == "not_authorized_here"
+    assert packet["next_slurm_go_no_go"]["s30_escalation_status"] == "not_ready_incomplete_s20"
     assert "no paper/dissertation claim edits" in packet["claim_boundary"]
     assert any(
         item["path"] == "campaign_manifest.json" for item in packet["promotable_review_files"]
@@ -119,6 +122,13 @@ def test_missing_job_artifact_metadata_fails_closed(tmp_path: Path) -> None:
         "campaign_manifest.json" in packet["retrieved_artifacts"]["missing_required_metadata_files"]
     )
     assert packet["coverage_snapshot"]["episode_rows"] == 0
+    assert (
+        packet["next_slurm_go_no_go"]["s20_archive_readiness"]
+        == "blocked_missing_retrieved_metadata"
+    )
+    assert (
+        packet["next_slurm_go_no_go"]["s30_escalation_status"] == "not_ready_missing_s20_metadata"
+    )
 
 
 def test_dry_run_command_prints_markdown_packet(tmp_path: Path, capsys) -> None:
@@ -151,6 +161,40 @@ def test_tracked_packet_fixture_renders_without_raw_artifacts(capsys) -> None:
     captured = capsys.readouterr()
     assert exit_code == 0
     assert "Status: `diagnostic_only`" in captured.out
+    assert "claim_promotion: `no_go`" in captured.out
+    assert "s30_escalation_status: `defer_until_claim_owner_authorizes_escalation`" in captured.out
     assert "File count: 56" in captured.out
     assert "requiring ignored output" in captured.out
     assert "no paper/dissertation claim edits" in captured.out
+
+
+def test_tracked_packet_rejects_claim_promotion_go(tmp_path: Path) -> None:
+    """Tracked packet fixture must fail closed if it authorizes claim promotion."""
+
+    packet = extractor.load_packet_fixture(extractor.DEFAULT_PACKET_FIXTURE)
+    packet["next_slurm_go_no_go"]["claim_promotion"] = "go"
+    fixture = tmp_path / "claim-go.json"
+    fixture.write_text(json.dumps(packet), encoding="utf-8")
+
+    try:
+        extractor.load_packet_fixture(fixture)
+    except ValueError as exc:
+        assert "claim_promotion must remain no_go" in str(exc)
+    else:
+        raise AssertionError("claim promotion drift should fail closed")
+
+
+def test_tracked_packet_rejects_issue_3798_s30_submit_authorization(tmp_path: Path) -> None:
+    """Issue #3798 packet must not silently become a Slurm submission authorization."""
+
+    packet = extractor.load_packet_fixture(extractor.DEFAULT_PACKET_FIXTURE)
+    packet["next_slurm_go_no_go"]["s30_submission_from_issue_3798"] = "authorized"
+    fixture = tmp_path / "s30-authorized.json"
+    fixture.write_text(json.dumps(packet), encoding="utf-8")
+
+    try:
+        extractor.load_packet_fixture(fixture)
+    except ValueError as exc:
+        assert "must not authorize S30 submission" in str(exc)
+    else:
+        raise AssertionError("S30 authorization drift should fail closed")


### PR DESCRIPTION
## Summary
Adds a structured `next_slurm_go_no_go` block to the existing post-13175 S20/S30 evidence-gap packet and makes the tracked packet fixture fail closed if it starts authorizing claim promotion or S30 submission from issue #3798.

## Linked Issues
- Relates to `#3798`
- Relates to `#1554`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: merged `#3806`, merged `#3819`
- Stack follow-up issues: none opened
- Safe review independently: yes
- Review dependency reason, any: Extends the existing #3798 packet owner; no benchmark runner, Slurm submission, metric, planner, or paper-facing claim surface changed.

## What Changed
- Added `next_slurm_go_no_go` to the retrieved job-13175 packet JSON and Markdown.
- Extended `extract_s20_s30_evidence_gap_packet.py` to compute and render the decision block.
- Added fixture guards that reject `claim_promotion != no_go` and reject any S30 submission authorization from #3798.
- Added focused test coverage for complete, incomplete, tracked, and drifted packet states.

## Why Matters
- Added value: The packet now exposes the next Slurm go/no-go state as machine-checkable data, not only narrative evidence-gap text.
- Expected impact: Future agents cannot silently treat the retrieved S20 job as claim-ready or treat #3798 as S30 submission authorization.
- Why worth merging now: #3806/#3819 already made the packet reproducible; this follow-up closes the remaining go/no-go status gap without duplicating that work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Prevent premature S20/S30 claim promotion from retrieved job-13175 metadata.
- Comparator or baseline, applicable: NA; diagnostic packet/checker only.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only
- Decision stop rule, applicable: Claim promotion remains `no_go`; #3798 compute submission remains `not_authorized`; S30 remains deferred until separately authorized.
- Parent issue, claim map, registry, context note, synthesis surface update: Updates `docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.{json,md}`.
- New research/benchmark/metric/paper-facing analysis tool, any: No new analysis method; extends existing packet/checker metadata only.

## Domain-Aware Approval
- Required PR: yes, diagnostic evidence classification surface.
- Approver/review source waiver: Pending reviewer judgment; this PR does not change benchmark semantics or promote claims.
- Validity checklist:
  - Target claim/hypothesis: No S20/S30 paper/dissertation claim promoted.
  - Comparator split/evidence validity: NA; packet summarizes retrieved metadata only.
  - Fallback/degraded exclusions: Archive-readiness checker still exits fail-closed without canonical result-store artifacts.
  - Claim boundary: diagnostic-only evidence-gap packet.
  - Implementation integrity vs experimental validity: Guarded fixture metadata only; no Slurm or benchmark execution.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes; fixture render shows `claim_promotion: no_go`, `s30_submission_from_issue_3798: not_authorized_here`, and `s30_escalation_status: defer_until_claim_owner_authorizes_escalation`.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue; use fail-closed archive-readiness checker before any claim decision.
- Follow-up question issue weak, negative, non-transfer results: none opened.

## Next Empirical Action
- Rerun needed: no.
- Extractor analysis tool needed: no; existing extractor extended.
- Artifact missing unavailable: canonical result-store files remain absent from the archive-readiness checker.
- Stop / revise / continue decision: continue only through a separately authorized archive/result-store readiness lane; no #3798 Slurm submit.
- Proposed child issue existing follow-up: #1554 remains the parent archive-readiness/evidence lane.

## Validation / Proof
- `uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py` -> passed, 6 tests.
- `uv run ruff check scripts/validation/extract_s20_s30_evidence_gap_packet.py tests/validation/test_extract_s20_s30_evidence_gap_packet.py` -> passed.
- `uv run ruff format --check scripts/validation/extract_s20_s30_evidence_gap_packet.py tests/validation/test_extract_s20_s30_evidence_gap_packet.py` -> passed.
- `uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --packet-fixture docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json --markdown` -> passed; rendered diagnostic-only go/no-go block.
- `uv run python scripts/validation/check_s20_s30_archive_readiness.py --json` -> exited 1 by design; fail-closed because canonical result-store files are missing.
- `git diff --check` -> passed.

## Performance Evidence
- Performance-sensitive change? no.
- Baseline runtime: NA; no runtime claim.
- Changed runtime: NA; no runtime claim.
- Representative command: `uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py`.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: Packet no longer fails closed when claim promotion or S30 submission authorization drifts.

## Risks / Rollout
- Compatibility risks: Low; new JSON field is additive and existing CLI output remains Markdown/JSON.
- Failure modes: Downstream consumers assuming an exact JSON key set may need to ignore the added field.
- Rollback fallback plan: Revert this PR; prior packet remains available but lacks machine-checkable go/no-go status.

## Docs / Provenance
- Updated docs: `docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.md`.
- Relevant design provenance notes: #3798, #3806, #3819, #1554.
- Any assumptions need preserved: Retrieved job 13175 metadata remains diagnostic-only; ignored `output/` raw artifacts are not durable proof.

## Downstream Propagation
- Parent issue updated (yes/no/NA): PR links #3798; no separate issue comment yet.
- Claim map / benchmark report updated (yes/no/NA): NA, no claim promotion.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA; existing evidence file path unchanged.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: This PR only guards the existing diagnostic packet; archive/result-store readiness remains fail-closed.

## Follow-Up Issues
- Deferred work: canonical result-store archive readiness for #1554, and any S30 escalation only after separate authorization.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer should verify closely: The `next_slurm_go_no_go` field should remain `claim_promotion=no_go` and `s30_submission_from_issue_3798=not_authorized_here`.
- Any known limitations: This does not recover raw ignored artifacts and does not create benchmark-strength evidence.
