### PR TITLE
Issue #3275: fail closed malformed archive entries

### DIFF
--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -264,6 +264,11 @@ def _load_archive(path: Path) -> tuple[str, dict[str, Any] | None, str]:
     entries = payload.get("entries")
     if not isinstance(entries, list) or not entries:
         return BLOCKED, payload, "archive_has_no_entries"
+    non_object_indexes = [
+        str(index) for index, entry in enumerate(entries) if not isinstance(entry, dict)
+    ]
+    if non_object_indexes:
+        return BLOCKED, payload, f"archive_entries_not_objects:{','.join(non_object_indexes)}"
     return READY, payload, "ok"
 
 

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -224,6 +224,59 @@ def test_malformed_archive_payload_fails_closed(tmp_path: Path) -> None:
     )
 
 
+def test_non_object_archive_entries_fail_closed(tmp_path: Path) -> None:
+    """Archive entries must be objects before readiness metadata can be trusted."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun_payload = {
+        "schema_version": "adversarial_failure_archive.v1",
+        "entries": ["not-an-entry"],
+    }
+    rerun = tmp_path / "rerun.json"
+    rerun.write_text(json.dumps(rerun_payload), encoding="utf-8")
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.rerun_entry_count == 0
+    assert "rerun_archive_blocked:archive_entries_not_objects:0" in readiness.blockers
+
+
+def test_mixed_archive_entry_shapes_fail_closed_with_index(tmp_path: Path) -> None:
+    """Malformed source entry indexes are reported instead of silently dropped."""
+
+    source_payload = {
+        "schema_version": "adversarial_failure_archive.v1",
+        "entries": [
+            _entry("source_0000", family="family_a", seed=1),
+            ["not-an-entry"],
+        ],
+    }
+    source = tmp_path / "source.json"
+    source.write_text(json.dumps(source_payload), encoding="utf-8")
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.source_entry_count == 1
+    assert "source_archive_blocked:archive_entries_not_objects:1" in readiness.blockers
+
+
 def test_missing_certification_metadata_blocks_rerun_archive(tmp_path: Path) -> None:
     """Every rerun archive entry must carry certification metadata."""
 


### PR DESCRIPTION
## Issue

Closes no issue. Related: https://github.com/ll7/robot_sf_ll7/issues/3275

## Scope Summary

This is a bounded readiness/fail-closed slice for issue #3275. It tightens certified failure-archive input validation so `failure_archive_rerun_readiness` rejects archives whose `entries` list contains non-object values instead of silently dropping malformed entries before overlap/certification checks.

The change adds regression coverage for:

- rerun archives whose entries are all malformed non-object values;
- source archives with mixed valid and malformed entries, preserving the malformed entry index in the blocker token.

## Validation

- `./scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` -> passed, 17 tests.
- `./scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` -> passed.
- `./scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` -> passed, 2 files already formatted.
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 ./scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh` -> passed; clean-head stamp `output/validation/pr_ready/issue-3275-certified-archive-readiness-manifest-shape.json` for `d84e8cc54d5bbba8aa4c9eae81e0c57f5599e773`.
- `./scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> fresh, clean tree.

## Artifact Classification

Generated validation artifacts under `output/validation/` and `output/coverage/` are ignored, worktree-local proof outputs only. No durable benchmark artifact is introduced.

## Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. This PR does not run the proposal model on a real disjoint certified failure archive and does not report benchmark yield.
