### PR TITLE
#3653: add fail-closed SNQI normalized-input preflight for sensitivity diagnostics

### DIFF
--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -177,6 +177,7 @@ from robot_sf.benchmark.snqi.campaign_contract import (
     evaluate_snqi_contract,
     resolve_weight_mapping,
     sanitize_baseline_stats,
+    validate_snqi_normalized_inputs,
 )
 from robot_sf.benchmark.synthetic_actuation import (
     SYNTHETIC_ACTUATION_CLAIM_SCOPE,
@@ -1877,6 +1878,16 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         baseline_for_eval, baseline_warnings = sanitize_baseline_stats(snqi_baseline)
         baseline_adjustments = len(baseline_warnings)
         warnings.extend(baseline_warnings)
+    normalized_input_issues = validate_snqi_normalized_inputs(
+        episodes=episodes,
+        baseline=baseline_for_eval,
+    )
+    if normalized_input_issues:
+        raise RuntimeError(
+            "SNQI sensitivity preflight failed: "
+            + "; ".join(sorted(set(normalized_input_issues)))
+        )
+
 
     thresholds = SnqiContractThresholds(
         rank_alignment_warn=cfg.snqi_contract.rank_alignment_warn_threshold,

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -1878,14 +1878,16 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
         baseline_for_eval, baseline_warnings = sanitize_baseline_stats(snqi_baseline)
         baseline_adjustments = len(baseline_warnings)
         warnings.extend(baseline_warnings)
-    normalized_input_issues = validate_snqi_normalized_inputs(
-        episodes=episodes,
-        baseline=baseline_for_eval,
-    )
-    if normalized_input_issues:
-        raise RuntimeError(
-            "SNQI sensitivity preflight failed: " + "; ".join(sorted(set(normalized_input_issues)))
+    if cfg.paper_facing and cfg.snqi_contract.enabled:
+        normalized_input_issues = validate_snqi_normalized_inputs(
+            episodes=episodes,
+            baseline=baseline_for_eval,
         )
+        if normalized_input_issues:
+            raise RuntimeError(
+                "SNQI sensitivity preflight failed: "
+                + "; ".join(sorted(set(normalized_input_issues)))
+            )
 
     thresholds = SnqiContractThresholds(
         rank_alignment_warn=cfg.snqi_contract.rank_alignment_warn_threshold,

--- a/robot_sf/benchmark/camera_ready_campaign.py
+++ b/robot_sf/benchmark/camera_ready_campaign.py
@@ -1884,10 +1884,8 @@ def run_campaign(  # noqa: C901, PLR0912, PLR0915
     )
     if normalized_input_issues:
         raise RuntimeError(
-            "SNQI sensitivity preflight failed: "
-            + "; ".join(sorted(set(normalized_input_issues)))
+            "SNQI sensitivity preflight failed: " + "; ".join(sorted(set(normalized_input_issues)))
         )
-
 
     thresholds = SnqiContractThresholds(
         rank_alignment_warn=cfg.snqi_contract.rank_alignment_warn_threshold,

--- a/robot_sf/benchmark/snqi/campaign_contract.py
+++ b/robot_sf/benchmark/snqi/campaign_contract.py
@@ -32,22 +32,27 @@ SNQI_NORMALIZED_METRIC_NAMES = (
 )
 
 
+_VALIDATE_SNQI_MAX_ISSUES = 50
+
+
 def validate_snqi_normalized_inputs(
     episodes: Sequence[Mapping[str, Any]],
     baseline: Mapping[str, Mapping[str, float]],
     *,
     normalized_metrics: Sequence[str] = SNQI_NORMALIZED_METRIC_NAMES,
+    max_issues: int = _VALIDATE_SNQI_MAX_ISSUES,
 ) -> list[str]:
     """Validate normalized inputs required by SNQI sensitivity diagnostics.
 
     Returns:
-        List of issue strings; empty when all required normalized inputs are present and finite.
+        List of issue strings (capped at max_issues); empty when all required normalized inputs
+        are present and finite.
     """
     issues: list[str] = []
     baseline_map = baseline if isinstance(baseline, Mapping) else {}
 
     for metric in normalized_metrics:
-        entry = baseline_map.get(metric) if isinstance(baseline_map, Mapping) else None
+        entry = baseline_map.get(metric)
         if not isinstance(entry, Mapping):
             issues.append(f"baseline[{metric}] missing")
             continue
@@ -57,6 +62,9 @@ def validate_snqi_normalized_inputs(
             issues.append(f"baseline[{metric}].p95 non-finite")
 
     for index, episode in enumerate(episodes):
+        if len(issues) >= max_issues:
+            issues.append(f"... and more (truncated at {max_issues})")
+            break
         metrics = episode.get("metrics") if isinstance(episode, Mapping) else None
         if not isinstance(metrics, Mapping):
             issues.append(f"episode[{index}] metrics payload missing")

--- a/robot_sf/benchmark/snqi/campaign_contract.py
+++ b/robot_sf/benchmark/snqi/campaign_contract.py
@@ -38,7 +38,11 @@ def validate_snqi_normalized_inputs(
     *,
     normalized_metrics: Sequence[str] = SNQI_NORMALIZED_METRIC_NAMES,
 ) -> list[str]:
-    """Validate normalized inputs required by SNQI sensitivity diagnostics."""
+    """Validate normalized inputs required by SNQI sensitivity diagnostics.
+
+    Returns:
+        List of issue strings; empty when all required normalized inputs are present and finite.
+    """
     issues: list[str] = []
     baseline_map = baseline if isinstance(baseline, Mapping) else {}
 

--- a/robot_sf/benchmark/snqi/campaign_contract.py
+++ b/robot_sf/benchmark/snqi/campaign_contract.py
@@ -24,6 +24,45 @@ _STARTUP_METRIC_NAMES = (
     "jerk_mean",
 )
 
+SNQI_NORMALIZED_METRIC_NAMES = (
+    "collisions",
+    "near_misses",
+    "force_exceed_events",
+    "jerk_mean",
+)
+
+
+def validate_snqi_normalized_inputs(
+    episodes: Sequence[Mapping[str, Any]],
+    baseline: Mapping[str, Mapping[str, float]],
+    *,
+    normalized_metrics: Sequence[str] = SNQI_NORMALIZED_METRIC_NAMES,
+) -> list[str]:
+    """Validate normalized inputs required by SNQI sensitivity diagnostics."""
+    issues: list[str] = []
+    baseline_map = baseline if isinstance(baseline, Mapping) else {}
+
+    for metric in normalized_metrics:
+        entry = baseline_map.get(metric) if isinstance(baseline_map, Mapping) else None
+        if not isinstance(entry, Mapping):
+            issues.append(f"baseline[{metric}] missing")
+            continue
+        if not _is_finite(entry.get("med")):
+            issues.append(f"baseline[{metric}].med non-finite")
+        if not _is_finite(entry.get("p95")):
+            issues.append(f"baseline[{metric}].p95 non-finite")
+
+    for index, episode in enumerate(episodes):
+        metrics = episode.get("metrics") if isinstance(episode, Mapping) else None
+        if not isinstance(metrics, Mapping):
+            issues.append(f"episode[{index}] metrics payload missing")
+            continue
+        for metric in normalized_metrics:
+            if not _is_finite(metrics.get(metric)):
+                issues.append(f"episode[{index}] metrics[{metric}] non-finite")
+
+    return issues
+
 _WEIGHT_COMPONENT_SPECS: tuple[dict[str, str], ...] = (
     {
         "weight_name": "w_success",

--- a/robot_sf/benchmark/snqi/campaign_contract.py
+++ b/robot_sf/benchmark/snqi/campaign_contract.py
@@ -67,6 +67,7 @@ def validate_snqi_normalized_inputs(
 
     return issues
 
+
 _WEIGHT_COMPONENT_SPECS: tuple[dict[str, str], ...] = (
     {
         "weight_name": "w_success",

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -5528,3 +5528,89 @@ def _get_comparability_path() -> str:
     repo_root = get_repository_root()
     path = repo_root / "configs" / "benchmarks" / "alyassi_comparability_map_v1.yaml"
     return path.as_posix()
+
+
+def test_run_campaign_fails_fast_on_missing_snqi_normalized_term(tmp_path: Path, monkeypatch) -> None:
+    """Missing normalized SNQI metric should fail sensitivity preflight."""
+    scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
+    scenario_abs = (tmp_path / scenario_rel).resolve()
+    scenario_abs.parent.mkdir(parents=True, exist_ok=True)
+    scenario_abs.write_text(
+        "- name: smoke\n  map_file: maps/svg_maps/classic_crossing.svg\n  seeds: [111]\n",
+        encoding="utf-8",
+    )
+
+    config_path = tmp_path / "campaign_snqi_missing_metric.yaml"
+    config_path.write_text(
+        "\n".join(
+            [
+                "name: snqi_missing_metric_campaign",
+                f"scenario_matrix: {scenario_rel.as_posix()}",
+                "paper_facing: true",
+                "paper_profile_version: paper-matrix-v1",
+                "comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml",
+                "seed_policy:",
+                "  mode: fixed-list",
+                "  seeds: [111]",
+                "snqi_contract:",
+                "  enabled: true",
+                "  enforcement: error",
+                "  rank_alignment_warn_threshold: 1.2",
+                "  rank_alignment_fail_threshold: 1.1",
+                "  outcome_separation_warn_threshold: 1.2",
+                "  outcome_separation_fail_threshold: 1.1",
+                "  calibration_seed: 123",
+                "  calibration_trials: 10",
+                "planners:",
+                "  - key: goal",
+                "    algo: goal",
+                "    planner_group: core",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    cfg = load_campaign_config(config_path)
+
+    def _fake_run_batch(*args, **kwargs):
+        del args
+        out_path = Path(kwargs["out_path"])
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(
+            json.dumps(
+                {
+                    "episode_id": "e-goal-0",
+                    "scenario_id": "mock",
+                    "seed": 111,
+                    "scenario_params": {"algo": "goal", "metadata": {"archetype": "crossing"}},
+                    "metrics": {
+                        "success": 0.0,
+                        "collisions": 1.0,
+                        "near_misses": 2.0,
+                        "time_to_goal_norm": 1.0,
+                        "comfort_exposure": 0.8,
+                        "force_exceed_events": 3.0,
+                    },
+                    "algorithm_metadata": {"algorithm": "goal", "status": "ok"},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return {
+            "total_jobs": 1,
+            "written": 1,
+            "failed_jobs": 0,
+            "failures": [],
+            "preflight": {"status": "ok", "learned_policy_contract": {"status": "not_applicable"}},
+            "algorithm_readiness": {
+                "name": "goal",
+                "tier": "baseline-ready",
+                "profile": "baseline-safe",
+            },
+        }
+
+    monkeypatch.setattr("robot_sf.benchmark.camera_ready_campaign.run_batch", _fake_run_batch)
+
+    with pytest.raises(RuntimeError, match="SNQI sensitivity preflight failed"):
+        run_campaign(cfg, output_root=tmp_path / "campaign_out", label="snqi_missing_metric")

--- a/tests/benchmark/test_camera_ready_campaign.py
+++ b/tests/benchmark/test_camera_ready_campaign.py
@@ -5530,7 +5530,9 @@ def _get_comparability_path() -> str:
     return path.as_posix()
 
 
-def test_run_campaign_fails_fast_on_missing_snqi_normalized_term(tmp_path: Path, monkeypatch) -> None:
+def test_run_campaign_fails_fast_on_missing_snqi_normalized_term(
+    tmp_path: Path, monkeypatch
+) -> None:
     """Missing normalized SNQI metric should fail sensitivity preflight."""
     scenario_rel = Path("configs/scenarios/single/francis2023_blind_corner.yaml")
     scenario_abs = (tmp_path / scenario_rel).resolve()


### PR DESCRIPTION
## Issue
- https://github.com/ll7/robot_sf_ll7/issues/3653

## Scope summary
- Added a fail-closed SNQI normalized-input preflight in `run_campaign` before contract sensitivity evaluation.
- New validator in `robot_sf.benchmark.snqi.campaign_contract` checks required normalized SNQI terms (`collisions`, `near_misses`, `force_exceed_events`, `jerk_mean`) exist and are finite in both baseline payload and per-episode metrics.
- Added regression test to ensure campaign execution fails fast with a `RuntimeError` when normalized SNQI terms are missing.
- No claim of broader semantic change: this is a guardrail-only validation and error-path addition.

## Validation
- `python -m py_compile robot_sf/benchmark/camera_ready_campaign.py robot_sf/benchmark/snqi/campaign_contract.py tests/benchmark/test_camera_ready_campaign.py`
  - Exit: `0`
- `BASE_REF=origin/main uv run python -m pytest tests/benchmark/test_camera_ready_campaign.py -k "test_run_campaign_fails_fast_on_missing_snqi_normalized_term"`
  - Exit: `0`
- `BASE_REF=origin/main uv run python -m pytest tests/benchmark/test_camera_ready_campaign.py -k "snqi_contract or sensitivity or fails_fast_on_missing_snqi_normalized_term"`
  - Exit: `0`

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Autonomous merge-gate metadata
issue disposition: leave open
stale-open audit: checked
