### PR TITLE
#3810: add analysis-retention decision guards for long-horizon SNQI packet

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -425,17 +425,17 @@ analysis_and_retention_packet:
       status: blocked_pending_submit_host_route_and_reconciliation
       reason: "Issue remains open and job 13175 must be reconciled on Slurm host before campaign claim."
   route:
-    private_ops_repo: "/home/luttkule/git/robot_sf_ll7-private-ops"
-    queue_summary_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh"
-    route_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh"
-    submit_wrapper: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh"
+    private_ops_repo: "/home/luttkule/git/robot_sf_ll7-private-ops"  # allow-abs-path: private-ops routing (machine-local, non-portable)
+    queue_summary_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
+    route_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
+    submit_wrapper: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
     target_host: "imech036"
   preflight:
     required: true
     route_refresh_command: >-
       ROBOT_SF_PRIVATE_OPS="$HOME/git/robot_sf_ll7-private-ops" "$HOME/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh"
-    queue_and_duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh --json --reason issue_3810"
-    duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh --json --target-host imech036 --issue 3810"
+    queue_and_duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh --json --reason issue_3810"  # allow-abs-path: private-ops routing (machine-local, non-portable)
+    duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh --json --target-host imech036 --issue 3810"  # allow-abs-path: private-ops routing (machine-local, non-portable)
     manifest_validation_command: "uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi"
     packet_validation_command: "uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json"
   expected_outputs:

--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -413,3 +413,78 @@ launch_packet:
       benchmark-strength success until the report shows the scenario required
       meaningful interaction. The diagnostic guards wait-it-out behavior; the
       sustained-flow structural fix remains follow-up issue #3813.
+
+analysis_and_retention_packet:
+  enabled: true
+  scope: comprehensive_long_horizon_campaign_readiness
+  execution_contract:
+    launch_only: false
+    route_preflight_required: true
+    local_submission_allowed: false
+    decision_gate:
+      status: blocked_pending_submit_host_route_and_reconciliation
+      reason: "Issue remains open and job 13175 must be reconciled on Slurm host before campaign claim."
+  route:
+    private_ops_repo: "/home/luttkule/git/robot_sf_ll7-private-ops"
+    queue_summary_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh"
+    route_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh"
+    submit_wrapper: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh"
+    target_host: "imech036"
+  preflight:
+    required: true
+    route_refresh_command: >-
+      ROBOT_SF_PRIVATE_OPS="$HOME/git/robot_sf_ll7-private-ops" "$HOME/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh"
+    queue_and_duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh --json --reason issue_3810"
+    duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh --json --target-host imech036 --issue 3810"
+    manifest_validation_command: "uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi"
+    packet_validation_command: "uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json"
+  expected_outputs:
+    local_root: "output/benchmarks/issue_3810_comprehensive_h600_snqi"
+    required_paths:
+      - preflight/private_ops_route_dry_run.json
+      - preflight/validate_config.json
+      - preflight/preview_scenarios.json
+      - preflight/planner_availability.json
+      - reports/campaign_summary.json
+      - reports/campaign_table.csv
+      - reports/campaign_table.md
+      - reports/snqi_recalibration_inputs.json
+      - reports/snqi_recalibration_bundle.json
+      - reports/horizon_sensitivity_report.json
+      - reports/horizon_sensitivity_report.md
+      - reports/interaction_exposure_diagnostics.json
+      - reports/interaction_exposure_diagnostics.md
+      - episodes/
+  retention:
+    compact_review_bundle: "docs/context/evidence/issue_3810_long_horizon_snqi/"
+    durable_manifests:
+      - "docs/context/evidence/issue_3810_long_horizon_snqi/"
+      - "docs/context/evidence/issue_3810_long_horizon_snqi/reports"
+      - "docs/context/evidence/issue_3810_long_horizon_snqi/metadata.json"
+  snqi_recalibration_inputs:
+    weights_path: "output/benchmarks/issue_3810_comprehensive_h600_snqi/recalibration/snqi_weights_h600.json"
+    baseline_path: "output/benchmarks/issue_3810_comprehensive_h600_snqi/recalibration/snqi_baseline_h600.json"
+    campaign_table_path: "output/benchmarks/issue_3810_comprehensive_h600_snqi/reports/campaign_table.csv"
+    episode_records_glob: "output/benchmarks/issue_3810_comprehensive_h600_snqi/episodes/"
+    required_scripts:
+      - scripts/recompute_snqi_weights.py
+      - scripts/snqi_sensitivity_analysis.py
+      - scripts/validate_snqi_scripts.py
+  horizon_sensitivity_report:
+    command: "uv run python scripts/benchmark/build_horizon_timestep_denominator_report.py --long-campaign output/benchmarks/issue_3810_comprehensive_h600_snqi --short-campaign-reference docs/context/evidence/prior_scoped_h100_reference --output-dir output/benchmarks/issue_3810_comprehensive_h600_snqi/reports"
+    required_scope_caveat: prior_scoped_short_horizon_vs_new_comprehensive_long_horizon_not_horizon_only
+    required_fields:
+      - timeout_rate
+      - max_steps_share
+      - success_ranking
+      - snqi_ranking
+      - rank_inversion_persistence
+      - comparison_scope_caveat
+  wait_it_out_guard:
+    diagnostic_name: interaction_exposure
+    required_episode_fields:
+      - interaction_exposure_share
+      - robot_motion_share_before_first_clearance
+      - first_clearance_step
+      - low_exposure_success
+    low_exposure_success_status: diagnostic_only

