### PR TITLE
Issue #3723: print SNQI canonical decision status

### DIFF
--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -167,6 +167,13 @@ def _print_text_report(report: dict[str, Any]) -> None:
     """Print a compact human-readable report."""
     print(CLAIM_BOUNDARY)
     print(f"SNQI governance status: {report['status']}")
+    canonical_decision = report["weights"]["source_summary"]["canonical_decision"]
+    print(
+        "Canonical SNQI weight decision: "
+        f"{canonical_decision['status']}; "
+        f"selected_versioned_id={canonical_decision['selected_versioned_id']}; "
+        f"ambiguous_label={canonical_decision['ambiguous_unversioned_label']}"
+    )
     if report["blockers"]:
         print("Blocking diagnostics:")
         for blocker in report["blockers"]:

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -131,6 +131,9 @@ def test_governance_text_lists_per_term_normalization_status(
     assert main(["--repo-root", str(REPO_ROOT), "--allow-current-blockers"]) == 0
 
     out = capsys.readouterr().out
+    assert "Canonical SNQI weight decision: unresolved_decision_required" in out
+    assert "selected_versioned_id=None" in out
+    assert "ambiguous_label=canonical" in out
     assert "Weight sources:" in out
     assert "code_default (code_default, <code default>): canonical=True" in out
     assert "versioned_id=snqi_weights_code_default_v1" in out


### PR DESCRIPTION
## Summary
Makes the human-readable SNQI governance preflight print the unresolved canonical-weight decision status that already exists in the structured JSON report.

## Linked Issues
- Relates to `#3723`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: `#3723` remains open for the maintainer canonical-weight decision
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- `scripts/validation/check_snqi_governance.py` now prints `Canonical SNQI weight decision: unresolved_decision_required; selected_versioned_id=None; ambiguous_label=canonical` in text mode.
- `tests/benchmark/test_snqi_governance_preflight.py` pins that text output alongside the existing inventory and normalization diagnostics.

## Why Matters
- Added value: the text preflight now explicitly defers the canonical SNQI weight choice instead of only exposing that state in JSON.
- Expected impact: diagnostic/preflight output is clearer; current SNQI scoring and weight semantics are unchanged.
- Why worth merging now: issue #3723 remains decision-required, and this keeps the fail-closed report aligned with that boundary.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3723 provenance blocker visibility only; no canonical weight decision.
- Comparator or baseline, applicable: current `origin/main` text preflight output.
- Evidence tier: diagnostic probe
- Result classification: diagnostic-only
- Decision stop rule, applicable: text output must report unresolved decision status while preserving current fail-closed blockers.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue remains open; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - existing diagnostic preflight text output only.

## Domain-Aware Approval
- Required for this PR: yes - evidence-validity-sensitive diagnostic classification
- Required for PR: yes - evidence-validity-sensitive diagnostic classification
- Required PR: yes - evidence-validity-sensitive diagnostic classification
- Domains reviewed: SNQI weight provenance diagnostics for #3723; no metric/scoring semantics
- Status: waived
- Approver/review source or waiver: self-reviewed text-only diagnostic output; Claude Code on imech156-u owns full PR gate after open per task handoff
- Approver/review source waiver: self-reviewed text-only diagnostic output; Claude Code on imech156-u owns full PR gate after open per task handoff
- Validity checklist:
  - Target claim/hypothesis: text preflight reports unresolved canonical SNQI weight decision status
  - Comparator or split/evidence validity: existing targeted preflight text-path proof only; no planner ranking comparison is made
  - Fallback/degraded exclusions: existing fail-closed blockers remain blockers, not successful benchmark evidence
  - Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits
  - Implementation integrity vs experimental validity: targeted tests and command output exercise the changed text path without changing structured JSON or scoring

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, the text preflight prints the unresolved decision status.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes, current repo still reports #3723 and #3699 blockers.
- Result route: continue with maintainer decision on #3723.
- Follow-up question issue weak, negative, non-transfer results: #3723 remains the decision surface.

## Next Empirical Action
- Rerun needed: no full benchmark rerun for this diagnostic text change.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with #3723 canonical-weight decision outside this PR.
- Proposed child issue existing follow-up: #3723.

## Validation / Proof
- `uv run pytest tests/benchmark/test_snqi_governance_preflight.py tests/test_snqi_weights_inventory.py tests/benchmark/test_snqi_weight_inventory_cli.py -q` -> 20 passed.
- `uv run python scripts/validation/check_snqi_governance.py --allow-current-blockers` -> exit 0; prints `Canonical SNQI weight decision: unresolved_decision_required; selected_versioned_id=None; ambiguous_label=canonical` and preserves #3723/#3699 blockers.
- `uv run ruff check scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_governance_preflight.py` -> passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` initially stopped before validation because no PR body source was configured; rerun with this body file is recorded below before opening.

## Risks / Rollout
- Compatibility risks: low; text-only preflight output addition.
- Failure modes: downstream text parsers expecting exact line positions could need adjustment, though no structured JSON keys changed.
- Rollback fallback plan: revert the added print and focused assertions.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3723 live issue and merged governance preflight history.
- Any assumptions need to preserved: this PR explicitly defers the canonical-weight decision and does not promote any versioned ID.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, per task authorization comment_issue_or_pr=false.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): no.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): no.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no metric/scoring semantics change.

## Follow-Up Issues
- Deferred work: maintainer canonical SNQI weight decision remains in #3723.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that the PR only changes diagnostic text output and its focused test.
- Known limitation: this does not resolve the conflicting canonical SNQI weight sets.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a clearer SNQI governance status line to the human-readable preflight report, showing the canonical weight decision along with its selected versioned ID and ambiguous label.
  * Updated validation output so this decision is visible before blocker details, making report results easier to interpret.

* **Tests**
  * Expanded coverage to confirm the new canonical decision details appear in the text report.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->