### PR TITLE
Issue #3723: surface SNQI source records in governance blocker

### DIFF
--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -103,6 +103,21 @@ def build_governance_report(
                     "More than one SNQI source currently declares or implies "
                     "canonical status while disagreeing on weight direction."
                 ),
+                "discovered_weight_sources": [
+                    {
+                        "name": record["name"],
+                        "kind": record["kind"],
+                        "relpath": record["relpath"],
+                        "versioned_id": record["versioned_id"],
+                        "declares_canonical": record["declares_canonical"],
+                        "available": record["available"],
+                        "dominant_term": record["dominant_term"],
+                        "scale_class": record["scale_class"],
+                        "content_sha256": record["content_sha256"],
+                        "load_error": record["load_error"],
+                    }
+                    for record in weight_report["records"]
+                ],
                 "registered_sources": source_summary["registered_sources"],
                 "discovered_shipped_sources": source_summary["discovered_shipped_sources"],
                 "canonical_declaring_sources": source_summary["canonical_declaring_sources"],

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -39,17 +39,21 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
         "camera_ready_v3",
         "model_canonical_v1",
     ]
-    discovered_by_name = {
-        source["name"]: source for source in blocker_3723["discovered_weight_sources"]
-    }
-    records_by_name = {record["name"]: record for record in report["weights"]["records"]}
-    assert list(discovered_by_name) == [
+    # Assert the raw source sequence (order + length) before keying by name so a
+    # duplicate-name regression cannot be masked by later entries overwriting earlier
+    # ones in the dict comprehension below.
+    expected_source_names = [
         "code_default",
         "camera_ready_v1",
         "camera_ready_v2",
         "camera_ready_v3",
         "model_canonical_v1",
     ]
+    discovered_sources = blocker_3723["discovered_weight_sources"]
+    assert [source["name"] for source in discovered_sources] == expected_source_names
+    discovered_by_name = {source["name"]: source for source in discovered_sources}
+    records_by_name = {record["name"]: record for record in report["weights"]["records"]}
+    assert list(discovered_by_name) == expected_source_names
     assert discovered_by_name["code_default"] == {
         "name": "code_default",
         "kind": "code_default",

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -39,6 +39,34 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
         "camera_ready_v3",
         "model_canonical_v1",
     ]
+    discovered_by_name = {
+        source["name"]: source for source in blocker_3723["discovered_weight_sources"]
+    }
+    assert list(discovered_by_name) == [
+        "code_default",
+        "camera_ready_v1",
+        "camera_ready_v2",
+        "camera_ready_v3",
+        "model_canonical_v1",
+    ]
+    assert discovered_by_name["code_default"] == {
+        "name": "code_default",
+        "kind": "code_default",
+        "relpath": None,
+        "versioned_id": "snqi_weights_code_default_v1",
+        "declares_canonical": True,
+        "available": True,
+        "dominant_term": "w_collisions",
+        "scale_class": "raw",
+        "content_sha256": report["weights"]["records"][0]["content_sha256"],
+        "load_error": None,
+    }
+    model_source = discovered_by_name["model_canonical_v1"]
+    assert model_source["relpath"] == "model/snqi_canonical_weights_v1.json"
+    assert model_source["versioned_id"] == "snqi_weights_model_canonical_v1"
+    assert model_source["declares_canonical"] is True
+    assert model_source["dominant_term"] == "w_jerk"
+    assert model_source["content_sha256"]
     assert blocker_3723["canonical_declaring_sources"] == [
         "code_default",
         "model_canonical_v1",

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -42,6 +42,7 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
     discovered_by_name = {
         source["name"]: source for source in blocker_3723["discovered_weight_sources"]
     }
+    records_by_name = {record["name"]: record for record in report["weights"]["records"]}
     assert list(discovered_by_name) == [
         "code_default",
         "camera_ready_v1",
@@ -58,7 +59,7 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
         "available": True,
         "dominant_term": "w_collisions",
         "scale_class": "raw",
-        "content_sha256": report["weights"]["records"][0]["content_sha256"],
+        "content_sha256": records_by_name["code_default"]["content_sha256"],
         "load_error": None,
     }
     model_source = discovered_by_name["model_canonical_v1"]


### PR DESCRIPTION
## Summary

Expose full Social Navigation Quality Index (SNQI) weight-source records directly inside the fail-closed #3723 governance blocker.

## Linked Issues

- Relates to `#3723`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3723`
- Safe to review independently: yes
- Review dependency reason, any: none

## What Changed

- Added `discovered_weight_sources` to the #3723 `weight_provenance_conflict` blocker emitted by `scripts/validation/check_snqi_governance.py`.
- The blocker now carries each discovered source's kind, path, versioned ID, canonical flag, dominant term, scale class, availability, SHA-256 fingerprint, and load error.
- Extended the focused governance test to assert all discovered code/default and shipped JSON sources are present in the fail-closed blocker payload.

## Why Matters

- Added value: downstream preflight consumers can inspect the complete SNQI weight-source inventory from the blocker payload itself.
- Expected impact: provenance reporting is clearer without changing scoring or selecting a canonical weight set.
- Why worth merging now: #3723 remains decision-required, and this keeps the remaining decision grounded in explicit source records.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #3723 SNQI weight provenance conflict reporting only.
- Comparator or baseline, applicable: current `origin/main` governance blocker payload.
- Evidence tier: NA - support reporting payload only; no benchmark result claim
- Result classification: NA - no research result; existing preflight remains diagnostic-only
- Decision stop rule, applicable: fail-closed checker still exits non-zero for unresolved #3723/#3699 blockers; inspection mode exposes source records.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3723 remains open for canonical-weight decision.
- New research/benchmark/metric/paper-facing analysis tool, any: none; existing governance preflight report payload refinement only.

## Domain-Aware Approval

- Required PR: no - support reporting payload only; no benchmark result, figure eligibility, or paper-facing claim changes.
- Domains reviewed: NA - approval not required.
- Status: not required.
- Approver/review source waiver: NA - no evidence-validity approval required for additive preflight payload field.
- Validity checklist:
- Target claim/hypothesis: NA - no research claim.
- Comparator or split/evidence validity: NA - no benchmark comparison claim.
- Fallback/degraded exclusions: NA - no benchmark execution.
- Claim boundary: reports discovered weight sources and conflicts only; does not choose canonical weights.
- Implementation integrity vs experimental validity: tests prove report shape only, not experimental validity.

## Falsification / Non-Transfer Check

- Did mechanism activate? yes; `discovered_weight_sources` appears in inspection-mode JSON.
- Did intervention change command source, selected command, trajectory, route progress? no; report-only payload refinement.
- Did scenario actually contain targeted failure mode? yes; current repository still reports #3723 `canonical_direction_conflict`.
- Result route: continue through #3723 maintainer canonical-weight decision.
- Follow-up question issue weak, negative, non-transfer results: #3723 remains the follow-up decision issue.

## Next Empirical Action

- Rerun needed: no full benchmark campaign run for this reporting-only change.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with #3723 canonical-weight source decision outside this PR.
- Proposed child issue existing follow-up: #3723.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_governance_preflight.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_governance_preflight.py tests/test_snqi_weights_inventory.py -q` -> 19 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --json` -> exit 2 as expected for current unresolved #3723/#3699 blockers
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_snqi_governance.py --json --allow-current-blockers` -> exit 0; output includes `discovered_weight_sources` with versioned IDs and `content_sha256` values
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_governance_preflight.py` -> passed

## Risks / Rollout

- Compatibility risks: downstream JSON consumers may see an additive blocker field.
- Failure modes: payload could become stale if future source records add fields not copied into the blocker.
- Rollback fallback plan: remove additive blocker field and test assertions.

## Docs / Provenance

- Updated docs: none; report payload and focused test only.
- Relevant design provenance notes: issue #3723 live thread and existing SNQI weights provenance docs.
- Any assumptions need to preserved: all discovered sources should remain visible in `weights.records`; blocker payload copies the review-critical subset.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no, comments not authorized for this run.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no; existing issue #3723 remains open.
- Not applicable because: no benchmark campaign, registry, claim-map, or paper-facing claim changed.

## Follow-Up Issues

- Deferred work: choose or explicitly version the canonical SNQI weight source; remains tracked by #3723.
- Issues opened follow-up: none; #3723 already tracks the decision-required remainder.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No canonical SNQI weight decision.

## Artifact Classification

No generated benchmark artifacts are promoted. Temporary validation JSON was written under `/tmp` only.

## Reviewer Notes

- Verify that this remains additive report-only JSON and does not alter `compute_snqi` or weight loading semantics.
- Known limitation: #3723 remains unresolved until a maintainer chooses or versions the canonical weight source.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Governance conflict reports now include richer diagnostic details for blocked weight provenance conflicts.
  * When a conflict is detected, the report now shows discovered weight sources with more context, including source type, location, versioned ID, canonical status, load issues, dominant term, scale class, and content hash.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Issue Disposition
Leave open: #3723 remains decision-required for canonical/versioned SNQI weight-source policy; this PR only improves fail-closed provenance reporting and does not choose canonical weights or close the issue.

## Stale-Open Audit
Checked by orchestration stale-open audit on 2026-06-30: #3723 is not in the high-confidence stale-open closure queue; current closure-review queue contains #3556 and #3207 only.


issue disposition: leave open because #3723 remains decision-required for canonical/versioned SNQI weight-source policy; this PR is report-only provenance plumbing.
stale-open audit: checked 2026-06-30; #3723 is not in the high-confidence stale-open closure queue (#3556 and #3207 are pending there).
