### PR TITLE
Issue #3813: wire sustained-flow preflight command

### DIFF
--- a/configs/benchmarks/issue_3813_sustained_flow_launch_packet.yaml
+++ b/configs/benchmarks/issue_3813_sustained_flow_launch_packet.yaml
@@ -20,6 +20,7 @@ campaign:
     matrix_path: configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml
     contract_path: configs/scenarios/contracts/issue_3813_sustained_flow_contracts.yaml
     preflight_helper: robot_sf.benchmark.sustained_flow_preflight.preflight_sustained_flow_matrix
+    preflight_command: "uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json"
     scope: opt_in_sustained_flow_t_intersection_scaffold
     scenario_ids:
       - issue_3813_sustained_flow_t_intersection_light

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -22,6 +22,7 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SCENARIO_SET = REPO_ROOT / "configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml"
 CONTRACTS = REPO_ROOT / "configs/scenarios/contracts/issue_3813_sustained_flow_contracts.yaml"
 LAUNCH_PACKET = REPO_ROOT / "configs/benchmarks/issue_3813_sustained_flow_launch_packet.yaml"
+PREFLIGHT_SCRIPT = REPO_ROOT / "scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py"
 
 
 def _load_yaml(path: Path) -> dict:
@@ -147,6 +148,13 @@ def test_launch_packet_keeps_no_submit_and_fail_closed_boundaries() -> None:
     assert campaign["scenario_suite"]["contract_path"] == (
         "configs/scenarios/contracts/issue_3813_sustained_flow_contracts.yaml"
     )
+    assert campaign["scenario_suite"]["preflight_helper"] == (
+        "robot_sf.benchmark.sustained_flow_preflight.preflight_sustained_flow_matrix"
+    )
+    assert campaign["scenario_suite"]["preflight_command"] == (
+        "uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json"
+    )
+    assert PREFLIGHT_SCRIPT.is_file()
     assert campaign["metrics"]["success_boundary"].startswith("Sustained progress")
     assert (
         "missing continuous-spawn runtime support"


### PR DESCRIPTION
## Summary
Relates to #3813.

This PR wires the issue #3813 sustained-flow launch packet to the existing CPU-only preflight command and extends the focused scaffold test to prove the packet points at the real helper and validation script.

## Scope
- Adds `scenario_suite.preflight_command` to `configs/benchmarks/issue_3813_sustained_flow_launch_packet.yaml`.
- Extends `tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` to assert the helper path, command string, and script path stay discoverable.
- Assumption: this is the ready-queue local scenario-generator/preflight slice only; the broader sustained-flow runtime and metric semantics remain tracked by #3813.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q` -> passed, 4 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` -> passed; report includes `conforms: true`, `variant_count: 3`, `runtime_support: metadata_only`, `benchmark_evidence: false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` -> passed.
- `CUDA_VISIBLE_DEVICES= PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr_body_issue_3813.md scripts/dev/pr_ready_check.sh` -> passed; freshness stamp recorded for `aac2c1c1cbcca27ec7887fd5fb5202a9f1060dd2`.

## Explicit Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Deferred Work
- Remaining sustained-flow runtime support, sustained-progress metric certification, and interaction-exposure sanity checks stay in #3813.

## Downstream Propagation
- Parent issue updated: no, current authorization excludes issue/PR comments.
- Claim map / benchmark report updated: not applicable.
- Leaderboard / artifact catalog updated: not applicable.
- Registry or config index updated: not applicable.
- Context index / memory note updated: not applicable.
