### PR TITLE
Issue #3810: refresh launch packet for imech156

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -217,7 +217,7 @@ launch_packet:
   decision: blocked_pending_submit_host_route_and_reconciliation
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  target_host: imech036
+  target_host: imech156-u
   blocking_jobs:
     - 13175
   live_issue_state:
@@ -262,7 +262,7 @@ launch_packet:
       private submit wrapper named below until those checks return go.
     private_ops_dry_run:
       required_before_submit: true
-      target_host: imech036
+      target_host: imech156-u
       evidence_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
       current_public_status: route_unverified
       required_fields:
@@ -280,7 +280,7 @@ launch_packet:
         The dry run must record decision=go before submission. If job 13175 is
         not terminal/reconciled, if an issue #3810 duplicate exists, if the
         owning worktree is dirty, or if the private submit wrapper lacks
-        imech036 support, the decision remains blocked.
+        imech156-u support, the decision remains blocked.
   interpretation_gate:
     status: blocked_pending_active_run_retention_reconciliation
     required_before_claim: true

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -194,7 +194,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
     )
-    _require(launch_packet.get("target_host") == "imech036", "target host must be imech036")
+    _require(launch_packet.get("target_host") == "imech156-u", "target host must be imech156-u")
     blocking_jobs = launch_packet.get("blocking_jobs")
     _require(isinstance(blocking_jobs, list), "blocking_jobs must be a list")
     _require(13175 in blocking_jobs, "job 13175 must block submit until reconciled")
@@ -254,7 +254,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
     dry_run = _require_mapping(go_no_go, "private_ops_dry_run")
     _require(dry_run.get("required_before_submit") is True, "private-ops dry run required")
-    _require(dry_run.get("target_host") == "imech036", "private-ops dry run host mismatch")
+    _require(dry_run.get("target_host") == "imech156-u", "private-ops dry run host mismatch")
     _require(
         dry_run.get("current_public_status") == "route_unverified",
         "private-ops dry run must be route_unverified in public packet",
@@ -277,8 +277,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "private-ops dry run fields missing",
     )
     _require(
-        "imech036 support" in str(dry_run.get("decision_policy", "")),
-        "private-ops dry run must gate imech036 support",
+        "imech156-u support" in str(dry_run.get("decision_policy", "")),
+        "private-ops dry run must gate imech156-u support",
     )
 
     interpretation_gate = _require_mapping(launch_packet, "interpretation_gate")

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -34,7 +34,7 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert summary["target_host"] == "imech036"
+    assert summary["target_host"] == "imech156-u"
     assert summary["blocking_jobs"] == [13175]
     assert summary["job_13175_state"] == "requires_submit_host_refresh"
     assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
@@ -104,7 +104,7 @@ def test_issue_3810_packet_rejects_stale_target_host() -> None:
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "target host must be imech036" in str(exc)
+        assert "target host must be imech156-u" in str(exc)
     else:
         raise AssertionError("packet should reject stale target host")
 
@@ -132,7 +132,7 @@ def test_issue_3810_packet_rejects_decision_policy_without_target_host_gate() ->
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "private-ops dry run must gate imech036 support" in str(exc)
+        assert "private-ops dry run must gate imech156-u support" in str(exc)
     else:
         raise AssertionError("packet should reject a decision policy missing the host gate")
 


### PR DESCRIPTION
## Summary
Refresh the issue #3810 long-horizon Social Navigation Quality Index (SNQI) no-submit launch packet so its fail-closed submit-host route contract targets `imech156-u`.

This is a launch-packet/checker update only; it does not run a benchmark or submit compute.

## Linked Issues
- Relates to #3810

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #3813 for sustained-flow scenario variants
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Updated the checked-in issue #3810 launch packet target host and private-ops dry-run host from `imech036` to `imech156-u`.
- Updated the fail-closed validator and tests so stale target-host or missing host-support wording is rejected for `imech156-u`.

## Why Matters
- Added value: aligns the public no-submit decision packet with the requested target submit host while preserving the blocked/go-no-go guard.
- Expected impact: future submit-host reconciliation must prove `imech156-u` route support before any submission.
- Why worth merging now: avoids a stale host route in the launch packet while issue #3810 remains `state:running`.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Blocker only: the issue #3810 launch packet must name the correct submit host for a future comprehensive h600 campaign decision.
- Comparator or baseline, applicable: `origin/main` packet targeting `imech036`.
- Evidence tier: NA - no benchmark evidence; launch-packet host contract only
- Result classification: NA - no research result; blocker bookkeeping only
- Decision stop rule, applicable: validator must pass with `target_host: imech156-u`, compute submission disabled, and `slurm_job_id: not_submitted`.
- Parent issue, claim map, registry, context note, synthesis surface update: #3810
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool.

