### PR TITLE
Issue #3723: add fail-closed SNQI weight source discovery

### DIFF
--- a/robot_sf/benchmark/snqi/weights_inventory.py
+++ b/robot_sf/benchmark/snqi/weights_inventory.py
@@ -37,6 +37,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
 
@@ -50,6 +51,13 @@ if TYPE_CHECKING:
 _SIMPLEX_TOL = 1e-3
 # Tolerance when comparing normalized weight *directions* across sources.
 _DIRECTION_TOL = 1e-6
+
+# Bounded shipped-file discovery. Keep this intentionally narrow so generated
+# reports or unrelated schemas do not become provenance inputs.
+_SHIPPED_WEIGHT_FILE_GLOBS = (
+    "model/*snqi*weight*.json",
+    "configs/**/*snqi*weight*.json",
+)
 
 
 @dataclass(frozen=True)
@@ -105,6 +113,47 @@ WEIGHT_SOURCES: tuple[WeightSourceSpec, ...] = (
         declares_canonical=False,
     ),
 )
+
+
+def _source_name_from_relpath(relpath: str) -> str:
+    """Build a stable diagnostic source name for an unregistered shipped file.
+
+    Returns:
+        Source name safe for JSON reports and deterministic comparisons.
+    """
+    stem = relpath.removesuffix(".json")
+    return "unregistered_" + re.sub(r"[^a-zA-Z0-9]+", "_", stem).strip("_").lower()
+
+
+def discover_shipped_weight_source_specs(repo_root: Path) -> list[WeightSourceSpec]:
+    """Discover shipped SNQI weight JSON files under bounded source directories.
+
+    Registered files keep their explicit names and canonical declarations. Matching files that are
+    not in :data:`WEIGHT_SOURCES` are returned as ``unregistered_shipped_json`` records so the
+    inventory reports every discovered shipped weight file instead of silently relying on the static
+    registry.
+
+    Returns:
+        Shipped JSON source specs, including registered files and any unregistered matches.
+    """
+    registered_by_path = {spec.relpath: spec for spec in WEIGHT_SOURCES if spec.relpath is not None}
+    discovered: dict[str, WeightSourceSpec] = dict(registered_by_path)
+
+    for pattern in _SHIPPED_WEIGHT_FILE_GLOBS:
+        for path in repo_root.glob(pattern):
+            if not path.is_file():
+                continue
+            relpath = path.relative_to(repo_root).as_posix()
+            if relpath in discovered:
+                continue
+            discovered[relpath] = WeightSourceSpec(
+                name=_source_name_from_relpath(relpath),
+                kind="unregistered_shipped_json",
+                relpath=relpath,
+                declares_canonical="canonical" in relpath.lower(),
+            )
+
+    return [discovered[relpath] for relpath in sorted(discovered)]
 
 
 @dataclass
@@ -290,20 +339,23 @@ def _build_record(spec: WeightSourceSpec, repo_root: Path) -> WeightSetRecord:
 
 
 def inventory_weight_sets(repo_root: Path | None = None) -> list[WeightSetRecord]:
-    """Discover and load every registered SNQI weight set.
+    """Discover and load registered and bounded shipped SNQI weight sets.
 
     Args:
         repo_root: Repository root used to resolve shipped JSON paths. Defaults
             to :func:`get_repository_root`.
 
     Returns:
-        One :class:`WeightSetRecord` per entry in :data:`WEIGHT_SOURCES`, in
-        registry order. Sources that fail to load are returned with
+        One :class:`WeightSetRecord` per registered or discovered shipped source, with the
+        code-default source first and shipped files in path order. Sources that fail to load are
+        returned with
         ``available=False`` and a populated ``load_error`` (fail-closed: a
         missing/broken file is surfaced, not silently skipped).
     """
     root = (repo_root or get_repository_root()).resolve()
-    return [_build_record(spec, root) for spec in WEIGHT_SOURCES]
+    shipped = discover_shipped_weight_source_specs(root)
+    specs = [spec for spec in WEIGHT_SOURCES if spec.relpath is None] + shipped
+    return [_build_record(spec, root) for spec in specs]
 
 
 def _directions_disagree(a: dict[str, float], b: dict[str, float]) -> bool:
@@ -420,6 +472,30 @@ def _duplicate_label_conflicts(
     return conflicts
 
 
+def _unregistered_weight_source_conflicts(
+    records: list[WeightSetRecord],
+) -> list[WeightProvenanceConflict]:
+    """Fail closed when shipped SNQI weight files are absent from the provenance registry.
+
+    Returns:
+        Error conflict when unregistered shipped weight sources are present, otherwise empty list.
+    """
+    unregistered = [r for r in records if r.kind == "unregistered_shipped_json"]
+    if not unregistered:
+        return []
+    return [
+        WeightProvenanceConflict(
+            kind="unregistered_shipped_weight_source",
+            severity="error",
+            sources=[r.name for r in unregistered],
+            detail=(
+                "discovered shipped SNQI weight JSON files not listed in WEIGHT_SOURCES; "
+                "register or explicitly exclude them before treating provenance inventory complete."
+            ),
+        )
+    ]
+
+
 def detect_conflicts(records: list[WeightSetRecord]) -> list[WeightProvenanceConflict]:
     """Detect provenance conflicts among discovered weight sets.
 
