### PR TITLE
Issue #3723: fingerprint SNQI weight inventory sources

### DIFF
--- a/robot_sf/benchmark/snqi/cli.py
+++ b/robot_sf/benchmark/snqi/cli.py
@@ -281,6 +281,7 @@ def cmd_inventory_weights(args: argparse.Namespace) -> int:
                         f"- {rec.name:18s} dominant={rec.dominant_term:14s} "
                         f"scale={rec.scale_class:18s} "
                         f"canonical={'yes' if rec.declares_canonical else 'no'} "
+                        f"sha256={(rec.content_sha256 or 'unknown')[:12]} "
                         f"({rec.relpath or 'code default'})"
                     )
                 else:

--- a/robot_sf/benchmark/snqi/weights_inventory.py
+++ b/robot_sf/benchmark/snqi/weights_inventory.py
@@ -35,6 +35,7 @@ scaling split is tracked separately in #3699.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import re
@@ -169,6 +170,7 @@ class WeightSetRecord:
     weight_sum: float | None = None
     dominant_term: str | None = None
     scale_class: str | None = None
+    content_sha256: str | None = None
     load_error: str | None = None
 
     def normalized_direction(self) -> dict[str, float] | None:
@@ -255,6 +257,7 @@ class WeightInventoryReport:
                     "weight_sum": r.weight_sum,
                     "dominant_term": r.dominant_term,
                     "scale_class": r.scale_class,
+                    "content_sha256": r.content_sha256,
                     "load_error": r.load_error,
                 }
                 for r in self.records
@@ -323,6 +326,12 @@ def _finalize_record(record: WeightSetRecord) -> None:
     )
 
 
