### PR TITLE
#3275 adversarial: bounded rerun readiness fail-closed fixtures

### DIFF
--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -8,8 +8,8 @@ The check is readiness/leakage evidence only. It does not run benchmark campaign
 
 ## Implementation
 
-- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads a source archive and rerun archive, checks archive-ID leakage, records family/seed overlap provenance, and requires certification metadata on rerun archive entries.
-- `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI.
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads a source archive and rerun archive, checks archive-ID leakage, records family/seed overlap provenance, requires certification metadata on rerun archive entries, and can validate supplied null-test prerequisite metadata.
+- `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI, including optional `--null-test-prerequisites` input.
 - Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
 
 ## Validation
@@ -19,4 +19,6 @@ Focused tests cover:
 - disjoint certified archives passing the metadata gate;
 - overlapping archive IDs blocking leakage;
 - missing rerun certification metadata blocking readiness;
+- complete null-test prerequisite metadata staying ready;
+- missing or invalid null-test prerequisite metadata blocking readiness;
 - diagnostic-only rerun outputs staying diagnostic-only.

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -69,6 +69,16 @@ _DIAGNOSTIC_STATUS_KEYS = (
     "result_classification",
     "status",
 )
+_NULL_TEST_REQUIRED_KEYS = (
+    "null_tests_reject_null",
+    "shuffled_outcome_null_test",
+    "ranking_permutation_test",
+)
+_NULL_TEST_CONTAINER_KEYS = (
+    "independent_evaluation",
+    "null_test_prerequisites",
+    "null_tests",
+)
 
 
 @dataclass(frozen=True)
@@ -87,6 +97,10 @@ class FailureArchiveRerunReadiness:
     missing_certification_archive_ids: list[str] = field(default_factory=list)
     invalid_certification_archive_ids: list[str] = field(default_factory=list)
     diagnostic_only_outputs: list[str] = field(default_factory=list)
+    null_test_prerequisite_source: str | None = None
+    null_test_prerequisite_status: str = "not_checked"
+    missing_null_test_prerequisites: list[str] = field(default_factory=list)
+    invalid_null_test_prerequisites: list[str] = field(default_factory=list)
     blockers: list[str] = field(default_factory=list)
     warnings: list[str] = field(default_factory=list)
 
@@ -115,6 +129,10 @@ class FailureArchiveRerunReadiness:
             "missing_certification_archive_ids": list(self.missing_certification_archive_ids),
             "invalid_certification_archive_ids": list(self.invalid_certification_archive_ids),
             "diagnostic_only_outputs": list(self.diagnostic_only_outputs),
+            "null_test_prerequisite_source": self.null_test_prerequisite_source,
+            "null_test_prerequisite_status": self.null_test_prerequisite_status,
+            "missing_null_test_prerequisites": list(self.missing_null_test_prerequisites),
+            "invalid_null_test_prerequisites": list(self.invalid_null_test_prerequisites),
             "blockers": list(self.blockers),
             "warnings": list(self.warnings),
         }
