### PR TITLE
Issue #3699: expose mixed SNQI normalization inputs

### DIFF
--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -73,6 +73,16 @@ def build_governance_report(
             }
         )
     if normalization.mixed_scale:
+        mixed_inputs = [
+            {
+                "term": term.term,
+                "metric_key": term.metric_key,
+                "weight_name": term.weight_name,
+                "normalization_status": term.normalization_status,
+                "measurement_basis": term.measurement_basis,
+            }
+            for term in normalization.penalty_terms
+        ]
         blockers.append(
             {
                 "issue": 3699,
@@ -82,6 +92,7 @@ def build_governance_report(
                     "baseline-normalized terms, so weights are not comparable "
                     "relative priorities."
                 ),
+                "mixed_inputs": mixed_inputs,
             }
         )
     if baseline_stats is not None and normalization.missing_baseline_coverage:

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -23,6 +23,20 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
     assert report["weights"]["has_blocking_conflict"] is True
     assert report["normalization"]["mixed_scale"] is True
     assert set(report["normalization"]["raw_penalty_terms"]) == {"time", "comfort"}
+    blocker_3699 = next(
+        blocker for blocker in report["blockers"] if blocker["kind"] == "mixed_normalization_basis"
+    )
+    status_by_term = {
+        entry["term"]: entry["normalization_status"] for entry in blocker_3699["mixed_inputs"]
+    }
+    assert status_by_term == {
+        "time": "raw_unbounded",
+        "collisions": "baseline_normalized_bounded",
+        "near": "baseline_normalized_bounded",
+        "comfort": "raw_unbounded",
+        "force_exceed": "baseline_normalized_bounded",
+        "jerk": "baseline_normalized_bounded",
+    }
 
 
 def test_governance_main_fails_closed_but_allows_inspection(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds a machine-readable `mixed_inputs` list to the fail-closed SNQI governance blocker for issue #3699, so the preflight names each raw or baseline-normalized penalty input directly on the blocker that fails the gate.

## Linked Issues
- Relates #3699

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: decision-required normalization redesign remains on #3699
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `mixed_inputs` to the `mixed_normalization_basis` blocker emitted by `scripts/validation/check_snqi_governance.py`.
- Extended `tests/benchmark/test_snqi_governance_preflight.py` to assert the blocker lists `time` and `comfort` as `raw_unbounded` and the other penalty terms as `baseline_normalized_bounded`.

## Why Matters
- Added value: consumers no longer need to join against the separate normalization payload to see which exact SNQI inputs make the #3699 blocker fail closed.
- Expected impact: diagnostic/preflight visibility only; no scoring, weight, or normalization behavior changes.
- Why worth merging now: preserves the reversible first-slice path while keeping the redesign decision explicit.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3699 diagnostic blocker visibility for mixed SNQI normalization inputs.
- Comparator or baseline, applicable: current governance report on `origin/main` without blocker-local `mixed_inputs`.
- Evidence tier: NA - diagnostic preflight payload only; no benchmark result or metric semantics changed.
- Result classification: NA - no research result or benchmark claim; reporting surface only.
- Decision stop rule, applicable: focused tests pass and default governance command still exits fail-closed with #3699 `mixed_inputs` present.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue remains open; no claim map or benchmark result update.
- New research/benchmark/metric/paper-facing analysis tool, any: none; extends existing governance preflight payload only.

## Domain-Aware Approval
- Required: no - research guidance fields are NA and no benchmark claim is made.
- Domains reviewed: NA - diagnostic preflight payload only.
- Status: waived - no domain-sensitive result claimed.
- Approver/review source waiver: waived because this PR only adds a blocker-local JSON field and tests; it does not change scoring, ranking, normalization, or claims.
- Validity checklist: diagnostic payload only; targeted tests verify reported normalization statuses and unchanged fail-closed behavior.
- Target claim/hypothesis: #3699 mixed-input visibility, not SNQI score validity.
- Comparator split/evidence validity: existing `origin/main` governance report lacks blocker-local mixed-input detail; changed report adds it on the same fail-closed blocker.
- Fallback/degraded exclusions: no planner or benchmark execution; no fallback/degraded run counted.
- Claim boundary: no scoring, ranking, weight, normalization, or paper/dissertation claim change.
- Implementation integrity vs experimental validity: tests prove gate payload behavior, not research result validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, #3699 blocker JSON includes `mixed_inputs`.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, current SNQI governance preflight still detects mixed raw/baseline-normalized penalty inputs.
- Result route: continue; normalization redesign remains decision-required.
- Follow-up question issue weak, negative, non-transfer results: none opened.

## Next Empirical Action
- Rerun needed: no full benchmark campaign run for this diagnostic payload slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with maintainer decision on normalize-vs-bound in #3699.
- Proposed child issue existing follow-up: #3699 remains the follow-up decision surface.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_governance_preflight.py tests/benchmark/test_snqi_normalization_inventory.py -q` -> 15 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_governance_preflight.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --json` -> exit 2 as expected; report includes #3699 `mixed_inputs` and remains fail-closed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> pending rerun after this PR body source is supplied.

Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Resource Impact
- Baseline runtime: NA, no runtime path or benchmark campaign changed.
- Changed runtime: NA, no runtime path or benchmark campaign changed.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --json`.
- Hot-path call count profile anchor: NA, diagnostic preflight payload only.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if governance consumers require the blocker schema to remain without `mixed_inputs`.

## Risks / Rollout
- Compatibility risks: low; adds a field to one blocker payload without removing existing fields.
- Failure modes: downstream strict-schema consumers could reject an unknown blocker key.
- Rollback fallback plan: remove `mixed_inputs`; separate normalization payload remains available.

## Docs / Provenance
- Updated docs: none; behavior is covered by tests and PR body.
- Relevant design provenance notes: issue #3699 latest reversible first-slice guidance.
- Any assumptions need to preserved: blocker-local mixed input listing is reversible and diagnostic-only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; authorization disallows issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark, registry, claim-map, leaderboard, or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: maintainer decision on normalize raw terms versus document bounded raw-term asymmetry remains in #3699.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the #3699 blocker carries `mixed_inputs` while `compute_snqi()` and normalization behavior remain untouched.
- Known limitation: this does not clear the underlying mixed normalization basis; it only improves fail-closed diagnostics.
