### PR TITLE
training: add predictive retraining readiness packet (#3214)

### DIFF
--- a/configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml
+++ b/configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml
@@ -1,0 +1,49 @@
+# Issue #3214 hard-case predictive retraining readiness decision packet.
+#
+# Scope boundary: public static readiness only. This packet does not submit Slurm/GPU compute,
+# run a full benchmark campaign, publish a retrained checkpoint, or edit paper/dissertation claims.
+schema_version: predictive-retraining-readiness.v1
+issue: "#3214"
+candidate_id: crossing_conflict_weighted_predictive_retraining
+scope: decision_packet_only
+claim_boundary: >
+  Public decision packet only: no Slurm or GPU submission, no full benchmark campaign run, no
+  retrained checkpoint publication, and no paper or dissertation claim edit.
+
+inputs:
+  weighting_spec: configs/training/predictive/predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml
+  pipeline_config: configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
+  followup_issue: "#3254"
+
+prior_result:
+  status: verified_negative
+  evidence_status: diagnostic negative result only; not benchmark, leaderboard, or paper claim
+  source_issue: "#3254"
+  source_pr: "#3515"
+  observed_success_rate: 0.087
+  gate_min_success_rate: 0.30
+  conclusion: >
+    The crossing-conflict weighted predictive retrain improved trajectory-prediction accuracy but
+    did not clear closed-loop policy gates. Treat further same-packet retraining as blocked until a
+    public control-law-side change exists.
+
+launch_decision:
+  state: blocked_until_control_law_change
+  compute_submit_allowed: false
+  fail_closed_on_missing: true
+  required_before_rerun:
+    - control_law_change_config
+    - updated_public_config_or_pr
+    - checkpoint_provenance_plan
+    - hard_seed_evaluation_plan
+
+commands:
+  local_readiness_check: >
+    uv run python scripts/training/check_predictive_retraining_readiness.py
+    --packet configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml
+
+out_of_scope:
+  - full benchmark campaign run
+  - Slurm or GPU submission
+  - model checkpoint promotion
+  - paper or dissertation claim edits

--- a/robot_sf/training/predictive_retraining_readiness.py
+++ b/robot_sf/training/predictive_retraining_readiness.py
@@ -1,0 +1,203 @@
+"""Fail-closed readiness checks for predictive retraining decision packets."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_VERSION = "predictive-retraining-readiness.v1"
+DECISION_BLOCKED = "retraining_blocked"
+DECISION_READY = "retraining_launch_ready"
+DEFAULT_PACKET = "configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml"
+
+_NEGATIVE_PRIOR_STATUSES = {"verified_negative", "negative_result"}
+_REQUIRED_RERUN_ITEMS = {
+    "control_law_change_config",
+    "checkpoint_provenance_plan",
+    "hard_seed_evaluation_plan",
+}
+
+
+class PredictiveRetrainingReadinessError(ValueError):
+    """Raised when a predictive retraining readiness packet cannot be evaluated."""
+
+
+def load_readiness_packet(packet_path: Path) -> dict[str, Any]:
+    """Load a readiness packet from YAML.
+
+    Returns:
+        Parsed readiness packet mapping.
+    """
+
+    if not packet_path.is_file():
+        raise PredictiveRetrainingReadinessError(f"readiness packet is not a file: {packet_path}")
+    payload = yaml.safe_load(packet_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise PredictiveRetrainingReadinessError(
+            f"readiness packet must be a mapping: {packet_path}"
+        )
+    return payload
+
+
+def evaluate_retraining_readiness(
+    packet_path: Path | str = DEFAULT_PACKET,
+    *,
+    repo_root: Path | str | None = None,
+) -> dict[str, Any]:
+    """Evaluate whether a predictive retraining packet is launch-ready.
+
+    The checker performs only static public-repository checks. It never submits compute, fetches
+    private artifacts, or upgrades diagnostic training evidence into a benchmark or paper claim.
+
+    Returns:
+        Static readiness report with packet completeness, launch decision, and blockers.
+    """
+
+    root = Path(repo_root).resolve() if repo_root is not None else Path.cwd().resolve()
+    packet = _resolve_path(packet_path, root)
+    payload = load_readiness_packet(packet)
+
+    blockers: list[str] = []
+    warnings: list[str] = []
+    _validate_static_contract(payload, packet, root, blockers, warnings)
+
+    prior_result = _mapping(payload.get("prior_result"))
+    launch_decision = _mapping(payload.get("launch_decision"))
+    prior_status = str(prior_result.get("status") or "").strip()
+    decision_state = str(launch_decision.get("state") or "").strip()
+    compute_submit_allowed = bool(launch_decision.get("compute_submit_allowed", False))
+
+    if prior_status in _NEGATIVE_PRIOR_STATUSES:
+        if decision_state != "blocked_until_control_law_change":
+            blockers.append(
+                "launch_decision.state must be blocked_until_control_law_change after a "
+                "verified negative prior retraining result"
+            )
+        _validate_required_rerun_items(launch_decision, blockers)
+
+    launch_ready = (
+        not blockers and compute_submit_allowed and prior_status not in _NEGATIVE_PRIOR_STATUSES
+    )
+    decision = DECISION_READY if launch_ready else DECISION_BLOCKED
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "ok",
+        "issue": payload.get("issue"),
+        "candidate_id": payload.get("candidate_id"),
+        "packet": str(packet),
+        "packet_complete": not blockers,
+        "launch_ready": launch_ready,
+        "decision": decision,
+        "decision_state": decision_state,
+        "prior_result_status": prior_status,
+        "compute_submit_allowed": compute_submit_allowed,
+        "blockers": blockers,
+        "warnings": warnings,
+        "evidence_boundary": payload.get("claim_boundary"),
+    }
+
+
+def _validate_static_contract(
+    payload: dict[str, Any],
+    packet_path: Path,
+    repo_root: Path,
+    blockers: list[str],
+    warnings: list[str],
+) -> None:
+    """Validate packet fields that make a public launch decision reproducible."""
+
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        blockers.append(f"schema_version must be {SCHEMA_VERSION!r}")
+    issue = str(payload.get("issue") or "").strip()
+    if issue not in {"#3214", "3214"}:
+        blockers.append("issue must be #3214")
+    _require_non_empty_string(payload, "candidate_id", blockers)
+    claim_boundary = str(payload.get("claim_boundary") or "")
+    for required_text in ("no Slurm", "no full benchmark", "no paper"):
+        if required_text.lower() not in claim_boundary.lower():
+            blockers.append(f"claim_boundary must state {required_text!r}")
+
+    inputs = _mapping(payload.get("inputs"))
+    _require_existing_repo_path(inputs, "weighting_spec", packet_path, repo_root, blockers)
+    _require_existing_repo_path(inputs, "pipeline_config", packet_path, repo_root, blockers)
+
+    prior_result = _mapping(payload.get("prior_result"))
+    _require_non_empty_string(prior_result, "status", blockers, prefix="prior_result")
+    _require_non_empty_string(prior_result, "source_issue", blockers, prefix="prior_result")
+    evidence_status = str(prior_result.get("evidence_status") or "")
+    if "paper" not in evidence_status.lower() or "not" not in evidence_status.lower():
+        warnings.append("prior_result.evidence_status should explicitly avoid paper-claim status")
+
+    launch_decision = _mapping(payload.get("launch_decision"))
+    if launch_decision.get("fail_closed_on_missing") is not True:
+        blockers.append("launch_decision.fail_closed_on_missing must be true")
+    if launch_decision.get("compute_submit_allowed") is not False:
+        blockers.append("launch_decision.compute_submit_allowed must be false for this PR scope")
+
+
+def _validate_required_rerun_items(launch_decision: dict[str, Any], blockers: list[str]) -> None:
+    required = launch_decision.get("required_before_rerun")
+    if not isinstance(required, list):
+        blockers.append("launch_decision.required_before_rerun must be a list")
+        return
+    observed = {str(item).strip() for item in required if str(item).strip()}
+    missing = sorted(_REQUIRED_RERUN_ITEMS - observed)
+    if missing:
+        blockers.append(
+            "launch_decision.required_before_rerun missing required items: " + ", ".join(missing)
+        )
+
+
+def _mapping(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _require_non_empty_string(
+    mapping: dict[str, Any],
+    key: str,
+    blockers: list[str],
+    *,
+    prefix: str | None = None,
+) -> None:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        field = f"{prefix}.{key}" if prefix else key
+        blockers.append(f"{field} must be a non-empty string")
+
+
+def _require_existing_repo_path(
+    mapping: dict[str, Any],
+    key: str,
+    packet_path: Path,
+    repo_root: Path,
+    blockers: list[str],
+) -> None:
+    value = mapping.get(key)
+    if not isinstance(value, str) or not value.strip():
+        blockers.append(f"inputs.{key} must be a non-empty path string")
+        return
+    resolved = _resolve_path(value, repo_root, base=packet_path.parent)
+    if not resolved.is_file():
+        blockers.append(f"inputs.{key} does not exist: {value}")
+
+
+def _resolve_path(path: Path | str, repo_root: Path, *, base: Path | None = None) -> Path:
+    candidate = Path(path)
+    if candidate.is_absolute():
+        return candidate.resolve()
+    if str(path).startswith(("configs/", "scripts/", "docs/", "robot_sf/", "tests/")):
+        return (repo_root / candidate).resolve()
+    return ((base or repo_root) / candidate).resolve()
+
+
+__all__ = [
+    "DECISION_BLOCKED",
+    "DECISION_READY",
+    "DEFAULT_PACKET",
+    "PredictiveRetrainingReadinessError",
+    "evaluate_retraining_readiness",
+    "load_readiness_packet",
+]

--- a/scripts/training/check_predictive_retraining_readiness.py
+++ b/scripts/training/check_predictive_retraining_readiness.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+"""Check predictive retraining launch readiness without submitting compute."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.training.predictive_retraining_readiness import (
+    DEFAULT_PACKET,
+    PredictiveRetrainingReadinessError,
+    evaluate_retraining_readiness,
+)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--packet", type=Path, default=Path(DEFAULT_PACKET))
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument(
+        "--require-launch-ready",
+        action="store_true",
+        help="Return non-zero when the packet is valid but blocked from launch.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    """Run the readiness CLI and return a shell-friendly exit code."""
+
+    args = _parse_args()
+    try:
+        report = evaluate_retraining_readiness(args.packet, repo_root=args.repo_root)
+    except PredictiveRetrainingReadinessError as exc:
+        print(json.dumps({"status": "failed", "error": str(exc)}, indent=2, sort_keys=True))
+        return 2
+
+    print(json.dumps(report, indent=2, sort_keys=True))
+    if args.require_launch_ready and not report["launch_ready"]:
+        return 3
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/training/test_predictive_retraining_readiness.py
+++ b/tests/training/test_predictive_retraining_readiness.py
@@ -1,0 +1,155 @@
+"""Tests for predictive retraining readiness decision packets."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.training.predictive_retraining_readiness import (
+    DECISION_BLOCKED,
+    PredictiveRetrainingReadinessError,
+    evaluate_retraining_readiness,
+    load_readiness_packet,
+)
+from scripts.training import check_predictive_retraining_readiness as readiness_cli
+
+
+def _write_packet(tmp_path: Path, payload: dict[str, object]) -> Path:
+    packet = tmp_path / "packet.yaml"
+    packet.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return packet
+
+
+def _complete_payload(tmp_path: Path) -> dict[str, object]:
+    weighting_spec = tmp_path / "weighting.yaml"
+    pipeline_config = tmp_path / "pipeline.yaml"
+    weighting_spec.write_text("profile_id: test\n", encoding="utf-8")
+    pipeline_config.write_text("experiment:\n  run_id: test\n", encoding="utf-8")
+    return {
+        "schema_version": "predictive-retraining-readiness.v1",
+        "issue": "#3214",
+        "candidate_id": "crossing_conflict_weighted_predictive_retraining",
+        "claim_boundary": (
+            "No Slurm submission, no full benchmark campaign run, and no paper claim edit."
+        ),
+        "inputs": {
+            "weighting_spec": str(weighting_spec),
+            "pipeline_config": str(pipeline_config),
+        },
+        "prior_result": {
+            "status": "verified_negative",
+            "evidence_status": "diagnostic negative result only; not paper claim",
+            "source_issue": "#3254",
+        },
+        "launch_decision": {
+            "state": "blocked_until_control_law_change",
+            "compute_submit_allowed": False,
+            "fail_closed_on_missing": True,
+            "required_before_rerun": [
+                "control_law_change_config",
+                "checkpoint_provenance_plan",
+                "hard_seed_evaluation_plan",
+            ],
+        },
+    }
+
+
+def test_default_issue_3214_packet_is_complete_but_launch_blocked() -> None:
+    """Checked-in packet is complete but must not authorize blind retraining."""
+
+    repo = Path(__file__).resolve().parents[2]
+    report = evaluate_retraining_readiness(repo_root=repo)
+
+    assert report["issue"] == "#3214"
+    assert report["packet_complete"] is True
+    assert report["launch_ready"] is False
+    assert report["decision"] == DECISION_BLOCKED
+    assert report["prior_result_status"] == "verified_negative"
+    assert report["compute_submit_allowed"] is False
+    assert report["blockers"] == []
+
+
+def test_complete_negative_result_packet_blocks_without_missing_prerequisites(
+    tmp_path: Path,
+) -> None:
+    """A complete packet reports the negative-result decision instead of missing inputs."""
+
+    packet = _write_packet(tmp_path, _complete_payload(tmp_path))
+
+    report = evaluate_retraining_readiness(packet, repo_root=tmp_path)
+
+    assert report["packet_complete"] is True
+    assert report["launch_ready"] is False
+    assert report["decision"] == DECISION_BLOCKED
+    assert report["blockers"] == []
+
+
+def test_missing_retraining_prerequisites_fail_closed(tmp_path: Path) -> None:
+    """Missing control-law/provenance prerequisites keep packet incomplete."""
+
+    payload = _complete_payload(tmp_path)
+    payload["launch_decision"] = {
+        "state": "blocked_until_control_law_change",
+        "compute_submit_allowed": False,
+        "fail_closed_on_missing": True,
+        "required_before_rerun": ["control_law_change_config"],
+    }
+    packet = _write_packet(tmp_path, payload)
+
+    report = evaluate_retraining_readiness(packet, repo_root=tmp_path)
+
+    assert report["packet_complete"] is False
+    assert report["launch_ready"] is False
+    assert any("checkpoint_provenance_plan" in blocker for blocker in report["blockers"])
+    assert any("hard_seed_evaluation_plan" in blocker for blocker in report["blockers"])
+
+
+def test_missing_input_path_fails_closed(tmp_path: Path) -> None:
+    """Missing public config inputs are surfaced as blockers, not launch-ready state."""
+
+    payload = _complete_payload(tmp_path)
+    payload["inputs"] = {
+        "weighting_spec": str(tmp_path / "missing_weighting.yaml"),
+        "pipeline_config": str(tmp_path / "missing_pipeline.yaml"),
+    }
+    packet = _write_packet(tmp_path, payload)
+
+    report = evaluate_retraining_readiness(packet, repo_root=tmp_path)
+
+    assert report["packet_complete"] is False
+    assert report["launch_ready"] is False
+    assert any("inputs.weighting_spec does not exist" in blocker for blocker in report["blockers"])
+    assert any("inputs.pipeline_config does not exist" in blocker for blocker in report["blockers"])
+
+
+def test_cli_require_launch_ready_exits_blocked(monkeypatch, tmp_path: Path, capsys) -> None:
+    """CLI can be used as a fail-closed launch gate when compute authorization exists later."""
+
+    packet = _write_packet(tmp_path, _complete_payload(tmp_path))
+    monkeypatch.setattr(
+        readiness_cli,
+        "_parse_args",
+        lambda: readiness_cli.argparse.Namespace(
+            packet=packet,
+            repo_root=tmp_path,
+            require_launch_ready=True,
+        ),
+    )
+
+    assert readiness_cli.main() == 3
+    report = json.loads(capsys.readouterr().out)
+    assert report["decision"] == DECISION_BLOCKED
+    assert report["launch_ready"] is False
+
+
+def test_load_readiness_packet_rejects_non_mapping(tmp_path: Path) -> None:
+    """Malformed packet YAML remains operator error."""
+
+    packet = tmp_path / "bad.yaml"
+    packet.write_text("- not\n- mapping\n", encoding="utf-8")
+
+    with pytest.raises(PredictiveRetrainingReadinessError, match="must be a mapping"):
+        load_readiness_packet(packet)


