### PR TITLE
Issue #3810: guard active long-horizon launch packet

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -220,6 +220,16 @@ launch_packet:
   target_host: imech039
   blocking_jobs:
     - 13175
+  live_issue_state:
+    checked_date: "2026-06-30"
+    source: gh_issue_view_3810_labels
+    required_label: "state:running"
+    submit_blocker: true
+    resolution_required_before_submit: >
+      Issue #3810 is still marked "state:running", so a submit-host go
+      decision must first prove the active run is reconciled or no longer
+      relevant. Public packet checks must keep this as a blocker until the
+      live issue state changes and the packet is refreshed.
   ledger_reconciliation:
     checked_date: "2026-06-29"
     source: private_ops_jobs_and_queue_read_only_needs_submit_host_refresh
@@ -259,6 +269,7 @@ launch_packet:
         - target_host
         - queue_summary_timestamp
         - duplicate_status
+        - live_issue_state
         - job_13175_state
         - route_id
         - submit_wrapper_supports_target_host

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -160,6 +160,20 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(isinstance(blocking_jobs, list), "blocking_jobs must be a list")
     _require(13175 in blocking_jobs, "job 13175 must block submit until reconciled")
 
+    live_issue_state = _require_mapping(launch_packet, "live_issue_state")
+    _require(
+        live_issue_state.get("required_label") == "state:running",
+        "live issue state must record state:running blocker",
+    )
+    _require(
+        live_issue_state.get("submit_blocker") is True,
+        "live issue state must block submit while running",
+    )
+    _require(
+        "reconciled" in str(live_issue_state.get("resolution_required_before_submit", "")),
+        "live issue state must require reconciliation before submit",
+    )
+
     ledger = _require_mapping(launch_packet, "ledger_reconciliation")
     _require(
         ledger.get("job_13175_state") == "requires_submit_host_refresh",
@@ -212,6 +226,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
             "target_host",
             "queue_summary_timestamp",
             "duplicate_status",
+            "live_issue_state",
             "job_13175_state",
             "route_id",
             "submit_wrapper_supports_target_host",
@@ -291,6 +306,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "blocking_jobs": blocking_jobs,
         "job_13175_state": ledger["job_13175_state"],
         "issue_3810_duplicate_status": ledger["issue_3810_duplicate_status"],
+        "live_issue_state": live_issue_state["required_label"],
         "go_no_go": go_no_go["recommendation"],
         "private_ops_dry_run": dry_run["current_public_status"],
     }

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -38,6 +38,7 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["blocking_jobs"] == [13175]
     assert summary["job_13175_state"] == "requires_submit_host_refresh"
     assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
+    assert summary["live_issue_state"] == "state:running"
     assert summary["go_no_go"] == "blocked_pending_submit_host_route_and_reconciliation"
     assert summary["private_ops_dry_run"] == "route_unverified"
 
@@ -79,6 +80,32 @@ def test_issue_3810_packet_rejects_stale_job_13175_reconciliation() -> None:
         assert "job 13175 reconciliation must require submit-host refresh" in str(exc)
     else:
         raise AssertionError("packet should reject stale job 13175 reconciliation")
+
+
+def test_issue_3810_packet_rejects_nonblocking_live_issue_state() -> None:
+    """The live state:running label remains a submit blocker."""
+    packet = _load_packet()
+    packet["launch_packet"]["live_issue_state"]["submit_blocker"] = False
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "live issue state must block submit while running" in str(exc)
+    else:
+        raise AssertionError("packet should reject a nonblocking live issue state")
+
+
+def test_issue_3810_packet_rejects_stale_live_issue_label() -> None:
+    """A packet with changed live issue state must be refreshed before submit."""
+    packet = _load_packet()
+    packet["launch_packet"]["live_issue_state"]["required_label"] = "state:ready"
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "live issue state must record state:running blocker" in str(exc)
+    else:
+        raise AssertionError("packet should reject stale live issue label")
 
 
 def test_issue_3810_packet_rejects_missing_private_ops_dry_run() -> None:


### PR DESCRIPTION
## Summary

Part of #3810 — narrow launch-packet guard slice. The parent issue stays open;
its remaining long-horizon campaign / SNQI-recalibration / report acceptance
criteria are out of scope here.

- Records the live issue `state:running` label as an explicit no-submit blocker in the issue #3810 long-horizon Social Navigation Quality Index (SNQI) launch packet.
- Requires private-ops dry-run evidence to include `live_issue_state` before any submit-host go decision.
- Extends the packet checker and tests so stale or nonblocking live issue state fails closed.

## Validation

- `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` - passed.
- `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q` - passed, 16 tests.
- `uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` - passed.
- `ROBOT_SF_PRIVATE_OPS="$HOME/git/robot_sf_ll7-private-ops" "$HOME/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh" --cluster licca --route-id decision-packet-only --public-repo "$PWD" --output output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json` - passed as read-only dry run; output reported `submitted:false`, `slurm_test_only=missing_sbatch`, and missing auth/dependency gates.
- `uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` - passed.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Artifact Policy

Generated validation outputs under `output/` remain disposable local validation artifacts and are not committed.
