### PR TITLE
Issue #3482: record release collision-count boundary

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -17,6 +17,14 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+  - path: docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/manifest.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_3482_event_ledger_reconciliation_guard/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/README.md
+++ b/docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/README.md
@@ -1,0 +1,26 @@
+# Issue #3482 Release 0.0.2 Collision-Count Boundary
+
+This bundle records the current release `0.0.2` collision-count claim boundary after
+`EpisodeEventLedger.v1` exact/derived reconciliation surfaced a discrepancy: exact collision
+outcomes are present, but the derived collision-count metric is not usable as paper-ready evidence
+until the durable reconciliation bundle is promoted and affected tables are annotated.
+
+## Contents
+
+| File | Purpose |
+| --- | --- |
+| `manifest.json` | Machine-readable boundary: exact outcomes remain usable with the ledger boundary, while release `0.0.2` collision-count metrics stay blocked. |
+
+## Validation
+
+```bash
+uv run python scripts/validation/check_release_0_0_2_collision_count_boundary.py --json
+```
+
+The checker fails closed if the manifest marks the release `0.0.2` collision-count metric as
+claim-ready while the documented exact/derived discrepancy and open gates remain.
+
+## Scope Boundary
+
+This is not a full benchmark campaign run, not a Slurm/GPU submission, not the committed durable
+`0.0.2` reconciliation bundle, and not a paper or dissertation claim edit.

--- a/docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/manifest.json
+++ b/docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/manifest.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "issue_3482_release_0_0_2_collision_count_boundary.v1",
+  "issue": 3482,
+  "release_tag": "0.0.2",
+  "generated_on": "2026-06-30",
+  "purpose": "Machine-readable claim boundary for release 0.0.2 collision-count metrics after EpisodeEventLedger.v1 exact/derived reconciliation surfaced a discrepancy.",
+  "source": {
+    "type": "issue_comment_summary",
+    "url": "https://github.com/ll7/robot_sf_ll7/issues/3482#issuecomment-4835303925",
+    "artifact_status": "diagnostic_summary_only_not_committed_release_bundle",
+    "release_bundle": "https://github.com/ll7/robot_sf_ll7/releases/tag/0.0.2"
+  },
+  "diagnostic_summary": {
+    "total_episodes": 987,
+    "exact_collision_events": 241,
+    "derived_collision_count_positive_episodes": 0,
+    "reconciliation_violations": 241,
+    "violation": "exact collision event requires collision metric > 0"
+  },
+  "claim_boundaries": {
+    "exact_collision_outcome_status": "usable_with_event_ledger_boundary",
+    "collision_count_metric_status": "blocked_pending_artifact_promotion_and_table_annotation",
+    "open_gates": [
+      "committed_0_0_2_reconciliation_bundle",
+      "paper_table_collision_count_annotation"
+    ]
+  },
+  "forbidden_claims_until_gates_close": [
+    "Do not use release 0.0.2 total_collision_count or collision-count-derived tables as paper-ready evidence.",
+    "Do not treat zero positive derived collision counts as evidence that release 0.0.2 had zero collisions.",
+    "Do not close issue #3482 solely from this manifest; it records a boundary, not the durable 0.0.2 reconciliation bundle."
+  ],
+  "allowed_uses": [
+    "Preserve the exact-vs-derived discrepancy as a fail-closed evidence boundary.",
+    "Use exact collision outcomes through EpisodeEventLedger.v1 with the documented boundary.",
+    "Route remaining work to artifact promotion and table annotation without rerunning benchmarks from this checker."
+  ],
+  "validator": "scripts/validation/check_release_0_0_2_collision_count_boundary.py"
+}

