### PR TITLE
Issue #3700: cover TTC near-miss diagnostic fixtures

### DIFF
--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -120,6 +120,44 @@ def test_near_miss_region_only():
     assert np.isclose(values["mean_clearance"], 0.1)
 
 
+def test_ttc_near_miss_counts_fast_approach_beyond_distance_threshold():
+    """Opt-in TTC near-miss flags a fast converging pair before distance threshold crossing."""
+    ep = _make_episode(T=3, K=1)
+    ep.dt = 1.0
+    ep.robot_pos[:, 0] = [0.0, 1.0, 2.0]
+    ep.robot_vel[:, 0] = 1.0
+    ep.peds_pos[:, 0, 0] = [6.0, 5.0, 4.0]
+
+    values = compute_all_metrics(ep, horizon=3, experimental_near_miss_ttc=True)
+
+    assert values["near_misses"] == 0.0
+    assert values["min_clearance"] == pytest.approx(0.6)
+    assert values["near_misses_ttc"] == 1.0
+    assert values["near_misses_ttc_status"] == "ok"
+    assert values["near_miss_ttc__max_closing_speed_mps"] == pytest.approx(2.0)
+    assert values["near_miss_ttc__min_ttc_s"] == pytest.approx(1.0)
+
+
+def test_ttc_near_miss_ignores_slow_drift_at_equal_clearance():
+    """Opt-in TTC near-miss separates slow drift from fast approach at equal clearance."""
+    ep = _make_episode(T=3, K=1)
+    ep.dt = 1.0
+    ep.robot_pos[:, 0] = [0.0, 0.1, 0.2]
+    ep.robot_vel[:, 0] = 0.1
+    ep.peds_pos[:, 0, 0] = 2.2
+
+    baseline = compute_all_metrics(ep, horizon=3)
+    values = compute_all_metrics(ep, horizon=3, experimental_near_miss_ttc=True)
+
+    assert "near_misses_ttc" not in baseline
+    assert values["near_misses"] == baseline["near_misses"] == 0.0
+    assert values["min_clearance"] == baseline["min_clearance"] == pytest.approx(0.6)
+    assert values["near_misses_ttc"] == 0.0
+    assert values["near_misses_ttc_status"] == "ok"
+    assert values["near_miss_ttc__max_closing_speed_mps"] == pytest.approx(0.1)
+    assert values["near_miss_ttc__min_ttc_s"] == pytest.approx(20.0)
+
+
 def test_mixed_collision_and_near_miss():
     # First two timesteps overlap (collision), next two are positive-clearance near-misses.
     """TODO docstring. Document this function."""


### PR DESCRIPTION
## Summary
Adds focused synthetic metric tests for issue #3700's opt-in TTC-aware near-miss diagnostic surface. The fixtures prove `near_misses_ttc` distinguishes fast approach from slow drift at equal clearance while preserving legacy distance-only `near_misses` behavior.

## Linked Issues
- Closes `#3700`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: `NA`

## What Changed
- Added a fast converging robot-pedestrian fixture where `near_misses_ttc` counts a TTC near miss before the distance threshold is crossed.
- Added a slow-drift fixture at the same minimum clearance where `near_misses_ttc` remains zero.
- Asserted the opt-in flag does not emit TTC keys by default and does not change legacy `near_misses`.

## Why Matters
- Added value: Covers the public opt-in metric surface requested by #3700 with controlled synthetic trajectories.
- Expected impact: Maintainers can review TTC near-miss semantics without changing legacy benchmark outputs or SNQI scoring.
- Why worth merging now: The diagnostic implementation is already present on `origin/main`; these tests lock the intended first reversible slice.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Blocks regressions in the diagnostic metric semantics for fast approach versus slow drift at equal clearance.
- Comparator or baseline, applicable: Existing distance-only `near_misses` and default `compute_all_metrics(...)` output without the opt-in flag.
- Evidence tier: NA - test-only fixture coverage, no benchmark evidence claim.
- Result classification: NA - no research result claim.
- Decision stop rule, applicable: Tests pass when `near_misses_ttc` counts only the fast converging fixture and legacy `near_misses` remains unchanged.
- Parent issue, claim map, registry, context note, synthesis surface update: Parent issue #3700.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool; this PR adds fixture coverage for an existing opt-in diagnostic surface.

## Domain-Aware Approval
- Required PR: no - test-only coverage with no research result, benchmark interpretation, or paper-facing claim.
- Domains reviewed: NA - no domain-sensitive result claim.
- Status: not required.
- Approver/review source waiver: NA - PR body classifies the change as test-only fixture coverage; reviewer still owns final approval.
- Validity checklist:
- Target claim/hypothesis: diagnostic metric distinguishes closing-speed/TTC risk in controlled fixtures.
- Comparator or split/evidence validity: synthetic fast-approach and slow-drift fixtures share minimum clearance while differing closing speed/TTC.
- Fallback/degraded exclusions: no fallback or degraded benchmark execution is used.
- Claim boundary: diagnostic-only fixture coverage, not benchmark evidence.
- Implementation integrity vs experimental validity: implementation already existed; this PR adds tests for public metric behavior.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? NA - unit fixture tests only.
- Did scenario actually contain targeted failure mode? yes, controlled equal-clearance fast approach versus slow drift.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: none.

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue with review; defer calibration/SNQI adoption.
- Proposed child issue existing follow-up: none.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_metrics.py -q -k 'ttc_near_miss or near_miss_region_only or mixed_collision_and_near_miss'` - passed, 4 passed / 88 deselected.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_metrics.py -q` - passed, 92 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/test_metrics.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/test_metrics.py` - passed.
- `uv sync --all-extras` - passed after final readiness reported the fresh worktree was missing analytics extras.
- `PR_READY_PR_BODY_FILE=output/pr_body_issue_3700.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; freshness stamp recorded for `c5bfb092e0eec44e6483eccfc8b3bdca4b0e137c`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no SNQI wiring, no threshold calibration.

## Performance Evidence
- Baseline runtime: NA - test-only metric fixture coverage.
- Changed runtime: NA - test-only metric fixture coverage.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_metrics.py -q`
- Hot-path call count profile anchor: NA - no performance claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: Revert if the fixture semantics are judged the wrong public contract for #3700.

## Risks / Rollout
- Compatibility risks: Low; tests only, no runtime behavior change.
- Failure modes: The tests encode the current diagnostic threshold semantics but do not calibrate a safety threshold.
- Rollback fallback plan: Revert this test-only commit.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3700 and maintainer scoping comment on 2026-06-29.
- Any assumptions need to preserved: `near_misses_ttc` remains opt-in diagnostic-only and is not consumed by SNQI in this slice.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: test-only diagnostic coverage; no benchmark result, registry entry, leaderboard, claim map, or paper-facing surface changes.

## Follow-Up Issues
- Deferred work: threshold calibration, SNQI adoption, and full benchmark campaign remain out of scope.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the two fixtures share `min_clearance == 0.6` while only the fast-approach trajectory has `near_misses_ttc == 1.0`.
- Known limitations: diagnostic-only synthetic tests; no claim about real benchmark ranking, threshold calibration, or safety outcome strength.
