### PR TITLE
Issue #3425: gate finalizer required artifact readiness

### DIFF
--- a/scripts/validation/preflight_slurm_finalizer.py
+++ b/scripts/validation/preflight_slurm_finalizer.py
@@ -30,6 +30,8 @@ What it checks (each maps to an acceptance criterion of #3425):
   public issue/PR traceability.
 * ``durable_pointer_present`` — every *successful* finalizer carries a durable
   pointer (the "durable pointers missing" fail-closed case).
+* ``required_artifacts_complete`` — every *successful* finalizer reports all
+  required artifacts present before a durable pointer can unblock a claim.
 * ``claim_boundary_present`` — every finalizer carries a claim boundary so the
   downstream summary/claim decision stays inside an explicit boundary.
 * ``evidence_root_present`` — advisory: the compact evidence root exists so the
@@ -460,6 +462,58 @@ def _check_durable_pointer(inputs: LoadedInputs) -> PreflightCheck:
     )
 
 
+def _check_required_artifacts_complete(inputs: LoadedInputs) -> PreflightCheck:
+    """Require successful finalizers to report complete required artifacts."""
+    successful = [
+        finalizer
+        for finalizer in inputs.finalizers
+        if finalizer.classification in _SUCCESS_CLASSIFICATIONS
+    ]
+    if not inputs.finalizers:
+        return PreflightCheck(
+            name="required_artifacts_complete",
+            status=_SKIPPED,
+            severity=_REQUIRED,
+            detail="no finalizer records to inspect",
+            remediation="resolve finalizer_manifests_present first",
+        )
+    if not successful:
+        return PreflightCheck(
+            name="required_artifacts_complete",
+            status=_READY,
+            severity=_REQUIRED,
+            detail="no successful finalizers require complete artifact status yet",
+        )
+
+    incomplete = sorted(
+        f"{finalizer.job_id}({finalizer.artifact_status})"
+        for finalizer in successful
+        if finalizer.artifact_status != "all_required_present"
+    )
+    if incomplete:
+        return PreflightCheck(
+            name="required_artifacts_complete",
+            status=_BLOCKED,
+            severity=_REQUIRED,
+            detail=(
+                "successful finalizer(s) do not report all required artifacts present: "
+                f"{', '.join(incomplete)}"
+            ),
+            remediation=(
+                "rerun or repair the finalizer inputs until successful records carry "
+                "artifact_status=all_required_present, or reclassify the job as blocked/"
+                "incomplete before claim handoff"
+            ),
+        )
+
+    return PreflightCheck(
+        name="required_artifacts_complete",
+        status=_READY,
+        severity=_REQUIRED,
+        detail="every successful finalizer reports all required artifacts present",
+    )
+
+
 def _check_claim_boundary(inputs: LoadedInputs) -> PreflightCheck:
     """Require every finalizer to carry a claim boundary."""
     if not inputs.finalizers:
@@ -547,6 +601,7 @@ def preflight(
         _check_finalizer_linkage(inputs),
         _check_issue_traceability(inputs),
         _check_durable_pointer(inputs),
+        _check_required_artifacts_complete(inputs),
         _check_claim_boundary(inputs),
         _check_evidence_root(evidence_root),
     ]

--- a/tests/validation/test_preflight_slurm_finalizer.py
+++ b/tests/validation/test_preflight_slurm_finalizer.py
@@ -57,6 +57,7 @@ def _write_finalizer(
     issue: int = 3425,
     job_id: str = "12345",
     classification: str = "success",
+    artifact_status: str = "all_required_present",
     durable_uri: str | None = "wandb://entity/project/run",
     claim_boundary: str | None = "smoke evidence only",
 ) -> Path:
@@ -66,7 +67,7 @@ def _write_finalizer(
         "issue_number": issue,
         "job_id": job_id,
         "classification": classification,
-        "artifact_status": "all_required_present",
+        "artifact_status": artifact_status,
     }
     if durable_uri is not None:
         payload["durable_uri"] = durable_uri
@@ -104,6 +105,7 @@ def test_ready_when_all_inputs_present(tmp_path: Path) -> None:
     assert report["input_errors"] == []
     statuses = {check["name"]: check["status"] for check in report["checks"]}
     assert statuses["durable_pointer_present"] == "ready"
+    assert statuses["required_artifacts_complete"] == "ready"
     assert statuses["finalizer_manifest_linkage"] == "ready"
     assert statuses["claim_boundary_present"] == "ready"
 
@@ -134,6 +136,24 @@ def test_blocks_when_durable_pointer_is_worktree_local(tmp_path: Path) -> None:
     blocker = next(b for b in report["blockers"] if b["check"] == "durable_pointer_present")
     assert "non-durable or local artifact pointer" in blocker["detail"]
     assert "worktree-local" in blocker["remediation"]
