### PR TITLE
Issue #3810: retarget long-horizon packet to imech156-u

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -224,7 +224,7 @@ launch_packet:
   decision: blocked_pending_submit_host_route_and_reconciliation
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  target_host: imech039
+  target_host: imech156-u
   blocking_jobs:
     - 13175
   live_issue_state:
@@ -269,7 +269,7 @@ launch_packet:
       private submit wrapper named below until those checks return go.
     private_ops_dry_run:
       required_before_submit: true
-      target_host: imech039
+      target_host: imech156-u
       evidence_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
       current_public_status: route_unverified
       required_fields:
@@ -287,7 +287,7 @@ launch_packet:
         The dry run must record decision=go before submission. If job 13175 is
         not terminal/reconciled, if an issue #3810 duplicate exists, if the
         owning worktree is dirty, or if the private submit wrapper lacks
-        imech039 support, the decision remains blocked.
+        imech156-u support, the decision remains blocked.
   interpretation_gate:
     status: blocked_pending_active_run_retention_reconciliation
     required_before_claim: true
@@ -429,7 +429,7 @@ analysis_and_retention_packet:
     queue_summary_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
     route_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
     submit_wrapper: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
-    target_host: "imech039"
+    target_host: "imech156-u"
   preflight:
     required: true
     route_refresh_command: >-

--- a/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
@@ -12,7 +12,7 @@ from typing import Any
 import yaml
 
 DEFAULT_PACKET = Path("configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml")
