### PR TITLE
Issue #3813: preflight sustained-flow scenario scaffold

### DIFF
--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -1,0 +1,386 @@
+"""Preflight checks for sustained-flow scenario scaffold variants.
+
+Issue #3813 introduces metadata-only continuous-spawn scenario variants. These
+checks intentionally do not claim runtime continuous respawn exists; they prove
+the opt-in scaffold is complete, enumerable, and fail-closed for benchmark use.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from robot_sf.training.scenario_loader import load_scenarios
+
+SUSTAINED_FLOW_PREFLIGHT_SCHEMA_VERSION = "issue_3813.sustained_flow_preflight.v1"
+DEFAULT_SUSTAINED_FLOW_SCENARIO_SET = (
+    Path(__file__).resolve().parents[2]
+    / "configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml"
+)
+EXPECTED_SUSTAINED_FLOW_TIERS: tuple[tuple[str, float, float, tuple[int, ...]], ...] = (
+    ("light", 0.02, 6.0, (381301, 381302, 381303)),
+    ("medium", 0.05, 12.0, (381311, 381312, 381313)),
+    ("heavy", 0.08, 18.0, (381321, 381322, 381323)),
+)
+REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE: tuple[str, ...] = (
+    "continuous pedestrian respawn runtime support",
+    "progress-rate metric implementation",
+    "interaction-exposure diagnostic sanity check",
+    "scenario_cert.v1 eligibility review",
+)
+
+
+@dataclass(frozen=True)
+class SustainedFlowVariant:
+    """Validated sustained-flow scaffold variant summary."""
+
+    name: str
+    density_tier: str
+    ped_density: float
+    spawn_rate_per_min: float
+    seeds: tuple[int, ...]
+    map_file: str
+
+
+@dataclass(frozen=True)
+class SustainedFlowPreflightReport:
+    """Structured result for the issue #3813 scenario scaffold preflight."""
+
+    schema_version: str
+    scenario_set: str
+    conforms: bool
+    variants: tuple[SustainedFlowVariant, ...]
+    errors: tuple[str, ...]
+    benchmark_evidence: bool = False
+    runtime_support: str = "metadata_only"
+
+
+def _repo_relative(path: Path) -> str:
+    repo_root = Path(__file__).resolve().parents[2]
+    try:
+        return path.resolve().relative_to(repo_root).as_posix()
+    except ValueError:
+        return path.as_posix()
+
+
+def _load_raw_yaml(path: Path) -> dict[str, Any]:
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Scenario set must be a mapping: {path}")
+    return data
+
+
+def _require_equal(errors: list[str], name: str, field: str, actual: Any, expected: Any) -> None:
+    if actual != expected:
+        errors.append(f"{name}: {field} must be {expected}")
+
+
+def _check_basic_metadata(
+    metadata: dict[str, Any],
+    *,
+    name: str,
+    expected_tier: str,
+) -> list[str]:
+    errors: list[str] = []
+    _require_equal(
+        errors,
+        name,
+        "metadata.pack_id",
+        metadata.get("pack_id"),
+        "issue_3813_sustained_flow_scaffold_v0",
+    )
+    _require_equal(
+        errors,
+        name,
+        "metadata.status",
+        metadata.get("status"),
+        "pre_benchmark_scaffold",
+    )
+    _require_equal(
+        errors, name, "metadata.enabled_by_default", metadata.get("enabled_by_default"), False
+    )
+    _require_equal(
+        errors, name, "metadata.benchmark_evidence", metadata.get("benchmark_evidence"), False
+    )
+    _require_equal(errors, name, "metadata.density", metadata.get("density"), expected_tier)
+    return errors
+
+
+def _check_continuous_spawn(
+    metadata: dict[str, Any],
+    *,
+    name: str,
+    expected_tier: str,
+    expected_spawn_rate: float,
+) -> list[str]:
+    continuous_spawn = metadata.get("continuous_spawn")
+    if not isinstance(continuous_spawn, dict):
+        return [f"{name}: metadata.continuous_spawn block is required"]
+
+    errors: list[str] = []
+    _require_equal(
+        errors,
+        name,
+        "continuous_spawn.required_before_benchmark_use",
+        continuous_spawn.get("required_before_benchmark_use"),
+        True,
+    )
+    _require_equal(
+        errors,
+        name,
+        "continuous_spawn.intended_process",
+        continuous_spawn.get("intended_process"),
+        "poisson_respawn",
+    )
+    _require_equal(
+        errors,
+        name,
+        "continuous_spawn.current_runtime_support",
+        continuous_spawn.get("current_runtime_support"),
+        "metadata_only",
+    )
+    _require_equal(
+        errors,
+        name,
+        "continuous_spawn.target_density_tier",
+        continuous_spawn.get("target_density_tier"),
+        expected_tier,
+    )
+    _require_equal(
+        errors,
+        name,
+        "continuous_spawn.spawn_rate_per_min",
+        float(continuous_spawn.get("spawn_rate_per_min", -1.0)),
+        expected_spawn_rate,
+    )
+    return errors
+
+
+def _check_termination_and_metric(
+    scenario: dict[str, Any],
+    metadata: dict[str, Any],
+    *,
+    name: str,
+) -> list[str]:
+    errors: list[str] = []
+    termination = metadata.get("termination")
+    if not isinstance(termination, dict):
+        errors.append(f"{name}: metadata.termination block is required")
+    else:
+        _require_equal(errors, name, "termination.mode", termination.get("mode"), "time_bounded")
+        _require_equal(
+            errors,
+            name,
+            "termination.goal_reach_is_not_primary_success",
+            termination.get("goal_reach_is_not_primary_success"),
+            True,
+        )
+        sim_steps = scenario.get("simulation_config", {}).get("max_episode_steps")
+        _require_equal(
+            errors,
+            name,
+            "termination.max_episode_steps",
+            termination.get("max_episode_steps"),
+            sim_steps,
+        )
+
+    success_metric = metadata.get("success_metric")
+    if not isinstance(success_metric, dict):
+        errors.append(f"{name}: metadata.success_metric block is required")
+    else:
+        _require_equal(
+            errors,
+            name,
+            "success_metric.id",
+            success_metric.get("id"),
+            "sustained_progress_rate_m_per_s",
+        )
+
+    blockers = tuple(metadata.get("requires_before_benchmark_use", ()))
+    if blockers != REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE:
+        errors.append(f"{name}: requires_before_benchmark_use must match the fail-closed list")
+    return errors
+
+
+def _check_metadata_fail_closed(
+    scenario: dict[str, Any],
+    *,
+    expected_tier: str,
+    expected_spawn_rate: float,
+) -> list[str]:
+    name = str(scenario.get("name", "<unnamed>"))
+    metadata = scenario.get("metadata")
+    if not isinstance(metadata, dict):
+        return [f"{name}: metadata block is required"]
+
+    errors: list[str] = []
+    errors.extend(_check_basic_metadata(metadata, name=name, expected_tier=expected_tier))
+    errors.extend(
+        _check_continuous_spawn(
+            metadata,
+            name=name,
+            expected_tier=expected_tier,
+            expected_spawn_rate=expected_spawn_rate,
+        )
+    )
+    errors.extend(_check_termination_and_metric(scenario, metadata, name=name))
+    return errors
+
+
+def _validate_variant(
+    scenario: dict[str, Any],
+    *,
+    scenario_set: Path,
+    expected_by_tier: dict[str, tuple[float, float, tuple[int, ...]]],
+    seen_seeds: set[int],
+) -> tuple[SustainedFlowVariant | None, list[str]]:
+    """Validate one scenario variant against the sustained-flow scaffold contract.
+
+    Returns:
+        Optional variant summary and any validation errors for the scenario.
+    """
+
+    errors: list[str] = []
+    name = str(scenario.get("name", "<unnamed>"))
+    metadata = scenario.get("metadata", {})
+    tier = str(metadata.get("density", ""))
+    if tier not in expected_by_tier:
+        return None, [f"{name}: unexpected sustained-flow density tier {tier!r}"]
+
+    expected_ped_density, expected_spawn_rate, expected_seeds = expected_by_tier[tier]
+    simulation_config = scenario.get("simulation_config", {})
+    ped_density = float(simulation_config.get("ped_density", -1.0))
+    seeds = tuple(scenario.get("seeds", ()))
+    map_file = str(scenario.get("map_file", ""))
+    map_path = (scenario_set.parent / map_file).resolve()
+
+    if not name.startswith(f"issue_3813_sustained_flow_t_intersection_{tier}"):
+        errors.append(f"{name}: scenario name must include issue, family, and tier")
+    _require_equal(errors, name, "ped_density", ped_density, expected_ped_density)
+    _require_equal(errors, name, "seeds", seeds, expected_seeds)
+    for seed in seeds:
+        if seed in seen_seeds:
+            errors.append(f"{name}: duplicate seed {seed}")
+        seen_seeds.add(seed)
+    if not map_path.exists():
+        errors.append(f"{name}: map_file does not resolve to an existing file: {map_file}")
+
+    errors.extend(
+        _check_metadata_fail_closed(
+            scenario,
+            expected_tier=tier,
+            expected_spawn_rate=expected_spawn_rate,
+        )
+    )
+    return (
+        SustainedFlowVariant(
+            name=name,
+            density_tier=tier,
+            ped_density=ped_density,
+            spawn_rate_per_min=expected_spawn_rate,
+            seeds=seeds,
+            map_file=map_file,
+        ),
+        errors,
+    )
+
+
+def preflight_sustained_flow_scenario_set(
+    path: str | Path = DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
+) -> SustainedFlowPreflightReport:
+    """Validate and enumerate the issue #3813 sustained-flow scaffold.
+
+    Returns:
+        Sustained-flow preflight report with variants and fail-closed errors.
+    """
+
+    scenario_set = Path(path).resolve()
+    errors: list[str] = []
+    if not scenario_set.exists():
+        return SustainedFlowPreflightReport(
+            schema_version=SUSTAINED_FLOW_PREFLIGHT_SCHEMA_VERSION,
+            scenario_set=_repo_relative(scenario_set),
+            conforms=False,
+            variants=(),
+            errors=(f"scenario set does not exist: {scenario_set}",),
+        )
+
+    raw = _load_raw_yaml(scenario_set)
+    if raw.get("schema_version") != "robot_sf.scenario_matrix.v1":
+        errors.append("schema_version must be robot_sf.scenario_matrix.v1")
+
+    loaded = load_scenarios(scenario_set)
+    if len(loaded) != len(EXPECTED_SUSTAINED_FLOW_TIERS):
+        errors.append(
+            f"expected {len(EXPECTED_SUSTAINED_FLOW_TIERS)} sustained-flow variants, "
+            f"found {len(loaded)}"
+        )
+
+    variants: list[SustainedFlowVariant] = []
+    seen_seeds: set[int] = set()
+    expected_by_tier = {
+        tier: (ped_density, spawn_rate, seeds)
+        for tier, ped_density, spawn_rate, seeds in EXPECTED_SUSTAINED_FLOW_TIERS
+    }
+    expected_order = [tier for tier, *_ in EXPECTED_SUSTAINED_FLOW_TIERS]
+    observed_order: list[str] = []
+
+    for scenario in loaded:
+        metadata = scenario.get("metadata", {})
+        tier = str(metadata.get("density", ""))
+        observed_order.append(tier)
+        variant, variant_errors = _validate_variant(
+            scenario,
+            scenario_set=scenario_set,
+            expected_by_tier=expected_by_tier,
+            seen_seeds=seen_seeds,
+        )
+        errors.extend(variant_errors)
+        if variant is not None:
+            variants.append(variant)
+
+    if observed_order != expected_order:
+        errors.append(
+            "density tiers must enumerate light, medium, heavy in deterministic order; "
+            f"observed {observed_order}"
+        )
+
+    return SustainedFlowPreflightReport(
+        schema_version=SUSTAINED_FLOW_PREFLIGHT_SCHEMA_VERSION,
+        scenario_set=_repo_relative(scenario_set),
+        conforms=not errors,
+        variants=tuple(variants),
+        errors=tuple(errors),
+    )
+
+
+def sustained_flow_preflight_to_dict(report: SustainedFlowPreflightReport) -> dict[str, Any]:
+    """Serialize a sustained-flow preflight report.
+
+    Returns:
+        JSON-serializable sustained-flow preflight payload.
+    """
+
+    return {
+        "schema_version": report.schema_version,
+        "scenario_set": report.scenario_set,
+        "conforms": report.conforms,
+        "benchmark_evidence": report.benchmark_evidence,
+        "runtime_support": report.runtime_support,
+        "variant_count": len(report.variants),
+        "variants": [
+            {
+                "name": variant.name,
+                "density_tier": variant.density_tier,
+                "ped_density": variant.ped_density,
+                "spawn_rate_per_min": variant.spawn_rate_per_min,
+                "seeds": list(variant.seeds),
+                "map_file": variant.map_file,
+            }
+            for variant in report.variants
+        ],
+        "errors": list(report.errors),
+    }

