### PR TITLE
Issue #3653: fail closed SNQI export preflight

### DIFF
--- a/scripts/tools/analyze_snqi_scalarization_sensitivity.py
+++ b/scripts/tools/analyze_snqi_scalarization_sensitivity.py
@@ -67,19 +67,23 @@ def main(argv: list[str] | None = None) -> int:
     weights = load_weight_mapping(args.weights)
     baseline = load_baseline_mapping(args.baseline)
 
+    preflight = classify_scalarization_sensitivity_inputs(
+        records,
+        weights=weights,
+        baseline=baseline,
+        planner_key=args.planner_key,
+        fallback_planner_key=args.fallback_planner_key,
+    )
     if args.preflight_only:
-        preflight = classify_scalarization_sensitivity_inputs(
-            records,
-            weights=weights,
-            baseline=baseline,
-            planner_key=args.planner_key,
-            fallback_planner_key=args.fallback_planner_key,
-        )
         print(json.dumps(preflight, indent=2))
         return 0 if preflight["status"] == SENSITIVITY_PREFLIGHT_READY else 2
 
     if args.output_dir is None:
         raise SystemExit("--output-dir is required unless --preflight-only is set")
+
+    if preflight["status"] != SENSITIVITY_PREFLIGHT_READY:
+        print(json.dumps(preflight, indent=2))
+        return 2
 
     report = build_scalarization_sensitivity_report(
         records,

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -430,7 +430,7 @@ def test_cli_writes_scalarization_artifacts(tmp_path: Path, capsys) -> None:
     """CLI writes the same report-ready artifact family."""
     episodes_path = tmp_path / "episodes.jsonl"
     episodes_path.write_text(
-        "\n".join(json.dumps(record) for record in _episodes()) + "\n",
+        "\n".join(json.dumps(record) for record in _preflight_episodes()) + "\n",
         encoding="utf-8",
     )
     weights_path = tmp_path / "weights.json"
@@ -496,6 +496,41 @@ def test_cli_preflight_only_blocks_invalid_inputs(tmp_path: Path, capsys) -> Non
     stdout = json.loads(capsys.readouterr().out)
     assert stdout["status"] == SENSITIVITY_PREFLIGHT_BLOCKED
     assert any(issue["code"] == "missing_scenario_horizon" for issue in stdout["issues"])
+
+
+def test_cli_export_blocks_invalid_inputs_before_artifacts(tmp_path: Path, capsys) -> None:
+    """Normal export path also refuses blocked preflight inputs before writing artifacts."""
+    records = _preflight_episodes()
+    records[0].pop("scenario_id")
+    episodes_path = tmp_path / "episodes.jsonl"
+    episodes_path.write_text(
+        "\n".join(json.dumps(record) for record in records) + "\n",
+        encoding="utf-8",
+    )
+    weights_path = tmp_path / "weights.json"
+    weights_path.write_text(json.dumps(_weights()), encoding="utf-8")
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(_baseline()), encoding="utf-8")
+    output_dir = tmp_path / "artifacts"
+
+    exit_code = scalarization_cli_main(
+        [
+            "--episodes",
+            str(episodes_path),
+            "--weights",
+            str(weights_path),
+            "--baseline",
+            str(baseline_path),
+            "--output-dir",
+            str(output_dir),
+        ]
+    )
+
+    assert exit_code == 2
+    stdout = json.loads(capsys.readouterr().out)
+    assert stdout["status"] == SENSITIVITY_PREFLIGHT_BLOCKED
+    assert any(issue["code"] == "missing_scenario_horizon" for issue in stdout["issues"])
+    assert not output_dir.exists()
 
 
 def test_baseline_loader_refuses_missing_normalized_fixture_input(tmp_path: Path) -> None:


### PR DESCRIPTION
## Issue

Relates https://github.com/ll7/robot_sf_ll7/issues/3653

## Scope Summary

- Makes the legacy `scripts/tools/analyze_snqi_scalarization_sensitivity.py` export path run the existing SNQI scalarization-sensitivity preflight before writing artifacts.
- Blocked or malformed inputs now return exit code `2` with the preflight payload instead of exporting Pareto-front or decision-disagreement artifacts.
- Updates the export success fixture to use preflight-ready scenario-horizon records and adds a regression test proving blocked inputs write no artifact directory.

## Validation

- `../../robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py -q` - passed, 30 tests.
- `../../robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` - passed.
- `../../robot_sf_ll7/scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/tools/analyze_snqi_scalarization_sensitivity.py tests/benchmark/test_snqi_scalarization_sensitivity.py` - passed, 2 files already formatted.
- `CUDA_VISIBLE_DEVICES= BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed after `uv sync --all-extras`; freshness stamp `output/validation/pr_ready/issue-3653-snqi-normalized-input-preflight-codex8.json` for `c3d1768797398fdec95231b2647d149400b25909`.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Notes

- Assumption: the smallest remaining reversible slice is to close the older tools-script export bypass using the already-established preflight contract, not to change SNQI scoring, weights, normalization, or research conclusions.
- Artifact classification: validation outputs are local ignored `output/` readiness/coverage artifacts only; no durable benchmark artifact is promoted.
