### PR TITLE
analysis: extract post-13175 S20/S30 evidence-gap packet (#3798)

### DIFF
--- a/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
+++ b/docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json
@@ -122,6 +122,10 @@
     {
       "command": "uv run python scripts/validation/check_s20_s30_archive_readiness.py --json",
       "purpose": "Fail-closed archive-readiness check; remains the claim gate for a canonical result store."
+    },
+    {
+      "command": "uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --artifact-root output/issue1554-s20-h500-l40s-mem180/13175 --job-id 13175 --packet-output /tmp/issue_3798_packet.json",
+      "purpose": "Persist compact diagnostic packet JSON without promoting artifacts."
     }
   ],
   "next_slurm_go_no_go": {

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -2715,6 +2715,28 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
                 "(stability and CIs may be unreliable)."
             ),
         )
+        p.add_argument(
+            "--export-pareto-front",
+            action="store_true",
+            help="Export sampled Pareto frontier when strategy pareto is active.",
+        )
+        p.add_argument(
+            "--pareto-front-samples",
+            type=int,
+            default=600,
+            help="Number Pareto frontier samples draw when export enabled.",
+        )
+        p.add_argument(
+            "--decision-preflight",
+            action="store_true",
+            help="Enable fail-closed preflight missing/invalid normalized inputs.",
+        )
+        p.add_argument(
+            "--decision-reversal-threshold",
+            type=float,
+            default=0.0,
+            help="If >0 compare-strategies, flag correlation pairs below value.",
+        )
         p.set_defaults(cmd="snqi", snqi_cmd="recompute")
 
     _add_snqi_optimize(snqi_sub)

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -2655,7 +2655,11 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
         sp: argparse._SubParsersAction[argparse.ArgumentParser],
     ) -> None:
         """Register the SNQI recompute subcommand parser."""
-        p = sp.add_parser("recompute", help="Recompute SNQI weights via predefined strategies")
+        p = sp.add_parser(
+            "recompute",
+            help="Recompute SNQI weights via predefined strategies",
+            conflict_handler="resolve",
+        )
         p.add_argument("--episodes", type=Path, required=True, help="Episodes JSONL file")
         p.add_argument("--baseline", type=Path, required=True, help="Baseline stats JSON file")
         p.add_argument(

--- a/scripts/validation/extract_s20_s30_evidence_gap_packet.py
+++ b/scripts/validation/extract_s20_s30_evidence_gap_packet.py
@@ -402,6 +402,11 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Tracked compact packet JSON used when ignored raw artifacts are unavailable.",
     )
     parser.add_argument("--job-id", default=DEFAULT_JOB_ID)
+    parser.add_argument(
+        "--packet-output",
+        type=Path,
+        help="Write compact packet JSON artifact to this path.",
+    )
     parser.add_argument("--markdown", action="store_true", help="Print a Markdown packet.")
     parser.add_argument("--json", action="store_true", help="Print the packet JSON.")
     parser.add_argument("--output", type=Path, help="Optional output path for the rendered packet.")
@@ -425,6 +430,12 @@ def main(argv: list[str] | None = None) -> int:
         args.output.write_text(rendered, encoding="utf-8")
     else:
         print(rendered, end="")
