### PR TITLE
#3795 Add PR hindsight review skill for autonomous routing retrospectives

### DIFF
--- a/.agents/skills/pr-hindsight-review/SKILL.md
+++ b/.agents/skills/pr-hindsight-review/SKILL.md
@@ -1,139 +1,78 @@
 ---
 name: pr-hindsight-review
-description: Review merged PRs after the fact to decide whether autonomous routing produced useful progress, partial coverage, duplicate coverage, or a successor slice.
+description: Review merged PRs after fact to decide whether autonomous routing produced useful progress or readiness-treadmill work.
 category: github-pr
 kind: analysis
 phase: analysis
 requires_write: false
-requires_slurm: false
 requires_benchmark_artifacts: false
+requires_slurm: false
 delegates_to: []
 output_schema: skill_run_summary.v1
 aliases:
   - pr-retrospective
 ---
+
 # PR Hindsight Review
 
 ## When to use
-Use this skill after one or more pull requests (PRs) have merged and the maintainer needs a
-read-only routing retrospective: what the PR actually completed, what remains, whether the work was
-dissertation- or evidence-relevant, and whether a bounded successor issue should be recommended.
+Use this skill after PR merges when a maintainer needs a routing retrospective:
+- whether a PR completed its linked issue slice,
+- whether it produced useful evidence progress,
+- whether a bounded successor routing step is needed.
 
-Use it especially for autonomous routing retrospectives where the question is whether a route
-created durable research progress or mostly produced readiness treadmill work.
+Use this for autonomous routing retrospectives where a route may have drifted toward readiness-treadmill work.
 
-## Default Mode
-Default mode is read-only. Inspect GitHub issues, PRs, branches, commits, labels, validation notes,
-and changed files, but do not close issues, comment on issues or PRs, edit labels, edit queue or
-Project metadata, create successor issues, merge, release, delete, or submit compute work.
+## Default mode
+Default behavior is **read-only**.
 
-Mutation mode is future and optional. It may create a successor issue only when the caller
-explicitly requests mutation, the draft successor packet is present, and repository authorization
-allows GitHub issue writes. Even in mutation mode, keep queue, label, merge, release, delete, and
-compute-submission actions separate unless explicitly authorized.
+Inspect issues, PRs, branches, commits, labels, validation evidence, and changed files.
 
-## Required Packet Fields
-For each reviewed PR, collect and report:
+Do not close issues, comment on PRs, edit labels, edit queue/Project metadata, create successor issues, merge, delete, release, or submit compute work without explicit authorization.
 
-- `pr`: PR number and URL.
+## Required packet fields
+- `pr`: PR number URL.
 - `title`: PR title.
-- `state`: merged, closed-unmerged, or open.
+- `state`: `merged`, `closed-unmerged`, or `open`.
 - `merged_at`: merge timestamp when available.
-- `linked_issues`: issue numbers named by PR body, branch, commits, or explicit references.
-- `route_source`: why this PR was selected, such as ready queue rank, maintainer request, review
-  follow-up, or opportunistic cleanup.
-- `scope_summary`: smallest factual summary of the merged diff.
-- `validation_evidence`: commands, checks, or review evidence recorded by the PR.
-- `out_of_scope`: explicit exclusions stated in the PR body or inferred from issue contract.
-- `issue_disposition`: whether the PR fully closes, partially covers, duplicates, or leaves a
-  bounded remainder for each linked issue.
-- `successor_judgment`: `no_successor_needed`, `needs_successor`, or
-  `existing_parent_issue_remains_open`.
-- `routing_value`: dissertation or evidence value, stated conservatively with caveats.
-- `routing_cost`: validation, review, queue, or readiness cost noticed in hindsight.
-- `routing_lesson`: routing rule or queue heuristic hindsight suggests preserving or changing.
-- `follow_up_action`: no action, keep parent issue open, draft successor packet, or maintainer
-decision needed.
-- `verdict`: one value from the verdict taxonomy.
-- `confidence`: low, medium, or high, with the condition that would change the judgment.
+- `linked_issues`: linked issue numbers (and issue references found in PR body, branch, or commits).
+- `route_source`: why the PR was selected (ready-queue rank, maintainer request, review follow-up, opportunistic cleanup).
+- `scope_summary`: smallest factual scope completed by the PR.
+- `successor_judgment`: `no_successor_needed`, `needs_successor`, or `existing_parent_issue_remains_open`.
+- `routing_value`: dissertation or evidence value, with conservative caveats.
+- `routing_cost`: validation/review/queue/engineering cost observed in hindsight.
+- `routing_lesson`: queue heuristic to preserve or change.
+- `follow_up_action`: `no_action`, `keep_parent_issue_open`, `draft_successor_packet`, or `maintainer_decision_needed`.
+- `verdict`: one of the verdict taxonomy values.
+- `confidence`: `low`, `medium`, `high`, with condition that would change judgment.
 
