### PR TITLE
Issue #3653: fail closed missing SNQI campaign input

### DIFF
--- a/robot_sf/benchmark/snqi_scalarization_sensitivity.py
+++ b/robot_sf/benchmark/snqi_scalarization_sensitivity.py
@@ -659,6 +659,57 @@ def input_file_provenance(path: Path | None) -> dict[str, str | None]:
     return {"path": str(path), "sha256": hashlib.sha256(data).hexdigest()}
 
 
+def missing_input_preflight(
+    path: Path,
+    *,
+    input_kind: str,
+    application_packet: Path | None = None,
+) -> dict[str, Any]:
+    """Build a blocked SNQI sensitivity preflight for a missing input artifact.
+
+    This is for application-packet gates where the next valid step is to
+    hydrate or promote the referenced input, not to emit diagnostic artifacts
+    from an incomplete campaign surface.
+
+    Returns:
+        JSON-ready blocked preflight payload with missing-input provenance.
+    """
+    provenance: dict[str, Any] = {input_kind: {"path": str(path), "sha256": None, "exists": False}}
+    if application_packet is not None:
+        if application_packet.exists():
+            provenance["application_packet"] = {
+                **input_file_provenance(application_packet),
+                "exists": True,
+            }
+        else:
+            provenance["application_packet"] = {
+                "path": str(application_packet),
+                "sha256": None,
+                "exists": False,
+            }
+    return {
+        "schema_version": SCALARIZATION_SENSITIVITY_PREFLIGHT_SCHEMA,
+        "ready": False,
+        "status": SENSITIVITY_PREFLIGHT_BLOCKED,
+        "record_count": 0,
+        "planner_count": 0,
+        "scenario_horizon_count": 0,
+        "missing_scenario_horizon_cells": {},
+        "inputs": {"provenance": provenance},
+        "issues": [
+            {
+                "code": f"missing_{input_kind}_file",
+                "severity": SENSITIVITY_PREFLIGHT_BLOCKED,
+                "message": (
+                    f"missing {input_kind} input file {path}; hydrate or promote the "
+                    "referenced campaign artifact before exporting SNQI scalarization "
+                    "sensitivity diagnostics"
+                ),
+            }
+        ],
+    }
+
+
 def format_markdown(report: Mapping[str, Any]) -> str:
     """Render the report as Markdown.
 
@@ -1228,5 +1279,6 @@ __all__ = [
     "load_baseline_mapping",
     "load_jsonl",
     "load_weight_mapping",
+    "missing_input_preflight",
     "write_diagnostic_artifacts",
 ]

--- a/scripts/benchmark/snqi_scalarization_sensitivity_export.py
+++ b/scripts/benchmark/snqi_scalarization_sensitivity_export.py
@@ -23,6 +23,7 @@ from robot_sf.benchmark.snqi_scalarization_sensitivity import (
     load_baseline_mapping,
     load_jsonl,
     load_weight_mapping,
+    missing_input_preflight,
     write_diagnostic_artifacts,
 )
 
@@ -48,6 +49,11 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument("--stem", default="snqi_scalarization_sensitivity")
     parser.add_argument(
+        "--application-packet",
+        type=Path,
+        help="Optional tracked packet proving the campaign application surface being gated.",
+    )
+    parser.add_argument(
         "--preflight-out",
         type=Path,
         help="Optional JSON path for the readiness preflight payload.",
@@ -60,6 +66,18 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     args = _build_parser().parse_args(argv)
 
+    if not args.episodes.exists():
+        preflight = missing_input_preflight(
+            args.episodes,
+            input_kind="episodes",
+            application_packet=args.application_packet,
+        )
+        if args.preflight_out is not None:
+            args.preflight_out.parent.mkdir(parents=True, exist_ok=True)
+            args.preflight_out.write_text(json.dumps(preflight, indent=2), encoding="utf-8")
+        print(json.dumps(preflight, indent=2), file=sys.stderr)
+        return 2
+
     records = load_jsonl(args.episodes)
     baseline = load_baseline_mapping(args.baseline)
     weights = load_weight_mapping(args.weights)
@@ -68,6 +86,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         "baseline": input_file_provenance(args.baseline),
         "weights": input_file_provenance(args.weights),
     }
+    if args.application_packet is not None:
+        provenance["application_packet"] = input_file_provenance(args.application_packet)
 
     preflight = classify_scalarization_sensitivity_inputs(
         records,

--- a/scripts/tools/analyze_snqi_scalarization_sensitivity.py
+++ b/scripts/tools/analyze_snqi_scalarization_sensitivity.py
@@ -22,6 +22,7 @@ from robot_sf.benchmark.snqi_scalarization_sensitivity import (
     load_baseline_mapping,
     load_jsonl,
     load_weight_mapping,
+    missing_input_preflight,
     write_diagnostic_artifacts,
 )
 
@@ -53,6 +54,18 @@ def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         default=list(DEFAULT_SWEEP_FACTORS),
         help="Multipliers applied one SNQI weight at a time.",
     )
+    parser.add_argument(
+        "--application-packet",
+        type=Path,
+        default=None,
+        help="Optional tracked packet proving the campaign application surface being gated.",
+    )
+    parser.add_argument(
+        "--preflight-out",
+        type=Path,
+        default=None,
+        help="Optional JSON path for the readiness preflight payload.",
+    )
     return parser.parse_args(argv)
 
 
@@ -63,9 +76,28 @@ def main(argv: list[str] | None = None) -> int:
         Process exit code.
     """
     args = _parse_args(argv)