### PR DESCRIPTION
## Summary
Adds a public fail-closed readiness packet for issue #3214 after the crossing-conflict weighted predictive retraining follow-up was verified as a negative result.

The packet and checker make the current decision explicit: the retraining slice is complete as a decision packet, but not launch-ready for blind resubmission until a public control-law-side change exists.

## Linked Issues
- Relates to #3214
- Relates to #3254

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: The checker only reads existing public #3214/#3254 config paths and static packet fields.

## What Changed
- Added `configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml`, a static decision packet for the #3214 hard-case predictive retraining lane.
- Added `robot_sf.training.predictive_retraining_readiness` and `scripts/training/check_predictive_retraining_readiness.py` to validate packet completeness and fail closed when launch prerequisites are missing.
- Added focused tests covering the checked-in packet, complete blocked packets, missing prerequisite items, missing public config inputs, CLI blocked exit code, and malformed YAML.

## Why Matters
- Added value: Maintainers can distinguish “packet complete but launch blocked by verified negative result” from “packet incomplete.”
- Expected impact: Prevents blind reruns of the same crossing-conflict weighted predictive retraining packet after the documented negative result.
- Why worth merging now: Issue #3214 remains open/ready, while #3254 now records a negative result; this preserves the public launch decision without submitting compute or promoting claims.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3214 hard-case predictive retraining launch decision after #3254 negative result.
- Comparator or baseline, applicable: NA - no new run or benchmark comparison in this PR.
- Evidence tier: NA - static support checker and decision packet; no empirical evidence generated.
- Result classification: NA - no research result; this only records a blocked launch decision.
- Decision stop rule, applicable: launch remains blocked unless a public control-law-side change/config exists plus checkpoint provenance and hard-seed evaluation plans.
- Parent issue, claim map, registry, context note, synthesis surface update: Parent issue #3214; follow-up evidence-producing issue #3254 is already closed as negative.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - static readiness checker only, no interpretation of new benchmark evidence.

