### PR TITLE
Issue #2557: add replica artifact readiness checker

### DIFF
--- a/robot_sf/benchmark/issue_2557_replica_readiness.py
+++ b/robot_sf/benchmark/issue_2557_replica_readiness.py
@@ -1,0 +1,370 @@
+"""Read-only readiness checks for issue #2557 fixed-seed replica artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+SCHEMA_VERSION = "issue-2557-replica-readiness.v1"
+DEFAULT_MANIFEST = Path(
+    "docs/context/evidence/issue_2557_reward_curriculum_partial_2026-06-08/seed_summary.json"
+)
+DEFAULT_CONFIG_TEMPLATE = (
+    "configs/training/ppo/ablations/"
+    "expert_ppo_issue_2557_reward_curriculum_promotion_10m_env22_eval_aligned_"
+    "large_capacity_seed{seed}_fixed.yaml"
+)
+REQUIRED_ROW_FIELDS = (
+    "seed",
+    "job_id",
+    "partition",
+    "run_id",
+    "eval_step",
+    "success_rate",
+    "collision_rate",
+    "snqi",
+    "wandb_url",
+    "run_summary_sha256",
+    "eval_timeline_sha256",
+    "source_config_sha256",
+)
+REQUIRED_SOURCE_FIELDS = ("branch", "commit", "seeds")
+SHA256_RE = re.compile(r"^[0-9a-f]{64}$")
+WANDB_URL_RE = re.compile(r"^https://wandb\.ai/[^/]+/[^/]+/runs/[^/]+$")
+
+
+@dataclass(frozen=True)
+class ReplicaReadinessResult:
+    """Structured artifact-readiness verdict for one compact replica manifest."""
+
+    manifest_path: str
+    ready: bool
+    allow_partial: bool
+    expected_seeds: tuple[int, ...]
+    present_seeds: tuple[int, ...]
+    missing_seeds: tuple[int, ...]
+    blockers: tuple[str, ...]
+    warnings: tuple[str, ...]
+    metadata: dict[str, Any]
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return stable JSON-serializable report payload."""
+
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "manifest_path": self.manifest_path,
+            "ready": self.ready,
+            "allow_partial": self.allow_partial,
+            "expected_seeds": list(self.expected_seeds),
+            "present_seeds": list(self.present_seeds),
+            "missing_seeds": list(self.missing_seeds),
+            "blockers": list(self.blockers),
+            "warnings": list(self.warnings),
+            "metadata": self.metadata,
+        }
+
+
+def _repo_relative(path: Path, repo_root: Path) -> str:
+    try:
+        return path.resolve().relative_to(repo_root.resolve()).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    if not path.is_file():
+        raise FileNotFoundError(f"Manifest file not found: {path}")
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected top-level JSON object")
+    return payload
+
+
+def _parse_expected_seeds(raw: str | None) -> tuple[int, ...]:
+    if not raw:
+        return ()
+    seeds: set[int] = set()
+    for chunk in raw.split(","):
+        value = chunk.strip()
+        if not value:
+            continue
+        if "-" in value:
+            start_raw, end_raw = value.split("-", 1)
+            start = int(start_raw)
+            end = int(end_raw)
+            if start > end:
+                raise ValueError(f"seed range start exceeds end: {value}")
+            seeds.update(range(start, end + 1))
+        else:
+            seeds.add(int(value))
+    return tuple(sorted(seeds))
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, int | float) and not isinstance(value, bool) and math.isfinite(value)
+
+
+def _check_row_required_fields(row: dict[str, Any], *, index: int) -> list[str]:
+    return [f"rows[{index}] missing {field}" for field in REQUIRED_ROW_FIELDS if field not in row]
+
+
+def _check_row_numeric_fields(row: dict[str, Any], *, seed: Any) -> list[str]:
+    blockers: list[str] = []
+    for field in ("job_id", "eval_step"):
+        value = row.get(field)
+        if not isinstance(value, int) or isinstance(value, bool):
+            blockers.append(f"seed {seed}: {field} must be an integer")
+
+    for field in ("success_rate", "collision_rate", "snqi"):
+        if not _is_finite_number(row.get(field)):
+            blockers.append(f"seed {seed}: {field} must be a finite number")
+    return blockers
+
+
+def _check_row_provenance_fields(row: dict[str, Any], *, seed: Any) -> list[str]:
+    blockers: list[str] = []
+    wandb_url = row.get("wandb_url")
+    if not isinstance(wandb_url, str) or not WANDB_URL_RE.match(wandb_url):
+        blockers.append(f"seed {seed}: wandb_url must be a W&B run URL")
+
+    for field in ("run_summary_sha256", "eval_timeline_sha256", "source_config_sha256"):
+        value = row.get(field)
+        if not isinstance(value, str) or not SHA256_RE.match(value):
+            blockers.append(f"seed {seed}: {field} must be a sha256 hex digest")
+    return blockers
+
+
+def _check_row(row: Any, *, index: int) -> tuple[int | None, list[str]]:
+    blockers: list[str] = []
+    if not isinstance(row, dict):
+        return None, [f"rows[{index}] must be an object"]
+
+    blockers.extend(_check_row_required_fields(row, index=index))
+
+    seed = row.get("seed")
+    if not isinstance(seed, int) or isinstance(seed, bool):
+        blockers.append(f"rows[{index}].seed must be an integer")
+        seed_value: int | None = None
+    else:
+        seed_value = seed
+
+    blockers.extend(_check_row_numeric_fields(row, seed=seed))
+
+    partition = row.get("partition")
+    if partition not in {"a30", "l40s"}:
+        blockers.append(f"seed {seed}: partition must be a30 or l40s")
+
+    blockers.extend(_check_row_provenance_fields(row, seed=seed))
+    return seed_value, blockers
+
+
+def _check_source_worktrees(payload: dict[str, Any]) -> list[str]:
+    blockers: list[str] = []
+    sources = payload.get("source_worktrees")
+    if not isinstance(sources, list) or not sources:
+        return ["source_worktrees must be a non-empty list"]
+    for index, source in enumerate(sources):
+        if not isinstance(source, dict):
+            blockers.append(f"source_worktrees[{index}] must be an object")
+            continue
+        for field in REQUIRED_SOURCE_FIELDS:
+            if field not in source:
+                blockers.append(f"source_worktrees[{index}] missing {field}")
+        commit = source.get("commit")
+        if not isinstance(commit, str) or not re.match(r"^[0-9a-f]{40}$", commit):
+            blockers.append(f"source_worktrees[{index}].commit must be a 40-char git sha")
+        seeds = source.get("seeds")
+        if (
+            not isinstance(seeds, list)
+            or not seeds
+            or any(not isinstance(seed, int) or isinstance(seed, bool) for seed in seeds)
+        ):
+            blockers.append(f"source_worktrees[{index}].seeds must be non-empty integer list")
+    return blockers
+
+
+def _check_manifest_boundary(
+    payload: dict[str, Any], *, allow_partial: bool
+) -> tuple[list[str], list[str]]:
+    blockers: list[str] = []
+    warnings: list[str] = []
+    schema = payload.get("schema_version")
+    if not isinstance(schema, str) or not schema.startswith("issue_2557_reward_curriculum"):
+        blockers.append("schema_version must be an issue_2557_reward_curriculum manifest")
+
+    claim_boundary = payload.get("claim_boundary")
+    if not isinstance(claim_boundary, str) or not claim_boundary.strip():
+        blockers.append("claim_boundary must describe the evidence boundary")
+    elif ("partial" in claim_boundary or "not_full" in claim_boundary) and not allow_partial:
+        blockers.append(
+            "manifest is explicitly partial; rerun with allow_partial only for diagnostics"
+        )
+
+    incomplete = payload.get("incomplete_or_pending_seeds")
+    if isinstance(incomplete, list) and incomplete and not allow_partial:
+        blockers.append("manifest still lists incomplete_or_pending_seeds")
+    elif isinstance(incomplete, list) and incomplete:
+        warnings.append("manifest lists incomplete_or_pending_seeds; diagnostic-only readiness")
+    return blockers, warnings
+
+
+def _check_rows(payload: dict[str, Any]) -> tuple[list[int], int, list[str]]:
+    blockers: list[str] = []
+    rows = payload.get("rows")
+    if not isinstance(rows, list) or not rows:
+        return [], 0, ["rows must be a non-empty list"]
+
+    present: list[int] = []
+    for index, row in enumerate(rows):
+        seed, row_blockers = _check_row(row, index=index)
+        blockers.extend(row_blockers)
+        if seed is not None:
+            present.append(seed)
+
+    duplicate_seeds = sorted({seed for seed in present if present.count(seed) > 1})
+    for seed in duplicate_seeds:
+        blockers.append(f"seed {seed}: duplicate manifest row")
+    return present, len(rows), blockers
+
+
+def _check_aggregate(payload: dict[str, Any], *, row_count: int) -> list[str]:
+    aggregate = payload.get("aggregate")
+    if not isinstance(aggregate, dict):
+        return ["aggregate must be an object"]
+    if aggregate.get("count") != row_count:
+        return ["aggregate.count must match number of rows"]
+    return []
+
+
+def _check_expected_configs(
+    *,
+    root: Path,
+    expected_seeds: tuple[int, ...],
+    config_template: str,
+) -> list[str]:
+    blockers: list[str] = []
+    for seed in expected_seeds:
+        config = root / config_template.format(seed=seed)
+        if not config.is_file():
+            blockers.append(f"seed {seed}: expected config missing: {_repo_relative(config, root)}")
+    return blockers
+
+
+def assess_issue_2557_replica_readiness(
+    manifest_path: Path = DEFAULT_MANIFEST,
+    *,
+    repo_root: Path | None = None,
+    expected_seeds: tuple[int, ...] = (),
+    config_template: str = DEFAULT_CONFIG_TEMPLATE,
+    allow_partial: bool = False,
+) -> ReplicaReadinessResult:
+    """Assess whether a compact issue #2557 seed-replica manifest is analysis-ready.
+
+    The checker is read-only and does not inspect Slurm, W&B, raw logs, checkpoints, or videos.
+    It validates the compact manifest and local config/provenance pointers needed before a
+    downstream analyzer can safely promote or interpret the artifact bundle.
+
+    Returns:
+        Structured readiness verdict with blockers, warnings, and seed coverage metadata.
+    """
+
+    root = (repo_root or Path.cwd()).resolve()
+    manifest_path = manifest_path if manifest_path.is_absolute() else root / manifest_path
+    payload = _load_manifest(manifest_path)
+
+    blockers, warnings = _check_manifest_boundary(payload, allow_partial=allow_partial)
+    blockers.extend(_check_source_worktrees(payload))
+    present, row_count, row_blockers = _check_rows(payload)
+    blockers.extend(row_blockers)
+
+    present_seeds = tuple(sorted(set(present)))
+    missing_seeds = tuple(seed for seed in expected_seeds if seed not in present_seeds)
+    for seed in missing_seeds:
+        blockers.append(f"seed {seed}: missing replica row")
+
+    blockers.extend(_check_aggregate(payload, row_count=row_count))
+    blockers.extend(
+        _check_expected_configs(
+            root=root,
+            expected_seeds=expected_seeds,
+            config_template=config_template,
+        )
+    )
+
+    metadata = {
+        "manifest_schema_version": payload.get("schema_version"),
+        "claim_boundary": payload.get("claim_boundary"),
+        "row_count": row_count,
+        "incomplete_or_pending_seeds": payload.get("incomplete_or_pending_seeds")
+        if isinstance(payload.get("incomplete_or_pending_seeds"), list)
+        else [],
+    }
+    return ReplicaReadinessResult(
+        manifest_path=_repo_relative(manifest_path, root),
+        ready=not blockers,
+        allow_partial=allow_partial,
+        expected_seeds=expected_seeds,
+        present_seeds=present_seeds,
+        missing_seeds=missing_seeds,
+        blockers=tuple(blockers),
+        warnings=tuple(warnings),
+        metadata=metadata,
+    )
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point for the issue #2557 artifact-readiness checker.
+
+    Returns:
+        Process exit code, where 0 means ready and 1 means not ready.
+    """
+
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--manifest", default=str(DEFAULT_MANIFEST), help="Compact seed manifest JSON."
+    )
+    parser.add_argument(
+        "--expected-seeds",
+        default="501-508",
+        help="Comma/range list of fixed seeds that must have manifest rows.",
+    )
+    parser.add_argument(
+        "--config-template",
+        default=DEFAULT_CONFIG_TEMPLATE,
+        help="Repo-relative format string for expected per-seed configs; must contain {seed}.",
+    )
+    parser.add_argument(
+        "--allow-partial",
+        action="store_true",
+        help="Permit explicitly partial manifests for diagnostic inspection only.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON report.")
+    args = parser.parse_args(argv)
+
+    result = assess_issue_2557_replica_readiness(
+        Path(args.manifest),
+        expected_seeds=_parse_expected_seeds(args.expected_seeds),
+        config_template=args.config_template,
+        allow_partial=args.allow_partial,
+    )
+    payload = result.to_payload()
+    if args.json:
+        sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+    else:
+        status = "ready" if result.ready else "not_ready"
+        sys.stdout.write(f"issue #2557 replica artifact readiness: {status}\n")
+        for blocker in result.blockers:
+            sys.stdout.write(f"- blocker: {blocker}\n")
+        for warning in result.warnings:
+            sys.stdout.write(f"- warning: {warning}\n")
+    return 0 if result.ready else 1
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/scripts/benchmark/check_issue_2557_replica_readiness.py
+++ b/scripts/benchmark/check_issue_2557_replica_readiness.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Thin CLI wrapper for issue #2557 fixed-seed replica artifact readiness."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from robot_sf.benchmark.issue_2557_replica_readiness import main  # noqa: E402
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_issue_2557_replica_readiness.py
+++ b/tests/benchmark/test_issue_2557_replica_readiness.py
@@ -1,0 +1,292 @@
+"""Tests for issue #2557 fixed-seed replica artifact-readiness preflight."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from robot_sf.benchmark.issue_2557_replica_readiness import (
+    assess_issue_2557_replica_readiness,
+    main,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+CHECKER = REPO_ROOT / "scripts" / "benchmark" / "check_issue_2557_replica_readiness.py"
+TRACKED_SEED_SUMMARY = (
+    REPO_ROOT
+    / "docs/context/evidence/issue_2557_reward_curriculum_partial_2026-06-08/seed_summary.json"
+)
+
+
+def _row(seed: int) -> dict:
+    return {
+        "seed": seed,
+        "job_id": 12000 + seed,
+        "partition": "a30" if seed % 2 else "l40s",
+        "run_id": f"issue2557_seed{seed}",
+        "eval_step": 10_000_000,
+        "success_rate": 0.9,
+        "collision_rate": 0.1,
+        "snqi": 0.2,
+        "wandb_url": f"https://wandb.ai/ll7/robot_sf/runs/seed{seed}",
+        "run_summary_sha256": "a" * 64,
+        "eval_timeline_sha256": "b" * 64,
+        "source_config_sha256": "c" * 64,
+    }
+
+
+def _write_manifest(
+    path: Path, *, seeds: tuple[int, ...] = (501, 502), partial: bool = False
+) -> Path:
+    payload = {
+        "schema_version": "issue_2557_reward_curriculum_partial.v2",
+        "generated_utc": "2026-06-10T13:17:36Z",
+        "source_commit": "fixture",
+        "branch": "fixture",
+        "source_worktrees": [
+            {
+                "branch": "issue-2557-fixture",
+                "commit": "1" * 40,
+                "seeds": list(seeds),
+            }
+        ],
+        "claim_boundary": "diagnostic_training_evidence",
+        "incomplete_or_pending_seeds": [999] if partial else [],
+        "aggregate": {"count": len(seeds)},
+        "rows": [_row(seed) for seed in seeds],
+    }
+    if partial:
+        payload["claim_boundary"] = "expanded_partial_training_evidence_not_full_seed_batch"
+    path.write_text(json.dumps(payload), encoding="utf-8")
+    return path
+
+
+def _write_configs(root: Path, seeds: tuple[int, ...]) -> str:
+    template = "configs/seed{seed}.yaml"
+    for seed in seeds:
+        config = root / template.format(seed=seed)
+        config.parent.mkdir(parents=True, exist_ok=True)
+        config.write_text(f"seed: {seed}\n", encoding="utf-8")
+    return template
+
+
+def test_ready_when_required_seed_rows_and_provenance_present(tmp_path: Path) -> None:
+    """A complete compact manifest with expected configs is ready."""
+
+    manifest = _write_manifest(tmp_path / "seed_summary.json")
+    template = _write_configs(tmp_path, (501, 502))
+
+    result = assess_issue_2557_replica_readiness(
+        manifest,
+        repo_root=tmp_path,
+        expected_seeds=(501, 502),
+        config_template=template,
+    )
+
+    assert result.ready is True
+    assert result.blockers == ()
+    assert result.present_seeds == (501, 502)
+
+
+def test_missing_replica_row_blocks_readiness(tmp_path: Path) -> None:
+    """Expected seed coverage fails closed when a replica row is absent."""
+
+    manifest = _write_manifest(tmp_path / "seed_summary.json", seeds=(501,))
+    template = _write_configs(tmp_path, (501, 502))
+
+    result = assess_issue_2557_replica_readiness(
+        manifest,
+        repo_root=tmp_path,
+        expected_seeds=(501, 502),
+        config_template=template,
+    )
+
+    assert result.ready is False
+    assert "seed 502: missing replica row" in result.blockers
+
+
+def test_missing_required_provenance_blocks_readiness(tmp_path: Path) -> None:
+    """Each replica row must carry downstream provenance pointers."""
+
+    manifest = _write_manifest(tmp_path / "seed_summary.json")
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    del payload["rows"][0]["wandb_url"]
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+    template = _write_configs(tmp_path, (501, 502))
+
+    result = assess_issue_2557_replica_readiness(
+        manifest,
+        repo_root=tmp_path,
+        expected_seeds=(501, 502),
+        config_template=template,
+    )
+
+    assert result.ready is False
+    assert "rows[0] missing wandb_url" in result.blockers
+
+
+def test_malformed_replica_manifest_reports_field_blockers(tmp_path: Path) -> None:
+    """Malformed rows and source-worktree metadata produce explicit blockers."""
+
+    manifest = _write_manifest(tmp_path / "seed_summary.json")
+    payload = json.loads(manifest.read_text(encoding="utf-8"))
+    payload["schema_version"] = "wrong.v1"
+    payload["claim_boundary"] = ""
+    payload["source_worktrees"] = [{"branch": "fixture", "commit": "short", "seeds": []}]
+    payload["aggregate"] = {"count": 99}
+    payload["rows"] = [
+        "not-a-row",
+        {
+            **_row(501),
+            "seed": "501",
+            "job_id": True,
+            "eval_step": "10000000",
+            "success_rate": "0.9",
+            "collision_rate": None,
+            "snqi": float("nan"),
+            "partition": "cpu",
+            "wandb_url": "not-a-wandb-url",
+            "run_summary_sha256": "bad",
+        },
+        _row(502),
+        _row(502),
+    ]
+    manifest.write_text(json.dumps(payload), encoding="utf-8")
+    template = _write_configs(tmp_path, (501, 502))
+
+    result = assess_issue_2557_replica_readiness(
+        manifest,
+        repo_root=tmp_path,
+        expected_seeds=(501, 502),
+        config_template=template,
+    )
+
+    assert result.ready is False
+    assert "schema_version must be an issue_2557_reward_curriculum manifest" in result.blockers
+    assert "claim_boundary must describe the evidence boundary" in result.blockers
+    assert "source_worktrees[0].commit must be a 40-char git sha" in result.blockers
+    assert "source_worktrees[0].seeds must be non-empty integer list" in result.blockers
+    assert "rows[0] must be an object" in result.blockers
+    assert "rows[1].seed must be an integer" in result.blockers
+    assert "seed 501: duplicate manifest row" not in result.blockers
+    assert "seed 502: duplicate manifest row" in result.blockers
+    assert "aggregate.count must match number of rows" in result.blockers
+
+
+def test_partial_manifest_fails_closed_unless_diagnostic_allowed(tmp_path: Path) -> None:
+    """Partial bundles are blocked unless explicitly inspected as diagnostics."""
+
+    manifest = _write_manifest(tmp_path / "seed_summary.json", partial=True)
+    _write_configs(tmp_path, (501, 502))
+    template = str(tmp_path / "configs/seed{seed}.yaml")
+
+    blocked = assess_issue_2557_replica_readiness(
+        manifest,
+        repo_root=tmp_path,
+        expected_seeds=(501, 502),
+        config_template=template,
+    )
+    diagnostic = assess_issue_2557_replica_readiness(
+        manifest,
+        repo_root=tmp_path,
+        expected_seeds=(501, 502),
+        config_template=template,
+        allow_partial=True,
+    )
+
+    assert blocked.ready is False
+    assert any("partial" in blocker for blocker in blocked.blockers)
+    assert diagnostic.ready is True
+    assert diagnostic.warnings
+
+
+def test_tracked_issue_2557_summary_remains_diagnostic_only() -> None:
+    """The public #2557 summary stays blocked unless partial diagnostics are explicit."""
+
+    blocked = assess_issue_2557_replica_readiness(
+        TRACKED_SEED_SUMMARY,
+        repo_root=REPO_ROOT,
+        expected_seeds=(501, 502, 503, 504, 505, 506, 507, 508),
+    )
+    diagnostic = assess_issue_2557_replica_readiness(
+        TRACKED_SEED_SUMMARY,
+        repo_root=REPO_ROOT,
+        expected_seeds=(501, 502, 503, 504, 505, 506, 507, 508),
+        allow_partial=True,
+    )
+
+    assert blocked.ready is False
+    assert "manifest still lists incomplete_or_pending_seeds" in blocked.blockers
+    assert diagnostic.ready is True
+    assert diagnostic.metadata["row_count"] == 14
+    assert diagnostic.warnings == (
+        "manifest lists incomplete_or_pending_seeds; diagnostic-only readiness",
+    )
+
+
+def test_main_emits_text_summary_for_ready_manifest(tmp_path: Path, capsys) -> None:
+    """The in-process CLI path emits the human-readable ready summary."""
+
+    manifest = _write_manifest(tmp_path / "seed_summary.json")
+    _write_configs(tmp_path, (501, 502))
+    template = str(tmp_path / "configs/seed{seed}.yaml")
+
+    exit_code = main(
+        [
+            "--manifest",
+            str(manifest),
+            "--expected-seeds",
+            "501,502",
+            "--config-template",
+            template,
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "issue #2557 replica artifact readiness: ready" in captured.out
+
+
+def test_main_rejects_reversed_seed_range(tmp_path: Path) -> None:
+    """Seed range parsing rejects reversed ranges before readiness assessment."""
+
+    manifest = _write_manifest(tmp_path / "seed_summary.json")
+
+    try:
+        main(["--manifest", str(manifest), "--expected-seeds", "502-501"])
+    except ValueError as exc:
+        assert "seed range start exceeds end" in str(exc)
+    else:  # pragma: no cover - defensive assertion message
+        raise AssertionError("main should reject reversed seed range")
+
+
+def test_cli_json_reports_missing_seed(tmp_path: Path) -> None:
+    """The CLI emits machine-readable missing-seed blockers."""
+
+    manifest = _write_manifest(tmp_path / "seed_summary.json", seeds=(501,))
+    template = _write_configs(tmp_path, (501, 502))
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(CHECKER),
+            "--manifest",
+            str(manifest),
+            "--expected-seeds",
+            "501-502",
+            "--config-template",
+            template,
+            "--json",
+        ],
+        cwd=tmp_path,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 1, completed.stdout
+    payload = json.loads(completed.stdout)
+    assert payload["ready"] is False
+    assert payload["missing_seeds"] == [502]


### PR DESCRIPTION
## Summary
Adds a read-only, fail-closed artifact-readiness checker for issue #2557 fixed-seed queue-fill replica summaries and provenance.

Issue link: https://github.com/ll7/robot_sf_ll7/issues/2557

## Linked Issues
- Refs #2557

## Stack / Dependency
- Base dependency: origin/main includes #3829 packet extraction.
- Required prior PRs: none.
- Safe review independently: yes.
- Review dependency reason, any: this is a narrow checker on tracked public evidence and does not require Slurm state.

## What Changed
- Added `robot_sf.benchmark.issue_2557_replica_readiness` to validate compact replica summary rows, expected seed coverage, source-worktree provenance, W&B run URLs, SHA-256 pointers, aggregate row count, and expected config presence.
- Added `scripts/benchmark/check_issue_2557_replica_readiness.py` as the CLI entry point.
- Added focused fixture tests for present/missing rows, missing provenance, partial-manifest fail-closed behavior, CLI JSON output, and the tracked #2557 seed summary.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: artifact-promotion readiness blocker for #2557 fixed-seed replica outputs.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - support helper.
- Result classification: NA - support helper; the tracked #2557 evidence remains diagnostic-only, but this PR does not classify a new result.
- Decision stop rule, applicable: default checker exits nonzero while the tracked manifest is explicitly partial; `--allow-partial` is diagnostic-only.
- Parent issue, claim map, registry, context note, synthesis surface update: #2557 and the existing #3829 packet.
- New research/benchmark/metric/paper-facing analysis tool, any: support helper only; it validates readiness inputs and does not interpret benchmark results.

## Domain-Aware Approval
- Required PR: yes - evidence-validity-sensitive diagnostic classification.
- Domains reviewed: evidence classification, artifact provenance boundary.
- Status: waived for support-checker PR.
- Approver/review source waiver: waiver because this PR only validates compact manifest readiness fields and promotes no benchmark-success, ranking, paper, or dissertation claim.
- Validity checklist: fail-closed on partial tracked evidence; fallback/degraded execution cannot be counted because this checker does not run Slurm or benchmarks.
- Target claim/hypothesis: issue #2557 artifact-promotion readiness remains diagnostic-only.
- Comparator or split/evidence validity: manifest-only validation checks input completeness without interpreting comparator results.
- Fallback/degraded exclusions: Slurm and benchmark execution are outside this checker, so fallback or degraded rows cannot be counted as success.
- Claim boundary: diagnostic artifact-readiness only.
- Implementation integrity vs experimental validity: validates manifest shape/provenance, not experimental validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - support checker.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue local artifact-finalizer audit when raw artifacts or durable pointers are available.
- Follow-up question issue weak, negative, non-transfer results: #2557 remains open for artifact promotion/finalizer audit.

## Next Empirical Action
- Rerun needed: no.
- Extractor analysis tool needed: no new extractor; #3829 already added the packet extractor.
- Artifact missing unavailable: raw Slurm logs, checkpoints, W&B payloads, episode logs, and per-scenario evaluations are not promoted by this PR.
- Stop / revise / continue decision: continue only with local artifact-finalizer audit; do not submit more replicas from this PR.
- Proposed child issue existing follow-up: #2557.

## Validation / Proof
- `uv run pytest tests/benchmark/test_issue_2557_replica_readiness.py` - passed, 9 tests.
- `uv run pytest tests/validation/test_extract_issue_2557_replica_readiness_packet.py tests/benchmark/test_issue_2557_replica_readiness.py` - passed, 11 tests.
- `uv run ruff check robot_sf/benchmark/issue_2557_replica_readiness.py scripts/benchmark/check_issue_2557_replica_readiness.py tests/benchmark/test_issue_2557_replica_readiness.py` - passed.
- `uv run ruff format --check robot_sf/benchmark/issue_2557_replica_readiness.py scripts/benchmark/check_issue_2557_replica_readiness.py tests/benchmark/test_issue_2557_replica_readiness.py` - passed.
- `uv run python scripts/benchmark/check_issue_2557_replica_readiness.py --json` - exited 1 as expected because the tracked manifest is partial and lists incomplete seeds.
- `PR_READY_PR_BODY_FILE=/tmp/issue2557_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - pending at PR creation time.

Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Hot Path
- Baseline runtime: NA, support checker only.
- Changed runtime: NA, support checker only.
- Representative command: `uv run python scripts/benchmark/check_issue_2557_replica_readiness.py --json`
- Hot-path call count profile anchor: NA, no runtime hot path.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: checker blocks a complete valid manifest or allows a partial manifest without `--allow-partial`.

## Risks / Rollout
- Compatibility risks: low; new opt-in checker and script only.
- Failure modes: schema expectations may need extension if future evidence summaries add different provenance fields.
- Rollback fallback plan: remove the new checker and continue using the #3829 packet extractor.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #2557 issue comments, #3829 readiness packet, and `docs/context/issue_2557_recovered_diagnostic_seeds.md`.
- Any assumptions need to preserved: tracked public summary remains diagnostic-only unless partial mode is explicit.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR adds a local readiness checker and does not promote benchmark, registry, claim-map, or paper-facing evidence.

## Follow-Up Issues
- Deferred work: #2557 remains the linked follow-up for local artifact-finalizer audit when raw artifacts or durable pointers are available.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that default behavior blocks the tracked partial #2557 summary and that `--allow-partial` is clearly diagnostic-only.
- Known limitation: this checker reads tracked compact summaries and local configs only; it does not query Slurm, W&B, checkpoints, raw logs, episode JSONL, or videos.
