### PR TITLE
Issue #3798: fail closed on stale S20/S30 packet metadata

### DIFF
--- a/scripts/validation/extract_s20_s30_evidence_gap_packet.py
+++ b/scripts/validation/extract_s20_s30_evidence_gap_packet.py
@@ -130,7 +130,33 @@ def load_packet_fixture(packet_fixture: Path) -> dict[str, Any]:
         raise ValueError(f"{packet_fixture} claim_promotion must remain no_go")
     if go_no_go.get("s30_submission_from_issue_3798") != "not_authorized_here":
         raise ValueError(f"{packet_fixture} must not authorize S30 submission from issue #3798")
+    _validate_packet_freshness(packet_fixture, packet)
     return packet
+
+
+def _validate_packet_freshness(packet_fixture: Path, packet: dict[str, Any]) -> None:
+    """Fail closed when tracked packet metadata no longer supports its own summary."""
+
+    coverage = packet.get("coverage_snapshot", {})
+    planners = coverage.get("planners", [])
+    if coverage.get("planner_count") != len(planners):
+        raise ValueError(f"{packet_fixture} planner_count must match listed planners")
+    if coverage.get("seed_count") != len(coverage.get("seeds", [])):
+        raise ValueError(f"{packet_fixture} seed_count must match listed seeds")
+
+    required_review_paths = set(PROMOTABLE_REVIEW_FILES)
+    observed_review_paths = {item.get("path") for item in packet.get("promotable_review_files", [])}
+    missing_review_paths = sorted(required_review_paths - observed_review_paths)
+    if missing_review_paths:
+        raise ValueError(
+            f"{packet_fixture} missing promotable review files: {missing_review_paths}"
+        )
+
+    for item in packet.get("promotable_review_files", []):
+        if not item.get("sha256"):
+            raise ValueError(f"{packet_fixture} promotable review file missing sha256")
+        if "not a claim upgrade" not in item.get("promotion_scope", ""):
+            raise ValueError(f"{packet_fixture} promotable review file promoted a claim")
 
 
 def render_markdown(packet: dict[str, Any]) -> str:

