### PR TITLE
Issue #3653: add fixture-backed SNQI sensitivity export coverage

### DIFF
--- a/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py
@@ -302,6 +302,47 @@ def test_cli_refuses_blocked_inputs_and_writes_only_preflight(tmp_path: Path) ->
     assert not out_dir.exists()
 
 
+def test_cli_exports_report_ready_artifacts_from_fixture_files(tmp_path: Path) -> None:
+    """Valid fixture files pass preflight and emit all diagnostic artifacts."""
+    episodes, baseline, weights = _write_fixture_inputs_from_fixtures(
+        tmp_path,
+        episodes_file="valid_episodes.jsonl",
+    )
+    out_dir = tmp_path / "artifacts"
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/benchmark/snqi_scalarization_sensitivity_export.py",
+            "--episodes",
+            str(episodes),
+            "--baseline",
+            str(baseline),
+            "--weights",
+            str(weights),
+            "--output-dir",
+            str(out_dir),
+            "--stem",
+            "issue_3653_fixture",
+        ],
+        check=False,
+        cwd=Path(__file__).resolve().parents[2],
+        text=True,
+        capture_output=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert (out_dir / "issue_3653_fixture.json").exists()
+    assert (out_dir / "issue_3653_fixture_planner_rows.csv").exists()
+    assert (out_dir / "issue_3653_fixture_decision_disagreement.csv").exists()
+    assert (out_dir / "issue_3653_fixture.md").exists()
+    assert (out_dir / "issue_3653_fixture_pareto.svg").exists()
+
+    payload = json.loads((out_dir / "issue_3653_fixture.json").read_text(encoding="utf-8"))
+    assert payload["schema_version"] == "snqi_scalarization_sensitivity.v1"
+    assert payload["pareto_front"]["points"]
+    assert payload["decision_disagreement"]["pairwise_reversal_count"] >= 0
+
+
 def test_cli_refuses_malformed_normalized_inputs_and_writes_preflight(tmp_path: Path) -> None:
     """Malformed normalized SNQI terms remain export artifacts off, preflight only."""
     records = _valid_records()


### PR DESCRIPTION
## Summary
Adds fixture-backed regression coverage for the SNQI scalarization-sensitivity CLI ready path.

## Linked Issues
- Relates to `#3653`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added a CLI test that copies committed valid normalized SNQI fixture files and verifies successful export of the JSON report, planner-rows CSV, decision-disagreement CSV, Markdown report, and Pareto SVG.

## Why Matters
- Added value: covers the ready fixture-to-artifact path for issue #3653 after the fail-closed malformed-input slices.
- Expected impact: prevents regressions where valid normalized fixtures pass preflight but fail to emit the full report-ready artifact set.
- Why worth merging now: narrow test-only coverage for a safety-metric diagnostic surface.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: fixture-backed SNQI scalarization-sensitivity export readiness for issue #3653.
- Comparator or baseline, applicable: existing fail-closed malformed/missing-input fixture tests.
- Evidence tier: NA - test-only regression coverage
- Result classification: NA - no research result claim
- Decision stop rule, applicable: CLI exits 0 and emits all expected report artifacts from committed valid fixtures.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3653 remains open for empirical valid-campaign consumption.
- New research/benchmark/metric/paper-facing analysis tool, any: none; test-only coverage of existing analysis CLI.

## Domain-Aware Approval

- Required PR: yes - evidence-validity-sensitive result classification
- Domains reviewed: evidence classification, figure eligibility
- Status: waived
- Approver/review source waiver: maintainer waiver; test-only test coverage, no benchmark claim promotion, issue #3653 remains open for empirical campaign evidence
- Validity checklist:
  - Target claim/hypothesis: issue claim boundary stays test-only
  - Comparator or split/evidence validity: existing targeted smoke proof only
  - Fallback/degraded exclusions: fallback/degraded evidence remains excluded
  - Claim boundary: no paper-facing benchmark claim
  - Implementation integrity vs experimental validity: tests prove gate behavior, not result validity


## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? no; test-only coverage.
- Did scenario actually contain targeted failure mode? NA; valid fixture export path.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: issue #3653 live comments identify empirical valid-campaign consumption as the remaining blocker.

## Next Empirical Action
- Rerun needed: no for this fixture coverage slice.
- Extractor analysis tool needed: no for this fixture coverage slice.
- Artifact missing unavailable: durable valid campaign evidence is not consumed by this PR.
- Stop / revise / continue decision: continue via issue #3653 empirical campaign-surface follow-up.
- Proposed child issue existing follow-up: issue #3653 remains open.

## Validation / Proof
- PASS: `uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py -q` (9 passed)
- PASS: `uv run ruff check tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py`
- PASS: `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/output/validation/pr_bodies/issue_3653_pr_body.md scripts/dev/pr_ready_check.sh`

## Performance Validation
- Baseline runtime: NA, test-only regression coverage.
- Changed runtime: NA, test-only regression coverage.
- Representative command: `uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity_issue_3653.py -q`
- Hot-path call count profile anchor: NA, no performance claim.
- Cache-hit reuse counter: NA, no caching claim.
- Rollback failure criterion: fixture-backed ready CLI export test fails or expected artifact set is incomplete.

## Risks / Rollout
- Compatibility risks: low; test-only change.
- Failure modes: may still miss campaign-surface schema drift outside committed fixtures.
- Rollback fallback plan: revert the test-only commit.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3653 comments.
- Any assumptions need to preserved: this PR covers the ready-queue fixture/export preflight objective, while empirical campaign consumption remains out of scope.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark, registry, claim-map, paper-facing, or durable artifact propagation changes.

## Follow-Up Issues
- Deferred work: empirical application of the Pareto-front / decision-disagreement export on valid campaign evidence remains in issue #3653.
- Issues opened follow-up: none

## Reviewer Notes
- Anything reviewer verify closely: the new test uses committed valid fixture files rather than synthetic in-memory records.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
