### PR TITLE
Issue #2921: fail closed on malformed proposal archives

### DIFF
--- a/robot_sf/adversarial/proposal_model.py
+++ b/robot_sf/adversarial/proposal_model.py
@@ -35,10 +35,12 @@ class FailureArchiveProposalModel:
         self.search_space = search_space
         self.entries: list[dict[str, Any]] = []
         self.state = "active"
+        self.state_reason = "archive_loaded"
 
         # Load archive data
-        if not archive_path_or_data:
+        if archive_path_or_data is None:
             self.state = "blocked"
+            self.state_reason = "missing_archive"
             return
 
         try:
@@ -46,6 +48,7 @@ class FailureArchiveProposalModel:
                 path = Path(archive_path_or_data)
                 if not path.exists() or path.stat().st_size == 0:
                     self.state = "blocked"
+                    self.state_reason = "missing_or_empty_archive_file"
                     return
                 with open(path, encoding="utf-8") as f:
                     data = json.load(f)
@@ -54,24 +57,37 @@ class FailureArchiveProposalModel:
 
             if not isinstance(data, dict) or "entries" not in data:
                 self.state = "blocked"
+                self.state_reason = "malformed_archive_payload"
+                return
+
+            try:
+                failure_archive_feature_rows(data)
+            except ValueError as exc:
+                self.state = "blocked"
+                self.state_reason = f"invalid_failure_archive_schema: {exc}"
                 return
 
             raw_entries = data.get("entries", [])
             if not isinstance(raw_entries, list):
                 self.state = "blocked"
+                self.state_reason = "malformed_archive_entries"
                 return
             if not raw_entries:
                 self.state = "blocked"
+                self.state_reason = "empty_archive_entries"
                 return
             if any(
                 not isinstance(entry, dict) or not isinstance(entry.get("candidate", {}), dict)
                 for entry in raw_entries
             ):
                 self.state = "blocked"
+                self.state_reason = "missing_candidate_metadata"
                 return
             self.entries = raw_entries
+            self.state_reason = "archive_loaded"
         except (ValueError, TypeError, json.JSONDecodeError, OSError):
             self.state = "blocked"
+            self.state_reason = "archive_load_error"
 
     def get_tabular_view(self) -> list[dict[str, Any]]:
         """Build a tabular feature view from archive entries."""

--- a/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
+++ b/tests/adversarial/test_adversarial_proposal_model_issue_2921.py
@@ -37,11 +37,17 @@ def test_proposal_model_initialization_and_blocked_state() -> None:
     # Empty dict
     model_empty_dict = FailureArchiveProposalModel({})
     assert model_empty_dict.state == "blocked"
+    assert model_empty_dict.state_reason == "malformed_archive_payload"
+
+    entries_only = FailureArchiveProposalModel({"entries": create_synthetic_archive()["entries"]})
+    assert entries_only.state == "blocked"
+    assert entries_only.state_reason.startswith("invalid_failure_archive_schema:")
 
     # Valid dict
     archive_data = create_synthetic_archive()
     model_active = FailureArchiveProposalModel(archive_data)
     assert model_active.state == "active"
+    assert model_active.state_reason == "archive_loaded"
     assert len(model_active.entries) == 2
 
 


### PR DESCRIPTION
## Issue

Closes/addresses https://github.com/ll7/robot_sf_ll7/issues/2921

## Scope Summary

- Tightens `FailureArchiveProposalModel` so only `None` is treated as a missing archive; malformed dictionaries now fail closed as malformed archive payloads.
- Validates proposal-model archive payloads through the canonical `adversarial_failure_archive.v1` feature-row exporter before marking the model active.
- Adds `state_reason` diagnostics for blocked/active archive loading states and regression coverage for schema-less `entries` payloads.

This is a bounded readiness/claim-boundary slice. It does not train or submit a learned proposal model, and it does not claim held-out yield improvement.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/adversarial/test_adversarial_proposal_model_issue_2921.py -q` - passed (14 tests)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/adversarial/test_failure_archive.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py -q` - passed (21 tests)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/adversarial/proposal_model.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/adversarial/run_proposal_vs_random_issue_2921.py --help` - passed

Attempted broader collection with `uv run python -m pytest tests/ -k "adversarial and (proposal or archive)" -q`; it failed during collection because this worktree environment lacks optional packages including `torch`, `stable_baselines3`, `duckdb`, `pyarrow`, `sqlalchemy`, and `optuna`, before exercising the focused tests.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No benchmark, paper-grade, or held-out-yield claim promotion.

## Artifact Classification

No durable generated artifacts are committed. Validation outputs remain local/ephemeral.