+    if not args.episodes.exists():
+        preflight = missing_input_preflight(
+            args.episodes,
+            input_kind="episodes",
+            application_packet=args.application_packet,
+        )
+        if args.preflight_out is not None:
+            args.preflight_out.parent.mkdir(parents=True, exist_ok=True)
+            args.preflight_out.write_text(json.dumps(preflight, indent=2), encoding="utf-8")
+        print(json.dumps(preflight, indent=2), file=sys.stderr)
+        return 2
+
     records = load_jsonl(args.episodes)
     weights = load_weight_mapping(args.weights)
     baseline = load_baseline_mapping(args.baseline)
+    provenance = {
+        "episodes": input_file_provenance(args.episodes),
+        "weights": input_file_provenance(args.weights),
+        "baseline": input_file_provenance(args.baseline),
+    }
+    if args.application_packet is not None:
+        provenance["application_packet"] = input_file_provenance(args.application_packet)
 
     preflight = classify_scalarization_sensitivity_inputs(
         records,
@@ -74,6 +106,9 @@ def main(argv: list[str] | None = None) -> int:
         planner_key=args.planner_key,
         fallback_planner_key=args.fallback_planner_key,
     )
+    if args.preflight_out is not None:
+        args.preflight_out.parent.mkdir(parents=True, exist_ok=True)
+        args.preflight_out.write_text(json.dumps(preflight, indent=2), encoding="utf-8")
     if args.preflight_only:
         print(json.dumps(preflight, indent=2))
         return 0 if preflight["status"] == SENSITIVITY_PREFLIGHT_READY else 2
@@ -92,11 +127,7 @@ def main(argv: list[str] | None = None) -> int:
         planner_key=args.planner_key,
         fallback_planner_key=args.fallback_planner_key,
         sweep_factors=args.sweep_factors,
