### PR TITLE
Issue #3080: fail closed on Package C seed contract gaps

### DIFF
--- a/scripts/tools/prediction_package_c_readiness.py
+++ b/scripts/tools/prediction_package_c_readiness.py
@@ -192,6 +192,29 @@ def _collect_seed_plan(repo_root: Path) -> list[int]:
     return sorted(seeds)
 
 
+def _missing_seed_contracts(repo_root: Path) -> list[str]:
+    """Return missing same-seed contract fields from coordination configs."""
+    missing: list[str] = []
+
+    open_loop = _load_yaml(repo_root / CONFIG_OPEN_LOOP)
+    open_loop_seeds = {seed for seed in open_loop.get("seeds", []) or [] if isinstance(seed, int)}
+    if not open_loop_seeds:
+        missing.append(f"{CONFIG_OPEN_LOOP}::seeds")
+
+    closed_loop = _load_yaml(repo_root / CONFIG_CLOSED_LOOP)
+    fixture = closed_loop.get("fixture", {})
+    closed_loop_seed = fixture.get("seed") if isinstance(fixture, dict) else None
+    if not isinstance(closed_loop_seed, int):
+        missing.append(f"{CONFIG_CLOSED_LOOP}::fixture.seed")
+    elif open_loop_seeds and closed_loop_seed not in open_loop_seeds:
+        missing.append(
+            f"{CONFIG_CLOSED_LOOP}::fixture.seed={closed_loop_seed} "
+            f"not declared in {CONFIG_OPEN_LOOP}::seeds"
+        )
+
+    return missing
+
+
 def _collect_output_roots(repo_root: Path) -> list[str]:
     """Return declared output/evidence roots from the coordination configs.
 
@@ -241,6 +264,8 @@ def assess_arm(
     required = list(REQUIRED_CONFIGS) + list(REQUIRED_CODE)
     present = [rel for rel in required if _exists(repo_root, rel)]
     missing = [rel for rel in required if not _exists(repo_root, rel)]
+    if not missing:
+        missing.extend(_missing_seed_contracts(repo_root))
 
     # The arm-specific deterministic baseline must be registered (control arm
     # has no baseline and is always satisfied).

--- a/tests/tools/test_prediction_package_c_readiness.py
+++ b/tests/tools/test_prediction_package_c_readiness.py
@@ -101,6 +101,42 @@ def test_missing_config_marks_arms_missing(tmp_path: Path) -> None:
     assert all(REQUIRED_CONFIGS[1] in arm["missing_inputs"] for arm in report["arms"])
 
 
+def test_missing_seed_contract_marks_arms_missing(tmp_path: Path) -> None:
+    """A seedless open-loop config cannot satisfy the Package C same-seed plan."""
+    _write_wired_repo(tmp_path, with_coupling_store=True)
+    (tmp_path / REQUIRED_CONFIGS[0]).write_text(
+        "output:\n  evidence_dir: docs/context/evidence/issue_2915\n",
+        encoding="utf-8",
+    )
+
+    report = assess_package_c_readiness(
+        tmp_path,
+        coupling_result_store=tmp_path / "result_store",
+    )
+
+    assert report["overall_status"] == "missing"
+    assert all(arm["status"] == "missing" for arm in report["arms"])
+    assert all(f"{REQUIRED_CONFIGS[0]}::seeds" in arm["missing_inputs"] for arm in report["arms"])
+
+
+def test_mismatched_coupling_seed_marks_arms_missing(tmp_path: Path) -> None:
+    """The closed-loop seed must be part of the open-loop same-seed plan."""
+    _write_wired_repo(tmp_path, with_coupling_store=True)
+    (tmp_path / REQUIRED_CONFIGS[1]).write_text(
+        "fixture:\n  seed: 999\n",
+        encoding="utf-8",
+    )
+
+    report = assess_package_c_readiness(
+        tmp_path,
+        coupling_result_store=tmp_path / "result_store",
+    )
+
+    assert report["overall_status"] == "missing"
+    assert all(arm["status"] == "missing" for arm in report["arms"])
+    assert all("fixture.seed=999" in arm["missing_inputs"][0] for arm in report["arms"])
+
+
 def test_missing_baseline_only_marks_that_arm_missing(tmp_path: Path) -> None:
     """A baseline absent from the forecast module marks only its own arm missing.
 


