### PR TITLE
Issue #3723: print SNQI weight version IDs in preflight

### DIFF
--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -170,6 +170,7 @@ def _print_text_report(report: dict[str, Any]) -> None:
         print(
             f"  - {record['name']} ({record['kind']}, {relpath}): "
             f"canonical={record['declares_canonical']}; "
+            f"versioned_id={record['versioned_id']}; "
             f"dominant={record['dominant_term']}; scale={record['scale_class']}; "
             f"sha256={fingerprint}; {status}"
         )

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -86,10 +86,13 @@ def test_governance_text_lists_per_term_normalization_status(
     out = capsys.readouterr().out
     assert "Weight sources:" in out
     assert "code_default (code_default, <code default>): canonical=True" in out
+    assert "versioned_id=snqi_weights_code_default_v1" in out
     assert "model_canonical_v1 (shipped_json, model/snqi_canonical_weights_v1.json)" in out
+    assert "versioned_id=snqi_weights_model_canonical_v1" in out
     assert (
         "camera_ready_v3 (shipped_json, configs/benchmarks/snqi_weights_camera_ready_v3.json)"
     ) in out
+    assert "versioned_id=snqi_weights_camera_ready_v3" in out
     assert "dominant=w_collisions; scale=raw; sha256=" in out
     assert "dominant=w_near; scale=normalized_simplex; sha256=" in out
     assert "Code-default vs shipped JSON directions:" in out


### PR DESCRIPTION
## Summary
Print explicit SNQI weight `versioned_id` values in the human SNQI governance preflight output, matching the structured JSON inventory added for #3723.

This is diagnostic-only: it keeps the current fail-closed provenance conflict visible and does not select canonical weights or change scoring.

## Linked Issues
- Relates to `#3723`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `versioned_id=...` to each weight-source line in `scripts/validation/check_snqi_governance.py` text output.
- Extended the focused governance preflight test to assert the code-default, model-canonical, and camera-ready version IDs appear in the human report.

## Why Matters
- Added value: closes a small remaining report-surface gap where the JSON report named versioned SNQI weight IDs but the human preflight text did not.
- Expected impact: reviewers and downstream users can see the exact diagnostic weight version labels without parsing JSON.
- Why worth merging now: #3723 remains decision-required; this keeps reporting explicit while preserving the maintainer decision gate.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3723 SNQI weight-source provenance ambiguity.
- Comparator or baseline, applicable: current `origin/main` governance text output.
- Evidence tier: NA - diagnostic text-output support only, no benchmark evidence claim.
- Result classification: NA - no research result or benchmark interpretation.
- Decision stop rule, applicable: stop at reporting explicit version IDs; do not choose a canonical weight set.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3723 remains open for maintainer canonical-source decision.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool.

## Domain-Aware Approval
- Required PR: benchmark diagnostic change for #3723 SNQI provenance blocker.
- Domains reviewed: SNQI weight provenance diagnostics; governance preflight text output.
- Status: waived.
- Approver/review source waiver: maintainer-scoped issue #3723 authorizes bounded diagnostic inventory/preflight work without choosing canonical weights; this PR only prints already-computed version IDs in text output.
- Approval or blocker note: waived for implementation integrity only; #3723 remains blocked on maintainer canonical-source decision.
- Validity checklist: no scoring, ranking, normalization, or benchmark semantics changed.
- Target claim/hypothesis: #3723 provenance ambiguity remains unresolved and visible.
- Comparator or split/evidence validity: focused tests compare report output shape only; planner comparator and experimental split interpretation are out of scope.
- Fallback/degraded exclusions: no fallback or degraded benchmark execution.
- Claim boundary: diagnostic reporting only.
- Implementation integrity vs experimental validity: tests cover text output; no experimental validity claim is made.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, text output now includes `versioned_id=` fields.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, existing fail-closed SNQI provenance conflict remains present.
- Result route: continue maintainer canonical-weight decision.
- Follow-up question issue weak, negative, non-transfer results: #3723 remains the decision-required surface.

## Next Empirical Action
- Rerun needed: no full benchmark campaign run.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue #3723 maintainer canonical-source decision.
- Proposed child issue existing follow-up: #3723.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_governance_preflight.py tests/test_snqi_weights_inventory.py -q` -> 18 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_governance_preflight.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers` -> exit 0; report still fails closed internally with #3723 `weight_provenance_conflict` and #3699 `mixed_normalization_basis` blockers under inspection mode.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/robot_sf_ll7_pr_3723_body.md scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh` -> passed; freshness stamp `output/validation/pr_ready/issue-3723-snqi-weight-preflight-codex5.json` at `5864def2cc866ef1429d16e3fd77f437f8404c18`.
- Baseline runtime: NA, no runtime performance claim.
- Changed runtime: NA, no runtime performance claim.
- Representative command: `uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers`.
- Hot-path call count profile anchor: NA, no hot-path or caching claim.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if text consumers require the prior compact weight-source line without version IDs.

## Risks / Rollout
- Compatibility risks: low; human text output gains one additive field per weight source.
- Failure modes: brittle text-output consumers may need to accept the additional token.
- Rollback fallback plan: remove the additive `versioned_id` field from text output and its assertions.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3723 live body/comments and existing SNQI governance preflight.
- Any assumptions need to preserved: explicit version IDs are reversible diagnostic metadata, not a canonical-weight decision.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, user authorization forbids issue/PR comments from this agent.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is diagnostic preflight text output only; no benchmark, registry, claim-map, leaderboard, or paper-facing claim changes.

## Follow-Up Issues
- Deferred work: #3723 maintainer decision on canonical SNQI weight source and any resulting deprecation/rename.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that `compute_snqi`, `recompute_snqi_weights`, shipped JSON files, and fail-closed conflict logic are unchanged.
- Known limitations: no canonical weight source selected; no full benchmark campaign run; no Slurm/GPU submission; no paper/dissertation claim edits.
