### PR TITLE
Issue #1554: synthesize Slurm evidence before next queue entry

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -17,6 +17,14 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+  - path: docs/context/evidence/issue_1554_slurm_evidence_2026-06-30/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_1554_slurm_evidence_2026-06-30/packet.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_3482_event_ledger_reconciliation_guard/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -120,6 +120,12 @@ Policy caveats:
 
 ## Current Bundles
 
+- `issue_1554_slurm_evidence_2026-06-30/`: queue-decision packet over completed #1554
+Slurm jobs 13192, 13198, and 13203. Classifies job 13198 as the completed S20/H500
+result matrix to analyze before any duplicate rerun, preserves its soft SNQI contract
+warning as a paper-claim blocker, and confirms no Slurm/GPU submission, artifact
+deletion, or paper/dissertation claim edit.
+
 - `issue_3207_simulator_dependence_validity_boundary_packet_2026-06-29/`: checker packet over
   the merged #3207 bounded actual fidelity-sensitivity slice. Classifies the current evidence as
   `no_claim` / `not_benchmark_evidence` because the slice is not full fixed scope and rank evidence

--- a/docs/context/evidence/issue_1554_slurm_evidence_2026-06-30/README.md
+++ b/docs/context/evidence/issue_1554_slurm_evidence_2026-06-30/README.md
@@ -1,0 +1,52 @@
+# Issue #1554 Slurm Evidence Packet
+
+This packet synthesizes completed jobs 13192, 13198, and 13203. It is a queue-decision artifact only; it does not edit paper or dissertation claims.
+
+- status: `analysis_before_submit`
+- jobs synthesized: `13192, 13198, 13203`
+- next queue recommendation: Do not enqueue another duplicate S20/H500 planner-family run yet. Analyze job 13198 first, including the soft SNQI contract warning, then submit only a targeted follow-up for an explicit analysis gap or validated config/schema unblock.
+
+## Job Findings
+
+### Job 13192
+
+- campaign: `2026-06-issue1554-best-ppo-compare-run`
+- config: `configs/benchmarks/paper_experiment_matrix_v1_best_ppo_compare.yaml`
+- public commit: `182a4ebb5b44165ffc3608a3c20580fbf9e8add6`
+- Slurm result: `COMPLETED` / `0:0`
+- role: `comparison_run`
+- finding: Best-PPO comparison run completed and produced two ok planner rows with 144 episodes per planner. This is comparison evidence, not a paper/dissertation claim by itself.
+- artifact summary: {"matrix_rows": 2, "planner_row_status_counts": {"ok": 2}, "planner_rows": 2, "warnings": []}
+- limitations: Small comparison slice only; use for queue direction, not broad planner-ranking claims.
+
+### Job 13198
+
+- campaign: `2026-06-issue1554-s20-h500-split-mem180-run`
+- config: `configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml`
+- public commit: `12a188de7246aad3b9088ea76e6a25a20029f976`
+- Slurm result: `COMPLETED` / `0:0`
+- role: `result_matrix`
+- finding: The 180 GB split planner-family S20/H500 run completed in 01:42:35 and produced nine ok planner rows with 960 episodes per planner.
+- artifact summary: {"matrix_rows": 9, "planner_row_status_counts": {"ok": 9}, "planner_rows": 9, "warnings": ["SNQI contract status=fail with snqi_contract.enforcement=warn; campaign marked soft contract warning."]}
+- limitations: SNQI contract warning blocks paper-grade interpretation until analyzed.; Analyze this result before scheduling another duplicate S20/H500 planner-family run.
+
+### Job 13203
+
+- campaign: `2026-06-issue1554-current-main-smoke-preflight`
+- config: `configs/benchmarks/camera_ready_smoke_all_planners.yaml`
+- public commit: `7c1e63997c724064468f64ace698731deacf201e`
+- Slurm result: `COMPLETED` / `0:0`
+- role: `smoke_preflight`
+- finding: Current-main smoke/preflight completed in 26 seconds with workers=1, one scenario, and eight planners.
+- artifact summary: {"planner_count": 8, "scenario_count": 1, "warnings": [], "workers": 1}
+- limitations: Smoke/preflight only; it proves launcher/config plumbing but does not replace result analysis.
+
+## Claim Blockers
+
+- job `13198`: SNQI contract warning blocks paper-grade interpretation until analyzed.; Analyze this result before scheduling another duplicate S20/H500 planner-family run.
+
+## Forbidden Actions
+
+- no Slurm/GPU submission
+- no artifact deletion
+- no paper/dissertation claim edits

