### PR TITLE
Issue #3810: refresh imech039 long-horizon packet guard

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -224,7 +224,7 @@ launch_packet:
   decision: blocked_pending_submit_host_route_and_reconciliation
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  target_host: imech156-u
+  target_host: imech039
   blocking_jobs:
     - 13175
   live_issue_state:
@@ -269,7 +269,7 @@ launch_packet:
       private submit wrapper named below until those checks return go.
     private_ops_dry_run:
       required_before_submit: true
-      target_host: imech156-u
+      target_host: imech039
       evidence_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
       current_public_status: route_unverified
       required_fields:
@@ -287,7 +287,7 @@ launch_packet:
         The dry run must record decision=go before submission. If job 13175 is
         not terminal/reconciled, if an issue #3810 duplicate exists, if the
         owning worktree is dirty, or if the private submit wrapper lacks
-        imech156-u support, the decision remains blocked.
+        imech039 support, the decision remains blocked.
   interpretation_gate:
     status: blocked_pending_active_run_retention_reconciliation
     required_before_claim: true
@@ -429,13 +429,13 @@ analysis_and_retention_packet:
     queue_summary_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
     route_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
     submit_wrapper: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
-    target_host: "imech156-u"
+    target_host: "imech039"
   preflight:
     required: true
     route_refresh_command: >-
       ROBOT_SF_PRIVATE_OPS="$HOME/git/robot_sf_ll7-private-ops" "$HOME/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh"
-    queue_and_duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh --json --reason issue_3810"  # allow-abs-path: private-ops routing (machine-local, non-portable)
-    duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh --json --target-host imech156-u --issue 3810"  # allow-abs-path: private-ops routing (machine-local, non-portable)
+    queue_and_duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh --limit 100"  # allow-abs-path: private-ops routing (machine-local, non-portable)
+    duplicate_check_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh --limit 100"  # allow-abs-path: private-ops routing (machine-local, non-portable); read-only queue/ledger duplicate review for issue_3810
     manifest_validation_command: "uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi"
     packet_validation_command: "uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json"
   expected_outputs:

--- a/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
@@ -12,6 +12,7 @@ from typing import Any
 import yaml
 
 DEFAULT_PACKET = Path("configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml")
