### PR TITLE
Issue #3653: guard SNQI packet report fields

### DIFF
--- a/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
+++ b/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
@@ -264,6 +264,14 @@ def _packet_preflight_output_path(packet: Mapping[str, Any]) -> Path | None:
     return _repo_relative_path(value, "export.command_template.--preflight-out")
 
 
+def _require_export_report_fields(packet: Mapping[str, Any], report: Mapping[str, Any]) -> None:
+    success = _require_mapping(packet, "success_criteria")
+    required = {str(item) for item in _require_sequence(success, "required_report_fields")}
+    missing = sorted(field for field in required if field not in report)
+    if missing:
+        raise PacketError(f"export report missing required fields: {missing}")
+
+
 def export_if_ready(
     packet: Mapping[str, Any],
     *,
@@ -328,6 +336,7 @@ def export_if_ready(
         preflight_output.write_text(json.dumps(preflight, indent=2, sort_keys=True) + "\n")
 
     report = build_scalarization_sensitivity_report(records, weights=weights, baseline=baseline)
+    _require_export_report_fields(packet, report)
     artifacts = write_diagnostic_artifacts(report, resolved_output_dir)
     artifact_paths = {
         "json": artifacts.json_path,

--- a/tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py
+++ b/tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py
@@ -180,6 +180,25 @@ def test_issue_3653_export_if_ready_blocks_missing_campaign_input() -> None:
         raise AssertionError("export_if_ready should block missing raw campaign episodes")
 
 
+def test_issue_3653_export_report_contract_rejects_missing_required_field() -> None:
+    """Application export success requires configured decision/Pareto report sections."""
+
+    packet = _load_packet()
+    report = {
+        field: {}
+        for field in packet["success_criteria"]["required_report_fields"]
+        if field != "decision_disagreement"
+    }
+
+    try:
+        _MODULE._require_export_report_fields(packet, report)
+    except _MODULE.PacketError as exc:
+        assert "export report missing required fields" in str(exc)
+        assert "decision_disagreement" in str(exc)
+    else:
+        raise AssertionError("missing report fields should fail closed")
+
+
 def test_issue_3653_export_if_ready_writes_required_artifacts(tmp_path: Path) -> None:
     """Ready campaign-shaped inputs run through preflight and emit the packet artifact set."""
 


### PR DESCRIPTION
## Summary
Adds a fail-closed report-contract guard for the issue #3653 SNQI decision-disagreement application packet export path. The checker now verifies a ready export report contains the configured decision/Pareto sections before treating packet export as successful.

## Linked Issues
- Relates #3653

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: existing #3653
- Safe review independently: yes

## What Changed
- Added `_require_export_report_fields()` in `scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py` and call it inside `export_if_ready()` before artifact success handling.
- Added regression coverage proving missing required report sections fail closed.

## Why Matters
- Added value: prevents the #3653 application packet from accepting artifact filenames alone when the underlying report omits required decision/Pareto data sections.
- Expected impact: safer fail-closed empirical handoff once raw campaign episodes are hydrated.
- Why worth merging now: it closes a narrow checker correctness gap without running benchmark, GPU, or Slurm work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3653 SNQI scalarization-sensitivity / Pareto-front application packet must not mark export successful unless required decision-disagreement and Pareto report fields exist.
- Comparator or baseline, applicable: `configs/benchmarks/snqi_baseline_camera_ready_v3.json` and `configs/benchmarks/snqi_weights_camera_ready_v3.json` are referenced by the existing packet; this PR does not compare planner outcomes.
- Evidence level: targeted smoke on committed fixture path only.
- Result category: checker guard only.
- Decision stop rule, applicable: missing configured report fields must raise `PacketError` before artifact success handling.
- Parent issue, claim map, registry, context note, synthesis surface update: #3653 remains open; no claim map or paper-facing surface updated.
- New research/benchmark/metric/paper-facing analysis tool, any: none; this is a support checker guard for an existing application packet.

## Domain-Aware Approval
Required PR: yes - waived for benchmark-validity approval because this PR only hardens fail-closed checker behavior and does not interpret empirical results.
Domains reviewed: SNQI scalarization-sensitivity packet guard; benchmark validity remains with open issue #3653.
Status: waived for this tooling slice.
Approver/review source waiver: PR gate review; no benchmark, metric-semantics, figure-eligibility, or paper-facing claim is changed.
Target claim/hypothesis: checker success requires configured report fields before export success.
Comparator or split/evidence validity: not evaluated here; valid campaign consumption remains open in #3653.
Comparator split/evidence validity: not evaluated here; valid campaign consumption remains open in #3653.
Fallback/degraded exclusions: no fallback/degraded benchmark rows are treated as evidence.
Claim scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no SNQI primary safety ranking claim.
Implementation integrity vs experimental validity: targeted tests cover implementation integrity only; experimental validity remains unproven until #3653 consumes the valid campaign evidence surface.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, by direct unit coverage of missing configured report fields.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? fixture-level malformed report only; no campaign scenario evidence consumed.
- Result route: continue via #3653 once raw campaign episodes are available.
- Follow-up question issue weak, negative, non-transfer results: #3653 remains the open empirical follow-up.

## Next Empirical Action
- Rerun needed: yes, once raw campaign episodes are promoted or hydrated.
- Extractor analysis tool needed: no new tool; use existing SNQI scalarization-sensitivity export.
- Artifact missing unavailable: `output/issue1554-s20-h500-l40s-mem180/13175/reports/episodes.jsonl` remains absent locally, so valid campaign export still blocks until raw episode JSONL is promoted or hydrated.
- Stop / revise / continue decision: continue only when campaign input is available through the existing packet schema key.
- Proposed child issue existing follow-up: existing #3653 remains open for the empirical application.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py tests/benchmark/test_snqi_scalarization_sensitivity.py -q`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py --json`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py --export-if-ready --json` exits 2 with expected fail-closed `episodes_jsonl missing` status while job 13175 raw campaign input is absent.

## Performance / Hot-Path Impact
- Baseline runtime: NA; validation checker guard only.
- Changed runtime: NA; validation checker guard only.
- Representative command: `uv run pytest tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py -q`.
- Hot-path call count profile anchor: NA; not a runtime planner or benchmark hot path.
- Cache-hit reuse counter: NA; no caching claimed.
- Rollback failure criterion: revert if the checker rejects a valid report that contains every configured `success_criteria.required_report_fields` entry.

## Risks / Rollout
- Compatibility risks: low; guard only applies to `export_if_ready()` success handling for this packet checker.
- Failure modes: future report schema changes must update `success_criteria.required_report_fields` in the packet or the checker will fail closed.
- Rollback fallback plan: revert this commit to restore prior checker behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: existing packet `configs/benchmarks/issue_3653_snqi_decision_disagreement_packet.yaml`; evidence packet `docs/context/evidence/issue_3798_post_13175_s20_s30_evidence_gap_packet.json`.
- Any assumptions need to preserved: remaining empirical blocker is raw campaign `episodes.jsonl` hydration/promotion, not another fixture-only export run.

## Downstream Propagation
- Parent issue updated: not yet; #3653 remains open and should receive the normal post-merge disposition comment.
- Claim map / benchmark report updated: no.
- Leaderboard / artifact catalog updated: no.
- Registry or config index updated: no.
- Context index / memory note updated: no.
- Follow-up issue opened deferred propagation: no; existing #3653 is the follow-up.
- Not applicable because: this PR does not promote benchmark, registry, claim-map, or paper-facing evidence.

## Follow-Up Issues
- Deferred work: hydrate or promote `output/issue1554-s20-h500-l40s-mem180/13175/reports/episodes.jsonl`, then run the SNQI scalarization-sensitivity export on that valid campaign evidence surface.
- Issues opened follow-up: existing #3653 remains open.

## Reviewer Notes
- Verify `success_criteria.required_report_fields` remains the packet source of truth for required report sections.
- Known limitation: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a stricter validation check to ensure export reports include all fields required by the packet configuration.
  * If any required report field is missing, the process now stops with a clear error instead of continuing with incomplete output.

* **Tests**
  * Added coverage for the new validation behavior, confirming missing report fields are rejected with an appropriate error message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->