### PR TITLE
Issue #3653: export SNQI decision-disagreement table

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -989,9 +989,9 @@ def _write_decision_disagreement_csv(path: Path, report: Mapping[str, Any]) -> N
         rows.append(
             {
                 "comparison": "base_snqi_vs_constraints_first",
-                "left_order": " > ".join(str(item) for item in disagreement.get("snqi_order", [])),
+                "left_order": " > ".join(str(item) for item in report.get("base_snqi_order", [])),
                 "right_order": " > ".join(
-                    str(item) for item in disagreement.get("constraints_first_order", [])
+                    str(item) for item in report.get("constraints_first_order", [])
                 ),
                 "pairwise_reversal_count": disagreement.get("pairwise_reversal_count", ""),
                 "pairwise_disagreement_rate": disagreement.get("pairwise_disagreement_rate", ""),

--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -45,6 +45,7 @@ class DiagnosticArtifacts:
 
     json_path: Path
     csv_path: Path
+    decision_disagreement_csv_path: Path
     markdown_path: Path
     svg_path: Path
 
@@ -495,14 +496,18 @@ def write_diagnostic_artifacts(
     output_dir.mkdir(parents=True, exist_ok=True)
     json_path = output_dir / f"{stem}.json"
     csv_path = output_dir / f"{stem}_planner_rows.csv"
+    decision_disagreement_csv_path = output_dir / f"{stem}_decision_disagreement.csv"
     markdown_path = output_dir / f"{stem}.md"
     svg_path = output_dir / f"{stem}_pareto.svg"
 
     json_path.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     _write_planner_csv(csv_path, report)
+    _write_decision_disagreement_csv(decision_disagreement_csv_path, report)
     markdown_path.write_text(format_markdown(report), encoding="utf-8")
     svg_path.write_text(format_pareto_svg(report), encoding="utf-8")
-    return DiagnosticArtifacts(json_path, csv_path, markdown_path, svg_path)
+    return DiagnosticArtifacts(
+        json_path, csv_path, decision_disagreement_csv_path, markdown_path, svg_path
+    )
 
 
 def load_jsonl(path: Path) -> list[dict[str, Any]]:
@@ -973,6 +978,41 @@ def _write_planner_csv(path: Path, report: Mapping[str, Any]) -> None:
         writer.writeheader()
         for row in report.get("planner_rows", []):
             writer.writerow({header: row.get(header, "") for header in headers})
+
+
+def _write_decision_disagreement_csv(path: Path, report: Mapping[str, Any]) -> None:
+    """Write the scalar-vs-constraints decision-disagreement table."""
+
+    disagreement = report.get("decision_disagreement", {})
+    rows = []
+    if isinstance(disagreement, Mapping):
+        rows.append(
+            {
+                "comparison": "base_snqi_vs_constraints_first",
+                "left_order": " > ".join(str(item) for item in disagreement.get("snqi_order", [])),
+                "right_order": " > ".join(
+                    str(item) for item in disagreement.get("constraints_first_order", [])
+                ),
+                "pairwise_reversal_count": disagreement.get("pairwise_reversal_count", ""),
+                "pairwise_disagreement_rate": disagreement.get("pairwise_disagreement_rate", ""),
+                "claim_boundary": report.get("claim_boundary", ""),
+            }
+        )
+
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(
+            handle,
+            fieldnames=[
+                "comparison",
+                "left_order",
+                "right_order",
+                "pairwise_reversal_count",
+                "pairwise_disagreement_rate",
+                "claim_boundary",
+            ],
+        )
+        writer.writeheader()
+        writer.writerows(rows)
 
 
 def _rank_order(scores: Mapping[str, float], *, higher_is_better: bool) -> list[str]:

--- a/scripts/benchmark/snqi_scalarization_sensitivity_export.py
+++ b/scripts/benchmark/snqi_scalarization_sensitivity_export.py
@@ -101,6 +101,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "artifacts": {
                     "json": str(artifacts.json_path),
                     "csv": str(artifacts.csv_path),
+                    "decision_disagreement_csv": str(artifacts.decision_disagreement_csv_path),
                     "markdown": str(artifacts.markdown_path),
                     "svg": str(artifacts.svg_path),
                 },

--- a/scripts/tools/analyze_snqi_scalarization_sensitivity.py
+++ b/scripts/tools/analyze_snqi_scalarization_sensitivity.py
@@ -100,6 +100,7 @@ def main(argv: list[str] | None = None) -> int:
             {
                 "json": str(artifacts.json_path),
                 "csv": str(artifacts.csv_path),
+                "decision_disagreement_csv": str(artifacts.decision_disagreement_csv_path),
                 "markdown": str(artifacts.markdown_path),
                 "svg": str(artifacts.svg_path),
                 "decision_disagreement_rate": report["summary"]["decision_disagreement_rate"],

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -288,6 +288,12 @@ def test_artifact_writer_creates_report_ready_files(tmp_path: Path) -> None:
     disagreement_csv_text = artifacts.decision_disagreement_csv_path.read_text(encoding="utf-8")
     assert "comparison,left_order,right_order,pairwise_reversal_count" in disagreement_csv_text
     assert "base_snqi_vs_constraints_first" in disagreement_csv_text
+    # The order columns must be populated, not silently blank, so the table shows which
+    # planners' rankings disagree (not just the aggregate reversal count).
+    base_order = " > ".join(report["base_snqi_order"])
+    constraints_order = " > ".join(report["constraints_first_order"])
+    assert base_order in disagreement_csv_text
+    assert constraints_order in disagreement_csv_text
     markdown = artifacts.markdown_path.read_text(encoding="utf-8")
     assert "not benchmark evidence" in markdown
     svg = artifacts.svg_path.read_text(encoding="utf-8")

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -285,6 +285,9 @@ def test_artifact_writer_creates_report_ready_files(tmp_path: Path) -> None:
     assert json.loads(artifacts.json_path.read_text(encoding="utf-8"))["schema_version"]
     csv_text = artifacts.csv_path.read_text(encoding="utf-8")
     assert "planner,snqi_rank,constraints_first_rank" in csv_text
+    disagreement_csv_text = artifacts.decision_disagreement_csv_path.read_text(encoding="utf-8")
+    assert "comparison,left_order,right_order,pairwise_reversal_count" in disagreement_csv_text
+    assert "base_snqi_vs_constraints_first" in disagreement_csv_text
     markdown = artifacts.markdown_path.read_text(encoding="utf-8")
     assert "not benchmark evidence" in markdown
     svg = artifacts.svg_path.read_text(encoding="utf-8")

--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -264,9 +264,15 @@ def test_cli_exports_report_ready_artifacts(tmp_path: Path) -> None:
     assert result.returncode == 0, result.stderr
     assert (out_dir / "issue_3653.json").exists()
     assert (out_dir / "issue_3653_planner_rows.csv").exists()
+    assert (out_dir / "issue_3653_decision_disagreement.csv").exists()
     assert (out_dir / "issue_3653.md").exists()
     assert (out_dir / "issue_3653_pareto.svg").exists()
 
     payload = json.loads((out_dir / "issue_3653.json").read_text(encoding="utf-8"))
     assert payload["schema_version"] == "snqi_scalarization_sensitivity.v1"
     assert payload["pareto_front"]["points"]
+    disagreement_csv = (out_dir / "issue_3653_decision_disagreement.csv").read_text(
+        encoding="utf-8"
+    )
+    assert "base_snqi_vs_constraints_first" in disagreement_csv
+    assert "not benchmark evidence" in disagreement_csv


### PR DESCRIPTION
## Issue
Closes https://github.com/ll7/robot_sf_ll7/issues/3653

## Scope Summary
- Adds a dedicated `*_decision_disagreement.csv` artifact to the existing SNQI scalarization-sensitivity export.
- Keeps the table derived from the already fail-closed report payload; no SNQI formula, weight, or benchmark semantics change.
- Exposes the new artifact path from both SNQI sensitivity CLI entry points.
- Extends focused tests to assert the decision-disagreement table and diagnostic claim boundary are exported with the Pareto artifacts.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py`
  - Passed: 18 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_plots_pareto.py`
  - Passed: 3 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi_scalarization_sensitivity.py scripts/benchmark/snqi_scalarization_sensitivity_export.py scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py`
  - Passed: all checks passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/snqi_scalarization_sensitivity.py scripts/benchmark/snqi_scalarization_sensitivity_export.py scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py`
  - Passed: 5 files already formatted.
- `git diff --check`
  - Passed.

## Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Residual Risk
- Full PR readiness and improvement cycle are intentionally left to Claude Code on `imech156-u` per handoff instruction.
