### PR TITLE
Issue #3637: require reactivity rank analysis contract

### DIFF
--- a/configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml
+++ b/configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml
@@ -80,6 +80,22 @@ replay:
 min_planners: 3
 min_seeds: 20
 
+# Machine-checked post-run analysis contract. This is metadata only: it does not run or interpret
+# the benchmark, and it does not promote a paper/dissertation claim.
+rank_stability_analysis:
+  paired_seed_resampling: true
+  required_metrics:
+    - collision_rate
+    - near_miss_rate
+    - min_separation_m
+  rank_metric: collision_rate
+  seed_sufficiency_gate_command: >-
+    uv run python scripts/tools/seed_sufficiency_gate.py --input-json <frozen_gate_input.json>
+  replay_limitation_required: true
+  claim_boundary: >-
+    No paper-facing claim until post-run seed-sufficiency gate and claim-card review confirm
+    rank-stability evidence with the replay force-off limitation.
+
 # After preflight passes, the run + post-run analysis (OUT OF SCOPE for #3637 implementation slice):
 run_command: |
   # Paired reactive-vs-replay campaign across the declared planners + seeds (real runner).

--- a/robot_sf/benchmark/reactivity_replay_preflight.py
+++ b/robot_sf/benchmark/reactivity_replay_preflight.py
@@ -406,7 +406,7 @@ def build_preflight_manifest(plan: ReactivityReplayRunPlan) -> dict[str, Any]:
 def run_plan_from_packet(packet: dict[str, Any]) -> ReactivityReplayRunPlan:
     """Build a :class:`ReactivityReplayRunPlan` from a launch-packet mapping (e.g. parsed YAML).
 
-    Expected shape (only the listed keys are read; extras are ignored)::
+    Expected shape (only the listed keys are read; other extras are ignored)::
 
         planners: [goal, orca, social_force]
         scenario_set: configs/scenarios/sets/classic_crossing_subset.yaml
@@ -417,8 +417,19 @@ def run_plan_from_packet(packet: dict[str, Any]) -> ReactivityReplayRunPlan:
         replay:
           is_trajectory_playback: false
           limitation: "..."              # defaults to the canonical REPLAY_LIMITATION
+        rank_stability_analysis:         # required post-run analysis contract (fails closed)
+          paired_seed_resampling: true
+          required_metrics: [collision_rate, near_miss_rate, min_separation_m]
+          rank_metric: collision_rate
+          seed_sufficiency_gate_command: "uv run python scripts/tools/seed_sufficiency_gate.py ..."
+          replay_limitation_required: true
+          claim_boundary: "No paper-facing claim until post-run ..."
         min_planners: 3                  # optional override
         min_seeds: 20                    # optional override
+
+    The packet parses with ``rank_stability_analysis`` defaulting to an empty mapping when absent,
+    but the manifest then preflights as ``blocked`` because the contract check fails closed (see
+    :func:`_check_rank_stability_analysis`).
 
     Returns:
         ReactivityReplayRunPlan: The parsed run plan.

--- a/robot_sf/benchmark/reactivity_replay_preflight.py
+++ b/robot_sf/benchmark/reactivity_replay_preflight.py
@@ -56,6 +56,12 @@ MIN_RANK_STABILITY_SEEDS = 20
 #: The #3573 diagnostic small matrix used 4 seeds; a paper-grade plan must strictly exceed it.
 DIAGNOSTIC_SEED_COUNT = 4
 
+#: Metrics that must be preserved for the post-run rank-stability gate.
+REQUIRED_RANK_STABILITY_METRICS = ("collision_rate", "near_miss_rate", "min_separation_m")
+
+#: Canonical post-run gate command family. Packets may add arguments but must route here.
+RANK_STABILITY_GATE_COMMAND = "scripts/tools/seed_sufficiency_gate.py"
+
 
 @dataclass(frozen=True, slots=True)
 class ReactivityReplayRunPlan:
@@ -74,6 +80,8 @@ class ReactivityReplayRunPlan:
         replay_is_trajectory_playback: Whether the replay arm is pre-recorded trajectory playback.
             Must be ``False`` for this ablation (live force-off, not playback).
         replay_limitation: Human-readable limitation note that must accompany every artifact.
+        rank_stability_analysis: Plan-level post-run analysis contract metadata. This is not a
+            measured result and does not claim rank stability.
         min_planners: Override for the planner-count floor (defaults to :data:`MIN_PLANNERS`).
         min_seeds: Override for the seed-count floor (defaults to :data:`MIN_RANK_STABILITY_SEEDS`).
     """
