### PR TITLE
Issue #3699: flag SNQI contribution weight exceedance

### DIFF
--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -232,6 +232,11 @@ class TermContribution:
     signed_contribution: float
     absolute_share: float
 
+    @property
+    def exceeds_weight_bound(self) -> bool:
+        """Whether this term contributes more than its nominal weight magnitude."""
+        return abs(self.signed_contribution) > abs(self.weight)
+
     def to_dict(self) -> dict[str, object]:
         """Return JSON-serializable contribution diagnostics."""
         return {
@@ -245,6 +250,7 @@ class TermContribution:
             "weight": self.weight,
             "signed_contribution": self.signed_contribution,
             "absolute_share": self.absolute_share,
+            "exceeds_weight_bound": self.exceeds_weight_bound,
             "bounded": self.term.bounded,
             "measurement_basis": self.term.measurement_basis,
         }
@@ -299,6 +305,11 @@ def build_snqi_contribution_diagnostics(
         for c in contributions
         if c.term.is_penalty and c.term.scaling == SCALING_BASELINE_NORMALIZED
     )
+    weight_bound_exceedances = [
+        contribution.to_dict()
+        for contribution in contributions
+        if contribution.term.is_penalty and contribution.exceeds_weight_bound
+    ]
     return {
         "schema_version": "snqi_normalization_contributions.v1",
         "diagnostic_only": True,
@@ -307,6 +318,8 @@ def build_snqi_contribution_diagnostics(
         "raw_penalty_absolute_share": raw_penalty_share,
         "baseline_normalized_penalty_absolute_share": normalized_penalty_share,
         "raw_penalty_terms_dominate": raw_penalty_share > normalized_penalty_share,
+        "weight_bound_exceedances": weight_bound_exceedances,
+        "has_weight_bound_exceedance": bool(weight_bound_exceedances),
         "terms": [contribution.to_dict() for contribution in contributions],
     }
 

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -202,7 +202,8 @@ def _print_text_report(report: dict[str, Any]) -> None:
         f"raw_penalty_share={contributions['raw_penalty_absolute_share']:.3f}; "
         "baseline_normalized_penalty_share="
         f"{contributions['baseline_normalized_penalty_absolute_share']:.3f}; "
-        f"raw_penalty_terms_dominate={contributions['raw_penalty_terms_dominate']}"
+        f"raw_penalty_terms_dominate={contributions['raw_penalty_terms_dominate']}; "
+        f"has_weight_bound_exceedance={contributions['has_weight_bound_exceedance']}"
     )
 
 

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -42,6 +42,11 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
     assert contributions["diagnostic_only"] is True
     assert contributions["mixed_basis"] is True
     assert contributions["raw_penalty_terms_dominate"] is True
