### PR TITLE
Issue #3810: fail-close h600 SNQI launch packet

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -214,18 +214,21 @@ validation:
   dry_run: required
 
 launch_packet:
-  decision: ready_after_live_queue_and_duplicate_check
+  decision: blocked_pending_submit_host_route_and_reconciliation
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  blocking_jobs: []
+  target_host: imech039
+  blocking_jobs:
+    - 13175
   ledger_reconciliation:
     checked_date: "2026-06-29"
-    source: private_ops_jobs_and_queue_read_only
-    job_13175_state: analyzed
+    source: private_ops_jobs_and_queue_read_only_needs_submit_host_refresh
+    job_13175_state: requires_submit_host_refresh
     job_13175_campaign: 2026-06-issue1554-s20-h500-l40s-mem180
     job_13175_relevance: >
-      Completed and analyzed #1554 lane; not a #3810 blocker after read-only
-      private-ops reconciliation.
+      Older #1554 lane that must be rechecked from the Slurm-capable submit host
+      before any #3810 submission. A stale public packet must not treat it as
+      reconciled without fresh private-ops evidence.
     running_related_jobs:
       - job_id: 13198
         state: running
@@ -234,9 +237,9 @@ launch_packet:
           Separate #1554 evidence-yield lane, not a #3810 duplicate. A
           Slurm-capable submit host must still refresh live queue pressure
           before any #3810 submission.
-    issue_3810_duplicate_status: none_found
+    issue_3810_duplicate_status: requires_submit_host_refresh
   go_no_go:
-    recommendation: go_after_submit_host_live_checks
+    recommendation: blocked_pending_submit_host_route_and_reconciliation
     local_submission_status: no_submit_current_machine
     exact_local_decision_command: >-
       uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -244,9 +247,29 @@ launch_packet:
       --json
     slurm_command_status: >
       Not safe to freeze in this public packet without live submit-host queue
-      pressure, duplicate check, clean-worktree proof, and private route
-      selection. Use the private submit wrapper named below only after those
-      checks return go.
+      pressure, duplicate check, clean-worktree proof, job 13175 reconciliation,
+      target-host route support, and private route selection. Do not use the
+      private submit wrapper named below until those checks return go.
+    private_ops_dry_run:
+      required_before_submit: true
+      target_host: imech039
+      evidence_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
+      current_public_status: route_unverified
+      required_fields:
+        - target_host
+        - queue_summary_timestamp
+        - duplicate_status
+        - job_13175_state
+        - route_id
+        - submit_wrapper_supports_target_host
+        - owning_worktree
+        - owning_worktree_clean
+        - decision
+      decision_policy: >
+        The dry run must record decision=go before submission. If job 13175 is
+        not terminal/reconciled, if an issue #3810 duplicate exists, if the
+        owning worktree is dirty, or if the private submit wrapper lacks
+        imech039 support, the decision remains blocked.
   route:
     private_ops_repo: /home/luttkule/git/robot_sf_ll7-private-ops  # allow-abs-path: private-ops routing (machine-local, non-portable)
     queue_summary_command: /home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh  # allow-abs-path: private-ops routing (machine-local, non-portable)

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -146,8 +146,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
 
     _require(
-        launch_packet.get("decision") == "ready_after_live_queue_and_duplicate_check",
-        "decision must require live queue and duplicate checks",
+        launch_packet.get("decision") == "blocked_pending_submit_host_route_and_reconciliation",
+        "decision must stay blocked pending submit-host route and reconciliation",
     )
     _require(
         launch_packet.get("compute_submit_authorized") is False, "compute submit must be false"
@@ -155,18 +155,19 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
     )
+    _require(launch_packet.get("target_host") == "imech039", "target host must be imech039")
     blocking_jobs = launch_packet.get("blocking_jobs")
     _require(isinstance(blocking_jobs, list), "blocking_jobs must be a list")
