### PR TITLE
Issue #3216: downgrade underpowered headline rank claims

### DIFF
--- a/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+++ b/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
@@ -568,7 +568,8 @@ def build_adjacent_rank_claims(
 
     Adjacent planners with overlapping confidence intervals are downgraded to
     ``not_statistically_distinguishable_budget`` so the packet cannot be read
-    as support for a strict paper-facing ordering.
+    as support for a strict paper-facing ordering. Adjacent planner statements
+    below the paper-grade seed threshold are classified ``diagnostic_only``.
     """
 
     cell_by_key = {
@@ -590,10 +591,18 @@ def build_adjacent_rank_claims(
             lower_stats = _metric_stats(lower_cell, rank_metric)
             if higher_stats is None or lower_stats is None:
                 continue
+            min_pair_seeds = min(higher_cell.seed_count, lower_cell.seed_count)
             if invalid_rank_metric_reason:
                 decision = "blocked_invalid_metric"
                 rationale = (
                     f"rank metric {rank_metric!r} is contract-invalid: {invalid_rank_metric_reason}"
+                )
+            elif min_pair_seeds < PAPER_GRADE_MIN_SEEDS:
+                decision = "diagnostic_only"
+                rationale = (
+                    "Adjacent-rank statement is diagnostic only because the paired cells "
+                    f"have min_seeds={min_pair_seeds}, below the paper-grade threshold "
+                    f"{PAPER_GRADE_MIN_SEEDS}."
                 )
             elif _ci_overlap(higher_stats, lower_stats):
                 decision = "not_statistically_distinguishable_budget"
@@ -750,6 +759,7 @@ def _append_packet_reasons(
     s30_reasons: list[str],
     *,
     overlap_claims: Sequence[AdjacentRankClaim],
+    diagnostic_only_claims: Sequence[AdjacentRankClaim],
     invalid_rank_metric: bool,
     metric_gaps: Sequence[str],
     snqi_contract_warning: bool,
@@ -759,6 +769,8 @@ def _append_packet_reasons(
 
     if overlap_claims:
         s30_reasons.append("adjacent_rank_ci_overlap_requires_claim_downgrade_or_more_data")
+    if diagnostic_only_claims:
+        s30_reasons.append("seed_budget_below_paper_grade_diagnostic_only")
     if invalid_rank_metric:
         manuscript_blockers.append("invalid_rank_metric_contract")
         s30_reasons.append("rank_metric_contract_invalid")
@@ -795,6 +807,9 @@ def build_decision_packet(
         for claim in adjacent_rank_claims
         if claim.decision == "not_statistically_distinguishable_budget"
     ]
+    diagnostic_only_claims = [
+        claim for claim in adjacent_rank_claims if claim.decision == "diagnostic_only"
+    ]
     invalid_metric_claims = [
         claim for claim in adjacent_rank_claims if claim.decision == "blocked_invalid_metric"
     ]
@@ -824,6 +839,7 @@ def build_decision_packet(
         manuscript_blockers,
         s30_reasons,
         overlap_claims=overlap_claims,
+        diagnostic_only_claims=diagnostic_only_claims,
         invalid_rank_metric=invalid_rank_metric,
         metric_gaps=metric_gaps,
         snqi_contract_warning=snqi_contract_warning,
@@ -858,6 +874,7 @@ def build_decision_packet(
         "identifiable_scenario_count": len(identifiable),
         "unstable_rank_scenarios": unstable_rank_scenarios,
         "adjacent_overlap_count": len(overlap_claims),
+        "diagnostic_only_claim_count": len(diagnostic_only_claims),
         "invalid_metric_claim_count": len(invalid_metric_claims),
         "invalid_rank_metric_reason": invalid_rank_metric_reason,
         "rank_profile": rank_profile,
@@ -1099,6 +1116,9 @@ def _append_decision_packet_markdown(lines: list[str], decision_packet: Mapping[
     lines.append(f"- **Minimum seed count**: {decision_packet['min_seed_count']}")
     lines.append(
         f"- **Adjacent CI-overlap downgrades**: {decision_packet['adjacent_overlap_count']}"
+    )
+    lines.append(
+        f"- **Diagnostic-only adjacent claims**: {decision_packet['diagnostic_only_claim_count']}"
     )
     if decision_packet["manuscript_blockers"]:
         blockers = ", ".join(decision_packet["manuscript_blockers"])

--- a/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
@@ -108,6 +108,23 @@ def test_adjacent_ci_overlap_downgrades_strict_rank_claim() -> None:
     )
 
 
+def test_underpowered_adjacent_rank_statement_is_diagnostic_only() -> None:
+    """Sub-S20 local rows never emit strict adjacent-rank separability claims."""
+    rows = [
+        _row("crossing", "hybrid", [0.90] * 10),
+        _row("crossing", "ppo", [0.50] * 10),
+    ]
+
+    report = build_report(rows, ReportConfig(bootstrap_samples=32, resamples=16))
+
+    assert report["adjacent_rank_claims"][0]["decision"] == "diagnostic_only"
+    assert report["decision_packet"]["diagnostic_only_claim_count"] == 1
+    assert (
+        "seed_budget_below_paper_grade_diagnostic_only"
+        in (report["decision_packet"]["s30_reasons"])
+    )
+
+
 def test_invalid_rank_metric_blocks_metric_claims() -> None:
     """SNQI or other rank-metric contract warnings fail closed for rank statements."""
     report = build_report(

--- a/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py
@@ -133,8 +133,8 @@ def test_stable_ordering_has_high_tau_and_no_flips():
 def test_overlapping_ordering_shows_rank_instability():
     """Two planners with heavily overlapping per-seed values flip under resamples."""
     rows = [
-        _cell_row("bottleneck", "a", {"snqi": [0.50, 0.55, 0.45, 0.52, 0.48]}),
-        _cell_row("bottleneck", "b", {"snqi": [0.51, 0.46, 0.54, 0.49, 0.53]}),
+        _cell_row("bottleneck", "a", {"snqi": [0.50, 0.55, 0.45, 0.52, 0.48] * 4}),
+        _cell_row("bottleneck", "b", {"snqi": [0.51, 0.46, 0.54, 0.49, 0.53] * 4}),
     ]
     cells = mod.build_cell_results(
         rows, metrics=["snqi"], bootstrap_samples=0, confidence=0.95, bootstrap_seed=1
@@ -262,8 +262,8 @@ def test_adjacent_rank_claims_downgrade_overlapping_ci() -> None:
     """Adjacent planners with overlapping CIs are not strict headline claims."""
 
     rows = [
-        _cell_row("bottleneck", "a", {"snqi": [0.50, 0.55, 0.45, 0.52, 0.48]}),
-        _cell_row("bottleneck", "b", {"snqi": [0.51, 0.46, 0.54, 0.49, 0.53]}),
+        _cell_row("bottleneck", "a", {"snqi": [0.50, 0.55, 0.45, 0.52, 0.48] * 4}),
+        _cell_row("bottleneck", "b", {"snqi": [0.51, 0.46, 0.54, 0.49, 0.53] * 4}),
     ]
 
     report = _report(rows)
@@ -278,8 +278,8 @@ def test_adjacent_rank_claims_mark_ci_separable() -> None:
     """Well-separated adjacent planner CIs are labeled separable."""
 
     rows = [
-        _cell_row("merging", "best", {"snqi": [0.90, 0.91, 0.92, 0.93, 0.94]}),
-        _cell_row("merging", "worst", {"snqi": [0.10, 0.11, 0.09, 0.12, 0.10]}),
+        _cell_row("merging", "best", {"snqi": [0.90, 0.91, 0.92, 0.93, 0.94] * 4}),
+        _cell_row("merging", "worst", {"snqi": [0.10, 0.11, 0.09, 0.12, 0.10] * 4}),
     ]
 
     report = _report(rows)
@@ -397,10 +397,7 @@ def test_dry_run_fixture_stays_diagnostic_and_fail_closed() -> None:
     assert degraded["counted"] is False
     assert "degraded" in degraded["exclusion_reason"]
     assert len(report["rank_stability"]) == 2
-    assert any(
-        claim["decision"] == "not_statistically_distinguishable_budget"
-        for claim in report["adjacent_rank_claims"]
-    )
+    assert any(claim["decision"] == "diagnostic_only" for claim in report["adjacent_rank_claims"])
 
 
 def test_dry_run_cli_writes_report_without_rows_file(tmp_path) -> None:


### PR DESCRIPTION
## Issue

Related issue: https://github.com/ll7/robot_sf_ll7/issues/3216. This is a local preflight/support-helper slice only; the parent issue must remain open because paper-grade headline evidence, manuscript-table propagation, and the S30 decision remain outstanding.

## Scope

This PR tightens the local #3216 headline CI/rank-stability preflight so adjacent-rank planner statements below the paper-grade seed threshold are classified `diagnostic_only` instead of emitting strict separability or overlap decisions. The decision packet now reports `diagnostic_only_claim_count` and adds `seed_budget_below_paper_grade_diagnostic_only` to S30/local-preflight reasons.

## Validation

- `uv run ruff check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py` - passed
- `uv run python -m pytest tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py -q` - passed, 35 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --help` - passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --dry-run --output-dir output/issue3216-pr4044-gate-dry-run --bootstrap-samples 32 --rank-resamples 16 --fail-on-decision-blocker` - expected exit 4; wrote diagnostic dry-run packet with `classification=diagnostic`, `manuscript_table_status=blocked`, `s30_decision_status=needs_review`, `diagnostic_only_claim_count=3`, and `seed_budget_below_paper_grade_diagnostic_only` in `s30_reasons`
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` - passed on head `c55f0563c1fa5f48cc69b8d4386b031a5ba6074b`; core lane reported 1689 passed, optional lane completed successfully
- GitHub CI: pending at gate review time only for `fast-feedback (2)`; all other required checks observed passing

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: prevent underpowered adjacent-rank statements from being interpreted as paper-facing rank-separability claims.
- Comparator or baseline, applicable: previous local preflight behavior could still classify sub-S20 adjacent statements through CI overlap/separability decisions.
- Evidence tier: targeted smoke / local preflight; no benchmark or manuscript claim promoted.
- Result classification: diagnostic-only support-helper behavior.
- Decision stop rule, applicable: sub-S20 adjacent-rank statements must be `diagnostic_only`; invalid rank metrics still fail closed before seed-budget classification.
- Parent issue, claim map, registry, context note, synthesis surface update: #3216 remains open for full evidence and propagation.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - existing #3216 support-helper tightened; representative dry-run and focused tests cover the changed contract.

## Domain-Aware Approval

Not required for merge as a support-helper/preflight correction. It does not promote benchmark evidence, change paper-facing conclusions, or complete the parent issue.

## Next Empirical Action

- Rerun needed: no for this local preflight slice; yes for #3216 closure.
- Extractor analysis tool needed: no new tool in this PR.
- Artifact missing unavailable: paper-grade headline evidence / manuscript-table propagation / S30 decision remain outside this PR.
- Stop / revise / continue decision: continue #3216 after merge; keep issue open.

## Risks / Rollout

- Compatibility risks: low; adds a more conservative classification path for underpowered adjacent-rank statements.
- Failure modes: downstream consumers that expected sub-S20 CI-overlap labels now receive `diagnostic_only` and must not treat those rows as paper-grade rank evidence.
- Rollback fallback plan: revert this PR to restore previous local-preflight classification behavior.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no; issue remains open and already records outstanding closure work.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no; #3216 remains the active follow-up.
- Not applicable because: this PR changes local preflight classification only and explicitly does not propagate manuscript or benchmark claims.

## Follow-Up Issues

- Deferred work: keep #3216 open for paper-grade headline evidence, manuscript-table propagation, and the S30 decision.
- Issues opened follow-up: none.

## Reviewer Notes

- Verify the classification precedence: invalid rank metric remains `blocked_invalid_metric`; sub-S20 adjacent claims become `diagnostic_only`; S20+ adjacent claims can still be CI-overlap downgraded or CI-separable.

