### PR TITLE
Issue #3214: tighten crossing-conflict retrain output preflight

### DIFF
--- a/robot_sf/training/predictive_retrain_preflight.py
+++ b/robot_sf/training/predictive_retrain_preflight.py
@@ -94,8 +94,8 @@ def validate_retrain_preflight(
     mixing = _validate_mixing(config, config_dir, errors)
     training = _validate_training(config, errors)
     evaluation = _validate_evaluation(config, config_dir, root, errors)
-    provenance = _validate_provenance(config, root, errors)
     output_root = _validate_output(config, errors)
+    provenance = _validate_provenance(config, root, errors, output_root=output_root)
 
     if errors:
         joined = "\n- ".join(errors)
@@ -410,6 +410,8 @@ def _validate_provenance(
     config: dict[str, Any],
     repo_root: Path,
     errors: list[str],
+    *,
+    output_root: str | None = None,
 ) -> dict[str, Any] | None:
     provenance = _require_mapping(config, "provenance", errors)
     if provenance is None:
@@ -417,6 +419,11 @@ def _validate_provenance(
 
     resolved: dict[str, str] = {}
     missing_artifacts: list[str] = []
+    resolved_output_root = (
+        _resolve_path(output_root, repo_root)
+        if isinstance(output_root, str) and output_root
+        else None
+    )
     for key in _EXPECTED_PROVENANCE_KEYS:
         value = provenance.get(key)
         if not isinstance(value, str) or not value.strip():
@@ -424,6 +431,10 @@ def _validate_provenance(
             continue
         path = _resolve_path(value, repo_root)
         resolved[key] = str(path)
+        if resolved_output_root is not None and not _is_relative_to(path, resolved_output_root):
+            errors.append(
+                f"provenance.{key} must resolve under output.root {output_root!r}: {value}"
+            )
         if not path.exists():
             missing_artifacts.append(str(path))
 
@@ -439,6 +450,14 @@ def _validate_provenance(
         "paths": resolved,
         "missing_artifacts": missing_artifacts,
     }
+
+
+def _is_relative_to(path: Path, parent: Path) -> bool:
+    try:
+        path.relative_to(parent)
+    except ValueError:
+        return False
+    return True
 
 
 def _validate_output(config: dict[str, Any], errors: list[str]) -> str | None:

--- a/tests/training/test_predictive_retrain_preflight.py
+++ b/tests/training/test_predictive_retrain_preflight.py
@@ -304,6 +304,22 @@ def test_missing_output_root_fails(tmp_path: Path) -> None:
         validate_retrain_preflight(path, repo_root=tmp_path)
 
 
+def test_provenance_paths_must_stay_under_output_root(tmp_path: Path) -> None:
+    """Expected checkpoint lineage cannot escape the declared output root."""
+    config = _base_config(tmp_path)
+    config["provenance"]["checkpoint_path"] = (
+        "output/tmp/other_predictive_pipeline/training/demo/predictive_model.pt"
+    )
+    path = _write_config(tmp_path, config)
+
+    with pytest.raises(PredictiveRetrainPreflightError) as exc_info:
+        validate_retrain_preflight(path, repo_root=tmp_path)
+
+    message = str(exc_info.value)
+    assert "provenance.checkpoint_path" in message
+    assert "must resolve under output.root" in message
+
+
 def test_aggregates_multiple_errors(tmp_path: Path) -> None:
     """All independent failures surface in one error message."""
     config = _base_config(tmp_path)


### PR DESCRIPTION
## Summary

- Part of #3214 (bounded preflight/launch-packet checker slice; the broader retraining campaign stays open).
- Tightens `validate_retrain_preflight` so expected checkpoint, checkpoint-provenance, and hard-seed evaluation outputs must resolve under the declared `output.root`.
- Adds a focused fixture regression test for provenance paths escaping the output root.

## Scope

This is a static, local preflight-only change for crossing-conflict predictive retraining readiness. It checks config/output lineage before launch and does not change augmentation, data mixing, training, evaluation semantics, or model selection.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_predictive_retrain_preflight.py tests/training/test_predictive_retraining_readiness.py -q` - passed, 35 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/predictive_retrain_preflight.py tests/training/test_predictive_retrain_preflight.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_predictive_retrain_preflight.py --config configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml --repo-root . --json` - passed; config status `valid` and provenance artifacts remain expected-missing under `output/tmp/predictive_planner/pipeline`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/training/check_predictive_retraining_readiness.py --packet configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml --repo-root .` - passed; packet `status=ok`, `launch_ready=false`, `compute_submit_allowed=false`.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed on dirty tree before commit: 1679 passed, 2 skipped.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-3214-pr-body.md scripts/dev/pr_ready_check.sh` - passed with clean-tree freshness stamp at `c0d1cc04b72aeaba07c646e208d3d7c66a1f8953`; core lane `1681 passed`, predictive lane completed successfully.

## Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits. Generated `.venv`, `output/coverage/`, and `output/validation/` files are ignored local validation artifacts and are not part of this PR.

