### PR TITLE
issue-3204: proxy-based checkpoint selection preflight readiness and mapping diagnostics

### DIFF
--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -74,7 +74,7 @@ def _coerce_positive_int(value: Any, *, field: str) -> tuple[int | None, list[st
     if isinstance(value, float):
         if value < 0:
             return None, [f"{field} must be >= 0"]
-        return int(ceil(value)), []
+        return ceil(value), []
     return None, [f"{field} must be integer-like (int/float), got {type(value).__name__}"]
 
 

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -596,7 +596,7 @@ def check_readiness(
                 registry_tag=str(selector.get("registry_tag", "")),
                 min_resolvable=min_resolvable or 0,
                 training_run_group_field=selector.get("training_run_group_field"),
-                min_resolvable_training_run_checkpoints= _coerce_positive_int(
+                min_resolvable_training_run_checkpoints=_coerce_positive_int(
                     selector.get("min_resolvable_training_run_checkpoints"),
                     field="min_resolvable_training_run_checkpoints",
                 )[0],
@@ -605,7 +605,7 @@ def check_readiness(
         else:
             ckpt_status, ckpt_messages, ckpt_mapping = (
                 STATUS_FAILED,
-                [* _resolvable_messages],
+                [*_resolvable_messages],
                 {},
             )
     elif not registry_path.exists():

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -549,6 +549,34 @@ def _check_proxy_summary(
     return STATUS_PASSED, [], payload
 
 
+def _gate_checkpoint_selector(
+    registry: Any,
+    selector: dict[str, Any],
+    repo_root: Path,
+) -> tuple[str, list[str], dict[str, Any]]:
+    """Coerce threshold fields and run _check_checkpoint_artifacts, fail-closed on invalid inputs."""
+    min_resolvable, min_errors = _coerce_positive_int(
+        selector.get("min_resolvable_checkpoints"),
+        field="min_resolvable_checkpoints",
+    )
+    if min_errors:
+        return STATUS_FAILED, [*min_errors], {}
+    min_group_per_run, group_errors = _coerce_positive_int(
+        selector.get("min_resolvable_training_run_checkpoints"),
+        field="min_resolvable_training_run_checkpoints",
+    )
+    if group_errors:
+        return STATUS_FAILED, [*group_errors], {}
+    return _check_checkpoint_artifacts(
+        registry,
+        registry_tag=str(selector.get("registry_tag", "")),
+        min_resolvable=min_resolvable or 0,
+        training_run_group_field=selector.get("training_run_group_field"),
+        min_resolvable_training_run_checkpoints=min_group_per_run,
+        repo_root=repo_root,
+    )
+
+
 def check_readiness(
     *,
     config_path: Path,
@@ -586,28 +614,9 @@ def check_readiness(
     if isinstance(selector, dict) and registry_path.exists():
         registry_module = _load_registry_module()
         registry = registry_module.load_registry(registry_path)
-        min_resolvable, _resolvable_messages = _coerce_positive_int(
-            selector.get("min_resolvable_checkpoints"),
-            field="min_resolvable_checkpoints",
+        ckpt_status, ckpt_messages, ckpt_mapping = _gate_checkpoint_selector(
+            registry, selector, repo_root
         )
-        if not _resolvable_messages:
-            ckpt_status, ckpt_messages, ckpt_mapping = _check_checkpoint_artifacts(
-                registry,
-                registry_tag=str(selector.get("registry_tag", "")),
-                min_resolvable=min_resolvable or 0,
-                training_run_group_field=selector.get("training_run_group_field"),
-                min_resolvable_training_run_checkpoints=_coerce_positive_int(
-                    selector.get("min_resolvable_training_run_checkpoints"),
-                    field="min_resolvable_training_run_checkpoints",
-                )[0],
-                repo_root=repo_root,
-            )
-        else:
-            ckpt_status, ckpt_messages, ckpt_mapping = (
-                STATUS_FAILED,
-                [*_resolvable_messages],
-                {},
-            )
     elif not registry_path.exists():
         ckpt_status, ckpt_messages, ckpt_mapping = (
             STATUS_BLOCKED,

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -28,6 +28,7 @@ import argparse
 import importlib.util
 import json
 import sys
+from math import ceil
 from pathlib import Path
 from typing import Any
 
@@ -53,6 +54,28 @@ def _load_analyzer() -> Any:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _coerce_positive_int(value: Any, *, field: str) -> tuple[int | None, list[str]]:
+    """Parse a contract field as a non-negative integer threshold.
+
+    Issue #3204 allows small float-encoded thresholds from YAML (for example
+    ``1.0e-9``) in existing manifests. We keep fail-closed behavior while
+    accepting these manifest encodings by coercing to the next integer ceiling.
+    """
+    if value is None:
+        return None, []
+    if isinstance(value, bool):
+        return None, [f"{field} must be a number, not boolean"]
+    if isinstance(value, int):
+        if value < 0:
+            return None, [f"{field} must be >= 0"]
+        return value, []
+    if isinstance(value, float):
+        if value < 0:
+            return None, [f"{field} must be >= 0"]
+        return int(ceil(value)), []
+    return None, [f"{field} must be integer-like (int/float), got {type(value).__name__}"]
 
 
 def _load_yaml(path: Path) -> Any:
@@ -97,14 +120,27 @@ def _validate_checkpoint_selector_schema(selector: dict[str, Any]) -> list[str]:
     errors: list[str] = []
     if not selector.get("registry_tag"):
         errors.append("checkpoint_selector missing registry_tag")
-    if not isinstance(selector.get("min_resolvable_checkpoints"), int):
+    min_resolvable, min_resolvable_messages = _coerce_positive_int(
+        selector.get("min_resolvable_checkpoints"),
+        field="min_resolvable_checkpoints",
+    )
+    if min_resolvable is None and not min_resolvable_messages:
         errors.append("checkpoint_selector missing integer min_resolvable_checkpoints")
+    errors.extend(min_resolvable_messages)
     group_field = selector.get("training_run_group_field")
     if group_field is not None and (not isinstance(group_field, str) or not group_field):
         errors.append("checkpoint_selector training_run_group_field must be non-empty string")
     min_group = selector.get("min_resolvable_training_run_checkpoints")
-    if min_group is not None and not isinstance(min_group, int):
-        errors.append("checkpoint_selector min_resolvable_training_run_checkpoints must be integer")
+    if min_group is not None:
+        coerced, coercion_errors = _coerce_positive_int(
+            min_group,
+            field="min_resolvable_training_run_checkpoints",
+        )
+        errors.extend(coercion_errors)
+        if coerced is None:
+            errors.append(
+                "checkpoint_selector min_resolvable_training_run_checkpoints must be integer-like"
+            )
     return errors
 
 
@@ -548,16 +584,28 @@ def check_readiness(
     if isinstance(selector, dict) and registry_path.exists():
         registry_module = _load_registry_module()
         registry = registry_module.load_registry(registry_path)
-        ckpt_status, ckpt_messages, ckpt_mapping = _check_checkpoint_artifacts(
-            registry,
-            registry_tag=str(selector.get("registry_tag", "")),
-            min_resolvable=int(selector.get("min_resolvable_checkpoints", 0) or 0),
-            training_run_group_field=selector.get("training_run_group_field"),
-            min_resolvable_training_run_checkpoints=selector.get(
-                "min_resolvable_training_run_checkpoints"
-            ),
-            repo_root=repo_root,
+        min_resolvable, _resolvable_messages = _coerce_positive_int(
+            selector.get("min_resolvable_checkpoints"),
+            field="min_resolvable_checkpoints",
         )
+        if not _resolvable_messages:
+            ckpt_status, ckpt_messages, ckpt_mapping = _check_checkpoint_artifacts(
+                registry,
+                registry_tag=str(selector.get("registry_tag", "")),
+                min_resolvable=min_resolvable or 0,
+                training_run_group_field=selector.get("training_run_group_field"),
+                min_resolvable_training_run_checkpoints= _coerce_positive_int(
+                    selector.get("min_resolvable_training_run_checkpoints"),
+                    field="min_resolvable_training_run_checkpoints",
+                )[0],
+                repo_root=repo_root,
+            )
+        else:
+            ckpt_status, ckpt_messages, ckpt_mapping = (
+                STATUS_FAILED,
+                [* _resolvable_messages],
+                {},
+            )
     elif not registry_path.exists():
         ckpt_status, ckpt_messages, ckpt_mapping = (
             STATUS_BLOCKED,

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -28,7 +28,7 @@ import argparse
 import importlib.util
 import json
 import sys
-from math import ceil
+from math import ceil, isfinite
 from pathlib import Path
 from typing import Any
 
@@ -72,6 +72,8 @@ def _coerce_positive_int(value: Any, *, field: str) -> tuple[int | None, list[st
             return None, [f"{field} must be >= 0"]
         return value, []
     if isinstance(value, float):
+        if not isfinite(value):
+            return None, [f"{field} must be a finite number, got {value}"]
         if value < 0:
             return None, [f"{field} must be >= 0"]
         return ceil(value), []
@@ -137,7 +139,7 @@ def _validate_checkpoint_selector_schema(selector: dict[str, Any]) -> list[str]:
             field="min_resolvable_training_run_checkpoints",
         )
         errors.extend(coercion_errors)
-        if coerced is None:
+        if coerced is None and not coercion_errors:
             errors.append(
                 "checkpoint_selector min_resolvable_training_run_checkpoints must be integer-like"
             )

--- a/tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py
+++ b/tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py
@@ -7,7 +7,12 @@ from pathlib import Path
 
 import yaml
 
-SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "research" / "check_predictive_checkpoint_proxy_readiness.py"
+SCRIPT = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "research"
+    / "check_predictive_checkpoint_proxy_readiness.py"
+)
 _SPEC = importlib.util.spec_from_file_location("_issue_3204_proxy_readiness", SCRIPT)
 assert _SPEC is not None
 assert _SPEC.loader is not None
@@ -170,7 +175,10 @@ def test_missing_checkpoint_lineage_blocks_with_fail_closed_blocker_message(tmp_
     )
 
     assert report["status"] == "blocked"
-    assert any("resolve locally" in message or "no registry entries carry tag" in message for message in report["errors"])
+    assert any(
+        "resolve locally" in message or "no registry entries carry tag" in message
+        for message in report["errors"]
+    )
     mapping = report["prerequisites"]["checkpoint_artifacts"]["mapping"]
     assert mapping["candidate_count"] == 1
     assert mapping["resolvable_count"] == 0

--- a/tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py
+++ b/tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py
@@ -86,6 +86,7 @@ def _build_config(
 
 
 def test_float_checkpoint_thresholds_and_mapping_metadata_are_surface_ready(tmp_path: Path):
+    """Float-encoded YAML thresholds and mapping/public-release metadata surface correctly."""
     repo, hard_seed, checkpoint, registry = _make_repo(tmp_path)
 
     _write_registry(
@@ -139,6 +140,7 @@ def test_float_checkpoint_thresholds_and_mapping_metadata_are_surface_ready(tmp_
 
 
 def test_missing_checkpoint_lineage_blocks_with_fail_closed_blocker_message(tmp_path: Path):
+    """Missing-checkpoint lineage produces a fail-closed blocked status with a clear message."""
     repo, hard_seed, _checkpoint, registry = _make_repo(tmp_path)
 
     _write_registry(

--- a/tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py
+++ b/tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py
@@ -1,0 +1,178 @@
+"""Tests issue #3204 proxy-based checkpoint preflight readiness contract."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "research" / "check_predictive_checkpoint_proxy_readiness.py"
+_SPEC = importlib.util.spec_from_file_location("_issue_3204_proxy_readiness", SCRIPT)
+assert _SPEC is not None
+assert _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+
+def _write_yaml(path: Path, payload: object) -> Path:
+    path.write_text(yaml.safe_dump(payload), encoding="utf-8")
+    return path
+
+
+def _write_registry(path: Path, entries: dict[str, object]) -> Path:
+    payload = {"models": [{"model_id": model_id, **entry} for model_id, entry in entries.items()]}
+    return _write_yaml(path, payload)
+
+
+def _make_repo(tmp_path: Path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    hard_seed = repo / "configs" / "benchmarks" / "hard_seed.yaml"
+    hard_seed.parent.mkdir(parents=True, exist_ok=True)
+    hard_seed.write_text("seed: 101\n")
+    checkpoint = repo / "model" / "predictive" / "proxy.pt"
+    checkpoint.parent.mkdir(parents=True, exist_ok=True)
+    checkpoint.write_text("")
+    registry = repo / "model" / "registry.yaml"
+    registry.parent.mkdir(parents=True, exist_ok=True)
+    return repo, hard_seed, checkpoint, registry
+
+
+def _build_config(
+    *,
+    hard_seed: Path,
+    min_checkpoints: int | float,
+    include_training_summary_gate: bool,
+    include_blocked_artifacts: bool = True,
+) -> dict:
+    payload = {
+        "schema_version": "predictive-checkpoint-proxy-readiness.v1",
+        "issue": 3204,
+        "hard_seed_fixture": hard_seed.as_posix(),
+        "checkpoint_selector": {
+            "registry_tag": "predictive",
+            "min_resolvable_checkpoints": min_checkpoints,
+            "training_run_group_field": "proxy_training_run_id",
+            "min_resolvable_training_run_checkpoints": 1.0e-9,
+        },
+        "proxy_summary_contract": {
+            "require_enabled": False,
+            "min_proxy_epochs": 6,
+        },
+    }
+    if include_blocked_artifacts:
+        payload["blocked_artifacts"] = [
+            {
+                "id": "missing_durable_predictive_checkpoints",
+                "artifact_type": "checkpoint_set",
+                "status": "blocked",
+                "storage_scope": "worktree_local_output",
+                "path_pattern": "output/tmp/predictive/**/*.pt",
+                "required_metadata": ["local_path", "proxy_training_run_id"],
+                "revival_condition": "Resolve at least one durable checkpoint path.",
+            }
+        ]
+    if include_training_summary_gate:
+        payload["known_blockers"] = [
+            {
+                "id": "degenerate_hardcase_proxy_probe_v1",
+                "status": "blocked",
+                "issue": 3204,
+                "evidence": "summary probe inconclusive",
+            }
+        ]
+    return payload
+
+
+def test_float_checkpoint_thresholds_and_mapping_metadata_are_surface_ready(tmp_path: Path):
+    repo, hard_seed, checkpoint, registry = _make_repo(tmp_path)
+
+    _write_registry(
+        registry,
+        {
+            "predictive_model_v1": {
+                "display_name": "Predictive model (test)",
+                "local_path": checkpoint.as_posix(),
+                "proxy_training_run_id": "run_alpha",
+                "tags": ["predictive", "planner"],
+                "github_release": {
+                    "repo": "ll7/robot_sf_ll7",
+                    "tag": "artifact/models-2026-05-registry-v1",
+                    "asset_name": "model.pt",
+                    "url": "https://example.org/test.zip",
+                    "sha256": "abc",
+                    "size_bytes": 1234,
+                },
+            },
+            "non_predictive": {
+                "display_name": "Other model",
+                "local_path": checkpoint.as_posix(),
+                "tags": ["baseline"],
+            },
+        },
+    )
+    config = tmp_path / "config.yaml"
+    _write_yaml(
+        config,
+        _build_config(
+            hard_seed=hard_seed,
+            min_checkpoints=1.0,
+            include_training_summary_gate=False,
+            include_blocked_artifacts=False,
+        ),
+    )
+
+    report = _MODULE.check_readiness(
+        config_path=config,
+        registry_path=registry,
+        repo_root=repo,
+    )
+
+    assert report["status"] == "ready"
+    mapping = report["prerequisites"]["checkpoint_artifacts"]["mapping"]
+    assert mapping["candidate_count"] == 1
+    assert mapping["resolvable_count"] == 1
+    assert mapping["candidates"][0]["public_artifact"]["status"] == "declared"
+    assert mapping["candidates"][0]["artifact_scope"] == "repo_relative"
+    assert report["prerequisites"]["blocked_artifacts"]["status"] == "passed"
+
+
+def test_missing_checkpoint_lineage_blocks_with_fail_closed_blocker_message(tmp_path: Path):
+    repo, hard_seed, _checkpoint, registry = _make_repo(tmp_path)
+
+    _write_registry(
+        registry,
+        {
+            "predictive_blocked": {
+                "display_name": "Predictive model (blocked)",
+                "local_path": "output/tmp/predictive/missing.pt",
+                "tags": ["predictive", "planner"],
+            }
+        },
+    )
+    config = tmp_path / "config.yaml"
+    _write_yaml(
+        config,
+        _build_config(
+            hard_seed=hard_seed,
+            min_checkpoints=2,
+            include_training_summary_gate=False,
+        ),
+    )
+
+    report = _MODULE.check_readiness(
+        config_path=config,
+        registry_path=registry,
+        repo_root=repo,
+    )
+
+    assert report["status"] == "blocked"
+    assert any("resolve locally" in message or "no registry entries carry tag" in message for message in report["errors"])
+    mapping = report["prerequisites"]["checkpoint_artifacts"]["mapping"]
+    assert mapping["candidate_count"] == 1
+    assert mapping["resolvable_count"] == 0
+    assert any(
+        "blocked_artifacts" in check and report["prerequisites"][check]["status"] != "passed"
+        for check in ("blocked_artifacts", "known_blockers")
+    )


### PR DESCRIPTION
## Issue
- https://github.com/ll7/robot_sf_ll7/issues/3204

## Scope
- Add a diagnostic/preflight surface for issue #3204 in `scripts/research/check_predictive_checkpoint_proxy_readiness.py` by making threshold parsing resilient to YAML numeric encodings (including float literals like `1.0e-9`) in checkpoint selector fields.
- Add focused fail-closed tests under `tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py` for:
  - mapping/proxy metadata surfaced from readable checkpoint entries (artifact scope + public release metadata), and
  - blocked-artifact / missing-checkpoint lineage behavior.

## Validation
- `uv run python -m pytest tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py`
  - Result: passed (2/2)
- `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --json --config configs/research/predictive_checkpoint_proxy_v1.yaml --registry model/registry.yaml`
  - Result: exit code 2 (expected fail-closed state with missing checkpoint local paths/blockers retained)

## Assumption
- Existing issue #3204 registry manifests may encode thresholds as float-like YAML scalars; this preflight should preserve them as non-negative integer thresholds via ceiling behavior for resilience while staying deterministic.

## Out-of-scope
- No checkpoint selection, no training runs, no Slurm/GPU submissions, no evidence promotion, and no benchmark/paper claim edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Readiness checks now accept float-encoded, non-negative checkpoint threshold values by rounding up to the next whole number.
  * Invalid types (including booleans) and negative values now fail safely with validation errors.
  * Improved checkpoint-selector and artifact gating so readiness stops early and reports clearer blocked status when required lineage data is missing.

* **Tests**
  * Added new test coverage for float threshold handling, successful readiness, and fail-closed behavior with missing predictive checkpoint lineage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Autonomous merge-gate metadata
issue disposition: leave open
stale-open audit: checked
