### PR TITLE
Issue #3810: block stale long-horizon SNQI launch packet

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -214,18 +214,21 @@ validation:
   dry_run: required
 
 launch_packet:
-  decision: ready_after_live_queue_and_duplicate_check
+  decision: blocked_pending_submit_host_route_and_reconciliation
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  blocking_jobs: []
+  target_host: imech039
+  blocking_jobs:
+    - 13175
   ledger_reconciliation:
     checked_date: "2026-06-29"
-    source: private_ops_jobs_and_queue_read_only
-    job_13175_state: analyzed
+    source: private_ops_jobs_and_queue_read_only_needs_submit_host_refresh
+    job_13175_state: requires_submit_host_refresh
     job_13175_campaign: 2026-06-issue1554-s20-h500-l40s-mem180
     job_13175_relevance: >
-      Completed and analyzed #1554 lane; not a #3810 blocker after read-only
-      private-ops reconciliation.
+      Older #1554 lane that must be rechecked from the Slurm-capable submit host
+      before any #3810 submission. A stale public packet must not treat it as
+      reconciled without fresh private-ops evidence.
     running_related_jobs:
       - job_id: 13198
         state: running
@@ -234,9 +237,9 @@ launch_packet:
           Separate #1554 evidence-yield lane, not a #3810 duplicate. A
           Slurm-capable submit host must still refresh live queue pressure
           before any #3810 submission.
-    issue_3810_duplicate_status: none_found
+    issue_3810_duplicate_status: requires_submit_host_refresh
   go_no_go:
-    recommendation: go_after_submit_host_live_checks
+    recommendation: blocked_pending_submit_host_route_and_reconciliation
     local_submission_status: no_submit_current_machine
     exact_local_decision_command: >-
       uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -244,9 +247,29 @@ launch_packet:
       --json
     slurm_command_status: >
       Not safe to freeze in this public packet without live submit-host queue
-      pressure, duplicate check, clean-worktree proof, and private route
-      selection. Use the private submit wrapper named below only after those
-      checks return go.
+      pressure, duplicate check, clean-worktree proof, job 13175 reconciliation,
+      target-host route support, and private route selection. Do not use the
+      private submit wrapper named below until those checks return go.
+    private_ops_dry_run:
+      required_before_submit: true
+      target_host: imech039
+      evidence_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
+      current_public_status: route_unverified
+      required_fields:
+        - target_host
+        - queue_summary_timestamp
+        - duplicate_status
+        - job_13175_state
+        - route_id
+        - submit_wrapper_supports_target_host
+        - owning_worktree
+        - owning_worktree_clean
+        - decision
+      decision_policy: >
+        The dry run must record decision=go before submission. If job 13175 is
+        not terminal/reconciled, if an issue #3810 duplicate exists, if the
+        owning worktree is dirty, or if the private submit wrapper lacks
+        imech039 support, the decision remains blocked.
   route:
     private_ops_repo: /home/luttkule/git/robot_sf_ll7-private-ops  # allow-abs-path: private-ops routing (machine-local, non-portable)
     queue_summary_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh  # allow-abs-path: private-ops routing (machine-local, non-portable)

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -146,8 +146,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
 
     _require(
-        launch_packet.get("decision") == "ready_after_live_queue_and_duplicate_check",
-        "decision must require live queue and duplicate checks",
+        launch_packet.get("decision") == "blocked_pending_submit_host_route_and_reconciliation",
+        "decision must stay blocked pending submit-host route and reconciliation",
     )
     _require(
         launch_packet.get("compute_submit_authorized") is False, "compute submit must be false"
@@ -155,18 +155,19 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
     )
+    _require(launch_packet.get("target_host") == "imech039", "target host must be imech039")
     blocking_jobs = launch_packet.get("blocking_jobs")
     _require(isinstance(blocking_jobs, list), "blocking_jobs must be a list")
