### PR TITLE
Issue #3699: add SNQI normalization contract diagnostic

### DIFF
--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -256,6 +256,60 @@ class TermContribution:
         }
 
 
+def _build_normalization_contract(
+    contributions: list[TermContribution],
+    *,
+    raw_penalty_share: float,
+    normalized_penalty_share: float,
+    weight_bound_exceedances: list[dict[str, object]],
+) -> dict[str, object]:
+    """Summarize whether weighted SNQI penalties are comparable as configured.
+
+    Returns:
+        JSON-serializable diagnostic contract status for this contribution row.
+    """
+    raw_penalties = [
+        c for c in contributions if c.term.is_penalty and c.term.scaling == SCALING_RAW
+    ]
+    normalized_penalties = [
+        c
+        for c in contributions
+        if c.term.is_penalty and c.term.scaling == SCALING_BASELINE_NORMALIZED
+    ]
+    raw_unbounded = [c for c in raw_penalties if not c.term.bounded]
+
+    comparable = not raw_unbounded and bool(normalized_penalties)
+    status = "comparable_weight_basis" if comparable else "mixed_unbounded_penalty_basis"
+
+    reasons: list[str] = []
+    if raw_unbounded:
+        reasons.append(
+            "Raw unbounded penalty terms bypass normalize_metric, so their weights are not "
+            "directly comparable with baseline-normalized penalty weights."
+        )
+    if raw_penalty_share > normalized_penalty_share:
+        reasons.append(
+            "Raw penalty terms contribute a larger absolute share than baseline-normalized "
+            "penalty terms for this diagnostic row."
+        )
+    if weight_bound_exceedances:
+        reasons.append("At least one weighted contribution exceeds its nominal weight magnitude.")
+
+    return {
+        "schema_version": "snqi_normalization_contract.v1",
+        "diagnostic_only": True,
+        "status": status,
+        "weights_comparable": comparable,
+        "raw_unbounded_penalty_terms": [c.term.term for c in raw_unbounded],
+        "baseline_normalized_penalty_terms": [c.term.term for c in normalized_penalties],
+        "raw_penalty_absolute_share": raw_penalty_share,
+        "baseline_normalized_penalty_absolute_share": normalized_penalty_share,
+        "weight_bound_exceedance_terms": [str(entry["term"]) for entry in weight_bound_exceedances],
+        "decision_required_issue": 3699 if not comparable else None,
+        "reasons": reasons,
+    }
+
+
 def build_snqi_contribution_diagnostics(
     metrics: dict[str, float | int | bool],
     weights: dict[str, float],
@@ -310,6 +364,12 @@ def build_snqi_contribution_diagnostics(
         for contribution in contributions
         if contribution.term.is_penalty and contribution.exceeds_weight_bound
     ]
+    normalization_contract = _build_normalization_contract(
+        contributions,
+        raw_penalty_share=raw_penalty_share,
+        normalized_penalty_share=normalized_penalty_share,
+        weight_bound_exceedances=weight_bound_exceedances,
+    )
     return {
         "schema_version": "snqi_normalization_contributions.v1",
         "diagnostic_only": True,
@@ -320,6 +380,7 @@ def build_snqi_contribution_diagnostics(
         "raw_penalty_terms_dominate": raw_penalty_share > normalized_penalty_share,
         "weight_bound_exceedances": weight_bound_exceedances,
         "has_weight_bound_exceedance": bool(weight_bound_exceedances),
+        "normalization_contract": normalization_contract,
         "terms": [contribution.to_dict() for contribution in contributions],
     }
 

--- a/scripts/benchmark/snqi_normalization_inventory_report.py
+++ b/scripts/benchmark/snqi_normalization_inventory_report.py
@@ -165,6 +165,13 @@ def main(argv: Sequence[str] | None = None) -> int:  # noqa: C901
                 f"weight={term['weight']}; signed={term['signed_contribution']}; "
                 f"absolute_share={term['absolute_share']}"
             )
+        contract = contribution_payload["normalization_contract"]
+        print(
+            "Normalization contract: "
+            f"status={contract['status']}; "
+            f"weights_comparable={contract['weights_comparable']}; "
+            f"decision_required_issue={contract['decision_required_issue']}"
+        )
 
     if args.json_out is not None:
         payload = {"claim_boundary": CLAIM_BOUNDARY, "inventory": inventory.to_dict()}

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -47,6 +47,9 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
         "time",
         "comfort",
     }
