### PR TITLE
Issue #3214: tighten predictive retrain launch preflight

### DIFF
--- a/configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml
+++ b/configs/training/predictive/predictive_retraining_readiness_issue_3214.yaml
@@ -15,6 +15,32 @@ inputs:
   pipeline_config: configs/training/predictive/predictive_crossing_conflict_weighted_issue_3254.yaml
   followup_issue: "#3254"
 
+data_prerequisites:
+  base_collection: pipeline_config.base_collection
+  hardcase_collection: pipeline_config.hardcase_collection
+  weighting_spec: inputs.weighting_spec
+  note: >-
+    Static public-repo preflight only. Dataset materialization remains out of scope until compute
+    submission is explicitly authorized.
+
+expected_checkpoint_lineage:
+  candidate_model_id: predictive_proxy_selected_v2_xl_ego
+  checkpoint_path: output/tmp/predictive_planner/pipeline/training/predictive_crossing_conflict_weighted_issue_3254_xl_ego/predictive_model.pt
+  checkpoint_provenance_path: output/tmp/predictive_planner/pipeline/training/predictive_crossing_conflict_weighted_issue_3254_xl_ego/checkpoint_provenance.json
+  registry_policy: promote only after checkpoint provenance and hard-seed evaluation evidence exist
+
+evaluation_config:
+  hard_seed_benchmark: configs/benchmarks/predictive_hard_seeds_v1.yaml
+  planner_grid: configs/benchmarks/predictive_sweep_planner_grid_v1.yaml
+  summary_path: output/tmp/predictive_planner/pipeline/evaluation/predictive_crossing_conflict_weighted_issue_3254_xl_ego_hard_seeds/summary.json
+  gate_note: keep trajectory validation metrics separate from closed-loop hard-seed benchmark gate
+
+output_roots:
+  pipeline_root: output/tmp/predictive_planner/pipeline
+  training_root: output/tmp/predictive_planner/pipeline/training
+  evaluation_root: output/tmp/predictive_planner/pipeline/evaluation
+  durable_policy: worktree-local output only until an explicit checkpoint promotion step
+
 prior_result:
   status: verified_negative
   evidence_status: diagnostic negative result only; not benchmark, leaderboard, or paper claim

--- a/robot_sf/training/predictive_retraining_readiness.py
+++ b/robot_sf/training/predictive_retraining_readiness.py
@@ -18,6 +18,26 @@ _REQUIRED_RERUN_ITEMS = {
     "checkpoint_provenance_plan",
     "hard_seed_evaluation_plan",
 }
+_REQUIRED_PACKET_SECTIONS = {
+    "data_prerequisites",
+    "expected_checkpoint_lineage",
+    "evaluation_config",
+    "output_roots",
+}
+_REQUIRED_PIPELINE_SCENARIOS = {
+    "scenario_matrix",
+    "hard_seed_manifest",
+    "planner_grid",
+}
+_REQUIRED_PIPELINE_COLLECTIONS = {
+    "base_collection",
+    "hardcase_collection",
+}
+_REQUIRED_PIPELINE_PROVENANCE = {
+    "checkpoint_path",
+    "checkpoint_provenance_path",
+    "hard_seed_evaluation_summary",
+}
 
 
 class PredictiveRetrainingReadinessError(ValueError):
