### PR TITLE
Issue #3813: check sustained-flow generator drift

### DIFF
--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -8,6 +8,9 @@ from itertools import pairwise
 from pathlib import Path
 from typing import Any
 
+from robot_sf.scenario_certification.sustained_flow import (
+    generate_expected_sustained_flow_scenarios,
+)
 from robot_sf.training.scenario_loader import load_scenarios
 
 PREFLIGHT_SCHEMA_VERSION = "sustained_flow_preflight.v1"
@@ -119,6 +122,7 @@ def preflight_sustained_flow_matrix(matrix_path: str | Path) -> SustainedFlowPre
         blocking_reasons.append(str(exc))
     else:
         blocking_reasons.extend(_variant_blockers(variants))
+        blocking_reasons.extend(_generator_drift_blockers(variants))
 
     if not variants:
         blocking_reasons.append("no sustained-flow variants were enumerated")
@@ -189,6 +193,33 @@ def _variant_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, 
         if not variant.seeds:
             blockers.append(f"{variant.name}: at least one seed is required")
     return tuple(blockers)
+
+
+def _generator_drift_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, ...]:
+    """Fail closed when the checked-in matrix drifts from the canonical generator.
+
+    Returns:
+        Blocking reasons when generator-owned variant fields drift.
+    """
+    generated_variants = tuple(
+        _variant_from_scenario(row) for row in generate_expected_sustained_flow_scenarios()
+    )
+    observed_profile = tuple(_variant_generator_profile(variant) for variant in variants)
+    expected_profile = tuple(_variant_generator_profile(variant) for variant in generated_variants)
+    if observed_profile == expected_profile:
+        return ()
+    return ("sustained-flow matrix must match canonical generated variant definitions",)
+
+
+def _variant_generator_profile(variant: SustainedFlowVariant) -> tuple[object, ...]:
+    return (
+        variant.name,
+        variant.density_tier,
+        variant.ped_density,
+        variant.spawn_rate_per_min,
+        variant.max_episode_steps,
+        variant.seeds,
+    )
 
 
 def _runtime_readiness(

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -133,6 +133,30 @@ def test_sustained_flow_preflight_accepts_runtime_supported_matrix(tmp_path: Pat
     assert payload["blocking_reasons"] == []
 
 
+def test_sustained_flow_preflight_rejects_generator_drift(tmp_path: Path) -> None:
+    """Preflight fails closed if YAML rows stop matching the generator."""
+
+    matrix = _load_yaml(SCENARIO_SET)
+    for scenario in matrix["scenarios"]:
+        scenario["metadata"]["continuous_spawn"]["current_runtime_support"] = (
+            RUNTIME_SUPPORTED_VALUE
+        )
+    matrix["scenarios"][1]["metadata"]["continuous_spawn"]["spawn_rate_per_min"] = 13.0
+
+    drifted_matrix = tmp_path / "drifted_sustained_flow.yaml"
+    drifted_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+
+    payload = preflight_sustained_flow_matrix(drifted_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert payload["variant_count"] == 3
+    assert (
+        "sustained-flow matrix must match canonical generated variant definitions"
+        in payload["blocking_reasons"]
+    )
+
+
 def test_sustained_flow_preflight_rejects_wrong_spawn_process(tmp_path: Path) -> None:
     """Continuous-spawn variants must name the supported respawn process."""
 


### PR DESCRIPTION
## Summary
Adds a generator-drift guard to the issue #3813 sustained-flow preflight so the checked-in continuous-spawn scenario matrix must keep matching the canonical generator-owned variant definitions.

## Linked Issues
- Relates `#3813`
- Issue: https://github.com/ll7/robot_sf_ll7/issues/3813

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- `preflight_sustained_flow_matrix` now compares stable generator-owned fields against `generate_expected_sustained_flow_scenarios()`.
- Added a focused enumeration test proving the preflight fails closed when a checked-in variant drifts from the canonical generator.

## Why Matters
- Added value: catches accidental YAML/generator divergence before sustained-flow rows can be treated as benchmark eligible.
- Expected impact: local preflight coverage only; no campaign or runtime continuous-spawn implementation.
- Why worth merging now: it tightens the existing #3813 scaffold without widening benchmark semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: scenario-generator/preflight correctness for the #3813 sustained-flow scaffold.
- Comparator or baseline, applicable: existing preflight accepted runtime-supported synthetic matrices without checking generator drift.
- Evidence tier: NA - support preflight guard
- Result classification: NA - implementation guard only
- Decision stop rule, applicable: generator-owned field drift must make benchmark eligibility fail closed.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3813 remains open for runtime support, metrics, and campaign evidence.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support preflight guard only.

## Domain-Aware Approval
- Required PR: yes - evidence-validity-sensitive benchmark preflight result classification
- Domains reviewed: benchmark preflight boundary and fail-closed scenario eligibility
- Status: waived
- Approver/review source waiver: maintainer-scoped ready-queue authorization for local scenario-generator/preflight slice; no benchmark claim, metric semantics, paper-facing interpretation, or campaign result.
- Validity checklist: preflight-only diagnostic guard; fallback/degraded execution remains non-success evidence.
- Target claim/hypothesis: generator and YAML scenario definitions remain synchronized.
- Comparator or split/evidence validity: focused mutation test changes one generated field and observes fail-closed status.
- Fallback/degraded exclusions: current scaffold still reports metadata-only runtime support and benchmark evidence false.
- Claim boundary: not sustained-flow benchmark evidence.
- Implementation integrity vs experimental validity: implementation-only guard; experimental validity deferred to #3813 follow-up work.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? not tested in this PR
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3813 remains open for runtime and campaign proof.

## Next Empirical Action
- Rerun needed: no full campaign in this PR
- Extractor analysis tool needed: no
- Artifact missing unavailable: runtime continuous-spawn support, sustained progress-rate metric, interaction-exposure sanity proof, pure-wait baseline proof.
- Stop / revise / continue decision: continue with runtime implementation slice after this preflight guard.
- Proposed child issue existing follow-up: #3813

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py tests/scenario_certification/test_sustained_flow_preflight.py -q` - passed, 17 tests
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` - passed; `conforms=true`, `variant_count=3`, `benchmark_evidence=false`, `runtime_support=metadata_only`

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance
- Baseline runtime: NA - no runtime hot path claimed.
- Changed runtime: NA - no runtime hot path claimed.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py tests/scenario_certification/test_sustained_flow_preflight.py -q`
- Hot-path call count profile anchor: NA - preflight-only guard.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if supported runtime matrices matching generator definitions become incorrectly blocked.

## Risks / Rollout
- Compatibility risks: low; compares stable generated scenario fields and excludes runtime-support value so future runtime-supported matrices can still pass.
- Failure modes: generator and YAML may intentionally diverge before the test is updated, which will fail closed.
- Rollback fallback plan: remove `_generator_drift_blockers` and its focused drift test.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: issue #3813 and existing sustained-flow scaffold comments.
- Any assumptions need to preserved: generator-owned fields are name, density tier, pedestrian density, spawn rate, max episode steps, and seeds; runtime support remains separately checked.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR adds a local preflight guard and does not create benchmark evidence or new artifacts.

## Follow-Up Issues
- Deferred work: runtime continuous-spawn support, sustained progress-rate metric, interaction-exposure sanity proof, pure-wait baseline proof, campaign/runner evidence.
- Issues opened follow-up: #3813

## Reviewer Notes
- Verify that runtime support is intentionally excluded from the generator profile so later runtime-supported matrices can pass when stable generator fields match.
- Known limitation: this remains a scaffold/preflight slice, not sustained-flow benchmark evidence.