--- a/docs/context/evidence/issue_1554_slurm_evidence_2026-06-30/packet.json
+++ b/docs/context/evidence/issue_1554_slurm_evidence_2026-06-30/packet.json
@@ -1,0 +1,96 @@
+{
+  "claim_blockers": [
+    {
+      "job": 13198,
+      "limitations": [
+        "SNQI contract warning blocks paper-grade interpretation until analyzed.",
+        "Analyze this result before scheduling another duplicate S20/H500 planner-family run."
+      ]
+    }
+  ],
+  "evidence": [
+    {
+      "artifact_summary": {
+        "matrix_rows": 2,
+        "planner_row_status_counts": {
+          "ok": 2
+        },
+        "planner_rows": 2,
+        "warnings": []
+      },
+      "campaign": "2026-06-issue1554-best-ppo-compare-run",
+      "config": "configs/benchmarks/paper_experiment_matrix_v1_best_ppo_compare.yaml",
+      "exit_code": "0:0",
+      "finding": "Best-PPO comparison run completed and produced two ok planner rows with 144 episodes per planner. This is comparison evidence, not a paper/dissertation claim by itself.",
+      "job": 13192,
+      "limitations": [
+        "Small comparison slice only; use for queue direction, not broad planner-ranking claims."
+      ],
+      "public_commit": "182a4ebb5b44165ffc3608a3c20580fbf9e8add6",
+      "role": "comparison_run",
+      "slurm_state": "COMPLETED"
+    },
+    {
+      "artifact_summary": {
+        "matrix_rows": 9,
+        "planner_row_status_counts": {
+          "ok": 9
+        },
+        "planner_rows": 9,
+        "warnings": [
+          "SNQI contract status=fail with snqi_contract.enforcement=warn; campaign marked soft contract warning."
+        ]
+      },
+      "campaign": "2026-06-issue1554-s20-h500-split-mem180-run",
+      "config": "configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml",
+      "exit_code": "0:0",
+      "finding": "The 180 GB split planner-family S20/H500 run completed in 01:42:35 and produced nine ok planner rows with 960 episodes per planner.",
+      "job": 13198,
+      "limitations": [
+        "SNQI contract warning blocks paper-grade interpretation until analyzed.",
+        "Analyze this result before scheduling another duplicate S20/H500 planner-family run."
+      ],
+      "public_commit": "12a188de7246aad3b9088ea76e6a25a20029f976",
+      "role": "result_matrix",
+      "slurm_state": "COMPLETED"
+    },
+    {
+      "artifact_summary": {
+        "planner_count": 8,
+        "scenario_count": 1,
+        "warnings": [],
+        "workers": 1
+      },
+      "campaign": "2026-06-issue1554-current-main-smoke-preflight",
+      "config": "configs/benchmarks/camera_ready_smoke_all_planners.yaml",
+      "exit_code": "0:0",
+      "finding": "Current-main smoke/preflight completed in 26 seconds with workers=1, one scenario, and eight planners.",
+      "job": 13203,
+      "limitations": [
+        "Smoke/preflight only; it proves launcher/config plumbing but does not replace result analysis."
+      ],
+      "public_commit": "7c1e63997c724064468f64ace698731deacf201e",
+      "role": "smoke_preflight",
+      "slurm_state": "COMPLETED"
+    }
+  ],
+  "forbidden_actions_confirmed": {
+    "artifact_deletion": false,
+    "compute_submit": false,
+    "paper_or_dissertation_claim_edits": false
+  },
+  "issue": 1554,
+  "jobs_synthesized": [
+    13192,
+    13198,
+    13203
+  ],
+  "next_slurm_queue_recommendation": "Do not enqueue another duplicate S20/H500 planner-family run yet. Analyze job 13198 first, including the soft SNQI contract warning, then submit only a targeted follow-up for an explicit analysis gap or validated config/schema unblock.",
+  "schema_version": "issue1554-slurm-evidence-packet.v1",
+  "status": "analysis_before_submit",
+  "successful_jobs": [
+    13192,
+    13198,
+    13203
+  ]
+}