-EXPECTED_TARGET_HOST = "imech039"
+EXPECTED_TARGET_HOST = "imech156-u"
 
 REQUIRED_PRE_FLIGHT_MARKERS = {
     "ROBOT_SF_PRIVATE_OPS",

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -12,7 +12,7 @@ from typing import Any
 import yaml
 
 DEFAULT_PACKET = Path("configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml")
-EXPECTED_TARGET_HOST = "imech039"
+EXPECTED_TARGET_HOST = "imech156-u"
 REQUIRED_OUTPUTS = {
     "preflight/private_ops_route_dry_run.json",
     "reports/snqi_recalibration_inputs.json",

--- a/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
@@ -35,8 +35,8 @@ def test_issue_3810_analysis_packet_rejects_bad_target_host() -> None:
     """The packet must keep the reconciled submit-host target."""
 
     packet = _load_packet()
-    packet["analysis_and_retention_packet"]["route"]["target_host"] = "imech156-u"
-    with pytest.raises(_MODULE.PacketError, match="target host must be imech039"):
+    packet["analysis_and_retention_packet"]["route"]["target_host"] = "imech039"
+    with pytest.raises(_MODULE.PacketError, match="target host must be imech156-u"):
         _MODULE.validate_packet(packet)
 
 
@@ -46,7 +46,7 @@ def test_issue_3810_analysis_packet_rejects_stale_private_ops_flags() -> None:
     packet = _load_packet()
     packet["analysis_and_retention_packet"]["preflight"]["duplicate_check_command"] = (
         "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh "
-        "--limit 100 --json --target-host imech039 --issue 3810"
+        "--limit 100 --json --target-host imech156-u --issue 3810"
     )
     with pytest.raises(_MODULE.PacketError, match="stale private-ops flags"):
         _MODULE.validate_packet(packet)

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -35,7 +35,7 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert summary["target_host"] == "imech039"
+    assert summary["target_host"] == "imech156-u"
     assert summary["blocking_jobs"] == [13175]
     assert summary["job_13175_state"] == "requires_submit_host_refresh"
     assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
@@ -100,12 +100,12 @@ def test_issue_3810_packet_rejects_nonblocking_live_issue_state() -> None:
 def test_issue_3810_packet_rejects_stale_target_host() -> None:
     """The launch-packet target host must match the requested Slurm decision host."""
     packet = _load_packet()
-    packet["launch_packet"]["target_host"] = "imech156-u"
+    packet["launch_packet"]["target_host"] = "imech039"
 
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "target host must be imech039" in str(exc)
+        assert "target host must be imech156-u" in str(exc)
     else:
         raise AssertionError("packet should reject stale target host")
 
@@ -113,7 +113,7 @@ def test_issue_3810_packet_rejects_stale_target_host() -> None:
 def test_issue_3810_packet_rejects_stale_dry_run_target_host() -> None:
     """The private-ops dry-run target host is guarded independently of the packet host."""
     packet = _load_packet()
-    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["target_host"] = "imech156-u"
+    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["target_host"] = "imech039"
 
     try:
         _MODULE.validate_packet(packet)
@@ -133,7 +133,7 @@ def test_issue_3810_packet_rejects_decision_policy_without_target_host_gate() ->
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "private-ops dry run must gate imech039 support" in str(exc)
+        assert "private-ops dry run must gate imech156-u support" in str(exc)
     else:
         raise AssertionError("packet should reject a decision policy missing the host gate")
 


### PR DESCRIPTION
## Summary
Retargets the issue #3810 fail-closed long-horizon Social Navigation Quality Index (SNQI) launch and analysis packet back to `imech156-u`.

No benchmark campaign was run, no Slurm/GPU job was submitted, and no paper/dissertation claim text was changed.

## Linked Issues
- Relates `#3810`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Updated the #3810 launch packet target host, dry-run gate, and analysis retention route to `imech156-u`.
- Updated both public validators and focused tests so stale `imech039` assumptions fail closed.

## Why Matters
- Added value: keeps the no-submit launch/analysis packet aligned with the current target host.
- Expected impact: public checks now require `imech156-u` for the packet and analysis route.
- Why worth merging now: avoids stale-host drift before any submit-host decision packet is treated as go.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocked launch-packet host alignment for issue #3810.
- Comparator or baseline, applicable: prior packet target host `imech039`.
- Evidence tier: NA - launch-packet metadata refresh only, no benchmark evidence produced.
- Result classification: NA - no research result or benchmark interpretation.
- Decision stop rule, applicable: packet remains blocked until submit-host route/queue/job-13175 reconciliation is fresh.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3810 remains open.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - no new analysis tool.

## Domain-Aware Approval
- Required PR: benchmark-facing launch packet requires explicit domain-aware waiver; no result interpretation.
- Domains reviewed: evidence classification, claim boundary, fallback/degraded exclusions.
- Status: waived
- Approval or blocker note: ready-queue scope authorizes launch-packet-only, no-submit host refresh; no benchmark result or paper-facing claim is interpreted.
- Validity checklist: no fallback/degraded benchmark rows are promoted; no h600 campaign output is interpreted.
- Target claim/hypothesis: host-aligned launch packet only.
- Comparator or split/evidence validity: no benchmark comparison run; packet only preserves the future comparison caveat.
- Fallback/degraded exclusions: retained in packet validators.
- Claim boundary: launch packet only.
- Implementation integrity vs experimental validity: validators and tests cover the host contract; experimental validity remains blocked on future campaign evidence.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, validators report `target_host: imech156-u`.
- Did intervention change command source, selected command, trajectory, route progress? command source only; no route submission.
- Did scenario actually contain targeted failure mode? NA - no campaign run.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3810 remains open for execution and interpretation.

## Next Empirical Action
- Rerun needed: yes, before any claim: comprehensive h600 campaign after submit-host go decision.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: retained campaign outputs, SNQI recalibration bundle, horizon-sensitivity report, interaction-exposure diagnostics, durable external artifact pointer.
- Stop / revise / continue decision: continue, but submit remains blocked.
- Proposed child issue existing follow-up: #3813 remains the sustained-flow structural follow-up.

## Validation / Proof
- `uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` -> pass, reports `target_host: imech156-u`, `compute_submit_authorized: false`, `slurm_job_id: not_submitted`.
- `uv run python scripts/validation/check_issue_3810_long_horizon_analysis_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` -> pass, reports `target_host: imech156-u`.
- `uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py -q` -> pass, 37 tests.
- `uv run ruff check ...` and `uv run ruff format --check ...` on changed Python files -> pass.
- `uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` -> pass, diagnostic dry-run rows only.
- Private-ops read-only preflight for `imech156-u` -> no submission; public worktree clean, CUDA ok, `missing_sbatch`, W&B online auth missing.
- Private-ops queue discovery -> no ready queue entries; existing #3810 queue rows are submitted/done, so this PR does not submit or duplicate compute work.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: future private-ops route support for `imech156-u` still must be proven on the submit host.
- Failure modes: stale queue/job state could make the packet non-go, as intended.
- Rollback fallback plan: revert this host retarget if maintainer direction changes again.

## Docs / Provenance
- Updated docs: NA.
- Relevant design provenance notes: issue #3810 live comments and existing packet history.
- Any assumptions need to preserved: `imech156-u` is the requested target host for this ready-queue slice.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): no, no benchmark evidence.
- Leaderboard / artifact catalog updated (yes/no/NA): no.
- Registry or config index updated (yes/no/NA): no.
- Context index / memory note updated (yes/no/NA): no.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is a no-submit launch/analysis packet refresh, not benchmark result propagation.

## Follow-Up Issues
- Deferred work: submit-host queue/duplicate/worktree/route refresh, benchmark execution, durable retention bundle, SNQI recalibration, horizon-sensitivity report, interaction-exposure diagnostics, provenance/archive updates, bounded claim/report interpretation.
- Issues opened follow-up: existing #3810.

## Reviewer Notes
- Verify the host contract stays fail-closed and the packet still blocks on job 13175 and submit-host route reconciliation.
- Known limitations: private-ops checkout was dirty/behind during read-only discovery; no private ledger mutation was made.