-        input_provenance={
-            "episodes": input_file_provenance(args.episodes),
-            "weights": input_file_provenance(args.weights),
-            "baseline": input_file_provenance(args.baseline),
-        },
+        input_provenance=provenance,
     )
     artifacts = write_diagnostic_artifacts(report, args.output_dir)
     print(

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -559,6 +559,56 @@ def test_cli_export_blocks_invalid_inputs_before_artifacts(tmp_path: Path, capsy
     assert not output_dir.exists()
 
 
+def test_cli_application_packet_blocks_missing_campaign_episodes(tmp_path: Path, capsys) -> None:
+    """Application-packet gate fails closed while campaign episode JSONL is absent."""
+    missing_episodes = tmp_path / "output" / "13175" / "reports" / "episodes.jsonl"
+    weights_path = tmp_path / "weights.json"
+    weights_path.write_text(json.dumps(_weights()), encoding="utf-8")
+    baseline_path = tmp_path / "baseline.json"
+    baseline_path.write_text(json.dumps(_baseline()), encoding="utf-8")
+    packet_path = tmp_path / "issue_3653_application_packet.json"
+    packet_path.write_text(
+        json.dumps(
+            {
+                "schema_version": "snqi_scalarization_application_packet.v1",
+                "job_id": "13175",
+                "required_input": str(missing_episodes),
+            }
+        ),
+        encoding="utf-8",
+    )
+    output_dir = tmp_path / "artifacts"
+    preflight_out = tmp_path / "preflight.json"
+
+    exit_code = scalarization_cli_main(
+        [
+            "--episodes",
+            str(missing_episodes),
+            "--weights",
+            str(weights_path),
+            "--baseline",
+            str(baseline_path),
+            "--output-dir",
+            str(output_dir),
+            "--application-packet",
+            str(packet_path),
+            "--preflight-out",
+            str(preflight_out),
+        ]
+    )
+
+    assert exit_code == 2
+    stderr = json.loads(capsys.readouterr().err)
+    written = json.loads(preflight_out.read_text(encoding="utf-8"))
+    assert stderr == written
+    assert stderr["status"] == SENSITIVITY_PREFLIGHT_BLOCKED
+    assert stderr["issues"][0]["code"] == "missing_episodes_file"
+    assert stderr["inputs"]["provenance"]["episodes"]["exists"] is False
+    assert stderr["inputs"]["provenance"]["application_packet"]["path"] == str(packet_path)
+    assert len(stderr["inputs"]["provenance"]["application_packet"]["sha256"]) == 64
+    assert not output_dir.exists()
+
+
 def test_baseline_loader_refuses_missing_normalized_fixture_input(tmp_path: Path) -> None:
     """Baseline fixture loader fails closed before export on missing normalized stats."""
     baseline = _baseline()


### PR DESCRIPTION
## Summary

Refs #3653.

This PR adds a fail-closed Social Navigation Quality Index (SNQI) scalarization-sensitivity application preflight for missing campaign episode JSONL inputs. When an application packet points at a campaign surface such as job `13175` but the required `reports/episodes.jsonl` is absent, the CLI now emits a structured blocked preflight payload with input provenance and writes no diagnostic artifacts.

## Scope

- Add reusable `missing_input_preflight(...)` payload construction for SNQI scalarization diagnostics.
- Add `--application-packet` and `--preflight-out` support to the canonical SNQI scalarization CLI, plus matching support in the benchmark wrapper.
- Add fixture-backed regression coverage that missing campaign episodes fail closed with exit code `2`, no artifact directory, and tracked packet provenance.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py` - passed, 27 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/test_plots_pareto.py` - passed, 3 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/snqi_scalarization_sensitivity.py scripts/tools/analyze_snqi_scalarization_sensitivity.py scripts/benchmark/snqi_scalarization_sensitivity_export.py tests/benchmark/test_snqi_scalarization_sensitivity.py` - passed.
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=output/pr_body_issue_3653.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed on clean committed head `544f9521`, including core lane 1688 passed and optional-extra lane.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

## Follow-Up Issues

- #3653 remains open for the empirical application step: hydrate or promote a valid campaign episode JSONL surface, then consume the decision-disagreement/Pareto export before treating the issue as research-complete.

## Domain-Aware Approval

- Required PR: domain-aware approval required; waived for analysis-tooling checker slice.
- Domains reviewed: SNQI scalarization diagnostic readiness, Pareto-front export gating, evidence classification.
- Status: waived
- Approval blocker note: current maintainer task authorizes the analysis-tooling fail-closed checker slice; empirical application and claim promotion remain blocked.
- Validity checklist:
  - Target claim/hypothesis: #3653 remains analysis-tooling until a valid campaign surface consumes the export.
  - Comparator or split/evidence validity: existing targeted smoke proof covers missing-input gating only.
  - Fallback/degraded exclusions: no fallback/degraded benchmark execution is counted as success evidence.
  - Claim scope: no benchmark, ranking, safety, paper, or dissertation claim is promoted.
  - Implementation integrity vs experimental validity: tests prove CLI/preflight behavior, not empirical result validity.

## Downstream Propagation

This is analysis tooling and regression coverage. It does not promote job `13175`, S20/S30 results, Pareto-front artifacts, rankings, safety claims, or paper-facing conclusions. The remaining research-complete blocker is still to hydrate/promote a valid campaign episode JSONL surface and consume the decision-disagreement/Pareto export there.
