### PR TITLE
Issue #3204: validate proxy summary metadata readiness

### DIFF
--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -545,7 +545,7 @@ def _check_checkpoint_artifacts(
     return STATUS_PASSED, [], mapping
 
 
-def _check_proxy_summary(
+def _check_proxy_summary(  # noqa: C901
     summary_path: Path,
     *,
     analyzer: Any,
@@ -570,6 +570,10 @@ def _check_proxy_summary(
         return STATUS_FAILED, [f"training summary unreadable: {exc}"], {}
     if not isinstance(summary, dict):
         return STATUS_FAILED, ["training summary must be a JSON object/mapping"], {}
+
+    metadata_errors = _validate_proxy_summary_metadata(summary, require_enabled=require_enabled)
+    if metadata_errors:
+        return _blocked_proxy_metadata_result(metadata_errors)
 
     report = analyzer.analyze_summary(summary)
     verdict = report.get("verdict")
@@ -608,6 +612,39 @@ def _check_proxy_summary(
     if errors:
         return STATUS_BLOCKED, errors, payload
     return STATUS_PASSED, [], payload
+
+
+def _blocked_proxy_metadata_result(
+    metadata_errors: list[str],
+) -> tuple[str, list[str], dict[str, Any]]:
+    """Return a compact fail-closed payload for missing proxy metadata."""
+    return (
+        STATUS_BLOCKED,
+        metadata_errors,
+        {
+            "proxy_enabled": False,
+            "n_proxy_epochs": 0,
+            "schema_status": "missing_proxy_metadata",
+        },
+    )
+
+
+def _validate_proxy_summary_metadata(
+    summary: dict[str, Any], *, require_enabled: bool
+) -> list[str]:
+    """Validate proxy-summary schema before analyzer normalizes missing fields."""
+    proxy = summary.get("proxy")
+    if not isinstance(proxy, dict):
+        return ["training summary missing proxy mapping"]
+
+    errors: list[str] = []
+    if require_enabled and proxy.get("enabled") is not True:
+        errors.append("training summary proxy.enabled must be true")
+
+    history = proxy.get("history")
+    if not isinstance(history, list):
+        errors.append("training summary proxy.history must be a list")
+    return errors
 
 
 def _gate_checkpoint_selector(

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -355,6 +355,48 @@ def test_blocked_when_proxy_disabled(tmp_path):
     )
 
 
+def test_blocked_when_proxy_summary_missing_proxy_mapping(tmp_path):
+    """Missing proxy metadata is blocked explicitly, not normalized to no epochs."""
+    config = _write_config(tmp_path, min_resolvable=2, min_epochs=2)
+    registry = _write_registry(tmp_path, present_count=2, absent_count=0)
+    summary = tmp_path / "summary.json"
+    summary.write_text(json.dumps({"model_id": "m"}), encoding="utf-8")
+
+    report = mod.check_readiness(
+        config_path=config,
+        registry_path=registry,
+        repo_root=_REPO_ROOT,
+        training_summary=summary,
+    )
+
+    summary_check = report["prerequisites"]["proxy_training_summary"]
+    assert report["status"] == "blocked"
+    assert summary_check["status"] == "blocked"
+    assert any("missing proxy mapping" in m for m in summary_check["messages"])
+    assert summary_check["summary"]["schema_status"] == "missing_proxy_metadata"
+
+
+def test_blocked_when_proxy_history_missing(tmp_path):
+    """A proxy-enabled summary without proxy.history is blocked as missing metadata."""
+    config = _write_config(tmp_path, min_resolvable=2, min_epochs=2)
+    registry = _write_registry(tmp_path, present_count=2, absent_count=0)
+    summary = tmp_path / "summary.json"
+    summary.write_text(json.dumps({"model_id": "m", "proxy": {"enabled": True}}), encoding="utf-8")
+
+    report = mod.check_readiness(
+        config_path=config,
+        registry_path=registry,
+        repo_root=_REPO_ROOT,
+        training_summary=summary,
+    )
+
+    summary_check = report["prerequisites"]["proxy_training_summary"]
+    assert report["status"] == "blocked"
+    assert summary_check["status"] == "blocked"
+    assert any("proxy.history" in m for m in summary_check["messages"])
+    assert summary_check["summary"]["schema_status"] == "missing_proxy_metadata"
+
+
 def test_blocked_when_summary_not_a_mapping(tmp_path):
     """A training summary whose JSON is not an object fails closed without crashing."""
     config = _write_config(tmp_path, min_resolvable=2, min_epochs=2)


### PR DESCRIPTION
## Summary
- Refs #3204.
- Tightens predictive checkpoint proxy readiness preflight so malformed training summaries missing `proxy` metadata fail closed with explicit schema messages instead of being normalized into a generic no-epochs result.
- Adds focused fixture coverage for missing `proxy` mapping and missing `proxy.history` blocked states.

## Issue Disposition
- #3204 remains open. This PR is a diagnostic/readiness slice only.
- It does not produce the required Spearman proxy-vs-hard-success result across >=6 checkpoints from >=1 real training run.
- It does not run the A/B proxy-selected vs ADE-selected hard-seed benchmark.
- The current readiness command still reports `status=blocked` because durable predictive checkpoints and a non-degenerate proxy-enabled training summary are unavailable.

## Validation
- `uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py -q` - passed
- `uv run ruff format scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` - passed
- `uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` - passed
- `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --json` - exit 2 expected, reports `status=blocked` missing durable predictive checkpoints blocked artifact inventory
- `PR_READY_PR_BODY_FILE=/tmp/issue3204_pr_body.md PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed; stamp `output/validation/pr_ready/issue-3204-proxy-readiness-diagnostic-20260701.json`, head `3f875f172b45b3f3b9433f7a3530df7a00499a9d`

## Out of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No checkpoint selection, training, artifact hydration, or evidence promotion.