+    assert contributions["has_weight_bound_exceedance"] is True
+    assert {term["term"] for term in contributions["weight_bound_exceedances"]} == {
+        "time",
+        "comfort",
+    }
     assert (
         contributions["raw_penalty_absolute_share"]
         > contributions["baseline_normalized_penalty_absolute_share"]
@@ -96,6 +101,7 @@ def test_governance_text_lists_per_term_normalization_status(
     assert "jerk (jerk_mean, w_jerk): baseline_normalized_bounded" in out
     assert "Contribution diagnostic:" in out
     assert "raw_penalty_terms_dominate=True" in out
+    assert "has_weight_bound_exceedance=True" in out
 
 
 def test_governance_report_checks_optional_baseline_coverage(tmp_path: Path) -> None:

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -206,12 +206,17 @@ def test_contribution_diagnostics_reconstruct_snqi_and_flag_raw_dominance():
     assert diagnostics["raw_penalty_terms_dominate"] is True
     assert diagnostics["raw_penalty_absolute_share"] == pytest.approx(0.5)
     assert diagnostics["baseline_normalized_penalty_absolute_share"] == pytest.approx(0.4)
+    assert diagnostics["has_weight_bound_exceedance"] is True
+    assert {term["term"] for term in diagnostics["weight_bound_exceedances"]} == {"time", "comfort"}
     assert signed_total == pytest.approx(compute_snqi(metrics, weights, baseline_stats))
 
     by_term = {term["term"]: term for term in diagnostics["terms"]}
     assert by_term["time"]["scaled_value"] == pytest.approx(3.0)
+    assert by_term["time"]["exceeds_weight_bound"] is True
     assert by_term["comfort"]["scaled_value"] == pytest.approx(2.0)
+    assert by_term["comfort"]["exceeds_weight_bound"] is True
     assert by_term["collisions"]["scaled_value"] == pytest.approx(1.0)
+    assert by_term["collisions"]["exceeds_weight_bound"] is False
     assert by_term["time"]["normalization_status"] == "raw_unbounded"
     assert by_term["collisions"]["normalization_status"] == "baseline_normalized_bounded"
 


### PR DESCRIPTION
## Summary
Adds diagnostic-only SNQI contribution checker fields that flag when a penalty term's absolute weighted contribution exceeds its nominal weight magnitude. This makes the current raw `time` and `comfort` non-comparability visible without changing `compute_snqi`, weights, normalization defaults, or paper-facing claims.

## Linked Issues
- Relates to `#3699`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `TermContribution.exceeds_weight_bound` and per-term JSON output.
- Added aggregate `has_weight_bound_exceedance` and `weight_bound_exceedances` fields to SNQI contribution diagnostics.
- Surfaced the aggregate flag in `scripts/validation/check_snqi_governance.py` text output.
- Extended focused SNQI normalization/governance tests to prove `time` and `comfort` are flagged while baseline-normalized terms stay within their nominal weight bound on the synthetic fixture.

## Why Matters
- Added value: Reviewers can see the concrete contribution-level symptom behind issue #3699, not just the raw-vs-normalized basis labels.
- Expected impact: Diagnostic/preflight output becomes more actionable while emitted SNQI scores remain byte-for-byte governed by the existing formula.
- Why worth merging now: It is a reversible checker slice that supports the still-open normalization redesign decision without changing benchmark semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3699 mixed-basis SNQI normalization blocker.
- Comparator or baseline, applicable: existing diagnostic-only SNQI contribution report on `origin/main`.
- Evidence tier: NA - support-helper diagnostic checker only; no benchmark result claim.
- Result classification: NA - support helper; no research or benchmark result is promoted.
- Decision stop rule, applicable: checker must identify raw unbounded penalty contributions that exceed nominal weight magnitude without changing score reconstruction.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3699 remains open for normalize-vs-bound decision; no claim map update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - extends existing support diagnostic; no new interpretation tool or benchmark campaign.

## Domain-Aware Approval
- Required for PR: domain-aware approval required because benchmark diagnostic surface changed.
- Required PR: domain-aware approval required because benchmark diagnostic surface changed.
- Domains reviewed: SNQI normalization diagnostics, contribution checker payload, governance preflight text output.
- Status: waived - no benchmark result, paper claim, planner ranking, or canonical SNQI semantics are promoted.
- Approver/review source or waiver: self-review waiver for diagnostic-only additive fields; Claude Code on `imech156-u` owns downstream full PR gate and merge authority.
- Approval or blocker note: waiver because the PR adds diagnostic-only additive fields and promotes no benchmark result, planner ranking, or paper-facing claim.
- Validity checklist:
- Target claim/hypothesis: issue #3699 mixed-basis diagnostic visibility only; no result claim.
- Comparator split/evidence validity: no planner comparator or scenario split is interpreted; validation uses a synthetic mixed-basis SNQI metric row only to prove the checker flags raw unbounded contribution exceedance.
- Comparator or split/evidence validity: no planner comparator or scenario split is interpreted; validation uses a synthetic mixed-basis SNQI metric row only to prove the checker flags raw unbounded contribution exceedance.
- Comparator split evidence validity: no planner comparator or scenario split is interpreted; validation uses a synthetic mixed-basis SNQI metric row only to prove the checker flags raw unbounded contribution exceedance.
- Fallback/degraded exclusions: no planner execution, adapter path, fallback mode, or degraded benchmark run occurs.
- Claim boundary: diagnostic-only SNQI governance output; no score, ranking, or canonical semantics change.
- Implementation integrity vs experimental validity: targeted tests verify JSON/text output and score reconstruction.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - synthetic mixed-basis fixture flags `time` and `comfort`.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes - fixture includes raw time and comfort values greater than 1 with normalized count terms clamped to 1.
- Result route: continue - use as decision support for remaining #3699 normalization redesign.
- Follow-up question issue weak, negative, non-transfer results: #3699 remains the follow-up decision surface.

## Next Empirical Action
- Rerun needed: no for this checker slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with maintainer decision on normalize raw terms versus documented bounded raw-term asymmetry.
- Proposed child issue existing follow-up: #3699.

## Validation / Proof
- `uv run ruff format robot_sf/benchmark/snqi/normalization_inventory.py scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py` -> exit 0; 2 files reformatted, 2 unchanged.
- `python -m py_compile robot_sf/benchmark/snqi/normalization_inventory.py scripts/validation/check_snqi_governance.py` -> exit 0.
- `uv run pytest tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py -q` -> exit 0; 20 passed.
- `uv run ruff check robot_sf/benchmark/snqi/normalization_inventory.py scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py` -> exit 0.
- `git diff --check` -> exit 0.
- `uv run python scripts/validation/check_snqi_governance.py --allow-current-blockers` -> exit 0; reports `has_weight_bound_exceedance=True`.
- `uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers | python -m json.tool >/tmp/snqi_governance_issue3699.json && ...` -> exit 0; reports `True` and `['time', 'comfort']`.

## Performance / Cost Envelope
- Baseline runtime: NA - no runtime performance claim.
- Changed runtime: NA - no runtime performance claim.
- Representative command: `uv run pytest tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py -q`
- Hot-path call count profile anchor: NA - diagnostic preflight path only.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: revert if downstream consumers cannot tolerate the additive diagnostic JSON fields.

## Risks / Rollout
- Compatibility risks: Additive JSON fields only; no existing key semantics changed.
- Failure modes: Downstream strict-schema consumers of contribution diagnostics could reject new fields if they disallow additive keys.
- Rollback fallback plan: Remove the added fields and text output line; tests isolate the behavior.

## Docs / Provenance
- Updated docs: NA - no public semantics change.
- Relevant design provenance notes: issue #3699.
- Any assumptions need to preserved: Assumes additive diagnostic fields are acceptable as the reversible slice; no normalization redesign is chosen here.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - user authorization forbids issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA - #3699 remains open.
- Not applicable because: this PR adds diagnostic-only checker fields and does not change benchmark semantics, paper claims, configs, registry entries, or durable artifacts.

## Follow-Up Issues
- Deferred work: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits; #3699 still needs normalize-vs-bound decision.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that `compute_snqi` output reconstruction remains unchanged and that only diagnostic payload/text fields are added.
- Any known limitations: This does not resolve the mixed normalization basis; it makes contribution-level non-comparability explicit.