--- a/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
+++ b/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
@@ -198,3 +198,35 @@ def test_tracked_packet_rejects_issue_3798_s30_submit_authorization(tmp_path: Pa
         assert "must not authorize S30 submission" in str(exc)
     else:
         raise AssertionError("S30 authorization drift should fail closed")
+
+
+def test_tracked_packet_rejects_stale_planner_count(tmp_path: Path) -> None:
+    """Tracked packet fixture must fail closed if summary counts drift."""
+
+    packet = extractor.load_packet_fixture(extractor.DEFAULT_PACKET_FIXTURE)
+    packet["coverage_snapshot"]["planner_count"] += 1
+    fixture = tmp_path / "stale-planner-count.json"
+    fixture.write_text(json.dumps(packet), encoding="utf-8")
+
+    try:
+        extractor.load_packet_fixture(fixture)
+    except ValueError as exc:
+        assert "planner_count must match listed planners" in str(exc)
+    else:
+        raise AssertionError("stale planner count should fail closed")
+
+
+def test_tracked_packet_rejects_claim_promoting_review_file(tmp_path: Path) -> None:
+    """Promotable review files stay diagnostic and checksum-backed."""
+
+    packet = extractor.load_packet_fixture(extractor.DEFAULT_PACKET_FIXTURE)
+    packet["promotable_review_files"][0]["promotion_scope"] = "paper claim upgrade"
+    fixture = tmp_path / "claim-promoting-review-file.json"
+    fixture.write_text(json.dumps(packet), encoding="utf-8")
+
+    try:
+        extractor.load_packet_fixture(fixture)
+    except ValueError as exc:
+        assert "promotable review file promoted a claim" in str(exc)
+    else:
+        raise AssertionError("claim-promoting review file should fail closed")


### PR DESCRIPTION
## Summary
Adds fail-closed freshness invariants for the tracked post-13175 S20/S30 evidence-gap packet so the public fixture cannot drift from its own planner/seed counts or promote review files beyond diagnostic scope.

## Linked Issues
- Relates to #3798

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- `load_packet_fixture()` now rejects internally stale tracked packet metadata: planner count vs listed planners, seed count vs listed seeds, missing promotable review files, missing checksums, or review-file scopes that imply claim promotion.
- Added focused fixture tests for stale planner counts and claim-promoting review-file scope.

## Why Matters
- Added value: keeps the compact public job 13175 packet self-checking without requiring ignored raw output artifacts.
- Expected impact: stale or over-claiming packet edits fail closed during the dry-run/fixture validation path.
- Why worth merging now: issue #3798 is specifically about a bounded evidence-gap packet and validation commands that prove it stays current without promoting paper/dissertation claims.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3798 diagnostic evidence-gap packet freshness; no research claim promotion.
- Comparator or baseline, applicable: current tracked fixture loader accepted schema-safe but internally stale count/scope drift.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only
- Decision stop rule, applicable: tracked fixture must remain diagnostic-only and internally consistent, otherwise fail closed.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3798; existing packet files under `docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.*`.
- New research/benchmark/metric/paper-facing analysis tool, any: no new tool; this tightens the existing issue #3798 packet checker.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: diagnostic-only guard; no benchmark interpretation or paper-facing claim changes.
- Validity checklist: no fallback/degraded benchmark success claimed; archive-readiness remains fail-closed.
- Target claim/hypothesis: NA, no promoted research claim.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: archive-readiness checker remains blocked when canonical result-store artifacts are missing.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation only enforces tracked packet consistency.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: canonical result-store artifacts remain missing; archive-readiness checker reports blocked.
- Stop / revise / continue decision: continue with review of this fail-closed packet guard only.
- Proposed child issue existing follow-up: NA

## Validation / Proof
- `uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py` - passed, 8 tests.
- `uv run ruff check scripts/validation/extract_s20_s30_evidence_gap_packet.py tests/validation/test_extract_s20_s30_evidence_gap_packet.py` - passed.
- `uv run ruff format --check scripts/validation/extract_s20_s30_evidence_gap_packet.py tests/validation/test_extract_s20_s30_evidence_gap_packet.py` - passed, 2 files already formatted.
- `uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --packet-fixture docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json --markdown >/tmp/issue3798_packet_final.md` - passed; printed the diagnostic-only packet without submitting Slurm or editing claims.
- `uv run python scripts/validation/check_s20_s30_archive_readiness.py --json` - expected fail-closed `exit_code=1`; reports missing canonical result-store files and blocks claim promotion.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; 1679 passed, 2 skipped; freshness stamp `output/validation/pr_ready/issue-3798-evidence-gap-packet-fresh.json` for head `6f8d64a4de85082f197395802b96dfe0e7918dea`.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` - passed; fresh clean tree for head `6f8d64a4de85082f197395802b96dfe0e7918dea`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## UI / Screenshots
NA, no UI changes.

## Performance Evidence
NA, no performance claim.

## Risks / Rollout
- Compatibility risks: low; only the existing tracked packet fixture loader gets stricter.
- Failure modes: future legitimate packet schema changes may need to update freshness invariants and tests together.
- Rollback fallback plan: revert the single commit to restore the prior schema-only fixture load behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3798 and existing packet fixture under `docs/context/evidence/`.
- Any assumptions need to preserved: issue #3798 is not authorization for S30 submission or claim promotion.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized for this task.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): no.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): NA, no new packet document.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR tightens an existing diagnostic packet checker and does not change benchmark results, registry entries, claim maps, or paper-facing surfaces.

## Follow-Up Issues
- Deferred work: canonical result-store artifacts remain missing; archive-readiness checker correctly blocks claim promotion.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the stricter loader still accepts the tracked fixture and rejects stale/over-claiming mutations.
- Known limitation: this does not rehydrate or promote ignored job 13175 artifacts; it only guards the tracked public packet.
