### PR TITLE
Tighten Package B base-config preflight for issue #3079

### DIFF
--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -21,6 +21,8 @@ MANIFEST_SCHEMA_VERSION = "adversarial-package-b-comparison.v1"
 EXPECTED_ISSUE = 3079
 EXPECTED_BUDGETS = (16, 32, 64)
 EXPECTED_SAMPLERS = ("random", "coordinate", "optuna")
+EXPECTED_POLICY = "goal"
+EXPECTED_OBJECTIVE = "worst_case_snqi"
 EXPECTED_REPORTING_FIELDS = frozenset(
     {
         "first_failure_iteration",
@@ -306,12 +308,13 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
         if not checks[f"{key}_exists"]:
             blockers.append(f"base_config.{key} must point at an existing repository file")
 
-    for key in ("policy", "objective"):
-        checks[f"{key}_declared"] = isinstance(base_config.get(key), str) and bool(
-            base_config.get(key).strip()
-        )
-        if not checks[f"{key}_declared"]:
-            blockers.append(f"base_config.{key} must be a non-empty string")
+    checks["policy_expected"] = base_config.get("policy") == EXPECTED_POLICY
+    if not checks["policy_expected"]:
+        blockers.append(f"base_config.policy must be {EXPECTED_POLICY!r}")
+
+    checks["objective_expected"] = base_config.get("objective") == EXPECTED_OBJECTIVE
+    if not checks["objective_expected"]:
+        blockers.append(f"base_config.objective must be {EXPECTED_OBJECTIVE!r}")
 
     budgets = _as_int_tuple(payload.get("budget_grid"))
     checks["budget_grid"] = budgets == EXPECTED_BUDGETS
@@ -476,6 +479,10 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
         "repeated_seeds": list(seeds),
         "example_command_repeated_seeds": list(command_seeds),
         "samplers": list(samplers),
+        "base_config": {
+            "policy": base_config.get("policy"),
+            "objective": base_config.get("objective"),
+        },
         "research_package_registry": _repo_relative(registry_path, root),
         "runner": _repo_relative(runner_path, root) if runner_path else None,
         "runner_reporting_fields": sorted(runner_row_fields),

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -125,6 +125,10 @@ def test_committed_package_b_manifest_preflights_without_running_benchmark() -> 
     assert result.metadata["budget_grid"] == [16, 32, 64]
     assert result.metadata["repeated_seeds"] == [1101, 2202, 3303]
     assert "held_out_family_yield" in result.metadata["runner_reporting_fields"]
+    assert result.metadata["base_config"] == {
+        "policy": "goal",
+        "objective": "worst_case_snqi",
+    }
     assert (
         result.metadata["research_package_registry"]
         == "configs/research/research_package_registry_issue_3057.yaml"
@@ -401,6 +405,24 @@ def test_preflight_blocks_missing_inputs_and_output_paths(tmp_path: Path) -> Non
     assert result.checks["search_space_exists"] is False
     assert result.checks["output_dir_under_issue_path"] is False
     assert result.checks["out_json_under_issue_path"] is False
+
+
+def test_preflight_blocks_base_config_policy_objective_drift(tmp_path: Path) -> None:
+    """Package-B local metadata must stay bound to the intended policy and objective."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["base_config"]["policy"] = "orca"
+    payload["base_config"]["objective"] = "nearest_collision"
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["policy_expected"] is False
+    assert result.checks["objective_expected"] is False
+    assert any("base_config.policy" in blocker for blocker in result.blockers)
+    assert any("base_config.objective" in blocker for blocker in result.blockers)
 
 
 def test_preflight_blocks_output_artifact_command_drift(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Tightens the issue #3079 Package B adversarial preflight so the manifest must stay bound to the expected local base configuration policy and objective before any benchmark campaign can run.

## Linked Issues
- Relates to `#3079`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added fail-closed checks that `base_config.policy` is `goal` and `base_config.objective` is `worst_case_snqi`.
- Added the preflighted base-config policy/objective values to the structured preflight metadata.
- Added focused synthetic coverage for policy/objective drift plus committed-manifest metadata coverage.

## Why Matters
- Added value: prevents a drifted local manifest from silently validating the wrong Package B readiness slice.
- Expected impact: readiness checker is stricter without executing the benchmark campaign.
- Why worth merging now: issue #3079 remains open for the full campaign, and this closes another bounded provenance gap safely on the shared PC.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3079 readiness/provenance blocker for Package B manifest consistency only.
- Comparator or baseline, applicable: existing preflight accepted any non-empty policy/objective strings.
- Evidence tier: NA - support preflight checker; validation proof is listed below
- Result classification: NA - support checker only
- Decision stop rule, applicable: checker fails closed when policy/objective metadata drifts from the intended Package B base config.
- Parent issue, claim map, registry, context note, synthesis surface update: #3079 remains open for the actual benchmark campaign.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker only; no falsification yield interpretation.

## Domain-Aware Approval
- Required PR: yes
- Domains reviewed: benchmark readiness metadata
- Status: waived
- Approver/review source waiver: maintainer-supplied scope explicitly limits this PR to readiness/provenance gating with no campaign execution or interpretation.
- Target claim/hypothesis: #3079 Package B preflight metadata must fail closed before execution when local base-config policy/objective drift.
- Comparator or split/evidence validity: no comparator split or benchmark evidence validity changes; focused tests cover checker behavior only.
- Fallback/degraded exclusions: existing preflight exclusions remain intact; no fallback/degraded rows are counted as evidence.
- Claim boundary: readiness/provenance only, not benchmark evidence and not paper-facing.
- Implementation integrity vs experimental validity: tests prove the stricter guard; experimental validity remains out of scope for the full #3079 campaign.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: no
- Stop / revise / continue decision: continue #3079 full benchmark campaign separately.
- Proposed child issue existing follow-up: #3079 remains the follow-up for actual budget-matched execution.

## Validation / Proof
- `uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py -q` -> passed, 24 passed.
- `uv run python scripts/tools/preflight_adversarial_package_b.py --manifest configs/adversarial/issue_3079_package_b_budget_matched.yaml --repo-root .` -> passed, `blocked=false` with `policy_expected=true` and `objective_expected=true`.
- `uv run ruff check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` -> passed.
- `uv run ruff format --check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` -> passed.
- `git diff --check` -> passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed on dirty tree before commit, 1679 passed, 2 skipped.
- Final clean-head readiness rerun is recorded after this body is available.

Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Evidence
- Baseline runtime: NA - no performance or caching claim.
- Changed runtime: NA - no performance or caching claim.
- Representative command: `uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py -q`
- Hot-path call count profile anchor: NA - no hot-path runtime change.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if valid Package B manifest preflight fails or drifted policy/objective metadata no longer blocks.

## Risks / Rollout
- Compatibility risks: narrow manifest contract is stricter; intentional for issue #3079 Package B.
- Failure modes: future Package B scope changes policy/objective and must update constants/tests deliberately.
- Rollback fallback plan: revert this commit to restore previous non-empty-string behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3079 and prior support PRs #3781, #3785, #3787, #3790, #3791.
- Any assumptions need to preserved: Package B readiness is currently scoped to `goal` policy and `worst_case_snqi` objective.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: support/preflight-only change; #3079 remains open for benchmark execution and reporting.

## Follow-Up Issues
- Deferred work: actual budget-matched adversarial comparison run, certified/replayable failure counting, held-out-family yield, replay success, first-failure, best-objective, invalid-rate reporting.
- Issues opened follow-up: none; existing issue #3079 covers the remaining campaign work.

## Reviewer Notes
- Verify this remains a fail-closed metadata check only.
- Known limitations: no benchmark campaign execution, no Slurm/GPU submission, no paper/dissertation claim edits.
