### PR TITLE
Issue #3080: report Package C preflight output roots

### DIFF
--- a/scripts/tools/prediction_package_c_readiness.py
+++ b/scripts/tools/prediction_package_c_readiness.py
@@ -55,6 +55,10 @@ CONFIG_OPEN_LOOP = "configs/research/forecast_baseline_comparison_issue_2915.yam
 CONFIG_CLOSED_LOOP = "configs/research/forecast_risk_coupling_issue_2916.yaml"
 # Live observation perturbation replay entry point (#2777).
 SCRIPT_OBSERVATION_REPLAY = "scripts/benchmark/run_observation_noise_envelope.py"
+DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT = (
+    "docs/context/evidence/issue_2755_observation_noise_envelope_2026-06-13"
+)
+DEFAULT_CLOSED_LOOP_OUTPUT_ROOT = "output/issue_2916_coupling_gate"
 
 # Required code entry points shared by every arm.  Each maps to a coordination
 # stage named in the issue's verified entry points.
@@ -191,18 +195,22 @@ def _collect_seed_plan(repo_root: Path) -> list[int]:
 def _collect_output_roots(repo_root: Path) -> list[str]:
     """Return declared output/evidence roots from the coordination configs.
 
-    Only the open-loop config (#2915) declares an ``output`` block today; the
-    coupling runner (#2916) writes through the canonical campaign result store.
-    Local ``output/`` paths are not durable evidence; durable results must point
-    at tracked evidence, a manifest, or an approved external artifact URI.
+    Package C spans three stages. The open-loop config (#2915) declares its
+    evidence directory in YAML, while observation replay (#2777) and closed-loop
+    coupling (#2916) expose default runner roots. Local ``output/`` paths are
+    not durable evidence; durable results must point at tracked evidence, a
+    manifest, or an approved external artifact URI.
     """
-    roots: list[str] = []
+    roots: list[str] = [
+        DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT,
+        DEFAULT_CLOSED_LOOP_OUTPUT_ROOT,
+    ]
     open_loop = _load_yaml(repo_root / CONFIG_OPEN_LOOP)
     output = open_loop.get("output", {})
     if isinstance(output, dict):
         evidence_dir = output.get("evidence_dir")
         if isinstance(evidence_dir, str):
-            roots.append(evidence_dir)
+            roots.insert(0, evidence_dir)
     return roots
 
 

--- a/tests/tools/test_prediction_package_c_readiness.py
+++ b/tests/tools/test_prediction_package_c_readiness.py
@@ -12,6 +12,8 @@ from typing import TYPE_CHECKING
 
 from scripts.tools.prediction_package_c_readiness import (
     ARMS,
+    DEFAULT_CLOSED_LOOP_OUTPUT_ROOT,
+    DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT,
     REQUIRED_CODE,
     REQUIRED_CONFIGS,
     assess_package_c_readiness,
@@ -67,7 +69,11 @@ def test_all_arms_blocked_when_inputs_present_but_no_coupling_store(tmp_path: Pa
     assert report["overall_status"] == "blocked"
     assert [arm["status"] for arm in report["arms"]] == ["blocked"] * len(ARMS)
     assert report["seed_plan"] == [111, 2868]
-    assert report["output_roots"] == ["docs/context/evidence/issue_2915"]
+    assert report["output_roots"] == [
+        "docs/context/evidence/issue_2915",
+        DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT,
+        DEFAULT_CLOSED_LOOP_OUTPUT_ROOT,
+    ]
     # The named blocker references the #2916 coupling gate, not a vague reason.
     assert all("#2916" in arm["blockers"][0] for arm in report["arms"])
 
@@ -153,3 +159,8 @@ def test_real_repo_preflight_is_wired_and_fails_closed() -> None:
     assert all(arm["missing_inputs"] == [] for arm in report["arms"])
     # The real seed plan is the same-seed union declared by #2915 and #2916.
     assert report["seed_plan"] == [111, 2868]
+    assert report["output_roots"] == [
+        "docs/context/evidence/issue_2915_forecast_baselines_2026-06-20",
+        DEFAULT_OBSERVATION_REPLAY_OUTPUT_ROOT,
+        DEFAULT_CLOSED_LOOP_OUTPUT_ROOT,
+    ]


### PR DESCRIPTION
## Summary
Tightens the issue #3080 Package C readiness helper so its preflight report lists output roots for all three coordination stages: open-loop forecast comparison, observation perturbation replay, and closed-loop forecast-risk coupling.

## Linked Issues
- Relates https://github.com/ll7/robot_sf_ll7/issues/3080

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Safe review independently: yes
- Review dependency reason: this is a read-only metadata/test slice for the existing Package C helper.

## What Changed
- Added explicit Package C default output roots for #2777 observation replay and #2916 closed-loop coupling to `scripts/tools/prediction_package_c_readiness.py`.
- Kept the #2915 open-loop evidence root derived from YAML first in the reported `output_roots` list.
- Extended fixture and real-repo tests to assert the full three-stage output-root inventory while preserving fail-closed blocked behavior when #2916 durable artifacts are absent.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support helper only; improves readiness visibility for the #3080 blocker packet.
- Comparator or baseline, applicable: NA.
- Evidence tier: targeted smoke / fixture tests for readiness metadata; not benchmark evidence.
- Result classification: blocker-resolution slice; no forecast-performance result.
- Decision stop rule, applicable: Package C remains blocked until #2916 durable coupling artifacts exist.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3080 remains the parent surface.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - existing read-only helper only, no interpretation of research evidence.

## Domain-Aware Approval
- Approver/review source waiver: not required; no benchmark execution, metric semantics, or paper-facing claim changed.
- Validity checklist: fail-closed status preserved; no fallback/degraded execution treated as success.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: Package C still reports blocked without #2916 durable store.
- Claim boundary: readiness/preflight inventory only.
- Implementation integrity vs experimental validity: code lists declared roots; it does not evaluate outcome validity.

## Validation / Proof
- `uv run pytest tests/tools/test_prediction_package_c_readiness.py -q` -> passed, 6 tests.
- `uv run ruff check scripts/tools/prediction_package_c_readiness.py tests/tools/test_prediction_package_c_readiness.py` -> passed.
- `uv run python scripts/tools/prediction_package_c_readiness.py --output-json /tmp/package_c_readiness.json` -> expected exit 1; JSON reports `overall_status: blocked`, seed plan `[111, 2868]`, all three output roots, and `coupling_result_store_available: false`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: low; JSON output gains additional `output_roots` entries but status vocabulary and arm schema are unchanged.
- Failure modes: downstream consumers expecting exactly one output root would need to handle the fuller list.
- Rollback fallback plan: revert this metadata/test commit.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized for this task.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a readiness metadata slice, not evidence-producing Package C execution.

## Follow-Up Issues
- Deferred work: execute #2916 and supply durable coupling result store before Package C can become ready.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the #2777 and #2916 output-root constants match their current runner defaults.
- Known limitation: the helper intentionally reports `blocked` until a #2916 durable `summary.json` store is supplied.
