### PR TITLE
Issue #3813: expose sustained-flow runtime readiness

### DIFF
--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -17,6 +17,31 @@ RUNTIME_SUPPORTED_VALUE = "runtime_continuous_spawn"
 
 
 @dataclass(frozen=True, slots=True)
+class SustainedFlowRuntimeReadiness:
+    """Structured runtime-readiness verdict for sustained-flow candidates."""
+
+    status: str
+    expected_runtime_support: str
+    observed_runtime_support: tuple[str, ...]
+
+    @property
+    def supported(self) -> bool:
+        """Whether every variant advertises real continuous-spawn runtime support."""
+
+        return self.status == "supported"
+
+    def to_payload(self) -> dict[str, Any]:
+        """Return JSON/YAML friendly representation."""
+
+        return {
+            "status": self.status,
+            "supported": self.supported,
+            "expected_runtime_support": self.expected_runtime_support,
+            "observed_runtime_support": list(self.observed_runtime_support),
+        }
+
+
+@dataclass(frozen=True, slots=True)
 class SustainedFlowVariant:
     """Resolved continuous-spawn variant from a scenario matrix row."""
 
@@ -45,13 +70,14 @@ class SustainedFlowPreflight:
     matrix_path: str
     variant_count: int
     variants: tuple[SustainedFlowVariant, ...]
+    runtime_readiness: SustainedFlowRuntimeReadiness
     blocking_reasons: tuple[str, ...]
 
     @property
     def benchmark_eligible(self) -> bool:
         """Whether the matrix may be interpreted as benchmark evidence."""
 
-        return self.status == "available"
+        return self.status == "available" and self.runtime_readiness.supported
 
     def to_payload(self) -> dict[str, Any]:
         """Return a JSON/YAML friendly representation."""
@@ -62,6 +88,7 @@ class SustainedFlowPreflight:
             "benchmark_eligible": self.benchmark_eligible,
             "matrix_path": self.matrix_path,
             "variant_count": self.variant_count,
+            "runtime_readiness": self.runtime_readiness.to_payload(),
             "variants": [variant.to_payload() for variant in self.variants],
             "blocking_reasons": list(self.blocking_reasons),
         }
@@ -93,6 +120,7 @@ def preflight_sustained_flow_matrix(matrix_path: str | Path) -> SustainedFlowPre
         blocking_reasons.append("spawn_rate_per_min must increase across density tiers")
     if variants and not _strictly_increasing_ped_density(variants):
         blocking_reasons.append("ped_density must increase across density tiers")
+    runtime_readiness = _runtime_readiness(variants)
 
     status = "available" if not blocking_reasons else "not_available"
     return SustainedFlowPreflight(
@@ -101,6 +129,7 @@ def preflight_sustained_flow_matrix(matrix_path: str | Path) -> SustainedFlowPre
         matrix_path=path.as_posix(),
         variant_count=len(variants),
         variants=variants,
+        runtime_readiness=runtime_readiness,
         blocking_reasons=tuple(blocking_reasons),
     )
 
@@ -156,6 +185,18 @@ def _variant_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, 
     return tuple(blockers)
 
 
+def _runtime_readiness(
+    variants: tuple[SustainedFlowVariant, ...],
+) -> SustainedFlowRuntimeReadiness:
+    observed = tuple(dict.fromkeys(variant.current_runtime_support for variant in variants))
+    status = "supported" if variants and observed == (RUNTIME_SUPPORTED_VALUE,) else "not_supported"
+    return SustainedFlowRuntimeReadiness(
+        status=status,
+        expected_runtime_support=RUNTIME_SUPPORTED_VALUE,
+        observed_runtime_support=observed,
+    )
+
+
 def _strictly_increasing_spawn_rates(variants: tuple[SustainedFlowVariant, ...]) -> bool:
     rates = [variant.spawn_rate_per_min for variant in variants]
     return all(left < right for left, right in pairwise(rates))
@@ -201,6 +242,7 @@ __all__ = [
     "RUNTIME_SUPPORTED_VALUE",
     "SustainedFlowPreflight",
     "SustainedFlowPreflightError",
+    "SustainedFlowRuntimeReadiness",
     "SustainedFlowVariant",
     "preflight_sustained_flow_matrix",
 ]

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -82,6 +82,12 @@ def test_sustained_flow_preflight_enumerates_variants_and_fails_closed() -> None
     assert payload["status"] == "not_available"
     assert payload["benchmark_eligible"] is False
     assert payload["variant_count"] == 3
