### PR TITLE
Issue #3810: gate comprehensive h600 report interpretation

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -281,6 +281,30 @@ launch_packet:
         not terminal/reconciled, if an issue #3810 duplicate exists, if the
         owning worktree is dirty, or if the private submit wrapper lacks
         imech039 support, the decision remains blocked.
+  interpretation_gate:
+    status: blocked_pending_active_run_retention_reconciliation
+    required_before_claim: true
+    required_before_report_publication: true
+    active_run_state: state:running
+    blockers:
+      - active_run_state
+      - retention_paths_missing
+      - route_config_provenance_incomplete
+      - snqi_recalibration_inputs_missing
+      - interaction_exposure_diagnostics_missing
+    required_evidence:
+      - private_ops_route_dry_run
+      - retained_compact_review_bundle
+      - external_artifact_pointer
+      - snqi_recalibration_bundle
+      - horizon_sensitivity_report
+      - interaction_exposure_diagnostics
+    decision_policy: >
+      The comprehensive h600 report remains analysis-blocked while issue #3810
+      is state:running or any retention, route/config provenance, Social
+      Navigation Quality Index recalibration, or interaction-exposure diagnostic
+      evidence is absent. Passing this public packet validator is not permission
+      to interpret, publish, or promote benchmark claims.
   route:
     private_ops_repo: /home/luttkule/git/robot_sf_ll7-private-ops  # allow-abs-path: private-ops routing (machine-local, non-portable)
     queue_summary_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh  # allow-abs-path: private-ops routing (machine-local, non-portable)

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -33,6 +33,21 @@ REQUIRED_EXPOSURE_FIELDS = {
     "first_clearance_step",
     "low_exposure_success",
 }
+REQUIRED_INTERPRETATION_GATE_EVIDENCE = {
+    "private_ops_route_dry_run",
+    "retained_compact_review_bundle",
+    "external_artifact_pointer",
+    "snqi_recalibration_bundle",
+    "horizon_sensitivity_report",
+    "interaction_exposure_diagnostics",
+}
+REQUIRED_INTERPRETATION_GATE_BLOCKERS = {
+    "active_run_state",
+    "retention_paths_missing",
+    "route_config_provenance_incomplete",
+    "snqi_recalibration_inputs_missing",
+    "interaction_exposure_diagnostics_missing",
+}
 
 
 class PacketError(ValueError):
@@ -266,6 +281,41 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "private-ops dry run must gate imech039 support",
     )
 
+    interpretation_gate = _require_mapping(launch_packet, "interpretation_gate")
+    _require(
+        interpretation_gate.get("status") == "blocked_pending_active_run_retention_reconciliation",
+        "interpretation gate must stay blocked pending active-run reconciliation",
+    )
+    _require(
+        interpretation_gate.get("required_before_claim") is True,
+        "interpretation gate must be required before claims",
+    )
+    _require(
+        interpretation_gate.get("required_before_report_publication") is True,
+        "interpretation gate must be required before report publication",
+    )
+    _require(
+        interpretation_gate.get("active_run_state") == "state:running",
+        "interpretation gate must record active run state",
+    )
+    gate_blockers = set(interpretation_gate.get("blockers") or [])
+    _require(
+        REQUIRED_INTERPRETATION_GATE_BLOCKERS <= gate_blockers,
+        "interpretation gate blockers missing",
+    )
+    gate_evidence = set(interpretation_gate.get("required_evidence") or [])
+    _require(
+        REQUIRED_INTERPRETATION_GATE_EVIDENCE <= gate_evidence,
+        "interpretation gate evidence missing",
+    )
+    gate_policy = str(interpretation_gate.get("decision_policy", ""))
+    _require(
+        "state:running" in gate_policy
+        and "not permission" in gate_policy
+        and "promote benchmark claims" in gate_policy,
+        "interpretation gate must block claim promotion",
+    )
+
     route = _require_mapping(launch_packet, "route")
     _require(
         str(route.get("submit_policy")) == "no_submit_until_decision_packet_go",
@@ -333,6 +383,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "live_issue_state": live_issue_state["required_label"],
         "go_no_go": go_no_go["recommendation"],
         "private_ops_dry_run": dry_run["current_public_status"],
+        "interpretation_gate": interpretation_gate["status"],
     }
 
 

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -41,6 +41,7 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["live_issue_state"] == "state:running"
     assert summary["go_no_go"] == "blocked_pending_submit_host_route_and_reconciliation"
     assert summary["private_ops_dry_run"] == "route_unverified"
+    assert summary["interpretation_gate"] == "blocked_pending_active_run_retention_reconciliation"
 
 
 def test_issue_3810_packet_rejects_authorized_submit() -> None:
@@ -119,6 +120,49 @@ def test_issue_3810_packet_rejects_missing_private_ops_dry_run() -> None:
         assert "private_ops_dry_run must be a mapping" in str(exc)
     else:
         raise AssertionError("packet should reject missing private-ops dry run")
+
+
+def test_issue_3810_packet_rejects_unblocked_interpretation_gate() -> None:
+    """The active run must stay analysis-blocking until retention reconciles."""
+    packet = _load_packet()
+    packet["launch_packet"]["interpretation_gate"]["status"] = "ready_for_claims"
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "interpretation gate must stay blocked" in str(exc)
+    else:
+        raise AssertionError("packet should reject an unblocked interpretation gate")
+
+
+def test_issue_3810_packet_rejects_missing_interpretation_evidence() -> None:
+    """Report interpretation requires retained evidence and analysis inputs."""
+    packet = _load_packet()
+    packet["launch_packet"]["interpretation_gate"]["required_evidence"].remove(
+        "external_artifact_pointer"
+    )
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "interpretation gate evidence missing" in str(exc)
+    else:
+        raise AssertionError("packet should reject missing interpretation evidence")
+
+
+def test_issue_3810_packet_rejects_claim_promotion_policy() -> None:
+    """Passing the public packet must not imply benchmark claim promotion."""
+    packet = _load_packet()
+    packet["launch_packet"]["interpretation_gate"]["decision_policy"] = (
+        "Reports may be promoted after the local public packet passes."
+    )
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "interpretation gate must block claim promotion" in str(exc)
+    else:
+        raise AssertionError("packet should reject weak interpretation policy")
 
 
 def test_issue_3810_packet_rejects_missing_go_no_go_status() -> None:


### PR DESCRIPTION
## Summary

- Adds an explicit interpretation gate to the issue #3810 comprehensive h600 launch packet.
- Requires active-run state, retention paths, route/config provenance, Social Navigation Quality Index recalibration inputs, horizon-sensitivity report output, and interaction-exposure diagnostics before h600 outputs can be interpreted or promoted as benchmark evidence.
- Extends the existing issue #3810 packet validator and focused tests so stale or incomplete interpretation state fails closed.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3810

## Validation

- `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` passed.
- `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q` passed, 21 tests.
- `uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` passed.
- `uv run ruff format --check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` passed.
- Read-only private-ops queue summary ran; no Slurm submission was performed. Queue snapshot reported active ledger jobs and the packet remains blocked on submit-host route/reconciliation.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Artifact And Claim Boundary

This PR updates a launch/interpretation packet and validator only. It does not establish comprehensive h600 benchmark results, Social Navigation Quality Index recalibration, horizon sensitivity, or wait-it-out conclusions.