-    _require(13175 not in blocking_jobs, "analyzed job 13175 must not remain blocking")
+    _require(13175 in blocking_jobs, "job 13175 must block submit until reconciled")
 
     ledger = _require_mapping(launch_packet, "ledger_reconciliation")
     _require(
-        ledger.get("job_13175_state") == "analyzed",
-        "job 13175 reconciliation must be analyzed",
+        ledger.get("job_13175_state") == "requires_submit_host_refresh",
+        "job 13175 reconciliation must require submit-host refresh",
     )
     _require(
-        ledger.get("issue_3810_duplicate_status") == "none_found",
-        "issue #3810 duplicate status must be none_found",
+        ledger.get("issue_3810_duplicate_status") == "requires_submit_host_refresh",
+        "issue #3810 duplicate status must require submit-host refresh",
     )
     running_related_jobs = ledger.get("running_related_jobs")
     _require(
@@ -176,8 +177,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
 
     go_no_go = _require_mapping(launch_packet, "go_no_go")
     _require(
-        go_no_go.get("recommendation") == "go_after_submit_host_live_checks",
-        "go/no-go recommendation must require submit-host live checks",
+        go_no_go.get("recommendation") == "blocked_pending_submit_host_route_and_reconciliation",
+        "go/no-go recommendation must remain blocked",
     )
     _require(
         go_no_go.get("local_submission_status") == "no_submit_current_machine",
@@ -193,6 +194,37 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         "Not safe to freeze" in (str(slurm_status) if slurm_status is not None else ""),
         "slurm command status must explain why final submit command is not frozen",
+    )
+    _require(
+        "job 13175" in (str(slurm_status) if slurm_status is not None else ""),
+        "go/no-go must mention job 13175 reconciliation",
+    )
+    dry_run = _require_mapping(go_no_go, "private_ops_dry_run")
+    _require(dry_run.get("required_before_submit") is True, "private-ops dry run required")
+    _require(dry_run.get("target_host") == "imech039", "private-ops dry run host mismatch")
+    _require(
+        dry_run.get("current_public_status") == "route_unverified",
+        "private-ops dry run must be route_unverified in public packet",
+    )
+    dry_run_fields = set(dry_run.get("required_fields") or [])
+    _require(
+        {
+            "target_host",
+            "queue_summary_timestamp",
+            "duplicate_status",
+            "job_13175_state",
+            "route_id",
+            "submit_wrapper_supports_target_host",
+            "owning_worktree",
+            "owning_worktree_clean",
+            "decision",
+        }
+        <= dry_run_fields,
+        "private-ops dry run fields missing",
+    )
+    _require(
+        "imech039 support" in str(dry_run.get("decision_policy", "")),
+        "private-ops dry run must gate imech039 support",
     )
 
     route = _require_mapping(launch_packet, "route")
@@ -255,10 +287,12 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "planner_count": len(planner_rows),
         "compute_submit_authorized": launch_packet["compute_submit_authorized"],
         "slurm_job_id": launch_packet["slurm_job_id"],
+        "target_host": launch_packet["target_host"],
         "blocking_jobs": blocking_jobs,
         "job_13175_state": ledger["job_13175_state"],
         "issue_3810_duplicate_status": ledger["issue_3810_duplicate_status"],
         "go_no_go": go_no_go["recommendation"],
+        "private_ops_dry_run": dry_run["current_public_status"],
     }
 
 

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -34,10 +34,12 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert summary["blocking_jobs"] == []
-    assert summary["job_13175_state"] == "analyzed"
-    assert summary["issue_3810_duplicate_status"] == "none_found"
-    assert summary["go_no_go"] == "go_after_submit_host_live_checks"
+    assert summary["target_host"] == "imech039"
+    assert summary["blocking_jobs"] == [13175]
+    assert summary["job_13175_state"] == "requires_submit_host_refresh"
+    assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
+    assert summary["go_no_go"] == "blocked_pending_submit_host_route_and_reconciliation"
+    assert summary["private_ops_dry_run"] == "route_unverified"
 
 
 def test_issue_3810_packet_rejects_authorized_submit() -> None:
@@ -53,17 +55,43 @@ def test_issue_3810_packet_rejects_authorized_submit() -> None:
         raise AssertionError("packet should reject compute submission authorization")
 
 
-def test_issue_3810_packet_rejects_stale_analyzed_job_blocker() -> None:
-    """A reconciled analyzed job must not stay as a submission blocker."""
+def test_issue_3810_packet_rejects_missing_job_13175_blocker() -> None:
+    """Job 13175 stays a blocker until submit-host reconciliation is recorded."""
     packet = _load_packet()
-    packet["launch_packet"]["blocking_jobs"] = [13175]
+    packet["launch_packet"]["blocking_jobs"] = []
 
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "13175" in str(exc)
+        assert "job 13175 must block submit" in str(exc)
     else:
-        raise AssertionError("packet should reject stale job 13175 blocker")
+        raise AssertionError("packet should reject missing job 13175 blocker")
+
+
+def test_issue_3810_packet_rejects_stale_job_13175_reconciliation() -> None:
+    """Stale analyzed state cannot unlock the public launch packet."""
+    packet = _load_packet()
+    packet["launch_packet"]["ledger_reconciliation"]["job_13175_state"] = "analyzed"
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "job 13175 reconciliation must require submit-host refresh" in str(exc)
+    else:
+        raise AssertionError("packet should reject stale job 13175 reconciliation")
+
+
+def test_issue_3810_packet_rejects_missing_private_ops_dry_run() -> None:
+    """The packet must name the submit-host dry-run evidence contract."""
+    packet = _load_packet()
+    packet["launch_packet"]["go_no_go"].pop("private_ops_dry_run")
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "private_ops_dry_run must be a mapping" in str(exc)
+    else:
+        raise AssertionError("packet should reject missing private-ops dry run")
 
 
 def test_issue_3810_packet_rejects_missing_go_no_go_status() -> None:


### PR DESCRIPTION
## Summary
Tightens the issue #3810 long-horizon Social Navigation Quality Index (SNQI) launch packet so it remains blocked until the submit host records fresh route, duplicate, clean-worktree, and job `13175` reconciliation evidence.