+def _weights_content_sha256(weights: dict[str, float]) -> str:
+    """Return stable fingerprint for synthetic/code-defined weight mappings."""
+    payload = json.dumps(weights, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
 def _build_record(spec: WeightSourceSpec, repo_root: Path) -> WeightSetRecord:
     """Load a single source into a :class:`WeightSetRecord` (never raises).
 
@@ -344,6 +353,7 @@ def _build_record(spec: WeightSourceSpec, repo_root: Path) -> WeightSetRecord:
         # empty baseline stats because the "canonical" method ignores them.
         weights = dict(recompute_snqi_weights({}, method="canonical").weights)
         record.weights = {k: float(weights[k]) for k in WEIGHT_NAMES}
+        record.content_sha256 = _weights_content_sha256(record.weights)
         record.available = True
         _finalize_record(record)
         return record
@@ -354,7 +364,9 @@ def _build_record(spec: WeightSourceSpec, repo_root: Path) -> WeightSetRecord:
         record.load_error = "file not found"
         return record
     try:
-        raw = json.loads(path.read_text(encoding="utf-8"))
+        raw_bytes = path.read_bytes()
+        record.content_sha256 = hashlib.sha256(raw_bytes).hexdigest()
+        raw = json.loads(raw_bytes.decode("utf-8"))
         record.weights = _extract_weights(raw)
     except (OSError, ValueError, json.JSONDecodeError) as exc:
         record.load_error = str(exc)

--- a/tests/benchmark/test_snqi_weight_inventory_cli.py
+++ b/tests/benchmark/test_snqi_weight_inventory_cli.py
@@ -28,6 +28,7 @@ def test_weights_inventory_alias_reports_conflict_fail_closed(
         "camera_ready_v2",
         "camera_ready_v3",
     }
+    assert all(len(record["content_sha256"]) == 64 for record in payload["records"])
     assert any(
         conflict["kind"] == "canonical_direction_conflict"
         and conflict["severity"] == "error"

--- a/tests/test_snqi_weights_inventory.py
+++ b/tests/test_snqi_weights_inventory.py
@@ -7,6 +7,7 @@ does not change any current scoring behavior.
 
 from __future__ import annotations
 
+import hashlib
 import json
 from typing import TYPE_CHECKING
 
@@ -102,6 +103,20 @@ def test_inventory_discovers_all_registered_sources(tmp_path):
     assert code.weights == _CODE_DEFAULT
     assert code.dominant_term == "w_collisions"
     assert code.scale_class == "raw"
+    assert (
+        code.content_sha256
+        == hashlib.sha256(
+            json.dumps(_CODE_DEFAULT, sort_keys=True, separators=(",", ":")).encode("utf-8")
+        ).hexdigest()
+    )
+
+    available_records = [r for r in records if r.available]
+    assert all(r.content_sha256 for r in available_records)
+    model = next(r for r in records if r.name == "model_canonical_v1")
+    assert (
+        model.content_sha256
+        == hashlib.sha256((repo / "model/snqi_canonical_weights_v1.json").read_bytes()).hexdigest()
+    )
 
 
 def test_code_default_matches_recompute_canonical(tmp_path):
@@ -232,6 +247,12 @@ def test_unregistered_shipped_weight_file_reported_fail_closed(tmp_path):
     assert len(unregistered) == 1
     assert unregistered[0].relpath == "configs/benchmarks/snqi_weights_experimental_v9.json"
     assert unregistered[0].available
+    assert (
+        unregistered[0].content_sha256
+        == hashlib.sha256(
+            (repo / "configs/benchmarks/snqi_weights_experimental_v9.json").read_bytes()
+        ).hexdigest()
+    )
 
     summary = report.to_dict()["source_summary"]
     assert summary["registered_source_count"] == 5


### PR DESCRIPTION
## Summary
Adds stable SHA-256 fingerprints to the SNQI weight-set inventory so each discovered code/default or shipped JSON weight source has a reproducible provenance marker in JSON and text diagnostics.

## Linked Issues
- Related issue: #3723
- Relates to `#3723`
- Issue link: https://github.com/ll7/robot_sf_ll7/issues/3723

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `content_sha256` to SNQI weight inventory records and serialized reports.
- Fingerprints code-default weights from a stable sorted JSON payload and shipped JSON sources from file bytes.
- Shows a short SHA-256 prefix in the human-readable inventory CLI.
- Extended focused inventory and CLI tests to assert fingerprints are emitted.

## Why Matters
- Added value: makes the existing fail-closed #3723 inventory more provenance-complete without choosing canonical weights.
- Expected impact: diagnostic reports can distinguish exact source contents even when labels or dominant terms collide.
- Why worth merging now: strengthens evidence hygiene for the known canonical-label conflict while preserving current scoring.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3723 diagnostic inventory/provenance clarity only.
- Comparator or baseline, applicable: current inventory records source path, weights, dominant term, scale, and conflicts but no source fingerprint.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only
- Decision stop rule, applicable: focused tests prove fingerprints are present and fail-closed conflict detection still fires.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3723 remains open for maintainer canonical-weight decision.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - extends an existing diagnostic inventory only.

## Domain-Aware Approval
- Required PR: yes - diagnostic benchmark/provenance surface touches SNQI governance reporting.
- Domains reviewed: SNQI weight provenance, benchmark diagnostic preflight.
- Status: pending
- Approval or blocker note: pending reviewer judgment; blocker is confirmation that fingerprint reporting is diagnostic-only and does not promote a canonical SNQI claim.
- Validity checklist: deterministic source hashing is reported only as provenance metadata; no SNQI scoring semantics changed.
- Target claim/hypothesis: unresolved canonical SNQI weight conflict remains visible.
- Comparator or split/evidence validity: no comparator split is used; evidence validity rests on deterministic source hashing plus current fail-closed conflict tests.
- Fallback/degraded exclusions: no fallback/degraded benchmark rows produced.
- Claim boundary: no canonical weight chosen; no ranking, benchmark, paper, or dissertation claim edited.
- Implementation integrity vs experimental validity: implementation only adds fingerprints to inventory outputs.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - CLI and JSON inventory now emit SHA-256 fingerprints.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes - current repo still reports #3723 `canonical_direction_conflict` fail-closed.
- Result route: continue - maintainer canonical-weight decision remains separate.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no full benchmark campaign run.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none for this diagnostic slice.
- Stop / revise / continue decision: continue with maintainer canonical-weight decision outside this PR.
- Proposed child issue existing follow-up: #3723 remains the decision-required parent.

## Validation / Proof
- `uv run ruff format robot_sf/benchmark/snqi/weights_inventory.py robot_sf/benchmark/snqi/cli.py tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_weight_inventory_cli.py && uv run ruff check robot_sf/benchmark/snqi/weights_inventory.py robot_sf/benchmark/snqi/cli.py tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_weight_inventory_cli.py` -> passed.
- `uv run pytest tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_weight_inventory_cli.py -q` -> 12 passed.
- `uv run python -m robot_sf.benchmark.snqi.cli inventory --no-fail-on-conflict` -> exit 0; reports five sources with SHA-256 prefixes and the existing conflicts.
- `uv run python -m robot_sf.benchmark.snqi.cli inventory` -> exit 2 as expected; fail-closed #3723 conflict preserved.
- `uv run python scripts/validation/check_snqi_governance.py --allow-current-blockers --json` -> exit 0; status remains `failed` with #3723 and #3699 blockers visible.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> exit 2 before running full gate because domain-aware approval is pending/required for benchmark diagnostic work; Claude Code on `imech156-u` owns full PR gate, improvement cycle, and merge authority.

## Performance Profile
- Baseline runtime: NA - no runtime performance claim.
- Changed runtime: NA - no runtime performance claim.
- Representative command: `uv run python -m robot_sf.benchmark.snqi.cli inventory --no-fail-on-conflict`
- Hot-path call count profile anchor: NA - diagnostic CLI/report field only.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: fingerprint field breaks inventory CLI/tests or changes SNQI scoring behavior.

## Risks / Rollout
- Compatibility risks: low; adds an optional output field to inventory records and CLI display text.
- Failure modes: downstream strict JSON consumers could reject the added field if they assumed a closed schema.
- Rollback fallback plan: remove `content_sha256` field and related display/tests.

## Docs / Provenance
- Updated docs: none; existing diagnostics docs already describe the inventory/preflight surface.
- Relevant design provenance notes: #3723 live issue and existing SNQI weight provenance docs.
- Any assumptions need to preserved: code-default fingerprint hashes the sorted in-memory weight mapping; shipped JSON fingerprint hashes raw file bytes.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - comment authorization is false.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: diagnostic inventory enhancement only; no benchmark campaign, claim map, leaderboard, or paper-facing artifact changed.

## Follow-Up Issues
- Deferred work: maintainer decision on canonical SNQI weight source; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Issues opened follow-up: none - #3723 remains the decision-required parent and comment authorization is false.

## Reviewer Notes
- Verify closely that `compute_snqi` and `recompute_snqi_weights("canonical")` semantics are untouched.
- Known limitations: this PR does not resolve the canonical conflict; it only makes exact source contents easier to identify.
