### PR TITLE
Issue #3204: fail closed incomplete proxy checkpoint artifact metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Tightened the proxy checkpoint-selection readiness preflight (#3204) so registry entries with
+  declared-but-incomplete public release metadata fail closed before they can be treated as ready
+  checkpoint inputs.
 * Added a machine-readable known-blocker map to the proxy checkpoint-selection readiness preflight
   (#3204). The checker now reports configured blocker IDs and revival conditions as a fail-closed
   prerequisite without running training, selecting a checkpoint, or promoting benchmark evidence.

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -515,6 +515,28 @@ def _check_checkpoint_artifacts(
             mapping,
         )
 
+    incomplete_public_artifacts = [
+        (
+            str(candidate["model_id"]),
+            candidate["public_artifact"].get("missing_fields") or [],
+        )
+        for candidate in candidates
+        if candidate["public_artifact"]["status"] == "incomplete"
+    ]
+    if incomplete_public_artifacts:
+        missing = [
+            f"{model_id} missing {', '.join(fields)}"
+            for model_id, fields in incomplete_public_artifacts
+        ]
+        return (
+            STATUS_BLOCKED,
+            [
+                "declared public artifact metadata is incomplete; "
+                f"blocked release metadata entries: {'; '.join(missing)}"
+            ],
+            mapping,
+        )
+
     group_messages = _training_run_group_blocker(
         mapping, registry_tag=registry_tag, min_resolvable=min_resolvable
     )

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -579,8 +579,8 @@ def test_blocked_artifact_path_pattern_required(tmp_path):
     assert any("missing path_pattern" in message for message in config_check["messages"])
 
 
-def test_checkpoint_mapping_surfaces_incomplete_public_metadata(tmp_path):
-    """Missing public release metadata stays visible in checkpoint mapping output."""
+def test_incomplete_public_metadata_blocks_checkpoint_readiness(tmp_path):
+    """Declared public release metadata must be complete before readiness."""
     config = _write_config(tmp_path, min_resolvable=1)
     data = yaml.safe_load(config.read_text(encoding="utf-8"))
     data["known_blockers"] = [
@@ -620,9 +620,11 @@ def test_checkpoint_mapping_surfaces_incomplete_public_metadata(tmp_path):
     candidate = ckpt["mapping"]["candidates"][0]
     public_artifact = candidate["public_artifact"]
 
-    assert ckpt["status"] == "passed"
+    assert report["status"] == "blocked"
+    assert ckpt["status"] == "blocked"
     assert public_artifact["status"] == "incomplete"
     assert "sha256" in public_artifact["missing_fields"]
+    assert any("public artifact metadata is incomplete" in message for message in ckpt["messages"])
 
 
 def test_blocked_artifact_summary_is_reported_for_decision_packet(tmp_path: Path):


### PR DESCRIPTION
## Summary
Tightens the #3204 proxy checkpoint-selection readiness checker so registry entries with declared but incomplete public release metadata fail closed before checkpoint inputs can be treated as ready.

## Linked Issues
- Relates `#3204`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added fail-closed handling for incomplete `github_release` metadata in `scripts/research/check_predictive_checkpoint_proxy_readiness.py`.
- Updated the incomplete public metadata fixture test to require blocked readiness.
- Added a changelog entry for the readiness-contract tightening.

## Why Matters
- Added value: prevents a partially described public artifact from being counted as a ready checkpoint input.
- Expected impact: clearer diagnostic readiness packet for missing mapping/provenance metadata.
- Why worth merging now: #3204 remains blocked on durable/hydrated predictive checkpoints and non-degenerate proxy summaries; this makes the blocker state more explicit without spending compute.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3204 readiness blocker for proxy-based checkpoint selection inputs and artifact metadata.
- Comparator or baseline, applicable: current readiness checker allowed locally-present entries with incomplete declared release metadata to pass checkpoint-artifact readiness.
- Evidence tier: NA - support checker; focused tests validate checker behavior only.
- Result classification: NA - support checker; no research result or blocker-resolution claim.
- Decision stop rule, applicable: NA; no checkpoint selection or benchmark result is produced.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3204 remains open/blocked; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker tightening only.

## Domain-Aware Approval
Required PR: yes
Domains reviewed: readiness metadata, artifact provenance
Status: waived
Approver/review source waiver: no benchmark claim, no checkpoint selection, no Slurm/GPU submission, and no paper/dissertation claim edit; domain review deferred to Claude Code on imech156-u after PR open.
Validity checklist: no benchmark execution, no fallback/degraded result treated as evidence.
Target claim/hypothesis: unchanged readiness blocker for issue #3204.
Comparator split/evidence validity: no comparator split or benchmark evidence is evaluated in this PR; only incomplete declared release metadata is blocked.
Fallback/degraded exclusions: no fallback or degraded execution is classified as successful evidence.
Claim boundary: readiness metadata/preflight only.
Implementation integrity vs experimental validity: implementation affects readiness gating, not experimental interpretation.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue / NA
- Follow-up question issue weak, negative, non-transfer results: #3204 remains blocked pending durable checkpoint artifacts and non-degenerate proxy-enabled training summary.

## Next Empirical Action
- Rerun needed: no
- Extractor analysis tool needed: no
- Artifact missing unavailable: durable/hydrated predictive checkpoints and non-degenerate proxy-enabled training summary remain unavailable.
- Stop / revise / continue decision: continue only after inputs exist; this PR does not unblock compute.
- Proposed child issue existing follow-up: existing open issue #3204 tracks the remaining blocker; no new issue opened.

## Validation / Proof
- `PYTEST_NUM_WORKERS=4 uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py -q` -> passed.
- `uv run ruff format scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed, 2 files unchanged.
- `uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed.
- `git diff --check` -> passed.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=4 PR_READY_PR_BODY_FILE=/tmp/robot_sf_ll7_issue_3204_pr_body.md scripts/dev/pr_ready_check.sh` -> passed; 1688 tests passed; freshness stamp recorded clean head f2e90170820538f344a4a23977027097d7912ee7.

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Runtime / Performance
- Baseline runtime: NA, no runtime performance claim.
- Changed runtime: NA, no runtime performance claim.
- Representative command: `PYTEST_NUM_WORKERS=4 uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py -q`
- Hot-path call count profile anchor: NA, readiness checker only.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if valid complete public metadata is incorrectly blocked or incomplete metadata is not reported in the readiness packet.

## Risks / Rollout
- Compatibility risks: low; only affects #3204 diagnostic checker readiness status for entries that explicitly declare incomplete release metadata.
- Failure modes: overly strict blocking if a caller intentionally uses local-only checkpoint fixtures with partial release metadata.
- Rollback fallback plan: revert the checker branch and fixture expectation.

## Docs / Provenance
- Updated docs: `CHANGELOG.md`
- Relevant design provenance notes: existing #3204 readiness checker and issue comments.
- Any assumptions need to preserved: declared `github_release` metadata is intended as provenance metadata; if declared, it should be complete before readiness.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comment authorization is false.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: diagnostic readiness checker only; no benchmark, registry, claim-map, or paper-facing result changed.

## Follow-Up Issues
- Deferred work: hydrate/promote durable predictive checkpoints and provide non-degenerate proxy-enabled training summary before selection analysis.
- Issues opened follow-up: existing open issue `#3204` tracks the remaining blocker.

## Reviewer Notes
- Please verify the fail-closed behavior only applies to entries that declare incomplete public release metadata; entries with no release metadata still follow existing local-path readiness behavior.
- Known limitations: no checkpoint selection, benchmark campaign, Slurm/GPU submission, or claim edit is included.
