### PR TITLE
Issue #3078: harden Package A readiness checker

### DIFF
--- a/configs/benchmarks/issue_3078_package_a_readiness.yaml
+++ b/configs/benchmarks/issue_3078_package_a_readiness.yaml
@@ -1,82 +1,110 @@
 # Package A readiness manifest (issue #3078).
 #
-# Scope: this manifest declares the *input prerequisites* that must exist before a
-# Package A campaign (seed/planner-rank stability + held-out scenario-family transfer)
-# can be executed. It is consumed by `scripts/validation/check_package_a_readiness.py`,
-# which fails closed when any declared prerequisite is missing.
+# Scope: declare input prerequisites and command contracts before Package A
+# campaign execution. This is consumed by
+# `scripts/validation/check_package_a_readiness.py` and fails closed when
+# prerequisites, no-submit gates, or durable-evidence gates are malformed.
 #
-# This manifest does NOT execute the benchmark, submit Slurm, interpret ranks, or move
-# any claim boundary. It is a provenance/readiness gate only. Actual execution and
-# interpretation are owned by the canonical campaign runners referenced below and are
-# tracked under issue #3078 / parent #3057.
-schema_version: package-a-readiness.v0.1
+# This manifest does NOT execute benchmarks, submit compute, interpret ranks,
+# or move any paper-facing claim boundary.
+schema_version: package-a-readiness.v0.2
 
 package:
   id: issue_3078_package_a_readiness
   issue: 3078
   parent_issue: 3057
   purpose: >
-    Verify that held-out-family inputs, seed-plan metadata, and output locations are
-    present and well-formed before a Package A rank-stability / held-out-family
-    transfer campaign is launched.
+    Verify held-out-family inputs, seed-plan metadata, command contracts, output
+    locations, and no-submit/no-claim gates before Package A rank-stability /
+    held-out-family transfer campaign launch.
   claim_boundary: >
-    Readiness/provenance gating only. A passing check proves the declared input
-    prerequisites exist; it does NOT constitute benchmark evidence, rank interpretation,
-    or a paper-facing claim.
+    Readiness/provenance gating only. A passing check proves declared input
+    prerequisites and decision-packet metadata exist; it is not benchmark
+    evidence, rank interpretation, or a paper-facing claim.
 
-# Held-out scenario-family transfer inputs. Every path must exist on disk for the
-# held-out transfer rows to be runnable with a valid leakage audit.
 heldout_family_inputs:
   description: >
-    Frozen held-out scenario-family pilot definition plus the disjoint training-pool
-    and held-out evaluation scenario sets used for the leakage audit and transfer-delta.
+    Frozen held-out scenario-family pilot definition plus disjoint training-pool
+    and held-out evaluation scenario sets used for leakage audit and transfer
+    delta.
   required_paths:
-    - experiments/issue_2128_heldout_family_transfer_pilot.yaml
-    - configs/scenarios/sets/issue_2128_heldout_family_transfer_training_pool.yaml
-    - configs/scenarios/sets/issue_2128_heldout_family_transfer_pilot_eval.yaml
+  - experiments/issue_2128_heldout_family_transfer_pilot.yaml
+  - configs/scenarios/sets/issue_2128_heldout_family_transfer_training_pool.yaml
+  - configs/scenarios/sets/issue_2128_heldout_family_transfer_pilot_eval.yaml
   leakage_audit_tool: scripts/tools/validate_heldout_transfer_partitions.py
 
-# Seed-plan metadata for the seed/planner-rank stability analysis. The metadata fields
-# below must be declared (so the seed plan is explicit and reproducible) and the
-# referenced seed tooling must exist on disk.
 seed_plan:
   description: >
-    Seed-sufficiency analysis plan for rank stability. Metadata is declared here so the
-    seed budget and acceptance gate are explicit before execution.
-  mode: seed-sufficiency-gated
-  min_seeds: 5
-  rank_metric: kendall_tau
+    Existing seed-sufficiency/rank-stability tooling Package A must consume
+    rather than reimplement.
+  mode: seed_sufficiency_then_rank_stability
+  min_seeds: 10
+  rank_metric: snqi
   required_paths:
-    - scripts/tools/analyze_seed_sufficiency.py
-    - scripts/tools/seed_sufficiency_gate.py
-    - robot_sf/benchmark/seed_variance.py
-  # Metadata keys that MUST be present and non-empty in this section for the plan to be
-  # considered explicit. The checker validates presence, not numeric correctness.
+  - scripts/tools/analyze_seed_sufficiency.py
+  - scripts/tools/seed_sufficiency_gate.py
+  - robot_sf/benchmark/seed_variance.py
   required_metadata:
-    - mode
-    - min_seeds
-    - rank_metric
+  - mode
+  - min_seeds
+  - rank_metric
 