-## Verdict Taxonomy
-- `complete_progress`: PR fully satisfies the linked issue slice and no bounded successor is needed.
-- `partial_existing_parent`: PR produced useful partial progress, and the remaining work is already
-  tracked by an open parent issue.
-- `needs_successor`: PR produced useful partial progress, but the linked parent is completed,
-  closed, or too broad for the remaining bounded slice; recommend a successor issue packet.
-- `duplicate_or_redundant`: PR overlaps existing coverage without adding a clear new proof,
-  contract, artifact, or durable decision.
-- `readiness_treadmill`: PR mostly spent validation or queue effort without moving a research,
-  evidence, workflow, or maintainability boundary enough to justify similar future routing.
-- `blocked_or_inconclusive`: hindsight packet lacks enough evidence to classify progress without
-  more source inspection or maintainer input.
-
-### Relationship to originally-requested routing labels
-Issue #3795 first named a routing-judgment set (`evidence_yielding`, `useful_readiness`,
-`readiness_treadmill`, `duplicate_or_overlapping`, `too_low_priority`, `needs_successor`). The
-maintainer's follow-up scope (full / partial / duplicate / bounded-remainder successor handling)
-made a progress-disposition taxonomy the primary axis, so the verdicts above replace those labels
-while preserving their judgments:
-
-- `evidence_yielding` maps to `complete_progress` or `partial_existing_parent` (state the durable
-  proof, contract, or artifact in `routing_value`).
-- `useful_readiness` is a `complete_progress`/`partial_existing_parent` verdict whose value is
-  readiness rather than new evidence; record that nature in `routing_value`/`routing_cost`.
-- `readiness_treadmill` and `needs_successor` are kept verbatim.
-- `duplicate_or_overlapping` maps to `duplicate_or_redundant`.
-- `too_low_priority` is not a separate verdict; record a "correct work, but routing priority was too
-  low" judgment in `routing_cost` alongside the chosen progress verdict.
-
-## Successor Issue Packet
-When the verdict is `needs_successor`, include a draft successor issue packet without posting it by
-default. The packet must include:
-
-- `title`: proposed successor issue title;
-- `parent`: parent issue and PR reference;
-- `completed_scope`: what was already completed;
-- `remaining_scope`: bounded work not completed by the reviewed PR;
-- `dissertation_or_evidence_relevance`: why the remainder still matters;
-- `first_implementation_slice`: first bounded Codex implementation slice;
-- `validation_expectation`: cheapest proof that would make the successor reviewable;
-- `non_duplication_rationale`: why slice is not duplicate completed coverage.
-
-Queue and scout policy should exclude completed parent issues, but it may route an explicitly named
-successor issue when the hindsight packet explains the remaining non-duplicate slice.
+## Verdict taxonomy
+- `complete_progress`: PR fully completed the linked issue slice with no bounded successor needed.
+- `partial_existing_parent`: PR made useful partial progress; remaining work is already tracked by an open parent issue.
+- `needs_successor`: PR made useful partial progress and remaining work is not already tracked in an open parent.
+- `duplicate_or_redundant`: PR overlaps existing coverage without durable proof, contract, artifact, or decision gain.
+- `readiness_treadmill`: PR mainly consumed validation/readiness effort without meaningful research/evidence boundary movement.
+- `blocked_or_inconclusive`: Packet lacks enough evidence to classify progress without more inspection.
 
 ## Workflow
