### PR TITLE
Issue #3810: refresh imech039 h600 packet guard

### DIFF
--- a/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
+++ b/configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml
@@ -224,30 +224,25 @@ launch_packet:
   decision: blocked_pending_submit_host_route_and_reconciliation
   compute_submit_authorized: false
   slurm_job_id: not_submitted
-  target_host: imech156-u
+  target_host: imech039
   blocking_jobs:
     - 13175
   readiness_refresh:
     checked_date: "2026-07-01"
-    target_host: imech156-u
+    target_host: imech039
     live_issue_command: gh issue view 3810 --repo ll7/robot_sf_ll7 --comments
     open_pr_dedupe_command: >-
       gh pr list --repo ll7/robot_sf_ll7 --state open
       --search '3810 OR "long-horizon" OR "SNQI" OR "wait-it-out"'
       --json number,title,headRefName,url,isDraft
-    current_pr: 4030
-    open_pr_matches:
-    - number: 4030
-      title: "Issue #3810: refresh long-horizon packet readiness guard"
-      headRefName: issue-3810-long-horizon-imech156u-packet-refresh-20260701
-      url: https://github.com/ll7/robot_sf_ll7/pull/4030
-      isDraft: false
+    current_pr: null
+    open_pr_matches: []
     blocking_open_pr_matches: []
-    latest_merged_packet_pr: 4029
+    latest_merged_packet_pr: 4030
     decision: >-
-      Public readiness refresh found only current review PR #4030 and no
-      additional open PR covering issue #3810. Current origin/main already
-      includes the imech156-u packet retarget. This refresh is not submit-host
+      Public readiness refresh found no open PR covering issue #3810 before
+      this branch. Current origin/main includes merged packet PR #4030, but
+      the packet needs imech039 submit-host alignment. This refresh is not submit-host
       queue, duplicate, worktree, or private-ops route proof.
   live_issue_state:
     checked_date: "2026-07-01"
@@ -291,7 +286,7 @@ launch_packet:
       private submit wrapper named below until those checks return go.
     private_ops_dry_run:
       required_before_submit: true
-      target_host: imech156-u
+      target_host: imech039
       evidence_path: output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json
       current_public_status: route_unverified
       required_fields:
@@ -309,7 +304,7 @@ launch_packet:
         The dry run must record decision=go before submission. If job 13175 is
         not terminal/reconciled, if an issue #3810 duplicate exists, if the
         owning worktree is dirty, or if the private submit wrapper lacks
-        imech156-u support, the decision remains blocked.
+        imech039 support, the decision remains blocked.
   interpretation_gate:
     status: blocked_pending_active_run_retention_reconciliation
     required_before_claim: true
@@ -451,7 +446,7 @@ analysis_and_retention_packet:
     queue_summary_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
     route_command: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/route_job.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
     submit_wrapper: "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/submit_and_record.sh"  # allow-abs-path: private-ops routing (machine-local, non-portable)
-    target_host: "imech156-u"
+    target_host: "imech039"
   preflight:
     required: true
     route_refresh_command: >-

--- a/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_analysis_packet.py
@@ -19,7 +19,7 @@ if str(SCRIPT_DIR) not in sys.path:
 from issue_3810_readiness_refresh import validate_readiness_refresh  # noqa: E402
 
 DEFAULT_PACKET = Path("configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml")
