### PR TITLE
Issue #3215: tighten predictive tournament readiness report

### DIFF
--- a/scripts/tools/predictive_tournament_readiness.py
+++ b/scripts/tools/predictive_tournament_readiness.py
@@ -32,6 +32,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 # config builder, and the portfolio scenario set used as the map-runner gate.
 SHARED_PROTOCOL_PATHS: tuple[Path, ...] = (
     Path("configs/benchmarks/predictive_hard_seeds_v1.yaml"),
+    Path("configs/benchmarks/predictive_sweep_planner_grid_v1.yaml"),
     Path("scripts/validation/run_predictive_success_campaign.py"),
     Path("scripts/tools/campaign_result_store.py"),
     Path("robot_sf/benchmark/predictive_planner_config.py"),
@@ -76,6 +77,7 @@ ARMS: tuple[ArmSpec, ...] = (
         ),
         required_paths=(
             Path("scripts/research/analyze_predictive_checkpoint_proxy.py"),
+            Path("configs/research/predictive_checkpoint_proxy_v1.yaml"),
             Path("configs/benchmarks/predictive_hard_seeds_v1.yaml"),
         ),
         expected_output_path=Path("output/tmp/predictive_planner/campaigns/tournament_selection"),
@@ -105,6 +107,7 @@ ARMS: tuple[ArmSpec, ...] = (
             "under the shared protocol."
         ),
         required_paths=(
+            Path("configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml"),
             Path(
                 "configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml"
             ),
@@ -221,6 +224,11 @@ def _component_to_dict(component: ComponentReadiness) -> dict:
         "display_name": component.display_name,
         "status": component.status,
         "paths": [{"path": p.path, "exists": p.exists} for p in component.paths],
+        "expected_configs": [p.path for p in component.paths if p.path.startswith("configs/")],
+        "blockers": [
+            {"path": path, "reason": "required prerequisite path is missing"}
+            for path in component.missing_paths
+        ],
         "missing_paths": component.missing_paths,
         "description": component.description,
     }
@@ -228,6 +236,7 @@ def _component_to_dict(component: ComponentReadiness) -> dict:
         payload["child_issue"] = component.child_issue
     if component.expected_output_path is not None:
         payload["expected_output_path"] = component.expected_output_path
+        payload["expected_output_paths"] = [component.expected_output_path]
     if component.notes:
         payload["notes"] = component.notes
     return payload

--- a/tests/test_predictive_tournament_readiness.py
+++ b/tests/test_predictive_tournament_readiness.py
@@ -79,6 +79,27 @@ def test_missing_arm_path_reports_blocked_with_blockers(tmp_path: Path) -> None:
     assert report["prerequisites_status"] == "blocked"
     assert model["status"] == "blocked"
     assert missing.as_posix() in model["missing_paths"]
+    assert model["blockers"] == [
+        {"path": missing.as_posix(), "reason": "required prerequisite path is missing"}
+    ]
+
+
+def test_report_surfaces_expected_configs_and_output_paths(tmp_path: Path) -> None:
+    """Machine-readable report names per-arm configs and expected output paths."""
+    _stage_all_prerequisites(tmp_path)
+
+    report = evaluate_readiness(tmp_path)
+    shared = report["shared_protocol"]
+    selection = next(arm for arm in report["arms"] if arm["id"] == "selection")
+    model = next(arm for arm in report["arms"] if arm["id"] == "model")
+
+    assert "configs/benchmarks/predictive_sweep_planner_grid_v1.yaml" in shared["expected_configs"]
+    assert "configs/research/predictive_checkpoint_proxy_v1.yaml" in selection["expected_configs"]
+    assert (
+        "configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml"
+        in model["expected_configs"]
+    )
+    assert selection["expected_output_paths"] == [selection["expected_output_path"]]
 
 
 def test_missing_shared_protocol_blocks_overall(tmp_path: Path) -> None:
@@ -127,7 +148,8 @@ def test_model_arm_uses_frozen_weighted_training_config() -> None:
     model = next(arm for arm in ARMS if arm.arm_id == "model")
 
     assert [path.as_posix() for path in model.required_paths] == [
-        "configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml"
+        "configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml",
+        "configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml",
     ]
     assert model.child_issue == 3214
     assert "#3254" in model.notes


### PR DESCRIPTION
## Summary

Relates to #3215.

Adds a narrow, CPU-only readiness-report refinement for the predictive hard-case tournament helper. The report now surfaces explicit expected config paths, expected output path lists, and structured blockers for the selection, authority, and model arms while preserving the existing fail-closed behavior.

## Scope

- Extends `scripts/tools/predictive_tournament_readiness.py` to include shared planner-grid, selection proxy, and model readiness packet prerequisites.
- Adds machine-readable `expected_configs`, `expected_output_paths`, and `blockers` fields to readiness components.
- Adds focused fixture coverage for ready/blocked/missing portfolio-arm status and the new report fields.

## Validation

- `uv run pytest tests/test_predictive_tournament_readiness.py -q` — passed, 14 tests.
- `uv run ruff check scripts/tools/predictive_tournament_readiness.py tests/test_predictive_tournament_readiness.py` — passed.
- `uv run python scripts/tools/predictive_tournament_readiness.py --json` — passed; local prerequisites ready, `run_authorized: false`.

## Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, no tournament ranking, and no paper/dissertation claim edits.

## Follow-Up Issues

No new follow-up issue opened. #3215 remains open for full tournament execution, Slurm/GPU submission, ranking, synthesis, or claim edits outside this readiness-checker slice.
