### PR TITLE
Issue #3810: refresh long-horizon packet for imech036

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -217,7 +217,7 @@ launch_packet:
   decision: blocked_pending_submit_host_route_and_reconciliation
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  target_host: imech039
+  target_host: imech036
   blocking_jobs:
     - 13175
   live_issue_state:
@@ -262,7 +262,7 @@ launch_packet:
       private submit wrapper named below until those checks return go.
     private_ops_dry_run:
       required_before_submit: true
-      target_host: imech039
+      target_host: imech036
       evidence_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
       current_public_status: route_unverified
       required_fields:
@@ -280,7 +280,7 @@ launch_packet:
         The dry run must record decision=go before submission. If job 13175 is
         not terminal/reconciled, if an issue #3810 duplicate exists, if the
         owning worktree is dirty, or if the private submit wrapper lacks
-        imech039 support, the decision remains blocked.
+        imech036 support, the decision remains blocked.
   interpretation_gate:
     status: blocked_pending_active_run_retention_reconciliation
     required_before_claim: true

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -194,7 +194,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
     )
-    _require(launch_packet.get("target_host") == "imech039", "target host must be imech039")
+    _require(launch_packet.get("target_host") == "imech036", "target host must be imech036")
     blocking_jobs = launch_packet.get("blocking_jobs")
     _require(isinstance(blocking_jobs, list), "blocking_jobs must be a list")
     _require(13175 in blocking_jobs, "job 13175 must block submit until reconciled")
@@ -254,7 +254,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
     dry_run = _require_mapping(go_no_go, "private_ops_dry_run")
     _require(dry_run.get("required_before_submit") is True, "private-ops dry run required")
-    _require(dry_run.get("target_host") == "imech039", "private-ops dry run host mismatch")
+    _require(dry_run.get("target_host") == "imech036", "private-ops dry run host mismatch")
     _require(
         dry_run.get("current_public_status") == "route_unverified",
         "private-ops dry run must be route_unverified in public packet",
@@ -277,8 +277,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "private-ops dry run fields missing",
     )
     _require(
-        "imech039 support" in str(dry_run.get("decision_policy", "")),
-        "private-ops dry run must gate imech039 support",
+        "imech036 support" in str(dry_run.get("decision_policy", "")),
+        "private-ops dry run must gate imech036 support",
     )
 
     interpretation_gate = _require_mapping(launch_packet, "interpretation_gate")

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -34,7 +34,7 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert summary["target_host"] == "imech039"
+    assert summary["target_host"] == "imech036"
     assert summary["blocking_jobs"] == [13175]
     assert summary["job_13175_state"] == "requires_submit_host_refresh"
     assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
@@ -94,6 +94,23 @@ def test_issue_3810_packet_rejects_nonblocking_live_issue_state() -> None:
         assert "live issue state must block submit while running" in str(exc)
     else:
         raise AssertionError("packet should reject a nonblocking live issue state")
+
+
+def test_issue_3810_packet_rejects_stale_target_host() -> None:
+    """The packet must match the requested Slurm decision host."""
+    packet = _load_packet()
+    packet["launch_packet"]["target_host"] = "imech039"
+    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["target_host"] = "imech039"
+    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["decision_policy"] = (
+        "submission remains blocked until imech039 support is proven."
+    )
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "target host must be imech036" in str(exc)
+    else:
+        raise AssertionError("packet should reject stale target host")
 
 
 def test_issue_3810_packet_rejects_stale_live_issue_label() -> None:

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -97,13 +97,9 @@ def test_issue_3810_packet_rejects_nonblocking_live_issue_state() -> None:
 
 
 def test_issue_3810_packet_rejects_stale_target_host() -> None:
-    """The packet must match the requested Slurm decision host."""
+    """The launch-packet target host must match the requested Slurm decision host."""
     packet = _load_packet()
     packet["launch_packet"]["target_host"] = "imech039"
-    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["target_host"] = "imech039"
-    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["decision_policy"] = (
-        "submission remains blocked until imech039 support is proven."
-    )
 
     try:
         _MODULE.validate_packet(packet)
@@ -111,6 +107,34 @@ def test_issue_3810_packet_rejects_stale_target_host() -> None:
         assert "target host must be imech036" in str(exc)
     else:
         raise AssertionError("packet should reject stale target host")
+
+
+def test_issue_3810_packet_rejects_stale_dry_run_target_host() -> None:
+    """The private-ops dry-run target host is guarded independently of the packet host."""
+    packet = _load_packet()
+    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["target_host"] = "imech039"
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "private-ops dry run host mismatch" in str(exc)
+    else:
+        raise AssertionError("packet should reject a stale dry-run target host")
+
+
+def test_issue_3810_packet_rejects_decision_policy_without_target_host_gate() -> None:
+    """The dry-run decision policy must still gate on the requested host support."""
+    packet = _load_packet()
+    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["decision_policy"] = (
+        "submission remains blocked until route support is proven."
+    )
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "private-ops dry run must gate imech036 support" in str(exc)
+    else:
+        raise AssertionError("packet should reject a decision policy missing the host gate")
 
 
 def test_issue_3810_packet_rejects_stale_live_issue_label() -> None:


### PR DESCRIPTION
## Summary

Refreshes the issue #3810 long-horizon Social Navigation Quality Index (SNQI) launch packet for the requested Slurm decision host, `imech036`. The packet remains fail-closed: no compute submission is authorized, the private-ops dry run must prove target-host route support, and interpretation remains blocked while the live issue is `state:running`.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3810

## Scope

- Updates the public launch packet target host and private-ops dry-run target host from stale `imech039` to `imech036`.
- Updates the packet validator so stale target-host packets fail closed.
- Adds a focused regression test that rejects reverting the packet to the old target host.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` passed; summary reports `target_host=imech036`, `compute_submit_authorized=false`, `slurm_job_id=not_submitted`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q` passed, 22 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` passed.
- `git diff --check` passed.
- Private-ops read-only evidence: `queue_summary.sh` exited 0 with `ready_entries: 0`; `submit_and_record.sh --help` exited 0 and currently lists `--cluster <licca|imech192>`, so `imech036` route support remains unproven and the packet correctly remains blocked pending dry-run evidence.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` passed after this PR body was provided.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Downstream Propagation

- Parent issue updated: no, comments are not authorized for this run.
- Claim map / benchmark report updated: not applicable, no benchmark evidence.
- Leaderboard / artifact catalog updated: not applicable.
- Registry or config index updated: not applicable.
- Context index / memory note updated: not applicable.
- Follow-up issue opened: no.

## Artifact Classification

The generated `output/research_campaign_packets/issue_3810_long_horizon_snqi/` files are disposable validation output and are not committed. Durable benchmark artifacts remain required before any future claim promotion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the launch packet validation to accept the new target host value.
  * Ensured stale packets using the old target host are rejected with a clear validation error.

* **Tests**
  * Added coverage for rejecting outdated target-host configurations.
  * Updated existing validation checks to match the current expected host.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->