### PR TITLE
Issue #3275: require source archive certification readiness

### DIFF
--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -1,14 +1,14 @@
 # Issue #3275 Failure Archive Rerun Readiness
 
-This note records a metadata-only gate for rerunning the adversarial proposal model on a separate certified failure archive.
+This note records the metadata-only gate for rerunning an adversarial proposal model on a separate certified failure archive.
 
 ## Boundary
 
-The check is readiness/leakage evidence only. It does not run benchmark campaigns, submit compute jobs, publish artifacts, or claim that adversarial proposal models improve failure discovery.
+The check is readiness/leakage evidence only. It does not run benchmark campaigns, submit compute jobs, publish artifacts, or claim adversarial proposal models improve failure discovery.
 
 ## Implementation
 
-- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads a source archive and rerun archive, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, or `candidate.scenario_seed`), requires certification metadata on rerun archive entries, and can validate supplied null-test prerequisite metadata.
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), requires passing certification metadata on source and rerun archive entries, and validates supplied null-test prerequisite metadata.
 - `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI, including optional `--null-test-prerequisites` input.
 - Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
 
@@ -18,8 +18,9 @@ Focused tests cover:
 
 - disjoint certified archives passing the metadata gate;
 - overlapping archive IDs blocking leakage;
-- missing overlap metadata (`archive_id`, scenario family, or `candidate.scenario_seed`) blocking readiness;
-- missing rerun certification metadata blocking readiness;
+- missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`) blocking readiness;
+- missing or failed source archive certification metadata blocking readiness;
+- missing or failed rerun archive certification metadata blocking readiness;
 - complete null-test prerequisite metadata staying ready;
 - missing or invalid null-test prerequisite metadata blocking readiness;
 - diagnostic-only rerun outputs staying diagnostic-only.

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -96,6 +96,8 @@ class FailureArchiveRerunReadiness:
     overlap_provenance: dict[str, Any] = field(default_factory=dict)
     archive_id_overlap: list[str] = field(default_factory=list)
     missing_overlap_metadata_archive_ids: list[str] = field(default_factory=list)
+    source_missing_certification_archive_ids: list[str] = field(default_factory=list)
+    source_invalid_certification_archive_ids: list[str] = field(default_factory=list)
     missing_certification_archive_ids: list[str] = field(default_factory=list)
     invalid_certification_archive_ids: list[str] = field(default_factory=list)
     diagnostic_only_outputs: list[str] = field(default_factory=list)
@@ -129,6 +131,12 @@ class FailureArchiveRerunReadiness:
             "overlap_provenance": dict(self.overlap_provenance),
             "archive_id_overlap": list(self.archive_id_overlap),
             "missing_overlap_metadata_archive_ids": list(self.missing_overlap_metadata_archive_ids),
+            "source_missing_certification_archive_ids": list(
+                self.source_missing_certification_archive_ids
+            ),
+            "source_invalid_certification_archive_ids": list(
+                self.source_invalid_certification_archive_ids
+            ),
             "missing_certification_archive_ids": list(self.missing_certification_archive_ids),
             "invalid_certification_archive_ids": list(self.invalid_certification_archive_ids),
             "diagnostic_only_outputs": list(self.diagnostic_only_outputs),
