### PR TITLE
Issue #3215: update predictive tournament readiness gates

### DIFF
--- a/scripts/tools/predictive_tournament_readiness.py
+++ b/scripts/tools/predictive_tournament_readiness.py
@@ -3,16 +3,15 @@
 
 The epic #3215 runs three hard-case levers concurrently as a tournament -- Selection
 (#3204), Authority (#3213), and Model (#3214) -- under a shared benchmark protocol, then
-synthesizes a single decision. The full campaign is SLURM/GPU-gated and needs maintainer
-budget pre-authorization, so this helper deliberately does **not** submit jobs, run the
-tournament, or rank arms.
+synthesizes a single decision. The full campaign is SLURM/GPU-gated; this helper
+deliberately does **not** submit jobs, run the tournament, or rank arms.
 
 Instead it answers a narrow, repeatable question: *are the local prerequisites in place to
 launch each arm?* For every arm and for the shared protocol it inventories the expected
 configs, harness scripts, and output path, then classifies the arm as ``ready`` (all local
 prerequisites present) or ``blocked`` (one or more missing). The report is presence-only and
-fail-closed: it never marks the tournament itself authorized to run, because that remains
-gated on the open child issues and the maintainer-set overnight SLURM budget.
+fail-closed: it never marks tournament execution authorized, even when local
+prerequisites are present.
 
 Example:
     uv run python scripts/tools/predictive_tournament_readiness.py
@@ -40,12 +39,12 @@ SHARED_PROTOCOL_PATHS: tuple[Path, ...] = (
 )
 
 # The tournament run is gated on more than local files: the three child bets must be ready
-# and the maintainer must pre-authorize a bounded overnight SLURM/GPU budget. These are
+# and any compute submission must happen outside this read-only helper. These are
 # standing run blockers recorded so a "prerequisites ready" report is never mistaken for
 # "authorized to launch".
 RUN_GATES: tuple[str, ...] = (
     "child bets #3204 / #3213 / #3214 must reach their own decision rules",
-    "maintainer must pre-authorize a bounded overnight SLURM/GPU budget (#3144 capacity policy)",
+    "compute submission must happen outside this read-only helper under #3144 capacity policy",
     "Autonomous Usage Stop Guard must permit unattended execution",
 )
 
@@ -107,12 +106,14 @@ ARMS: tuple[ArmSpec, ...] = (
         ),
         required_paths=(
             Path(
-                "configs/training/predictive/"
-                "predictive_crossing_conflict_hardcase_mixing_issue_3214.yaml"
+                "configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml"
             ),
         ),
         expected_output_path=Path("output/tmp/predictive_planner/campaigns/tournament_model"),
-        notes="Retraining itself consumes the overnight GPU budget; only the config is checked here.",
+        notes=(
+            "Checks the frozen #3254 weighted crossing-conflict config for the #3214 "
+            "model arm; retraining itself remains compute-gated."
+        ),
     ),
 )
 

--- a/tests/test_predictive_tournament_readiness.py
+++ b/tests/test_predictive_tournament_readiness.py
@@ -122,6 +122,26 @@ def test_arms_cover_the_three_named_bets() -> None:
     assert {arm.child_issue for arm in ARMS} == {3204, 3213, 3214}
 
 
+def test_model_arm_uses_frozen_weighted_training_config() -> None:
+    """Model arm follows #3215's #3214 -> #3254 frozen config handoff."""
+    model = next(arm for arm in ARMS if arm.arm_id == "model")
+
+    assert [path.as_posix() for path in model.required_paths] == [
+        "configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml"
+    ]
+    assert model.child_issue == 3214
+    assert "#3254" in model.notes
+
+
+def test_run_gates_preserve_read_only_boundary_without_stale_budget_blocker() -> None:
+    """Live issue says budget was decided; helper still cannot submit compute."""
+    gate_text = "\n".join(RUN_GATES)
+
+    assert "pre-authorize" not in gate_text
+    assert "outside this read-only helper" in gate_text
+    assert "Autonomous Usage Stop Guard" in gate_text
+
+
 def test_render_text_runs_and_mentions_status(tmp_path: Path) -> None:
     """The text renderer produces output and surfaces the prerequisite status."""
     _stage_all_prerequisites(tmp_path)


### PR DESCRIPTION
## Summary
Updates the existing predictive hard-case tournament readiness helper for issue #3215 so its model arm checks the frozen #3254 weighted crossing-conflict config and its run gates no longer report stale maintainer budget pre-authorization as missing.

## Linked Issues
- Relates to `#3215`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- The model arm prerequisite now points to `configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml`, preserving #3214 as the model child issue.
- Run gates keep the no-submit boundary but replace the stale pre-authorization blocker with an explicit read-only helper / #3144 capacity-policy boundary.
- Added focused fixture tests for the frozen model-config handoff and the corrected run-gate contract.

## Why Matters
- Added value: keeps the existing tournament-readiness report aligned with the live #3215 issue comments.
- Expected impact: local readiness reports identify selection, authority, and model prerequisites without launching Slurm or ranking arms.
- Why worth merging now: stale run-gate and model-config references could mislead the next handoff packet.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support helper only; no research claim or benchmark result is promoted.
- Comparator or baseline, applicable: NA
- Evidence tier: NA - support helper
- Result classification: NA - support helper
- Decision stop rule, applicable: NA
- Parent issue, claim map, registry, context note, synthesis surface update: #3215 remains the parent issue; no claim map or synthesis update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - updates an existing readiness checker and does not interpret evidence.

## Domain-Aware Approval
- Approver/review source waiver: not required; support helper only, no result interpretation.
- Validity checklist: NA
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA - support helper
- Fallback/degraded exclusions: helper reports prerequisites only and does not classify fallback/degraded benchmark rows.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation-only readiness contract update.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no mechanism claim.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: NA
- Stop / revise / continue decision: NA
- Proposed child issue existing follow-up: NA

## Validation / Proof
- `uv run ruff format scripts/tools/predictive_tournament_readiness.py tests/test_predictive_tournament_readiness.py --check` - passed
- `uv run ruff check scripts/tools/predictive_tournament_readiness.py tests/test_predictive_tournament_readiness.py` - passed
- `uv run pytest tests/test_predictive_tournament_readiness.py -q` - passed, 13 tests
- `uv run python scripts/tools/predictive_tournament_readiness.py --json` - passed; reports prerequisites ready and `run_authorized: false`
- Explicit out-of-scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance
- Baseline runtime: NA - no runtime claim.
- Changed runtime: NA - no runtime claim.
- Representative command: `uv run python scripts/tools/predictive_tournament_readiness.py --json`
- Hot-path call count profile anchor: NA - no hot-path change.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: readiness report points to stale model config or treats this read-only helper as launch authorization.

## Risks / Rollout
- Compatibility risks: low; output schema is unchanged, but one model prerequisite path and one run-gate string change.
- Failure modes: downstream consumers matching exact run-gate text may need to update expectations.
- Rollback fallback plan: revert this PR to restore prior readiness strings and model prerequisite path.

## Docs / Provenance
- Updated docs: module docstring only.
- Relevant design provenance notes: live #3215 comments, especially 2026-06-21 launch-readiness and correction notes.
- Any assumptions need to preserved: the #3254 weighted config is the frozen launch packet input for the #3214 model arm.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized for this task.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: this is a support helper update, not a benchmark, registry, claim-map, or paper-facing change.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes
- Verify that `run_authorized` remains false and the helper still does not submit Slurm/GPU work.
- Known limitations: readiness is presence-only and does not prove campaign quality, rank arms, or validate result durability.
