### PR TITLE
benchmark: bind ScenarioBelief preflight seeds for issue #3635

### DIFF
--- a/configs/benchmarks/scenario_belief_drop_vs_retain_issue_3556.yaml
+++ b/configs/benchmarks/scenario_belief_drop_vs_retain_issue_3556.yaml
@@ -96,6 +96,15 @@ belief_uncertainty_source:
 # unsafe-to-ignore). Fill with the canonical scenario set + seed_sets_v1 tier before submit.
 scenario_family: configs/scenarios/sets/issue_3635_near_safe_occlusion_bearing_crossing.yaml
 seed_set: issue_3635_s3_contract_only
+seed_sets:
+  issue_3635_s3_contract_only:
+    purpose: >-
+      Bounded paired-seed preflight fixture for issue #3635 arm-contract checks.
+      Not a seed-sufficiency claim or full campaign matrix.
+    seeds:
+    - 363501
+    - 363502
+    - 363503
 
 metric_surface:
   # Episode-level safety metrics (mirrors the #3471 harness): collisions, near misses, minimum

--- a/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
+++ b/scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py
@@ -53,7 +53,8 @@ REQUIRED_MODES = ("oracle", "uncertain_retained", "uncertain_dropped")
 #: A planner key guaranteed not to consume the uncertainty sidecar, used to prove fail-closed.
 _UNSUPPORTED_PROBE_KEY = "campaign_preflight_unsupported_probe"
 DEFAULT_SCENARIO_SET = "configs/scenarios/sets/issue_3635_near_safe_occlusion_bearing_crossing.yaml"
