### PR TITLE
Issue #3425: block local finalizer artifact pointers

### DIFF
--- a/docs/context/issue_3425_slurm_to_claim_blocker.md
+++ b/docs/context/issue_3425_slurm_to_claim_blocker.md
@@ -105,6 +105,10 @@ the smallest external action to unblock it; exit `2` means an input could not be
 reuses the canonical loaders in `scripts/tools/reconcile_slurm_evidence.py`, so it evaluates exactly
 the inputs the real reconciliation consumes.
 
+Successful finalizers must point at durable artifact storage (`wandb`, `http(s)`, `s3`, `gs`,
+or `dvc`). Worktree-local paths such as `output/...` are blocked because `output/` is not durable
+across machines or worktrees.
+
 ## Current Decision
 
 `block`: no SLURM job was submitted, no finalizer manifest was produced, no durable pointer was

--- a/scripts/validation/preflight_slurm_finalizer.py
+++ b/scripts/validation/preflight_slurm_finalizer.py
@@ -78,6 +78,14 @@ SCHEMA_VERSION = "slurm-finalizer-preflight.v1"
 # Finalizer classifications that mean the job produced final artifacts and is
 # therefore expected to carry a durable pointer before a claim can be made.
 _SUCCESS_CLASSIFICATIONS = {"success"}
+_DURABLE_POINTER_PREFIXES = (
+    "wandb://",
+    "https://",
+    "http://",
+    "s3://",
+    "gs://",
+    "dvc://",
+)
 
 # The readiness gate makes no research claim; it only reports whether the inputs
 # for the vertical slice are present and provenance-complete.
