### PR TITLE
Issue #3653: record SNQI scalarization diagnostic provenance

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -9,6 +9,7 @@ does not change SNQI definitions, benchmark metrics, or claim status.
 from __future__ import annotations
 
 import csv
+import hashlib
 import html
 import json
 import math
@@ -370,6 +371,7 @@ def build_scalarization_sensitivity_report(
     planner_key: str = "planner_key",
     fallback_planner_key: str = "planner",
     sweep_factors: Sequence[float] = DEFAULT_SWEEP_FACTORS,
+    input_provenance: Mapping[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a SNQI scalarization-sensitivity and Pareto-front report.
 
@@ -454,6 +456,7 @@ def build_scalarization_sensitivity_report(
             "planners": len(grouped),
             "episodes": sum(len(rows) for rows in grouped.values()),
             "sweep_factors": [float(factor) for factor in sweep_factors],
+            "provenance": dict(input_provenance or {}),
         },
         "base_snqi_order": base_order,
         "constraints_first_order": constraints_order,
@@ -559,6 +562,15 @@ def load_baseline_mapping(path: Path | None) -> dict[str, dict[str, float]]:
             "p95": float(entry.get("p95", entry.get("med", 1.0))),
         }
     return baseline
+
+
+def input_file_provenance(path: Path | None) -> dict[str, str | None]:
+    """Return path and SHA-256 provenance for an optional diagnostic input file."""
+
+    if path is None:
+        return {"path": None, "sha256": None}
+    data = path.read_bytes()
+    return {"path": str(path), "sha256": hashlib.sha256(data).hexdigest()}
 
 
 def format_markdown(report: Mapping[str, Any]) -> str:
@@ -1023,6 +1035,7 @@ __all__ = [
     "classify_scalarization_sensitivity_inputs",
     "format_markdown",
     "format_pareto_svg",
+    "input_file_provenance",
     "load_baseline_mapping",
     "load_jsonl",
     "load_weight_mapping",

--- a/scripts/tools/analyze_snqi_scalarization_sensitivity.py
+++ b/scripts/tools/analyze_snqi_scalarization_sensitivity.py
@@ -18,6 +18,7 @@ from robot_sf.benchmark.snqi_scalarization_sensitivity import (
     SENSITIVITY_PREFLIGHT_READY,
     build_scalarization_sensitivity_report,
     classify_scalarization_sensitivity_inputs,
+    input_file_provenance,
     load_baseline_mapping,
     load_jsonl,
     load_weight_mapping,
@@ -87,6 +88,11 @@ def main(argv: list[str] | None = None) -> int:
         planner_key=args.planner_key,
         fallback_planner_key=args.fallback_planner_key,
         sweep_factors=args.sweep_factors,
+        input_provenance={
+            "episodes": input_file_provenance(args.episodes),
+            "weights": input_file_provenance(args.weights),
+            "baseline": input_file_provenance(args.baseline),
+        },
     )
     artifacts = write_diagnostic_artifacts(report, args.output_dir)
     print(

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -13,6 +13,7 @@ from robot_sf.benchmark.snqi_scalarization_sensitivity import (
     build_scalarization_sensitivity_report,
     classify_scalarization_sensitivity_inputs,
     format_pareto_svg,
+    input_file_provenance,
     load_jsonl,
     write_diagnostic_artifacts,
 )
@@ -261,6 +262,25 @@ def test_artifact_writer_creates_report_ready_files(tmp_path: Path) -> None:
     assert "safe-slow" in svg
 
 
+def test_report_records_input_provenance_for_auditable_weight_sweeps(tmp_path: Path) -> None:
+    """Report payload can carry input hashes without changing SNQI semantics."""
+
+    weights_path = tmp_path / "weights.json"
+    weights_path.write_text(json.dumps(_weights(), sort_keys=True), encoding="utf-8")
+
+    report = build_scalarization_sensitivity_report(
+        _episodes(),
+        weights=_weights(),
+        baseline=_baseline(),
+        sweep_factors=[1.0],
+        input_provenance={"weights": input_file_provenance(weights_path)},
+    )
+
+    provenance = report["inputs"]["provenance"]["weights"]
+    assert provenance["path"] == str(weights_path)
+    assert len(provenance["sha256"]) == 64
+
+
 def test_load_jsonl_rejects_non_object_records(tmp_path: Path) -> None:
     """JSONL loader fails closed on non-object records."""
 
@@ -327,6 +347,9 @@ def test_cli_writes_scalarization_artifacts(tmp_path: Path, capsys) -> None:
     assert Path(stdout["csv"]).exists()
     assert Path(stdout["markdown"]).exists()
     assert Path(stdout["svg"]).exists()
+    payload = json.loads(Path(stdout["json"]).read_text(encoding="utf-8"))
+    assert payload["inputs"]["provenance"]["weights"]["path"] == str(weights_path)
+    assert len(payload["inputs"]["provenance"]["weights"]["sha256"]) == 64
 
 
 def test_cli_preflight_only_blocks_invalid_inputs(tmp_path: Path, capsys) -> None:


### PR DESCRIPTION
## Summary
Adds input provenance to the existing Social Navigation Quality Index (SNQI) scalarization-sensitivity diagnostic export so Pareto-front and decision-disagreement artifacts record the episode, weight, and baseline file paths plus SHA-256 hashes when invoked through the CLI.

## Linked Issues
- Relates to #3653

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added optional `input_provenance` to `build_scalarization_sensitivity_report`.
- Added `input_file_provenance()` for SHA-256 input hashing.
- Wired `scripts/tools/analyze_snqi_scalarization_sensitivity.py` to include episode, weight, and baseline provenance in generated JSON.
- Extended focused SNQI scalarization-sensitivity tests to assert report and CLI provenance.

## Why Matters
- Added value: the diagnostic artifacts now preserve which frozen SNQI weight file and baseline inputs produced the decision-disagreement/Pareto export.
- Expected impact: better reviewability and reproducibility for issue #3653 without changing SNQI metric semantics.
- Why worth merging now: the live issue comment identifies the remaining closure slice as Pareto-front export plus decision-disagreement table; provenance keeps those artifacts auditable.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3653 readiness for SNQI scalarization-sensitivity/Pareto diagnostic artifact provenance.
- Comparator or baseline, applicable: existing scalarization-sensitivity report payload without input hashes.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision stop rule, applicable: focused tests prove ready/blocked/malformed classification remains intact and CLI JSON includes input provenance.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3653.
- New research/benchmark/metric/paper-facing analysis tool, any: no new analysis tool; this hardens the existing diagnostic export.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: no benchmark, metric semantic, or paper-facing claim change.
- Validity checklist:
  - Target claim/hypothesis: diagnostic artifact provenance only.
  - Comparator split/evidence validity: NA.
  - Fallback/degraded exclusions: no benchmark campaign run.
  - Claim boundary: diagnostic-only; not benchmark evidence.
  - Implementation integrity vs experimental validity: tests cover report and CLI output shape.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this provenance slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no durable campaign artifact promoted in this PR.
- Stop / revise / continue decision: continue with downstream full diagnostic review outside this PR if needed.
- Proposed child issue existing follow-up: #3653 remains the parent diagnostic issue.

## Validation / Proof
- `uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py` passed, 11 tests.
- `uv run ruff check robot_sf/benchmark/snqi_scalarization_sensitivity.py scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` passed.
- `CUDA_VISIBLE_DEVICES= BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed on synced branch head `d5d97c7a35d6242808fe7b52d2c6d76af9af9da5`; stamp: `output/validation/pr_ready/issue-3653-analysis-snqi-scalarization-sensitivity-pareto-front-export-decision-rev.json`.
- Earlier full gate without `CUDA_VISIBLE_DEVICES=` failed only from unrelated CUDA out-of-memory in optional PPO/feature-extractor tests on the crowded local GPU; CPU-only rerun passed.

## Risks / Rollout
- Compatibility risks: low; report callers get an additional `inputs.provenance` mapping, defaulting to `{}`.
- Failure modes: supplied paths are hashed at CLI runtime, so missing files still fail through existing load paths.
- Rollback fallback plan: revert this commit to remove provenance fields and CLI hashing.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3653.
- Any assumptions need to preserved: this does not change metric semantics or promote SNQI as a primary index.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a bounded diagnostic-readiness hardening change, not a benchmark result or paper-facing claim.

## Follow-Up Issues
- Deferred work: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Issues opened follow-up: none.

## Reviewer Notes
- Please verify the provenance field is sufficient for the frozen weight file path called out in #3653.
- Known limitation: this PR does not run or publish the full single-campaign diagnostic artifacts.
