### PR TITLE
Issue #3275: fail closed missing archive overlap metadata

### DIFF
--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -8,7 +8,7 @@ The check is readiness/leakage evidence only. It does not run benchmark campaign
 
 ## Implementation
 
-- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads a source archive and rerun archive, checks archive-ID leakage, records family/seed overlap provenance, requires certification metadata on rerun archive entries, and can validate supplied null-test prerequisite metadata.
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads a source archive and rerun archive, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, or `candidate.scenario_seed`), requires certification metadata on rerun archive entries, and can validate supplied null-test prerequisite metadata.
 - `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI, including optional `--null-test-prerequisites` input.
 - Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
 
@@ -18,6 +18,7 @@ Focused tests cover:
 
 - disjoint certified archives passing the metadata gate;
 - overlapping archive IDs blocking leakage;
+- missing overlap metadata (`archive_id`, scenario family, or `candidate.scenario_seed`) blocking readiness;
 - missing rerun certification metadata blocking readiness;
 - complete null-test prerequisite metadata staying ready;
 - missing or invalid null-test prerequisite metadata blocking readiness;

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -23,6 +23,7 @@ from robot_sf.adversarial.disjoint_evaluation import (
     ARCHIVE_SCHEMA_VERSION,
     archive_sha256,
     compute_overlap_provenance,
+    scenario_family_key,
 )
 
 READY = "ready"
@@ -94,6 +95,7 @@ class FailureArchiveRerunReadiness:
     rerun_archive_sha256: str | None = None
     overlap_provenance: dict[str, Any] = field(default_factory=dict)
     archive_id_overlap: list[str] = field(default_factory=list)
+    missing_overlap_metadata_archive_ids: list[str] = field(default_factory=list)
     missing_certification_archive_ids: list[str] = field(default_factory=list)
     invalid_certification_archive_ids: list[str] = field(default_factory=list)
     diagnostic_only_outputs: list[str] = field(default_factory=list)
@@ -126,6 +128,7 @@ class FailureArchiveRerunReadiness:
             "rerun_archive_sha256": self.rerun_archive_sha256,
             "overlap_provenance": dict(self.overlap_provenance),
             "archive_id_overlap": list(self.archive_id_overlap),
+            "missing_overlap_metadata_archive_ids": list(self.missing_overlap_metadata_archive_ids),
             "missing_certification_archive_ids": list(self.missing_certification_archive_ids),
             "invalid_certification_archive_ids": list(self.invalid_certification_archive_ids),
             "diagnostic_only_outputs": list(self.diagnostic_only_outputs),
@@ -180,6 +183,8 @@ def classify_failure_archive_rerun_readiness(
     overlap = compute_overlap_provenance(source_entries, rerun_entries)
     archive_id_overlap = list(overlap.get("archive_id_overlap", []))
     blockers.extend(_overlap_blockers(overlap))
+    missing_overlap_metadata = _overlap_metadata_gaps(source_entries, rerun_entries)
+    blockers.extend(_count_blockers("missing_overlap_metadata", missing_overlap_metadata))
 
     missing_certification, invalid_certification = _certification_gaps(rerun_entries)
     blockers.extend(_count_blockers("missing_certification_metadata", missing_certification))
@@ -205,6 +210,7 @@ def classify_failure_archive_rerun_readiness(
         rerun_archive_sha256=rerun_hash,
         overlap_provenance=overlap,
         archive_id_overlap=archive_id_overlap,
+        missing_overlap_metadata_archive_ids=missing_overlap_metadata,
         missing_certification_archive_ids=missing_certification,
         invalid_certification_archive_ids=invalid_certification,
         diagnostic_only_outputs=diagnostic_outputs,
@@ -274,6 +280,27 @@ def _count_blockers(blocker: str, values: list[str]) -> list[str]:
     """Return a single count blocker when values are present."""
 
     return [f"{blocker}:{len(values)}"] if values else []
+
+
+def _overlap_metadata_gaps(
+    source_entries: list[dict[str, Any]],
+    rerun_entries: list[dict[str, Any]],
+) -> list[str]:
+    """Return archive IDs whose metadata cannot prove disjointness."""
+
+    gaps: list[str] = []
+    for side, entries in (("source", source_entries), ("rerun", rerun_entries)):
+        for index, entry in enumerate(entries):
+            archive_id = str(entry.get("archive_id") or f"{side}:<entry:{index}>")
+            entry_gaps: list[str] = []
+            if scenario_family_key(entry) == "unknown_family":
+                entry_gaps.append("scenario_family")
+            candidate = entry.get("candidate")
+            if not isinstance(candidate, dict) or candidate.get("scenario_seed") is None:
+                entry_gaps.append("scenario_seed")
+            if entry_gaps:
+                gaps.append(f"{side}:{archive_id}:{','.join(entry_gaps)}")
+    return gaps
 
 
 def _certification_gaps(entries: list[dict[str, Any]]) -> tuple[list[str], list[str]]:

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -291,8 +291,11 @@ def _overlap_metadata_gaps(
     gaps: list[str] = []
     for side, entries in (("source", source_entries), ("rerun", rerun_entries)):
         for index, entry in enumerate(entries):
-            archive_id = str(entry.get("archive_id") or f"{side}:<entry:{index}>")
+            raw_archive_id = entry.get("archive_id")
+            archive_id = str(raw_archive_id or f"{side}:<entry:{index}>")
             entry_gaps: list[str] = []
+            if raw_archive_id is None:
+                entry_gaps.append("archive_id")
             if scenario_family_key(entry) == "unknown_family":
                 entry_gaps.append("scenario_family")
             candidate = entry.get("candidate")

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -128,9 +128,10 @@ def test_scenario_family_and_seed_overlap_is_reported_as_blockers(tmp_path: Path
 
 
 def test_missing_overlap_metadata_blocks_readiness(tmp_path: Path) -> None:
-    """Missing scenario-family or seed metadata must fail closed."""
+    """Missing archive-id, scenario-family, or seed metadata must fail closed."""
 
     source_entry = _entry("source_0000", family="family_a", seed=1)
+    source_entry.pop("archive_id")
     source_entry.pop("cluster_key")
     source_entry.pop("failure_attribution")
     rerun_entry = _entry("rerun_0000", family="family_b", seed=101)
@@ -143,7 +144,7 @@ def test_missing_overlap_metadata_blocks_readiness(tmp_path: Path) -> None:
 
     assert readiness.status == BLOCKED
     assert readiness.missing_overlap_metadata_archive_ids == [
-        "source:source_0000:scenario_family",
+        "source:source:<entry:0>:archive_id,scenario_family",
         "rerun:rerun_0000:scenario_seed",
     ]
     assert "missing_overlap_metadata:2" in readiness.blockers

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -127,6 +127,31 @@ def test_scenario_family_and_seed_overlap_is_reported_as_blockers(tmp_path: Path
     assert readiness.overlap_provenance["seed_overlap"] == [42]
 
 
+def test_missing_overlap_metadata_blocks_readiness(tmp_path: Path) -> None:
+    """Missing scenario-family or seed metadata must fail closed."""
+
+    source_entry = _entry("source_0000", family="family_a", seed=1)
+    source_entry.pop("cluster_key")
+    source_entry.pop("failure_attribution")
+    rerun_entry = _entry("rerun_0000", family="family_b", seed=101)
+    rerun_entry["candidate"].pop("scenario_seed")
+    source = _archive(tmp_path / "source.json", [source_entry])
+    rerun = _archive(tmp_path / "rerun.json", [rerun_entry])
+
+    readiness = classify_failure_archive_rerun_readiness(source, rerun)
+    payload = readiness.to_payload()
+
+    assert readiness.status == BLOCKED
+    assert readiness.missing_overlap_metadata_archive_ids == [
+        "source:source_0000:scenario_family",
+        "rerun:rerun_0000:scenario_seed",
+    ]
+    assert "missing_overlap_metadata:2" in readiness.blockers
+    assert payload["missing_overlap_metadata_archive_ids"] == (
+        readiness.missing_overlap_metadata_archive_ids
+    )
+
+
 def test_missing_archive_payload_blocks_ready_path(tmp_path: Path) -> None:
     """Missing archive file paths must fail closed for both source and rerun."""
 


### PR DESCRIPTION
## Summary
Adds a fail-closed readiness check for missing archive overlap metadata before a proposal-model rerun can be treated as using disjoint certified failure archives.

## Linked Issues
- Relates to `#3275`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## Changed
- Extended `failure_archive_rerun_readiness` to report `missing_overlap_metadata_archive_ids`.
- Blocks readiness when source or rerun archive entries lack `archive_id`, scenario-family metadata, or `candidate.scenario_seed`, because disjointness cannot be proven without those fields.
- Added a synthetic fixture test covering missing source archive ID, missing source scenario-family metadata, and missing rerun seed metadata.
- Updated `docs/context/issue_3275_failure_archive_rerun_readiness.md` so the context note matches the fail-closed overlap metadata contract.

