### PR TITLE
Issue #3275: require null-test prerequisites for archive readiness

### DIFF
--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -8,7 +8,7 @@ The check is readiness/leakage evidence only. It does not run benchmark campaign
 
 ## Implementation
 
-- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), requires passing certification metadata on source and rerun archive entries, and validates supplied null-test prerequisite metadata.
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
 - `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI, including optional `--null-test-prerequisites` input.
 - Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
 
@@ -22,5 +22,5 @@ Focused tests cover:
 - missing or failed source archive certification metadata blocking readiness;
 - missing or failed rerun archive certification metadata blocking readiness;
 - complete null-test prerequisite metadata staying ready;
-- missing or invalid null-test prerequisite metadata blocking readiness;
+- missing, absent, or invalid null-test prerequisite metadata blocking readiness;
 - diagnostic-only rerun outputs staying diagnostic-only.

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -382,7 +382,7 @@ def _null_test_prerequisite_gaps(
     """Return fail-closed gaps for optional null-test prerequisite metadata."""
 
     if payload_or_path is None:
-        return None, "not_checked", [], []
+        return None, "blocked", ["null_test_prerequisites"], []
     if isinstance(payload_or_path, dict):
         source = "inline_payload"
         payload: dict[str, Any] | None = payload_or_path

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -56,6 +56,16 @@ def _archive(path: Path, entries: list[dict]) -> Path:
     return path
 
 
+def _null_test_prerequisites() -> dict:
+    """Return complete null-test prerequisite metadata."""
+
+    return {
+        "null_tests_reject_null": True,
+        "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.01},
+        "ranking_permutation_test": {"status": "complete", "p_value": 0.02},
+    }
+
+
 def test_disjoint_certified_archives_are_ready(tmp_path: Path) -> None:
     """Disjoint archive IDs and certified rerun rows pass the metadata gate."""
 
@@ -74,13 +84,38 @@ def test_disjoint_certified_archives_are_ready(tmp_path: Path) -> None:
         ],
     )
 
-    readiness = classify_failure_archive_rerun_readiness(source, rerun)
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
 
     assert readiness.status == READY
     assert readiness.ready is True
     assert readiness.archive_id_overlap == []
     assert readiness.missing_certification_archive_ids == []
     assert readiness.to_payload()["claim_boundary"].startswith("readiness/leakage check only")
+
+
+def test_missing_null_test_prerequisite_input_blocks_readiness(tmp_path: Path) -> None:
+    """Absent null-test prerequisite metadata fails closed."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(source, rerun)
+
+    assert readiness.status == BLOCKED
+    assert readiness.ready is False
+    assert readiness.null_test_prerequisite_status == BLOCKED
+    assert readiness.missing_null_test_prerequisites == ["null_test_prerequisites"]
+    assert "missing_null_test_prerequisites:1" in readiness.blockers
 
 
 def test_overlapping_archive_ids_block_leakage(tmp_path: Path) -> None:
@@ -304,6 +339,7 @@ def test_diagnostic_only_output_caps_otherwise_ready_inputs(tmp_path: Path) -> N
         source,
         rerun,
         rerun_output=rerun_output,
+        null_test_prerequisites=_null_test_prerequisites(),
     )
 
     assert readiness.status == DIAGNOSTIC_ONLY


### PR DESCRIPTION
## Summary
Tightens the issue #3275 failure-archive rerun readiness gate so absent null-test prerequisite metadata fails closed instead of allowing an otherwise-ready verdict.

## Linked Issues
- Relates to #3275

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Treat missing `null_test_prerequisites` as a readiness blocker in `failure_archive_rerun_readiness`.
- Updated focused fixtures so `ready` and `diagnostic_only` cases provide valid null-test prerequisite metadata.
- Added a regression test for absent null-test prerequisite input and refreshed the issue #3275 context note.

## Why Matters
- Added value: prevents source/rerun archive readiness from being marked ready before null-test prerequisites are present.
- Expected impact: safer fail-closed readiness packet for certified failure archive reruns.
- Why worth merging now: it closes a narrow evidence-hygiene gap without running or claiming benchmark results.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3275 readiness blocker for disjoint certified failure archive reruns.
- Comparator or baseline, applicable: previous checker allowed `null_test_prerequisite_status=not_checked` without a blocker.
- Evidence tier: NA
- Result classification: NA
- Decision stop rule, applicable: readiness remains blocked until certified source/rerun archives, overlap metadata, and null-test prerequisites all pass.
- Parent issue, claim map, registry, context note, synthesis surface update: `docs/context/issue_3275_failure_archive_rerun_readiness.md`
- New research/benchmark/metric/paper-facing analysis tool, any: NA - tightens existing support checker only. Focused tests are listed in Validation / Proof.

## Domain-Aware Approval

- Required PR: yes
- Domains reviewed: readiness/leakage gate for issue #3275 certified failure archive rerun inputs
- Status: blocked pending reviewer approval
- Approval or blocker note: reviewer must confirm the stricter null-test prerequisite gate is the desired #3275 readiness behavior.
- Target claim/hypothesis: no held-out yield claim made; this only tightens readiness blocking.
- Comparator or split/evidence validity: synthetic fixture proof compares previous omitted-prerequisite acceptance against blocked readiness.
- Fallback/degraded exclusions: missing null-test prerequisite input is blocked, not accepted as ready.
- Claim boundary: readiness/leakage check only; no benchmark, paper, or dissertation claim promotion.
- Implementation integrity vs experimental validity: implementation changed only prerequisite classification and focused tests cover the changed contract.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, missing null-test prerequisite fixture now returns `blocked`.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? NA - synthetic metadata fixture only.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: full proposal-model evaluation remains out of scope for this PR.

## Next Empirical Action
- Rerun needed: no for this readiness slice; yes for full #3275 campaign outside this PR.
- Extractor analysis tool needed: no
- Artifact missing unavailable: real certified failure archive inputs remain outside this PR.
- Stop / revise / continue decision: continue once real inputs are available.
- Proposed child issue existing follow-up: #3275 remains the parent/full rerun issue.

## Validation / Proof
- `uv run python -m pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` -> passed, 15 tests.
- `uv run python -m pytest tests/adversarial/test_archive_readiness.py -q` -> passed, 21 tests.
- `uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` -> passed.
- `uv run ruff format --check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` -> passed.
- `git diff --check` -> passed.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout
- Compatibility risks: callers that omit null-test prerequisites will now receive `blocked` rather than `ready`.
- Failure modes: a caller may need to pass an explicit prerequisite report before using the checker as a ready gate.
- Rollback fallback plan: revert the single classification line if the checker must return to optional null-test metadata.

## Docs / Provenance
- Updated docs: `docs/context/issue_3275_failure_archive_rerun_readiness.md`
- Relevant design provenance notes: issue #3275 live contract.
- Any assumptions need to preserved: missing null-test prerequisite metadata should fail closed for readiness.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): no, existing context note updated directly.
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR changes a checker contract only and does not produce benchmark evidence.

## Follow-Up Issues
- Deferred work: full proposal-model evaluation on real disjoint certified archive inputs; real archive acquisition; no held-out yield claim in this PR. Tracked by #3275.
- Issues opened follow-up: #3275

## Reviewer Notes
- Verify that `null_test_prerequisites=None` should be blocked for the #3275 readiness gate.
- Known limitation: this PR does not run the proposal model, fabricate archive inputs, or report benchmark yield.
