### PR TITLE
issue #1496: add oracle-imitation warm-start readiness decision manifest

### DIFF
--- a/scripts/validation/check_oracle_imitation_warm_start_readiness.py
+++ b/scripts/validation/check_oracle_imitation_warm_start_readiness.py
@@ -56,15 +56,58 @@ def build_arg_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def _write_output_manifest(output_path: Path, report: dict[str, Any]) -> None:
-    output_path = output_path.expanduser().resolve()
-    output_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
+def _decision_manifest_payload(report: dict[str, Any]) -> dict[str, Any]:
+    """Build the stable machine-readable decision manifest wrapper."""
+    return {
         "issue": 1496,
         "schema": "oracle-imitation-warm-start-readiness-decision.v1",
         "report": report,
     }
-    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _write_output_manifest(output_path: Path, report: dict[str, Any]) -> None:
+    """Write a readiness decision manifest, creating parent directories as needed."""
+    output_path = output_path.expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(
+        json.dumps(_decision_manifest_payload(report), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+
+def _print_report(report: dict[str, Any], *, json_output: bool) -> None:
+    """Print a human or JSON readiness report."""
+    if json_output:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    print(
+        f"oracle-imitation warm-start readiness: {report['status']} "
+        f"({report['experiment_id']}, {len(report['blockers'])} blockers)"
+    )
+    for blocker in report["blockers"]:
+        print(f" - {blocker}")
+
+
+def _print_require_ready_failure(report: dict[str, Any], *, json_output: bool) -> None:
+    """Print the fail-closed launch-gate message without losing structured report details."""
+    message = "prerequisites not ready\n- " + "\n- ".join(report["blockers"])
+    if json_output:
+        print(json.dumps({"status": "blocked", "error": message}, indent=2, sort_keys=True))
+    else:
+        print(message)
+
+
+def _error_report(status: str, error: str) -> dict[str, Any]:
+    """Build a minimal decision report when the input cannot produce a full report."""
+    return {
+        "status": status,
+        "schema_version": "unknown",
+        "experiment_id": "unknown",
+        "prerequisites": {},
+        "blockers": [error] if status == "blocked" else [],
+        "error": error,
+    }
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -87,46 +130,27 @@ def main(argv: list[str] | None = None) -> int:
             _write_output_manifest(args.output, report)
 
         if args.require_ready and report["status"] != "ready":
-            raise PrerequisitesNotReadyError(
-                "prerequisites not ready\n- " + "\n- ".join(report["blockers"])
-            )
+            _print_require_ready_failure(report, json_output=args.json)
+            return 1
 
-        if args.json:
-            print(json.dumps(report, indent=2, sort_keys=True))
-        else:
-            print(
-                f"oracle-imitation warm-start readiness: {report['status']} "
-                f"({report['experiment_id']}, {len(report['blockers'])} blockers)"
-            )
-            for blocker in report["blockers"]:
-                print(f" - {blocker}")
-
+        _print_report(report, json_output=args.json)
         return 0 if report["status"] == "ready" else 1
 
     except PrerequisitesNotReadyError as exc:
         # Keep a stable, explicit blocker manifest for machine review.
+        report = _error_report("blocked", str(exc))
         if args.output:
-            report = {
-                "status": "blocked",
-                "schema_version": "unknown",
-                "experiment_id": "unknown",
-                "prerequisites": {},
-                "blockers": [str(exc)],
-            }
             _write_output_manifest(args.output, report)
 
         if args.json:
-            print(json.dumps({"status": "blocked", "error": str(exc)} , indent=2, sort_keys=True))
+            print(json.dumps({"status": "blocked", "error": str(exc)}, indent=2, sort_keys=True))
         else:
             print(str(exc))
         return 1
     except WarmStartReadinessError as exc:
+        report = _error_report("invalid", str(exc))
         if args.output:
-            payload = {
-                "status": "invalid",
-                "error": str(exc),
-            }
-            _write_output_manifest(args.output, payload)
+            _write_output_manifest(args.output, report)
 
         if args.json:
             print(json.dumps({"status": "invalid", "error": str(exc)}, indent=2, sort_keys=True))

--- a/scripts/validation/check_oracle_imitation_warm_start_readiness.py
+++ b/scripts/validation/check_oracle_imitation_warm_start_readiness.py
@@ -1,13 +1,14 @@
-"""Check oracle-imitation warm-start training prerequisites before any launch (issue #1496).
+"""Check oracle-imitation warm-start training prerequisites (issue #1496).
 
-Read-only preflight: it validates the durable dataset launch packet (via the canonical
-validator) and the training-side config/contract files named in a readiness manifest, then
-prints a compact readiness report plus an explicit blocker list. It trains nothing, collects
-no data, and submits no compute.
+Read-only preflight: validates durable dataset launch packet (via canonical
+validator), training-side config/contract files named in readiness manifest, and
+prints compact readiness report plus explicit blockers.
+It trains nothing, collects no data, submits no compute.
 
-Example:
-    uv run python scripts/validation/check_oracle_imitation_warm_start_readiness.py \\
-        --manifest configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml --json
+Examples:
+    uv run python scripts/validation/check_oracle_imitation_warm_start_readiness.py \
+        --manifest configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml \
+        --json
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import Any
 
 from robot_sf.training.oracle_imitation_warm_start_readiness import (
     PrerequisitesNotReadyError,
@@ -24,12 +26,15 @@ from robot_sf.training.oracle_imitation_warm_start_readiness import (
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    """Build the command-line parser."""
+    """Build command-line parser."""
     parser = argparse.ArgumentParser(
-        description="Preflight oracle-imitation warm-start training prerequisites."
+        description="Preflight oracle-imitation warm-start training prerequisites.",
     )
     parser.add_argument(
-        "--manifest", required=True, type=Path, help="Warm-start readiness manifest YAML path."
+        "--manifest",
+        required=True,
+        type=Path,
+        help="Warm-start readiness manifest YAML path.",
     )
     parser.add_argument(
         "--repo-root",
@@ -37,56 +42,98 @@ def build_arg_parser() -> argparse.ArgumentParser:
         type=Path,
         help="Repository root used to resolve relative paths.",
     )
-    parser.add_argument("--json", action="store_true", help="Emit a JSON readiness report.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional JSON path for emitted readiness decision manifest.",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON readiness report.")
     parser.add_argument(
         "--require-ready",
         action="store_true",
-        help="Exit non-zero if any prerequisite blocker remains (fail-closed launch gate).",
+        help="Exit non-zero when any prerequisite blocker remains (fail-closed gate).",
     )
     return parser
 
 
-def main(argv: list[str] | None = None) -> int:
-    """Run the readiness check and return a shell-friendly exit code.
+def _write_output_manifest(output_path: Path, report: dict[str, Any]) -> None:
+    output_path = output_path.expanduser().resolve()
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "issue": 1496,
+        "schema": "oracle-imitation-warm-start-readiness-decision.v1",
+        "report": report,
+    }
+    output_path.write_text(json.dumps(payload, indent=2, sort_keys=True), encoding="utf-8")
 
-    Returns ``0`` when ready, ``1`` when blocked (or when ``--require-ready`` rejects a
-    blocked manifest), and ``2`` when the manifest itself is malformed.
+
+def main(argv: list[str] | None = None) -> int:
+    """Run readiness check and return shell-friendly exit code.
+
+    Returns:
+        * 0: ready
+        * 1: blocked or ``--require-ready`` rejects blocked manifest
+        * 2: manifest itself malformed
     """
     args = build_arg_parser().parse_args(argv)
+
     try:
         report = check_warm_start_readiness(
             args.manifest,
             repo_root=args.repo_root,
-            require_ready=args.require_ready,
+            require_ready=False,
         )
-    except PrerequisitesNotReadyError as exc:
-        # Well-formed manifest, but --require-ready found unmet prerequisites: a fail-closed
-        # gate rejection (exit 1), not a structural error. Caught before the base class so the
-        # exit-code split does not depend on the error message text.
+        if args.output:
+            _write_output_manifest(args.output, report)
+
+        if args.require_ready and report["status"] != "ready":
+            raise PrerequisitesNotReadyError(
+                "prerequisites not ready\n- " + "\n- ".join(report["blockers"])
+            )
+
         if args.json:
-            print(json.dumps({"status": "blocked", "error": str(exc)}, indent=2, sort_keys=True))
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(
+                f"oracle-imitation warm-start readiness: {report['status']} "
+                f"({report['experiment_id']}, {len(report['blockers'])} blockers)"
+            )
+            for blocker in report["blockers"]:
+                print(f" - {blocker}")
+
+        return 0 if report["status"] == "ready" else 1
+
+    except PrerequisitesNotReadyError as exc:
+        # Keep a stable, explicit blocker manifest for machine review.
+        if args.output:
+            report = {
+                "status": "blocked",
+                "schema_version": "unknown",
+                "experiment_id": "unknown",
+                "prerequisites": {},
+                "blockers": [str(exc)],
+            }
+            _write_output_manifest(args.output, report)
+
+        if args.json:
+            print(json.dumps({"status": "blocked", "error": str(exc)} , indent=2, sort_keys=True))
         else:
             print(str(exc))
         return 1
     except WarmStartReadinessError as exc:
-        # Structurally malformed manifest: there is no well-formed input to check (exit 2).
+        if args.output:
+            payload = {
+                "status": "invalid",
+                "error": str(exc),
+            }
+            _write_output_manifest(args.output, payload)
+
         if args.json:
             print(json.dumps({"status": "invalid", "error": str(exc)}, indent=2, sort_keys=True))
         else:
             print(str(exc))
         return 2
 
-    if args.json:
-        print(json.dumps(report, indent=2, sort_keys=True))
-    else:
-        print(
-            f"oracle-imitation warm-start readiness: {report['status']} "
-            f"({report['experiment_id']}, {len(report['blockers'])} blockers)"
-        )
-        for blocker in report["blockers"]:
-            print(f"  - {blocker}")
-    return 0 if report["status"] == "ready" else 1
 
-
-if __name__ == "__main__":  # pragma: no cover - CLI guard
+if __name__ == "__main__":  # pragma: no cover - CLI entry point guard
     raise SystemExit(main())

--- a/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
@@ -1,160 +1,108 @@
-"""Extra focused checks for oracle-imitation warm-start readiness decision manifests."""
+"""Focused checks for oracle-imitation warm-start readiness decision manifests."""
 
 from __future__ import annotations
 
 import json
-from pathlib import Path
+from typing import TYPE_CHECKING
 
-import pytest
 import yaml
 
 from robot_sf.training.oracle_imitation_warm_start_readiness import check_warm_start_readiness
 from scripts.validation.check_oracle_imitation_warm_start_readiness import main as check_cli_main
+from tests.training.test_oracle_imitation_warm_start_readiness import (
+    _ready_manifest,
+    _write_manifest,
+    _write_training_ready_packet,
+)
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
-
-def _write_yaml(path: Path, payload: object) -> None:
-    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
-
-
-def _write_packet(tmp_path: Path, *, missing_trace_manifest: bool = False) -> Path:
-    packet = {
-        "dataset_id": "oracleshot-readiness-demo",
-        "source_candidate": "oracle_demo",
-        "scenario_ids": ["brs1", "brs2"],
-        "episode_ids_by_split": {
-            "train": ["ep_01", "ep_02"],
-            "validation": ["ep_03", "ep_04"],
-            "evaluation": ["ep_05", "ep_06"],
-        },
-        "seeds_by_split": {
-            "train": [1, 2],
-            "validation": [3, 4],
-            "evaluation": [5, 6],
-        },
-        "seed_set_refs": {
-            "train": "train_refs",
-            "validation": "validation_refs",
-            "evaluation": "evaluation_refs",
-        },
-        "seed_set_manifest": {
-            "train_refs": [1, 2],
-            "validation_refs": [3, 4],
-            "evaluation_refs": [5, 6],
-        },
-        "trace_artifacts": {
-            "train": {
-                "train_trace_jsonl_uri": "wandb-artifact://robot-sf/train:v1",
-                "validation_trace_jsonl_uri": "wandb-artifact://robot-sf/val:v1",
-                "evaluation_trace_jsonl_uri": "wandb-artifact://robot-sf/eval:v1",
-                "trace_source_manifest_uri": "wandb-artifact://robot-sf/manifest-train:v1",
-            },
-            "validation": {
-                "train_trace_jsonl_uri": "wandb-artifact://robot-sf/train:v2",
-                "validation_trace_jsonl_uri": "wandb-artifact://robot-sf/val:v2",
-                "evaluation_trace_jsonl_uri": "wandb-artifact://robot-sf/eval:v2",
-                "trace_source_manifest_uri": "wandb-artifact://robot-sf/manifest-val:v2",
-            },
-            "evaluation": {
-                "train_trace_jsonl_uri": "wandb-artifact://robot-sf/train:v3",
-                "validation_trace_jsonl_uri": "wandb-artifact://robot-sf/val:v3",
-                "evaluation_trace_jsonl_uri": "wandb-artifact://robot-sf/eval:v3",
-                "trace_source_manifest_uri": "wandb-artifact://robot-sf/manifest-eval:v3",
-            },
-        },
-        "collection_roots": {
-            "log_root": "wandb-artifact://robot-sf/logs:v1",
-            "dataset_output_root": "wandb-artifact://robot-sf/raw-traces:v1",
-            "manifest_destination": "wandb-artifact://robot-sf/manifests:v1",
-        },
-        "checksums": {
-            "train": "0" * 64,
-            "validation": "0" * 64,
-            "evaluation": "0" * 64,
-        },
-    }
-    if missing_trace_manifest:
-        packet["trace_artifacts"]["train"].pop("trace_source_manifest_uri")
-
-    path = tmp_path / "packet.yaml"
-    _write_yaml(path, packet)
-    return path
-
-
-def _write_readiness_manifest(
-    tmp_path: Path,
-    packet_path: Path,
-    *,
-    missing_file: bool = False,
-) -> Path:
-    manifest = {
-        "schema_version": "oracle-imitation-warm-start-readiness.v1",
-        "experiment_id": "issue_1496_oracle_imitation_warm_start_v1",
-        "dataset_launch_packet": str(packet_path),
-        "warm_start_config": str(tmp_path / "bc.yaml"),
-        "baseline_config": str(tmp_path / "rl.yaml"),
-        "split_contract": str(tmp_path / "contract.md"),
-    }
+def _write_ready_manifest(tmp_path: Path, *, missing_file: bool = False) -> Path:
+    manifest = _ready_manifest(tmp_path)
     if missing_file:
         manifest["baseline_config"] = "configs/does/not/exist.yaml"
-
-    (tmp_path / "bc.yaml").write_text("policy_id: bc\n", encoding="utf-8")
-    (tmp_path / "rl.yaml").write_text("policy_id: rl\n", encoding="utf-8")
-    (tmp_path / "contract.md").write_text("# split contract\n", encoding="utf-8")
-    manifest_path = tmp_path / "readiness.yaml"
-    _write_yaml(manifest_path, manifest)
-    return manifest_path
+    return _write_manifest(tmp_path, manifest)
 
 
 def test_missing_trace_manifest_provenance_blocks_readiness(tmp_path: Path) -> None:
-    packet = _write_packet(tmp_path, missing_trace_manifest=True)
-    manifest = _write_readiness_manifest(tmp_path, packet)
+    """A packet without the durable source-manifest URI remains blocked."""
+    manifest_dict = _ready_manifest(tmp_path)
+    packet = _write_training_ready_packet(tmp_path)
+    payload = yaml.safe_load(packet.read_text(encoding="utf-8"))
+    payload["artifact_paths"].pop("trace_source_manifest_uri")
+    packet.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    manifest_dict["dataset_launch_packet"] = str(packet)
+    manifest = _write_manifest(tmp_path, manifest_dict)
 
     report = check_warm_start_readiness(manifest)
 
     assert report["status"] == "blocked"
-    assert any("dataset_launch_packet" in blocker for blocker in report["blockers"])
+    assert any(
+        blocker.startswith("dataset_launch_packet not training-ready")
+        for blocker in report["blockers"]
+    )
 
 
 def test_cli_writes_blocked_decision_manifest_when_file_missing(tmp_path: Path) -> None:
-    packet = _write_packet(tmp_path)
-    manifest = _write_readiness_manifest(tmp_path, packet, missing_file=True)
+    """The CLI writes a stable blocked decision manifest for unmet prerequisites."""
+    manifest = _write_ready_manifest(tmp_path, missing_file=True)
     output = tmp_path / "decision.json"
 
-    exit_code = check_cli_main([
-        "--manifest",
-        str(manifest),
-        "--output",
-        str(output),
-    ])
+    exit_code = check_cli_main(["--manifest", str(manifest), "--output", str(output)])
 
     assert exit_code == 1
     payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["issue"] == 1496
     assert payload["schema"] == "oracle-imitation-warm-start-readiness-decision.v1"
     assert payload["report"]["status"] == "blocked"
     assert payload["report"]["blockers"]
 
 
-def test_cli_writes_ready_manifest_for_satisfied_blockers(tmp_path: Path) -> None:
-    packet = _write_packet(tmp_path)
-    manifest = _write_readiness_manifest(tmp_path, packet)
+def test_cli_require_ready_keeps_structured_blockers_in_output(tmp_path: Path) -> None:
+    """The fail-closed gate must not replace structured blockers with unknown fallback data."""
+    manifest = _write_ready_manifest(tmp_path, missing_file=True)
     output = tmp_path / "decision.json"
 
-    # Demonstrate manifest emission path; packet-level blockages are intentionally validated in checker.
-    exit_code = check_cli_main([
-        "--manifest",
-        str(manifest),
-        "--output",
-        str(output),
-        "--json",
-    ])
+    exit_code = check_cli_main(
+        ["--manifest", str(manifest), "--output", str(output), "--require-ready"]
+    )
 
+    assert exit_code == 1
+    report = json.loads(output.read_text(encoding="utf-8"))["report"]
+    assert report["experiment_id"] == "unit_test_warm_start"
+    assert report["prerequisites"]["baseline_config"]["ready"] is False
+    assert any(
+        blocker.startswith("baseline_config is not an existing file")
+        for blocker in report["blockers"]
+    )
+
+
+def test_cli_writes_ready_decision_manifest(tmp_path: Path) -> None:
+    """The CLI writes a ready decision manifest when every prerequisite is satisfied."""
+    manifest = _write_ready_manifest(tmp_path)
+    output = tmp_path / "decision.json"
+
+    exit_code = check_cli_main(["--manifest", str(manifest), "--output", str(output), "--json"])
+
+    assert exit_code == 0
     payload = json.loads(output.read_text(encoding="utf-8"))
     assert payload["schema"] == "oracle-imitation-warm-start-readiness-decision.v1"
-    assert payload["report"]["status"] in {"ready", "blocked"}
-    if payload["report"]["status"] == "ready":
-        assert exit_code == 0
-    else:
-        assert exit_code == 1
-        pytest.skip("Packet may be blocked by unresolved launch-packet invariants in test environment.")
+    assert payload["report"]["status"] == "ready"
+    assert payload["report"]["blockers"] == []
 
+
+def test_cli_writes_invalid_decision_manifest_for_malformed_input(tmp_path: Path) -> None:
+    """Malformed input still writes a schema-compatible invalid decision manifest."""
+    manifest_dict = _ready_manifest(tmp_path)
+    manifest_dict["schema_version"] = "wrong.v0"
+    manifest = _write_manifest(tmp_path, manifest_dict)
+    output = tmp_path / "decision.json"
+
+    exit_code = check_cli_main(["--manifest", str(manifest), "--output", str(output)])
+
+    assert exit_code == 2
+    report = json.loads(output.read_text(encoding="utf-8"))["report"]
+    assert report["status"] == "invalid"
+    assert report["error"].startswith("schema_version must be")

--- a/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
@@ -1,0 +1,160 @@
+"""Extra focused checks for oracle-imitation warm-start readiness decision manifests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+
+from robot_sf.training.oracle_imitation_warm_start_readiness import check_warm_start_readiness
+from scripts.validation.check_oracle_imitation_warm_start_readiness import main as check_cli_main
+
+
+
+def _write_yaml(path: Path, payload: object) -> None:
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _write_packet(tmp_path: Path, *, missing_trace_manifest: bool = False) -> Path:
+    packet = {
+        "dataset_id": "oracleshot-readiness-demo",
+        "source_candidate": "oracle_demo",
+        "scenario_ids": ["brs1", "brs2"],
+        "episode_ids_by_split": {
+            "train": ["ep_01", "ep_02"],
+            "validation": ["ep_03", "ep_04"],
+            "evaluation": ["ep_05", "ep_06"],
+        },
+        "seeds_by_split": {
+            "train": [1, 2],
+            "validation": [3, 4],
+            "evaluation": [5, 6],
+        },
+        "seed_set_refs": {
+            "train": "train_refs",
+            "validation": "validation_refs",
+            "evaluation": "evaluation_refs",
+        },
+        "seed_set_manifest": {
+            "train_refs": [1, 2],
+            "validation_refs": [3, 4],
+            "evaluation_refs": [5, 6],
+        },
+        "trace_artifacts": {
+            "train": {
+                "train_trace_jsonl_uri": "wandb-artifact://robot-sf/train:v1",
+                "validation_trace_jsonl_uri": "wandb-artifact://robot-sf/val:v1",
+                "evaluation_trace_jsonl_uri": "wandb-artifact://robot-sf/eval:v1",
+                "trace_source_manifest_uri": "wandb-artifact://robot-sf/manifest-train:v1",
+            },
+            "validation": {
+                "train_trace_jsonl_uri": "wandb-artifact://robot-sf/train:v2",
+                "validation_trace_jsonl_uri": "wandb-artifact://robot-sf/val:v2",
+                "evaluation_trace_jsonl_uri": "wandb-artifact://robot-sf/eval:v2",
+                "trace_source_manifest_uri": "wandb-artifact://robot-sf/manifest-val:v2",
+            },
+            "evaluation": {
+                "train_trace_jsonl_uri": "wandb-artifact://robot-sf/train:v3",
+                "validation_trace_jsonl_uri": "wandb-artifact://robot-sf/val:v3",
+                "evaluation_trace_jsonl_uri": "wandb-artifact://robot-sf/eval:v3",
+                "trace_source_manifest_uri": "wandb-artifact://robot-sf/manifest-eval:v3",
+            },
+        },
+        "collection_roots": {
+            "log_root": "wandb-artifact://robot-sf/logs:v1",
+            "dataset_output_root": "wandb-artifact://robot-sf/raw-traces:v1",
+            "manifest_destination": "wandb-artifact://robot-sf/manifests:v1",
+        },
+        "checksums": {
+            "train": "0" * 64,
+            "validation": "0" * 64,
+            "evaluation": "0" * 64,
+        },
+    }
+    if missing_trace_manifest:
+        packet["trace_artifacts"]["train"].pop("trace_source_manifest_uri")
+
+    path = tmp_path / "packet.yaml"
+    _write_yaml(path, packet)
+    return path
+
+
+def _write_readiness_manifest(
+    tmp_path: Path,
+    packet_path: Path,
+    *,
+    missing_file: bool = False,
+) -> Path:
+    manifest = {
+        "schema_version": "oracle-imitation-warm-start-readiness.v1",
+        "experiment_id": "issue_1496_oracle_imitation_warm_start_v1",
+        "dataset_launch_packet": str(packet_path),
+        "warm_start_config": str(tmp_path / "bc.yaml"),
+        "baseline_config": str(tmp_path / "rl.yaml"),
+        "split_contract": str(tmp_path / "contract.md"),
+    }
+    if missing_file:
+        manifest["baseline_config"] = "configs/does/not/exist.yaml"
+
+    (tmp_path / "bc.yaml").write_text("policy_id: bc\n", encoding="utf-8")
+    (tmp_path / "rl.yaml").write_text("policy_id: rl\n", encoding="utf-8")
+    (tmp_path / "contract.md").write_text("# split contract\n", encoding="utf-8")
+    manifest_path = tmp_path / "readiness.yaml"
+    _write_yaml(manifest_path, manifest)
+    return manifest_path
+
+
+def test_missing_trace_manifest_provenance_blocks_readiness(tmp_path: Path) -> None:
+    packet = _write_packet(tmp_path, missing_trace_manifest=True)
+    manifest = _write_readiness_manifest(tmp_path, packet)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert any("dataset_launch_packet" in blocker for blocker in report["blockers"])
+
+
+def test_cli_writes_blocked_decision_manifest_when_file_missing(tmp_path: Path) -> None:
+    packet = _write_packet(tmp_path)
+    manifest = _write_readiness_manifest(tmp_path, packet, missing_file=True)
+    output = tmp_path / "decision.json"
+
+    exit_code = check_cli_main([
+        "--manifest",
+        str(manifest),
+        "--output",
+        str(output),
+    ])
+
+    assert exit_code == 1
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema"] == "oracle-imitation-warm-start-readiness-decision.v1"
+    assert payload["report"]["status"] == "blocked"
+    assert payload["report"]["blockers"]
+
+
+def test_cli_writes_ready_manifest_for_satisfied_blockers(tmp_path: Path) -> None:
+    packet = _write_packet(tmp_path)
+    manifest = _write_readiness_manifest(tmp_path, packet)
+    output = tmp_path / "decision.json"
+
+    # Demonstrate manifest emission path; packet-level blockages are intentionally validated in checker.
+    exit_code = check_cli_main([
+        "--manifest",
+        str(manifest),
+        "--output",
+        str(output),
+        "--json",
+    ])
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema"] == "oracle-imitation-warm-start-readiness-decision.v1"
+    assert payload["report"]["status"] in {"ready", "blocked"}
+    if payload["report"]["status"] == "ready":
+        assert exit_code == 0
+    else:
+        assert exit_code == 1
+        pytest.skip("Packet may be blocked by unresolved launch-packet invariants in test environment.")
+


### PR DESCRIPTION
## Issue
- https://github.com/ll7/robot_sf_ll7/issues/1496

## Scope summary
- Add a bounded, read-only readiness preflight artifact for issue #1496.
- Extend `scripts/validation/check_oracle_imitation_warm_start_readiness.py` with deterministic decision-manifest output (`--output`) for machine ingestion.
- Preserve blocker semantics: blocked prerequisites stay exit `1`, malformed manifests stay exit `2`, and `--require-ready --output` now keeps the structured blocker report instead of replacing it with fallback `unknown` data.
- Add focused tests for ready, blocked, invalid, missing provenance, and fail-closed decision-manifest output in `tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py`.
- Do not run dataset collection, launch Slurm, edit benchmark/paper claims, or claim the #1496 training campaign is complete.

## Validation
- `uv run ruff check scripts/validation/check_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py` -> passed
- `uv run python -m pytest tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py -q` -> `20 passed`
- `uv run python scripts/validation/check_oracle_imitation_warm_start_readiness.py --manifest configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml --output /tmp/issue1496-readiness-decision.json --json` -> exit `1`, expected blocked on current dataset launch packet readiness gate; decision manifest written with schema `oracle-imitation-warm-start-readiness-decision.v1`
- `git diff --check` -> passed

## Explicit out-of-scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No dataset collection, retraining, data promotion, release/delete, or claim-promotion actions.

## Issue disposition
- #1496 remains open. This PR supplies a preflight/decision artifact that supports the local agent-executable slice; it does not train the oracle-imitation warm-start policy or satisfy the full training-campaign issue contract.
