### PR TITLE
Issue #3204: surface predictive proxy artifact provenance

### DIFF
--- a/configs/research/predictive_checkpoint_proxy_v1.yaml
+++ b/configs/research/predictive_checkpoint_proxy_v1.yaml
@@ -22,6 +22,9 @@ hard_seed_fixture: configs/benchmarks/predictive_hard_seeds_v1.yaml
 # -> present/absent) without downloading.
 checkpoint_selector:
   registry_tag: predictive
+  # The readiness checker maps declared public artifact metadata (release asset,
+  # checksum, size) but does not hydrate or download it. Local checkpoint
+  # resolution remains the fail-closed gate.
   # Minimum distinct, locally-resolvable checkpoints required by the issue's
   # claim contract (">= 6 checkpoints from >= 1 real training run").
   min_resolvable_checkpoints: 6
@@ -51,9 +54,11 @@ known_blockers:
   - id: missing_durable_predictive_checkpoints
     status: blocked
     evidence: >
-      model/registry.yaml predictive entries currently point at non-durable
+      model/registry.yaml predictive local_path entries currently point at
       output/tmp or output/model_cache paths that do not resolve in a clean
-      checkout.
+      checkout. Some entries declare public release metadata, but the readiness
+      slice does not hydrate those assets and still gates on locally resolvable
+      checkpoint files.
     revival_condition: >
       Promote or hydrate at least six predictive checkpoints from one real
       training run into durable, locally resolvable registry local_path entries.

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -188,8 +188,33 @@ def _artifact_scope(local_path: Any, resolved: Path | None, repo_root: Path) -> 
     return "unknown"
 
 
-def _checkpoint_mapping_entry(model_id: str, local_path: Any, repo_root: Path) -> dict[str, Any]:
+def _public_artifact_metadata(entry: dict[str, Any]) -> dict[str, Any]:
+    """Return durable public artifact metadata declared in the model registry."""
+    release = entry.get("github_release")
+    if not isinstance(release, dict):
+        return {"status": "missing", "source": None}
+
+    required = ("repo", "tag", "asset_name", "url", "sha256", "size_bytes")
+    missing = [key for key in required if release.get(key) in (None, "")]
+    return {
+        "status": "declared" if not missing else "incomplete",
+        "source": "github_release",
+        "repo": release.get("repo"),
+        "tag": release.get("tag"),
+        "asset_name": release.get("asset_name"),
+        "url": release.get("url"),
+        "sha256": release.get("sha256"),
+        "size_bytes": release.get("size_bytes"),
+        "metadata_asset": release.get("metadata_asset"),
+        "missing_fields": missing,
+    }
+
+
+def _checkpoint_mapping_entry(
+    model_id: str, entry: dict[str, Any], repo_root: Path
+) -> dict[str, Any]:
     """Build one fail-closed checkpoint mapping row without selecting any checkpoint."""
+    local_path = entry.get("local_path")
     resolved = _resolve_local_path(local_path, repo_root)
     scope = _artifact_scope(local_path, resolved, repo_root)
 
@@ -211,6 +236,7 @@ def _checkpoint_mapping_entry(model_id: str, local_path: Any, repo_root: Path) -
         "local_path": local_path,
         "resolved_path": str(resolved) if resolved is not None else None,
         "artifact_scope": scope,
+        "public_artifact": _public_artifact_metadata(entry),
         "status": status,
         "reason": reason,
         "present": status == "present",
