### PR TITLE
Issue #3216: add deterministic local headline CI preflight fixture test

### DIFF
--- a/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
@@ -775,8 +775,8 @@ def test_constraints_first_profile_flags_partial_metric_coverage(tmp_path) -> No
     assert "constraints_first_metric_gap" in packet["s30_reasons"]
 
 
-def test_decision_packet_marks_seed_budget_reason_even_with_high_deterministic_overlap() -> None:
-    """Deterministic high-overlap fixture marks S30 local-preflight as ready and review-only."""
+def test_decision_packet_s20_high_overlap_clears_s30_local_preflight() -> None:
+    """S20-budget high-overlap rows clear the S30 local preflight gate (no S30 reasons, no blocker)."""
     rows = [
         _cell_row(
             "squeeze",

--- a/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
@@ -773,3 +773,37 @@ def test_constraints_first_profile_flags_partial_metric_coverage(tmp_path) -> No
     assert packet["constraints_first_metric_gaps"] == ["collisions", "near_misses"]
     assert "constraints_first_metrics_missing" in packet["manuscript_blockers"]
     assert "constraints_first_metric_gap" in packet["s30_reasons"]
+
+
+def test_decision_packet_marks_seed_budget_reason_even_with_high_deterministic_overlap() -> None:
+    """Deterministic high-overlap fixture marks S30 local-preflight as ready and review-only."""
+    rows = [
+        _cell_row(
+            "squeeze",
+            "planner_a",
+            {
+                "snqi": [0.50, 0.51, 0.49, 0.52, 0.50] * 4,
+            },
+        ),
+        _cell_row(
+            "squeeze",
+            "planner_b",
+            {
+                "snqi": [0.49, 0.50, 0.48, 0.51, 0.49] * 4,
+            },
+        ),
+    ]
+    report = _report(
+        rows,
+        metrics=("snqi",),
+        bootstrap_samples=1000,
+        rank_metric="snqi",
+        rank_profile="snqi_diagnostic",
+        resamples=300,
+    )
+    packet = report["decision_packet"]
+    assert packet["manuscript_table_status"] == "ready_for_table_review_no_claim_promotion"
+    assert packet["s30_decision_status"] == "not_required_by_local_preflight"
+    assert packet["min_seed_count"] == 20
+    assert packet["s30_reasons"] == []
+    assert not mod.decision_packet_has_blocker(packet)


### PR DESCRIPTION
## Summary
Issue: https://github.com/ll7/robot_sf_ll7/issues/3216

### Scope completed
- Add deterministic fixture coverage for local #3216 preflight logic in `tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py`.
- New test validates high-seed local preflight behavior (`squeeze` synthetic cell pair) remains non-blocking for manuscript table review when S30 path is not required locally and records deterministic seed-count metadata.

### Validation
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --help`
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --dry-run --output-dir /tmp/issue3216-dryrun-rx`
- `uv run python -m pytest tests/benchmark/test_seed_variance.py tests/benchmark/test_fidelity_rank_stability.py -q`
- `uv run python -m pytest tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py -q`

### Notes / assumptions
- Decision is fail-closed by design for insufficient evidence; this PR intentionally keeps behavior local-only and conservative.

### Out of scope
- No full benchmark campaign rerun.
- No Slurm/GPU submission or campaign execution.
- No manuscript/paper claim edits or paper/dissertation language changes.

## Autonomous merge-gate metadata
issue disposition: leave open
stale-open audit: checked
