### PR TITLE
Issue #3216: add headline CI decision packet

### DIFF
--- a/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+++ b/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
@@ -649,6 +649,77 @@ def classify(
     )
 
 
+def build_decision_packet(
+    cells: Sequence[CellResult],
+    rank_stability: Sequence[ScenarioRankStability],
+    adjacent_rank_claims: Sequence[AdjacentRankClaim],
+) -> dict[str, Any]:
+    """Build a conservative manuscript/S30 decision packet."""
+    counted = [cell for cell in cells if cell.counted]
+    excluded = [cell for cell in cells if not cell.counted]
+    identifiable = [entry for entry in rank_stability if entry.rank_identifiable]
+    unstable_rank_scenarios = [
+        entry.scenario_id
+        for entry in identifiable
+        if entry.top1_stable is False
+        or (entry.rank_flip_rate is not None and entry.rank_flip_rate > 0.0)
+    ]
+    overlap_claims = [
+        claim
+        for claim in adjacent_rank_claims
+        if claim.decision == "not_statistically_distinguishable_budget"
+    ]
+
+    min_seed_count = min((cell.seed_count for cell in counted), default=0)
+    manuscript_blockers: list[str] = []
+    s30_reasons: list[str] = []
+
+    if not counted:
+        manuscript_blockers.append("no_counted_cells")
+        s30_reasons.append("missing_counted_headline_rows")
+    if excluded:
+        manuscript_blockers.append("non_promotable_cells_present")
+        s30_reasons.append("resolve_or_disclose_excluded_cells")
+    if min_seed_count < PAPER_GRADE_MIN_SEEDS:
+        manuscript_blockers.append("missing_increased_seed_budget")
+        s30_reasons.append("minimum_seed_count_below_s20")
+    if not identifiable:
+        manuscript_blockers.append("no_identifiable_rankings")
+        s30_reasons.append("rank_stability_not_identifiable")
+    if overlap_claims:
+        s30_reasons.append("adjacent_rank_ci_overlap_requires_claim_downgrade_or_more_data")
+    if unstable_rank_scenarios:
+        s30_reasons.append("rank_resampling_instability_present")
+
+    if manuscript_blockers:
+        manuscript_table_status = "blocked"
+    else:
+        manuscript_table_status = "ready_for_table_review_no_claim_promotion"
+
+    if min_seed_count < PAPER_GRADE_MIN_SEEDS or unstable_rank_scenarios or overlap_claims:
+        s30_decision_status = "needs_review"
+    elif not counted or excluded or not identifiable:
+        s30_decision_status = "blocked"
+    else:
+        s30_decision_status = "not_required_by_local_preflight"
+
+    return {
+        "manuscript_table_status": manuscript_table_status,
+        "manuscript_blockers": manuscript_blockers,
+        "s30_decision_status": s30_decision_status,
+        "s30_reasons": s30_reasons,
+        "min_seed_count": min_seed_count,
+        "paper_grade_min_seeds": PAPER_GRADE_MIN_SEEDS,
+        "excluded_cell_count": len(excluded),
+        "identifiable_scenario_count": len(identifiable),
+        "unstable_rank_scenarios": unstable_rank_scenarios,
+        "adjacent_overlap_count": len(overlap_claims),
+        "claim_boundary": (
+            "Decision packet is local preflight only; no manuscript or paper claim is promoted."
+        ),
+    }
+
+
 def build_report(
     rows: Sequence[Mapping[str, Any]],
     config: ReportConfig | None = None,
@@ -687,6 +758,7 @@ def build_report(
         rank_metric=rank_metric,
         higher_is_better=higher_is_better,
     )
+    decision_packet = build_decision_packet(cells, rank_stability, adjacent_rank_claims)
     classification, rationale = classify(cells, rank_stability)
     counted = [cell for cell in cells if cell.counted]
     excluded = [cell for cell in cells if not cell.counted]
@@ -728,6 +800,7 @@ def build_report(
         "cells": [cell.to_dict() for cell in cells],
         "rank_stability": [r.to_dict() for r in rank_stability],
         "adjacent_rank_claims": [claim.to_dict() for claim in adjacent_rank_claims],
+        "decision_packet": decision_packet,
         "excluded_cell_reasons": [
             {
                 "scenario_id": cell.scenario_id,
@@ -805,6 +878,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             f"| {claim['lower_rank_planner']} | {claim['rank_metric']} "
             f"| {claim['decision']} | {claim['rationale']} |"
         )
+    _append_decision_packet_markdown(lines, report["decision_packet"])
     if report["excluded_cell_reasons"]:
         lines.append("")
         lines.append("## Excluded cells (fail-closed)")
@@ -818,6 +892,25 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             )
     lines.append("")
     return "\n".join(lines)
+
+
+def _append_decision_packet_markdown(lines: list[str], decision_packet: Mapping[str, Any]) -> None:
+    """Append the manuscript/S30 decision packet markdown section."""
+    lines.append("## Manuscript/S30 decision packet")
+    lines.append("")
+    lines.append(f"- **Manuscript table status**: `{decision_packet['manuscript_table_status']}`")
+    lines.append(f"- **S30 decision status**: `{decision_packet['s30_decision_status']}`")
+    lines.append(f"- **Minimum seed count**: {decision_packet['min_seed_count']}")
+    lines.append(
+        f"- **Adjacent CI-overlap downgrades**: {decision_packet['adjacent_overlap_count']}"
+    )
+    if decision_packet["manuscript_blockers"]:
+        blockers = ", ".join(decision_packet["manuscript_blockers"])
+        lines.append(f"- **Manuscript blockers**: {blockers}")
+    if decision_packet["s30_reasons"]:
+        reasons = ", ".join(decision_packet["s30_reasons"])
+        lines.append(f"- **S30 reasons**: {reasons}")
+    lines.append(f"- **Packet boundary**: {decision_packet['claim_boundary']}")
 
 
 def _dry_run_rows() -> list[dict[str, Any]]:

--- a/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
@@ -282,6 +282,70 @@ def test_adjacent_rank_claims_mark_ci_separable() -> None:
     assert claim["decision"] == "ci_separable"
 
 
+def test_decision_packet_blocks_small_seed_manifest_table_update() -> None:
+    """Small-seed rows are not ready for manuscript table review."""
+
+    rows = [
+        _cell_row("merging", "best", {"snqi": [0.90, 0.91, 0.92, 0.93, 0.94]}),
+        _cell_row("merging", "worst", {"snqi": [0.10, 0.11, 0.09, 0.12, 0.10]}),
+    ]
+
+    packet = _report(rows)["decision_packet"]
+
+    assert packet["manuscript_table_status"] == "blocked"
+    assert packet["s30_decision_status"] == "needs_review"
+    assert "missing_increased_seed_budget" in packet["manuscript_blockers"]
+    assert "minimum_seed_count_below_s20" in packet["s30_reasons"]
+
+
+def test_decision_packet_keeps_s30_review_open_for_adjacent_overlap() -> None:
+    """S20 rows with adjacent CI overlap require claim downgrade or more data review."""
+
+    rows = [
+        _cell_row(
+            "bottleneck",
+            "hybrid_a",
+            {"snqi": [0.50, 0.55, 0.45, 0.52, 0.48] * 4},
+        ),
+        _cell_row(
+            "bottleneck",
+            "hybrid_b",
+            {"snqi": [0.51, 0.46, 0.54, 0.49, 0.53] * 4},
+        ),
+    ]
+
+    packet = _report(rows)["decision_packet"]
+
+    assert packet["manuscript_table_status"] == "ready_for_table_review_no_claim_promotion"
+    assert packet["s30_decision_status"] == "needs_review"
+    assert packet["adjacent_overlap_count"] == 1
+    assert "adjacent_rank_ci_overlap_requires_claim_downgrade_or_more_data" in packet["s30_reasons"]
+
+
+def test_decision_packet_can_clear_s30_by_local_preflight_only() -> None:
+    """S20 separable/stable fixture records no local S30 blocker."""
+
+    rows = [
+        _cell_row(
+            "merging",
+            "best",
+            {"snqi": [0.90, 0.91, 0.92, 0.93, 0.94] * 4},
+        ),
+        _cell_row(
+            "merging",
+            "worst",
+            {"snqi": [0.10, 0.11, 0.09, 0.12, 0.10] * 4},
+        ),
+    ]
+
+    packet = _report(rows)["decision_packet"]
+
+    assert packet["manuscript_table_status"] == "ready_for_table_review_no_claim_promotion"
+    assert packet["s30_decision_status"] == "not_required_by_local_preflight"
+    assert packet["s30_reasons"] == []
+    assert "no manuscript or paper claim is promoted" in packet["claim_boundary"]
+
+
 def test_dry_run_fixture_stays_diagnostic_and_fail_closed() -> None:
     """Built-in dry-run rows exercise CI/rank paths without paper-claim promotion."""
 


### PR DESCRIPTION
## Issue

Fixes/advances #3216: benchmark: paper-grade headline planner comparison (confidence intervals + rank stability at increased seed budget)

## Scope summary

Adds a local no-submit decision packet to the existing issue #3216 headline CI/rank-stability harness:

- emits `decision_packet` in `result.json` with manuscript-table readiness, S30 decision status, seed/exclusion/rank-stability blockers, and adjacent-CI overlap counts;
- renders the same packet in `report.md` for reviewer handoff;
- keeps the packet conservative: it can mark local preflight readiness, but it does not promote manuscript or paper claims;
- adds deterministic fixture tests for small-seed blocking, S20 adjacent-overlap review, and S20 separable/stable local preflight.

Assumption: the smallest useful remaining local slice is a machine-readable decision packet over the existing harness outputs, because prior merged slices already added the dry-run, per-cell CI, rank-stability, and adjacent-rank downgrade mechanics.

## Validation

- `uv run ruff format --check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py` - passed
- `uv run ruff check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py` - passed
- `uv run pytest tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py -q` - passed, 18 tests
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --help` - passed
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --dry-run --bootstrap-samples 0 --rank-resamples 25 --output-dir output/validation/issue3216_decision_packet_dry_run_final` - passed, `classification=diagnostic counted=5 excluded=1`

## Explicit out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Downstream propagation

- Parent issue: #3216 remains open for real manuscript/S30 decision use.
- Claim map / benchmark report / leaderboard: not updated; this PR changes local preflight tooling only.
- Generated artifacts: dry-run output under `output/validation/issue3216_decision_packet_dry_run_final` is ignored local validation output, not committed durable evidence.
