### PR TITLE
Issue #3574: add heterogeneous control-trace readiness diagnostics

### DIFF
--- a/robot_sf/benchmark/heterogeneous_population_metrics.py
+++ b/robot_sf/benchmark/heterogeneous_population_metrics.py
@@ -59,6 +59,39 @@ class PedestrianMetric:
     value: float
 
 
+@dataclass(frozen=True, slots=True)
+class ControlTraceReadiness:
+    """Readiness diagnostic for per-pedestrian control-trace metric extraction."""
+
+    status: str
+    metric_key: str
+    pedestrian_count: int
+    step_count: int
+    archetype_counts: dict[str, int]
+    blockers: tuple[str, ...]
+
+    @property
+    def ready(self) -> bool:
+        """Return true when the trace can feed the per-archetype metric harness."""
+
+        return self.status == "ready"
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a stable JSON-serializable diagnostic payload."""
+
+        return {
+            "schema_version": HETEROGENEOUS_POPULATION_METRICS_SCHEMA,
+            "source": "pedestrian_control_trace",
+            "metric_key": self.metric_key,
+            "status": self.status,
+            "ready": self.ready,
+            "pedestrian_count": self.pedestrian_count,
+            "step_count": self.step_count,
+            "archetype_counts": dict(sorted(self.archetype_counts.items())),
+            "blockers": list(self.blockers),
+        }
+
+
 def cvar(values: Sequence[float], alpha: float, *, higher_is_safer: bool) -> float:
     """Return the CVaR (mean of the worst ``alpha`` tail) of a metric.
 
@@ -77,6 +110,80 @@ def cvar(values: Sequence[float], alpha: float, *, higher_is_safer: bool) -> flo
     k = max(1, math.ceil(alpha * arr.size))
     tail = arr[:k] if higher_is_safer else arr[-k:]
     return float(np.mean(tail))
