### PR TITLE
Issue #3204: surface proxy checkpoint readiness blocked artifacts

### DIFF
--- a/configs/research/predictive_checkpoint_proxy_v1.yaml
+++ b/configs/research/predictive_checkpoint_proxy_v1.yaml
@@ -52,6 +52,35 @@ proxy_summary_contract:
   # success spread strictly greater than this counts as non-degenerate.
   min_success_spread: 1.0e-9
 
+# Structured blocked-artifact inventory for the readiness checker. These entries are not evidence
+# and are not hydrated by the preflight; they make missing or degenerate proxy inputs explicit before
+# any checkpoint-selection run is treated as ready.
+blocked_artifacts:
+  - id: missing_durable_predictive_checkpoints
+    artifact_type: checkpoint_set
+    status: blocked
+    storage_scope: worktree_local_output
+    path_pattern: model/registry.yaml predictive local_path entries
+    required_metadata:
+      - local_path
+      - proxy_training_run_id
+      - durable checksum or public release metadata
+    revival_condition: >
+      Promote or hydrate at least six predictive checkpoints from one real training run into
+      durable, locally resolvable registry local_path entries.
+  - id: degenerate_hardcase_proxy_probe_v1
+    artifact_type: proxy_training_summary
+    status: blocked
+    storage_scope: worktree_local_output
+    path_pattern: output/tmp/**/hardcase_proxy_probe_v1*/**/training_summary.json
+    required_metadata:
+      - proxy.enabled=true
+      - proxy.history epoch records
+      - non-degenerate hard-seed success_rate spread
+    revival_condition: >
+      Provide a proxy.enabled training summary with at least six usable proxy epochs and
+      non-degenerate hard-seed success spread from plateau-breaking lineage.
+
 # Current issue #3204 blocker map. The preflight does not hydrate artifacts or
 # run training, but unresolved entries keep the report fail-closed until the
 # contract is updated with durable evidence.

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -85,6 +85,7 @@ def _check_config(config: Any, config_path: Path) -> tuple[str, list[str]]:
     summary_contract = config.get("proxy_summary_contract")
     if summary_contract is not None and not isinstance(summary_contract, dict):
         errors.append("proxy_summary_contract must be mapping when provided")
+    errors.extend(_validate_blocked_artifact_schema(config.get("blocked_artifacts")))
     errors.extend(_validate_known_blocker_schema(config.get("known_blockers")))
     if errors:
         return STATUS_FAILED, errors
@@ -128,6 +129,71 @@ def _validate_known_blocker_schema(known_blockers: Any) -> list[str]:
                 f"known_blockers[{index}] status must be one of {sorted(_KNOWN_BLOCKER_STATUSES)}"
             )
     return errors
+
+
+def _validate_blocked_artifact_schema(blocked_artifacts: Any) -> list[str]:
+    """Validate optional blocked-artifact inventory in the readiness contract."""
+    if blocked_artifacts is None:
+        return []
+    if not isinstance(blocked_artifacts, list):
+        return ["blocked_artifacts must be a list when provided"]
+
+    errors: list[str] = []
+    required_fields = ("id", "artifact_type", "status", "storage_scope", "revival_condition")
+    for index, artifact in enumerate(blocked_artifacts):
+        if not isinstance(artifact, dict):
+            errors.append(f"blocked_artifacts[{index}] must be a mapping")
+            continue
+        for field_name in required_fields:
+            value = artifact.get(field_name)
+            if not isinstance(value, str) or not value:
+                errors.append(f"blocked_artifacts[{index}] missing {field_name}")
+        artifact_status = artifact.get("status")
+        if artifact_status not in _KNOWN_BLOCKER_STATUSES:
+            errors.append(
+                f"blocked_artifacts[{index}] status must be one of "
+                f"{sorted(_KNOWN_BLOCKER_STATUSES)}"
+            )
+        metadata = artifact.get("required_metadata", [])
+        if metadata is not None and (
+            not isinstance(metadata, list)
+            or any(not isinstance(item, str) or not item for item in metadata)
+        ):
+            errors.append(f"blocked_artifacts[{index}] required_metadata must be a list of strings")
+    return errors
+
+
+def _check_blocked_artifacts(config: dict[str, Any]) -> tuple[str, list[str], list[dict[str, Any]]]:
+    """Expose blocked input artifacts as a fail-closed report section."""
+    artifacts = config.get("blocked_artifacts") or []
+    if not isinstance(artifacts, list):
+        return STATUS_FAILED, ["blocked_artifacts must be a list"], []
+
+    normalized: list[dict[str, Any]] = []
+    messages: list[str] = []
+    failed = False
+    blocked = False
+    for index, artifact in enumerate(artifacts):
+        if not isinstance(artifact, dict):
+            failed = True
+            messages.append(f"blocked_artifacts[{index}] must be a mapping")
+            continue
+        artifact_id = str(artifact.get("id", "unnamed"))
+        status = artifact.get("status")
+        if status not in _KNOWN_BLOCKER_STATUSES:
+            failed = True
+            messages.append(f"blocked_artifacts[{index}] has unsupported status: {status}")
+            continue
+        normalized.append(dict(artifact))
+        if status == STATUS_BLOCKED:
+            blocked = True
+            messages.append(f"blocked artifact remains blocked: {artifact_id}")
+
+    if failed:
+        return STATUS_FAILED, messages, normalized
+    if blocked:
+        return STATUS_BLOCKED, messages, normalized
+    return STATUS_PASSED, messages, normalized
 
 
 def _check_known_blockers(config: dict[str, Any]) -> tuple[str, list[str], list[dict[str, Any]]]:
