### PR TITLE
Issue #3637: check reactivity replay preflight exclusions

### DIFF
--- a/configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml
+++ b/configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml
@@ -97,6 +97,11 @@ rank_stability_analysis:
     rank-stability evidence with the replay force-off limitation.
 
 # After preflight passes, the run + post-run analysis (OUT OF SCOPE for #3637 implementation slice):
+out_of_scope:
+- no_full_benchmark_campaign
+- no_slurm_gpu_submission
+- no_paper_dissertation_claim_edits
+
 run_command: |
   # Paired reactive-vs-replay campaign across the declared planners + seeds (real runner).
   uv run python scripts/benchmark/run_reactivity_ablation_campaign_issue_3573.py \

--- a/robot_sf/benchmark/reactivity_replay_preflight.py
+++ b/robot_sf/benchmark/reactivity_replay_preflight.py
@@ -573,10 +573,16 @@ def _resolve_rank_stability_analysis(packet: dict[str, Any]) -> dict[str, Any]:
 
 
 def _resolve_out_of_scope(packet: dict[str, Any]) -> tuple[str, ...]:
-    """Return packet-level exclusions that keep preflight from implying evidence."""
-    raw = packet.get("out_of_scope", ())
+    """Return packet-level exclusions that keep preflight from implying evidence.
+
+    A missing key resolves to the empty tuple so the ``out_of_scope`` check fails
+    closed with an actionable blocked manifest (mirroring
+    ``_resolve_rank_stability_analysis``), rather than raising before manifest
+    construction. A present-but-malformed value still raises.
+    """
+    raw = packet.get("out_of_scope", [])
     if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
-        raise ValueError("packet 'out_of_scope' must be list strings")
+        raise ValueError("packet 'out_of_scope' must be a list of strings when present")
     return tuple(raw)
 
 

--- a/robot_sf/benchmark/reactivity_replay_preflight.py
+++ b/robot_sf/benchmark/reactivity_replay_preflight.py
@@ -62,6 +62,14 @@ REQUIRED_RANK_STABILITY_METRICS = ("collision_rate", "near_miss_rate", "min_sepa
 #: Canonical post-run gate command family. Packets may add arguments but must route here.
 RANK_STABILITY_GATE_COMMAND = "scripts/tools/seed_sufficiency_gate.py"
 
+#: Explicitly excluded actions for this preflight slice. These are machine-checked so a
+#: launch packet cannot be mistaken for benchmark evidence or a compute submission request.
+REQUIRED_OUT_OF_SCOPE = (
+    "no_full_benchmark_campaign",
+    "no_slurm_gpu_submission",
+    "no_paper_dissertation_claim_edits",
+)
+
 
 @dataclass(frozen=True, slots=True)
 class ReactivityReplayRunPlan:
@@ -94,6 +102,7 @@ class ReactivityReplayRunPlan:
     replay_is_trajectory_playback: bool = REPLAY_IS_TRAJECTORY_PLAYBACK
     replay_limitation: str = REPLAY_LIMITATION
     rank_stability_analysis: dict[str, Any] = field(default_factory=dict)
+    out_of_scope: tuple[str, ...] = REQUIRED_OUT_OF_SCOPE
     min_planners: int = MIN_PLANNERS
     min_seeds: int = MIN_RANK_STABILITY_SEEDS
     #: Minimum horizon for the contrast to register (diagnostic family observation, #3573).
@@ -334,6 +343,28 @@ def _check_replay_limitation(plan: ReactivityReplayRunPlan) -> CheckResult:
     return CheckResult(name="replay_limitation", passed=ok, detail=detail)
 
 
+def _check_out_of_scope(plan: ReactivityReplayRunPlan) -> CheckResult:
+    """Validate the non-execution / non-claim boundary travels with the packet.
+
+    Returns:
+        CheckResult: ``out_of_scope`` check outcome.
+    """
+    declared = set(plan.out_of_scope)
+    required = set(REQUIRED_OUT_OF_SCOPE)
+    missing = sorted(required - declared)
+    extras = sorted(declared - required)
+    ok = not missing
+    detail = (
+        "explicitly excludes full benchmark campaign, Slurm/GPU submission, and "
+        "paper/dissertation claim edits"
+        if ok
+        else f"missing required out_of_scope exclusions: {', '.join(missing)}"
+    )
+    if extras:
+        detail = f"{detail}; extra exclusions declared: {', '.join(extras)}"
+    return CheckResult(name="out_of_scope", passed=ok, detail=detail)
+
+
 _CHECKS = (
     _check_planner_count,
     _check_arms,
@@ -343,6 +374,7 @@ _CHECKS = (
     _check_scenario_set_digest,
     _check_rank_stability_analysis,
     _check_replay_limitation,
+    _check_out_of_scope,
 )
 
 
@@ -382,6 +414,7 @@ def build_preflight_manifest(plan: ReactivityReplayRunPlan) -> dict[str, Any]:
             "scenario_set_sha256": plan.scenario_set_sha256,
             "horizon": plan.horizon,
             "rank_stability_analysis": dict(plan.rank_stability_analysis),
+            "out_of_scope": list(plan.out_of_scope),
             "min_planners": plan.min_planners,
             "min_seeds": plan.min_seeds,
         },
@@ -400,6 +433,7 @@ def build_preflight_manifest(plan: ReactivityReplayRunPlan) -> dict[str, Any]:
             "by scripts/tools/seed_sufficiency_gate.py; 'replay' is live force-off, not trajectory "
             "playback."
         ),
