### PR TITLE
Issue #3216: refresh headline packet config hash

### DIFF
--- a/configs/benchmarks/headline_ci_rank_stability_issue_3216_launch_packet.yaml
+++ b/configs/benchmarks/headline_ci_rank_stability_issue_3216_launch_packet.yaml
@@ -43,7 +43,7 @@ claim_gate:
 # detection. Re-verify with: sha256sum <path>.
 runnable_config:
   config: configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml
-  config_sha256: 3bf75ebb05cc5523c33271e956b21b14749fc427fc9d986438c83d09eee8b75c
+  config_sha256: 249968670830c3b710e1407aecb2256d140cd1ba76294766421447bd89357f15
   scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
   scenario_matrix_sha256: d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5
   horizon_schedule: configs/policy_search/scenario_horizons_h500.yaml

--- a/scripts/benchmark/run_issue3216_headline_campaign.sh
+++ b/scripts/benchmark/run_issue3216_headline_campaign.sh
@@ -63,7 +63,7 @@ check_sha() {
     echo "  DRIFT    $path"; echo "    expected $expected"; echo "    actual   $actual"; drift=1
   fi
 }
-check_sha "configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml" "3bf75ebb05cc5523c33271e956b21b14749fc427fc9d986438c83d09eee8b75c"
+check_sha "configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml" "249968670830c3b710e1407aecb2256d140cd1ba76294766421447bd89357f15"
 check_sha "configs/scenarios/classic_interactions_francis2023.yaml"                       "d9e148e4b544b4c7e2b6ba98e599aef47046d114e0e25645f021946674cb9dc5"
 check_sha "configs/policy_search/scenario_horizons_h500.yaml"                             "4da9f6eb78c98d1afdf9ac43fde1cbfcac9447edb8491520e8c51d85d3b14fce"
 check_sha "configs/benchmarks/seed_sets_v1.yaml"                                          "3aaab9171517b8d33bafc679d4a2c740864db0f96650e24d75c4c7e927d239e6"


### PR DESCRIPTION
## Summary

Refreshes the #3216 headline CI/rank-stability launch packet checksum for the current `configs/benchmarks/paper_experiment_matrix_v1_scenario_horizons_h500_s20.yaml` content.

## Validation

- `bash -n scripts/benchmark/run_issue3216_headline_campaign.sh`
- `bash scripts/benchmark/run_issue3216_headline_campaign.sh --campaign-id issue3216_preflight_probe_20260630 --output-root output/issue3216-preflight-probe-20260630` reached the actual S20 campaign after passing checksum, seed-budget, and ORCA/RVO2 preflight; interrupted intentionally to avoid running the campaign locally.

## Claim Boundary

No benchmark result or ranking claim is promoted. This only unblocks the existing Slurm-gated #3216 payload from failing closed on stale launch-packet drift.
