### PR TITLE
Issue #3425: pin finalizer preflight issue traceability

### DIFF
--- a/scripts/validation/preflight_slurm_finalizer.py
+++ b/scripts/validation/preflight_slurm_finalizer.py
@@ -27,7 +27,7 @@ What it checks (each maps to an acceptance criterion of #3425):
 * ``finalizer_manifest_linkage`` — every finalizer ``job_id`` resolves to a
   submission-manifest job (the "manifest linkage missing" fail-closed case).
 * ``issue_traceability_matches`` — queue/finalizer issue numbers agree for
-  public issue/PR traceability.
+  public issue/PR traceability and, by default, match issue ``3425``.
 * ``durable_pointer_present`` — every *successful* finalizer carries a durable
   pointer (the "durable pointers missing" fail-closed case).
 * ``required_artifacts_complete`` — every *successful* finalizer reports all
@@ -342,7 +342,9 @@ def _check_finalizer_linkage(inputs: LoadedInputs) -> PreflightCheck:
     )
 
 
-def _check_issue_traceability(inputs: LoadedInputs) -> PreflightCheck:
+def _check_issue_traceability(
+    inputs: LoadedInputs, *, expected_issue: int | None
+) -> PreflightCheck:
     """Require queue and finalizer issue numbers to agree when both are present."""
     # Normalize via the canonical coercion so the gate reads issue numbers
     # exactly as the reconciler does. ``QueueEntry.issue`` is ``str | int | None``
@@ -391,6 +393,17 @@ def _check_issue_traceability(inputs: LoadedInputs) -> PreflightCheck:
             severity=_REQUIRED,
             detail=f"queue issue(s) {queue_issues} differ from finalizer issue(s) {finalizer_issues}",
             remediation="align queue and finalizer issue numbers before claim decision handoff",