+
+
+def assess_control_trace_readiness(
+    control_trace: Mapping[str, Any],
+    metric_key: str,
+) -> ControlTraceReadiness:
+    """Assess whether a control trace has the fields required for per-archetype metrics.
+
+    The readiness check is intentionally non-raising so orchestration code can emit a
+    blocked diagnostic packet. Metric extraction still raises through
+    ``pedestrian_metric_observations_from_control_trace`` when a caller tries to use
+    an incomplete trace.
+
+    Returns:
+        Readiness diagnostic with coverage counts and fail-closed blockers.
+    """
+
+    normalized_metric_key = str(metric_key).strip()
+    blockers: list[str] = []
+    pedestrian_count = 0
+    step_count = 0
+    archetype_counts: dict[str, int] = {}
+
+    if not normalized_metric_key:
+        blockers.append("metric_key must be non-empty")
+
+    try:
+        pedestrians = _control_trace_pedestrians(control_trace)
+    except ValueError as exc:
+        blockers.append(str(exc))
+        return ControlTraceReadiness(
+            status="blocked",
+            metric_key=normalized_metric_key,
+            pedestrian_count=0,
+            step_count=0,
+            archetype_counts={},
+            blockers=tuple(blockers),
+        )
+
+    pedestrian_count = len(pedestrians)
+    for pedestrian_index, pedestrian in enumerate(pedestrians):
+        if not isinstance(pedestrian, Mapping):
+            blockers.append(f"control_trace.pedestrians[{pedestrian_index}] must be mapping")
+            continue
+
+        try:
+            archetype = _control_trace_archetype(pedestrian, pedestrian_index)
+        except ValueError as exc:
+            blockers.append(str(exc))
+        else:
+            archetype_counts[archetype] = archetype_counts.get(archetype, 0) + 1
+
+        if not normalized_metric_key:
+            continue
+
+        try:
+            values = _control_trace_metric_values(
+                pedestrian,
+                pedestrian_index,
+                normalized_metric_key,
+            )
+        except (TypeError, ValueError) as exc:
+            blockers.append(str(exc))
+        else:
+            step_count += int(values.size)
+
+    return ControlTraceReadiness(
+        status="ready" if not blockers else "blocked",
+        metric_key=normalized_metric_key,
+        pedestrian_count=pedestrian_count,
+        step_count=step_count,
+        archetype_counts=archetype_counts,
+        blockers=tuple(blockers),
+    )
 
 
 def per_archetype_metrics(
@@ -308,7 +415,9 @@ def mean_matched_heterogeneity_effect(
 
 __all__ = [
     "HETEROGENEOUS_POPULATION_METRICS_SCHEMA",
+    "ControlTraceReadiness",
     "PedestrianMetric",
+    "assess_control_trace_readiness",
     "cvar",
     "mean_matched_heterogeneity_effect",
     "pedestrian_metric_observations_from_control_trace",

--- a/tests/benchmark/test_heterogeneous_population_metrics.py
+++ b/tests/benchmark/test_heterogeneous_population_metrics.py
@@ -9,6 +9,7 @@ import pytest
 from robot_sf.benchmark.heterogeneous_population_metrics import (
     HETEROGENEOUS_POPULATION_METRICS_SCHEMA,
     PedestrianMetric,
+    assess_control_trace_readiness,
     cvar,
     mean_matched_heterogeneity_effect,
     pedestrian_metric_observations_from_control_trace,
@@ -154,6 +155,59 @@ def test_per_archetype_metrics_from_control_trace_normalizes_metric_key_provenan
     )
 
     assert report["metric_key"] == "speed_m_s"
+
+
+def test_control_trace_readiness_reports_trace_field_coverage() -> None:
+    """Complete traces produce a compact readiness packet before metric aggregation."""
+
+    readiness = assess_control_trace_readiness(_control_trace(), " speed_m_s ")
+
+    assert readiness.ready
+    assert readiness.to_dict() == {
+        "schema_version": HETEROGENEOUS_POPULATION_METRICS_SCHEMA,
+        "source": "pedestrian_control_trace",
+        "metric_key": "speed_m_s",
+        "status": "ready",
+        "ready": True,
+        "pedestrian_count": 3,
+        "step_count": 9,
+        "archetype_counts": {"cautious": 2, "hurried": 1},
+        "blockers": [],
+    }
+
+
+def test_control_trace_readiness_blocks_missing_metric_field() -> None:
+    """Missing per-step fields are visible before the harness consumes the trace."""
+
+    trace = _control_trace()
+    del trace["pedestrians"][1]["steps"][2]["speed_m_s"]
+
+    readiness = assess_control_trace_readiness(trace, "speed_m_s")
+
+    assert not readiness.ready
+    assert readiness.status == "blocked"
+    assert readiness.pedestrian_count == 3
+    assert readiness.step_count == 6
+    assert readiness.archetype_counts == {"cautious": 2, "hurried": 1}
+    assert readiness.blockers == ("control_trace.pedestrians[1].steps[2] missing 'speed_m_s'",)
+
+
+def test_control_trace_readiness_blocks_empty_trace_without_raising() -> None:
+    """Missing trace inputs become fail-closed diagnostics, not partial metrics."""
+
+    readiness = assess_control_trace_readiness({"pedestrians": []}, "speed_m_s")
+
+    assert readiness.to_dict() == {
+        "schema_version": HETEROGENEOUS_POPULATION_METRICS_SCHEMA,
+        "source": "pedestrian_control_trace",
+        "metric_key": "speed_m_s",
+        "status": "blocked",
+        "ready": False,
+        "pedestrian_count": 0,
+        "step_count": 0,
+        "archetype_counts": {},
+        "blockers": ["control_trace.pedestrians must be non-empty"],
+    }
 
 
 def test_control_trace_extraction_supports_final_step_reducer() -> None:


### PR DESCRIPTION
## Summary

Issue: #3574.

Implements a bounded metric-harness/readiness slice for the mean-matched heterogeneous-population ablation follow-up:

- adds a non-raising `ControlTraceReadiness` diagnostic for per-pedestrian control traces;
- reports normalized metric key, pedestrian count, step coverage, archetype counts, and fail-closed blockers;
- keeps the existing metric extraction path fail-closed when callers attempt to consume incomplete traces.

## Scope

This PR is limited to the per-archetype metric harness readiness layer. It does not run or claim results from the broader heterogeneous-population ablation.

## Validation

- `uv run pytest tests/benchmark/test_heterogeneous_population_metrics.py` - passed, 27 tests.
- `uv run pytest tests/benchmark/test_pedestrian_control_trace.py` - passed, 7 tests.
- `uv run ruff format robot_sf/benchmark/heterogeneous_population_metrics.py tests/benchmark/test_heterogeneous_population_metrics.py && uv run ruff check robot_sf/benchmark/heterogeneous_population_metrics.py tests/benchmark/test_heterogeneous_population_metrics.py` - passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed before commit.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final PR_READY_PR_BODY_FILE=output/issue_3574_pr_body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed on clean committed head `4f5ec73362578ab63e4dd60f20db9600795bc9b2`.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No response-law mixture sweep or rank-order sensitivity report.

## Artifacts

Generated validation artifacts remain ignored under `output/` and are not committed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a control-trace readiness check that returns a clear pass/fail status instead of raising errors.
  * Included coverage details such as pedestrian and step counts, plus trace archetype breakdowns, to help identify incomplete inputs.
* **Bug Fixes**
  * Improved handling of missing or empty control traces by marking them as blocked with an explanatory message.
  * Added validation for required per-step values to better detect unsupported or incomplete trace data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->