### PR TITLE
Issue #3813: add sustained-flow scenario generator check

### DIFF
--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -73,6 +73,69 @@ def iter_expected_sustained_flow_variant_specs() -> tuple[SustainedFlowVariantSp
     )
 
 
+def generate_expected_sustained_flow_scenarios() -> list[dict[str, Any]]:
+    """Generate full metadata-only scenario rows for the sustained-flow scaffold.
+
+    This helper deliberately materializes only the pre-benchmark scenario-matrix
+    rows. It does not implement continuous pedestrian respawn or promote the
+    family to benchmark evidence.
+
+    Returns:
+        Scenario-matrix rows in deterministic light, medium, heavy order.
+    """
+
+    scenarios: list[dict[str, Any]] = []
+    for spec in iter_expected_sustained_flow_variant_specs():
+        scenarios.append(
+            {
+                "name": spec.name,
+                "map_file": spec.map_file,
+                "simulation_config": {
+                    "max_episode_steps": spec.max_episode_steps,
+                    "ped_density": spec.ped_density,
+                    "robot_config": {},
+                },
+                "metadata": {
+                    "archetype": _SUSTAINED_FLOW_FAMILY,
+                    "density": spec.density_tier,
+                    "flow": "continuous_crossing",
+                    "pack_id": "issue_3813_sustained_flow_scaffold_v0",
+                    "status": "pre_benchmark_scaffold",
+                    "enabled_by_default": False,
+                    "benchmark_evidence": False,
+                    "claim_boundary": (
+                        "Opt-in scenario-matrix scaffold only. Do not cite as sustained-flow "
+                        "benchmark evidence until runtime continuous spawn, progress metrics, "
+                        "and interaction-exposure diagnostics are implemented and validated."
+                    ),
+                    "continuous_spawn": {
+                        "required_before_benchmark_use": True,
+                        "intended_process": "poisson_respawn",
+                        "spawn_rate_per_min": spec.spawn_rate_per_min,
+                        "target_density_tier": spec.density_tier,
+                        "current_runtime_support": "metadata_only",
+                    },
+                    "success_metric": {
+                        "id": "sustained_progress_rate_m_per_s",
+                        "definition": (
+                            "Net robot path progress toward the route goal divided by simulated "
+                            "episode seconds under non-clearing pedestrian demand."
+                        ),
+                        "wait_policy_expectation": "zero_or_near_zero_progress",
+                    },
+                    "termination": {
+                        "mode": "time_bounded",
+                        "max_episode_steps": spec.max_episode_steps,
+                        "goal_reach_is_not_primary_success": True,
+                    },
+                    "requires_before_benchmark_use": list(REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE),
+                },
+                "seeds": list(spec.seeds),
+            }
+        )
+    return scenarios
+
+
 @dataclass(frozen=True)
 class SustainedFlowVariant:
     """Validated sustained-flow scaffold variant summary."""

--- a/tests/benchmark/test_issue_3813_sustained_flow_scenarios.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scenarios.py
@@ -12,7 +12,7 @@ from robot_sf.scenario_certification.sustained_flow import (
     DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
     EXPECTED_SUSTAINED_FLOW_TIERS,
     REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE,
-    iter_expected_sustained_flow_variant_specs,
+    generate_expected_sustained_flow_scenarios,
     preflight_sustained_flow_scenario_set,
     sustained_flow_preflight_to_dict,
 )
@@ -124,15 +124,6 @@ def test_issue_3813_checked_in_matrix_matches_generated_variant_specs() -> None:
     """Generated preflight specs match the checked-in sustained-flow scaffold."""
 
     scenarios = load_scenarios(DEFAULT_SUSTAINED_FLOW_SCENARIO_SET)
-    specs = iter_expected_sustained_flow_variant_specs()
+    generated = generate_expected_sustained_flow_scenarios()
 
-    assert len(scenarios) == len(specs)
-    for scenario, spec in zip(scenarios, specs, strict=True):
-        metadata = scenario["metadata"]
-        assert scenario["name"] == spec.name
-        assert scenario["map_file"] == spec.map_file
-        assert scenario["simulation_config"]["max_episode_steps"] == spec.max_episode_steps
-        assert scenario["simulation_config"]["ped_density"] == spec.ped_density
-        assert scenario["seeds"] == list(spec.seeds)
-        assert metadata["density"] == spec.density_tier
-        assert metadata["continuous_spawn"]["spawn_rate_per_min"] == spec.spawn_rate_per_min
+    assert scenarios == generated


