### PR TITLE
Issue #3213: tighten maneuver-authority sweep manifest checker

### DIFF
--- a/robot_sf/benchmark/maneuver_authority_sweep_manifest.py
+++ b/robot_sf/benchmark/maneuver_authority_sweep_manifest.py
@@ -22,6 +22,7 @@ _REQUIRED_ARM_METADATA = (
 _REQUIRED_ADAPTER_FIELDS = ("command_space", "robot_kinematics", "execution_mode")
 _REQUIRED_OUTPUT_FIELDS = ("campaign_root", "campaign_summary", "campaign_report")
 _MALFORMED_CODES = {
+    "algo_config_mismatch",
     "duplicate_arm_name",
     "invalid_action_lattice_metadata",
     "invalid_arm",
@@ -116,19 +117,19 @@ def _validate_repo_path(
     return relative
 
 
-def _grid_variant_names(repo_root: Path, grid_path: str | None) -> set[str]:
-    """Return declared grid variant names, or an empty set when unavailable."""
+def _grid_variants_by_name(repo_root: Path, grid_path: str | None) -> dict[str, dict[str, Any]]:
+    """Return declared grid variants keyed by name, or an empty mapping when unavailable."""
     if grid_path is None:
-        return set()
+        return {}
     path = repo_root / grid_path
     if not path.exists():
-        return set()
+        return {}
     payload = _load_yaml(path)
     variants = payload.get("variants", []) if isinstance(payload, dict) else []
     return {
-        str(variant.get("name"))
+        str(variant["name"]): variant
         for variant in variants
-        if isinstance(variant, dict) and variant.get("name")
+        if isinstance(variant, dict) and isinstance(variant.get("name"), str) and variant["name"]
     }
 
 
@@ -265,11 +266,11 @@ def _validate_shared_paths(
     payload: dict[str, Any],
     repo_root: Path,
     diagnostics: list[dict[str, Any]],
-) -> set[str]:
+) -> dict[str, dict[str, Any]]:
     """Validate shared manifest paths.
 
     Returns:
-        Known variant names from the referenced benchmark grid, or an empty set.
+        Known variants from the referenced benchmark grid keyed by name, or an empty mapping.
     """
     grid_path = _validate_repo_path(
         repo_root=repo_root,
@@ -285,7 +286,7 @@ def _validate_shared_paths(
         code="missing_hard_seed_manifest",
         diagnostics=diagnostics,
     )
-    return _grid_variant_names(repo_root, grid_path)
+    return _grid_variants_by_name(repo_root, grid_path)
 
 
 def _validate_arm_identity(
@@ -313,7 +314,7 @@ def _validate_grid_variant(
     *,
     arm: dict[str, Any],
     arm_name: str,
-    grid_variants: set[str],
+    grid_variants: dict[str, dict[str, Any]],
     diagnostics: list[dict[str, Any]],
 ) -> Any:
     """Validate the declared grid variant.
@@ -329,6 +330,31 @@ def _validate_grid_variant(
             _diagnostic("unknown_grid_variant", arm=arm_name, grid_variant=grid_variant)
         )
     return grid_variant
+
+
+def _validate_grid_variant_config(
+    *,
+    arm: dict[str, Any],
+    arm_name: str,
+    grid_variant: Any,
+    grid_variants: dict[str, dict[str, Any]],
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Validate that manifest arm config matches the referenced benchmark-grid variant."""
+    if not isinstance(grid_variant, str) or grid_variant not in grid_variants:
+        return
+    grid_algo_config = grid_variants[grid_variant].get("algo_config")
+    arm_algo_config = arm.get("algo_config")
+    if isinstance(grid_algo_config, str) and arm_algo_config != grid_algo_config:
+        diagnostics.append(
+            _diagnostic(
+                "algo_config_mismatch",
+                arm=arm_name,
+                grid_variant=grid_variant,
+                expected=grid_algo_config,
+                actual=arm_algo_config,
+            )
+        )
 
 
 def _report_arm(arm: dict[str, Any], arm_name: str, grid_variant: Any) -> dict[str, Any]:
@@ -347,7 +373,7 @@ def _report_arm(arm: dict[str, Any], arm_name: str, grid_variant: Any) -> dict[s
 def _validate_arms(
     payload: dict[str, Any],
     repo_root: Path,
-    grid_variants: set[str],
+    grid_variants: dict[str, dict[str, Any]],
     diagnostics: list[dict[str, Any]],
 ) -> list[dict[str, Any]]:
     """Validate all sweep arms.
@@ -373,7 +399,7 @@ def _validate_arms(
         )
         if arm_name is None:
             continue
-        _validate_repo_path(
+        algo_config = _validate_repo_path(
             repo_root=repo_root,
             path_value=arm.get("algo_config"),
             field="algo_config",
@@ -387,6 +413,14 @@ def _validate_arms(
             grid_variants=grid_variants,
             diagnostics=diagnostics,
         )
+        if algo_config is not None and (repo_root / algo_config).exists():
+            _validate_grid_variant_config(
+                arm=arm,
+                arm_name=arm_name,
+                grid_variant=grid_variant,
+                grid_variants=grid_variants,
+                diagnostics=diagnostics,
+            )
         _validate_arm_metadata(arm, arm_name, diagnostics)
         report_arms.append(_report_arm(arm, arm_name, grid_variant))
     return report_arms

--- a/tests/benchmark/test_maneuver_authority_sweep_manifest.py
+++ b/tests/benchmark/test_maneuver_authority_sweep_manifest.py
@@ -67,6 +67,48 @@ def test_missing_arm_config_fails_closed_with_path_diagnostic(tmp_path: Path) ->
     assert report["diagnostics"][0]["path"] == "configs/algos/hardcase_authority/absent.yaml"
 
 
+def test_missing_benchmark_grid_fails_closed_without_config_mismatch(tmp_path: Path) -> None:
+    """Unavailable grid inputs should remain ordinary missing inputs, not arm drift."""
+    repo_root = Path.cwd()
+    payload = _load_manifest(repo_root)
+    payload["benchmark_grid"] = "configs/benchmarks/absent_authority_grid.yaml"
+    manifest = _write_manifest(tmp_path, payload)
+
+    report = check_maneuver_authority_sweep_manifest(manifest, repo_root=repo_root)
+
+    assert report["status"] == MANIFEST_STATUS_MISSING
+    assert {
+        "code": "missing_benchmark_grid",
+        "field": "benchmark_grid",
+        "path": "configs/benchmarks/absent_authority_grid.yaml",
+        "arm": None,
+    } in report["diagnostics"]
+    assert not any(
+        diagnostic["code"] == "algo_config_mismatch" for diagnostic in report["diagnostics"]
+    )
+
+
+def test_arm_config_must_match_referenced_grid_variant(tmp_path: Path) -> None:
+    """Sweep arm metadata should fail closed when it drifts from the benchmark grid."""
+    repo_root = Path.cwd()
+    payload = _load_manifest(repo_root)
+    payload["arms"][1]["algo_config"] = payload["arms"][0]["algo_config"]
+    manifest = _write_manifest(tmp_path, payload)
+
+    report = check_maneuver_authority_sweep_manifest(manifest, repo_root=repo_root)
+
+    assert report["status"] == MANIFEST_STATUS_MALFORMED
+    assert {
+        "arm": "high_angular",
+        "code": "algo_config_mismatch",
+        "grid_variant": "high_angular",
+        "expected": (
+            "configs/algos/hardcase_authority/prediction_planner_authority_high_angular.yaml"
+        ),
+        "actual": ("configs/algos/hardcase_authority/prediction_planner_authority_baseline.yaml"),
+    } in report["diagnostics"]
+
+
 def test_malformed_arm_metadata_fails_closed(tmp_path: Path) -> None:
     """Sweep arms without action/turn/adapter metadata should fail closed."""
     repo_root = Path.cwd()


### PR DESCRIPTION
## Summary
Tightens the issue #3213 maneuver-authority sweep manifest checker so each declared sweep arm must match the `algo_config` for its referenced benchmark-grid variant.

## Linked Issues
- Relates to `#3213`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Load the referenced benchmark grid as a variant map instead of only a name set.
- Add fail-closed `algo_config_mismatch` diagnostics when a manifest arm drifts from the referenced grid variant.
- Add a fixture test for grid/arm config mismatch while preserving existing missing-config and malformed-metadata behavior.

## Why Matters
- Added value: prevents a preflight manifest from silently pairing one authority arm name with another arm's config.
- Expected impact: stronger metadata-only validation before any hard-case maneuver-authority sweep is launched.
- Why worth merging now: low-risk checker hardening for the issue #3213 manifest slice.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support checker only.
- Comparator or baseline, applicable: NA
- Evidence tier: NA - support checker only
- Result classification: NA - support checker only
- Decision stop rule, applicable: NA
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3213 only; no claim-map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - this tightens an existing manifest checker and does not interpret results.

## Domain-Aware Approval
- Approver/review source waiver: not required
- Validity checklist: NA - no benchmark result or paper-facing claim.
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: no fallback/degraded execution is run or promoted.
- Claim boundary: metadata-only preflight; not benchmark evidence.
- Implementation integrity vs experimental validity: targeted tests cover the checker contract.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - checker-only change.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA
- Extractor analysis tool needed: no
- Artifact missing unavailable: NA
- Stop / revise / continue decision: NA
- Proposed child issue existing follow-up: NA

## Validation / Proof
- `uv run python -m pytest tests/benchmark/test_maneuver_authority_sweep_manifest.py tests/validation/test_maneuver_authority_sweep_manifest.py -q` - passed
- `uv run ruff check robot_sf/benchmark/maneuver_authority_sweep_manifest.py tests/benchmark/test_maneuver_authority_sweep_manifest.py` - passed
- `uv run ruff format --check robot_sf/benchmark/maneuver_authority_sweep_manifest.py tests/benchmark/test_maneuver_authority_sweep_manifest.py` - passed
- `uv run python scripts/tools/check_maneuver_authority_sweep_manifest.py --repo-root .` - passed

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Hot-Path
- Baseline runtime: NA - checker-only metadata validation.
- Changed runtime: NA - checker-only metadata validation.
- Representative command: `uv run python scripts/tools/check_maneuver_authority_sweep_manifest.py --repo-root .`
- Hot-path call count profile anchor: NA - not runtime benchmark code.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: canonical issue #3213 manifest fails readiness or mismatch diagnostics misclassify missing inputs.

## Risks / Rollout
- Compatibility risks: low; new malformed diagnostic only applies when an existing arm config disagrees with the referenced grid variant.
- Failure modes: stale manifests with copied arm configs now fail closed.
- Rollback fallback plan: revert the checker/test commit.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: issue #3213 and existing manifest/checker files.
- Any assumptions need to preserved: this PR assumes the benchmark grid remains the source of truth for arm-to-config mapping.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: metadata-only checker hardening; no new benchmark evidence or promoted configuration.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes
- Verify that missing ordinary inputs remain `missing`, while existing but mismatched arm configs become `malformed`.
- Known limitations: does not validate generated output existence and does not run the sweep.
