### PR TITLE
Issue #3700: emit opt-in TTC near-miss metric

### DIFF
--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -25,9 +25,11 @@ Implemented categories:
   socnavbench_path_irregularity.
 - Experimental (optional): pedestrian-impact deltas for acceleration and
   heading turn-rate near-vs-far from the robot (enabled via
-  ``compute_all_metrics(..., experimental_ped_impact=True)``), plus diagnostic
+  ``compute_all_metrics(..., experimental_ped_impact=True)``), diagnostic
   human-interaction exposure proxies (enabled via
-  ``compute_all_metrics(..., experimental_human_interaction_proxy=True)``).
+  ``compute_all_metrics(..., experimental_human_interaction_proxy=True)``), and
+  opt-in time-to-collision near-miss counts (enabled via
+  ``compute_all_metrics(..., experimental_near_miss_ttc=True)``).
 
 Missing/optional data handling:
 - Empty pedestrian sets (K=0) return 0.0 for collision counts and ``NaN`` for distances where
@@ -317,6 +319,42 @@ def _compute_robot_ped_distance_summary(data: EpisodeData) -> dict[str, float]:
         "min_clearance": float(clearances.min()),
         "mean_clearance": float(np.mean(min_clearances)),
         "robot_ped_within_5m_frac": float(np.count_nonzero(min_dists < 5.0) / step_count),
+    }
+
+
+def _compute_near_miss_ttc_metrics(
+    data: EpisodeData,
+    *,
+    t_thr: float | None,
+) -> dict[str, Any]:
+    """Return opt-in TTC near-miss metrics without changing legacy ``near_misses``.
+
+    Unsupported timing or trajectory inputs fail closed: the count key is omitted and
+    status/reason metadata explains why the TTC diagnostic could not be computed.
+    """
+    from robot_sf.benchmark.near_miss_ttc import (  # noqa: PLC0415
+        DIAGNOSTIC_TTC_THRESHOLD_S,
+        NearMissTtcInputError,
+        compute_ttc_near_miss_diagnostic,
+    )
+
+    threshold_s = DIAGNOSTIC_TTC_THRESHOLD_S if t_thr is None else float(t_thr)
+    try:
+        diagnostic = compute_ttc_near_miss_diagnostic(data, t_thr=threshold_s)
+    except NearMissTtcInputError as exc:
+        reasons = tuple(exc.readiness.reasons) if exc.readiness is not None else (str(exc),)
+        return {
+            "near_misses_ttc_status": "unsupported-inputs",
+            "near_misses_ttc_threshold_s": threshold_s,
+            "near_misses_ttc_unsupported_reasons": list(reasons),
+        }
+
+    count = float(diagnostic["near_miss_ttc__count"])
+    return {
+        **diagnostic,
+        "near_misses_ttc": count,
+        "near_misses_ttc_status": str(diagnostic["near_miss_ttc__status"]),
+        "near_misses_ttc_threshold_s": float(diagnostic["near_miss_ttc__threshold_s"]),
     }
 
 
@@ -2754,7 +2792,7 @@ METRIC_NAMES: list[str] = [
 ]
 
 
