### PR TITLE
Issue #3813: preflight sustained-flow generator rows

### DIFF
--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -429,6 +429,55 @@ def _validate_variant(
     )
 
 
+def _validate_loaded_sustained_flow_variants(
+    loaded: list[dict[str, Any]],
+    *,
+    scenario_set: Path,
+) -> tuple[list[SustainedFlowVariant], list[str]]:
+    """Validate loaded sustained-flow rows from YAML or generated definitions.
+
+    Returns:
+        Variant summaries and validation errors.
+    """
+
+    errors: list[str] = []
+    if len(loaded) != len(EXPECTED_SUSTAINED_FLOW_TIERS):
+        errors.append(
+            f"expected {len(EXPECTED_SUSTAINED_FLOW_TIERS)} sustained-flow variants, "
+            f"found {len(loaded)}"
+        )
+
+    variants: list[SustainedFlowVariant] = []
+    seen_seeds: set[int] = set()
+    expected_by_tier = {
+        tier: (ped_density, spawn_rate, seeds)
+        for tier, ped_density, spawn_rate, seeds in EXPECTED_SUSTAINED_FLOW_TIERS
+    }
+    expected_order = [tier for tier, *_ in EXPECTED_SUSTAINED_FLOW_TIERS]
+    observed_order: list[str] = []
+    for scenario in loaded:
+        metadata = scenario.get("metadata", {})
+        tier = str(metadata.get("density", ""))
+        observed_order.append(tier)
+        variant, variant_errors = _validate_variant(
+            scenario,
+            scenario_set=scenario_set,
+            expected_by_tier=expected_by_tier,
+            seen_seeds=seen_seeds,
+        )
+        errors.extend(variant_errors)
+        if variant is not None:
+            variants.append(variant)
+
+    if observed_order != expected_order:
+        errors.append(
+            "density tiers must enumerate light, medium, heavy in deterministic order; "
+            f"observed {observed_order}"
+        )
+
+    return variants, errors
+
+
 def preflight_sustained_flow_scenario_set(
     path: str | Path = DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
 ) -> SustainedFlowPreflightReport:
