### PR TITLE
Issue #3810: long-horizon packet retargets launch/validation to imech156-u

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -224,7 +224,7 @@ launch_packet:
   decision: blocked_pending_submit_host_route_and_reconciliation
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  target_host: imech039
+  target_host: imech156-u
   blocking_jobs:
     - 13175
   live_issue_state:
@@ -269,7 +269,7 @@ launch_packet:
       private submit wrapper named below until those checks return go.
     private_ops_dry_run:
       required_before_submit: true
-      target_host: imech039
+      target_host: imech156-u
       evidence_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
       current_public_status: route_unverified
       required_fields:
@@ -287,7 +287,7 @@ launch_packet:
         The dry run must record decision=go before submission. If job 13175 is
         not terminal/reconciled, if an issue #3810 duplicate exists, if the
         owning worktree is dirty, or if the private submit wrapper lacks
-        imech039 support, the decision remains blocked.
+        imech156-u support, the decision remains blocked.
   interpretation_gate:
     status: blocked_pending_active_run_retention_reconciliation
     required_before_claim: true

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -197,7 +197,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
     )
-    _require(launch_packet.get("target_host") == "imech039", "target host must be imech039")
+    _require(launch_packet.get("target_host") == "imech156-u", "target host must be imech156-u")
     blocking_jobs = launch_packet.get("blocking_jobs")
     _require(isinstance(blocking_jobs, list), "blocking_jobs must be a list")
     _require(13175 in blocking_jobs, "job 13175 must block submit until reconciled")
@@ -257,7 +257,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
     dry_run = _require_mapping(go_no_go, "private_ops_dry_run")
     _require(dry_run.get("required_before_submit") is True, "private-ops dry run required")
-    _require(dry_run.get("target_host") == "imech039", "private-ops dry run host mismatch")
+    _require(dry_run.get("target_host") == "imech156-u", "private-ops dry run host mismatch")
     _require(
         dry_run.get("current_public_status") == "route_unverified",
         "private-ops dry run must be route_unverified in public packet",
@@ -280,8 +280,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "private-ops dry run fields missing",
     )
     _require(
-        "imech039 support" in str(dry_run.get("decision_policy", "")),
-        "private-ops dry run must gate imech039 support",
+        "imech156-u support" in str(dry_run.get("decision_policy", "")),
+        "private-ops dry run must gate imech156-u support",
     )
 
     interpretation_gate = _require_mapping(launch_packet, "interpretation_gate")

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -35,7 +35,7 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert summary["target_host"] == "imech039"
+    assert summary["target_host"] == "imech156-u"
     assert summary["blocking_jobs"] == [13175]
     assert summary["job_13175_state"] == "requires_submit_host_refresh"
     assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
@@ -105,7 +105,7 @@ def test_issue_3810_packet_rejects_stale_target_host() -> None:
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "target host must be imech039" in str(exc)
+        assert "target host must be imech156-u" in str(exc)
     else:
         raise AssertionError("packet should reject stale target host")
 
@@ -133,7 +133,7 @@ def test_issue_3810_packet_rejects_decision_policy_without_target_host_gate() ->
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "private-ops dry run must gate imech039 support" in str(exc)
+        assert "private-ops dry run must gate imech156-u support" in str(exc)
     else:
         raise AssertionError("packet should reject a decision policy missing the host gate")
 


### PR DESCRIPTION
## Issue
- https://github.com/ll7/robot_sf_ll7/issues/3810

## Scope summary
- Adjusts the issue #3810 long-horizon launch packet and validator to use the requested submit decision host `imech156-u`.
- Keeps campaign strictly in fail-closed decision-packet mode (no Slurm submission, no claim promotion).
- Aligns packet text, checker assertions, and issue-specific tests for target-host gating.
- Updates retained fields tied to SNQI recalibration + wait-it-out/interaction-exposure diagnostics while preserving the existing campaign contract.

## Validation
- `uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` (exit 0)
- `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` (exit 0)
- `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q` (exit 0)

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission (no-submit decision packet only).
- No paper/dissertation claim edits.
- No public claim promotion until private-ops pass and route/queue/retention reconciliation are completed.
