### PR TITLE
Issue #3723: fail closed uncomparable SNQI canonical weights

### DIFF
--- a/robot_sf/benchmark/snqi/weights_inventory.py
+++ b/robot_sf/benchmark/snqi/weights_inventory.py
@@ -547,6 +547,33 @@ def _canonical_load_error_conflicts(
     ]
 
 
+def _canonical_uncomparable_direction_conflicts(
+    loaded_canonical: list[WeightSetRecord],
+) -> list[WeightProvenanceConflict]:
+    """Fail closed when canonical sources load but have no comparable direction.
+
+    Returns:
+        One ``canonical_uncomparable_direction`` (error) conflict per source
+        whose weights cannot be normalized into a direction for provenance
+        comparison.
+    """
+    return [
+        WeightProvenanceConflict(
+            kind="canonical_uncomparable_direction",
+            severity="error",
+            sources=[r.name],
+            detail=(
+                f"canonical-declaring source '{r.name}' "
+                f"({r.relpath or 'code default'}) loaded but has no comparable "
+                "weight direction; provenance inventory cannot decide whether "
+                "it matches another canonical source."
+            ),
+        )
+        for r in loaded_canonical
+        if r.normalized_direction() is None
+    ]
+
+
 def _canonical_direction_conflicts(
     loaded_canonical: list[WeightSetRecord],
 ) -> list[WeightProvenanceConflict]:
@@ -688,6 +715,9 @@ def detect_conflicts(records: list[WeightSetRecord]) -> list[WeightProvenanceCon
 
     * ``canonical_load_error`` (error): a canonical-declaring source failed to
       load. Inventory cannot certify provenance, so this fails closed.
+    * ``canonical_uncomparable_direction`` (error): a canonical-declaring
+      source loaded but has no scale-independent direction for provenance
+      comparison.
     * ``canonical_direction_conflict`` (error): two canonical-declaring sources
       disagree on their (scale-independent) weight direction — i.e. the same
       "canonical" label yields different rankings.
@@ -707,6 +737,7 @@ def detect_conflicts(records: list[WeightSetRecord]) -> list[WeightProvenanceCon
 
     conflicts: list[WeightProvenanceConflict] = []
     conflicts += _canonical_load_error_conflicts(canonical)
+    conflicts += _canonical_uncomparable_direction_conflicts(loaded_canonical)
     conflicts += _canonical_direction_conflicts(loaded_canonical)
     conflicts += _unregistered_weight_source_conflicts(records)
     conflicts += _code_default_shipped_direction_conflicts(records)

--- a/tests/test_snqi_weights_inventory.py
+++ b/tests/test_snqi_weights_inventory.py
@@ -300,6 +300,44 @@ def test_zero_sum_shipped_source_reports_comparison_unavailable_reason():
     assert comparison.load_error == "no_comparable_direction"
 
 
+def test_zero_sum_canonical_source_fails_closed_as_uncomparable_direction():
+    """Canonical-labeled source must be comparable, not merely loadable."""
+    code_default = WeightSetRecord(
+        name="code_default",
+        kind="code_default",
+        relpath=None,
+        versioned_id="snqi_weights_code_default_v1",
+        declares_canonical=True,
+        available=True,
+        weights=dict.fromkeys(WEIGHT_NAMES, 1.0),
+        weight_sum=float(len(WEIGHT_NAMES)),
+        dominant_term="w_success",
+        scale_class="raw",
+    )
+    zero_sum = WeightSetRecord(
+        name="model_canonical_zero",
+        kind="shipped_json",
+        relpath="model/snqi_canonical_zero.json",
+        versioned_id="snqi_weights_model_canonical_zero",
+        declares_canonical=True,
+        available=True,
+        weights=dict.fromkeys(WEIGHT_NAMES, 0.0),
+        weight_sum=0.0,
+        dominant_term=None,
+        scale_class=None,
+        load_error=None,
+    )
+
+    conflicts = detect_conflicts([code_default, zero_sum])
+
+    uncomparable = [
+        conflict for conflict in conflicts if conflict.kind == "canonical_uncomparable_direction"
+    ]
+    assert len(uncomparable) == 1
+    assert uncomparable[0].severity == "error"
+    assert uncomparable[0].sources == ["model_canonical_zero"]
+
+
 def test_no_blocking_conflict_when_canonical_sources_agree(tmp_path):
     """When the model canonical file matches the code default, preflight passes."""
     repo = _make_fixture_repo(tmp_path, model_jerk_dominant=False)


### PR DESCRIPTION
## Summary
- Related to #3723.
- Adds a fail-closed SNQI weight provenance conflict kind for canonical-labeled sources that load successfully but cannot be normalized into a comparable weight direction.
- Extends the focused SNQI weight inventory test fixture to prove zero-sum canonical-labeled sources fail closed without changing current scoring behavior.

## Scope
This is a bounded diagnostic/preflight improvement only. It does not choose canonical weights, change SNQI metric semantics, alter shipped weight values, rerun campaigns, or edit paper/dissertation claims.

## Validation
- `uv run pytest tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_governance_preflight.py tests/benchmark/test_snqi_normalization_inventory.py -q` -> 35 passed.
- `uv run ruff check robot_sf/benchmark/snqi/weights_inventory.py tests/test_snqi_weights_inventory.py` -> passed.
- `uv run ruff format --check robot_sf/benchmark/snqi/weights_inventory.py tests/test_snqi_weights_inventory.py` -> 2 files already formatted.
- `uv run python scripts/validation/check_snqi_governance.py --json` -> expected exit 2; existing #3723 `weight_provenance_conflict` and #3699 `mixed_normalization_basis` remain visible.
- `uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers` -> exit 0; inspection mode reports the same current blockers.

## Explicitly Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Artifact Classification
No generated benchmark artifacts are promoted. Local validation output remains disposable under the worktree/common validation output paths.
