### PR TITLE
adversarial: strengthen disjoint archive readiness overlap checks

### DIFF
--- a/robot_sf/adversarial/disjoint_evaluation.py
+++ b/robot_sf/adversarial/disjoint_evaluation.py
@@ -527,26 +527,25 @@ def _readiness_blocking_reasons(
     reasons: list[str] = []
     if not schema_ok:
         reasons.append(f"unexpected_schema_version:{schema_version!r}")
-    if stats.non_dict_count:
-        reasons.append(f"non_object_entries:{stats.non_dict_count}")
     if stats.entry_count < min_entries:
         reasons.append(f"too_few_entries:{stats.entry_count}<{min_entries}")
-    if stats.missing_archive_id:
-        reasons.append(f"entries_missing_archive_id:{stats.missing_archive_id}")
-    if stats.missing_seed:
-        reasons.append(f"entries_missing_scenario_seed:{stats.missing_seed}")
-    if stats.missing_attribution:
-        reasons.append(f"entries_missing_failure_attribution:{stats.missing_attribution}")
-    if stats.unknown_family:
-        reasons.append(f"entries_unknown_family:{stats.unknown_family}")
-    if stats.distinct_family_count < _MIN_DISJOINT_FAMILIES:
-        reasons.append(f"insufficient_scenario_families:{stats.distinct_family_count}")
-    if stats.scenario_family_overlap_count:
-        reasons.append(f"scenario_family_overlap:{stats.scenario_family_overlap_count}")
-    if stats.seed_overlap_count:
-        reasons.append(f"seed_overlap:{stats.seed_overlap_count}")
-    if stats.archive_id_overlap_count:
-        reasons.append(f"archive_id_overlap:{stats.archive_id_overlap_count}")
+    counted_blockers = (
+        ("non_object_entries", stats.non_dict_count),
+        ("entries_missing_archive_id", stats.missing_archive_id),
+        ("entries_missing_scenario_seed", stats.missing_seed),
+        ("entries_missing_failure_attribution", stats.missing_attribution),
+        ("entries_unknown_family", stats.unknown_family),
+        (
+            "insufficient_scenario_families",
+            stats.distinct_family_count
+            if stats.distinct_family_count < _MIN_DISJOINT_FAMILIES
+            else 0,
+        ),
+        ("scenario_family_overlap", stats.scenario_family_overlap_count),
+        ("seed_overlap", stats.seed_overlap_count),
+        ("archive_id_overlap", stats.archive_id_overlap_count),
+    )
+    reasons.extend(f"{name}:{count}" for name, count in counted_blockers if count)
     if not stats.disjoint_split_possible:
         reasons.append("no_disjoint_split_possible")
     return reasons
@@ -609,9 +608,7 @@ def assess_archive_readiness(
         and not stats.seed_overlap_count
         and not stats.archive_id_overlap_count
     )
-    null_test_prerequisites_ready = (
-        overlap_metadata_ready and not stats.missing_attribution
-    )
+    null_test_prerequisites_ready = overlap_metadata_ready and not stats.missing_attribution
 
     ready = not reasons
     return ArchiveReadinessReport(

--- a/robot_sf/adversarial/disjoint_evaluation.py
+++ b/robot_sf/adversarial/disjoint_evaluation.py
@@ -407,6 +407,9 @@ class ArchiveReadinessReport:
     entries_missing_scenario_seed: int
     entries_missing_failure_attribution: int
     entries_unknown_family: int
+    scenario_family_overlap_count: int
+    seed_overlap_count: int
+    archive_id_overlap_count: int
     archive_sha256: str | None = None
     blocking_reasons: list[str] = field(default_factory=list)
 
@@ -425,6 +428,9 @@ class ArchiveReadinessReport:
             "entries_missing_scenario_seed": self.entries_missing_scenario_seed,
             "entries_missing_failure_attribution": self.entries_missing_failure_attribution,
             "entries_unknown_family": self.entries_unknown_family,
+            "scenario_family_overlap_count": self.scenario_family_overlap_count,
+            "seed_overlap_count": self.seed_overlap_count,
+            "archive_id_overlap_count": self.archive_id_overlap_count,
             "archive_sha256": self.archive_sha256,
             "blocking_reasons": list(self.blocking_reasons),
         }
@@ -443,6 +449,9 @@ def _not_ready(status: str, *reasons: str, **fields: Any) -> ArchiveReadinessRep
         "entries_missing_scenario_seed": 0,
         "entries_missing_failure_attribution": 0,
         "entries_unknown_family": 0,
+        "scenario_family_overlap_count": 0,
+        "seed_overlap_count": 0,
+        "archive_id_overlap_count": 0,
         "archive_sha256": None,
     }
     defaults.update(fields)
