### PR TITLE
Issue #3699: add SNQI contribution diagnostics

### DIFF
--- a/robot_sf/benchmark/snqi/__init__.py
+++ b/robot_sf/benchmark/snqi/__init__.py
@@ -16,7 +16,9 @@ from .exit_codes import (
 )
 from .normalization_inventory import (
     NormalizationInventory,
+    TermContribution,
     TermScaling,
+    build_snqi_contribution_diagnostics,
     build_snqi_normalization_inventory,
 )
 from .schema import EXPECTED_SCHEMA_VERSION, assert_all_finite, validate_snqi
@@ -31,11 +33,11 @@ from .weights_inventory import (
 from .weights_validation import validate_weights_mapping
 
 __all__ = [
+    # Exit codes
     "EXIT_INPUT_ERROR",
     "EXIT_MISSING_METRIC_ERROR",
     "EXIT_OPTIONAL_DEPS_MISSING",
     "EXIT_RUNTIME_ERROR",
-    # Exit codes
     "EXIT_SUCCESS",
     "EXIT_VALIDATION_ERROR",
     "EXPECTED_SCHEMA_VERSION",
@@ -44,10 +46,12 @@ __all__ = [
     "NormalizationInventory",
     # Weight-set provenance inventory
     "SNQIWeightProvenanceError",
+    "TermContribution",
     "TermScaling",
     "WeightInventoryReport",
     "assert_all_finite",
     "build_inventory_report",
+    "build_snqi_contribution_diagnostics",
     "build_snqi_normalization_inventory",
     # Core compute
     "compute_snqi",

--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -217,6 +217,101 @@ def scaled_term_value(
 
 
 @dataclass(frozen=True)
+class TermContribution:
+    """Weighted SNQI component contribution for one metric row.
+
+    The signed value mirrors ``compute_snqi`` exactly: reward terms are positive
+    and penalty terms are negative. ``absolute_share`` is diagnostic only and is
+    normalized by the sum of absolute weighted contributions for the row.
+    """
+
+    term: TermScaling
+    raw_value: float | int | bool
+    scaled_value: float
+    weight: float
+    signed_contribution: float
+    absolute_share: float
+
+    def to_dict(self) -> dict[str, object]:
+        """Return JSON-serializable contribution diagnostics."""
+        return {
+            "term": self.term.term,
+            "weight_name": self.term.weight_name,
+            "metric_key": self.term.metric_key,
+            "scaling": self.term.scaling,
+            "normalization_status": self.term.normalization_status,
+            "raw_value": self.raw_value,
+            "scaled_value": self.scaled_value,
+            "weight": self.weight,
+            "signed_contribution": self.signed_contribution,
+            "absolute_share": self.absolute_share,
+            "bounded": self.term.bounded,
+            "measurement_basis": self.term.measurement_basis,
+        }
+
+
+def build_snqi_contribution_diagnostics(
+    metrics: dict[str, float | int | bool],
+    weights: dict[str, float],
+    baseline_stats: dict[str, dict[str, float]],
+) -> dict[str, object]:
+    """Build read-only weighted contribution diagnostics for one SNQI row.
+
+    This checker intentionally does not normalize the raw terms or alter any
+    score. It exposes how much each mixed-basis term contributes under the
+    current formula so issue #3699 can be reviewed without silently promoting a
+    normalization redesign.
+
+    Returns:
+        JSON-serializable diagnostic payload with per-term contributions and
+        aggregate raw-vs-baseline-normalized penalty shares.
+    """
+    preliminary: list[tuple[TermScaling, float | int | bool, float, float, float]] = []
+    absolute_total = 0.0
+    for term in SNQI_TERM_SCALING:
+        raw_value = metrics.get(term.metric_key, term.default)
+        scaled_value = scaled_term_value(term, metrics, baseline_stats)
+        weight = float(weights.get(term.weight_name, 1.0))
+        signed_contribution = term.sign * weight * scaled_value
+        absolute_total += abs(signed_contribution)
+        preliminary.append((term, raw_value, scaled_value, weight, signed_contribution))
+
+    contributions = [
+        TermContribution(
+            term=term,
+            raw_value=raw_value,
+            scaled_value=scaled_value,
+            weight=weight,
+            signed_contribution=signed_contribution,
+            absolute_share=(
+                abs(signed_contribution) / absolute_total if absolute_total > 0.0 else 0.0
+            ),
+        )
+        for term, raw_value, scaled_value, weight, signed_contribution in preliminary
+    ]
+    raw_penalty_share = sum(
+        c.absolute_share
+        for c in contributions
+        if c.term.is_penalty and c.term.scaling == SCALING_RAW
+    )
+    normalized_penalty_share = sum(
+        c.absolute_share
+        for c in contributions
+        if c.term.is_penalty and c.term.scaling == SCALING_BASELINE_NORMALIZED
+    )
+    return {
+        "schema_version": "snqi_normalization_contributions.v1",
+        "diagnostic_only": True,
+        "mixed_basis": bool(raw_penalty_share and normalized_penalty_share),
+        "absolute_contribution_total": absolute_total,
+        "raw_penalty_absolute_share": raw_penalty_share,
+        "baseline_normalized_penalty_absolute_share": normalized_penalty_share,
+        "raw_penalty_terms_dominate": raw_penalty_share > normalized_penalty_share,
+        "terms": [contribution.to_dict() for contribution in contributions],
+    }
+
+
+@dataclass(frozen=True)
 class NormalizationInventory:
     """Structured inventory of SNQI per-term normalization status.
 
@@ -353,7 +448,9 @@ __all__ = [
     "SCALING_RAW",
     "SNQI_TERM_SCALING",
     "NormalizationInventory",
+    "TermContribution",
     "TermScaling",
+    "build_snqi_contribution_diagnostics",
     "build_snqi_normalization_inventory",
     "format_normalization_report",
     "scaled_term_value",

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -24,6 +24,7 @@ from robot_sf.benchmark.snqi.exit_codes import (
     EXIT_VALIDATION_ERROR,
 )
 from robot_sf.benchmark.snqi.normalization_inventory import (
+    build_snqi_contribution_diagnostics,
     build_snqi_normalization_inventory,
 )
 from robot_sf.benchmark.snqi.weights_inventory import build_inventory_report
@@ -34,6 +35,31 @@ CLAIM_BOUNDARY = (
     "change normalization, change compute_snqi output, or make SNQI a primary "
     "safety ranking."
 )
+
+CONTRIBUTION_DIAGNOSTIC_METRICS = {
+    "success": 1.0,
+    "time_to_goal_norm": 3.0,
+    "collisions": 9.0,
+    "near_misses": 9.0,
+    "comfort_exposure": 2.0,
+    "force_exceed_events": 9.0,
+    "jerk_mean": 9.0,
+}
+CONTRIBUTION_DIAGNOSTIC_WEIGHTS = {
+    "w_success": 1.0,
+    "w_time": 1.0,
+    "w_collisions": 1.0,
+    "w_near": 1.0,
+    "w_comfort": 1.0,
+    "w_force_exceed": 1.0,
+    "w_jerk": 1.0,
+}
+CONTRIBUTION_DIAGNOSTIC_BASELINE_STATS = {
+    "collisions": {"med": 0.0, "p95": 1.0},
+    "near_misses": {"med": 0.0, "p95": 1.0},
+    "force_exceed_events": {"med": 0.0, "p95": 1.0},
+    "jerk_mean": {"med": 0.0, "p95": 1.0},
+}
 
 
 def _load_baseline_stats(path: Path | None) -> dict[str, dict[str, float]] | None:
@@ -59,6 +85,11 @@ def build_governance_report(
     """Build a structured SNQI governance diagnostic report."""
     weights = build_inventory_report(repo_root)
     normalization = build_snqi_normalization_inventory(baseline_stats)
+    contribution_diagnostics = build_snqi_contribution_diagnostics(
+        CONTRIBUTION_DIAGNOSTIC_METRICS,
+        CONTRIBUTION_DIAGNOSTIC_WEIGHTS,
+        CONTRIBUTION_DIAGNOSTIC_BASELINE_STATS,
+    )
 
     blockers: list[dict[str, Any]] = []
     if weights.has_blocking_conflict:
@@ -115,6 +146,7 @@ def build_governance_report(
         "blockers": blockers,
         "weights": weights.to_dict(),
         "normalization": normalization.to_dict(),
+        "normalization_contributions": contribution_diagnostics,
     }
 
 
@@ -151,6 +183,14 @@ def _print_text_report(report: dict[str, Any]) -> None:
             f"{term['normalization_status']}; role={role}; "
             f"basis={term['measurement_basis']}; note={term['note']}"
         )
+    contributions = report["normalization_contributions"]
+    print(
+        "Contribution diagnostic: "
+        f"raw_penalty_share={contributions['raw_penalty_absolute_share']:.3f}; "
+        "baseline_normalized_penalty_share="
+        f"{contributions['baseline_normalized_penalty_absolute_share']:.3f}; "
+        f"raw_penalty_terms_dominate={contributions['raw_penalty_terms_dominate']}"
+    )
 
 
 def _build_parser() -> argparse.ArgumentParser:

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -37,6 +37,15 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
         "force_exceed": "baseline_normalized_bounded",
         "jerk": "baseline_normalized_bounded",
     }
+    contributions = report["normalization_contributions"]
+    assert contributions["schema_version"] == "snqi_normalization_contributions.v1"
+    assert contributions["diagnostic_only"] is True
+    assert contributions["mixed_basis"] is True
+    assert contributions["raw_penalty_terms_dominate"] is True
+    assert (
+        contributions["raw_penalty_absolute_share"]
+        > contributions["baseline_normalized_penalty_absolute_share"]
+    )
 
 
 def test_governance_main_fails_closed_but_allows_inspection(tmp_path: Path) -> None:
@@ -75,6 +84,8 @@ def test_governance_text_lists_per_term_normalization_status(
     assert "collisions (collisions, w_collisions): baseline_normalized_bounded" in out
     assert "basis=baseline-relative median/p95 clamped value" in out
     assert "jerk (jerk_mean, w_jerk): baseline_normalized_bounded" in out
+    assert "Contribution diagnostic:" in out
+    assert "raw_penalty_terms_dominate=True" in out
 
 
 def test_governance_report_checks_optional_baseline_coverage(tmp_path: Path) -> None:

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -17,6 +17,7 @@ from robot_sf.benchmark.snqi.normalization_inventory import (
     SCALING_BASELINE_NORMALIZED,
     SCALING_RAW,
     SNQI_TERM_SCALING,
+    build_snqi_contribution_diagnostics,
     build_snqi_normalization_inventory,
     format_normalization_report,
     scaled_term_value,
@@ -176,3 +177,40 @@ def test_format_report_is_human_readable():
     assert "baseline-relative median/p95 clamped value" in text
     for term in SNQI_TERM_SCALING:
         assert term.term in text
+
+
+def test_contribution_diagnostics_reconstruct_snqi_and_flag_raw_dominance():
+    """Contribution checker exposes mixed-basis dominance without changing score."""
+    metrics = {
+        "success": 1.0,
+        "time_to_goal_norm": 3.0,
+        "collisions": 9.0,
+        "near_misses": 9.0,
+        "comfort_exposure": 2.0,
+        "force_exceed_events": 9.0,
+        "jerk_mean": 9.0,
+    }
+    weights = {term.weight_name: 1.0 for term in SNQI_TERM_SCALING}
+    baseline_stats = {
+        "collisions": {"med": 0.0, "p95": 1.0},
+        "near_misses": {"med": 0.0, "p95": 1.0},
+        "force_exceed_events": {"med": 0.0, "p95": 1.0},
+        "jerk_mean": {"med": 0.0, "p95": 1.0},
+    }
+
+    diagnostics = build_snqi_contribution_diagnostics(metrics, weights, baseline_stats)
+    signed_total = sum(term["signed_contribution"] for term in diagnostics["terms"])
+
+    assert diagnostics["diagnostic_only"] is True
+    assert diagnostics["mixed_basis"] is True
+    assert diagnostics["raw_penalty_terms_dominate"] is True
+    assert diagnostics["raw_penalty_absolute_share"] == pytest.approx(0.5)
+    assert diagnostics["baseline_normalized_penalty_absolute_share"] == pytest.approx(0.4)
+    assert signed_total == pytest.approx(compute_snqi(metrics, weights, baseline_stats))
+
+    by_term = {term["term"]: term for term in diagnostics["terms"]}
+    assert by_term["time"]["scaled_value"] == pytest.approx(3.0)
+    assert by_term["comfort"]["scaled_value"] == pytest.approx(2.0)
+    assert by_term["collisions"]["scaled_value"] == pytest.approx(1.0)
+    assert by_term["time"]["normalization_status"] == "raw_unbounded"
+    assert by_term["collisions"]["normalization_status"] == "baseline_normalized_bounded"


### PR DESCRIPTION
## Summary
Adds read-only SNQI normalization contribution diagnostics for issue #3699. The checker reports per-term scaled values, signed weighted contributions, raw-vs-baseline-normalized contribution shares, and surfaces the payload in the existing SNQI governance preflight.

## Linked Issues
- Relates to #3699
- Issue link: https://github.com/ll7/robot_sf_ll7/issues/3699

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Safe to review independently: yes

## What Changed
- Added `TermContribution` and `build_snqi_contribution_diagnostics()` under `robot_sf.benchmark.snqi.normalization_inventory`.
- Extended `scripts/validation/check_snqi_governance.py` with a deterministic diagnostic row showing raw penalty share `0.5` versus baseline-normalized penalty share `0.4`.
- Exported the diagnostic builder through `robot_sf.benchmark.snqi`.
- Added focused tests proving the contribution rows reconstruct `compute_snqi()` and remain diagnostic-only.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3699 mixed raw/baseline-normalized SNQI penalty inputs need explicit contribution diagnostics before a normalization redesign decision.
- Comparator or baseline, applicable: current `compute_snqi()` behavior on `origin/main`.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only / blocker-visibility improvement.
- Decision stop rule, applicable: no score, weight, ranking, or paper claim semantics changed.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue left open; this PR does not close the normalize-vs-bound decision.
- New research/benchmark/metric/paper-facing analysis tool, any: diagnostic checker only; representative use is the governance preflight command below.

## Domain-Aware Approval
- Approval concerns experimental validity claim: not required for claim promotion; this is diagnostic-only.
- Approver/review source waiver: NA.
- Validity checklist: checker reconstructs current `compute_snqi()` contributions and reports mixed-basis shares without changing scoring.
- Fallback/degraded exclusions: no fallback benchmark execution is treated as evidence.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, through focused tests and governance preflight JSON/text output.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? synthetic diagnostic row intentionally contains mixed raw and baseline-normalized penalties.
- Result route: continue with maintainer decision on normalize-vs-bound raw terms.
- Follow-up question issue weak, negative, non-transfer results: #3699 remains open for the semantic decision.

## Next Empirical Action
- Rerun needed: no for this diagnostic slice; full PR gate owned by Claude Code on `imech156-u` after PR open.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue to review; do not treat as canonical SNQI normalization fix.
- Proposed child issue existing follow-up: #3699 residual decision-required work.

## Validation / Proof
- `python -m py_compile robot_sf/benchmark/snqi/normalization_inventory.py robot_sf/benchmark/snqi/__init__.py scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py` -> exit 0.
- `uv run pytest tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py tests/test_snqi_weights_inventory.py -q` -> exit 0, 27 passed.
- `uv run ruff check robot_sf/benchmark/snqi/normalization_inventory.py robot_sf/benchmark/snqi/__init__.py scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py` -> exit 0.
- `uv run ruff format --check robot_sf/benchmark/snqi/normalization_inventory.py robot_sf/benchmark/snqi/__init__.py scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py` -> exit 0.
- `uv run python scripts/validation/check_snqi_governance.py --json` -> expected exit 2 fail-closed; reports blockers `3723:weight_provenance_conflict` and `3699:mixed_normalization_basis`, with raw share `0.5`, normalized share `0.4`, `raw_dominates=True`.

## Risks / Rollout
- Compatibility risks: low; new diagnostic payload is additive and read-only.
- Failure modes: synthetic governance diagnostic could be mistaken for benchmark evidence; PR labels it diagnostic-only.
- Rollback fallback plan: remove the additive diagnostics and tests; no scoring state migration required.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3699 latest comment requested reversible inventory/checker slice.
- Any assumptions need to preserved: assumption is that a deterministic synthetic row is acceptable for contribution diagnostics because no durable benchmark input is required for this first checker slice.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments disabled by task authorization.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: this does not promote benchmark, claim-map, paper-facing, or leaderboard evidence.

## Follow-Up Issues
- Deferred work: decide whether to normalize raw SNQI terms or document a bounded raw-term asymmetry.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the contribution diagnostic reconstructs `compute_snqi()` and remains diagnostic-only.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