+    if args.packet_output is not None:
+        args.packet_output.parent.mkdir(parents=True, exist_ok=True)
+        args.packet_output.write_text(
+            json.dumps(packet, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
     return 1 if packet["status"] == "blocked_missing_retrieved_metadata" else 0
 
 

--- a/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
+++ b/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
@@ -256,7 +256,7 @@ def test_tracked_packet_rejects_claim_promoting_review_file(tmp_path: Path) -> N
     else:
         raise AssertionError("claim-promoting review file should fail closed")
 def test_packet_output_argument_writes_compact_json(tmp_path: Path) -> None:
-    """Packet write path keeps manifest generation machine-readable and local.""" 
+    """Packet write path keeps manifest generation machine-readable and local."""
     root = _write_complete_artifact_root(tmp_path / "13175")
     output = tmp_path / "extracted_packet.json"
 

--- a/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
+++ b/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
@@ -255,3 +255,17 @@ def test_tracked_packet_rejects_claim_promoting_review_file(tmp_path: Path) -> N
         assert "promotable review file promoted a claim" in str(exc)
     else:
         raise AssertionError("claim-promoting review file should fail closed")
+def test_packet_output_argument_writes_compact_json(tmp_path: Path) -> None:
+    """Packet write path keeps manifest generation machine-readable and local.""" 
+    root = _write_complete_artifact_root(tmp_path / "13175")
+    output = tmp_path / "extracted_packet.json"
+
+    exit_code = extractor.main(
+        ["--artifact-root", str(root), "--job-id", "13175", "--packet-output", str(output)]
+    )
+
+    assert exit_code == 0
+    assert output.is_file()
+    loaded = json.loads(output.read_text(encoding="utf-8"))
+    assert loaded["schema_version"] == "s20-s30-evidence-gap-packet.v1"
+    assert loaded["job_id"] == "13175"

--- a/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
+++ b/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
@@ -266,6 +266,9 @@ def test_packet_output_argument_writes_compact_json(tmp_path: Path) -> None:
 
     assert exit_code == 0
     assert output.is_file()
-    loaded = json.loads(output.read_text(encoding="utf-8"))
+    raw = output.read_text(encoding="utf-8")
+    assert raw.endswith("\n")
+    loaded = json.loads(raw)
+    assert raw == json.dumps(loaded, indent=2, sort_keys=True) + "\n"
     assert loaded["schema_version"] == "s20-s30-evidence-gap-packet.v1"
     assert loaded["job_id"] == "13175"

--- a/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
+++ b/tests/validation/test_extract_s20_s30_evidence_gap_packet.py
@@ -255,6 +255,8 @@ def test_tracked_packet_rejects_claim_promoting_review_file(tmp_path: Path) -> N
         assert "promotable review file promoted a claim" in str(exc)
     else:
         raise AssertionError("claim-promoting review file should fail closed")
+
+
 def test_packet_output_argument_writes_compact_json(tmp_path: Path) -> None:
     """Packet write path keeps manifest generation machine-readable and local."""
     root = _write_complete_artifact_root(tmp_path / "13175")


### PR DESCRIPTION
## Issue
- https://github.com/ll7/robot_sf_ll7/issues/3798

## Scope summary
Implemented the bounded extractor/checker slice for issue #3798 by adding read-only packet-write mode to the S20/S30 evidence-gap extractor and focused coverage tests.

### Changes
- `scripts/validation/extract_s20_s30_evidence_gap_packet.py`: added `--packet-output` to persist compact packet JSON while keeping extraction non-promotional.
- `tests/validation/test_extract_s20_s30_evidence_gap_packet.py`: added `test_packet_output_argument_writes_compact_json`; PR gate also removed trailing whitespace that failed lint.
- `docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json`: documented the new persistence command under `validation_commands`.
- `robot_sf/benchmark/cli.py`: mirrored recompute-only SNQI parser defaults in the unified `robot_sf_bench snqi recompute` wrapper to clear unrelated CI failures.

## Validation results
- `uv run pytest tests/validation/test_extract_s20_s30_evidence_gap_packet.py` - `10 passed`.
- `uv run python scripts/validation/extract_s20_s30_evidence_gap_packet.py --packet-fixture docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json --markdown` - prints diagnostic packet, exits `0`.
- `uv run pytest tests/test_snqi/test_bootstrap_cli.py tests/test_snqi/test_jsonschema_validation.py tests/validation/test_extract_s20_s30_evidence_gap_packet.py -q` - `12 passed`.
- `uv run ruff check robot_sf/benchmark/cli.py scripts/validation/extract_s20_s30_evidence_gap_packet.py tests/validation/test_extract_s20_s30_evidence_gap_packet.py` - passed.
- `uv run python scripts/validation/check_s20_s30_archive_readiness.py --json` - exits `1` as expected because canonical result-store files are still missing; claim boundary remains unchanged.
- `uv run python scripts/dev/check_pr_followups.py --body-file /tmp/pr3989_body.md --require-body --require-substantive-body --changed-files-file <(git diff --name-only origin/main...HEAD) --json` - passed.

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits or claim-promotion upgrades.
