### PR TITLE
Add SNQI normalization checker packet for issue #3699

### DIFF
--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -206,21 +206,15 @@ def build_governance_report(
             "weights_comparable"
         ],
         "status": contribution_diagnostics["normalization_contract"]["status"],
-        "raw_penalty_absolute_share": contribution_diagnostics[
-            "raw_penalty_absolute_share"
-        ],
+        "raw_penalty_absolute_share": contribution_diagnostics["raw_penalty_absolute_share"],
         "baseline_normalized_penalty_absolute_share": contribution_diagnostics[
             "baseline_normalized_penalty_absolute_share"
         ],
-        "raw_penalty_terms_dominate": contribution_diagnostics[
-            "raw_penalty_terms_dominate"
+        "raw_penalty_terms_dominate": contribution_diagnostics["raw_penalty_terms_dominate"],
+        "has_weight_bound_exceedance": contribution_diagnostics["has_weight_bound_exceedance"],
+        "weight_bound_exceedance_terms": contribution_diagnostics["normalization_contract"][
+            "weight_bound_exceedance_terms"
         ],
-        "has_weight_bound_exceedance": contribution_diagnostics[
-            "has_weight_bound_exceedance"
-        ],
-        "weight_bound_exceedance_terms": contribution_diagnostics[
-            "normalization_contract"
-        ]["weight_bound_exceedance_terms"],
     }
 
     return {

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -194,6 +194,35 @@ def build_governance_report(
             }
         )
 
+    normalization_checker = {
+        "issue": 3699,
+        "decision_required": True,
+        "assumption": (
+            "No score semantics changed; this report only surfaces mixed-basis "
+            "diagnostics and baseline coverage gaps for issue #3699."
+        ),
+        "mixed_scale": normalization.mixed_scale,
+        "weights_comparable": contribution_diagnostics["normalization_contract"][
+            "weights_comparable"
+        ],
+        "status": contribution_diagnostics["normalization_contract"]["status"],
+        "raw_penalty_absolute_share": contribution_diagnostics[
+            "raw_penalty_absolute_share"
+        ],
+        "baseline_normalized_penalty_absolute_share": contribution_diagnostics[
+            "baseline_normalized_penalty_absolute_share"
+        ],
+        "raw_penalty_terms_dominate": contribution_diagnostics[
+            "raw_penalty_terms_dominate"
+        ],
+        "has_weight_bound_exceedance": contribution_diagnostics[
+            "has_weight_bound_exceedance"
+        ],
+        "weight_bound_exceedance_terms": contribution_diagnostics[
+            "normalization_contract"
+        ]["weight_bound_exceedance_terms"],
+    }
+
     return {
         "schema_version": "snqi_governance_preflight.v1",
         "claim_boundary": CLAIM_BOUNDARY,
@@ -202,6 +231,7 @@ def build_governance_report(
         "weights": weights.to_dict(),
         "normalization": normalization.to_dict(),
         "normalization_contributions": contribution_diagnostics,
+        "normalization_checker": normalization_checker,
     }
 
 
@@ -289,6 +319,13 @@ def _print_text_report(report: dict[str, Any]) -> None:
         f"has_weight_bound_exceedance={contributions['has_weight_bound_exceedance']}; "
         "weight_bound_exceedance_terms="
         f"{', '.join(contributions['normalization_contract']['weight_bound_exceedance_terms']) or 'none'}"
+    )
+    checker = report["normalization_checker"]
+    print(
+        "Normalization checker: "
+        f"issue={checker['issue']} decision_required={checker['decision_required']} "
+        f"weights_comparable={checker['weights_comparable']} mixed_scale={checker['mixed_scale']} "
+        f"status={checker['status']} assumption='{checker['assumption']}'"
     )
 
 

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -231,6 +231,7 @@ def test_governance_report_checks_optional_baseline_coverage(tmp_path: Path) -> 
     assert missing
     assert set(missing[0]["metrics"]) == {"force_exceed_events", "jerk_mean"}
 
+
 def test_governance_checker_payload_is_referenced_in_report() -> None:
     """Normalization checker packet is included in machine-parseable report."""
     report = build_governance_report(repo_root=REPO_ROOT)

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -230,3 +230,48 @@ def test_governance_report_checks_optional_baseline_coverage(tmp_path: Path) -> 
     missing = [b for b in report["blockers"] if b["kind"] == "missing_baseline_coverage"]
     assert missing
     assert set(missing[0]["metrics"]) == {"force_exceed_events", "jerk_mean"}
+
+def test_governance_checker_payload_is_referenced_in_report() -> None:
+    """Normalization checker packet is included in machine-parseable report."""
+    report = build_governance_report(repo_root=REPO_ROOT)
+    checker = report["normalization_checker"]
+    assert checker["issue"] == 3699
+    assert checker["decision_required"] is True
+    assert checker["assumption"] == (
+        "No score semantics changed; this report only surfaces mixed-basis "
+        "diagnostics and baseline coverage gaps for issue #3699."
+    )
+    assert checker["mixed_scale"] is True
+    assert checker["weights_comparable"] is False
+    assert checker["status"] == "mixed_unbounded_penalty_basis"
+    assert checker["raw_penalty_terms_dominate"] is True
+    assert checker["has_weight_bound_exceedance"] is True
+    contributions = report["normalization_contributions"]
+    assert checker["raw_penalty_absolute_share"] == pytest.approx(
+        contributions["raw_penalty_absolute_share"]
+    )
+    assert checker["baseline_normalized_penalty_absolute_share"] == pytest.approx(
+        contributions["baseline_normalized_penalty_absolute_share"]
+    )
+
+
+def test_governance_report_json_exports_normalization_checker(tmp_path: Path) -> None:
+    """JSON export includes the checker packet for external consumers."""
+    out = tmp_path / "snqi_governance.json"
+    exit_code = main(
+        [
+            "--repo-root",
+            str(REPO_ROOT),
+            "--json",
+            "--json-out",
+            str(out),
+            "--allow-current-blockers",
+        ]
+    )
+    assert exit_code == 0
+    assert out.is_file()
+    payload = json.loads(out.read_text(encoding="utf-8"))
+    checker = payload["normalization_checker"]
+    assert isinstance(checker["assumption"], str)
+    assert "No score semantics changed" in checker["assumption"]
+    assert checker["decision_required"] is True


### PR DESCRIPTION
## Summary
- Adds a minimal, reversible SNQI normalization decision checker packet for issue #3699 in `check_snqi_governance.py`.
- Keeps scoring unchanged (legacy mixed-basis behavior preserved) and emits a structured diagnostic packet describing mixed-scale assumptions.
- Extends governance preflight coverage to ensure the packet is serialized in JSON output and visible in text reports.

## Scope
- Files changed: `scripts/validation/check_snqi_governance.py`, `tests/benchmark/test_snqi_governance_preflight.py`.
- This is a diagnostics/validation-only slice; it does not change SNQI computation, weights, or canonical scoring.

## Validation
- `python -m compileall scripts/validation/check_snqi_governance.py tests/benchmark/test_snqi_governance_preflight.py`
- `uv run pytest tests/benchmark/test_snqi_governance_preflight.py`

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Autonomous merge-gate metadata
issue disposition: leave open
stale-open audit: checked
