### PR TITLE
Issue #3213: Add maneuver-authority sweep manifest preflight

### DIFF
--- a/configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml
+++ b/configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml
@@ -1,26 +1,109 @@
 # Bounded maneuver-authority sweep grid for issue #3213.
 #
 # This grid is consumed by scripts/validation/run_predictive_success_campaign.py.
-# It mirrors a minimal subset of the generated full algo configs under
-# configs/algos/hardcase_authority/ so the first local run can test the core
-# authority levers without launching the full nine-variant family.
+# The metadata below is preflight-only: it documents the authority lever for each
+# arm and the expected artifact paths without running or interpreting a sweep.
+schema_version: maneuver_authority_sweep_manifest.v1
+issue: 3213
+hard_seed_manifest: configs/benchmarks/predictive_hard_seeds_v1.yaml
+expected_output:
+  root: output/benchmarks/issue_3213_maneuver_authority
+  summary: output/benchmarks/issue_3213_maneuver_authority/campaign_summary.json
+  report: output/benchmarks/issue_3213_maneuver_authority/campaign_report.md
 variants:
   - name: baseline
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_baseline.yaml
+    expected_output:
+      hard_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/hard__baseline__<checkpoint-token>.jsonl
+      global_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/global__baseline__<checkpoint-token>.jsonl
+    authority_metadata:
+      action_lattice:
+        inherits_defaults: true
+        description: Baseline camera-ready candidate headings and speeds.
+      turn_authority:
+        inherits_defaults: true
+        max_angular_speed_rad_s: 1.2
+      kinematic_adapter:
+        mode: predictive_planner_default
+        config_source: configs/algos/hardcase_authority/prediction_planner_authority_baseline.yaml
+        changed_params: []
     params: {}
-
   - name: high_angular
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_high_angular.yaml
+    expected_output:
+      hard_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/hard__high_angular__<checkpoint-token>.jsonl
+      global_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/global__high_angular__<checkpoint-token>.jsonl
+    authority_metadata:
+      action_lattice:
+        candidate_heading_deltas_rad:
+          [-1.047198, -0.785398, -0.523599, -0.261799, 0.0, 0.261799, 0.523599, 0.785398, 1.047198]
+        candidate_speed_samples_m_s: inherits_defaults
+      turn_authority:
+        max_angular_speed_rad_s: 1.8
+      kinematic_adapter:
+        mode: predictive_planner_config_overrides
+        config_source: configs/algos/hardcase_authority/prediction_planner_authority_high_angular.yaml
+        changed_params:
+          - max_angular_speed
+          - predictive_candidate_heading_deltas
     params:
       max_angular_speed: 1.8
       predictive_candidate_heading_deltas:
         [-1.047198, -0.785398, -0.523599, -0.261799, 0.0, 0.261799, 0.523599, 0.785398, 1.047198]
-
   - name: dense_lattice
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_dense_lattice.yaml
+    expected_output:
+      hard_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/hard__dense_lattice__<checkpoint-token>.jsonl
+      global_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/global__dense_lattice__<checkpoint-token>.jsonl
+    authority_metadata:
+      action_lattice:
+        candidate_heading_deltas_rad:
+          [-1.047198, -0.785398, -0.523599, -0.261799, 0.0, 0.261799, 0.523599, 0.785398, 1.047198]
+        candidate_speed_samples_m_s: [0.0, 0.15, 0.3, 0.45, 0.6, 0.8, 1.0]
+      turn_authority:
+        inherits_defaults: true
+        max_angular_speed_rad_s: 1.2
+      kinematic_adapter:
+        mode: predictive_planner_config_overrides
+        config_source: configs/algos/hardcase_authority/prediction_planner_authority_dense_lattice.yaml
+        changed_params:
+          - predictive_candidate_heading_deltas
+          - predictive_candidate_speeds
     params:
       predictive_candidate_heading_deltas:
         [-1.047198, -0.785398, -0.523599, -0.261799, 0.0, 0.261799, 0.523599, 0.785398, 1.047198]
       predictive_candidate_speeds: [0.0, 0.15, 0.3, 0.45, 0.6, 0.8, 1.0]
