### PR TITLE
Issue #3385: move camera-ready artifact writers into package

### DIFF
--- a/robot_sf/benchmark/camera_ready/_artifacts.py
+++ b/robot_sf/benchmark/camera_ready/_artifacts.py
@@ -7,6 +7,9 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from robot_sf.benchmark.camera_ready._util import _sanitize_csv_cell
+from robot_sf.benchmark.camera_ready_campaign_config import _AMV_DIMENSIONS
+from robot_sf.benchmark.seed_variance import build_seed_variability_csv_rows
+from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -78,3 +81,411 @@ def _write_table_artifacts(
     _write_csv(csv_path, csv_rows)
     _write_markdown_table(md_path, rows, headers=headers)
     return csv_path, md_path
+
+
+def _write_matrix_summary_artifacts(
+    reports_dir: Path,
+    rows: list[dict[str, Any]],
+) -> tuple[Path, Path]:
+    """Write matrix-definition summary artifacts.
+
+    Returns:
+        Tuple of ``(matrix_summary_json_path, matrix_summary_csv_path)``.
+    """
+    json_path = reports_dir / "matrix_summary.json"
+    csv_path = reports_dir / "matrix_summary.csv"
+    payload = {
+        "schema_version": "benchmark-matrix-summary.v1",
+        "rows": rows,
+    }
+    _write_json(json_path, payload)
+    _write_csv(csv_path, rows)
+    return json_path, csv_path
+
+
+def _write_seed_variability_artifacts(
+    reports_dir: Path,
+    payload: dict[str, Any],
+) -> tuple[Path, Path]:
+    """Write paper-facing seed-variability JSON and CSV artifacts.
+
+    Returns:
+        Tuple of ``(json_path, csv_path)`` for the generated artifacts.
+    """
+    json_path = reports_dir / "seed_variability_by_scenario.json"
+    csv_path = reports_dir / "seed_variability_by_scenario.csv"
+    _write_json(json_path, payload)
+    csv_rows = build_seed_variability_csv_rows(
+        payload.get("rows") or [],
+        metrics=payload.get("metrics") or [],
+    )
+    _write_csv(csv_path, csv_rows)
+    return json_path, csv_path
+
+
+def _write_seed_episode_rows_artifact(
+    reports_dir: Path,
+    rows: list[dict[str, Any]],
+) -> Path:
+    """Write flat planner-aware per-episode seed traceability CSV.
+
+    Returns:
+        Path to the generated CSV artifact.
+    """
+    csv_path = reports_dir / "seed_episode_rows.csv"
+    _write_csv(csv_path, rows)
+    return csv_path
+
+
+def _write_statistical_sufficiency_artifact(
+    reports_dir: Path,
+    payload: dict[str, Any],
+) -> Path:
+    """Write statistical sufficiency JSON artifact.
+
+    Returns:
+        Path to the generated JSON artifact.
+    """
+    json_path = reports_dir / "statistical_sufficiency.json"
+    _write_json(json_path, payload)
+    return json_path
+
+
+def _write_amv_coverage_artifacts(
+    reports_dir: Path,
+    summary: dict[str, Any],
+) -> tuple[Path, Path]:
+    """Write AMV coverage summary JSON + Markdown artifacts.
+
+    Returns:
+        tuple[Path, Path]: Output paths ``(json_path, markdown_path)``.
+    """
+    json_path = reports_dir / "amv_coverage_summary.json"
+    md_path = reports_dir / "amv_coverage_summary.md"
+    _write_json(json_path, summary)
+
+    lines = [
+        "# AMV Coverage Summary",
+        "",
+        f"- Status: `{summary.get('status', 'unknown')}`",
+        f"- Profile: `{summary.get('profile_name', 'unknown')}`",
+        f"- Contract version: `{summary.get('contract_version', 'unknown')}`",
+        f"- Enforcement: `{summary.get('coverage_enforcement', 'warn')}`",
+        f"- Scenario count: `{summary.get('scenario_count', 0)}`",
+        "",
+        "| Dimension | Required | Observed | Missing |",
+        "|---|---|---|---|",
+    ]
+    required = summary.get("required_dimensions", {})
+    observed = summary.get("observed_dimensions", {})
+    missing = summary.get("missing_dimensions", {})
+    for dimension in _AMV_DIMENSIONS:
+        required_values = ", ".join(required.get(dimension, [])) or "-"
+        observed_values = ", ".join(observed.get(dimension, [])) or "-"
+        missing_values = ", ".join(missing.get(dimension, [])) or "-"
+        lines.append(
+            "| "
+            f"{_escape_markdown_cell(dimension)} | "
+            f"{_escape_markdown_cell(required_values)} | "
+            f"{_escape_markdown_cell(observed_values)} | "
+            f"{_escape_markdown_cell(missing_values)} |"
+        )
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return json_path, md_path
+
+
+def _write_actuation_envelope_artifacts(
+    reports_dir: Path,
+    payload: dict[str, Any],
+) -> tuple[Path, Path]:
+    """Write synthetic actuation-envelope JSON and Markdown artifacts.
+
+    Returns:
+        Paths to the JSON and Markdown artifacts.
+    """
+    json_path = reports_dir / "actuation_envelope_summary.json"
+    md_path = reports_dir / "actuation_envelope_summary.md"
+    _write_json(json_path, payload)
+    lines = [
+        "# Synthetic Actuation Envelope Summary",
+        "",
+        f"- Campaign ID: `{payload.get('campaign_id', 'unknown')}`",
+        f"- Claim boundary: {payload.get('claim_boundary', '')}",
+        "",
+        "## Profile",
+        "",
+    ]
+    profile = payload.get("synthetic_actuation_profile")
+    if isinstance(profile, dict):
+        for key, value in profile.items():
+            lines.append(f"- {key}: `{value}`")
+    lines.append(f"- AMV coverage status: `{payload.get('amv_coverage_status', 'unknown')}`")
+    scenario_rows = payload.get("scenario_amv_rows")
+    if isinstance(scenario_rows, list) and scenario_rows:
+        lines.extend(["", "## Scenario AMV Rows", ""])
+        for row in scenario_rows:
+            if not isinstance(row, dict):
+                continue
+            lines.append(
+                "- "
+                f"{row.get('name', 'unknown')} ({row.get('scenario_family', 'unknown')}): "
+                f"{json.dumps(row.get('amv', {}), sort_keys=True)}"
+            )
+    rows = payload.get("rows")
+    if isinstance(rows, list) and rows:
+        lines.extend(["", "## Planner Rows", ""])
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            saturation = row.get("saturation_metrics")
+            if not isinstance(saturation, dict):
+                saturation = {}
+            lines.append(
+                "- "
+                f"{row.get('planner_key', 'unknown')} ({row.get('algo', 'unknown')}, "
+                f"{row.get('kinematics', 'unknown')}): status={row.get('status', 'unknown')}, "
+                f"projection={row.get('projection_policy', 'unknown')}, "
+                f"planner_cmd={row.get('planner_command_space', 'unknown')}, "
+                f"benchmark_cmd={row.get('benchmark_command_space', 'unknown')}, "
+                f"clip={saturation.get('command_clip_fraction', 'not_available')}, "
+                f"yaw_sat={saturation.get('yaw_rate_saturation_fraction', 'not_available')}, "
+                f"braking_peak={saturation.get('signed_braking_peak_m_s2', 'not_available')}"
+            )
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return json_path, md_path
+
+
+def _markdown_rows_from_mapping_rows(
+    rows: list[dict[str, Any]],
+    columns: tuple[str, ...],
+) -> list[str]:
+    """Render Markdown table rows from mapping rows and column order.
+
+    Returns:
+        list[str]: Markdown table rows in ``| a | b |`` form.
+    """
+    output: list[str] = []
+    for row in rows:
+        cells = [_escape_markdown_cell(row.get(column)) for column in columns]
+        output.append("| " + " | ".join(cells) + " |")
+    return output
+
+
+def _write_comparability_artifacts(
+    reports_dir: Path,
+    summary: dict[str, Any],
+) -> tuple[Path, Path]:
+    """Write comparability summary JSON + Markdown artifacts.
+
+    Returns:
+        tuple[Path, Path]: Output paths ``(json_path, markdown_path)``.
+    """
+    json_path = reports_dir / "comparability_matrix.json"
+    md_path = reports_dir / "comparability_matrix.md"
+    _write_json(json_path, summary)
+    lines = [
+        "# Alyassi Comparability Summary",
+        "",
+        f"- Mapping path: `{summary.get('mapping_path', 'unknown')}`",
+        f"- Mapping version: `{summary.get('mapping_version', 'unknown')}`",
+        f"- Mapping hash: `{summary.get('mapping_hash', 'unknown')}`",
+        "",
+        "## Coverage Overlap Matrix",
+        "",
+        "| Robot SF Family | Scenario Count | Alyassi Category | Overlap |",
+        "|---|---:|---|---|",
+    ]
+    lines.extend(
+        _markdown_rows_from_mapping_rows(
+            list(summary.get("coverage_overlap_rows", [])),
+            ("robot_sf_family", "scenario_count", "alyassi_category", "overlap"),
+        )
+    )
+    lines.extend(
+        [
+            "",
+            "## Metric Comparability",
+            "",
+            "| Metric | Classification | Alyassi Metric | Rationale |",
+            "|---|---|---|---|",
+        ]
+    )
+    lines.extend(
+        _markdown_rows_from_mapping_rows(
+            list(summary.get("metric_comparability_rows", [])),
+            ("metric", "classification", "alyassi_metric", "rationale"),
+        )
+    )
+    lines.extend(["", "## AMV-Specific Extensions", ""])
+    extensions = summary.get("amv_specific_extensions", [])
+    if extensions:
+        for extension in extensions:
+            lines.append(f"- {_escape_markdown_cell(extension)}")
+    else:
+        lines.append("- none")
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return json_path, md_path
+
+
+def _write_snqi_diagnostics_artifacts(  # noqa: C901
+    reports_dir: Path,
+    payload: dict[str, Any],
+) -> tuple[Path, Path, Path]:
+    """Write SNQI diagnostics JSON/Markdown and sensitivity CSV artifacts.
+
+    Returns:
+        Tuple of ``(json_path, markdown_path, csv_path)``.
+    """
+    json_path = reports_dir / "snqi_diagnostics.json"
+    md_path = reports_dir / "snqi_diagnostics.md"
+    csv_path = reports_dir / "snqi_sensitivity.csv"
+    _write_json(json_path, payload)
+
+    lines = [
+        "# SNQI Diagnostics",
+        "",
+        f"- Contract status: `{payload.get('contract_status', 'unknown')}`",
+        f"- Rank alignment (Spearman): `{payload.get('rank_alignment_spearman', 0.0):.4f}`",
+        f"- Outcome separation: `{payload.get('outcome_separation', 0.0):.4f}`",
+        f"- Objective score: `{payload.get('objective_score', 0.0):.4f}`",
+        f"- Dominant component: `{payload.get('dominant_component', 'unknown')}`",
+        f"- Dominant component mean |contribution|: `{payload.get('dominant_component_mean_abs', 0.0):.4f}`",
+        "",
+        "## SNQI Assets",
+        "",
+        f"- Weights path: `{payload.get('weights_path', 'derived')}`",
+        f"- Weights version: `{payload.get('weights_version', 'unknown')}`",
+        f"- Weights SHA-256: `{payload.get('weights_sha256', 'unknown')}`",
+        f"- Baseline path: `{payload.get('baseline_path', 'derived')}`",
+        f"- Baseline version: `{payload.get('baseline_version', 'unknown')}`",
+        f"- Baseline SHA-256: `{payload.get('baseline_sha256', 'unknown')}`",
+        "",
+        "## Baseline Normalization",
+        "",
+        f"- Source: `{payload.get('baseline_source', 'unknown')}`",
+        f"- Degeneracy adjustments: `{payload.get('baseline_adjustments', 0)}`",
+        "",
+        "## Positioning",
+        "",
+        f"- Recommendation: `{payload.get('positioning', {}).get('recommendation', 'unknown')}`",
+        f"- Claim scope: `{payload.get('positioning', {}).get('claim_scope', 'unknown')}`",
+        f"- Aligned variable metrics: `{payload.get('positioning', {}).get('aligned_metric_count', 0)}` / `{payload.get('positioning', {}).get('variable_metric_count', 0)}`",
+        "",
+        "## Planner Ordering",
+        "",
+        "| Rank | Planner | Kinematics | Mean SNQI | Episodes |",
+        "|---:|---|---|---:|---:|",
+    ]
+    ordering = payload.get("planner_ordering")
+    if isinstance(ordering, list):
+        for row in ordering:
+            lines.append(
+                "| {rank} | {planner_key} | {kinematics} | {mean_snqi:.6f} | {episode_count} |".format(
+                    rank=int(row.get("rank", 0) or 0),
+                    planner_key=str(row.get("planner_key", "unknown")),
+                    kinematics=str(row.get("kinematics", "unknown")),
+                    mean_snqi=float(row.get("mean_snqi", 0.0) or 0.0),
+                    episode_count=int(row.get("episode_count", 0) or 0),
+                )
+            )
+    lines.extend(
+        [
+            "",
+            "## Component Correlations",
+            "",
+            "| Metric | Direction | Spearman | Variable | Aligned |",
+            "|---|---|---:|---|---|",
+        ]
+    )
+    correlations = payload.get("component_correlations")
+    if isinstance(correlations, dict):
+        for metric_name, row in sorted(correlations.items()):
+            spearman = row.get("spearman")
+            spearman_text = "n/a" if spearman is None else f"{float(spearman):.6f}"
+            aligned = row.get("aligned_with_expected_direction")
+            aligned_text = "n/a" if aligned is None else ("yes" if aligned else "no")
+            lines.append(
+                "| {metric} | {direction} | {spearman} | {variable} | {aligned} |".format(
+                    metric=_escape_markdown_cell(str(metric_name)),
+                    direction=_escape_markdown_cell(str(row.get("direction", "unknown"))),
+                    spearman=spearman_text,
+                    variable="yes" if bool(row.get("variable")) else "no",
+                    aligned=aligned_text,
+                )
+            )
+    lines.extend(
+        [
+            "",
+            "## Component Dominance (mean absolute contribution)",
+            "",
+            "| Component | Mean |",
+            "|---|---:|",
+        ]
+    )
+    dominance = payload.get("component_dominance")
+    if isinstance(dominance, dict):
+        for key, value in sorted(dominance.items()):
+            lines.append(f"| {_escape_markdown_cell(key)} | {float(value):.6f} |")
+    caveats = payload.get("positioning", {}).get("caveats")
+    if isinstance(caveats, list) and caveats:
+        lines.extend(["", "## Caveats", ""])
+        for caveat in caveats:
+            lines.append(f"- {_escape_markdown_cell(str(caveat))}")
+    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    calibrated = payload.get("calibrated_weights")
+    headers = (
+        "component",
+        "metric_name",
+        "configured_weight",
+        "configured_weight_share",
+        "calibrated_weight",
+        "delta",
+        "mean_abs_contribution",
+        "mean_abs_score_delta_if_ablated",
+        "episode_rank_correlation_if_ablated",
+        "planner_rank_correlation_if_ablated",
+        "planner_order_changed_if_ablated",
+        "sensitivity_rank",
+    )
+    rows: list[dict[str, Any]] = []
+    sensitivity_rows = payload.get("weight_sensitivity")
+    sensitivity_by_component = (
+        {str(row.get("weight_name")): row for row in sensitivity_rows if isinstance(row, dict)}
+        if isinstance(sensitivity_rows, list)
+        else {}
+    )
+    if isinstance(calibrated, dict):
+        configured = payload.get("configured_weights", {})
+        for name in WEIGHT_NAMES:
+            configured_value = float((configured or {}).get(name, 1.0))
+            calibrated_value = float(calibrated.get(name, configured_value))
+            sensitivity = sensitivity_by_component.get(name, {})
+            rows.append(
+                {
+                    "component": name,
+                    "metric_name": sensitivity.get("metric_name", ""),
+                    "configured_weight": configured_value,
+                    "configured_weight_share": float(
+                        sensitivity.get("configured_weight_share", 0.0)
+                    ),
+                    "calibrated_weight": calibrated_value,
+                    "delta": calibrated_value - configured_value,
+                    "mean_abs_contribution": float(sensitivity.get("mean_abs_contribution", 0.0)),
+                    "mean_abs_score_delta_if_ablated": float(
+                        sensitivity.get("mean_abs_score_delta_if_ablated", 0.0)
+                    ),
+                    "episode_rank_correlation_if_ablated": float(
+                        sensitivity.get("episode_rank_correlation_if_ablated", 1.0)
+                    ),
+                    "planner_rank_correlation_if_ablated": float(
+                        sensitivity.get("planner_rank_correlation_if_ablated", 1.0)
+                    ),
+                    "planner_order_changed_if_ablated": bool(
+                        sensitivity.get("planner_order_changed_if_ablated")
+                    ),
+                    "sensitivity_rank": int(sensitivity.get("sensitivity_rank", 0) or 0),
+                }
+            )
+    _write_csv(csv_path, [{key: row.get(key) for key in headers} for row in rows])
+    return json_path, md_path, csv_path

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -7,7 +7,6 @@ bundle for archival/release pipelines.
 
 from __future__ import annotations
 
-import json
 import math
 import subprocess
 import time
@@ -25,9 +24,18 @@ from robot_sf.benchmark.aggregate import compute_aggregates_with_ci, read_jsonl
 from robot_sf.benchmark.artifact_publication import export_publication_bundle
 from robot_sf.benchmark.camera_ready._artifacts import (  # noqa: F401 - re-exported for back-compat
     _escape_markdown_cell,
+    _markdown_rows_from_mapping_rows,
+    _write_actuation_envelope_artifacts,
+    _write_amv_coverage_artifacts,
+    _write_comparability_artifacts,
     _write_csv,
     _write_json,
     _write_markdown_table,
+    _write_matrix_summary_artifacts,
+    _write_seed_episode_rows_artifact,
+    _write_seed_variability_artifacts,
+    _write_snqi_diagnostics_artifacts,
+    _write_statistical_sufficiency_artifact,
     _write_table_artifacts,
 )
 from robot_sf.benchmark.camera_ready._config import (  # noqa: F401 - re-exported for back-compat
@@ -152,7 +160,6 @@ from robot_sf.benchmark.orca_preflight import check_orca_rvo2_preflight
 from robot_sf.benchmark.runner import run_batch
 from robot_sf.benchmark.seed_variance import (
     build_seed_episode_rows,
-    build_seed_variability_csv_rows,
 )
 from robot_sf.benchmark.snqi.campaign_contract import (
     SnqiContractThresholds,
@@ -168,7 +175,6 @@ from robot_sf.benchmark.snqi.campaign_contract import (
     resolve_weight_mapping,
     sanitize_baseline_stats,
 )
-from robot_sf.benchmark.snqi.compute import WEIGHT_NAMES
 from robot_sf.benchmark.synthetic_actuation import (
     SYNTHETIC_ACTUATION_CLAIM_SCOPE,
     SyntheticActuationProfile,
@@ -867,414 +873,6 @@ def load_campaign_config(path: Path) -> CampaignConfig:  # noqa: C901, PLR0912, 
     )
     _validate_campaign_config(cfg)
     return cfg
-
-
-def _write_matrix_summary_artifacts(
-    reports_dir: Path,
-    rows: list[dict[str, Any]],
-) -> tuple[Path, Path]:
-    """Write matrix-definition summary artifacts.
-
-    Returns:
-        Tuple of ``(matrix_summary_json_path, matrix_summary_csv_path)``.
-    """
-    json_path = reports_dir / "matrix_summary.json"
-    csv_path = reports_dir / "matrix_summary.csv"
-    payload = {
-        "schema_version": "benchmark-matrix-summary.v1",
-        "rows": rows,
-    }
-    _write_json(json_path, payload)
-    _write_csv(csv_path, rows)
-    return json_path, csv_path
-
-
-def _write_seed_variability_artifacts(
-    reports_dir: Path,
-    payload: dict[str, Any],
-) -> tuple[Path, Path]:
-    """Write paper-facing seed-variability JSON and CSV artifacts.
-
-    Returns:
-        Tuple of ``(json_path, csv_path)`` for the generated artifacts.
-    """
-    json_path = reports_dir / "seed_variability_by_scenario.json"
-    csv_path = reports_dir / "seed_variability_by_scenario.csv"
-    _write_json(json_path, payload)
-    csv_rows = build_seed_variability_csv_rows(
-        payload.get("rows") or [],
-        metrics=payload.get("metrics") or [],
-    )
-    _write_csv(csv_path, csv_rows)
-    return json_path, csv_path
-
-
-def _write_seed_episode_rows_artifact(
-    reports_dir: Path,
-    rows: list[dict[str, Any]],
-) -> Path:
-    """Write flat planner-aware per-episode seed traceability CSV.
-
-    Returns:
-        Path to the generated CSV artifact.
-    """
-    csv_path = reports_dir / "seed_episode_rows.csv"
-    _write_csv(csv_path, rows)
-    return csv_path
-
-
-def _write_statistical_sufficiency_artifact(
-    reports_dir: Path,
-    payload: dict[str, Any],
-) -> Path:
-    """Write statistical sufficiency JSON artifact.
-
-    Returns:
-        Path to the generated JSON artifact.
-    """
-    json_path = reports_dir / "statistical_sufficiency.json"
-    _write_json(json_path, payload)
-    return json_path
-
-
-def _write_amv_coverage_artifacts(
-    reports_dir: Path,
-    summary: dict[str, Any],
-) -> tuple[Path, Path]:
-    """Write AMV coverage summary JSON + Markdown artifacts.
-
-    Returns:
-        tuple[Path, Path]: Output paths ``(json_path, markdown_path)``.
-    """
-    json_path = reports_dir / "amv_coverage_summary.json"
-    md_path = reports_dir / "amv_coverage_summary.md"
-    _write_json(json_path, summary)
-
-    lines = [
-        "# AMV Coverage Summary",
-        "",
-        f"- Status: `{summary.get('status', 'unknown')}`",
-        f"- Profile: `{summary.get('profile_name', 'unknown')}`",
-        f"- Contract version: `{summary.get('contract_version', 'unknown')}`",
-        f"- Enforcement: `{summary.get('coverage_enforcement', 'warn')}`",
-        f"- Scenario count: `{summary.get('scenario_count', 0)}`",
-        "",
-        "| Dimension | Required | Observed | Missing |",
-        "|---|---|---|---|",
-    ]
-    required = summary.get("required_dimensions", {})
-    observed = summary.get("observed_dimensions", {})
-    missing = summary.get("missing_dimensions", {})
-    for dimension in _AMV_DIMENSIONS:
-        required_values = ", ".join(required.get(dimension, [])) or "-"
-        observed_values = ", ".join(observed.get(dimension, [])) or "-"
-        missing_values = ", ".join(missing.get(dimension, [])) or "-"
-        lines.append(
-            "| "
-            f"{_escape_markdown_cell(dimension)} | "
-            f"{_escape_markdown_cell(required_values)} | "
-            f"{_escape_markdown_cell(observed_values)} | "
-            f"{_escape_markdown_cell(missing_values)} |"
-        )
-    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    return json_path, md_path
-
-
-def _write_actuation_envelope_artifacts(
-    reports_dir: Path,
-    payload: dict[str, Any],
-) -> tuple[Path, Path]:
-    """Write synthetic actuation-envelope JSON and Markdown artifacts.
-
-    Returns:
-        Paths to the JSON and Markdown artifacts.
-    """
-    json_path = reports_dir / "actuation_envelope_summary.json"
-    md_path = reports_dir / "actuation_envelope_summary.md"
-    _write_json(json_path, payload)
-    lines = [
-        "# Synthetic Actuation Envelope Summary",
-        "",
-        f"- Campaign ID: `{payload.get('campaign_id', 'unknown')}`",
-        f"- Claim boundary: {payload.get('claim_boundary', '')}",
-        "",
-        "## Profile",
-        "",
-    ]
-    profile = payload.get("synthetic_actuation_profile")
-    if isinstance(profile, dict):
-        for key, value in profile.items():
-            lines.append(f"- {key}: `{value}`")
-    lines.append(f"- AMV coverage status: `{payload.get('amv_coverage_status', 'unknown')}`")
-    scenario_rows = payload.get("scenario_amv_rows")
-    if isinstance(scenario_rows, list) and scenario_rows:
-        lines.extend(["", "## Scenario AMV Rows", ""])
-        for row in scenario_rows:
-            if not isinstance(row, dict):
-                continue
-            lines.append(
-                "- "
-                f"{row.get('name', 'unknown')} ({row.get('scenario_family', 'unknown')}): "
-                f"{json.dumps(row.get('amv', {}), sort_keys=True)}"
-            )
-    rows = payload.get("rows")
-    if isinstance(rows, list) and rows:
-        lines.extend(["", "## Planner Rows", ""])
-        for row in rows:
-            if not isinstance(row, dict):
-                continue
-            saturation = row.get("saturation_metrics")
-            if not isinstance(saturation, dict):
-                saturation = {}
-            lines.append(
-                "- "
-                f"{row.get('planner_key', 'unknown')} ({row.get('algo', 'unknown')}, "
-                f"{row.get('kinematics', 'unknown')}): status={row.get('status', 'unknown')}, "
-                f"projection={row.get('projection_policy', 'unknown')}, "
-                f"planner_cmd={row.get('planner_command_space', 'unknown')}, "
-                f"benchmark_cmd={row.get('benchmark_command_space', 'unknown')}, "
-                f"clip={saturation.get('command_clip_fraction', 'not_available')}, "
-                f"yaw_sat={saturation.get('yaw_rate_saturation_fraction', 'not_available')}, "
-                f"braking_peak={saturation.get('signed_braking_peak_m_s2', 'not_available')}"
-            )
-    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    return json_path, md_path
-
-
-def _markdown_rows_from_mapping_rows(
-    rows: list[dict[str, Any]],
-    columns: tuple[str, ...],
-) -> list[str]:
-    """Render Markdown table rows from mapping rows and column order.
-
-    Returns:
-        list[str]: Markdown table rows in ``| a | b |`` form.
-    """
-    output: list[str] = []
-    for row in rows:
-        cells = [_escape_markdown_cell(row.get(column)) for column in columns]
-        output.append("| " + " | ".join(cells) + " |")
-    return output
-
-
-def _write_comparability_artifacts(
-    reports_dir: Path,
-    summary: dict[str, Any],
-) -> tuple[Path, Path]:
-    """Write comparability summary JSON + Markdown artifacts.
-
-    Returns:
-        tuple[Path, Path]: Output paths ``(json_path, markdown_path)``.
-    """
-    json_path = reports_dir / "comparability_matrix.json"
-    md_path = reports_dir / "comparability_matrix.md"
-    _write_json(json_path, summary)
-    lines = [
-        "# Alyassi Comparability Summary",
-        "",
-        f"- Mapping path: `{summary.get('mapping_path', 'unknown')}`",
-        f"- Mapping version: `{summary.get('mapping_version', 'unknown')}`",
-        f"- Mapping hash: `{summary.get('mapping_hash', 'unknown')}`",
-        "",
-        "## Coverage Overlap Matrix",
-        "",
-        "| Robot SF Family | Scenario Count | Alyassi Category | Overlap |",
-        "|---|---:|---|---|",
-    ]
-    lines.extend(
-        _markdown_rows_from_mapping_rows(
-            list(summary.get("coverage_overlap_rows", [])),
-            ("robot_sf_family", "scenario_count", "alyassi_category", "overlap"),
-        )
-    )
-    lines.extend(
-        [
-            "",
-            "## Metric Comparability",
-            "",
-            "| Metric | Classification | Alyassi Metric | Rationale |",
-            "|---|---|---|---|",
-        ]
-    )
-    lines.extend(
-        _markdown_rows_from_mapping_rows(
-            list(summary.get("metric_comparability_rows", [])),
-            ("metric", "classification", "alyassi_metric", "rationale"),
-        )
-    )
-    lines.extend(["", "## AMV-Specific Extensions", ""])
-    extensions = summary.get("amv_specific_extensions", [])
-    if extensions:
-        for extension in extensions:
-            lines.append(f"- {_escape_markdown_cell(extension)}")
-    else:
-        lines.append("- none")
-    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-    return json_path, md_path
-
-
-def _write_snqi_diagnostics_artifacts(  # noqa: C901
-    reports_dir: Path,
-    payload: dict[str, Any],
-) -> tuple[Path, Path, Path]:
-    """Write SNQI diagnostics JSON/Markdown and sensitivity CSV artifacts.
-
-    Returns:
-        Tuple of ``(json_path, markdown_path, csv_path)``.
-    """
-    json_path = reports_dir / "snqi_diagnostics.json"
-    md_path = reports_dir / "snqi_diagnostics.md"
-    csv_path = reports_dir / "snqi_sensitivity.csv"
-    _write_json(json_path, payload)
-
-    lines = [
-        "# SNQI Diagnostics",
-        "",
-        f"- Contract status: `{payload.get('contract_status', 'unknown')}`",
-        f"- Rank alignment (Spearman): `{payload.get('rank_alignment_spearman', 0.0):.4f}`",
-        f"- Outcome separation: `{payload.get('outcome_separation', 0.0):.4f}`",
-        f"- Objective score: `{payload.get('objective_score', 0.0):.4f}`",
-        f"- Dominant component: `{payload.get('dominant_component', 'unknown')}`",
-        f"- Dominant component mean |contribution|: `{payload.get('dominant_component_mean_abs', 0.0):.4f}`",
-        "",
-        "## SNQI Assets",
-        "",
-        f"- Weights path: `{payload.get('weights_path', 'derived')}`",
-        f"- Weights version: `{payload.get('weights_version', 'unknown')}`",
-        f"- Weights SHA-256: `{payload.get('weights_sha256', 'unknown')}`",
-        f"- Baseline path: `{payload.get('baseline_path', 'derived')}`",
-        f"- Baseline version: `{payload.get('baseline_version', 'unknown')}`",
-        f"- Baseline SHA-256: `{payload.get('baseline_sha256', 'unknown')}`",
-        "",
-        "## Baseline Normalization",
-        "",
-        f"- Source: `{payload.get('baseline_source', 'unknown')}`",
-        f"- Degeneracy adjustments: `{payload.get('baseline_adjustments', 0)}`",
-        "",
-        "## Positioning",
-        "",
-        f"- Recommendation: `{payload.get('positioning', {}).get('recommendation', 'unknown')}`",
-        f"- Claim scope: `{payload.get('positioning', {}).get('claim_scope', 'unknown')}`",
-        f"- Aligned variable metrics: `{payload.get('positioning', {}).get('aligned_metric_count', 0)}` / `{payload.get('positioning', {}).get('variable_metric_count', 0)}`",
-        "",
-        "## Planner Ordering",
-        "",
-        "| Rank | Planner | Kinematics | Mean SNQI | Episodes |",
-        "|---:|---|---|---:|---:|",
-    ]
-    ordering = payload.get("planner_ordering")
-    if isinstance(ordering, list):
-        for row in ordering:
-            lines.append(
-                "| {rank} | {planner_key} | {kinematics} | {mean_snqi:.6f} | {episode_count} |".format(
-                    rank=int(row.get("rank", 0) or 0),
-                    planner_key=str(row.get("planner_key", "unknown")),
-                    kinematics=str(row.get("kinematics", "unknown")),
-                    mean_snqi=float(row.get("mean_snqi", 0.0) or 0.0),
-                    episode_count=int(row.get("episode_count", 0) or 0),
-                )
-            )
-    lines.extend(
-        [
-            "",
-            "## Component Correlations",
-            "",
-            "| Metric | Direction | Spearman | Variable | Aligned |",
-            "|---|---|---:|---|---|",
-        ]
-    )
-    correlations = payload.get("component_correlations")
-    if isinstance(correlations, dict):
-        for metric_name, row in sorted(correlations.items()):
-            spearman = row.get("spearman")
-            spearman_text = "n/a" if spearman is None else f"{float(spearman):.6f}"
-            aligned = row.get("aligned_with_expected_direction")
-            aligned_text = "n/a" if aligned is None else ("yes" if aligned else "no")
-            lines.append(
-                "| {metric} | {direction} | {spearman} | {variable} | {aligned} |".format(
-                    metric=_escape_markdown_cell(str(metric_name)),
-                    direction=_escape_markdown_cell(str(row.get("direction", "unknown"))),
-                    spearman=spearman_text,
-                    variable="yes" if bool(row.get("variable")) else "no",
-                    aligned=aligned_text,
-                )
-            )
-    lines.extend(
-        [
-            "",
-            "## Component Dominance (mean absolute contribution)",
-            "",
-            "| Component | Mean |",
-            "|---|---:|",
-        ]
-    )
-    dominance = payload.get("component_dominance")
-    if isinstance(dominance, dict):
-        for key, value in sorted(dominance.items()):
-            lines.append(f"| {_escape_markdown_cell(key)} | {float(value):.6f} |")
-    caveats = payload.get("positioning", {}).get("caveats")
-    if isinstance(caveats, list) and caveats:
-        lines.extend(["", "## Caveats", ""])
-        for caveat in caveats:
-            lines.append(f"- {_escape_markdown_cell(str(caveat))}")
-    md_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
-
-    calibrated = payload.get("calibrated_weights")
-    headers = (
-        "component",
-        "metric_name",
-        "configured_weight",
-        "configured_weight_share",
-        "calibrated_weight",
-        "delta",
-        "mean_abs_contribution",
-        "mean_abs_score_delta_if_ablated",
-        "episode_rank_correlation_if_ablated",
-        "planner_rank_correlation_if_ablated",
-        "planner_order_changed_if_ablated",
-        "sensitivity_rank",
-    )
-    rows: list[dict[str, Any]] = []
-    sensitivity_rows = payload.get("weight_sensitivity")
-    sensitivity_by_component = (
-        {str(row.get("weight_name")): row for row in sensitivity_rows if isinstance(row, dict)}
-        if isinstance(sensitivity_rows, list)
-        else {}
-    )
-    if isinstance(calibrated, dict):
-        configured = payload.get("configured_weights", {})
-        for name in WEIGHT_NAMES:
-            configured_value = float((configured or {}).get(name, 1.0))
-            calibrated_value = float(calibrated.get(name, configured_value))
-            sensitivity = sensitivity_by_component.get(name, {})
-            rows.append(
-                {
-                    "component": name,
-                    "metric_name": sensitivity.get("metric_name", ""),
-                    "configured_weight": configured_value,
-                    "configured_weight_share": float(
-                        sensitivity.get("configured_weight_share", 0.0)
-                    ),
-                    "calibrated_weight": calibrated_value,
-                    "delta": calibrated_value - configured_value,
-                    "mean_abs_contribution": float(sensitivity.get("mean_abs_contribution", 0.0)),
-                    "mean_abs_score_delta_if_ablated": float(
-                        sensitivity.get("mean_abs_score_delta_if_ablated", 0.0)
-                    ),
-                    "episode_rank_correlation_if_ablated": float(
-                        sensitivity.get("episode_rank_correlation_if_ablated", 1.0)
-                    ),
-                    "planner_rank_correlation_if_ablated": float(
-                        sensitivity.get("planner_rank_correlation_if_ablated", 1.0)
-                    ),
-                    "planner_order_changed_if_ablated": bool(
-                        sensitivity.get("planner_order_changed_if_ablated")
-                    ),
-                    "sensitivity_rank": int(sensitivity.get("sensitivity_rank", 0) or 0),
-                }
-            )
-    _write_csv(csv_path, [{key: row.get(key) for key in headers} for row in rows])
-    return json_path, md_path, csv_path
 
 
 def prepare_campaign_preflight(

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -15,6 +15,7 @@ import pytest
 import yaml
 from loguru import logger
 
+import robot_sf.benchmark.camera_ready._artifacts as camera_ready_artifacts_module
 import robot_sf.benchmark.camera_ready_campaign as camera_ready_campaign_module
 from robot_sf.benchmark.artifact_publication import PublicationBundleResult
 from robot_sf.benchmark.camera_ready._artifacts import (
@@ -67,6 +68,26 @@ from robot_sf.benchmark.synthetic_actuation import (
     validate_synthetic_actuation_variability_distribution,
 )
 from robot_sf.common.artifact_paths import get_repository_root
+
+
+def test_camera_ready_campaign_reexports_package_artifact_helpers() -> None:
+    """Legacy camera_ready_campaign imports expose moved artifact helpers."""
+    helper_names = (
+        "_markdown_rows_from_mapping_rows",
+        "_write_actuation_envelope_artifacts",
+        "_write_amv_coverage_artifacts",
+        "_write_comparability_artifacts",
+        "_write_matrix_summary_artifacts",
+        "_write_seed_episode_rows_artifact",
+        "_write_seed_variability_artifacts",
+        "_write_snqi_diagnostics_artifacts",
+        "_write_statistical_sufficiency_artifact",
+    )
+
+    for helper_name in helper_names:
+        assert getattr(camera_ready_campaign_module, helper_name) is getattr(
+            camera_ready_artifacts_module, helper_name
+        )
 
 
 def test_scenario_with_kinematics_patches_copy_without_mutating_input() -> None:


### PR DESCRIPTION
## Summary

- Advances https://github.com/ll7/robot_sf_ll7/issues/3385 with one incremental decomposition slice; the parent issue stays **open** for the remaining work (further `summaries`/`reporting`/`route_clearance` extraction beyond what already landed, thinning `run_campaign` into an orchestrator, and dropping the `noqa: C901, PLR0912, PLR0915` suppressions).
- Moves the remaining campaign-specific artifact writer helpers from `robot_sf/benchmark/camera_ready_campaign.py` into `robot_sf/benchmark/camera_ready/_artifacts.py`.
- Keeps the legacy `camera_ready_campaign` private helper names as re-exports/call targets so existing tests and imports keep working.
- Adds a regression test that the legacy module exposes the moved artifact helpers from the package module.

## Validation

- `uv run ruff check --fix robot_sf/benchmark/camera_ready_campaign.py robot_sf/benchmark/camera_ready/_artifacts.py tests/benchmark/test_camera_ready_campaign.py` - passed
- `uv run pytest tests/benchmark/test_camera_ready_campaign.py` - passed, 124 tests
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed on dirty tree before commit, 1679 passed, 2 skipped
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue3385_pr_body.md scripts/dev/pr_ready_check.sh` - passed; clean-tree freshness stamp for 810f0f3f

## Scope

- This is a bounded slice of the multi-PR decomposition in #3385 ("one PR per step"). It does not complete the parent issue's acceptance criteria; `run_campaign` is intentionally left unchanged (still carries the `noqa` suppressions).

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No behavioral refactor of `run_campaign` beyond preserving its moved artifact helper call targets.

## Artifact Classification

- `output/coverage/` and `output/validation/pr_ready/` were generated by local validation and are ignored, temporary validation artifacts.
