### PR TITLE
Issue #3813: define sustained-flow continuous-spawn preflight

### DIFF
--- a/configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml
+++ b/configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml
@@ -27,6 +27,12 @@ scenarios:
       continuous_spawn:
         required_before_benchmark_use: true
         intended_process: poisson_respawn
+        definition:
+          demand_model: non_clearing_poisson_flow
+          respawn_trigger: pedestrian_exits_route_corridor
+          spawn_budget: time_bounded_episode
+          minimum_active_pedestrians: 1
+          clearing_policy: disallow_empty_scene_wait_success
         spawn_rate_per_min: 6.0
         target_density_tier: light
         current_runtime_support: metadata_only
@@ -68,6 +74,12 @@ scenarios:
       continuous_spawn:
         required_before_benchmark_use: true
         intended_process: poisson_respawn
+        definition:
+          demand_model: non_clearing_poisson_flow
+          respawn_trigger: pedestrian_exits_route_corridor
+          spawn_budget: time_bounded_episode
+          minimum_active_pedestrians: 1
+          clearing_policy: disallow_empty_scene_wait_success
         spawn_rate_per_min: 12.0
         target_density_tier: medium
         current_runtime_support: metadata_only
@@ -109,6 +121,12 @@ scenarios:
       continuous_spawn:
         required_before_benchmark_use: true
         intended_process: poisson_respawn
+        definition:
+          demand_model: non_clearing_poisson_flow
+          respawn_trigger: pedestrian_exits_route_corridor
+          spawn_budget: time_bounded_episode
+          minimum_active_pedestrians: 1
+          clearing_policy: disallow_empty_scene_wait_success
         spawn_rate_per_min: 18.0
         target_density_tier: heavy
         current_runtime_support: metadata_only

--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from robot_sf.scenario_certification.sustained_flow import (
+    EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
     SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE,
     generate_expected_sustained_flow_scenarios,
 )
@@ -53,6 +54,7 @@ class SustainedFlowVariant:
     density_tier: str
     ped_density: float
     spawn_rate_per_min: float
+    spawn_definition: dict[str, object]
     current_runtime_support: str
     max_episode_steps: int
     seeds: tuple[int, ...]
@@ -161,6 +163,10 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
         raise SustainedFlowPreflightError(
             f"{name}: continuous_spawn.intended_process must be {SUPPORTED_SPAWN_PROCESS!r}"
         )
+    if continuous_spawn.get("definition") != EXPECTED_CONTINUOUS_SPAWN_DEFINITION:
+        raise SustainedFlowPreflightError(
+            f"{name}: continuous_spawn.definition must match non-clearing demand contract"
+        )
 
     seeds = scenario.get("seeds", [])
     if not isinstance(seeds, list) or not all(isinstance(seed, int) for seed in seeds):
@@ -173,6 +179,7 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
         spawn_rate_per_min=_required_float(
             continuous_spawn, "spawn_rate_per_min", scenario_name=name
         ),
+        spawn_definition=dict(EXPECTED_CONTINUOUS_SPAWN_DEFINITION),
         current_runtime_support=_required_str(
             continuous_spawn, "current_runtime_support", scenario_name=name
         ),
@@ -218,6 +225,7 @@ def _variant_generator_profile(variant: SustainedFlowVariant) -> tuple[object, .
         variant.density_tier,
         variant.ped_density,
         variant.spawn_rate_per_min,
+        tuple(sorted(variant.spawn_definition.items())),
         variant.max_episode_steps,
         variant.seeds,
     )

--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -31,6 +31,13 @@ REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE: tuple[str, ...] = (
     "interaction-exposure diagnostic sanity check",
     "scenario_cert.v1 eligibility review",
 )