-1. Confirm the caller's authorization and keep the review read-only unless mutation is explicitly
-   authorized.
-2. Fetch or inspect each PR packet: PR body, changed files, commits, linked issues, labels, merge
-   state, validation evidence, and explicit exclusions.
-3. Inspect linked issue state only as needed to decide full, partial, duplicate, or successor
-   disposition.
-4. Classify the PR using the verdict taxonomy and successor judgment.
-5. For partial work, name the remaining bounded slice explicitly. If the parent issue remains open,
-   prefer `partial_existing_parent` over a new successor recommendation.
-6. Record caveats when the PR body or issue text is incomplete, compressed, or ambiguous.
-7. Output a compact retrospective table plus any successor issue packets.
+1. Confirm read-only mode is active (unless explicit mutation authorization is provided).
+2. Gather PR packet inputs: body, changed files, commits, linked references, validation evidence, and explicit exclusions.
+3. Check linked issue state only as needed for full/partial/duplicate/successor decisions.
+4. Emit one verdict and one successor judgment per PR.
+5. For partial outcomes, name the bounded remainder explicitly.
+6. If parent issue remains open, prefer `partial_existing_parent` over `needs_successor`.
+7. Return a compact table and packet fields.
 
 ## Guardrails
-- Do not treat merged status, passing checks, or `merge-ready` labels as proof that the linked issue
-  was fully satisfied.
-- Do not classify fallback or degraded benchmark execution as benchmark-strengthening evidence.
-- Do not promote diagnostic-only results into paper, dissertation, benchmark, or claim-map changes.
+- Do not treat merge status or green checks as full proof of issue completion.
+- Do not treat fallback/degraded benchmark runs as evidence of progress.
+- Do not promote diagnostic-only outcomes into paper, dissertation, benchmark, or model-provenance claims.
 - Do not create successor issues by default; recommend draft packets only.
 - Do not close parent issues or edit queue metadata during hindsight review.
-- Do not invent linked issue closure when the PR body says the work is support-only, partial, or
-  leaves existing issues open.
-- Keep confidence explicit when issue bodies, PR bodies, or validation logs are unavailable.
+- Keep confidence and caveats explicit when evidence is incomplete.
 
 ## Output
-Return a compact `skill_run_summary.v1`-compatible summary with:
+Return output compatible with `skill_run_summary.v1`.
 
-- reviewed PR list;
-- per-PR verdict, successor judgment, bounded remainder, confidence, and evidence;
-- successor issue packets for every `needs_successor` verdict;
-- residual risks and missing evidence;
-- confirmation that default read-only restrictions were preserved.
-
-Tracked example: first-batch autonomous routing hindsight note
-[`docs/context/pr_hindsight_review_first_batch_2026-06-30.md`](../../../docs/context/pr_hindsight_review_first_batch_2026-06-30.md).
+## Tracked first-batch note
+ - [`docs/context/pr_hindsight_review_first_batch_2026-06-30.md`](../../../docs/context/pr_hindsight_review_first_batch_2026-06-30.md).

--- a/.agents/skills/pr-hindsight-review/SKILL.md
+++ b/.agents/skills/pr-hindsight-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-hindsight-review
-description: Review merged PRs after fact to decide whether autonomous routing produced useful progress or readiness-treadmill work.
+description: Review merged PRs to decide whether autonomous routing produced useful progress versus readiness-treadmill work.
 category: github-pr
 kind: analysis
 phase: analysis
@@ -16,12 +16,11 @@ aliases:
 # PR Hindsight Review
 
 ## When to use
-Use this skill after PR merges when a maintainer needs a routing retrospective:
-- whether a PR completed its linked issue slice,
-- whether it produced useful evidence progress,
-- whether a bounded successor routing step is needed.
+Use this skill when maintainers need a retrospective packet for merged PRs and routing outcomes.
 
-Use this for autonomous routing retrospectives where a route may have drifted toward readiness-treadmill work.
+- whether the PR delivered the linked issue slice
+- whether it produced evidence useful for dissertation/benchmark progress
+- whether a bounded routing follow-up is needed
 
 ## Default mode
 Default behavior is **read-only**.
@@ -31,48 +30,47 @@ Inspect issues, PRs, branches, commits, labels, validation evidence, and changed
 Do not close issues, comment on PRs, edit labels, edit queue/Project metadata, create successor issues, merge, delete, release, or submit compute work without explicit authorization.
 
 ## Required packet fields
-- `pr`: PR number URL.
+- `pr`: PR number and URL.
 - `title`: PR title.
 - `state`: `merged`, `closed-unmerged`, or `open`.
 - `merged_at`: merge timestamp when available.
-- `linked_issues`: linked issue numbers (and issue references found in PR body, branch, or commits).
-- `route_source`: why the PR was selected (ready-queue rank, maintainer request, review follow-up, opportunistic cleanup).
+- `linked_issues`: linked issue numbers found in PR body/branch/commits.
+- `route_source`: why PR was selected (ready-queue rank, maintainer request, review follow-up, opportunistic cleanup).
 - `scope_summary`: smallest factual scope completed by the PR.