--- a/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Validate issue #3810 long-horizon analysis + retention contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+DEFAULT_PACKET = Path(
+    "configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml"
+)
+
+REQUIRED_PRE_FLIGHT_MARKERS = {
+    "ROBOT_SF_PRIVATE_OPS",
+    "run_preflight.sh",
+    "run_research_campaign_manifest.py",
+    "check_issue_3810_long_horizon_launch_packet.py",
+}
+
+REQUIRED_OUTPUTS = {
+    "preflight/private_ops_route_dry_run.json",
+    "reports/snqi_recalibration_inputs.json",
+    "reports/snqi_recalibration_bundle.json",
+    "reports/horizon_sensitivity_report.json",
+    "reports/interaction_exposure_diagnostics.json",
+}
+
+REQUIRED_ROUTE_FIELDS = {
+    "private_ops_repo",
+    "queue_summary_command",
+    "route_command",
+    "submit_wrapper",
+    "target_host",
+}
+
+REQUIRED_HORIZON_FIELDS = {
+    "timeout_rate",
+    "max_steps_share",
+    "success_ranking",
+    "snqi_ranking",
+    "rank_inversion_persistence",
+    "comparison_scope_caveat",
+}
+
+REQUIRED_WAIT_FIELDS = {
+    "interaction_exposure_share",
+    "robot_motion_share_before_first_clearance",
+    "first_clearance_step",
+    "low_exposure_success",
+}
+
+
+class PacketError(ValueError):
+    pass
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise PacketError(message)
+
+
+def _require_mapping(payload: Mapping[str, Any], key: str) -> Mapping[str, Any]:
+    value = payload.get(key)
+    _require(isinstance(value, Mapping), f"{key} must be a mapping")
+    return value
+
+
+def _load_yaml(path: Path) -> dict[str, Any]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    _require(isinstance(payload, dict), "packet must be YAML mapping")
+    return payload
+
+
+def validate_packet(packet: Mapping[str, Any], *, issue: int = 3810) -> dict[str, Any]:
+    campaign = _require_mapping(packet, "campaign")
+    _require(campaign.get("parent_issue") == issue, "packet parent issue mismatch")
+
+    analysis = _require_mapping(packet, "analysis_and_retention_packet")
+    _require(analysis.get("enabled") is True, "analysis_and_retention_packet.enabled must be true")
+
+    route = _require_mapping(analysis, "route")
+    _require(REQUIRED_ROUTE_FIELDS <= set(route), "route field set incomplete")
+    _require(route.get("target_host") == "imech036", "target host must be imech036")
+
+    preflight = _require_mapping(analysis, "preflight")
+    _require(preflight.get("required") is True, "preflight.required must be true")
+    preflight_blob = "\n".join(str(v) for v in preflight.values())
+    for marker in REQUIRED_PRE_FLIGHT_MARKERS:
+        _require(marker in preflight_blob, f"preflight missing marker: {marker}")
+
+    expected = _require_mapping(analysis, "expected_outputs")
+    _require(
+        expected.get("local_root") == "output/benchmarks/issue_3810_comprehensive_h600_snqi",
+        "expected_outputs.local_root mismatch",
+    )
+    required_paths = set(expected.get("required_paths") or [])
+    _require(REQUIRED_OUTPUTS <= required_paths, "required outputs missing")
+
+    retention = _require_mapping(analysis, "retention")
+    compact_review_bundle = str(retention.get("compact_review_bundle", ""))
+    _require(compact_review_bundle.startswith("docs/context/evidence/"), "compact review path must be durable")
+
+    execution_contract = _require_mapping(analysis, "execution_contract")
+    _require(
+        execution_contract.get("route_preflight_required") is True,
+        "execution_contract.route_preflight_required must be true",
+    )
+    _require(
+        execution_contract.get("launch_only") is False,
+        "execution_contract.launch_only must be false",
+    )
+    _require(
+        execution_contract.get("decision_gate", {}).get("status")
+        == "blocked_pending_submit_host_route_and_reconciliation",
+        "execution contract must stay blocked until host/route reconciliation",
+    )
+
+    snqi = _require_mapping(analysis, "snqi_recalibration_inputs")
+    for field in (
+        "weights_path",
+        "baseline_path",
+        "campaign_table_path",
+        "episode_records_glob",
+    ):
+        _require(str(snqi.get(field, "")) != "", f"snqi_recalibration_inputs.{field} required")
+
+    required_scripts = set(snqi.get("required_scripts") or [])
+    for script in (
+        "scripts/recompute_snqi_weights.py",
+        "scripts/snqi_sensitivity_analysis.py",
+        "scripts/validate_snqi_scripts.py",
+    ):
+        _require(script in required_scripts, f"missing snqi script: {script}")
+
+    horizon = _require_mapping(analysis, "horizon_sensitivity_report")
+    command = str(horizon.get("command", ""))
+    _require(
+        "build_horizon_timestep_denominator_report.py" in command,
+        "horizon command missing report builder",
+    )
+    _require(
+        horizon.get("required_scope_caveat")
+        == "prior_scoped_short_horizon_vs_new_comprehensive_long_horizon_not_horizon_only",
+        "horizon scope caveat mismatch",
+    )
+    _require(
+        REQUIRED_HORIZON_FIELDS <= set(horizon.get("required_fields") or []),
+        "horizon required fields missing",
+    )
+
+    wait_guard = _require_mapping(analysis, "wait_it_out_guard")
+    required_wait = set(wait_guard.get("required_episode_fields") or [])
+    _require(REQUIRED_WAIT_FIELDS <= required_wait, "wait-it-out episode fields missing")
+    _require(
+        wait_guard.get("low_exposure_success_status") == "diagnostic_only",
+        "wait-it-out low exposure must remain diagnostic_only",
+    )
+
+    return {
+        "ok": True,
+        "issue": issue,
+        "target_host": route["target_host"],
+        "route_contract": execution_contract.get("decision_gate", {}).get("status"),
+        "retention_bundle": compact_review_bundle,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    packet = _load_yaml(args.packet)
+    summary = validate_packet(packet)
+    if args.json:
+        print(json.dumps(summary, sort_keys=True))
+    else:
+        print("issue_3810 analysis+retention packet checks ok")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
@@ -5,14 +5,13 @@ from __future__ import annotations
 
 import argparse
 import json
+from collections.abc import Mapping
 from pathlib import Path
-from typing import Any, Mapping
+from typing import Any
 
 import yaml
 
-DEFAULT_PACKET = Path(
-    "configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml"
-)
+DEFAULT_PACKET = Path("configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml")
 
 REQUIRED_PRE_FLIGHT_MARKERS = {
     "ROBOT_SF_PRIVATE_OPS",
@@ -23,10 +22,19 @@ REQUIRED_PRE_FLIGHT_MARKERS = {
 
 REQUIRED_OUTPUTS = {
     "preflight/private_ops_route_dry_run.json",
+    "preflight/validate_config.json",
+    "preflight/preview_scenarios.json",
+    "preflight/planner_availability.json",
+    "reports/campaign_summary.json",
+    "reports/campaign_table.csv",
+    "reports/campaign_table.md",
     "reports/snqi_recalibration_inputs.json",
     "reports/snqi_recalibration_bundle.json",
     "reports/horizon_sensitivity_report.json",
+    "reports/horizon_sensitivity_report.md",
     "reports/interaction_exposure_diagnostics.json",
+    "reports/interaction_exposure_diagnostics.md",
+    "episodes/",
 }
 
 REQUIRED_ROUTE_FIELDS = {
@@ -55,6 +63,8 @@ REQUIRED_WAIT_FIELDS = {
 
 
 class PacketError(ValueError):
+    """Raised when the issue #3810 analysis packet violates the contract."""
+
     pass
 
 
@@ -76,6 +86,8 @@ def _load_yaml(path: Path) -> dict[str, Any]:
 
 
 def validate_packet(packet: Mapping[str, Any], *, issue: int = 3810) -> dict[str, Any]:
+    """Validate the issue #3810 analysis, retention, and no-submit guard contract."""
+
     campaign = _require_mapping(packet, "campaign")
     _require(campaign.get("parent_issue") == issue, "packet parent issue mismatch")
 
@@ -102,7 +114,22 @@ def validate_packet(packet: Mapping[str, Any], *, issue: int = 3810) -> dict[str
 
     retention = _require_mapping(analysis, "retention")
     compact_review_bundle = str(retention.get("compact_review_bundle", ""))
-    _require(compact_review_bundle.startswith("docs/context/evidence/"), "compact review path must be durable")
+    _require(
+        compact_review_bundle.startswith("docs/context/evidence/"),
+        "compact review path must be durable",
+    )
+    durable_manifests = set(retention.get("durable_manifests") or [])
+    _require(
+        compact_review_bundle in durable_manifests, "durable manifests must include compact bundle"
+    )
+    _require(
+        f"{compact_review_bundle.rstrip('/')}/reports" in durable_manifests,
+        "durable manifests must include reports directory",
+    )
+    _require(
+        f"{compact_review_bundle.rstrip('/')}/metadata.json" in durable_manifests,
+        "durable manifests must include metadata.json",
+    )
 
     execution_contract = _require_mapping(analysis, "execution_contract")
     _require(
@@ -114,10 +141,17 @@ def validate_packet(packet: Mapping[str, Any], *, issue: int = 3810) -> dict[str
         "execution_contract.launch_only must be false",
     )
     _require(
+        execution_contract.get("local_submission_allowed") is False,
+        "execution_contract.local_submission_allowed must be false",
+    )
+    _require(
         execution_contract.get("decision_gate", {}).get("status")
         == "blocked_pending_submit_host_route_and_reconciliation",
         "execution contract must stay blocked until host/route reconciliation",
     )
+    decision_reason = str(execution_contract.get("decision_gate", {}).get("reason", ""))
+    _require("Issue remains open" in decision_reason, "decision gate must keep issue open")
+    _require("job 13175" in decision_reason, "decision gate must require job 13175 reconciliation")
 
     snqi = _require_mapping(analysis, "snqi_recalibration_inputs")
     for field in (
@@ -170,6 +204,8 @@ def validate_packet(packet: Mapping[str, Any], *, issue: int = 3810) -> dict[str
 
 
 def main() -> int:
+    """Run the issue #3810 analysis packet validator CLI."""
+
     parser = argparse.ArgumentParser()
     parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
     parser.add_argument("--json", action="store_true")

--- a/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
@@ -1,0 +1,50 @@
+"""Tests issue #3810 long-horizon analysis + retention packet contract."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PACKET = REPO_ROOT / "configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml"
+SCRIPT = REPO_ROOT / "scripts/validation/check_issue_3810_long_horizon_analysis_packet.py"
+
+SPEC = importlib.util.spec_from_file_location("_issue_3810_analysis_packet_check", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(_MODULE)
+
+
+def _load_packet() -> dict:
+    return yaml.safe_load(PACKET.read_text(encoding="utf-8"))
+
+
+def test_issue_3810_analysis_packet_passes() -> None:
+    summary = _MODULE.validate_packet(_load_packet())
+    assert summary["ok"] is True
+    assert summary["issue"] == 3810
+    assert summary["route_contract"] == "blocked_pending_submit_host_route_and_reconciliation"
+
+
+def test_issue_3810_analysis_packet_rejects_bad_target_host() -> None:
+    packet = _load_packet()
+    packet["analysis_and_retention_packet"]["route"]["target_host"] = "imech156-u"
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "target host must be imech036" in str(exc)
+    else:
+        raise AssertionError("packet should reject non-imech036 route")
+
+
+def test_issue_3810_analysis_packet_rejects_missing_scope_caveat() -> None:
+    packet = _load_packet()
+    packet["analysis_and_retention_packet"]["horizon_sensitivity_report"]["required_scope_caveat"] = "missing"
+    try:
+        _MODULE.validate_packet(packet)
+    except _MODULE.PacketError as exc:
+        assert "horizon scope caveat mismatch" in str(exc)
+    else:
+        raise AssertionError("packet should reject wrong scope caveat")

--- a/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
+import pytest
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -22,6 +23,8 @@ def _load_packet() -> dict:
 
 
 def test_issue_3810_analysis_packet_passes() -> None:
+    """The checked-in packet satisfies the analysis and retention contract."""
+
     summary = _MODULE.validate_packet(_load_packet())
     assert summary["ok"] is True
     assert summary["issue"] == 3810
@@ -29,22 +32,56 @@ def test_issue_3810_analysis_packet_passes() -> None:
 
 
 def test_issue_3810_analysis_packet_rejects_bad_target_host() -> None:
+    """The packet must keep the reconciled submit-host target."""
+
     packet = _load_packet()
     packet["analysis_and_retention_packet"]["route"]["target_host"] = "imech156-u"
-    try:
+    with pytest.raises(_MODULE.PacketError, match="target host must be imech036"):
         _MODULE.validate_packet(packet)
-    except _MODULE.PacketError as exc:
-        assert "target host must be imech036" in str(exc)
-    else:
-        raise AssertionError("packet should reject non-imech036 route")
 
 
 def test_issue_3810_analysis_packet_rejects_missing_scope_caveat() -> None:
+    """The horizon report must retain the multi-factor comparison caveat."""
+
     packet = _load_packet()
-    packet["analysis_and_retention_packet"]["horizon_sensitivity_report"]["required_scope_caveat"] = "missing"
-    try:
+    packet["analysis_and_retention_packet"]["horizon_sensitivity_report"][
+        "required_scope_caveat"
+    ] = "missing"
+    with pytest.raises(_MODULE.PacketError, match="horizon scope caveat mismatch"):
         _MODULE.validate_packet(packet)
-    except _MODULE.PacketError as exc:
-        assert "horizon scope caveat mismatch" in str(exc)
-    else:
-        raise AssertionError("packet should reject wrong scope caveat")
+
+
+def test_issue_3810_analysis_packet_rejects_local_submission() -> None:
+    """The analysis packet must remain no-submit on the local machine."""
+
+    packet = _load_packet()
+    packet["analysis_and_retention_packet"]["execution_contract"]["local_submission_allowed"] = True
+    with pytest.raises(
+        _MODULE.PacketError,
+        match="execution_contract.local_submission_allowed must be false",
+    ):
+        _MODULE.validate_packet(packet)
+
+
+def test_issue_3810_analysis_packet_rejects_missing_job_reconciliation_reason() -> None:
+    """The decision gate must retain the active job reconciliation blocker."""
+
+    packet = _load_packet()
+    packet["analysis_and_retention_packet"]["execution_contract"]["decision_gate"]["reason"] = (
+        "Issue remains open."
+    )
+    with pytest.raises(_MODULE.PacketError, match="decision gate must require job 13175"):
+        _MODULE.validate_packet(packet)
+
+
+def test_issue_3810_analysis_packet_rejects_incomplete_retention_manifest() -> None:
+    """The retention manifest must preserve reviewable report and metadata paths."""
+
+    packet = _load_packet()
+    packet["analysis_and_retention_packet"]["retention"]["durable_manifests"] = [
+        "docs/context/evidence/issue_3810_long_horizon_snqi/"
+    ]
+    with pytest.raises(
+        _MODULE.PacketError, match="durable manifests must include reports directory"
+    ):
+        _MODULE.validate_packet(packet)


### PR DESCRIPTION
## Issue
- Relates to https://github.com/ll7/robot_sf_ll7/issues/3810

## Scope summary
- Added `analysis_and_retention_packet` to `configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml` so the long-horizon Social Navigation Quality Index (SNQI) packet explicitly fail-closes launch -> analysis -> retention execution.
- Added `scripts/validation/check_issue_3810_long_horizon_analysis_packet.py` to validate route/script/preflight fields, required outputs, retention paths, SNQI recalibration inputs, horizon-sensitivity report command, wait-it-out exposure diagnostic constraints, no-local-submit status, and active job reconciliation blockers.
- Added `tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py` focused contract coverage for issue #3810.

## Issue disposition
- Leave #3810 open. This PR is a launch/analysis-retention guard slice only.
- It does not submit Slurm work, run the comprehensive h600 campaign, recalibrate SNQI, publish a horizon-sensitivity report, emit interaction-exposure diagnostics from campaign outputs, archive benchmark artifacts, or establish benchmark/dissertation evidence.

## Validation
- `uv run python scripts/dev/run_compact_validation.py -- scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_3810_long_horizon_analysis_packet.py --json`
- `uv run python scripts/dev/run_compact_validation.py -- scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py -q`
- `uv run python scripts/dev/run_compact_validation.py -- scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_issue_3810_long_horizon_analysis_packet.py tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (1680 passed, 2 skipped)

## Out of scope
- No Slurm/GPU submission.
- No full benchmark execution.
- No paper/dissertation claim edits.
