### PR TITLE
Issue #3653: add SNQI packet export gate

### DIFF
--- a/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
+++ b/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
@@ -235,16 +235,150 @@ def validate_packet(packet: Mapping[str, Any], *, repo_root: Path | None = None)
     }
 
 
+def _command_template_value(export: Mapping[str, Any], flag: str) -> str | None:
+    """Return the argument value that follows a flag in the packet command template."""
+
+    template = export.get("command_template")
+    if not isinstance(template, Sequence) or isinstance(template, (str, bytes)):
+        return None
+    for index, item in enumerate(template):
+        if item == flag and index + 1 < len(template):
+            value = template[index + 1]
+            if isinstance(value, str):
+                return value
+    return None
+
+
+def _packet_export_output_dir(packet: Mapping[str, Any]) -> Path:
+    export = _require_mapping(packet, "export")
+    value = _command_template_value(export, "--output-dir")
+    _require(value is not None, "export.command_template must include --output-dir")
+    return _repo_relative_path(value, "export.command_template.--output-dir")
+
+
+def _packet_preflight_output_path(packet: Mapping[str, Any]) -> Path | None:
+    export = _require_mapping(packet, "export")
+    value = _command_template_value(export, "--preflight-out")
+    if value is None:
+        return None
+    return _repo_relative_path(value, "export.command_template.--preflight-out")
+
+
+def export_if_ready(
+    packet: Mapping[str, Any],
+    *,
+    repo_root: Path | None = None,
+    output_dir: Path | None = None,
+) -> dict[str, Any]:
+    """Run the packet's SNQI export only when the campaign input is present and ready."""
+
+    from robot_sf.benchmark.snqi_scalarization_sensitivity import (
+        SENSITIVITY_PREFLIGHT_READY,
+        build_scalarization_sensitivity_report,
+        classify_scalarization_sensitivity_inputs,
+        load_baseline_mapping,
+        load_jsonl,
+        load_weight_mapping,
+        write_diagnostic_artifacts,
+    )
+
+    repo_root = repo_root or _repo_root()
+    summary = validate_packet(packet, repo_root=repo_root)
+    inputs = _require_mapping(packet, "inputs")
+    episodes_rel = _repo_relative_path(inputs.get("episodes_jsonl"), "inputs.episodes_jsonl")
+    episodes = repo_root / episodes_rel
+    if not episodes.is_file():
+        raise PacketError(f"episodes_jsonl missing: {episodes_rel} (status: {EXPECTED_STATUS})")
+
+    weights = load_weight_mapping(
+        repo_root / _repo_relative_path(inputs.get("weights_path"), "inputs.weights_path")
+    )
+    baseline = load_baseline_mapping(
+        repo_root / _repo_relative_path(inputs.get("baseline_path"), "inputs.baseline_path")
+    )
+    records = load_jsonl(episodes)
+    if len(records) != int(summary["expected_episode_count"]):
+        raise PacketError(
+            "episodes_jsonl row count mismatch: "
+            f"expected {summary['expected_episode_count']}, found {len(records)}"
+        )
+    preflight = classify_scalarization_sensitivity_inputs(
+        records,
+        weights=weights,
+        baseline=baseline,
+    )
+    if preflight["status"] != SENSITIVITY_PREFLIGHT_READY:
+        raise PacketError(
+            "SNQI scalarization-sensitivity preflight not ready: "
+            f"{preflight['status']} issues={preflight['issues']}"
+        )
+
+    resolved_output_dir = output_dir or (repo_root / _packet_export_output_dir(packet))
+    resolved_output_dir.mkdir(parents=True, exist_ok=True)
+    preflight_rel = _packet_preflight_output_path(packet)
+    preflight_output = (
+        resolved_output_dir / "preflight.json"
+        if output_dir is not None
+        else repo_root / preflight_rel
+        if preflight_rel is not None
+        else None
+    )
+    if preflight_output is not None:
+        preflight_output.parent.mkdir(parents=True, exist_ok=True)
+        preflight_output.write_text(json.dumps(preflight, indent=2, sort_keys=True) + "\n")
+
+    report = build_scalarization_sensitivity_report(records, weights=weights, baseline=baseline)
+    artifacts = write_diagnostic_artifacts(report, resolved_output_dir)
+    artifact_paths = {
+        "json": artifacts.json_path,
+        "csv": artifacts.csv_path,
+        "decision_disagreement_csv": artifacts.decision_disagreement_csv_path,
+        "markdown": artifacts.markdown_path,
+        "svg": artifacts.svg_path,
+    }
+    required = {
+        str(item)
+        for item in _require_sequence(_require_mapping(packet, "export"), "required_artifacts")
+    }
+    written = {path.name for path in artifact_paths.values()}
+    missing = sorted(required - written)
+    if missing:
+        raise PacketError(f"export missing required artifacts: {missing}")
+
+    return {
+        **summary,
+        "status": "exported",
+        "preflight_status": preflight["status"],
+        "output_dir": str(resolved_output_dir),
+        "artifacts": {key: str(path) for key, path in artifact_paths.items()},
+        "decision_disagreement_rate": report["summary"]["decision_disagreement_rate"],
+    }
+
+
 def main(argv: Sequence[str] | None = None) -> int:
     """Run the packet checker CLI."""
 
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--packet", type=Path, default=DEFAULT_PACKET)
     parser.add_argument("--json", action="store_true", help="Emit machine-readable summary.")
