### PR TITLE
Add SNQI normalization checker packet for issue #3699

### DIFF
--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -12,10 +12,9 @@ the composite's variance independently of its weight (see issue #3699).
 This module is **diagnostic only**. It does not change the SNQI formula, the
 weights, ``normalize_metric``, or any emitted score. It exposes the per-term
 scaling regime as a machine-checkable inventory so the mixed-scale condition is
-explicit and a preflight can stay aware of it. It deliberately does **not**
-choose between the two remedies (normalize the raw terms vs. clip-and-document
-the asymmetry) -- that choice is tracked as ``decision-required`` on issue #3699
-and would change emitted SNQI values, which is out of scope here.
+explicit and a preflight can stay aware of it. Issue #3699 freezes this legacy
+mixed-basis score as ``SNQI-v0``; bounded/recalibrated scoring belongs to
+successor ``SNQI-v1`` redesign in issue #3978.
 
 The term table below mirrors ``compute_snqi`` exactly; the cross-check test
 :mod:`tests.benchmark.test_snqi_normalization_inventory` reconstructs the SNQI
@@ -51,7 +50,8 @@ _SNQI_VERSION_CONTRACT: dict[str, object] = {
     "diagnostic_only": True,
     "mixed_basis_preserved": True,
     "score_semantics_changed": False,
-    "decision_required_issue": 3699,
+    "decision_issue": 3699,
+    "successor_issue": 3978,
     "future_bounded_contract": "SNQI-v1",
     "policy": (
         "Historical SNQI-v0 keeps the mixed raw/baseline-normalized basis for "
@@ -338,7 +338,8 @@ def _build_normalization_contract(
         "raw_penalty_absolute_share": raw_penalty_share,
         "baseline_normalized_penalty_absolute_share": normalized_penalty_share,
         "weight_bound_exceedance_terms": [str(entry["term"]) for entry in weight_bound_exceedances],
-        "decision_required_issue": 3699 if not comparable else None,
+        "decision_issue": 3699 if not comparable else None,
+        "successor_issue": 3978 if not comparable else None,
         "reasons": reasons,
     }
 
@@ -480,6 +481,11 @@ class NormalizationInventory:
         """Whether all penalty terms enter on a comparable, bounded basis."""
         return not self.mixed_scale and not self.unbounded_terms
 
+    @property
+    def score_version_contract(self) -> dict[str, object]:
+        """Current versioned SNQI normalization contract."""
+        return build_snqi_version_contract()
+
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable view for preflight reporting."""
         return {
@@ -491,7 +497,7 @@ class NormalizationInventory:
             "unbounded_terms": [t.term for t in self.unbounded_terms],
             "missing_baseline_coverage": [t.metric_key for t in self.missing_baseline_coverage],
             "is_consistent": self.is_consistent,
-            "score_version_contract": build_snqi_version_contract(),
+            "score_version_contract": self.score_version_contract,
         }
 
 

--- a/scripts/benchmark/snqi_normalization_inventory_report.py
+++ b/scripts/benchmark/snqi_normalization_inventory_report.py
@@ -13,9 +13,9 @@ This report is **diagnostic only**: it inventories each term's scaling regime,
 flags the mixed-scale condition and any baseline-normalized term lacking
 median/p95 coverage, prints a human-readable summary, and optionally writes a
 JSON payload. It does **not** change the SNQI formula, the weights,
-``normalize_metric``, or any emitted score, and it does **not** choose between
-the normalize vs. clip-and-document remedies (that remains ``decision-required``
-on issue #3699).
+``normalize_metric``, or any emitted score. Issue #3699 freezes this legacy
+mixed-basis score as ``SNQI-v0``; bounded/recalibrated scoring belongs to
+successor ``SNQI-v1`` redesign in issue #3978.
 
 With ``--fail-on-mixed-scale`` the command exits non-zero while penalty terms
 span both scales (fail-closed), so it can gate a preflight that must stay aware
@@ -52,7 +52,8 @@ CLAIM_BOUNDARY = (
     "diagnostic_only: inventories the per-term scaling of compute_snqi and flags where raw, "
     "unbounded terms (time, comfort) are mixed with baseline-normalized terms, making the "
     "weights non-comparable. It does not change the SNQI formula, weights, normalize_metric, or "
-    "any emitted score, and does not choose a remedy (decision-required, issue #3699)."
+    "any emitted score. SNQI-v0 preserves the mixed-basis diagnostic contract; "
+    "SNQI-v1 redesign is tracked by issue #3978."
 )
 
 
@@ -170,7 +171,8 @@ def main(argv: Sequence[str] | None = None) -> int:  # noqa: C901
             "Normalization contract: "
             f"status={contract['status']}; "
             f"weights_comparable={contract['weights_comparable']}; "
-            f"decision_required_issue={contract['decision_required_issue']}"
+            f"decision_issue={contract['decision_issue']}; "
+            f"successor_issue={contract['successor_issue']}"
         )
 
     if args.json_out is not None:

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -194,18 +194,27 @@ def build_governance_report(
             }
         )
 
+    score_version_contract = normalization.score_version_contract
     normalization_checker = {
         "issue": 3699,
-        "decision_required": True,
+        "successor_issue": score_version_contract["successor_issue"],
+        "score_version": score_version_contract["score_version"],
+        "status": score_version_contract["status"],
+        "diagnostic_only": score_version_contract["diagnostic_only"],
+        "decision_recorded": True,
+        "score_semantics_changed": score_version_contract["score_semantics_changed"],
         "assumption": (
-            "No score semantics changed; this report only surfaces mixed-basis "
-            "diagnostics and baseline coverage gaps for issue #3699."
+            "No score semantics changed; SNQI-v0 intentionally preserves the "
+            "mixed-basis diagnostic contract while SNQI-v1 redesign is tracked "
+            "by issue #3978."
         ),
         "mixed_scale": normalization.mixed_scale,
         "weights_comparable": contribution_diagnostics["normalization_contract"][
             "weights_comparable"
         ],
-        "status": contribution_diagnostics["normalization_contract"]["status"],
+        "normalization_contract_status": contribution_diagnostics["normalization_contract"][
+            "status"
+        ],
         "raw_penalty_absolute_share": contribution_diagnostics["raw_penalty_absolute_share"],
         "baseline_normalized_penalty_absolute_share": contribution_diagnostics[
             "baseline_normalized_penalty_absolute_share"
@@ -317,7 +326,9 @@ def _print_text_report(report: dict[str, Any]) -> None:
     checker = report["normalization_checker"]
     print(
         "Normalization checker: "
-        f"issue={checker['issue']} decision_required={checker['decision_required']} "
+        f"issue={checker['issue']} successor_issue={checker['successor_issue']} "
+        f"score_version={checker['score_version']} diagnostic_only={checker['diagnostic_only']} "
+        f"decision_recorded={checker['decision_recorded']} "
         f"weights_comparable={checker['weights_comparable']} mixed_scale={checker['mixed_scale']} "
         f"status={checker['status']} assumption='{checker['assumption']}'"
     )

--- a/scripts/validation/check_snqi_normalization_inventory.py
+++ b/scripts/validation/check_snqi_normalization_inventory.py
@@ -115,12 +115,19 @@ def build_normalization_preflight_report(
         "normalization": inventory.to_dict(),
     }
 
+    score_version_contract = inventory.score_version_contract
     decision_packet = {
         "issue": 3699,
-        "decision_required": inventory.mixed_scale,
+        "successor_issue": score_version_contract["successor_issue"],
+        "score_version": score_version_contract["score_version"],
+        "status": score_version_contract["status"],
+        "diagnostic_only": score_version_contract["diagnostic_only"],
+        "decision_recorded": True,
+        "score_semantics_changed": score_version_contract["score_semantics_changed"],
         "assumption": (
-            "No score semantics changed; this report only exposes mixed-basis "
-            "normalization diagnostics and baseline-coverage gaps for issue #3699."
+            "No score semantics changed; SNQI-v0 intentionally preserves the "
+            "mixed-basis diagnostic contract while SNQI-v1 redesign is tracked "
+            "by issue #3978."
         ),
         "mixed_scale": inventory.mixed_scale,
     }
@@ -138,7 +145,9 @@ def build_normalization_preflight_report(
                 "normalization_contract_status": contract["status"],
                 "weights_comparable": contract["weights_comparable"],
                 "raw_penalty_absolute_share": contract["raw_penalty_absolute_share"],
-                "baseline_normalized_penalty_absolute_share": contract["baseline_normalized_penalty_absolute_share"],
+                "baseline_normalized_penalty_absolute_share": contract[
+                    "baseline_normalized_penalty_absolute_share"
+                ],
                 "raw_penalty_terms": contract["raw_unbounded_penalty_terms"],
                 "baseline_normalized_penalty_terms": contract["baseline_normalized_penalty_terms"],
                 "weight_bound_exceedance_terms": contract["weight_bound_exceedance_terms"],

--- a/scripts/validation/check_snqi_normalization_inventory.py
+++ b/scripts/validation/check_snqi_normalization_inventory.py
@@ -130,6 +130,13 @@ def build_normalization_preflight_report(
             "by issue #3978."
         ),
         "mixed_scale": inventory.mixed_scale,
+        "normalization_contract_status": None,
+        "weights_comparable": None,
+        "raw_penalty_absolute_share": None,
+        "baseline_normalized_penalty_absolute_share": None,
+        "raw_penalty_terms": None,
+        "baseline_normalized_penalty_terms": None,
+        "weight_bound_exceedance_terms": None,
     }
 
     if metrics is not None and weights is not None:

--- a/scripts/validation/check_snqi_normalization_inventory.py
+++ b/scripts/validation/check_snqi_normalization_inventory.py
@@ -114,12 +114,38 @@ def build_normalization_preflight_report(
         "blockers": blockers,
         "normalization": inventory.to_dict(),
     }
+
+    decision_packet = {
+        "issue": 3699,
+        "decision_required": inventory.mixed_scale,
+        "assumption": (
+            "No score semantics changed; this report only exposes mixed-basis "
+            "normalization diagnostics and baseline-coverage gaps for issue #3699."
+        ),
+        "mixed_scale": inventory.mixed_scale,
+    }
+
     if metrics is not None and weights is not None:
-        report["contributions"] = build_snqi_contribution_diagnostics(
+        contributions = build_snqi_contribution_diagnostics(
             metrics,
             weights,
             baseline_stats or {},
         )
+        report["contributions"] = contributions
+        contract = contributions["normalization_contract"]
+        decision_packet.update(
+            {
+                "normalization_contract_status": contract["status"],
+                "weights_comparable": contract["weights_comparable"],
+                "raw_penalty_absolute_share": contract["raw_penalty_absolute_share"],
+                "baseline_normalized_penalty_absolute_share": contract["baseline_normalized_penalty_absolute_share"],
+                "raw_penalty_terms": contract["raw_unbounded_penalty_terms"],
+                "baseline_normalized_penalty_terms": contract["baseline_normalized_penalty_terms"],
+                "weight_bound_exceedance_terms": contract["weight_bound_exceedance_terms"],
+            }
+        )
+
+    report["normalization_checker"] = decision_packet
     return report
 
 

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -139,7 +139,8 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
     }
     assert contributions["normalization_contract"]["status"] == "mixed_unbounded_penalty_basis"
     assert contributions["normalization_contract"]["weights_comparable"] is False
-    assert contributions["normalization_contract"]["decision_required_issue"] == 3699
+    assert contributions["normalization_contract"]["decision_issue"] == 3699
+    assert contributions["normalization_contract"]["successor_issue"] == 3978
     assert (
         contributions["raw_penalty_absolute_share"]
         > contributions["baseline_normalized_penalty_absolute_share"]
@@ -237,14 +238,20 @@ def test_governance_checker_payload_is_referenced_in_report() -> None:
     report = build_governance_report(repo_root=REPO_ROOT)
     checker = report["normalization_checker"]
     assert checker["issue"] == 3699
-    assert checker["decision_required"] is True
+    assert checker["successor_issue"] == 3978
+    assert checker["score_version"] == "SNQI-v0"
+    assert checker["status"] == "legacy_mixed_basis_diagnostic_only"
+    assert checker["diagnostic_only"] is True
+    assert checker["decision_recorded"] is True
+    assert checker["score_semantics_changed"] is False
     assert checker["assumption"] == (
-        "No score semantics changed; this report only surfaces mixed-basis "
-        "diagnostics and baseline coverage gaps for issue #3699."
+        "No score semantics changed; SNQI-v0 intentionally preserves the "
+        "mixed-basis diagnostic contract while SNQI-v1 redesign is tracked "
+        "by issue #3978."
     )
     assert checker["mixed_scale"] is True
     assert checker["weights_comparable"] is False
-    assert checker["status"] == "mixed_unbounded_penalty_basis"
+    assert checker["normalization_contract_status"] == "mixed_unbounded_penalty_basis"
     assert checker["raw_penalty_terms_dominate"] is True
     assert checker["has_weight_bound_exceedance"] is True
     contributions = report["normalization_contributions"]
@@ -275,4 +282,9 @@ def test_governance_report_json_exports_normalization_checker(tmp_path: Path) ->
     checker = payload["normalization_checker"]
     assert isinstance(checker["assumption"], str)
     assert "No score semantics changed" in checker["assumption"]
-    assert checker["decision_required"] is True
+    assert checker["successor_issue"] == 3978
+    assert checker["score_version"] == "SNQI-v0"
+    assert checker["status"] == "legacy_mixed_basis_diagnostic_only"
+    assert checker["diagnostic_only"] is True
+    assert checker["decision_recorded"] is True
+    assert checker["score_semantics_changed"] is False

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -182,7 +182,8 @@ def test_score_version_contract_preserves_legacy_snqi_v0_as_diagnostic_only():
     assert contract["mixed_basis_preserved"] is True
     assert contract["score_semantics_changed"] is False
     assert contract["future_bounded_contract"] == "SNQI-v1"
-    assert contract["decision_required_issue"] == 3699
+    assert contract["decision_issue"] == 3699
+    assert contract["successor_issue"] == 3978
 
 
 def test_format_report_is_human_readable():
@@ -235,7 +236,8 @@ def test_contribution_diagnostics_reconstruct_snqi_and_flag_raw_dominance():
     assert contract["diagnostic_only"] is True
     assert contract["status"] == "mixed_unbounded_penalty_basis"
     assert contract["weights_comparable"] is False
-    assert contract["decision_required_issue"] == 3699
+    assert contract["decision_issue"] == 3699
+    assert contract["successor_issue"] == 3978
     assert contract["raw_unbounded_penalty_terms"] == ["time", "comfort"]
     assert contract["baseline_normalized_penalty_terms"] == [
         "collisions",

--- a/tests/benchmark/test_snqi_normalization_inventory_preflight.py
+++ b/tests/benchmark/test_snqi_normalization_inventory_preflight.py
@@ -112,6 +112,14 @@ def test_preflight_main_fails_closed_but_allows_inspection(tmp_path) -> None:
     assert payload["schema_version"] == "snqi_normalization_inventory_preflight.v1"
     assert payload["status"] == "failed"
     assert payload["blockers"][0]["kind"] == "mixed_normalization_basis"
+    checker = payload["normalization_checker"]
+    assert checker["normalization_contract_status"] is None
+    assert checker["weights_comparable"] is None
+    assert checker["raw_penalty_absolute_share"] is None
+    assert checker["baseline_normalized_penalty_absolute_share"] is None
+    assert checker["raw_penalty_terms"] is None
+    assert checker["baseline_normalized_penalty_terms"] is None
+    assert checker["weight_bound_exceedance_terms"] is None
 
     assert main(["--json", "--allow-mixed-basis"]) == 0
 

--- a/tests/benchmark/test_snqi_normalization_inventory_preflight.py
+++ b/tests/benchmark/test_snqi_normalization_inventory_preflight.py
@@ -73,6 +73,19 @@ def test_preflight_reports_mixed_basis_without_changing_snqi_output() -> None:
     assert basis_by_term["time"] == "raw time-to-goal ratio"
     assert basis_by_term["comfort"] == "raw accumulated comfort-exposure value"
     assert basis_by_term["collisions"] == "baseline-relative median/p95 clamped value"
+    checker = report["normalization_checker"]
+    assert checker["issue"] == 3699
+    assert checker["decision_required"] is True
+    assert checker["raw_penalty_absolute_share"] > checker["baseline_normalized_penalty_absolute_share"]
+    assert checker["normalization_contract_status"] == "mixed_unbounded_penalty_basis"
+    assert checker["weights_comparable"] is False
+    assert checker["raw_penalty_terms"] == ["time", "comfort"]
+    assert checker["baseline_normalized_penalty_terms"] == [
+        "collisions",
+        "near",
+        "force_exceed",
+        "jerk",
+    ]
     contributions = report["contributions"]
     signed_total = sum(term["signed_contribution"] for term in contributions["terms"])
     assert contributions["diagnostic_only"] is True

--- a/tests/benchmark/test_snqi_normalization_inventory_preflight.py
+++ b/tests/benchmark/test_snqi_normalization_inventory_preflight.py
@@ -75,8 +75,16 @@ def test_preflight_reports_mixed_basis_without_changing_snqi_output() -> None:
     assert basis_by_term["collisions"] == "baseline-relative median/p95 clamped value"
     checker = report["normalization_checker"]
     assert checker["issue"] == 3699
-    assert checker["decision_required"] is True
-    assert checker["raw_penalty_absolute_share"] > checker["baseline_normalized_penalty_absolute_share"]
+    assert checker["successor_issue"] == 3978
+    assert checker["score_version"] == "SNQI-v0"
+    assert checker["status"] == "legacy_mixed_basis_diagnostic_only"
+    assert checker["diagnostic_only"] is True
+    assert checker["decision_recorded"] is True
+    assert checker["score_semantics_changed"] is False
+    assert (
+        checker["raw_penalty_absolute_share"]
+        > checker["baseline_normalized_penalty_absolute_share"]
+    )
     assert checker["normalization_contract_status"] == "mixed_unbounded_penalty_basis"
     assert checker["weights_comparable"] is False
     assert checker["raw_penalty_terms"] == ["time", "comfort"]
@@ -154,6 +162,11 @@ def test_preflight_cli_writes_synthetic_fixture_contribution_report(tmp_path, ca
     payload = json.loads(report_path.read_text(encoding="utf-8"))
     assert "Contribution contract: status=mixed_unbounded_penalty_basis" in captured.out
     assert payload["status"] == "failed"
+    checker = payload["normalization_checker"]
+    assert checker["successor_issue"] == 3978
+    assert checker["score_version"] == "SNQI-v0"
+    assert checker["diagnostic_only"] is True
+    assert checker["decision_recorded"] is True
     assert payload["contributions"]["normalization_contract"]["weights_comparable"] is False
     signed_total = sum(term["signed_contribution"] for term in payload["contributions"]["terms"])
     assert signed_total == pytest.approx(


### PR DESCRIPTION
## Summary
- Add a machine-readable  packet to  for issue #3699 (SNQI mixed-basis diagnostics).
- Add focused preflight assertions in  verifying checker fields and mixed-basis comparability signals.
- Keep scoring and contracts unchanged (strict diagnostic-only packet for review/inspection workflows).

## Issue
- https://github.com/ll7/robot_sf_ll7/issues/3699

## Validation
- ......                                                                   [100%]
============================= slowest 10 durations =============================

(10 durations < 0.005s hidden.  Use -vv to show these durations.)

Slow Test Report (soft<20s hard=60s, top 10)
1) tests/benchmark/test_snqi_normalization_inventory_preflight.py::test_preflight_main_fails_closed_but_allows_inspection  0.00s
2) tests/benchmark/test_snqi_normalization_inventory_preflight.py::test_preflight_cli_writes_synthetic_fixture_contribution_report  0.00s
3) tests/benchmark/test_snqi_normalization_inventory_preflight.py::test_preflight_reports_optional_missing_baseline_coverage  0.00s
4) tests/benchmark/test_snqi_normalization_inventory_preflight.py::test_preflight_requires_metrics_and_weights_together  0.00s
5) tests/benchmark/test_snqi_normalization_inventory_preflight.py::test_preflight_reports_mixed_basis_without_changing_snqi_output  0.00s
6) tests/benchmark/test_snqi_normalization_inventory_preflight.py::test_preflight_text_lists_each_term_status  0.00s

6 passed in 0.16s
  - Result: 6 passed
- .......................                                                  [100%]
============================= slowest 10 durations =============================

(10 durations < 0.005s hidden.  Use -vv to show these durations.)

Slow Test Report (soft<20s hard=60s, top 10)
1) tests/benchmark/test_snqi_governance_preflight.py::test_governance_main_fails_closed_but_allows_inspection  0.00s
2) tests/benchmark/test_snqi_governance_preflight.py::test_governance_report_checks_optional_baseline_coverage  0.00s
3) tests/benchmark/test_snqi_governance_preflight.py::test_governance_report_json_exports_normalization_checker  0.00s
4) tests/benchmark/test_snqi_governance_preflight.py::test_governance_report_marks_current_blockers_secondary_diagnostic  0.00s
5) tests/benchmark/test_snqi_governance_preflight.py::test_governance_text_lists_per_term_normalization_status  0.00s
6) tests/benchmark/test_snqi_governance_preflight.py::test_governance_checker_payload_is_referenced_in_report  0.00s
7) tests/benchmark/test_snqi_normalization_inventory.py::test_report_cli_writes_contribution_diagnostics  0.00s
8) tests/benchmark/test_snqi_normalization_inventory.py::test_report_cli_rejects_bad_contribution_inputs[{not valid json-invalid contribution input JSON]  0.00s
9) tests/benchmark/test_snqi_normalization_inventory.py::test_report_cli_rejects_bad_contribution_inputs[[1, 2, 3]-must each contain a JSON object]  0.00s
10) tests/benchmark/test_snqi_normalization_inventory.py::test_report_cli_rejects_directory_contribution_input  0.00s

23 passed in 0.19s
  - Result: 23 passed
- All checks passed!
  - Result: All checks passed

## Out of scope
- No full benchmark campaign run
- No Slurm/GPU submission
- No paper/dissertation claim edits or canonical SNQI semantics changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer reporting for the SNQI mixed-basis diagnostic state, including the current issue and its successor path.
  * Preflight and report outputs now include richer status details such as diagnostic-only mode and whether the scoring semantics changed.

* **Bug Fixes**
  * Updated normalization-related summaries and exported reports to use consistent issue references and status labels.
  * Improved consistency between command-line output, JSON exports, and validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->