### PR TITLE
analysis: #3653 add fixture-backed SNQI scalarization export regression

### DIFF
--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -337,9 +337,7 @@ def test_cli_exports_report_ready_artifacts_from_fixture_files(tmp_path: Path) -
     assert (out_dir / "issue_3653_fixture.md").exists()
     assert (out_dir / "issue_3653_fixture_pareto.svg").exists()
 
-    payload = json.loads(
-        (out_dir / "issue_3653_fixture.json").read_text(encoding="utf-8")
-    )
+    payload = json.loads((out_dir / "issue_3653_fixture.json").read_text(encoding="utf-8"))
     assert payload["schema_version"] == "snqi_scalarization_sensitivity.v1"
     assert payload["pareto_front"]["points"]
     assert payload["decision_disagreement"]["pairwise_reversal_count"] >= 0

--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -302,6 +302,49 @@ def test_cli_refuses_blocked_inputs_and_writes_only_preflight(tmp_path: Path) ->
     assert not out_dir.exists()
 
 
+def test_cli_exports_report_ready_artifacts_from_fixture_files(tmp_path: Path) -> None:
+    """Valid fixture files pass preflight and emit all diagnostic artifacts."""
+    episodes, baseline, weights = _write_fixture_inputs_from_fixtures(
+        tmp_path,
+        episodes_file="valid_episodes.jsonl",
+    )
+    out_dir = tmp_path / "artifacts"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/benchmark/snqi_scalarization_sensitivity_export.py",
+            "--episodes",
+            str(episodes),
+            "--baseline",
+            str(baseline),
+            "--weights",
+            str(weights),
+            "--output-dir",
+            str(out_dir),
+            "--stem",
+            "issue_3653_fixture",
+        ],
+        check=False,
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (out_dir / "issue_3653_fixture.json").exists()
+    assert (out_dir / "issue_3653_fixture_planner_rows.csv").exists()
+    assert (out_dir / "issue_3653_fixture_decision_disagreement.csv").exists()
+    assert (out_dir / "issue_3653_fixture.md").exists()
+    assert (out_dir / "issue_3653_fixture_pareto.svg").exists()
+
+    payload = json.loads(
+        (out_dir / "issue_3653_fixture.json").read_text(encoding="utf-8")
+    )
+    assert payload["schema_version"] == "snqi_scalarization_sensitivity.v1"
+    assert payload["pareto_front"]["points"]
+    assert payload["decision_disagreement"]["pairwise_reversal_count"] >= 0
+
+
 def test_cli_refuses_malformed_normalized_inputs_and_writes_preflight(tmp_path: Path) -> None:
     """Malformed normalized SNQI terms remain export artifacts off, preflight only."""
     records = _valid_records()


### PR DESCRIPTION
## Issue
- Relates to https://github.com/ll7/robot_sf_ll7/issues/3653
- Does not close #3653; the parent issue remains open for valid-campaign consumption of the Pareto-front / decision-disagreement export.

## Scope
- Adds fixture-backed CLI export regression coverage for Social Navigation Quality Index (SNQI) scalarization sensitivity in `tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py`.
- Reuses the issue fixture corpus in `tests/benchmark/fixtures/snqi_scalarization_sensitivity_issue_3653/` to validate that normalized, valid fixture files pass preflight and emit all required diagnostic artifacts: JSON, planner rows CSV, decision-disagreement CSV, Markdown, and Pareto SVG.
- Keeps existing fail-closed coverage for malformed or missing normalized inputs in the same module.

## Validation
- `uv run ruff check tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py`
- `uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py -q`
- Result: PASS locally after merging current `origin/main` into the PR branch.

## Out Of Scope
- No valid campaign evidence consumption.
- No full benchmark campaign rerun.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Issue Disposition
- #3653 should remain open after this PR. This PR is a regression-coverage slice for the export path, not the empirical application required to treat #3653 as research-complete.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for the CLI export workflow using fixture data.
  * Verifies the command completes successfully and produces the expected report artifacts, including JSON, CSV, Markdown, and SVG outputs.
  * Confirms exported data includes the expected schema details and report contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->