### PR TITLE
Issue #3653: fail closed on missing SNQI export terms

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -380,6 +380,7 @@ def build_scalarization_sensitivity_report(
         dominance, and Pareto-front rows.
     """
 
+    _validate_export_required_terms(records)
     grouped = _group_records(records, planner_key, fallback_planner_key)
     if len(grouped) < 2:
         raise ValueError("at least two planners are required for rank-sensitivity diagnostics")
@@ -725,6 +726,24 @@ def _group_records(
             raise ValueError(f"record {index} missing planner key {planner_key!r}")
         grouped.setdefault(str(planner), []).append(record)
     return grouped
+
+
+def _validate_export_required_terms(records: Sequence[Mapping[str, Any]]) -> None:
+    """Fail closed before export when required SNQI terms would otherwise default."""
+
+    for index, record in enumerate(records, start=1):
+        metrics = _metrics(record)
+        for metric in REQUIRED_SENSITIVITY_METRICS:
+            if metric not in metrics:
+                raise ValueError(
+                    f"record {index} missing required SNQI term {metric!r}; "
+                    "run scalarization-sensitivity preflight before export"
+                )
+            if not _is_finite_metric(metrics.get(metric)):
+                raise ValueError(
+                    f"record {index} non-finite required SNQI term {metric!r}; "
+                    "run scalarization-sensitivity preflight before export"
+                )
 
 
 def _planner_snqi_scores(

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import json
 from pathlib import Path
 
+import pytest
+
 from robot_sf.benchmark.snqi_scalarization_sensitivity import (
     SCALARIZATION_SENSITIVITY_SCHEMA,
     SENSITIVITY_PREFLIGHT_BLOCKED,
@@ -238,6 +240,34 @@ def test_report_exports_decision_disagreement_and_weight_reversals() -> None:
         "fast-risky",
         "safe-slow",
     }
+
+
+def test_report_export_refuses_missing_normalized_time_term() -> None:
+    """Direct report export fails closed when normalized time input is absent."""
+
+    records = _episodes()
+    del records[0]["metrics"]["time_to_goal_norm"]
+
+    with pytest.raises(ValueError, match="missing required SNQI term 'time_to_goal_norm'"):
+        build_scalarization_sensitivity_report(
+            records,
+            weights=_weights(),
+            baseline=_baseline(),
+        )
+
+
+def test_report_export_refuses_non_finite_normalized_time_term() -> None:
+    """Direct report export fails closed when normalized time input is invalid."""
+
+    records = _episodes()
+    records[0]["metrics"]["time_to_goal_norm"] = "nan"
+
+    with pytest.raises(ValueError, match="non-finite required SNQI term 'time_to_goal_norm'"):
+        build_scalarization_sensitivity_report(
+            records,
+            weights=_weights(),
+            baseline=_baseline(),
+        )
 
 
 def test_artifact_writer_creates_report_ready_files(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds a library-level fail-closed guard so SNQI scalarization-sensitivity report export refuses records with missing or non-finite required normalized SNQI terms before producing Pareto or decision-disagreement artifacts.

## Linked Issues
- Relates to `#3653`
- Issue link: https://github.com/ll7/robot_sf_ll7/issues/3653

## Stack / Dependency
- Base dependency: none
- Required prior PRs: prior #3653 work is already merged on `origin/main`
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: this is a residual guard over the existing SNQI scalarization diagnostic export path

## What Changed
- Added `build_scalarization_sensitivity_report()` export validation for required SNQI terms before SNQI scoring can apply defaults.
- Added regression tests for missing and non-finite `time_to_goal_norm` direct builder inputs.

## Why Matters
- Added value: direct library callers now fail closed the same way the CLI preflight/export path is intended to.
- Expected impact: prevents report-ready Pareto-front and decision-disagreement artifacts from being emitted on invalid normalized inputs.
- Why worth merging now: issue #3653 is evidence-boundary work, and the residual gap was small but could silently produce misleading diagnostics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: SNQI scalarization-sensitivity export must refuse invalid normalized inputs before producing diagnostic artifacts.
- Comparator or baseline, applicable: `origin/main` allowed direct builder export when `time_to_goal_norm` was absent.
- Evidence tier: NA - validation guard only, no research result claim
- Result classification: NA - no research result claim
- Decision stop rule, applicable: focused regression tests pass and local PR readiness passes.
- Parent issue, claim map, registry, context note, synthesis surface update: #3653
- New research/benchmark/metric/paper-facing analysis tool, any: no new analysis tool; guard on existing diagnostic export.

## Domain-Aware Approval
- Approver/review source waiver: pending reviewer
- Validity checklist:
- Target claim/hypothesis: export refuses invalid normalized SNQI inputs.
- Comparator split/evidence validity: direct builder regression tests cover the prior silent-default path.
- Fallback/degraded exclusions: no fallback or degraded benchmark execution used.
- Claim boundary: diagnostic/export guard only, not benchmark evidence.
- Implementation integrity vs experimental validity: implementation changes input validation only; no SNQI formula or benchmark ranking semantics changed.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, tests assert `ValueError` on missing and non-finite normalized time.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? yes, fixture records directly remove or corrupt `time_to_goal_norm`.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: none

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue with review
- Proposed child issue existing follow-up: none

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py` -> 13 passed
- `test -f tests/test_plots_pareto.py && scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_plots_pareto.py || { echo 'tests/test_plots_pareto.py not present'; exit 0; }` -> 3 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` -> 2 files left unchanged; all checks passed
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> 1679 passed, 2 skipped; interim dirty-tree stamp only because run preceded commit
- Final clean-head readiness: pending at PR open time, run with this body file before push

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Notes
- Baseline runtime: NA, no performance claim
- Changed runtime: NA, no performance claim
- Representative command: `uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py`
- Hot-path call count profile anchor: NA, no hot-path performance claim
- Cache-hit reuse counter: NA, no caching claimed
- Rollback failure criterion: revert if valid SNQI scalarization fixture export is rejected or invalid normalized inputs can still produce artifacts.

## Risks / Rollout
- Compatibility risks: direct callers that relied on missing required SNQI terms defaulting during diagnostic export will now receive `ValueError`.
- Failure modes: overly strict required-term validation could block intentionally partial diagnostic fixtures.
- Rollback fallback plan: remove the builder guard while keeping CLI preflight behavior unchanged.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: issue #3653 and existing merged SNQI scalarization diagnostic implementation
- Any assumptions need to preserved: the residual issue slice is fail-closed export behavior over fixtures; no claim promotion.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, commenting not authorized in this task
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR changes validation semantics for an existing diagnostic export and does not add benchmark results, registry entries, or paper-facing claims.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes
- Verify closely that the guard is scoped to required SNQI terms and does not change SNQI scoring weights, normalization, rank computation, or Pareto-front rendering.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