--- a/scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py
+++ b/scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Validate the issue #3813 sustained-flow scenario scaffold.
+
+This is a CPU-only static preflight. It proves the continuous-spawn variants are
+enumerable and fail closed as metadata-only scaffold entries; it does not run a
+benchmark campaign or submit compute.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from robot_sf.scenario_certification.sustained_flow import (
+    DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
+    preflight_sustained_flow_scenario_set,
+    sustained_flow_preflight_to_dict,
+)
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--scenario-set",
+        type=Path,
+        default=DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
+        help="Scenario matrix to validate.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit the full JSON report.")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Run the sustained-flow scaffold preflight CLI.
+
+    Returns:
+        Process exit code: zero when the scaffold conforms, non-zero otherwise.
+    """
+
+    args = _parse_args(sys.argv[1:] if argv is None else argv)
+    report = preflight_sustained_flow_scenario_set(args.scenario_set)
+    payload = sustained_flow_preflight_to_dict(report)
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        result = "PASS" if report.conforms else "FAIL"
+        print(f"{result}: {payload['scenario_set']}")
+        print(f"variants: {payload['variant_count']}")
+        print(f"runtime_support: {payload['runtime_support']}")
+        print(f"benchmark_evidence: {payload['benchmark_evidence']}")
+        for error in payload["errors"]:
+            print(f"ERROR: {error}")
+
+    return 0 if report.conforms else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_issue_3813_sustained_flow_scenarios.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scenarios.py
@@ -1,0 +1,119 @@
+"""Enumeration coverage for issue #3813 sustained-flow scenario variants."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+from robot_sf.scenario_certification.sustained_flow import (
+    DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
+    EXPECTED_SUSTAINED_FLOW_TIERS,
+    REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE,
+    preflight_sustained_flow_scenario_set,
+    sustained_flow_preflight_to_dict,
+)
+from robot_sf.training.scenario_loader import load_scenarios
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_issue_3813_sustained_flow_scenarios_enumerate_expected_tiers() -> None:
+    """Scenario matrix enumerates the light, medium, and heavy sustained-flow tiers."""
+
+    scenarios = load_scenarios(DEFAULT_SUSTAINED_FLOW_SCENARIO_SET)
+    assert len(scenarios) == 3
+
+    expected = {
+        tier: {
+            "ped_density": ped_density,
+            "spawn_rate_per_min": spawn_rate_per_min,
+            "seeds": list(seeds),
+        }
+        for tier, ped_density, spawn_rate_per_min, seeds in EXPECTED_SUSTAINED_FLOW_TIERS
+    }
+    observed_tiers = [scenario["metadata"]["density"] for scenario in scenarios]
+    assert observed_tiers == ["light", "medium", "heavy"]
+
+    for scenario in scenarios:
+        metadata = scenario["metadata"]
+        tier = metadata["density"]
+        assert scenario["name"] == f"issue_3813_sustained_flow_t_intersection_{tier}"
+        assert scenario["simulation_config"]["max_episode_steps"] == 600
+        assert scenario["simulation_config"]["ped_density"] == expected[tier]["ped_density"]
+        assert scenario["seeds"] == expected[tier]["seeds"]
+        assert (
+            metadata["continuous_spawn"]["spawn_rate_per_min"]
+            == expected[tier]["spawn_rate_per_min"]
+        )
+        assert metadata["continuous_spawn"]["target_density_tier"] == tier
+
+
+def test_issue_3813_sustained_flow_scenarios_fail_closed_for_benchmark_use() -> None:
+    """The scaffold remains metadata-only and cannot be mistaken for benchmark evidence."""
+
+    raw = yaml.safe_load(DEFAULT_SUSTAINED_FLOW_SCENARIO_SET.read_text(encoding="utf-8"))
+    assert raw["schema_version"] == "robot_sf.scenario_matrix.v1"
+
+    for scenario in raw["scenarios"]:
+        metadata = scenario["metadata"]
+        assert metadata["enabled_by_default"] is False
+        assert metadata["benchmark_evidence"] is False
+        assert metadata["status"] == "pre_benchmark_scaffold"
+        assert metadata["requires_before_benchmark_use"] == list(
+            REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE
+        )
+        assert metadata["continuous_spawn"] == {
+            "required_before_benchmark_use": True,
+            "intended_process": "poisson_respawn",
+            "spawn_rate_per_min": metadata["continuous_spawn"]["spawn_rate_per_min"],
+            "target_density_tier": metadata["density"],
+            "current_runtime_support": "metadata_only",
+        }
+        assert metadata["termination"]["mode"] == "time_bounded"
+        assert metadata["termination"]["goal_reach_is_not_primary_success"] is True
+        assert metadata["success_metric"]["id"] == "sustained_progress_rate_m_per_s"
+
+
+def test_issue_3813_sustained_flow_preflight_report_conforms() -> None:
+    """The no-submit preflight reports the scenario scaffold as enumerable only."""
+
+    report = preflight_sustained_flow_scenario_set(DEFAULT_SUSTAINED_FLOW_SCENARIO_SET)
+    payload = sustained_flow_preflight_to_dict(report)
+
+    assert report.conforms is True
+    assert report.errors == ()
+    assert payload["benchmark_evidence"] is False
+    assert payload["runtime_support"] == "metadata_only"
+    assert payload["variant_count"] == 3
+    assert [variant["density_tier"] for variant in payload["variants"]] == [
+        "light",
+        "medium",
+        "heavy",
+    ]
+
+
+def test_issue_3813_sustained_flow_preflight_cli_json() -> None:
+    """The validation CLI exposes the same preflight contract for PR checks."""
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py",
+            "--scenario-set",
+            str(DEFAULT_SUSTAINED_FLOW_SCENARIO_SET),
+            "--json",
+        ],
+        cwd=REPO_ROOT,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = yaml.safe_load(result.stdout)
+
+    assert payload["conforms"] is True
+    assert payload["variant_count"] == 3
+    assert payload["benchmark_evidence"] is False
+    assert payload["runtime_support"] == "metadata_only"


