### PR TITLE
issue #3653: add malformed normalized-input preflight regression for SNQI scalarization export

### DIFF
--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -269,10 +269,7 @@ def test_cli_refuses_malformed_normalized_inputs_and_writes_preflight(tmp_path: 
     assert preflight_out.exists()
     payload = json.loads(preflight_out.read_text(encoding="utf-8"))
     assert payload["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
-    assert any(
-        issue["code"] == "out_of_range_normalized_term"
-        for issue in payload["issues"]
-    )
+    assert any(issue["code"] == "out_of_range_normalized_term" for issue in payload["issues"])
     assert not out_dir.exists()
 
 

--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -234,6 +234,48 @@ def test_cli_refuses_blocked_inputs_and_writes_only_preflight(tmp_path: Path) ->
     assert not out_dir.exists()
 
 
+def test_cli_refuses_malformed_normalized_inputs_and_writes_preflight(tmp_path: Path) -> None:
+    """Malformed normalized SNQI terms remain exported artifacts off, preflight only."""
+    records = _valid_records()
+    metrics = records[0]["metrics"]
+    assert isinstance(metrics, dict)
+    metrics["time_to_goal_norm"] = 1.8
+
+    episodes, baseline, weights = _write_fixture_inputs(tmp_path, records)
+    out_dir = tmp_path / "artifacts"
+    preflight_out = tmp_path / "preflight.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/benchmark/snqi_scalarization_sensitivity_export.py",
+            "--episodes",
+            str(episodes),
+            "--baseline",
+            str(baseline),
+            "--weights",
+            str(weights),
+            "--output-dir",
+            str(out_dir),
+            "--preflight-out",
+            str(preflight_out),
+        ],
+        check=False,
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        capture_output=True,
+    )
+    assert result.returncode == 2
+    assert preflight_out.exists()
+    payload = json.loads(preflight_out.read_text(encoding="utf-8"))
+    assert payload["status"] == SENSITIVITY_PREFLIGHT_MALFORMED
+    assert any(
+        issue["code"] == "out_of_range_normalized_term"
+        for issue in payload["issues"]
+    )
+    assert not out_dir.exists()
+
+
 def test_cli_exports_report_ready_artifacts(tmp_path: Path) -> None:
     """Ready inputs write JSON, CSV, Markdown, and SVG diagnostic artifacts."""
 


### PR DESCRIPTION
## Issue
- Relates to https://github.com/ll7/robot_sf_ll7/issues/3653
- Does not close #3653; the issue remains open for empirical application on a valid campaign surface.

## Scope summary
- Added focused regression test to enforce fail-closed behavior for the SNQI scalarization-sensitivity fixture export when normalized terms are malformed.
- Specifically verifies out-of-range `time_to_goal_norm` in input episodes is rejected by CLI preflight as malformed and does not emit diagnostic artifacts.
- Gate fix: formatted the added assertion so CI `ruff format --check .` passes.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/ci_driver.sh lint` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py tests/benchmark/test_snqi_scalarization_sensitivity.py tests/test_plots_pareto.py -q` - passed, 35 tests
- GitHub `pr-body-contracts` - pending on pushed head at gate time

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No decision-disagreement export consumption on a valid campaign surface; that remains the #3653 blocker.
