### PR TITLE
#3813 Add runtime sustained-flow variant generator preflight

### DIFF
--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from robot_sf.scenario_certification.sustained_flow import (
+    SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE,
     generate_expected_sustained_flow_scenarios,
 )
 from robot_sf.training.scenario_loader import load_scenarios
@@ -16,7 +17,7 @@ from robot_sf.training.scenario_loader import load_scenarios
 PREFLIGHT_SCHEMA_VERSION = "sustained_flow_preflight.v1"
 SUSTAINED_FLOW_ARCHETYPE = "sustained_flow_t_intersection"
 SUPPORTED_SPAWN_PROCESS = "poisson_respawn"
-RUNTIME_SUPPORTED_VALUE = "runtime_continuous_spawn"
+RUNTIME_SUPPORTED_VALUE = SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE
 
 
 @dataclass(frozen=True, slots=True)

--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -34,6 +34,8 @@ REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE: tuple[str, ...] = (
 _SUSTAINED_FLOW_FAMILY = "sustained_flow_t_intersection"
 _SUSTAINED_FLOW_MAP_FILE = "../../../maps/svg_maps/classic_t_intersection.svg"
 _SUSTAINED_FLOW_MAX_EPISODE_STEPS = 600
+SUSTAINED_FLOW_METADATA_ONLY_RUNTIME_SUPPORT = "metadata_only"
+SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE = "runtime_continuous_spawn"
 
 
 @dataclass(frozen=True)
@@ -73,8 +75,11 @@ def iter_expected_sustained_flow_variant_specs() -> tuple[SustainedFlowVariantSp
     )
 
 
-def generate_expected_sustained_flow_scenarios() -> list[dict[str, Any]]:
-    """Generate full metadata-only scenario rows for the sustained-flow scaffold.
+def generate_expected_sustained_flow_scenarios(
+    *,
+    current_runtime_support: str = SUSTAINED_FLOW_METADATA_ONLY_RUNTIME_SUPPORT,
+) -> list[dict[str, Any]]:
+    """Generate full scenario rows for the sustained-flow scaffold.
 
     This helper deliberately materializes only the pre-benchmark scenario-matrix
     rows. It does not implement continuous pedestrian respawn or promote the
@@ -113,7 +118,7 @@ def generate_expected_sustained_flow_scenarios() -> list[dict[str, Any]]:
                         "intended_process": "poisson_respawn",
                         "spawn_rate_per_min": spec.spawn_rate_per_min,
                         "target_density_tier": spec.density_tier,
-                        "current_runtime_support": "metadata_only",
+                        "current_runtime_support": current_runtime_support,
                     },
                     "success_metric": {
                         "id": "sustained_progress_rate_m_per_s",
@@ -134,6 +139,22 @@ def generate_expected_sustained_flow_scenarios() -> list[dict[str, Any]]:
             }
         )
     return scenarios
+
+
+def generate_runtime_supported_sustained_flow_scenarios() -> list[dict[str, Any]]:
+    """Generate sustained-flow rows that advertise continuous-spawn runtime support.
+
+    This is preflight/checker input, not benchmark evidence. It separates
+    generator drift checks from the later runner proof that continuous pedestrian
+    respawn is actually implemented.
+
+    Returns:
+        Scenario-matrix rows in deterministic light, medium, heavy order.
+    """
+
+    return generate_expected_sustained_flow_scenarios(
+        current_runtime_support=SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE
+    )
 
 
 @dataclass(frozen=True)

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -16,6 +16,9 @@ from robot_sf.benchmark.sustained_flow_preflight import (
     RUNTIME_SUPPORTED_VALUE,
     preflight_sustained_flow_matrix,
 )
+from robot_sf.scenario_certification.sustained_flow import (
+    generate_runtime_supported_sustained_flow_scenarios,
+)
 from robot_sf.training.scenario_loader import load_scenarios
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
@@ -112,10 +115,7 @@ def test_sustained_flow_preflight_accepts_runtime_supported_matrix(tmp_path: Pat
     """Runtime-supported rows become eligible only when every variant opts in."""
 
     matrix = _load_yaml(SCENARIO_SET)
-    for scenario in matrix["scenarios"]:
-        scenario["metadata"]["continuous_spawn"]["current_runtime_support"] = (
-            RUNTIME_SUPPORTED_VALUE
-        )
+    matrix["scenarios"] = generate_runtime_supported_sustained_flow_scenarios()
 
     supported_matrix = tmp_path / "runtime_supported_sustained_flow.yaml"
     supported_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")

--- a/tests/scenario_certification/test_sustained_flow_preflight.py
+++ b/tests/scenario_certification/test_sustained_flow_preflight.py
@@ -30,6 +30,22 @@ def test_expected_variants_enumerate_deterministically() -> None:
     assert spawn_rates == [6.0, 12.0, 18.0]
 
 
+def test_runtime_supported_variants_enumerate_deterministically() -> None:
+    """Runtime-supported generator preserves deterministic sustained-flow tiers."""
+
+    generated = sustained_flow.generate_runtime_supported_sustained_flow_scenarios()
+
+    assert [scenario["metadata"]["density"] for scenario in generated] == [
+        "light",
+        "medium",
+        "heavy",
+    ]
+    assert {
+        scenario["metadata"]["continuous_spawn"]["current_runtime_support"]
+        for scenario in generated
+    } == {sustained_flow.SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE}
+
+
 def test_preflight_conforms_for_commit_scaffold() -> None:
     """Current scaffold set satisfies fail-closed sustained-flow preflight."""
     report = sustained_flow.preflight_sustained_flow_scenario_set(SCENARIO_SET)


### PR DESCRIPTION
## Summary
- Adds an explicit runtime-supported sustained-flow scenario generator for issue #3813 preflight/checker inputs.
- Keeps the checked-in sustained-flow scenario scaffold metadata-only and fail-closed for benchmark evidence.
- Reuses the scenario-certification runtime-support constant from benchmark preflight to avoid drift.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3813

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/scenario_certification/sustained_flow.py robot_sf/benchmark/sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/scenario_certification/test_sustained_flow_preflight.py` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q` - passed, 12 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` - passed, conforms=true, variant_count=3, runtime_support=metadata_only, benchmark_evidence=false
- `PR_READY_PR_BODY_FILE=/tmp/issue-3813-pr-body.D5jgzU.md PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` - passed; core lane 1689 passed; optional-extra lane passed; freshness stamp recorded for 9e4628217c3cbfb306e478e1b770c5f5233b55b6

## Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