## Domain-Aware Approval
- Required for this PR: not required because this PR makes no benchmark, SNQI, horizon, paper, or dissertation claim.
- Domains reviewed: launch-packet host contract only.
- Status: not required; benchmark interpretation remains blocked by #3810.
- Approval or blocker note: #3810 is still `state:running`; live submit-host queue, duplicate status, job 13175 reconciliation, durable retention paths, SNQI recalibration inputs, and interaction-exposure diagnostics must be proven before any benchmark claim.
- Approver/review source waiver: NA - no evidence-validity approval requested.
- Validity checklist: no benchmark evidence claimed; fallback/degraded exclusions unchanged; active-run interpretation gate remains blocked.
- Target claim/hypothesis: blocker only, target host route contract must name `imech156-u`.
- Comparator or split/evidence validity: blocked by unreconciled #3810 active-run retention and private route evidence; no comparator interpretation is valid in this PR
- Fallback/degraded exclusions: unchanged; weak rows still cannot count as benchmark-strength evidence.
- Claim boundary: launch packet only; benchmark, SNQI, horizon, paper, and dissertation claims remain out of scope
- Implementation integrity vs experimental validity: validator and focused tests cover the packet contract; empirical validity remains blocked.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no benchmark mechanism run.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue - submit-host reconciliation remains blocked until private dry-run evidence returns go.
- Follow-up question issue weak, negative, non-transfer results: #3810 remains the parent issue; #3813 tracks sustained-flow variants.

## Next Empirical Action
- Rerun needed: no for this PR; yes before any benchmark claim or Slurm submission.
- Extractor analysis tool needed: no for this PR.
- Artifact missing unavailable: live submit-host queue/duplicate/worktree-clean proof and durable benchmark outputs remain unavailable.
- Stop / revise / continue decision: continue only after #3810 active-run retention reconciliation and private route dry-run go.
- Proposed child issue existing follow-up: #3813.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` -> exit 0; reports `target_host: imech156-u`, `compute_submit_authorized: false`, `slurm_job_id: not_submitted`, `go_no_go: blocked_pending_submit_host_route_and_reconciliation`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` -> exit 0; 24 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` -> exit 0; all checks passed.
- `ROBOT_SF_PRIVATE_OPS=/home/luttkule/git/robot_sf_ll7-private-ops /home/luttkule/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh --cluster licca --route-id decision-packet-only --public-repo "$PWD" --output output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json && python -m json.tool output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json` -> exit 0; local dry-run artifact reports `submitted: false`, `route_id: decision-packet-only`, dirty files present before commit, `slurm_test_only: missing_sbatch`, and no Slurm submission.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` initially stopped because no PR body source was configured; final run will use this body file before opening.

## Risks / Rollout
- Compatibility risks: low; string contract change for one launch packet host.
- Failure modes: private submit wrapper may still lack `imech156-u` support; packet intentionally remains blocked until that is proven on the submit host.
- Rollback fallback plan: revert this commit to restore the prior `imech036` host contract.

## Docs / Provenance
- Updated docs: NA - packet is the provenance surface.
- Relevant design provenance notes: #3810 current issue body and prior merged launch-packet PRs.
- Any assumptions need to preserved: target host for this ready-queue slice is `imech156-u`; no compute submission is authorized.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - authorization forbids issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR only refreshes a no-submit launch packet/checker host contract and makes no benchmark, registry, claim-map, paper-facing, or leaderboard claim.

## Follow-Up Issues
- Deferred work: full benchmark campaign run, Slurm/GPU submission, SNQI recalibration, horizon-sensitivity report, durable evidence retention, paper/dissertation claim edits remain tracked by #3810; sustained-flow scenario variants remain tracked by #3813.
- Issues opened follow-up: #3810 and #3813 are existing open follow-up issues; none opened in this no-comment/no-submit PR.

## Reviewer Notes
- Anything reviewer should verify closely: the validator still fails closed if target host, dry-run host, or host-support decision policy drift.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the long-horizon launch packet and its validation checks to use the current target host value.
  * Aligned related dry-run and decision-gating checks with the new host requirement, preventing false validation failures.
  * Refreshed expected error messages in tests to match the updated host reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->