### PR TITLE
Issue #3699: add SNQI mixed-basis fixture checker

### DIFF
--- a/scripts/validation/check_snqi_normalization_inventory.py
+++ b/scripts/validation/check_snqi_normalization_inventory.py
@@ -24,6 +24,7 @@ from robot_sf.benchmark.snqi.exit_codes import (
     EXIT_VALIDATION_ERROR,
 )
 from robot_sf.benchmark.snqi.normalization_inventory import (
+    build_snqi_contribution_diagnostics,
     build_snqi_normalization_inventory,
 )
 
@@ -49,10 +50,31 @@ def _load_baseline_stats(path: Path | None) -> dict[str, dict[str, float]] | Non
     return raw
 
 
+def _load_json_object(path: Path | None, *, label: str) -> dict[str, Any] | None:
+    """Load an optional JSON object for synthetic contribution diagnostics."""
+    if path is None:
+        return None
+    if not path.is_file():
+        raise ValueError(f"{label} file not found: {path}")
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"could not load {label} JSON {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise ValueError(f"{label} must be JSON object: {path}")
+    return raw
+
+
 def build_normalization_preflight_report(
     baseline_stats: dict[str, dict[str, float]] | None = None,
+    *,
+    metrics: dict[str, Any] | None = None,
+    weights: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the issue #3699 normalization inventory preflight payload."""
+    if (metrics is None) != (weights is None):
+        raise ValueError("metrics and weights must be provided together")
+
     inventory = build_snqi_normalization_inventory(baseline_stats)
     blockers: list[dict[str, Any]] = []
 
@@ -85,13 +107,20 @@ def build_normalization_preflight_report(
             }
         )
 
-    return {
+    report: dict[str, Any] = {
         "schema_version": "snqi_normalization_inventory_preflight.v1",
         "claim_boundary": CLAIM_BOUNDARY,
         "status": "failed" if blockers else "passed",
         "blockers": blockers,
         "normalization": inventory.to_dict(),
     }
+    if metrics is not None and weights is not None:
+        report["contributions"] = build_snqi_contribution_diagnostics(
+            metrics,
+            weights,
+            baseline_stats or {},
+        )
+    return report
 
 
 def _print_text_report(report: dict[str, Any]) -> None:
@@ -121,6 +150,16 @@ def _print_text_report(report: dict[str, Any]) -> None:
             f"{term['normalization_status']}; role={role}; "
             f"basis={term['measurement_basis']}; note={term['note']}"
         )
+    if "contributions" in report:
+        contract = report["contributions"]["normalization_contract"]
+        print(
+            "Contribution contract: "
+            f"status={contract['status']}; "
+            f"weights_comparable={contract['weights_comparable']}; "
+            f"raw_penalty_share={contract['raw_penalty_absolute_share']:.6g}; "
+            "baseline_normalized_penalty_share="
+            f"{contract['baseline_normalized_penalty_absolute_share']:.6g}"
+        )
 
 
 def _build_parser() -> argparse.ArgumentParser:
@@ -130,6 +169,8 @@ def _build_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Optional baseline-stats JSON for normalized-term coverage checks.",
     )