@@ -453,41 +502,11 @@ def preflight_sustained_flow_scenario_set(
     if raw.get("schema_version") != "robot_sf.scenario_matrix.v1":
         errors.append("schema_version must be robot_sf.scenario_matrix.v1")
 
-    loaded = load_scenarios(scenario_set)
-    if len(loaded) != len(EXPECTED_SUSTAINED_FLOW_TIERS):
-        errors.append(
-            f"expected {len(EXPECTED_SUSTAINED_FLOW_TIERS)} sustained-flow variants, "
-            f"found {len(loaded)}"
-        )
-
-    variants: list[SustainedFlowVariant] = []
-    seen_seeds: set[int] = set()
-    expected_by_tier = {
-        tier: (ped_density, spawn_rate, seeds)
-        for tier, ped_density, spawn_rate, seeds in EXPECTED_SUSTAINED_FLOW_TIERS
-    }
-    expected_order = [tier for tier, *_ in EXPECTED_SUSTAINED_FLOW_TIERS]
-    observed_order: list[str] = []
-
-    for scenario in loaded:
-        metadata = scenario.get("metadata", {})
-        tier = str(metadata.get("density", ""))
-        observed_order.append(tier)
-        variant, variant_errors = _validate_variant(
-            scenario,
-            scenario_set=scenario_set,
-            expected_by_tier=expected_by_tier,
-            seen_seeds=seen_seeds,
-        )
-        errors.extend(variant_errors)
-        if variant is not None:
-            variants.append(variant)
-
-    if observed_order != expected_order:
-        errors.append(
-            "density tiers must enumerate light, medium, heavy in deterministic order; "
-            f"observed {observed_order}"
-        )
+    variants, variant_errors = _validate_loaded_sustained_flow_variants(
+        load_scenarios(scenario_set),
+        scenario_set=scenario_set,
+    )
+    errors.extend(variant_errors)
 
     return SustainedFlowPreflightReport(
         schema_version=SUSTAINED_FLOW_PREFLIGHT_SCHEMA_VERSION,
@@ -509,41 +528,10 @@ def preflight_generated_sustained_flow_scenarios() -> SustainedFlowPreflightRepo
     """
 
     scenario_set = DEFAULT_SUSTAINED_FLOW_SCENARIO_SET.resolve()
-    loaded = generate_expected_sustained_flow_scenarios()
-    errors: list[str] = []
-    if len(loaded) != len(EXPECTED_SUSTAINED_FLOW_TIERS):
-        errors.append(
-            f"expected {len(EXPECTED_SUSTAINED_FLOW_TIERS)} sustained-flow variants, "
-            f"found {len(loaded)}"
-        )
-
-    variants: list[SustainedFlowVariant] = []
-    seen_seeds: set[int] = set()
-    expected_by_tier = {
-        tier: (ped_density, spawn_rate, seeds)
-        for tier, ped_density, spawn_rate, seeds in EXPECTED_SUSTAINED_FLOW_TIERS
-    }
-    expected_order = [tier for tier, *_ in EXPECTED_SUSTAINED_FLOW_TIERS]
-    observed_order: list[str] = []
-    for scenario in loaded:
-        metadata = scenario.get("metadata", {})
-        tier = str(metadata.get("density", ""))
-        observed_order.append(tier)
-        variant, variant_errors = _validate_variant(
-            scenario,
-            scenario_set=scenario_set,
-            expected_by_tier=expected_by_tier,
-            seen_seeds=seen_seeds,
-        )
-        errors.extend(variant_errors)
-        if variant is not None:
-            variants.append(variant)
-
-    if observed_order != expected_order:
-        errors.append(
-            "density tiers must enumerate light, medium, heavy in deterministic order; "
-            f"observed {observed_order}"
-        )
+    variants, errors = _validate_loaded_sustained_flow_variants(
+        generate_expected_sustained_flow_scenarios(),
+        scenario_set=scenario_set,
+    )
 
     return SustainedFlowPreflightReport(
         schema_version=SUSTAINED_FLOW_PREFLIGHT_SCHEMA_VERSION,

--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -498,6 +498,62 @@ def preflight_sustained_flow_scenario_set(
     )
 
 
+def preflight_generated_sustained_flow_scenarios() -> SustainedFlowPreflightReport:
+    """Validate the canonical generator before rows are materialized to YAML.
+
+    This is a generator preflight only: it proves the deterministic
+    light/medium/heavy continuous-spawn definitions remain internally
+    enumerable and fail-closed, without promoting them to benchmark evidence.
+    Returns:
+        Sustained-flow preflight report for canonical generated rows.
+    """
+
+    scenario_set = DEFAULT_SUSTAINED_FLOW_SCENARIO_SET.resolve()
+    loaded = generate_expected_sustained_flow_scenarios()
+    errors: list[str] = []
+    if len(loaded) != len(EXPECTED_SUSTAINED_FLOW_TIERS):
+        errors.append(
+            f"expected {len(EXPECTED_SUSTAINED_FLOW_TIERS)} sustained-flow variants, "
+            f"found {len(loaded)}"
+        )
+
+    variants: list[SustainedFlowVariant] = []
+    seen_seeds: set[int] = set()
+    expected_by_tier = {
+        tier: (ped_density, spawn_rate, seeds)
+        for tier, ped_density, spawn_rate, seeds in EXPECTED_SUSTAINED_FLOW_TIERS
+    }
+    expected_order = [tier for tier, *_ in EXPECTED_SUSTAINED_FLOW_TIERS]
+    observed_order: list[str] = []
+    for scenario in loaded:
+        metadata = scenario.get("metadata", {})
+        tier = str(metadata.get("density", ""))
+        observed_order.append(tier)
+        variant, variant_errors = _validate_variant(
+            scenario,
+            scenario_set=scenario_set,
+            expected_by_tier=expected_by_tier,
+            seen_seeds=seen_seeds,
+        )
+        errors.extend(variant_errors)
+        if variant is not None:
+            variants.append(variant)
+
+    if observed_order != expected_order:
+        errors.append(
+            "density tiers must enumerate light, medium, heavy in deterministic order; "
+            f"observed {observed_order}"
+        )
+
+    return SustainedFlowPreflightReport(
+        schema_version=SUSTAINED_FLOW_PREFLIGHT_SCHEMA_VERSION,
+        scenario_set="generated:issue_3813_sustained_flow_scaffold_v0",
+        conforms=not errors,
+        variants=tuple(variants),
+        errors=tuple(errors),
+    )
+
+
 def sustained_flow_preflight_to_dict(report: SustainedFlowPreflightReport) -> dict[str, Any]:
     """Serialize a sustained-flow preflight report.
 

--- a/scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py
+++ b/scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py
@@ -15,6 +15,7 @@ from pathlib import Path
 
 from robot_sf.scenario_certification.sustained_flow import (
     DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
+    preflight_generated_sustained_flow_scenarios,
     preflight_sustained_flow_scenario_set,
     sustained_flow_preflight_to_dict,
 )
@@ -28,6 +29,11 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         default=DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
         help="Scenario matrix to validate.",
     )
+    parser.add_argument(
+        "--generated",
+        action="store_true",
+        help="Validate canonical generator output instead of a YAML scenario set.",
+    )
     parser.add_argument("--json", action="store_true", help="Emit the full JSON report.")
     return parser.parse_args(argv)
 
@@ -40,7 +46,11 @@ def main(argv: list[str] | None = None) -> int:
     """
 
     args = _parse_args(sys.argv[1:] if argv is None else argv)
-    report = preflight_sustained_flow_scenario_set(args.scenario_set)
+    report = (
+        preflight_generated_sustained_flow_scenarios()
+        if args.generated
+        else preflight_sustained_flow_scenario_set(args.scenario_set)
+    )
     payload = sustained_flow_preflight_to_dict(report)
 
     if args.json:

--- a/tests/scenario_certification/test_sustained_flow_preflight.py
+++ b/tests/scenario_certification/test_sustained_flow_preflight.py
@@ -30,6 +30,25 @@ def test_expected_variants_enumerate_deterministically() -> None:
     assert spawn_rates == [6.0, 12.0, 18.0]
 
 
+def test_generated_variants_pass_generator_preflight() -> None:
+    """Canonical generator rows validate before YAML materialization."""
+
+    report = sustained_flow.preflight_generated_sustained_flow_scenarios()
+    payload = sustained_flow.sustained_flow_preflight_to_dict(report)
+
+    assert payload["scenario_set"] == "generated:issue_3813_sustained_flow_scaffold_v0"
+    assert payload["conforms"] is True
+    assert payload["benchmark_evidence"] is False
+    assert payload["runtime_support"] == "metadata_only"
+    assert payload["variant_count"] == 3
+    assert [variant["density_tier"] for variant in payload["variants"]] == [
+        "light",
+        "medium",
+        "heavy",
+    ]
+    assert payload["errors"] == []
+
+
 def test_runtime_supported_variants_enumerate_deterministically() -> None:
     """Runtime-supported generator preserves deterministic sustained-flow tiers."""
 
@@ -91,3 +110,23 @@ def test_preflight_cli_outputs_json_payload() -> None:
         payload["scenario_set"]
         == "configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml"
     )
+
+
+def test_preflight_cli_outputs_generated_json_payload() -> None:
+    """Validation script can preflight generator rows directly."""
+
+    command = [
+        sys.executable,
+        str(PREFLIGHT_SCRIPT),
+        "--generated",
+        "--json",
+    ]
+
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == sustained_flow.SUSTAINED_FLOW_PREFLIGHT_SCHEMA_VERSION
+    assert payload["conforms"] is True
+    assert payload["variant_count"] == 3
+    assert payload["scenario_set"] == "generated:issue_3813_sustained_flow_scaffold_v0"


### PR DESCRIPTION
## Issue

Closes part of https://github.com/ll7/robot_sf_ll7/issues/3813

## Scope Summary

- Adds a generator preflight entry point for the canonical issue #3813 sustained-flow light/medium/heavy continuous-spawn scenario rows before YAML materialization.
- Adds `--generated` to `scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py` so automation can validate generator output directly.
- Adds focused enumeration tests for the Python API and CLI generator-preflight path.

Assumption: this PR is a reversible preflight/checker slice only. It preserves `runtime_support: metadata_only`, `benchmark_evidence: false`, and does not claim sustained-flow benchmark readiness.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/scenario_certification/sustained_flow.py scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py tests/scenario_certification/test_sustained_flow_preflight.py` -> passed (`1 file reformatted, 2 files left unchanged`; final rerun `3 files left unchanged`).
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/scenario_certification/sustained_flow.py scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py tests/scenario_certification/test_sustained_flow_preflight.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q` -> passed, 15 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` -> passed; `conforms=true`, `variant_count=3`, `runtime_support=metadata_only`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --generated --json` -> passed; `conforms=true`, `variant_count=3`, `runtime_support=metadata_only`, `benchmark_evidence=false`.
- `git diff --check` -> passed.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No runtime continuous pedestrian respawn implementation or sustained-progress metric implementation.

## Artifact / Evidence Boundary

No generated benchmark artifacts are committed. CLI output is validation evidence only; the scenario family remains metadata-only and not benchmark evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for validating automatically generated sustained-flow scenario scaffolds.
  * Added a new CLI option to run validation against the generated scenario set and return the same PASS/FAIL or JSON output format.
* **Tests**
  * Expanded coverage for generated scenario validation.
  * Added CLI checks to confirm the generated JSON output includes the expected scenario set, variant count, and success status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->