+    assert payload["runtime_readiness"] == {
+        "status": "not_supported",
+        "supported": False,
+        "expected_runtime_support": RUNTIME_SUPPORTED_VALUE,
+        "observed_runtime_support": ["metadata_only"],
+    }
     assert [variant["density_tier"] for variant in payload["variants"]] == [
         "light",
         "medium",
@@ -100,6 +106,31 @@ def test_sustained_flow_preflight_enumerates_variants_and_fails_closed() -> None
     assert all(
         f"expected {RUNTIME_SUPPORTED_VALUE!r}" in reason for reason in payload["blocking_reasons"]
     )
+
+
+def test_sustained_flow_preflight_accepts_runtime_supported_matrix(tmp_path: Path) -> None:
+    """Runtime-supported rows become eligible only when every variant opts in."""
+
+    matrix = _load_yaml(SCENARIO_SET)
+    for scenario in matrix["scenarios"]:
+        scenario["metadata"]["continuous_spawn"]["current_runtime_support"] = (
+            RUNTIME_SUPPORTED_VALUE
+        )
+
+    supported_matrix = tmp_path / "runtime_supported_sustained_flow.yaml"
+    supported_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+
+    payload = preflight_sustained_flow_matrix(supported_matrix).to_payload()
+
+    assert payload["status"] == "available"
+    assert payload["benchmark_eligible"] is True
+    assert payload["runtime_readiness"] == {
+        "status": "supported",
+        "supported": True,
+        "expected_runtime_support": RUNTIME_SUPPORTED_VALUE,
+        "observed_runtime_support": [RUNTIME_SUPPORTED_VALUE],
+    }
+    assert payload["blocking_reasons"] == []
 
 
 def test_sustained_flow_contract_defines_progress_metric_and_reference() -> None:


### PR DESCRIPTION
## Summary
Adds a structured runtime-readiness verdict to the sustained-flow benchmark preflight payload for issue #3813, so continuous-spawn scenario variants remain explicitly fail-closed while runtime support is metadata-only.

## Linked Issues
- Relates to #3813

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #3813 remains open for runtime continuous respawn, progress metric, exposure sanity proof, and campaign integration evidence
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `SustainedFlowRuntimeReadiness` to `robot_sf.benchmark.sustained_flow_preflight`.
- Included `runtime_readiness` in the preflight payload and made `benchmark_eligible` depend on supported runtime readiness.
- Extended #3813 focused tests to prove the checked-in metadata-only scaffold is not supported, and a synthetic runtime-supported matrix is eligible.

## Why Matters
- Added value: downstream launch/preflight tooling can distinguish enumerable scenario variants from runtime-supported sustained-flow benchmark candidates without parsing free-form blockers.
- Expected impact: closes a local preflight/checker gap while preserving the existing fail-closed boundary.
- Why worth merging now: it reduces the chance that metadata-only continuous-spawn variants are misread as benchmark evidence.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3813 sustained-flow scenario preflight blocker; no benchmark result claim.
- Comparator or baseline, applicable: NA
- Evidence tier: NA - preflight support helper; validation listed below
- Result classification: NA - no research or benchmark result claim
- Decision stop rule, applicable: checked-in metadata-only scaffold reports not supported and synthetic runtime-supported matrix reports eligible.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3813 remains open.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - preflight support helper only, no interpretation of research evidence.

## Domain-Aware Approval
- Required PR: yes - evidence-validity-sensitive result classification
- Domains reviewed: evidence classification, benchmark eligibility gating
- Status: waived
- Approver/review source waiver: maintainer waiver; preflight support helper only and no benchmark result claim
- Validity checklist:
- Target claim/hypothesis: issue #3813 benchmark claim boundary remains open; this PR only gates preflight eligibility
- Comparator or split/evidence validity: existing targeted smoke proof only; no comparator split or benchmark evidence is introduced
- Fallback/degraded exclusions: metadata-only runtime support remains excluded from benchmark eligibility
- Claim boundary: preflight payload shape and focused tests only; no full campaign evidence
- Implementation integrity vs experimental validity: tests prove gate behavior, not sustained-flow result validity

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, preflight payload now includes runtime readiness and benchmark eligibility requires support.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? not evaluated; no campaign run.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3813 remaining runtime/progress/exposure work.

## Next Empirical Action
- Rerun needed: yes, after runtime continuous spawn and sustained progress metric implementation.
- Extractor analysis tool needed: no
- Artifact missing unavailable: runtime continuous respawn support, progress metric, interaction-exposure sanity proof, campaign integration evidence.
- Stop / revise / continue decision: continue in #3813.
- Proposed child issue existing follow-up: continue under #3813; no new issue opened.

## Validation / Proof
- `uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py tests/scenario_certification/test_sustained_flow_preflight.py` - passed, 15 tests.
- `uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` - passed; reports `conforms=true`, `runtime_support=metadata_only`, `benchmark_evidence=false`, `variant_count=3`.
- `uv run ruff check robot_sf/benchmark/sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` - passed.
- `CUDA_VISIBLE_DEVICES= PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/issue_3813_pr_body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; freshness stamp recorded for clean head `24314f02a6b21c96cca3db1f711455dbd91093e9`.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance / Scale
- Baseline runtime: NA, no runtime/campaign path changed.
- Changed runtime: NA, preflight payload/test-only change.
- Representative command: `uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py tests/scenario_certification/test_sustained_flow_preflight.py`
- Hot-path call count profile anchor: NA, no hot path changed.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if metadata-only sustained-flow scaffold becomes benchmark eligible or runtime-supported synthetic matrix does not become eligible.

## Risks / Rollout
- Compatibility risks: payload gains a new `runtime_readiness` key and `benchmark_eligible` is now explicitly tied to runtime readiness; intended for fail-closed semantics.
- Failure modes: callers assuming status alone implies benchmark eligibility should use `benchmark_eligible`.
- Rollback fallback plan: revert this PR to restore the previous payload shape.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: issue #3813 comments and prior merged scaffold/preflight PRs.
- Any assumptions need to preserved: `current_runtime_support: runtime_continuous_spawn` is the reversible preflight marker for future real runtime support.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comment authorization not granted.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: support/preflight slice only; no benchmark, registry, claim-map, or paper-facing result.

## Follow-Up Issues
- Deferred work: runtime continuous pedestrian respawn support; sustained progress-rate metric; interaction-exposure sanity check; pure wait baseline proof; campaign integration evidence.
- Issues opened follow-up: none; existing parent issue #3813 tracks the deferred runtime, metric, exposure, wait-baseline, and campaign evidence work

## Reviewer Notes
- Anything reviewer should verify closely: whether `runtime_continuous_spawn` is the right marker string for future runtime support.
- Any known limitations: this does not implement runtime respawn, metrics, exposure sanity checks, or campaign evidence.
