### PR TITLE
Issue #3723: list SNQI weight sources in governance preflight

### DIFF
--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -161,6 +161,19 @@ def _print_text_report(report: dict[str, Any]) -> None:
     else:
         print("No blocking SNQI governance diagnostics detected.")
 
+    weight_records = report["weights"]["records"]
+    print("Weight sources:")
+    for record in weight_records:
+        relpath = record["relpath"] or "<code default>"
+        status = "available" if record["available"] else f"unavailable: {record['load_error']}"
+        fingerprint = record["content_sha256"] or "n/a"
+        print(
+            f"  - {record['name']} ({record['kind']}, {relpath}): "
+            f"canonical={record['declares_canonical']}; "
+            f"dominant={record['dominant_term']}; scale={record['scale_class']}; "
+            f"sha256={fingerprint}; {status}"
+        )
+
     weight_conflicts = report["weights"]["conflicts"]
     if weight_conflicts:
         print("Weight provenance conflicts:")

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -76,6 +76,16 @@ def test_governance_text_lists_per_term_normalization_status(
     assert main(["--repo-root", str(REPO_ROOT), "--allow-current-blockers"]) == 0
 
     out = capsys.readouterr().out
+    assert "Weight sources:" in out
+    assert "code_default (code_default, <code default>): canonical=True" in out
+    assert "model_canonical_v1 (shipped_json, model/snqi_canonical_weights_v1.json)" in out
+    assert (
+        "camera_ready_v3 (shipped_json, configs/benchmarks/snqi_weights_camera_ready_v3.json)"
+    ) in out
+    assert "dominant=w_collisions; scale=raw; sha256=" in out
+    assert "dominant=w_near; scale=normalized_simplex; sha256=" in out
+    assert "Weight provenance conflicts:" in out
+    assert "error canonical_direction_conflict (code_default, model_canonical_v1)" in out
     assert "Term normalization status:" in out
     assert "time (time_to_goal_norm, w_time): raw_unbounded" in out
     assert "basis=raw time-to-goal ratio" in out


### PR DESCRIPTION
## Summary
Expose the SNQI governance preflight's discovered weight-source inventory in human-readable text output, not only JSON.

Issue link: https://github.com/ll7/robot_sf_ll7/issues/3723

## Linked Issues
- Relates `#3723`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: Small diagnostic text-output/test slice on current `origin/main`.

## What Changed
- `scripts/validation/check_snqi_governance.py` now prints each discovered SNQI weight source in text mode, including source path, canonical flag, dominant term, scale class, content SHA-256 fingerprint, and availability.
- `tests/benchmark/test_snqi_governance_preflight.py` asserts the text report lists the code default, shipped JSON sources, and fail-closed provenance conflict.

## Why Matters
- Added value: the combined preflight now reports the full SNQI weight-source inventory to users who run the default text command, not just JSON consumers.
- Expected impact: diagnostic-only observability for the existing #3723 fail-closed blocker.
- Why worth merging now: it reduces ambiguity while preserving the maintainer decision boundary on canonical weights.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3723 SNQI weight provenance conflict visibility.
- Comparator or baseline, applicable: current text preflight showed conflict kinds but not the full source inventory.
- Evidence tier: NA - support helper; no research, benchmark-result, metric, or paper-facing claim.
- Result classification: NA - diagnostic text-output support only.
- Decision stop rule, applicable: text preflight lists all discovered SNQI weight sources and still fails closed on unresolved blocker.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue remains open for maintainer canonical-weight decision.
- New research/benchmark/metric/paper-facing analysis tool, any: none; this extends existing preflight output only.

## Domain-Aware Approval
- Required PR: yes - benchmark diagnostic preflight text output.
- Domains reviewed: evidence classification, claim boundary.
- Status: approved
- Approver/review source waiver: self-review; no benchmark semantics or canonical-weight decision changed.
- Validity checklist: diagnostic-only text output from existing inventory data.
- Target claim/hypothesis: unresolved #3723 provenance conflict is visible.
- Comparator split/evidence validity: existing text preflight output showed conflicts but not full weight-source inventory.
- Fallback/degraded exclusions: no fallback or degraded benchmark execution used.
- Claim boundary: no canonical SNQI weights selected; no scoring, normalization, campaign, or paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation only renders existing structured inventory fields.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? yes, current repository still has #3723 `weight_provenance_conflict`.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: maintainer canonical-weight decision remains in #3723.

## Next Empirical Action
- Rerun needed: no full benchmark campaign run.
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue with maintainer decision on canonical SNQI source.
- Proposed child issue existing follow-up: #3723 remains open.

## Validation / Proof
- `uv run ruff check scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_governance_preflight.py` -> passed.
- `uv run pytest tests/benchmark/test_snqi_governance_preflight.py tests/benchmark/test_snqi_normalization_inventory.py tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_weight_inventory_cli.py -q` -> 28 passed.
- `uv run python scripts/validation/check_snqi_governance.py --json` -> exit 2 as expected, reporting #3723 `weight_provenance_conflict`, all five weight sources, and no scoring change.
- `uv run python scripts/validation/check_snqi_governance.py --allow-current-blockers` -> exit 0 and text output lists all five weight sources plus provenance conflicts.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Impact
- Baseline runtime: NA; text rendering only.
- Changed runtime: NA; text rendering only.
- Representative command: `uv run python scripts/validation/check_snqi_governance.py --allow-current-blockers`
- Hot-path call count profile anchor: NA; not a benchmark hot path.
- Cache-hit reuse counter: NA; no caching claimed.
- Rollback failure criterion: governance preflight output omits discovered weight sources or focused tests regress.

## Risks / Rollout
- Compatibility risks: low; JSON schema and exit-code behavior unchanged.
- Failure modes: text output grows by five lines in current repo.
- Rollback fallback plan: revert this rendering/test-only commit.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3723 and existing SNQI governance preflight.
- Any assumptions need to preserved: this PR does not choose or rename canonical weights.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: diagnostic text-output improvement only; #3723 remains the decision surface.

## Follow-Up Issues
- Deferred work: maintainer canonical SNQI weight-source decision remains open in #3723.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that the PR only renders existing inventory data and does not alter `compute_snqi`, weight loading, or JSON report semantics.
- Known limitations: the unresolved #3723 conflict intentionally remains fail-closed.