+        "out_of_scope": list(plan.out_of_scope),
     }
 
 
@@ -465,6 +499,7 @@ def run_plan_from_packet(packet: dict[str, Any]) -> ReactivityReplayRunPlan:
     if not isinstance(limitation, str):
         raise ValueError("packet 'replay.limitation' must be a string")
     analysis = _resolve_rank_stability_analysis(packet)
+    out_of_scope = _resolve_out_of_scope(packet)
 
     overrides: dict[str, Any] = {}
     if "min_planners" in packet:
@@ -481,6 +516,7 @@ def run_plan_from_packet(packet: dict[str, Any]) -> ReactivityReplayRunPlan:
         replay_is_trajectory_playback=is_playback,
         replay_limitation=limitation,
         rank_stability_analysis=dict(analysis),
+        out_of_scope=out_of_scope,
         **overrides,
     )
 
@@ -536,6 +572,14 @@ def _resolve_rank_stability_analysis(packet: dict[str, Any]) -> dict[str, Any]:
     return dict(analysis)
 
 
+def _resolve_out_of_scope(packet: dict[str, Any]) -> tuple[str, ...]:
+    """Return packet-level exclusions that keep preflight from implying evidence."""
+    raw = packet.get("out_of_scope", ())
+    if not isinstance(raw, list) or not all(isinstance(item, str) for item in raw):
+        raise ValueError("packet 'out_of_scope' must be list strings")
+    return tuple(raw)
+
+
 __all__ = [
     "DIAGNOSTIC_SEED_COUNT",
     "ISSUE",
@@ -543,6 +587,7 @@ __all__ = [
     "MIN_RANK_STABILITY_SEEDS",
     "PREFLIGHT_SCHEMA",
     "RANK_STABILITY_GATE_COMMAND",
+    "REQUIRED_OUT_OF_SCOPE",
     "REQUIRED_RANK_STABILITY_METRICS",
     "CheckResult",
     "ReactivityReplayRunPlan",

--- a/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
+++ b/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
@@ -259,6 +259,21 @@ def test_run_plan_from_packet_rejects_malformed(packet):
         run_plan_from_packet(packet)
 
 
+def test_packet_missing_out_of_scope_blocks_gracefully():
+    """A packet omitting out_of_scope fails closed via the check, not a raw ValueError."""
+    packet = {
+        "planners": list(_ready_plan().planners),
+        "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
+        "horizon": 300,
+        "seeds": list(range(101, 121)),
+        "rank_stability_analysis": _rank_stability_analysis(),
+    }
+    manifest = build_preflight_manifest(run_plan_from_packet(packet))
+    assert manifest["status"] == "blocked"
+    assert manifest["plan"]["out_of_scope"] == []
+    assert _checks_by_name(run_plan_from_packet(packet))["out_of_scope"] is False
+
+
 def test_shipped_packet_preflights_ready():
     """Regression guard: the canonical shipped launch packet must preflight as ready."""
     packet = yaml.safe_load(SHIPPED_PACKET.read_text(encoding="utf-8"))

--- a/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
+++ b/tests/benchmark/test_reactivity_replay_preflight_issue_3637.py
@@ -20,6 +20,7 @@ from robot_sf.benchmark.reactivity_replay_preflight import (
     MIN_RANK_STABILITY_SEEDS,
     PREFLIGHT_SCHEMA,
     RANK_STABILITY_GATE_COMMAND,
+    REQUIRED_OUT_OF_SCOPE,
     REQUIRED_RANK_STABILITY_METRICS,
     ReactivityReplayRunPlan,
     build_preflight_manifest,
@@ -64,6 +65,11 @@ def _rank_stability_analysis() -> dict[str, object]:
     }
 
 
+def _out_of_scope() -> list[str]:
+    """Return the required non-execution / non-claim exclusions."""
+    return list(REQUIRED_OUT_OF_SCOPE)
+
+
 def _ready_plan(**overrides) -> ReactivityReplayRunPlan:
     """A plan that passes every precondition unless overridden."""
     seeds = _ready_seeds()
@@ -101,6 +107,19 @@ def test_manifest_always_carries_replay_limitation():
     assert "not pre-recorded trajectory playback" in limitation["note"].lower()
     assert "rank stability" in manifest["claim_boundary"].lower()
     assert manifest["plan"]["rank_stability_analysis"]["paired_seed_resampling"] is True
+    assert manifest["out_of_scope"] == list(REQUIRED_OUT_OF_SCOPE)
+    assert manifest["plan"]["out_of_scope"] == list(REQUIRED_OUT_OF_SCOPE)
+
+
+def test_missing_out_of_scope_metadata_blocks():
+    """Packets must state the non-execution / non-claim boundary explicitly."""
+    assert _checks_by_name(_ready_plan(out_of_scope=()))["out_of_scope"] is False
+
+
+def test_weakened_out_of_scope_metadata_blocks():
+    """Dropping any required exclusion prevents ready preflight."""
+    plan = _ready_plan(out_of_scope=("no_full_benchmark_campaign", "no_slurm_gpu_submission"))
+    assert _checks_by_name(plan)["out_of_scope"] is False
 
 
 def test_too_few_planners_blocks():
@@ -200,6 +219,7 @@ def test_run_plan_from_packet_shared_seeds_are_paired():
         "horizon": 300,
         "seeds": list(range(101, 121)),
         "rank_stability_analysis": _rank_stability_analysis(),
+        "out_of_scope": _out_of_scope(),
     }
     plan = run_plan_from_packet(packet)
     assert set(plan.arm_seeds) == set(REACTIVITY_ARMS)
@@ -216,6 +236,7 @@ def test_run_plan_from_packet_explicit_arm_seeds():
         "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
         "horizon": 300,
         "arm_seeds": {"reactive": seeds, "replay": seeds},
+        "out_of_scope": _out_of_scope(),
     }
     plan = run_plan_from_packet(packet)
     assert plan.arm_seeds["reactive"] == tuple(seeds)
