### PR TITLE
Issue #3216: add headline CI dry-run preflight

### DIFF
--- a/docs/context/issue_3216_headline_ci_rank_stability.md
+++ b/docs/context/issue_3216_headline_ci_rank_stability.md
@@ -22,6 +22,9 @@ and the **SLURM launch packet** for the increased-seed-budget run.
 
 - Loads headline rows via `canonical_table_export.load_rows_json`
   (`--rows` or `--campaign`).
+- Supports `--dry-run` for a deterministic local preflight that exercises the
+  same report builder without campaign artifacts or Slurm submission; the fixture
+  remains diagnostic-only.
 - **Per cell**: point estimate + bootstrap/per-seed confidence interval on the
   primary metrics, with fail-closed cell status — `degraded` / `fallback` /
   `not_available` execution modes and non-success row statuses are excluded and

--- a/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+++ b/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
@@ -820,6 +820,58 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def _dry_run_rows() -> list[dict[str, Any]]:
+    """Return deterministic fixture rows for local CLI preflight.
+
+    The fixture is intentionally below the nominal seed threshold. It proves the
+    parser, CI, downgrade, and rank-stability paths execute without requiring a
+    campaign artifact or cluster submission, but it cannot promote a benchmark
+    claim.
+    """
+
+    def row(
+        scenario: str,
+        planner: str,
+        snqi_values: Sequence[float],
+        *,
+        row_status: str = "successful_evidence",
+        execution_mode: str = "nominal",
+    ) -> dict[str, Any]:
+        per_seed = [
+            {
+                "seed": 900 + index,
+                "metrics": {
+                    "success": 1.0 if value >= 0.5 else 0.0,
+                    "collisions": 0.0 if value >= 0.5 else 1.0,
+                    "near_misses": 0.0,
+                    "snqi": value,
+                },
+            }
+            for index, value in enumerate(snqi_values)
+        ]
+        return {
+            "scenario_family": scenario,
+            "planner_key": planner,
+            "row_status": row_status,
+            "execution_mode": execution_mode,
+            "per_seed": per_seed,
+        }
+
+    return [
+        row("dry_run_merging", "stable_top", [0.91, 0.92, 0.90, 0.93, 0.91]),
+        row("dry_run_merging", "stable_mid", [0.56, 0.54, 0.55, 0.57, 0.56]),
+        row("dry_run_merging", "stable_low", [0.20, 0.18, 0.21, 0.19, 0.20]),
+        row("dry_run_bottleneck", "overlap_a", [0.50, 0.55, 0.45, 0.52, 0.48]),
+        row("dry_run_bottleneck", "overlap_b", [0.51, 0.46, 0.54, 0.49, 0.53]),
+        row(
+            "dry_run_bottleneck",
+            "excluded_degraded",
+            [0.80, 0.81, 0.82, 0.83, 0.84],
+            execution_mode="degraded",
+        ),
+    ]
+
+
 def _fmt(value: Any) -> str:
     """Format a float-or-None for markdown.
 
@@ -857,6 +909,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         type=str,
         help="Campaign id/root; resolves to <root>/reports/headline_rows.json.",
     )
+    src.add_argument(
+        "--dry-run",
+        action="store_true",
+        help=(
+            "Run deterministic built-in fixture rows through the report path. "
+            "This writes output files but does not require campaign data."
+        ),
+    )
     parser.add_argument(
         "--metrics",
         type=str,
@@ -892,6 +952,8 @@ def _resolve_rows_path(args: argparse.Namespace) -> str:
     Returns:
         Filesystem path to the rows JSON list.
     """
+    if args.dry_run:
+        return "builtin://issue3216-dry-run"
     if args.rows:
         return args.rows
     return str(Path(args.campaign) / "reports" / "headline_rows.json")
