### PR TITLE
Issue #3723: report default-vs-shipped SNQI weight mismatches

### DIFF
--- a/robot_sf/benchmark/snqi/weights_inventory.py
+++ b/robot_sf/benchmark/snqi/weights_inventory.py
@@ -600,6 +600,34 @@ def _scale_split_conflicts(loaded: list[WeightSetRecord]) -> list[WeightProvenan
     ]
 
 
+def _code_default_shipped_direction_conflicts(
+    records: list[WeightSetRecord],
+) -> list[WeightProvenanceConflict]:
+    """Warn when shipped JSON sources differ from the code-default direction.
+
+    This is diagnostic-only: versioned shipped files may intentionally differ, but the
+    preflight should make each code-default-vs-JSON divergence explicit for #3723.
+
+    Returns:
+        Warning-level conflicts for shipped JSON directions that differ from the
+        code default.
+    """
+    return [
+        WeightProvenanceConflict(
+            kind="code_default_shipped_direction_mismatch",
+            severity="warning",
+            sources=["code_default", comparison.source],
+            detail=(
+                "code-default SNQI weights and shipped JSON source "
+                f"'{comparison.source}' ({comparison.relpath}) have different "
+                "scale-independent weight directions; no canonical source is selected."
+            ),
+        )
+        for comparison in compare_code_default_to_shipped_sources(records)
+        if comparison.relationship == "different_direction"
+    ]
+
+
 def _duplicate_label_conflicts(
     loaded: list[WeightSetRecord],
 ) -> list[WeightProvenanceConflict]:
@@ -681,6 +709,7 @@ def detect_conflicts(records: list[WeightSetRecord]) -> list[WeightProvenanceCon
     conflicts += _canonical_load_error_conflicts(canonical)
     conflicts += _canonical_direction_conflicts(loaded_canonical)
     conflicts += _unregistered_weight_source_conflicts(records)
+    conflicts += _code_default_shipped_direction_conflicts(records)
     conflicts += _scale_split_conflicts(loaded)
     conflicts += _duplicate_label_conflicts(loaded)
 

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -143,6 +143,8 @@ def test_governance_text_lists_per_term_normalization_status(
     )
     assert "Weight provenance conflicts:" in out
     assert "error canonical_direction_conflict (code_default, model_canonical_v1)" in out
+    assert "warning code_default_shipped_direction_mismatch (code_default, camera_ready_v1)" in out
+    assert "warning code_default_shipped_direction_mismatch (code_default, camera_ready_v3)" in out
     assert "Term normalization status:" in out
     assert "time (time_to_goal_norm, w_time): raw_unbounded" in out
     assert "basis=raw time-to-goal ratio" in out

--- a/tests/test_snqi_weights_inventory.py
+++ b/tests/test_snqi_weights_inventory.py
@@ -152,6 +152,18 @@ def test_repo_code_default_is_reported_distinct_from_shipped_canonical_model():
         conflict.severity == "error" and conflict.sources == ["code_default", "model_canonical_v1"]
         for conflict in canonical_conflicts
     )
+    shipped_mismatches = [
+        conflict
+        for conflict in report.conflicts
+        if conflict.kind == "code_default_shipped_direction_mismatch"
+    ]
+    assert sorted(conflict.sources[1] for conflict in shipped_mismatches) == [
+        "camera_ready_v1",
+        "camera_ready_v2",
+        "camera_ready_v3",
+        "model_canonical_v1",
+    ]
+    assert all(conflict.severity == "warning" for conflict in shipped_mismatches)
     assert report.has_blocking_conflict
 
 
@@ -166,6 +178,16 @@ def test_conflicting_canonical_sources_detected_fail_closed(tmp_path):
     assert summary["unregistered_shipped_source_count"] == 0
     assert summary["canonical_declaring_sources"] == ["code_default", "model_canonical_v1"]
     assert summary["blocking_conflict_kinds"] == ["canonical_direction_conflict"]
+    shipped_mismatches = [
+        c for c in report.conflicts if c.kind == "code_default_shipped_direction_mismatch"
+    ]
+    assert sorted(c.sources for c in shipped_mismatches) == [
+        ["code_default", "camera_ready_v1"],
+        ["code_default", "camera_ready_v2"],
+        ["code_default", "camera_ready_v3"],
+        ["code_default", "model_canonical_v1"],
+    ]
+    assert all(c.severity == "warning" for c in shipped_mismatches)
 
     direction_conflicts = [c for c in report.conflicts if c.kind == "canonical_direction_conflict"]
     assert direction_conflicts, "expected a canonical direction conflict"


### PR DESCRIPTION
## Summary
- Related to #3723.
- Adds warning-level SNQI provenance conflicts for every shipped JSON weight source whose scale-independent direction differs from `recompute_snqi_weights("canonical")` code defaults.
- Keeps the existing `canonical_direction_conflict` fail-closed blocker unchanged and does not select canonical weights or change scoring.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py tests/benchmark/test_snqi_weight_inventory_cli.py -q` -> 19 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/snqi/weights_inventory.py tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi/weights_inventory.py tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py` -> All checks passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --json` -> exit 2 as expected; reports #3723 `weight_provenance_conflict`, #3699 `mixed_normalization_basis`, and four warning-level `code_default_shipped_direction_mismatch` conflicts.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers` -> exit 0; reports four mismatch warnings while preserving unresolved blocker status.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue3723_pr_body.7gwyJm.md scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh` -> passed; freshness stamp for `cb52e601326a50c05da39fa43157c2c9157cf720` recorded at `output/validation/pr_ready/issue-3723-snqi-weight-inventory-codex8.json`.

## Out of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No canonical SNQI weight selection, no weight retuning, and no SNQI scoring semantics changes.

## Artifacts
- Generated `output/coverage/` and `output/validation/pr_ready/` artifacts are local validation outputs and are not promoted or committed.
