### PR TITLE
Issue #3798: cover S20/S30 evidence-gap packet dry run

### DIFF
--- a/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
+++ b/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import csv
 import json
+import subprocess
+import sys
 from typing import TYPE_CHECKING
 
 from scripts.validation import extract_s20_s30_evidence_gap_packet as extractor
@@ -166,6 +168,29 @@ def test_tracked_packet_fixture_renders_without_raw_artifacts(capsys) -> None:
     assert "File count: 56" in captured.out
     assert "requiring ignored output" in captured.out
     assert "no paper/dissertation claim edits" in captured.out
+
+
+def test_tracked_packet_dry_run_command_executes_without_submission() -> None:
+    """Published dry-run command prints the tracked packet without raw output artifacts."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            "scripts/validation/extract_s20_s30_evidence_gap_packet.py",
+            "--packet-fixture",
+            "docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json",
+            "--markdown",
+        ],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert "Status: `diagnostic_only`" in completed.stdout
+    assert "claim_promotion: `no_go`" in completed.stdout
+    assert "without submitting Slurm" in completed.stdout
+    assert "no paper/dissertation claim edits" in completed.stdout
+    assert "Traceback" not in completed.stderr
 
 
 def test_tracked_packet_rejects_claim_promotion_go(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds executable subprocess coverage for the issue #3798 post-13175 S20/S30 evidence-gap packet dry-run command. The compact packet itself is already present on `origin/main`; this PR proves the published command can print it from tracked metadata without raw `output/` artifacts or Slurm submission.

## Linked Issues
- Closes `#3798`
- Issue link: https://github.com/ll7/robot_sf_ll7/issues/3798

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added a subprocess test for `scripts/validation/extract_s20_s30_evidence_gap_packet.py --packet-fixture ... --markdown`.
- The test asserts the printed packet keeps `diagnostic_only`, `claim_promotion: no_go`, no Slurm submission, and no paper/dissertation claim edits.

## Why Matters
- Added value: proves the packet's public dry-run validation command works from tracked metadata.
- Expected impact: stronger fail-closed coverage for the post-13175 evidence-gap packet.
- Why worth merging now: issue #3798 asks that validation commands prove the packet is current.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3798 evidence-gap packet validation currency only.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - validation coverage only; no research result produced.
- Result classification: NA - no research result; packet content remains diagnostic-only.
- Decision stop rule, applicable: dry-run command exits 0 and prints no-claim boundaries from the tracked fixture.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3798 packet fixture and context catalog already present on `origin/main`.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - test coverage only; no new analysis semantics.

## Domain-Aware Approval
- Required PR: no - this PR is validation coverage only and makes no research, benchmark, metric, or paper-facing claim
- Domains reviewed: NA - no evidence validity review required for test-only coverage
- Status: not required
- Approver/review source waiver: NA - no evidence-validity-sensitive result classification in this PR
- Validity checklist:
  - Target claim/hypothesis: no research claim; test proves the tracked packet dry-run command remains executable
  - Comparator split/evidence validity: no comparator split is evaluated or changed
  - Fallback/degraded exclusions: archive-readiness checker remains fail-closed when canonical result store is missing
  - Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits
  - Implementation integrity vs experimental validity: implementation test verifies CLI behavior; it does not interpret benchmark evidence

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - subprocess invoked the published dry-run command.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action
- Rerun needed: no for this test-only slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: canonical S20/S30 result store remains absent in this checkout; checker reports blocked.
- Stop / revise / continue decision: continue with claim-gated follow-up only when separately authorized.
- Proposed child issue existing follow-up: none opened.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py -q` -> pass, 9 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/validation/test_extract_s20_s30_evidence_gap_packet.py` -> pass.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/validation/test_extract_s20_s30_evidence_gap_packet.py` -> pass.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --packet-fixture docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json --markdown` -> pass; rendered expected diagnostic/no-claim boundaries.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_s20_s30_archive_readiness.py --json` -> exit 1 expected blocked; result store files missing, so no claim promotion.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: low; test-only change.
- Failure modes: subprocess invocation could expose cwd assumptions; test uses repository-relative command just like the published validation command.
- Rollback fallback plan: revert the test addition.

## Docs / Provenance
- Updated docs: none in this PR; packet docs already tracked on `origin/main`.
- Relevant design provenance notes: `docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json` and `.md`.
- Any assumptions need to preserved: job 13175 packet remains diagnostic-only and does not authorize S30 submission or claim promotion.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; issue/PR comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): already present on `origin/main`.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is validation coverage only and makes no benchmark or paper-facing claim.

## Follow-Up Issues
- Deferred work: canonical result-store promotion and any S30 escalation remain separate authorized lanes.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer verify closely: the new subprocess test covers the exact tracked-fixture dry-run path.
- Any known limitations: it does not require local raw artifacts under `output/` and does not make archive-readiness pass.
