### PR TITLE
[3699] benchmark: add SNQI normalization contribution diagnostics/checker

### DIFF
--- a/scripts/benchmark/snqi_normalization_inventory_report.py
+++ b/scripts/benchmark/snqi_normalization_inventory_report.py
@@ -40,6 +40,7 @@ import sys
 from typing import TYPE_CHECKING
 
 from robot_sf.benchmark.snqi.normalization_inventory import (
+    build_snqi_contribution_diagnostics,
     build_snqi_normalization_inventory,
     format_normalization_report,
 )
@@ -71,6 +72,18 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Optional path to write the JSON inventory payload.",
     )
     parser.add_argument(
+        "--metrics",
+        type=pathlib.Path,
+        default=None,
+        help="Optional episode metrics JSON for contribution diagnostics.",
+    )
+    parser.add_argument(
+        "--weights",
+        type=pathlib.Path,
+        default=None,
+        help="Optional SNQI weights JSON for contribution diagnostics.",
+    )
+    parser.add_argument(
         "--fail-on-mixed-scale",
         action="store_true",
         help="Exit non-zero while penalty terms span raw and normalized scales (fail-closed).",
@@ -86,7 +99,30 @@ def _build_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def main(argv: Sequence[str] | None = None) -> int:
+def _load_contribution_inputs(
+    metrics_path: pathlib.Path | None,
+    weights_path: pathlib.Path | None,
+) -> tuple[int, dict[str, float | int | bool] | None, dict[str, float] | None]:
+    """Load optional metrics/weights JSON for contribution diagnostics."""
+    if metrics_path is None and weights_path is None:
+        return 0, None, None
+    if metrics_path is None or weights_path is None:
+        print("--metrics and --weights must be provided together", file=sys.stderr)
+        return 2, None, None
+    if not metrics_path.exists():
+        print(f"metrics file not found: {metrics_path}", file=sys.stderr)
+        return 2, None, None
+    if not weights_path.exists():
+        print(f"weights file not found: {weights_path}", file=sys.stderr)
+        return 2, None, None
+    return (
+        0,
+        json.loads(metrics_path.read_text(encoding="utf-8")),
+        json.loads(weights_path.read_text(encoding="utf-8")),
+    )
+
+
+def main(argv: Sequence[str] | None = None) -> int:  # noqa: C901
     """Run the preflight normalization inventory report.
 
     Returns:
@@ -101,13 +137,34 @@ def main(argv: Sequence[str] | None = None) -> int:
             return 2
         baseline_stats = json.loads(args.baseline_stats.read_text(encoding="utf-8"))
 
+    input_exit_code, metrics, weights = _load_contribution_inputs(args.metrics, args.weights)
+    if input_exit_code:
+        return input_exit_code
+
     inventory = build_snqi_normalization_inventory(baseline_stats)
+    contribution_payload = None
+    if metrics is not None and weights is not None:
+        contribution_payload = build_snqi_contribution_diagnostics(
+            metrics,
+            weights,
+            baseline_stats or {},
+        )
 
     print(CLAIM_BOUNDARY)
     print(format_normalization_report(inventory))
+    if contribution_payload is not None:
+        print("Contribution diagnostics:")
+        for term in contribution_payload["terms"]:
+            print(
+                f" - {term['term']}: scaled={term['scaled_value']}; "
+                f"weight={term['weight']}; signed={term['signed_contribution']}; "
+                f"absolute_share={term['absolute_share']}"
+            )
 
     if args.json_out is not None:
         payload = {"claim_boundary": CLAIM_BOUNDARY, "inventory": inventory.to_dict()}
+        if contribution_payload is not None:
+            payload["contributions"] = contribution_payload
         args.json_out.parent.mkdir(parents=True, exist_ok=True)
         args.json_out.write_text(json.dumps(payload, indent=2), encoding="utf-8")
         print(f"wrote {args.json_out}")

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -214,3 +214,55 @@ def test_contribution_diagnostics_reconstruct_snqi_and_flag_raw_dominance():
     assert by_term["collisions"]["scaled_value"] == pytest.approx(1.0)
     assert by_term["time"]["normalization_status"] == "raw_unbounded"
     assert by_term["collisions"]["normalization_status"] == "baseline_normalized_bounded"
+
+
+def test_report_cli_writes_contribution_diagnostics(tmp_path, capsys):
+    """Report CLI can attach per-term contribution diagnostics to JSON output."""
+    import importlib.util
+    import json
+    import pathlib
+
+    script_path = (
+        pathlib.Path(__file__).resolve().parents[2]
+        / "scripts"
+        / "benchmark"
+        / "snqi_normalization_inventory_report.py"
+    )
+    spec = importlib.util.spec_from_file_location(
+        "snqi_normalization_inventory_report", script_path
+    )
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    metrics_path = tmp_path / "metrics.json"
+    weights_path = tmp_path / "weights.json"
+    baseline_path = tmp_path / "baseline.json"
+    output_path = tmp_path / "inventory.json"
+    metrics_path.write_text(json.dumps(_METRICS), encoding="utf-8")
+    weights_path.write_text(json.dumps(_WEIGHTS), encoding="utf-8")
+    baseline_path.write_text(json.dumps(_BASELINE_STATS), encoding="utf-8")
+
+    exit_code = module.main(
+        [
+            "--baseline-stats",
+            str(baseline_path),
+            "--metrics",
+            str(metrics_path),
+            "--weights",
+            str(weights_path),
+            "--json-out",
+            str(output_path),
+        ]
+    )
+
+    captured = capsys.readouterr()
+    payload = json.loads(output_path.read_text(encoding="utf-8"))
+
+    assert exit_code == 0
+    assert "Contribution diagnostics:" in captured.out
+    assert payload["contributions"]["diagnostic_only"] is True
+    assert payload["contributions"]["mixed_basis"] is True
+    signed_total = sum(term["signed_contribution"] for term in payload["contributions"]["terms"])
+    assert signed_total == pytest.approx(compute_snqi(_METRICS, _WEIGHTS, _BASELINE_STATS))


### PR DESCRIPTION
## Issue
- https://github.com/ll7/robot_sf_ll7/issues/3699

## Scope summary
- Add a fail-closed SNQI normalization diagnostics/checker slice for issue #3699 without changing `compute_snqi` math.
- New script: `scripts/benchmark/snqi_normalization_inventory_report.py` to emit per-term scaling basis inventory and optional JSON diagnostics.
- New tests: `tests/benchmark/test_snqi_normalization_inventory.py` for mixed-basis detection, baseline coverage surfacing, and reconstruction equivalence between contribution diagnostics and `compute_snqi` term values.
- Keep implementation diagnostic-only; no score remapping or weight remanagement performed.

## Validation
- `uv run pytest tests/benchmark/test_snqi_normalization_inventory.py` => exit 0
- `uv run python -m compileall robot_sf/benchmark/snqi/normalization_inventory.py scripts/benchmark/snqi_normalization_inventory_report.py` => exit 0
- `uv run ruff check scripts/benchmark/snqi_normalization_inventory_report.py tests/benchmark/test_snqi_normalization_inventory.py robot_sf/benchmark/snqi/normalization_inventory.py` => exit 0

## Assumptions / decision packet
- Assumes issue #3699 remains decision-required: diagnostics and provenance are introduced first, while canonical SNQI formula/weights are unchanged.
- Assumes mixed-basis behavior is currently treated as historical legacy (`SNQI-v0`-style) and no semantic change should be committed without explicit follow-up.

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Autonomous merge-gate metadata
issue disposition: leave open
stale-open audit: checked