+EXPECTED_TARGET_HOST = "imech039"
 
 REQUIRED_PRE_FLIGHT_MARKERS = {
     "ROBOT_SF_PRIVATE_OPS",
@@ -96,13 +97,32 @@ def validate_packet(packet: Mapping[str, Any], *, issue: int = 3810) -> dict[str
 
     route = _require_mapping(analysis, "route")
     _require(REQUIRED_ROUTE_FIELDS <= set(route), "route field set incomplete")
-    _require(route.get("target_host") == "imech156-u", "target host must be imech156-u")
+    _require(
+        route.get("target_host") == EXPECTED_TARGET_HOST,
+        f"target host must be {EXPECTED_TARGET_HOST}",
+    )
 
     preflight = _require_mapping(analysis, "preflight")
     _require(preflight.get("required") is True, "preflight.required must be true")
     preflight_blob = "\n".join(str(v) for v in preflight.values())
     for marker in REQUIRED_PRE_FLIGHT_MARKERS:
         _require(marker in preflight_blob, f"preflight missing marker: {marker}")
+    queue_command = str(preflight.get("queue_and_duplicate_check_command", ""))
+    duplicate_command = str(preflight.get("duplicate_check_command", ""))
+    _require(
+        "queue_summary.sh" in queue_command and "--limit" in queue_command,
+        "queue duplicate check must use current queue_summary interface",
+    )
+    _require(
+        "queue_summary.sh" in duplicate_command and "--limit" in duplicate_command,
+        "duplicate check must use current queue_summary interface",
+    )
+    stale_flags = {"--json", "--target-host", "--issue"}
+    stale_command_blob = f"{queue_command}\n{duplicate_command}"
+    _require(
+        not any(flag in stale_command_blob for flag in stale_flags),
+        "preflight queue commands must not use stale private-ops flags",
+    )
 
     expected = _require_mapping(analysis, "expected_outputs")
     _require(

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -12,6 +12,7 @@ from typing import Any
 import yaml
 
 DEFAULT_PACKET = Path("configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml")
+EXPECTED_TARGET_HOST = "imech039"
 REQUIRED_OUTPUTS = {
     "preflight/private_ops_route_dry_run.json",
     "reports/snqi_recalibration_inputs.json",
@@ -218,7 +219,10 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     _require(
         launch_packet.get("slurm_job_id") == "not_submitted", "slurm job must be not_submitted"
     )
-    _require(launch_packet.get("target_host") == "imech156-u", "target host must be imech156-u")
+    _require(
+        launch_packet.get("target_host") == EXPECTED_TARGET_HOST,
+        f"target host must be {EXPECTED_TARGET_HOST}",
+    )
     blocking_jobs = launch_packet.get("blocking_jobs")
     _require(isinstance(blocking_jobs, list), "blocking_jobs must be a list")
     _require(13175 in blocking_jobs, "job 13175 must block submit until reconciled")
@@ -278,7 +282,10 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
     )
     dry_run = _require_mapping(go_no_go, "private_ops_dry_run")
     _require(dry_run.get("required_before_submit") is True, "private-ops dry run required")
-    _require(dry_run.get("target_host") == "imech156-u", "private-ops dry run host mismatch")
+    _require(
+        dry_run.get("target_host") == EXPECTED_TARGET_HOST,
+        "private-ops dry run host mismatch",
+    )
     _require(
         dry_run.get("current_public_status") == "route_unverified",
         "private-ops dry run must be route_unverified in public packet",
@@ -301,8 +308,8 @@ def validate_packet(packet: dict[str, Any]) -> dict[str, Any]:  # noqa: PLR0915
         "private-ops dry run fields missing",
     )
     _require(
-        "imech156-u support" in str(dry_run.get("decision_policy", "")),
-        "private-ops dry run must gate imech156-u support",
+        f"{EXPECTED_TARGET_HOST} support" in str(dry_run.get("decision_policy", "")),
+        f"private-ops dry run must gate {EXPECTED_TARGET_HOST} support",
     )
 
     interpretation_gate = _require_mapping(launch_packet, "interpretation_gate")

--- a/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
@@ -35,8 +35,20 @@ def test_issue_3810_analysis_packet_rejects_bad_target_host() -> None:
     """The packet must keep the reconciled submit-host target."""
 
     packet = _load_packet()
-    packet["analysis_and_retention_packet"]["route"]["target_host"] = "imech036"
-    with pytest.raises(_MODULE.PacketError, match="target host must be imech156-u"):
+    packet["analysis_and_retention_packet"]["route"]["target_host"] = "imech156-u"
+    with pytest.raises(_MODULE.PacketError, match="target host must be imech039"):
+        _MODULE.validate_packet(packet)
+
+
+def test_issue_3810_analysis_packet_rejects_stale_private_ops_flags() -> None:
+    """The packet must not advertise unsupported private-ops queue flags."""
+
+    packet = _load_packet()
+    packet["analysis_and_retention_packet"]["preflight"]["duplicate_check_command"] = (
+        "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh "
+        "--json --target-host imech039 --issue 3810"
+    )
+    with pytest.raises(_MODULE.PacketError, match="current queue_summary interface"):
         _MODULE.validate_packet(packet)
 
 

--- a/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
@@ -45,10 +45,10 @@ def test_issue_3810_analysis_packet_rejects_stale_private_ops_flags() -> None:
 
     packet = _load_packet()
     packet["analysis_and_retention_packet"]["preflight"]["duplicate_check_command"] = (
-        "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh "
-        "--json --target-host imech039 --issue 3810"
+        "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh "
+        "--limit 100 --json --target-host imech039 --issue 3810"
     )
-    with pytest.raises(_MODULE.PacketError, match="current queue_summary interface"):
+    with pytest.raises(_MODULE.PacketError, match="stale private-ops flags"):
         _MODULE.validate_packet(packet)
 
 

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -35,7 +35,7 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert summary["target_host"] == "imech156-u"
+    assert summary["target_host"] == "imech039"
     assert summary["blocking_jobs"] == [13175]
     assert summary["job_13175_state"] == "requires_submit_host_refresh"
     assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
@@ -100,12 +100,12 @@ def test_issue_3810_packet_rejects_nonblocking_live_issue_state() -> None:
 def test_issue_3810_packet_rejects_stale_target_host() -> None:
     """The launch-packet target host must match the requested Slurm decision host."""
     packet = _load_packet()
-    packet["launch_packet"]["target_host"] = "imech036"
+    packet["launch_packet"]["target_host"] = "imech156-u"
 
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "target host must be imech156-u" in str(exc)
+        assert "target host must be imech039" in str(exc)
     else:
         raise AssertionError("packet should reject stale target host")
 
@@ -113,7 +113,7 @@ def test_issue_3810_packet_rejects_stale_target_host() -> None:
 def test_issue_3810_packet_rejects_stale_dry_run_target_host() -> None:
     """The private-ops dry-run target host is guarded independently of the packet host."""
     packet = _load_packet()
-    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["target_host"] = "imech036"
+    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["target_host"] = "imech156-u"
 
     try:
         _MODULE.validate_packet(packet)
@@ -133,7 +133,7 @@ def test_issue_3810_packet_rejects_decision_policy_without_target_host_gate() ->
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "private-ops dry run must gate imech156-u support" in str(exc)
+        assert "private-ops dry run must gate imech039 support" in str(exc)
     else:
         raise AssertionError("packet should reject a decision policy missing the host gate")
 


### PR DESCRIPTION
## Summary

Issue: https://github.com/ll7/robot_sf_ll7/issues/3810

- Retarget the no-submit Issue #3810 long-horizon Social Navigation Quality Index (SNQI) launch and analysis/retention packet to submit host `imech039`.
- Keep the fail-closed guards intact: compute submission remains unauthorized, Slurm job ID remains `not_submitted`, job 13175 still requires submit-host reconciliation, and interpretation remains blocked until active-run retention evidence is reconciled.
- Replace stale private-ops queue/duplicate command examples with the currently supported read-only `queue_summary.sh --limit 100` interface and add validator coverage to reject the old unsupported flags.

## Validation

- `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` - passed; reports `target_host: imech039`, `compute_submit_authorized: false`, `slurm_job_id: not_submitted`, and blocker job 13175.
- `uv run python scripts/validation/check_issue_3810_long_horizon_analysis_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` - passed; reports `target_host: imech039`.
- `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py -q` - passed, 37 tests.
- `uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` - passed; dry-run rows remain diagnostic.
- `ROBOT_SF_PRIVATE_OPS="$HOME/git/robot_sf_ll7-private-ops" "$HOME/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh" --cluster licca --route-id decision-packet-only --public-repo "$PWD" --output output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json` - passed; dry-run reported `submitted: false`.
- `/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh --limit 100` - passed; read-only queue summary reported no ready entries and one active ledger job.
- `PR_READY_PR_BODY_FILE=/tmp/issue_3810_imech039_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed on clean committed HEAD with `1686 passed, 2 skipped`.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No Social Navigation Quality Index (SNQI) recalibration execution.
- No horizon-sensitivity report publication.
- No paper/dissertation claim edits.

## Artifact Policy

Generated dry-run artifacts under `output/` are ignored local validation outputs only. They are not committed and are not durable benchmark evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated validation and packet checks to use a new required target host and matching support gate.
  * Improved preflight checks to use the current queue summary command format and reject outdated flag usage.
  * Aligned tests with the new expected host and added coverage for stale command patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->