## Linked Issues
- Relates to `#3810`

## Stack / Dependency
- Base dependency: none
- Prior PRs required: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Changes `configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml` from a static `go_after_submit_host_live_checks` state to `blocked_pending_submit_host_route_and_reconciliation`.
- Records `imech039` as the target host, keeps job `13175` in `blocking_jobs`, and requires a private-ops dry-run evidence record before any submission.
- Extends `scripts/validation/check_issue_3810_long_horizon_launch_packet.py` and tests to reject stale analyzed-job, duplicate-status, and missing dry-run fields.

## Why Matters
- Added value: prevents a stale public packet from being interpreted as Slurm-ready while job `13175` or target-host routing remains unreconciled.
- Expected impact: safer handoff for the long-horizon h600 launch packet without launching compute.
- Why worth merging now: issue #3810 is `state:running`; this keeps the public packet fail-closed before the next submit-host decision.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker for launching the #3810 long-horizon SNQI recalibration campaign.
- Comparator or baseline, applicable: NA; no benchmark results are produced.
- Evidence tier: NA - launch-packet guard only; no benchmark evidence produced.
- Result classification: NA - no research result; this only preserves a no-submit guard.
- Decision stop rule, applicable: submit only after private-ops dry run records `decision=go`.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3810.
- New research/benchmark/metric/paper-facing analysis tool, any: NA; this only tightens an existing packet checker.

## Domain-Aware Approval
- Required PR: yes - evidence-validity-sensitive launch packet
- Domains reviewed: benchmark launch packet, Slurm no-submit gate, artifact provenance
- Status: waived
- Approver/review source waiver: maintainer waiver; Claude Code owns full PR gate, improvement cycle, and merge authority after open
- Validity checklist: packet remains launch-packet-only and fail-closed.
- Target claim/hypothesis: prevents stale #3810 launch packet from being treated as Slurm-ready before submit-host dry-run evidence.
- Comparator split/evidence validity: no comparator split or benchmark result is evaluated; validation only proves packet/checker guard semantics.
- Fallback/degraded exclusions: preserved in packet row-status policy.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: checker enforces the no-submit gate; experimental validity stays deferred to the eventual run.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes; validator summary now reports `blocking_jobs: [13175]`, `job_13175_state: requires_submit_host_refresh`, and `private_ops_dry_run: route_unverified`.
- Did intervention change command source, selected command, trajectory, route progress? yes; launch recommendation is blocked pending route/reconciliation evidence.
- Did scenario actually contain targeted failure mode? NA; no scenario execution.
- Result route: continue after submit-host dry run records `decision=go`.
- Follow-up question issue weak, negative, non-transfer results: #3810 remains the parent.

## Next Empirical Action
- Rerun needed: yes, but only after submit-host decision packet is go.
- Extractor analysis tool needed: no new tool in this PR.
- Artifact missing unavailable: private-ops dry-run evidence for `imech039`; durable benchmark artifacts from the eventual campaign.
- Stop / revise / continue decision: stop before submission until route, duplicate, clean-worktree, and job `13175` reconciliation checks pass.
- Proposed child issue existing follow-up: #3810; sustained-flow structural follow-up remains #3813.

## Validation / Proof
- `python3 scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` -> exit 0; reports blocked/no-submit state with `blocking_jobs: [13175]`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q` -> exit 0; 14 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` -> exit 0.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` -> exit 0.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` -> exit 0.
- `/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh` -> exit 0; `ready_entries: 0`, `active_ledger_jobs: 1`, `Next Ready - none`.
- `/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh --help` -> exit 0; usage lists `--cluster <licca|imech192>`, so `imech039` support is not proven by the current public packet.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` initially failed before PR body was supplied; rerun with this body is expected before opening.

## Performance / Hot Path
- Baseline runtime: NA; no runtime path changed.
- Changed runtime: NA.
- Representative command: `python3 scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json`
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: validator accepts stale `analyzed` job `13175`, missing private-ops dry-run fields, or direct compute authorization.

## Risks / Rollout
- Compatibility risks: downstream submit-host workflow must now provide explicit dry-run evidence before submission.
- Failure modes: if private ops has already reconciled `13175`, the public packet still requires recording that fresh state before unblocking.
- Rollback fallback plan: revert this commit only if maintainers intentionally want the packet to advertise a ready-after-live-checks state without the explicit dry-run contract.

## Docs / Provenance
- Updated docs: launch packet YAML only.
- Relevant design provenance notes: issue #3810 comments and prior PRs #3814/#3826.
- Any assumptions need to preserved: target host is `imech039`; public packet must remain no-submit until private-ops route support and job `13175` reconciliation are recorded.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; comment authorization is false for this task.
- Claim map / benchmark report updated (yes/no/NA): NA; no benchmark claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR only tightens a launch packet/checker and produces no campaign evidence.

## Follow-Up Issues
- Deferred work: submit-host dry run and eventual h600 campaign execution remain under #3810.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that the blocked state is intentional: this PR does not submit Slurm work and does not claim job `13175` is terminal.
- Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
