### PR TITLE
Issue #3723: name SNQI weight inventory versions

### DIFF
--- a/robot_sf/benchmark/snqi/weights_inventory.py
+++ b/robot_sf/benchmark/snqi/weights_inventory.py
@@ -77,6 +77,7 @@ class WeightSourceSpec:
     name: str
     kind: str
     relpath: str | None
+    versioned_id: str
     declares_canonical: bool
 
 
@@ -87,30 +88,35 @@ WEIGHT_SOURCES: tuple[WeightSourceSpec, ...] = (
         name="code_default",
         kind="code_default",
         relpath=None,
+        versioned_id="snqi_weights_code_default_v1",
         declares_canonical=True,
     ),
     WeightSourceSpec(
         name="model_canonical_v1",
         kind="shipped_json",
         relpath="model/snqi_canonical_weights_v1.json",
+        versioned_id="snqi_weights_model_canonical_v1",
         declares_canonical=True,
     ),
     WeightSourceSpec(
         name="camera_ready_v1",
         kind="shipped_json",
         relpath="configs/benchmarks/snqi_weights_camera_ready_v1.json",
+        versioned_id="snqi_weights_camera_ready_v1",
         declares_canonical=False,
     ),
     WeightSourceSpec(
         name="camera_ready_v2",
         kind="shipped_json",
         relpath="configs/benchmarks/snqi_weights_camera_ready_v2.json",
+        versioned_id="snqi_weights_camera_ready_v2",
         declares_canonical=False,
     ),
     WeightSourceSpec(
         name="camera_ready_v3",
         kind="shipped_json",
         relpath="configs/benchmarks/snqi_weights_camera_ready_v3.json",
+        versioned_id="snqi_weights_camera_ready_v3",
         declares_canonical=False,
     ),
 )
@@ -151,6 +157,7 @@ def discover_shipped_weight_source_specs(repo_root: Path) -> list[WeightSourceSp
                 name=_source_name_from_relpath(relpath),
                 kind="unregistered_shipped_json",
                 relpath=relpath,
+                versioned_id=_source_name_from_relpath(relpath),
                 declares_canonical="canonical" in relpath.lower(),
             )
 
@@ -164,6 +171,7 @@ class WeightSetRecord:
     name: str
     kind: str
     relpath: str | None
+    versioned_id: str
     declares_canonical: bool
     available: bool
     weights: dict[str, float] = field(default_factory=dict)
@@ -251,9 +259,22 @@ class WeightInventoryReport:
             "unavailable_source_count": len(unavailable_records),
             "blocking_conflict_count": len(blocking_conflicts),
             "registered_sources": [r.name for r in registered_records],
+            "registered_versioned_ids": [r.versioned_id for r in registered_records],
             "discovered_shipped_sources": [r.name for r in shipped_records],
+            "discovered_shipped_versioned_ids": [r.versioned_id for r in shipped_records],
             "unregistered_shipped_sources": [r.name for r in unregistered_records],
             "canonical_declaring_sources": [r.name for r in canonical_records],
+            "canonical_declaring_versioned_ids": [r.versioned_id for r in canonical_records],
+            "canonical_decision": {
+                "status": "unresolved_decision_required",
+                "issue": 3723,
+                "selected_versioned_id": None,
+                "ambiguous_unversioned_label": "canonical",
+                "message": (
+                    "No SNQI weight source is promoted as benchmark-canonical by this "
+                    "diagnostic inventory; reports should name a versioned_id explicitly."
+                ),
+            },
             "unavailable_sources": [r.name for r in unavailable_records],
             "blocking_conflict_kinds": [c.kind for c in blocking_conflicts],
             "code_default_shipped_direction_comparisons": [
@@ -285,6 +306,7 @@ class WeightInventoryReport:
                     "name": r.name,
                     "kind": r.kind,
                     "relpath": r.relpath,
+                    "versioned_id": r.versioned_id,
                     "declares_canonical": r.declares_canonical,
                     "available": r.available,
                     "weights": r.weights,
@@ -377,6 +399,7 @@ def _build_record(spec: WeightSourceSpec, repo_root: Path) -> WeightSetRecord:
         name=spec.name,
         kind=spec.kind,
         relpath=spec.relpath,
+        versioned_id=spec.versioned_id,
         declares_canonical=spec.declares_canonical,
         available=False,
     )

