### PR TITLE
Issue #3466: wire AMMV feasibility artifact telemetry

### DIFF
--- a/robot_sf/benchmark/ammv_feasibility.py
+++ b/robot_sf/benchmark/ammv_feasibility.py
@@ -17,6 +17,7 @@ a deliberate follow-up; this evaluator is pure and side-effect free.
 
 from __future__ import annotations
 
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
@@ -133,6 +134,7 @@ def evaluate_command_feasibility(
         "schema_version": AMMV_FEASIBILITY_SCHEMA,
         "evidence_kind": "diagnostic_proxy",
         "proxy_kind": "internal_non_hardware",
+        "status": "available",
         "n_commands": int(v.shape[0]),
         "min_stability_margin": min_margin,
         "tip_over_violation": bool(tip_over_steps),
@@ -143,8 +145,69 @@ def evaluate_command_feasibility(
     }
 
 
+def _fail_closed_artifact_payload(reason: str, *, n_commands: int = 0) -> dict[str, Any]:
+    """Return a non-hardware diagnostic payload that cannot be mistaken for feasible evidence."""
+    return {
+        "schema_version": AMMV_FEASIBILITY_SCHEMA,
+        "evidence_kind": "diagnostic_proxy",
+        "proxy_kind": "internal_non_hardware",
+        "status": "missing_inputs",
+        "reason": reason,
+        "n_commands": int(n_commands),
+        "min_stability_margin": None,
+        "tip_over_violation": True,
+        "n_tip_over_steps": None,
+        "rollover_event": "AMMV_FEASIBILITY_INPUTS_MISSING",
+        "n_curvature_violations": None,
+        "feasible": False,
+    }
+
+
+def evaluate_artifact_command_feasibility(
+    commands: Sequence[Mapping[str, Any]] | object,
+    *,
+    params: AmmvFeasibilityParams | None = None,
+) -> dict[str, Any]:
+    """Evaluate AMMV feasibility from per-step artifact command payloads.
+
+    The map-runner artifact surface stores normalized selected actions as mappings with
+    ``linear_velocity`` and ``angular_velocity`` fields. Missing or holonomic-only command payloads
+    fail closed because the three-wheeled proxy cannot infer yaw-rate feasibility from ``vx/vy``.
+
+    Returns:
+        Versioned ``ammv_feasibility.v1`` diagnostic telemetry marked ``internal_non_hardware``.
+    """
+
+    if not isinstance(commands, Sequence) or isinstance(commands, (str, bytes)):
+        return _fail_closed_artifact_payload("commands must be a sequence of mappings")
+    if not commands:
+        return _fail_closed_artifact_payload("commands sequence is empty")
+
+    velocities: list[float] = []
+    turn_rates: list[float] = []
+    for idx, command in enumerate(commands):
+        if not isinstance(command, Mapping):
+            return _fail_closed_artifact_payload(
+                f"command {idx} is not a mapping",
+                n_commands=len(velocities),
+            )
+        if "linear_velocity" not in command or "angular_velocity" not in command:
+            return _fail_closed_artifact_payload(
+                f"command {idx} lacks linear_velocity/angular_velocity",
+                n_commands=len(velocities),
+            )
+        velocities.append(float(command["linear_velocity"]))
+        turn_rates.append(float(command["angular_velocity"]))
+
+    try:
+        return evaluate_command_feasibility(velocities, turn_rates, params=params)
+    except (TypeError, ValueError) as exc:
+        return _fail_closed_artifact_payload(str(exc), n_commands=len(velocities))
+
+
 __all__ = [
     "AMMV_FEASIBILITY_SCHEMA",
     "AmmvFeasibilityParams",
+    "evaluate_artifact_command_feasibility",
     "evaluate_command_feasibility",
 ]

--- a/robot_sf/benchmark/map_runner_batch_runner.py
+++ b/robot_sf/benchmark/map_runner_batch_runner.py
@@ -35,6 +35,12 @@ def _initial_feasibility_totals() -> FeasibilityTotals:
         "sum_abs_delta_angular": 0.0,
         "max_abs_delta_linear": 0.0,
         "max_abs_delta_angular": 0.0,
+        "ammv_commands_evaluated": 0,
+        "ammv_episode_count": 0,
+        "ammv_feasible_episode_count": 0,
+        "ammv_tip_over_episode_count": 0,
+        "ammv_curvature_violation_count": 0,
+        "ammv_min_stability_margin": float("inf"),
     }
 
 