-# Frozen protocol / canonical result store the campaign must write through.
 frozen_protocol:
   description: >
-    Frozen research-engine suite and canonical campaign result store that anchor the
-    Package A protocol. These are inputs to (not outputs of) the readiness check.
+    Frozen research-engine suite and canonical campaign result-store anchors
+    Package A must write through.
   required_paths:
-    - configs/benchmarks/issue_3059_research_engine_suite_v0.yaml
-    - scripts/tools/campaign_result_store.py
-    - robot_sf/benchmark/benchmark_row_claim.py
+  - configs/benchmarks/issue_3059_research_engine_suite_v0.yaml
+  - scripts/tools/campaign_result_store.py
+  - robot_sf/benchmark/benchmark_row_claim.py
 
-# Local output location for any generated readiness/preflight artifacts. The checker
-# validates the declared location is safe (under output/, disposable); it does not
-# require the directory to already exist because it is produced by execution.
+command_contracts:
+  contracts:
+  - id: seed_sufficiency_surface
+    stage: readiness_probe
+    command: uv run python scripts/tools/analyze_seed_sufficiency.py --help
+    allowed_in_readiness_check: true
+    executes_benchmark_campaign: false
+    required_paths:
+    - scripts/tools/analyze_seed_sufficiency.py
+    - robot_sf/benchmark/seed_variance.py
+  - id: heldout_family_leakage_audit
+    stage: readiness_probe
+    command: >
+      uv run python scripts/tools/validate_heldout_transfer_partitions.py
+      configs/benchmarks/issue_2128_heldout_family_transfer_partitions.yaml
+    allowed_in_readiness_check: true
+    executes_benchmark_campaign: false
+    required_paths:
+    - scripts/tools/validate_heldout_transfer_partitions.py
+    - configs/benchmarks/issue_2128_heldout_family_transfer_partitions.yaml
+  - id: future_package_a_campaign
+    stage: future_campaign_execution
+    command: >
+      uv run python scripts/tools/run_camera_ready_benchmark.py
+      --config configs/benchmarks/issue_2128_heldout_family_transfer_pilot.yaml
+      --mode preflight
+      --label issue3078-package-a-readiness
+      --output-root output/benchmarks/issue_3078_package_a_readiness
+    allowed_in_readiness_check: false
+    executes_benchmark_campaign: true
+    required_paths:
+    - scripts/tools/run_camera_ready_benchmark.py
+    - configs/benchmarks/issue_2128_heldout_family_transfer_pilot.yaml
+
 outputs:
   local_root: output/benchmarks/issue_3078_package_a_readiness
   disposable: true
 
-# Durable-evidence plan: where a tracked, reviewable readiness record should live if the
-# readiness verdict is promoted. Must not point into the disposable output/ tree.
 durable_evidence:
   plan:
     path: docs/context/evidence/issue_3078_package_a_readiness
     required_before_claim: true
+
+readiness_decision:
+  benchmark_campaign_run: false
+  compute_submit_authorized: false
+  ranking_claim_promotion: false
+  paper_claim_edits: false
+  fallback_degraded_success_allowed: false
+  result_classification_required: true

--- a/scripts/validation/check_package_a_readiness.py
+++ b/scripts/validation/check_package_a_readiness.py
@@ -71,6 +71,18 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _clean_str(value: Any) -> str:
+    """Coerce a manifest scalar to a stripped string, treating ``None`` as empty.
+
+    A bare ``str(None)`` yields the literal ``"None"``, which would otherwise
+    pass downstream non-empty checks and let a ``null`` YAML field masquerade as
+    a present value. Returning ``""`` for ``None`` keeps the checker fail-closed.
+    """
+    if value is None:
+        return ""
+    return str(value).strip()
+
+
 def _load_manifest(path: Path) -> dict[str, Any]:
     """Load manifest YAML, raising ManifestError on non-mapping documents."""
     if not path.exists():
