### PR TITLE
Issue #3204: add blocked-artifact summary to proxy-checkpoint readiness packet

### DIFF
--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -67,6 +67,7 @@ def _summarize_blocked_artifacts(
         "by_storage_scope": by_storage_scope,
     }
 
+
 DEFAULT_CONFIG = Path("configs/research/predictive_checkpoint_proxy_v1.yaml")
 DEFAULT_REGISTRY = Path("model/registry.yaml")
 

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -41,6 +41,32 @@ STATUS_FAILED = "failed"
 STATUS_BLOCKED = "blocked"
 _KNOWN_BLOCKER_STATUSES = frozenset({STATUS_BLOCKED, "resolved", "diagnostic"})
 
+
+def _summarize_blocked_artifacts(
+    artifacts: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build compact counts for blocked-artifact decision telemetry."""
+    if not artifacts:
+        return {
+            "total": 0,
+            "by_status": {},
+            "by_storage_scope": {},
+        }
+
+    by_status: dict[str, int] = {}
+    by_storage_scope: dict[str, int] = {}
+    for artifact in artifacts:
+        status = artifact.get("status", "unknown")
+        scope = artifact.get("storage_scope", "unknown")
+        by_status[str(status)] = by_status.get(str(status), 0) + 1
+        by_storage_scope[str(scope)] = by_storage_scope.get(str(scope), 0) + 1
+
+    return {
+        "total": len(artifacts),
+        "by_status": by_status,
+        "by_storage_scope": by_storage_scope,
+    }
+
 DEFAULT_CONFIG = Path("configs/research/predictive_checkpoint_proxy_v1.yaml")
 DEFAULT_REGISTRY = Path("model/registry.yaml")
 
@@ -671,6 +697,7 @@ def check_readiness(
             "status": artifact_status,
             "messages": artifact_messages,
             "artifacts": artifact_payload,
+            "summary": _summarize_blocked_artifacts(artifact_payload),
         }
 
         blocker_status, blocker_messages, blocker_payload = _check_known_blockers(cfg)

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -623,3 +623,47 @@ def test_checkpoint_mapping_surfaces_incomplete_public_metadata(tmp_path):
     assert ckpt["status"] == "passed"
     assert public_artifact["status"] == "incomplete"
     assert "sha256" in public_artifact["missing_fields"]
+
+
+def test_blocked_artifact_summary_is_reported_for_decision_packet(tmp_path: Path):
+    """Blocked-artifact metadata emits compact summary counts in readiness packet."""
+    config = _write_config(
+        tmp_path,
+        min_resolvable=2,
+        min_epochs=2,
+        known_blockers=[
+            {
+                "id": "missing_durable_predictive_checkpoints",
+                "status": "blocked",
+                "revival_condition": "hydrate checkpoint artifacts",
+            }
+        ],
+    )
+    data = yaml.safe_load(config.read_text(encoding="utf-8"))
+    data["blocked_artifacts"] = [
+        {
+            "id": "missing_blocked_artifact",
+            "artifact_type": "checkpoint_set",
+            "status": "blocked",
+            "storage_scope": "worktree_local_output",
+            "path_pattern": "output/tmp/predictive/**/*.pt",
+            "required_metadata": ["local_path", "proxy_training_run_id"],
+            "revival_condition": "Promote / hydrate deterministic inputs to local paths",
+        }
+    ]
+    config.write_text(yaml.safe_dump(data, sort_keys=False), encoding="utf-8")
+    registry = _write_registry(tmp_path, present_count=2, absent_count=0)
+
+    report = mod.check_readiness(
+        config_path=config,
+        registry_path=registry,
+        repo_root=_REPO_ROOT,
+    )
+
+    blocked = report["prerequisites"]["blocked_artifacts"]
+    assert blocked["status"] == "blocked"
+    assert "summary" in blocked
+    summary = blocked["summary"]
+    assert summary["total"] >= 1
+    assert summary["by_status"].get("blocked", 0) >= 1
+    assert summary["by_storage_scope"].get("worktree_local_output", 0) >= 1


### PR DESCRIPTION
## Summary
- Issue: https://github.com/ll7/robot_sf_ll7/issues/3204
- Scope: Add a small diagnostics surface extension for proxy-based checkpoint-selection readiness by threading a compact blocked-artifact summary into the readiness decision packet, and add focused fixture coverage.
- Behavior added: The readiness report at `scripts/research/check_predictive_checkpoint_proxy_readiness.py` now emits `prerequisites.blocked_artifacts.summary` with counts by status and storage scope; tests now assert this signal in the decision packet when blocked artifacts are configured.
- This is read-only and fail-closed: no checkpoint selection, no training, no benchmark run, no Slurm submission.

## Validation
- `uv run python -m py_compile scripts/research/check_predictive_checkpoint_proxy_readiness.py`
- `uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py -q`
- `uv run pytest tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py -q`

## Out of scope
- No full benchmark campaign run
- No Slurm or GPU submission
- No model-training execution
- No paper/dissertation claim edits or evidence promotion