-def compute_all_metrics(  # noqa: PLR0913, PLR0915
+def compute_all_metrics(  # noqa: D417, PLR0913, PLR0915
     data: EpisodeData,
     *,
     horizon: int,
@@ -2762,8 +2800,10 @@ def compute_all_metrics(  # noqa: PLR0913, PLR0915
     robot_max_speed: float | None = None,
     experimental_ped_impact: bool = False,
     experimental_human_interaction_proxy: bool = False,
+    experimental_near_miss_ttc: bool = False,
     ped_impact_radius_m: float = 2.0,
     ped_impact_window_steps: int = 5,
+    near_miss_ttc_threshold_s: float | None = None,
     social_proxemic_radius_m: float = 1.2,
     human_proxy_yield_speed_mps: float = 0.15,
     control_data: EpisodeData | None = None,
@@ -2899,6 +2939,8 @@ def compute_all_metrics(  # noqa: PLR0913, PLR0915
     values["force_gradient_norm_mean"] = force_gradient_norm_mean(data)
     values.update(rollover_stability_metrics(data))
     values.update(clear_tracking_metrics(data))
+    if experimental_near_miss_ttc:
+        values.update(_compute_near_miss_ttc_metrics(data, t_thr=near_miss_ttc_threshold_s))
     values["wall_collisions"] = values["obstacle_collision_count"]
     values["clearing_distance_min"] = clearing_distance_min(data)
     values["clearing_distance_avg"] = clearing_distance_avg(data)

--- a/robot_sf/benchmark/metrics.py
+++ b/robot_sf/benchmark/metrics.py
@@ -2792,7 +2792,7 @@ METRIC_NAMES: list[str] = [
 ]
 
 
-def compute_all_metrics(  # noqa: D417, PLR0913, PLR0915
+def compute_all_metrics(  # noqa: PLR0913, PLR0915
     data: EpisodeData,
     *,
     horizon: int,
@@ -2824,10 +2824,18 @@ def compute_all_metrics(  # noqa: D417, PLR0913, PLR0915
             estimate near-vs-far pedestrian acceleration and turn-rate deltas.
         experimental_human_interaction_proxy: Enable optional diagnostic ``human_proxy_*`` metrics
             for mechanism reports. These are simulation proxies only.
+        experimental_near_miss_ttc: Enable the opt-in, diagnostic-only time-to-collision near-miss
+            surface (``near_misses_ttc`` plus ``near_miss_ttc__*`` status/threshold keys). The
+            legacy distance-based ``near_misses`` metric is unchanged and emitted regardless. When
+            inputs are unsupported the count key is omitted and a ``near_misses_ttc_status`` of
+            ``"unsupported-inputs"`` is reported (fail-closed, never a false zero).
         ped_impact_radius_m: Near/far distance threshold in meters used by experimental pedestrian
             impact metrics.
         ped_impact_window_steps: Trailing smoothing window length (timesteps) used by
             experimental pedestrian impact metrics.
+        near_miss_ttc_threshold_s: TTC threshold (seconds) for the opt-in near-miss count when
+            ``experimental_near_miss_ttc`` is enabled. ``None`` uses the uncalibrated diagnostic
+            placeholder ``DIAGNOSTIC_TTC_THRESHOLD_S``.
         social_proxemic_radius_m: Personal-space radius used by exploratory social acceptability
             metrics when ``experimental_ped_impact`` is enabled.
         human_proxy_yield_speed_mps: Robot speed threshold used to detect proxy yielding.
@@ -2838,7 +2846,10 @@ def compute_all_metrics(  # noqa: D417, PLR0913, PLR0915
         dict[str, Any]: Mapping from metric name (e.g., ``success``, ``force_q50``,
         ``force_gradient_norm_mean``) to the computed scalar value. When
         ``experimental_ped_impact`` is enabled, additional ``ped_impact_*`` and
-        exploratory ``social_proxemic_*`` keys are included.
+        exploratory ``social_proxemic_*`` keys are included. When
+        ``experimental_near_miss_ttc`` is enabled, opt-in ``near_misses_ttc`` and
+        ``near_miss_ttc__*`` diagnostic keys are included (diagnostic-only, not benchmark
+        evidence).
     """
     if shortest_path_len is None:
         shortest_path_len = float(np.linalg.norm(data.robot_pos[0] - data.goal))  # simple fallback

--- a/tests/benchmark/test_near_miss_ttc.py
+++ b/tests/benchmark/test_near_miss_ttc.py
@@ -12,7 +12,7 @@ import json
 import numpy as np
 import pytest
 
-from robot_sf.benchmark.metrics import EpisodeData
+from robot_sf.benchmark.metrics import EpisodeData, compute_all_metrics
 from robot_sf.benchmark.near_miss_ttc import (
     DIAGNOSTIC_TTC_THRESHOLD_S,
     NearMissTtcInputError,
@@ -226,6 +226,80 @@ def test_canonical_near_misses_metric_unchanged():
 
     assert before == after
     assert before > 0.0  # sanity: the canonical metric actually fired here
+
+
+def test_compute_all_metrics_omits_ttc_metric_by_default():
+    """TTC near-miss count is opt-in; default metrics keep legacy surface."""
+    data = _fast_head_on_episode()
+
+    metrics = compute_all_metrics(data, horizon=data.robot_pos.shape[0])
+
+    assert metrics["near_misses"] == 0.0
+    assert "near_misses_ttc" not in metrics
+    assert "near_miss_ttc__count" not in metrics
+
+
+def test_compute_all_metrics_emits_opt_in_ttc_count_and_keeps_legacy_metric():
+    """Opt-in TTC count flags fast approach while distance near_misses stays unchanged."""
+    data = _fast_head_on_episode()
+
+    metrics = compute_all_metrics(
+        data,
+        horizon=data.robot_pos.shape[0],
+        experimental_near_miss_ttc=True,
+        near_miss_ttc_threshold_s=1.0,
+    )
+
+    assert metrics["near_misses"] == 0.0
+    assert metrics["near_misses_ttc"] > 0.0
+    assert metrics["near_misses_ttc_status"] == "ok"
+    assert metrics["near_misses_ttc_threshold_s"] == 1.0
+    assert metrics["near_miss_ttc__count"] == metrics["near_misses_ttc"]
+
+
+def test_compute_all_metrics_ttc_contrasts_fast_and_slow_at_equal_clearance():
+    """Equal static clearance can produce different TTC risk when closing speed differs."""
+    fast = _fast_head_on_episode()
+    slow = _make_episode(
+        robot_pos=np.column_stack([np.arange(6) * 0.01, np.zeros(6)]),
+        peds_pos=np.zeros((6, 1, 2)),
+        dt=0.1,
+    )
+    slow.peds_pos[:, 0, 0] = 4.0 - np.arange(6) * 0.01
+
+    fast_metrics = compute_all_metrics(
+        fast,
+        horizon=fast.robot_pos.shape[0],
+        experimental_near_miss_ttc=True,
+        near_miss_ttc_threshold_s=1.0,
+    )
+    slow_metrics = compute_all_metrics(
+        slow,
+        horizon=slow.robot_pos.shape[0],
+        experimental_near_miss_ttc=True,
+        near_miss_ttc_threshold_s=1.0,
+    )
+
+    assert fast_metrics["near_misses"] == slow_metrics["near_misses"] == 0.0
+    assert fast_metrics["near_misses_ttc"] > 0.0
+    assert slow_metrics["near_misses_ttc"] == 0.0
+
+
+def test_compute_all_metrics_ttc_fails_closed_on_unsupported_inputs():
+    """Invalid TTC inputs expose unsupported status instead of false zero count."""
+    data = _fast_head_on_episode()
+    data.dt = 0.0
+
+    metrics = compute_all_metrics(
+        data,
+        horizon=data.robot_pos.shape[0],
+        experimental_near_miss_ttc=True,
+    )
+
+    assert metrics["near_misses"] == 0.0
+    assert "near_misses_ttc" not in metrics
+    assert metrics["near_misses_ttc_status"] == "unsupported-inputs"
+    assert any("dt" in reason for reason in metrics["near_misses_ttc_unsupported_reasons"])
 
 
 # --- Issue #3808 read-only decision packet -------------------------------------


### PR DESCRIPTION
## Issue

Addresses part of https://github.com/ll7/robot_sf_ll7/issues/3700.

## Scope Summary

Adds an opt-in time-to-collision (TTC) near-miss count emitted by `compute_all_metrics` when `experimental_near_miss_ttc=True`.

- Keeps the legacy distance-based `near_misses` metric unchanged and omitted from the new behavior by default.
- Emits `near_misses_ttc` as a count alias over the existing diagnostic `near_miss_ttc__count` surface.
- Emits `near_misses_ttc_status` and `near_misses_ttc_threshold_s`; unsupported inputs fail closed with reasons instead of a false zero count.
- Adds synthetic fixtures contrasting fast approach vs slow drift at equal static distance behavior.

Assumption: this PR implements the reversible TTC-threshold count slice proposed in the latest #3700 scoping comment. Velocity-weighted severity, threshold calibration, and SNQI adoption remain decision-required follow-up work.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/metrics.py tests/benchmark/test_near_miss_ttc.py` -> passed; 2 files left unchanged.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/metrics.py tests/benchmark/test_near_miss_ttc.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_near_miss_ttc.py tests/test_metrics.py tests/benchmark/test_signalized_runtime_metadata.py tests/unit/benchmark/test_force_sample_stats.py -q` -> passed; 133 passed in 2.41s.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed on dirty tree before commit; 1679 passed, 2 skipped in 43.58s.

## Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

No SNQI/scoring wiring, velocity-weighted severity variant, or calibrated TTC threshold choice in this PR.

## Artifact Classification

Only routine local validation outputs were produced under `output/coverage/` and `output/validation/pr_ready/`; these are ignored local proof artifacts and are not durable benchmark evidence.

## Downstream Propagation

Not benchmark evidence. This PR adds diagnostic metric plumbing and focused synthetic tests only; no claim map, leaderboard, benchmark report, or paper-facing surface is updated.