-    _require(13175 not in blocking_jobs, "analyzed job 13175 must not remain blocking")
+    _require(13175 in blocking_jobs, "job 13175 must block submit until reconciled")
 
     ledger = _require_mapping(launch_packet, "ledger_reconciliation")
     _require(
-        ledger.get("job_13175_state") == "analyzed",
-        "job 13175 reconciliation must be analyzed",
+        ledger.get("job_13175_state") == "requires_submit_host_refresh",
+        "job 13175 reconciliation must require submit-host refresh",
     )
     _require(
-        ledger.get("issue_3810_duplicate_status") == "none_found",
-        "issue #3810 duplicate status must be none_found",
+        ledger.get("issue_3810_duplicate_status") == "requires_submit_host_refresh",
+        "issue #3810 duplicate status must require submit-host refresh",
     )
     running_related_jobs = ledger.get("running_related_jobs")
     _require(
@@ -176,8 +177,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
 
     go_no_go = _require_mapping(launch_packet, "go_no_go")
     _require(
-        go_no_go.get("recommendation") == "go_after_submit_host_live_checks",
-        "go/no-go recommendation must require submit-host live checks",
+        go_no_go.get("recommendation") == "blocked_pending_submit_host_route_and_reconciliation",
+        "go/no-go recommendation must remain blocked",
     )
     _require(
         go_no_go.get("local_submission_status") == "no_submit_current_machine",
@@ -193,6 +194,37 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         "Not safe to freeze" in (str(slurm_status) if slurm_status is not None else ""),
         "slurm command status must explain why final submit command is not frozen",
+    )
+    _require(
+        "job 13175" in (str(slurm_status) if slurm_status is not None else ""),
+        "go/no-go must mention job 13175 reconciliation",
+    )
+    dry_run = _require_mapping(go_no_go, "private_ops_dry_run")
+    _require(dry_run.get("required_before_submit") is True, "private-ops dry run required")
+    _require(dry_run.get("target_host") == "imech039", "private-ops dry run host mismatch")
+    _require(
+        dry_run.get("current_public_status") == "route_unverified",
+        "private-ops dry run must be route_unverified in public packet",
+    )
+    dry_run_fields = set(dry_run.get("required_fields") or [])
+    _require(
+        {
+            "target_host",
+            "queue_summary_timestamp",
+            "duplicate_status",
+            "job_13175_state",
+            "route_id",
+            "submit_wrapper_supports_target_host",
+            "owning_worktree",
+            "owning_worktree_clean",
+            "decision",
+        }
+        <= dry_run_fields,
+        "private-ops dry run fields missing",
+    )
+    _require(
+        "imech039 support" in str(dry_run.get("decision_policy", "")),
+        "private-ops dry run must gate imech039 support",
     )
 
     route = _require_mapping(launch_packet, "route")
@@ -255,10 +287,12 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "planner_count": len(planner_rows),
         "compute_submit_authorized": launch_packet["compute_submit_authorized"],
         "slurm_job_id": launch_packet["slurm_job_id"],
+        "target_host": launch_packet["target_host"],
         "blocking_jobs": blocking_jobs,
         "job_13175_state": ledger["job_13175_state"],
         "issue_3810_duplicate_status": ledger["issue_3810_duplicate_status"],
         "go_no_go": go_no_go["recommendation"],
+        "private_ops_dry_run": dry_run["current_public_status"],
     }
 
 

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -34,10 +34,12 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert summary["blocking_jobs"] == []
-    assert summary["job_13175_state"] == "analyzed"
-    assert summary["issue_3810_duplicate_status"] == "none_found"
-    assert summary["go_no_go"] == "go_after_submit_host_live_checks"
+    assert summary["target_host"] == "imech039"
+    assert summary["blocking_jobs"] == [13175]
+    assert summary["job_13175_state"] == "requires_submit_host_refresh"
+    assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
+    assert summary["go_no_go"] == "blocked_pending_submit_host_route_and_reconciliation"
+    assert summary["private_ops_dry_run"] == "route_unverified"
 
 
 def test_issue_3810_packet_rejects_authorized_submit() -> None:
@@ -53,17 +55,43 @@ def test_issue_3810_packet_rejects_authorized_submit() -> None:
         raise AssertionError("packet should reject compute submission authorization")
 
 
-def test_issue_3810_packet_rejects_stale_analyzed_job_blocker() -> None:
-    """A reconciled analyzed job must not stay as a submission blocker."""
+def test_issue_3810_packet_rejects_missing_job_13175_blocker() -> None:
+    """Job 13175 stays a blocker until submit-host reconciliation is recorded."""
     packet = _load_packet()
-    packet["launch_packet"]["blocking_jobs"] = [13175]
+    packet["launch_packet"]["blocking_jobs"] = []
 
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "13175" in str(exc)
+        assert "job 13175 must block submit" in str(exc)
     else:
-        raise AssertionError("packet should reject stale job 13175 blocker")
+        raise AssertionError("packet should reject missing job 13175 blocker")
+
+
+def test_issue_3810_packet_rejects_stale_job_13175_reconciliation() -> None:
+    """Stale analyzed state cannot unlock the public launch packet."""
+    packet = _load_packet()
+    packet["launch_packet"]["ledger_reconciliation"]["job_13175_state"] = "analyzed"
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "job 13175 reconciliation must require submit-host refresh" in str(exc)
+    else:
+        raise AssertionError("packet should reject stale job 13175 reconciliation")
+
+
+def test_issue_3810_packet_rejects_missing_private_ops_dry_run() -> None:
+    """The packet must name the submit-host dry-run evidence contract."""
+    packet = _load_packet()
+    packet["launch_packet"]["go_no_go"].pop("private_ops_dry_run")
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "private_ops_dry_run must be a mapping" in str(exc)
+    else:
+        raise AssertionError("packet should reject missing private-ops dry run")
 
 
 def test_issue_3810_packet_rejects_missing_go_no_go_status() -> None:


### PR DESCRIPTION
## Summary
Fail-close the issue #3810 h600 Social Navigation Quality Index (SNQI) launch packet until the Slurm-capable submit host refreshes route support, duplicate status, clean-worktree state, and job 13175 reconciliation.

## Linked Issues
- Relates to `#3810`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: `NA`

## What Changed
- Changed `configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml` from a stale "ready after live checks" state to `blocked_pending_submit_host_route_and_reconciliation` for target host `imech039`.
- Added a required private-ops dry-run evidence contract with fields for queue timestamp, duplicate status, job 13175 state, route id, submit-wrapper host support, owning worktree, cleanliness, and final decision.
- Updated the packet checker and tests so job 13175 and submit-host route verification remain fail-closed until fresh evidence exists.

## Why Matters
- Added value: prevents a stale public packet from being treated as Slurm-ready while issue #3810 is still in active-run / retention-reconciliation state.
- Expected impact: Claude or the submit-host owner gets an explicit go/no-go contract before any h600 campaign launch.
- Why worth merging now: the issue currently says active run state and private-ops retention paths must reconcile before interpretation.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker only; guards the #3810 comprehensive h600 launch packet from premature submission.
- Comparator or baseline, applicable: previous packet state on `origin/main` allowed `ready_after_live_queue_and_duplicate_check`.
- Evidence tier: launch packet
- Result classification: blocker-resolution
- Decision stop rule, applicable: submission remains blocked until the private-ops dry run records `decision=go`.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3810.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker for a no-submit launch packet.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: blocked for campaign submission; no benchmark interpretation claim is made.
- Approver/review source waiver: maintainer issue direction permits a reversible decision-packet implementation; Claude on `imech156-u` owns full PR gate after opening.
- Validity checklist: packet explicitly states launch-packet-only and no benchmark evidence.
- Target claim/hypothesis: NA - no research result claim.
- Comparator split/evidence validity: prior scoped h100 versus comprehensive h600 remains labeled multi-factor, not horizon-only.
- Fallback/degraded exclusions: packet checker preserves fail-closed row status treatment.
- Claim boundary: no Slurm submission, no SNQI recalibration result, no paper/dissertation claim edit.
- Implementation integrity vs experimental validity: this PR only strengthens launch gating.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, checker now rejects missing job 13175 blocking state and missing private-ops dry-run contract.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? issue-level submit readiness failure mode, not scenario execution.
- Result route: continue only after submit-host dry-run evidence.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: yes, on the Slurm-capable submit host only.
- Extractor analysis tool needed: no for this PR.
- Artifact missing unavailable: private-ops route dry-run JSON and any full h600 campaign outputs.
- Stop / revise / continue decision: stop before submission until dry run reports `decision=go`.
- Proposed child issue existing follow-up: #3810 remains the owning issue.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --json` exited 0.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q` exited 0.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` exited 0.
- `git diff --check origin/main...HEAD` exited 0.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` exited 0.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` exited 0 with `fresh: true`.

## Benchmark Analysis Quality
- Baseline runtime: NA - no runtime performance claim.
- Changed runtime: NA - no runtime performance claim.
- Representative command: `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --json`
- Hot-path call count profile anchor: NA - no hot-path change.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if submit-host dry-run evidence should be optional or job 13175 is no longer a blocker in the private ledger.

## Risks / Rollout
- Compatibility risks: stricter checker will fail older packet states until private-ops reconciliation is recorded.
- Failure modes: target host support may exist privately but remains unverified from this public worktree.
- Rollback fallback plan: restore the previous go/no-go values after durable submit-host evidence is available.

## Docs / Provenance
- Updated docs: no standalone docs; public YAML packet is the reviewable launch/retention contract.
- Relevant design provenance notes: issue #3810 live body and comments.
- Any assumptions need to preserved: target host is `imech039`; job 13175 remains a blocker until submit-host reconciliation proves otherwise.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments are not authorized in this run.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a fail-closed launch packet/checker change only; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Follow-Up Issues
- Deferred work: run the private-ops dry run on `imech039`, reconcile job 13175, then launch only if the packet decision becomes go.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer verify closely: whether `blocking_jobs: [13175]` still matches the private-ops ledger at review time.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