@@ -447,6 +523,7 @@ def detect_conflicts(records: list[WeightSetRecord]) -> list[WeightProvenanceCon
     conflicts: list[WeightProvenanceConflict] = []
     conflicts += _canonical_load_error_conflicts(canonical)
     conflicts += _canonical_direction_conflicts(loaded_canonical)
+    conflicts += _unregistered_weight_source_conflicts(records)
     conflicts += _scale_split_conflicts(loaded)
     conflicts += _duplicate_label_conflicts(loaded)
 
@@ -504,6 +581,7 @@ __all__ = [
     "WeightSourceSpec",
     "build_inventory_report",
     "detect_conflicts",
+    "discover_shipped_weight_source_specs",
     "inventory_weight_sets",
     "preflight_snqi_weight_sets",
 ]

--- a/tests/test_snqi_weights_inventory.py
+++ b/tests/test_snqi_weights_inventory.py
@@ -210,3 +210,26 @@ def test_detect_conflicts_is_deterministic(tmp_path):
     severities = [c.severity for c in detect_conflicts(records)]
     # errors must precede warnings/info
     assert severities == sorted(severities, key={"error": 0, "warning": 1, "info": 2}.get)
+
+
+def test_unregistered_shipped_weight_file_reported_fail_closed(tmp_path):
+    """Bounded discovery reports shipped SNQI weight files missing from the registry."""
+    repo = _make_fixture_repo(tmp_path)
+    _write_weights(
+        tmp_path / "configs/benchmarks/snqi_weights_experimental_v9.json",
+        _CODE_DEFAULT,
+    )
+
+    report = build_inventory_report(repo)
+    unregistered = [r for r in report.records if r.kind == "unregistered_shipped_json"]
+    assert len(unregistered) == 1
+    assert unregistered[0].relpath == "configs/benchmarks/snqi_weights_experimental_v9.json"
+    assert unregistered[0].available
+
+    conflicts = [c for c in report.conflicts if c.kind == "unregistered_shipped_weight_source"]
+    assert conflicts
+    assert conflicts[0].severity == "error"
+    assert conflicts[0].sources == [unregistered[0].name]
+    assert report.has_blocking_conflict
+    with pytest.raises(SNQIWeightProvenanceError, match="unregistered_shipped_weight_source"):
+        preflight_snqi_weight_sets(repo, strict=True)


### PR DESCRIPTION
## Summary
Adds bounded shipped-file discovery to the Social Navigation Quality Index (SNQI) weight inventory so matching shipped weight JSON files outside the provenance registry are reported and fail closed.

## Linked Issues
- Relates to `#3723`
- Issue URL: https://github.com/ll7/robot_sf_ll7/issues/3723

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #3723 remains decision-required for canonical weight source selection
- Safe to review independently: yes

## What Changed
- `robot_sf/benchmark/snqi/weights_inventory.py` now discovers bounded shipped SNQI weight JSON files under `model/` and `configs/` instead of relying only on the static registry.
- Unregistered discovered shipped weight files are included as inventory records and reported as `unregistered_shipped_weight_source` errors in strict preflight.
- Added fixture coverage proving an extra shipped SNQI weight file is reported fail-closed without changing current scoring behavior.

## Why Matters
- Added value: closes a diagnostic blind spot where future shipped SNQI weight files could avoid the #3723 inventory by not being listed in `WEIGHT_SOURCES`.
- Expected impact: provenance/preflight reporting is more complete; SNQI scoring and current canonical/default weights are unchanged.
- Why worth merging now: it strengthens the fail-closed evidence-hygiene slice without making the maintainer-only canonical-weight decision.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3723 diagnostic provenance inventory completeness for conflicting SNQI weight sources.
- Comparator or baseline, applicable: current inventory registry-only source enumeration.
- Evidence tier: NA - support helper; validation uses targeted tests but does not publish benchmark evidence.
- Result classification: NA - support helper; reports diagnostic preflight state only.
- Decision stop rule, applicable: unregistered shipped SNQI weight JSONs must be visible in inventory and strict preflight must fail closed.
- Parent issue, claim map, registry, context note, synthesis surface update: #3723 remains open for canonical source decision.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper only; no SNQI interpretation or campaign evidence promoted.

## Domain-Aware Approval
- Required for this PR: no - support helper only; no research result, benchmark interpretation, or paper-facing claim is changed.
- Domains reviewed: SNQI provenance inventory, benchmark governance preflight.
- Status: not required - support helper only.
- Approver/review source or waiver: NA - domain approval not required because this PR changes diagnostic inventory reporting only.
- Approval or blocker note: NA - no SNQI claim, benchmark interpretation, or metric semantics changed.
- Validity checklist:
- Target claim/hypothesis: #3723 provenance inventory completeness; diagnostic-only.
- Comparator or split/evidence validity: fixture test exercises an extra shipped JSON file outside registry and strict preflight failure.
- Fallback/degraded exclusions: no benchmark execution or fallback path involved.
- Claim boundary: does not choose canonical weights, change SNQI semantics, or promote SNQI claims.
- Implementation integrity vs experimental validity: implementation only changes inventory/preflight reporting; focused tests prove gate behavior, not benchmark validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, fixture unregistered shipped weight file is reported and strict preflight raises.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, fixture adds `configs/benchmarks/snqi_weights_experimental_v9.json` outside registry.
- Result route: continue #3723 canonical source decision separately.
- Follow-up question issue weak, negative, non-transfer results: #3723 remains decision-required.

## Next Empirical Action
- Rerun needed: no full campaign rerun for this diagnostic slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue to maintainer canonical-weight decision in #3723.
- Proposed child issue existing follow-up: #3723.

## Validation / Proof
- `uv run ruff format robot_sf/benchmark/snqi/weights_inventory.py tests/test_snqi_weights_inventory.py && uv run ruff check robot_sf/benchmark/snqi/weights_inventory.py tests/test_snqi_weights_inventory.py` -> passed.
- `uv run pytest tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_weight_inventory_cli.py tests/benchmark/test_snqi_governance_preflight.py -q` -> 16 passed.
- `uv run python scripts/validation/check_snqi_governance.py --json` -> exit 2 as expected; reports #3723 `weight_provenance_conflict` and #3699 `mixed_normalization_basis` while listing all current shipped weight records.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed as interim dirty-tree validation before commit; 1679 passed, 2 skipped.
- `CUDA_VISIBLE_DEVICES="" PR_READY_PR_BODY_FILE=/tmp/issue3723_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; clean-tree stamp recorded for head `9e92b0b8f3abc0461ec4293b4c62be9adc46ba8f`.

Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: low; no scoring or weight values changed.
- Failure modes: matching a future shipped SNQI weight JSON under the bounded paths will require explicit registration or exclusion before strict preflight passes.
- Rollback fallback plan: revert the inventory discovery/error addition to restore registry-only reporting.

## Docs / Provenance
- Updated docs: none; behavior is covered by code docstrings and focused tests.
- Relevant design provenance notes: #3723 issue and existing SNQI governance preflight.
- Any assumptions need to preserved: bounded discovery is intentionally limited to shipped `model/` and `configs/` SNQI weight JSON paths.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, commenting not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA; #3723 remains the follow-up decision surface.
- Not applicable because: this is a diagnostic inventory/preflight support change only.

## Follow-Up Issues
- Deferred work: choose and document the canonical SNQI weight source in #3723.
- Issues opened follow-up: none.

## Reviewer Notes
- Final readiness was run CPU-only because an earlier GPU-enabled optional-extra run hit CUDA out-of-memory in unrelated Stable-Baselines3 feature-extractor tests.
- Verify closely that discovery remains bounded and does not include generated `output/` artifacts or schemas.
- Known limitations: does not choose canonical weights, change metric semantics, rerun campaigns, or edit paper/dissertation claims.