## Why Matters
- Added value: prevents malformed certified failure archives from appearing disjoint only because required overlap metadata is absent.
- Expected impact: readiness reports fail closed with an explicit metadata blocker.
- Why worth merging now: issue #3275 is evidence-hygiene work; this bounded prerequisite check should land before any real archive rerun is interpreted.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3275 archive-readiness blocker for proving disjoint source/evaluation failure archives.
- Comparator or baseline, applicable: `origin/main` readiness checker allowed missing overlap metadata to avoid overlap detection.
- Evidence tier: NA - support checker; targeted fixture validation listed below.
- Result classification: NA - no research result or benchmark claim.
- Decision stop rule, applicable: no held-out yield claim; checker only reports readiness blockers.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3275 remains open for the real certified archive rerun.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - extends an existing support checker only.

## Domain-Aware Approval
- Required PR: yes - evidence-readiness checker touches benchmark-labelled issue #3275.
- Approver/review source waiver: maintainer-requested bounded readiness slice; no claim promotion and no benchmark run.
- Target claim/hypothesis: issue #3275 claim boundary stays readiness-only.
- Comparator split/evidence validity: targeted fixture proof only; no real split, held-out interpretation, or proposal-vs-random yield claim.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution used.
- Claim boundary: readiness/leakage check only.
- Implementation integrity vs experimental validity: tests prove fail-closed metadata gate behavior, not experimental validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, synthetic fixture reports `missing_overlap_metadata:2` while naming all missing fields.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA - metadata fixture only.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: #3275 still needs real disjoint certified archive rerun.