### PR DESCRIPTION
## Summary
Adds a reusable generator for the issue #3813 sustained-flow continuous-spawn scenario rows and tightens the enumeration test so the checked-in matrix must match the generated fail-closed scaffold exactly.

## Linked Issues
- Relates `#3813`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `generate_expected_sustained_flow_scenarios()` to materialize the metadata-only light/medium/heavy sustained-flow scenario rows from the canonical variant specs.
- Updated the issue #3813 enumeration test to compare the checked-in scenario matrix against the generated rows, including fail-closed metadata, continuous-spawn parameters, seeds, and termination/success-metric metadata.

## Why Matters
- Added value: reduces drift risk between the sustained-flow variant definitions and checked-in scenario matrix.
- Expected impact: local preflight/enumeration coverage for the continuous-spawn scaffold is stricter without claiming runtime continuous-spawn support.
- Why worth merging now: it is a small checker/generator slice that supports the ready-queue objective without running a campaign.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: structural scenario scaffold for wait-it-out mitigation; checker/generator only.
- Comparator or baseline, applicable: NA - no benchmark comparison.
- Evidence tier: NA - support helper with focused validation
- Result classification: NA - no benchmark result
- Decision stop rule, applicable: scenario generator output must exactly match checked-in matrix and preflight must remain metadata-only/fail-closed.
- Parent issue, claim map, registry, context note, synthesis surface update: #3813.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper, no interpretation of benchmark evidence.

## Domain-Aware Approval
approval concerns experimental validity waived / pending / blocked / not required
- Approver/review source waiver: not required; this does not change benchmark interpretation or promote evidence.
- Validity checklist:
- Target claim/hypothesis: generator/preflight consistency only.
- Comparator split/evidence validity: NA - no comparator or benchmark evidence claim.
- Fallback/degraded exclusions: runtime support remains `metadata_only`; benchmark evidence remains false.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation integrity covered by focused tests and preflight; experimental validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no planner/runtime campaign.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? unknown - no full campaign.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: continuous-spawn runtime support and sustained-progress metric still need separate implementation before benchmark evidence.

## Next Empirical Action
- Rerun needed: no for this checker slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: runtime continuous-spawn support and full campaign evidence remain out of scope.
- Stop / revise / continue decision: continue with runtime/metric work before claim promotion.
- Proposed child issue existing follow-up: #3813 remains the parent tracking surface.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/benchmark/test_issue_3813_sustained_flow_scenarios.py::test_issue_3813_checked_in_matrix_matches_generated_variant_specs -q` -> passed, 1 test.
- `scripts/dev/run_worktree_shared_venv.sh -- python -m pytest tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q` -> passed, 9 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/scenario_certification/sustained_flow.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format robot_sf/scenario_certification/sustained_flow.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py --check` -> passed, 2 files already formatted.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` -> passed; `conforms=true`, `benchmark_evidence=false`, `runtime_support=metadata_only`, `variant_count=3`.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=/tmp/issue3813_pr_body.md scripts/dev/pr_ready_check.sh` -> pending in this PR body; see latest run result before merge.
- Baseline runtime: NA - no runtime benchmark claimed.
- Changed runtime: NA - no runtime benchmark claimed.
- Representative command: `scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json`.
- Hot-path call count profile anchor: NA - no hot-path performance claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: generator output no longer matches checked-in scenario matrix or preflight no longer reports metadata-only/fail-closed status.

## Risks / Rollout
- Compatibility risks: low; helper is additive and tests cover exact matrix parity.
- Failure modes: duplicated metadata literals can drift if future YAML wording changes without updating the generator.
- Rollback fallback plan: revert this commit; existing preflight scaffold remains intact.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3813 sustained-flow scaffold and existing preflight files.
- Any assumptions need to preserved: continuous-spawn variants are still metadata-only and disabled by default.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - user authorization disallows issue/PR comments from this agent.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no benchmark claim promotion.

## Follow-Up Issues
- Deferred work: continuous pedestrian respawn runtime support, sustained-progress metric implementation, interaction-exposure sanity check, scenario certification eligibility review, and full benchmark campaign remain deferred to `#3813`.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer should verify closely: generator output intentionally duplicates the checked-in metadata contract so the test catches drift.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
