### PR TITLE
Issue #3808 add TTC near-miss packet output path

### DIFF
--- a/scripts/validation/render_ttc_near_miss_decision_packet.py
+++ b/scripts/validation/render_ttc_near_miss_decision_packet.py
@@ -12,6 +12,7 @@ import argparse
 import json
 import sys
 from collections.abc import Callable
+from pathlib import Path
 
 import numpy as np
 
@@ -136,6 +137,16 @@ def render_packets_json(packets: dict[str, NearMissTtcDecisionPacket]) -> str:
     return json.dumps(payload, indent=2, sort_keys=True, allow_nan=False) + "\n"
 
 
+def write_packet_output(text: str, output_path: Path | None) -> None:
+    """Write packet text to ``output_path`` or stdout for dry-run inspection."""
+    if output_path is None:
+        sys.stdout.write(text)
+        return
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(text, encoding="utf-8")
+
+
 def _parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
@@ -156,6 +167,11 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default="markdown",
         help="Output format for the dry-run packet.",
     )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional file path for the rendered packet. Defaults to stdout.",
+    )
     return parser.parse_args(argv)
 
 
@@ -164,9 +180,10 @@ def main(argv: list[str] | None = None) -> int:
     args = _parse_args(sys.argv[1:] if argv is None else argv)
     packets = build_packets(fixture=args.fixture, threshold_s=args.threshold_s)
     if args.format == "json":
-        sys.stdout.write(render_packets_json(packets))
+        rendered = render_packets_json(packets)
     else:
-        sys.stdout.write(render_packets_markdown(packets))
+        rendered = render_packets_markdown(packets)
+    write_packet_output(rendered, args.output)
     return 0
 
 

--- a/tests/validation/test_render_ttc_near_miss_decision_packet.py
+++ b/tests/validation/test_render_ttc_near_miss_decision_packet.py
@@ -75,3 +75,31 @@ def test_cli_json_single_fixture() -> None:
     payload = json.loads(completed.stdout)
     assert set(payload["fixtures"]) == {"opening"}
     assert payload["fixtures"]["opening"]["diagnostic_status"] == "no-approaching-pairs"
+
+
+def test_cli_json_output_path_writes_packet(tmp_path: Path) -> None:
+    """CLI can materialize a deterministic packet for review handoff."""
+    output_path = tmp_path / "nested" / "ttc_packet.json"
+
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(SCRIPT),
+            "--fixture",
+            "missing-timing",
+            "--format",
+            "json",
+            "--output",
+            str(output_path),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    assert completed.returncode == 0, completed.stderr
+    assert completed.stdout == ""
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+    assert set(payload["fixtures"]) == {"missing-timing"}
+    assert payload["fixtures"]["missing-timing"]["diagnostic_status"] == "unsupported-inputs"


### PR DESCRIPTION
## Summary
Add an explicit `--output` path to the deterministic TTC near-miss decision packet renderer so reviewers can materialize the JSON or Markdown packet for handoff while preserving the existing stdout dry-run behavior.

## Linked Issues
- Relates to https://github.com/ll7/robot_sf_ll7/issues/3808

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `--output <path>` to `scripts/validation/render_ttc_near_miss_decision_packet.py`; parent directories are created and stdout remains the default when omitted.
- Added focused CLI coverage proving a strict JSON packet can be written for the `missing-timing` fail-closed fixture.

## Why Matters
- Added value: makes the issue #3808 decision packet easy to materialize as a review artifact without changing TTC near-miss metric semantics.
- Expected impact: deterministic packet rendering over existing diagnostic fixtures.
- Why worth merging now: small support improvement for a ready-queue evidence-boundary slice.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Issue #3808 packet handoff support only.
- Comparator or baseline, applicable: Existing stdout-only renderer.
- Evidence tier: NA - support helper for deterministic packet materialization; no research or benchmark claim.
- Result classification: NA - no research result or benchmark claim.
- Decision stop rule, applicable: Focused renderer tests and dry-run packet render pass.
- Parent issue, claim map, registry, context note, synthesis surface update: Parent issue #3808; no claim-map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper for an existing diagnostic-only renderer; no research interpretation added.

## Domain-Aware Approval
- Required PR: no - support helper only; no evidence-validity-sensitive claim is promoted.
- Domains reviewed: metric semantics, benchmark interpretation, paper-facing claims.
- Status: waived.
- Approver/review source waiver: maintainer ready-queue authorization delegates full PR gate to Claude Code after opening; this PR changes only optional packet materialization support.
- Validity checklist:
  - Target claim/hypothesis: no metric claim promotion; only packet materialization support for issue #3808.
  - Comparator or split/evidence validity: existing stdout-only deterministic fixtures versus optional file-output rendering of the same deterministic fixtures; no planner split or benchmark comparator is interpreted.
  - Fallback/degraded exclusions: fail-closed fixture status remains `unsupported-inputs`; no fallback/degraded benchmark row is counted as success.
  - Claim boundary: diagnostic decision packet only; no canonical metric replacement.
  - Implementation integrity vs experimental validity: implementation integrity covered by focused tests; experimental validity unchanged.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, CLI writes a JSON packet to an explicit path.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, focused test uses `missing-timing` unsupported-inputs fixture.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this support slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with reviewer gate.
- Proposed child issue existing follow-up: NA

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_near_miss_ttc.py tests/validation/test_render_ttc_near_miss_decision_packet.py -q` exited 0.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/render_ttc_near_miss_decision_packet.py tests/validation/test_render_ttc_near_miss_decision_packet.py` exited 0.
- `tmpdir=$(mktemp -d); scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/render_ttc_near_miss_decision_packet.py --fixture missing-timing --format json --output "$tmpdir/packet/ttc.json"; test -s "$tmpdir/packet/ttc.json"; python -m json.tool "$tmpdir/packet/ttc.json" >/dev/null; rm -rf "$tmpdir"` exited 0.
- `PR_READY_PR_BODY_FILE=/tmp/issue3808_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` exited 0; final freshness stamp recorded for head `bbcc85515f87a86569b97dc1b75c8255397d686c`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Runtime
- Baseline runtime: NA, no runtime performance claim.
- Changed runtime: NA, no runtime performance claim.
- Representative command: `scripts/validation/render_ttc_near_miss_decision_packet.py --fixture missing-timing --format json --output <path>`.
- Hot-path call count profile anchor: NA, no hot-path claim.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if the renderer stops preserving stdout default behavior or writes malformed packet JSON.

## Risks / Rollout
- Compatibility risks: low; `--output` is optional and stdout remains default.
- Failure modes: invalid destination permissions fail normally through `Path.write_text`.
- Rollback fallback plan: remove optional output-path plumbing and test.

## Docs / Provenance
- Updated docs: NA.
- Relevant design provenance notes: issue #3808 and existing TTC diagnostic renderer.
- Any assumptions need to preserved: output files are handoff artifacts, not durable benchmark evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comment authorization is false.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: support helper only; no benchmark, registry, claim-map, or paper-facing evidence changes.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none

## Reviewer Notes
- Verify that the optional file-output path remains diagnostic-only and does not imply packet artifacts are durable benchmark evidence.
- Known limitations: existing issue #3808 body appears compressed through the API, so scope was taken from the ready-queue prompt plus merged prior #3808 PR history; this PR intentionally avoids broad semantic changes.
