### PR TITLE
Issue #3699: expose SNQI term measurement basis

### DIFF
--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -52,6 +52,7 @@ class TermScaling:
         weight_name: Weight coefficient key (e.g. ``"w_time"``).
         metric_key: Episode-metric key consumed for this term.
         scaling: One of :data:`SCALING_RAW` or :data:`SCALING_BASELINE_NORMALIZED`.
+        measurement_basis: Native unit or normalization basis for the post-scaling value.
         sign: ``+1`` for the reward term (success), ``-1`` for penalty terms.
         bounded: Whether this term's post-scaling contribution is bounded.
         default: Value substituted when ``metric_key`` is absent from metrics
@@ -63,6 +64,7 @@ class TermScaling:
     weight_name: str
     metric_key: str
     scaling: str
+    measurement_basis: str
     sign: int
     bounded: bool
     default: float
@@ -89,6 +91,7 @@ class TermScaling:
             "weight_name": self.weight_name,
             "metric_key": self.metric_key,
             "scaling": self.scaling,
+            "measurement_basis": self.measurement_basis,
             "normalization_status": self.normalization_status,
             "sign": self.sign,
             "is_penalty": self.is_penalty,
@@ -109,6 +112,7 @@ SNQI_TERM_SCALING: tuple[TermScaling, ...] = (
         weight_name="w_success",
         metric_key="success",
         scaling=SCALING_RAW,
+        measurement_basis="raw 0/1 episode success indicator",
         sign=+1,
         bounded=True,
         default=0.0,
@@ -119,6 +123,7 @@ SNQI_TERM_SCALING: tuple[TermScaling, ...] = (
         weight_name="w_time",
         metric_key="time_to_goal_norm",
         scaling=SCALING_RAW,
+        measurement_basis="raw time-to-goal ratio",
         sign=-1,
         bounded=False,
         default=1.0,
@@ -129,6 +134,7 @@ SNQI_TERM_SCALING: tuple[TermScaling, ...] = (
         weight_name="w_collisions",
         metric_key="collisions",
         scaling=SCALING_BASELINE_NORMALIZED,
+        measurement_basis="baseline-relative median/p95 clamped value",
         sign=-1,
         bounded=True,
         default=0.0,
@@ -139,6 +145,7 @@ SNQI_TERM_SCALING: tuple[TermScaling, ...] = (
         weight_name="w_near",
         metric_key="near_misses",
         scaling=SCALING_BASELINE_NORMALIZED,
+        measurement_basis="baseline-relative median/p95 clamped value",
         sign=-1,
         bounded=True,
         default=0.0,
@@ -149,6 +156,7 @@ SNQI_TERM_SCALING: tuple[TermScaling, ...] = (
         weight_name="w_comfort",
         metric_key="comfort_exposure",
         scaling=SCALING_RAW,
+        measurement_basis="raw accumulated comfort-exposure value",
         sign=-1,
         bounded=False,
         default=0.0,
@@ -159,6 +167,7 @@ SNQI_TERM_SCALING: tuple[TermScaling, ...] = (
         weight_name="w_force_exceed",
         metric_key="force_exceed_events",
         scaling=SCALING_BASELINE_NORMALIZED,
+        measurement_basis="baseline-relative median/p95 clamped value",
         sign=-1,
         bounded=True,
         default=0.0,
@@ -169,6 +178,7 @@ SNQI_TERM_SCALING: tuple[TermScaling, ...] = (
         weight_name="w_jerk",
         metric_key="jerk_mean",
         scaling=SCALING_BASELINE_NORMALIZED,
+        measurement_basis="baseline-relative median/p95 clamped value",
         sign=-1,
         bounded=True,
         default=0.0,
@@ -311,11 +321,14 @@ def format_normalization_report(inventory: NormalizationInventory) -> str:
         A multi-line string suitable for preflight / CLI output.
     """
     lines = ["SNQI per-term normalization inventory (issue #3699)"]
-    header = f"  {'term':<13}{'scaling':<22}{'bounded':<9}metric_key"
+    header = f"  {'term':<13}{'scaling':<22}{'bounded':<9}{'metric_key':<24}basis"
     lines.append(header)
     for term in inventory.terms:
         bounded = "yes" if term.bounded else "NO"
-        lines.append(f"  {term.term:<13}{term.scaling:<22}{bounded:<9}{term.metric_key}")
+        lines.append(
+            f"  {term.term:<13}{term.scaling:<22}{bounded:<9}"
+            f"{term.metric_key:<24}{term.measurement_basis}"
+        )
     lines.append(f"  mixed_scale            : {inventory.mixed_scale}")
     lines.append(
         "  raw penalty terms      : "

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -137,7 +137,8 @@ def _print_text_report(report: dict[str, Any]) -> None:
         role = "penalty" if term["is_penalty"] else "reward"
         print(
             f"  - {term['term']} ({term['metric_key']}, {term['weight_name']}): "
-            f"{term['normalization_status']}; role={role}; note={term['note']}"
+            f"{term['normalization_status']}; role={role}; "
+            f"basis={term['measurement_basis']}; note={term['note']}"
         )
 
 

--- a/scripts/validation/check_snqi_normalization_inventory.py
+++ b/scripts/validation/check_snqi_normalization_inventory.py
@@ -118,7 +118,8 @@ def _print_text_report(report: dict[str, Any]) -> None:
         role = "penalty" if term["is_penalty"] else "reward"
         print(
             f" - {term['term']} ({term['metric_key']}, {term['weight_name']}): "
-            f"{term['normalization_status']}; role={role}; note={term['note']}"
+            f"{term['normalization_status']}; role={role}; "
+            f"basis={term['measurement_basis']}; note={term['note']}"
         )
 
 

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -55,8 +55,11 @@ def test_governance_text_lists_per_term_normalization_status(
     out = capsys.readouterr().out
     assert "Term normalization status:" in out
     assert "time (time_to_goal_norm, w_time): raw_unbounded" in out
+    assert "basis=raw time-to-goal ratio" in out
     assert "comfort (comfort_exposure, w_comfort): raw_unbounded" in out
+    assert "basis=raw accumulated comfort-exposure value" in out
     assert "collisions (collisions, w_collisions): baseline_normalized_bounded" in out
+    assert "basis=baseline-relative median/p95 clamped value" in out
     assert "jerk (jerk_mean, w_jerk): baseline_normalized_bounded" in out
 
 

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -160,6 +160,10 @@ def test_to_dict_is_json_serializable_and_self_consistent():
     assert status_by_term["time"] == "raw_unbounded"
     assert status_by_term["comfort"] == "raw_unbounded"
     assert status_by_term["collisions"] == "baseline_normalized_bounded"
+    basis_by_term = {term["term"]: term["measurement_basis"] for term in encoded["terms"]}
+    assert basis_by_term["time"] == "raw time-to-goal ratio"
+    assert basis_by_term["comfort"] == "raw accumulated comfort-exposure value"
+    assert basis_by_term["collisions"] == "baseline-relative median/p95 clamped value"
 
 
 def test_format_report_is_human_readable():
@@ -167,5 +171,8 @@ def test_format_report_is_human_readable():
     inv = build_snqi_normalization_inventory(_BASELINE_STATS)
     text = format_normalization_report(inv)
     assert "issue #3699" in text
+    assert "basis" in text
+    assert "raw time-to-goal ratio" in text
+    assert "baseline-relative median/p95 clamped value" in text
     for term in SNQI_TERM_SCALING:
         assert term.term in text

--- a/tests/benchmark/test_snqi_normalization_inventory_preflight.py
+++ b/tests/benchmark/test_snqi_normalization_inventory_preflight.py
@@ -63,6 +63,12 @@ def test_preflight_reports_mixed_basis_without_changing_snqi_output() -> None:
     assert status_by_term["time"] == "raw_unbounded"
     assert status_by_term["comfort"] == "raw_unbounded"
     assert status_by_term["collisions"] == "baseline_normalized_bounded"
+    basis_by_term = {
+        term["term"]: term["measurement_basis"] for term in report["normalization"]["terms"]
+    }
+    assert basis_by_term["time"] == "raw time-to-goal ratio"
+    assert basis_by_term["comfort"] == "raw accumulated comfort-exposure value"
+    assert basis_by_term["collisions"] == "baseline-relative median/p95 clamped value"
 
 
 def test_preflight_main_fails_closed_but_allows_inspection(tmp_path) -> None:
@@ -85,8 +91,11 @@ def test_preflight_text_lists_each_term_status(capsys: pytest.CaptureFixture[str
 
     assert "Term normalization status:" in out
     assert "time (time_to_goal_norm, w_time): raw_unbounded" in out
+    assert "basis=raw time-to-goal ratio" in out
     assert "comfort (comfort_exposure, w_comfort): raw_unbounded" in out
+    assert "basis=raw accumulated comfort-exposure value" in out
     assert "collisions (collisions, w_collisions): baseline_normalized_bounded" in out
+    assert "basis=baseline-relative median/p95 clamped value" in out
     assert "jerk (jerk_mean, w_jerk): baseline_normalized_bounded" in out
 
 


### PR DESCRIPTION
## Summary
Adds explicit measurement-basis metadata to the Social Navigation Quality Index (SNQI) normalization inventory so each term reports both its normalization status and native basis. This is diagnostic-only and does not change SNQI scoring, weights, or normalization behavior.

## Linked Issues
- Relates to `#3699`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: `NA`

## What Changed
- Added `measurement_basis` to each SNQI term inventory entry.
- Included the basis in the standalone normalization checker and combined governance preflight text output.
- Extended focused tests to assert mixed-basis metadata is surfaced fail-closed while existing `compute_snqi` outputs remain unchanged.

## Why Matters
- Added value: reviewers can see raw time/comfort bases versus baseline-relative median/p95 clamped bases directly in the preflight payload.
- Expected impact: clearer diagnostic inventory for the mixed raw/baseline-normalized SNQI basis in issue #3699.
- Why worth merging now: it tightens the reversible diagnostic surface without choosing the normalize-vs-bound redesign.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3699 diagnostic blocker that SNQI terms currently mix raw and baseline-normalized bases.
- Comparator or baseline, applicable: current `compute_snqi` output on synthetic fixture.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision stop rule, applicable: no scoring behavior changes; tests must continue reconstructing `compute_snqi` exactly.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3699.
- New research/benchmark/metric/paper-facing analysis tool, any: `NA - extends existing diagnostic preflight metadata only.`

## Domain-Aware Approval
- Required for this PR: yes - benchmark diagnostic preflight metadata.
- Domains reviewed: evidence classification, benchmark diagnostic boundary, fallback exclusions.
- Status: waived.
- Approver/review source or waiver: diagnostic-only metadata update; no benchmark ranking, scoring, metric semantics, or paper-facing claim change.
- Validity checklist:
- Target claim/hypothesis: mixed SNQI term basis remains diagnostic-only.
- Comparator or split/evidence validity: synthetic fixture checks unchanged `compute_snqi` output.
- Fallback/degraded exclusions: no benchmark execution or fallback/degraded rows.
- Claim boundary: no SNQI redesign, no scoring behavior change, no primary safety-ranking promotion.
- Implementation integrity vs experimental validity: tests verify metadata serialization/text output and unchanged score reconstruction.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - diagnostic metadata only.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA - synthetic metadata/preflight fixture.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: maintainer decision remains normalize raw terms vs document bounded raw-term asymmetry.

## Next Empirical Action
- Rerun needed: no.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with maintainer decision on SNQI redesign outside this PR.
- Proposed child issue existing follow-up: issue #3699 remains the decision surface.

## Validation / Proof
- `uv run pytest tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_normalization_inventory_preflight.py tests/benchmark/test_snqi_governance_preflight.py -q` -> 19 passed.
- `uv run ruff check robot_sf/benchmark/snqi/normalization_inventory.py scripts/validation/check_snqi_normalization_inventory.py scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_normalization_inventory_preflight.py tests/benchmark/test_snqi_governance_preflight.py` -> All checks passed.
- `uv run python scripts/validation/check_snqi_normalization_inventory.py --json --allow-mixed-basis` -> exit 0; report status `failed` with `mixed_normalization_basis` blocker and `measurement_basis` entries.
- `uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers` -> exit 0; report status `failed` with #3699/#3723 blockers and `measurement_basis` entries.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Evidence
- Runtime-sensitive change: no.
- Baseline runtime: `NA - metadata-only diagnostic preflight change; no runtime claim.`
- Changed runtime: `NA - metadata-only diagnostic preflight change; no runtime claim.`
- Representative command: `uv run pytest tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_normalization_inventory_preflight.py tests/benchmark/test_snqi_governance_preflight.py -q`
- Hot-path call count profile anchor: `NA - not a hot-path or caching change.`
- Cache-hit reuse counter: `NA - no caching claimed.`
- Rollback failure criterion: metadata breaks preflight JSON/text contract or changes reconstructed `compute_snqi` output.

## Risks / Rollout
- Compatibility risks: low; adds a JSON field and text detail to existing diagnostic reports.
- Failure modes: downstream parsers assuming an exact term field set could need to ignore the new field.
- Rollback fallback plan: remove `measurement_basis` field and associated text/test assertions.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3699.
- Any assumptions need to preserved: raw terms remain intentionally unresolved; this PR only inventories their basis.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments are not authorized for this task.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: no benchmark campaign, registry, claim-map, leaderboard, or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: maintainer decision on normalizing raw terms versus documenting/bounding raw-term asymmetry remains out of scope and stays tracked by #3699.
- Issues opened follow-up: #3699.

## Reviewer Notes
- Verify that `measurement_basis` is metadata-only and the existing score reconstruction test still guards unchanged `compute_snqi` behavior.
- Known limitations: does not redesign SNQI, alter weights, clear the fail-closed blocker, or make SNQI benchmark-strength evidence.
