### PR TITLE
Issue #3699: expose SNQI contribution diagnostics in report

### DIFF
--- a/scripts/benchmark/snqi_normalization_inventory_report.py
+++ b/scripts/benchmark/snqi_normalization_inventory_report.py
@@ -109,17 +109,22 @@ def _load_contribution_inputs(
     if metrics_path is None or weights_path is None:
         print("--metrics and --weights must be provided together", file=sys.stderr)
         return 2, None, None
-    if not metrics_path.exists():
+    if not metrics_path.is_file():
         print(f"metrics file not found: {metrics_path}", file=sys.stderr)
         return 2, None, None
-    if not weights_path.exists():
+    if not weights_path.is_file():
         print(f"weights file not found: {weights_path}", file=sys.stderr)
         return 2, None, None
-    return (
-        0,
-        json.loads(metrics_path.read_text(encoding="utf-8")),
-        json.loads(weights_path.read_text(encoding="utf-8")),
-    )
+    try:
+        metrics = json.loads(metrics_path.read_text(encoding="utf-8"))
+        weights = json.loads(weights_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"invalid contribution input JSON: {exc}", file=sys.stderr)
+        return 2, None, None
+    if not isinstance(metrics, dict) or not isinstance(weights, dict):
+        print("--metrics and --weights must each contain a JSON object", file=sys.stderr)
+        return 2, None, None
+    return 0, metrics, weights
 
 
 def main(argv: Sequence[str] | None = None) -> int:  # noqa: C901

--- a/scripts/benchmark/snqi_normalization_inventory_report.py
+++ b/scripts/benchmark/snqi_normalization_inventory_report.py
@@ -40,6 +40,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from robot_sf.benchmark.snqi.normalization_inventory import (
+    build_snqi_contribution_diagnostics,
     build_snqi_normalization_inventory,
     format_normalization_report,
 )
@@ -71,6 +72,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Optional path to write the JSON inventory payload.",
     )
     parser.add_argument(
+        "--metrics",
+        type=pathlib.Path,
+        default=None,
+        help="Optional episode metrics JSON for contribution diagnostics.",
+    )
+    parser.add_argument(
+        "--weights",
+        type=pathlib.Path,
+        default=None,
+        help="Optional SNQI weights JSON for contribution diagnostics.",
+    )
+    parser.add_argument(
         "--fail-on-mixed-scale",
         action="store_true",
         help="Exit non-zero while penalty terms span raw and normalized scales (fail-closed).",
@@ -86,7 +99,30 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def _load_contribution_inputs(
+    metrics_path: pathlib.Path | None,
+    weights_path: pathlib.Path | None,
+) -> tuple[int, dict[str, float | int | bool] | None, dict[str, float] | None]:
+    """Load optional metrics/weights JSON for contribution diagnostics."""
+    if metrics_path is None and weights_path is None:
+        return 0, None, None
+    if metrics_path is None or weights_path is None:
+        print("--metrics and --weights must be provided together", file=sys.stderr)
+        return 2, None, None
+    if not metrics_path.exists():
+        print(f"metrics file not found: {metrics_path}", file=sys.stderr)
+        return 2, None, None
+    if not weights_path.exists():
+        print(f"weights file not found: {weights_path}", file=sys.stderr)
+        return 2, None, None
+    return (
+        0,
+        json.loads(metrics_path.read_text(encoding="utf-8")),
+        json.loads(weights_path.read_text(encoding="utf-8")),
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:  # noqa: C901
     """Run the preflight normalization inventory report.
 
     Returns:
@@ -101,13 +137,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 2
         baseline_stats = json.loads(args.baseline_stats.read_text(encoding="utf-8"))
 
+    input_exit_code, metrics, weights = _load_contribution_inputs(args.metrics, args.weights)
+    if input_exit_code:
+        return input_exit_code
+
     inventory = build_snqi_normalization_inventory(baseline_stats)
+    contribution_payload = None
+    if metrics is not None and weights is not None:
+        contribution_payload = build_snqi_contribution_diagnostics(
+            metrics,
+            weights,
+            baseline_stats or {},
+        )
 
     print(CLAIM_BOUNDARY)
     print(format_normalization_report(inventory))
+    if contribution_payload is not None:
+        print("Contribution diagnostics:")
+        for term in contribution_payload["terms"]:
+            print(
+                f" - {term['term']}: scaled={term['scaled_value']}; "
+                f"weight={term['weight']}; signed={term['signed_contribution']}; "
+                f"absolute_share={term['absolute_share']}"
+            )
 
     if args.json_out is not None:
         payload = {"claim_boundary": CLAIM_BOUNDARY, "inventory": inventory.to_dict()}
+        if contribution_payload is not None:
+            payload["contributions"] = contribution_payload
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
         args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         print(f"wrote {args.json_out}")

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -214,3 +214,55 @@ def test_contribution_diagnostics_reconstruct_snqi_and_flag_raw_dominance():
     assert by_term["collisions"]["scaled_value"] == pytest.approx(1.0)
     assert by_term["time"]["normalization_status"] == "raw_unbounded"
     assert by_term["collisions"]["normalization_status"] == "baseline_normalized_bounded"
+
+
+def test_report_cli_writes_contribution_diagnostics(tmp_path, capsys):
+    """Report CLI can attach per-term contribution diagnostics to JSON output."""
+    import importlib.util
+    import json
+    import pathlib
+
+    script_path = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "benchmark"
+        / "snqi_normalization_inventory_report.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "snqi_normalization_inventory_report", script_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    metrics_path = tmp_path / "metrics.json"
+    weights_path = tmp_path / "weights.json"
+    baseline_path = tmp_path / "baseline.json"
+    output_path = tmp_path / "inventory.json"
+    metrics_path.write_text(json.dumps(_METRICS), encoding="utf-8")
+    weights_path.write_text(json.dumps(_WEIGHTS), encoding="utf-8")
+    baseline_path.write_text(json.dumps(_BASELINE_STATS), encoding="utf-8")
+
+    exit_code = module.main(
+        [
+            "--baseline-stats",
+            str(baseline_path),
+            "--metrics",
+            str(metrics_path),
+            "--weights",
+            str(weights_path),
+            "--json-out",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert "Contribution diagnostics:" in captured.out
+    assert payload["contributions"]["diagnostic_only"] is True
+    assert payload["contributions"]["mixed_basis"] is True
+    signed_total = sum(term["signed_contribution"] for term in payload["contributions"]["terms"])
+    assert signed_total == pytest.approx(compute_snqi(_METRICS, _WEIGHTS, _BASELINE_STATS))

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -266,3 +266,72 @@ def test_report_cli_writes_contribution_diagnostics(tmp_path, capsys):
     assert payload["contributions"]["mixed_basis"] is True
     signed_total = sum(term["signed_contribution"] for term in payload["contributions"]["terms"])
     assert signed_total == pytest.approx(compute_snqi(_METRICS, _WEIGHTS, _BASELINE_STATS))
+
+
+def _load_report_module():
+    """Import the report CLI script as a module for direct ``main()`` testing."""
+    import importlib.util
+    import pathlib
+
+    script_path = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "benchmark"
+        / "snqi_normalization_inventory_report.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "snqi_normalization_inventory_report", script_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize(
+    ("metrics_text", "expected_stderr"),
+    [
+        ("{not valid json", "invalid contribution input JSON"),
+        ("[1, 2, 3]", "must each contain a JSON object"),
+    ],
+)
+def test_report_cli_rejects_bad_contribution_inputs(
+    tmp_path, capsys, metrics_text, expected_stderr
+):
+    """Malformed or non-object contribution JSON fails closed with exit code 2.
+
+    Without hardening these inputs escaped as tracebacks (JSONDecodeError) or
+    crashed inside ``build_snqi_contribution_diagnostics`` (non-mapping payload)
+    instead of returning the CLI's intended input-error exit code.
+    """
+    import json
+
+    module = _load_report_module()
+    metrics_path = tmp_path / "metrics.json"
+    weights_path = tmp_path / "weights.json"
+    metrics_path.write_text(metrics_text, encoding="utf-8")
+    weights_path.write_text(json.dumps(_WEIGHTS), encoding="utf-8")
+
+    exit_code = module.main(["--metrics", str(metrics_path), "--weights", str(weights_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert expected_stderr in captured.err
+
+
+def test_report_cli_rejects_directory_contribution_input(tmp_path, capsys):
+    """A directory passed as a metrics path fails closed instead of erroring out."""
+    import json
+
+    module = _load_report_module()
+    metrics_dir = tmp_path / "metrics_dir"
+    metrics_dir.mkdir()
+    weights_path = tmp_path / "weights.json"
+    weights_path.write_text(json.dumps(_WEIGHTS), encoding="utf-8")
+
+    exit_code = module.main(["--metrics", str(metrics_dir), "--weights", str(weights_path)])
+
+    captured = capsys.readouterr()
+    assert exit_code == 2
+    assert "metrics file not found" in captured.err


### PR DESCRIPTION
# Issue #3699: expose SNQI contribution diagnostics in report

Issue: https://github.com/ll7/robot_sf_ll7/issues/3699

## Scope
- Adds optional metrics and weights inputs to `scripts/benchmark/snqi_normalization_inventory_report.py` so the report can include existing SNQI contribution diagnostics in text and JSON output.
- Adds focused coverage that the CLI writes mixed-basis contribution output and reconstructs the current `compute_snqi()` score.

## Validation
- `uv run pytest tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py tests/test_snqi_weights_inventory.py -q` -> 28 passed.
- `uv run ruff check scripts/benchmark/snqi_normalization_inventory_report.py tests/benchmark/test_snqi_normalization_inventory.py && uv run ruff format --check scripts/benchmark/snqi_normalization_inventory_report.py tests/benchmark/test_snqi_normalization_inventory.py` -> passed.
- `uv run python -m py_compile robot_sf/benchmark/snqi/normalization_inventory.py scripts/benchmark/snqi_normalization_inventory_report.py tests/benchmark/test_snqi_normalization_inventory.py && git diff --check` -> passed.

## Domain-Aware Approval
- Required PR: no - checker-only implementation; no result interpretation or claim boundary changed
- Domains reviewed: NA
- Status: not required
- Approver/review source or waiver: NA - implementation integrity only
- Validity checklist:
- Target claim/hypothesis: no benchmark claim advanced
- Comparator or split/evidence validity: no campaign, comparator split, or result interpretation changed
- Fallback/degraded exclusions: no benchmark rows are interpreted
- Claim boundary: contribution diagnostics reconstruct current scoring only
- Implementation integrity vs experimental validity: tests prove CLI/report behavior only

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No SNQI formula, normalization semantics, or weight changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional contribution diagnostics mode to the SNQI normalization report.
  * The report can now accept optional metrics and weights inputs together and include term-level contribution details in both console output and JSON exports.

* **Bug Fixes**
  * Improved input validation so incomplete or missing diagnostics inputs now fail early with clear errors.
  * Kept existing fail-safe checks intact while expanding the report output with additional diagnostic context.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->