### PR TITLE
Issue #3079: tighten Package B command readiness preflight

### DIFF
--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -152,6 +152,28 @@ def _extract_repeated_seed_args(command: str) -> tuple[tuple[int, ...], list[str
     return tuple(seed_args), warnings
 
 
+def _extract_option_values(command: str, option: str) -> tuple[tuple[str, ...], list[str]]:
+    """Return all values passed to a repeatable argparse option."""
+    warnings: list[str] = []
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        warnings.append(f"example_command could not be parsed by shlex: {exc}")
+        return (), warnings
+
+    values: list[str] = []
+    prefix = f"{option}="
+    for index, token in enumerate(tokens):
+        if token == option:
+            if index + 1 >= len(tokens):
+                warnings.append(f"example_command has {option} without value")
+                continue
+            values.append(tokens[index + 1])
+        elif token.startswith(prefix):
+            values.append(token.removeprefix(prefix))
+    return tuple(values), warnings
+
+
 def _under_output_prefix(path: Path | None, repo_root: Path) -> bool:
     if path is None:
         return False
@@ -457,6 +479,56 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
             "example_command --seed values must exactly match repeated_seeds "
             f"{list(seeds)}, got {list(command_seeds)}"
         )
+
+    command_samplers, sampler_warnings = _extract_option_values(example_command, "--sampler")
+    warnings.extend(sampler_warnings)
+    checks["example_command_sampler_set"] = not command_samplers or command_samplers == samplers
+    if not checks["example_command_sampler_set"]:
+        blockers.append(
+            "example_command --sampler values must be absent or exactly match samplers "
+            f"{list(samplers)}, got {list(command_samplers)}"
+        )
+
+    command_scenario_templates, scenario_warnings = _extract_option_values(
+        example_command, "--scenario-template"
+    )
+    warnings.extend(scenario_warnings)
+    checks["example_command_scenario_template"] = not command_scenario_templates or tuple(
+        _resolve_repo_path(root, value) for value in command_scenario_templates
+    ) == (_resolve_repo_path(root, base_config.get("scenario_template")),)
+    if not checks["example_command_scenario_template"]:
+        blockers.append(
+            "example_command --scenario-template must be absent or match "
+            "base_config.scenario_template"
+        )
+
+    command_search_spaces, search_space_warnings = _extract_option_values(
+        example_command, "--search-space"
+    )
+    warnings.extend(search_space_warnings)
+    checks["example_command_search_space"] = not command_search_spaces or tuple(
+        _resolve_repo_path(root, value) for value in command_search_spaces
+    ) == (_resolve_repo_path(root, base_config.get("search_space")),)
+    if not checks["example_command_search_space"]:
+        blockers.append(
+            "example_command --search-space must be absent or match base_config.search_space"
+        )
+
+    command_policies, policy_warnings = _extract_option_values(example_command, "--policy")
+    warnings.extend(policy_warnings)
+    checks["example_command_policy"] = not command_policies or command_policies == (
+        str(base_config.get("policy")),
+    )
+    if not checks["example_command_policy"]:
+        blockers.append("example_command --policy must be absent or match base_config.policy")
+
+    command_objectives, objective_warnings = _extract_option_values(example_command, "--objective")
+    warnings.extend(objective_warnings)
+    checks["example_command_objective"] = not command_objectives or command_objectives == (
+        str(base_config.get("objective")),
+    )
+    if not checks["example_command_objective"]:
+        blockers.append("example_command --objective must be absent or match base_config.objective")
 
     output_dir, out_json, output_warnings = _extract_output_paths(example_command, root)
     warnings.extend(output_warnings)

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -425,6 +425,58 @@ def test_preflight_blocks_base_config_policy_objective_drift(tmp_path: Path) -> 
     assert any("base_config.objective" in blocker for blocker in result.blockers)
 
 
+def test_preflight_blocks_example_command_sampler_drift(tmp_path: Path) -> None:
+    """Executable sampler plan must not narrow the manifest sampler set."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--package-b-budget-grid --seed 1101 --seed 2202 --seed 3303 "
+        "--sampler random --sampler coordinate "
+        "--output-dir output/adversarial/issue_3079_package_b "
+        "--out-json output/adversarial/issue_3079_package_b/report.json"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["example_command_sampler_set"] is False
+    assert any("example_command --sampler values" in blocker for blocker in result.blockers)
+
+
+def test_preflight_blocks_example_command_base_config_drift(tmp_path: Path) -> None:
+    """Executable input metadata must not drift from the manifest base_config."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    _write_file(tmp_path / "configs/scenarios/templates/doorway.yaml")
+    _write_file(tmp_path / "configs/adversarial/doorway_space.yaml")
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--scenario-template configs/scenarios/templates/doorway.yaml "
+        "--search-space configs/adversarial/doorway_space.yaml "
+        "--policy orca --objective nearest_collision "
+        "--package-b-budget-grid --seed 1101 --seed 2202 --seed 3303 "
+        "--output-dir output/adversarial/issue_3079_package_b "
+        "--out-json output/adversarial/issue_3079_package_b/report.json"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["example_command_scenario_template"] is False
+    assert result.checks["example_command_search_space"] is False
+    assert result.checks["example_command_policy"] is False
+    assert result.checks["example_command_objective"] is False
+    assert any("example_command --scenario-template" in blocker for blocker in result.blockers)
+    assert any("example_command --search-space" in blocker for blocker in result.blockers)
+    assert any("example_command --policy" in blocker for blocker in result.blockers)
+    assert any("example_command --objective" in blocker for blocker in result.blockers)
+
+
 def test_preflight_blocks_output_artifact_command_drift(tmp_path: Path) -> None:
     """Declared output artifacts must match executable example paths."""
     manifest = _base_manifest(tmp_path)


### PR DESCRIPTION
## Summary
Tightens the issue #3079 Package B readiness preflight so the executable example command must stay aligned with the manifest sampler set and base input metadata. This is a bounded fail-closed checker update only; it does not run or interpret the Package B benchmark campaign.

## Linked Issues
- Relates to `#3079`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: `NA`

## What Changed
- Added static extraction for repeatable argparse-style option values in `adversarial_package_b_preflight`.
- Added fail-closed checks that `example_command` `--sampler`, `--scenario-template`, `--search-space`, `--policy`, and `--objective` values are absent/defaulted or exactly match the manifest metadata.
- Added synthetic tests for sampler narrowing and base-config command drift.

## Why Matters
- Added value: prevents a Package B manifest from looking ready while its executable example silently runs a different sampler or input configuration.
- Expected impact: stronger readiness/provenance gating before any budget-matched adversarial falsification campaign is launched.
- Why worth merging now: issue #3079 has accumulated preflight slices; this closes another reversible command/manifest parity gap without consuming benchmark or Slurm resources.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: readiness/provenance blocker for Package B command/manifest parity under issue #3079.
- Comparator or baseline, applicable: NA - support checker only.
- Evidence tier: NA - support checker only
- Result classification: NA - no research result
- Decision stop rule, applicable: preflight must fail closed on command sampler/input drift and the checked-in manifest must still pass without executing the campaign.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3079 remains open for the full campaign run and interpretation.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper; no research result interpretation.

## Domain-Aware Approval
- Required PR: yes
- Domains reviewed: evidence classification, benchmark readiness, claim boundary
- Status: approved
- Approver/review source waiver: support-checker self-review; no benchmark result or paper-facing claim is promoted.
- Validity checklist:
- Target claim/hypothesis: Package B command metadata parity only.
- Comparator or split/evidence validity: targeted preflight proof only; no campaign comparator executed.
- Fallback/degraded exclusions: preserved as manifest/reporting preflight metadata only.
- Claim boundary: not paper-facing benchmark evidence.
- Implementation integrity vs experimental validity: implementation checked locally; experimental validity remains future #3079 campaign work.
## Falsification / Non-Transfer Check
- Did mechanism activate? NA - support checker only.
- Did intervention change command source, selected command, trajectory, route progress? no benchmark execution.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: continue remaining Package B campaign work under #3079.

## Next Empirical Action
- Rerun needed: yes - full Package B campaign remains out of scope for this PR.
- Extractor analysis tool needed: NA
- Artifact missing unavailable: none for this readiness slice.
- Stop / revise / continue decision: continue under #3079 after review.
- Proposed child issue existing follow-up: #3079 remains the parent for campaign execution, certified/replayable failure counting, held-out-family yield reporting, and interpretation.

## Validation / Proof
- `uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py` - passed, 26 tests.
- `uv run python scripts/tools/preflight_adversarial_package_b.py --manifest configs/adversarial/issue_3079_package_b_budget_matched.yaml --repo-root . --output output/validation/issue_3079_package_b_preflight.json` - passed, `blocked: false`.
- `uv run ruff check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` - passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed as interim dirty-tree readiness before commit, 1679 passed, 2 skipped.
- `CUDA_VISIBLE_DEVICES= PR_READY_PR_BODY_FILE=$PWD/output/validation/pr_ready/issue_3079_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed, clean-tree final readiness stamp for `ae3ac87b`.

## Performance Evidence
- Baseline runtime: NA - no performance claim.
- Changed runtime: NA - no performance claim.
- Representative command: `uv run pytest tests/benchmark/test_adversarial_package_b_preflight.py`
- Hot-path call count profile anchor: NA - no performance claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: preflight no longer fails closed when the example command drifts from manifest samplers or base input metadata.

## Risks / Rollout
- Compatibility risks: low; the new checks accept omitted command options when runner defaults match the manifest.
- Failure modes: future explicit command overrides must match manifest metadata or the readiness checker blocks.
- Rollback fallback plan: revert this checker/test commit if it blocks a valid Package B command shape.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3079 and prior Package B preflight slices.
- Any assumptions need to preserved: omitted example-command options intentionally rely on current runner defaults that match the manifest.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - comment authorization is false.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this is a bounded readiness/preflight checker slice; the full benchmark campaign, Slurm/GPU submission, falsification-yield interpretation, and paper/dissertation claim edits are explicitly out of scope.

## Follow-Up Issues
- Deferred work: full budget-matched Package B adversarial comparison run; certified/replayable valid failure counting; held-out-family yield, replay success, first-failure, best-objective, invalid-rate reporting; interpretation with narrow-archive caveat.
- Issues opened follow-up: none; #3079 remains open.

## Reviewer Notes
- Anything reviewer verify closely: command/manifest parity checks intentionally accept absent `--sampler` and base-config options because the runner defaults currently match the manifest.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