--- a/scripts/benchmark/build_issue1554_slurm_evidence_packet.py
+++ b/scripts/benchmark/build_issue1554_slurm_evidence_packet.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Build the issue #1554 Slurm evidence synthesis packet.
+
+The input is a small public fixture distilled from completed Slurm job metadata and
+retrieved benchmark summaries. It intentionally does not read private queue state,
+submit jobs, or promote paper/dissertation claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+CLAIM_BLOCKING_WARNINGS = ("SNQI", "contract")
+
+
+@dataclass(frozen=True, slots=True)
+class JobEvidence:
+    """Public, non-secret metadata for one completed Slurm job."""
+
+    job_id: int
+    campaign: str
+    config: str
+    slurm_state: str
+    exit_code: str
+    public_commit: str
+    finding: str
+    evidence_role: str
+    artifact_summary: dict[str, Any]
+    limitations: list[str]
+
+    @property
+    def completed_successfully(self) -> bool:
+        """Whether Slurm completed without a process-level failure."""
+        return self.slurm_state == "COMPLETED" and self.exit_code == "0:0"
+
+    @property
+    def has_claim_blocker(self) -> bool:
+        """Whether the row carries a warning that blocks paper-grade interpretation."""
+        text = " ".join(self.limitations + self.artifact_summary.get("warnings", []))
+        return any(fragment in text for fragment in CLAIM_BLOCKING_WARNINGS)
+
+
+def _load_jobs(path: Path) -> list[JobEvidence]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    jobs = payload.get("jobs", payload)
+    if not isinstance(jobs, list):
+        raise ValueError(f"{path} must contain a JSON list or an object with a 'jobs' list")
+    return [JobEvidence(**job) for job in jobs]
+
+
+def build_packet(jobs: list[JobEvidence]) -> dict[str, Any]:
+    """Build a deterministic next-decision packet from completed job evidence."""
+    job_ids = [job.job_id for job in jobs]
+    if job_ids != [13192, 13198, 13203]:
+        raise ValueError(f"issue #1554 packet expects jobs [13192, 13198, 13203], got {job_ids}")
+
+    successful_jobs = [job.job_id for job in jobs if job.completed_successfully]
+    claim_blockers = [
+        {"job": job.job_id, "limitations": job.limitations} for job in jobs if job.has_claim_blocker
+    ]
+    result_jobs = [
+        job.job_id
+        for job in jobs
+        if job.evidence_role in {"result_matrix", "comparison_run"} and job.completed_successfully
+    ]
+
+    if 13198 in result_jobs:
+        recommendation = (
+            "Do not enqueue another duplicate S20/H500 planner-family run yet. Analyze job 13198 "
+            "first, including the soft SNQI contract warning, then submit only a targeted follow-up "
+            "for an explicit analysis gap or validated config/schema unblock."
+        )
+        status = "analysis_before_submit"
+    else:
+        recommendation = (
+            "No result-producing S20/H500 matrix is available; prepare the smallest public config or "
+            "checker unblock before another queue entry."
+        )
+        status = "blocked_until_result_matrix"
+
+    return {
+        "schema_version": "issue1554-slurm-evidence-packet.v1",
+        "issue": 1554,
+        "jobs_synthesized": job_ids,
+        "status": status,
+        "successful_jobs": successful_jobs,
+        "claim_blockers": claim_blockers,
+        "evidence": [
+            {
+                "job": job.job_id,
+                "campaign": job.campaign,
+                "config": job.config,
+                "public_commit": job.public_commit,
+                "slurm_state": job.slurm_state,
+                "exit_code": job.exit_code,
+                "role": job.evidence_role,
+                "finding": job.finding,
+                "artifact_summary": job.artifact_summary,
+                "limitations": job.limitations,
+            }
+            for job in jobs
+        ],
+        "next_slurm_queue_recommendation": recommendation,
+        "forbidden_actions_confirmed": {
+            "compute_submit": False,
+            "artifact_deletion": False,
+            "paper_or_dissertation_claim_edits": False,
+        },
+    }
+
+
+def render_markdown(packet: dict[str, Any]) -> str:
+    """Render the synthesis packet for review in docs/context/evidence."""
+    lines = [
+        "# Issue #1554 Slurm Evidence Packet",
+        "",
+        "This packet synthesizes completed jobs 13192, 13198, and 13203. It is a "
+        "queue-decision artifact only; it does not edit paper or dissertation claims.",
+        "",
+        f"- status: `{packet['status']}`",
+        f"- jobs synthesized: `{', '.join(str(job) for job in packet['jobs_synthesized'])}`",
+        f"- next queue recommendation: {packet['next_slurm_queue_recommendation']}",
+        "",
+        "## Job Findings",
+        "",
+    ]
+    for item in packet["evidence"]:
+        summary = item["artifact_summary"]
+        lines.extend(
+            [
+                f"### Job {item['job']}",
+                "",
+                f"- campaign: `{item['campaign']}`",
+                f"- config: `{item['config']}`",
+                f"- public commit: `{item['public_commit']}`",
+                f"- Slurm result: `{item['slurm_state']}` / `{item['exit_code']}`",
+                f"- role: `{item['role']}`",
+                f"- finding: {item['finding']}",
+                f"- artifact summary: {json.dumps(summary, sort_keys=True)}",
+                f"- limitations: {'; '.join(item['limitations']) or 'none recorded'}",
+                "",
+            ]
+        )
+    if packet["claim_blockers"]:
+        lines.extend(["## Claim Blockers", ""])
+        for blocker in packet["claim_blockers"]:
+            lines.append(f"- job `{blocker['job']}`: {'; '.join(blocker['limitations'])}")
+        lines.append("")
+    lines.extend(
+        [
+            "## Forbidden Actions",
+            "",
+            "- no Slurm/GPU submission",
+            "- no artifact deletion",
+            "- no paper/dissertation claim edits",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def main() -> int:
+    """Run the command-line packet builder."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--input", type=Path, required=True, help="Job evidence fixture JSON.")
+    parser.add_argument("--output-json", type=Path, required=True, help="Packet JSON output path.")
+    parser.add_argument(
+        "--output-md", type=Path, required=True, help="Packet Markdown output path."
+    )
+    args = parser.parse_args()
+
+    jobs = _load_jobs(args.input)
+    packet = build_packet(jobs)
+    args.output_json.parent.mkdir(parents=True, exist_ok=True)
+    args.output_md.parent.mkdir(parents=True, exist_ok=True)
+    args.output_json.write_text(
+        json.dumps(packet, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    args.output_md.write_text(render_markdown(packet), encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/fixtures/issue1554_slurm_evidence/jobs_13192_13198_13203.json
+++ b/tests/benchmark/fixtures/issue1554_slurm_evidence/jobs_13192_13198_13203.json
@@ -1,0 +1,68 @@
+{
+  "jobs": [
+    {
+      "job_id": 13192,
+      "campaign": "2026-06-issue1554-best-ppo-compare-run",
+      "config": "configs/benchmarks/paper_experiment_matrix_v1_best_ppo_compare.yaml",
+      "slurm_state": "COMPLETED",
+      "exit_code": "0:0",
+      "public_commit": "182a4ebb5b44165ffc3608a3c20580fbf9e8add6",
+      "finding": "Best-PPO comparison run completed and produced two ok planner rows with 144 episodes per planner. This is comparison evidence, not a paper/dissertation claim by itself.",
+      "evidence_role": "comparison_run",
+      "artifact_summary": {
+        "matrix_rows": 2,
+        "planner_rows": 2,
+        "planner_row_status_counts": {
+          "ok": 2
+        },
+        "warnings": []
+      },
+      "limitations": [
+        "Small comparison slice only; use for queue direction, not broad planner-ranking claims."
+      ]
+    },
+    {
+      "job_id": 13198,
+      "campaign": "2026-06-issue1554-s20-h500-split-mem180-run",
+      "config": "configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml",
+      "slurm_state": "COMPLETED",
+      "exit_code": "0:0",
+      "public_commit": "12a188de7246aad3b9088ea76e6a25a20029f976",
+      "finding": "The 180 GB split planner-family S20/H500 run completed in 01:42:35 and produced nine ok planner rows with 960 episodes per planner.",
+      "evidence_role": "result_matrix",
+      "artifact_summary": {
+        "matrix_rows": 9,
+        "planner_rows": 9,
+        "planner_row_status_counts": {
+          "ok": 9
+        },
+        "warnings": [
+          "SNQI contract status=fail with snqi_contract.enforcement=warn; campaign marked soft contract warning."
+        ]
+      },
+      "limitations": [
+        "SNQI contract warning blocks paper-grade interpretation until analyzed.",
+        "Analyze this result before scheduling another duplicate S20/H500 planner-family run."
+      ]
+    },
+    {
+      "job_id": 13203,
+      "campaign": "2026-06-issue1554-current-main-smoke-preflight",
+      "config": "configs/benchmarks/camera_ready_smoke_all_planners.yaml",
+      "slurm_state": "COMPLETED",
+      "exit_code": "0:0",
+      "public_commit": "7c1e63997c724064468f64ace698731deacf201e",
+      "finding": "Current-main smoke/preflight completed in 26 seconds with workers=1, one scenario, and eight planners.",
+      "evidence_role": "smoke_preflight",
+      "artifact_summary": {
+        "scenario_count": 1,
+        "planner_count": 8,
+        "workers": 1,
+        "warnings": []
+      },
+      "limitations": [
+        "Smoke/preflight only; it proves launcher/config plumbing but does not replace result analysis."
+      ]
+    }
+  ]
+}

--- a/tests/benchmark/test_issue1554_slurm_evidence_packet.py
+++ b/tests/benchmark/test_issue1554_slurm_evidence_packet.py
@@ -1,0 +1,78 @@
+"""Tests for the issue #1554 Slurm evidence synthesis packet builder."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).parents[2] / "scripts" / "benchmark" / "build_issue1554_slurm_evidence_packet.py"
+)
+
+spec = importlib.util.spec_from_file_location("issue1554_slurm_evidence_packet", SCRIPT)
+assert spec is not None
+assert spec.loader is not None
+module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = module
+spec.loader.exec_module(module)
+
+build_packet = module.build_packet
+render_markdown = module.render_markdown
+_load_jobs = module._load_jobs
+
+
+FIXTURE = (
+    Path(__file__).parent / "fixtures" / "issue1554_slurm_evidence" / "jobs_13192_13198_13203.json"
+)
+
+
+def test_issue1554_packet_recommends_analysis_before_duplicate_submit() -> None:
+    """The completed S20/H500 result should route to analysis, not duplicate submission."""
+    jobs = _load_jobs(FIXTURE)
+
+    packet = build_packet(jobs)
+
+    assert packet["jobs_synthesized"] == [13192, 13198, 13203]
+    assert packet["status"] == "analysis_before_submit"
+    assert packet["successful_jobs"] == [13192, 13198, 13203]
+    assert (
+        "Do not enqueue another duplicate S20/H500 planner-family run yet"
+        in packet["next_slurm_queue_recommendation"]
+    )
+    assert packet["claim_blockers"] == [
+        {
+            "job": 13198,
+            "limitations": [
+                "SNQI contract warning blocks paper-grade interpretation until analyzed.",
+                "Analyze this result before scheduling another duplicate S20/H500 planner-family run.",
+            ],
+        }
+    ]
+    assert packet["forbidden_actions_confirmed"] == {
+        "compute_submit": False,
+        "artifact_deletion": False,
+        "paper_or_dissertation_claim_edits": False,
+    }
+
+
+def test_issue1554_packet_markdown_names_jobs_and_forbidden_actions() -> None:
+    """The Markdown packet names the evidence set and forbidden actions."""
+    packet = build_packet(_load_jobs(FIXTURE))
+
+    rendered = render_markdown(packet)
+
+    assert "completed jobs 13192, 13198, and 13203" in rendered
+    assert "Job 13198" in rendered
+    assert "no Slurm/GPU submission" in rendered
+    assert "no paper/dissertation claim edits" in rendered
+
+
+def test_issue1554_packet_json_is_serializable() -> None:
+    """The packet remains plain JSON for durable evidence review."""
+    packet = build_packet(_load_jobs(FIXTURE))
+
+    encoded = json.dumps(packet, sort_keys=True)
+
+    assert "issue1554-slurm-evidence-packet.v1" in encoded


### PR DESCRIPTION
## Summary

Links #1554.

This PR adds a public, fixture-backed queue-decision packet for the completed #1554 Slurm jobs 13192, 13198, and 13203. The packet classifies job 13198 as the completed S20/H500 planner-family result matrix that should be analyzed before any duplicate rerun, preserves its soft SNQI contract warning as a paper-claim blocker, and records the current-main smoke/preflight proof from job 13203.

No Slurm/GPU submission, no artifact deletion, and no paper/dissertation claim edits were performed.

## Evidence Synthesized

- Job 13192: completed best-PPO comparison run, two ok planner rows, useful as comparison/queue-direction evidence only.
- Job 13198: completed 180 GB split planner-family S20/H500 result matrix, nine ok planner rows, soft SNQI contract warning remains a paper-grade claim blocker.
- Job 13203: completed current-main smoke/preflight with workers=1, one scenario, eight planners; proves launcher/config plumbing only.

## Next Queue-Entry Condition

Do not enqueue another duplicate S20/H500 planner-family run yet. Analyze job 13198 first, including the soft SNQI contract warning. A new Slurm entry is safe only after that analysis identifies an explicit gap or a validated public config/schema unblock.

## Validation

- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_issue1554_slurm_evidence_packet.py --input tests/benchmark/fixtures/issue1554_slurm_evidence/jobs_13192_13198_13203.json --output-json docs/context/evidence/issue_1554_slurm_evidence_2026-06-30/packet.json --output-md docs/context/evidence/issue_1554_slurm_evidence_2026-06-30/README.md` - passed
- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/build_issue1554_slurm_evidence_packet.py tests/benchmark/test_issue1554_slurm_evidence_packet.py` - passed
- `/home/luttkule/git/robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue1554_slurm_evidence_packet.py` - passed, 3 tests
- `git diff --check` - passed
- `uv sync --all-extras` - passed
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - rerun with this PR body before opening

## Downstream Propagation

The durable packet is registered in `docs/context/evidence/README.md`. It is a queue-decision and analysis-unblock artifact, not benchmark-strength or paper-facing claim promotion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new evidence packet generator and supporting output for completed job runs.
  * Introduced a new packaged evidence bundle with JSON and human-readable documentation.

* **Documentation**
  * Updated the evidence index and bundle listings to include the new issue evidence set.
  * Added detailed notes on job results, findings, limitations, and next-step guidance.

* **Tests**
  * Added coverage to verify packet contents, status routing, output formatting, and JSON validity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->