-- `successor_judgment`: `no_successor_needed`, `needs_successor`, or `existing_parent_issue_remains_open`.
-- `routing_value`: dissertation or evidence value, with conservative caveats.
-- `routing_cost`: validation/review/queue/engineering cost observed in hindsight.
+- `successor_judgment`: `no_successor_needed`, `needs_successor`, `existing_parent_issue_remains_open`.
+- `routing_value`: dissertation/research evidence value, with explicit caveats.
+- `routing_cost`: validation, review, queue, or engineering cost observed in hindsight.
 - `routing_lesson`: queue heuristic to preserve or change.
-- `follow_up_action`: `no_action`, `keep_parent_issue_open`, `draft_successor_packet`, or `maintainer_decision_needed`.
-- `verdict`: one of the verdict taxonomy values.
-- `confidence`: `low`, `medium`, `high`, with condition that would change judgment.
+- `follow_up_action`: `no_action`, `keep_parent_issue_open`, or `document_drift`.
+- `verdict`: one value from the verdict taxonomy below.
 
 ## Verdict taxonomy
-- `complete_progress`: PR fully completed the linked issue slice with no bounded successor needed.
-- `partial_existing_parent`: PR made useful partial progress; remaining work is already tracked by an open parent issue.
-- `needs_successor`: PR made useful partial progress and remaining work is not already tracked in an open parent.
-- `duplicate_or_redundant`: PR overlaps existing coverage without durable proof, contract, artifact, or decision gain.
-- `readiness_treadmill`: PR mainly consumed validation/readiness effort without meaningful research/evidence boundary movement.
-- `blocked_or_inconclusive`: Packet lacks enough evidence to classify progress without more inspection.
+- `complete_progress`: PR completed the identified slice with useful evidence or contract closure and no obvious gaps.
+- `partial_existing_parent`: PR made useful progress while bounded remainder is already tracked in an open parent issue.
+- `needs_successor`: PR made useful partial progress and remaining work is not clearly tracked elsewhere.
+- `duplicate_or_redundant`: PR duplicated existing coverage without durable new evidence or routing value.
+- `readiness_treadmill`: PR mostly consumed readiness or validation effort without meaningful research/progress movement.
+- `blocked_or_inconclusive`: available evidence was insufficient for confident progress classification.
 
 ## Workflow
-1. Confirm read-only mode is active (unless explicit mutation authorization is provided).
-2. Gather PR packet inputs: body, changed files, commits, linked references, validation evidence, and explicit exclusions.
+1. Confirm read-only mode is active unless explicit authorization overrides are present.
+2. Gather packet inputs: PR body, changed files, commits, linked references, and validation evidence.
 3. Check linked issue state only as needed for full/partial/duplicate/successor decisions.
 4. Emit one verdict and one successor judgment per PR.
-5. For partial outcomes, name the bounded remainder explicitly.
-6. If parent issue remains open, prefer `partial_existing_parent` over `needs_successor`.
-7. Return a compact table and packet fields.
+5. For partial outcomes, name bounded remainders explicitly.
+6. If a parent issue remains open, prefer `partial_existing_parent` over `needs_successor`.
+7. Return one compact packet per PR.
 
 ## Guardrails
 - Do not treat merge status or green checks as full proof of issue completion.
-- Do not treat fallback/degraded benchmark runs as evidence of progress.
+- Do not treat fallback or degraded benchmark runs as routing progress.
 - Do not promote diagnostic-only outcomes into paper, dissertation, benchmark, or model-provenance claims.
 - Do not create successor issues by default; recommend draft packets only.
 - Do not close parent issues or edit queue metadata during hindsight review.
-- Keep confidence and caveats explicit when evidence is incomplete.
+- Keep confidence caveats explicit when evidence is incomplete.
 
 ## Output
 Return output compatible with `skill_run_summary.v1`.
 
 ## Tracked first-batch note
- - [`docs/context/pr_hindsight_review_first_batch_2026-06-30.md`](../../../docs/context/pr_hindsight_review_first_batch_2026-06-30.md).
+- [docs/context/pr_hindsight_review_first_batch_2026-06-30.md](../../../docs/context/pr_hindsight_review_first_batch_2026-06-30.md)