@@ -243,6 +264,8 @@ def test_shipped_packet_preflights_ready():
     packet = yaml.safe_load(SHIPPED_PACKET.read_text(encoding="utf-8"))
     manifest = build_preflight_manifest(run_plan_from_packet(packet))
     assert manifest["status"] == "ready", manifest["blocking_issues"]
+    assert packet["out_of_scope"] == list(REQUIRED_OUT_OF_SCOPE)
+    assert manifest["out_of_scope"] == list(REQUIRED_OUT_OF_SCOPE)
 
 
 def test_scenario_set_checksum_mismatch_blocks(tmp_path):
@@ -299,6 +322,7 @@ def test_cli_blocked_packet_exit_one(tmp_path):
                 "scenario_set": "configs/scenarios/sets/classic_crossing_subset.yaml",
                 "horizon": 300,
                 "seeds": list(range(101, 121)),
+                "out_of_scope": _out_of_scope(),
             }
         ),
         encoding="utf-8",


### PR DESCRIPTION
## Summary
- Issue: #3637.
- Adds a machine-checked `out_of_scope` boundary to the issue #3637 reactivity-vs-replay rank-study launch packet and preflight manifest.
- Extends the checker/tests so the packet fails closed if it omits the explicit exclusions for benchmark execution, Slurm/GPU submission, or paper/dissertation claim edits.

## Scope
This is a bounded manifest/checker hardening slice for the seed-sufficient reactivity-vs-replay rank study. It does not run or interpret the increased-seed benchmark.

## Validation
- `uv run ruff check robot_sf/benchmark/reactivity_replay_preflight.py tests/benchmark/test_reactivity_replay_preflight_issue_3637.py` - passed
- `uv run pytest tests/benchmark/test_reactivity_replay_preflight_issue_3637.py -q` - passed, 35 tests
- `uv run python scripts/benchmark/preflight_reactivity_replay_rank_study_issue_3637.py --packet configs/benchmarks/reactivity_replay_rank_study_issue_3637_launch_packet.yaml --json` - passed, status `ready`, includes `out_of_scope`
- `PR_READY_PR_BODY_FILE=/tmp/robot_sf_issue_3637/pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; freshness stamp `output/validation/pr_ready/issue-3637-reactivity-replay-rank-study-preflight-codex.json` for `2f0d961d`

## Follow-Up Issues
- None opened. Existing issue #3637 remains the tracking issue for the full benchmark campaign, post-run rank-stability analysis, and paper/dissertation claim review.

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No rank-stability interpretation.

## Artifact and downstream propagation
- No generated benchmark artifacts are committed.
- Temporary validation JSON was written under `/tmp/robot_sf_issue_3637/` only.
- Downstream paper/dissertation claims remain blocked on the actual post-run seed-sufficiency gate and claim-card review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added explicit “out of scope” metadata to the launch packet and preflight checks.
  * Readiness checks now verify required exclusions are present before a run can proceed.

* **Bug Fixes**
  * Missing or incomplete out-of-scope details now block execution cleanly instead of failing unexpectedly.
  * Packet and manifest outputs now consistently carry the same out-of-scope information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->