### PR TITLE
Issue #3723: summarize SNQI weight source inventory

### DIFF
--- a/robot_sf/benchmark/snqi/weights_inventory.py
+++ b/robot_sf/benchmark/snqi/weights_inventory.py
@@ -211,13 +211,39 @@ class WeightInventoryReport:
         """True if any conflict is severe enough to fail a preflight."""
         return any(c.severity == "error" for c in self.conflicts)
 
+    @property
+    def source_summary(self) -> dict[str, object]:
+        """Summarize discovery/provenance surface for preflight consumers."""
+        shipped_records = [r for r in self.records if r.relpath is not None]
+        registered_records = [r for r in self.records if r.kind in {"code_default", "shipped_json"}]
+        unregistered_records = [r for r in self.records if r.kind == "unregistered_shipped_json"]
+        canonical_records = [r for r in self.records if r.declares_canonical]
+        unavailable_records = [r for r in self.records if not r.available]
+        blocking_conflicts = [c for c in self.conflicts if c.severity == "error"]
+        return {
+            "registered_source_count": len(WEIGHT_SOURCES),
+            "discovered_shipped_source_count": len(shipped_records),
+            "unregistered_shipped_source_count": len(unregistered_records),
+            "canonical_declaring_source_count": len(canonical_records),
+            "unavailable_source_count": len(unavailable_records),
+            "blocking_conflict_count": len(blocking_conflicts),
+            "registered_sources": [r.name for r in registered_records],
+            "discovered_shipped_sources": [r.name for r in shipped_records],
+            "unregistered_shipped_sources": [r.name for r in unregistered_records],
+            "canonical_declaring_sources": [r.name for r in canonical_records],
+            "unavailable_sources": [r.name for r in unavailable_records],
+            "blocking_conflict_kinds": [c.kind for c in blocking_conflicts],
+        }
+
     def to_dict(self) -> dict:
         """Build a JSON-serializable representation of the report.
 
         Returns:
-            A dict with ``records``, ``conflicts``, and ``has_blocking_conflict``.
+            A dict with ``source_summary``, ``records``, ``conflicts``, and
+            ``has_blocking_conflict``.
         """
         return {
+            "source_summary": self.source_summary,
             "records": [
                 {
                     "name": r.name,

--- a/tests/test_snqi_weights_inventory.py
+++ b/tests/test_snqi_weights_inventory.py
@@ -117,6 +117,13 @@ def test_conflicting_canonical_sources_detected_fail_closed(tmp_path):
     repo = _make_fixture_repo(tmp_path, model_jerk_dominant=True)
     report = build_inventory_report(repo)
 
+    summary = report.to_dict()["source_summary"]
+    assert summary["registered_source_count"] == 5
+    assert summary["discovered_shipped_source_count"] == 4
+    assert summary["unregistered_shipped_source_count"] == 0
+    assert summary["canonical_declaring_sources"] == ["code_default", "model_canonical_v1"]
+    assert summary["blocking_conflict_kinds"] == ["canonical_direction_conflict"]
+
     direction_conflicts = [c for c in report.conflicts if c.kind == "canonical_direction_conflict"]
     assert direction_conflicts, "expected a canonical direction conflict"
     assert set(direction_conflicts[0].sources) == {"code_default", "model_canonical_v1"}
@@ -225,6 +232,16 @@ def test_unregistered_shipped_weight_file_reported_fail_closed(tmp_path):
     assert len(unregistered) == 1
     assert unregistered[0].relpath == "configs/benchmarks/snqi_weights_experimental_v9.json"
     assert unregistered[0].available
+
+    summary = report.to_dict()["source_summary"]
+    assert summary["registered_source_count"] == 5
+    assert summary["discovered_shipped_source_count"] == 5
+    assert summary["unregistered_shipped_source_count"] == 1
+    assert summary["unregistered_shipped_sources"] == [unregistered[0].name]
+    assert summary["blocking_conflict_kinds"] == [
+        "canonical_direction_conflict",
+        "unregistered_shipped_weight_source",
+    ]
 
     conflicts = [c for c in report.conflicts if c.kind == "unregistered_shipped_weight_source"]
     assert conflicts


### PR DESCRIPTION
## Summary
Adds a machine-readable `source_summary` to the SNQI weight inventory report so the preflight exposes registered, discovered shipped, unregistered, canonical-declaring, unavailable, and blocking-conflict counts directly.

## Linked Issues
- Relates #3723
- Issue link: https://github.com/ll7/robot_sf_ll7/issues/3723

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `weights.source_summary` to SNQI weight inventory/governance JSON output.
- Covered the current canonical-direction conflict and the unregistered shipped-weight fail-closed fixture path in focused tests.

## Why Matters
- Added value: reviewers and automation can see whether all shipped SNQI weight files were discovered and registered without reconstructing that state from the raw record list.
- Expected impact: diagnostic/reporting only.
- Why worth merging now: improves #3723 evidence hygiene without choosing canonical weights or changing scoring.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3723 diagnostic inventory/preflight reporting for conflicting SNQI weight provenance.
- Comparator or baseline, applicable: current inventory JSON records/conflicts only.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only
- Decision stop rule, applicable: source summary appears in inventory/governance JSON and focused tests prove current conflict plus unregistered-source fail-closed behavior.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3723 remains open for canonical-weight decision.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - existing diagnostic report surface only.

## Domain-Aware Approval
- Required for this PR: yes - diagnostic evidence-classification wording appears in the PR body.
- Domains reviewed: evidence classification, claim boundary
- Status: waived
- Approver/review source or waiver: maintainer issue authorization scopes this PR to reporting-only diagnostics; Claude Code owns full PR gate after open.
- Validity checklist: no full benchmark campaign run; no fallback/degraded benchmark result promoted.
- Target claim/hypothesis: diagnostic inventory visibility only.
- Comparator or split/evidence validity: focused fixture tests.
- Fallback/degraded exclusions: NA - no benchmark execution.
- Claim boundary: no canonical weight choice, no SNQI scoring/ranking change.
- Implementation integrity vs experimental validity: implementation adds report metadata only.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - JSON output now includes `weights.source_summary`.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? yes - fixture covers conflicting canonical sources and unregistered shipped JSON.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: canonical-weight decision remains #3723 follow-up.

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue with maintainer canonical-weight decision separately.
- Proposed child issue existing follow-up: #3723 remains the decision surface.

## Validation / Proof
- `uv run pytest tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_weight_inventory_cli.py tests/benchmark/test_snqi_governance_preflight.py -q` -> 16 passed.
- `uv run ruff format robot_sf/benchmark/snqi/weights_inventory.py tests/test_snqi_weights_inventory.py && uv run ruff check robot_sf/benchmark/snqi/weights_inventory.py tests/test_snqi_weights_inventory.py` -> passed.
- `uv run python scripts/validation/check_snqi_governance.py --json` -> exit 2 as expected; fail-closed blockers remain visible and JSON includes `weights.source_summary`.
- `PYTEST_XDIST_AUTO_NUM_WORKERS=1 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/validation/pr_body_issue_3723.md scripts/dev/pr_ready_check.sh` -> passed.
- Baseline runtime: NA - no runtime benchmark claim.
- Changed runtime: NA - no runtime benchmark claim.
- Representative command: `uv run python scripts/validation/check_snqi_governance.py --json`
- Hot-path call count profile anchor: NA - no runtime/caching claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: remove the metadata field if downstream consumers reject the schema addition.

## Risks / Rollout
- Compatibility risks: low; additive JSON field only.
- Failure modes: downstream strict schema consumers could need to ignore the new `source_summary` field.
- Rollback fallback plan: revert this commit; existing records/conflicts output remains available.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3723 live discussion and existing SNQI governance preflight.
- Any assumptions need to preserved: this PR is inventory/preflight-only and does not decide canonical weights.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark result, registry change, artifact catalog update, leaderboard update, or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: canonical SNQI weight decision/versioning remains out of scope and stays tracked by #3723.
- Issues opened follow-up: #3723.

## Reviewer Notes
- Anything reviewer verify closely: `weights.source_summary` counts remain derived from the same records used by conflict detection.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
