### PR TITLE
Issue #3699: expose SNQI-v0 normalization contract

### DIFF
--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -39,6 +39,33 @@ SCALING_BASELINE_NORMALIZED = "baseline_normalized"
 NORMALIZED_LOWER = 0.0
 NORMALIZED_UPPER = 1.0
 
+SNQI_LEGACY_SCORE_VERSION = "SNQI-v0"
+SNQI_LEGACY_SCORE_STATUS = "legacy_mixed_basis_diagnostic_only"
+
+
+def build_snqi_version_contract() -> dict[str, object]:
+    """Return the current versioned SNQI normalization contract.
+
+    Issue #3699's current product decision preserves historical SNQI as a
+    legacy diagnostic while deferring any bounded/recalibrated score to a
+    separately versioned contract.
+    """
+
+    return {
+        "schema_version": "snqi_score_version_contract.v1",
+        "score_version": SNQI_LEGACY_SCORE_VERSION,
+        "status": SNQI_LEGACY_SCORE_STATUS,
+        "diagnostic_only": True,
+        "mixed_basis_preserved": True,
+        "score_semantics_changed": False,
+        "decision_required_issue": 3699,
+        "future_bounded_contract": "SNQI-v1",
+        "policy": (
+            "Historical SNQI-v0 keeps the mixed raw/baseline-normalized basis for "
+            "reproducibility and must not be used as a primary safety ranking."
+        ),
+    }
+
 
 @dataclass(frozen=True)
 class TermScaling:
@@ -381,6 +408,7 @@ def build_snqi_contribution_diagnostics(
         "weight_bound_exceedances": weight_bound_exceedances,
         "has_weight_bound_exceedance": bool(weight_bound_exceedances),
         "normalization_contract": normalization_contract,
+        "score_version_contract": build_snqi_version_contract(),
         "terms": [contribution.to_dict() for contribution in contributions],
     }
 
@@ -457,6 +485,7 @@ class NormalizationInventory:
             "unbounded_terms": [t.term for t in self.unbounded_terms],
             "missing_baseline_coverage": [t.metric_key for t in self.missing_baseline_coverage],
             "is_consistent": self.is_consistent,
+            "score_version_contract": build_snqi_version_contract(),
         }
 
 
@@ -499,6 +528,8 @@ def format_normalization_report(inventory: NormalizationInventory) -> str:
             f"{term.metric_key:<24}{term.measurement_basis}"
         )
     lines.append(f"  mixed_scale            : {inventory.mixed_scale}")
+    contract = build_snqi_version_contract()
+    lines.append(f"  score version          : {contract['score_version']} ({contract['status']})")
     lines.append(
         "  raw penalty terms      : "
         + (", ".join(t.term for t in inventory.raw_penalty_terms) or "<none>")
@@ -520,12 +551,15 @@ __all__ = [
     "NORMALIZED_UPPER",
     "SCALING_BASELINE_NORMALIZED",
     "SCALING_RAW",
+    "SNQI_LEGACY_SCORE_STATUS",
+    "SNQI_LEGACY_SCORE_VERSION",
     "SNQI_TERM_SCALING",
     "NormalizationInventory",
     "TermContribution",
     "TermScaling",
     "build_snqi_contribution_diagnostics",
     "build_snqi_normalization_inventory",
+    "build_snqi_version_contract",
     "format_normalization_report",
     "scaled_term_value",
 ]

--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -42,6 +42,23 @@ NORMALIZED_UPPER = 1.0
 SNQI_LEGACY_SCORE_VERSION = "SNQI-v0"
 SNQI_LEGACY_SCORE_STATUS = "legacy_mixed_basis_diagnostic_only"
 
+# Static SNQI score-version contract. All values are immutable scalars, so a
+# shallow copy is sufficient to isolate callers from mutating the shared source.
+_SNQI_VERSION_CONTRACT: dict[str, object] = {
+    "schema_version": "snqi_score_version_contract.v1",
+    "score_version": SNQI_LEGACY_SCORE_VERSION,
+    "status": SNQI_LEGACY_SCORE_STATUS,
+    "diagnostic_only": True,
+    "mixed_basis_preserved": True,
+    "score_semantics_changed": False,
+    "decision_required_issue": 3699,
+    "future_bounded_contract": "SNQI-v1",
+    "policy": (
+        "Historical SNQI-v0 keeps the mixed raw/baseline-normalized basis for "
+        "reproducibility and must not be used as a primary safety ranking."
+    ),
+}
+
 
 def build_snqi_version_contract() -> dict[str, object]:
     """Return the current versioned SNQI normalization contract.
@@ -49,22 +66,11 @@ def build_snqi_version_contract() -> dict[str, object]:
     Issue #3699's current product decision preserves historical SNQI as a
     legacy diagnostic while deferring any bounded/recalibrated score to a
     separately versioned contract.
+
+    Returns a fresh shallow copy so callers cannot mutate the shared constant.
     """
 
-    return {
-        "schema_version": "snqi_score_version_contract.v1",
-        "score_version": SNQI_LEGACY_SCORE_VERSION,
-        "status": SNQI_LEGACY_SCORE_STATUS,
-        "diagnostic_only": True,
-        "mixed_basis_preserved": True,
-        "score_semantics_changed": False,
-        "decision_required_issue": 3699,
-        "future_bounded_contract": "SNQI-v1",
-        "policy": (
-            "Historical SNQI-v0 keeps the mixed raw/baseline-normalized basis for "
-            "reproducibility and must not be used as a primary safety ranking."
-        ),
-    }
+    return _SNQI_VERSION_CONTRACT.copy()
 
 
 @dataclass(frozen=True)

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -215,6 +215,13 @@ def _print_text_report(report: dict[str, Any]) -> None:
         f"raw_penalty_terms={', '.join(normalization['raw_penalty_terms']) or 'none'}; "
         f"unbounded_terms={', '.join(normalization['unbounded_terms']) or 'none'}"
     )
