### PR TITLE
Issue #3078 validate Package A held-out readiness contract

### DIFF
--- a/scripts/validation/check_package_a_readiness.py
+++ b/scripts/validation/check_package_a_readiness.py
@@ -261,6 +261,26 @@ def _check_command_contract(
             report.missing_paths.append(rel_path)
 
 
+def _check_package_a_heldout_partition_contract(
+    repo_root: Path, command_contracts: dict[str, Any], report: ReadinessReport
+) -> None:
+    """Validate Package A held-out-family output roles without running campaigns."""
+    from scripts.tools.validate_heldout_transfer_partitions import validate_partition_manifest
+
+    contracts = command_contracts.get("contracts")
+    if not isinstance(contracts, list):
+        return
+    for index, contract in enumerate(contracts):
+        if not isinstance(contract, dict):
+            continue
+        if contract.get("id") != "heldout_family_leakage_audit":
+            continue
+        for rel_path in _required_paths(contract, f"command_contracts.contracts[{index}]"):
+            path = repo_root / rel_path
+            if path.exists() and path.name.endswith("heldout_family_transfer_partitions.yaml"):
+                report.issues.extend(validate_partition_manifest(path))
+
+
 def _check_outputs(outputs: dict[str, Any], report: ReadinessReport) -> None:
     """Verify declared output location is safe and disposable."""
     local_root = _clean_str(outputs.get("local_root"))
@@ -324,6 +344,7 @@ def check_readiness(manifest_path: Path, *, repo_root: Path | None = None) -> Re
 
     _check_paths(repo_root, manifest["frozen_protocol"], "frozen_protocol", report)
     _check_command_contracts(repo_root, manifest["command_contracts"], report)
+    _check_package_a_heldout_partition_contract(repo_root, manifest["command_contracts"], report)
     _check_outputs(manifest["outputs"], report)
     _check_durable_evidence(manifest["durable_evidence"], report)
     _check_readiness_decision(manifest["readiness_decision"], report)

--- a/tests/validation/test_check_package_a_readiness.py
+++ b/tests/validation/test_check_package_a_readiness.py
@@ -131,6 +131,40 @@ def test_fails_closed_on_missing_heldout_input(tmp_path: Path) -> None:
     assert "configs/sets/eval_set.yaml" in report.missing_paths
 
 
+def test_fails_closed_on_invalid_heldout_partition_contract(tmp_path: Path) -> None:
+    """Package A readiness validates held-out transfer output roles."""
+    manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    partition_relpath = "configs/benchmarks/issue_2128_heldout_family_transfer_partitions.yaml"
+    tool_relpath = "scripts/tools/validate_heldout_transfer_partitions.py"
+    partition_path = tmp_path / partition_relpath
+    partition_path.parent.mkdir(parents=True, exist_ok=True)
+    partition_data = yaml.safe_load((REPO_ROOT / partition_relpath).read_text(encoding="utf-8"))
+    partition_data["planned_outputs"] = [
+        output
+        for output in partition_data["planned_outputs"]
+        if output.get("evidence_role") != "transfer_delta_figure"
+    ]
+    partition_path.write_text(yaml.safe_dump(partition_data, sort_keys=False), encoding="utf-8")
+    tool_path = tmp_path / tool_relpath
+    tool_path.parent.mkdir(parents=True, exist_ok=True)
+    tool_path.write_text("# fixture\n", encoding="utf-8")
+    data["command_contracts"]["contracts"].append(
+        {
+            "id": "heldout_family_leakage_audit",
+            "stage": "readiness_probe",
+            "command": "uv run python scripts/tools/validate_heldout_transfer_partitions.py x",
+            "allowed_in_readiness_check": True,
+            "executes_benchmark_campaign": False,
+            "required_paths": [tool_relpath, partition_relpath],
+        }
+    )
+    manifest_path.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    report = checker.check_readiness(manifest_path, repo_root=tmp_path)
+    assert report.status == "not_ready"
+    assert any("transfer_delta_figure" in issue for issue in report.issues)
+
+
 def test_fails_closed_on_missing_seed_metadata(tmp_path: Path) -> None:
     """A seed plan missing required metadata is not_ready even if files exist."""
     manifest_path = _synthetic_manifest(tmp_path, create_inputs=True)


### PR DESCRIPTION
## Summary
Adds a fail-closed Package A readiness check that validates the referenced held-out-family transfer partition manifest output-role contract before Package A is treated as locally ready.

## Linked Issues
- Relates to #3078
- Parent: #3057

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- `scripts/validation/check_package_a_readiness.py` now validates the Package A held-out-family leakage-audit partition manifest with the canonical `validate_heldout_transfer_partitions.py` checker.
- `tests/validation/test_check_package_a_readiness.py` adds a regression proving Package A readiness fails closed when the held-out transfer output roles are incomplete.

## Why Matters
- Added value: prevents a Package A readiness packet from passing when the held-out-family table/figure/transfer-delta contract is malformed.
- Expected impact: tighter local readiness boundary for issue #3078 without running a benchmark campaign.
- Why worth merging now: it turns part of the issue acceptance criteria into an executable preflight check while compute submission remains out of scope.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Package A readiness/blocker boundary for held-out-family transfer packet completeness.
- Comparator or baseline, applicable: NA - no benchmark result or planner comparison is produced.
- Evidence tier: diagnostic probe / readiness checker.
- Result classification: blocker-resolution for the checker slice; not benchmark evidence.
- Decision stop rule, applicable: readiness remains fail-closed if the held-out partition manifest lacks required evidence roles.
- Parent issue, claim map, registry, context note, synthesis surface update: #3078 / #3057; no claim map update because no campaign result is produced.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - extends an existing readiness checker and uses an existing partition validator.

## Domain-Aware Approval
- Required for this PR: yes - benchmark readiness boundary
- Domains reviewed: benchmark readiness, held-out-family transfer partition contract
- Status: waived
- Approval or blocker note: Full Package A claim approval is blocked until issue #3078 supplies canonical result-store evidence, seed-sufficiency analysis, held-out-family transfer outputs, and claim-card review. This PR only tightens the readiness checker and makes no claim promotion.
- Approver/review source or waiver: Self-reviewed checker-only waiver: this PR validates readiness metadata only; Package A benchmark claim approval remains blocked under #3078 until campaign evidence and claim-card review exist.
- Validity checklist: fail-closed checker only.
- Target claim/hypothesis: NA - no claim promotion.
- Comparator or split/evidence validity: held-out partition manifest contract is validated; no rows executed.
- Fallback/degraded exclusions: preserved; fallback/degraded rows are not treated as success evidence.
- Claim boundary: readiness/provenance gate only.
- Implementation integrity vs experimental validity: implementation checks manifest structure; experimental validity remains deferred to the actual Package A campaign and claim-card review.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, targeted regression fails readiness when `transfer_delta_figure` is missing.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, synthetic test removes a required held-out transfer output role.
- Result route: continue to Package A execution after remaining evidence inputs exist.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: yes, actual Package A retained-bundle/held-out-family campaign execution remains out of scope.
- Extractor analysis tool needed: no for this checker slice.
- Artifact missing unavailable: canonical campaign result store and seed-sufficiency analysis report were intentionally not supplied to the decision-packet command.
- Stop / revise / continue decision: continue once owner/executor supplies campaign evidence.
- Proposed child issue existing follow-up: #3078 remains the execution issue.

## Validation / Proof
- `python3 -m py_compile scripts/validation/check_package_a_readiness.py tests/validation/test_check_package_a_readiness.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_package_a_readiness.py tests/tools/test_validate_heldout_transfer_partitions.py -q` - passed, 19 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_package_a_readiness.py --json` - passed, status `ready`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/validate_heldout_transfer_partitions.py configs/benchmarks/issue_2128_heldout_family_transfer_partitions.yaml` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/tools/analyze_seed_sufficiency.py --help` - passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed before commit, 1679 passed / 2 skipped; dirty stamp only because changes were uncommitted at that time.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue3078_pr_body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed on clean committed head `4a17a114`; 1681 passed / 2 skipped; freshness stamp status `passed`, tree_state `clean`.

## Risks / Rollout
- Compatibility risks: low; adds stricter validation to an issue-specific readiness checker.
- Failure modes: if a future Package A manifest renames the held-out leakage-audit command id, this specific cross-check would not run until the checker is updated.
- Rollback fallback plan: revert this PR to restore prior file-existence-only readiness behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3078 and parent #3057.
- Any assumptions need to preserved: current scope is a reversible readiness/checker slice, not full Package A execution.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, issue comments were not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark result.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR does not produce campaign artifacts, ranking evidence, or claim-card outputs.

## Follow-Up Issues
- Deferred work: execute full Package A campaign with retained bundles/result store/seed-sufficiency report and claim-card review under #3078.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that the stricter check remains readiness-only and does not execute benchmark campaigns.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
