### PR TITLE
Issue #3798: stabilize S20/S30 evidence-gap packet paths

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -2636,7 +2636,9 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+    legacy_dirty_evidence: true
   - path: docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+    legacy_dirty_evidence: true

--- a/docs/context/evidence/README.md
+++ b/docs/context/evidence/README.md
@@ -126,6 +126,11 @@ result matrix to analyze before any duplicate rerun, preserves its soft SNQI con
 warning as a paper-claim blocker, and confirms no Slurm/GPU submission, artifact
 deletion, or paper/dissertation claim edit.
 
+- `issue_3798_post_13175_s20_s30_evidence_gap_packet.{md,json}`: diagnostic-only packet over
+retrieved job 13175 S20/H500 artifacts for the post-#1554 evidence gap. Names the compact
+reviewable metadata files, records that S30 remains an unexecuted escalation path, and preserves
+the no-submit/no-claim boundary for paper or dissertation use.
+
 - `issue_3207_simulator_dependence_validity_boundary_packet_2026-06-29/`: checker packet over
   the merged #3207 bounded actual fidelity-sensitivity slice. Classifies the current evidence as
   `no_claim` / `not_benchmark_evidence` because the slice is not full fixed scope and rank evidence

--- a/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
+++ b/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
@@ -3,7 +3,7 @@
   "job_id": "13175",
   "status": "diagnostic_only",
   "claim_boundary": "diagnostic-only evidence-gap packet; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, and no S20/S30 claim promotion",