+    version_contract = normalization["score_version_contract"]
+    print(
+        "Score version contract: "
+        f"{version_contract['score_version']}; "
+        f"status={version_contract['status']}; "
+        f"diagnostic_only={version_contract['diagnostic_only']}"
+    )
     print("Term normalization status:")
     for term in normalization["terms"]:
         role = "penalty" if term["is_penalty"] else "reward"

--- a/scripts/validation/check_snqi_normalization_inventory.py
+++ b/scripts/validation/check_snqi_normalization_inventory.py
@@ -142,6 +142,13 @@ def _print_text_report(report: dict[str, Any]) -> None:
         "baseline_normalized_penalty_terms="
         f"{', '.join(normalization['normalized_penalty_terms']) or 'none'}"
     )
+    version_contract = normalization["score_version_contract"]
+    print(
+        "Score version contract: "
+        f"{version_contract['score_version']}; "
+        f"status={version_contract['status']}; "
+        f"diagnostic_only={version_contract['diagnostic_only']}"
+    )
     print("Term normalization status:")
     for term in normalization["terms"]:
         role = "penalty" if term["is_penalty"] else "reward"

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -64,6 +64,11 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
     assert comparisons_by_source["model_canonical_v1"]["source_dominant_term"] == "w_jerk"
     assert comparisons_by_source["camera_ready_v3"]["relationship"] == "different_direction"
     assert comparisons_by_source["camera_ready_v3"]["source_dominant_term"] == "w_near"
+    assert report["normalization"]["score_version_contract"]["score_version"] == "SNQI-v0"
+    assert (
+        report["normalization"]["score_version_contract"]["status"]
+        == "legacy_mixed_basis_diagnostic_only"
+    )
     blocker_3699 = next(
         blocker for blocker in report["blockers"] if blocker["kind"] == "mixed_normalization_basis"
     )
@@ -84,6 +89,7 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
     assert contributions["mixed_basis"] is True
     assert contributions["raw_penalty_terms_dominate"] is True
     assert contributions["has_weight_bound_exceedance"] is True
