### PR TITLE
Issue #3216: add headline rank CI downgrade packet

### DIFF
--- a/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+++ b/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
@@ -44,6 +44,7 @@ from collections import defaultdict
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from itertools import pairwise
 from pathlib import Path
 from typing import Any
 
@@ -181,6 +182,44 @@ class ScenarioRankStability:
             "kendall_tau_min": self.kendall_tau_min,
             "rank_flip_rate": self.rank_flip_rate,
             "top1_stable": self.top1_stable,
+        }
+
+
+@dataclass(frozen=True)
+class AdjacentRankClaim:
+    """Adjacent-rank CI overlap decision for one scenario ranking."""
+
+    scenario_id: str
+    rank_metric: str
+    higher_is_better: bool
+    higher_rank_planner: str
+    lower_rank_planner: str
+    higher_rank_mean: float
+    lower_rank_mean: float
+    higher_rank_ci_low: float
+    higher_rank_ci_high: float
+    lower_rank_ci_low: float
+    lower_rank_ci_high: float
+    decision: str
+    rationale: str
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe adjacent-rank claim decision."""
+
+        return {
+            "scenario_id": self.scenario_id,
+            "rank_metric": self.rank_metric,
+            "higher_is_better": self.higher_is_better,
+            "higher_rank_planner": self.higher_rank_planner,
+            "lower_rank_planner": self.lower_rank_planner,
+            "higher_rank_mean": self.higher_rank_mean,
+            "lower_rank_mean": self.lower_rank_mean,
+            "higher_rank_ci_low": self.higher_rank_ci_low,
+            "higher_rank_ci_high": self.higher_rank_ci_high,
+            "lower_rank_ci_low": self.lower_rank_ci_low,
+            "lower_rank_ci_high": self.lower_rank_ci_high,
+            "decision": self.decision,
+            "rationale": self.rationale,
         }
 
 
@@ -479,6 +518,89 @@ def build_rank_stability(
     return out
 
 
+def _metric_stats(cell: CellResult, metric: str) -> dict[str, float] | None:
+    """Return complete metric statistics for CI decisions."""
+
+    stats = cell.metrics.get(metric)
+    if not stats:
+        return None
+    required = ("mean", "ci_low", "ci_high")
+    if any(_coerce_float(stats.get(key)) is None for key in required):
+        return None
+    return stats
+
+
+def _ci_overlap(a: dict[str, float], b: dict[str, float]) -> bool:
+    """Return whether two confidence intervals overlap."""
+
+    return max(float(a["ci_low"]), float(b["ci_low"])) <= min(
+        float(a["ci_high"]),
+        float(b["ci_high"]),
+    )
+
+
+def build_adjacent_rank_claims(
+    cells: Sequence[CellResult],
+    rank_stability: Sequence[ScenarioRankStability],
+    *,
+    rank_metric: str,
+    higher_is_better: bool,
+) -> list[AdjacentRankClaim]:
+    """Build adjacent-rank downgrade decisions from per-cell CIs.
+
+    Adjacent planners with overlapping confidence intervals are downgraded to
+    ``not_statistically_distinguishable_budget`` so the packet cannot be read
+    as support for a strict paper-facing ordering.
+    """
+
+    cell_by_key = {
+        (cell.scenario_id, cell.planner_key): cell
+        for cell in cells
+        if cell.counted and _metric_stats(cell, rank_metric) is not None
+    }
+    claims: list[AdjacentRankClaim] = []
+    for stability in rank_stability:
+        ranking = stability.point_ranking
+        if len(ranking) < 2:
+            continue
+        for higher_planner, lower_planner in pairwise(ranking):
+            higher_cell = cell_by_key.get((stability.scenario_id, higher_planner))
+            lower_cell = cell_by_key.get((stability.scenario_id, lower_planner))
+            if higher_cell is None or lower_cell is None:
+                continue
+            higher_stats = _metric_stats(higher_cell, rank_metric)
+            lower_stats = _metric_stats(lower_cell, rank_metric)
+            if higher_stats is None or lower_stats is None:
+                continue
+            if _ci_overlap(higher_stats, lower_stats):
+                decision = "not_statistically_distinguishable_budget"
+                rationale = (
+                    "Adjacent-rank confidence intervals overlap; downgrade any strict "
+                    "planner-beats-planner claim at this seed budget."
+                )
+            else:
+                decision = "ci_separable"
+                rationale = "Adjacent-rank confidence intervals do not overlap."
+            claims.append(
+                AdjacentRankClaim(
+                    scenario_id=stability.scenario_id,
+                    rank_metric=rank_metric,
+                    higher_is_better=higher_is_better,
+                    higher_rank_planner=higher_planner,
+                    lower_rank_planner=lower_planner,
+                    higher_rank_mean=float(higher_stats["mean"]),
+                    lower_rank_mean=float(lower_stats["mean"]),
+                    higher_rank_ci_low=float(higher_stats["ci_low"]),
+                    higher_rank_ci_high=float(higher_stats["ci_high"]),
+                    lower_rank_ci_low=float(lower_stats["ci_low"]),
+                    lower_rank_ci_high=float(lower_stats["ci_high"]),
+                    decision=decision,
+                    rationale=rationale,
+                )
+            )
+    return claims
+
+
 def classify(
     cells: Sequence[CellResult],
     rank_stability: Sequence[ScenarioRankStability],
@@ -559,6 +681,12 @@ def build_report(
         resamples=config.resamples,
         rng_seed=config.rank_seed,
     )
+    adjacent_rank_claims = build_adjacent_rank_claims(
+        cells,
+        rank_stability,
+        rank_metric=rank_metric,
+        higher_is_better=higher_is_better,
+    )
     classification, rationale = classify(cells, rank_stability)
     counted = [cell for cell in cells if cell.counted]
     excluded = [cell for cell in cells if not cell.counted]
@@ -599,6 +727,7 @@ def build_report(
         ],
         "cells": [cell.to_dict() for cell in cells],
         "rank_stability": [r.to_dict() for r in rank_stability],
+        "adjacent_rank_claims": [claim.to_dict() for claim in adjacent_rank_claims],
         "excluded_cell_reasons": [
             {
                 "scenario_id": cell.scenario_id,
@@ -662,6 +791,19 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             f"| {entry['resamples']} | {_fmt(entry['kendall_tau_mean'])} "
             f"| {_fmt(entry['kendall_tau_min'])} | {_fmt(entry['rank_flip_rate'])} "
             f"| {entry['top1_stable']} |"
+        )
+    lines.append("")
+    lines.append("## Adjacent-rank claim downgrades")
+    lines.append("")
+    lines.append(
+        "| scenario | higher-rank planner | lower-rank planner | metric | decision | rationale |"
+    )
+    lines.append("| --- | --- | --- | --- | --- | --- |")
+    for claim in report["adjacent_rank_claims"]:
+        lines.append(
+            f"| {claim['scenario_id']} | {claim['higher_rank_planner']} "
+            f"| {claim['lower_rank_planner']} | {claim['rank_metric']} "
+            f"| {claim['decision']} | {claim['rationale']} |"
         )
     if report["excluded_cell_reasons"]:
         lines.append("")

--- a/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
@@ -247,3 +247,36 @@ def test_both_input_shapes_supported(shape: str):
         [row], metrics=["snqi"], bootstrap_samples=0, confidence=0.95, bootstrap_seed=1
     )
     assert cells[0].metrics["snqi"]["count"] == 3.0
+
+
+def test_adjacent_rank_claims_downgrade_overlapping_ci() -> None:
+    """Adjacent planners with overlapping CIs are not strict headline claims."""
+
+    rows = [
+        _cell_row("bottleneck", "a", {"snqi": [0.50, 0.55, 0.45, 0.52, 0.48]}),
+        _cell_row("bottleneck", "b", {"snqi": [0.51, 0.46, 0.54, 0.49, 0.53]}),
+    ]
+
+    report = _report(rows)
+
+    assert len(report["adjacent_rank_claims"]) == 1
+    claim = report["adjacent_rank_claims"][0]
+    assert claim["decision"] == "not_statistically_distinguishable_budget"
+    assert "overlap" in claim["rationale"]
+
+
+def test_adjacent_rank_claims_mark_ci_separable() -> None:
+    """Well-separated adjacent planner CIs are labeled separable."""
+
+    rows = [
+        _cell_row("merging", "best", {"snqi": [0.90, 0.91, 0.92, 0.93, 0.94]}),
+        _cell_row("merging", "worst", {"snqi": [0.10, 0.11, 0.09, 0.12, 0.10]}),
+    ]
+
+    report = _report(rows)
+
+    assert len(report["adjacent_rank_claims"]) == 1
+    claim = report["adjacent_rank_claims"][0]
+    assert claim["higher_rank_planner"] == "best"
+    assert claim["lower_rank_planner"] == "worst"
+    assert claim["decision"] == "ci_separable"


### PR DESCRIPTION
## Issue

Fixes/advances #3216: benchmark: paper-grade headline planner comparison (confidence intervals + rank stability at increased seed budget)

## Scope summary

This PR keeps the existing no-submit issue #3216 headline CI/rank-stability harness local-only and adds an explicit adjacent-rank CI downgrade packet:

- emits `adjacent_rank_claims` in `result.json` for each adjacent pair in the per-scenario rank order;
- labels overlapping adjacent confidence intervals as `not_statistically_distinguishable_budget` so strict planner-beats-planner claims fail closed at the current seed budget;
- labels non-overlapping adjacent confidence intervals as `ci_separable`;
- renders the same decisions in the Markdown report;
- adds deterministic fixture tests for both downgrade and separable cases.

Assumption: adjacent-rank CI overlap is the smallest reversible local preflight slice for the live issue comments that say h500 top planners should be treated as tied unless confidence intervals separate. This PR does not reinterpret benchmark results or promote paper-grade claims.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py` — passed (`2 files left unchanged`, `All checks passed!`).
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py -q` — passed (`13 passed`).
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --help` — passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark/ -k "seed_variance or ranking or aggregate" -q` — passed (`47 passed`).
- `uv sync --all-extras` — completed after the first full PR gate exposed missing optional `duckdb` in the fresh worktree venv.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` — passed; core lane reported `1679 passed, 2 skipped`, optional-extra lane completed, broad exception ratchet passed, and readiness stamp was written for `d225a90758e5c166649d2fd5799084c89b1f9238`.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` — passed (`fresh: true`, clean tree).

## Artifact classification

Generated validation artifacts under `output/coverage/` and `output/validation/pr_ready/` are ignored local validation outputs only; none were committed.

## Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
