### PR TITLE
Issue #3204: map proxy checkpoint readiness blockers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Added a machine-readable known-blocker map to the proxy checkpoint-selection readiness preflight
+  (#3204). The checker now reports configured blocker IDs and revival conditions as a fail-closed
+  prerequisite without running training, selecting a checkpoint, or promoting benchmark evidence.
+
 
 * Added a **diagnostic missing-export blocker report** for frozen-trace `EpisodeEventLedger.v1`
   before/after reconciliation (#3482). New `build_missing_frozen_trace_export_report`

--- a/configs/research/predictive_checkpoint_proxy_v1.yaml
+++ b/configs/research/predictive_checkpoint_proxy_v1.yaml
@@ -44,6 +44,30 @@ proxy_summary_contract:
   # success spread strictly greater than this counts as non-degenerate.
   min_success_spread: 1.0e-9
 
+# Current issue #3204 blocker map. The preflight does not hydrate artifacts or
+# run training, but unresolved entries keep the report fail-closed until the
+# contract is updated with durable evidence.
+known_blockers:
+  - id: missing_durable_predictive_checkpoints
+    status: blocked
+    evidence: >
+      model/registry.yaml predictive entries currently point at non-durable
+      output/tmp or output/model_cache paths that do not resolve in a clean
+      checkout.
+    revival_condition: >
+      Promote or hydrate at least six predictive checkpoints from one real
+      training run into durable, locally resolvable registry local_path entries.
+  - id: degenerate_hardcase_proxy_probe_v1
+    status: blocked
+    evidence: >
+      The known hardcase_proxy_probe_v1 summary records no hard-seed success
+      spread, so the merged analyzer reports an inconclusive proxy-vs-ADE
+      comparison.
+    revival_condition: >
+      Provide a proxy.enabled training summary with at least six usable proxy
+      epochs and non-degenerate hard-seed success spread from a plateau-breaking
+      lineage.
+
 # Baseline selector this study compares against.
 ade_baseline:
   metric: val_ade

--- a/docs/context/issue_3204_proxy_checkpoint_selection_readiness.md
+++ b/docs/context/issue_3204_proxy_checkpoint_selection_readiness.md
@@ -25,6 +25,11 @@ reusable check so the blocked state is machine-checkable and the revival conditi
   fail-closed boundary plus a pin on the live-registry blocked state.
 
 ## Current observed state (live registry)
+The readiness contract now includes a `known_blockers` list so the checker reports current blocker
+status and revival conditions even when no training summary artifact is supplied. The current
+configured blockers are missing durable predictive checkpoints and the degenerate
+`hardcase_proxy_probe_v1` summary.
+
 
 All 8 `predictive_*` registry entries resolve to absent, non-durable `output/tmp/...` paths in a
 clean checkout, so the preflight reports `blocked` with `resolvable_count = 0 < 6`. This matches the

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -38,6 +38,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 STATUS_PASSED = "passed"
 STATUS_FAILED = "failed"
 STATUS_BLOCKED = "blocked"
+_KNOWN_BLOCKER_STATUSES = frozenset({STATUS_BLOCKED, "resolved", "diagnostic"})
 
 DEFAULT_CONFIG = Path("configs/research/predictive_checkpoint_proxy_v1.yaml")
 DEFAULT_REGISTRY = Path("model/registry.yaml")
@@ -84,9 +85,66 @@ def _check_config(config: Any, config_path: Path) -> tuple[str, list[str]]:
     summary_contract = config.get("proxy_summary_contract")
     if summary_contract is not None and not isinstance(summary_contract, dict):
         errors.append("proxy_summary_contract must be a mapping when provided")
+    errors.extend(_validate_known_blocker_schema(config.get("known_blockers")))
     if errors:
         return STATUS_FAILED, errors
     return STATUS_PASSED, []
+
+
+def _validate_known_blocker_schema(known_blockers: Any) -> list[str]:
+    """Validate optional known-blocker metadata in the readiness contract."""
+    if known_blockers is None:
+        return []
+    if not isinstance(known_blockers, list):
+        return ["known_blockers must be a list when provided"]
+
+    errors: list[str] = []
+    for index, blocker in enumerate(known_blockers):
+        if not isinstance(blocker, dict):
+            errors.append(f"known_blockers[{index}] must be a mapping")
+            continue
+        blocker_id = blocker.get("id")
+        blocker_status = blocker.get("status")
+        if not isinstance(blocker_id, str) or not blocker_id:
+            errors.append(f"known_blockers[{index}] missing id")
+        if blocker_status not in _KNOWN_BLOCKER_STATUSES:
+            errors.append(
+                f"known_blockers[{index}] status must be one of {sorted(_KNOWN_BLOCKER_STATUSES)}"
+            )
+    return errors
+
+
+def _check_known_blockers(config: dict[str, Any]) -> tuple[str, list[str], list[dict[str, Any]]]:
+    """Expose configured known blocker status as a fail-closed report section."""
+    blockers = config.get("known_blockers") or []
+    if not isinstance(blockers, list):
+        return STATUS_FAILED, ["known_blockers must be a list"], []
+
+    normalized: list[dict[str, Any]] = []
+    messages: list[str] = []
+    failed = False
+    blocked = False
+    for index, blocker in enumerate(blockers):
+        if not isinstance(blocker, dict):
+            failed = True
+            messages.append(f"known_blockers[{index}] must be a mapping")
+            continue
+        blocker_id = str(blocker.get("id", "unnamed"))
+        status = blocker.get("status")
+        if status not in _KNOWN_BLOCKER_STATUSES:
+            failed = True
+            messages.append(f"known_blockers[{index}] has unsupported status: {status}")
+            continue
+        normalized.append(dict(blocker))
+        if status == STATUS_BLOCKED:
+            blocked = True
+            messages.append(f"known blocker remains blocked: {blocker_id}")
+
+    if failed:
+        return STATUS_FAILED, messages, normalized
+    if blocked:
+        return STATUS_BLOCKED, messages, normalized
+    return STATUS_PASSED, messages, normalized
 
 
 def _check_hard_seed_fixture(fixture_path: Path) -> tuple[str, list[str]]:
@@ -301,6 +359,14 @@ def check_readiness(
             "status": summary_status,
             "messages": summary_messages,
             "summary": summary_payload,
+        }
+
+    if cfg:
+        blocker_status, blocker_messages, blocker_payload = _check_known_blockers(cfg)
+        prerequisites["known_blockers"] = {
+            "status": blocker_status,
+            "messages": blocker_messages,
+            "blockers": blocker_payload,
         }
 
     errors: list[str] = []

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -24,7 +24,13 @@ _spec.loader.exec_module(mod)
 _HARD_SEED_FIXTURE = "configs/benchmarks/predictive_hard_seeds_v1.yaml"
 
 
-def _write_config(root: Path, *, min_resolvable: int = 2, min_epochs: int = 4) -> Path:
+def _write_config(
+    root: Path,
+    *,
+    min_resolvable: int = 2,
+    min_epochs: int = 4,
+    known_blockers: list[dict[str, str]] | None = None,
+) -> Path:
     """Write a minimal but valid readiness contract pointing at the real hard-seed fixture."""
     config = {
         "schema_version": "predictive-checkpoint-proxy-readiness.v1",
@@ -39,6 +45,8 @@ def _write_config(root: Path, *, min_resolvable: int = 2, min_epochs: int = 4) -
             "min_success_spread": 1.0e-9,
         },
     }
+    if known_blockers is not None:
+        config["known_blockers"] = known_blockers
     path = root / "proxy_config.yaml"
     path.write_text(yaml.safe_dump(config, sort_keys=False), encoding="utf-8")
     return path
@@ -190,6 +198,62 @@ def test_blocked_when_summary_not_a_mapping(tmp_path):
     summary_check = report["prerequisites"]["proxy_training_summary"]
     assert summary_check["status"] == "failed"
     assert any("JSON object" in m for m in summary_check["messages"])
+
+
+def test_blocked_when_known_blocker_configured(tmp_path):
+    """Configured known blockers are surfaced and keep preflight fail-closed."""
+    config = _write_config(
+        tmp_path,
+        min_resolvable=2,
+        min_epochs=2,
+        known_blockers=[
+            {
+                "id": "degenerate_hardcase_proxy_probe_v1",
+                "status": "blocked",
+                "revival_condition": "provide a non-degenerate proxy summary",
+            }
+        ],
+    )
+    registry = _write_registry(tmp_path, present_count=2, absent_count=0)
+    summary = _write_summary(tmp_path, enabled=True, pairs=[(1.0, 0.1), (0.8, 0.4)])
+    report = mod.check_readiness(
+        config_path=config,
+        registry_path=registry,
+        repo_root=_REPO_ROOT,
+        training_summary=summary,
+    )
+    blockers = report["prerequisites"]["known_blockers"]
+    assert report["status"] == "blocked"
+    assert blockers["status"] == "blocked"
+    assert blockers["blockers"][0]["id"] == "degenerate_hardcase_proxy_probe_v1"
+
+
+def test_ready_when_known_blocker_resolved(tmp_path):
+    """Resolved known blockers stay in the map without blocking readiness."""
+    config = _write_config(
+        tmp_path,
+        min_resolvable=2,
+        min_epochs=2,
+        known_blockers=[
+            {
+                "id": "degenerate_hardcase_proxy_probe_v1",
+                "status": "resolved",
+                "revival_condition": "non-degenerate proxy summary supplied",
+            }
+        ],
+    )
+    registry = _write_registry(tmp_path, present_count=2, absent_count=0)
+    summary = _write_summary(tmp_path, enabled=True, pairs=[(1.0, 0.1), (0.8, 0.4)])
+    report = mod.check_readiness(
+        config_path=config,
+        registry_path=registry,
+        repo_root=_REPO_ROOT,
+        training_summary=summary,
+    )
+    blockers = report["prerequisites"]["known_blockers"]
+    assert report["status"] == "ready"
+    assert blockers["status"] == "passed"
+    assert blockers["blockers"][0]["status"] == "resolved"
 
 
 def test_ready_when_inputs_present_and_summary_has_spread(tmp_path):


### PR DESCRIPTION
## Summary
Adds machine-readable known-blocker reporting to the issue #3204 proxy checkpoint-selection readiness preflight. The checker remains diagnostic-only and fail-closed: it reports unresolved blocker IDs and revival conditions without selecting checkpoints, running training, or promoting benchmark evidence.

## Linked Issues
- Relates to #3204

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `known_blockers` entries to `configs/research/predictive_checkpoint_proxy_v1.yaml` for missing durable predictive checkpoints and the degenerate `hardcase_proxy_probe_v1` summary.
- Extended `scripts/research/check_predictive_checkpoint_proxy_readiness.py` to validate and report configured known blockers as a fail-closed prerequisite.
- Added fixture tests for blocked and resolved known-blocker states, and updated the context note/changelog.

## Why Matters
- Added value: issue #3204's current blocker status is now visible in the default readiness report, even when no training summary artifact is supplied.
- Expected impact: clearer handoff/revival signal for future plateau-breaking runs.
- Why worth merging now: it improves evidence readiness without compute submission or claim promotion.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker visibility for proxy-based checkpoint-selection readiness in #3204.
- Comparator or baseline, applicable: NA - support checker only.
- Evidence tier: NA - support checker only; no benchmark or research result claim.
- Result classification: NA - support checker only.
- Decision stop rule, applicable: NA - no selector adoption decision in this PR.
- Parent issue, claim map, registry, context note, synthesis surface update: `docs/context/issue_3204_proxy_checkpoint_selection_readiness.md` updated.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - extends existing preflight; does not interpret benchmark evidence.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: support checker only; no benchmark interpretation or paper-facing claim.
- Validity checklist: no full benchmark campaign run; no Slurm/GPU submission; no paper/dissertation claim edits.
- Target claim/hypothesis: NA - no claim is promoted.
- Comparator split/evidence validity: NA - no comparator split or evidence interpretation changed.
- Fallback/degraded exclusions: no fallback/degraded benchmark success is reported.
- Claim boundary: diagnostic readiness/preflight only.
- Implementation integrity vs experimental validity: tests validate fail-closed checker behavior, not proxy effectiveness.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no planner run.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3204 remains blocked until durable checkpoints and non-degenerate proxy summary exist.

## Next Empirical Action
- Rerun needed: no for this PR; yes for issue #3204 evidence once artifacts exist.
- Extractor analysis tool needed: no
- Artifact missing unavailable: durable predictive checkpoints and non-degenerate proxy-enabled training summary.
- Stop / revise / continue decision: continue when blockers clear.
- Proposed child issue existing follow-up: existing #3214/#3254 plateau-breaking lineages.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py -q` -> passed, 12 tests.
- `git diff --check` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --json` -> expected exit 2, status `blocked`, known blockers `missing_durable_predictive_checkpoints`, `degenerate_hardcase_proxy_probe_v1`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Budget
- Baseline runtime: NA - no runtime path changed.
- Changed runtime: NA - no runtime path changed.
- Representative command: `uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py -q`
- Hot-path call count profile anchor: NA
- Cache-hit reuse counter: NA
- Rollback failure criterion: readiness checker stops reporting known blockers fail-closed or fixture tests fail.

## Risks / Rollout
- Compatibility risks: low; existing configs without `known_blockers` continue to pass schema validation.
- Failure modes: stale blocker metadata could keep the checker blocked until the config is updated with durable evidence.
- Rollback fallback plan: revert the config/checker/test additions.

## Docs / Provenance
- Updated docs: `docs/context/issue_3204_proxy_checkpoint_selection_readiness.md`, `CHANGELOG.md`.
- Relevant design provenance notes: issue #3204 comments and existing #3204 readiness preflight.
- Any assumptions need to preserved: known blockers are explicit contract metadata and must be updated when durable artifacts clear them.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): config updated only.
- Context index / memory note updated (yes/no/NA): context note updated; index already references the note.
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: diagnostic checker hardening only, no benchmark result or artifact promotion.

## Follow-Up Issues
- Deferred work: hydrate/promote >=6 predictive checkpoints and provide non-degenerate proxy-enabled training summary before conclusive #3204 analysis.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that `known_blockers` remains fail-closed but resolved blockers do not prevent synthetic ready-state tests.
- Any known limitations: default checker output remains blocked until the issue #3204 blocker metadata is updated after durable evidence exists.
