### PR TITLE
[#3216] issue-3216: lock local headline CI S30 blocker preflight

### DIFF
--- a/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
@@ -538,6 +538,78 @@ def test_cli_decision_blocker_gate_passes_clear_local_preflight(tmp_path) -> Non
     assert result["decision_packet"]["s30_decision_status"] == "not_required_by_local_preflight"
 
 
+def test_decision_packet_blocks_only_s30_overlap_without_manuscript_blocker() -> None:
+    """S30 overlap downgrades still fail local blockers when manuscript table is clear."""
+    rows = [
+        _cell_row("bottleneck", "best", {"snqi": [0.50, 0.55, 0.45, 0.52, 0.48] * 4}),
+        _cell_row("bottleneck", "mid", {"snqi": [0.51, 0.46, 0.54, 0.49, 0.53] * 4}),
+    ]
+    report = _report(
+        rows,
+        metrics=("snqi",),
+        bootstrap_samples=1000,
+        rank_metric="snqi",
+        rank_profile="snqi_diagnostic",
+        resamples=200,
+    )
+    packet = report["decision_packet"]
+    assert packet["manuscript_table_status"] == "ready_for_table_review_no_claim_promotion"
+    assert packet["s30_decision_status"] == "needs_review"
+    assert "adjacent_rank_ci_overlap_requires_claim_downgrade_or_more_data" in packet["s30_reasons"]
+    assert mod.decision_packet_has_blocker(packet) is True
+
+
+def test_cli_fail_on_blocker_triggers_when_only_s30_needs_review(tmp_path: Path) -> None:
+    """S30-only overlap downgrade in local preflight exits with blocker code."""
+    rows = [
+        {
+            "scenario_family": "bottleneck",
+            "planner_key": "best",
+            "row_status": "successful_evidence",
+            "execution_mode": "nominal",
+            "per_seed": [
+                {"seed": 100 + idx, "metrics": {"snqi": [0.50, 0.51, 0.49, 0.52, 0.48][idx % 5]}}
+                for idx in range(20)
+            ],
+        },
+        {
+            "scenario_family": "bottleneck",
+            "planner_key": "mid",
+            "row_status": "successful_evidence",
+            "execution_mode": "nominal",
+            "per_seed": [
+                {
+                    "seed": 200 + idx,
+                    "metrics": {"snqi": [0.49, 0.50, 0.48, 0.51, 0.49][idx % 5]},
+                }
+                for idx in range(20)
+            ],
+        },
+    ]
+    rows_path = tmp_path / "rows.json"
+    rows_path.write_text(json.dumps(rows), encoding="utf-8")
+    out_dir = tmp_path / "s30_blocker"
+    exit_code = mod.main(
+        [
+            "--rows",
+            str(rows_path),
+            "--metrics",
+            "snqi",
+            "--bootstrap-samples",
+            "0",
+            "--rank-resamples",
+            "200",
+            "--fail-on-decision-blocker",
+            "--output-dir",
+            str(out_dir),
+        ]
+    )
+    assert exit_code == 4
+    packet = json.loads((out_dir / "result.json").read_text(encoding="utf-8"))["decision_packet"]
+    assert packet["s30_decision_status"] == "needs_review"
+    assert mod.decision_packet_has_blocker(packet) is True
+
+
 def _job_13198_packet(tmp_path) -> Path:
     """Write a compact deterministic job-13198 evidence packet fixture."""
 


### PR DESCRIPTION
## Scope summary
- Add deterministic local downgrade guard tests for issue #3216 headline rank-stability preflight.
- New regression coverage ensures S30 overlap downgrades fail the local preflight gate (`decision_packet_has_blocker`) when manuscript table status is otherwise clear.
- New fixture test ensures `--fail-on-decision-blocker` returns hard-exit for S30-overlap-only blockers.

## Validation
- `uv run pytest tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py`
- `uv run pytest tests/tools/test_seed_sufficiency_gate.py -q -k "not canonical_result_store"`
- `uv run pytest tests/tools/test_analyze_seed_sufficiency.py -q`
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --help`
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --dry-run --bootstrap-samples 0 --rank-resamples 25 --output-dir /tmp/issue3216_preflight_dry_final`

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits or promotion beyond local preflight decision packet status.

## Issue
- https://github.com/ll7/robot_sf_ll7/issues/3216

## Autonomous merge-gate metadata
issue disposition: leave open
stale-open audit: checked