## Domain-Aware Approval
- Required PR: none - static support checker and decision packet only.
- Domains reviewed: predictive retraining launch readiness, benchmark exclusion, paper-claim exclusion.
- Status: waived
- Approver/review source waiver: Waived because this PR records a blocked launch-readiness decision and makes no new benchmark, model-improvement, leaderboard, paper, or dissertation claim.
- Target claim or hypothesis: NA - no new empirical claim.
- Comparator or split evidence validity: NA - no benchmark run.
- Fallback or degraded exclusions: No benchmark execution in scope.
- Boundary reviewed: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity versus experimental validity: Implementation validates packet fields and existing public config paths only.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no new training mechanism executed.
- Did intervention change command source, selected command, trajectory, route progress? NA - static checker only.
- Did scenario actually contain targeted failure mode? NA - no scenario execution.
- Result route: stop
- Follow-up question issue weak, negative, non-transfer results: #3254 documents the negative training result; this PR records the launch block.

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: no new artifact required for this readiness packet.
- Stop / revise / continue decision: stop blind reruns; revise only after a public control-law-side change.
- Proposed child issue existing follow-up: #3254 already captured the evidence-producing follow-up and negative result.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_predictive_retraining_readiness.py -q` -> passed, 6 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_run_predictive_training_pipeline.py::test_issue_3254_config_targets_crossing_conflict_weighting_spec tests/training/test_predictive_retraining_readiness.py -q` -> passed, 7 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/predictive_retraining_readiness.py scripts/training/check_predictive_retraining_readiness.py tests/training/test_predictive_retraining_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/training/predictive_retraining_readiness.py scripts/training/check_predictive_retraining_readiness.py tests/training/test_predictive_retraining_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/training/check_predictive_retraining_readiness.py --packet configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml --require-launch-ready` -> expected blocked exit code 3; JSON reported `packet_complete: true`, `launch_ready: false`, `decision: retraining_blocked`, `compute_submit_allowed: false`.

