### PR TITLE
Issue #3385: extract camera-ready run-state helpers

### DIFF
--- a/robot_sf/benchmark/camera_ready/_run_state.py
+++ b/robot_sf/benchmark/camera_ready/_run_state.py
@@ -1,0 +1,202 @@
+"""Run-state and provenance helpers for camera-ready campaigns.
+
+Extracted from ``robot_sf.benchmark.camera_ready_campaign`` as a bounded
+package-decomposition slice for issue #3385. The legacy module re-exports these
+helpers so existing imports keep working while orchestration is split gradually.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from datetime import datetime
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+from urllib.parse import urlsplit, urlunsplit
+
+from robot_sf.benchmark.camera_ready._config import _sanitize_name
+from robot_sf.benchmark.fallback_policy import (
+    resolve_execution_mode as _resolve_benchmark_execution_mode,
+)
+from robot_sf.benchmark.observation_noise import (
+    load_observation_noise_spec,
+    normalize_observation_noise_spec,
+)
+from robot_sf.benchmark.utils import _git_hash_fallback
+from robot_sf.common.artifact_paths import get_repository_root
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from robot_sf.benchmark.camera_ready_campaign_config import CampaignConfig
+
+
+def _campaign_success_counters(
+    run_entries: Sequence[Mapping[str, Any]],
+    *,
+    expected_core_runs: int | None = None,
+) -> dict[str, Any]:
+    """Return campaign success counters, anchoring success on planners present."""
+    total_runs = 0
+    successful_runs = 0
+    core_total_runs = 0
+    core_successful_runs = 0
+
+    for entry in run_entries:
+        total_runs += 1
+        is_ok = str(entry.get("status", "")) == "ok"
+        if is_ok:
+            successful_runs += 1
+
+        planner_group = str((entry.get("planner") or {}).get("planner_group", "")).strip().lower()
+        if planner_group == "core":
+            core_total_runs += 1
+            if is_ok:
+                core_successful_runs += 1
+
+    if expected_core_runs is None:
+        expected_core_runs = core_total_runs
+
+    if core_total_runs:
+        success_basis = "core"
+        benchmark_success = core_successful_runs == core_total_runs == expected_core_runs
+    else:
+        success_basis = "all"
+        benchmark_success = total_runs > 0 and successful_runs == total_runs
+
+    return {
+        "benchmark_success": benchmark_success,
+        "benchmark_success_basis": success_basis,
+        "total_runs": total_runs,
+        "successful_runs": successful_runs,
+        "core_total_runs": core_total_runs,
+        "core_successful_runs": core_successful_runs,
+    }
+
+
+def _resolve_execution_mode(algorithm_metadata_contract: Any) -> str:
+    """Resolve execution mode from algorithm metadata payload with legacy fallbacks.
+
+    Returns:
+        Resolved execution mode string, or ``"unknown"`` when unavailable.
+    """
+    return _resolve_benchmark_execution_mode(algorithm_metadata_contract)
+
+
+def _sanitize_git_remote(remote: str) -> str:
+    """Remove credentials from git remote URLs before persisting provenance metadata.
+
+    Returns:
+        Credential-free remote URL when parseable, otherwise original input.
+    """
+    if not remote or "://" not in remote:
+        return remote
+    try:
+        parsed = urlsplit(remote)
+    except ValueError:
+        return remote
+    if not parsed.hostname:
+        return remote
+    netloc = parsed.hostname
+    if parsed.port is not None:
+        netloc = f"{netloc}:{parsed.port}"
+    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
+
+
+def _git_context() -> dict[str, str]:
+    """Collect lightweight git metadata for campaign provenance.
+
+    Returns:
+        Mapping with ``commit``, ``branch``, and sanitized ``remote`` fields.
+    """
+
+    def _run(args: list[str]) -> str:
+        """Run a git command and degrade to ``unknown`` when provenance is unavailable.
+
+        Returns:
+            Decoded command output, or ``"unknown"`` on command failure.
+        """
+        try:
+            out = subprocess.check_output(args, stderr=subprocess.DEVNULL)
+            return out.decode("utf-8", errors="replace").strip()
+        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+            return "unknown"
+
+    return {
+        "commit": _git_hash_fallback(),
+        "branch": _run(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
+        "remote": _sanitize_git_remote(_run(["git", "config", "--get", "remote.origin.url"])),
+    }
+
+
+def _campaign_id(cfg: CampaignConfig, *, label: str | None = None) -> str:
+    """Build a unique campaign identifier from config name and wall-clock timestamp.
+
+    Returns:
+        Campaign identifier used for output directories and manifests.
+    """
+    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    base = _sanitize_name(cfg.name)
+    if label:
+        suffix = _sanitize_name(label)
+        return f"{base}_{suffix}_{stamp}"
+    return f"{base}_{stamp}"
+
+
+def _resolve_campaign_id(
+    cfg: CampaignConfig,
+    *,
+    label: str | None = None,
+    campaign_id: str | None = None,
+) -> str:
+    """Resolve the output campaign identifier.
+
+    Returns:
+        Explicit sanitized campaign id when provided, otherwise timestamped id.
+    """
+    if campaign_id is not None:
+        normalized = _sanitize_name(campaign_id)
+        if not normalized:
+            raise ValueError("campaign_id must contain at least one alphanumeric character")
+        return normalized
+    return _campaign_id(cfg, label=label)
+
+
+def _resolve_path(raw_path: str | None, *, base_dir: Path) -> Path | None:
+    """Resolve paths relative to ``base_dir``.
+
+    Returns:
+        Absolute resolved path, or ``None`` when no path was provided.
+    """
+    if not raw_path:
+        return None
+    path = Path(raw_path)
+    if path.is_absolute():
+        return path
+
+    candidate = (base_dir / path).resolve()
+    if candidate.exists():
+        return candidate
+
+    repo_candidate = (get_repository_root() / path).resolve()
+    if repo_candidate.exists():
+        return repo_candidate
+
+    return candidate
+
+
+def _resolve_observation_noise(raw: Any, *, base_dir: Path) -> dict[str, Any] | None:
+    """Resolve an optional inline or file-backed observation-noise config.
+
+    Returns:
+        Normalized noise spec, or ``None`` when no profile was configured.
+    """
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return normalize_observation_noise_spec(raw)
+    if isinstance(raw, str) and raw.strip():
+        path = _resolve_path(raw, base_dir=base_dir)
+        if path is None or not path.is_file():
+            raise FileNotFoundError(f"Could not resolve observation_noise '{raw}'")
+        return load_observation_noise_spec(path)
+    raise ValueError("observation_noise must be mapping or YAML file path")

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -8,13 +8,10 @@ bundle for archival/release pipelines.
 from __future__ import annotations
 
 import math
-import subprocess
 import time
 from dataclasses import asdict
-from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
-from urllib.parse import urlsplit, urlunsplit
+from typing import Any
 
 import yaml
 from loguru import logger
@@ -99,6 +96,16 @@ from robot_sf.benchmark.camera_ready._route_clearance import (  # noqa: F401 - r
 from robot_sf.benchmark.camera_ready._route_clearance import (
     _build_route_clearance_warnings as _build_route_clearance_warnings_impl,
 )
+from robot_sf.benchmark.camera_ready._run_state import (  # noqa: F401 - re-exported for back-compat
+    _campaign_id,
+    _campaign_success_counters,
+    _git_context,
+    _resolve_campaign_id,
+    _resolve_execution_mode,
+    _resolve_observation_noise,
+    _resolve_path,
+    _sanitize_git_remote,
+)
 from robot_sf.benchmark.camera_ready._summaries import (  # noqa: F401 - re-exported for back-compat
     _ACTUATION_REPORT_METRICS,
     _SEED_VARIABILITY_METRICS,
@@ -143,16 +150,12 @@ from robot_sf.benchmark.fallback_policy import (
     summarize_campaign_outcome,
     summarize_campaign_status_axes,
 )
-from robot_sf.benchmark.fallback_policy import (
-    resolve_execution_mode as _resolve_benchmark_execution_mode,
-)
 from robot_sf.benchmark.latency_stress import (
     load_latency_stress_profile,
     not_available_latency_metrics,
     validate_latency_stress_profile,
 )
 from robot_sf.benchmark.observation_noise import (
-    load_observation_noise_spec,
     normalize_observation_noise_spec,
     observation_noise_hash,
 )
@@ -183,7 +186,6 @@ from robot_sf.benchmark.synthetic_actuation import (
 )
 from robot_sf.benchmark.utils import (
     _config_hash,
-    _git_hash_fallback,
     load_optional_json,
 )
 from robot_sf.common.artifact_paths import (
@@ -193,52 +195,9 @@ from robot_sf.common.artifact_paths import (
 )
 from robot_sf.nav.svg_map_parser import convert_map
 
-if TYPE_CHECKING:
-    from collections.abc import Mapping, Sequence
-
 CAMPAIGN_SCHEMA_VERSION = "benchmark-camera-ready-campaign.v1"
 DEFAULT_EPISODE_SCHEMA_PATH = Path("robot_sf/benchmark/schemas/episode.schema.v1.json")
 _normalized_kinematics_matrix = _kinematics_matrix_or_default
-
-
-def _campaign_success_counters(
-    run_entries: Sequence[Mapping[str, Any]], *, expected_core_runs: int | None = None
-) -> dict[str, Any]:
-    """Return campaign success counters, anchoring success on core planners when present."""
-    total_runs = 0
-    successful_runs = 0
-    core_total_runs = 0
-    core_successful_runs = 0
-
-    for entry in run_entries:
-        total_runs += 1
-        is_ok = str(entry.get("status", "")) == "ok"
-        if is_ok:
-            successful_runs += 1
-
-        planner_group = str((entry.get("planner") or {}).get("planner_group", "")).strip().lower()
-        if planner_group == "core":
-            core_total_runs += 1
-            if is_ok:
-                core_successful_runs += 1
-
-    if expected_core_runs is None:
-        expected_core_runs = core_total_runs
-
-    if core_total_runs:
-        success_basis = "core"
-        benchmark_success = core_successful_runs == core_total_runs == expected_core_runs
-    else:
-        success_basis = "all"
-        benchmark_success = total_runs > 0 and successful_runs == total_runs
-    return {
-        "benchmark_success": benchmark_success,
-        "benchmark_success_basis": success_basis,
-        "successful_runs": successful_runs,
-        "total_runs": total_runs,
-        "core_successful_runs": core_successful_runs,
-        "core_total_runs": core_total_runs,
-    }
 
 
 def _build_route_clearance_warnings(
@@ -266,135 +225,6 @@ def _build_route_clearance_warnings(
         )
     finally:
         _route_clearance_module.convert_map = original_convert_map
-
-
-def _resolve_execution_mode(algorithm_metadata_contract: Any) -> str:
-    """Resolve execution mode from algorithm metadata payload with legacy fallbacks.
-
-    Returns:
-        Resolved execution mode string, or ``"unknown"`` when unavailable.
-    """
-    return _resolve_benchmark_execution_mode(algorithm_metadata_contract)
-
-
-def _sanitize_git_remote(remote: str) -> str:
-    """Remove credentials from git remote URLs before persisting provenance metadata.
-
-    Returns:
-        Credential-free remote URL when parseable, otherwise original input.
-    """
-    if not remote or "://" not in remote:
-        return remote
-    try:
-        parsed = urlsplit(remote)
-    except ValueError:
-        return remote
-    if not parsed.hostname:
-        return remote
-    netloc = parsed.hostname
-    if parsed.port is not None:
-        netloc = f"{netloc}:{parsed.port}"
-    return urlunsplit((parsed.scheme, netloc, parsed.path, parsed.query, parsed.fragment))
-
-
-def _git_context() -> dict[str, str]:
-    """Collect lightweight git metadata for campaign provenance.
-
-    Returns:
-        Mapping with ``commit``, ``branch``, and ``remote`` fields.
-    """
-
-    def _run(args: list[str]) -> str:
-        """Run a git command and degrade to ``unknown`` when provenance is unavailable.
-
-        Returns:
-            str: Decoded command output, or ``"unknown"`` on command failure.
-        """
-        try:
-            out = subprocess.check_output(args, stderr=subprocess.DEVNULL)
-            return out.decode("utf-8", errors="replace").strip()
-        except (subprocess.CalledProcessError, FileNotFoundError, OSError):
-            return "unknown"
-
-    return {
-        "commit": _git_hash_fallback(),
-        "branch": _run(["git", "rev-parse", "--abbrev-ref", "HEAD"]),
-        "remote": _sanitize_git_remote(_run(["git", "config", "--get", "remote.origin.url"])),
-    }
-
-
-def _campaign_id(cfg: CampaignConfig, *, label: str | None = None) -> str:
-    """Build a unique campaign identifier from config name and wall-clock timestamp.
-
-    Returns:
-        Campaign identifier used for output directories and manifests.
-    """
-    stamp = datetime.now().strftime("%Y%m%d_%H%M%S")
-    base = _sanitize_name(cfg.name)
-    if label:
-        suffix = _sanitize_name(label)
-        return f"{base}_{suffix}_{stamp}"
-    return f"{base}_{stamp}"
-
-
-def _resolve_campaign_id(
-    cfg: CampaignConfig,
-    *,
-    label: str | None = None,
-    campaign_id: str | None = None,
-) -> str:
-    """Resolve the output campaign identifier.
-
-    Returns:
-        Explicit sanitized campaign id when provided, otherwise a timestamped id.
-    """
-    if campaign_id is not None:
-        normalized = _sanitize_name(campaign_id)
-        if not normalized:
-            raise ValueError("campaign_id must contain at least one alphanumeric character")
-        return normalized
-    return _campaign_id(cfg, label=label)
-
-
-def _resolve_path(raw_path: str | None, *, base_dir: Path) -> Path | None:
-    """Resolve optional paths relative to ``base_dir``.
-
-    Returns:
-        Absolute resolved path, or ``None`` when no path was provided.
-    """
-    if not raw_path:
-        return None
-    path = Path(raw_path)
-    if path.is_absolute():
-        return path
-
-    candidate = (base_dir / path).resolve()
-    if candidate.exists():
-        return candidate
-
-    repo_candidate = (get_repository_root() / path).resolve()
-    if repo_candidate.exists():
-        return repo_candidate
-
-    return candidate
-
-
-def _resolve_observation_noise(raw: Any, *, base_dir: Path) -> dict[str, Any] | None:
-    """Resolve an optional inline or file-backed observation-noise config.
-
-    Returns:
-        Normalized noise spec, or ``None`` when no profile is configured.
-    """
-    if raw is None:
-        return None
-    if isinstance(raw, dict):
-        return normalize_observation_noise_spec(raw)
-    if isinstance(raw, str) and raw.strip():
-        path = _resolve_path(raw, base_dir=base_dir)
-        if path is None or not path.is_file():
-            raise FileNotFoundError(f"Could not resolve observation_noise '{raw}'")
-        return load_observation_noise_spec(path)
-    raise ValueError("observation_noise must be a mapping or YAML file path")
 
 
 def _validate_campaign_config(cfg: CampaignConfig) -> None:  # noqa: C901, PLR0912, PLR0915

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -16,6 +16,7 @@ import yaml
 from loguru import logger
 
 import robot_sf.benchmark.camera_ready._artifacts as camera_ready_artifacts_module
+import robot_sf.benchmark.camera_ready._run_state as camera_ready_run_state_module
 import robot_sf.benchmark.camera_ready_campaign as camera_ready_campaign_module
 from robot_sf.benchmark.artifact_publication import PublicationBundleResult
 from robot_sf.benchmark.camera_ready._artifacts import (
@@ -39,6 +40,7 @@ from robot_sf.benchmark.camera_ready_campaign import (
     _build_actuation_envelope_summary,
     _build_breakdown_rows,
     _build_scenario_amv_lookup,
+    _campaign_success_counters,
     _extract_amv_taxonomy,
     _jsonable_repo_relative,
     _load_campaign_scenarios,
@@ -88,6 +90,43 @@ def test_camera_ready_campaign_reexports_package_artifact_helpers() -> None:
         assert getattr(camera_ready_campaign_module, helper_name) is getattr(
             camera_ready_artifacts_module, helper_name
         )
+
+
+def test_camera_ready_campaign_reexports_package_run_state_helpers() -> None:
+    """Legacy camera_ready_campaign imports expose moved run-state helpers."""
+    helper_names = (
+        "_campaign_id",
+        "_campaign_success_counters",
+        "_git_context",
+        "_resolve_campaign_id",
+        "_resolve_execution_mode",
+        "_resolve_observation_noise",
+        "_resolve_path",
+        "_sanitize_git_remote",
+    )
+
+    for helper_name in helper_names:
+        assert getattr(camera_ready_campaign_module, helper_name) is getattr(
+            camera_ready_run_state_module, helper_name
+        )
+
+
+def test_campaign_success_counters_core_success_ignores_experimental_failure() -> None:
+    """Campaign success is anchored on complete successful core planners when present."""
+    counters = _campaign_success_counters(
+        [
+            {"status": "ok", "planner": {"planner_group": "core"}},
+            {"status": "not_available", "planner": {"planner_group": "experimental"}},
+        ],
+        expected_core_runs=1,
+    )
+
+    assert counters["benchmark_success"] is True
+    assert counters["benchmark_success_basis"] == "core"
+    assert counters["total_runs"] == 2
+    assert counters["successful_runs"] == 1
+    assert counters["core_total_runs"] == 1
+    assert counters["core_successful_runs"] == 1
 
 
 def test_scenario_with_kinematics_patches_copy_without_mutating_input() -> None:


### PR DESCRIPTION
## Summary
Extract camera-ready campaign run-state and provenance helpers into `robot_sf.benchmark.camera_ready._run_state` while preserving the legacy `camera_ready_campaign.py` import surface.

This is a bounded issue #3385 decomposition slice; it does not change benchmark semantics or dissertation/paper claims.

## Linked Issues
- Relates `#3385`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `robot_sf/benchmark/camera_ready/_run_state.py` for campaign success counters, execution-mode resolution, sanitized git provenance, campaign id/path resolution, and observation-noise config resolution.
- Re-exported the moved helpers from `robot_sf/benchmark/camera_ready_campaign.py` for backwards-compatible internal/test imports.
- Added focused tests for the re-export surface and the core-planner success counter contract.

## Why Matters
- Added value: reduces the remaining `camera_ready_campaign.py` monolith by another leaf concern without changing the public surface.
- Expected impact: smaller orchestration module and clearer package ownership for run-state/provenance helpers.
- Why worth merging now: issue #3385 is explicitly incremental; this is a reversible, behavior-preserving package slice on top of the already-merged artifact-writer extraction.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - refactor-only maintainability slice for issue #3385.
- Comparator or baseline, applicable: NA.
- Evidence tier: NA - support refactor.
- Result classification: NA - support refactor; no research result claimed.
- Decision stop rule, applicable: focused tests and lint pass for moved helper surface.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3385 only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support refactor only.

## Domain-Aware Approval
approval concerns experimental validity waived / pending / blocked / not required: not required
- Approver/review source waiver: NA - no evidence classification, benchmark interpretation, or paper-facing claim change.
- Validity checklist: NA.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: NA.
- Claim boundary: unchanged.
- Implementation integrity vs experimental validity: implementation-only refactor; validation targets import compatibility and existing camera-ready campaign tests.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - refactor-only.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue incremental #3385 decomposition in later PRs.
- Proposed child issue existing follow-up: continue under #3385.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/camera_ready_campaign.py robot_sf/benchmark/camera_ready/_run_state.py tests/benchmark/test_camera_ready_campaign.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/camera_ready_campaign.py robot_sf/benchmark/camera_ready/_run_state.py tests/benchmark/test_camera_ready_campaign.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_camera_ready_campaign.py -q` -> passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue-3385-pr-body.md scripts/dev/pr_ready_check.sh` -> passed; freshness stamp recorded for head `b38507b86011e75aa2894588afad5467d2fd4907`.

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Hot Path
- Baseline runtime: NA - refactor-only; no runtime behavior claim.
- Changed runtime: NA - refactor-only; no runtime behavior claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_camera_ready_campaign.py -q`
- Hot-path call count profile anchor: NA - no performance/caching claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if import compatibility or camera-ready campaign tests regress.

## Risks / Rollout
- Compatibility risks: low; legacy helper names remain re-exported from `camera_ready_campaign.py`.
- Failure modes: accidental divergence between moved helper and legacy behavior; covered by focused re-export and success-counter tests plus existing campaign tests.
- Rollback fallback plan: revert this PR; no artifact migration required.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3385.
- Any assumptions need to preserved: this is an incremental package-decomposition slice, not the full `run_campaign` decomposition.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized for this run.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: no benchmark result, registry change, claim-map change, or paper-facing change.

## Follow-Up Issues
- Deferred work: remaining #3385 slices can continue moving validation/config/reporting/orchestration concerns and eventually shrink `run_campaign`.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer verify closely: `_campaign_success_counters` return keys and behavior are preserved; helper names remain available from `robot_sf.benchmark.camera_ready_campaign`.
- Any known limitations: does not complete the full #3385 decomposition and does not remove the `run_campaign` complexity suppressions.
