### PR TITLE
#3384 refactor: extract adaptive proxemic policy builder

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -120,6 +120,7 @@ from robot_sf.benchmark.map_runner_observations import (
 )
 from robot_sf.benchmark.map_runner_observations import obs_to_ppo_format as _obs_to_ppo_format
 from robot_sf.benchmark.map_runner_policies import adapters as _adapter_policy_builders
+from robot_sf.benchmark.map_runner_policies import adaptive_proxemic as _adaptive_proxemic_builder
 from robot_sf.benchmark.map_runner_policies import goal as _goal_policy_builder
 from robot_sf.benchmark.map_runner_policies import registry as _policy_builder_registry
 from robot_sf.benchmark.map_runner_policies import safety_barrier as _safety_barrier_builder
@@ -189,10 +190,6 @@ from robot_sf.benchmark.utils import (
 )
 from robot_sf.common.math_utils import wrap_angle_pi as _normalize_heading
 from robot_sf.gym_env.environment_factory import make_robot_env
-from robot_sf.planner.adaptive_proxemic_selector import (
-    AdaptiveProxemicSelectorAdapter,
-    build_adaptive_proxemic_selector_config,
-)
 from robot_sf.planner.gap_prediction import (
     GapAwarePredictionAdapter,
     build_gap_prediction_config,
@@ -1012,6 +1009,10 @@ _POLICY_BUILDERS: dict[str, _policy_builder_registry.PolicyBuilder] = {
         _adapter_policy_builders.LIDAR_SOCIAL_FORCE_KEYS,
         _adapter_policy_builders.build_lidar_social_force,
     ),
+    **dict.fromkeys(
+        _adaptive_proxemic_builder.ADAPTIVE_PROXEMIC_SELECTOR_KEYS,
+        _adaptive_proxemic_builder.build,
+    ),
     **dict.fromkeys(_safety_barrier_builder.ADAPTER_ALGO_KEYS, _safety_barrier_builder.build),
 }
 
@@ -1114,38 +1115,6 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
             adapter_name="HybridRuleLocalPlannerAdapter",
             robot_kinematics=robot_kinematics,
             normalized_robot_command_mode=normalized_robot_command_mode,
-        )
-
-    if algo_key in {"adaptive_proxemic_selector_v0", "adaptive_proxemic_selector_v1"}:
-        selector_algo_config = dict(algo_config)
-        selector_algo_config.setdefault(
-            "selector_version",
-            "v1" if algo_key == "adaptive_proxemic_selector_v1" else "v0",
-        )
-        selector_config = build_adaptive_proxemic_selector_config(selector_algo_config)
-        adapter = AdaptiveProxemicSelectorAdapter(config=selector_config)
-        meta["adaptive_proxemic_selector"] = {
-            "status": "enabled",
-            "selector_version": selector_config.selector_version,
-            "diagnostic_only": bool(selector_config.diagnostic_only),
-            "claim_boundary": selector_config.claim_boundary,
-            "profile_sources": [
-                selector_config.profiles[name].source_candidate
-                for name in ("conservative", "neutral", "open")
-            ],
-        }
-        return _build_adapter_policy(
-            algo_key=algo_key,
-            algo_config=selector_algo_config,
-            meta=meta,
-            adapter=adapter,
-            adapter_name="AdaptiveProxemicSelectorAdapter",
-            robot_kinematics=robot_kinematics,
-            normalized_robot_command_mode=normalized_robot_command_mode,
-            limitations=(
-                "diagnostic-only selector over fixed proxemic profiles; "
-                "not benchmark or comfort evidence"
-            ),
         )
 
     if algo_key == "topology_guided_hybrid_rule_v0":

