### PR TITLE
Issue #3653: fail closed invalid SNQI normalization stats

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -304,6 +304,7 @@ def _add_pareto_preflight_issues(
     baseline: Mapping[str, Mapping[str, float]],
     min_planners: int,
 ) -> None:
+    _add_normalization_preflight_issues(state, baseline)
     if len(state.grouped) < min_planners or state.malformed:
         return
     try:
@@ -330,6 +331,43 @@ def _add_pareto_preflight_issues(
             SENSITIVITY_PREFLIGHT_MALFORMED,
             f"could not derive Pareto prerequisites: {exc}",
         )
+
+
+def _add_normalization_preflight_issues(
+    state: _SensitivityPreflightState, baseline: Mapping[str, Mapping[str, float]]
+) -> None:
+    for metric in ("collisions", "near_misses", "force_exceed_events", "jerk_mean"):
+        stats = baseline.get(metric)
+        if not isinstance(stats, Mapping):
+            state.add_issue(
+                "malformed_baseline_stats",
+                SENSITIVITY_PREFLIGHT_MALFORMED,
+                f"baseline metric {metric!r} must provide med/p95 mapping",
+            )
+            continue
+        try:
+            med = float(stats["med"])
+            p95 = float(stats["p95"])
+        except (KeyError, TypeError, ValueError) as exc:
+            state.add_issue(
+                "malformed_baseline_stats",
+                SENSITIVITY_PREFLIGHT_MALFORMED,
+                f"baseline metric {metric!r} must provide finite med/p95 values: {exc}",
+            )
+            continue
+        if not math.isfinite(med) or not math.isfinite(p95):
+            state.add_issue(
+                "non_finite_baseline_stats",
+                SENSITIVITY_PREFLIGHT_MALFORMED,
+                f"baseline metric {metric!r} has non-finite med/p95 values",
+            )
+            continue
+        if p95 <= med:
+            state.add_issue(
+                "degenerate_baseline_range",
+                SENSITIVITY_PREFLIGHT_MALFORMED,
+                f"baseline metric {metric!r} must satisfy p95 > med",
+            )
 
 
 def _format_preflight_report(

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -214,7 +214,37 @@ def test_preflight_malformed_for_non_mapping_baseline_value() -> None:
     )
 
     assert report["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
-    assert any(issue["code"] == "pareto_prerequisite_error" for issue in report["issues"])
+    assert any(issue["code"] == "malformed_baseline_stats" for issue in report["issues"])
+
+
+def test_preflight_malformed_for_degenerate_baseline_range() -> None:
+    """Degenerate normalized baseline stats cannot support sensitivity export."""
+    baseline = _baseline()
+    baseline["collisions"] = {"med": 1.0, "p95": 1.0}
+
+    report = classify_scalarization_sensitivity_inputs(
+        _preflight_episodes(),
+        weights=_weights(),
+        baseline=baseline,
+    )
+
+    assert report["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
+    assert any(issue["code"] == "degenerate_baseline_range" for issue in report["issues"])
+
+
+def test_preflight_malformed_for_non_finite_baseline_stats() -> None:
+    """Non-finite normalized baseline stats fail closed before export."""
+    baseline = _baseline()
+    baseline["near_misses"] = {"med": 0.0, "p95": float("nan")}
+
+    report = classify_scalarization_sensitivity_inputs(
+        _preflight_episodes(),
+        weights=_weights(),
+        baseline=baseline,
+    )
+
+    assert report["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
+    assert any(issue["code"] == "non_finite_baseline_stats" for issue in report["issues"])
 
 
 def test_report_exports_decision_disagreement_and_weight_reversals() -> None:


### PR DESCRIPTION
## Summary
Tightens the Social Navigation Quality Index (SNQI) scalarization-sensitivity preflight so invalid normalization baseline stats fail closed before diagnostic export.

## Linked Issues
- Relates to #3653

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added explicit preflight validation for normalized SNQI baseline stats used by the sensitivity/Pareto diagnostic: each required baseline-normalized metric must provide finite `med`/`p95` values and satisfy `p95 > med`.
- Updated fixture tests so malformed, non-finite, and degenerate baseline stats return explicit fail-closed issue codes instead of reaching later Pareto prerequisite derivation.

## Why Matters
- Added value: prevents decision-reversal diagnostics from exporting over invalid normalized inputs.
- Expected impact: readiness reports now identify malformed normalization provenance directly.
- Why worth merging now: issue #3653 remains evidence-boundary work; this narrows a fixture-level invalid-input gap without changing SNQI scoring semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: SNQI scalarization-sensitivity diagnostics must refuse invalid/missing normalized inputs before export.
- Comparator or baseline, applicable: existing fixture preflight accepted degenerate/non-finite normalization stats until later computation paths.
- Evidence tier: targeted smoke
- Result classification: blocker-resolution
- Decision stop rule, applicable: focused SNQI sensitivity/export tests pass and branch diff stays limited to preflight validation.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3653 remains open for empirical application on a valid campaign surface.
- New research/benchmark/metric/paper-facing analysis tool, any: no new tool; existing diagnostic preflight tightened only.

## Domain-Aware Approval
- Required for this PR: yes - evidence-validity-sensitive result classification
- Domains reviewed: evidence classification, figure eligibility
- Status: waived
- Approver/review source or waiver: maintainer waiver diagnostic-only preflight update
- Validity checklist:
  - Target claim/hypothesis: issue claim boundary stays diagnostic-only
  - Comparator or split/evidence validity: existing targeted smoke proof only
  - Fallback/degraded exclusions: fallback/degraded evidence remains excluded
  - Claim boundary: no paper-facing benchmark claim
  - Implementation integrity vs experimental validity: tests prove gate behavior, not result validity

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, targeted tests exercise malformed, non-finite, and degenerate baseline stats.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? yes, fixture baseline stats are intentionally invalid.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: empirical application remains tracked by #3653 / #3266 validity dependency.

## Next Empirical Action
- Rerun needed: yes, for full empirical closure on a valid campaign surface outside this PR.
- Extractor analysis tool needed: no
- Artifact missing unavailable: valid campaign surface not generated here.
- Stop / revise / continue decision: continue with empirical application after valid inputs are available.
- Proposed child issue existing follow-up: #3653 remains the parent closure surface; #3266 remains the valid-input dependency named by the issue.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py -q` -> passed, 20 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` -> passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed after worktree bootstrap with `uv sync --all-extras`.

## Performance / Runtime
- Baseline runtime: targeted SNQI sensitivity/export tests about 17s on fixture suite.
- Changed runtime: targeted SNQI sensitivity/export tests about 17s on same fixture suite.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py -q`
- Hot-path call count profile anchor: NA, preflight fixture validation only.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: readiness reports fail to reject non-finite or degenerate normalized baseline stats.

## Risks / Rollout
- Compatibility risks: inputs with missing, non-finite, or non-increasing baseline stats now fail preflight instead of being normalized through fallback behavior.
- Failure modes: callers relying on degenerate baseline stats for diagnostic export will need to repair baseline provenance.
- Rollback fallback plan: revert this commit to restore prior permissive preflight behavior.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: issue #3653 live body says tooling/export may be complete but empirical application remains.
- Any assumptions need to preserved: this PR assumes fail-closed normalized-input validation is in scope, while full campaign application is out of scope.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, authorization forbids issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no empirical claim promotion.

## Follow-Up Issues
- Deferred work: consume decision-disagreement export on a valid campaign surface before research-complete closure of #3653.
- Issues opened follow-up: none

## Reviewer Notes
- Verify closely that stricter `p95 > med` preflight behavior is acceptable for issue #3653 diagnostics even though canonical `compute_snqi` retains its fallback denominator behavior.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
