### PR TITLE
Issue #3275: add failure archive rerun readiness check

### DIFF
--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -1,0 +1,22 @@
+# Issue #3275 Failure Archive Rerun Readiness
+
+This note records a metadata-only gate for rerunning the adversarial proposal model on a separate certified failure archive.
+
+## Boundary
+
+The check is readiness/leakage evidence only. It does not run benchmark campaigns, submit compute jobs, publish artifacts, or claim that adversarial proposal models improve failure discovery.
+
+## Implementation
+
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads a source archive and rerun archive, checks archive-ID leakage, records family/seed overlap provenance, and requires certification metadata on rerun archive entries.
+- `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI.
+- Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
+
+## Validation
+
+Focused tests cover:
+
+- disjoint certified archives passing the metadata gate;
+- overlapping archive IDs blocking leakage;
+- missing rerun certification metadata blocking readiness;
+- diagnostic-only rerun outputs staying diagnostic-only.

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -1,0 +1,333 @@
+"""Readiness and leakage checks for proposal-model failure-archive reruns.
+
+This module answers one bounded issue #3275 question without running a
+benchmark campaign:
+
+    Can a proposal model trained or selected from one certified failure archive
+    be rerun against a separate certified failure archive without archive-ID
+    leakage or missing certification metadata?
+
+The verdict is intentionally fail-closed. Overlap or missing required metadata
+blocks readiness. Diagnostic-only rerun outputs are preserved as diagnostics
+and never promoted to benchmark evidence.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from robot_sf.adversarial.disjoint_evaluation import (
+    ARCHIVE_SCHEMA_VERSION,
+    archive_sha256,
+    compute_overlap_provenance,
+)
+
+READY = "ready"
+DIAGNOSTIC_ONLY = "diagnostic_only"
+BLOCKED = "blocked"
+
+SCHEMA_VERSION = "failure_archive_rerun_readiness.v1"
+CLAIM_BOUNDARY = (
+    "readiness/leakage check only; no benchmark campaign run, no adversarial-improvement claim, "
+    "no dissertation or paper-facing claim promotion"
+)
+
+_CERTIFICATION_KEYS = (
+    "certification_metadata",
+    "certification",
+    "certification_status",
+    "candidate_certification",
+    "scenario_certification",
+    "scenario_certificate",
+)
+_PASSING_CERTIFICATION_STATUSES = {
+    "accepted",
+    "certified",
+    "certified_valid_failure",
+    "pass",
+    "passed",
+    "ready",
+    "valid",
+}
+_DIAGNOSTIC_ONLY_VALUES = {
+    "diagnostic",
+    "diagnostic-only",
+    "diagnostic_only",
+    "held_out_diagnostic_only",
+    "not_benchmark_evidence",
+    "plumbing_validation_only",
+}
+_DIAGNOSTIC_STATUS_KEYS = (
+    "claim_boundary",
+    "diagnostic_only",
+    "evidence_status",
+    "held_out_evidence_status",
+    "interpretation",
+    "result_classification",
+    "status",
+)
+
+
+@dataclass(frozen=True)
+class FailureArchiveRerunReadiness:
+    """Fail-closed readiness verdict for a disjoint failure-archive rerun."""
+
+    status: str
+    source_archive: str
+    rerun_archive: str
+    source_entry_count: int = 0
+    rerun_entry_count: int = 0
+    source_archive_sha256: str | None = None
+    rerun_archive_sha256: str | None = None
+    overlap_provenance: dict[str, Any] = field(default_factory=dict)
+    archive_id_overlap: list[str] = field(default_factory=list)
+    missing_certification_archive_ids: list[str] = field(default_factory=list)
+    invalid_certification_archive_ids: list[str] = field(default_factory=list)
+    diagnostic_only_outputs: list[str] = field(default_factory=list)
+    blockers: list[str] = field(default_factory=list)
+    warnings: list[str] = field(default_factory=list)
+
+    @property
+    def ready(self) -> bool:
+        """Return whether this rerun input is ready for a diagnostic rerun."""
+
+        return self.status == READY
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return a JSON-serializable readiness payload."""
+
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "claim_boundary": CLAIM_BOUNDARY,
+            "status": self.status,
+            "ready": self.ready,
+            "source_archive": self.source_archive,
+            "rerun_archive": self.rerun_archive,
+            "source_entry_count": self.source_entry_count,
+            "rerun_entry_count": self.rerun_entry_count,
+            "source_archive_sha256": self.source_archive_sha256,
+            "rerun_archive_sha256": self.rerun_archive_sha256,
+            "overlap_provenance": dict(self.overlap_provenance),
+            "archive_id_overlap": list(self.archive_id_overlap),
+            "missing_certification_archive_ids": list(self.missing_certification_archive_ids),
+            "invalid_certification_archive_ids": list(self.invalid_certification_archive_ids),
+            "diagnostic_only_outputs": list(self.diagnostic_only_outputs),
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+        }
+
+
+def classify_failure_archive_rerun_readiness(
+    source_archive: str | Path,
+    rerun_archive: str | Path,
+    *,
+    rerun_output: str | Path | None = None,
+) -> FailureArchiveRerunReadiness:
+    """Classify whether a proposal-model rerun archive is disjoint and certified.
+
+    Args:
+        source_archive: Archive used to fit/select/rank proposal-model candidates.
+        rerun_archive: Separate archive intended for the rerun/evaluation slice.
+        rerun_output: Optional rerun report JSON. Diagnostic-only markers cap the
+            verdict at ``diagnostic_only`` when inputs otherwise pass.
+
+    Returns:
+        A fail-closed readiness verdict. The function never runs planners,
+        benchmarks, proposal sampling, or artifact publication.
+    """
+
+    source_path = Path(source_archive)
+    rerun_path = Path(rerun_archive)
+    source_status, source_payload, source_reason = _load_archive(source_path)
+    rerun_status, rerun_payload, rerun_reason = _load_archive(rerun_path)
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    if source_status != READY:
+        blockers.append(f"source_archive_{source_status}:{source_reason}")
+    if rerun_status != READY:
+        blockers.append(f"rerun_archive_{rerun_status}:{rerun_reason}")
+
+    source_entries = _archive_entries(source_payload)
+    rerun_entries = _archive_entries(rerun_payload)
+    source_hash = archive_sha256(source_payload) if isinstance(source_payload, dict) else None
+    rerun_hash = archive_sha256(rerun_payload) if isinstance(rerun_payload, dict) else None
+
+    overlap = compute_overlap_provenance(source_entries, rerun_entries)
+    archive_id_overlap = list(overlap.get("archive_id_overlap", []))
+    if archive_id_overlap:
+        blockers.append(f"archive_id_overlap:{len(archive_id_overlap)}")
+    if overlap.get("scenario_family_overlap_count", 0):
+        blockers.append(
+            f"scenario_family_overlap:{overlap['scenario_family_overlap_count']}"
+        )
+    if overlap.get("seed_overlap_count", 0):
+        blockers.append(f"seed_overlap:{overlap['seed_overlap_count']}")
+
+    missing_certification, invalid_certification = _certification_gaps(rerun_entries)
+    if missing_certification:
+        blockers.append(f"missing_certification_metadata:{len(missing_certification)}")
+    if invalid_certification:
+        blockers.append(f"invalid_certification_status:{len(invalid_certification)}")
+
+    diagnostic_outputs = _diagnostic_only_outputs(Path(rerun_output) if rerun_output else None)
+    status = BLOCKED if blockers else READY
+    if status == READY and diagnostic_outputs:
+        status = DIAGNOSTIC_ONLY
+
+    return FailureArchiveRerunReadiness(
+        status=status,
+        source_archive=str(source_archive),
+        rerun_archive=str(rerun_archive),
+        source_entry_count=len(source_entries),
+        rerun_entry_count=len(rerun_entries),
+        source_archive_sha256=source_hash,
+        rerun_archive_sha256=rerun_hash,
+        overlap_provenance=overlap,
+        archive_id_overlap=archive_id_overlap,
+        missing_certification_archive_ids=missing_certification,
+        invalid_certification_archive_ids=invalid_certification,
+        diagnostic_only_outputs=diagnostic_outputs,
+        blockers=blockers,
+        warnings=warnings,
+    )
+
+
+def _load_archive(path: Path) -> tuple[str, dict[str, Any] | None, str]:
+    """Load one archive JSON and validate its top-level shape.
+
+    Returns:
+        ``(status, payload, reason)`` with ``payload`` present only when JSON
+        parsing succeeded.
+    """
+
+    if not path.exists():
+        return BLOCKED, None, f"path_missing:{path}"
+    if path.stat().st_size == 0:
+        return BLOCKED, None, f"file_empty:{path}"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return BLOCKED, None, f"unreadable:{exc}"
+    if not isinstance(payload, dict):
+        return BLOCKED, None, "payload_not_object"
+    schema_version = payload.get("schema_version")
+    if schema_version != ARCHIVE_SCHEMA_VERSION:
+        return BLOCKED, payload, f"unexpected_schema_version:{schema_version!r}"
+    entries = payload.get("entries")
+    if not isinstance(entries, list) or not entries:
+        return BLOCKED, payload, "archive_has_no_entries"
+    return READY, payload, "ok"
+
+
+def _archive_entries(payload: dict[str, Any] | None) -> list[dict[str, Any]]:
+    """Return dictionary entries from a parsed archive payload."""
+
+    if not isinstance(payload, dict):
+        return []
+    entries = payload.get("entries")
+    if not isinstance(entries, list):
+        return []
+    return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _certification_gaps(entries: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
+    """Return archive IDs missing or failing rerun certification metadata."""
+
+    missing: list[str] = []
+    invalid: list[str] = []
+    for index, entry in enumerate(entries):
+        archive_id = str(entry.get("archive_id") or f"<entry:{index}>")
+        certification = _first_certification_value(entry)
+        if certification is None:
+            missing.append(archive_id)
+            continue
+        status = _certification_status(certification)
+        if status and status not in _PASSING_CERTIFICATION_STATUSES:
+            invalid.append(archive_id)
+    return missing, invalid
+
+
+def _first_certification_value(entry: dict[str, Any]) -> Any:
+    """Return the first recognized certification metadata field."""
+
+    for key in _CERTIFICATION_KEYS:
+        value = entry.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _certification_status(value: Any) -> str | None:
+    """Normalize a certification metadata value into a status token.
+
+    Returns:
+        Lowercase certification status when available, otherwise ``None``.
+    """
+
+    if isinstance(value, str):
+        return value.strip().lower() or None
+    if isinstance(value, dict):
+        for key in ("status", "verdict", "classification", "result"):
+            raw_status = value.get(key)
+            if isinstance(raw_status, str) and raw_status.strip():
+                return raw_status.strip().lower()
+        return "certified" if value else None
+    if isinstance(value, bool):
+        return "passed" if value else "failed"
+    return None
+
+
+def _diagnostic_only_outputs(path: Path | None) -> list[str]:
+    """Return diagnostic-only markers from an optional rerun output JSON."""
+
+    if path is None:
+        return []
+    if not path.exists() or path.stat().st_size == 0:
+        return [f"rerun_output_unavailable:{path}"]
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return [f"rerun_output_unreadable:{exc}"]
+    if not isinstance(payload, dict):
+        return ["rerun_output_not_object"]
+    markers: list[str] = []
+    _collect_diagnostic_markers(payload, markers, prefix="")
+    return sorted(set(markers))
+
+
+def _collect_diagnostic_markers(payload: Any, markers: list[str], *, prefix: str) -> None:
+    """Collect diagnostic-only status markers from nested report payloads."""
+
+    if isinstance(payload, dict):
+        for key, value in payload.items():
+            child_prefix = f"{prefix}.{key}" if prefix else str(key)
+            if key in _DIAGNOSTIC_STATUS_KEYS and _is_diagnostic_only_value(value):
+                markers.append(f"{child_prefix}:{value}")
+            _collect_diagnostic_markers(value, markers, prefix=child_prefix)
+    elif isinstance(payload, list):
+        for index, value in enumerate(payload):
+            _collect_diagnostic_markers(value, markers, prefix=f"{prefix}[{index}]")
+
+
+def _is_diagnostic_only_value(value: Any) -> bool:
+    """Return whether a report value explicitly marks diagnostic-only evidence."""
+
+    if isinstance(value, bool):
+        return value is True
+    if not isinstance(value, str):
+        return False
+    normalized = value.strip().lower().replace(" ", "_")
+    return normalized in _DIAGNOSTIC_ONLY_VALUES or "diagnostic_only" in normalized
+
+
+__all__ = [
+    "BLOCKED",
+    "DIAGNOSTIC_ONLY",
+    "READY",
+    "FailureArchiveRerunReadiness",
+    "classify_failure_archive_rerun_readiness",
+]

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -244,7 +244,7 @@ def _certification_gaps(entries: list[dict[str, Any]]) -> tuple[list[str], list[
             missing.append(archive_id)
             continue
         status = _certification_status(certification)
-        if status and status not in _PASSING_CERTIFICATION_STATUSES:
+        if status is None or status not in _PASSING_CERTIFICATION_STATUSES:
             invalid.append(archive_id)
     return missing, invalid
 
@@ -266,16 +266,22 @@ def _certification_status(value: Any) -> str | None:
         Lowercase certification status when available, otherwise ``None``.
     """
 
+    if isinstance(value, bool):
+        return "passed" if value else "failed"
     if isinstance(value, str):
         return value.strip().lower() or None
     if isinstance(value, dict):
         for key in ("status", "verdict", "classification", "result"):
-            raw_status = value.get(key)
+            if key not in value:
+                continue
+            raw_status = value[key]
+            if isinstance(raw_status, bool):
+                return "passed" if raw_status else "failed"
             if isinstance(raw_status, str) and raw_status.strip():
                 return raw_status.strip().lower()
+            if raw_status is None or (isinstance(raw_status, str) and not raw_status.strip()):
+                return "failed"
         return "certified" if value else None
-    if isinstance(value, bool):
-        return "passed" if value else "failed"
     return None
 
 

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -161,9 +161,7 @@ def classify_failure_archive_rerun_readiness(
     if archive_id_overlap:
         blockers.append(f"archive_id_overlap:{len(archive_id_overlap)}")
     if overlap.get("scenario_family_overlap_count", 0):
-        blockers.append(
-            f"scenario_family_overlap:{overlap['scenario_family_overlap_count']}"
-        )
+        blockers.append(f"scenario_family_overlap:{overlap['scenario_family_overlap_count']}")
     if overlap.get("seed_overlap_count", 0):
         blockers.append(f"seed_overlap:{overlap['seed_overlap_count']}")
 

--- a/scripts/validation/check_failure_archive_rerun_readiness.py
+++ b/scripts/validation/check_failure_archive_rerun_readiness.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Check proposal-model rerun readiness for disjoint certified failure archives.
+
+This issue #3275 validation gate reads archive metadata only. It does not run
+benchmarks, proposal-model inference, SLURM jobs, or artifact publication.
+
+Exit codes:
+- ``0``: archive inputs are ready for a diagnostic rerun.
+- ``2``: inputs pass leakage/certification checks, but supplied output is
+  diagnostic-only and not benchmark evidence.
+- ``3``: readiness is blocked by leakage, missing certification metadata, or
+  malformed inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.failure_archive_rerun_readiness import (
+    BLOCKED,
+    DIAGNOSTIC_ONLY,
+    READY,
+    classify_failure_archive_rerun_readiness,
+)
+
+_EXIT_CODES = {READY: 0, DIAGNOSTIC_ONLY: 2, BLOCKED: 3}
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Return CLI argument parser."""
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source-archive",
+        type=Path,
+        required=True,
+        help="Failure archive used to fit/select proposal-model candidates.",
+    )
+    parser.add_argument(
+        "--rerun-archive",
+        type=Path,
+        required=True,
+        help="Disjoint certified failure archive intended for the rerun slice.",
+    )
+    parser.add_argument(
+        "--rerun-output",
+        type=Path,
+        default=None,
+        help="Optional rerun report JSON; diagnostic-only markers cap the verdict.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help="Optional path to write the JSON readiness report.",
+    )
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the readiness check and return a fail-closed exit code."""
+
+    args = _build_parser().parse_args(argv)
+    readiness = classify_failure_archive_rerun_readiness(
+        args.source_archive,
+        args.rerun_archive,
+        rerun_output=args.rerun_output,
+    )
+    payload = readiness.to_payload()
+    rendered = json.dumps(payload, indent=2, sort_keys=True)
+    if args.output is not None:
+        args.output.parent.mkdir(parents=True, exist_ok=True)
+        args.output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return _EXIT_CODES.get(readiness.status, 3)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -1,0 +1,185 @@
+"""Tests for issue #3275 failure-archive rerun readiness/leakage checks."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from robot_sf.benchmark.failure_archive_rerun_readiness import (
+    BLOCKED,
+    DIAGNOSTIC_ONLY,
+    READY,
+    classify_failure_archive_rerun_readiness,
+)
+from scripts.validation.check_failure_archive_rerun_readiness import main as readiness_cli_main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _entry(
+    archive_id: str,
+    *,
+    family: str,
+    seed: int,
+    certified: bool = True,
+) -> dict:
+    """Build a minimal failure-archive entry fixture."""
+
+    entry = {
+        "archive_id": archive_id,
+        "cluster_key": {
+            "policy": "goal",
+            "scenario_template": family,
+            "primary_failure": "collision",
+            "termination_reason": "collision",
+        },
+        "candidate": {"scenario_seed": seed},
+        "failure_attribution": {
+            "primary_failure": "collision",
+            "details": {"termination_reason": "collision"},
+        },
+    }
+    if certified:
+        entry["certification_metadata"] = {
+            "status": "passed",
+            "source": "unit-test scenario_cert.v1 fixture",
+        }
+    return entry
+
+
+def _archive(path: Path, entries: list[dict]) -> Path:
+    """Write an adversarial failure archive fixture."""
+
+    payload = {"schema_version": "adversarial_failure_archive.v1", "entries": entries}
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def test_disjoint_certified_archives_are_ready(tmp_path: Path) -> None:
+    """Disjoint archive IDs and certified rerun rows pass the metadata gate."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [
+            _entry("source_0000", family="family_a", seed=1),
+            _entry("source_0001", family="family_a", seed=2),
+        ],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [
+            _entry("rerun_0000", family="family_b", seed=101),
+            _entry("rerun_0001", family="family_b", seed=102),
+        ],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(source, rerun)
+
+    assert readiness.status == READY
+    assert readiness.ready is True
+    assert readiness.archive_id_overlap == []
+    assert readiness.missing_certification_archive_ids == []
+    assert readiness.to_payload()["claim_boundary"].startswith("readiness/leakage check only")
+
+
+def test_overlapping_archive_ids_block_leakage(tmp_path: Path) -> None:
+    """Archive-ID overlap between source and rerun archives blocks readiness."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("shared_failure", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("shared_failure", family="family_b", seed=101)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(source, rerun)
+
+    assert readiness.status == BLOCKED
+    assert readiness.archive_id_overlap == ["shared_failure"]
+    assert "archive_id_overlap:1" in readiness.blockers
+
+
+def test_missing_certification_metadata_blocks_rerun_archive(tmp_path: Path) -> None:
+    """Every rerun archive entry must carry certification metadata."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101, certified=False)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(source, rerun)
+
+    assert readiness.status == BLOCKED
+    assert readiness.missing_certification_archive_ids == ["rerun_0000"]
+    assert "missing_certification_metadata:1" in readiness.blockers
+
+
+def test_diagnostic_only_output_caps_otherwise_ready_inputs(tmp_path: Path) -> None:
+    """Diagnostic-only rerun outputs cannot be promoted to benchmark evidence."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    rerun_output = tmp_path / "rerun_output.json"
+    rerun_output.write_text(
+        json.dumps(
+            {
+                "schema_version": "proposal_model_rerun.v1",
+                "result_classification": "diagnostic_only",
+                "benchmark_evidence": False,
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        rerun_output=rerun_output,
+    )
+
+    assert readiness.status == DIAGNOSTIC_ONLY
+    assert readiness.ready is False
+    assert readiness.blockers == []
+    assert readiness.diagnostic_only_outputs == ["result_classification:diagnostic_only"]
+
+
+def test_cli_exit_codes_and_writes_report(tmp_path: Path, capsys) -> None:
+    """CLI returns 0 for ready inputs and writes the JSON payload."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    output = tmp_path / "readiness.json"
+
+    exit_code = readiness_cli_main(
+        [
+            "--source-archive",
+            str(source),
+            "--rerun-archive",
+            str(rerun),
+            "--output",
+            str(output),
+        ]
+    )
+
+    assert exit_code == 0
+    assert json.loads(output.read_text(encoding="utf-8"))["status"] == READY
+    assert json.loads(capsys.readouterr().out)["status"] == READY

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -121,6 +121,34 @@ def test_missing_certification_metadata_blocks_rerun_archive(tmp_path: Path) -> 
     assert "missing_certification_metadata:1" in readiness.blockers
 
 
+def test_failed_or_falsy_certification_status_is_invalid(tmp_path: Path) -> None:
+    """Explicitly failed or falsy certification status must fail closed, not pass."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    cases = [
+        {"status": "failed", "source": "unit-test"},
+        {"status": False},
+        {"status": None},
+        {"status": ""},
+        "",
+        {},
+    ]
+    for index, certification in enumerate(cases):
+        entry = _entry(f"rerun_{index:04d}", family="family_b", seed=200 + index)
+        entry["certification_metadata"] = certification
+        rerun = _archive(tmp_path / f"rerun_{index}.json", [entry])
+
+        readiness = classify_failure_archive_rerun_readiness(source, rerun)
+
+        assert readiness.status == BLOCKED, certification
+        assert readiness.invalid_certification_archive_ids == [f"rerun_{index:04d}"], certification
+        assert readiness.missing_certification_archive_ids == [], certification
+        assert "invalid_certification_status:1" in readiness.blockers, certification
+
+
 def test_diagnostic_only_output_caps_otherwise_ready_inputs(tmp_path: Path) -> None:
     """Diagnostic-only rerun outputs cannot be promoted to benchmark evidence."""
 


### PR DESCRIPTION
## Summary

Implements a bounded issue #3275 readiness/leakage slice for rerunning the adversarial proposal model on a disjoint certified failure archive.

- Adds `robot_sf/benchmark/failure_archive_rerun_readiness.py` to load source/rerun failure archives, fail closed on archive-ID/family/seed overlap, require rerun certification metadata, and cap diagnostic-only rerun reports at `diagnostic_only`.
- Adds `scripts/validation/check_failure_archive_rerun_readiness.py` as a JSON CLI with explicit exit codes for ready, diagnostic-only, and blocked states.
- Adds focused fixtures/tests for overlapping archive IDs, missing certification metadata, diagnostic-only outputs, and the CLI path.
- Adds a context note documenting the boundary.

## Evidence Boundary

Readiness/leakage check only. This PR does not run benchmark campaigns, submit compute jobs, publish artifacts, or claim adversarial improvement.

## Scope (bounded slice of #3275)

This is a metadata-only readiness/leakage gate. It does **not** complete issue #3275. The parent issue stays open; remaining work includes:

- Running the proposal-vs-random comparison against a real populated certified failure archive (not fixtures).
- Independent planner-execution outcomes for the disjoint eval split (Batch 2).
- Shuffled-outcome and proposal-ranking permutation null tests on non-circular outcomes.
- Held-out yield reporting under the issue #2921 stop rule.

Refs #3275 (does not close the parent).

## Validation

- `uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q`
- `uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py scripts/validation/check_failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py`
- `uv run ruff format --check` on the touched files
- `git diff --check`
