### PR TITLE
analysis: SNQI scalarization-sensitivity + Pareto-front export decision-reversal diagnostic (#3653)

### DIFF
--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -213,10 +213,7 @@ def test_preflight_malformed_for_out_of_range_bounded_term() -> None:
         baseline=_baseline(),
     )
     assert report["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
-    assert any(
-        issue["code"] == "out_of_range_normalized_term" for issue in report["issues"]
-    )
-
+    assert any(issue["code"] == "out_of_range_normalized_term" for issue in report["issues"])
 
 
 def test_preflight_malformed_for_non_mapping_baseline_value() -> None:

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -203,6 +203,22 @@ def test_preflight_malformed_for_non_finite_term() -> None:
     assert any(issue["code"] == "non_finite_required_term" for issue in report["issues"])
 
 
+def test_preflight_malformed_for_out_of_range_bounded_term() -> None:
+    """Out-of-range bounded SNQI terms are malformed, not merely blocked."""
+    records = _preflight_episodes()
+    records[0]["metrics"]["time_to_goal_norm"] = 1.6
+    report = classify_scalarization_sensitivity_inputs(
+        records,
+        weights=_weights(),
+        baseline=_baseline(),
+    )
+    assert report["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
+    assert any(
+        issue["code"] == "out_of_range_normalized_term" for issue in report["issues"]
+    )
+
+
+
 def test_preflight_malformed_for_non_mapping_baseline_value() -> None:
     """A baseline metric value that is not a mapping is classified malformed, not crashed."""
     baseline = _baseline()
@@ -294,6 +310,19 @@ def test_report_export_refuses_non_finite_normalized_time_term() -> None:
     records[0]["metrics"]["time_to_goal_norm"] = "nan"
 
     with pytest.raises(ValueError, match="non-finite required SNQI term 'time_to_goal_norm'"):
+        build_scalarization_sensitivity_report(
+            records,
+            weights=_weights(),
+            baseline=_baseline(),
+        )
+
+
+def test_report_export_refuses_out_of_range_normalized_time_term() -> None:
+    """Direct report export fails closed when normalized time input is outside [0, 1]."""
+    records = _episodes()
+    records[0]["metrics"]["time_to_goal_norm"] = 1.3
+
+    with pytest.raises(ValueError, match=r"outside \[0, 1\]"):
         build_scalarization_sensitivity_report(
             records,
             weights=_weights(),


### PR DESCRIPTION
## Summary
- Adds focused regression coverage for fail-closed SNQI scalarization-sensitivity handling when bounded normalized inputs are outside the required [0, 1] range.
- Scope covers preflight classification and direct export guardrails in  via:
  - 
  - 

## Issue
- https://github.com/ll7/robot_sf_ll7/issues/3653

## Validation
- ============================= test session starts ==============================
platform linux -- Python 3.12.3, pytest-9.1.1, pluggy-1.6.0
rootdir: /home/luttkule/git/robot_sf_ll7.worktrees/issue-3653-analysis-snqi-scalarization-sensitivity-pareto-front-export-decision-rev
configfile: pyproject.toml
plugins: cov-7.0.0, split-0.11.0, xdist-3.8.0
collected 29 items

tests/benchmark/test_snqi_scalarization_sensitivity.py ................. [ 58%]
.........                                                                [ 89%]
tests/test_plots_pareto.py ...                                           [100%]

============================= slowest 10 durations =============================
0.24s call     tests/test_plots_pareto.py::test_save_pdf_option
0.12s call     tests/test_plots_pareto.py::test_save_png_creates_file

(8 durations < 0.005s hidden.  Use -vv to show these durations.)

Slow Test Report (soft<20s hard=60s, top 10)
1) tests/test_plots_pareto.py::test_save_pdf_option  0.24s
2) tests/test_plots_pareto.py::test_save_png_creates_file  0.12s
3) tests/benchmark/test_snqi_scalarization_sensitivity.py::test_cli_writes_scalarization_artifacts  0.00s
4) tests/benchmark/test_snqi_scalarization_sensitivity.py::test_artifact_writer_creates_report_ready_files  0.00s
5) tests/benchmark/test_snqi_scalarization_sensitivity.py::test_report_exports_decision_disagreement_and_weight_reversals  0.00s
6) tests/benchmark/test_snqi_scalarization_sensitivity.py::test_cli_preflight_only_blocks_invalid_inputs  0.00s
7) tests/benchmark/test_snqi_scalarization_sensitivity.py::test_cli_export_blocks_invalid_inputs_before_artifacts  0.00s
8) tests/benchmark/test_snqi_scalarization_sensitivity.py::test_cli_refuses_malformed_baseline_without_writing_artifacts  0.00s
9) tests/benchmark/test_snqi_scalarization_sensitivity.py::test_report_records_input_provenance_for_auditable_weight_sweeps  0.00s
10) tests/benchmark/test_snqi_scalarization_sensitivity.py::test_svg_renderer_marks_pareto_points  0.00s

============================== 29 passed in 0.63s ==============================
- All checks passed!

## Evidence
- New tests enforce that out-of-range bounded normalized input () is treated as malformed/fail-closed in both preflight and direct export paths.
- Failures are explicit and prevent artifact emission through existing export CLI behavior.

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