@@ -123,6 +143,8 @@ def _validate_static_contract(
     inputs = _mapping(payload.get("inputs"))
     _require_existing_repo_path(inputs, "weighting_spec", packet_path, repo_root, blockers)
     _require_existing_repo_path(inputs, "pipeline_config", packet_path, repo_root, blockers)
+    _validate_launch_packet_sections(payload, blockers)
+    _validate_pipeline_config(inputs, packet_path, repo_root, blockers)
 
     prior_result = _mapping(payload.get("prior_result"))
     _require_non_empty_string(prior_result, "status", blockers, prefix="prior_result")
@@ -149,6 +171,152 @@ def _validate_required_rerun_items(launch_decision: dict[str, Any], blockers: li
         blockers.append(
             "launch_decision.required_before_rerun missing required items: " + ", ".join(missing)
         )
+
+
+def _validate_launch_packet_sections(payload: dict[str, Any], blockers: list[str]) -> None:
+    """Require the issue #3214 packet to name each launch-preflight concern explicitly."""
+
+    missing = sorted(section for section in _REQUIRED_PACKET_SECTIONS if section not in payload)
+    if missing:
+        blockers.append("readiness packet missing sections: " + ", ".join(missing))
+
+    data_prerequisites = _mapping(payload.get("data_prerequisites"))
+    for key in ("base_collection", "hardcase_collection", "weighting_spec"):
+        _require_non_empty_string(data_prerequisites, key, blockers, prefix="data_prerequisites")
+
+    checkpoint_lineage = _mapping(payload.get("expected_checkpoint_lineage"))
+    for key in ("candidate_model_id", "checkpoint_path", "checkpoint_provenance_path"):
+        _require_non_empty_string(
+            checkpoint_lineage,
+            key,
+            blockers,
+            prefix="expected_checkpoint_lineage",
+        )
+    for key in ("checkpoint_path", "checkpoint_provenance_path"):
+        _require_packet_output_path(
+            checkpoint_lineage, key, blockers, "expected_checkpoint_lineage"
+        )
+
+    evaluation_config = _mapping(payload.get("evaluation_config"))
+    for key in ("hard_seed_benchmark", "planner_grid", "summary_path"):
+        _require_non_empty_string(evaluation_config, key, blockers, prefix="evaluation_config")
+    for key in ("hard_seed_benchmark", "planner_grid"):
+        _require_packet_config_path(evaluation_config, key, blockers, "evaluation_config")
+    _require_packet_output_path(evaluation_config, "summary_path", blockers, "evaluation_config")
+
+    output_roots = _mapping(payload.get("output_roots"))
+    for key in ("pipeline_root", "training_root", "evaluation_root"):
+        _require_non_empty_string(output_roots, key, blockers, prefix="output_roots")
+        _require_packet_output_path(output_roots, key, blockers, "output_roots")
+
+
+def _validate_pipeline_config(
+    inputs: dict[str, Any],
+    packet_path: Path,
+    repo_root: Path,
+    blockers: list[str],
+) -> None:
+    """Validate the public predictive retraining pipeline config referenced by the packet."""
+
+    pipeline_value = inputs.get("pipeline_config")
+    if not isinstance(pipeline_value, str) or not pipeline_value.strip():
+        return
+    pipeline_path = _resolve_path(pipeline_value, repo_root, base=packet_path.parent)
+    if not pipeline_path.is_file():
+        return
+    pipeline = yaml.safe_load(pipeline_path.read_text(encoding="utf-8"))
+    if not isinstance(pipeline, dict):
+        blockers.append(f"inputs.pipeline_config must be mapping YAML: {pipeline_value}")
+        return
+
+    _validate_pipeline_output_contract(pipeline, blockers)
+    _validate_pipeline_scenario_paths(pipeline, pipeline_path, repo_root, blockers)
+
+    for key in _REQUIRED_PIPELINE_COLLECTIONS:
+        if not isinstance(pipeline.get(key), dict):
+            blockers.append(f"pipeline_config.{key} must be mapping")
+
+    training = _mapping(pipeline.get("training"))
+    _require_non_empty_string(training, "model_id", blockers, prefix="pipeline_config.training")
+
+    evaluation = _mapping(pipeline.get("evaluation"))
+    for key in ("horizon", "dt", "workers", "campaign_workers"):
+        if key not in evaluation:
+            blockers.append(f"pipeline_config.evaluation.{key} must be set")
+
+
+def _validate_pipeline_output_contract(
+    pipeline: dict[str, Any],
+    blockers: list[str],
+) -> None:
+    """Validate output root and expected-missing checkpoint provenance contract."""
+
+    output = _mapping(pipeline.get("output"))
+    root_value = output.get("root")
+    if not isinstance(root_value, str) or not root_value.strip():
+        blockers.append("pipeline_config.output.root must be non-empty path string")
+    elif not _is_repo_output_path(root_value):
+        blockers.append("pipeline_config.output.root must stay under output/")
+
+    provenance = _mapping(output.get("provenance") or pipeline.get("provenance"))
+    for key in _REQUIRED_PIPELINE_PROVENANCE:
+        value = provenance.get(key)
+        if not isinstance(value, str) or not value.strip():
+            blockers.append(
+                f"pipeline_config.output.provenance.{key} must be non-empty path string"
+            )
+        elif not _is_repo_output_path(value):
+            blockers.append(f"pipeline_config.output.provenance.{key} must stay under output/")
+    if provenance.get("status") != "expected_missing_until_training":
+        blockers.append(
+            "pipeline_config.output.provenance.status must be expected_missing_until_training"
+        )
+
+
+def _validate_pipeline_scenario_paths(
+    pipeline: dict[str, Any],
+    pipeline_path: Path,
+    repo_root: Path,
+    blockers: list[str],
+) -> None:
+    """Validate public scenario and benchmark config inputs used by the launch packet."""
+
+    scenarios = _mapping(pipeline.get("scenarios"))
+    for key in _REQUIRED_PIPELINE_SCENARIOS:
+        value = scenarios.get(key)
+        if not isinstance(value, str) or not value.strip():
+            blockers.append(f"pipeline_config.scenarios.{key} must be non-empty path string")
+            continue
+        resolved = _resolve_path(value, repo_root, base=pipeline_path.parent)
+        if not resolved.is_file():
+            blockers.append(f"pipeline_config.scenarios.{key} does not exist: {value}")
+
+
+def _is_repo_output_path(value: str) -> bool:
+    path = Path(value)
+    return not path.is_absolute() and path.parts[:1] == ("output",)
+
+
+def _require_packet_output_path(
+    mapping: dict[str, Any],
+    key: str,
+    blockers: list[str],
+    prefix: str,
+) -> None:
+    value = mapping.get(key)
+    if isinstance(value, str) and value.strip() and not _is_repo_output_path(value):
+        blockers.append(f"{prefix}.{key} must stay under output/")
+
+
+def _require_packet_config_path(
+    mapping: dict[str, Any],
+    key: str,
+    blockers: list[str],
+    prefix: str,
+) -> None:
+    value = mapping.get(key)
+    if isinstance(value, str) and value.strip() and not value.startswith("configs/"):
+        blockers.append(f"{prefix}.{key} must point under configs/")
 
 
 def _mapping(value: Any) -> dict[str, Any]:

--- a/tests/training/test_predictive_retraining_readiness.py
+++ b/tests/training/test_predictive_retraining_readiness.py
@@ -1,4 +1,4 @@
-"""Tests for predictive retraining readiness decision packets."""
+"""Tests predictive retraining readiness decision packets."""
 
 from __future__ import annotations
 
@@ -23,21 +23,95 @@ def _write_packet(tmp_path: Path, payload: dict[str, object]) -> Path:
     return packet
 
 
+def _write_pipeline_config(tmp_path: Path) -> Path:
+    scenario_dir = tmp_path / "configs"
+    scenario_dir.mkdir()
+    scenario_matrix = scenario_dir / "scenarios.yaml"
+    hard_seed_manifest = scenario_dir / "hard_seeds.yaml"
+    planner_grid = scenario_dir / "planner_grid.yaml"
+    for path in (scenario_matrix, hard_seed_manifest, planner_grid):
+        path.write_text("{}\n", encoding="utf-8")
+
+    pipeline_config = tmp_path / "pipeline.yaml"
+    pipeline_config.write_text(
+        yaml.safe_dump(
+            {
+                "experiment": {"run_id": "test"},
+                "output": {
+                    "root": "output/tmp/predictive_planner/pipeline",
+                    "provenance": {
+                        "status": "expected_missing_until_training",
+                        "checkpoint_path": (
+                            "output/tmp/predictive_planner/pipeline/training/test/"
+                            "predictive_model.pt"
+                        ),
+                        "checkpoint_provenance_path": (
+                            "output/tmp/predictive_planner/pipeline/training/test/"
+                            "checkpoint_provenance.json"
+                        ),
+                        "hard_seed_evaluation_summary": (
+                            "output/tmp/predictive_planner/pipeline/evaluation/test/summary.json"
+                        ),
+                    },
+                },
+                "scenarios": {
+                    "scenario_matrix": str(scenario_matrix),
+                    "hard_seed_manifest": str(hard_seed_manifest),
+                    "planner_grid": str(planner_grid),
+                },
+                "base_collection": {"max_steps": 10},
+                "hardcase_collection": {"max_steps": 10},
+                "training": {"model_id": "test_predictive_model"},
+                "evaluation": {
+                    "horizon": 120,
+                    "dt": 0.1,
+                    "workers": 1,
+                    "campaign_workers": 1,
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return pipeline_config
+
+
 def _complete_payload(tmp_path: Path) -> dict[str, object]:
     weighting_spec = tmp_path / "weighting.yaml"
-    pipeline_config = tmp_path / "pipeline.yaml"
+    pipeline_config = _write_pipeline_config(tmp_path)
     weighting_spec.write_text("profile_id: test\n", encoding="utf-8")
-    pipeline_config.write_text("experiment:\n  run_id: test\n", encoding="utf-8")
     return {
         "schema_version": "predictive-retraining-readiness.v1",
         "issue": "#3214",
         "candidate_id": "crossing_conflict_weighted_predictive_retraining",
         "claim_boundary": (
-            "No Slurm submission, no full benchmark campaign run, and no paper claim edit."
+            "No Slurm submission, no full benchmark campaign run, no paper claim edit."
         ),
         "inputs": {
             "weighting_spec": str(weighting_spec),
             "pipeline_config": str(pipeline_config),
+        },
+        "data_prerequisites": {
+            "base_collection": "pipeline_config.base_collection",
+            "hardcase_collection": "pipeline_config.hardcase_collection",
+            "weighting_spec": "inputs.weighting_spec",
+        },
+        "expected_checkpoint_lineage": {
+            "candidate_model_id": "test_predictive_model",
+            "checkpoint_path": "output/tmp/predictive_planner/pipeline/training/test/predictive_model.pt",
+            "checkpoint_provenance_path": (
+                "output/tmp/predictive_planner/pipeline/training/test/checkpoint_provenance.json"
+            ),
+        },
+        "evaluation_config": {
+            "hard_seed_benchmark": "configs/hard_seeds.yaml",
+            "planner_grid": "configs/planner_grid.yaml",
+            "summary_path": "output/tmp/predictive_planner/pipeline/evaluation/test/summary.json",
+        },
+        "output_roots": {
+            "pipeline_root": "output/tmp/predictive_planner/pipeline",
+            "training_root": "output/tmp/predictive_planner/pipeline/training",
+            "evaluation_root": "output/tmp/predictive_planner/pipeline/evaluation",
         },
         "prior_result": {
             "status": "verified_negative",
@@ -58,7 +132,7 @@ def _complete_payload(tmp_path: Path) -> dict[str, object]:
 
 
 def test_default_issue_3214_packet_is_complete_but_launch_blocked() -> None:
-    """Checked-in packet is complete but must not authorize blind retraining."""
+    """Checked-in packet complete but must not authorize blind retraining."""
 
     repo = Path(__file__).resolve().parents[2]
     report = evaluate_retraining_readiness(repo_root=repo)
@@ -75,7 +149,7 @@ def test_default_issue_3214_packet_is_complete_but_launch_blocked() -> None:
 def test_complete_negative_result_packet_blocks_without_missing_prerequisites(
     tmp_path: Path,
 ) -> None:
-    """A complete packet reports the negative-result decision instead of missing inputs."""
+    """A complete packet reports negative-result decision instead missing inputs."""
 
     packet = _write_packet(tmp_path, _complete_payload(tmp_path))
 
@@ -85,6 +159,66 @@ def test_complete_negative_result_packet_blocks_without_missing_prerequisites(
     assert report["launch_ready"] is False
     assert report["decision"] == DECISION_BLOCKED
     assert report["blockers"] == []
+
+
+def test_missing_launch_packet_sections_fail_closed(tmp_path: Path) -> None:
+    """Missing launch-packet sections surface as explicit blockers."""
+
+    payload = _complete_payload(tmp_path)
+    payload.pop("expected_checkpoint_lineage")
+    payload.pop("evaluation_config")
+    packet = _write_packet(tmp_path, payload)
+
+    report = evaluate_retraining_readiness(packet, repo_root=tmp_path)
+
+    assert report["packet_complete"] is False
+    assert report["launch_ready"] is False
+    assert any("expected_checkpoint_lineage" in blocker for blocker in report["blockers"])
+    assert any("evaluation_config" in blocker for blocker in report["blockers"])
+
+
+def test_missing_pipeline_retraining_prerequisites_fail_closed(tmp_path: Path) -> None:
+    """Missing data, evaluation, provenance, or output-root config blocks launch readiness."""
+
+    payload = _complete_payload(tmp_path)
+    pipeline_config = tmp_path / "pipeline.yaml"
+    pipeline = yaml.safe_load(pipeline_config.read_text(encoding="utf-8"))
+    pipeline.pop("hardcase_collection")
+    pipeline["scenarios"]["hard_seed_manifest"] = "missing_hard_seeds.yaml"
+    pipeline["output"]["root"] = "/tmp/not-a-repo-output"
+    pipeline["output"]["provenance"].pop("checkpoint_provenance_path")
+    pipeline["output"]["provenance"]["status"] = "ready"
+    pipeline["evaluation"].pop("horizon")
+    pipeline_config.write_text(yaml.safe_dump(pipeline, sort_keys=False), encoding="utf-8")
+    packet = _write_packet(tmp_path, payload)
+
+    report = evaluate_retraining_readiness(packet, repo_root=tmp_path)
+
+    assert report["packet_complete"] is False
+    assert report["launch_ready"] is False
+    assert any(
+        "pipeline_config.hardcase_collection must be mapping" in blocker
+        for blocker in report["blockers"]
+    )
+    assert any(
+        "pipeline_config.scenarios.hard_seed_manifest does not exist" in blocker
+        for blocker in report["blockers"]
+    )
+    assert any(
+        "pipeline_config.output.root must stay under output/" in blocker
+        for blocker in report["blockers"]
+    )
+    assert any(
+        "pipeline_config.output.provenance.checkpoint_provenance_path" in blocker
+        for blocker in report["blockers"]
+    )
+    assert any(
+        "pipeline_config.output.provenance.status" in blocker for blocker in report["blockers"]
+    )
+    assert any(
+        "pipeline_config.evaluation.horizon must be set" in blocker
+        for blocker in report["blockers"]
+    )
 
 
 def test_missing_retraining_prerequisites_fail_closed(tmp_path: Path) -> None:
@@ -108,7 +242,7 @@ def test_missing_retraining_prerequisites_fail_closed(tmp_path: Path) -> None:
 
 
 def test_missing_input_path_fails_closed(tmp_path: Path) -> None:
-    """Missing public config inputs are surfaced as blockers, not launch-ready state."""
+    """Missing public config inputs surfaced blockers, not launch-ready state."""
 
     payload = _complete_payload(tmp_path)
     payload["inputs"] = {
@@ -126,7 +260,7 @@ def test_missing_input_path_fails_closed(tmp_path: Path) -> None:
 
 
 def test_cli_require_launch_ready_exits_blocked(monkeypatch, tmp_path: Path, capsys) -> None:
-    """CLI can be used as a fail-closed launch gate when compute authorization exists later."""
+    """CLI can be used as fail-closed gate if compute authorization exists later."""
 
     packet = _write_packet(tmp_path, _complete_payload(tmp_path))
     monkeypatch.setattr(
@@ -151,5 +285,6 @@ def test_load_readiness_packet_rejects_non_mapping(tmp_path: Path) -> None:
     packet = tmp_path / "bad.yaml"
     packet.write_text("- not\n- mapping\n", encoding="utf-8")
 
-    with pytest.raises(PredictiveRetrainingReadinessError, match="must be a mapping"):
+    with pytest.raises(PredictiveRetrainingReadinessError) as exc_info:
         load_readiness_packet(packet)
+    assert "must be a mapping" in str(exc_info.value)


### PR DESCRIPTION
## Summary
Tightens the issue #3214 predictive retraining readiness checker so the public launch packet fails closed unless it names and validates the crossing-conflict data prerequisites, checkpoint lineage, evaluation config, and output roots.

This is a static launch-packet/preflight slice only. It does not train a model or claim any improvement.

## Linked Issues
- Relates to `#3214`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3214`
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added issue #3214 readiness checks for packet sections: data prerequisites, expected checkpoint lineage, evaluation config, and output roots.
- Added validation of the referenced predictive retraining pipeline config for required data collection sections, scenario/benchmark config paths, expected-missing checkpoint provenance, evaluation settings, and `output/`-scoped roots.
- Updated the checked-in readiness packet with explicit launch-packet fields and expanded focused tests for complete and missing prerequisite states.

## Why Matters
- Added value: makes the crossing-conflict retraining launch packet auditable before any compute submission.
- Expected impact: missing or unsafe prerequisites are reported as blockers instead of silently allowing ambiguous retraining setup.
- Why worth merging now: it keeps the dissertation-critical retraining lane bounded to a public, reviewable preflight state.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3214 launch readiness blocker for crossing-conflict predictive retraining.
- Comparator or baseline, applicable: NA - no model result or benchmark comparison.
- Evidence tier: NA - static launch-packet preflight helper; no research evidence result.
- Result classification: NA - no model, benchmark, metric, or paper-facing result.
- Decision stop rule, applicable: the checker must report the checked-in packet complete but launch-blocked, and missing prerequisites must fail closed.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3214 remains the parent training campaign; no claim map or registry update in this PR.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - static preflight helper only.

## Domain-Aware Approval
- Required PR: not applicable - no domain approval PR is required for this static launch-packet preflight.
- Domains reviewed: training launch readiness, predictive retraining packet validation
- Status: waived - no benchmark, model, metric, or paper-facing result is claimed.
- approval concerns experimental validity claim waived / pending / blocked / not required: waived - launch-packet preflight only; no benchmark, model, metric, or paper-facing result is claimed.
- Approver/review source waiver: self-waiver for static preflight slice; full PR gate owner can revisit before merge.
- Validity checklist: static packet validation only; no fallback/degraded benchmark result treated as success.
- Target claim/hypothesis: no research result claim.
- Comparator split/evidence validity: no comparator split is evaluated by this preflight-only PR.
- Fallback/degraded exclusions: NA
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: code checks readiness fields; it does not interpret experimental validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no trained mechanism.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: stop
- Follow-up question issue weak, negative, non-transfer results: #3214 remains the campaign issue.

## Next Empirical Action
- Rerun needed: yes, only after maintainers authorize compute submission separately.
- Extractor analysis tool needed: no
- Artifact missing unavailable: retrained checkpoint and hard-seed evaluation are intentionally absent.
- Stop / revise / continue decision: stop before compute submission in this PR.
- Proposed child issue existing follow-up: #3214

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_predictive_retraining_readiness.py -q` - passed, 8 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/predictive_retraining_readiness.py tests/training/test_predictive_retraining_readiness.py scripts/training/check_predictive_retraining_readiness.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/training/check_predictive_retraining_readiness.py` - passed with `packet_complete=true`, `launch_ready=false`, and no blockers.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/validation/pr_ready/pr_body_issue_3214.md scripts/dev/pr_ready_check.sh` - passed.

## Performance
- Baseline runtime: NA - static preflight only.
- Changed runtime: NA - static preflight only.
- Representative command: `uv run python scripts/training/check_predictive_retraining_readiness.py`
- Hot-path call count profile anchor: NA - no hot path changed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: readiness checker no longer fails closed on missing launch-packet prerequisites.

## Risks / Rollout
- Compatibility risks: stricter issue #3214 packet validation may surface blockers for incomplete packets.
- Failure modes: legitimate future packet shapes may need explicit new fields before launch readiness passes.
- Rollback fallback plan: revert this PR to restore the prior narrower packet validation.

## Docs / Provenance
- Updated docs: NA
- Relevant design provenance notes: checked-in issue #3214 readiness packet.
- Any assumptions need to preserved: the referenced pipeline config's top-level `provenance` block is accepted as the current public config shape.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, commenting not authorized for this task.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: this PR makes no benchmark, registry, model, artifact, leaderboard, or paper-facing claim.

## Follow-Up Issues
- Deferred work: training, checkpoint promotion, hard-seed evaluation, and any claim synthesis remain outside this PR; tracked by #3214.
- Issues opened follow-up: none - existing issue #3214 tracks the deferred campaign work.

## Reviewer Notes
- Verify closely: the checker remains static and fail-closed; it does not require generated datasets/checkpoints to exist before compute authorization.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
