### PR TITLE
Issue #3653: expose SNQI decision-disagreement CSV in export summary

### DIFF
--- a/scripts/benchmark/snqi_scalarization_sensitivity_export.py
+++ b/scripts/benchmark/snqi_scalarization_sensitivity_export.py
@@ -121,6 +121,7 @@ def main(argv: Sequence[str] | None = None) -> int:
                 "artifacts": {
                     "json": str(artifacts.json_path),
                     "csv": str(artifacts.csv_path),
+                    "decision_disagreement_csv": str(artifacts.decision_disagreement_csv_path),
                     "markdown": str(artifacts.markdown_path),
                     "svg": str(artifacts.svg_path),
                 },

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -439,9 +439,10 @@ def test_export_cli_summary_reports_decision_disagreement_csv(tmp_path: Path) ->
         check=False,
     )
 
-    payload = json.loads(completed.stdout)
-    decision_csv = Path(payload["artifacts"]["decision_disagreement_csv"])
     assert completed.returncode == 0, completed.stderr
+    payload = json.loads(completed.stdout)
+    assert set(payload["artifacts"]) == {"json", "csv", "decision_disagreement_csv", "markdown", "svg"}
+    decision_csv = Path(payload["artifacts"]["decision_disagreement_csv"])
     assert payload["status"] == "exported"
     assert decision_csv.name == "snqi_scalarization_sensitivity_decision_disagreement.csv"
     assert decision_csv.is_file()

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -441,7 +441,13 @@ def test_export_cli_summary_reports_decision_disagreement_csv(tmp_path: Path) ->
 
     assert completed.returncode == 0, completed.stderr
     payload = json.loads(completed.stdout)
-    assert set(payload["artifacts"]) == {"json", "csv", "decision_disagreement_csv", "markdown", "svg"}
+    assert set(payload["artifacts"]) == {
+        "json",
+        "csv",
+        "decision_disagreement_csv",
+        "markdown",
+        "svg",
+    }
     decision_csv = Path(payload["artifacts"]["decision_disagreement_csv"])
     assert payload["status"] == "exported"
     assert decision_csv.name == "snqi_scalarization_sensitivity_decision_disagreement.csv"

--- a/tests/benchmark/test_snqi_scalarization_sensitivity.py
+++ b/tests/benchmark/test_snqi_scalarization_sensitivity.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -401,6 +403,48 @@ def test_artifact_writer_creates_report_ready_files(tmp_path: Path) -> None:
     svg = artifacts.svg_path.read_text(encoding="utf-8")
     assert svg.startswith("<svg")
     assert "safe-slow" in svg
