### PR TITLE
Issue #3204: refine proxy checkpoint readiness mapping

### DIFF
--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -167,6 +167,56 @@ def _resolve_local_path(local_path: Any, repo_root: Path) -> Path | None:
     return candidate
 
 
+def _artifact_scope(local_path: Any, resolved: Path | None, repo_root: Path) -> str:
+    """Classify whether a registry path names durable or worktree-local storage."""
+    if not isinstance(local_path, str) or not local_path:
+        return "invalid"
+
+    path = Path(local_path)
+    if path.parts and path.parts[0] == "output":
+        return "worktree_local_output"
+
+    if resolved is not None:
+        try:
+            relative = resolved.resolve().relative_to(repo_root.resolve())
+        except ValueError:
+            return "external_or_absolute"
+        if relative.parts and relative.parts[0] == "output":
+            return "worktree_local_output"
+        return "repo_relative"
+
+    return "unknown"
+
+
+def _checkpoint_mapping_entry(model_id: str, local_path: Any, repo_root: Path) -> dict[str, Any]:
+    """Build one fail-closed checkpoint mapping row without selecting any checkpoint."""
+    resolved = _resolve_local_path(local_path, repo_root)
+    scope = _artifact_scope(local_path, resolved, repo_root)
+
+    if resolved is None:
+        status = "invalid_local_path"
+        reason = "local_path missing or not a non-empty string"
+    elif resolved.is_file():
+        status = "present"
+        reason = "regular file resolves locally"
+    elif resolved.is_dir():
+        status = "not_checkpoint_file"
+        reason = "local_path resolves to a directory"
+    else:
+        status = "missing_local_path"
+        reason = "local_path does not resolve to a regular file"
+
+    return {
+        "model_id": model_id,
+        "local_path": local_path,
+        "resolved_path": str(resolved) if resolved is not None else None,
+        "artifact_scope": scope,
+        "status": status,
+        "reason": reason,
+        "present": status == "present",
+    }
+
+
 def _check_checkpoint_artifacts(
     registry: dict[str, dict[str, Any]],
     *,
@@ -189,25 +239,21 @@ def _check_checkpoint_artifacts(
         if tag not in tags:
             continue
         local_path = entry.get("local_path")
-        resolved = _resolve_local_path(local_path, repo_root)
-        # Only a regular file counts as a resolvable checkpoint: a mis-registered local_path
-        # pointing at a directory must not let the preflight report ready (fail-closed).
-        present = bool(resolved and resolved.is_file())
-        candidates.append(
-            {
-                "model_id": model_id,
-                "local_path": local_path,
-                "present": present,
-            }
-        )
+        candidates.append(_checkpoint_mapping_entry(model_id, local_path, repo_root))
 
     candidates.sort(key=lambda item: str(item["model_id"]))
     resolvable = [c for c in candidates if c["present"]]
+    blocked_by_status: dict[str, int] = {}
+    for candidate in candidates:
+        if candidate["present"]:
+            continue
+        blocked_by_status[candidate["status"]] = blocked_by_status.get(candidate["status"], 0) + 1
     mapping = {
         "registry_tag": registry_tag,
         "min_resolvable_checkpoints": min_resolvable,
         "candidate_count": len(candidates),
         "resolvable_count": len(resolvable),
+        "blocked_by_status": blocked_by_status,
         "candidates": candidates,
     }
 
@@ -218,12 +264,12 @@ def _check_checkpoint_artifacts(
             mapping,
         )
     if len(resolvable) < min_resolvable:
-        absent = [c["model_id"] for c in candidates if not c["present"]]
+        absent = [f"{c['model_id']} ({c['status']})" for c in candidates if not c["present"]]
         return (
             STATUS_BLOCKED,
             [
                 f"only {len(resolvable)} of {len(candidates)} '{registry_tag}' checkpoints resolve "
-                f"locally; need >= {min_resolvable}. Absent local_path for: {', '.join(absent)}"
+                f"locally; need >= {min_resolvable}. Blocked local_path entries: {', '.join(absent)}"
             ],
             mapping,
         )

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -128,7 +128,50 @@ def test_blocked_when_checkpoint_local_path_is_directory(tmp_path):
     ckpt = report["prerequisites"]["checkpoint_artifacts"]
     assert ckpt["status"] == "blocked"
     assert ckpt["mapping"]["resolvable_count"] == 0
+    assert ckpt["mapping"]["blocked_by_status"] == {"not_checkpoint_file": 1}
+    assert ckpt["mapping"]["candidates"][0]["status"] == "not_checkpoint_file"
+    assert ckpt["mapping"]["candidates"][0]["reason"] == "local_path resolves to a directory"
     assert report["status"] == "blocked"
+
+
+def test_blocked_mapping_classifies_invalid_local_path(tmp_path):
+    """A predictive registry entry without local_path is an explicit blocked mapping row."""
+    config = _write_config(tmp_path, min_resolvable=1)
+    models = [{"model_id": "predictive_missing_path", "tags": ["predictive"]}]
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(yaml.safe_dump({"version": 1, "models": models}), encoding="utf-8")
+
+    report = mod.check_readiness(config_path=config, registry_path=registry, repo_root=_REPO_ROOT)
+
+    ckpt = report["prerequisites"]["checkpoint_artifacts"]
+    assert report["status"] == "blocked"
+    assert ckpt["mapping"]["blocked_by_status"] == {"invalid_local_path": 1}
+    assert ckpt["mapping"]["candidates"][0]["status"] == "invalid_local_path"
+    assert ckpt["mapping"]["candidates"][0]["artifact_scope"] == "invalid"
+
+
+def test_blocked_mapping_classifies_worktree_local_output_artifact(tmp_path):
+    """A missing output/ checkpoint is reported as worktree-local, not durable evidence."""
+    config = _write_config(tmp_path, min_resolvable=1)
+    models = [
+        {
+            "model_id": "predictive_output_tmp",
+            "local_path": "output/tmp/predictive/run/checkpoint.pt",
+            "tags": ["predictive"],
+        }
+    ]
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(yaml.safe_dump({"version": 1, "models": models}), encoding="utf-8")
+
+    report = mod.check_readiness(config_path=config, registry_path=registry, repo_root=_REPO_ROOT)
+
+    ckpt = report["prerequisites"]["checkpoint_artifacts"]
+    candidate = ckpt["mapping"]["candidates"][0]
+    assert report["status"] == "blocked"
+    assert ckpt["mapping"]["blocked_by_status"] == {"missing_local_path": 1}
+    assert candidate["status"] == "missing_local_path"
+    assert candidate["artifact_scope"] == "worktree_local_output"
+    assert candidate["resolved_path"].endswith("output/tmp/predictive/run/checkpoint.pt")
 
 
 def test_blocked_when_too_few_checkpoints_resolve(tmp_path):
@@ -142,6 +185,7 @@ def test_blocked_when_too_few_checkpoints_resolve(tmp_path):
     mapping = ckpt["mapping"]
     assert mapping["candidate_count"] == 6  # the ppo entry is excluded
     assert mapping["resolvable_count"] == 2
+    assert mapping["blocked_by_status"] == {"missing_local_path": 4}
     # Absent checkpoints are surfaced by model_id for actionable triage.
     assert any("predictive_absent_0" in m for m in ckpt["messages"])
 


### PR DESCRIPTION
## Summary
Refines the existing #3204 predictive-checkpoint proxy readiness preflight so blocked checkpoint candidates report why they are unusable and whether they point at worktree-local `output/` storage.

## Linked Issues
- Relates to `#3204`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added per-candidate checkpoint mapping metadata: resolved path, artifact scope, blocked status, and reason.
- Added aggregate `blocked_by_status` counts for checkpoint artifact readiness.
- Added focused fixture tests for directory paths, missing `local_path`, worktree-local `output/` artifacts, and too-few-resolvable checkpoint summaries.

## Why Matters
- Added value: makes the current blocked state actionable without selecting checkpoints or running a benchmark.
- Expected impact: reviewers can distinguish missing durable predictive checkpoints from malformed registry rows and local-only output paths.
- Why worth merging now: #3204 is blocked on artifacts; clearer fail-closed diagnostics reduce rediscovery before the next plateau-breaking run is available.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker only; proxy-based checkpoint selection inputs are not ready until durable checkpoints and non-degenerate proxy history exist.
- Comparator or baseline, applicable: NA; no selector comparison is run.
- Evidence tier: NA - support helper; no research result or benchmark evidence is produced.
- Result classification: NA - support helper; current blocked state is reported but not resolved.
- Decision stop rule, applicable: NA; this PR does not select or promote a checkpoint.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3204.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - hardens an existing support preflight and exercises it on synthetic fixtures plus the current registry blocked state.

## Domain-Aware Approval
- Approver/review source waiver: not required; no research claim, evidence classification, comparison methodology, figure eligibility, benchmark interpretation, or paper-facing surface is changed.
- Validity checklist: diagnostic readiness only; fail-closed current-state report remains blocked.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution.
- Claim boundary: readiness metadata only.
- Implementation integrity vs experimental validity: tests cover metadata classification without changing selector semantics.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: existing #3204 remains blocked until durable inputs exist.

## Next Empirical Action
- Rerun needed: no for this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: durable predictive checkpoints and non-degenerate proxy training summary remain unavailable.
- Stop / revise / continue decision: continue only after inputs are available.
- Proposed child issue existing follow-up: existing #3204/#3215 lineage.

## Validation / Proof
- `uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py -q` - passed, 14 tests.
- `uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` - passed.
- `uv run ruff format --check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` - passed.
- `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --json` - expected exit 2; report stayed `blocked` with 8 candidates, 0 resolvable, `blocked_by_status={"missing_local_path": 8}`, artifact scope `worktree_local_output`.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Considerations
- Baseline runtime: NA; metadata-only preflight classification, no hot path claimed.
- Changed runtime: NA; no benchmark or training runtime claimed.
- Representative command: `uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py -q`.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: revert if readiness reports stop failing closed for missing or non-file checkpoint paths.

## Risks / Rollout
- Compatibility risks: JSON consumers may see additional keys in checkpoint mapping rows; existing keys are preserved.
- Failure modes: over-specific artifact scope classification could need refinement for future durable cache locations.
- Rollback fallback plan: remove the metadata additions and keep the prior present/absent mapping.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3204 issue comments and existing readiness contract.
- Any assumptions need to preserved: `output/` paths are worktree-local and not durable artifact evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; user authorization forbids issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a diagnostic support hardening PR and does not promote benchmark evidence or artifacts.

## Follow-Up Issues
- Deferred work: #3204 / #3215 track running the proxy-vs-ADE selector study after durable predictive checkpoints and non-degenerate proxy history exist.
- Issues opened follow-up: none; existing #3204 and portfolio #3215 already track the remaining empirical work.

## Reviewer Notes
- Verify the PR preserves fail-closed behavior for missing predictive checkpoints.
- Known limitation: current registry remains blocked; this PR intentionally does not hydrate or choose checkpoints.
