### PR TITLE
Issue #3653: harden SNQI export packet report checks

### DIFF
--- a/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
+++ b/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
@@ -310,7 +310,7 @@ def _require_populated_pareto_front(report: Mapping[str, Any]) -> None:
 
 
 def _require_populated_decision_disagreement(report: Mapping[str, Any]) -> None:
-    """Require finite decision-disagreement summary values."""
+    """Require usable decision-disagreement summary values."""
 
     disagreement = _require_mapping(report, "decision_disagreement")
     for field in (
@@ -322,13 +322,27 @@ def _require_populated_decision_disagreement(report: Mapping[str, Any]) -> None:
     ):
         if field not in disagreement:
             raise PacketError(f"export report decision_disagreement missing field {field!r}")
+    for field in ("snqi_winner", "constraints_first_winner"):
+        if not isinstance(disagreement[field], str) or not disagreement[field].strip():
+            raise PacketError(
+                f"export report decision_disagreement field {field!r} must be non-empty string"
+            )
+    if not isinstance(disagreement["winner_disagreement"], bool):
+        raise PacketError(
+            "export report decision_disagreement field 'winner_disagreement' must be boolean"
+        )
     try:
         disagreement_rate = float(disagreement["pairwise_disagreement_rate"])
-        reversal_count = int(disagreement["pairwise_reversal_count"])
+        reversal_count_raw = float(disagreement["pairwise_reversal_count"])
     except (TypeError, ValueError) as exc:
         raise PacketError("export report decision_disagreement numeric fields are invalid") from exc
     if not math.isfinite(disagreement_rate) or not 0.0 <= disagreement_rate <= 1.0:
         raise PacketError("export report decision_disagreement rate must be finite in [0, 1]")
+    if not math.isfinite(reversal_count_raw) or not reversal_count_raw.is_integer():
+        raise PacketError(
+            "export report decision_disagreement reversal count must be finite integer"
+        )
+    reversal_count = int(reversal_count_raw)
     if reversal_count < 0:
         raise PacketError("export report decision_disagreement reversal count must be non-negative")
 

--- a/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
+++ b/scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import math
 import sys
 from collections.abc import Mapping, Sequence
 from pathlib import Path