+    parser.add_argument("--metrics", type=Path, help="Optional fixture metrics JSON object.")
+    parser.add_argument("--weights", type=Path, help="Optional fixture weights JSON object.")
     parser.add_argument("--json", action="store_true", help="Emit JSON to stdout.")
     parser.add_argument("--json-out", type=Path, help="Write JSON report to this path.")
     parser.add_argument(
@@ -145,7 +186,13 @@ def main(argv: list[str] | None = None) -> int:
     args = _build_parser().parse_args(argv)
     try:
         baseline_stats = _load_baseline_stats(args.baseline_stats)
-        report = build_normalization_preflight_report(baseline_stats)
+        metrics = _load_json_object(args.metrics, label="metrics")
+        weights = _load_json_object(args.weights, label="weights")
+        report = build_normalization_preflight_report(
+            baseline_stats,
+            metrics=metrics,
+            weights=weights,
+        )
     except ValueError as exc:
         print(f"ERROR: {exc}", file=sys.stderr)
         return EXIT_INPUT_ERROR

--- a/tests/benchmark/test_snqi_normalization_inventory_preflight.py
+++ b/tests/benchmark/test_snqi_normalization_inventory_preflight.py
@@ -43,7 +43,11 @@ _MIXED_BASIS_FIXTURE = {
 def test_preflight_reports_mixed_basis_without_changing_snqi_output() -> None:
     """Synthetic mixed-basis fixture fails closed while scoring remains unchanged."""
     before = compute_snqi(_MIXED_BASIS_FIXTURE, _WEIGHTS, _BASELINE_STATS)
-    report = build_normalization_preflight_report(_BASELINE_STATS)
+    report = build_normalization_preflight_report(
+        _BASELINE_STATS,
+        metrics=_MIXED_BASIS_FIXTURE,
+        weights=_WEIGHTS,
+    )
     after = compute_snqi(_MIXED_BASIS_FIXTURE, _WEIGHTS, _BASELINE_STATS)
 
     assert before == pytest.approx(after)
@@ -69,6 +73,13 @@ def test_preflight_reports_mixed_basis_without_changing_snqi_output() -> None:
     assert basis_by_term["time"] == "raw time-to-goal ratio"
     assert basis_by_term["comfort"] == "raw accumulated comfort-exposure value"
     assert basis_by_term["collisions"] == "baseline-relative median/p95 clamped value"
+    contributions = report["contributions"]
+    signed_total = sum(term["signed_contribution"] for term in contributions["terms"])
+    assert contributions["diagnostic_only"] is True
+    assert contributions["mixed_basis"] is True
+    assert contributions["normalization_contract"]["status"] == "mixed_unbounded_penalty_basis"
+    assert contributions["normalization_contract"]["weights_comparable"] is False
+    assert signed_total == pytest.approx(before)
 
 
 def test_preflight_main_fails_closed_but_allows_inspection(tmp_path) -> None:
@@ -97,6 +108,55 @@ def test_preflight_text_lists_each_term_status(capsys: pytest.CaptureFixture[str
     assert "collisions (collisions, w_collisions): baseline_normalized_bounded" in out
     assert "basis=baseline-relative median/p95 clamped value" in out
     assert "jerk (jerk_mean, w_jerk): baseline_normalized_bounded" in out
+
+
+def test_preflight_cli_writes_synthetic_fixture_contribution_report(tmp_path, capsys) -> None:
+    """CLI accepts a synthetic mixed-basis fixture and writes contribution diagnostics."""
+    baseline_path = tmp_path / "baseline_stats.json"
+    metrics_path = tmp_path / "metrics.json"
+    weights_path = tmp_path / "weights.json"
+    report_path = tmp_path / "normalization_report.json"
+    baseline_path.write_text(json.dumps(_BASELINE_STATS), encoding="utf-8")
+    metrics_path.write_text(json.dumps(_MIXED_BASIS_FIXTURE), encoding="utf-8")
+    weights_path.write_text(json.dumps(_WEIGHTS), encoding="utf-8")
+
+    assert (
+        main(
+            [
+                "--baseline-stats",
+                str(baseline_path),
+                "--metrics",
+                str(metrics_path),
+                "--weights",
+                str(weights_path),
+                "--json-out",
+                str(report_path),
+                "--allow-mixed-basis",
+            ]
+        )
+        == 0
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(report_path.read_text(encoding="utf-8"))
+    assert "Contribution contract: status=mixed_unbounded_penalty_basis" in captured.out
+    assert payload["status"] == "failed"
+    assert payload["contributions"]["normalization_contract"]["weights_comparable"] is False
+    signed_total = sum(term["signed_contribution"] for term in payload["contributions"]["terms"])
+    assert signed_total == pytest.approx(
+        compute_snqi(_MIXED_BASIS_FIXTURE, _WEIGHTS, _BASELINE_STATS)
+    )
+
+
+def test_preflight_requires_metrics_and_weights_together(tmp_path, capsys) -> None:
+    """Fixture diagnostics fail closed when metrics/weights are incomplete."""
+    metrics_path = tmp_path / "metrics.json"
+    metrics_path.write_text(json.dumps(_MIXED_BASIS_FIXTURE), encoding="utf-8")
+
+    assert main(["--metrics", str(metrics_path)]) == 1
+
+    captured = capsys.readouterr()
+    assert "metrics and weights must be provided together" in captured.err
 
 
 def test_preflight_reports_optional_missing_baseline_coverage(tmp_path) -> None:


### PR DESCRIPTION
## Summary
Adds fixture-driven SNQI normalization contribution diagnostics to the fail-closed issue #3699 preflight checker. This is diagnostic-only: it does not change `compute_snqi`, weights, normalization, rankings, or paper-facing claims.

## Linked Issues
- Relates to `#3699`
- Issue link: https://github.com/ll7/robot_sf_ll7/issues/3699

## Stack / Dependency
- Base dependency: `origin/main` at `b9d6d2de7`
- Required prior PRs: none
- Stack follow-up issues: `#3699` remains open for the normalize-vs-bound/versioning decision
- Safe to review independently: yes
- Review dependency reason, any: none

## What Changed
- `scripts/validation/check_snqi_normalization_inventory.py` now accepts optional `--metrics` and `--weights` JSON fixture inputs, emits per-term contribution diagnostics, and prints the normalization contract when fixture inputs are supplied.
- `tests/benchmark/test_snqi_normalization_inventory_preflight.py` now proves the synthetic mixed-basis fixture fails closed, reports `mixed_unbounded_penalty_basis`, and reconstructs unchanged `compute_snqi` output.

## Why Matters
- Added value: reviewers can verify issue #3699's mixed raw/baseline-normalized contribution problem on an explicit synthetic fixture through the validation checker.
- Expected impact: clearer fail-closed diagnostics without changing Social Navigation Quality Index (SNQI) scoring semantics.
- Why worth merging now: it matches the reversible first-slice direction in the live issue while preserving the unresolved normalization decision.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3699 mixed SNQI normalization basis visibility.
- Comparator or baseline, applicable: current `origin/main` preflight checker without fixture-driven contribution diagnostics.
- Evidence tier: diagnostic probe.
- Result classification: diagnostic-only.
- Decision stop rule, applicable: stop at reporting mixed-basis contribution diagnostics; do not normalize raw terms or reinterpret rankings.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3699 remains open for versioned normalization policy.
- New research/benchmark/metric/paper-facing analysis tool, any: support checker extension only; representative use covered by focused tests and direct checker invocation below.

## Domain-Aware Approval
- Approver/review source waiver: implementation integrity only; no benchmark or paper claim promoted.
- Validity checklist: no scoring, ranking, weight, normalization, benchmark campaign, or paper/dissertation claim semantics changed.
- Target claim/hypothesis: mixed-basis SNQI contribution diagnostics are emitted for a synthetic fixture.
- Comparator split/evidence validity: synthetic fixture proves checker behavior only; no planner comparison claimed.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution.
- Claim boundary: secondary diagnostic-only checker output.
- Implementation integrity vs experimental validity: tests verify checker output and unchanged `compute_snqi`; experimental validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, checker output includes `mixed_unbounded_penalty_basis` and `weights_comparable=False` when fixture inputs are supplied.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, synthetic fixture contains raw unbounded time/comfort terms alongside baseline-normalized count terms.
- Result route: continue #3699 policy decision.
- Follow-up question issue weak, negative, non-transfer results: #3699 remains decision-required for normalize-vs-bound and versioning.

## Next Empirical Action
- Rerun needed: no full benchmark campaign run in this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with maintainer decision on SNQI-v0/SNQI-v1 normalization policy.
- Proposed child issue existing follow-up: #3699.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m py_compile scripts/validation/check_snqi_normalization_inventory.py tests/benchmark/test_snqi_normalization_inventory_preflight.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_normalization_inventory_preflight.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_normalization_inventory_report.py tests/benchmark/test_snqi_governance_preflight.py -q` -> 27 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_snqi_normalization_inventory.py tests/benchmark/test_snqi_normalization_inventory_preflight.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/check_snqi_normalization_inventory.py tests/benchmark/test_snqi_normalization_inventory_preflight.py` -> 2 files already formatted.
- Direct checker invocation on temporary synthetic fixture with `--allow-mixed-basis --json-out` -> exit 0; JSON summary showed `status=failed`, `contract=mixed_unbounded_penalty_basis`, `weights_comparable=False`.
- Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Hot Path
- Baseline runtime: NA, support checker extension only.
- Changed runtime: NA, no hot-path benchmark runtime claim.
- Representative command: focused pytest/checker commands above.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: fixture diagnostics fail to reconstruct `compute_snqi` or checker stops fail-closing mixed basis.

## Risks / Rollout
- Compatibility risks: additive JSON/text fields when optional fixture inputs are supplied; default checker output remains the existing static inventory shape.
- Failure modes: malformed metrics/weights JSON now returns the existing input-error code path.
- Rollback fallback plan: remove optional `--metrics`/`--weights` handling and associated tests.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3699 body and latest comment proposing a reversible fail-closed checker slice.
- Any assumptions need to preserved: mixed-basis diagnostics are reversible and diagnostic-only; SNQI-v0/SNQI-v1 policy remains undecided.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, user authorization forbids issue/PR comments beyond opening this PR.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: diagnostic checker extension only; no benchmark, registry, claim-map, leaderboard, or paper-facing claim changes.

## Follow-Up Issues
- Deferred work: #3699 maintainer decision on preserving mixed-basis SNQI-v0 as diagnostic-only versus defining a versioned recalibrated SNQI-v1.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that `compute_snqi`, `normalize_metric`, weight files, and ranking semantics are untouched.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
