### PR TITLE
Issue #3216: add headline decision preflight gate

### DIFF
--- a/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+++ b/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
@@ -1079,6 +1079,17 @@ def render_markdown(report: Mapping[str, Any]) -> str:
     return "\n".join(lines)
 
 
+def decision_packet_has_blocker(decision_packet: Mapping[str, Any]) -> bool:
+    """Return whether a decision packet should fail a local preflight.
+
+    The report itself is still useful when this returns ``True``; the non-zero
+    CLI mode is for automation that wants a hard gate before table or S30 work.
+    """
+    return decision_packet.get("manuscript_table_status") == "blocked" or decision_packet.get(
+        "s30_decision_status"
+    ) in {"blocked", "needs_review"}
+
+
 def _append_decision_packet_markdown(lines: list[str], decision_packet: Mapping[str, Any]) -> None:
     """Append the manuscript/S30 decision packet markdown section."""
     lines.append("## Manuscript/S30 decision packet")
@@ -1251,6 +1262,14 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         default="output/issue_3216_headline_ci/report",
         help="Directory for result.json and report.md.",
     )
+    parser.add_argument(
+        "--fail-on-decision-blocker",
+        action="store_true",
+        help=(
+            "Return exit code 4 after writing outputs when the local decision "
+            "packet still blocks manuscript-table or S30 decisions."
+        ),
+    )
     return parser.parse_args(argv)
 
 
@@ -1326,6 +1345,15 @@ def main(argv: Sequence[str] | None = None) -> int:
         f"counted={report['inputs']['counted_cells']} "
         f"excluded={report['inputs']['excluded_cells']} -> {out_dir}"
     )
+    if args.fail_on_decision_blocker and decision_packet_has_blocker(report["decision_packet"]):
+        packet = report["decision_packet"]
+        print(
+            "decision_blocker=true "
+            f"manuscript_table_status={packet['manuscript_table_status']} "
+            f"s30_decision_status={packet['s30_decision_status']}",
+            file=sys.stderr,
+        )
+        return 4
     return 0
 
 

--- a/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
@@ -457,6 +457,87 @@ def test_dry_run_cli_can_fail_closed_invalid_rank_metric(tmp_path) -> None:
     assert "**Rank metric contract**: `invalid`" in markdown_text
 
 
+def test_cli_decision_blocker_gate_fails_after_writing_report(tmp_path) -> None:
+    """Dry-run preflight can be used as a hard gate while preserving artifacts."""
+
+    out_dir = tmp_path / "blocked_report"
+
+    exit_code = mod.main(
+        [
+            "--dry-run",
+            "--bootstrap-samples",
+            "0",
+            "--rank-resamples",
+            "25",
+            "--fail-on-decision-blocker",
+            "--output-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert exit_code == 4
+    result = json.loads((out_dir / "result.json").read_text(encoding="utf-8"))
+    assert mod.decision_packet_has_blocker(result["decision_packet"]) is True
+    assert result["decision_packet"]["s30_decision_status"] == "needs_review"
+    assert (out_dir / "report.md").is_file()
+
+
+def test_cli_decision_blocker_gate_passes_clear_local_preflight(tmp_path) -> None:
+    """S20 separable/stable fixture passes the local blocker gate."""
+
+    rows = [
+        _cell_row(
+            "merging",
+            "best",
+            {
+                "success": [0.90, 0.91, 0.92, 0.93, 0.94] * 4,
+                "collisions": [0.02, 0.01, 0.02, 0.01, 0.02] * 4,
+                "near_misses": [0.04, 0.03, 0.04, 0.03, 0.04] * 4,
+                "snqi": [0.90, 0.91, 0.92, 0.93, 0.94] * 4,
+            },
+        ),
+        _cell_row(
+            "merging",
+            "worst",
+            {
+                "success": [0.10, 0.11, 0.09, 0.12, 0.10] * 4,
+                "collisions": [0.80, 0.82, 0.81, 0.83, 0.80] * 4,
+                "near_misses": [0.70, 0.72, 0.71, 0.73, 0.70] * 4,
+                "snqi": [0.10, 0.11, 0.09, 0.12, 0.10] * 4,
+            },
+        ),
+    ]
+    rows_path = tmp_path / "rows.json"
+    rows_path.write_text(json.dumps(rows), encoding="utf-8")
+    out_dir = tmp_path / "clear_report"
+
+    exit_code = mod.main(
+        [
+            "--rows",
+            str(rows_path),
+            "--metrics",
+            "success",
+            "collisions",
+            "near_misses",
+            "snqi",
+            "--rank-profile",
+            "constraints_first",
+            "--bootstrap-samples",
+            "0",
+            "--rank-resamples",
+            "25",
+            "--fail-on-decision-blocker",
+            "--output-dir",
+            str(out_dir),
+        ]
+    )
+
+    assert exit_code == 0
+    result = json.loads((out_dir / "result.json").read_text(encoding="utf-8"))
+    assert mod.decision_packet_has_blocker(result["decision_packet"]) is False
+    assert result["decision_packet"]["s30_decision_status"] == "not_required_by_local_preflight"
+
+
 def _job_13198_packet(tmp_path) -> Path:
     """Write a compact deterministic job-13198 evidence packet fixture."""
 


### PR DESCRIPTION
## Summary

Addresses #3216: https://github.com/ll7/robot_sf_ll7/issues/3216

Adds a local hard-gate option to the existing #3216 headline confidence interval and rank-stability report harness:

- `--fail-on-decision-blocker` writes `result.json` and `report.md` as before, then returns exit code `4` when the decision packet still blocks manuscript-table use or leaves the S30 decision in review/blocked state.
- Adds deterministic fixture tests for both blocked dry-run output and a clear S20-style local preflight.

## Validation

- `uv run pytest tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py -q` passed.
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --help` passed.
- `uv run ruff format scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py` passed.
- `uv run ruff check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py` passed.
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --dry-run --bootstrap-samples 0 --rank-resamples 25 --fail-on-decision-blocker --output-dir output/issue3216-dry-run-gate` returned expected exit code `4` after writing outputs because the built-in fixture remains diagnostic and S30 needs review.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed before commit with a dirty-tree interim stamp.
- `CUDA_VISIBLE_DEVICES= PYTEST_NUM_WORKERS=1 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/pr_body_issue_3216.md scripts/dev/pr_ready_check.sh` passed on clean head `8b4e1ffdfbb4939e9c1ab4bda89c75f307831211`.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Follow-Up Issues

- #3216 remains open for full campaign evidence, S30 decision handling, and manuscript table/claim edits.