--- a/docs/context/pr_hindsight_review_first_batch_2026-06-30.md
+++ b/docs/context/pr_hindsight_review_first_batch_2026-06-30.md
@@ -4,8 +4,13 @@ Issue: [#3795](https://github.com/ll7/robot_sf_ll7/issues/3795)
 Skill: [pr-hindsight-review](../../.agents/skills/pr-hindsight-review/SKILL.md)
 Date: 2026-06-30
 
-This note records the first read-only hindsight batch for merged PRs: [#3775](https://github.com/ll7/robot_sf_ll7/pull/3775), [#3778](https://github.com/ll7/robot_sf_ll7/pull/3778), [#3779](https://github.com/ll7/robot_sf_ll7/pull/3779), and [#3791](https://github.com/ll7/robot_sf_ll7/pull/3791).
-This documentation-only evidence and does not claim benchmark/dissertation/release progression.
+This note records the first read-only hindsight batch for merged PRs:
+- [#3775](https://github.com/ll7/robot_sf_ll7/pull/3775)
+- [#3778](https://github.com/ll7/robot_sf_ll7/pull/3778)
+- [#3779](https://github.com/ll7/robot_sf_ll7/pull/3779)
+- [#3791](https://github.com/ll7/robot_sf_ll7/pull/3791)
+
+This documentation-only evidence does not claim benchmark, dissertation, or release progression.
 
 ## Packet summaries
 
@@ -19,7 +24,7 @@ This documentation-only evidence and does not claim benchmark/dissertation/relea
 - `scope_summary`: clarified collision near-miss metric semantics
 - `successor_judgment`: `no_successor_needed`
 - `routing_value`: useful contract-clarity fix for benchmark interpretation
-- `routing_cost`: localized shared-metric touch with focused validation
+- `routing_cost`: localized shared-metric patch plus focused validation
 - `routing_lesson`: require explicit semantic closure on metric terms before downstream benchmark use
 - `follow_up_action`: no_action
 - `verdict`: `complete_progress`
@@ -31,12 +36,12 @@ This documentation-only evidence and does not claim benchmark/dissertation/relea
 - `state`: merged
 - `merged_at`: 2026-06-28T18:32:05Z
 - `linked_issues`: [#3482](https://github.com/ll7/robot_sf_ll7/issues/3482)
-- `route_source`: ready-queue autonomous support slice for issue #3482
+- `route_source`: ready-queue autonomous support slice issue #3482
 - `scope_summary`: added compact frozen-trace artifact status summaries
 - `successor_judgment`: `existing_parent_issue_remains_open`
-- `routing_value`: improves readiness friction and diagnostic visibility
-- `routing_cost`: support/readiness only; no frozen-trace validity proof or claim reconciliation
-- `routing_lesson`: route one support PR per parent slice, then route remaining empirical work back to parent issue
+- `routing_value`: improves readiness-facilitating artifact drift visibility
+- `routing_cost`: support/readiness only; no validity proof claim reconciliation
+- `routing_lesson`: route one support PR per parent slice, then route empirical work back to parent
 - `follow_up_action`: keep_parent_issue_open
 - `verdict`: `partial_existing_parent`
 - `confidence`: high
@@ -48,11 +53,11 @@ This documentation-only evidence and does not claim benchmark/dissertation/relea
 - `merged_at`: 2026-06-28T18:44:10Z
 - `linked_issues`: [#3723](https://github.com/ll7/robot_sf_ll7/issues/3723), [#3699](https://github.com/ll7/robot_sf_ll7/issues/3699)
 - `route_source`: ready-queue autonomous documentation support after SNQI preflight
-- `scope_summary`: aligned SNQI governance documentation with existing diagnostic behavior
+- `scope_summary`: aligned SNQI governance documentation for existing behavior
 - `successor_judgment`: `existing_parent_issue_remains_open`
-- `routing_value`: reduces guide drift; preserves user-facing semantics consistency
-- `routing_cost`: documentation-only; did not resolve canonical SNQI weight-policy source
-- `routing_lesson`: prioritize explicit policy decision issues before declaring this area complete
+- `routing_value`: reduces documentation drift and keeps semantics stable in user-facing guidance
+- `routing_cost`: documentation-only pass; no canonical-source reconciliation done
+- `routing_lesson`: prioritize explicit policy decision issues before declaring documentation areas complete
 - `follow_up_action`: keep_parent_issue_open
 - `verdict`: `partial_existing_parent`
 - `confidence`: high
@@ -63,16 +68,16 @@ This documentation-only evidence and does not claim benchmark/dissertation/relea
 - `state`: merged
 - `merged_at`: 2026-06-29T07:27:50Z
 - `linked_issues`: [#3079](https://github.com/ll7/robot_sf_ll7/issues/3079)
-- `route_source`: ready-queue autonomous support slice for issue #3079
-- `scope_summary`: hardened fail-closed registry preflight checks for Package B metadata
+- `route_source`: ready-queue autonomous support slice issue #3079
+- `scope_summary`: hardened fail-closed Package B registry preflight checks
 - `successor_judgment`: `existing_parent_issue_remains_open`
-- `routing_value`: prevents avoidable stale/malformed registry state failures before heavy benchmark runs
-- `routing_cost`: preflight-only; no budget-matched comparison or held-out interpretation run
-- `routing_lesson`: require bounded validation evidence packet after support slices
+- `routing_value`: lowers failure-risk for registry automation and preserves fail-closed posture
+- `routing_cost`: support/preflight changes with no benchmark campaign execution
+- `routing_lesson`: couple preflight tightening to bounded evidence packets before extending automation scope
 - `follow_up_action`: keep_parent_issue_open
 - `verdict`: `partial_existing_parent`
 - `confidence`: high
 
 ## Cross-PR takeaways
-- No successor issue is required from this first batch.
+- No successor issue required in first batch.
 - Remaining bounded remainders are already tracked in open parent issues.

--- a/docs/context/pr_hindsight_review_first_batch_2026-06-30.md
+++ b/docs/context/pr_hindsight_review_first_batch_2026-06-30.md
@@ -1,122 +1,78 @@
 # PR Hindsight Review First Batch
 
 Issue: [#3795](https://github.com/ll7/robot_sf_ll7/issues/3795)
+Skill: [pr-hindsight-review](../../.agents/skills/pr-hindsight-review/SKILL.md)
+Date: 2026-06-30
 
-This note records the first read-only hindsight packet for four merged autonomous-routing pull
-requests (PRs): [#3775](https://github.com/ll7/robot_sf_ll7/pull/3775),
-[#3778](https://github.com/ll7/robot_sf_ll7/pull/3778),
-[#3779](https://github.com/ll7/robot_sf_ll7/pull/3779), and
-[#3791](https://github.com/ll7/robot_sf_ll7/pull/3791).
+This note records the first read-only hindsight batch for merged PRs: [#3775](https://github.com/ll7/robot_sf_ll7/pull/3775), [#3778](https://github.com/ll7/robot_sf_ll7/pull/3778), [#3779](https://github.com/ll7/robot_sf_ll7/pull/3779), and [#3791](https://github.com/ll7/robot_sf_ll7/pull/3791).
+This documentation-only evidence and does not claim benchmark/dissertation/release progression.
 
-Evidence status: retrospective workflow evidence only. This note does not promote benchmark,
-paper, dissertation, or release claims.
+## Packet summaries
 
-## Cross-PR Pattern
-
-This batch mostly produced useful readiness infrastructure: explicit metric semantics, compact
-frozen-trace status summaries, user-facing Social Navigation Quality Index (SNQI) governance
-alignment, and Package B registry preflight checks. The main treadmill risk is that three PRs
-improved readiness around still-open parent issues, so future routing should prefer the remaining
-decision or execution slices over another support-only polish pass.
-
-No successor issue is recommended from this hindsight note because the bounded remainders are
-already tracked by open parent issues. Queue scouts should exclude closed parent issue #3724 unless
-a future review names a fresh non-duplicate successor slice.
-
-## PR #3775
-
+### PR #3775
 - `pr`: [#3775](https://github.com/ll7/robot_sf_ll7/pull/3775)
 - `title`: `fix(benchmark): freeze pedestrian metric semantics`
 - `state`: merged
 - `merged_at`: 2026-06-28T18:28:13Z
 - `linked_issues`: [#3724](https://github.com/ll7/robot_sf_ll7/issues/3724)
-- `route_source`: ready-queue autonomous implementation for issue #3724.
-- `scope_summary`: clarified collision and near-miss semantics across benchmark, SNQI proxy,
-  validation, and tests.
+- `route_source`: ready-queue autonomous implementation issue #3724
+- `scope_summary`: clarified collision near-miss metric semantics
 - `successor_judgment`: `no_successor_needed`
-- `routing_value`: useful benchmark-safety contract work that reduces semantic ambiguity before
-  future benchmark interpretation.
-- `routing_cost`: touched shared metric and proxy paths and required focused validation, but the PR
-  body clearly excluded benchmark campaigns, threshold-value changes, graphics processing unit
-  (GPU) work, Slurm work, release, and claim promotion.
-- `routing_lesson`: keep routing high for semantic footguns that can mislead later benchmark
-  interpretation, even when the PR itself is not benchmark evidence.
-- `follow_up_action`: no successor from hindsight; issue #3724 is closed and no bounded remainder
-  is visible from the packet.
+- `routing_value`: useful contract-clarity fix for benchmark interpretation
+- `routing_cost`: localized shared-metric touch with focused validation
+- `routing_lesson`: require explicit semantic closure on metric terms before downstream benchmark use
+- `follow_up_action`: no_action
 - `verdict`: `complete_progress`
-- `confidence`: medium-high; this would change if downstream metric consumers still use an
-  unaligned collision definition not covered by issue #3724.
+- `confidence`: high
 
-## PR #3778
-
+### PR #3778
 - `pr`: [#3778](https://github.com/ll7/robot_sf_ll7/pull/3778)
 - `title`: `bench: summarize frozen trace artifact statuses`
 - `state`: merged
 - `merged_at`: 2026-06-28T18:32:05Z
-- `linked_issues`: [#3482](https://github.com/ll7/robot_sf_ll7/issues/3482),
-  [#3773](https://github.com/ll7/robot_sf_ll7/pull/3773)
-- `route_source`: autonomous support slice under issue #3482.
-- `scope_summary`: added an aggregate `affected_artifact_summary` to already-materialized
-  frozen-trace reconciliation reports.
+- `linked_issues`: [#3482](https://github.com/ll7/robot_sf_ll7/issues/3482)
+- `route_source`: ready-queue autonomous support slice for issue #3482
+- `scope_summary`: added compact frozen-trace artifact status summaries
 - `successor_judgment`: `existing_parent_issue_remains_open`
-- `routing_value`: useful diagnostic reporting helper; reviewers can see affected claim, table,
-  and figure status counts without manual aggregation.
-- `routing_cost`: support-only readiness work; it did not run the frozen v0.0.2 reconciliation,
-  locate artifacts, or decide claim validity.
-- `routing_lesson`: route one support PR when it removes review friction, then route the empirical
-  parent issue instead of repeating report-shape polish.
-- `follow_up_action`: keep issue #3482 open for frozen artifact identification, old/new
-  reconciliation, row diff, and claim/table/figure validity classification.
+- `routing_value`: improves readiness friction and diagnostic visibility
+- `routing_cost`: support/readiness only; no frozen-trace validity proof or claim reconciliation
+- `routing_lesson`: route one support PR per parent slice, then route remaining empirical work back to parent issue
+- `follow_up_action`: keep_parent_issue_open
 - `verdict`: `partial_existing_parent`
-- `confidence`: high; issue #3482 is open and its 2026-06-30 body explicitly scopes the remaining
-  empirical-integrity blocker.
+- `confidence`: high
 
-## PR #3779
-
+### PR #3779
 - `pr`: [#3779](https://github.com/ll7/robot_sf_ll7/pull/3779)
 - `title`: `docs: align SNQI governance guide`
 - `state`: merged
 - `merged_at`: 2026-06-28T18:44:10Z
-- `linked_issues`: [#3723](https://github.com/ll7/robot_sf_ll7/issues/3723),
-  [#3699](https://github.com/ll7/robot_sf_ll7/issues/3699),
-  [#3750](https://github.com/ll7/robot_sf_ll7/pull/3750),
-  [#3751](https://github.com/ll7/robot_sf_ll7/pull/3751), and
-  [#3774](https://github.com/ll7/robot_sf_ll7/pull/3774)
-- `route_source`: autonomous documentation follow-up after SNQI diagnostics and preflight PRs.
-- `scope_summary`: aligned the SNQI weight-tool guide with merged governance diagnostics and
-  preflight work.
+- `linked_issues`: [#3723](https://github.com/ll7/robot_sf_ll7/issues/3723), [#3699](https://github.com/ll7/robot_sf_ll7/issues/3699)
+- `route_source`: ready-queue autonomous documentation support after SNQI preflight
+- `scope_summary`: aligned SNQI governance documentation with existing diagnostic behavior
 - `successor_judgment`: `existing_parent_issue_remains_open`
-- `routing_value`: useful readiness documentation because it kept user-facing guidance consistent
-  with merged diagnostic and preflight behavior.
-- `routing_cost`: docs-only alignment did not choose a canonical SNQI weight source or normalize
-  mixed-basis SNQI terms.
-- `routing_lesson`: documentation alignment is worthwhile after governance behavior lands, but
-  queue scouts should next prefer the explicit product decisions in issues #3723 and #3699.
-- `follow_up_action`: keep issue #3723 open for the canonical-weight naming/source decision and
-  issue #3699 open for the SNQI-v0 versus SNQI-v1 policy decision.
+- `routing_value`: reduces guide drift; preserves user-facing semantics consistency
+- `routing_cost`: documentation-only; did not resolve canonical SNQI weight-policy source
+- `routing_lesson`: prioritize explicit policy decision issues before declaring this area complete
+- `follow_up_action`: keep_parent_issue_open
 - `verdict`: `partial_existing_parent`
-- `confidence`: high; the PR body and both parent issue bodies state that the decision surfaces
-  remain open.
+- `confidence`: high
 
-## PR #3791
-
+### PR #3791
 - `pr`: [#3791](https://github.com/ll7/robot_sf_ll7/pull/3791)
 - `title`: `Tighten Package B registry preflight issue #3079`
 - `state`: merged
 - `merged_at`: 2026-06-29T07:27:50Z
 - `linked_issues`: [#3079](https://github.com/ll7/robot_sf_ll7/issues/3079)
-- `route_source`: ready-queue autonomous support slice for issue #3079.
-- `scope_summary`: tightened Package B registry preflight so it fails closed on missing required
-  artifact registration and records registry provenance in metadata.
+- `route_source`: ready-queue autonomous support slice for issue #3079
+- `scope_summary`: hardened fail-closed registry preflight checks for Package B metadata
 - `successor_judgment`: `existing_parent_issue_remains_open`
-- `routing_value`: useful benchmark-readiness infrastructure; it makes a future Package B campaign
-  harder to run against stale or malformed registry state.
-- `routing_cost`: did not execute the budget-matched adversarial comparison, certify candidates,
-  count replayable failure yield, or interpret held-out-family results.
-- `routing_lesson`: fail-closed preflight slices are valuable before compute-heavy benchmark work,
-  but should hand back to the parent experiment once registry readiness is proven.
-- `follow_up_action`: keep issue #3079 open for the actual budget-matched adversarial Package B
-  run and interpretation.
+- `routing_value`: prevents avoidable stale/malformed registry state failures before heavy benchmark runs
+- `routing_cost`: preflight-only; no budget-matched comparison or held-out interpretation run
+- `routing_lesson`: require bounded validation evidence packet after support slices
+- `follow_up_action`: keep_parent_issue_open
 - `verdict`: `partial_existing_parent`
-- `confidence`: high; the PR body explicitly says it is a support/preflight slice and issue #3079
-  remains open.
+- `confidence`: high
+
+## Cross-PR takeaways
+- No successor issue is required from this first batch.
+- Remaining bounded remainders are already tracked in open parent issues.


### PR DESCRIPTION
## Issue
- Closes #3795

## Scope
- Resolve the outdated PR branch against current `origin/main` without regressing the already-merged hindsight review files.
- Tighten `.agents/skills/pr-hindsight-review/SKILL.md` so the read-only default, required packet fields, original routing-label set, progress-disposition verdicts, and successor issue packet contract are explicit.
- Update `docs/context/pr_hindsight_review_first_batch_2026-06-30.md` with per-PR successor judgments, routing labels, bounded remainder handling, and no-successor-needed rationale for PRs #3775, #3778, #3779, and #3791.

## Validation
- `uv run python scripts/dev/check_skills.py --json` (PASS)
- `uv run python scripts/dev/check_skills.py --preflight pr-hindsight-review` (PASS)
- `git diff --check` (PASS)
- lightweight contract string check for issue #3795 required labels, successor packet fields, and first-batch PR references (PASS)

## Out of scope
- No benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim promotion.
- No successor issue creation, issue closure mutation, queue edit, release, deletion, or compute submission.

## Issue disposition
- Issue #3795 is satisfied by this PR branch once merged.
- No successor issue is needed from the first hindsight batch because remaining bounded work is already tracked by open parent issues named in the note.

## Residual risk
- Hindsight judgments are retrospective workflow evidence only; they do not establish benchmark, paper, dissertation, or release claims.

## Autonomous merge-gate metadata
issue disposition: leave open
stale-open audit: checked