-
   - name: nearfield_turn
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_nearfield_turn.yaml
+    expected_output:
+      hard_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/hard__nearfield_turn__<checkpoint-token>.jsonl
+      global_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/global__nearfield_turn__<checkpoint-token>.jsonl
+    authority_metadata:
+      action_lattice:
+        near_field_heading_deltas_rad:
+          [
+            -1.570796,
+            -1.047198,
+            -0.785398,
+            -0.523599,
+            -0.261799,
+            0.0,
+            0.261799,
+            0.523599,
+            0.785398,
+            1.047198,
+            1.570796,
+          ]
+        near_field_speed_cap_m_s: 0.8
+      turn_authority:
+        inherits_defaults: true
+        max_angular_speed_rad_s: 1.2
+      kinematic_adapter:
+        mode: predictive_near_field_adapter
+        config_source: configs/algos/hardcase_authority/prediction_planner_authority_nearfield_turn.yaml
+        changed_params:
+          - predictive_near_field_heading_deltas
+          - predictive_near_field_speed_cap
     params:
       predictive_near_field_heading_deltas:
         [
@@ -37,16 +120,47 @@ variants:
           1.570796,
         ]
       predictive_near_field_speed_cap: 0.8
-
   - name: combined_max_authority
+    algo_config: configs/algos/hardcase_authority/prediction_planner_authority_combined_max_authority.yaml
+    expected_output:
+      hard_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/hard__combined_max_authority__<checkpoint-token>.jsonl
+      global_jsonl_pattern: output/benchmarks/issue_3213_maneuver_authority/global__combined_max_authority__<checkpoint-token>.jsonl
+    authority_metadata:
+      action_lattice:
+        candidate_heading_deltas_rad:
+          [-1.047198, -0.785398, -0.523599, -0.261799, 0.0, 0.261799, 0.523599, 0.785398, 1.047198]
+        candidate_speed_samples_m_s: [0.0, 0.15, 0.3, 0.45, 0.6, 0.8, 1.0]
+        near_field_heading_deltas_rad:
+          [
+            -1.570796,
+            -1.047198,
+            -0.785398,
+            -0.523599,
+            -0.261799,
+            0.0,
+            0.261799,
+            0.523599,
+            0.785398,
+            1.047198,
+            1.570796,
+          ]
+        near_field_speed_cap_m_s: 0.8
+      turn_authority:
+        max_angular_speed_rad_s: 1.8
+      kinematic_adapter:
+        mode: combined_predictive_authority_overrides
+        config_source: configs/algos/hardcase_authority/prediction_planner_authority_combined_max_authority.yaml
+        changed_params:
+          - max_angular_speed
+          - predictive_candidate_heading_deltas
+          - predictive_candidate_speeds
+          - predictive_near_field_heading_deltas
+          - predictive_near_field_speed_cap
     params:
       max_angular_speed: 1.8
       predictive_candidate_heading_deltas:
         [-1.047198, -0.785398, -0.523599, -0.261799, 0.0, 0.261799, 0.523599, 0.785398, 1.047198]
       predictive_candidate_speeds: [0.0, 0.15, 0.3, 0.45, 0.6, 0.8, 1.0]