@@ -905,7 +967,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     """
     args = parse_args(argv)
     rows_path = _resolve_rows_path(args)
-    rows = load_rows_json(rows_path)
+    rows = _dry_run_rows() if args.dry_run else load_rows_json(rows_path)
     config = ReportConfig(
         metrics=tuple(args.metrics),
         rank_metric=args.rank_metric,
@@ -916,7 +978,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         resamples=args.rank_resamples,
         rank_seed=args.rank_seed,
     )
-    report = build_report(rows, config, campaign=args.campaign, rows_path=rows_path)
+    campaign = "dry-run" if args.dry_run else args.campaign
+    report = build_report(rows, config, campaign=campaign, rows_path=rows_path)
     out_dir = Path(args.output_dir)
     out_dir.mkdir(parents=True, exist_ok=True)
     (out_dir / "result.json").write_text(

--- a/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
@@ -280,3 +280,48 @@ def test_adjacent_rank_claims_mark_ci_separable() -> None:
     assert claim["higher_rank_planner"] == "best"
     assert claim["lower_rank_planner"] == "worst"
     assert claim["decision"] == "ci_separable"
+
+
+def test_dry_run_fixture_stays_diagnostic_and_fail_closed() -> None:
+    """Built-in dry-run rows exercise CI/rank paths without paper-claim promotion."""
+
+    rows = mod._dry_run_rows()
+    report = _report(rows)
+
+    assert report["classification"] == "diagnostic"
+    assert report["inputs"]["excluded_cells"] == 1
+    assert any(cell["planner_key"] == "excluded_degraded" for cell in report["cells"])
+    degraded = next(cell for cell in report["cells"] if cell["planner_key"] == "excluded_degraded")
+    assert degraded["counted"] is False
+    assert "degraded" in degraded["exclusion_reason"]
+    assert len(report["rank_stability"]) == 2
+    assert any(
+        claim["decision"] == "not_statistically_distinguishable_budget"
+        for claim in report["adjacent_rank_claims"]
+    )
+
+
+def test_dry_run_cli_writes_report_without_rows_file(tmp_path) -> None:
+    """CLI dry-run does not require a rows path or campaign artifact."""
+
+    out_dir = tmp_path / "report"
+
+    exit_code = mod.main(
+        [
+            "--dry-run",
+            "--bootstrap-samples",
+            "0",
+            "--rank-resamples",
+            "25",
+            "--output-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    result = out_dir / "result.json"
+    markdown = out_dir / "report.md"
+    assert result.is_file()
+    assert markdown.is_file()
+    assert "builtin://issue3216-dry-run" in result.read_text(encoding="utf-8")
+    assert "**Classification**: `diagnostic`" in markdown.read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary
Adds deterministic `--dry-run` support to the existing issue #3216 headline confidence-interval and rank-stability report harness. The dry-run exercises the report path locally without campaign artifacts or Slurm submission and remains diagnostic-only.

## Linked Issues
- Relates `#3216`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added built-in deterministic dry-run rows to `scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py`.
- Added tests for dry-run classification, fail-closed degraded-row exclusion, rank-stability output, adjacent-rank downgrade, and CLI file output.
- Documented the dry-run preflight in the issue #3216 context note.

## Why Matters
- Added value: local preflight now matches the validation hint and can exercise the issue #3216 checker without a real campaign artifact.
- Expected impact: faster no-submit verification of the headline CI/rank-stability harness surface.
- Why worth merging now: small reversible support-tool slice over an existing issue #3216 harness.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3216 local preflight can run without campaign data; no benchmark ranking claim is promoted.
- Comparator or baseline, applicable: existing CLI required `--rows` or `--campaign`.
- Evidence tier: targeted smoke
- Result classification: diagnostic-only
- Decision stop rule, applicable: dry-run output must classify diagnostic and preserve fail-closed degraded-row exclusion.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3216 context note updated.
- New research/benchmark/metric/paper-facing analysis tool, any: no new analysis tool; existing harness gains deterministic dry-run fixture only.

## Domain-Aware Approval
Required for this PR: required - evidence-validity-sensitive result classification
Domains reviewed: evidence classification, benchmark-tool claim boundary
Status: waived
Approver/review source or waiver: maintainer waiver for diagnostic-only support-tool preflight with no benchmark result claim promotion
Validity checklist:
Target claim/hypothesis: issue claim boundary stays diagnostic-only
Comparator split/evidence validity: existing targeted smoke proof only
Comparator or split/evidence validity: existing targeted smoke proof only
Fallback/degraded exclusions: fallback/degraded evidence remains excluded
Claim boundary: no paper-facing benchmark claim
Implementation integrity vs experimental validity: tests prove gate behavior, not result validity

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - support-tool fixture only
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: none for this support-tool slice

## Next Empirical Action
- Rerun needed: no for this support-tool slice
- Extractor analysis tool needed: no
- Artifact missing unavailable: no durable campaign artifact required for dry-run
- Stop / revise / continue decision: continue; full issue #3216 empirical campaign/claim work remains outside this PR
- Proposed child issue existing follow-up: none

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py -q` -> passed, 15 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --dry-run --bootstrap-samples 0 --rank-resamples 25 --output-dir output/validation/issue3216_dry_run_final` -> passed, `classification=diagnostic counted=5 excluded=1`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --help` -> passed, help lists `--dry-run`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py` -> passed.

## Performance Check
- Baseline runtime: NA - no runtime claim
- Changed runtime: NA - no runtime claim
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --dry-run --bootstrap-samples 0 --rank-resamples 25 --output-dir output/validation/issue3216_dry_run_final`
- Hot-path call count profile anchor: NA - no performance-sensitive path changed
- Cache-hit reuse counter: NA - no caching claimed
- Rollback failure criterion: dry-run no longer emits diagnostic classification or fail-closed degraded exclusion.

## Risks / Rollout
- Compatibility risks: low; `--rows` and `--campaign` behavior remains unchanged.
- Failure modes: deterministic fixture could drift from real input shape if the harness contract changes.
- Rollback fallback plan: remove `--dry-run` and keep existing `--rows`/`--campaign` paths.

## Docs / Provenance
- Updated docs: `docs/context/issue_3216_headline_ci_rank_stability.md`
- Relevant design provenance notes: issue #3216 existing context note and harness.
- Any assumptions need to preserved: dry-run fixture is a diagnostic local preflight, not benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - authorization disallows issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA - no claim promoted.
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA - existing context note updated directly.
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: this PR adds a support-tool dry-run and does not promote benchmark, registry, claim-map, or paper-facing results.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes
- Verify that `--dry-run` remains mutually exclusive with `--rows` and `--campaign` and that dry-run output is diagnostic-only.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
