### PR TITLE
Issue #3653: require active SNQI optional inputs

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -277,8 +277,7 @@ def _add_metric_preflight_issues(
 
     for metric in OPTIONAL_SENSITIVITY_METRICS:
         if metric not in metrics:
-            weight_name = OPTIONAL_WEIGHTED_SENSITIVITY_METRICS[metric]
-            if _is_active_weight(weights.get(weight_name, 0.0)):
+            if _is_active_optional_weight(weights, metric):
                 state.add_issue(
                     "missing_weighted_optional_term",
                     SENSITIVITY_PREFLIGHT_BLOCKED,
@@ -841,8 +840,7 @@ def _validate_export_required_terms(
                 )
         for metric in OPTIONAL_SENSITIVITY_METRICS:
             if metric not in metrics:
-                weight_name = OPTIONAL_WEIGHTED_SENSITIVITY_METRICS[metric]
-                if _is_active_weight(weights.get(weight_name, 0.0)):
+                if _is_active_optional_weight(weights, metric):
                     raise ValueError(
                         f"record {index} missing weighted SNQI term {metric!r}; "
                         "run scalarization-sensitivity preflight before export"
@@ -1165,7 +1163,24 @@ def _is_active_weight(value: Any) -> bool:
         weight = float(value)
     except (TypeError, ValueError):
         return False
-    return math.isfinite(weight) and not math.isclose(weight, 0.0)
+    return math.isfinite(weight) and weight != 0.0
+
+
+def _is_active_optional_weight(weights: Any, metric: str) -> bool:
+    """Whether ``metric``'s SNQI weight is present and active in ``weights``.
+
+    Returns:
+        ``True`` when ``weights`` is a mapping carrying an active (finite,
+        nonzero) weight for ``metric``. Returns ``False`` when ``weights`` is
+        not a mapping, so malformed-weight inputs are reported by the dedicated
+        ``weights_not_mapping`` check instead of crashing the preflight/export
+        guards with ``AttributeError``.
+    """
+
+    if not isinstance(weights, Mapping):
+        return False
+    weight_name = OPTIONAL_WEIGHTED_SENSITIVITY_METRICS[metric]
+    return _is_active_weight(weights.get(weight_name, 0.0))
 
 
 def _mean(values: Iterable[float]) -> float:

--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -37,6 +37,10 @@ REQUIRED_SENSITIVITY_METRICS = (
     "comfort_exposure",
 )
 OPTIONAL_SENSITIVITY_METRICS = ("force_exceed_events", "jerk_mean")
+OPTIONAL_WEIGHTED_SENSITIVITY_METRICS = {
+    "force_exceed_events": "w_force_exceed",
+    "jerk_mean": "w_jerk",
+}
 BOUNDED_NORMALIZED_SENSITIVITY_METRICS = (
     "success",
     "time_to_goal_norm",
@@ -119,7 +123,7 @@ def classify_scalarization_sensitivity_inputs(
     state = _SensitivityPreflightState.empty()
     records = _validate_preflight_inputs(state, records, weights, baseline)
     _collect_preflight_records(
-        state, records, planner_key, fallback_planner_key, scenario_key, horizon_key
+        state, records, weights, planner_key, fallback_planner_key, scenario_key, horizon_key
     )
     missing_cells = _add_global_preflight_issues(state, records, min_planners)
     _add_pareto_preflight_issues(state, weights, baseline, min_planners)
@@ -166,6 +170,7 @@ def _validate_preflight_inputs(
 def _collect_preflight_records(
     state: _SensitivityPreflightState,
     records: Sequence[Mapping[str, Any]],
+    weights: Mapping[str, float],
     planner_key: str,
     fallback_planner_key: str,
     scenario_key: str,
@@ -183,6 +188,7 @@ def _collect_preflight_records(
             state,
             index,
             record,
+            weights,
             planner_key,
             fallback_planner_key,
             scenario_key,
@@ -194,6 +200,7 @@ def _collect_preflight_record(
     state: _SensitivityPreflightState,
     index: int,
     record: Mapping[str, Any],
+    weights: Mapping[str, float],
     planner_key: str,
     fallback_planner_key: str,
     scenario_key: str,
@@ -220,7 +227,7 @@ def _collect_preflight_record(
         )
         return
 
-    _add_metric_preflight_issues(state, index, _metrics(record))
+    _add_metric_preflight_issues(state, index, _metrics(record), weights)
     planner_name = str(planner)
     scenario_horizon = (str(scenario), str(horizon))
     state.grouped.setdefault(planner_name, []).append(record)
@@ -240,7 +247,10 @@ def _preflight_planner(
 
 
 def _add_metric_preflight_issues(
-    state: _SensitivityPreflightState, index: int, metrics: Mapping[str, Any]
+    state: _SensitivityPreflightState,
+    index: int,
+    metrics: Mapping[str, Any],
+    weights: Mapping[str, float],
 ) -> None:
     for metric in REQUIRED_SENSITIVITY_METRICS:
         if metric not in metrics:
@@ -266,7 +276,15 @@ def _add_metric_preflight_issues(
             )
 
     for metric in OPTIONAL_SENSITIVITY_METRICS:
-        if metric in metrics and not _is_finite_metric(metrics.get(metric)):
+        if metric not in metrics:
+            weight_name = OPTIONAL_WEIGHTED_SENSITIVITY_METRICS[metric]
+            if _is_active_weight(weights.get(weight_name, 0.0)):
+                state.add_issue(
+                    "missing_weighted_optional_term",
+                    SENSITIVITY_PREFLIGHT_BLOCKED,
+                    f"record {index} missing weighted SNQI term {metric!r}",
+                )
+        elif not _is_finite_metric(metrics.get(metric)):
             state.add_issue(
                 "non_finite_optional_term",
                 SENSITIVITY_PREFLIGHT_MALFORMED,
@@ -433,7 +451,7 @@ def build_scalarization_sensitivity_report(
         dominance, and Pareto-front rows.
     """
 
-    _validate_export_required_terms(records)
+    _validate_export_required_terms(records, weights)
     grouped = _group_records(records, planner_key, fallback_planner_key)
     if len(grouped) < 2:
         raise ValueError("at least two planners are required for rank-sensitivity diagnostics")
@@ -796,7 +814,9 @@ def _group_records(
     return grouped
 
 
-def _validate_export_required_terms(records: Sequence[Mapping[str, Any]]) -> None:
+def _validate_export_required_terms(
+    records: Sequence[Mapping[str, Any]], weights: Mapping[str, float]
+) -> None:
     """Fail closed before export when required SNQI terms would otherwise default."""
 
     for index, record in enumerate(records, start=1):
@@ -817,6 +837,19 @@ def _validate_export_required_terms(records: Sequence[Mapping[str, Any]]) -> Non
             ):
                 raise ValueError(
                     f"record {index} normalized SNQI term {metric!r} outside [0, 1]; "
+                    "run scalarization-sensitivity preflight before export"
+                )
+        for metric in OPTIONAL_SENSITIVITY_METRICS:
+            if metric not in metrics:
+                weight_name = OPTIONAL_WEIGHTED_SENSITIVITY_METRICS[metric]
+                if _is_active_weight(weights.get(weight_name, 0.0)):
+                    raise ValueError(
+                        f"record {index} missing weighted SNQI term {metric!r}; "
+                        "run scalarization-sensitivity preflight before export"
+                    )
+            elif not _is_finite_metric(metrics.get(metric)):
+                raise ValueError(
+                    f"record {index} non-finite optional SNQI term {metric!r}; "
                     "run scalarization-sensitivity preflight before export"
                 )
 
@@ -1125,6 +1158,14 @@ def _is_finite_metric(value: Any) -> bool:
 
 def _is_unit_interval(value: Any) -> bool:
     return 0.0 <= float(value) <= 1.0
+
+
+def _is_active_weight(value: Any) -> bool:
+    try:
+        weight = float(value)
+    except (TypeError, ValueError):
+        return False
+    return math.isfinite(weight) and not math.isclose(weight, 0.0)
 
 
 def _mean(values: Iterable[float]) -> float:

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -301,6 +301,38 @@ def test_report_export_refuses_non_finite_normalized_time_term() -> None:
         )
 
 
+def test_preflight_blocks_missing_active_optional_normalized_term() -> None:
+    """Weighted optional normalized terms must be present before export."""
+
+    records = _preflight_episodes()
+    weights = _weights()
+    weights["w_jerk"] = 0.25
+
+    report = classify_scalarization_sensitivity_inputs(
+        records,
+        weights=weights,
+        baseline=_baseline(),
+    )
+
+    assert report["status"] == SENSITIVITY_PREFLIGHT_BLOCKED
+    assert any(issue["code"] == "missing_weighted_optional_term" for issue in report["issues"])
+
+
+def test_report_export_refuses_missing_active_optional_normalized_term() -> None:
+    """Direct export fails closed instead of defaulting active optional terms to zero."""
+
+    records = _episodes()
+    weights = _weights()
+    weights["w_force_exceed"] = 0.5
+
+    with pytest.raises(ValueError, match="missing weighted SNQI term 'force_exceed_events'"):
+        build_scalarization_sensitivity_report(
+            records,
+            weights=weights,
+            baseline=_baseline(),
+        )
+
+
 def test_artifact_writer_creates_report_ready_files(tmp_path: Path) -> None:
     """Artifact writer emits report-ready JSON, CSV, Markdown, and SVG."""
 

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -318,6 +318,19 @@ def test_preflight_blocks_missing_active_optional_normalized_term() -> None:
     assert any(issue["code"] == "missing_weighted_optional_term" for issue in report["issues"])
 
 
+def test_preflight_reports_non_mapping_weights_without_crashing() -> None:
+    """Non-mapping weights stay a graceful malformed report, not an AttributeError."""
+
+    report = classify_scalarization_sensitivity_inputs(
+        _preflight_episodes(),
+        weights=None,
+        baseline=_baseline(),
+    )
+
+    assert report["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
+    assert any(issue["code"] == "weights_not_mapping" for issue in report["issues"])
+
+
 def test_report_export_refuses_missing_active_optional_normalized_term() -> None:
     """Direct export fails closed instead of defaulting active optional terms to zero."""
 


### PR DESCRIPTION
## Summary
Require active optional normalized Social Navigation Quality Index (SNQI) inputs before scalarization-sensitivity preflight/export can proceed.

## Linked Issues
- Relates to #3653

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: #3266 / #3810 remain the empirical valid-input lanes
- Safe to review independently: yes
- Review dependency reason, any: this is a narrow fail-closed input-validation slice over existing issue #3653 tooling.

## What Changed
- Added a shared optional-metric-to-weight map for the SNQI scalarization-sensitivity diagnostic.
- Preflight now reports `missing_weighted_optional_term` when `force_exceed_events` or `jerk_mean` is absent while its SNQI weight is active.
- Direct report export now raises before defaulting missing active optional normalized terms to zero.
- Added regression tests for preflight and direct export behavior.

## Why Matters
- Added value: prevents decision-reversal diagnostics from silently treating missing weighted optional normalized inputs as zero-valued evidence.
- Expected impact: fail-closed fixture/export behavior is stricter without changing zero-weight optional-term fixtures.
- Why worth merging now: it closes a small remaining input-validity gap in the #3653 diagnostic surface.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3653 scalarization-sensitivity diagnostic input validity.
- Comparator or baseline, applicable: existing `origin/main` behavior could export with missing active optional terms.
- Evidence tier: NA - validation guard only; no research or benchmark result claim
- Result classification: NA - validation guard only; no research result claim
- Decision stop rule, applicable: focused tests prove missing active optional inputs block preflight and direct export.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3653 remains open for empirical application on valid campaign input.
- New research/benchmark/metric/paper-facing analysis tool, any: no new tool; this tightens existing diagnostic export validation.

## Domain-Aware Approval
- Required for this PR: no - validation guard only; no research or benchmark result claim.
- Domains reviewed: NA
- Status: waived
- Approver/review source or waiver: self-waived as implementation-only guard; reviewer should treat this as code/test proof, not experimental-validity approval.
- Approval or blocker note: no benchmark interpretation or paper-facing claim is made.
- Validity checklist:
- Target claim/hypothesis: missing active optional normalized inputs must fail closed.
- Comparator or split/evidence validity: fixture-level regression coverage only; no benchmark comparator claim.
- Fallback/degraded exclusions: no benchmark fallback/degraded execution involved.
- Claim boundary: diagnostic/tooling guard only, not benchmark evidence.
- Implementation integrity vs experimental validity: implementation tested on the existing unit-level SNQI sensitivity suite.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? yes, synthetic fixtures omit active optional normalized terms.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3266 / #3810 continue empirical valid-input campaign work.

## Next Empirical Action
- Rerun needed: yes, outside this PR for the valid campaign surface.
- Extractor analysis tool needed: no
- Artifact missing unavailable: valid campaign consumption remains outside scope.
- Stop / revise / continue decision: continue with existing empirical lanes.
- Proposed child issue existing follow-up: #3266 / #3810.

## Validation / Proof
- `../../robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py` - passed, 22 tests.
- `../../robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` - passed.
- `python3 -m py_compile robot_sf/benchmark/snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` - passed.
- `git diff --check` - passed.
- Representative use on durable/versioned input: committed fixture-level tests in `tests/benchmark/test_snqi_scalarization_sensitivity.py`.
- Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance
- Baseline runtime: not measured; no performance claim.
- Changed runtime: not measured; no performance claim.
- Representative command: `uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py`
- Hot-path call count profile anchor: NA, validation guard only.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: active optional SNQI terms can again be omitted and silently defaulted during diagnostic export.

## Risks / Rollout
- Compatibility risks: active nonzero `w_force_exceed` or `w_jerk` now requires corresponding episode metrics.
- Failure modes: callers using active optional weights with legacy incomplete fixtures will receive fail-closed errors and must hydrate the missing normalized inputs.
- Rollback fallback plan: revert this commit if downstream proves those optional terms must stay defaultable even when weighted.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3653 live body and existing SNQI sensitivity module.
- Any assumptions need to preserved: zero-weight optional terms remain optional; nonzero optional weights mean the metric participates in the scalarization and must be present.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comment authorization is false.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR tightens validation only and does not publish benchmark or paper-facing evidence.

## Follow-Up Issues
- Deferred work: empirical application of the diagnostic on valid campaign input remains outside this PR and remains tracked by #3266 / #3810.
- Issues opened follow-up: existing #3266 and #3810; none opened here because comment_issue_or_pr authorization is false.

## Reviewer Notes
- Verify closely that active optional weights are the right boundary for turning optional metrics into required inputs.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