+
+
+def test_blocks_when_successful_finalizer_has_incomplete_required_artifacts(
+    tmp_path: Path,
+) -> None:
+    """A durable URI cannot unblock success when required artifacts are incomplete."""
+    inputs = _ready_inputs(tmp_path)
+    _write_finalizer(
+        tmp_path / "finalizer.json",
+        artifact_status="required_missing",
+    )
+
+    report = gate.preflight(**inputs)
+
+    assert report["ready"] is False
+    blocker = next(b for b in report["blockers"] if b["check"] == "required_artifacts_complete")
+    assert "12345(required_missing)" in blocker["detail"]
+    assert "artifact_status=all_required_present" in blocker["remediation"]
 
 
 def test_blocks_when_manifest_linkage_missing(tmp_path: Path) -> None:
@@ -255,6 +275,7 @@ def test_non_success_finalizer_does_not_require_durable_pointer(tmp_path: Path) 
 
     statuses = {check["name"]: check["status"] for check in report["checks"]}
     assert statuses["durable_pointer_present"] == "ready"
+    assert statuses["required_artifacts_complete"] == "ready"
 
 
 def test_malformed_finalizer_is_input_error(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds one fail-closed readiness check to the existing CPU-only SLURM-to-claim finalizer preflight: a successful finalizer must also report `artifact_status=all_required_present` before a durable pointer can unblock claim handoff.

## Linked Issues
- Relates to `#3425`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `required_artifacts_complete` to `scripts/validation/preflight_slurm_finalizer.py`.
- Extended synthetic finalizer tests to cover complete success, incomplete successful finalizers, and non-success finalizers.

## Why Matters
- Added value: prevents an inconsistent successful finalizer with missing required artifacts from passing the local readiness gate.
- Expected impact: tighter preflight evidence for the #3425 finalizer handoff without running SLURM or promoting claims.
- Why worth merging now: this is a small reversible blocker/provenance check on an existing issue-specific readiness gate.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3425 local finalizer readiness blocker; no benchmark or research claim is promoted.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - support preflight checker only; synthetic tests are validation, not research evidence.
- Result classification: NA - no research result or claim promotion.
- Decision stop rule, applicable: successful finalizer records with missing required artifacts now block readiness.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3425 only; no issue comment authorized in this run.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support preflight helper; it does not interpret research results.

## Domain-Aware Approval
- Required PR: yes
- Domains reviewed: evidence classification, claim boundary.
- Status: waived.
- Approver/review source or waiver: self-review waiver; PR tightens a local preflight gate and makes no benchmark or paper-facing claim.
- Approver/review source waiver: self-review waiver; PR tightens a local preflight gate and makes no benchmark or paper-facing claim.
- Validity checklist:
  - Target claim/hypothesis: #3425 readiness input completeness only.
  - Comparator or split/evidence validity: synthetic targeted preflight fixture only; no comparative benchmark evidence.
  - Fallback/degraded exclusions: no fallback/degraded benchmark execution performed.
  - Claim boundary: readiness gate only; no claim promotion.
  - Implementation integrity vs experimental validity: synthetic tests exercise the fail-closed contract.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, synthetic incomplete successful finalizer now blocks.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? yes, test fixture sets `classification=success` and `artifact_status=required_missing`.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this local preflight slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no durable artifact required for this checker-only PR.
- Stop / revise / continue decision: continue with downstream full PR gate owned by Claude Code on `imech156-u`.
- Proposed child issue existing follow-up: NA.

## Validation / Proof
- `uv run pytest tests/validation/test_preflight_slurm_finalizer.py -q` - passed, 16 tests.
- `uv run ruff check scripts/validation/preflight_slurm_finalizer.py tests/validation/test_preflight_slurm_finalizer.py` - passed.
- `uv run ruff format --check scripts/validation/preflight_slurm_finalizer.py tests/validation/test_preflight_slurm_finalizer.py` - passed after formatting.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed before commit; generated ignored `output/coverage/` and `output/validation/pr_ready/` artifacts.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - rerun for committed-head freshness before opening PR.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no release artifacts.

## Performance Evidence
NA - no runtime/performance improvement claimed.
- Baseline runtime: NA
- Changed runtime: NA
- Representative command: `uv run pytest tests/validation/test_preflight_slurm_finalizer.py -q`
- Hot-path call count profile anchor: NA
- Cache-hit reuse counter: NA
- Rollback failure criterion: readiness gate fails to block `classification=success` with incomplete required artifact status.

## Risks / Rollout
- Compatibility risks: a hand-authored or legacy successful finalizer with non-`all_required_present` artifact status will now block local readiness.
- Failure modes: finalizer records may need reclassification to blocked/incomplete before claim handoff.
- Rollback fallback plan: revert this PR if existing valid finalizer schemas intentionally allow successful records with incomplete required artifacts.

## Docs / Provenance
- Updated docs: inline checker docstring only.
- Relevant design provenance notes: issue #3425, existing preflight checker, existing reconciler finalizer transition semantics.
- Any assumptions need to preserved: successful finalizer records are claim-unblocking only when required artifacts are complete.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; comments not authorized for this run.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: this PR tightens a local checker and does not add benchmark results, artifacts, or paper-facing claims.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that `required_artifacts_complete` should be required only for successful finalizers; non-success finalizers remain eligible to proceed to diagnostic/block decisions.
- Any known limitations: synthetic tests only; no SLURM job submission or durable artifact promotion performed.