--- a/tests/test_snqi_weights_inventory.py
+++ b/tests/test_snqi_weights_inventory.py
@@ -101,6 +101,7 @@ def test_inventory_discovers_all_registered_sources(tmp_path):
 
     code = next(r for r in records if r.name == "code_default")
     assert code.available
+    assert code.versioned_id == "snqi_weights_code_default_v1"
     assert code.weights == _CODE_DEFAULT
     assert code.dominant_term == "w_collisions"
     assert code.scale_class == "raw"
@@ -219,6 +220,22 @@ def test_code_default_vs_shipped_direction_matrix(tmp_path):
         "camera_ready_v3",
         "model_canonical_v1",
     ]
+    summary = report.to_dict()["source_summary"]
+    assert summary["canonical_decision"] == {
+        "status": "unresolved_decision_required",
+        "issue": 3723,
+        "selected_versioned_id": None,
+        "ambiguous_unversioned_label": "canonical",
+        "message": (
+            "No SNQI weight source is promoted as benchmark-canonical by this "
+            "diagnostic inventory; reports should name a versioned_id explicitly."
+        ),
+    }
+    assert summary["canonical_declaring_versioned_ids"] == [
+        "snqi_weights_code_default_v1",
+        "snqi_weights_model_canonical_v1",
+    ]
+    assert "snqi_weights_camera_ready_v3" in summary["discovered_shipped_versioned_ids"]
 
 
 def test_zero_sum_shipped_source_reports_comparison_unavailable_reason():
@@ -232,6 +249,7 @@ def test_zero_sum_shipped_source_reports_comparison_unavailable_reason():
         name="code_default",
         kind="code_default",
         relpath=None,
+        versioned_id="snqi_weights_code_default_v1",
         declares_canonical=False,
         available=True,
         weights=dict.fromkeys(WEIGHT_NAMES, 1.0),
@@ -243,6 +261,7 @@ def test_zero_sum_shipped_source_reports_comparison_unavailable_reason():
         name="camera_ready_zero",
         kind="shipped_json",
         relpath="configs/benchmarks/snqi_weights_camera_ready_zero.json",
+        versioned_id="snqi_weights_camera_ready_zero",
         declares_canonical=False,
         available=True,  # the file loaded fine
         weights=dict.fromkeys(WEIGHT_NAMES, 0.0),
@@ -342,6 +361,10 @@ def test_unregistered_shipped_weight_file_reported_fail_closed(tmp_path):
     unregistered = [r for r in report.records if r.kind == "unregistered_shipped_json"]
     assert len(unregistered) == 1
     assert unregistered[0].relpath == "configs/benchmarks/snqi_weights_experimental_v9.json"