+
+
+def test_export_cli_summary_reports_decision_disagreement_csv(tmp_path: Path) -> None:
+    """Export CLI success payload names every report-ready artifact."""
+
+    episodes_path = tmp_path / "episodes.jsonl"
+    baseline_path = tmp_path / "baseline.json"
+    weights_path = tmp_path / "weights.json"
+    output_dir = tmp_path / "artifacts"
+    episodes_path.write_text(
+        "\n".join(json.dumps(record) for record in _preflight_episodes()) + "\n",
+        encoding="utf-8",
+    )
+    baseline_path.write_text(json.dumps(_baseline()), encoding="utf-8")
+    weights_path.write_text(json.dumps(_weights()), encoding="utf-8")
+
+    repo_root = Path(__file__).resolve().parents[2]
+    completed = subprocess.run(
+        [
+            sys.executable,
+            str(repo_root / "scripts/benchmark/snqi_scalarization_sensitivity_export.py"),
+            "--episodes",
+            str(episodes_path),
+            "--baseline",
+            str(baseline_path),
+            "--weights",
+            str(weights_path),
+            "--output-dir",
+            str(output_dir),
+        ],
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    payload = json.loads(completed.stdout)
+    decision_csv = Path(payload["artifacts"]["decision_disagreement_csv"])
+    assert completed.returncode == 0, completed.stderr
+    assert payload["status"] == "exported"
+    assert decision_csv.name == "snqi_scalarization_sensitivity_decision_disagreement.csv"
+    assert decision_csv.is_file()
 
 
 def test_report_records_input_provenance_for_auditable_weight_sweeps(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Expose the SNQI scalarization-sensitivity export's decision-disagreement CSV in the direct CLI success payload. Add a regression test that runs the public export script on campaign-shaped fixture input and verifies the required CSV path is reported and written.

## Linked Issues
- Relates to `#3653`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `decision_disagreement_csv` to `scripts/benchmark/snqi_scalarization_sensitivity_export.py` JSON success output.
- Added focused coverage in `tests/benchmark/test_snqi_scalarization_sensitivity.py` for the direct CLI export artifact map over ready campaign-shaped fixture data.

## Why Matters
- Added value: downstream packet/checker callers can fail closed on the explicit decision-disagreement artifact instead of inferring it from side effects.
- Expected impact: tighter report-ready artifact provenance for the issue #3653 SNQI diagnostic export path.
- Why worth merging now: issue #3653 remains open for empirical application; this narrows a small handoff gap in the command surface used for that application.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3653 SNQI decision-disagreement export handoff completeness.
- Comparator or baseline, applicable: origin/main CLI success payload did not name the decision-disagreement CSV.
- Evidence tier: NA - support helper with targeted validation proof.
- Result classification: NA - support helper.
- Decision stop rule, applicable: direct export CLI writes and reports the required decision-disagreement CSV on ready fixture input.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3653 remains open; no claim map update.
- New research/benchmark/metric/paper-facing analysis tool, any: no new tool; existing diagnostic CLI payload is completed for an already-required artifact.

## Domain-Aware Approval
- Required PR: yes - metric-facing diagnostic export command surface.
- Domains reviewed: SNQI diagnostic export contract, issue #3653 claim boundary.
- Status: approved - diagnostic-only implementation proof.
- Approver/review source waiver: current maintainer task authorization plus issue #3653 scope; no benchmark interpretation or claim promotion.
- Target claim/hypothesis: no research claim established.
- Comparator split/evidence validity: origin/main payload omitted one written required artifact; changed payload is checked on campaign-shaped fixture input only.
- Fallback/degraded exclusions: no fallback/degraded execution counted as evidence.
- Claim boundary: diagnostic export handoff only.
- Implementation integrity vs experimental validity: implementation integrity covered by focused tests; empirical validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, CLI output now includes the required key in a real script invocation.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? fixture is campaign-shaped smoke input, not a research failure-mode claim.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: issue #3653 still needs valid campaign evidence consumption.

## Next Empirical Action
- Rerun needed: yes, consume the export on valid job `13175` campaign episodes when hydrated/promoted.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: `output/issue1554-s20-h500-l40s-mem180/13175/reports/episodes.jsonl` remains the issue-recorded blocker.
- Stop / revise / continue decision: continue.
- Proposed child issue existing follow-up: existing issue #3653 remains the tracking surface.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py` - passed on head `4a2968d1d41decdfe70d6da6ff5bed126344b2ac`, 37 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/benchmark/snqi_scalarization_sensitivity_export.py tests/benchmark/test_snqi_scalarization_sensitivity.py` - passed on head `4a2968d1d41decdfe70d6da6ff5bed126344b2ac`.
- `PR_READY_PR_BODY_FILE=/tmp/pr4039-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh` via `uv run python scripts/dev/run_compact_validation.py -- ...` - attempted on head `4a2968d1d41decdfe70d6da6ff5bed126344b2ac`; failed in unrelated Torch/Stable-Baselines feature-extractor tests with local CUDA out-of-memory (GPU had about 23 MiB free). Focused SNQI exporter tests were not implicated. Summary: `.git/codex-agent-runs/active/compact-validation/validation-20260701T032214Z-1515616.summary.json`.
- GitHub CI required before merge.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Representative use: direct script invocation in `test_export_cli_summary_reports_decision_disagreement_csv` writes the report-ready decision-disagreement CSV on committed fixture-shaped input.
- Artifact classification: generated validation and coverage files are ignored under `output/`; no generated benchmark artifacts are committed.

## Performance Evidence
- Baseline runtime: NA, no performance claim.
- Changed runtime: NA, no performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py`
- Hot-path call count profile anchor: NA, no hot-path performance claim.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: CLI success JSON no longer reports a written required artifact or focused SNQI tests fail.

## Risks / Rollout
- Compatibility risks: low; adds a JSON key without removing existing keys.
- Failure modes: downstream callers that assumed only four artifact keys should ignore the added key or update assertions.
- Rollback fallback plan: revert this commit; artifact files are still written by existing exporter.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3653 live comments and existing packet `configs/benchmarks/issue_3653_snqi_decision_disagreement_packet.yaml`.
- Any assumptions need to preserved: this is a support-level diagnostic export handoff improvement, not empirical campaign evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, commenting not authorized.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): no.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR does not promote benchmark or paper-facing evidence; issue #3653 remains open for valid campaign consumption.

## Follow-Up Issues
- Deferred work: hydrate or promote job `13175` raw episode JSONL, run the SNQI scalarization-sensitivity export on that valid campaign surface, and review Pareto/decision-disagreement artifacts.
- Issues opened follow-up: existing open issue #3653.

## Reviewer Notes
- Verify closely: the direct CLI JSON payload now matches the already-written artifact set.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Export results now include an additional decision-disagreement CSV artifact in the final status output.
  * Improved validation coverage for the export flow to confirm the new artifact is reported and written successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->