-DEFAULT_SEEDS = list(range(101, 113))
+DEFAULT_SEED_SET = "issue_3635_s3_contract_only"
+DEFAULT_SEEDS = [363501, 363502, 363503]
 DEFAULT_FOV = 120.0
 NEAR_MISS_NOTE = (
     "real benchmark near_misses + collisions + min_clearance (no scripted unsafe-commit)"

--- a/tests/benchmark/test_issue_3635_scenario_belief_near_safe_family.py
+++ b/tests/benchmark/test_issue_3635_scenario_belief_near_safe_family.py
@@ -94,6 +94,7 @@ def test_issue_3635_campaign_manifest_distinguishes_three_belief_arms(tmp_path: 
 
     assert payload["scenario_family"] == SCENARIO_SET.relative_to(REPO_ROOT).as_posix()
     assert payload["seed_set"] == "issue_3635_s3_contract_only"
+    assert payload["seed_sets"][payload["seed_set"]]["seeds"] == [363501, 363502, 363503]
     assert payload["no_benchmark_result_claim"] is True
     assert set(payload["belief_modes"]) == set(campaign.MODES)
 
@@ -114,18 +115,20 @@ def test_issue_3635_campaign_manifest_distinguishes_three_belief_arms(tmp_path: 
 
 
 def test_issue_3635_runner_default_targets_new_family_and_applies_seed_matrix() -> None:
-    """The #3556 runner default resolves the #3635 family and caller-provided seed set."""
+    """The #3556 runner default resolves the #3635 family and bounded seed fixture."""
     payload = _load_yaml(BENCHMARK_CONFIG)
     expected_family = SCENARIO_SET.relative_to(REPO_ROOT).as_posix()
     assert campaign.DEFAULT_SCENARIO_SET == expected_family
     assert payload["scenario_family"] == expected_family
+    assert campaign.DEFAULT_SEED_SET == payload["seed_set"]
+    assert campaign.DEFAULT_SEEDS == payload["seed_sets"][payload["seed_set"]]["seeds"]
 
-    scenarios = campaign.load_campaign_scenarios(SCENARIO_SET, [101, 102])
+    scenarios = campaign.load_campaign_scenarios(SCENARIO_SET, campaign.DEFAULT_SEEDS)
     assert len(scenarios) == 1
     scenario = scenarios[0]
 
     assert scenario["name"] == "issue_3635_near_safe_occlusion_bearing_crossing"
-    assert scenario["seeds"] == [101, 102]
+    assert scenario["seeds"] == [363501, 363502, 363503]
     assert Path(scenario["map_file"]).is_absolute()
 
 

--- a/tests/benchmark/test_scenario_belief_near_safe_family_issue_3635.py
+++ b/tests/benchmark/test_scenario_belief_near_safe_family_issue_3635.py
@@ -88,4 +88,5 @@ def test_launch_packet_remains_proposal_not_benchmark_evidence() -> None:
     assert packet["no_benchmark_result_claim"] is True
     assert packet["claim_gate"]["no_claim_until_run"] is True
     assert {"issue": 3635} in packet["follows"]
+    assert packet["seed_sets"][packet["seed_set"]]["seeds"] == [363501, 363502, 363503]
     assert "fallback/degraded rows never count as success" in " ".join(packet["validation"])


### PR DESCRIPTION
## Summary
Refs #3635. This PR tightens the bounded ScenarioBelief drop-vs-retain preflight slice by binding the launch packet seed-set name (`issue_3635_s3_contract_only`) to an explicit three-seed fixture and making the campaign runner default use that fixture.

The runner default, launch packet, and near-safe crossing-family arm-contract tests now agree on the same bounded paired seeds. This is proposal/preflight work only; it does not run the paired-seed benchmark campaign or classify the causal drop-vs-retain outcome.

## Scope
- Adds versioned `seed_sets.issue_3635_s3_contract_only` fixture in `configs/benchmarks/scenario_belief_drop_vs_retain_issue_3556.yaml`.
- Changes the issue #3556 ScenarioBelief campaign runner defaults from the generic seed range to the issue #3635 bounded preflight seed fixture.
- Extends focused contract tests for the near-safe occlusion-bearing crossing family launch packet.

## Issue Disposition
- #3635 should stay open after this PR.
- This PR satisfies only the dispatchable first-slice acceptance from the 2026-06-29 issue comment: config/manifest loads and distinguishes `oracle`, `uncertain_retained`, and `uncertain_dropped` arms without running the paired-seed campaign.
- Remaining #3635 Definition Done items still require the actual `oracle` / `uncertain_retained` / `uncertain_dropped` paired-seed run, near-safe oracle confirmation, outcome classification, and interpretation recorded in `docs/context/`.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3635_scenario_belief_near_safe_family.py tests/benchmark/test_scenario_belief_near_safe_family_issue_3635.py -q` - passed; 8 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py --preflight-only` - passed; readiness gate only, no episodes rolled.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/run_belief_mode_safety_campaign_issue_3556.py tests/benchmark/test_issue_3635_scenario_belief_near_safe_family.py tests/benchmark/test_scenario_belief_near_safe_family_issue_3635.py` - passed.
- `git diff --check origin/main...HEAD` - passed.

## Research Scope
- Result claim: none. The launch packet still carries `no_benchmark_result_claim: true` and `evidence_status: proposal`.
- Domain review status: no external domain approval required for this proposal/preflight-only binding because #3635 remains open for campaign evidence and interpretation.
- Fallback/degraded handling: unchanged launch-packet validation says fallback/degraded rows never count as success; this PR produces no rows.
- Implementation proof: focused tests and `--preflight-only` prove input binding integrity only. Experimental validity awaits the #3635 paired-seed campaign.

## Risks / Rollout
- Compatibility risks: low; changes only defaults and contract tests for an existing launch packet path.
- Failure modes: a future runner invocation can still override `--seeds`; this PR only binds the default/preflight fixture.
- Rollback fallback plan: revert the runner default and `seed_sets.issue_3635_s3_contract_only` launch-packet addition.

## Follow-Up Issues
- Deferred work: #3635 remains open for benchmark execution, causal classification, and context-note interpretation.
- Issues opened follow-up: #3635