@@ -521,6 +587,13 @@ def check_readiness(
         }
 
     if cfg:
+        artifact_status, artifact_messages, artifact_payload = _check_blocked_artifacts(cfg)
+        prerequisites["blocked_artifacts"] = {
+            "status": artifact_status,
+            "messages": artifact_messages,
+            "artifacts": artifact_payload,
+        }
+
         blocker_status, blocker_messages, blocker_payload = _check_known_blockers(cfg)
         prerequisites["known_blockers"] = {
             "status": blocker_status,

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -402,6 +402,62 @@ def test_ready_when_known_blocker_resolved(tmp_path):
     assert blockers["blockers"][0]["status"] == "resolved"
 
 
+def test_blocked_when_artifact_inventory_has_blocked_state(tmp_path):
+    """Configured blocked artifacts surface separately from known blocker prose."""
+    config = _write_config(tmp_path, min_resolvable=2, min_epochs=2)
+    data = yaml.safe_load(config.read_text(encoding="utf-8"))
+    data["blocked_artifacts"] = [
+        {
+            "id": "degenerate_hardcase_proxy_probe_v1",
+            "artifact_type": "proxy_training_summary",
+            "status": "blocked",
+            "storage_scope": "worktree_local_output",
+            "path_pattern": "output/tmp/**/hardcase_proxy_probe_v1*/**/training_summary.json",
+            "required_metadata": ["proxy.enabled=true", "proxy.history"],
+            "revival_condition": "provide non-degenerate proxy summary",
+        }
+    ]
+    config.write_text(yaml.safe_dump(data), encoding="utf-8")
+    registry = _write_registry(tmp_path, present_count=2, absent_count=0)
+    summary = _write_summary(tmp_path, enabled=True, pairs=[(1.0, 0.1), (0.8, 0.4)])
+
+    report = mod.check_readiness(
+        config_path=config,
+        registry_path=registry,
+        repo_root=_REPO_ROOT,
+        training_summary=summary,
+    )
+
+    artifacts = report["prerequisites"]["blocked_artifacts"]
+    assert report["status"] == "blocked"
+    assert artifacts["status"] == "blocked"
+    assert artifacts["artifacts"][0]["artifact_type"] == "proxy_training_summary"
+    assert any("blocked artifact" in message for message in artifacts["messages"])
+
+
+def test_failed_when_blocked_artifact_metadata_malformed(tmp_path):
+    """Artifact inventory missing required metadata fails closed before readiness claims."""
+    config = _write_config(tmp_path, min_resolvable=2, min_epochs=2)
+    data = yaml.safe_load(config.read_text(encoding="utf-8"))
+    data["blocked_artifacts"] = [
+        {
+            "id": "missing_status",
+            "artifact_type": "checkpoint_set",
+            "storage_scope": "worktree_local_output",
+            "revival_condition": "hydrate checkpoints",
+        }
+    ]
+    config.write_text(yaml.safe_dump(data), encoding="utf-8")
+    registry = _write_registry(tmp_path, present_count=2, absent_count=0)
+
+    report = mod.check_readiness(config_path=config, registry_path=registry, repo_root=_REPO_ROOT)
+
+    config_check = report["prerequisites"]["readiness_config"]
+    assert report["status"] == "blocked"
+    assert config_check["status"] == "failed"
+    assert any("blocked_artifacts[0]" in message for message in config_check["messages"])
+
+
 def test_ready_when_inputs_present_and_summary_has_spread(tmp_path):
     """All inputs resolve and the summary has non-degenerate spread -> ready (exit 0)."""
     config = _write_config(tmp_path, min_resolvable=6, min_epochs=4)


### PR DESCRIPTION
## Summary
- Links #3204.
- Adds a structured `blocked_artifacts` inventory to the predictive checkpoint proxy readiness contract.
- Extends the fail-closed readiness checker to validate and report blocked artifact states separately from prose known blockers.
- Adds focused tests for blocked artifact reporting and malformed blocked-artifact metadata.

## Scope
This is a diagnostic readiness/preflight slice only. It does not select checkpoints, run training, hydrate or promote artifacts, submit Slurm/GPU work, or change benchmark/paper/dissertation claims.

## Validation
- `uv run ruff format scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed
- `uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed
- `uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py tests/research/test_analyze_predictive_checkpoint_proxy.py -q` -> passed, 25 tests
- `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --config configs/research/predictive_checkpoint_proxy_v1.yaml --registry model/registry.yaml` -> expected exit 2, fail-closed BLOCKED report with checkpoint_artifacts, blocked_artifacts, and known_blockers sections
- `PR_READY_PR_BODY_FILE=/tmp/issue-3204-pr-body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed, clean-tree stamp for `17aab1f6a85a0dc4e8cd09758134e8f477c1ca27`
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> fresh

## Explicitly Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No checkpoint selection, artifact hydration, or evidence promotion.