+    assert (
+        unregistered[0].versioned_id
+        == "unregistered_configs_benchmarks_snqi_weights_experimental_v9"
+    )
     assert unregistered[0].available
     assert (
         unregistered[0].content_sha256


### PR DESCRIPTION
## Summary
Adds explicit `versioned_id` labels and an unresolved canonical-decision packet to the existing fail-closed SNQI weight inventory, so reports can name the actual weight source without promoting an unversioned `canonical` set.

## Linked Issues
- Relates `#3723`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added versioned diagnostic IDs for the code default, model canonical JSON, and camera-ready SNQI weight JSON files.
- Added `source_summary.canonical_decision` with `status=unresolved_decision_required` and `selected_versioned_id=null`.
- Extended focused SNQI inventory tests to prove the versioned IDs, decision packet, fail-closed conflict reporting, and unregistered-source IDs.

## Why Matters
- Added value: removes another ambiguous reporting surface while preserving the maintainer decision gate for #3723.
- Expected impact: diagnostic/preflight output becomes easier to consume in follow-up decision packets and benchmark reports.
- Why worth merging now: the live issue says diagnostics are not product-complete unless the canonical naming/source decision is recorded or explicitly deferred; this records the deferral in machine-readable output.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3723 SNQI weight-source provenance ambiguity.
- Comparator or baseline, applicable: current `origin/main` inventory output.
- Evidence tier: NA - diagnostic metadata only, no benchmark evidence claimed
- Result classification: NA - diagnostic metadata only
- Decision stop rule, applicable: strict governance remains fail-closed while inspection output names every source with versioned IDs and does not select canonical weights.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue remains open for maintainer canonical-weight decision.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - existing checker output only.

## Domain-Aware Approval

Required: yes, domain-aware waiver required for diagnostic-only SNQI governance wording.
Required PR: required for diagnostic-only SNQI governance wording.
Domains reviewed: SNQI weight provenance, benchmark governance diagnostics.
Status: waived metadata-only diagnostic slice.
Approver/review source waiver: maintainer-scoped issue #3723 authorizes diagnostic inventory without choosing canonical weights; Claude Code on `imech156-u` owns full PR gate after open.
Approval or blocker note: waived because this PR only adds diagnostic metadata and leaves benchmark semantics unchanged.
Target claim/hypothesis: #3723 provenance ambiguity remains unresolved and explicit.
Comparator or split/evidence validity: no planner/result comparison is made; validity evidence is limited to current `origin/main` fail-closed governance output and focused fixture tests.
Fallback/degraded exclusions: no fallback or degraded benchmark execution.
Claim boundary: no canonical weight source selected, no SNQI metric semantics changed.
Implementation integrity vs experimental validity: tests cover report shape and unchanged scoring guard already present.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, JSON report now includes `versioned_id` and `canonical_decision`.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, current repo still has `canonical_direction_conflict`.
- Result route: continue; maintainer decision still required.
- Follow-up question issue weak, negative, non-transfer results: #3723 remains the decision surface.

## Next Empirical Action
- Rerun needed: no full benchmark campaign run for this diagnostic-only slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue to maintainer canonical-source decision.
- Proposed child issue existing follow-up: #3723.

## Validation / Proof
- `uv run pytest tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py -q` -> 18 passed.
- `uv run ruff check robot_sf/benchmark/snqi/weights_inventory.py tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py` -> passed.
- `uv run python scripts/validation/check_snqi_governance.py --json` -> exit 2, still fail-closed on current blockers.
- `uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers` -> exit 0, emits versioned IDs and unresolved canonical decision.
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> passed on dirty pre-commit tree: 1679 passed, 2 skipped.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/pr-3723-snqi-weight-inventory.md BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> passed on clean merged head `daef4062f`; freshness check passed for clean tree.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Runtime / Performance
- Baseline runtime: NA, metadata-only diagnostic output change.
- Changed runtime: NA, metadata-only diagnostic output change.
- Representative command: `uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers`.
- Hot-path call count profile anchor: NA, no benchmark hot path changed.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if downstream consumers require the prior report schema without `versioned_id` fields.

## Risks / Rollout
- Compatibility risks: low; JSON report adds fields but does not remove existing fields or change scoring.
- Failure modes: downstream strict schema consumers may need to tolerate additive fields.
- Rollback fallback plan: revert the additive report fields and tests.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3723 live body and comments.
- Any assumptions need to preserved: the PR assumes explicit versioned diagnostic IDs are reversible metadata, not a canonical-weight decision.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, per user authorization `comment_issue_or_pr: false`.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no; existing follow-up is #3723.
- Not applicable because: this is diagnostic inventory metadata; #3723 remains open for the maintainer canonical-source decision.

## Follow-Up Issues
- Deferred work: #3723 maintainer canonical-weight decision and any resulting rename/deprecation of `model/snqi_canonical_weights_v1.json`.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that `recompute_snqi_weights("canonical")`, shipped JSON values, and `compute_snqi` semantics are unchanged.
- Known limitations: this PR does not resolve which SNQI weight source is canonical.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stable version identifiers to SNQI weight inventory records and reports.
  * Inventory summaries now include clearer provenance details, including discovered and registered versioned IDs and canonical-selection diagnostics.

* **Bug Fixes**
  * Improved reporting for unregistered shipped weight files by assigning deterministic version identifiers.
  * Structured output now includes versioned IDs for each record, making downstream tracking more consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->