### PR TITLE
Issue #3699: cover SNQI normalization inventory preflight

### DIFF
--- a/tests/benchmark/test_snqi_normalization_inventory_report.py
+++ b/tests/benchmark/test_snqi_normalization_inventory_report.py
@@ -1,0 +1,89 @@
+"""Tests for the standalone SNQI normalization inventory report."""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import subprocess
+import sys
+
+from robot_sf.benchmark.snqi.compute import compute_snqi
+
+REPO_ROOT = pathlib.Path(__file__).parents[2]
+
+
+_BASELINE_STATS = {
+    "collisions": {"med": 1.0, "p95": 5.0},
+    "near_misses": {"med": 2.0, "p95": 8.0},
+    "force_exceed_events": {"med": 0.0, "p95": 4.0},
+    "jerk_mean": {"med": 0.1, "p95": 1.0},
+}
+
+_WEIGHTS = {
+    "w_success": 1.0,
+    "w_time": 0.8,
+    "w_collisions": 2.0,
+    "w_near": 1.0,
+    "w_comfort": 0.5,
+    "w_force_exceed": 1.5,
+    "w_jerk": 0.3,
+}
+
+_METRICS = {
+    "success": 1.0,
+    "time_to_goal_norm": 1.25,
+    "collisions": 3.0,
+    "near_misses": 4.0,
+    "comfort_exposure": 7.0,
+    "force_exceed_events": 2.0,
+    "jerk_mean": 0.7,
+}
+
+
+def test_standalone_report_fails_closed_without_changing_snqi(tmp_path) -> None:
+    """The issue #3699 report surfaces mixed inputs but never mutates scoring."""
+
+    baseline_path = tmp_path / "baseline_stats.json"
+    json_out = tmp_path / "inventory.json"
+    baseline_path.write_text(json.dumps(_BASELINE_STATS), encoding="utf-8")
+
+    before = compute_snqi(_METRICS, _WEIGHTS, _BASELINE_STATS)
+    result = subprocess.run(
+        [
+            sys.executable,
+            str(REPO_ROOT / "scripts/benchmark/snqi_normalization_inventory_report.py"),
+            "--baseline-stats",
+            str(baseline_path),
+            "--json-out",
+            str(json_out),
+            "--fail-on-mixed-scale",
+            "--fail-on-missing-baseline",
+        ],
+        cwd=REPO_ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    after = compute_snqi(_METRICS, _WEIGHTS, _BASELINE_STATS)
+
+    assert result.returncode == 1
+    assert "FAIL: SNQI penalty terms mix raw" in result.stderr
+    assert after == before
+
+    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    inventory = payload["inventory"]
+    assert inventory["mixed_scale"] is True
+    assert inventory["is_consistent"] is False
+    assert inventory["raw_penalty_terms"] == ["time", "comfort"]
+    assert inventory["normalized_penalty_terms"] == [
+        "collisions",
+        "near",
+        "force_exceed",
+        "jerk",
+    ]
+    assert inventory["missing_baseline_coverage"] == []
+
+    status_by_term = {term["term"]: term["normalization_status"] for term in inventory["terms"]}
+    assert status_by_term["time"] == "raw_unbounded"
+    assert status_by_term["comfort"] == "raw_unbounded"
+    assert status_by_term["collisions"] == "baseline_normalized_bounded"


### PR DESCRIPTION
## Summary
Adds a focused regression test for the standalone SNQI normalization inventory preflight from issue #3699. The test exercises the real CLI entry point, verifies it fails closed on mixed raw/baseline-normalized penalty terms, checks the JSON term-status payload, and confirms `compute_snqi()` remains byte-identical before and after the preflight run.

## Linked Issues
- Relates to #3699

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Safe review independently: yes

## What Changed
- Added `tests/benchmark/test_snqi_normalization_inventory_report.py`.
- The test runs `scripts/benchmark/snqi_normalization_inventory_report.py` with synthetic baseline stats and `--fail-on-mixed-scale`.
- The test asserts the report lists raw unbounded `time` and `comfort` terms, baseline-normalized bounded count-style terms, no missing baseline coverage for the fixture, and unchanged SNQI scoring output.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3699 diagnostic inventory/preflight coverage for mixed SNQI term normalization bases.
- Comparator or baseline, applicable: current `compute_snqi()` output on a synthetic fixture before and after the report CLI.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Parent issue, claim map, registry, context note, synthesis surface update: #3699.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - test-only coverage of an existing diagnostic CLI.

## Domain-Aware Approval
- Approver/review source waiver: not required for this PR because it does not change metric semantics, benchmark interpretation, scoring behavior, or paper-facing claims.
- Fallback/degraded exclusions: no benchmark campaign or planner execution is performed.
- Claim boundary: diagnostic-only coverage that the existing preflight surfaces mixed normalization inputs fail-closed.

## Validation / Proof
- `uv run pytest tests/benchmark/test_snqi_normalization_inventory_report.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py -q` -> passed, 16 tests.
- `uv run ruff check tests/benchmark/test_snqi_normalization_inventory_report.py` -> passed.
- `uv run python scripts/benchmark/snqi_normalization_inventory_report.py --json-out output/validation/issue_3699/snqi_normalization_inventory.json --fail-on-mixed-scale; code=$?; echo EXIT_CODE:$code` -> expected fail-closed `EXIT_CODE:1`, with `time` and `comfort` reported as raw penalty terms.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: none expected; test-only change.
- Failure modes: if the standalone report stops failing closed or its JSON payload stops listing the mixed basis, this regression test will fail.
- Rollback fallback plan: revert the test-only commit.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3699 and existing SNQI normalization inventory/governance preflight implementation.
- Any assumptions need to preserved: current issue direction is inventory/preflight only; normalization redesign remains decision-required and out of scope.

## Downstream Propagation
- Parent issue updated: no, per task authorization.
- Claim map / benchmark report updated: NA.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened deferred propagation: no.
- Not applicable because: this is test-only diagnostic coverage and does not establish or revise benchmark evidence.

## Follow-Up Issues
- Deferred work: maintainer decision on normalize-vs-bound SNQI raw terms remains on #3699.
- Issues opened follow-up: none.

## Reviewer Notes
- Please verify this remains a test-only proof slice and does not imply #3699's scoring-design decision is resolved.