@@ -270,6 +271,66 @@ def _require_export_report_fields(packet: Mapping[str, Any], report: Mapping[str
     missing = sorted(field for field in required if field not in report)
     if missing:
         raise PacketError(f"export report missing required fields: {missing}")
+    _require_populated_export_report(report)
+
+
+def _require_populated_export_report(report: Mapping[str, Any]) -> None:
+    """Require usable Pareto and decision-disagreement payloads before export success."""
+
+    _require_populated_pareto_front(report)
+    _require_populated_decision_disagreement(report)
+
+
+def _require_populated_pareto_front(report: Mapping[str, Any]) -> None:
+    """Require non-empty finite Pareto-front points."""
+
+    pareto = _require_mapping(report, "pareto_front")
+    points = pareto.get("points")
+    if not isinstance(points, Sequence) or isinstance(points, (str, bytes)) or not points:
+        raise PacketError("export report pareto_front.points must be a non-empty sequence")
+    for index, point in enumerate(points, start=1):
+        if not isinstance(point, Mapping):
+            raise PacketError(f"export report pareto_front point {index} must be a mapping")
+        for field in ("planner", "constraints_first_score", "snqi_mean"):
+            if field not in point:
+                raise PacketError(
+                    f"export report pareto_front point {index} missing field {field!r}"
+                )
+        for field in ("constraints_first_score", "snqi_mean"):
+            try:
+                value = float(point[field])
+            except (TypeError, ValueError) as exc:
+                raise PacketError(
+                    f"export report pareto_front point {index} non-numeric field {field!r}"
+                ) from exc
+            if not math.isfinite(value):
+                raise PacketError(
+                    f"export report pareto_front point {index} non-finite field {field!r}"
+                )
+
+
+def _require_populated_decision_disagreement(report: Mapping[str, Any]) -> None:
+    """Require finite decision-disagreement summary values."""
+
+    disagreement = _require_mapping(report, "decision_disagreement")
+    for field in (
+        "snqi_winner",
+        "constraints_first_winner",
+        "winner_disagreement",
+        "pairwise_disagreement_rate",
+        "pairwise_reversal_count",
+    ):
+        if field not in disagreement:
+            raise PacketError(f"export report decision_disagreement missing field {field!r}")
+    try:
+        disagreement_rate = float(disagreement["pairwise_disagreement_rate"])
+        reversal_count = int(disagreement["pairwise_reversal_count"])
+    except (TypeError, ValueError) as exc:
+        raise PacketError("export report decision_disagreement numeric fields are invalid") from exc
+    if not math.isfinite(disagreement_rate) or not 0.0 <= disagreement_rate <= 1.0:
+        raise PacketError("export report decision_disagreement rate must be finite in [0, 1]")
+    if reversal_count < 0:
+        raise PacketError("export report decision_disagreement reversal count must be non-negative")
 
 
 def export_if_ready(

--- a/tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py
+++ b/tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py
@@ -199,6 +199,70 @@ def test_issue_3653_export_report_contract_rejects_missing_required_field() -> N
         raise AssertionError("missing report fields should fail closed")
 
 
+def test_issue_3653_export_report_contract_rejects_empty_pareto_points() -> None:
+    """Application export success requires populated Pareto-front evidence."""
+
+    packet = _load_packet()
+    report = {
+        "decision_disagreement": {
+            "snqi_winner": "planner_a",
+            "constraints_first_winner": "planner_b",
+            "winner_disagreement": True,
+            "pairwise_disagreement_rate": 0.5,
+            "pairwise_reversal_count": 1,
+        },
+        "pareto_front": {"x": "constraints_first_score", "y": "snqi_mean", "points": []},
+        "planner_rows": [{"planner": "planner_a"}],
+        "weight_zero_ablation": {"w_success": {}},
+        "weight_sweep": {"w_success": []},
+        "term_dominance": [{"component": "success"}],
+    }
+
+    try:
+        _MODULE._require_export_report_fields(packet, report)
+    except _MODULE.PacketError as exc:
+        assert "pareto_front.points" in str(exc)
+    else:
+        raise AssertionError("empty Pareto-front export should fail closed")
+
+
+def test_issue_3653_export_report_contract_rejects_invalid_decision_rate() -> None:
+    """Application export success requires finite decision-disagreement values."""
+
+    packet = _load_packet()
+    report = {
+        "decision_disagreement": {
+            "snqi_winner": "planner_a",
+            "constraints_first_winner": "planner_b",
+            "winner_disagreement": True,
+            "pairwise_disagreement_rate": 1.5,
+            "pairwise_reversal_count": 1,
+        },
+        "pareto_front": {
+            "x": "constraints_first_score",
+            "y": "snqi_mean",
+            "points": [
+                {
+                    "planner": "planner_a",
+                    "constraints_first_score": 0.4,
+                    "snqi_mean": 0.2,
+                }
+            ],
+        },
+        "planner_rows": [{"planner": "planner_a"}],
+        "weight_zero_ablation": {"w_success": {}},
+        "weight_sweep": {"w_success": []},
+        "term_dominance": [{"component": "success"}],
+    }
+
+    try:
+        _MODULE._require_export_report_fields(packet, report)
+    except _MODULE.PacketError as exc:
+        assert "decision_disagreement rate" in str(exc)
+    else:
+        raise AssertionError("invalid decision-disagreement rate should fail closed")
+
+
 def test_issue_3653_export_if_ready_writes_required_artifacts(tmp_path: Path) -> None:
     """Ready campaign-shaped inputs run through preflight and emit the packet artifact set."""
 

--- a/tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py
+++ b/tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py
@@ -263,6 +263,43 @@ def test_issue_3653_export_report_contract_rejects_invalid_decision_rate() -> No
         raise AssertionError("invalid decision-disagreement rate should fail closed")
 
 
+def test_issue_3653_export_report_contract_rejects_fractional_reversal_count() -> None:
+    """Decision-disagreement reversal counts must be whole counts."""
+
+    packet = _load_packet()
+    report = {
+        "decision_disagreement": {
+            "snqi_winner": "planner_a",
+            "constraints_first_winner": "planner_b",
+            "winner_disagreement": True,
+            "pairwise_disagreement_rate": 0.5,
+            "pairwise_reversal_count": 1.5,
+        },
+        "pareto_front": {
+            "x": "constraints_first_score",
+            "y": "snqi_mean",
+            "points": [
+                {
+                    "planner": "planner_a",
+                    "constraints_first_score": 0.4,
+                    "snqi_mean": 0.2,
+                }
+            ],
+        },
+        "planner_rows": [{"planner": "planner_a"}],
+        "weight_zero_ablation": {"w_success": {}},
+        "weight_sweep": {"w_success": []},
+        "term_dominance": [{"component": "success"}],
+    }
+
+    try:
+        _MODULE._require_export_report_fields(packet, report)
+    except _MODULE.PacketError as exc:
+        assert "reversal count must be finite integer" in str(exc)
+    else:
+        raise AssertionError("fractional reversal count should fail closed")
+
+
 def test_issue_3653_export_if_ready_writes_required_artifacts(tmp_path: Path) -> None:
     """Ready campaign-shaped inputs run through preflight and emit the packet artifact set."""
 


### PR DESCRIPTION
## Summary
- Harden issue #3653 SNQI decision-disagreement packet export validation so export success requires populated Pareto-front points and usable decision-disagreement values.
- Require finite in-range disagreement rates, whole non-negative reversal counts, non-empty winner names, and boolean winner-disagreement flags before the packet checker accepts an exported report.
- Add focused regression coverage for empty Pareto-front output, invalid decision-disagreement rate, and fractional reversal counts.

## Issue
- Addresses: https://github.com/ll7/robot_sf_ll7/issues/3653
- Disposition: #3653 remains open. The packet still reports `blocked_missing_valid_campaign_episodes`; research-complete resolution still requires hydrating or promoting `output/issue1554-s20-h500-l40s-mem180/13175/reports/episodes.jsonl`, running `scripts/benchmark/snqi_scalarization_sensitivity_export.py`, and reviewing the Pareto/decision-disagreement artifacts on that valid campaign evidence surface.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/validation/test_check_issue_3653_snqi_decision_disagreement_packet.py -q` - passed; 12 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_snqi_scalarization_sensitivity.py::test_report_exports_decision_disagreement_and_weight_reversals -q` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_issue_3653_snqi_decision_disagreement_packet.py --json` - passed; packet status `ok`, current_status remains `blocked_missing_valid_campaign_episodes`.

## Out scope
- No full benchmark, GPU, Slurm, or heavy campaign run.
- No claim that the #3653 decision-disagreement/Pareto diagnostic has consumed valid job `13175` campaign evidence.

## Follow-Up Issues
- Deferred work: #3653 remains the open tracker for valid campaign evidence hydration/promotion and empirical export review.
- Issues opened follow-up: none; this PR does not split the remaining blocker because the existing issue already states the acceptance condition and current blocker.

## Reviewer Notes
- This is a support-level fail-closed report-contract hardening slice. It makes false success harder for the application packet, but it intentionally leaves the empirical application blocker open.