Explicit out-of-scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Evidence
- Baseline runtime: NA - no runtime/performance path changed.
- Changed runtime: NA - no runtime/performance path changed.
- Representative command: `uv run python scripts/training/check_predictive_retraining_readiness.py --packet configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml`
- Hot-path call count profile anchor: NA - static readiness checker only.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: Checker reports launch-ready for the default #3214 packet without a control-law-side change, or fails to surface missing prerequisite paths/items.

## Risks / Rollout
- Compatibility risks: Low; new checker and packet are additive.
- Failure modes: Packet schema may need extension if future retraining candidates should become launch-ready after a public control-law change.
- Rollback fallback plan: Remove the checker/packet; existing #3214/#3254 configs remain unchanged.

## Docs / Provenance
- Updated docs: NA - config packet and CLI are self-contained for this slice.
- Relevant design provenance notes: #3214 issue; #3254 negative-result comments and PR #3515.
- Any assumptions need to preserved: #3254’s negative result means same-packet retraining should remain blocked until a public control-law-side change exists.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - this PR body records the handoff; issue comments were not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: This is a launch-readiness decision packet and checker; it does not add benchmark results, model artifacts, or paper-facing claims.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes
- Verify closely that the default #3214 packet stays `packet_complete: true` but `launch_ready: false`.
- Known limitation: The checker is static and public-repo-only; it intentionally does not inspect private Slurm queues, W&B artifacts, or generated `output/` evidence.
- No new open follow-up issue is needed for this support slice; future retraining should be proposed only after a public control-law-side change exists.
