### PR TITLE
Issue #3653: SNQI scalarization-sensitivity + Pareto-front export (fail-closed fixture preflight)

### DIFF
--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import csv
 import json
 import shutil
 import subprocess
@@ -337,9 +338,7 @@ def test_cli_exports_report_ready_artifacts_from_fixture_files(tmp_path: Path) -
     assert (out_dir / "issue_3653_fixture.md").exists()
     assert (out_dir / "issue_3653_fixture_pareto.svg").exists()
 
-    payload = json.loads(
-        (out_dir / "issue_3653_fixture.json").read_text(encoding="utf-8")
-    )
+    payload = json.loads((out_dir / "issue_3653_fixture.json").read_text(encoding="utf-8"))
     assert payload["schema_version"] == "snqi_scalarization_sensitivity.v1"
     assert payload["pareto_front"]["points"]
     assert payload["decision_disagreement"]["pairwise_reversal_count"] >= 0
@@ -459,3 +458,22 @@ def test_cli_exports_report_ready_artifacts(tmp_path: Path) -> None:
     payload = json.loads((out_dir / "issue_3653.json").read_text(encoding="utf-8"))
     assert payload["schema_version"] == "snqi_scalarization_sensitivity.v1"
     assert payload["pareto_front"]["points"]
+
+    with (out_dir / "issue_3653_decision_disagreement.csv").open(
+        encoding="utf-8", newline=""
+    ) as handle:
+        disagreement_rows = list(csv.DictReader(handle))
+    assert disagreement_rows == [
+        {
+            "comparison": "base_snqi_vs_constraints_first",
+            "left_order": " > ".join(payload["base_snqi_order"]),
+            "right_order": " > ".join(payload["constraints_first_order"]),
+            "pairwise_reversal_count": str(
+                payload["decision_disagreement"]["pairwise_reversal_count"]
+            ),
+            "pairwise_disagreement_rate": str(
+                payload["decision_disagreement"]["pairwise_disagreement_rate"]
+            ),
+            "claim_boundary": payload["claim_boundary"],
+        }
+    ]

--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -302,6 +302,49 @@ def test_cli_refuses_blocked_inputs_and_writes_only_preflight(tmp_path: Path) ->
     assert not out_dir.exists()
 
 
+def test_cli_exports_report_ready_artifacts_from_fixture_files(tmp_path: Path) -> None:
+    """Valid fixture files pass preflight and emit all diagnostic artifacts."""
+    episodes, baseline, weights = _write_fixture_inputs_from_fixtures(
+        tmp_path,
+        episodes_file="valid_episodes.jsonl",
+    )
+    out_dir = tmp_path / "artifacts"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/benchmark/snqi_scalarization_sensitivity_export.py",
+            "--episodes",
+            str(episodes),
+            "--baseline",
+            str(baseline),
+            "--weights",
+            str(weights),
+            "--output-dir",
+            str(out_dir),
+            "--stem",
+            "issue_3653_fixture",
+        ],
+        check=False,
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (out_dir / "issue_3653_fixture.json").exists()
+    assert (out_dir / "issue_3653_fixture_planner_rows.csv").exists()
+    assert (out_dir / "issue_3653_fixture_decision_disagreement.csv").exists()
+    assert (out_dir / "issue_3653_fixture.md").exists()
+    assert (out_dir / "issue_3653_fixture_pareto.svg").exists()
+
+    payload = json.loads(
+        (out_dir / "issue_3653_fixture.json").read_text(encoding="utf-8")
+    )
+    assert payload["schema_version"] == "snqi_scalarization_sensitivity.v1"
+    assert payload["pareto_front"]["points"]
+    assert payload["decision_disagreement"]["pairwise_reversal_count"] >= 0
+
+
 def test_cli_refuses_malformed_normalized_inputs_and_writes_preflight(tmp_path: Path) -> None:
     """Malformed normalized SNQI terms remain export artifacts off, preflight only."""
     records = _valid_records()


### PR DESCRIPTION
## Issue
- Relates to https://github.com/ll7/robot_sf_ll7/issues/3653

## Scope summary
- Keep this PR as a focused regression-test hardening slice for the SNQI scalarization-sensitivity export path.
- Verify ready fixture inputs emit JSON, planner CSV, decision-disagreement CSV, Markdown, and Pareto SVG artifacts.
- Add a content-level assertion that the exported decision-disagreement CSV row matches the JSON report's base-SNQI order, constraints-first order, disagreement counts/rate, and diagnostic claim boundary.
- Keep changes scoped to tests only; no benchmark run logic, campaign orchestration, claim promotion, or paper/dissertation text changes.

## Validation
- `uv run ruff check tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py`
- `uv run ruff format --check tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py`
- `uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py -q`
- Local result at head `a842fdda1`: 9 passed.

## Out-of-scope / explicit exclusions
- No full benchmark campaign run.
- No GPU, Slurm, or heavy benchmark work.
- No claim that issue #3653 is research-complete.
- #3653 remains open until the Pareto-front / decision-disagreement export is consumed on a valid campaign evidence surface.

## Issue disposition
- Leave #3653 open. This PR strengthens the fixture-backed export proof, but it does not satisfy the current issue blocker: empirical application of the export on valid campaign evidence.