-EXPECTED_TARGET_HOST = "imech156-u"
+EXPECTED_TARGET_HOST = "imech039"
 
 REQUIRED_PRE_FLIGHT_MARKERS = {
     "ROBOT_SF_PRIVATE_OPS",

--- a/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
+++ b/scripts/validation/check_issue_3810_long_horizon_launch_packet.py
@@ -18,7 +18,7 @@ if str(SCRIPT_DIR) not in sys.path:
 from issue_3810_readiness_refresh import validate_readiness_refresh  # noqa: E402
 
 DEFAULT_PACKET = Path("configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml")
-EXPECTED_TARGET_HOST = "imech156-u"
+EXPECTED_TARGET_HOST = "imech039"
 REQUIRED_OUTPUTS = {
     "preflight/private_ops_route_dry_run.json",
     "reports/snqi_recalibration_inputs.json",

--- a/scripts/validation/issue_3810_readiness_refresh.py
+++ b/scripts/validation/issue_3810_readiness_refresh.py
@@ -5,9 +5,9 @@ from __future__ import annotations
 from collections.abc import Callable, Mapping
 from typing import Any
 
-EXPECTED_CURRENT_PR = 4030
-EXPECTED_HEAD_REF = "issue-3810-long-horizon-imech156u-packet-refresh-20260701"
-EXPECTED_LATEST_MERGED_PACKET_PR = 4029
+EXPECTED_CURRENT_PR = None
+EXPECTED_HEAD_REF = None
+EXPECTED_LATEST_MERGED_PACKET_PR = 4030
 EXPECTED_READINESS_DATE = "2026-07-01"
 
 Require = Callable[[bool, str], None]
@@ -44,24 +44,13 @@ def validate_readiness_refresh(
         )
 
     require(
-        readiness_refresh.get("current_pr") == EXPECTED_CURRENT_PR,
-        f"readiness refresh must record current review PR {EXPECTED_CURRENT_PR}",
+        readiness_refresh.get("current_pr") is EXPECTED_CURRENT_PR,
+        "readiness refresh must record no current review PR before branch publication",
     )
     open_pr_matches = readiness_refresh.get("open_pr_matches")
-    current_pr_matches = (
-        isinstance(open_pr_matches, list)
-        and len(open_pr_matches) == 1
-        and isinstance(open_pr_matches[0], Mapping)
-        and open_pr_matches[0].get("number") == EXPECTED_CURRENT_PR
-        and open_pr_matches[0].get("isDraft") is False
-    )
-    if require_head_ref:
-        current_pr_matches = (
-            current_pr_matches and open_pr_matches[0].get("headRefName") == EXPECTED_HEAD_REF
-        )
     require(
-        current_pr_matches,
-        f"readiness refresh must record exactly current non-draft PR {EXPECTED_CURRENT_PR}",
+        open_pr_matches == [],
+        "readiness refresh open_pr_matches must be empty before branch publication",
     )
     require(
         readiness_refresh.get("blocking_open_pr_matches") == [],

--- a/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py
@@ -35,8 +35,8 @@ def test_issue_3810_analysis_packet_rejects_bad_target_host() -> None:
     """The packet must keep the reconciled submit-host target."""
 
     packet = _load_packet()
-    packet["analysis_and_retention_packet"]["route"]["target_host"] = "imech039"
-    with pytest.raises(_MODULE.PacketError, match="target host must be imech156-u"):
+    packet["analysis_and_retention_packet"]["route"]["target_host"] = "imech156-u"
+    with pytest.raises(_MODULE.PacketError, match="target host must be imech039"):
         _MODULE.validate_packet(packet)
 
 
@@ -55,7 +55,7 @@ def test_issue_3810_analysis_packet_rejects_stale_private_ops_flags() -> None:
     packet = _load_packet()
     packet["analysis_and_retention_packet"]["preflight"]["duplicate_check_command"] = (
         "/home/luttkule/git/robot_sf_ll7-private-ops/ops/jobs/scripts/queue_summary.sh "
-        "--limit 100 --json --target-host imech156-u --issue 3810"
+        "--limit 100 --json --target-host imech039 --issue 3810"
     )
     with pytest.raises(_MODULE.PacketError, match="stale private-ops flags"):
         _MODULE.validate_packet(packet)

--- a/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
+++ b/tests/validation/test_check_issue_3810_long_horizon_launch_packet.py
@@ -35,7 +35,7 @@ def test_issue_3810_packet_passes_fail_closed_contract() -> None:
     assert summary["planner_count"] >= 10
     assert summary["compute_submit_authorized"] is False
     assert summary["slurm_job_id"] == "not_submitted"
-    assert summary["target_host"] == "imech156-u"
+    assert summary["target_host"] == "imech039"
     assert summary["blocking_jobs"] == [13175]
     assert summary["job_13175_state"] == "requires_submit_host_refresh"
     assert summary["issue_3810_duplicate_status"] == "requires_submit_host_refresh"
@@ -85,7 +85,7 @@ def test_issue_3810_packet_rejects_stale_readiness_refresh_date() -> None:
 
 
 def test_issue_3810_packet_rejects_open_pr_dedupe_matches() -> None:
-    """A matching PR beyond the current review PR must stop duplicate packet PRs."""
+    """A matching PR must stop duplicate packet PRs."""
     packet = _load_packet()
     packet["launch_packet"]["readiness_refresh"]["blocking_open_pr_matches"] = [
         {"number": 9999, "title": "Issue #3810 duplicate packet"}
@@ -99,17 +99,17 @@ def test_issue_3810_packet_rejects_open_pr_dedupe_matches() -> None:
         raise AssertionError("packet should reject open PR dedupe matches")
 
 
-def test_issue_3810_packet_rejects_missing_current_review_pr() -> None:
-    """The readiness snapshot must account for this review PR instead of hiding it."""
+def test_issue_3810_packet_rejects_non_null_current_pr_before_publication() -> None:
+    """The readiness snapshot must not pretend a branch PR already exists."""
     packet = _load_packet()
-    packet["launch_packet"]["readiness_refresh"]["open_pr_matches"] = []
+    packet["launch_packet"]["readiness_refresh"]["current_pr"] = 9999
 
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "exactly current non-draft PR 4030" in str(exc)
+        assert "no current review PR before branch publication" in str(exc)
     else:
-        raise AssertionError("packet should reject missing current PR snapshot")
+        raise AssertionError("packet should reject pre-populated current PR snapshot")
 
 
 def test_issue_3810_packet_rejects_stale_job_13175_reconciliation() -> None:
@@ -141,12 +141,12 @@ def test_issue_3810_packet_rejects_nonblocking_live_issue_state() -> None:
 def test_issue_3810_packet_rejects_stale_target_host() -> None:
     """The launch-packet target host must match the requested Slurm decision host."""
     packet = _load_packet()
-    packet["launch_packet"]["target_host"] = "imech039"
+    packet["launch_packet"]["target_host"] = "imech156-u"
 
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "target host must be imech156-u" in str(exc)
+        assert "target host must be imech039" in str(exc)
     else:
         raise AssertionError("packet should reject stale target host")
 
@@ -154,7 +154,7 @@ def test_issue_3810_packet_rejects_stale_target_host() -> None:
 def test_issue_3810_packet_rejects_stale_dry_run_target_host() -> None:
     """The private-ops dry-run target host is guarded independently of the packet host."""
     packet = _load_packet()
-    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["target_host"] = "imech039"
+    packet["launch_packet"]["go_no_go"]["private_ops_dry_run"]["target_host"] = "imech156-u"
 
     try:
         _MODULE.validate_packet(packet)
@@ -174,7 +174,7 @@ def test_issue_3810_packet_rejects_decision_policy_without_target_host_gate() ->
     try:
         _MODULE.validate_packet(packet)
     except _MODULE.PacketError as exc:
-        assert "private-ops dry run must gate imech156-u support" in str(exc)
+        assert "private-ops dry run must gate imech039 support" in str(exc)
     else:
         raise AssertionError("packet should reject a decision policy missing the host gate")
 


### PR DESCRIPTION
## Summary
Refreshes the issue #3810 long-horizon Social Navigation Quality Index (SNQI) no-submit packet for target host `imech039` and records that the latest merged packet guard is PR #4030 with no pre-existing open #3810 PR coverage before this branch.

## Linked Issues
- Relates `#3810`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: `#4030`
- Stack follow-up issues: `#3810` remains open for submit-host reconciliation, benchmark execution, retention, SNQI recalibration, horizon-sensitivity reporting, and interaction-exposure diagnostics.
- Safe review independently: yes
- Review dependency reason, any: no-submit packet/checker refresh only.

## What Changed
- Retargeted the #3810 launch and analysis/retention packet host guard from `imech156-u` to `imech039`.
- Updated the shared readiness validator to treat PR #4030 as the latest merged packet PR and require no current review PR in the pre-publication snapshot.
- Updated focused validation tests for the `imech039` host contract and no-current-PR readiness snapshot.

## Why Matters
- Added value: keeps the public #3810 launch packet aligned with the requested submit host while preserving fail-closed blockers.
- Expected impact: prevents stale host/readiness packet state from being mistaken for a Slurm go decision.
- Why worth merging now: low-risk guard refresh before Claude Code handles the full PR gate/improvement cycle.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3810 launch-packet readiness blocker only.
- Comparator or baseline, applicable: NA - no benchmark execution.
- Evidence tier: NA - workflow guard only; validation covers launch-packet integrity but no benchmark evidence is claimed.
- Result classification: NA - no research claim; blocker state remains under #3810.
- Decision stop rule, applicable: packet validators must pass while reporting `compute_submit_authorized: false`, `slurm_job_id: not_submitted`, active job `13175` requiring submit-host refresh, and `go_no_go: blocked_pending_submit_host_route_and_reconciliation`.
- Parent issue, claim map, registry, context note, synthesis surface update: #3810 remains open; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - validator/packet guard refresh only.

## Domain-Aware Approval
- Approval concerns experimental validity waived / pending / blocked / not required: not required - no benchmark result or paper-facing claim is made.
- Approver/review source waiver: no benchmark result or paper-facing claim is made.
- Validity checklist: fail-closed packet/checker validation only.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: NA.
- Fallback/degraded exclusions: packet still excludes fallback/degraded/blocked rows as benchmark-strength evidence.
- Claim boundary: launch packet only.
- Implementation integrity vs experimental validity: validates packet integrity; does not establish experimental validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - validators report `target_host: imech039` and no-submit blockers remain active.
- Did intervention change command source, selected command, trajectory, route progress? no - no Slurm submission or benchmark run.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue under #3810.
- Follow-up question issue weak, negative, non-transfer results: #3810 remaining execution/analysis work.

## Next Empirical Action
- Rerun needed: yes, only after submit-host queue/duplicate/worktree/job-13175 reconciliation says go.
- Extractor analysis tool needed: yes, existing #3810 SNQI and horizon-sensitivity analysis steps remain pending campaign outputs.
- Artifact missing unavailable: full h600 benchmark outputs, retained compact bundle, external artifact pointer, SNQI recalibration bundle, horizon-sensitivity report, interaction-exposure diagnostics.
- Stop / revise / continue decision: continue only after Slurm decision packet is go.
- Proposed child issue existing follow-up: #3810.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_3810_long_horizon_launch_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` - passed; reports `target_host: imech039`, `compute_submit_authorized: false`, `slurm_job_id: not_submitted`, `blocking_jobs: [13175]`, `go_no_go: blocked_pending_submit_host_route_and_reconciliation`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_3810_long_horizon_analysis_packet.py --packet configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --json` - passed; reports `target_host: imech039` and blocked route contract.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py -q` - passed, 41 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/issue_3810_readiness_refresh.py scripts/validation/check_issue_3810_long_horizon_launch_packet.py scripts/validation/check_issue_3810_long_horizon_analysis_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/validation/issue_3810_readiness_refresh.py scripts/validation/check_issue_3810_long_horizon_launch_packet.py scripts/validation/check_issue_3810_long_horizon_analysis_packet.py tests/validation/test_check_issue_3810_long_horizon_launch_packet.py tests/validation/test_check_issue_3810_long_horizon_analysis_packet.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/run_research_campaign_manifest.py configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml --output-dir output/research_campaign_packets/issue_3810_long_horizon_snqi` - passed; generated ignored diagnostic packet under `output/`.
- `ROBOT_SF_PRIVATE_OPS="$HOME/git/robot_sf_ll7-private-ops" "$HOME/git/robot_sf_ll7-private-ops/ops/preflight/run_preflight.sh" --cluster licca --route-id decision-packet-only --public-repo "$PWD" --output output/benchmarks/issue_3810_comprehensive_h600_snqi/preflight/private_ops_route_dry_run.json` - passed; JSON includes `submitted:false` and local dirty state from this branch's edited files before commit.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check configs/benchmarks/issue_3810_long_horizon_snqi_launch_packet.yaml ...` - failed as expected because Ruff parses YAML as Python; rerun above on Python files only passed.

Out-of-scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: low; changes are limited to issue #3810 packet validators and focused tests.
- Failure modes: packet can still be stale if live submit-host queue or issue state changes after this PR.
- Rollback fallback plan: revert this commit to restore previous host/readiness guard.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3810 live issue decisions and merged PR #4030.
- Any assumptions need preserved: pre-publication snapshot has no open #3810 PR coverage; after PR publication Claude Code owns full PR gate/improvement cycle.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comment authorization false.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark execution, no metric interpretation, no paper-facing claim.

## Follow-Up Issues
- Deferred work: submit-host queue/duplicate/worktree/job-13175 reconciliation, benchmark execution, durable retention bundle, SNQI recalibration, horizon-sensitivity report, interaction-exposure diagnostics, provenance/archive updates, bounded claim/report interpretation.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that the PR stays a no-submit guard refresh and does not close #3810.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