@@ -176,9 +188,9 @@ def _check_command_contract(
         report.issues.append(f"{prefix} must be mapping")
         return
 
-    contract_id = str(contract.get("id", "")).strip()
-    stage = str(contract.get("stage", "")).strip()
-    command = str(contract.get("command", "")).strip()
+    contract_id = _clean_str(contract.get("id"))
+    stage = _clean_str(contract.get("stage"))
+    command = _clean_str(contract.get("command"))
     executes_benchmark = contract.get("executes_benchmark_campaign")
     allowed_here = contract.get("allowed_in_readiness_check")
 
@@ -215,7 +227,7 @@ def _check_command_contract(
 
 def _check_outputs(outputs: dict[str, Any], report: ReadinessReport) -> None:
     """Verify declared output location is safe and disposable."""
-    local_root = str(outputs.get("local_root", "")).strip()
+    local_root = _clean_str(outputs.get("local_root"))
     if not local_root:
         report.issues.append("outputs.local_root is required")
         return
@@ -232,7 +244,7 @@ def _check_durable_evidence(durable_evidence: dict[str, Any], report: ReadinessR
         report.issues.append("durable_evidence.plan must be mapping")
         return
 
-    rel_path = str(plan.get("path", "")).strip()
+    rel_path = _clean_str(plan.get("path"))
     if not rel_path:
         report.issues.append("durable_evidence.plan.path is required")
     elif PurePosixPath(rel_path).parts[:1] == ("output",):

--- a/scripts/validation/check_package_a_readiness.py
+++ b/scripts/validation/check_package_a_readiness.py
@@ -1,24 +1,10 @@
 #!/usr/bin/env python3
-"""Fail-closed readiness checker for the Package A benchmark (issue #3078).
+"""Fail-closed readiness checker for Package A benchmark issue #3078.
 
-Package A is the seed/planner-rank stability plus held-out scenario-family transfer
-result for the dissertation benchmark (parent issue #3057). Before that campaign is
-executed, several input prerequisites must already exist: the held-out-family scenario
-inputs, the seed-plan tooling, and the frozen protocol / result-store entry points.
-
-This checker is deliberately bounded. It:
-
-- loads a Package A readiness manifest (see
-  ``configs/benchmarks/issue_3078_package_a_readiness.yaml``),
-- verifies that every declared input prerequisite path exists on disk,
-- verifies the seed-plan metadata fields are present and non-empty,
-- verifies the declared output location is safe (under ``output/`` and disposable),
-- and **fails closed** (non-zero exit, ``status: not_ready``) when any prerequisite is
-  missing or malformed.
-
-It does NOT execute the benchmark, submit Slurm/GPU jobs, interpret ranks, or move any
-claim boundary. A passing check is provenance/readiness evidence only, never benchmark
-evidence.
+Package A covers seed/planner-rank stability plus held-out scenario-family
+transfer under parent issue #3057. This checker validates the readiness
+decision packet only. It does not execute benchmark campaigns, submit compute,
+interpret rankings, or move any paper-facing claim boundary.
 """
 
 from __future__ import annotations
@@ -34,18 +20,20 @@ import yaml
 
 SCHEMA_VERSION = "package_a_readiness_report.v1"
 
-# Sections the manifest must declare for the readiness check to be meaningful.
 REQUIRED_SECTIONS = (
     "package",
     "heldout_family_inputs",
     "seed_plan",
     "frozen_protocol",
+    "command_contracts",
     "outputs",
+    "durable_evidence",
+    "readiness_decision",
 )
 
 
 class ManifestError(ValueError):
-    """Raised when the manifest is structurally unusable (cannot run the check)."""
+    """Raised when the manifest is structurally unusable."""
 
 
 @dataclass
@@ -56,22 +44,24 @@ class ReadinessReport:
     package_id: str
     schema_version: str = SCHEMA_VERSION
     checked_paths: list[dict[str, Any]] = field(default_factory=list)
+    checked_commands: list[dict[str, Any]] = field(default_factory=list)
     missing_paths: list[str] = field(default_factory=list)
     issues: list[str] = field(default_factory=list)
 
     @property
     def status(self) -> str:
-        """Return ``ready`` only when nothing is missing and no structural issue exists."""
+        """Return ``ready`` only when no missing path or structural issue exists."""
         return "ready" if not self.missing_paths and not self.issues else "not_ready"
 
     def to_dict(self) -> dict[str, Any]:
-        """Serialize the report to a JSON-friendly mapping."""
+        """Serialize report as a JSON-friendly mapping."""
         return {
             "schema_version": self.schema_version,
             "status": self.status,
             "manifest_path": self.manifest_path,
             "package_id": self.package_id,
             "checked_paths": self.checked_paths,
+            "checked_commands": self.checked_commands,
             "missing_paths": self.missing_paths,
             "issues": self.issues,
         }
@@ -82,23 +72,24 @@ def _repo_root() -> Path:
 
 
 def _load_manifest(path: Path) -> dict[str, Any]:
-    """Load the manifest YAML, raising ManifestError on a non-mapping document."""
+    """Load manifest YAML, raising ManifestError on non-mapping documents."""
     if not path.exists():
         raise ManifestError(f"Manifest not found: {path}")
     manifest = yaml.safe_load(path.read_text(encoding="utf-8"))
     if not isinstance(manifest, dict):
-        raise ManifestError("Manifest root must be a mapping")
-    missing_sections = [s for s in REQUIRED_SECTIONS if s not in manifest]
+        raise ManifestError("Manifest root must be mapping")
+    missing_sections = [section for section in REQUIRED_SECTIONS if section not in manifest]
     if missing_sections:
         raise ManifestError(f"Manifest missing required sections: {sorted(missing_sections)}")
     return manifest
 
 
 def _required_paths(section: dict[str, Any], section_name: str) -> list[str]:
-    """Return the ``required_paths`` list for a section, validating its shape."""
+    """Return ``required_paths`` for a section, validating shape."""
     raw = section.get("required_paths", [])
     if not isinstance(raw, list) or not raw:
-        raise ManifestError(f"{section_name}.required_paths must be a non-empty list")
+        raise ManifestError(f"{section_name}.required_paths must be non-empty list")
+
     paths: list[str] = []
     for item in raw:
         if not isinstance(item, str) or not item.strip():
@@ -113,10 +104,9 @@ def _check_paths(
     section_name: str,
     report: ReadinessReport,
 ) -> None:
-    """Record existence of every required path in a section into the report."""
+    """Record required path existence for a manifest section."""
     for rel_path in _required_paths(section, section_name):
-        candidate = repo_root / rel_path
-        exists = candidate.exists()
+        exists = (repo_root / rel_path).exists()
         report.checked_paths.append({"section": section_name, "path": rel_path, "exists": exists})
         if not exists:
             report.missing_paths.append(rel_path)
@@ -129,13 +119,14 @@ def _check_optional_tool(
     section_name: str,
     report: ReadinessReport,
 ) -> None:
-    """Check a single optional tool path declared under ``key`` if present."""
+    """Check a single optional tool path declared under ``key``."""
     tool = section.get(key)
     if tool is None:
         return
     if not isinstance(tool, str) or not tool.strip():
-        report.issues.append(f"{section_name}.{key} must be a non-empty string when present")
+        report.issues.append(f"{section_name}.{key} must be non-empty string when present")
         return
+
     rel_path = tool.strip()
     exists = (repo_root / rel_path).exists()
     report.checked_paths.append(
@@ -146,19 +137,79 @@ def _check_optional_tool(
 
 
 def _check_seed_plan_metadata(seed_plan: dict[str, Any], report: ReadinessReport) -> None:
-    """Verify the declared seed-plan metadata fields are present and non-empty."""
+    """Verify declared seed-plan metadata fields are present and non-empty."""
     required_metadata = seed_plan.get("required_metadata", [])
     if not isinstance(required_metadata, list) or not required_metadata:
-        report.issues.append("seed_plan.required_metadata must be a non-empty list")
+        report.issues.append("seed_plan.required_metadata must be non-empty list")
         return
+
     for key in required_metadata:
         value = seed_plan.get(key)
         if value is None or (isinstance(value, str) and not value.strip()):
-            report.issues.append(f"seed_plan metadata field '{key}' is missing or empty")
+            report.issues.append(f"seed_plan metadata field '{key}' missing or empty")
+
+
+def _check_command_contracts(
+    repo_root: Path, command_contracts: dict[str, Any], report: ReadinessReport
+) -> None:
+    """Verify command contracts are explicit metadata, not work to run here."""
+    contracts = command_contracts.get("contracts")
+    if not isinstance(contracts, list) or not contracts:
+        report.issues.append("command_contracts.contracts must be non-empty list")
+        return
+
+    for index, contract in enumerate(contracts):
+        _check_command_contract(repo_root, contract, index, report)
+
+
+def _check_command_contract(
+    repo_root: Path, contract: Any, index: int, report: ReadinessReport
+) -> None:
+    """Verify one command contract and its declared path dependencies."""
+    prefix = f"command_contracts.contracts[{index}]"
+    if not isinstance(contract, dict):
+        report.issues.append(f"{prefix} must be mapping")
+        return
+
+    contract_id = str(contract.get("id", "")).strip()
+    stage = str(contract.get("stage", "")).strip()
+    command = str(contract.get("command", "")).strip()
+    executes_benchmark = contract.get("executes_benchmark_campaign")
+    allowed_here = contract.get("allowed_in_readiness_check")
+
+    if not contract_id:
+        report.issues.append(f"{prefix}.id is required")
+    if not stage:
+        report.issues.append(f"{prefix}.stage is required")
+    if not command:
+        report.issues.append(f"{prefix}.command is required")
+    if not isinstance(executes_benchmark, bool):
+        report.issues.append(f"{prefix}.executes_benchmark_campaign must be boolean")
+    if not isinstance(allowed_here, bool):
+        report.issues.append(f"{prefix}.allowed_in_readiness_check must be boolean")
+    if executes_benchmark is True and allowed_here is True:
+        report.issues.append(
+            f"{prefix} cannot both execute benchmark campaign and be allowed in readiness check"
+        )
+
+    report.checked_commands.append(
+        {
+            "id": contract_id,
+            "stage": stage,
+            "allowed_in_readiness_check": allowed_here,
+            "executes_benchmark_campaign": executes_benchmark,
+        }
+    )
+
+    for rel_path in _required_paths(contract, prefix):
+        exists = (repo_root / rel_path).exists()
+        report.checked_paths.append({"section": prefix, "path": rel_path, "exists": exists})
+        if not exists:
+            report.missing_paths.append(rel_path)
 
 
 def _check_outputs(outputs: dict[str, Any], report: ReadinessReport) -> None:
-    """Verify the declared output location is safe (under output/, disposable)."""
+    """Verify declared output location is safe and disposable."""
     local_root = str(outputs.get("local_root", "")).strip()
     if not local_root:
         report.issues.append("outputs.local_root is required")
@@ -167,6 +218,40 @@ def _check_outputs(outputs: dict[str, Any], report: ReadinessReport) -> None:
         report.issues.append("outputs.local_root must stay under output/")
     if outputs.get("disposable") is not True:
         report.issues.append("outputs.disposable must be true for local output roots")
+
+
+def _check_durable_evidence(durable_evidence: dict[str, Any], report: ReadinessReport) -> None:
+    """Verify durable evidence plan exists outside disposable output."""
+    plan = durable_evidence.get("plan")
+    if not isinstance(plan, dict):
+        report.issues.append("durable_evidence.plan must be mapping")
+        return
+
+    rel_path = str(plan.get("path", "")).strip()
+    if not rel_path:
+        report.issues.append("durable_evidence.plan.path is required")
+    elif PurePosixPath(rel_path).parts[:1] == ("output",):
+        report.issues.append("durable_evidence.plan.path must not point under output/")
+
+    if plan.get("required_before_claim") is not True:
+        report.issues.append("durable_evidence.plan.required_before_claim must be true")
+
+
+def _check_readiness_decision(decision: dict[str, Any], report: ReadinessReport) -> None:
+    """Fail closed unless compute and claim promotion are explicitly disabled."""
+    required_false = {
+        "benchmark_campaign_run": "must remain false in readiness-only PR",
+        "compute_submit_authorized": "must remain false without compute authorization",
+        "ranking_claim_promotion": "must remain false until durable evidence is classified",
+        "paper_claim_edits": "must remain false in readiness-only PR",
+        "fallback_degraded_success_allowed": "must remain false under benchmark policy",
+    }
+    for key, message in required_false.items():
+        if decision.get(key) is not False:
+            report.issues.append(f"readiness_decision.{key} {message}")
+
+    if decision.get("result_classification_required") is not True:
+        report.issues.append("readiness_decision.result_classification_required must be true")
 
 
 def check_readiness(manifest_path: Path, *, repo_root: Path | None = None) -> ReadinessReport:
@@ -185,38 +270,38 @@ def check_readiness(manifest_path: Path, *, repo_root: Path | None = None) -> Re
     _check_seed_plan_metadata(seed_plan, report)
 
     _check_paths(repo_root, manifest["frozen_protocol"], "frozen_protocol", report)
+    _check_command_contracts(repo_root, manifest["command_contracts"], report)
     _check_outputs(manifest["outputs"], report)
-
+    _check_durable_evidence(manifest["durable_evidence"], report)
+    _check_readiness_decision(manifest["readiness_decision"], report)
     return report
 
 
-def _parse_args(argv: list[str] | None) -> argparse.Namespace:
+def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "--manifest",
         type=Path,
         default=_repo_root() / "configs" / "benchmarks" / "issue_3078_package_a_readiness.yaml",
-        help="Path to the Package A readiness manifest.",
+        help="Path to Package A readiness manifest.",
     )
     parser.add_argument(
         "--json",
         dest="as_json",
         action="store_true",
-        help="Emit the readiness report as JSON on stdout.",
+        help="Emit readiness report as JSON on stdout.",
     )
-    return parser.parse_args(argv)
+    return parser
 
 
 def main(argv: list[str] | None = None) -> int:
-    """CLI entry point; returns 0 when ready, 1 when not ready, 2 on manifest error."""
-    args = _parse_args(argv)
+    """CLI entry point."""
+    args = _build_parser().parse_args(argv)
     try:
         report = check_readiness(args.manifest)
     except ManifestError as exc:
         if args.as_json:
-            print(
-                json.dumps({"schema_version": SCHEMA_VERSION, "status": "error", "error": str(exc)})
-            )
+            print(json.dumps({"status": "not_ready", "error": str(exc)}, indent=2))
         else:
             print(f"ERROR: {exc}", file=sys.stderr)
         return 2
@@ -227,9 +312,9 @@ def main(argv: list[str] | None = None) -> int:
     else:
         print(f"Package A readiness: {payload['status']} ({payload['package_id']})")
         for missing in payload["missing_paths"]:
-            print(f"  missing prerequisite: {missing}")
+            print(f" missing prerequisite: {missing}")
         for issue in payload["issues"]:
-            print(f"  issue: {issue}")
+            print(f" issue: {issue}")
 
     return 0 if report.status == "ready" else 1
 

--- a/scripts/validation/check_package_a_readiness.py
+++ b/scripts/validation/check_package_a_readiness.py
@@ -81,6 +81,11 @@ def _load_manifest(path: Path) -> dict[str, Any]:
     missing_sections = [section for section in REQUIRED_SECTIONS if section not in manifest]
     if missing_sections:
         raise ManifestError(f"Manifest missing required sections: {sorted(missing_sections)}")
+    non_mapping = [
+        section for section in REQUIRED_SECTIONS if not isinstance(manifest[section], dict)
+    ]
+    if non_mapping:
+        raise ManifestError(f"Manifest sections must be mappings: {sorted(non_mapping)}")
     return manifest
 
 

--- a/tests/validation/test_check_package_a_readiness.py
+++ b/tests/validation/test_check_package_a_readiness.py
@@ -1,9 +1,7 @@
 """Tests for the Package A readiness checker (issue #3078).
 
-These tests use synthetic on-disk fixtures so they never execute the benchmark, touch
-Slurm, or interpret ranks. They prove the checker fails closed on missing prerequisites
-and passes only when every declared input exists. One smoke test exercises the real
-shipped manifest against the live repository tree.
+Tests use synthetic on-disk fixtures and never execute a benchmark, submit
+compute, or interpret planner ranks.
 """
 
 from __future__ import annotations
@@ -25,7 +23,7 @@ import check_package_a_readiness as checker  # noqa: E402
 
 
 def _synthetic_manifest(root: Path, *, create_inputs: bool = True) -> Path:
-    """Write a self-contained manifest plus (optionally) all its input files."""
+    """Write self-contained manifest plus, optionally, all input files."""
     inputs = {
         "heldout_family_inputs": [
             "experiments/heldout_pilot.yaml",
@@ -40,44 +38,92 @@ def _synthetic_manifest(root: Path, *, create_inputs: bool = True) -> Path:
             "configs/suite.yaml",
             "scripts/tools/result_store.py",
         ],
+        "command_contracts": [
+            "scripts/tools/analyze_seed_sufficiency.py",
+            "scripts/tools/run_camera_ready_benchmark.py",
+        ],
     }
     if create_inputs:
         for rel_paths in inputs.values():
-            for rel in rel_paths:
-                target = root / rel
+            for rel_path in rel_paths:
+                target = root / rel_path
                 target.parent.mkdir(parents=True, exist_ok=True)
                 target.write_text("# fixture\n", encoding="utf-8")
 
     manifest = {
-        "schema_version": "package-a-readiness.v0.1",
+        "schema_version": "package-a-readiness.v0.2",
         "package": {"id": "synthetic_package_a", "issue": 3078},
-        "heldout_family_inputs": {"required_paths": inputs["heldout_family_inputs"]},
+        "heldout_family_inputs": {
+            "required_paths": inputs["heldout_family_inputs"],
+            "leakage_audit_tool": "scripts/tools/analyze_seed_sufficiency.py",
+        },
         "seed_plan": {
-            "mode": "seed-sufficiency-gated",
-            "min_seeds": 5,
-            "rank_metric": "kendall_tau",
             "required_paths": inputs["seed_plan"],
             "required_metadata": ["mode", "min_seeds", "rank_metric"],
+            "mode": "seed_sufficiency_then_rank_stability",
+            "min_seeds": 10,
+            "rank_metric": "snqi",
         },
         "frozen_protocol": {"required_paths": inputs["frozen_protocol"]},
-        "outputs": {"local_root": "output/benchmarks/synthetic", "disposable": True},
+        "command_contracts": {
+            "contracts": [
+                {
+                    "id": "seed_surface",
+                    "stage": "readiness_probe",
+                    "command": "uv run python scripts/tools/analyze_seed_sufficiency.py --help",
+                    "allowed_in_readiness_check": True,
+                    "executes_benchmark_campaign": False,
+                    "required_paths": ["scripts/tools/analyze_seed_sufficiency.py"],
+                },
+                {
+                    "id": "future_campaign",
+                    "stage": "future_campaign_execution",
+                    "command": "uv run python scripts/tools/run_camera_ready_benchmark.py --config x",
+                    "allowed_in_readiness_check": False,
+                    "executes_benchmark_campaign": True,
+                    "required_paths": ["scripts/tools/run_camera_ready_benchmark.py"],
+                },
+            ]
+        },
+        "outputs": {
+            "local_root": "output/benchmarks/synthetic_package_a",
+            "disposable": True,
+        },
+        "durable_evidence": {
+            "plan": {
+                "path": "docs/context/evidence/synthetic_package_a",
+                "required_before_claim": True,
+            }
+        },
+        "readiness_decision": {
+            "benchmark_campaign_run": False,
+            "compute_submit_authorized": False,
+            "ranking_claim_promotion": False,
+            "paper_claim_edits": False,
+            "fallback_degraded_success_allowed": False,
+            "result_classification_required": True,
+        },
     }
     manifest_path = root / "manifest.yaml"
     manifest_path.write_text(yaml.safe_dump(manifest, sort_keys=False), encoding="utf-8")
     return manifest_path
 
 
-def test_ready_when_all_inputs_present(tmp_path: Path) -> None:
-    """A manifest whose declared inputs all exist reports ready."""
+def test_ready_when_all_declared_inputs_exist(tmp_path: Path) -> None:
+    """Synthetic fixture is ready when every declared prerequisite exists."""
     manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
     report = checker.check_readiness(manifest_path, repo_root=tmp_path)
     assert report.status == "ready"
     assert report.missing_paths == []
     assert report.issues == []
+    assert {command["id"] for command in report.checked_commands} == {
+        "seed_surface",
+        "future_campaign",
+    }
 
 
-def test_fails_closed_on_missing_input(tmp_path: Path) -> None:
-    """A missing held-out-family input makes the verdict not_ready."""
+def test_fails_closed_on_missing_heldout_input(tmp_path: Path) -> None:
+    """A missing held-out-family input makes verdict not_ready."""
     manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
     (tmp_path / "configs" / "sets" / "eval_set.yaml").unlink()
     report = checker.check_readiness(manifest_path, repo_root=tmp_path)
@@ -96,8 +142,19 @@ def test_fails_closed_on_missing_seed_metadata(tmp_path: Path) -> None:
     assert any("rank_metric" in issue for issue in report.issues)
 
 
+def test_fails_closed_when_campaign_command_allowed_in_readiness(tmp_path: Path) -> None:
+    """Campaign execution commands cannot be marked runnable by this checker."""
+    manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    data["command_contracts"]["contracts"][1]["allowed_in_readiness_check"] = True
+    manifest_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    report = checker.check_readiness(manifest_path, repo_root=tmp_path)
+    assert report.status == "not_ready"
+    assert any("cannot both execute benchmark campaign" in issue for issue in report.issues)
+
+
 def test_rejects_unsafe_output_root(tmp_path: Path) -> None:
-    """An output root outside output/ or not disposable is flagged as an issue."""
+    """An output root outside output/ is flagged."""
     manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
     data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
     data["outputs"]["local_root"] = "docs/benchmarks/leak"
@@ -107,8 +164,32 @@ def test_rejects_unsafe_output_root(tmp_path: Path) -> None:
     assert any("output/" in issue for issue in report.issues)
 
 
+def test_rejects_durable_evidence_under_output(tmp_path: Path) -> None:
+    """Durable evidence plan cannot point into disposable output."""
+    manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    data["durable_evidence"]["plan"]["path"] = "output/leaky_evidence"
+    manifest_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    report = checker.check_readiness(manifest_path, repo_root=tmp_path)
+    assert report.status == "not_ready"
+    assert any("durable_evidence.plan.path" in issue for issue in report.issues)
+
+
+def test_rejects_claim_or_compute_enabled_decision(tmp_path: Path) -> None:
+    """Readiness packet fails closed if compute or claim promotion is enabled."""
+    manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    data["readiness_decision"]["compute_submit_authorized"] = True
+    data["readiness_decision"]["ranking_claim_promotion"] = True
+    manifest_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    report = checker.check_readiness(manifest_path, repo_root=tmp_path)
+    assert report.status == "not_ready"
+    assert any("compute_submit_authorized" in issue for issue in report.issues)
+    assert any("ranking_claim_promotion" in issue for issue in report.issues)
+
+
 def test_manifest_error_on_missing_section(tmp_path: Path) -> None:
-    """A manifest missing a required section raises ManifestError."""
+    """A manifest missing required sections raises ManifestError."""
     manifest_path = tmp_path / "bad.yaml"
     manifest_path.write_text(yaml.safe_dump({"package": {"id": "x"}}), encoding="utf-8")
     with pytest.raises(checker.ManifestError):
@@ -116,7 +197,7 @@ def test_manifest_error_on_missing_section(tmp_path: Path) -> None:
 
 
 def test_cli_json_exit_code_not_ready(tmp_path: Path) -> None:
-    """CLI returns exit 1 and JSON status not_ready when a prerequisite is missing."""
+    """CLI returns exit 1 JSON status not_ready when prerequisites are missing."""
     manifest_path = _synthetic_manifest(tmp_path, create_inputs=False)
     completed = subprocess.run(
         [sys.executable, str(CHECKER), "--manifest", str(manifest_path), "--json"],
@@ -132,7 +213,7 @@ def test_cli_json_exit_code_not_ready(tmp_path: Path) -> None:
 
 
 def test_shipped_manifest_is_ready_against_repo() -> None:
-    """The shipped Package A manifest's declared inputs exist in the live repo tree."""
+    """The shipped Package A manifest's declared inputs exist in the repo tree."""
     report = checker.check_readiness(SHIPPED_MANIFEST, repo_root=REPO_ROOT)
     assert report.status == "ready", {
         "missing_paths": report.missing_paths,

--- a/tests/validation/test_check_package_a_readiness.py
+++ b/tests/validation/test_check_package_a_readiness.py
@@ -196,6 +196,16 @@ def test_manifest_error_on_missing_section(tmp_path: Path) -> None:
         checker.check_readiness(manifest_path, repo_root=tmp_path)
 
 
+def test_manifest_error_on_non_mapping_section(tmp_path: Path) -> None:
+    """A required section that is not a mapping fails closed with ManifestError."""
+    manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    data["seed_plan"] = ["not", "a", "mapping"]
+    manifest_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    with pytest.raises(checker.ManifestError):
+        checker.check_readiness(manifest_path, repo_root=tmp_path)
+
+
 def test_cli_json_exit_code_not_ready(tmp_path: Path) -> None:
     """CLI returns exit 1 JSON status not_ready when prerequisites are missing."""
     manifest_path = _synthetic_manifest(tmp_path, create_inputs=False)

--- a/tests/validation/test_check_package_a_readiness.py
+++ b/tests/validation/test_check_package_a_readiness.py
@@ -196,6 +196,28 @@ def test_manifest_error_on_missing_section(tmp_path: Path) -> None:
         checker.check_readiness(manifest_path, repo_root=tmp_path)
 
 
+def test_fails_closed_on_null_durable_evidence_path(tmp_path: Path) -> None:
+    """A null durable-evidence path must not be coerced to a valid string."""
+    manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    data["durable_evidence"]["plan"]["path"] = None
+    manifest_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    report = checker.check_readiness(manifest_path, repo_root=tmp_path)
+    assert report.status == "not_ready"
+    assert any("durable_evidence.plan.path is required" in issue for issue in report.issues)
+
+
+def test_fails_closed_on_null_contract_id(tmp_path: Path) -> None:
+    """A null command-contract id must not be coerced to the string 'None'."""
+    manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    data["command_contracts"]["contracts"][0]["id"] = None
+    manifest_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    report = checker.check_readiness(manifest_path, repo_root=tmp_path)
+    assert report.status == "not_ready"
+    assert any(".id is required" in issue for issue in report.issues)
+
+
 def test_manifest_error_on_non_mapping_section(tmp_path: Path) -> None:
     """A required section that is not a mapping fails closed with ManifestError."""
     manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)


### PR DESCRIPTION
## Summary
Refs #3078.

Hardens the existing Package A readiness checker/manifest for rank-stability and held-out-family readiness without running any benchmark campaign. The checker now validates:

- command-contract metadata for seed-sufficiency, leakage audit, and future campaign surfaces;
- durable-evidence plan stays outside disposable `output/`;
- readiness-only decision gates keep compute submission, benchmark execution, rank promotion, paper edits, and fallback/degraded success disabled.

## Linked Issue
- https://github.com/ll7/robot_sf_ll7/issues/3078

## Scope
- In scope: fail-closed readiness checker and decision-packet metadata for Package A prerequisites.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Claim boundary: readiness/provenance gating only; this PR does not promote ranking or benchmark evidence.

## Validation
- `uv run pytest tests/validation/test_check_package_a_readiness.py -q` - 10 passed.
- `uv run python scripts/validation/check_package_a_readiness.py --json` - exits 0, shipped manifest reports `status: ready`.
- `uv run ruff check scripts/validation/check_package_a_readiness.py tests/validation/test_check_package_a_readiness.py` - passed.
- `uv run ruff format --check scripts/validation/check_package_a_readiness.py tests/validation/test_check_package_a_readiness.py` - passed.
- `git diff --check` - passed.

## Artifact / Output Policy
- No durable benchmark artifact was produced.
- Local `output/validation/pr_bodies/issue_3078_pr_body.md` is ignored PR-body scratch only.

## Downstream Propagation
- Parent issue remains open for actual Package A campaign execution and claim-card review.
- No benchmark report, paper text, dissertation text, leaderboard, or claim map is updated here.