+    assert contributions["score_version_contract"]["score_semantics_changed"] is False
     assert {term["term"] for term in contributions["weight_bound_exceedances"]} == {
         "time",
         "comfort",
@@ -144,6 +150,10 @@ def test_governance_text_lists_per_term_normalization_status(
     assert "Weight provenance conflicts:" in out
     assert "error canonical_direction_conflict (code_default, model_canonical_v1)" in out
     assert "Term normalization status:" in out
+    assert (
+        "Score version contract: SNQI-v0; "
+        "status=legacy_mixed_basis_diagnostic_only; diagnostic_only=True"
+    ) in out
     assert "time (time_to_goal_norm, w_time): raw_unbounded" in out
     assert "basis=raw time-to-goal ratio" in out
     assert "comfort (comfort_exposure, w_comfort): raw_unbounded" in out

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -16,9 +16,12 @@ from robot_sf.benchmark.snqi.compute import compute_snqi
 from robot_sf.benchmark.snqi.normalization_inventory import (
     SCALING_BASELINE_NORMALIZED,
     SCALING_RAW,
+    SNQI_LEGACY_SCORE_STATUS,
+    SNQI_LEGACY_SCORE_VERSION,
     SNQI_TERM_SCALING,
     build_snqi_contribution_diagnostics,
     build_snqi_normalization_inventory,
+    build_snqi_version_contract,
     format_normalization_report,
     scaled_term_value,
 )
@@ -165,6 +168,21 @@ def test_to_dict_is_json_serializable_and_self_consistent():
     assert basis_by_term["time"] == "raw time-to-goal ratio"
     assert basis_by_term["comfort"] == "raw accumulated comfort-exposure value"
     assert basis_by_term["collisions"] == "baseline-relative median/p95 clamped value"
+    assert encoded["score_version_contract"] == build_snqi_version_contract()
+
+
+def test_score_version_contract_preserves_legacy_snqi_v0_as_diagnostic_only():
+    """Issue #3699 checker labels current SNQI semantics without changing scores."""
+
+    contract = build_snqi_version_contract()
+
+    assert contract["score_version"] == SNQI_LEGACY_SCORE_VERSION == "SNQI-v0"
+    assert contract["status"] == SNQI_LEGACY_SCORE_STATUS
+    assert contract["diagnostic_only"] is True
+    assert contract["mixed_basis_preserved"] is True
+    assert contract["score_semantics_changed"] is False
+    assert contract["future_bounded_contract"] == "SNQI-v1"
+    assert contract["decision_required_issue"] == 3699
 
 
 def test_format_report_is_human_readable():
@@ -173,6 +191,7 @@ def test_format_report_is_human_readable():
     text = format_normalization_report(inv)
     assert "issue #3699" in text
     assert "basis" in text
+    assert "SNQI-v0 (legacy_mixed_basis_diagnostic_only)" in text
     assert "raw time-to-goal ratio" in text
     assert "baseline-relative median/p95 clamped value" in text
     for term in SNQI_TERM_SCALING:
@@ -211,6 +230,7 @@ def test_contribution_diagnostics_reconstruct_snqi_and_flag_raw_dominance():
     assert signed_total == pytest.approx(compute_snqi(metrics, weights, baseline_stats))
 
     contract = diagnostics["normalization_contract"]
+    version_contract = diagnostics["score_version_contract"]
     assert contract["schema_version"] == "snqi_normalization_contract.v1"
     assert contract["diagnostic_only"] is True
     assert contract["status"] == "mixed_unbounded_penalty_basis"
@@ -227,6 +247,8 @@ def test_contribution_diagnostics_reconstruct_snqi_and_flag_raw_dominance():
     assert contract["baseline_normalized_penalty_absolute_share"] == pytest.approx(0.4)
     assert contract["weight_bound_exceedance_terms"] == ["time", "comfort"]
     assert "bypass normalize_metric" in contract["reasons"][0]
+    assert version_contract["score_version"] == "SNQI-v0"
+    assert version_contract["score_semantics_changed"] is False
 
     by_term = {term["term"]: term for term in diagnostics["terms"]}
     assert by_term["time"]["scaled_value"] == pytest.approx(3.0)


### PR DESCRIPTION
## Summary
- Adds a machine-readable SNQI-v0 score-version contract to the existing issue #3699 normalization inventory and contribution diagnostics.
- Surfaces the legacy mixed-basis checker contract in standalone and combined SNQI preflight text output.
- Adds focused tests proving the checker labels current semantics without changing SNQI scoring.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3699

## Validation
- `uv run python -m py_compile robot_sf/benchmark/snqi/normalization_inventory.py scripts/validation/check_snqi_normalization_inventory.py scripts/validation/check_snqi_governance.py`
- `uv run ruff format robot_sf/benchmark/snqi/normalization_inventory.py scripts/validation/check_snqi_normalization_inventory.py scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py && uv run ruff check robot_sf/benchmark/snqi/normalization_inventory.py scripts/validation/check_snqi_normalization_inventory.py scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py`
- `uv run pytest tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_normalization_inventory_report.py tests/benchmark/test_snqi_governance_preflight.py tests/test_snqi_weights_inventory.py -q`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh`

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No SNQI score semantic changes, rank changes, or canonical weight changes.

## Follow-Up Issues
- None. Residual bounded/recalibrated SNQI-v1 design remains tracked by issue #3699 decision context.

## Residual notes
- SNQI-v0 remains a legacy mixed raw/baseline-normalized checker surface.
- A bounded/recalibrated SNQI-v1 contract remains future decision/implementation work.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a visible score version contract to SNQI diagnostics and summary reports, including version, status, and diagnostic-only indicators.
  * Human-readable normalization and governance outputs now include clearer score-version details for easier review.

* **Bug Fixes**
  * Preserved legacy SNQI scoring semantics in diagnostic output while making the contract status explicit.
  * Added a forward-looking contract reference to support future score-version transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->