+        )
+    if expected_issue is not None and queue_issues != [expected_issue]:
+        return PreflightCheck(
+            name="issue_traceability_matches",
+            status=_BLOCKED,
+            severity=_REQUIRED,
+            detail=f"queue/finalizer issue(s) {queue_issues} do not match expected issue {expected_issue}",
+            remediation=(
+                "pass --issue for the intended handoff issue or regenerate queue/finalizer "
+                "metadata for the correct issue before public claim handoff"
+            ),
         )
     return PreflightCheck(
         name="issue_traceability_matches",
@@ -630,6 +643,7 @@ def preflight(
     submission_manifests: list[Path],
     finalizer_manifests: list[Path],
     evidence_root: Path | None = None,
+    expected_issue: int | None = 3425,
     generated_at: str | None = None,
 ) -> dict:
     """Evaluate readiness of the SLURM-to-claim finalizer slice inputs.
@@ -649,7 +663,7 @@ def preflight(
         _check_submission_manifests(submission_manifests, inputs),
         _check_finalizer_present(finalizer_manifests, inputs),
         _check_finalizer_linkage(inputs),
-        _check_issue_traceability(inputs),
+        _check_issue_traceability(inputs, expected_issue=expected_issue),
         _check_durable_pointer(inputs),
         _check_required_artifacts_complete(inputs),
         _check_claim_boundary(inputs),
@@ -679,6 +693,7 @@ def preflight(
             "submission_manifests": sorted(str(path) for path in submission_manifests),
             "finalizer_manifests": sorted(str(path) for path in finalizer_manifests),
             "evidence_root": str(evidence_root) if evidence_root is not None else None,
+            "expected_issue": expected_issue,
         },
         "checks": [asdict(check) for check in checks],
         "blockers": blockers,
@@ -756,6 +771,12 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Optional compact evidence root directory (advisory check).",
     )
     parser.add_argument(
+        "--issue",
+        type=int,
+        default=3425,
+        help="Expected public issue number for queue/finalizer traceability.",
+    )
+    parser.add_argument(
         "--generated-at",
         default=None,
         help="Optional stable generated_at timestamp for reproducible machine output.",
@@ -772,6 +793,7 @@ def main(argv: list[str] | None = None) -> int:
         submission_manifests=list(args.submission_manifest),
         finalizer_manifests=list(args.finalizer_manifest),
         evidence_root=args.evidence_root,
+        expected_issue=args.issue,
         generated_at=args.generated_at,
     )
 

--- a/tests/validation/test_preflight_slurm_finalizer.py
+++ b/tests/validation/test_preflight_slurm_finalizer.py
@@ -185,6 +185,31 @@ def test_blocks_when_issue_traceability_mismatches(tmp_path: Path) -> None:
     assert "align queue and finalizer issue numbers" in blocker["remediation"]
 
 
+def test_blocks_when_traceability_matches_wrong_expected_issue(tmp_path: Path) -> None:
+    """Consistent queue/finalizer metadata still must match issue #3425 by default."""
+    inputs = _ready_inputs(tmp_path)
+    _write_queue(inputs["queue_path"], issue=9999)
+    _write_finalizer(tmp_path / "finalizer.json", issue=9999)
+
+    report = gate.preflight(**inputs)
+
+    assert report["ready"] is False
+    blocker = next(b for b in report["blockers"] if b["check"] == "issue_traceability_matches")
+    assert "expected issue 3425" in blocker["detail"]
+
+
+def test_allows_explicit_expected_issue_override(tmp_path: Path) -> None:
+    """The checker stays reusable when a caller intentionally targets another issue."""
+    inputs = _ready_inputs(tmp_path)
+    _write_queue(inputs["queue_path"], issue=9999)
+    _write_finalizer(tmp_path / "finalizer.json", issue=9999)
+
+    report = gate.preflight(**inputs, expected_issue=9999)
+
+    assert report["ready"] is True
+    assert report["inputs"]["expected_issue"] == 9999
+
+
 def test_ready_when_queue_issue_recorded_as_string(tmp_path: Path) -> None:
     """A string-encoded queue issue (``issue: "3425"``) still matches the finalizer.
 


### PR DESCRIPTION
## Summary
Adds an issue-target guard to the SLURM-to-claim finalizer preflight so internally consistent queue/finalizer metadata must still match the intended public handoff issue, defaulting to #3425.

## Linked Issues
- Relates to https://github.com/ll7/robot_sf_ll7/issues/3425

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `expected_issue`/`--issue` to `scripts/validation/preflight_slurm_finalizer.py`; default is `3425`.
- The `issue_traceability_matches` readiness check now fails closed when queue and finalizer issue numbers agree with each other but do not match the requested issue.
- Added focused tests for the blocked wrong-issue path and explicit override path.

## Why Matters
- Added value: prevents a finalizer packet for the wrong issue from passing local readiness just because its queue/finalizer metadata is internally consistent.
- Expected impact: tighter local preflight evidence before a SLURM-capable host runs the finalizer-to-claim handoff.
- Why worth merging now: issue #3425 is evidence plumbing, and this is a reversible local checker improvement with no cluster side effects.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution support for #3425 local finalizer readiness; no research claim promoted.
- Comparator or baseline, applicable: NA - support checker.
- Evidence tier: NA - support checker; validation is targeted unit/CLI proof, not research evidence.
- Result classification: NA - support checker; does not classify empirical results.
- Decision stop rule, applicable: preflight blocks when issue metadata targets any issue other than the requested issue unless `--issue` is explicitly overridden.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3425 remains the tracking surface; no claim map update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper, does not interpret benchmark results.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required - support checker only, no empirical claim classification
- Approver/review source waiver: support checker only; no benchmark interpretation.
- Validity checklist: NA - no empirical result.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA - no comparator, split, or empirical validity claim.
- Fallback/degraded exclusions: no fallback/degraded execution counted as evidence.
- Claim boundary: local readiness/preflight only.
- Implementation integrity vs experimental validity: checker integrity covered by synthetic tests; experimental validity deferred to the actual SLURM slice.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, via synthetic wrong-issue test.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, synthetic queue/finalizer metadata agree on issue 9999 while default expected issue is 3425.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this checker slice; yes for the actual SLURM vertical slice outside this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: actual SLURM finalizer artifacts are out of scope here.
- Stop / revise / continue decision: continue to SLURM-capable execution after review.
- Proposed child issue existing follow-up: #3425 remains the follow-up surface.

## Validation / Proof
- `uv run pytest tests/validation/test_preflight_slurm_finalizer.py -q` - 20 passed in 0.21s before merge; 20 passed in 0.21s after merge.
- `uv run ruff check scripts/validation/preflight_slurm_finalizer.py tests/validation/test_preflight_slurm_finalizer.py` - passed.
- `uv run python scripts/validation/preflight_slurm_finalizer.py --help` - passed and shows `--issue ISSUE`.
- `PR_READY_PR_BODY_FILE=/tmp/issue3425_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; stamp `output/validation/pr_ready/issue-3425-finalizer-readiness-20260630-fresh.json` for head `1d173621`.

## Performance Validation
- Baseline runtime: NA - no runtime or caching claim.
- Changed runtime: NA - no runtime or caching claim.
- Representative command: `uv run pytest tests/validation/test_preflight_slurm_finalizer.py -q`.
- Hot-path call count profile anchor: NA - support checker, no hot-path claim.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: finalizer preflight no longer blocks internally consistent wrong-issue metadata by default.

## Risks / Rollout
- Compatibility risks: low; callers for other issues can pass `--issue <id>` or `expected_issue=<id>`.
- Failure modes: a generic reuse caller that omits `--issue` will now default to #3425 and block other issue packets.
- Rollback fallback plan: revert this commit or pass explicit `--issue` for non-3425 callers.

## Docs / Provenance
- Updated docs: script CLI/help docstring only.
- Relevant design provenance notes: existing `docs/context/issue_3425_slurm_to_claim_blocker.md` remains current.
- Any assumptions need to preserved: issue #3425 preflight defaults to #3425 because the script is explicitly issue-scoped.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; user authorization forbids issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no; existing follow-up/tracking issue is #3425.
- Not applicable because: no full benchmark campaign run, no SLURM/GPU submission, no paper/dissertation claim edits, no artifact release.

## Follow-Up Issues
- Deferred work: run the actual SLURM-to-claim finalizer slice on an authorized SLURM-capable host under #3425.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that defaulting to issue #3425 is acceptable for this issue-scoped checker; non-3425 reuse remains available through `--issue`.
- Known limitations: no full benchmark campaign run, no SLURM/GPU submission, no paper/dissertation claim edits, no release artifacts.