## Next Empirical Action
- Rerun needed: yes, full #3275 real archive rerun remains out of scope.
- Extractor analysis tool needed: no for this PR.
- Artifact missing unavailable: real certified failure archive inputs and independent planner-execution outcomes remain outside this PR.
- Stop / revise / continue decision: continue readiness hardening before claim-bearing rerun.
- Proposed child issue existing follow-up: #3275.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` - passed, 2 files unchanged.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` - passed, 12 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/adversarial/test_archive_readiness.py -q` - passed, 21 tests.
- `git diff --check` - passed.
- Broader CI is expected to rerun on pushed head SHA `a6592464bb7706e3e63b3af6830c5bc3a87b1f6b`.

## Performance Impact
- Baseline runtime: NA - metadata-only readiness check.
- Changed runtime: NA - metadata-only readiness check.
- Representative command: `uv run python -m pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q`.
- Hot-path call count profile anchor: NA - not on simulator or planner hot path.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: readiness gate falsely blocks well-formed disjoint certified archive inputs.

## Risks / Rollout
- Compatibility risks: readiness payload gains one additive field; no existing field removed.
- Failure modes: archives relying on absent overlap metadata now fail closed until manifests are fixed.
- Rollback fallback plan: revert the readiness-gate commits to restore previous permissive behavior.

## Docs / Provenance
- Updated docs: `docs/context/issue_3275_failure_archive_rerun_readiness.md`.
- Relevant design provenance notes: issue #3275.
- Any assumptions need to preserved: archive ID, scenario-family, and scenario-seed metadata are prerequisites for proving disjoint archive inputs.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; #3275 remains open and this PR body records the residual work.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no claim-bearing result produced.

## Follow-Up Issues
- Deferred work: real disjoint certified failure archive rerun with independent planner-execution outcomes, certification lineage, null-test reporting, and bounded held-out interpretation remains in #3275.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer verify closely: new blocker uses `scenario_family_key`, so entries with recoverable family metadata still pass the family portion of the metadata check.
- Any known limitations: PR does not run proposal-model evaluation, fabricate archive inputs, report benchmark yield, submit compute, merge, release, delete, or promote any claim.
