### PR TITLE
Issue #3723: expose SNQI weight blocker details

### DIFF
--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -93,6 +93,8 @@ def build_governance_report(
 
     blockers: list[dict[str, Any]] = []
     if weights.has_blocking_conflict:
+        weight_report = weights.to_dict()
+        source_summary = weight_report["source_summary"]
         blockers.append(
             {
                 "issue": 3723,
@@ -101,6 +103,17 @@ def build_governance_report(
                     "More than one SNQI source currently declares or implies "
                     "canonical status while disagreeing on weight direction."
                 ),
+                "registered_sources": source_summary["registered_sources"],
+                "discovered_shipped_sources": source_summary["discovered_shipped_sources"],
+                "canonical_declaring_sources": source_summary["canonical_declaring_sources"],
+                "blocking_conflicts": [
+                    conflict
+                    for conflict in weight_report["conflicts"]
+                    if conflict["severity"] == "error"
+                ],
+                "code_default_shipped_direction_comparisons": source_summary[
+                    "code_default_shipped_direction_comparisons"
+                ],
             }
         )
     if normalization.mixed_scale:

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -23,6 +23,47 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
     assert report["weights"]["has_blocking_conflict"] is True
     assert report["normalization"]["mixed_scale"] is True
     assert set(report["normalization"]["raw_penalty_terms"]) == {"time", "comfort"}
+    blocker_3723 = next(
+        blocker for blocker in report["blockers"] if blocker["kind"] == "weight_provenance_conflict"
+    )
+    assert blocker_3723["registered_sources"] == [
+        "code_default",
+        "camera_ready_v1",
+        "camera_ready_v2",
+        "camera_ready_v3",
+        "model_canonical_v1",
+    ]
+    assert blocker_3723["discovered_shipped_sources"] == [
+        "camera_ready_v1",
+        "camera_ready_v2",
+        "camera_ready_v3",
+        "model_canonical_v1",
+    ]
+    assert blocker_3723["canonical_declaring_sources"] == [
+        "code_default",
+        "model_canonical_v1",
+    ]
+    assert len(blocker_3723["blocking_conflicts"]) == 1
+    conflict = blocker_3723["blocking_conflicts"][0]
+    assert conflict["kind"] == "canonical_direction_conflict"
+    assert conflict["severity"] == "error"
+    assert conflict["sources"] == ["code_default", "model_canonical_v1"]
+    assert "dominant=w_collisions" in conflict["detail"]
+    assert "dominant=w_jerk" in conflict["detail"]
+    comparisons_by_source = {
+        comparison["source"]: comparison
+        for comparison in blocker_3723["code_default_shipped_direction_comparisons"]
+    }
+    assert set(comparisons_by_source) == {
+        "camera_ready_v1",
+        "camera_ready_v2",
+        "camera_ready_v3",
+        "model_canonical_v1",
+    }
+    assert comparisons_by_source["model_canonical_v1"]["relationship"] == "different_direction"
+    assert comparisons_by_source["model_canonical_v1"]["source_dominant_term"] == "w_jerk"
+    assert comparisons_by_source["camera_ready_v3"]["relationship"] == "different_direction"
+    assert comparisons_by_source["camera_ready_v3"]["source_dominant_term"] == "w_near"
     blocker_3699 = next(
         blocker for blocker in report["blockers"] if blocker["kind"] == "mixed_normalization_basis"
     )


### PR DESCRIPTION
## Summary
Expose the SNQI weight provenance inventory details directly in the top-level #3723 governance blocker. The preflight now includes registered sources, discovered shipped JSON sources, canonical-declaring sources, blocking conflicts, and code-default-to-shipped direction comparisons without selecting canonical weights or changing scoring.

## Linked Issues
- Relates to `#3723`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added self-contained SNQI weight source and conflict fields to the `weight_provenance_conflict` blocker emitted by `scripts/validation/check_snqi_governance.py`.
- Expanded focused governance preflight tests to assert the #3723 blocker reports all registered/discovered shipped sources, the canonical conflict, and code-default-vs-shipped direction comparisons.

## Why Matters
- Added value: reviewers and automation can read the fail-closed #3723 blocker without separately traversing the nested `weights` payload.
- Expected impact: diagnostic reporting only; current SNQI scoring output and canonical-weight decision state are unchanged.
- Why worth merging now: keeps the issue open for the maintainer decision while making the preflight blocker more actionable.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3723 diagnostic visibility for conflicting SNQI weight provenance.
- Comparator or baseline, applicable: current preflight JSON where the #3723 blocker only named the conflict class.
- Evidence tier: NA - support checker output only, no research result claimed
- Result classification: NA - no benchmark result claimed
- Decision stop rule, applicable: report all current SNQI weight sources and conflicts in preflight output while preserving scoring behavior.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3723 remains decision-required; no claim map update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - improves existing diagnostic preflight output only.

## Domain-Aware Approval
- Required for PR: yes
- Required PR: yes
- Required pull request: yes
- Domains reviewed: SNQI benchmark governance diagnostic reporting for issue #3723
- Status: waived
- Approver/review source waiver: Maintainer waiver by scope: diagnostic-only reporting of already-computed preflight inventory fields; no canonical weight selection, benchmark ranking change, or paper/dissertation claim change.
- Target claim/hypothesis: #3723 remains an unresolved decision-required blocker; this PR only makes the blocker self-contained in preflight JSON.
- Comparator or split/evidence validity: current `origin/main` preflight JSON vs changed preflight JSON on the same repository fixture state; no planner comparator or benchmark split is interpreted.
- Fallback/degraded exclusions: no benchmark execution, fallback mode, or degraded planner result is claimed.
- Claim boundary: diagnostic-only preflight reporting; no metric semantics or released benchmark claim changes.
- Implementation integrity vs experimental validity: focused tests assert report fields and existing fail-closed behavior; experimental validity remains for the future #3723 canonical-weight decision.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? yes, current repo has `canonical_direction_conflict` for `code_default` vs `model_canonical_v1`.
- Result route: continue with maintainer decision on canonical weight source in #3723.
- Follow-up question issue weak, negative, non-transfer results: existing #3723 decision-required work remains.

## Next Empirical Action
- Rerun needed: no full benchmark campaign run for this diagnostic-only reporting slice.
- Extractor analysis tool needed: no
- Artifact missing unavailable: none
- Stop / revise / continue decision: continue to maintainer canonical-weight decision in #3723.
- Proposed child issue existing follow-up: #3723 remains the follow-up decision issue.

## Validation / Proof
- `uv run ruff format scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_governance_preflight.py && uv run ruff check scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_governance_preflight.py` -> passed
- `uv run pytest tests/benchmark/test_snqi_governance_preflight.py tests/test_snqi_weights_inventory.py -q` -> 18 passed
- `uv run python scripts/validation/check_snqi_governance.py --json` -> exit 2 as expected, with #3723 blocker fields for registered sources, discovered shipped sources, blocking conflicts, and code-default-vs-shipped comparisons
- `uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers` -> exit 0, status remains failed for current diagnostic blockers
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=/tmp/pr_body_3723_codex6.md scripts/dev/pr_ready_check.sh` -> passed on merge head `002c60e5`; core lane 1682 passed; optional-extra lane passed; fresh clean-tree stamp written
- Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Runtime / Performance
- Baseline runtime: NA - reporting-only preflight JSON fields.
- Changed runtime: NA - reporting-only preflight JSON fields.
- Representative command: `uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers`
- Hot-path call count profile anchor: NA - no hot path or benchmark runtime claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if governance preflight no longer reports current #3723/#3699 blockers or changes SNQI scoring behavior.

## Risks / Rollout
- Compatibility risks: JSON consumers of blocker objects will see additional fields; existing keys are preserved.
- Failure modes: downstream strict-schema consumers of blocker objects could need to ignore additional diagnostic fields.
- Rollback fallback plan: revert this commit; nested `weights` payload still contains the underlying inventory.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: issue #3723 and existing SNQI governance preflight.
- Any assumptions need to preserved: no canonical source is selected by this PR.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - user authorization forbids issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: diagnostic-only preflight reporting; #3723 remains the decision-required follow-up.

## Follow-Up Issues
- Deferred work: maintainer decision in #3723 on canonical SNQI weight source or explicit versioning/labeling.
- Issues opened follow-up: none

## Reviewer Notes
- Verify this only lifts existing inventory details into the #3723 blocker and does not change `compute_snqi` or `recompute_snqi_weights`.
- Known limitations: the current repository still fails the strict SNQI governance preflight until #3723/#3699 decisions are resolved.