--- a/robot_sf/benchmark/map_runner_batch_summary.py
+++ b/robot_sf/benchmark/map_runner_batch_summary.py
@@ -39,6 +39,7 @@ def accumulate_batch_metadata(
     """
     impact_meta = (rec.get("algorithm_metadata") or {}).get("adapter_impact") or {}
     feasibility_meta = (rec.get("algorithm_metadata") or {}).get("kinematics_feasibility") or {}
+    ammv_meta = (rec.get("algorithm_metadata") or {}).get("ammv_feasibility") or {}
     adapter_requested_seen = False
     adapter_native_steps = 0
     adapter_adapted_steps = 0
@@ -69,6 +70,28 @@ def accumulate_batch_metadata(
             float(feasibility_totals["max_abs_delta_angular"]),
             _float_metadata_value(feasibility_meta.get("max_abs_delta_angular")),
         )
+    if isinstance(ammv_meta, dict):
+        feasibility_totals.setdefault("ammv_episode_count", 0)
+        feasibility_totals.setdefault("ammv_commands_evaluated", 0)
+        feasibility_totals.setdefault("ammv_curvature_violation_count", 0)
+        feasibility_totals.setdefault("ammv_feasible_episode_count", 0)
+        feasibility_totals.setdefault("ammv_tip_over_episode_count", 0)
+        feasibility_totals.setdefault("ammv_min_stability_margin", float("inf"))
+        feasibility_totals["ammv_episode_count"] += 1
+        feasibility_totals["ammv_commands_evaluated"] += int(ammv_meta.get("n_commands", 0) or 0)
+        feasibility_totals["ammv_curvature_violation_count"] += int(
+            ammv_meta.get("n_curvature_violations", 0) or 0
+        )
+        if bool(ammv_meta.get("feasible", False)):
+            feasibility_totals["ammv_feasible_episode_count"] += 1
+        if bool(ammv_meta.get("tip_over_violation", False)):
+            feasibility_totals["ammv_tip_over_episode_count"] += 1
+        margin = ammv_meta.get("min_stability_margin")
+        if margin is not None:
+            feasibility_totals["ammv_min_stability_margin"] = min(
+                float(feasibility_totals["ammv_min_stability_margin"]),
+                float(margin),
+            )
     return adapter_requested_seen, adapter_native_steps, adapter_adapted_steps
 
 
@@ -295,6 +318,25 @@ def build_completed_batch_summary(  # noqa: PLR0913
         ),
         "max_abs_delta_linear": float(feasibility_totals["max_abs_delta_linear"]),
         "max_abs_delta_angular": float(feasibility_totals["max_abs_delta_angular"]),
+    }
+    ammv_episode_count = int(feasibility_totals.get("ammv_episode_count", 0))
+    ammv_margin = float(feasibility_totals.get("ammv_min_stability_margin", float("inf")))
+    algo_contract["ammv_feasibility"] = {
+        "schema_version": "ammv_feasibility.v1",
+        "proxy_kind": "internal_non_hardware",
+        "episode_count": ammv_episode_count,
+        "commands_evaluated": int(feasibility_totals.get("ammv_commands_evaluated", 0)),
+        "min_stability_margin": (
+            ammv_margin if ammv_episode_count > 0 and ammv_margin != float("inf") else None
+        ),
+        "tip_over_violation": bool(
+            int(feasibility_totals.get("ammv_tip_over_episode_count", 0)) > 0
+        ),
+        "n_curvature_violations": int(feasibility_totals.get("ammv_curvature_violation_count", 0)),
+        "feasible": bool(
+            ammv_episode_count > 0
+            and int(feasibility_totals.get("ammv_feasible_episode_count", 0)) == ammv_episode_count
+        ),
     }
 
     summary = {

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -17,6 +17,7 @@ from robot_sf.benchmark.algorithm_metadata import (
     infer_execution_mode_from_counts,
     resolve_learned_checkpoint_observation_contract,
 )
+from robot_sf.benchmark.ammv_feasibility import evaluate_artifact_command_feasibility
 from robot_sf.benchmark.latency_stress import not_available_latency_metrics
 from robot_sf.benchmark.map_runner_actions import DEFAULT_KINEMATICS as _DEFAULT_KINEMATICS
 from robot_sf.benchmark.map_runner_actions import (
@@ -556,6 +557,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         previous_trace_ped_pos: np.ndarray | None = None
         previous_trace_heading = _observation_heading(obs)
         robot_headings: list[float] = []
+        ammv_command_actions: list[dict[str, Any]] = []
         view_integrity: dict[str, Any] | None = None
         for step_idx in range(horizon_val):
             policy_obs, step_noise_stats = apply_observation_noise(obs, noise_spec, noise_rng)
@@ -609,6 +611,8 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 )
                 policy_command = actuation_step.applied_command
                 current_command = actuation_step.applied_command
+            selected_action_payload = _command_action_payload(policy_command)
+            ammv_command_actions.append(selected_action_payload)
             if step_is_native:
                 # Policy already outputs native env actions (e.g. delta velocities);
                 # skip the absolute→delta conversion done by _policy_command_to_env_action.
@@ -658,7 +662,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                 )
                 planner_payload: dict[str, Any] = {
                     "event": "step",
-                    "selected_action": _command_action_payload(policy_command),
+                    "selected_action": selected_action_payload,
                 }
                 if actuation_step is not None:
                     planner_payload["amv"] = {
@@ -953,6 +957,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             impact["status"] = "not_applicable"
             impact["adapter_fraction"] = 0.0
     _finalize_feasibility_metadata(algo_meta)
+    algo_meta["ammv_feasibility"] = evaluate_artifact_command_feasibility(ammv_command_actions)
     if isinstance(planner_runtime_snapshot, dict):
         algo_meta["planner_runtime"] = planner_runtime_snapshot
     if record_planner_decision_trace:

--- a/tests/benchmark/test_ammv_feasibility.py
+++ b/tests/benchmark/test_ammv_feasibility.py
@@ -8,8 +8,11 @@ import pytest
 from robot_sf.benchmark.ammv_feasibility import (
     AMMV_FEASIBILITY_SCHEMA,
     AmmvFeasibilityParams,
+    evaluate_artifact_command_feasibility,
     evaluate_command_feasibility,
 )
+from robot_sf.benchmark.map_runner_batch_runner import _initial_feasibility_totals
+from robot_sf.benchmark.map_runner_batch_summary import accumulate_batch_metadata
 
 
 def test_feasible_command_sequence_is_classified_feasible() -> None:
@@ -97,6 +100,84 @@ def test_non_finite_commands_fail_closed() -> None:
         evaluate_command_feasibility(np.array([1.0, np.inf]), np.array([0.1, 0.1]))
     with pytest.raises(ValueError):
         evaluate_command_feasibility(np.array([1.0, 1.0]), np.array([0.1, np.nan]))
+
+
+def test_artifact_command_feasibility_extracts_versioned_fields() -> None:
+    """Per-step artifact selected actions expose AMMV feasibility telemetry."""
+    report = evaluate_artifact_command_feasibility(
+        [
+            {"linear_velocity": 0.5, "angular_velocity": 0.2},
+            {"linear_velocity": 0.6, "angular_velocity": 0.1},
+        ]
+    )
+
+    assert report["schema_version"] == AMMV_FEASIBILITY_SCHEMA
+    assert report["proxy_kind"] == "internal_non_hardware"
+    assert report["status"] == "available"
+    assert report["n_commands"] == 2
+    assert report["tip_over_violation"] is False
+    assert report["n_curvature_violations"] == 0
+    assert report["feasible"] is True
+
+
+def test_artifact_command_feasibility_fails_closed_for_missing_yaw_rate() -> None:
+    """Holonomic artifact actions cannot be promoted as AMMV-feasible command evidence."""
+    report = evaluate_artifact_command_feasibility([{"vx": 0.5, "vy": 0.0}])
+
+    assert report["schema_version"] == AMMV_FEASIBILITY_SCHEMA
+    assert report["proxy_kind"] == "internal_non_hardware"
+    assert report["status"] == "missing_inputs"
+    assert report["tip_over_violation"] is True
+    assert report["n_curvature_violations"] is None
+    assert report["feasible"] is False
+
+
+def test_artifact_command_feasibility_fails_closed_for_invalid_inputs() -> None:
+    """Malformed artifact command payloads stay diagnostic and infeasible."""
+    reports = [
+        evaluate_artifact_command_feasibility("not-a-command-sequence"),
+        evaluate_artifact_command_feasibility([]),
+        evaluate_artifact_command_feasibility(
+            [{"linear_velocity": 0.1, "angular_velocity": 0.0}, 1]
+        ),
+        evaluate_artifact_command_feasibility(
+            [{"linear_velocity": float("nan"), "angular_velocity": 0.0}]
+        ),
+    ]
+
+    assert all(report["schema_version"] == AMMV_FEASIBILITY_SCHEMA for report in reports)
+    assert all(report["status"] == "missing_inputs" for report in reports)
+    assert all(report["tip_over_violation"] is True for report in reports)
+    assert all(report["feasible"] is False for report in reports)
+
+
+def test_batch_metadata_folds_ammv_feasibility_fields() -> None:
+    """Batch summaries expose AMMV artifact telemetry without changing existing rows."""
+    totals = _initial_feasibility_totals()
+    requested_seen, native_steps, adapted_steps = accumulate_batch_metadata(
+        {
+            "algorithm_metadata": {
+                "ammv_feasibility": {
+                    "schema_version": AMMV_FEASIBILITY_SCHEMA,
+                    "proxy_kind": "internal_non_hardware",
+                    "n_commands": 3,
+                    "min_stability_margin": 0.25,
+                    "tip_over_violation": False,
+                    "n_curvature_violations": 1,
+                    "feasible": False,
+                }
+            }
+        },
+        feasibility_totals=totals,
+    )
+
+    assert (requested_seen, native_steps, adapted_steps) == (False, 0, 0)
+    assert totals["ammv_episode_count"] == 1
+    assert totals["ammv_commands_evaluated"] == 3
+    assert totals["ammv_min_stability_margin"] == pytest.approx(0.25)
+    assert totals["ammv_tip_over_episode_count"] == 0
+    assert totals["ammv_curvature_violation_count"] == 1
+    assert totals["ammv_feasible_episode_count"] == 0
 
 
 def test_invalid_params_rejected() -> None:

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -2690,6 +2690,14 @@ def test_run_map_episode_smoke(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(feasibility, dict)
     assert "projection_rate" in feasibility
     assert "infeasible_rate" in feasibility
+    ammv_feasibility = algo_md.get("ammv_feasibility")
+    assert isinstance(ammv_feasibility, dict)
+    assert ammv_feasibility["schema_version"] == "ammv_feasibility.v1"
+    assert ammv_feasibility["proxy_kind"] == "internal_non_hardware"
+    assert ammv_feasibility["min_stability_margin"] is not None
+    assert isinstance(ammv_feasibility["tip_over_violation"], bool)
+    assert ammv_feasibility["n_curvature_violations"] >= 0
+    assert isinstance(ammv_feasibility["feasible"], bool)
 
 
 def test_run_map_episode_closes_env_when_reset_fails(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary
Wires the existing `ammv_feasibility.v1` internal proxy evaluator into map-runner artifacts for issue #3466.

## Linked Issue
- Closes #3466
- Issue: https://github.com/ll7/robot_sf_ll7/issues/3466

## Scope
- Adds per-episode `algorithm_metadata.ammv_feasibility` telemetry with `min_stability_margin`, `tip_over_violation`, `n_curvature_violations`, and `feasible`.
- Adds batch-level `algorithm_metadata_contract.ammv_feasibility` aggregation marked `internal_non_hardware`.
- Keeps existing benchmark rows backward-compatible by adding a separate diagnostic block rather than changing existing metric columns.
- Missing artifact command inputs fail closed as diagnostic proxy metadata, not as AMMV-feasible evidence.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format robot_sf/benchmark/ammv_feasibility.py robot_sf/benchmark/map_runner_episode.py robot_sf/benchmark/map_runner_batch_runner.py robot_sf/benchmark/map_runner_batch_summary.py tests/benchmark/test_ammv_feasibility.py tests/benchmark/test_map_runner_utils.py && scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/benchmark/ammv_feasibility.py robot_sf/benchmark/map_runner_episode.py robot_sf/benchmark/map_runner_batch_runner.py robot_sf/benchmark/map_runner_batch_summary.py tests/benchmark/test_ammv_feasibility.py tests/benchmark/test_map_runner_utils.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/benchmark/test_ammv_feasibility.py tests/benchmark/test_map_runner_utils.py -q` - passed, 141 passed.

## Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No hardware-specific AMMV safety claims, full vehicle dynamics, or benchmark artifact promotion.

## Reviewer Notes
- `ammv_feasibility.v1` remains an internal non-hardware proxy. Holonomic-only command artifacts fail closed because yaw-rate feasibility cannot be inferred from `vx/vy`.
