### PR TITLE
Issue #3425: require finalizer claim decision readiness

### DIFF
--- a/scripts/tools/reconcile_slurm_evidence.py
+++ b/scripts/tools/reconcile_slurm_evidence.py
@@ -184,6 +184,7 @@ class FinalizerReport:
     job_id: str
     classification: str
     artifact_status: str
+    claim_decision: str | None
     claim_boundary: str | None
     durable_pointer: str | None
     output_pointers: tuple[str, ...]
@@ -325,6 +326,15 @@ def _extract_claim_boundary(payload: dict[str, Any]) -> str | None:
     return None
 
 
+def _extract_claim_decision(payload: dict[str, Any]) -> str | None:
+    """Extract final claim-decision/disposition field if present."""
+    for key in ("claim_decision", "claim-decision", "decision", "disposition"):
+        value = payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return _normalize_status(value).replace(" ", "_")
+    return None
+
+
 def _extract_finalizer_durable_pointer(payload: dict[str, Any]) -> str | None:
     """Extract a durable pointer from finalization payload fields."""
     for key in FINALIZER_DURABLE_POINTER_KEYS:
@@ -419,6 +429,7 @@ def _load_finalizer_report(path: Path) -> list[FinalizerReport]:
             job_id=job_id,
             classification=_normalize_status(payload.get("classification")),
             artifact_status=_normalize_status(payload.get("artifact_status")),
+            claim_decision=_extract_claim_decision(payload),
             claim_boundary=_extract_claim_boundary(payload),
             durable_pointer=_extract_finalizer_durable_pointer(payload),
             output_pointers=_extract_finalizer_output_pointers(payload),
@@ -741,6 +752,7 @@ def _finalizer_rows_from_payloads(  # noqa: C901, PLR0912, PLR0915
                 "queue_id": queue_id,
                 "seeds": list(seeds),
                 "artifact_status": finalizer.artifact_status,
+                "claim_decision": finalizer.claim_decision,
                 "claim_boundary": finalizer.claim_boundary,
                 "durable_pointer": finalizer.durable_pointer,
                 "output_pointers": list(finalizer.output_pointers),

--- a/scripts/validation/preflight_slurm_finalizer.py
+++ b/scripts/validation/preflight_slurm_finalizer.py
@@ -34,6 +34,8 @@ What it checks (each maps to an acceptance criterion of #3425):
   required artifacts present before a durable pointer can unblock a claim.
 * ``claim_boundary_present`` — every finalizer carries a claim boundary so the
   downstream summary/claim decision stays inside an explicit boundary.
+* ``claim_decision_present`` — every finalizer records a bounded final decision
+  disposition: ``promote``, ``keep diagnostic``, ``block``, or ``stop``.
 * ``evidence_root_present`` — advisory: the compact evidence root exists so the
   reconciler can confirm preservation.
 
@@ -88,6 +90,7 @@ _DURABLE_POINTER_PREFIXES = (
     "gs://",
     "dvc://",
 )
+_ALLOWED_CLAIM_DECISIONS = {"promote", "keep_diagnostic", "block", "stop"}
 
 # The readiness gate makes no research claim; it only reports whether the inputs
 # for the vertical slice are present and provenance-complete.
@@ -546,6 +549,53 @@ def _check_claim_boundary(inputs: LoadedInputs) -> PreflightCheck:
     )
 
 
+def _check_claim_decision(inputs: LoadedInputs) -> PreflightCheck:
+    """Require every finalizer carry an explicit bounded claim decision."""
+    if not inputs.finalizers:
+        return PreflightCheck(
+            name="claim_decision_present",
+            status=_SKIPPED,
+            severity=_REQUIRED,
+            detail="no finalizer records to inspect",
+            remediation="resolve finalizer_manifests_present first",
+        )
+    missing = sorted(
+        finalizer.job_id for finalizer in inputs.finalizers if not finalizer.claim_decision
+    )
+    if missing:
+        return PreflightCheck(
+            name="claim_decision_present",
+            status=_BLOCKED,
+            severity=_REQUIRED,
+            detail=f"finalizer(s) missing claim decision: {', '.join(missing)}",
+            remediation=(
+                "record finalizer claim_decision as one of promote, keep diagnostic, "
+                "block, or stop before claim handoff"
+            ),
+        )
+    invalid = sorted(
+        f"{finalizer.job_id}({finalizer.claim_decision})"
+        for finalizer in inputs.finalizers
+        if finalizer.claim_decision not in _ALLOWED_CLAIM_DECISIONS
+    )
+    if invalid:
+        return PreflightCheck(
+            name="claim_decision_present",
+            status=_BLOCKED,
+            severity=_REQUIRED,
+            detail=f"finalizer(s) carry unsupported claim decision: {', '.join(invalid)}",
+            remediation=(
+                "use one bounded issue #3425 decision: promote, keep diagnostic, block, or stop"
+            ),
+        )
+    return PreflightCheck(
+        name="claim_decision_present",
+        status=_READY,
+        severity=_REQUIRED,
+        detail="every finalizer carries a bounded claim decision",
+    )
+
+
 def _check_evidence_root(evidence_root: Path | None) -> PreflightCheck:
     """Advisory: the compact evidence root should exist for preservation checks."""
     if evidence_root is None:
@@ -603,6 +653,7 @@ def preflight(
         _check_durable_pointer(inputs),
         _check_required_artifacts_complete(inputs),
         _check_claim_boundary(inputs),
+        _check_claim_decision(inputs),
         _check_evidence_root(evidence_root),
     ]
 

--- a/tests/tools/test_reconcile_slurm_evidence.py
+++ b/tests/tools/test_reconcile_slurm_evidence.py
@@ -464,6 +464,7 @@ def test_finalizer_manifest_bridge_captures_output_pointer_and_transition(tmp_pa
                 }
             ],
             "claim_boundary": "compact local",
