### PR TITLE
Issue #3810: retarget h600 packet to imech036

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -217,7 +217,7 @@ launch_packet:
   decision: blocked_pending_submit_host_route_and_reconciliation
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  target_host: imech156-u
+  target_host: imech036
   blocking_jobs:
     - 13175
   live_issue_state:
@@ -262,7 +262,7 @@ launch_packet:
       private submit wrapper named below until those checks return go.
     private_ops_dry_run:
       required_before_submit: true
-      target_host: imech156-u
+      target_host: imech036
       evidence_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
       current_public_status: route_unverified
       required_fields:
@@ -280,7 +280,7 @@ launch_packet:
         The dry run must record decision=go before submission. If job 13175 is
         not terminal/reconciled, if an issue #3810 duplicate exists, if the
         owning worktree is dirty, or if the private submit wrapper lacks
-        imech156-u support, the decision remains blocked.
+        imech036 support, the decision remains blocked.
   interpretation_gate:
     status: blocked_pending_active_run_retention_reconciliation
     required_before_claim: true

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -194,7 +194,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
     )
-    _require(launch_packet.get("target_host") == "imech156-u", "target host must be imech156-u")
+    _require(launch_packet.get("target_host") == "imech036", "target host must be imech036")
     blocking_jobs = launch_packet.get("blocking_jobs")
     _require(isinstance(blocking_jobs, list), "blocking_jobs must be a list")
     _require(13175 in blocking_jobs, "job 13175 must block submit until reconciled")
@@ -254,7 +254,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
     dry_run = _require_mapping(go_no_go, "private_ops_dry_run")
     _require(dry_run.get("required_before_submit") is True, "private-ops dry run required")
-    _require(dry_run.get("target_host") == "imech156-u", "private-ops dry run host mismatch")
+    _require(dry_run.get("target_host") == "imech036", "private-ops dry run host mismatch")
     _require(
         dry_run.get("current_public_status") == "route_unverified",
         "private-ops dry run must be route_unverified in public packet",
@@ -277,8 +277,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "private-ops dry run fields missing",
     )
     _require(
-        "imech156-u support" in str(dry_run.get("decision_policy", "")),
-        "private-ops dry run must gate imech156-u support",
+        "imech036 support" in str(dry_run.get("decision_policy", "")),
+        "private-ops dry run must gate imech036 support",
     )
 
     interpretation_gate = _require_mapping(launch_packet, "interpretation_gate")

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -34,7 +34,7 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert summary["target_host"] == "imech156-u"
+    assert summary["target_host"] == "imech036"
     assert summary["blocking_jobs"] == [13175]
     assert summary["job_13175_state"] == "requires_submit_host_refresh"
     assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
@@ -104,7 +104,7 @@ def test_issue_3810_packet_rejects_stale_target_host() -> None:
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "target host must be imech156-u" in str(exc)
+        assert "target host must be imech036" in str(exc)
     else:
         raise AssertionError("packet should reject stale target host")
 
@@ -132,7 +132,7 @@ def test_issue_3810_packet_rejects_decision_policy_without_target_host_gate() ->
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "private-ops dry run must gate imech156-u support" in str(exc)
+        assert "private-ops dry run must gate imech036 support" in str(exc)
     else:
         raise AssertionError("packet should reject a decision policy missing the host gate")
 


### PR DESCRIPTION
## Summary
Retargets the issue #3810 comprehensive h600 launch packet and its fail-closed validator from `imech156-u` to the requested `imech036` decision host.

This is still a no-submit launch-packet-only change: the packet remains blocked on live submit-host route checks, job `13175` reconciliation, duplicate detection, active `state:running` issue status, retention paths, SNQI recalibration outputs, and interaction-exposure diagnostics.

## Linked Issues
- Relates to `#3810`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: none

## What Changed
- Updated `configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml` so the public packet names `imech036` as the target host in both `launch_packet.target_host` and the required private-ops dry-run contract.
- Updated `scripts/validation/check_issue_3810_long_horizon_launch_packet.py` so stale target-host packets fail closed unless they name `imech036`.
- Updated the focused validation tests to assert the `imech036` host contract.