+    assert contributions["normalization_contract"]["status"] == "mixed_unbounded_penalty_basis"
+    assert contributions["normalization_contract"]["weights_comparable"] is False
+    assert contributions["normalization_contract"]["decision_required_issue"] == 3699
     assert (
         contributions["raw_penalty_absolute_share"]
         > contributions["baseline_normalized_penalty_absolute_share"]

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -210,6 +210,24 @@ def test_contribution_diagnostics_reconstruct_snqi_and_flag_raw_dominance():
     assert {term["term"] for term in diagnostics["weight_bound_exceedances"]} == {"time", "comfort"}
     assert signed_total == pytest.approx(compute_snqi(metrics, weights, baseline_stats))
 
+    contract = diagnostics["normalization_contract"]
+    assert contract["schema_version"] == "snqi_normalization_contract.v1"
+    assert contract["diagnostic_only"] is True
+    assert contract["status"] == "mixed_unbounded_penalty_basis"
+    assert contract["weights_comparable"] is False
+    assert contract["decision_required_issue"] == 3699
+    assert contract["raw_unbounded_penalty_terms"] == ["time", "comfort"]
+    assert contract["baseline_normalized_penalty_terms"] == [
+        "collisions",
+        "near",
+        "force_exceed",
+        "jerk",
+    ]
+    assert contract["raw_penalty_absolute_share"] == pytest.approx(0.5)
+    assert contract["baseline_normalized_penalty_absolute_share"] == pytest.approx(0.4)
+    assert contract["weight_bound_exceedance_terms"] == ["time", "comfort"]
+    assert "bypass normalize_metric" in contract["reasons"][0]
+
     by_term = {term["term"]: term for term in diagnostics["terms"]}
     assert by_term["time"]["scaled_value"] == pytest.approx(3.0)
     assert by_term["time"]["exceeds_weight_bound"] is True
@@ -267,8 +285,10 @@ def test_report_cli_writes_contribution_diagnostics(tmp_path, capsys):
 
     assert exit_code == 0
     assert "Contribution diagnostics:" in captured.out
+    assert "Normalization contract: status=mixed_unbounded_penalty_basis" in captured.out
     assert payload["contributions"]["diagnostic_only"] is True
     assert payload["contributions"]["mixed_basis"] is True
+    assert payload["contributions"]["normalization_contract"]["weights_comparable"] is False
     signed_total = sum(term["signed_contribution"] for term in payload["contributions"]["terms"])
     assert signed_total == pytest.approx(compute_snqi(_METRICS, _WEIGHTS, _BASELINE_STATS))
 


### PR DESCRIPTION
## Summary
- Adds a read-only SNQI normalization contract object to contribution diagnostics.
- Surfaces the current mixed unbounded raw penalty basis as `mixed_unbounded_penalty_basis`, with `weights_comparable=false` and issue #3699 as the residual decision gate.
- Prints the same contract status in the SNQI normalization inventory report CLI and covers it in focused tests.

## Issue
- Refs ll7/robot_sf_ll7#3699 — bounded, reversible diagnostic checker slice only. The parent issue is `decision-required` (normalize-vs-bound the raw `time_to_goal_norm`/`comfort_exposure` terms) and must stay open. This PR intentionally uses no issue-closing keyword; the residual decision remains tracked via `decision_required_issue=3699` in the payload.

## Validation
- `uv run python -m pytest tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py` passed, 20 tests.
- `uv run python -m py_compile robot_sf/benchmark/snqi/normalization_inventory.py scripts/benchmark/snqi_normalization_inventory_report.py scripts/validation/check_snqi_governance.py` passed.
- `uv run ruff check robot_sf/benchmark/snqi/normalization_inventory.py scripts/benchmark/snqi_normalization_inventory_report.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py` passed.
- `uv run ruff format --check robot_sf/benchmark/snqi/normalization_inventory.py scripts/benchmark/snqi_normalization_inventory_report.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py` passed.
- `uv run python scripts/validation/check_snqi_governance.py --repo-root . --json --allow-current-blockers` passed and emitted `normalization_contract.status=mixed_unbounded_penalty_basis`.
- `uv run python scripts/benchmark/snqi_normalization_inventory_report.py --baseline-stats <temp> --metrics <temp> --weights <temp>` passed and printed the normalization contract status.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=/tmp/issue3699_pr_body.md scripts/dev/pr_ready_check.sh` passed.

## Scope / Out of Scope
- Checker/reporting change only; does not change `compute_snqi`, SNQI weights, normalization math, score outputs, ranking semantics, or paper/dissertation claims.
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Residual Risk
- The implementation assumes the most reversible next slice is to expose a machine-readable contribution contract for current rows, not to choose between normalizing raw terms or documenting/clipping asymmetry. That semantic decision remains explicit in the diagnostic payload via `decision_required_issue=3699`.
