### PR TITLE
Issue #3808 render TTC near-miss decision packet

### DIFF
--- a/scripts/validation/render_ttc_near_miss_decision_packet.py
+++ b/scripts/validation/render_ttc_near_miss_decision_packet.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Render deterministic TTC near-miss diagnostic decision packets.
+
+The command is intentionally read-only and fixture-backed. It converts the
+issue #3700 opt-in TTC diagnostic surface into review packets for issue #3808
+without changing canonical near-miss metrics or promoting benchmark claims.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Callable
+
+import numpy as np
+
+from robot_sf.benchmark.metrics import EpisodeData
+from robot_sf.benchmark.near_miss_ttc import (
+    DIAGNOSTIC_TTC_THRESHOLD_S,
+    NearMissTtcDecisionPacket,
+    build_ttc_near_miss_decision_packet,
+    render_ttc_near_miss_decision_packet_markdown,
+)
+
+FixtureBuilder = Callable[[], EpisodeData]
+
+
+def _make_episode(
+    robot_pos: np.ndarray,
+    peds_pos: np.ndarray,
+    *,
+    dt: float = 0.1,
+    robot_vel: np.ndarray | None = None,
+) -> EpisodeData:
+    """Build a minimal synthetic episode for deterministic packet fixtures."""
+    robot_pos = np.asarray(robot_pos, dtype=float)
+    peds_pos = np.asarray(peds_pos, dtype=float)
+    if robot_vel is None:
+        if robot_pos.ndim == 2 and robot_pos.shape[0] >= 2:
+            diffs = np.diff(robot_pos, axis=0) / dt
+            robot_vel = np.vstack([diffs[:1], diffs])
+        else:
+            robot_vel = np.zeros_like(robot_pos)
+
+    return EpisodeData(
+        robot_pos=robot_pos,
+        robot_vel=np.asarray(robot_vel, dtype=float),
+        robot_acc=np.zeros_like(robot_pos),
+        peds_pos=peds_pos,
+        ped_forces=np.zeros_like(peds_pos),
+        goal=np.array([10.0, 0.0]),
+        dt=dt,
+    )
+
+
+def _closing_fixture() -> EpisodeData:
+    """Fast converging robot/pedestrian pair with TTC diagnostic signal."""
+    n_steps = 6
+    robot_pos = np.zeros((n_steps, 2))
+    robot_pos[:, 0] = np.arange(n_steps) * 0.5
+    peds_pos = np.zeros((n_steps, 1, 2))
+    peds_pos[:, 0, 0] = 6.0 - np.arange(n_steps) * 0.5
+    return _make_episode(robot_pos, peds_pos)
+
+
+def _opening_fixture() -> EpisodeData:
+    """Diverging robot/pedestrian pair with no approaching TTC pair."""
+    n_steps = 6
+    robot_pos = np.zeros((n_steps, 2))
+    robot_pos[:, 0] = -np.arange(n_steps) * 0.2
+    peds_pos = np.zeros((n_steps, 1, 2))
+    peds_pos[:, 0, 0] = 3.0 + np.arange(n_steps) * 0.2
+    return _make_episode(robot_pos, peds_pos)
+
+
+def _missing_timing_fixture() -> EpisodeData:
+    """Valid trajectory arrays with invalid timing, which must fail closed."""
+    data = _closing_fixture()
+    data.dt = float("nan")
+    return data
+
+
+def _unsupported_trajectory_fixture() -> EpisodeData:
+    """Malformed pedestrian trajectory shape, which must fail closed."""
+    n_steps = 6
+    robot_pos = np.zeros((n_steps, 2))
+    return _make_episode(robot_pos, np.zeros((n_steps, 2)))
+
+
+FIXTURES: dict[str, FixtureBuilder] = {
+    "closing": _closing_fixture,
+    "opening": _opening_fixture,
+    "missing-timing": _missing_timing_fixture,
+    "unsupported-trajectory": _unsupported_trajectory_fixture,
+}
+
+
+def build_packets(
+    *,
+    fixture: str = "all",
+    threshold_s: float = DIAGNOSTIC_TTC_THRESHOLD_S,
+) -> dict[str, NearMissTtcDecisionPacket]:
+    """Build packet(s) for one fixture or every deterministic fixture."""
+    names = tuple(FIXTURES) if fixture == "all" else (fixture,)
+    return {
+        name: build_ttc_near_miss_decision_packet(FIXTURES[name](), t_thr=threshold_s)
+        for name in names
+    }
+
+
+def render_packets_markdown(packets: dict[str, NearMissTtcDecisionPacket]) -> str:
+    """Render all selected packets as one Markdown decision document."""
+    sections: list[str] = []
+    for name, packet in packets.items():
+        sections.extend(
+            [
+                f"## Fixture: `{name}`",
+                "",
+                render_ttc_near_miss_decision_packet_markdown(packet),
+            ]
+        )
+    return "\n\n".join(sections) + "\n"
+
+
+def render_packets_json(packets: dict[str, NearMissTtcDecisionPacket]) -> str:
+    """Render all selected packets as strict JSON."""
+    payload = {
+        "issue": 3808,
+        "claim_boundary": (
+            "diagnostic decision packet only; no canonical metric replacement, "
+            "benchmark campaign, or paper-facing claim"
+        ),
+        "fixtures": {name: packet.to_dict() for name, packet in packets.items()},
+    }
+    return json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--fixture",
+        choices=("all", *FIXTURES.keys()),
+        default="all",
+        help="Synthetic fixture to render; default renders every issue #3808 fixture.",
+    )
+    parser.add_argument(
+        "--threshold-s",
+        type=float,
+        default=DIAGNOSTIC_TTC_THRESHOLD_S,
+        help="Diagnostic TTC threshold to inspect. This is not a calibrated benchmark value.",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("markdown", "json"),
+        default="markdown",
+        help="Output format for the dry-run packet.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """CLI entry point."""
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    packets = build_packets(fixture=args.fixture, threshold_s=args.threshold_s)
+    if args.format == "json":
+        sys.stdout.write(render_packets_json(packets))
+    else:
+        sys.stdout.write(render_packets_markdown(packets))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/validation/test_render_ttc_near_miss_decision_packet.py
+++ b/tests/validation/test_render_ttc_near_miss_decision_packet.py
@@ -1,0 +1,77 @@
+"""Tests issue #3808 TTC near-miss diagnostic decision packet renderer."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts/validation/render_ttc_near_miss_decision_packet.py"
+
+_SPEC = importlib.util.spec_from_file_location("_issue_3808_ttc_packet", SCRIPT)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def test_all_fixtures_cover_issue_3808_decision_cases() -> None:
+    """All required fixtures render deterministic packet statuses."""
+    packets = _MODULE.build_packets()
+
+    assert set(packets) == {
+        "closing",
+        "opening",
+        "missing-timing",
+        "unsupported-trajectory",
+    }
+    assert packets["closing"].diagnostic_status == "ok"
+    assert packets["opening"].diagnostic_status == "no-approaching-pairs"
+    assert packets["missing-timing"].diagnostic_status == "unsupported-inputs"
+    assert packets["unsupported-trajectory"].diagnostic_status == "unsupported-inputs"
+
+
+def test_json_render_is_strict_and_keeps_claim_boundary() -> None:
+    """JSON output is reviewable and cannot contain NaN metric sentinels."""
+    packets = _MODULE.build_packets()
+    payload = json.loads(_MODULE.render_packets_json(packets))
+
+    assert payload["issue"] == 3808
+    assert "no canonical metric replacement" in payload["claim_boundary"]
+    assert payload["fixtures"]["opening"]["diagnostic"]["near_miss_ttc__min_ttc_s"] is None
+    assert payload["fixtures"]["missing-timing"]["diagnostic"] == {}
+
+
+def test_markdown_render_names_fixtures_and_non_claims() -> None:
+    """Markdown dry-run packet includes fixture labels and claim caveats."""
+    text = _MODULE.render_packets_markdown(_MODULE.build_packets())
+
+    assert "Fixture: `closing`" in text
+    assert "Fixture: `unsupported-trajectory`" in text
+    assert "Cannot Claim Before Canonical Metric Change" in text
+    assert "benchmark ranking" in text
+
+
+def test_cli_json_single_fixture() -> None:
+    """CLI dry-run renders a selected fixture as strict JSON."""
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--fixture",
+            "opening",
+            "--format",
+            "json",
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert set(payload["fixtures"]) == {"opening"}
+    assert payload["fixtures"]["opening"]["diagnostic_status"] == "no-approaching-pairs"


### PR DESCRIPTION
## Summary
Adds a deterministic dry-run renderer for the TTC near-miss diagnostic decision packet requested by issue #3808. The renderer uses synthetic fixtures for closing, opening, missing-timing, and unsupported trajectory cases and emits Markdown or strict JSON.

## Linked Issues
- Closes `#3808`
- Relates to `#3700`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `scripts/validation/render_ttc_near_miss_decision_packet.py` as a read-only fixture-backed packet renderer.
- Added focused validation tests for fixture coverage, strict JSON rendering, Markdown caveats, and single-fixture CLI output.

## Why Matters
- Added value: turns the existing opt-in TTC diagnostic surface into a bounded reviewer packet without changing canonical metrics.
- Expected impact: makes the #3700 TTC near-miss decision boundary inspectable through deterministic fixtures.
- Why worth merging now: small support slice that documents unsupported cases before any metric semantics decision.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3700 TTC near-miss decision boundary inspection only.
- Comparator or baseline, applicable: existing distance-based canonical near-miss semantics remain unchanged.
- Evidence tier: NA - support helper; the renderer does not interpret research evidence.
- Result classification: NA - support helper; no benchmark or metric claim is promoted.
- Decision stop rule, applicable: packet must render deterministic fixture statuses and no-claim caveats.
- Parent issue, claim map, registry, context note, synthesis surface update: #3808 / #3700; no claim-map or leaderboard update.
- New research/benchmark/metric/paper-facing analysis tool, any: support CLI only; representative use is the dry-run command below on committed synthetic fixtures.

## Domain-Aware Approval
- Required PR: yes - evidence-validity-sensitive result classification
- Domains reviewed: evidence classification, benchmark interpretation
- Status: waived
- Approver/review source or waiver: self-waived because the PR adds only a dry-run renderer over committed synthetic fixtures and promotes no metric, benchmark, planner-comparison, or paper claim.
- Validity checklist: diagnostic-only renderer over synthetic fixtures.
- Target claim/hypothesis: NA, decision packet only.
- Comparator or split/evidence validity: no comparator split is introduced; existing distance-based canonical near-miss semantics are only named as an unchanged boundary, and synthetic fixtures are used solely to verify renderer statuses.
- Fallback/degraded exclusions: unsupported inputs fail closed as `unsupported-inputs`.
- Claim boundary: no canonical metric replacement, no threshold calibration, no ranking/paper claim.
- Implementation integrity vs experimental validity: implementation can be reviewed by fixture statuses and strict JSON/Markdown output.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA, support renderer.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? synthetic fixtures cover closing, opening, missing timing, unsupported trajectory.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3700 remains the metric-semantics decision.

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue with review of the decision packet only.
- Proposed child issue existing follow-up: #3700.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark/test_near_miss_ttc.py tests/validation/test_render_ttc_near_miss_decision_packet.py -q` - passed, 29 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/render_ttc_near_miss_decision_packet.py tests/validation/test_render_ttc_near_miss_decision_packet.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/render_ttc_near_miss_decision_packet.py tests/validation/test_render_ttc_near_miss_decision_packet.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/render_ttc_near_miss_decision_packet.py --format json` - passed and rendered all four fixture packets.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance
- Baseline runtime: NA, support renderer.
- Changed runtime: CLI dry-run completes locally on synthetic fixtures.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/render_ttc_near_miss_decision_packet.py --format json`
- Hot-path call count profile anchor: NA, no campaign hot path changed.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: renderer emits metric-claim wording, fails closed incorrectly, or fixture statuses drift.

## Risks / Rollout
- Compatibility risks: low; new opt-in validation script and tests only.
- Failure modes: reviewer could overread diagnostic fixture output as metric evidence; PR body and packet caveats explicitly forbid that.
- Rollback fallback plan: revert the new script/test pair.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3808, parent issue #3700, prior diagnostic surface from #3748.
- Any assumptions need to preserved: deterministic synthetic fixtures are enough for this first decision-packet slice.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a diagnostic packet renderer only; it makes no benchmark, metric, leaderboard, or paper-facing claim.

## Follow-Up Issues
- Deferred work: #3700 metric-semantics decision remains open.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that the fixture packet statuses remain diagnostic-only and unsupported inputs do not become zero near-miss evidence.
- Known limitations: synthetic decision packet only; no available-output ingestion and no benchmark campaign proof.
