### PR TITLE
Issue #3465: tighten topology near-parity promotion gate

### DIFF
--- a/robot_sf/benchmark/near_parity_promotion_gate.py
+++ b/robot_sf/benchmark/near_parity_promotion_gate.py
@@ -1,14 +1,13 @@
 """Promotion-gate decision for the topology near-parity lane (issue #3465).
 
 #2540 isolated the topology near-parity selector as diagnostic-only and classified it ``revise``.
-The formal successor (this issue) compares the gate **enabled vs disabled** on the same
-scenario/seed contract and decides whether the lane stays diagnostic, revises, stops, or becomes
-eligible for stack promotion. This module is the pure **decision layer** that turns the paired
-comparison results into that verdict — fail-closed about fallback/degraded execution.
+The formal successor compares the gate **enabled vs disabled** on the same scenario/seed contract
+and decides whether the lane stays diagnostic, revises, stops, or becomes eligible for stack
+promotion.  This pure decision layer turns paired comparison results into that verdict and fails
+closed about fallback/degraded execution.
 
-The paired benchmark run itself (frozen config, gate-enabled/disabled arms over common seeds) needs
-the #3463 corrective work plus cluster execution and is deferred; this layer is pure and
-side-effect free, mirroring the accepted decision layers in this run (#3484, #3558, #3557).
+The paired benchmark run itself needs the #3463 corrective work plus cluster execution and is
+deferred; this layer is side-effect free and does not promote benchmark claims on its own.
 """
 
 from __future__ import annotations
@@ -16,7 +15,10 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any
 
+from robot_sf.benchmark.finite_checks import require_finite_fields
+
 NEAR_PARITY_GATE_SCHEMA = "near_parity_promotion_gate.v1"
+NEAR_PARITY_PROMOTION_GATE_SCHEMA = NEAR_PARITY_GATE_SCHEMA
 
 DIAGNOSTIC = "diagnostic"
 REVISE = "revise"
@@ -28,13 +30,13 @@ ELIGIBLE_FOR_PROMOTION = "eligible_for_promotion"
 class NearParityComparison:
     """Paired gate-enabled-vs-disabled comparison results for the near-parity lane.
 
-    Improvements are ``enabled − disabled`` on native execution; positive means the gate helped.
+    Improvements are ``enabled - disabled`` on native execution; positive means the gate helped.
 
     Attributes:
         safety_improvement: Safety-metric improvement (positive = safer with the gate on).
-        efficiency_improvement: Efficiency/progress improvement (positive = better with the gate on).
+        efficiency_improvement: Efficiency/progress improvement (positive = better with gate on).
         paired_significant: Whether the improvement is paired-statistically significant.
-        relies_on_fallback: Whether the improvement depends on fallback/degraded rows.
+        relies_on_fallback: Whether improvement depends on fallback/degraded rows.
         corrective_complete: Whether the #3463 corrective implementation is complete or waived.
     """
 
@@ -52,6 +54,9 @@ class PromotionThresholds:
     min_improvement: float = 0.02
 
 