@@ -186,6 +194,13 @@ def classify_failure_archive_rerun_readiness(
     missing_overlap_metadata = _overlap_metadata_gaps(source_entries, rerun_entries)
     blockers.extend(_count_blockers("missing_overlap_metadata", missing_overlap_metadata))
 
+    source_missing_certification, source_invalid_certification = _certification_gaps(source_entries)
+    blockers.extend(
+        _count_blockers("source_missing_certification_metadata", source_missing_certification)
+    )
+    blockers.extend(
+        _count_blockers("source_invalid_certification_status", source_invalid_certification)
+    )
     missing_certification, invalid_certification = _certification_gaps(rerun_entries)
     blockers.extend(_count_blockers("missing_certification_metadata", missing_certification))
     blockers.extend(_count_blockers("invalid_certification_status", invalid_certification))
@@ -211,6 +226,8 @@ def classify_failure_archive_rerun_readiness(
         overlap_provenance=overlap,
         archive_id_overlap=archive_id_overlap,
         missing_overlap_metadata_archive_ids=missing_overlap_metadata,
+        source_missing_certification_archive_ids=source_missing_certification,
+        source_invalid_certification_archive_ids=source_invalid_certification,
         missing_certification_archive_ids=missing_certification,
         invalid_certification_archive_ids=invalid_certification,
         diagnostic_only_outputs=diagnostic_outputs,

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -208,6 +208,27 @@ def test_missing_certification_metadata_blocks_rerun_archive(tmp_path: Path) -> 
     assert "missing_certification_metadata:1" in readiness.blockers
 
 
+def test_missing_source_certification_metadata_blocks_readiness(tmp_path: Path) -> None:
+    """The source archive must also carry certification metadata."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1, certified=False)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(source, rerun)
+
+    assert readiness.status == BLOCKED
+    assert readiness.source_missing_certification_archive_ids == ["source_0000"]
+    assert "source_missing_certification_metadata:1" in readiness.blockers
+    payload = readiness.to_payload()
+    assert payload["source_missing_certification_archive_ids"] == ["source_0000"]
+
+
 def test_failed_or_falsy_certification_status_is_invalid(tmp_path: Path) -> None:
     """Explicitly failed or falsy certification status must fail closed, not pass."""
 
@@ -234,6 +255,26 @@ def test_failed_or_falsy_certification_status_is_invalid(tmp_path: Path) -> None
         assert readiness.invalid_certification_archive_ids == [f"rerun_{index:04d}"], certification
         assert readiness.missing_certification_archive_ids == [], certification
         assert "invalid_certification_status:1" in readiness.blockers, certification
+
+
+def test_failed_source_certification_status_is_invalid(tmp_path: Path) -> None:
+    """Explicit source certification failures must fail closed, not pass."""
+
+    source_entry = _entry("source_0000", family="family_a", seed=1)
+    source_entry["certification_metadata"] = {"status": "failed", "source": "unit-test"}
+    source = _archive(tmp_path / "source.json", [source_entry])
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(source, rerun)
+
+    assert readiness.status == BLOCKED
+    assert readiness.source_invalid_certification_archive_ids == ["source_0000"]
+    assert "source_invalid_certification_status:1" in readiness.blockers
+    payload = readiness.to_payload()
+    assert payload["source_invalid_certification_archive_ids"] == ["source_0000"]
 
 
 def test_diagnostic_only_output_caps_otherwise_ready_inputs(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds a fail-closed source-archive certification check to the issue #3275 failure-archive rerun readiness packet. This keeps the readiness gate symmetric: both the source archive and rerun archive must carry passing certification metadata before a disjoint archive rerun can be marked ready.

## Linked Issues
- Relates to #3275

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added source-side missing and invalid certification metadata fields to `FailureArchiveRerunReadiness.to_payload()`.
- Added fail-closed blockers for missing or failed source archive certification metadata.
- Added synthetic fixture tests for missing and invalid source certification metadata.

## Why Matters
- Added value: closes a readiness hygiene gap where the rerun archive certification was checked but the source archive certification was not.
- Expected impact: malformed or uncertified source archives now block the packet before any rerun/evidence interpretation.
- Why worth merging now: the issue scope is explicitly readiness/fail-closed work before real archive inputs are used.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Blocker-resolution for certified disjoint failure-archive rerun readiness; no benchmark yield claim.
- Comparator or baseline, applicable: NA; structural checker only.
- Evidence tier: NA - support checker; targeted unit proof is listed under Validation
- Result classification: NA - support checker; no research result
- Decision stop rule, applicable: source or rerun archive entries missing passing certification metadata produce blocked readiness status.
- Parent issue, claim map, registry, context note, synthesis surface update: #3275
- New research/benchmark/metric/paper-facing analysis tool, any: NA; extends existing readiness checker and tests only.

## Domain-Aware Approval
approval concerns experimental validity claim: not required - support checker only, no benchmark or paper-facing claim
- Approver/review source waiver: not required; no benchmark result, metric interpretation, or paper-facing claim is promoted.
- Validity checklist: fail-closed synthetic fixtures only.
- Target claim/hypothesis: archive readiness hygiene, not model performance.
- Comparator split/evidence validity: NA - no comparator split, benchmark interpretation, or evidence-validity claim is changed.
- Fallback/degraded exclusions: no fallback/degraded benchmark execution added.
- Claim boundary: readiness/leakage check only.
- Implementation integrity vs experimental validity: implementation blocks missing/invalid source certification; it does not validate real archive content quality.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, in synthetic missing/invalid source certification tests.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA, fixture-level metadata gate only.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this PR; real archive evaluation remains out of scope.
- Extractor analysis tool needed: no
- Artifact missing unavailable: real certified failure archives remain outside this PR.
- Stop / revise / continue decision: continue with review; hand off full PR gate to Claude Code on imech156-u per task.
- Proposed child issue existing follow-up: #3275 remains the parent for real archive rerun work.

## Validation / Proof
- `uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` -> passed
- `git diff --check` -> passed
- `uv run ruff format robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py --check` -> passed
- `uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` -> passed
- Codex PR gate additional validation on `b268c00c0`: `uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` -> passed; `uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` -> passed; `uv run ruff format robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py --check` -> passed; `git diff --check` -> passed; `uv run python scripts/validation/check_failure_archive_rerun_readiness.py --help` -> passed.
- `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` initially blocked on missing analytics extras; after `uv sync --all-extras`, final mode required this PR body source. Re-run with `PR_READY_PR_BODY_FILE=/tmp/issue-3275-source-archive-certification-pr-body.md` is recorded before opening.

## Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No proposal-model evaluation.
- No fabricated archive inputs beyond synthetic unit-test fixtures.
- No benchmark yield report.

## Risks / Rollout
- Compatibility risks: existing rerun-side payload fields are preserved; new source-side fields are additive.
- Failure modes: downstream consumers that assume source certification is optional may now see blocked readiness, which is intended for certified archive reruns.
- Rollback fallback plan: revert this single commit to restore previous source-certification behavior.

## Docs / Provenance
- Updated docs: `docs/context/issue_3275_failure_archive_rerun_readiness.md` updated to record source and rerun certification symmetry.none; behavior is covered in existing issue-specific tests.
- Relevant design provenance notes: #3275 ready-queue scope asks for archive-readiness/fail-closed checks only.
- Any assumptions need to preserved: source and rerun archives are both intended to be certified archives.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no issue comment needed; PR now updates the existing issue context note.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): yes - existing issue context note updated
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark, registry, claim-map, leaderboard, artifact, or paper-facing evidence changed.

## Follow-Up Issues
- Deferred work: real disjoint certified failure archive rerun remains out of scope for this readiness PR and stays tracked by #3275.
- Issues opened follow-up: none

## Reviewer Notes
- Verify that source certification blockers are intentionally side-specific while existing rerun fields remain backward-compatible.
- Known limitations: this only checks metadata presence/status on synthetic fixtures; it does not certify real archive quality.