### PR TITLE
Issue #3810: enforce long-horizon launch packet retention paths

### DIFF
--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -144,6 +144,30 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         durable_path.startswith("docs/context/evidence/"), "durable path must be context evidence"
     )
+    retention_paths = _require_mapping(durable_evidence, "retention_paths")
+    compact_review_bundle = str(retention_paths.get("compact_review_bundle", ""))
+    external_artifact_pointer = str(retention_paths.get("external_artifact_pointer", ""))
+    private_ops_ledger = str(retention_paths.get("private_ops_ledger", ""))
+    local_output_boundary = str(durable_evidence.get("local_output_boundary", ""))
+    _require(
+        compact_review_bundle == durable_path,
+        "compact review bundle must match durable evidence path",
+    )
+    _require(
+        external_artifact_pointer == "wandb-or-release-artifact-required-before-claim",
+        "external artifact pointer policy missing",
+    )
+    _require(
+        private_ops_ledger.endswith("robot_sf_ll7-private-ops/ops/jobs/jobs.yaml"),
+        "private-ops ledger path missing",
+    )
+    _require(
+        "raw episode JSONL" in local_output_boundary, "local output boundary must mention raw JSONL"
+    )
+    _require(
+        "out of git" in local_output_boundary or "out git" in local_output_boundary,
+        "local output boundary must keep raw outputs out of git",
+    )
 
     _require(
         launch_packet.get("decision") == "blocked_pending_submit_host_route_and_reconciliation",

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -201,6 +201,34 @@ def test_issue_3810_packet_rejects_blank_matrix_path() -> None:
         raise AssertionError("packet should reject a blank scenario matrix path")
 
 
+def test_issue_3810_packet_rejects_missing_retention_paths() -> None:
+    """The packet must keep durable evidence retention paths reviewable."""
+    packet = _load_packet()
+    packet["durable_evidence"].pop("retention_paths")
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "retention_paths must be a mapping" in str(exc)
+    else:
+        raise AssertionError("packet should reject missing retention paths")
+
+
+def test_issue_3810_packet_rejects_untracked_raw_output_policy() -> None:
+    """Raw benchmark outputs must not become the durable evidence plan."""
+    packet = _load_packet()
+    packet["durable_evidence"]["local_output_boundary"] = (
+        "Keep generated outputs as durable benchmark evidence."
+    )
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "local output boundary must mention raw JSONL" in str(exc)
+    else:
+        raise AssertionError("packet should reject weak local output boundary")
+
+
 def test_issue_3810_packet_rejects_missing_campaign_id() -> None:
     """A missing campaign id fails closed instead of escaping as KeyError."""
     packet = _load_packet()


### PR DESCRIPTION
## Summary
Enforces the durable retention portion of the issue #3810 long-horizon Social Navigation Quality Index (SNQI) launch packet validator. This is a launch-packet/checker hardening PR only; it does not run or submit the benchmark campaign.

## Linked Issues
- Relates to `#3810`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none; prior issue #3810 packet PRs are already merged.
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- The issue #3810 packet validator now fails closed if `durable_evidence.retention_paths` is missing or weakened.
- Added regression tests for missing retention paths and raw-output-as-durable-evidence drift.

## Why Matters
- Added value: keeps the launch packet's retention contract executable, not just descriptive.
- Expected impact: prevents raw benchmark output paths from silently becoming the durable evidence plan.
- Why worth merging now: issue #3810 is still state:running and the launch packet is blocked pending submit-host reconciliation.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3810 launch-packet retention readiness, not benchmark results.
- Comparator or baseline, applicable: current packet validator on `origin/main`.
- Evidence tier: launch packet
- Result classification: blocker-resolution
- Decision stop rule, applicable: validator and tests pass while preserving no-submit state.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3810; no claim-map update because no benchmark evidence was produced.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - checker hardening only.

## Domain-Aware Approval
- Required for this PR: yes - evidence-validity-sensitive result classification
- Domains reviewed: evidence classification, figure eligibility
- Status: waived
- Approver/review source or waiver: no benchmark evidence checker-only waiver
- Validity checklist:
  - Target claim/hypothesis: issue #3810 launch-packet retention contract remains fail-closed
  - Comparator or split/evidence validity: no benchmark run performed; comparison boundary remains prior scoped short-horizon versus future comprehensive long-horizon
  - Fallback/degraded exclusions: fallback/degraded evidence remains excluded by existing validator tests
  - Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits
  - Implementation integrity vs experimental validity: tests prove retention gate behavior, not benchmark result validity

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, through focused validator tests.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA - no benchmark run.
- Result route: continue only after submit-host go/no-go packet.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: yes, only after issue #3810 submit-host decision packet is go.
- Extractor analysis tool needed: no for this PR.
- Artifact missing unavailable: full campaign outputs, SNQI recalibration bundle, horizon-sensitivity report, interaction-exposure diagnostics remain future artifacts.
- Stop / revise / continue decision: stop at launch-packet hardening; do not submit compute.
- Proposed child issue existing follow-up: #3813 covers sustained-flow scenario variants.

## Validation / Proof
- `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` passed.
- `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q` passed.
- `uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` passed.
- `uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` passed; output remains ignored/local.
- Read-only private preflight: `ROBOT_SF_PRIVATE_OPS="$HOME/git/robot_sf_ll7-private-ops" "$HOME/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh" --cluster licca --route-id decision-packet-only --public-repo "$PWD" --output output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json` passed as a dry run. It reported `git_state=ok`, `dirty_files=0`, `slurm_test_only=missing_sbatch`, `wandb_online=missing_auth`, `optional_deps=missing: cmake`, and `submitted=false`.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` will be rerun with this PR body before opening.

## Performance
- Baseline runtime: NA, no runtime behavior changed.
- Changed runtime: NA, validation-only checker change.
- Representative command: `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q`
- Hot-path call count profile anchor: NA, no runtime hot path changed.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: validator blocks a valid no-submit packet or permits missing retention paths.

## Risks / Rollout
- Compatibility risks: low; checker becomes stricter about existing issue #3810 packet fields.
- Failure modes: future packet schema relocation would need the checker updated with the schema.
- Rollback fallback plan: revert this single commit to restore previous validator behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3810 and the checked-in launch packet.
- Any assumptions need to preserved: retention paths are part of the fail-closed launch-packet contract.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark evidence.
- Leaderboard / artifact catalog updated (yes/no/NA): NA, no benchmark evidence.
- Registry or config index updated (yes/no/NA): NA, no registry/config index change.
- Context index / memory note updated (yes/no/NA): NA, no new durable evidence.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is launch-packet validator hardening only.

## Follow-Up Issues
- Deferred work: tracked by parent issue #3810; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the validator is intentionally strict about `durable_evidence.retention_paths` and local raw outputs staying out of git.
- Known limitations: private preflight remains route-unverified on this host because `sbatch` and W&B auth are unavailable; no compute was submitted. Full campaign execution remains tracked by parent issue #3810.
