### PR TITLE
Issue #3653: reject out-of-range SNQI normalized inputs

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -37,6 +37,11 @@ REQUIRED_SENSITIVITY_METRICS = (
     "comfort_exposure",
 )
 OPTIONAL_SENSITIVITY_METRICS = ("force_exceed_events", "jerk_mean")
+BOUNDED_NORMALIZED_SENSITIVITY_METRICS = (
+    "success",
+    "time_to_goal_norm",
+    "comfort_exposure",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -249,6 +254,15 @@ def _add_metric_preflight_issues(
                 "non_finite_required_term",
                 SENSITIVITY_PREFLIGHT_MALFORMED,
                 f"record {index} has non-finite SNQI term {metric!r}",
+            )
+
+        elif metric in BOUNDED_NORMALIZED_SENSITIVITY_METRICS and not _is_unit_interval(
+            metrics.get(metric)
+        ):
+            state.add_issue(
+                "out_of_range_normalized_term",
+                SENSITIVITY_PREFLIGHT_MALFORMED,
+                f"record {index} normalized SNQI term {metric!r} outside [0, 1]",
             )
 
     for metric in OPTIONAL_SENSITIVITY_METRICS:
@@ -798,6 +812,13 @@ def _validate_export_required_terms(records: Sequence[Mapping[str, Any]]) -> Non
                     f"record {index} non-finite required SNQI term {metric!r}; "
                     "run scalarization-sensitivity preflight before export"
                 )
+            if metric in BOUNDED_NORMALIZED_SENSITIVITY_METRICS and not _is_unit_interval(
+                metrics.get(metric)
+            ):
+                raise ValueError(
+                    f"record {index} normalized SNQI term {metric!r} outside [0, 1]; "
+                    "run scalarization-sensitivity preflight before export"
+                )
 
 
 def _planner_snqi_scores(
@@ -1100,6 +1121,10 @@ def _is_finite_metric(value: Any) -> bool:
         return math.isfinite(float(value))
     except (TypeError, ValueError):
         return False
+
+
+def _is_unit_interval(value: Any) -> bool:
+    return 0.0 <= float(value) <= 1.0
 
 
 def _mean(values: Iterable[float]) -> float:

--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -207,9 +207,7 @@ def test_preflight_malformed_out_of_range_normalized_input() -> None:
     )
 
     assert preflight["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
-    assert any(
-        issue["code"] == "out_of_range_normalized_term" for issue in preflight["issues"]
-    )
+    assert any(issue["code"] == "out_of_range_normalized_term" for issue in preflight["issues"])
     with pytest.raises(ValueError, match=r"time_to_goal_norm.*outside \[0, 1\]"):
         build_scalarization_sensitivity_report(records, weights=WEIGHTS, baseline=BASELINE)
 

--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -194,6 +194,26 @@ def test_preflight_malformed_non_finite_required_input() -> None:
     assert any(issue["code"] == "non_finite_required_term" for issue in preflight["issues"])
 
 
+def test_preflight_malformed_out_of_range_normalized_input() -> None:
+    """Finite normalized terms outside [0, 1] are malformed, not exportable."""
+
+    records = _valid_records()
+    metrics = records[0]["metrics"]
+    assert isinstance(metrics, dict)
+    metrics["time_to_goal_norm"] = 1.2
+
+    preflight = classify_scalarization_sensitivity_inputs(
+        records, weights=WEIGHTS, baseline=BASELINE
+    )
+
+    assert preflight["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
+    assert any(
+        issue["code"] == "out_of_range_normalized_term" for issue in preflight["issues"]
+    )
+    with pytest.raises(ValueError, match=r"time_to_goal_norm.*outside \[0, 1\]"):
+        build_scalarization_sensitivity_report(records, weights=WEIGHTS, baseline=BASELINE)
+
+
 def test_cli_refuses_blocked_inputs_and_writes_only_preflight(tmp_path: Path) -> None:
     """Blocked inputs return exit code 2 and do not create export artifacts."""
 


### PR DESCRIPTION
## Summary
- Tightens the Social Navigation Quality Index (SNQI) scalarization-sensitivity preflight to reject bounded normalized inputs outside `[0, 1]`.
- Applies the same fail-closed guard in direct report export so fixtures cannot bypass preflight and produce decision-disagreement/Pareto artifacts from invalid normalized terms.
- Adds issue #3653 regression coverage for finite but invalid `time_to_goal_norm` input.

## Issue
- Closes tooling slice of https://github.com/ll7/robot_sf_ll7/issues/3653

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py` - passed, 26 tests.
- `git diff --check` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py` - passed.
- `PR_READY_PR_BODY_FILE=/tmp/issue-3653-pr-body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; freshness stamp recorded clean tree at `ce4b5b937596c791ad6604d278f2c7d671b9085b`.

## Out of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Residual Risk
- This remains a tooling/preflight slice. The live issue notes empirical application on a valid campaign surface is still needed before treating the diagnostic as research-complete evidence.