### PR DESCRIPTION
## Summary

Implements the issue #3813 local preflight slice for the existing sustained-flow scenario scaffold:

- adds a CPU-only sustained-flow preflight checker for `configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml`
- adds a validation CLI that emits a structured report for the three continuous-spawn tiers
- adds enumeration tests for light, medium, and heavy variants, fail-closed metadata, seeds, spawn rates, and metadata-only benchmark status

Issue: https://github.com/ll7/robot_sf_ll7/issues/3813

## Validation

- `ruff check robot_sf/scenario_certification/sustained_flow.py scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py` - passed
- `ruff format --check robot_sf/scenario_certification/sustained_flow.py scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py` - passed
- `pytest tests/benchmark/test_issue_3813_sustained_flow_scenarios.py -q` - passed, 4 tests
- `python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` - passed, reports `conforms: true`, `variant_count: 3`, `runtime_support: metadata_only`, `benchmark_evidence: false`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed before commit, 1681 tests
- `PR_READY_PR_BODY_FILE=output/validation/pr_body_issue3813.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed, clean-tree stamp at `73cdb67b06de1256d83cbd75183db564006fa778`; core lane 1681 tests, broad exception ratchet passed with 287 entries

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No runtime continuous-spawn process implementation.
- No progress-rate metric implementation.
- No interaction-exposure diagnostic campaign.

## Artifact And Claim Boundary

This PR is scaffold/preflight evidence only. The scenario family remains metadata-only and explicitly `benchmark_evidence: false` until runtime respawn support, progress metrics, interaction-exposure sanity checks, and scenario certification eligibility are implemented and validated.
