### PR TITLE
Issue #3810: harden long-horizon launch packet decision contract

### DIFF
--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -389,7 +389,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "preflight public manifest check command missing",
     )
     _require(
-        "check_issue_3810_long_horizon_launch_packet.py" in str(preflight.get("public_packet_check", "")),
+        "check_issue_3810_long_horizon_launch_packet.py"
+        in str(preflight.get("public_packet_check", "")),
         "preflight public packet check command missing",
     )
 
@@ -440,7 +441,10 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
 
     exposure = _require_mapping(launch_packet, "wait_it_out_guard")
-    _require(exposure.get("diagnostic_name") == "interaction_exposure", "exposure diagnostic name incorrect")
+    _require(
+        exposure.get("diagnostic_name") == "interaction_exposure",
+        "exposure diagnostic name incorrect",
+    )
     exposure_fields = set(exposure.get("required_episode_fields") or [])
     _require(REQUIRED_EXPOSURE_FIELDS <= exposure_fields, "interaction exposure fields missing")
     _require(

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -19,6 +19,17 @@ REQUIRED_OUTPUTS = {
     "reports/horizon_sensitivity_report.json",
     "reports/interaction_exposure_diagnostics.json",
 }
+REQUIRED_VALIDATION_COMMAND_MARKERS = {
+    "run_research_campaign_manifest.py",
+    "check_issue_3810_long_horizon_launch_packet.py",
+    "test_check_issue_3810_long_horizon_launch_packet.py -q",
+}
+REQUIRED_ROUTE_FIELDS = {
+    "private_ops_repo",
+    "queue_summary_command",
+    "route_command",
+    "submit_wrapper",
+}
 REQUIRED_REPORT_FIELDS = {
     "timeout_rate",
     "max_steps_share",
@@ -92,6 +103,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     row_status_policy = _require_mapping(packet, "row_status_policy")
     outputs = _require_mapping(packet, "outputs")
     durable_evidence = _require_mapping(packet, "durable_evidence")
+    validation = _require_mapping(packet, "validation")
     launch_packet = _require_mapping(packet, "launch_packet")
 
     _require(packet.get("schema_version") == "research-campaign-manifest.v0.1", "unexpected schema")
@@ -153,6 +165,15 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(outputs.get("disposable") is True, "outputs must be disposable local output")
     required_paths = set(outputs.get("required_paths") or [])
     _require(REQUIRED_OUTPUTS <= required_paths, "required outputs missing issue #3810 artifacts")
+    validation_commands = validation.get("commands")
+    _require(isinstance(validation_commands, list), "validation.commands must be a list")
+    validation_command_blob = "\n".join(str(command) for command in validation_commands)
+    for marker in REQUIRED_VALIDATION_COMMAND_MARKERS:
+        _require(
+            marker in validation_command_blob,
+            f"validation.commands missing required marker: {marker}",
+        )
+    _require(validation.get("dry_run") == "required", "validation.dry_run must be required")
 
     durable_plan = _require_mapping(durable_evidence, "plan")
     durable_path = str(durable_plan.get("path", ""))
@@ -320,6 +341,12 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
 
     route = _require_mapping(launch_packet, "route")
+    route_fields = set(route.keys())
+    _require(REQUIRED_ROUTE_FIELDS <= route_fields, "route missing required fields")
+    _require(
+        str(route.get("private_ops_repo", "")) == route.get("private_ops_repo"),
+        "route.private_ops_repo must be present",
+    )
     _require(
         str(route.get("submit_policy")) == "no_submit_until_decision_packet_go",
         "submit policy missing",
@@ -328,12 +355,42 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         str(route.get("submit_wrapper", "")).endswith("submit_and_record.sh"),
         "submit wrapper missing",
     )
+    for field in ("private_ops_repo", "queue_summary_command", "route_command", "submit_wrapper"):
+        route_path = str(route.get(field, ""))
+        _require(route_path, f"route.{field} is required")
+        _require(PurePosixPath(route_path).is_absolute(), f"route.{field} must be absolute")
+        if field == "private_ops_repo":
+            _require(
+                route_path.endswith("robot_sf_ll7-private-ops"),
+                "route.private_ops_repo must point to private-ops checkout",
+            )
+            continue
+        _require(
+            "private-ops" in route_path,
+            f"route.{field} must use private-ops script path",
+        )
 
     preflight = _require_mapping(launch_packet, "preflight")
     _require("private_ops_dry_run" in preflight, "private-ops dry-run command missing")
     _require(
         "must not be invoked" in str(preflight.get("no_submit_guard", "")),
         "no-submit guard missing",
+    )
+    _require(
+        "public_manifest_check" in preflight,
+        "preflight missing public manifest check",
+    )
+    _require(
+        "public_packet_check" in preflight,
+        "preflight missing public packet check",
+    )
+    _require(
+        "run_research_campaign_manifest.py" in str(preflight.get("public_manifest_check", "")),
+        "preflight public manifest check command missing",
+    )
+    _require(
+        "check_issue_3810_long_horizon_launch_packet.py" in str(preflight.get("public_packet_check", "")),
+        "preflight public packet check command missing",
     )
 
     config_patch = _require_mapping(launch_packet, "config_patch")
@@ -342,6 +399,17 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(overrides.get("stop_on_failure") is False, "long run must keep collecting rows")
 
     snqi = _require_mapping(launch_packet, "snqi_recalibration")
+    snqi_inputs = _require_mapping(snqi, "inputs")
+    _require("campaign_table" in snqi_inputs, "SNQI campaign_table input missing")
+    _require("episode_records" in snqi_inputs, "SNQI episode_records input missing")
+    snqi_scripts = snqi.get("source_scripts") or snqi_inputs.get("source_scripts")
+    _require(isinstance(snqi_scripts, list), "SNQI source_scripts must be a list")
+    for required_script in (
+        "scripts/recompute_snqi_weights.py",
+        "scripts/snqi_sensitivity_analysis.py",
+        "scripts/validate_snqi_scripts.py",
+    ):
+        _require(required_script in snqi_scripts, f"SNQI source script missing: {required_script}")
     _require(
         str(snqi.get("checksum_policy")) == "checksum_pin_before_claim",
         "SNQI checksum policy missing",
@@ -353,6 +421,18 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
 
     report = _require_mapping(launch_packet, "horizon_sensitivity_report")
+    _require(
+        "build_horizon_timestep_denominator_report.py" in str(report.get("command", "")),
+        "horizon report command missing build_horizon_timestep_denominator_report.py",
+    )
+    _require(
+        "--long-campaign" in str(report.get("command", "")),
+        "horizon report command missing --long-campaign",
+    )
+    _require(
+        "--short-campaign-reference" in str(report.get("command", "")),
+        "horizon report command missing --short-campaign-reference",
+    )
     report_fields = set(report.get("required_fields") or [])
     _require(REQUIRED_REPORT_FIELDS <= report_fields, "horizon report fields missing")
     _require(
@@ -360,6 +440,7 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
 
     exposure = _require_mapping(launch_packet, "wait_it_out_guard")
+    _require(exposure.get("diagnostic_name") == "interaction_exposure", "exposure diagnostic name incorrect")
     exposure_fields = set(exposure.get("required_episode_fields") or [])
     _require(REQUIRED_EXPOSURE_FIELDS <= exposure_fields, "interaction exposure fields missing")
     _require(

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -389,3 +389,60 @@ def test_issue_3810_packet_cli_json() -> None:
     assert completed.returncode == 0, completed.stderr
     assert '"compute_submit_authorized": false' in completed.stdout
     assert '"max_episode_steps": 600' in completed.stdout
+
+
+def test_issue_3810_packet_rejects_missing_validation_commands() -> None:
+    """Packet validation must include all required command markers."""
+    packet = _load_packet()
+    packet["validation"]["commands"] = [
+        "echo noop",
+    ]
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "validation.commands missing required marker" in str(exc)
+    else:
+        raise AssertionError("packet should reject missing validation command markers")
+
+
+def test_issue_3810_packet_rejects_route_path_regression() -> None:
+    """Route commands must remain private-ops-backed until submit-host refresh."""
+    packet = _load_packet()
+    packet["launch_packet"]["route"]["queue_summary_command"] = "python scripts/dev/queue_summary.py"
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "route.queue_summary_command must be absolute" in str(exc)
+    else:
+        raise AssertionError("packet should reject non-private-ops queue summary command")
+
+
+def test_issue_3810_packet_rejects_missing_snqi_inputs() -> None:
+    """SNQI recalibration inputs and scripts must be explicit and locked."""
+    packet = _load_packet()
+    packet["launch_packet"]["snqi_recalibration"].pop("inputs")
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "inputs must be a mapping" in str(exc)
+    else:
+        raise AssertionError("packet should reject missing SNQI inputs")
+
+
+def test_issue_3810_packet_rejects_weak_horizon_report_command() -> None:
+    """Horizon sensitivity report command must include the long/short campaign refs."""
+    packet = _load_packet()
+    packet["launch_packet"]["horizon_sensitivity_report"]["command"] = (
+        "uv run python scripts/benchmark/build_horizon_timestep_denominator_report.py "
+        "--long-campaign output/benchmarks/issue_3810_comprehensive_h600_snqi/reports"
+    )
+
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "horizon report command missing --short-campaign-reference" in str(exc)
+    else:
+        raise AssertionError("packet should reject incomplete horizon command")

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -409,7 +409,9 @@ def test_issue_3810_packet_rejects_missing_validation_commands() -> None:
 def test_issue_3810_packet_rejects_route_path_regression() -> None:
     """Route commands must remain private-ops-backed until submit-host refresh."""
     packet = _load_packet()
-    packet["launch_packet"]["route"]["queue_summary_command"] = "python scripts/dev/queue_summary.py"
+    packet["launch_packet"]["route"]["queue_summary_command"] = (
+        "python scripts/dev/queue_summary.py"
+    )
 
     try:
         _MODULE.validate_packet(packet)


### PR DESCRIPTION
## Scope
- Prepared fail-closed packet validation hardening for issue #3810.
- Added required checks for validation command markers, route/preflight command contracts, Social Navigation Quality Index (SNQI) recalibration inputs/scripts, horizon-sensitivity command markers, and wait-it-out guard metadata.

## Reference
- Relates to #3810.
- Partial slice only: this PR should not close #3810.

## Validation
- `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json`
- `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q`
- `uv run ruff check scripts/validation/check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py`

## Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No SNQI recalibration result or horizon-sensitivity result is established by this PR.