## Why Matters
- Added value: aligns the checked-in #3810 launch packet with the current ready-queue target host.
- Expected impact: prevents stale `imech156-u` packet reuse when the intended decision host is `imech036`.
- Why worth merging now: the issue is live and still blocked on submit-host reconciliation; the host contract should be correct before any go/no-go packet is evaluated.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution only; public launch packet must target `imech036`.
- Comparator or baseline, applicable: previous packet on `origin/main` targeted `imech156-u`.
- Evidence tier: NA - launch-packet retarget only; no benchmark evidence is produced.
- Result classification: NA - blocker-resolution packet retarget only; no research result is claimed.
- Decision stop rule, applicable: checker must report `target_host: imech036`, `compute_submit_authorized: false`, and `go_no_go: blocked_pending_submit_host_route_and_reconciliation`.
- Parent issue, claim map, registry, context note, synthesis surface update: #3810 remains the parent; no benchmark report or claim map update because no benchmark evidence is produced.
- New research/benchmark/metric/paper-facing analysis tool, any: none.

## Domain-Aware Approval
- Required PR: yes - benchmark launch packet contract changes require explicit domain waiver.
- Domains reviewed: benchmark launch packet contract, fail-closed no-submit guard, target-host routing.
- Status: waived for this PR because it only retargets the no-submit packet and promotes no benchmark result.
- Approver/review source waiver: maintainer ready-queue authorization scoped this PR to launch-packet retargeting; full domain approval remains blocked until #3810 live run and retention reconciliation before any claim promotion.
- Validity checklist:
- Target claim/hypothesis: no research claim.
- Comparator or split/evidence validity: previous `origin/main` packet targeted `imech156-u`; changed packet targets `imech036`; no empirical comparator or campaign result is claimed.
- Fallback/degraded exclusions: existing fail-closed packet policy preserved.
- Claim boundary: launch packet only; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: validator and tests enforce the host contract only.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, validator summary now reports `target_host: imech036`.
- Did intervention change command source, selected command, trajectory, route progress? no runtime benchmark path changed.
- Did scenario actually contain targeted failure mode? NA, no scenario run.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3810 remains blocked until submit-host and retention reconciliation.

## Next Empirical Action
- Rerun needed: yes, but only after the #3810 Slurm decision packet is go.
- Extractor analysis tool needed: yes, per existing packet SNQI recalibration, horizon-sensitivity, and interaction-exposure outputs.
- Artifact missing unavailable: full h600 benchmark outputs, retained compact review bundle, external artifact pointer, private-ops go dry-run with required fields.
- Stop / revise / continue decision: continue only after live submit-host checks return go.
- Proposed child issue existing follow-up: #3813 covers sustained-flow structural follow-up; #3810 remains active for the h600 packet/run lane.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` -> exit 0; summary includes `target_host: imech036`, `compute_submit_authorized: false`, `slurm_job_id: not_submitted`, `go_no_go: blocked_pending_submit_host_route_and_reconciliation`.
- `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q` -> exit 0; 24 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` -> exit 0; diagnostic dry-run packet generated under ignored `output/`.
- `git diff --check` -> exit 0.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` -> exit 0.
- `scripts/dev/run_worktree_shared_venv.sh -- ruff format --check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py` -> exit 0.
- Private-ops dry-run command, no Slurm submission: `ROBOT_SF_PRIVATE_OPS="$HOME/git/robot_sf_ll7-private-ops" "$HOME/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh" --cluster licca --route-id decision-packet-only --public-repo "$PWD" --output output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json` -> exit 0; artifact reports `slurm_test_only` as `missing_sbatch` with `submitted: false`.

## Performance
- Baseline runtime: NA, no runtime benchmark claim.
- Changed runtime: NA, no runtime benchmark claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json`
- Hot-path call count profile anchor: NA, no hot path changed.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: validator summary no longer reports the intended `imech036` target host, or compute submission becomes authorized.

## Risks / Rollout
- Compatibility risks: submit-host naming may need another packet refresh if the queue owner changes target hosts again.
- Failure modes: private-ops preflight artifact currently lacks the packet's required go-decision fields, so it cannot unlock submission.
- Rollback fallback plan: revert this commit to restore the previous `imech156-u` packet contract.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3810 issue body/comments; prior packet PR #3934.
- Any assumptions need to preserved: `imech036` from the ready-queue request is the intended current decision host.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, user authorization disallows issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR produces no benchmark outputs and makes no paper-facing or benchmark-result claim.

## Follow-Up Issues
- Deferred work: full h600 benchmark campaign run, SNQI recalibration, horizon-sensitivity report, interaction-exposure diagnostics, and durable artifact retention after the Slurm decision packet is go.
- Issues opened follow-up: #3810 remains open for this deferred run and reconciliation work.

## Reviewer Notes
- Verify closely that every public host contract now says `imech036` and that `compute_submit_authorized` remains false.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