@@ -471,6 +480,9 @@ class _EntryStats:
     unknown_family: int
     distinct_family_count: int
     disjoint_split_possible: bool
+    scenario_family_overlap_count: int
+    seed_overlap_count: int
+    archive_id_overlap_count: int
 
 
 def _collect_entry_stats(
@@ -487,6 +499,10 @@ def _collect_entry_stats(
         split = disjoint_family_split(dict_entries, eval_fraction=eval_fraction, seed=split_seed)
         disjoint_split_possible = split.is_disjoint_split
 
+    overlap = compute_overlap_provenance([], [])
+    if disjoint_split_possible:
+        overlap = compute_overlap_provenance(split.fit_entries, split.eval_entries)
+
     return _EntryStats(
         entry_count=len(dict_entries),
         non_dict_count=len(entries) - len(dict_entries),
@@ -498,6 +514,9 @@ def _collect_entry_stats(
         unknown_family=sum(1 for e in dict_entries if scenario_family_key(e) == "unknown_family"),
         distinct_family_count=len(distinct_families),
         disjoint_split_possible=disjoint_split_possible,
+        scenario_family_overlap_count=len(overlap["scenario_family_overlap"]),
+        seed_overlap_count=len(overlap["seed_overlap"]),
+        archive_id_overlap_count=len(overlap["archive_id_overlap"]),
     )
 
 
@@ -522,6 +541,12 @@ def _readiness_blocking_reasons(
         reasons.append(f"entries_unknown_family:{stats.unknown_family}")
     if stats.distinct_family_count < _MIN_DISJOINT_FAMILIES:
         reasons.append(f"insufficient_scenario_families:{stats.distinct_family_count}")
+    if stats.scenario_family_overlap_count:
+        reasons.append(f"scenario_family_overlap:{stats.scenario_family_overlap_count}")
+    if stats.seed_overlap_count:
+        reasons.append(f"seed_overlap:{stats.seed_overlap_count}")
+    if stats.archive_id_overlap_count:
+        reasons.append(f"archive_id_overlap:{stats.archive_id_overlap_count}")
     if not stats.disjoint_split_possible:
         reasons.append("no_disjoint_split_possible")
     return reasons
@@ -577,9 +602,16 @@ def assess_archive_readiness(
     # to compare. Null tests additionally need a non-empty eval side, which the
     # disjoint-split check guarantees.
     overlap_metadata_ready = (
-        stats.disjoint_split_possible and not stats.missing_archive_id and not stats.missing_seed
+        stats.disjoint_split_possible
+        and not stats.missing_archive_id
+        and not stats.missing_seed
+        and not stats.scenario_family_overlap_count
+        and not stats.seed_overlap_count
+        and not stats.archive_id_overlap_count
     )
-    null_test_prerequisites_ready = stats.disjoint_split_possible and not stats.missing_attribution
+    null_test_prerequisites_ready = (
+        overlap_metadata_ready and not stats.missing_attribution
+    )
 
     ready = not reasons
     return ArchiveReadinessReport(
@@ -595,6 +627,9 @@ def assess_archive_readiness(
         entries_missing_scenario_seed=stats.missing_seed,
         entries_missing_failure_attribution=stats.missing_attribution,
         entries_unknown_family=stats.unknown_family,
+        scenario_family_overlap_count=stats.scenario_family_overlap_count,
+        seed_overlap_count=stats.seed_overlap_count,
+        archive_id_overlap_count=stats.archive_id_overlap_count,
         archive_sha256=archive_hash,
         blocking_reasons=reasons,
     )

--- a/tests/adversarial/test_archive_readiness.py
+++ b/tests/adversarial/test_archive_readiness.py
@@ -149,7 +149,6 @@ def test_missing_scenario_seed_breaks_overlap_metadata() -> None:
     assert "entries_missing_scenario_seed:1" in report.blocking_reasons
 
 
-
 def test_seed_overlap_becomes_readiness_blocker() -> None:
     """Shared scenario seeds across families blocks overlap metadata readiness."""
     archive_entries = [
@@ -178,6 +177,7 @@ def test_archive_id_overlap_becomes_readiness_blocker() -> None:
     assert report.overlap_metadata_ready is False
     assert report.ready is False
     assert "archive_id_overlap:1" in report.blocking_reasons
+
 
 def test_missing_failure_attribution_breaks_null_test_prereq() -> None:
     """Missing failure_attribution blocks the null-test prerequisite."""

--- a/tests/adversarial/test_archive_readiness.py
+++ b/tests/adversarial/test_archive_readiness.py
@@ -149,6 +149,36 @@ def test_missing_scenario_seed_breaks_overlap_metadata() -> None:
     assert "entries_missing_scenario_seed:1" in report.blocking_reasons
 
 
+
+def test_seed_overlap_becomes_readiness_blocker() -> None:
+    """Shared scenario seeds across families blocks overlap metadata readiness."""
+    archive_entries = [
+        _entry("family_a", "a0", 7),
+        _entry("family_a", "a1", 8),
+        _entry("family_b", "b0", 7),
+        _entry("family_b", "b1", 9),
+    ]
+    report = assess_archive_readiness(_archive(archive_entries), split_seed=0, eval_fraction=0.5)
+    assert report.seed_overlap_count == 1
+    assert report.overlap_metadata_ready is False
+    assert report.ready is False
+    assert "seed_overlap:1" in report.blocking_reasons
+
+
+def test_archive_id_overlap_becomes_readiness_blocker() -> None:
+    """Shared archive IDs across families blocks overlap metadata readiness."""
+    archive_entries = [
+        _entry("family_a", "same_id", 1),
+        _entry("family_a", "a1", 2),
+        _entry("family_b", "same_id", 3),
+        _entry("family_b", "b1", 4),
+    ]
+    report = assess_archive_readiness(_archive(archive_entries), split_seed=0, eval_fraction=0.5)
+    assert report.archive_id_overlap_count == 1
+    assert report.overlap_metadata_ready is False
+    assert report.ready is False
+    assert "archive_id_overlap:1" in report.blocking_reasons
+
 def test_missing_failure_attribution_breaks_null_test_prereq() -> None:
     """Missing failure_attribution blocks the null-test prerequisite."""
     entries = [_entry("A", "a0", 1), _entry("B", "b0", 2)]


### PR DESCRIPTION
## Issue
- Relates to #3275

## Scope summary
- Strengthens the fail-closed archive-readiness gate for issue #3275 by exposing scenario-family, scenario-seed, and archive-id overlap counters on `ArchiveReadinessReport`.
- Treats nonzero overlap counters as readiness blockers so `overlap_metadata_ready`, `null_test_prerequisites_ready`, and `ready` stay false when fit/eval provenance is not cleanly disjoint.
- Adds synthetic fixture coverage for seed-overlap and archive-id-overlap blockers.
- Refactors `_readiness_blocking_reasons` to keep the new blocker list under the Ruff complexity gate.

## Validation
- `uv run ruff check robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py`
- `uv run ruff format --check robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py`
- `uv run python -m pytest tests/adversarial/test_archive_readiness.py tests/adversarial/test_disjoint_evaluation.py -q`
- `uv run python -m pytest tests/adversarial -q`
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh`

## Out of scope / issue disposition
- No proposal-model evaluation run was performed.
- No benchmark evidence, held-out yield claim, dissertation claim, GPU campaign, or Slurm run is included.
- #3275 should remain open after this PR. The remaining issue contract is the real disjoint certified failure archive rerun with independent planner-execution outcomes, certification/candidate lineage, null-test reporting, and bounded held-out yield interpretation.