### PR DESCRIPTION
## Summary
Tightens the issue #3080 Package C readiness helper so malformed same-seed coordination configs fail closed. A Package C arm now reports `missing` when the open-loop config has no integer `seeds`, when the closed-loop config lacks `fixture.seed`, or when the closed-loop seed is not part of the open-loop seed plan.

## Linked Issues
- Closes `#3080`
- Relates to `#2916`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: This is a fail-closed readiness/preflight refinement only.

## What Changed
- Added shared seed-contract validation to `scripts/tools/prediction_package_c_readiness.py`.
- Added fixture tests for seedless open-loop config and mismatched closed-loop seed readiness failures.

## Why Matters
- Added value: Prevents Package C from reporting `ready` with an invalid or mismatched same-seed plan.
- Expected impact: Later Package C execution gets a clearer missing-input report before campaigns are attempted.
- Why worth merging now: It strengthens the preflight matrix without executing campaigns or changing predictor behavior.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Package C readiness inventory quality only; no forecast-performance claim.
- Comparator or baseline, applicable: NA - support helper.
- Evidence tier: NA - support helper
- Result classification: NA - support helper
- Decision stop rule, applicable: Seed contract gaps must surface as `missing`, not `ready`.
- Parent issue, claim map, registry, context note, synthesis surface update: Issue #3080 via PR linkage.
- New research/benchmark/metric/paper-facing analysis tool, any: No new analysis tool; existing preflight helper is tightened.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: NA - preflight support helper, no evidence interpretation.
- Validity checklist: NA - no campaign execution or result classification.
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA - no experimental comparison result.
- Fallback/degraded exclusions: Fail-closed statuses remain explicit; blocked/missing are not success evidence.
- Claim boundary: readiness/preflight only.
- Implementation integrity vs experimental validity: Focused tests cover the readiness contract.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no mechanism/result claim.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA - this PR does not run Package C.
- Extractor analysis tool needed: no
- Artifact missing unavailable: No artifact required by this PR; without a coupling result store the helper remains fail-closed.
- Stop / revise / continue decision: NA - support helper.
- Proposed child issue existing follow-up: none.

## Validation / Proof
- `uv run pytest tests/tools/test_prediction_package_c_readiness.py -q` - passed, 8 tests.
- `uv run ruff format scripts/tools/prediction_package_c_readiness.py tests/tools/test_prediction_package_c_readiness.py` - passed, reformatted one file.
- `uv run ruff check scripts/tools/prediction_package_c_readiness.py tests/tools/test_prediction_package_c_readiness.py` - passed.
- `uv run python scripts/tools/prediction_package_c_readiness.py --markdown` - expected fail-closed report: all four arms `blocked` pending #2916 durable result store.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` - initial attempt stopped before validation because analytics dependencies were missing; after `uv sync --all-extras`, the wrapper required this PR body source before stamping final readiness.

## Performance
- Baseline runtime: NA - no runtime/performance claim.
- Changed runtime: NA - no runtime/performance claim.
- Representative command: `uv run pytest tests/tools/test_prediction_package_c_readiness.py -q`
- Hot-path call count profile anchor: NA - no hot-path change.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: Revert if valid Package C configs are incorrectly reported as `missing`.

## Risks / Rollout
- Compatibility risks: Low; only tightens fail-closed readiness checks.
- Failure modes: A future valid multi-seed closed-loop config may need this helper generalized beyond the current `fixture.seed` contract.
- Rollback fallback plan: Revert this PR or relax `_missing_seed_contracts`.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: Issue #3080 and #2916 readiness comments.
- Any assumptions need to preserved: Current #2916 closed-loop config declares one `fixture.seed`; it must be included in the #2915 open-loop seed list.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized in this task.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: This PR changes a preflight checker only and does not produce benchmark evidence.

## Follow-Up Issues
- Deferred work: none.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that seed-contract gaps classify as `missing` only after required files exist.
- Known limitations: No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