@@ -85,6 +93,7 @@ class ReactivityReplayRunPlan:
     scenario_set_sha256: str | None = None
     replay_is_trajectory_playback: bool = REPLAY_IS_TRAJECTORY_PLAYBACK
     replay_limitation: str = REPLAY_LIMITATION
+    rank_stability_analysis: dict[str, Any] = field(default_factory=dict)
     min_planners: int = MIN_PLANNERS
     min_seeds: int = MIN_RANK_STABILITY_SEEDS
     #: Minimum horizon for the contrast to register (diagnostic family observation, #3573).
@@ -254,6 +263,57 @@ def _check_scenario_set_digest(plan: ReactivityReplayRunPlan) -> CheckResult:
     )
 
 
+def _check_rank_stability_analysis(plan: ReactivityReplayRunPlan) -> CheckResult:
+    """Validate the declared post-run rank-stability analysis contract.
+
+    Returns:
+        CheckResult: ``rank_stability_analysis`` check outcome.
+    """
+    analysis = plan.rank_stability_analysis
+    if not analysis:
+        return CheckResult(
+            name="rank_stability_analysis",
+            passed=False,
+            detail="rank_stability_analysis metadata must be present in launch packet",
+        )
+
+    metrics = analysis.get("required_metrics")
+    metric_set = set(metrics) if isinstance(metrics, list) else set()
+    missing_metrics = sorted(set(REQUIRED_RANK_STABILITY_METRICS) - metric_set)
+    rank_metric = analysis.get("rank_metric")
+    gate_command = str(analysis.get("seed_sufficiency_gate_command") or "")
+    claim_boundary = str(analysis.get("claim_boundary") or "").lower()
+    paired_resampling = analysis.get("paired_seed_resampling") is True
+    replay_caveat_required = analysis.get("replay_limitation_required") is True
+
+    failures: list[str] = []
+    if missing_metrics:
+        failures.append(f"missing required_metrics: {', '.join(missing_metrics)}")
+    if not isinstance(rank_metric, str) or rank_metric not in metric_set:
+        failures.append("rank_metric must be one of required_metrics")
+    if not paired_resampling:
+        failures.append("paired_seed_resampling must be true")
+    if RANK_STABILITY_GATE_COMMAND not in gate_command:
+        failures.append(
+            f"seed_sufficiency_gate_command must route through {RANK_STABILITY_GATE_COMMAND}"
+        )
+    if not replay_caveat_required:
+        failures.append("replay_limitation_required must be true")
+    if "no paper-facing" not in claim_boundary or "post-run" not in claim_boundary:
+        failures.append("claim_boundary must state no paper-facing claim until post-run review")
+
+    return CheckResult(
+        name="rank_stability_analysis",
+        passed=not failures,
+        detail=(
+            "post-run rank-stability contract declared: paired seed resampling, required metrics, "
+            "seed-sufficiency gate, replay caveat, and no-paper-claim boundary"
+            if not failures
+            else "; ".join(failures)
+        ),
+    )
+
+
 def _check_replay_limitation(plan: ReactivityReplayRunPlan) -> CheckResult:
     """Replay is force-off (not trajectory playback) and the limitation note is present.
 
@@ -281,6 +341,7 @@ _CHECKS = (
     _check_seed_budget,
     _check_horizon,
     _check_scenario_set_digest,
+    _check_rank_stability_analysis,
     _check_replay_limitation,
 )
 
@@ -320,6 +381,7 @@ def build_preflight_manifest(plan: ReactivityReplayRunPlan) -> dict[str, Any]:
             "scenario_set": plan.scenario_set,
             "scenario_set_sha256": plan.scenario_set_sha256,
             "horizon": plan.horizon,
+            "rank_stability_analysis": dict(plan.rank_stability_analysis),
             "min_planners": plan.min_planners,
             "min_seeds": plan.min_seeds,
         },
@@ -391,6 +453,7 @@ def run_plan_from_packet(packet: dict[str, Any]) -> ReactivityReplayRunPlan:
     limitation = replay.get("limitation", REPLAY_LIMITATION)
     if not isinstance(limitation, str):
         raise ValueError("packet 'replay.limitation' must be a string")
+    analysis = _resolve_rank_stability_analysis(packet)
 
     overrides: dict[str, Any] = {}
     if "min_planners" in packet:
@@ -406,6 +469,7 @@ def run_plan_from_packet(packet: dict[str, Any]) -> ReactivityReplayRunPlan:
         scenario_set_sha256=scenario_set_sha256,
         replay_is_trajectory_playback=is_playback,
         replay_limitation=limitation,
+        rank_stability_analysis=dict(analysis),
         **overrides,
     )
 
@@ -453,12 +517,22 @@ def _resolve_scenario_set_sha256(packet: dict[str, Any]) -> str | None:
     return scenario_set_sha256
 
 
+def _resolve_rank_stability_analysis(packet: dict[str, Any]) -> dict[str, Any]:
+    """Return optional rank-stability analysis metadata from the launch packet."""
+    analysis = packet.get("rank_stability_analysis", {})
+    if not isinstance(analysis, dict):
+        raise ValueError("packet 'rank_stability_analysis' must be a mapping when present")
+    return dict(analysis)
+
+
 __all__ = [
     "DIAGNOSTIC_SEED_COUNT",
     "ISSUE",
     "MIN_PLANNERS",
     "MIN_RANK_STABILITY_SEEDS",
     "PREFLIGHT_SCHEMA",
+    "RANK_STABILITY_GATE_COMMAND",
+    "REQUIRED_RANK_STABILITY_METRICS",
     "CheckResult",
     "ReactivityReplayRunPlan",
     "build_preflight_manifest",

--- a/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
+++ b/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
@@ -19,6 +19,8 @@ from robot_sf.benchmark.reactivity_replay_preflight import (
     DIAGNOSTIC_SEED_COUNT,
     MIN_RANK_STABILITY_SEEDS,
     PREFLIGHT_SCHEMA,
+    RANK_STABILITY_GATE_COMMAND,
+    REQUIRED_RANK_STABILITY_METRICS,
     ReactivityReplayRunPlan,
     build_preflight_manifest,
     check_run_plan,
@@ -46,6 +48,22 @@ def _ready_seeds() -> tuple[int, ...]:
     return tuple(range(101, 101 + MIN_RANK_STABILITY_SEEDS))
 
 
+def _rank_stability_analysis() -> dict[str, object]:
+    """Return required post-run analysis-contract metadata."""
+    return {
+        "paired_seed_resampling": True,
+        "required_metrics": list(REQUIRED_RANK_STABILITY_METRICS),
+        "rank_metric": REQUIRED_RANK_STABILITY_METRICS[0],
+        "seed_sufficiency_gate_command": (
+            f"uv run python {RANK_STABILITY_GATE_COMMAND} --input-json <frozen_gate_input.json>"
+        ),
+        "replay_limitation_required": True,
+        "claim_boundary": (
+            "No paper-facing claim until post-run seed-sufficiency gate and claim-card review."
+        ),
+    }
+
+
 def _ready_plan(**overrides) -> ReactivityReplayRunPlan:
     """A plan that passes every precondition unless overridden."""
     seeds = _ready_seeds()
@@ -54,6 +72,7 @@ def _ready_plan(**overrides) -> ReactivityReplayRunPlan:
         "arm_seeds": dict.fromkeys(REACTIVITY_ARMS, seeds),
         "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
         "horizon": 300,
+        "rank_stability_analysis": _rank_stability_analysis(),
     }
     base.update(overrides)
     return ReactivityReplayRunPlan(**base)
@@ -81,6 +100,7 @@ def test_manifest_always_carries_replay_limitation():
     assert limitation["is_trajectory_playback"] is False
     assert "not pre-recorded trajectory playback" in limitation["note"].lower()
     assert "rank stability" in manifest["claim_boundary"].lower()
+    assert manifest["plan"]["rank_stability_analysis"]["paired_seed_resampling"] is True
 
 
 def test_too_few_planners_blocks():
@@ -133,6 +153,21 @@ def test_missing_limitation_note_blocks():
     assert _checks_by_name(plan)["replay_limitation"] is False
 
 
+def test_missing_rank_stability_analysis_blocks():
+    """Missing post-run analysis contract blocks the preflight."""
+    plan = _ready_plan(rank_stability_analysis={})
+    assert _checks_by_name(plan)["rank_stability_analysis"] is False
+
+
+def test_incomplete_rank_stability_analysis_blocks():
+    """Analysis contract must name metrics, gate command, replay caveat, and claim boundary."""
+    analysis = _rank_stability_analysis()
+    analysis["required_metrics"] = ["collision_rate"]
+    analysis["paired_seed_resampling"] = False
+    plan = _ready_plan(rank_stability_analysis=analysis)
+    assert _checks_by_name(plan)["rank_stability_analysis"] is False
+
+
 def test_short_horizon_blocks():
     """A horizon below the contrast-registration floor blocks."""
     assert _checks_by_name(_ready_plan(horizon=50))["horizon"] is False
@@ -145,6 +180,7 @@ def test_run_plan_from_packet_shared_seeds_are_paired():
         "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
         "horizon": 300,
         "seeds": list(range(101, 121)),
+        "rank_stability_analysis": _rank_stability_analysis(),
     }
     plan = run_plan_from_packet(packet)
     assert set(plan.arm_seeds) == set(REACTIVITY_ARMS)

--- a/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
+++ b/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
@@ -168,6 +168,25 @@ def test_incomplete_rank_stability_analysis_blocks():
     assert _checks_by_name(plan)["rank_stability_analysis"] is False
 
 
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("required_metrics", ["collision_rate"]),
+        ("rank_metric", "unlisted_metric"),
+        ("paired_seed_resampling", False),
+        ("seed_sufficiency_gate_command", "uv run python scripts/tools/some_other_gate.py"),
+        ("replay_limitation_required", False),
+        ("claim_boundary", "rank stability looks good"),
+    ],
+)
+def test_each_rank_stability_field_fails_closed(field, value):
+    """Breaking any single fail-closed analysis field blocks the preflight."""
+    analysis = _rank_stability_analysis()
+    analysis[field] = value
+    plan = _ready_plan(rank_stability_analysis=analysis)
+    assert _checks_by_name(plan)["rank_stability_analysis"] is False
+
+
 def test_short_horizon_blocks():
     """A horizon below the contrast-registration floor blocks."""
     assert _checks_by_name(_ready_plan(horizon=50))["horizon"] is False


### PR DESCRIPTION
## Summary
Adds a fail-closed `rank_stability_analysis` contract to the issue #3637 reactivity-vs-replay launch packet and preflight manifest.

## Linked Issues
- Relates `#3637`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Extended `robot_sf.benchmark.reactivity_replay_preflight` to require post-run rank-stability analysis metadata: paired seed resampling, required metrics, rank metric, seed-sufficiency gate command, replay caveat requirement, and no-paper-claim boundary.
- Added that metadata to `configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml`.
- Added focused tests for missing/incomplete analysis metadata and manifest propagation.

## Why Matters
- Added value: strengthens the evidence-control layer before any increased-seed reactivity-vs-replay run is launched.
- Expected impact: launch packets fail closed when they omit the post-run analysis contract or replay-limitation requirement.
- Why worth merging now: this is a small checker/manifest slice that reduces ambiguity before compute is spent.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for issue #3637 launch-packet readiness.
- Comparator or baseline, applicable: NA - no benchmark campaign run.
- Evidence tier: NA - launch-packet metadata only; no research evidence generated.
- Result classification: NA - preflight metadata only; no benchmark result classified.
- Decision stop rule, applicable: preflight reports `ready` only when plan metadata is complete; it does not certify seed sufficiency.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3637 remains the parent; no claim map or paper/dissertation claim edit in this PR.
- New research/benchmark/metric/paper-facing analysis tool, any: no new analysis tool; this extends an existing preflight checker and launch packet only.

## Domain-Aware Approval
- Required PR: no - no research evidence, benchmark result, metric interpretation, or paper-facing claim is promoted.
- Domains reviewed: NA - metadata-only preflight checker.
- Status: waived
- Approver/review source waiver: preflight-only checker/manifest slice; no benchmark result, interpretation, or paper-facing claim is promoted.
- Validity checklist:
  - Target claim/hypothesis: no claim promoted; blocker-resolution only for launch-packet readiness.
  - Comparator or split/evidence validity: NA - no comparator result; planned arms remain paired by seed for future work.
  - Fallback/degraded exclusions: fallback/degraded execution is not counted as evidence; replay limitation is machine-checked as force-off, not trajectory playback.
  - Claim boundary: no paper-facing claim until post-run seed-sufficiency gate and claim-card review.
  - Implementation integrity vs experimental validity: focused tests and shipped packet preflight cover the implementation contract, not result validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no benchmark run.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: issue #3637 retains the increased-seed run/interpretation scope.

## Next Empirical Action
- Rerun needed: yes, outside this PR, for the actual seed-sufficient campaign.
- Extractor analysis tool needed: no new tool in this PR.
- Artifact missing unavailable: increased-seed benchmark artifacts are intentionally absent.
- Stop / revise / continue decision: continue to external campaign planning after review.
- Proposed child issue existing follow-up: #3637 remains open for the full run and conservative interpretation.

## Validation / Proof
- `uv run python -m py_compile robot_sf/benchmark/reactivity_replay_preflight.py tests/benchmark/test_reactivity_replay_preflight_issue_3637.py scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py` - passed
- `uv run ruff check robot_sf/benchmark/reactivity_replay_preflight.py tests/benchmark/test_reactivity_replay_preflight_issue_3637.py` - passed
- `uv run pytest tests/benchmark/test_reactivity_replay_preflight_issue_3637.py -q` - passed, 27 tests
- `uv run python scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py --packet configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml --json` - passed, status `ready`

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: existing packet-like callers that build `ReactivityReplayRunPlan` without analysis metadata now fail the new readiness check by design.
- Failure modes: overly strict metadata wording could block a valid launch packet until its claim-boundary text is updated.
- Rollback fallback plan: remove the `rank_stability_analysis` check and packet section if the contract proves too narrow.

## Docs / Provenance
- Updated docs: launch packet comments only.
- Relevant design provenance notes: issue #3637, prior #3573 diagnostic split, existing preflight checker.
- Any assumptions need to preserved: rank-stability sufficiency is decided only after post-run seed-sufficiency evidence, not by this preflight.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR is a preflight/manifest slice and does not produce benchmark evidence.

## Follow-Up Issues
- Deferred work: actual increased-seed benchmark campaign, rank-stability interpretation, and conservative docs/context write-up remain in #3637.
- Issues opened follow-up: none

## Reviewer Notes
- Verify the new check remains metadata-only and does not imply rank stability.
- Known limitations: it validates packet completeness, not the adequacy of the eventual run artifacts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new post-run rank-stability check to reactivity-vs-replay preflight.
  * Launch packets and manifests can now include required analysis details such as key metrics, seed-resampling status, and gate command reference.

* **Bug Fixes**
  * Preflight now blocks readiness when the rank-stability analysis contract is missing or incomplete.
  * Improved validation to ensure replay-related limitations and claim boundaries are clearly enforced before review.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->