@@ -238,13 +264,17 @@ def _check_checkpoint_artifacts(
         tags = {str(t).strip().lower() for t in (entry.get("tags") or [])}
         if tag not in tags:
             continue
-        local_path = entry.get("local_path")
-        candidates.append(_checkpoint_mapping_entry(model_id, local_path, repo_root))
+        candidates.append(_checkpoint_mapping_entry(model_id, entry, repo_root))
 
     candidates.sort(key=lambda item: str(item["model_id"]))
     resolvable = [c for c in candidates if c["present"]]
     blocked_by_status: dict[str, int] = {}
+    public_artifacts_by_status: dict[str, int] = {}
     for candidate in candidates:
+        artifact_status = str(candidate["public_artifact"]["status"])
+        public_artifacts_by_status[artifact_status] = (
+            public_artifacts_by_status.get(artifact_status, 0) + 1
+        )
         if candidate["present"]:
             continue
         blocked_by_status[candidate["status"]] = blocked_by_status.get(candidate["status"], 0) + 1
@@ -254,6 +284,7 @@ def _check_checkpoint_artifacts(
         "candidate_count": len(candidates),
         "resolvable_count": len(resolvable),
         "blocked_by_status": blocked_by_status,
+        "public_artifacts_by_status": public_artifacts_by_status,
         "candidates": candidates,
     }
 

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -174,6 +174,42 @@ def test_blocked_mapping_classifies_worktree_local_output_artifact(tmp_path):
     assert candidate["resolved_path"].endswith("output/tmp/predictive/run/checkpoint.pt")
 
 
+def test_blocked_mapping_surfaces_public_release_metadata(tmp_path):
+    """A release-backed checkpoint remains blocked until local, but provenance is mapped."""
+    config = _write_config(tmp_path, min_resolvable=1)
+    models = [
+        {
+            "model_id": "predictive_release_backed",
+            "local_path": "output/tmp/predictive/run/checkpoint.pt",
+            "tags": ["predictive"],
+            "github_release": {
+                "repo": "ll7/robot_sf_ll7",
+                "tag": "artifact/models-2026-05-registry-v1",
+                "asset_name": "predictive_release_backed.pt",
+                "url": "https://github.com/ll7/robot_sf_ll7/releases/download/tag/model.pt",
+                "sha256": "a" * 64,
+                "size_bytes": 123,
+                "metadata_asset": "predictive_release_backed-metadata.json",
+            },
+        }
+    ]
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(yaml.safe_dump({"version": 1, "models": models}), encoding="utf-8")
+
+    report = mod.check_readiness(config_path=config, registry_path=registry, repo_root=_REPO_ROOT)
+
+    ckpt = report["prerequisites"]["checkpoint_artifacts"]
+    candidate = ckpt["mapping"]["candidates"][0]
+    public_artifact = candidate["public_artifact"]
+    assert report["status"] == "blocked"
+    assert ckpt["mapping"]["public_artifacts_by_status"] == {"declared": 1}
+    assert candidate["status"] == "missing_local_path"
+    assert public_artifact["status"] == "declared"
+    assert public_artifact["source"] == "github_release"
+    assert public_artifact["asset_name"] == "predictive_release_backed.pt"
+    assert public_artifact["sha256"] == "a" * 64
+
+
 def test_blocked_when_too_few_checkpoints_resolve(tmp_path):
     """Fewer locally-resolvable checkpoints than the minimum fails closed (mapping metadata)."""
     config = _write_config(tmp_path, min_resolvable=6)


### PR DESCRIPTION
## Summary

Addresses https://github.com/ll7/robot_sf_ll7/issues/3204 with a readiness-only improvement for proxy-based predictive-planner checkpoint selection.

- Adds public artifact provenance to the existing checkpoint readiness mapping (`github_release` repo/tag/asset/url/checksum/size), without hydrating or downloading assets.
- Keeps local checkpoint resolution as the fail-closed readiness gate, so release-backed but absent local checkpoints remain blocked.
- Updates the issue #3204 readiness contract and focused fixture coverage for blocked release-backed artifacts.

## Scope

This PR is diagnostic/preflight only. It does not select checkpoints, run training, submit jobs, download or hydrate artifacts, promote evidence, or edit benchmark/paper/dissertation claims.

## Validation

- `uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py -q` - passed
- `uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` - passed
- `uv run ruff format --check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` - passed
- `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --json` - expected exit 2 blocked; live registry report shows 8 predictive candidates, 0 locally resolvable checkpoints, and public artifact metadata status counts `declared: 3`, `missing: 5`

## Out Of Scope

- No full benchmark campaign run.
- No SLURM/GPU submission.
- No paper/dissertation claim edits.

## Follow-Up

Not applicable because this PR keeps issue #3204 blocked until locally resolvable checkpoints and a non-degenerate proxy summary exist.