@@ -125,6 +143,7 @@ def classify_failure_archive_rerun_readiness(
     rerun_archive: str | Path,
     *,
     rerun_output: str | Path | None = None,
+    null_test_prerequisites: str | Path | dict[str, Any] | None = None,
 ) -> FailureArchiveRerunReadiness:
     """Classify whether a proposal-model rerun archive is disjoint and certified.
 
@@ -133,6 +152,8 @@ def classify_failure_archive_rerun_readiness(
         rerun_archive: Separate archive intended for the rerun/evaluation slice.
         rerun_output: Optional rerun report JSON. Diagnostic-only markers cap the
             verdict at ``diagnostic_only`` when inputs otherwise pass.
+        null_test_prerequisites: Optional JSON path or payload containing the
+            null-test readiness fields expected before any held-out claim.
 
     Returns:
         A fail-closed readiness verdict. The function never runs planners,
@@ -158,20 +179,18 @@ def classify_failure_archive_rerun_readiness(
 
     overlap = compute_overlap_provenance(source_entries, rerun_entries)
     archive_id_overlap = list(overlap.get("archive_id_overlap", []))
-    if archive_id_overlap:
-        blockers.append(f"archive_id_overlap:{len(archive_id_overlap)}")
-    if overlap.get("scenario_family_overlap_count", 0):
-        blockers.append(f"scenario_family_overlap:{overlap['scenario_family_overlap_count']}")
-    if overlap.get("seed_overlap_count", 0):
-        blockers.append(f"seed_overlap:{overlap['seed_overlap_count']}")
+    blockers.extend(_overlap_blockers(overlap))
 
     missing_certification, invalid_certification = _certification_gaps(rerun_entries)
-    if missing_certification:
-        blockers.append(f"missing_certification_metadata:{len(missing_certification)}")
-    if invalid_certification:
-        blockers.append(f"invalid_certification_status:{len(invalid_certification)}")
+    blockers.extend(_count_blockers("missing_certification_metadata", missing_certification))
+    blockers.extend(_count_blockers("invalid_certification_status", invalid_certification))
 
     diagnostic_outputs = _diagnostic_only_outputs(Path(rerun_output) if rerun_output else None)
+    null_source, null_status, missing_nulls, invalid_nulls = _null_test_prerequisite_gaps(
+        null_test_prerequisites
+    )
+    blockers.extend(_count_blockers("missing_null_test_prerequisites", missing_nulls))
+    blockers.extend(_count_blockers("invalid_null_test_prerequisites", invalid_nulls))
     status = BLOCKED if blockers else READY
     if status == READY and diagnostic_outputs:
         status = DIAGNOSTIC_ONLY
@@ -189,6 +208,10 @@ def classify_failure_archive_rerun_readiness(
         missing_certification_archive_ids=missing_certification,
         invalid_certification_archive_ids=invalid_certification,
         diagnostic_only_outputs=diagnostic_outputs,
+        null_test_prerequisite_source=null_source,
+        null_test_prerequisite_status=null_status,
+        missing_null_test_prerequisites=missing_nulls,
+        invalid_null_test_prerequisites=invalid_nulls,
         blockers=blockers,
         warnings=warnings,
     )
@@ -230,6 +253,27 @@ def _archive_entries(payload: dict[str, Any] | None) -> list[dict[str, Any]]:
     if not isinstance(entries, list):
         return []
     return [entry for entry in entries if isinstance(entry, dict)]
+
+
+def _overlap_blockers(overlap: dict[str, Any]) -> list[str]:
+    """Return blocker tokens from overlap provenance."""
+
+    blockers: list[str] = []
+    for key, blocker in (
+        ("archive_id_overlap_count", "archive_id_overlap"),
+        ("scenario_family_overlap_count", "scenario_family_overlap"),
+        ("seed_overlap_count", "seed_overlap"),
+    ):
+        count = overlap.get(key, 0)
+        if count:
+            blockers.append(f"{blocker}:{count}")
+    return blockers
+
+
+def _count_blockers(blocker: str, values: list[str]) -> list[str]:
+    """Return a single count blocker when values are present."""
+
+    return [f"{blocker}:{len(values)}"] if values else []
 
 
 def _certification_gaps(entries: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
@@ -283,6 +327,77 @@ def _certification_status(value: Any) -> str | None:
                 return "failed"
         return "certified" if value else None
     return None
+
+
+def _null_test_prerequisite_gaps(
+    payload_or_path: str | Path | dict[str, Any] | None,
+) -> tuple[str | None, str, list[str], list[str]]:
+    """Return fail-closed gaps for optional null-test prerequisite metadata."""
+
+    if payload_or_path is None:
+        return None, "not_checked", [], []
+    if isinstance(payload_or_path, dict):
+        source = "inline_payload"
+        payload: dict[str, Any] | None = payload_or_path
+        load_gap = None
+    else:
+        path = Path(payload_or_path)
+        source = str(path)
+        payload, load_gap = _load_json_object(path)
+    if load_gap is not None:
+        return source, "blocked", [], [load_gap]
+
+    prerequisites = _null_test_container(payload)
+    missing = [
+        key
+        for key in _NULL_TEST_REQUIRED_KEYS
+        if key not in prerequisites or prerequisites.get(key) in (None, "", [])
+    ]
+    invalid: list[str] = []
+    if prerequisites.get("null_tests_reject_null") is not True:
+        invalid.append("null_tests_reject_null_not_true")
+    for key in ("shuffled_outcome_null_test", "ranking_permutation_test"):
+        value = prerequisites.get(key)
+        if not isinstance(value, dict):
+            continue
+        if value.get("status") != "complete":
+            invalid.append(f"{key}_status_not_complete")
+        if "p_value" not in value:
+            invalid.append(f"{key}_missing_p_value")
+    status = "ready" if not missing and not invalid else "blocked"
+    return source, status, missing, invalid
+
+
+def _load_json_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:
+    """Load a JSON object, returning a compact fail-closed reason on failure.
+
+    Returns:
+        ``(payload, reason)`` with ``reason`` populated only when loading fails.
+    """
+
+    if not path.exists():
+        return None, f"null_test_prerequisites_missing:{path}"
+    if path.stat().st_size == 0:
+        return None, f"null_test_prerequisites_empty:{path}"
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        return None, f"null_test_prerequisites_unreadable:{exc}"
+    if not isinstance(payload, dict):
+        return None, "null_test_prerequisites_not_object"
+    return payload, None
+
+
+def _null_test_container(payload: dict[str, Any] | None) -> dict[str, Any]:
+    """Return the nested null-test prerequisite object from a report payload."""
+
+    if not isinstance(payload, dict):
+        return {}
+    for key in _NULL_TEST_CONTAINER_KEYS:
+        value = payload.get(key)
+        if isinstance(value, dict):
+            return value
+    return payload
 
 
 def _diagnostic_only_outputs(path: Path | None) -> list[str]:

--- a/scripts/validation/check_failure_archive_rerun_readiness.py
+++ b/scripts/validation/check_failure_archive_rerun_readiness.py
@@ -52,6 +52,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Optional rerun report JSON; diagnostic-only markers cap the verdict.",
     )
     parser.add_argument(
+        "--null-test-prerequisites",
+        type=Path,
+        default=None,
+        help="Optional null-test prerequisite JSON/report required before held-out claims.",
+    )
+    parser.add_argument(
         "--output",
         type=Path,
         default=None,
@@ -68,6 +74,7 @@ def main(argv: list[str] | None = None) -> int:
         args.source_archive,
         args.rerun_archive,
         rerun_output=args.rerun_output,
+        null_test_prerequisites=args.null_test_prerequisites,
     )
     payload = readiness.to_payload()
     rendered = json.dumps(payload, indent=2, sort_keys=True)

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -120,9 +120,10 @@ def test_scenario_family_and_seed_overlap_is_reported_as_blockers(tmp_path: Path
     assert "scenario_family_overlap:1" in readiness.blockers
     assert "seed_overlap:1" in readiness.blockers
     assert len(readiness.overlap_provenance["scenario_family_overlap"]) == 1
-    assert json.loads(readiness.overlap_provenance["scenario_family_overlap"][0]) == _entry(
-        "_", family="family_a", seed=0
-    )["cluster_key"]
+    assert (
+        json.loads(readiness.overlap_provenance["scenario_family_overlap"][0])
+        == _entry("_", family="family_a", seed=0)["cluster_key"]
+    )
     assert readiness.overlap_provenance["seed_overlap"] == [42]
 
 
@@ -138,7 +139,9 @@ def test_missing_archive_payload_blocks_ready_path(tmp_path: Path) -> None:
     readiness = classify_failure_archive_rerun_readiness(source, missing)
 
     assert readiness.status == BLOCKED
-    assert any(blocker.startswith("rerun_archive_blocked:path_missing") for blocker in readiness.blockers)
+    assert any(
+        blocker.startswith("rerun_archive_blocked:path_missing") for blocker in readiness.blockers
+    )
     assert not any(blocker.startswith("source_archive_blocked") for blocker in readiness.blockers)
 
 
@@ -156,8 +159,7 @@ def test_malformed_archive_payload_fails_closed(tmp_path: Path) -> None:
 
     assert readiness.status == BLOCKED
     assert any(
-        blocker.startswith("rerun_archive_blocked:unreadable")
-        for blocker in readiness.blockers
+        blocker.startswith("rerun_archive_blocked:unreadable") for blocker in readiness.blockers
     )
 
 

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -184,6 +184,83 @@ def test_diagnostic_only_output_caps_otherwise_ready_inputs(tmp_path: Path) -> N
     assert readiness.diagnostic_only_outputs == ["result_classification:diagnostic_only"]
 
 
+def test_null_test_prerequisites_can_be_checked_from_report(tmp_path: Path) -> None:
+    """Complete null-test prerequisite metadata keeps otherwise ready inputs ready."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = tmp_path / "prerequisites.json"
+    prerequisites.write_text(
+        json.dumps(
+            {
+                "schema_version": "adversarial_proposal_comparison.v1",
+                "null_tests": {
+                    "null_tests_reject_null": True,
+                    "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.01},
+                    "ranking_permutation_test": {"status": "complete", "p_value": 0.02},
+                },
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == READY
+    assert readiness.null_test_prerequisite_source == str(prerequisites)
+    assert readiness.null_test_prerequisite_status == READY
+    assert readiness.missing_null_test_prerequisites == []
+    assert readiness.invalid_null_test_prerequisites == []
+
+
+def test_missing_null_test_prerequisites_block_readiness(tmp_path: Path) -> None:
+    """Incomplete null-test prerequisite metadata fails closed."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = tmp_path / "prerequisites.json"
+    prerequisites.write_text(
+        json.dumps(
+            {
+                "null_tests": {
+                    "null_tests_reject_null": False,
+                    "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.5},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.null_test_prerequisite_status == BLOCKED
+    assert readiness.missing_null_test_prerequisites == ["ranking_permutation_test"]
+    assert "null_tests_reject_null_not_true" in readiness.invalid_null_test_prerequisites
+    assert "missing_null_test_prerequisites:1" in readiness.blockers
+    assert "invalid_null_test_prerequisites:1" in readiness.blockers
+
+
 def test_cli_exit_codes_and_writes_report(tmp_path: Path, capsys) -> None:
     """CLI returns 0 for ready inputs and writes the JSON payload."""
 
@@ -196,6 +273,17 @@ def test_cli_exit_codes_and_writes_report(tmp_path: Path, capsys) -> None:
         [_entry("rerun_0000", family="family_b", seed=101)],
     )
     output = tmp_path / "readiness.json"
+    prerequisites = tmp_path / "prerequisites.json"
+    prerequisites.write_text(
+        json.dumps(
+            {
+                "null_tests_reject_null": True,
+                "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.01},
+                "ranking_permutation_test": {"status": "complete", "p_value": 0.02},
+            }
+        ),
+        encoding="utf-8",
+    )
 
     exit_code = readiness_cli_main(
         [
@@ -203,11 +291,16 @@ def test_cli_exit_codes_and_writes_report(tmp_path: Path, capsys) -> None:
             str(source),
             "--rerun-archive",
             str(rerun),
+            "--null-test-prerequisites",
+            str(prerequisites),
             "--output",
             str(output),
         ]
     )
 
     assert exit_code == 0
-    assert json.loads(output.read_text(encoding="utf-8"))["status"] == READY
-    assert json.loads(capsys.readouterr().out)["status"] == READY
+    output_payload = json.loads(output.read_text(encoding="utf-8"))
+    stdout_payload = json.loads(capsys.readouterr().out)
+    assert output_payload["status"] == READY
+    assert output_payload["null_test_prerequisite_status"] == READY
+    assert stdout_payload["status"] == READY

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -102,6 +102,65 @@ def test_overlapping_archive_ids_block_leakage(tmp_path: Path) -> None:
     assert "archive_id_overlap:1" in readiness.blockers
 
 
+def test_scenario_family_and_seed_overlap_is_reported_as_blockers(tmp_path: Path) -> None:
+    """Family and seed overlap metadata must be treated as leakage blockers."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=42)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_a", seed=42)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(source, rerun)
+
+    assert readiness.status == BLOCKED
+    assert "scenario_family_overlap:1" in readiness.blockers
+    assert "seed_overlap:1" in readiness.blockers
+    assert len(readiness.overlap_provenance["scenario_family_overlap"]) == 1
+    assert json.loads(readiness.overlap_provenance["scenario_family_overlap"][0]) == _entry(
+        "_", family="family_a", seed=0
+    )["cluster_key"]
+    assert readiness.overlap_provenance["seed_overlap"] == [42]
+
+
+def test_missing_archive_payload_blocks_ready_path(tmp_path: Path) -> None:
+    """Missing archive file paths must fail closed for both source and rerun."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    missing = tmp_path / "missing.json"
+
+    readiness = classify_failure_archive_rerun_readiness(source, missing)
+
+    assert readiness.status == BLOCKED
+    assert any(blocker.startswith("rerun_archive_blocked:path_missing") for blocker in readiness.blockers)
+    assert not any(blocker.startswith("source_archive_blocked") for blocker in readiness.blockers)
+
+
+def test_malformed_archive_payload_fails_closed(tmp_path: Path) -> None:
+    """Malformed or non-object archives are blockers, never treated as ready."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    malformed = tmp_path / "malformed.json"
+    malformed.write_text("not-json", encoding="utf-8")
+
+    readiness = classify_failure_archive_rerun_readiness(source, malformed)
+
+    assert readiness.status == BLOCKED
+    assert any(
+        blocker.startswith("rerun_archive_blocked:unreadable")
+        for blocker in readiness.blockers
+    )
+
+
 def test_missing_certification_metadata_blocks_rerun_archive(tmp_path: Path) -> None:
     """Every rerun archive entry must carry certification metadata."""
 


### PR DESCRIPTION
## Issue
- https://github.com/ll7/robot_sf_ll7/issues/3275

## Scope summary
- Adds synthetic fixture coverage for issue #3275 failure-archive readiness fail-closed behavior.
- New tests cover missing/malformed archive input handling and overlap-metadata blockers in `tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py`.
- No proposal-model proposal execution or benchmark campaign is run.

## Validation
- `uv run python -m pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` ✅ (11 passed)
- `uv run ruff check tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` ✅

## Out of scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits or paper-facing evidence promotion.



## PR Gate Update 2026-06-30

- Issue disposition: leaves #3275 open. This PR is a bounded readiness/fail-closed fixture and CLI slice; it does not complete the broader disjoint certified failure archive rerun, independent planner-execution outcomes, certification campaign, null-test reporting, or held-out yield interpretation required by #3275.
- Local fix pushed: formatted `tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` to satisfy the CI lint/format gate.
- Additional validation after the fix:
  - `scripts/dev/ci_driver.sh lint` ✅
  - `uv run python -m pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` ✅ (11 passed)
  - `uv run python scripts/dev/check_pr_followups.py --body-file <tmp> --changed-files-file <tmp> --require-substantive-body --json` ✅
  - `uv run python scripts/validation/check_failure_archive_rerun_readiness.py --help` ✅
- No heavy benchmark, GPU, or Slurm work was run.