-  "artifact_root": "/home/luttkule/git/robot_sf_ll7/output/issue1554-s20-h500-l40s-mem180/13175",
+  "artifact_root": "output/issue1554-s20-h500-l40s-mem180/13175",
   "retrieved_artifacts": {
     "file_count": 56,
     "total_bytes": 185111675,

--- a/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.md
+++ b/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.md
@@ -18,7 +18,7 @@ This packet summarizes retrieved S20 (20-seed) job artifacts for issue #1554, ke
 
 ## Retrieved Artifacts
 
-- Artifact root: `/home/luttkule/git/robot_sf_ll7/output/issue1554-s20-h500-l40s-mem180/13175`
+- Artifact root: `output/issue1554-s20-h500-l40s-mem180/13175`
 - File count: 56
 - Total bytes: 185111675
 - Missing required metadata files: none

--- a/scripts/validation/extract_s20_s30_evidence_gap_packet.py
+++ b/scripts/validation/extract_s20_s30_evidence_gap_packet.py
@@ -118,7 +118,7 @@ def build_packet(artifact_root: Path, *, job_id: str = DEFAULT_JOB_ID) -> dict[s
 def _display_path(path: Path) -> str:
     """Return a stable repository-relative path when possible."""
     try:
-        return path.relative_to(Path.cwd()).as_posix()
+        return path.relative_to(Path.cwd().resolve()).as_posix()
     except ValueError:
         return path.as_posix()
 

--- a/scripts/validation/extract_s20_s30_evidence_gap_packet.py
+++ b/scripts/validation/extract_s20_s30_evidence_gap_packet.py
@@ -57,7 +57,7 @@ def build_packet(artifact_root: Path, *, job_id: str = DEFAULT_JOB_ID) -> dict[s
         "schema_version": SCHEMA_VERSION,
         "status": "blocked_missing_retrieved_metadata" if missing_files else "diagnostic_only",
         "job_id": str(job_id),
-        "artifact_root": str(root),
+        "artifact_root": _display_path(root),
         "claim_boundary": CLAIM_BOUNDARY,
         "campaign": _campaign_metadata(manifest, run_meta),
         "retrieved_artifacts": {
@@ -113,6 +113,14 @@ def build_packet(artifact_root: Path, *, job_id: str = DEFAULT_JOB_ID) -> dict[s
         ],
     }
     return packet
+
+
+def _display_path(path: Path) -> str:
+    """Return a stable repository-relative path when possible."""
+    try:
+        return path.relative_to(Path.cwd()).as_posix()
+    except ValueError:
+        return path.as_posix()
 
 
 def load_packet_fixture(packet_fixture: Path) -> dict[str, Any]:


### PR DESCRIPTION
## Summary
Stabilizes the post-13175 S20/S30 evidence-gap packet for issue #3798 by removing the machine-local absolute artifact path from the tracked packet and adding the packet to the evidence bundle index.

## Linked Issues
- Closes `#3798`
- Relates `#1554`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Render the packet artifact root as a repository-relative path when possible.
- Update the tracked Markdown and JSON packet to use `output/issue1554-s20-h500-l40s-mem180/13175` instead of a machine-local `/home/...` path.
- Mark the #3798 catalog entries as legacy dirty evidence because the packet intentionally records ignored-output provenance without promoting it.
- Add the #3798 packet to `docs/context/evidence/README.md` for discoverability.

## Why Matters
- Added value: makes the diagnostic packet portable across hosts and discoverable from the evidence bundle index.
- Expected impact: avoids leaking a local checkout path while preserving the evidence boundary around retrieved job 13175 artifacts.
- Why worth merging now: #3798 was still open even though the packet exists; this closes the remaining review/discoverability gap.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3798 post-13175 S20/S30 evidence-gap packet discoverability and portability only.
- Comparator or baseline, applicable: NA - no benchmark comparison is changed.
- Evidence tier: docs-only
- Result classification: NA - no new evidence result or interpretation.
- Decision stop rule, applicable: packet remains no-go for claim promotion and S30 submission from this issue.
- Parent issue, claim map, registry, context note, synthesis surface update: `docs/context/evidence/README.md` and `docs/context/catalog.yaml` updated.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - existing extractor only; no new interpretation surface.

## Domain-Aware Approval
- approval concerns experimental validity waived / pending / blocked / not required: not required
- Approver/review source waiver: no evidence classification or experimental interpretation changed.
- Validity checklist: diagnostic-only packet boundary preserved.
- Target claim/hypothesis: NA - no claim promotion.
- Comparator split/evidence validity: NA - no comparator split or evidence interpretation changed.
- Fallback/degraded exclusions: unchanged; archive-readiness remains fail-closed blocked.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation only changes path rendering and docs indexing.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - docs/path-stability support change.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue - packet remains diagnostic-only.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: canonical result-store files remain missing for archive-readiness claim promotion.
- Stop / revise / continue decision: continue only in a separately authorized claim/archive lane.
- Proposed child issue existing follow-up: none opened here.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/extract_s20_s30_evidence_gap_packet.py tests/validation/test_extract_s20_s30_evidence_gap_packet.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py` - passed, 9 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --packet-fixture docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json --markdown` - passed; renders repo-relative artifact root.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/evidence/README.md` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_docs_proof_consistency.py --path docs/context/catalog.yaml` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_s20_s30_archive_readiness.py --json` - expected exit 1 with `status: blocked`; confirms claim promotion remains fail-closed because canonical result-store files are missing.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Evidence
- Baseline runtime: NA - no runtime performance claim.
- Changed runtime: NA - no runtime performance claim.
- Representative command: `uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py`
- Hot-path call count profile anchor: NA - no hot path changed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if tracked packet again emits machine-local absolute artifact paths or docs proof consistency fails.

## Risks / Rollout
- Compatibility risks: low; packet schema and claim boundary remain unchanged.
- Failure modes: future generated packet may still reference an absolute path if artifacts live outside the checkout.
- Rollback fallback plan: revert this PR; existing packet remains diagnostic-only.

## Docs / Provenance
- Updated docs: `docs/context/evidence/README.md`, `docs/context/catalog.yaml`, tracked #3798 packet Markdown/JSON.
- Relevant design provenance notes: issue #3798, issue #1554 packet provenance.
- Any assumptions need to preserved: `legacy_dirty_evidence: true` is intentional because the packet records ignored-output provenance without promoting raw artifacts.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - authorization forbids issue comments.
- Claim map / benchmark report updated (yes/no/NA): NA - no claim edit.
- Leaderboard / artifact catalog updated (yes/no/NA): NA - no benchmark result promotion.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): evidence README and catalog updated.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a diagnostic packet portability/discoverability fix, not a benchmark or paper-facing claim.

## Follow-Up Issues
- Deferred work: run or satisfy the archive-readiness result-store gate in a separately authorized lane before any S20/S30 claim promotion.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer verify closely: confirm the catalog `legacy_dirty_evidence` flag is acceptable for this packet because it intentionally references ignored `output/` provenance.
- Any known limitations: archive-readiness remains blocked by missing canonical result-store files.