-      predictive_sequence_segments: 4
-      predictive_sequence_branch_factor: 6
-      predictive_sequence_beam_width: 12
       predictive_near_field_heading_deltas:
         [
           -1.570796,

--- a/scripts/validation/check_maneuver_authority_sweep_manifest.py
+++ b/scripts/validation/check_maneuver_authority_sweep_manifest.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+"""Fail-closed preflight for the issue #3213 maneuver-authority sweep manifest."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+SCHEMA_VERSION = "maneuver_authority_sweep_manifest.v1"
+DEFAULT_MANIFEST = Path("configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml")
+
+_ACTION_LATTICE_KEYS = {
+    "inherits_defaults",
+    "candidate_heading_deltas_rad",
+    "candidate_speed_samples_m_s",
+    "near_field_heading_deltas_rad",
+    "near_field_speed_cap_m_s",
+}
+
+
+def _as_mapping(value: Any, label: str, errors: list[str]) -> dict[str, Any]:
+    if isinstance(value, dict):
+        return value
+    errors.append(f"{label} must be a mapping")
+    return {}
+
+
+def _as_list(value: Any, label: str, errors: list[str]) -> list[Any]:
+    if isinstance(value, list):
+        return value
+    errors.append(f"{label} must be a list")
+    return []
+
+
+def _repo_path(repo_root: Path, value: Any, label: str, errors: list[str]) -> Path | None:
+    if not isinstance(value, str) or not value.strip():
+        errors.append(f"{label} must be a non-empty string path")
+        return None
+    path = Path(value)
+    if path.is_absolute():
+        errors.append(f"{label} must be repo-relative: {value}")
+        return None
+    return repo_root / path
+
+
+def _require_existing_path(repo_root: Path, value: Any, label: str, errors: list[str]) -> None:
+    path = _repo_path(repo_root, value, label, errors)
+    if path is not None and not path.exists():
+        errors.append(f"{label} does not exist: {value}")
+
+
+def _validate_expected_output(repo_root: Path, payload: dict[str, Any], errors: list[str]) -> None:
+    expected_output = _as_mapping(payload.get("expected_output"), "expected_output", errors)
+    for key in ("root", "summary", "report"):
+        _repo_path(repo_root, expected_output.get(key), f"expected_output.{key}", errors)
+    root = expected_output.get("root")
+    if isinstance(root, str) and not root.startswith("output/"):
+        errors.append("expected_output.root must stay under output/")
+
+
+def _validate_variant_metadata(
+    *,
+    repo_root: Path,
+    variant: dict[str, Any],
+    variant_name: str,
+    errors: list[str],
+) -> None:
+    _require_existing_path(
+        repo_root, variant.get("algo_config"), f"{variant_name}.algo_config", errors
+    )
+
+    expected_output = _as_mapping(
+        variant.get("expected_output"),
+        f"{variant_name}.expected_output",
+        errors,
+    )
+    for key in ("hard_jsonl_pattern", "global_jsonl_pattern"):
+        _repo_path(
+            repo_root, expected_output.get(key), f"{variant_name}.expected_output.{key}", errors
+        )
+
+    metadata = _as_mapping(
+        variant.get("authority_metadata"),
+        f"{variant_name}.authority_metadata",
+        errors,
+    )
+    action_lattice = _as_mapping(
+        metadata.get("action_lattice"),
+        f"{variant_name}.authority_metadata.action_lattice",
+        errors,
+    )
+    if action_lattice and not (_ACTION_LATTICE_KEYS & set(action_lattice)):
+        errors.append(f"{variant_name}.authority_metadata.action_lattice has no known lattice keys")
+
+    turn_authority = _as_mapping(
+        metadata.get("turn_authority"),
+        f"{variant_name}.authority_metadata.turn_authority",
+        errors,
+    )
+    if turn_authority and "max_angular_speed_rad_s" not in turn_authority:
+        errors.append(
+            f"{variant_name}.authority_metadata.turn_authority must include max_angular_speed_rad_s"
+        )
+
+    adapter = _as_mapping(
+        metadata.get("kinematic_adapter"),
+        f"{variant_name}.authority_metadata.kinematic_adapter",
+        errors,
+    )
+    if adapter:
+        mode = adapter.get("mode")
+        if not isinstance(mode, str) or not mode.strip():
+            errors.append(
+                f"{variant_name}.authority_metadata.kinematic_adapter.mode "
+                "must be a non-empty string"
+            )
+        _require_existing_path(
+            repo_root,
+            adapter.get("config_source"),
+            f"{variant_name}.authority_metadata.kinematic_adapter.config_source",
+            errors,
+        )
+        changed_params = _as_list(
+            adapter.get("changed_params"),
+            f"{variant_name}.authority_metadata.kinematic_adapter.changed_params",
+            errors,
+        )
+        params = _as_mapping(variant.get("params", {}), f"{variant_name}.params", errors)
+        missing_params = sorted(set(params) - set(changed_params))
+        if missing_params:
+            errors.append(
+                f"{variant_name}.authority_metadata.kinematic_adapter.changed_params "
+                f"does not cover params: {missing_params}"
+            )
+
+
+def build_report(manifest_path: Path, repo_root: Path) -> dict[str, Any]:
+    """Return a machine-readable preflight report for a maneuver-authority manifest."""
+    errors: list[str] = []
+    manifest_path = manifest_path if manifest_path.is_absolute() else repo_root / manifest_path
+    if not manifest_path.exists():
+        return {
+            "schema_version": SCHEMA_VERSION,
+            "status": "failed",
+            "manifest": str(manifest_path),
+            "errors": [f"manifest does not exist: {manifest_path}"],
+        }
+
+    payload = yaml.safe_load(manifest_path.read_text(encoding="utf-8")) or {}
+    payload = _as_mapping(payload, "manifest", errors)
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        errors.append(f"schema_version must be {SCHEMA_VERSION}")
+    if payload.get("issue") != 3213:
+        errors.append("issue must be 3213")
+    _require_existing_path(
+        repo_root, payload.get("hard_seed_manifest"), "hard_seed_manifest", errors
+    )
+    _validate_expected_output(repo_root, payload, errors)
+
+    variants = _as_list(payload.get("variants"), "variants", errors)
+    if len(variants) < 3:
+        errors.append("variants must include at least three authority settings")
+
+    names: set[str] = set()
+    for index, item in enumerate(variants, start=1):
+        variant = _as_mapping(item, f"variant #{index}", errors)
+        name = variant.get("name")
+        if not isinstance(name, str) or not name.strip():
+            errors.append(f"variant #{index}.name must be a non-empty string")
+            name = f"#{index}"
+        if name in names:
+            errors.append(f"duplicate variant name: {name}")
+        names.add(name)
+        _validate_variant_metadata(
+            repo_root=repo_root, variant=variant, variant_name=name, errors=errors
+        )
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "status": "failed" if errors else "ok",
+        "manifest": str(manifest_path),
+        "variant_count": len(variants),
+        "variants": sorted(names),
+        "errors": errors,
+        "note": "Preflight only; does not run sweeps or interpret benchmark success.",
+    }
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    """Parse CLI arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--repo-root", type=Path, default=Path.cwd())
+    parser.add_argument("--json-output", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the fail-closed manifest preflight."""
+    args = parse_args(argv)
+    report = build_report(args.manifest, args.repo_root)
+    rendered = json.dumps(report, indent=2, sort_keys=True)
+    if args.json_output is not None:
+        args.json_output.parent.mkdir(parents=True, exist_ok=True)
+        args.json_output.write_text(rendered + "\n", encoding="utf-8")
+    print(rendered)
+    return 0 if report["status"] == "ok" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/test_maneuver_authority_sweep_manifest.py
+++ b/tests/validation/test_maneuver_authority_sweep_manifest.py
@@ -1,0 +1,158 @@
+"""Tests for the issue #3213 maneuver-authority sweep manifest preflight."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+import yaml
+
+from scripts.validation import check_maneuver_authority_sweep_manifest as preflight
+
+
+def _write(path: Path, payload: dict) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _touch_repo_file(repo_root: Path, relative_path: str) -> None:
+    path = repo_root / relative_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("# fixture\n", encoding="utf-8")
+
+
+def _valid_payload() -> dict:
+    return {
+        "schema_version": preflight.SCHEMA_VERSION,
+        "issue": 3213,
+        "hard_seed_manifest": "configs/benchmarks/predictive_hard_seeds_v1.yaml",
+        "expected_output": {
+            "root": "output/benchmarks/issue_3213_maneuver_authority",
+            "summary": "output/benchmarks/issue_3213_maneuver_authority/campaign_summary.json",
+            "report": "output/benchmarks/issue_3213_maneuver_authority/campaign_report.md",
+        },
+        "variants": [
+            {
+                "name": "baseline",
+                "algo_config": "configs/algos/hardcase_authority/baseline.yaml",
+                "expected_output": {
+                    "hard_jsonl_pattern": "output/benchmarks/issue_3213_maneuver_authority/hard__baseline__<checkpoint-token>.jsonl",
+                    "global_jsonl_pattern": "output/benchmarks/issue_3213_maneuver_authority/global__baseline__<checkpoint-token>.jsonl",
+                },
+                "authority_metadata": {
+                    "action_lattice": {"inherits_defaults": True},
+                    "turn_authority": {"max_angular_speed_rad_s": 1.2},
+                    "kinematic_adapter": {
+                        "mode": "predictive_planner_default",
+                        "config_source": "configs/algos/hardcase_authority/baseline.yaml",
+                        "changed_params": [],
+                    },
+                },
+                "params": {},
+            },
+            {
+                "name": "high_angular",
+                "algo_config": "configs/algos/hardcase_authority/high_angular.yaml",
+                "expected_output": {
+                    "hard_jsonl_pattern": "output/benchmarks/issue_3213_maneuver_authority/hard__high_angular__<checkpoint-token>.jsonl",
+                    "global_jsonl_pattern": "output/benchmarks/issue_3213_maneuver_authority/global__high_angular__<checkpoint-token>.jsonl",
+                },
+                "authority_metadata": {
+                    "action_lattice": {"candidate_heading_deltas_rad": [-1.0, 0.0, 1.0]},
+                    "turn_authority": {"max_angular_speed_rad_s": 1.8},
+                    "kinematic_adapter": {
+                        "mode": "predictive_planner_config_overrides",
+                        "config_source": "configs/algos/hardcase_authority/high_angular.yaml",
+                        "changed_params": ["max_angular_speed"],
+                    },
+                },
+                "params": {"max_angular_speed": 1.8},
+            },
+            {
+                "name": "dense_lattice",
+                "algo_config": "configs/algos/hardcase_authority/dense_lattice.yaml",
+                "expected_output": {
+                    "hard_jsonl_pattern": "output/benchmarks/issue_3213_maneuver_authority/hard__dense_lattice__<checkpoint-token>.jsonl",
+                    "global_jsonl_pattern": "output/benchmarks/issue_3213_maneuver_authority/global__dense_lattice__<checkpoint-token>.jsonl",
+                },
+                "authority_metadata": {
+                    "action_lattice": {"candidate_speed_samples_m_s": [0.0, 0.5, 1.0]},
+                    "turn_authority": {"max_angular_speed_rad_s": 1.2},
+                    "kinematic_adapter": {
+                        "mode": "predictive_planner_config_overrides",
+                        "config_source": "configs/algos/hardcase_authority/dense_lattice.yaml",
+                        "changed_params": ["predictive_candidate_speeds"],
+                    },
+                },
+                "params": {"predictive_candidate_speeds": [0.0, 0.5, 1.0]},
+            },
+        ],
+    }
+
+
+def test_checked_in_issue_3213_manifest_passes_preflight() -> None:
+    """The committed #3213 sweep manifest has complete metadata but runs no benchmark."""
+    report = preflight.build_report(preflight.DEFAULT_MANIFEST, Path.cwd())
+
+    assert report["status"] == "ok"
+    assert report["variant_count"] >= 3
+    assert report["errors"] == []
+
+
+def test_missing_algo_config_fails_closed(tmp_path: Path) -> None:
+    """Missing referenced configs are explicit preflight errors."""
+    payload = _valid_payload()
+    repo_root = tmp_path
+    _touch_repo_file(repo_root, payload["hard_seed_manifest"])
+    for variant in payload["variants"]:
+        if variant["name"] != "high_angular":
+            _touch_repo_file(repo_root, variant["algo_config"])
+            _touch_repo_file(
+                repo_root,
+                variant["authority_metadata"]["kinematic_adapter"]["config_source"],
+            )
+    manifest = _write(repo_root / "manifest.yaml", payload)
+
+    report = preflight.build_report(manifest, repo_root)
+
+    assert report["status"] == "failed"
+    assert any("high_angular.algo_config does not exist" in error for error in report["errors"])
+
+
+@pytest.mark.parametrize(
+    ("mutation", "expected_error"),
+    [
+        (
+            lambda payload: payload["variants"][1].pop("authority_metadata"),
+            "high_angular.authority_metadata must be a mapping",
+        ),
+        (
+            lambda payload: payload["variants"][1]["authority_metadata"][
+                "kinematic_adapter"
+            ].update({"changed_params": []}),
+            "changed_params does not cover params",
+        ),
+    ],
+)
+def test_malformed_sweep_arm_metadata_fails_closed(
+    tmp_path: Path,
+    mutation,
+    expected_error: str,
+) -> None:
+    """Malformed arm metadata fails before a campaign can be mistaken for evidence."""
+    payload = _valid_payload()
+    mutation(payload)
+    repo_root = tmp_path
+    _touch_repo_file(repo_root, payload["hard_seed_manifest"])
+    for variant in payload["variants"]:
+        _touch_repo_file(repo_root, variant["algo_config"])
+        adapter = variant.get("authority_metadata", {}).get("kinematic_adapter", {})
+        if "config_source" in adapter:
+            _touch_repo_file(repo_root, adapter["config_source"])
+    manifest = _write(repo_root / "manifest.yaml", payload)
+
+    report = preflight.build_report(manifest, repo_root)
+
+    assert report["status"] == "failed"
+    assert any(expected_error in error for error in report["errors"])


### PR DESCRIPTION
## Summary
Adds a fail-closed manifest/checker slice for issue #3213 maneuver-authority sweep arms. This is preflight-only metadata and diagnostics; it does not run or interpret a benchmark campaign.

## Linked Issues
- Relates `#3213`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Extended `configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml` with `maneuver_authority_sweep_manifest.v1` metadata for five arms: action lattice, turn authority, kinematic adapter/config source, and expected output locations/patterns.
- Added `scripts/validation/check_maneuver_authority_sweep_manifest.py` to fail closed on missing manifest/config paths, malformed authority metadata, duplicate/underspecified variants, and incomplete params-to-metadata coverage.
- Added focused tests for the checked-in manifest, missing config diagnostics, and malformed sweep-arm metadata.

## Why Matters
- Added value: makes the existing #3213 sweep grid auditable before any campaign run.
- Expected impact: catches missing configs and malformed authority metadata before local/cluster benchmark time is spent.
- Why worth merging now: it is a bounded checker slice that supports future campaign handoff without changing planner behavior.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3213 maneuver-authority sweep setup/preflight only.
- Comparator or baseline, applicable: NA - no result comparison in this PR.
- Evidence tier: targeted smoke / support helper.
- Result classification: diagnostic-only setup; no benchmark result.
- Decision stop rule, applicable: NA - this PR does not adopt, reject, or rank authority variants.
- Parent issue, claim map, registry, context note, synthesis surface update: #3213 remains the parent issue; no claim map update because no result claim is made.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker only; it validates manifest metadata and paths, not research outcomes.

## Domain-Aware Approval
- Approver/review source waiver: not required; no evidence classification or benchmark interpretation change.
- Validity checklist: preflight validates metadata/path contracts only.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: no fallback/degraded row promoted; no campaign rows produced.
- Claim boundary: setup/preflight only.
- Implementation integrity vs experimental validity: implementation integrity tested via checker/tests; experimental validity deferred to actual campaign work.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no benchmark run.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue via future campaign only.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this PR; future campaign remains out of scope.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none for manifest preflight; checkpoint/campaign artifacts are not required by this PR.
- Stop / revise / continue decision: continue only after reviewer accepts preflight metadata.
- Proposed child issue existing follow-up: #3213 remains the campaign issue.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_maneuver_authority_sweep_manifest.py` -> passed; status `ok`, 5 variants, no errors.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_maneuver_authority_sweep_manifest.py -q` -> passed; 4 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_maneuver_authority_sweep_manifest.py tests/validation/test_maneuver_authority_sweep_manifest.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/check_maneuver_authority_sweep_manifest.py tests/validation/test_maneuver_authority_sweep_manifest.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_predictive_success_campaign.py --check-only --planner-grid configs/benchmarks/predictive_hardcase_authority_grid_issue_3213.yaml --hard-seed-manifest configs/benchmarks/predictive_hard_seeds_v1.yaml --output-dir output/tmp/issue_3213_manifest_check_compat` -> passed; compatibility check wrote manifest summary only, removed as disposable ignored output.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; 1679 passed, 2 skipped; freshness stamp for `2407fdc0ab3a578b1dedd94bf086166979b7ccca`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> passed; fresh=true, tree_state=clean.

Explicit out-of-scope note: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Evidence
- Baseline runtime: NA - no runtime/caching claim.
- Changed runtime: NA - no runtime/caching claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_maneuver_authority_sweep_manifest.py`.
- Hot-path call count profile anchor: NA - not a runtime optimization.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: checker incorrectly rejects the checked-in #3213 manifest or no longer reports missing config/malformed metadata fail-closed.

## Risks / Rollout
- Compatibility risks: low; campaign runner still consumes `variants[].params`; new fields are additive metadata.
- Failure modes: metadata can drift from future variant configs unless the preflight is kept in the validation path.
- Rollback fallback plan: revert this PR and use the prior grid without the metadata checker.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: existing `docs/context/issue_3213_maneuver_authority_setup.md` remains the setup note.
- Any assumptions need to preserved: per-variant JSONL output is represented as a checkpoint-token pattern because `run_predictive_success_campaign.py` includes checkpoint identity in generated filenames.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized for this run.
- Claim map / benchmark report updated (yes/no/NA): NA - no result claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR is a preflight/checker slice and does not change benchmark evidence, leaderboard status, or paper-facing claims.

## Follow-Up Issues
- Deferred work: full benchmark campaign execution/interpretation remains out of scope here.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that the metadata stays additive and that `variants[].params` remains compatible with `run_predictive_success_campaign.py`.
- Known limitation: checker validates manifest/config existence and metadata shape, not semantic equivalence between each YAML config and every listed metadata value.