--- a/scripts/validation/check_release_0_0_2_collision_count_boundary.py
+++ b/scripts/validation/check_release_0_0_2_collision_count_boundary.py
@@ -1,0 +1,201 @@
+#!/usr/bin/env python3
+"""Validate the release 0.0.2 collision-count claim boundary for issue #3482."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_MANIFEST = (
+    REPO_ROOT
+    / "docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/manifest.json"
+)
+SCHEMA_VERSION = "issue_3482_release_0_0_2_collision_count_boundary.v1"
+EXPECTED_RELEASE = "0.0.2"
+EXPECTED_COLLISION_COUNT_STATUS = "blocked_pending_artifact_promotion_and_table_annotation"
+EXPECTED_EXACT_OUTCOME_STATUS = "usable_with_event_ledger_boundary"
+REQUIRED_OPEN_GATES = {
+    "committed_0_0_2_reconciliation_bundle",
+    "paper_table_collision_count_annotation",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class BoundaryViolation:
+    """One manifest boundary violation."""
+
+    field: str
+    message: str
+
+
+def _load_manifest(path: Path) -> dict[str, Any]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        msg = f"{path}: expected JSON object"
+        raise ValueError(msg)
+    return payload
+
+
+def _validate_identity(payload: dict[str, Any]) -> list[BoundaryViolation]:
+    """Validate manifest identity fields."""
+    violations: list[BoundaryViolation] = []
+    if payload.get("schema_version") != SCHEMA_VERSION:
+        violations.append(
+            BoundaryViolation(
+                "schema_version",
+                f"expected {SCHEMA_VERSION}",
+            )
+        )
+    if payload.get("issue") != 3482:
+        violations.append(BoundaryViolation("issue", "expected issue 3482"))
+    if payload.get("release_tag") != EXPECTED_RELEASE:
+        violations.append(BoundaryViolation("release_tag", "expected release 0.0.2"))
+    return violations
+
+
+def _validate_diagnostic_summary(payload: dict[str, Any]) -> list[BoundaryViolation]:
+    """Validate diagnostic summary fields that keep the discrepancy explicit."""
+    violations: list[BoundaryViolation] = []
+    evidence = payload.get("diagnostic_summary")
+    if not isinstance(evidence, dict):
+        violations.append(BoundaryViolation("diagnostic_summary", "expected object"))
+        evidence = {}
+
+    exact_collision_events = evidence.get("exact_collision_events")
+    derived_collision_count_positive_episodes = evidence.get(
+        "derived_collision_count_positive_episodes"
+    )
+    reconciliation_violations = evidence.get("reconciliation_violations")
+    total_episodes = evidence.get("total_episodes")
+    if not isinstance(total_episodes, int) or total_episodes <= 0:
+        violations.append(BoundaryViolation("diagnostic_summary.total_episodes", "must be > 0"))
+    if not isinstance(exact_collision_events, int) or exact_collision_events <= 0:
+        violations.append(
+            BoundaryViolation("diagnostic_summary.exact_collision_events", "must be > 0")
+        )
+    if derived_collision_count_positive_episodes != 0:
+        violations.append(
+            BoundaryViolation(
+                "diagnostic_summary.derived_collision_count_positive_episodes",
+                "expected 0 for the documented release 0.0.2 discrepancy",
+            )
+        )
+    if reconciliation_violations != exact_collision_events:
+        violations.append(
+            BoundaryViolation(
+                "diagnostic_summary.reconciliation_violations",
+                "must equal exact collision events until the release discrepancy is resolved",
+            )
+        )
+    return violations
+
+
+def _validate_claim_boundaries(payload: dict[str, Any]) -> list[BoundaryViolation]:
+    """Validate claim boundary and open-gate fields."""
+    violations: list[BoundaryViolation] = []
+    boundaries = payload.get("claim_boundaries")
+    if not isinstance(boundaries, dict):
+        violations.append(BoundaryViolation("claim_boundaries", "expected object"))
+        boundaries = {}
+    if boundaries.get("exact_collision_outcome_status") != EXPECTED_EXACT_OUTCOME_STATUS:
+        violations.append(
+            BoundaryViolation(
+                "claim_boundaries.exact_collision_outcome_status",
+                f"expected {EXPECTED_EXACT_OUTCOME_STATUS}",
+            )
+        )
+    if boundaries.get("collision_count_metric_status") != EXPECTED_COLLISION_COUNT_STATUS:
+        violations.append(
+            BoundaryViolation(
+                "claim_boundaries.collision_count_metric_status",
+                f"expected {EXPECTED_COLLISION_COUNT_STATUS}",
+            )
+        )
+
+    open_gates = set(boundaries.get("open_gates") or ())
+    if not REQUIRED_OPEN_GATES.issubset(open_gates):
+        missing = sorted(REQUIRED_OPEN_GATES - open_gates)
+        violations.append(
+            BoundaryViolation(
+                "claim_boundaries.open_gates",
+                f"missing required gates: {', '.join(missing)}",
+            )
+        )
+    return violations
+
+
+def _validate_forbidden_claims(payload: dict[str, Any]) -> list[BoundaryViolation]:
+    """Validate blocked claim list."""
+    violations: list[BoundaryViolation] = []
+    forbidden = payload.get("forbidden_claims_until_gates_close")
+    if not isinstance(forbidden, list) or not forbidden:
+        violations.append(
+            BoundaryViolation(
+                "forbidden_claims_until_gates_close",
+                "must list blocked paper-facing collision-count claims",
+            )
+        )
+    return violations
+
+
+def validate_manifest(payload: dict[str, Any]) -> list[BoundaryViolation]:
+    """Return fail-closed validation errors for the release collision boundary manifest."""
+    violations: list[BoundaryViolation] = []
+    violations.extend(_validate_identity(payload))
+    violations.extend(_validate_diagnostic_summary(payload))
+    violations.extend(_validate_claim_boundaries(payload))
+    violations.extend(_validate_forbidden_claims(payload))
+
+    return violations
+
+
+def build_report(manifest_path: Path) -> dict[str, Any]:
+    """Build the deterministic release collision-boundary report."""
+    payload = _load_manifest(manifest_path)
+    violations = validate_manifest(payload)
+    return {
+        "schema_version": "release_0_0_2_collision_count_boundary_report.v1",
+        "manifest": str(manifest_path),
+        "status": "pass" if not violations else "fail",
+        "issue": payload.get("issue"),
+        "release_tag": payload.get("release_tag"),
+        "collision_count_metric_status": (
+            payload.get("claim_boundaries", {}).get("collision_count_metric_status")
+            if isinstance(payload.get("claim_boundaries"), dict)
+            else None
+        ),
+        "violations": [asdict(violation) for violation in violations],
+    }
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--manifest", type=Path, default=DEFAULT_MANIFEST)
+    parser.add_argument("--json", action="store_true", help="Emit machine-readable report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Validate the tracked release collision-count boundary manifest."""
+    args = _parse_args(argv)
+    report = build_report(args.manifest)
+    if args.json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+    elif report["status"] == "pass":
+        print(
+            "release 0.0.2 collision-count boundary valid: "
+            f"{report['collision_count_metric_status']}"
+        )
+    else:
+        for violation in report["violations"]:
+            print(f"{violation['field']}: {violation['message']}", file=sys.stderr)
+    return 0 if report["status"] == "pass" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/test_check_release_0_0_2_collision_count_boundary.py
+++ b/tests/validation/test_check_release_0_0_2_collision_count_boundary.py
@@ -1,0 +1,92 @@
+"""Tests release 0.0.2 collision-count claim-boundary checker."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT_PATH = ROOT / "scripts" / "validation" / "check_release_0_0_2_collision_count_boundary.py"
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_release_0_0_2_collision_count_boundary", SCRIPT_PATH
+)
+assert _SPEC is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+assert _SPEC.loader is not None
+sys.modules[_SPEC.name] = _MODULE
+_SPEC.loader.exec_module(_MODULE)
+
+DEFAULT_MANIFEST = _MODULE.DEFAULT_MANIFEST
+EXPECTED_COLLISION_COUNT_STATUS = _MODULE.EXPECTED_COLLISION_COUNT_STATUS
+build_report = _MODULE.build_report
+validate_manifest = _MODULE.validate_manifest
+
+
+def _manifest() -> dict:
+    """Load the tracked boundary manifest."""
+    return json.loads(DEFAULT_MANIFEST.read_text(encoding="utf-8"))
+
+
+def test_tracked_manifest_keeps_collision_count_metric_blocked() -> None:
+    """The checked-in boundary must not promote release 0.0.2 collision-count metrics."""
+    report = build_report(DEFAULT_MANIFEST)
+
+    assert report["status"] == "pass"
+    assert report["release_tag"] == "0.0.2"
+    assert report["collision_count_metric_status"] == EXPECTED_COLLISION_COUNT_STATUS
+
+
+def test_manifest_fails_if_collision_count_metric_marked_claim_ready() -> None:
+    """The checker rejects premature collision-count claim promotion."""
+    payload = _manifest()
+    payload["claim_boundaries"]["collision_count_metric_status"] = "paper_ready"
+
+    violations = validate_manifest(payload)
+
+    assert any(
+        violation.field == "claim_boundaries.collision_count_metric_status"
+        for violation in violations
+    )
+
+
+def test_manifest_fails_if_required_open_gate_is_removed() -> None:
+    """Artifact-promotion and table-annotation gates must remain explicit."""
+    payload = _manifest()
+    payload["claim_boundaries"]["open_gates"] = ["committed_0_0_2_reconciliation_bundle"]
+
+    violations = validate_manifest(payload)
+
+    assert any(violation.field == "claim_boundaries.open_gates" for violation in violations)
+
+
+def test_manifest_fails_if_exact_derived_discrepancy_is_erased() -> None:
+    """The boundary depends on preserving the documented release discrepancy."""
+    payload = _manifest()
+    payload["diagnostic_summary"]["derived_collision_count_positive_episodes"] = 241
+
+    violations = validate_manifest(payload)
+
+    assert any(
+        violation.field == "diagnostic_summary.derived_collision_count_positive_episodes"
+        for violation in violations
+    )
+
+
+def test_cli_reports_json_boundary() -> None:
+    """CLI emits a machine-readable pass report for the tracked manifest."""
+    result = subprocess.run(
+        [sys.executable, str(SCRIPT_PATH), "--json"],
+        cwd=ROOT,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    report = json.loads(result.stdout)
+    assert report["status"] == "pass"
+    assert report["collision_count_metric_status"] == EXPECTED_COLLISION_COUNT_STATUS


### PR DESCRIPTION
## Summary
Relates to https://github.com/ll7/robot_sf_ll7/issues/3482.

Records a machine-readable release `0.0.2` collision-count boundary manifest and validator for the remaining `EpisodeEventLedger.v1` exact/derived reconciliation risk. The manifest keeps exact collision outcomes usable only with the ledger boundary, while `total_collision_count` and collision-count-derived paper tables remain blocked pending durable artifact promotion and table annotation.

## Linked Issues
- Relates to `#3482`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: previous #3482 ledger/reconciliation/CI guard slices already merged
- Stack follow-up issues: `#3482`
- Safe review independently: yes
- Review dependency reason, any: This PR only records and validates a blocked boundary over already-reported issue evidence.

## What Changed
- Added `scripts/validation/check_release_0_0_2_collision_count_boundary.py` to validate the release collision-count boundary manifest.
- Added `docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/` with the manifest and README.
- Registered the evidence bundle in `docs/context/catalog.yaml`.
- Added focused tests proving the manifest passes while premature claim-ready promotion, missing gates, or erased exact/derived discrepancy fail closed.

## Why Matters
- Added value: preserves the live #3482 exact-vs-derived discrepancy as a machine-checkable boundary instead of a chat-only note.
- Expected impact: prevents release `0.0.2` collision-count metrics from being marked paper-ready before artifact promotion and table annotation are done.
- Why worth merging now: #3482 remains high-priority because paper-facing table reuse is blocked by this boundary.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: release `0.0.2` collision-count table reuse remains blocked until artifact promotion and table annotation.
- Comparator or baseline, applicable: NA - no benchmark run or comparator result.
- Evidence tier: NA - support checker over an existing issue boundary; no benchmark evidence produced.
- Result classification: NA - no research result classified; blocked boundary remains unchanged.
- Decision stop rule, applicable: checker must fail closed if `collision_count_metric_status` is promoted before required gates close.
- Parent issue, claim map, registry, context note, synthesis surface update: #3482 and `docs/context/evidence/issue_3482_release_0_0_2_collision_count_boundary/manifest.json`.
- New research/benchmark/metric/paper-facing analysis tool, any: small validation checker only; no new metric interpretation or benchmark result.

## Domain-Aware Approval
- Required PR: no - support checker only; no evidence-validity approval needed because no benchmark result, metric interpretation, or paper/dissertation claim is promoted.
- Approver/review source waiver: no domain approval required because this is a support checker that preserves a blocked boundary.
- Validity checklist:
  - Target claim/hypothesis: collision-count paper-table reuse remains blocked; no claim is promoted.
  - Comparator split/evidence validity: no comparator or split is evaluated; manifest uses the existing #3482 boundary only.
  - Fallback/degraded exclusions: no benchmark execution occurs, so no fallback/degraded row can be counted as success.
  - Claim boundary: explicit blocked status and open gates in manifest.
  - Implementation integrity vs experimental validity: tests validate fail-closed checker behavior only; they do not validate a new empirical conclusion.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no planner/runtime mechanism.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? The manifest preserves issue-comment boundary counts; it does not re-run traces.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: #3482 remains owner for durable bundle promotion and table annotation.

## Next Empirical Action
- Rerun needed: yes, outside this PR only if maintainers decide to regenerate/promote durable `0.0.2` reconciliation artifacts.
- Extractor analysis tool needed: no new tool in this PR; existing event-ledger reconciliation exporter remains canonical.
- Artifact missing unavailable: committed durable `0.0.2` reconciliation bundle and affected table annotations.
- Stop / revise / continue decision: continue #3482 artifact-promotion/table-annotation work separately.
- Proposed child issue existing follow-up: #3482.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_release_0_0_2_collision_count_boundary.py --json` - passed, status `pass`, no violations.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_release_0_0_2_collision_count_boundary.py -q` - passed, 5 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_event_ledger_reconciliation_guard.py tests/benchmark/test_event_ledger_reconciliation_export.py tests/validation/test_check_release_0_0_2_collision_count_boundary.py -q` - passed, 11 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_release_0_0_2_collision_count_boundary.py tests/validation/test_check_release_0_0_2_collision_count_boundary.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/check_release_0_0_2_collision_count_boundary.py tests/validation/test_check_release_0_0_2_collision_count_boundary.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python - <<'PY' ... json/yaml parse check ... PY` - passed.
- `git diff --check` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` initially failed because the fresh worktree lacked analytics dependencies; after `uv sync --all-extras`, readiness was rerun with this body file.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: low; new checker reads a committed manifest only.
- Failure modes: manifest may become stale after the durable bundle/table annotation work lands; update or retire it with that follow-up.
- Rollback fallback plan: revert the manifest/checker/test bundle.

## Docs / Provenance
- Updated docs: added issue #3482 evidence README/manifest and catalog entries.
- Relevant design provenance notes: `docs/context/issue_3482_metric_semantics_reconciliation.md`, `docs/context/evidence/issue_3482_event_ledger_reconciliation_guard/`.
- Any assumptions need preserved: boundary counts come from the #3482 issue comment, not from a newly committed raw release bundle.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - user authorization forbids issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): no - this PR adds a boundary manifest, not a claim-map promotion.
- Leaderboard / artifact catalog updated (yes/no/NA): no.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): yes - `docs/context/catalog.yaml`.
- Follow-up issue opened deferred propagation (yes/no/NA): no - #3482 remains the follow-up owner.
- Not applicable because: this PR does not promote benchmark results or edit paper-facing tables.

## Follow-Up Issues
- Deferred work: committed durable `0.0.2` reconciliation bundle promotion and affected collision-count table annotation.
- Issues opened follow-up: none; #3482 remains open.

## Reviewer Notes
- Verify closely: the checker intentionally treats `collision_count_metric_status` as blocked while `committed_0_0_2_reconciliation_bundle` and `paper_table_collision_count_annotation` remain open.
- Any known limitations: no release archive download, no benchmark rerun, and no claim promotion in this PR.