+            "claim_decision": "keep diagnostic",
         },
     )
 
@@ -499,6 +500,7 @@ def test_finalizer_manifest_bridge_captures_output_pointer_and_transition(tmp_pa
     assert bridge_row["durable_pointer"] == "wandb-artifact://robot-sf/finalizer/job-901:latest"
     assert bridge_row["output_pointers"]
     assert bridge_row["artifact_status"] == "all_required_present"
+    assert bridge_row["claim_decision"] == "keep_diagnostic"
     assert bridge_row["source_path"] == str(finalizer)
 
 

--- a/tests/validation/test_preflight_slurm_finalizer.py
+++ b/tests/validation/test_preflight_slurm_finalizer.py
@@ -60,6 +60,7 @@ def _write_finalizer(
     artifact_status: str = "all_required_present",
     durable_uri: str | None = "wandb://entity/project/run",
     claim_boundary: str | None = "smoke evidence only",
+    claim_decision: str | None = "keep diagnostic",
 ) -> Path:
     """Write a finalizer manifest matching the finalization schema."""
     payload: dict = {
@@ -73,6 +74,8 @@ def _write_finalizer(
         payload["durable_uri"] = durable_uri
     if claim_boundary is not None:
         payload["claim_boundary"] = claim_boundary
+    if claim_decision is not None:
+        payload["claim_decision"] = claim_decision
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
 
@@ -108,6 +111,7 @@ def test_ready_when_all_inputs_present(tmp_path: Path) -> None:
     assert statuses["required_artifacts_complete"] == "ready"
     assert statuses["finalizer_manifest_linkage"] == "ready"
     assert statuses["claim_boundary_present"] == "ready"
+    assert statuses["claim_decision_present"] == "ready"
 
 
 def test_blocks_when_durable_pointer_missing(tmp_path: Path) -> None:
@@ -234,6 +238,30 @@ def test_blocks_when_claim_boundary_missing(tmp_path: Path) -> None:
     assert report["ready"] is False
     blocker_names = {blocker["check"] for blocker in report["blockers"]}
     assert "claim_boundary_present" in blocker_names
+
+
+def test_blocks_when_claim_decision_missing(tmp_path: Path) -> None:
+    """A finalizer without a bounded claim decision fails closed."""
+    inputs = _ready_inputs(tmp_path)
+    _write_finalizer(tmp_path / "finalizer.json", claim_decision=None)
+
+    report = gate.preflight(**inputs)
+
+    assert report["ready"] is False
+    blocker = next(b for b in report["blockers"] if b["check"] == "claim_decision_present")
+    assert "claim_decision" in blocker["remediation"]
+
+
+def test_blocks_when_claim_decision_unsupported(tmp_path: Path) -> None:
+    """A finalizer cannot invent dispositions outside the issue #3425 contract."""
+    inputs = _ready_inputs(tmp_path)
+    _write_finalizer(tmp_path / "finalizer.json", claim_decision="publish paper claim")
+
+    report = gate.preflight(**inputs)
+
+    assert report["ready"] is False
+    blocker = next(b for b in report["blockers"] if b["check"] == "claim_decision_present")
+    assert "unsupported claim decision" in blocker["detail"]
 
 
 def test_blocks_when_finalizer_manifest_absent(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds a bounded local readiness check for issue #3425 finalizer handoff inputs: finalizer manifests must now carry an explicit claim-decision disposition before the SLURM-to-claim slice can be marked ready.

## Linked Issues
- Relates #3425

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none opened
- Safe review independently: yes

## What Changed
- Preserves `claim_decision` from SLURM finalizer manifests in the canonical reconciler bridge output.
- Extends `scripts/validation/preflight_slurm_finalizer.py` with a required `claim_decision_present` check.
- Allows only the bounded issue #3425 dispositions: `promote`, `keep diagnostic`, `block`, or `stop`.
- Adds focused synthetic tests for missing and unsupported claim decisions plus bridge propagation.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3425 local finalizer-readiness blocker only.
- Comparator or baseline, applicable: existing preflight accepted complete artifacts without proving a bounded final claim-decision field.
- Evidence tier: targeted smoke / local preflight tests.
- Result classification: blocker-resolution support helper.
- Decision stop rule, applicable: preflight remains blocked until finalizer manifests include a bounded decision disposition.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3425; no claim map update because this PR does not promote evidence.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper; it gates metadata and makes no research claim.

## Domain-Aware Approval
- approval concerns experimental validity waived / pending / blocked / not required: not required
- Approver/review source waiver: support helper only; no benchmark interpretation or claim promotion.
- Validity checklist: NA
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: no fallback/degraded benchmark execution performed or counted.
- Claim boundary: readiness gate only; no SLURM submission, full benchmark campaign, or paper/dissertation claim edit.
- Implementation integrity vs experimental validity: implementation integrity covered by targeted tests and PR readiness gate.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, synthetic finalizer manifests without or with unsupported claim decisions now block.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? synthetic preflight tests cover the targeted metadata failure mode.
- Result route: continue #3425 only when real SLURM artifacts provide bounded finalizer decisions.
- Follow-up question issue weak, negative, non-transfer results: none opened.

## Next Empirical Action
- Rerun needed: no for this local checker slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: real SLURM finalizer evidence remains outside this PR.
- Stop / revise / continue decision: continue on SLURM-capable host after real finalizer manifests include bounded decision metadata.
- Proposed child issue existing follow-up: #3425 remains the parent handoff issue.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_preflight_slurm_finalizer.py -q` -> passed, 18 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_preflight_slurm_finalizer.py tests/tools/test_reconcile_slurm_evidence.py tests/tools/test_slurm_job_finalize.py -q` -> passed, 49 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/reconcile_slurm_evidence.py scripts/validation/preflight_slurm_finalizer.py tests/validation/test_preflight_slurm_finalizer.py tests/tools/test_reconcile_slurm_evidence.py tests/tools/test_slurm_job_finalize.py` -> passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed; 1679 passed, 2 skipped; freshness stamp `output/validation/pr_ready/issue-3425-finalizer-readiness-v3.json` for `1262d98d8d2d9d07f2372b9ef5f599b2d23d62da`.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> fresh, clean tree.

## Out Of Scope
No full benchmark campaign run, no SLURM/GPU submission, no paper/dissertation claim edits, no release artifact publication, and no claim promotion.

## Risks / Rollout
- Compatibility risks: existing finalizer manifests without `claim_decision` will now fail this readiness preflight until the decision metadata is added.
- Failure modes: callers may need to add `claim_decision`/`decision`/`disposition` metadata to finalizer manifests before local preflight reports ready.
- Rollback fallback plan: revert the preflight check and reconciler field propagation if the finalizer handoff contract chooses a different decision-packet owner.

## Docs / Provenance
- Updated docs: inline CLI/checker contract in `scripts/validation/preflight_slurm_finalizer.py`.
- Relevant design provenance notes: issue #3425 and existing `docs/context/issue_3425_slurm_to_claim_blocker.md`.
- Any assumptions need to preserved: finalizer manifests are the reversible owner for the bounded decision value in this local checker slice.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, per task authorization no issue comments.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a local readiness checker slice and does not produce benchmark evidence or public claim movement.

## Follow-Up Issues
- Deferred work: real SLURM-to-claim vertical slice execution and finalizer evidence remains outside this PR.
- Issues opened follow-up: none.

## Reviewer Notes
- Review closely whether finalizer manifests are the preferred home for `claim_decision`; this PR records that as the reversible implementation assumption for the smallest checker slice.
- Known limitation: actual `scripts/tools/slurm_job_finalize.py` output without extra decision metadata will be blocked by this readiness gate until the handoff packet supplies the decision field.
