### PR TITLE
#1554 benchmark: add S20/S30 seed-budget archive readiness checker

### DIFF
--- a/scripts/validation/check_s20_s30_archive_readiness.py
+++ b/scripts/validation/check_s20_s30_archive_readiness.py
@@ -156,9 +156,7 @@ def build_report(
     result_store_files = _result_store_file_status(contract)
     bundle_outputs = _bundle_output_file_status(contract)
     missing_files = [path for path, present in result_store_files.items() if not present]
-    missing_bundle_outputs = [
-        path for path, present in bundle_outputs.items() if not present
-    ]
+    missing_bundle_outputs = [path for path, present in bundle_outputs.items() if not present]
     if missing_files:
         diagnostics.append(f"missing result-store files: {missing_files}")
     if missing_bundle_outputs:

--- a/scripts/validation/check_s20_s30_archive_readiness.py
+++ b/scripts/validation/check_s20_s30_archive_readiness.py
@@ -102,6 +102,10 @@ def parse_contract(
 
     required_metrics = _required_str_list(claim_gate, "required_metric_surface")
     planner_rows = _required_str_list(claim_gate, "planner_rows_to_confirm")
+    if len(set(required_metrics)) != len(required_metrics):
+        raise ValueError("required_metric_surface must not contain duplicates")
+    if len(set(planner_rows)) != len(planner_rows):
+        raise ValueError("planner_rows_to_confirm must not contain duplicate planner names")
     if not _required_str(claim_gate, "target_claim").strip():
         raise ValueError("claim_map_gate.target_claim must be non-empty")
     if not _required_str(claim_gate, "why_s10_insufficient").strip():
@@ -150,9 +154,15 @@ def build_report(
     diagnostics.extend(_contract_metadata_diagnostics(contract))
     diagnostics.extend(_execution_boundary_diagnostics(contract))
     result_store_files = _result_store_file_status(contract)
+    bundle_outputs = _bundle_output_file_status(contract)
     missing_files = [path for path, present in result_store_files.items() if not present]
+    missing_bundle_outputs = [
+        path for path, present in bundle_outputs.items() if not present
+    ]
     if missing_files:
         diagnostics.append(f"missing result-store files: {missing_files}")
+    if missing_bundle_outputs:
+        diagnostics.append(f"missing bundle outputs: {missing_bundle_outputs}")
 
     store_validation = validate_result_store(contract.result_store)
     if not store_validation.ok:
@@ -214,6 +224,8 @@ def build_report(
             "bundle_outputs": [str(path) for path in contract.bundle_outputs],
         },
         "expected_result_store_files": result_store_files,
+        "expected_bundle_outputs": {str(path): present for path, present in bundle_outputs.items()},
+        "missing_bundle_outputs": missing_bundle_outputs,
         "missing_artifact_diagnostics": diagnostics,
         "execution_boundary": {
             "full_campaign_in_this_issue": contract.full_campaign_in_this_issue,
@@ -283,6 +295,10 @@ def _result_store_file_status(contract: PacketContract) -> dict[str, bool]:
         rel_path: (contract.result_store / _validate_relative_path(rel_path)).is_file()
         for rel_path in contract.required_result_store_files
     }
+
+
+def _bundle_output_file_status(contract: PacketContract) -> dict[str, bool]:
+    return {str(path): path.is_file() for path in contract.bundle_outputs}
 
 
 def _planner_seed_coverage(

--- a/tests/validation/test_check_s20_s30_archive_readiness.py
+++ b/tests/validation/test_check_s20_s30_archive_readiness.py
@@ -77,10 +77,10 @@ def _write_packet(
                 "tables/manifest.json",
                 "figures/manifest.json",
             ],
-        "bundle": [
-            "output/issue_1554_s20_s30/bundle.json",
-            "output/issue_1554_s20_s30/BUNDLE.md",
-        ],
+            "bundle": [
+                "output/issue_1554_s20_s30/bundle.json",
+                "output/issue_1554_s20_s30/BUNDLE.md",
+            ],
         },
         "execution_boundary": {
             "full_campaign_in_this_issue": full_campaign_in_this_issue,
@@ -133,15 +133,9 @@ def test_complete_archive_metadata_and_store_pass(tmp_path: Path) -> None:
         command="uv run python scripts/tools/run_camera_ready_benchmark.py ...",
         analysis={"seed_resampling_rank_flip": {"rank_flip_observed": False}},
     )
-    (repo / "output/issue_1554_s20_s30/bundle.json").parent.mkdir(
-        parents=True, exist_ok=True
-    )
-    (repo / "output/issue_1554_s20_s30/bundle.json").write_text(
-        "{}", encoding="utf-8"
-    )
-    (repo / "output/issue_1554_s20_s30/BUNDLE.md").write_text(
-        "# S20/S30 Bundle", encoding="utf-8"
-    )
+    (repo / "output/issue_1554_s20_s30/bundle.json").parent.mkdir(parents=True, exist_ok=True)
+    (repo / "output/issue_1554_s20_s30/bundle.json").write_text("{}", encoding="utf-8")
+    (repo / "output/issue_1554_s20_s30/BUNDLE.md").write_text("# S20/S30 Bundle", encoding="utf-8")
 
     report = readiness.build_report(packet, repo)
 
@@ -304,15 +298,9 @@ def test_archive_reader_uses_campaign_result_store_parquet_fallback(
         study_id="issue_1554_test",
         command="uv run python scripts/tools/run_camera_ready_benchmark.py ...",
     )
-    (repo / "output/issue_1554_s20_s30/bundle.json").parent.mkdir(
-        parents=True, exist_ok=True
-    )
-    (repo / "output/issue_1554_s20_s30/bundle.json").write_text(
-        "{}", encoding="utf-8"
-    )
-    (repo / "output/issue_1554_s20_s30/BUNDLE.md").write_text(
-        "# S20/S30 Bundle", encoding="utf-8"
-    )
+    (repo / "output/issue_1554_s20_s30/bundle.json").parent.mkdir(parents=True, exist_ok=True)
+    (repo / "output/issue_1554_s20_s30/bundle.json").write_text("{}", encoding="utf-8")
+    (repo / "output/issue_1554_s20_s30/BUNDLE.md").write_text("# S20/S30 Bundle", encoding="utf-8")
     calls: list[Path] = []
     original = readiness.read_parquet_frame
 

--- a/tests/validation/test_check_s20_s30_archive_readiness.py
+++ b/tests/validation/test_check_s20_s30_archive_readiness.py
@@ -77,7 +77,10 @@ def _write_packet(
                 "tables/manifest.json",
                 "figures/manifest.json",
             ],
-            "bundle": ["bundle/bundle.json", "bundle/BUNDLE.md"],
+        "bundle": [
+            "output/issue_1554_s20_s30/bundle.json",
+            "output/issue_1554_s20_s30/BUNDLE.md",
+        ],
         },
         "execution_boundary": {
             "full_campaign_in_this_issue": full_campaign_in_this_issue,
@@ -129,6 +132,15 @@ def test_complete_archive_metadata_and_store_pass(tmp_path: Path) -> None:
         study_id="issue_1554_test",
         command="uv run python scripts/tools/run_camera_ready_benchmark.py ...",
         analysis={"seed_resampling_rank_flip": {"rank_flip_observed": False}},
+    )
+    (repo / "output/issue_1554_s20_s30/bundle.json").parent.mkdir(
+        parents=True, exist_ok=True
+    )
+    (repo / "output/issue_1554_s20_s30/bundle.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    (repo / "output/issue_1554_s20_s30/BUNDLE.md").write_text(
+        "# S20/S30 Bundle", encoding="utf-8"
     )
 
     report = readiness.build_report(packet, repo)
@@ -292,6 +304,15 @@ def test_archive_reader_uses_campaign_result_store_parquet_fallback(
         study_id="issue_1554_test",
         command="uv run python scripts/tools/run_camera_ready_benchmark.py ...",
     )
+    (repo / "output/issue_1554_s20_s30/bundle.json").parent.mkdir(
+        parents=True, exist_ok=True
+    )
+    (repo / "output/issue_1554_s20_s30/bundle.json").write_text(
+        "{}", encoding="utf-8"
+    )
+    (repo / "output/issue_1554_s20_s30/BUNDLE.md").write_text(
+        "# S20/S30 Bundle", encoding="utf-8"
+    )
     calls: list[Path] = []
     original = readiness.read_parquet_frame
 
@@ -434,5 +455,44 @@ def test_seed_tiers_must_be_unique_integers(tmp_path: Path) -> None:
     seeds = yaml.safe_load((repo / "seed_sets.yaml").read_text(encoding="utf-8"))
     seeds["paper_eval_s20"][0] = seeds["paper_eval_s20"][1]
     (repo / "seed_sets.yaml").write_text(yaml.safe_dump(seeds, sort_keys=False), encoding="utf-8")
+
+    assert readiness.main(["--packet", str(packet), "--repo-root", str(repo)]) == 2
+
+
+def test_missing_bundle_outputs_are_reported_as_blockers(tmp_path: Path) -> None:
+    """Missing declared bundle files blocks readiness as missing-artifact diagnostics."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    packet = _write_packet(repo / "packet.yaml", repo)
+    write_result_store(
+        repo / "store",
+        _complete_rows(),
+        study_id="issue_1554_test",
+        command="uv run python scripts/tools/run_camera_ready_benchmark.py ...",
+        analysis={"seed_resampling_rank_flip": {"rank_flip_observed": False}},
+    )
+
+    report = readiness.build_report(packet, repo)
+    assert report["status"] == readiness.BLOCKED
+    assert report["missing_bundle_outputs"] == [
+        str((repo / "output/issue_1554_s20_s30/bundle.json").resolve()),
+        str((repo / "output/issue_1554_s20_s30/BUNDLE.md").resolve()),
+    ]
+    assert any("missing bundle outputs" in item for item in report["missing_artifact_diagnostics"])
+
+
+def test_duplicate_planner_rows_in_contract_is_malformed(tmp_path: Path) -> None:
+    """Duplicate planner rows in claim metadata is malformed and fail-closed."""
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    packet = _write_packet(
+        repo / "packet.yaml",
+        repo,
+        metadata_overrides={
+            "claim_map_gate.planner_rows_to_confirm": ["goal", "goal"],
+        },
+    )
 
     assert readiness.main(["--packet", str(packet), "--repo-root", str(repo)]) == 2


### PR DESCRIPTION
## Summary
Adds fail-closed bundle-output diagnostics to the existing S20/S30 archive-readiness checker for issue #1554, plus focused tests for missing bundle outputs and duplicate planner-row metadata.

This is a partial archive-readiness guard only. It does not analyze Slurm job `13198`, produce `issue_1554_job_13198_constraints_first_analysis.{json,md}`, run a benchmark, promote artifacts, or establish a paper/dissertation claim.

## Linked Issues
- Relates `#1554`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: `NA`

## What Changed
- Reports declared `expected_artifacts.bundle` outputs as explicit missing-artifact blockers.
- Rejects duplicate `required_metric_surface` and `planner_rows_to_confirm` entries in the launch-packet contract.
- Adds focused validation tests for missing bundle outputs and duplicate planner rows.
- Formats the touched checker/test files so CI lint can pass.

## Why Matters
- Added value: prevents archive-readiness from passing when the declared reviewable bundle files are absent.
- Expected impact: keeps the issue #1554 S20/S30 path fail-closed until durable artifacts exist.
- Why worth merging now: improves the guardrail without running heavy benchmark, GPU, or SLURM work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: archive-readiness blocker for S20/S30 bundle publication; no benchmark result claim.
- Comparator or baseline, applicable: `NA - no benchmark comparison run`
- Evidence tier: targeted smoke / guardrail test
- Result classification: blocker-resolution for the readiness checker only
- Decision stop rule, applicable: checker remains blocked until required result-store files and bundle outputs exist.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #1554 remains open for current product-owner scope: analyze Slurm job `13198` first.
- New research/benchmark/metric/paper-facing analysis tool, any: `NA - extends existing support checker and does not interpret research evidence`

## Domain-Aware Approval
- Approval concerns experimental validity and waived / pending / blocked / not required: not required
- Approver/review source waiver: support checker only; no evidence classification, methodology, figure eligibility, benchmark interpretation, or paper-facing claim changes.
- Validity checklist: `NA`
- Target claim/hypothesis: no claim established
- Comparator split/evidence validity: no comparator run
- Fallback/degraded exclusions: checker preserves fail-closed row-status policy
- Claim boundary: archive-readiness only
- Implementation integrity vs experimental validity: local tests prove implementation integrity for the new guard; experimental validity remains unresolved in #1554.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - missing declared bundle outputs now block readiness.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? yes - fixture omits declared bundle outputs.
- Result route: narrow
- Follow-up question issue weak, negative, non-transfer results: #1554 remains the follow-up for job `13198` constraints-first analysis.

## Next Empirical Action
- Rerun needed: no for this checker change; yes outside this PR for #1554 job `13198` analysis.
- Extractor analysis tool needed: outside this PR, produce `issue_1554_job_13198_constraints_first_analysis.{json,md}` per issue body.
- Artifact missing unavailable: current worktree lacks the S20/S30 result store and bundle outputs, so the checker correctly reports `blocked`.
- Stop / revise / continue decision: stop this PR at guardrail improvement; continue #1554 analysis separately.
- Proposed child issue existing follow-up: existing #1554 remains open.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/validation/test_check_s20_s30_archive_readiness.py -q` (17 passed)
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_s20_s30_archive_readiness.py tests/validation/test_check_s20_s30_archive_readiness.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/check_s20_s30_archive_readiness.py tests/validation/test_check_s20_s30_archive_readiness.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_s20_s30_archive_readiness.py --json` (expected exit 1, reports `status: blocked` with missing result-store and missing bundle-output diagnostics)
- `git diff --check`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (passed locally on `00c47ec9c97090899fd25bae8752db3c46760762`)
- GitHub CI: 14/14 successful on `00c47ec9c97090899fd25bae8752db3c46760762`

## Performance
- Baseline runtime: `NA - no hot-path runtime behavior changed`
- Changed runtime: `NA - validation checker only`
- Representative command: `uv run python scripts/validation/check_s20_s30_archive_readiness.py --json`
- Hot-path call count profile anchor: `NA`
- Cache-hit reuse counter: `NA`
- Rollback failure criterion: checker passes readiness while declared bundle outputs are missing, or focused tests fail.

## Risks / Rollout
- Compatibility risks: low; report schema gains `expected_bundle_outputs` and `missing_bundle_outputs` fields.
- Failure modes: downstream consumers expecting readiness without bundle outputs will now receive `blocked`.
- Rollback fallback plan: revert this PR if the bundle-output contract is intentionally optional.

## Docs / Provenance
- Updated docs: `NA`
- Relevant design provenance notes: issue #1554 current body; existing launch packet `configs/benchmarks/s20_s30_seed_budget_issue_1554_launch_packet.yaml`
- Any assumptions need to preserved: `expected_artifacts.bundle` entries are required readiness outputs, not optional hints.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes - reopened after merge because this PR is partial.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR adds checker guardrails only and does not create or classify benchmark evidence.

## Follow-Up Issues
- Deferred work: analyze Slurm job `13198` and produce `issue_1554_job_13198_constraints_first_analysis.{json,md}`.
- Issues opened follow-up: none; #1554 remains open.

## Reviewer Notes
- This PR intentionally relates to #1554 but does not close it.
- Known limitations: no heavy benchmark, GPU, SLURM work, artifact promotion, or release/delete/claim promotion performed.