+EXPECTED_CONTINUOUS_SPAWN_DEFINITION: dict[str, object] = {
+    "demand_model": "non_clearing_poisson_flow",
+    "respawn_trigger": "pedestrian_exits_route_corridor",
+    "spawn_budget": "time_bounded_episode",
+    "minimum_active_pedestrians": 1,
+    "clearing_policy": "disallow_empty_scene_wait_success",
+}
 _SUSTAINED_FLOW_FAMILY = "sustained_flow_t_intersection"
 _SUSTAINED_FLOW_MAP_FILE = "../../../maps/svg_maps/classic_t_intersection.svg"
 _SUSTAINED_FLOW_MAX_EPISODE_STEPS = 600
@@ -116,6 +123,7 @@ def generate_expected_sustained_flow_scenarios(
                     "continuous_spawn": {
                         "required_before_benchmark_use": True,
                         "intended_process": "poisson_respawn",
+                        "definition": dict(EXPECTED_CONTINUOUS_SPAWN_DEFINITION),
                         "spawn_rate_per_min": spec.spawn_rate_per_min,
                         "target_density_tier": spec.density_tier,
                         "current_runtime_support": current_runtime_support,
@@ -165,6 +173,7 @@ class SustainedFlowVariant:
     density_tier: str
     ped_density: float
     spawn_rate_per_min: float
+    spawn_definition: dict[str, object]
     seeds: tuple[int, ...]
     map_file: str
 
@@ -258,6 +267,13 @@ def _check_continuous_spawn(
         "continuous_spawn.intended_process",
         continuous_spawn.get("intended_process"),
         "poisson_respawn",
+    )
+    _require_equal(
+        errors,
+        name,
+        "continuous_spawn.definition",
+        continuous_spawn.get("definition"),
+        EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
     )
     _require_equal(
         errors,
@@ -405,6 +421,7 @@ def _validate_variant(
             density_tier=tier,
             ped_density=ped_density,
             spawn_rate_per_min=expected_spawn_rate,
+            spawn_definition=dict(EXPECTED_CONTINUOUS_SPAWN_DEFINITION),
             seeds=seeds,
             map_file=map_file,
         ),
@@ -501,6 +518,7 @@ def sustained_flow_preflight_to_dict(report: SustainedFlowPreflightReport) -> di
                 "density_tier": variant.density_tier,
                 "ped_density": variant.ped_density,
                 "spawn_rate_per_min": variant.spawn_rate_per_min,
+                "spawn_definition": dict(variant.spawn_definition),
                 "seeds": list(variant.seeds),
                 "map_file": variant.map_file,
             }

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -177,6 +177,26 @@ def test_sustained_flow_preflight_rejects_wrong_spawn_process(tmp_path: Path) ->
     )
 
 
+def test_sustained_flow_preflight_rejects_wrong_spawn_definition(tmp_path: Path) -> None:
+    """Continuous-spawn variants must keep the non-clearing demand definition."""
+    matrix = _load_yaml(SCENARIO_SET)
+    matrix["scenarios"][0]["metadata"]["continuous_spawn"]["definition"]["clearing_policy"] = (
+        "allow_empty_scene_wait_success"
+    )
+
+    wrong_definition_matrix = tmp_path / "wrong_spawn_definition_sustained_flow.yaml"
+    wrong_definition_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+    payload = preflight_sustained_flow_matrix(wrong_definition_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert payload["variant_count"] == 0
+    assert any(
+        "continuous_spawn.definition must match non-clearing demand contract" in reason
+        for reason in payload["blocking_reasons"]
+    )
+
+
 def test_sustained_flow_contract_defines_progress_metric_and_reference() -> None:
     """The scenario contract points at the scaffold and keeps evidence boundaries explicit."""
 

--- a/tests/benchmark/test_issue_3813_sustained_flow_scenarios.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scenarios.py
@@ -10,6 +10,7 @@ import yaml
 
 from robot_sf.scenario_certification.sustained_flow import (
     DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
+    EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
     EXPECTED_SUSTAINED_FLOW_TIERS,
     REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE,
     generate_expected_sustained_flow_scenarios,
@@ -45,6 +46,7 @@ def test_issue_3813_sustained_flow_scenarios_enumerate_expected_tiers() -> None:
         assert scenario["simulation_config"]["max_episode_steps"] == 600
         assert scenario["simulation_config"]["ped_density"] == expected[tier]["ped_density"]
         assert scenario["seeds"] == expected[tier]["seeds"]
+        assert metadata["continuous_spawn"]["definition"] == EXPECTED_CONTINUOUS_SPAWN_DEFINITION
         assert (
             metadata["continuous_spawn"]["spawn_rate_per_min"]
             == expected[tier]["spawn_rate_per_min"]
@@ -69,6 +71,7 @@ def test_issue_3813_sustained_flow_scenarios_fail_closed_for_benchmark_use() -> 
         assert metadata["continuous_spawn"] == {
             "required_before_benchmark_use": True,
             "intended_process": "poisson_respawn",
+            "definition": EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
             "spawn_rate_per_min": metadata["continuous_spawn"]["spawn_rate_per_min"],
             "target_density_tier": metadata["density"],
             "current_runtime_support": "metadata_only",
@@ -118,6 +121,9 @@ def test_issue_3813_sustained_flow_preflight_cli_json() -> None:
     assert payload["variant_count"] == 3
     assert payload["benchmark_evidence"] is False
     assert payload["runtime_support"] == "metadata_only"
+    assert {
+        variant["density_tier"]: variant["spawn_definition"] for variant in payload["variants"]
+    } == {tier: EXPECTED_CONTINUOUS_SPAWN_DEFINITION for tier, *_ in EXPECTED_SUSTAINED_FLOW_TIERS}
 
 
 def test_issue_3813_checked_in_matrix_matches_generated_variant_specs() -> None:

--- a/tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from robot_sf.scenario_certification.sustained_flow import (
+    EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
     EXPECTED_SUSTAINED_FLOW_TIERS,
     REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE,
     generate_expected_sustained_flow_scenarios,
@@ -10,7 +11,7 @@ from robot_sf.scenario_certification.sustained_flow import (
 
 
 def test_issue_3813_sustained_flow_variants_are_stable_and_ordered() -> None:
-    """Generator output has deterministic variant naming ordered density tiers."""
+    """Generator output has deterministic variant naming and ordered density tiers."""
     generated = generate_expected_sustained_flow_scenarios()
     expected_tiers = tuple(tier for tier, *_ in EXPECTED_SUSTAINED_FLOW_TIERS)
     expected_spawn_rates = tuple(
@@ -27,6 +28,9 @@ def test_issue_3813_sustained_flow_variants_are_stable_and_ordered() -> None:
         )
         == expected_spawn_rates
     )
+    assert tuple(
+        scenario["metadata"]["continuous_spawn"]["definition"] for scenario in generated
+    ) == tuple(EXPECTED_CONTINUOUS_SPAWN_DEFINITION for _ in expected_tiers)
     assert tuple(
         tuple(scenario["metadata"]["requires_before_benchmark_use"]) for scenario in generated
     ) == tuple(REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE for _ in expected_tiers)


### PR DESCRIPTION
## Summary
Adds an explicit non-clearing continuous-spawn variant definition to the issue #3813 sustained-flow scaffold and preflight surfaces. This remains a metadata/preflight slice only, not benchmark evidence.

## Linked Issues
- Relates https://github.com/ll7/robot_sf_ll7/issues/3813

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #3813 remains open for runtime continuous respawn, sustained-progress metric proof, exposure sanity proof, pure-wait baseline proof, and campaign/runner evidence.
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added a canonical `EXPECTED_CONTINUOUS_SPAWN_DEFINITION` for non-clearing Poisson-flow scaffold rows.
- Added the definition to the checked-in light/medium/heavy sustained-flow scenario variants.
- Extended scenario-certification and benchmark preflights to require and serialize the definition, so generator drift fails closed.
- Added enumeration tests covering the new definition in generated rows, YAML rows, and CLI payloads.

## Why Matters
- Added value: makes the continuous-spawn scenario variant contract machine-checkable instead of prose-only.
- Expected impact: narrows the next #3813 implementation step while preserving fail-closed benchmark eligibility.
- Why worth merging now: strengthens the local generator/preflight slice requested by the ready queue without running a full campaign.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: sustained-flow preflight can enumerate explicit non-clearing continuous-spawn variant definitions for #3813.
- Comparator or baseline, applicable: existing metadata-only sustained-flow scaffold without explicit definition fields.
- Evidence tier: NA - preflight support helper; validation is local proof, not research evidence
- Result classification: NA - preflight support helper; no benchmark result interpreted
- Decision stop rule, applicable: focused tests and CLI preflight must pass; no benchmark claim promoted.
- Parent issue, claim map, registry, context note, synthesis surface update: #3813 remains the parent issue; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - preflight/schema guard only.

## Domain-Aware Approval
- Required PR: not applicable
- Domains reviewed: benchmark scenario preflight; no runtime benchmark validity claimed.
- Status: not applicable
- Approval blocker note: domain approval for benchmark-validity claims is blocked until #3813 has runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, and campaign/runner evidence. This PR is preflight-only.
- Approver/review source waiver: no benchmark evidence or paper-facing claim is promoted.
- Validity checklist: fail-closed scaffold remains `benchmark_evidence=false` and `runtime_support=metadata_only`.
- Target claim/hypothesis: preflight enumeration only.
- Comparator split/evidence validity: existing scaffold without machine-checkable non-clearing spawn definition; no planner comparison or benchmark validity claim.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution is reported as success.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation integrity checked by focused tests and PR readiness; experimental validity deferred to remaining #3813 work.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no runtime mechanism added.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? unknown; no campaign run.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3813 remaining contract.

## Next Empirical Action
- Rerun needed: no for this preflight slice; yes for remaining runtime/campaign work.
- Extractor analysis tool needed: no for this slice.
- Artifact missing unavailable: runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof.
- Stop / revise / continue decision: continue #3813 after this preflight slice.
- Proposed child issue existing follow-up: #3813.

## Validation / Proof
- `uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` - passed, 14 tests.
- `uv run ruff check robot_sf/scenario_certification/sustained_flow.py robot_sf/benchmark/sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` - passed.
- `uv run python scripts/dev/check_pr_followups.py --body-file /tmp/pr4047-body.md --changed-files-file /tmp/pr4047-files.txt --require-body --require-substantive-body --require-open-issues` - passed; #3813 remains open for deferred runtime/metric/campaign proof.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` - passed on head `3f29f1204ee87d67574711b3bcae6257c87c6172`; stamp `output/validation/pr_ready/pr-4047-gate.json`.

## Performance Impact
- Baseline runtime: NA - metadata/preflight only, no runtime performance claim.
- Changed runtime: NA - metadata/preflight only, no runtime performance claim.
- Representative command: `uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json`
- Hot-path call count profile anchor: NA - no runtime hot path changed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: sustained-flow preflight or scenario enumeration tests fail.

## Risks / Rollout
- Compatibility risks: preflight now rejects sustained-flow rows that omit or alter the non-clearing spawn definition.
- Failure modes: downstream fixtures expecting the older payload shape may need to account for `spawn_definition`.
- Rollback fallback plan: revert this commit to restore the prior metadata-only preflight contract.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3813 live issue and prior merged preflight slices.
- Any assumptions need to preserved: the definition is a reversible preflight contract, not proof that runtime respawn exists.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, per task authorization comment_issue_or_pr=false.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR does not promote benchmark, registry, claim-map, or paper-facing evidence.

## Follow-Up Issues
- Deferred work: runtime continuous pedestrian respawn support; sustained-progress metric proof; interaction-exposure sanity proof; pure-wait baseline proof; runnable campaign/runner benchmark evidence.
- Issues opened follow-up: none; #3813 remains open.

## Reviewer Notes
- Verify closely that `benchmark_evidence=false` and `runtime_support=metadata_only` remain intact.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