+    parser.add_argument(
+        "--export-if-ready",
+        action="store_true",
+        help="Run the diagnostic export when packet inputs are present and preflight-ready.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        help="Override the packet output directory for --export-if-ready.",
+    )
     args = parser.parse_args(argv)
 
     try:
-        summary = validate_packet(load_packet(args.packet))
+        packet = load_packet(args.packet)
+        if args.export_if_ready:
+            summary = export_if_ready(packet, output_dir=args.output_dir)
+        else:
+            summary = validate_packet(packet)
     except PacketError as exc:
         print(f"FAIL: {exc}", file=sys.stderr)
         return 2

--- a/tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py
+++ b/tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.util
 import json
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -25,6 +26,42 @@ def _load_packet() -> dict:
     payload = yaml.safe_load(PACKET.read_text(encoding="utf-8"))
     assert isinstance(payload, dict)
     return payload
+
+
+def _write_ready_episode_fixture(path: Path) -> None:
+    planners = [
+        "goal",
+        "hybrid_rule_v3_fast_progress_static_escape",
+        "orca",
+        "ppo",
+        "prediction_planner",
+        "sacadrl",
+        "scenario_adaptive_hybrid_orca_v1",
+        "social_force",
+        "socnav_sampling",
+    ]
+    rows = []
+    for planner_index, planner in enumerate(planners):
+        for episode_index in range(960):
+            rows.append(
+                {
+                    "scenario_id": "crossing",
+                    "horizon": 500,
+                    "planner_key": planner,
+                    "metrics": {
+                        "success": 1,
+                        "time_to_goal_norm": min(0.95, 0.05 + planner_index * 0.08),
+                        "collisions": 1 if planner_index == 0 else 0,
+                        "near_misses": planner_index % 3,
+                        "comfort_exposure": 0.01 * planner_index,
+                        "force_exceed_events": float(planner_index + 1),
+                        "jerk_mean": 0.08 + planner_index * 0.01,
+                    },
+                    "episode_index": episode_index,
+                }
+            )
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(row) for row in rows) + "\n", encoding="utf-8")
 
 
 def test_issue_3653_packet_passes_fail_closed_contract() -> None:
@@ -129,3 +166,36 @@ def test_issue_3653_check_cli_json() -> None:
     assert payload["status"] == "ok"
     assert payload["issue"] == 3653
     assert payload["current_status"] == "blocked_missing_valid_campaign_episodes"
+
+
+def test_issue_3653_export_if_ready_blocks_missing_campaign_input() -> None:
+    """The executable handoff refuses to export when job 13175 JSONL is absent."""
+
+    try:
+        _MODULE.export_if_ready(_load_packet())
+    except _MODULE.PacketError as exc:
+        assert "episodes_jsonl missing" in str(exc)
+        assert "blocked_missing_valid_campaign_episodes" in str(exc)
+    else:
+        raise AssertionError("export_if_ready should block missing raw campaign episodes")
+
+
+def test_issue_3653_export_if_ready_writes_required_artifacts(tmp_path: Path) -> None:
+    """Ready campaign-shaped inputs run through preflight and emit the packet artifact set."""
+
+    packet = _load_packet()
+    episodes = tmp_path / "episodes.jsonl"
+    output_dir = tmp_path / "export"
+    _write_ready_episode_fixture(episodes)
+    packet["inputs"]["episodes_jsonl"] = os.path.relpath(episodes, REPO_ROOT)
+    command_template = packet["export"]["command_template"]
+    command_template[command_template.index("--episodes") + 1] = packet["inputs"]["episodes_jsonl"]
+
+    summary = _MODULE.export_if_ready(packet, output_dir=output_dir)
+
+    assert summary["status"] == "exported"
+    assert summary["preflight_status"] == "ready"
+    assert summary["decision_disagreement_rate"] >= 0.0
+    assert (output_dir / "preflight.json").is_file()
+    for artifact in packet["export"]["required_artifacts"]:
+        assert (output_dir / artifact).is_file()


### PR DESCRIPTION
## Issue

Refs https://github.com/ll7/robot_sf_ll7/issues/3653

## Scope Summary

This PR adds an executable `--export-if-ready` gate to the issue #3653 SNQI decision-disagreement application packet checker. The default packet validation remains metadata-only and still reports the current `blocked_missing_valid_campaign_episodes` state for job `13175`; the new gate refuses to export when the raw campaign `episodes.jsonl` is missing, checks the expected 8,640-row count, runs the existing SNQI scalarization-sensitivity preflight, and writes the required JSON, planner CSV, decision-disagreement CSV, Markdown, SVG, and preflight artifacts only for ready inputs.

The tests add a campaign-shaped fixture proving the gate can emit the required artifact set, plus a fail-closed check for the missing real campaign input.

## Validation

- `uv run ruff format scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py` - passed; 2 files left unchanged after final run.
- `uv run ruff check scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py` - passed.
- `uv run pytest tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py tests/benchmark/test_snqi_scalarization_sensitivity.py` - passed, 34 tests.
- `uv run python scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py --json` - passed; reports status `ok`, issue `3653`, job `13175`, expected episode count `8640`, and current status `blocked_missing_valid_campaign_episodes`.
- `uv run python scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py --export-if-ready --json` - expected fail-closed exit 2 because `output/issue1554-s20-h500-l40s-mem180/13175/reports/episodes.jsonl` is not present.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No raw campaign artifact promotion or claim upgrade.

## Residual Risk

The real empirical application remains blocked until the raw job `13175` episode JSONL is promoted or hydratable at the packet path. Claude Code on `imech156-u` owns the full PR gate, improvement cycle, and merge authority after this PR opens.
