### PR TITLE
Issue #3216: fail closed on incomplete headline grid

### DIFF
--- a/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+++ b/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
@@ -163,7 +163,9 @@ class GridCompleteness:
     expected_planners: tuple[str, ...]
     expected_cell_count: int
     observed_cell_count: int
+    observed_expected_cell_count: int
     missing_cells: tuple[tuple[str, str], ...]
+    unexpected_cells: tuple[tuple[str, str], ...]
 
     @property
     def complete(self) -> bool:
@@ -179,10 +181,16 @@ class GridCompleteness:
             "expected_planners": list(self.expected_planners),
             "expected_cell_count": self.expected_cell_count,
             "observed_cell_count": self.observed_cell_count,
+            "observed_expected_cell_count": self.observed_expected_cell_count,
             "missing_cell_count": len(self.missing_cells),
             "missing_cells": [
                 {"scenario_id": scenario, "planner_key": planner}
                 for scenario, planner in self.missing_cells
+            ],
+            "unexpected_cell_count": len(self.unexpected_cells),
+            "unexpected_cells": [
+                {"scenario_id": scenario, "planner_key": planner}
+                for scenario, planner in self.unexpected_cells
             ],
             "complete": self.complete,
         }
@@ -461,16 +469,20 @@ def build_grid_completeness(
         return None
 
     observed = {(cell.scenario_id, cell.planner_key) for cell in cells}
-    expected = [(scenario, planner) for scenario in scenarios for planner in planners]
+    expected = tuple((scenario, planner) for scenario in scenarios for planner in planners)
+    expected_set = set(expected)
     missing = tuple(
         (scenario, planner) for scenario, planner in expected if (scenario, planner) not in observed
     )
+    unexpected = tuple(sorted(observed - expected_set))
     return GridCompleteness(
         expected_scenarios=scenarios,
         expected_planners=planners,
         expected_cell_count=len(expected),
         observed_cell_count=len(observed),
+        observed_expected_cell_count=len(observed & expected_set),
         missing_cells=missing,
+        unexpected_cells=unexpected,
     )
 
 
@@ -1099,9 +1111,10 @@ def _append_grid_completeness_markdown(lines: list[str], report: Mapping[str, An
     if not grid:
         return
     lines.append(
-        f"- **Expected grid**: {grid['observed_cell_count']} observed / "
+        f"- **Expected grid**: {grid['observed_expected_cell_count']} observed / "
         f"{grid['expected_cell_count']} expected; "
-        f"{grid['missing_cell_count']} missing"
+        f"{grid['missing_cell_count']} missing; "
+        f"{grid['unexpected_cell_count']} unexpected"
     )
 
 

--- a/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+++ b/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
@@ -122,6 +122,8 @@ class ReportConfig:
     resamples: int = DEFAULT_RANK_RESAMPLES
     rank_seed: int = DEFAULT_BOOTSTRAP_SEED
     invalid_rank_metric_reason: str | None = None
+    expected_scenarios: tuple[str, ...] = ()
+    expected_planners: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -150,6 +152,39 @@ class CellResult:
             "exclusion_reason": self.exclusion_reason,
             "seed_count": self.seed_count,
             "metrics": self.metrics,
+        }
+
+
+@dataclass(frozen=True)
+class GridCompleteness:
+    """Expected headline-grid coverage check for already-measured rows."""
+
+    expected_scenarios: tuple[str, ...]
+    expected_planners: tuple[str, ...]
+    expected_cell_count: int
+    observed_cell_count: int
+    missing_cells: tuple[tuple[str, str], ...]
+
+    @property
+    def complete(self) -> bool:
+        """Return whether all expected scenario/planner cells were present."""
+
+        return not self.missing_cells
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return JSON-safe completeness payload."""
+
+        return {
+            "expected_scenarios": list(self.expected_scenarios),
+            "expected_planners": list(self.expected_planners),
+            "expected_cell_count": self.expected_cell_count,
+            "observed_cell_count": self.observed_cell_count,
+            "missing_cell_count": len(self.missing_cells),
+            "missing_cells": [
+                {"scenario_id": scenario, "planner_key": planner}
+                for scenario, planner in self.missing_cells
+            ],
+            "complete": self.complete,
         }
 
 
@@ -410,6 +445,33 @@ def _counted_cells_by_scenario(
         if cell.counted:
             grouped[cell.scenario_id].append(cell)
     return dict(grouped)
+
+
+def build_grid_completeness(
+    cells: Sequence[CellResult],
+    *,
+    expected_scenarios: Sequence[str],
+    expected_planners: Sequence[str],
+) -> GridCompleteness | None:
+    """Check expected headline scenario/planner grid coverage."""
+
+    scenarios = tuple(dict.fromkeys(str(value) for value in expected_scenarios if str(value)))
+    planners = tuple(dict.fromkeys(str(value) for value in expected_planners if str(value)))
+    if not scenarios or not planners:
+        return None
+
+    observed = {(cell.scenario_id, cell.planner_key) for cell in cells}
+    expected = [(scenario, planner) for scenario in scenarios for planner in planners]
+    missing = tuple(
+        (scenario, planner) for scenario, planner in expected if (scenario, planner) not in observed
+    )
+    return GridCompleteness(
+        expected_scenarios=scenarios,
+        expected_planners=planners,
+        expected_cell_count=len(expected),
+        observed_cell_count=len(observed),
+        missing_cells=missing,
+    )
 
 
 def _resample_per_seed_means(rows: Sequence[Mapping[str, Any]], cell: CellResult, metric: str):
@@ -791,6 +853,7 @@ def build_decision_packet(
     rank_profile: str = "snqi_diagnostic",
     invalid_rank_metric_reason: str | None = None,
     job_evidence: Mapping[str, Any] | None = None,
+    grid_completeness: GridCompleteness | None = None,
 ) -> dict[str, Any]:
     """Build a conservative manuscript/S30 decision packet."""
     counted = [cell for cell in cells if cell.counted]
@@ -826,6 +889,9 @@ def build_decision_packet(
     if not counted:
         manuscript_blockers.append("no_counted_cells")
         s30_reasons.append("missing_counted_headline_rows")
+    if grid_completeness is not None and not grid_completeness.complete:
+        manuscript_blockers.append("headline_grid_incomplete")
+        s30_reasons.append("missing_expected_headline_cells")
     if excluded:
         manuscript_blockers.append("non_promotable_cells_present")
         s30_reasons.append("resolve_or_disclose_excluded_cells")
@@ -858,7 +924,12 @@ def build_decision_packet(
         or invalid_rank_metric
     ):
         s30_decision_status = "needs_review"
-    elif not counted or excluded or not identifiable:
+    elif (
+        not counted
+        or excluded
+        or not identifiable
+        or (grid_completeness is not None and not grid_completeness.complete)
+    ):
         s30_decision_status = "blocked"
     else:
         s30_decision_status = "not_required_by_local_preflight"
@@ -880,6 +951,9 @@ def build_decision_packet(
         "rank_profile": rank_profile,
         "constraints_first_required_metrics": list(CONSTRAINTS_FIRST_REQUIRED_METRICS),
         "constraints_first_metric_gaps": metric_gaps,
+        "grid_completeness": (
+            grid_completeness.to_dict() if grid_completeness is not None else None
+        ),
         "job_evidence_status": (job_evidence or {}).get("status"),
         "job_id": (job_evidence or {}).get("job"),
         "snqi_contract_warning": snqi_contract_warning,
@@ -914,6 +988,11 @@ def build_report(
         confidence=config.confidence,
         bootstrap_seed=config.bootstrap_seed,
     )
+    grid_completeness = build_grid_completeness(
+        cells,
+        expected_scenarios=config.expected_scenarios,
+        expected_planners=config.expected_planners,
+    )
     rank_stability = build_rank_stability(
         rows,
         cells,
@@ -936,6 +1015,7 @@ def build_report(
         rank_profile=config.rank_profile,
         invalid_rank_metric_reason=config.invalid_rank_metric_reason,
         job_evidence=job_evidence,
+        grid_completeness=grid_completeness,
     )
     classification, rationale = classify(cells, rank_stability)
     counted = [cell for cell in cells if cell.counted]
@@ -970,8 +1050,11 @@ def build_report(
             "invalid_rank_metric_reason": config.invalid_rank_metric_reason,
             "paper_grade_min_seeds": PAPER_GRADE_MIN_SEEDS,
             "nominal_min_seeds": NOMINAL_MIN_SEEDS,
+            "expected_scenarios": list(config.expected_scenarios),
+            "expected_planners": list(config.expected_planners),
         },
         "job_evidence": dict(job_evidence or {}),
+        "grid_completeness": grid_completeness.to_dict() if grid_completeness else None,
         "canonical_owners_reused": [
             "robot_sf.benchmark.seed_variance._stats_for_vals",
             "robot_sf.benchmark.seed_variance._bootstrap_mean_ci",
@@ -1009,6 +1092,19 @@ def _append_job_evidence_markdown(lines: list[str], job_evidence: Mapping[str, A
         lines.append("- **SNQI evidence status**: `diagnostic_only_contract_warning`")
 
 
+def _append_grid_completeness_markdown(lines: list[str], report: Mapping[str, Any]) -> None:
+    """Append expected-grid coverage line when the report checked one."""
+
+    grid = report.get("grid_completeness")
+    if not grid:
+        return
+    lines.append(
+        f"- **Expected grid**: {grid['observed_cell_count']} observed / "
+        f"{grid['expected_cell_count']} expected; "
+        f"{grid['missing_cell_count']} missing"
+    )
+
+
 def render_markdown(report: Mapping[str, Any]) -> str:
     """Render a markdown summary of the report.
 
@@ -1027,6 +1123,7 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         f"- **Cells**: {inputs['counted_cells']} counted / "
         f"{inputs['excluded_cells']} excluded (of {inputs['row_count']} rows)"
     )
+    _append_grid_completeness_markdown(lines, report)
     lines.append(f"- **Rank metric**: `{inputs['rank_metric']}`")
     lines.append(f"- **Rank profile**: `{inputs['rank_profile']}`")
     if inputs.get("invalid_rank_metric_reason"):
@@ -1246,6 +1343,21 @@ def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
+        "--expected-scenario",
+        action="append",
+        default=[],
+        help=(
+            "Expected scenario-family key in the headline grid. Repeat for every "
+            "required row family."
+        ),
+    )
+    parser.add_argument(
+        "--expected-planner",
+        action="append",
+        default=[],
+        help="Expected planner key in the headline grid. Repeat for every required planner.",
+    )
+    parser.add_argument(
         "--lower-is-better",
         action="store_true",
         help="Treat the rank metric as lower-is-better (default higher-is-better).",
@@ -1345,6 +1457,8 @@ def main(argv: Sequence[str] | None = None) -> int:
         resamples=args.rank_resamples,
         rank_seed=args.rank_seed,
         invalid_rank_metric_reason=invalid_rank_metric_reason,
+        expected_scenarios=tuple(args.expected_scenario),
+        expected_planners=tuple(args.expected_planner),
     )
     campaign = "dry-run" if args.dry_run else args.campaign
     report = build_report(

--- a/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
@@ -98,6 +98,7 @@ def test_expected_headline_grid_missing_cell_blocks_packet() -> None:
         _row("crossing", "hybrid", [0.90] * 20),
         _row("crossing", "ppo", [0.70] * 20),
         _row("doorway", "hybrid", [0.88] * 20),
+        _row("extra_family", "hybrid", [0.89] * 20),
     ]
 
     report = build_report(
@@ -117,6 +118,12 @@ def test_expected_headline_grid_missing_cell_blocks_packet() -> None:
     assert "missing_expected_headline_cells" in packet["s30_reasons"]
     assert packet["grid_completeness"]["missing_cells"] == [
         {"scenario_id": "doorway", "planner_key": "ppo"}
+    ]
+    assert packet["grid_completeness"]["expected_cell_count"] == 4
+    assert packet["grid_completeness"]["observed_cell_count"] == 4
+    assert packet["grid_completeness"]["observed_expected_cell_count"] == 3
+    assert packet["grid_completeness"]["unexpected_cells"] == [
+        {"scenario_id": "extra_family", "planner_key": "hybrid"}
     ]
 
 

--- a/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
@@ -92,6 +92,34 @@ def test_s20_preflight_stays_no_claim_but_allows_table_review() -> None:
     assert report["decision_packet"]["constraints_first_metric_gaps"] == []
 
 
+def test_expected_headline_grid_missing_cell_blocks_packet() -> None:
+    """A partial headline grid cannot pass even when present cells look stable."""
+    rows = [
+        _row("crossing", "hybrid", [0.90] * 20),
+        _row("crossing", "ppo", [0.70] * 20),
+        _row("doorway", "hybrid", [0.88] * 20),
+    ]
+
+    report = build_report(
+        rows,
+        ReportConfig(
+            bootstrap_samples=32,
+            resamples=16,
+            expected_scenarios=("crossing", "doorway"),
+            expected_planners=("hybrid", "ppo"),
+        ),
+    )
+
+    packet = report["decision_packet"]
+    assert packet["manuscript_table_status"] == "blocked"
+    assert packet["s30_decision_status"] == "blocked"
+    assert "headline_grid_incomplete" in packet["manuscript_blockers"]
+    assert "missing_expected_headline_cells" in packet["s30_reasons"]
+    assert packet["grid_completeness"]["missing_cells"] == [
+        {"scenario_id": "doorway", "planner_key": "ppo"}
+    ]
+
+
 def test_adjacent_ci_overlap_downgrades_strict_rank_claim() -> None:
     """Overlapping adjacent confidence intervals require a budget downgrade label."""
     rows = [


### PR DESCRIPTION
## Summary
Adds an explicit expected-grid completeness preflight to the #3216 headline confidence-interval/rank-stability report builder. Partial planner-by-scenario row sets now surface missing cells and block manuscript-table/S30 decision packets instead of looking clean for only the rows that arrived.

## Linked Issues
- Relates `#3216`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `GridCompleteness` reporting and `--expected-scenario` / `--expected-planner` CLI flags for explicit headline-grid coverage checks.
- Decision packets now add `headline_grid_incomplete` and `missing_expected_headline_cells` blockers when expected cells are absent.
- Clarified expected-grid coverage counts so extra observed rows cannot make a partial expected grid look complete; unexpected rows are reported separately.
- Added a deterministic fixture test proving a partial S20-quality grid blocks table/S30 decisions.

## Why Matters
- Added value: catches partial headline row sets before they can be interpreted as a complete paper-table preflight.
- Expected impact: local checker fails closed on missing expected planner/scenario cells.
- Why worth merging now: #3216 remains paper-critical and prior support slices did not make grid completeness explicit.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker for incomplete headline planner comparison row packets.
- Comparator or baseline, applicable: existing report builder behavior without expected-grid checks.
- Evidence tier: NA - support helper; deterministic tests cover checker behavior only.
- Result classification: NA - support helper; no benchmark result claim.
- Decision stop rule, applicable: expected cells missing => manuscript table and S30 decision packet blocked.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3216 remains the parent; this PR does not update claim maps or manuscript tables.
- New research/benchmark/metric/paper-facing analysis tool, any: no new analysis methodology; extends existing #3216 support checker only.

## Domain-Aware Approval
- Required PR: yes
- Domains reviewed: evidence classification, benchmark interpretation, paper-facing claim boundary
- Status: waived
- Approval or blocker note: maintainer task authorization permits opening this local support PR; merge/evidence promotion remains with Claude Code review on imech156-u
- Validity checklist:
- Target claim/hypothesis: no planner-performance claim; checker blocks incomplete headline row packets
- Comparator or split/evidence validity: deterministic fixture and CLI dry-run only, no benchmark comparator split claimed
- Fallback/degraded exclusions: unchanged; existing excluded-cell blockers remain excluded from success evidence
- Claim boundary: local preflight support only; no manuscript or paper claim promoted
- Implementation integrity vs experimental validity: tests prove fail-closed checker behavior, not planner-result validity

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, missing expected cells produce `headline_grid_incomplete` and `missing_expected_headline_cells`.
- Did intervention change command source, selected command, trajectory, route progress? no; report-only tooling.
- Did scenario actually contain targeted failure mode? deterministic fixture omits one expected cell.
- Result route: continue; use as preflight blocker until complete rows exist.
- Follow-up question issue weak, negative, non-transfer results: #3216 remains open for full evidence/manuscript/S30 work.

## Next Empirical Action
- Rerun needed: no for this support slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: full paper-grade headline campaign rows remain outside this PR.
- Stop / revise / continue decision: continue #3216 evidence lane after review.
- Proposed child issue existing follow-up: none opened; parent issue already tracks remaining work.

## Validation / Proof
- `uv run ruff format scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py && uv run ruff check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py` -> passed.
- `uv run pytest tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py -q` -> 8 passed.
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --dry-run --output-dir output/validation/pr4055-grid-smoke --bootstrap-samples 32 --rank-resamples 16 --expected-scenario dry_run_merging --expected-scenario dry_run_bottleneck --expected-planner stable_top --expected-planner stable_mid --expected-planner stable_low --fail-on-decision-blocker; test $? -eq 4` -> passed; expected decision-blocker exit confirmed.
- `CUDA_VISIBLE_DEVICES= uv run pytest tests/test_feature_extractors.py::TestIntegrationWithStableBaselines3::test_config_with_ppo tests/test_ppo_diagnostics.py::test_diagnostic_ppo_writes_grad_and_feature_stats -q` -> 2 passed; confirms earlier local readiness failure was CUDA memory state, not branch behavior.
- `CUDA_VISIBLE_DEVICES= PR_READY_PR_BODY_FILE=.git/codex-agent-runs/active/pr-4055-gate/pr-body.md BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> passed on head `344bc5d4f15e50933aae2dcefaafcaac252b7b4e`; readiness stamp `output/validation/pr_ready/issue-3216-rank-stability-ci-preflight.json`.
## Runtime / Performance Evidence
- Baseline runtime: NA, no runtime-performance claim.
- Changed runtime: NA, no runtime-performance claim.
- Representative command: `uv run pytest tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py -q`.
- Hot-path call count profile anchor: NA, report-preflight support helper only.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if complete expected grids are incorrectly blocked or missing expected cells no longer block decision packets.

## Risks / Rollout
- Compatibility risks: callers that opt into expected-grid args must provide exact scenario/planner keys matching row payloads.
- Failure modes: omitted expected-axis args preserve legacy behavior; wrong expected keys intentionally block as missing cells.
- Rollback fallback plan: remove expected-grid args from caller or revert this PR.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3216 live comments and existing launch packet.
- Any assumptions need to preserved: explicit expected-axis keys are supplied by caller; this PR does not infer the paper table shape from broad scenario configs.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; task forbids issue/PR comments.
- Claim map / benchmark report updated (yes/no/NA): no.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this is local preflight support only; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Follow-Up Issues
- Deferred work: #3216 still needs paper-grade headline evidence, manuscript-table propagation, and S30 decision.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify that missing expected grid cells block only when expected axes are supplied.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

