### PR TITLE
Tighten Package B budget-grid preflight for issue #3079

### DIFF
--- a/robot_sf/benchmark/adversarial_package_b_preflight.py
+++ b/robot_sf/benchmark/adversarial_package_b_preflight.py
@@ -174,6 +174,30 @@ def _extract_option_values(command: str, option: str) -> tuple[tuple[str, ...], 
     return tuple(values), warnings
 
 
+def _extract_budget_grid_flags(command: str) -> tuple[int, tuple[str, ...], list[str]]:
+    """Return Package-B grid flag count and explicit budget overrides."""
+    warnings: list[str] = []
+    try:
+        tokens = shlex.split(command)
+    except ValueError as exc:
+        warnings.append(f"example_command could not be parsed by shlex: {exc}")
+        return 0, (), warnings
+
+    budget_values: list[str] = []
+    grid_flag_count = 0
+    for index, token in enumerate(tokens):
+        if token == "--package-b-budget-grid":
+            grid_flag_count += 1
+        elif token == "--budget":
+            if index + 1 >= len(tokens):
+                warnings.append("example_command has --budget without value")
+                continue
+            budget_values.append(tokens[index + 1])
+        elif token.startswith("--budget="):
+            budget_values.append(token.removeprefix("--budget="))
+    return grid_flag_count, tuple(budget_values), warnings
+
+
 def _under_output_prefix(path: Path | None, repo_root: Path) -> bool:
     if path is None:
         return False
@@ -460,9 +484,19 @@ def preflight_package_b_manifest(  # noqa: C901, PLR0912, PLR0915
     if forbidden_hits:
         blockers.append(f"example_command includes forbidden action tokens: {forbidden_hits}")
 
-    checks["example_command_uses_package_b_grid"] = "--package-b-budget-grid" in example_command
+    budget_grid_flag_count, command_budget_values, budget_warnings = _extract_budget_grid_flags(
+        example_command
+    )
+    warnings.extend(budget_warnings)
+    checks["example_command_uses_package_b_grid"] = budget_grid_flag_count == 1
     if not checks["example_command_uses_package_b_grid"]:
-        blockers.append("example_command must use --package-b-budget-grid")
+        blockers.append("example_command must use exactly one --package-b-budget-grid")
+    checks["example_command_has_no_budget_overrides"] = not command_budget_values
+    if not checks["example_command_has_no_budget_overrides"]:
+        blockers.append(
+            "example_command must not mix --package-b-budget-grid with explicit "
+            f"--budget overrides: {list(command_budget_values)}"
+        )
 
     for seed in seeds:
         checks[f"example_command_seed_{seed}"] = (

--- a/tests/benchmark/test_adversarial_package_b_preflight.py
+++ b/tests/benchmark/test_adversarial_package_b_preflight.py
@@ -320,6 +320,69 @@ def test_preflight_blocks_example_command_seed_drift(tmp_path: Path) -> None:
     assert any("example_command --seed values" in blocker for blocker in result.blockers)
 
 
+def test_preflight_blocks_missing_package_b_budget_grid_flag(tmp_path: Path) -> None:
+    """Package-B command must select the fixed issue #3079 budget grid."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--seed 1101 --seed 2202 --seed 3303 "
+        "--output-dir output/adversarial/issue_3079_package_b "
+        "--out-json output/adversarial/issue_3079_package_b/report.json"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["example_command_uses_package_b_grid"] is False
+    assert any("exactly one --package-b-budget-grid" in blocker for blocker in result.blockers)
+
+
+def test_preflight_blocks_duplicate_package_b_budget_grid_flag(tmp_path: Path) -> None:
+    """Duplicate fixed-grid flags are treated as command drift."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--package-b-budget-grid --package-b-budget-grid "
+        "--seed 1101 --seed 2202 --seed 3303 "
+        "--output-dir output/adversarial/issue_3079_package_b "
+        "--out-json output/adversarial/issue_3079_package_b/report.json"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["example_command_uses_package_b_grid"] is False
+    assert any("exactly one --package-b-budget-grid" in blocker for blocker in result.blockers)
+
+
+def test_preflight_blocks_package_b_budget_overrides(tmp_path: Path) -> None:
+    """Package-B command cannot mix fixed grid mode with explicit budget overrides."""
+    manifest = _base_manifest(tmp_path)
+    payload = yaml.safe_load(manifest.read_text(encoding="utf-8"))
+    payload["example_command"] = (
+        "uv run python scripts/tools/compare_adversarial_samplers.py "
+        "--package-b-budget-grid --budget 16 --budget=32 "
+        "--seed 1101 --seed 2202 --seed 3303 "
+        "--output-dir output/adversarial/issue_3079_package_b "
+        "--out-json output/adversarial/issue_3079_package_b/report.json"
+    )
+    manifest.write_text(yaml.safe_dump(payload), encoding="utf-8")
+
+    result = preflight_package_b_manifest(manifest, repo_root=tmp_path)
+
+    assert result.ready is False
+    assert result.blocked is True
+    assert result.checks["example_command_uses_package_b_grid"] is True
+    assert result.checks["example_command_has_no_budget_overrides"] is False
+    assert any("explicit --budget overrides" in blocker for blocker in result.blockers)
+
+
 def test_preflight_accepts_equals_form_example_command_seed_args(tmp_path: Path) -> None:
     """The seed parser should mirror argparse's --seed=value spelling."""
     manifest = _base_manifest(tmp_path)


### PR DESCRIPTION
## Summary

Closes readiness slice for #3079 by tightening the Package B manifest preflight so its executable example command must use exactly one `--package-b-budget-grid` flag and must not mix that fixed grid with explicit `--budget` overrides.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3079

## Scope

- Added fail-closed parsing for Package B budget-grid command metadata.
- Added focused synthetic tests for missing grid flag, duplicate grid flag, and explicit `--budget` override drift.
- Kept the slice limited to readiness/preflight behavior in the existing Package B checker.

## Validation

- `uv run python -m pytest tests/benchmark/test_adversarial_package_b_preflight.py -q` - passed.
- `uv run python scripts/tools/preflight_adversarial_package_b.py --manifest configs/adversarial/issue_3079_package_b_budget_matched.yaml --output output/validation/package_b_preflight_issue_3079.json` - passed; shipped manifest reports `blocked: false`.
- `uv run ruff format --check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` - passed.
- `uv run ruff check robot_sf/benchmark/adversarial_package_b_preflight.py tests/benchmark/test_adversarial_package_b_preflight.py` - passed.
- `git diff --check` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=output/validation/pr_body/issue_3079_package_b_readiness.md scripts/dev/pr_ready_check.sh` - passed; freshness stamp for `036eaeaa1e9fca76cc976f15b3e698c171264e00` recorded at `output/validation/pr_ready/issue-3079-package-b-readiness-final-gate.json`.

## Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