--- a/robot_sf/benchmark/map_runner_policies/adaptive_proxemic.py
+++ b/robot_sf/benchmark/map_runner_policies/adaptive_proxemic.py
@@ -1,0 +1,87 @@
+"""Builder for adaptive-proxemic-selector map-runner policy family.
+
+Continuation of ``_build_policy`` decomposition (#3384). This module is a
+behavior-preserving move of the adaptive proxemic selector branch from
+``robot_sf.benchmark.map_runner`` into the policy-builder registry package.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from robot_sf.benchmark.map_runner_policy_common import build_adapter_policy
+from robot_sf.planner.adaptive_proxemic_selector import (
+    AdaptiveProxemicSelectorAdapter,
+    build_adaptive_proxemic_selector_config,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+#: Algorithm keys handled by the adaptive proxemic selector builder.
+ADAPTIVE_PROXEMIC_SELECTOR_KEYS = frozenset(
+    {"adaptive_proxemic_selector_v0", "adaptive_proxemic_selector_v1"}
+)
+
+
+def build(
+    algo_key: str,
+    algo_config: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    robot_command_mode: str | None = None,
+) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
+    """Build adaptive proxemic selector adapter policy metadata.
+
+    Args:
+        algo_key: Normalized algorithm key (one :data:`ADAPTIVE_PROXEMIC_SELECTOR_KEYS`).
+        algo_config: Algorithm configuration payload.
+        robot_kinematics: Runtime robot kinematics label for metadata enrichment.
+        robot_command_mode: Runtime robot command mode (for holonomic metadata labels).
+
+    Returns:
+        Policy callable and enriched metadata dictionary.
+    """
+    if algo_key not in ADAPTIVE_PROXEMIC_SELECTOR_KEYS:
+        supported = ", ".join(sorted(ADAPTIVE_PROXEMIC_SELECTOR_KEYS))
+        raise ValueError(
+            f"Unsupported adaptive proxemic selector algo_key {algo_key!r}; "
+            f"expected one of: {supported}"
+        )
+
+    normalized_robot_command_mode = (
+        str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
+    )
+    selector_algo_config = dict(algo_config)
+    selector_algo_config.setdefault(
+        "selector_version",
+        "v1" if algo_key == "adaptive_proxemic_selector_v1" else "v0",
+    )
+    selector_config = build_adaptive_proxemic_selector_config(selector_algo_config)
+    adapter = AdaptiveProxemicSelectorAdapter(config=selector_config)
+    meta: dict[str, Any] = {
+        "adaptive_proxemic_selector": {
+            "status": "enabled",
+            "selector_version": selector_config.selector_version,
+            "diagnostic_only": bool(selector_config.diagnostic_only),
+            "claim_boundary": selector_config.claim_boundary,
+            "profile_sources": [
+                selector_config.profiles[name].source_candidate
+                for name in ("conservative", "neutral", "open")
+            ],
+        }
+    }
+    return build_adapter_policy(
+        algo_key=algo_key,
+        algo_config=selector_algo_config,
+        meta=meta,
+        adapter=adapter,
+        adapter_name="AdaptiveProxemicSelectorAdapter",
+        robot_kinematics=robot_kinematics,
+        normalized_robot_command_mode=normalized_robot_command_mode,
+        limitations=(
+            "diagnostic-only selector over fixed proxemic profiles; "
+            "not benchmark or comfort evidence"
+        ),
+    )


### PR DESCRIPTION
## Summary

Extracts the adaptive proxemic selector policy-family branch from `map_runner._build_policy` into the existing `robot_sf.benchmark.map_runner_policies` registry package.

## Linked Issues

- Relates `#3384`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: Small behavior-preserving continuation of the already-landed policy-builder registry decomposition.

## What Changed

- Added `robot_sf/benchmark/map_runner_policies/adaptive_proxemic.py` for `adaptive_proxemic_selector_v0` and `adaptive_proxemic_selector_v1`.
- Registered both selector keys in `_POLICY_BUILDERS`.
- Removed the duplicate inline adaptive proxemic selector branch and its direct planner imports from `map_runner.py`.

## Why Matters

- Added value: shrinks the legacy `_build_policy` dispatcher while keeping the public `_build_policy` entry point and metadata behavior intact.
- Expected impact: easier isolated review and follow-up extraction of remaining policy families.
- Why worth merging now: bounded #3384 slice with existing focused tests for the migrated family.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: NA - refactor only, no research claim.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - support refactor.
- Result classification: NA - behavior-preserving support refactor.
- Decision stop rule, applicable: Focused map-runner utility tests and PR readiness pass.
- Parent issue, claim map, registry, context note, synthesis surface update: #3384 remains the parent decomposition issue.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool.

## Domain-Aware Approval

- Approver/review source waiver: not required.
- Validity checklist: NA - no benchmark interpretation or paper-facing claim.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: NA - no benchmark run or fallback success claim.
- Claim boundary: Refactor-only; no benchmark-strengthening evidence.
- Implementation integrity vs experimental validity: Existing tests exercise the migrated `_build_policy` path; no experimental validity claim is made.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA - no research mechanism.
- Did intervention change command source, selected command, trajectory, route progress? No intended behavior change.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action

- Rerun needed: no for this refactor slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue remaining #3384 family extractions in later bounded PRs.
- Proposed child issue existing follow-up: #3384.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policies/adaptive_proxemic.py tests/benchmark/test_map_runner_utils.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py::test_build_policy_routes_adaptive_proxemic_selector_with_diagnostics tests/benchmark/test_map_runner_utils.py::test_build_policy_routes_adaptive_proxemic_selector_v1_with_diagnostics -q` - passed, 2 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py -q` - passed, full file.
- `source .venv/bin/activate && BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed as interim dirty-tree proof, including `1681 passed`.
- `source .venv/bin/activate && CUDA_VISIBLE_DEVICES= PYTORCH_NVML_BASED_CUDA_CHECK=0 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr3384_body.md scripts/dev/pr_ready_check.sh` - passed at clean committed HEAD `6be2ca98c131a27c11a358329553f9daf2514b70`; readiness stamp recorded `status=passed`, `tree_state=clean`.

No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Performance Evidence

- Baseline runtime: NA - no performance claim.
- Changed runtime: NA - no performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py -q`.
- Hot-path call count profile anchor: NA - no performance claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: Adaptive proxemic selector `_build_policy` tests or PR readiness regress.

## Risks / Rollout

- Compatibility risks: Low; `_build_policy` signature and returned metadata are preserved for the migrated keys.
- Failure modes: Registry mapping typo would break adaptive proxemic selector construction.
- Rollback fallback plan: Revert the extraction commit to restore the inline branch.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: #3384.
- Any assumptions need to preserved: This is a behavior-preserving extraction only.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no, comments not authorized for this task.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: support refactor only; no benchmark, registry, claim-map, or paper-facing evidence changes.

## Follow-Up Issues

- Deferred work: Remaining `_build_policy` family extractions under #3384.
- Issues opened follow-up: none.

## Reviewer Notes

- Anything reviewer verify closely: metadata parity for `adaptive_proxemic_selector_v0/v1`.
- Any known limitations: No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