@@ -422,6 +430,26 @@ def _check_durable_pointer(inputs: LoadedInputs) -> PreflightCheck:
             remediation=(
                 "promote each job's artifacts to a durable store (wandb/s3/gs/dvc/https) and "
                 "record the durable URI in the finalizer manifest before claiming"
+            ),
+        )
+    local_only = sorted(
+        f"{finalizer.job_id}: {finalizer.durable_pointer}"
+        for finalizer in successful
+        if finalizer.durable_pointer is not None
+        and not finalizer.durable_pointer.startswith(_DURABLE_POINTER_PREFIXES)
+    )
+    if local_only:
+        return PreflightCheck(
+            name="durable_pointer_present",
+            status=_BLOCKED,
+            severity=_REQUIRED,
+            detail=(
+                "successful finalizer(s) use non-durable or local artifact pointer(s): "
+                f"{', '.join(local_only)}"
+            ),
+            remediation=(
+                "replace worktree-local artifact paths with durable wandb, http(s), s3, gs, "
+                "or dvc URI before claim decision handoff"
             ),
         )
     return PreflightCheck(

--- a/tests/validation/test_preflight_slurm_finalizer.py
+++ b/tests/validation/test_preflight_slurm_finalizer.py
@@ -123,6 +123,19 @@ def test_blocks_when_durable_pointer_missing(tmp_path: Path) -> None:
     assert "durable" in durable_blocker["remediation"]
 
 
+def test_blocks_when_durable_pointer_is_worktree_local(tmp_path: Path) -> None:
+    """A successful finalizer cannot use worktree-local output as durable proof."""
+    inputs = _ready_inputs(tmp_path)
+    _write_finalizer(tmp_path / "finalizer.json", durable_uri="output/job_12345/finalizer.json")
+
+    report = gate.preflight(**inputs)
+
+    assert report["ready"] is False
+    blocker = next(b for b in report["blockers"] if b["check"] == "durable_pointer_present")
+    assert "non-durable or local artifact pointer" in blocker["detail"]
+    assert "worktree-local" in blocker["remediation"]
+
+
 def test_blocks_when_manifest_linkage_missing(tmp_path: Path) -> None:
     """A finalizer whose job id has no manifest job fails closed on linkage."""
     inputs = _ready_inputs(tmp_path)


### PR DESCRIPTION
## Summary
Tightens the issue #3425 SLURM-to-claim finalizer readiness gate so successful finalizer manifests fail closed when their artifact pointer is worktree-local or otherwise non-durable.

## Linked Issues
- Relates to `#3425`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added durable-pointer provenance validation to `scripts/validation/preflight_slurm_finalizer.py`.
- Added a focused synthetic finalizer test proving `output/...` artifact pointers block claim handoff readiness.
- Updated the issue #3425 context note to document that worktree-local `output/` paths are not durable evidence.

## Why Matters
- Added value: prevents a completed SLURM finalizer from looking claim-ready when it only points at local worktree output.
- Expected impact: submit-host finalizer handoff reports a clear blocked state before any claim decision uses non-durable artifacts.
- Why worth merging now: this is a small local readiness/provenance slice for #3425 with no Slurm execution or claim promotion.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3425 finalizer readiness blocker for durable artifact provenance before claim-decision handoff.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - support/preflight helper only.
- Result classification: NA - support/preflight helper only, no research result produced.
- Decision stop rule, applicable: successful finalizers must carry durable `wandb`, `http(s)`, `s3`, `gs`, or `dvc` pointers before readiness can pass.
- Parent issue, claim map, registry, context note, synthesis surface update: context note `docs/context/issue_3425_slurm_to_claim_blocker.md` updated; no claim map or registry update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - hardens existing support preflight.

## Domain-Aware Approval
- Required PR: yes - evidence-validity-sensitive result classification on a research/benchmark-labeled support PR.
- Domains reviewed: finalizer readiness/provenance only.
- Status: waived.
- Approver/review source waiver: maintainer-provided scope explicitly limits this to local finalizer/readiness validation and forbids Slurm submission or claim promotion.
- Validity checklist:
  - Target claim/hypothesis: no benchmark or paper-facing claim; only blocks local artifact pointers in the finalizer readiness gate.
  - Comparator or split/evidence validity: no comparator, split, benchmark ranking, or campaign interpretation changed.
  - Fallback/degraded exclusions: no benchmark rows produced; fallback/degraded execution not counted.
  - Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
  - Implementation integrity vs experimental validity: focused synthetic tests prove checker blocks local artifact pointers; experimental validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - focused test exercises a successful finalizer with `output/...` durable URI.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA - synthetic preflight fixture only.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: #3425 still needs submit-host finalizer evidence; this PR only hardens local readiness.

## Next Empirical Action
- Rerun needed: yes, on SLURM-capable host after live queue, duplicate, and private-ops checks.
- Extractor analysis tool needed: no new extractor in this PR.
- Artifact missing unavailable: no durable SLURM finalizer artifact was produced by this PR.
- Stop / revise / continue decision: continue #3425 submit-host vertical slice separately.
- Proposed child issue existing follow-up: #3425 remains the parent execution lane.

## Validation / Proof
- `uv run pytest tests/validation/test_preflight_slurm_finalizer.py -q` - passed, 15 tests.
- `uv run ruff check scripts/validation/preflight_slurm_finalizer.py tests/validation/test_preflight_slurm_finalizer.py` - passed.
- `uv run ruff format --check scripts/validation/preflight_slurm_finalizer.py tests/validation/test_preflight_slurm_finalizer.py` - passed.
- `git diff --check` - passed.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Caching
- Performance-critical path changed: no.
- Baseline runtime: targeted test file about 1.3s wall time in this worktree.
- Changed runtime: targeted test file about 1.3s wall time in this worktree.
- Representative command: `uv run pytest tests/validation/test_preflight_slurm_finalizer.py -q`.
- Hot-path call count profile anchor: NA - metadata-only preflight.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if valid durable finalizer URIs are incorrectly blocked or local `output/...` paths stop failing closed.

## Risks / Rollout
- Compatibility risks: successful finalizer manifests with non-URI local paths now fail readiness; this is intentional for claim handoff.
- Failure modes: a legitimate durable store with an unsupported scheme would need an explicit prefix addition.
- Rollback fallback plan: revert the durable-pointer prefix check and focused test.

## Docs / Provenance
- Updated docs: `docs/context/issue_3425_slurm_to_claim_blocker.md`.
- Relevant design provenance notes: issue #3425 local readiness gate and repository artifact policy that `output/` is worktree-local.
- Any assumptions need to preserved: durable claim handoff pointers are expected to be `wandb`, `http(s)`, `s3`, `gs`, or `dvc` URIs.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, issue comments are not authorized for this task.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): context note updated; index unchanged because existing note already linked by path in PR.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: support/preflight-only change; no benchmark, registry, claim-map, leaderboard, or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: actual SLURM-to-claim vertical slice execution and finalizer evidence on an authorized submit host remains tracked by #3425.
- Issues opened follow-up: none; #3425 remains open for submit-host execution.

## Reviewer Notes
- Verify closely: accepted durable pointer schemes are intentionally conservative.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no durable artifacts were produced.
