### PR TITLE
Issue #3723: compare SNQI code default to shipped weights

### DIFF
--- a/robot_sf/benchmark/snqi/weights_inventory.py
+++ b/robot_sf/benchmark/snqi/weights_inventory.py
@@ -212,6 +212,13 @@ class WeightSourceComparison:
     source_dominant_term: str | None
     source_scale_class: str | None
     available: bool
+    """Whether the direction comparison itself could be computed.
+
+    This is distinct from source-load state: a source may load successfully yet
+    still be uncomparable (e.g. empty or zero-sum weights with no meaningful
+    direction), in which case ``available`` is False and ``load_error`` carries
+    the reason.
+    """
     load_error: str | None = None
 
 
@@ -467,16 +474,28 @@ def compare_code_default_to_shipped_sources(
     for record in records:
         if record.relpath is None:
             continue
+        relationship = _direction_relationship(code_default, record)
+        comparison_available = relationship != "unavailable"
+        if record.load_error is not None:
+            # The source failed to load; surface the underlying load error.
+            load_error = record.load_error
+        elif not comparison_available:
+            # The source loaded but has no comparable direction (empty or
+            # zero-sum weights); report a comparison-level reason rather than
+            # leaving an unexplained ``unavailable`` relationship.
+            load_error = "no_comparable_direction"
+        else:
+            load_error = None
         comparisons.append(
             WeightSourceComparison(
                 source=record.name,
                 relpath=record.relpath,
-                relationship=_direction_relationship(code_default, record),
+                relationship=relationship,
                 code_default_dominant_term=code_default.dominant_term,
                 source_dominant_term=record.dominant_term,
                 source_scale_class=record.scale_class,
-                available=record.available,
-                load_error=record.load_error,
+                available=comparison_available,
+                load_error=load_error,
             )
         )
     return comparisons

--- a/robot_sf/benchmark/snqi/weights_inventory.py
+++ b/robot_sf/benchmark/snqi/weights_inventory.py
@@ -202,6 +202,20 @@ class WeightProvenanceConflict:
 
 
 @dataclass
+class WeightSourceComparison:
+    """Diagnostic comparison between the code default and a shipped source."""
+
+    source: str
+    relpath: str | None
+    relationship: str
+    code_default_dominant_term: str | None
+    source_dominant_term: str | None
+    source_scale_class: str | None
+    available: bool
+    load_error: str | None = None
+
+
+@dataclass
 class WeightInventoryReport:
     """Structured result of an SNQI weight-set inventory pass."""
 
@@ -235,6 +249,19 @@ class WeightInventoryReport:
             "canonical_declaring_sources": [r.name for r in canonical_records],
             "unavailable_sources": [r.name for r in unavailable_records],
             "blocking_conflict_kinds": [c.kind for c in blocking_conflicts],
+            "code_default_shipped_direction_comparisons": [
+                {
+                    "source": comparison.source,
+                    "relpath": comparison.relpath,
+                    "relationship": comparison.relationship,
+                    "code_default_dominant_term": comparison.code_default_dominant_term,
+                    "source_dominant_term": comparison.source_dominant_term,
+                    "source_scale_class": comparison.source_scale_class,
+                    "available": comparison.available,
+                    "load_error": comparison.load_error,
+                }
+                for comparison in compare_code_default_to_shipped_sources(self.records)
+            ],
         }
 
     def to_dict(self) -> dict:
@@ -403,6 +430,56 @@ def _directions_disagree(a: dict[str, float], b: dict[str, float]) -> bool:
         True if any component differs beyond :data:`_DIRECTION_TOL`.
     """
     return any(abs(a[k] - b[k]) > _DIRECTION_TOL for k in WEIGHT_NAMES)
+
+
+def _direction_relationship(a: WeightSetRecord, b: WeightSetRecord) -> str:
+    """Classify two records by their scale-independent weight direction.
+
+    Returns:
+        ``same_direction``, ``different_direction``, or ``unavailable``.
+    """
+    if not a.available or not b.available:
+        return "unavailable"
+    da, db = a.normalized_direction(), b.normalized_direction()
+    if da is None or db is None:
+        return "unavailable"
+    if _directions_disagree(da, db):
+        return "different_direction"
+    return "same_direction"
+
+
+def compare_code_default_to_shipped_sources(
+    records: list[WeightSetRecord],
+) -> list[WeightSourceComparison]:
+    """Compare the code-default weights against every discovered shipped JSON source.
+
+    The issue #3723 ambiguity is specifically code default versus shipped JSON. This
+    diagnostic matrix makes every shipped source explicit without choosing a canonical set.
+
+    Returns:
+        One comparison per shipped JSON source in the inventory records.
+    """
+    code_default = next((r for r in records if r.name == "code_default"), None)
+    if code_default is None:
+        return []
+
+    comparisons: list[WeightSourceComparison] = []
+    for record in records:
+        if record.relpath is None:
+            continue
+        comparisons.append(
+            WeightSourceComparison(
+                source=record.name,
+                relpath=record.relpath,
+                relationship=_direction_relationship(code_default, record),
+                code_default_dominant_term=code_default.dominant_term,
+                source_dominant_term=record.dominant_term,
+                source_scale_class=record.scale_class,
+                available=record.available,
+                load_error=record.load_error,
+            )
+        )
+    return comparisons
 
 
 def _canonical_load_error_conflicts(
@@ -616,8 +693,10 @@ __all__ = [
     "WeightInventoryReport",
     "WeightProvenanceConflict",
     "WeightSetRecord",
+    "WeightSourceComparison",
     "WeightSourceSpec",
     "build_inventory_report",
+    "compare_code_default_to_shipped_sources",
     "detect_conflicts",
     "discover_shipped_weight_source_specs",
     "inventory_weight_sets",

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -174,6 +174,19 @@ def _print_text_report(report: dict[str, Any]) -> None:
             f"sha256={fingerprint}; {status}"
         )
 
+    comparisons = report["weights"]["source_summary"]["code_default_shipped_direction_comparisons"]
+    if comparisons:
+        print("Code-default vs shipped JSON directions:")
+        for comparison in comparisons:
+            detail = (
+                f"{comparison['relationship']}; "
+                f"source_dominant={comparison['source_dominant_term']}; "
+                f"source_scale={comparison['source_scale_class']}"
+            )
+            if not comparison["available"]:
+                detail += f"; unavailable={comparison['load_error']}"
+            print(f" - {comparison['source']} ({comparison['relpath']}): {detail}")
+
     weight_conflicts = report["weights"]["conflicts"]
     if weight_conflicts:
         print("Weight provenance conflicts:")

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -84,6 +84,11 @@ def test_governance_text_lists_per_term_normalization_status(
     ) in out
     assert "dominant=w_collisions; scale=raw; sha256=" in out
     assert "dominant=w_near; scale=normalized_simplex; sha256=" in out
+    assert "Code-default vs shipped JSON directions:" in out
+    assert (
+        "model_canonical_v1 (model/snqi_canonical_weights_v1.json): "
+        "different_direction; source_dominant=w_jerk; source_scale=raw" in out
+    )
     assert "Weight provenance conflicts:" in out
     assert "error canonical_direction_conflict (code_default, model_canonical_v1)" in out
     assert "Term normalization status:" in out

--- a/tests/test_snqi_weights_inventory.py
+++ b/tests/test_snqi_weights_inventory.py
@@ -21,6 +21,7 @@ from robot_sf.benchmark.snqi.compute import (
 from robot_sf.benchmark.snqi.weights_inventory import (
     SNQIWeightProvenanceError,
     build_inventory_report,
+    compare_code_default_to_shipped_sources,
     detect_conflicts,
     inventory_weight_sets,
     preflight_snqi_weight_sets,
@@ -186,6 +187,37 @@ def test_duplicate_weights_distinct_label_reported(tmp_path):
     report = build_inventory_report(repo)
     dups = [c for c in report.conflicts if c.kind == "duplicate_weights_distinct_label"]
     assert any(set(c.sources) == {"model_canonical_v1", "camera_ready_v1"} for c in dups)
+
+
+def test_code_default_vs_shipped_direction_matrix(tmp_path):
+    """Every shipped source is compared against the code default."""
+    repo = _make_fixture_repo(tmp_path)
+    report = build_inventory_report(repo)
+
+    comparisons = compare_code_default_to_shipped_sources(report.records)
+    by_source = {comparison.source: comparison for comparison in comparisons}
+
+    assert set(by_source) == {
+        "model_canonical_v1",
+        "camera_ready_v1",
+        "camera_ready_v2",
+        "camera_ready_v3",
+    }
+    assert by_source["model_canonical_v1"].relationship == "different_direction"
+    assert by_source["model_canonical_v1"].source_dominant_term == "w_jerk"
+    assert by_source["camera_ready_v1"].relationship == "different_direction"
+    assert by_source["camera_ready_v2"].relationship == "different_direction"
+    assert by_source["camera_ready_v3"].relationship == "different_direction"
+
+    summary_comparisons = report.to_dict()["source_summary"][
+        "code_default_shipped_direction_comparisons"
+    ]
+    assert [entry["source"] for entry in summary_comparisons] == [
+        "camera_ready_v1",
+        "camera_ready_v2",
+        "camera_ready_v3",
+        "model_canonical_v1",
+    ]
 
 
 def test_no_blocking_conflict_when_canonical_sources_agree(tmp_path):

--- a/tests/test_snqi_weights_inventory.py
+++ b/tests/test_snqi_weights_inventory.py
@@ -20,6 +20,7 @@ from robot_sf.benchmark.snqi.compute import (
 )
 from robot_sf.benchmark.snqi.weights_inventory import (
     SNQIWeightProvenanceError,
+    WeightSetRecord,
     build_inventory_report,
     compare_code_default_to_shipped_sources,
     detect_conflicts,
@@ -218,6 +219,44 @@ def test_code_default_vs_shipped_direction_matrix(tmp_path):
         "camera_ready_v3",
         "model_canonical_v1",
     ]
+
+
+def test_zero_sum_shipped_source_reports_comparison_unavailable_reason():
+    """A loaded-but-zero-sum source is unavailable for comparison, with a reason.
+
+    Guards that comparison availability is kept distinct from source-load state:
+    a source can load successfully yet have no comparable direction (zero-sum
+    weights), and the comparison must not surface an unexplained ``unavailable``.
+    """
+    code_default = WeightSetRecord(
+        name="code_default",
+        kind="code_default",
+        relpath=None,
+        declares_canonical=False,
+        available=True,
+        weights=dict.fromkeys(WEIGHT_NAMES, 1.0),
+        weight_sum=float(len(WEIGHT_NAMES)),
+        dominant_term="w_success",
+        scale_class="raw",
+    )
+    zero_sum = WeightSetRecord(
+        name="camera_ready_zero",
+        kind="shipped_json",
+        relpath="configs/benchmarks/snqi_weights_camera_ready_zero.json",
+        declares_canonical=False,
+        available=True,  # the file loaded fine
+        weights=dict.fromkeys(WEIGHT_NAMES, 0.0),
+        weight_sum=0.0,
+        dominant_term=None,
+        scale_class=None,
+        load_error=None,  # no source-load failure
+    )
+
+    [comparison] = compare_code_default_to_shipped_sources([code_default, zero_sum])
+
+    assert comparison.relationship == "unavailable"
+    assert comparison.available is False
+    assert comparison.load_error == "no_comparable_direction"
 
 
 def test_no_blocking_conflict_when_canonical_sources_agree(tmp_path):


### PR DESCRIPTION
## Summary

Related to https://github.com/ll7/robot_sf_ll7/issues/3723.

This PR adds a bounded diagnostic-only comparison matrix for SNQI weight provenance:

- compares `recompute_snqi_weights("canonical")` / `code_default` against every discovered shipped SNQI weight JSON source;
- reports each shipped source as `same_direction`, `different_direction`, or `unavailable`;
- exposes the matrix in both the structured inventory summary and the human governance preflight output.

It does not choose canonical weights, rename/deprecate any weight files, or change SNQI scoring semantics.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/snqi/weights_inventory.py scripts/validation/check_snqi_governance.py tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi/weights_inventory.py scripts/validation/check_snqi_governance.py tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py tests/benchmark/test_snqi_normalization_inventory.py -q` - passed, 33 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --allow-current-blockers --json` - passed, emits the new code-default vs shipped JSON comparison matrix.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --json` - expected fail-closed exit 2 for current unresolved governance blockers.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=output/validation/pr_ready/issue_3723_pr_body.md scripts/dev/pr_ready_check.sh` - exit 2, blocked at the domain-aware approval gate; Claude Code on `imech156-u` owns full PR gate and improvement cycle after PR open.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No canonical SNQI weight decision.

## Domain-Aware Approval

- Required PR: yes
- Required for PR: yes
- Domains reviewed: benchmark interpretation, evidence classification
- Status: pending
- Approver/review source or waiver: Claude Code on imech156-u owns full PR gate, improvement cycle, and merge authority after PR open.
- Validity checklist:
  - Target claim/hypothesis: issue #3723 remains a diagnostic-only SNQI weight provenance conflict, not a resolved canonical-weight claim.
  - Comparator or split/evidence validity: code-default weights are compared against every discovered shipped JSON weight source by scale-independent direction.
  - Fallback/degraded exclusions: no fallback or degraded benchmark execution is treated as evidence.
  - Claim boundary: inventory/preflight reporting only; no benchmark ranking or paper/dissertation claim is promoted.
  - Implementation integrity vs experimental validity: tests cover reporting and fail-closed behavior; domain validity remains pending reviewer approval.

## Artifact Notes

Generated validation outputs under `output/validation/` are ignored worktree-local artifacts only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new diagnostics section to the SNQI governance report showing how the code-default weight direction compares with each shipped JSON source.
  * Expanded the weights inventory report to include per-source comparison details, including direction match status, dominant term, scale class, and load errors when available.

* **Bug Fixes**
  * Improved human-readable validation output so direction differences are now surfaced more clearly in preflight checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->