+NearParityPromotionThresholds = PromotionThresholds
+
+
 def classify_near_parity_promotion(
     comparison: NearParityComparison,
     thresholds: PromotionThresholds | None = None,
@@ -60,23 +65,29 @@ def classify_near_parity_promotion(
 
     Decision order (first match wins):
 
-    1. corrective work not complete → ``diagnostic`` (the formal test is not yet runnable);
-    2. improvement relies on fallback/degraded rows → ``revise`` (fail-closed: it does not count);
-    3. a measurable safety or efficiency **regression** → ``stop``;
-    4. a measurable, paired-significant safety or efficiency improvement →
+    1. corrective work not complete -> ``diagnostic`` (the formal test is not yet runnable);
+    2. improvement relies on fallback/degraded rows -> ``revise`` (fail-closed, it does not count);
+    3. a measurable safety or efficiency regression -> ``stop``;
+    4. a measurable, paired-significant safety or efficiency improvement ->
        ``eligible_for_promotion`` (the only promote verdict);
-    5. otherwise (no measurable / non-significant difference) → ``revise``.
+    5. otherwise (no measurable / non-significant difference) -> ``revise``.
 
     Returns:
-        dict[str, Any]: Versioned verdict with ``promote`` flag and rationale.
+        Versioned verdict with promote flag, claim boundary, inputs, and rationale.
     """
+
     thresholds = thresholds or PromotionThresholds()
+    _validate_inputs(comparison, thresholds)
     verdict, rationale = _decide(comparison, thresholds)
+    promotable = verdict == ELIGIBLE_FOR_PROMOTION
     return {
         "schema_version": NEAR_PARITY_GATE_SCHEMA,
+        "issue": "3465",
         "evidence_kind": "diagnostic_proxy",
+        "claim_boundary": "promotion_gate_decision_only",
         "verdict": verdict,
-        "promote": verdict == ELIGIBLE_FOR_PROMOTION,
+        "promote": promotable,
+        "promotable": promotable,
         "rationale": rationale,
         "inputs": {
             "safety_improvement": comparison.safety_improvement,
@@ -84,12 +95,31 @@ def classify_near_parity_promotion(
             "paired_significant": comparison.paired_significant,
             "relies_on_fallback": comparison.relies_on_fallback,
             "corrective_complete": comparison.corrective_complete,
+            "min_improvement": thresholds.min_improvement,
         },
     }
 
 
+def _validate_inputs(comparison: NearParityComparison, thresholds: PromotionThresholds) -> None:
+    """Reject invalid decision inputs before any promotable verdict."""
+
+    require_finite_fields(
+        "comparison",
+        comparison,
+        ("safety_improvement", "efficiency_improvement"),
+    )
+    require_finite_fields("thresholds", thresholds, ("min_improvement",))
+    if thresholds.min_improvement < 0.0:
+        raise ValueError("thresholds.min_improvement must be non-negative")
+
+
 def _decide(c: NearParityComparison, t: PromotionThresholds) -> tuple[str, str]:
-    """Return the (verdict, rationale) for a comparison."""
+    """Return the (verdict, rationale) for a comparison.
+
+    Returns:
+        Verdict string and human-readable rationale.
+    """
+
     if not c.corrective_complete:
         return (
             DIAGNOSTIC,
@@ -117,9 +147,11 @@ __all__ = [
     "DIAGNOSTIC",
     "ELIGIBLE_FOR_PROMOTION",
     "NEAR_PARITY_GATE_SCHEMA",
+    "NEAR_PARITY_PROMOTION_GATE_SCHEMA",
     "REVISE",
     "STOP",
     "NearParityComparison",
+    "NearParityPromotionThresholds",
     "PromotionThresholds",
     "classify_near_parity_promotion",
 ]

--- a/robot_sf/benchmark/near_parity_promotion_gate.py
+++ b/robot_sf/benchmark/near_parity_promotion_gate.py
@@ -49,7 +49,12 @@ class NearParityComparison:
 
 @dataclass(frozen=True, slots=True)
 class PromotionThresholds:
-    """Minimum effect size for a measurable near-parity improvement/regression."""
+    """Minimum effect size for a measurable near-parity improvement/regression.
+
+    ``min_improvement`` must be strictly positive: a zero minimum effect size collapses the
+    regression and improvement boundaries onto exact equality and would mislabel a no-difference
+    comparison as ``stop``.
+    """
 
     min_improvement: float = 0.02
 
@@ -109,8 +114,8 @@ def _validate_inputs(comparison: NearParityComparison, thresholds: PromotionThre
         ("safety_improvement", "efficiency_improvement"),
     )
     require_finite_fields("thresholds", thresholds, ("min_improvement",))
-    if thresholds.min_improvement < 0.0:
-        raise ValueError("thresholds.min_improvement must be non-negative")
+    if thresholds.min_improvement <= 0.0:
+        raise ValueError("thresholds.min_improvement must be positive")
 
 
 def _decide(c: NearParityComparison, t: PromotionThresholds) -> tuple[str, str]:

--- a/tests/benchmark/test_near_parity_promotion_gate.py
+++ b/tests/benchmark/test_near_parity_promotion_gate.py
@@ -131,11 +131,16 @@ def test_non_finite_inputs_fail_closed_before_verdict() -> None:
         classify_near_parity_promotion(_comparison(safety_improvement=math.nan))
 
 
-def test_negative_threshold_is_rejected() -> None:
-    """Invalid threshold configuration fails before any promotable verdict."""
+@pytest.mark.parametrize("min_improvement", [-0.01, 0.0])
+def test_non_positive_threshold_is_rejected(min_improvement: float) -> None:
+    """Invalid threshold configuration fails before any verdict.
+
+    A zero threshold is rejected because it would collapse the regression and improvement
+    boundaries onto exact equality and mislabel a no-difference comparison as ``stop``.
+    """
 
     with pytest.raises(ValueError, match="min_improvement"):
         classify_near_parity_promotion(
             _comparison(safety_improvement=0.05),
-            PromotionThresholds(min_improvement=-0.01),
+            PromotionThresholds(min_improvement=min_improvement),
         )

--- a/tests/benchmark/test_near_parity_promotion_gate.py
+++ b/tests/benchmark/test_near_parity_promotion_gate.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+import json
+import math
+
+import pytest
+
 from robot_sf.benchmark.near_parity_promotion_gate import (
     DIAGNOSTIC,
     ELIGIBLE_FOR_PROMOTION,
@@ -9,12 +14,14 @@ from robot_sf.benchmark.near_parity_promotion_gate import (
     REVISE,
     STOP,
     NearParityComparison,
+    PromotionThresholds,
     classify_near_parity_promotion,
 )
 
 
-def _comparison(**overrides) -> NearParityComparison:
-    """Build a comparison with sensible defaults."""
+def _comparison(**overrides: object) -> NearParityComparison:
+    """Build a synthetic paired near-parity comparison."""
+
     kwargs = {
         "safety_improvement": 0.0,
         "efficiency_improvement": 0.0,
@@ -27,7 +34,8 @@ def _comparison(**overrides) -> NearParityComparison:
 
 
 def test_diagnostic_when_corrective_not_complete() -> None:
-    """Without the corrective implementation, the verdict is diagnostic (not runnable)."""
+    """Without the #3463 corrective implementation, the verdict is diagnostic."""
+
     verdict = classify_near_parity_promotion(
         _comparison(corrective_complete=False, safety_improvement=0.5)
     )
@@ -35,47 +43,99 @@ def test_diagnostic_when_corrective_not_complete() -> None:
     assert verdict["schema_version"] == NEAR_PARITY_GATE_SCHEMA
     assert verdict["verdict"] == DIAGNOSTIC
     assert verdict["promote"] is False
+    assert verdict["claim_boundary"] == "promotion_gate_decision_only"
+    assert "#3463" in verdict["rationale"]
 
 
 def test_fallback_reliant_improvement_is_revise() -> None:
-    """An improvement that relies on fallback/degraded rows must not count (fail-closed)."""
+    """An improvement that relies on fallback/degraded rows must not count."""
+
     verdict = classify_near_parity_promotion(
         _comparison(safety_improvement=0.5, relies_on_fallback=True)
     )
 
     assert verdict["verdict"] == REVISE
     assert verdict["promote"] is False
+    assert "fallback/degraded" in verdict["rationale"]
 
 
-def test_regression_is_stop() -> None:
-    """A measurable safety/efficiency regression must stop the lane."""
-    verdict = classify_near_parity_promotion(_comparison(efficiency_improvement=-0.1))
+@pytest.mark.parametrize(
+    ("safety_improvement", "efficiency_improvement"),
+    [
+        (-0.1, 0.0),
+        (0.0, -0.1),
+    ],
+)
+def test_regression_is_stop(
+    safety_improvement: float,
+    efficiency_improvement: float,
+) -> None:
+    """A measurable safety or efficiency regression must stop the lane."""
+
+    verdict = classify_near_parity_promotion(
+        _comparison(
+            safety_improvement=safety_improvement,
+            efficiency_improvement=efficiency_improvement,
+        )
+    )
 
     assert verdict["verdict"] == STOP
+    assert verdict["promote"] is False
 
 
 def test_significant_native_improvement_is_eligible_for_promotion() -> None:
     """A measurable, paired-significant native improvement is the only promote verdict."""
+
     verdict = classify_near_parity_promotion(
         _comparison(safety_improvement=0.05, paired_significant=True)
     )
 
     assert verdict["verdict"] == ELIGIBLE_FOR_PROMOTION
     assert verdict["promote"] is True
+    assert verdict["promotable"] is True
 
 
-def test_improvement_without_significance_is_revise() -> None:
-    """A non-significant improvement must not be promoted."""
-    verdict = classify_near_parity_promotion(
-        _comparison(safety_improvement=0.05, paired_significant=False)
-    )
+@pytest.mark.parametrize(
+    "comparison",
+    [
+        _comparison(),
+        _comparison(safety_improvement=0.05, paired_significant=False),
+        _comparison(safety_improvement=0.01, efficiency_improvement=0.01),
+    ],
+)
+def test_no_measurable_or_non_significant_improvement_is_revise(
+    comparison: NearParityComparison,
+) -> None:
+    """No measurable or non-significant difference keeps the lane at revise."""
+
+    verdict = classify_near_parity_promotion(comparison)
 
     assert verdict["verdict"] == REVISE
     assert verdict["promote"] is False
 
 
-def test_no_difference_is_revise() -> None:
-    """No measurable difference keeps the lane at revise."""
-    verdict = classify_near_parity_promotion(_comparison())
+def test_decision_payload_is_json_serializable() -> None:
+    """The decision packet carries stable issue metadata and JSON-serializes."""
 
-    assert verdict["verdict"] == REVISE
+    verdict = classify_near_parity_promotion(_comparison(safety_improvement=0.05))
+
+    assert verdict["issue"] == "3465"
+    assert verdict["inputs"]["min_improvement"] == 0.02
+    assert json.loads(json.dumps(verdict))["schema_version"] == NEAR_PARITY_GATE_SCHEMA
+
+
+def test_non_finite_inputs_fail_closed_before_verdict() -> None:
+    """NaN/Inf comparison values are rejected before classification."""
+
+    with pytest.raises(ValueError, match="comparison.safety_improvement"):
+        classify_near_parity_promotion(_comparison(safety_improvement=math.nan))
+
+
+def test_negative_threshold_is_rejected() -> None:
+    """Invalid threshold configuration fails before any promotable verdict."""
+
+    with pytest.raises(ValueError, match="min_improvement"):
+        classify_near_parity_promotion(
+            _comparison(safety_improvement=0.05),
+            PromotionThresholds(min_improvement=-0.01),
+        )


### PR DESCRIPTION
## Summary

Implements the controlled validation stack promotion gate slice for #3465 by tightening the existing pure `near_parity_promotion_gate.v1` decision layer.

- keeps the gate local and side-effect free
- preserves the existing dict-style checker API while adding explicit issue and claim-boundary metadata
- fails closed on non-finite paired-comparison inputs and invalid thresholds before any promotable verdict
- expands synthetic paired-comparison coverage for diagnostic, revise, stop, and eligible decisions, including the missing #3463 corrective-complete precondition

Issue: https://github.com/ll7/robot_sf_ll7/issues/3465

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/near_parity_promotion_gate.py tests/benchmark/test_near_parity_promotion_gate.py` — passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/near_parity_promotion_gate.py tests/benchmark/test_near_parity_promotion_gate.py` — passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_near_parity_promotion_gate.py` — passed, 11 tests
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed before commit on dirty tree, 1679 passed, 2 skipped
- `PR_READY_PR_BODY_FILE=/tmp/issue-3465-pr-body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed on clean committed tree, stamp head `efa606e2e8fcb697132841e819c8167c1dbc2cd4`

## Out of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No planner promotion claim; this PR only records the fail-closed local decision/checker slice.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer promotion decision details, including a new “promotable” flag and additional diagnostic fields in results.
  * Improved decision reporting so the applied improvement threshold is shown in outputs.

* **Bug Fixes**
  * Added stricter input checks to reject invalid numeric values and negative improvement thresholds.
  * Refined decision guidance for near-parity cases to better distinguish when to promote, revise, or stop.

* **Tests**
  * Expanded coverage for regression, promotion, and non-promotable scenarios.
  * Added checks for stable, JSON-ready results and validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->