### PR TITLE
Issue #3275: validate archive null-test p-values

### DIFF
--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -15,6 +15,7 @@ and never promoted to benchmark evidence.
 from __future__ import annotations
 
 import json
+import math
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -416,8 +417,21 @@ def _null_test_prerequisite_gaps(
             invalid.append(f"{key}_status_not_complete")
         if "p_value" not in value:
             invalid.append(f"{key}_missing_p_value")
+        elif not _valid_probability(value["p_value"]):
+            invalid.append(f"{key}_invalid_p_value")
     status = "ready" if not missing and not invalid else "blocked"
     return source, status, missing, invalid
+
+
+def _valid_probability(value: Any) -> bool:
+    """Return whether ``value`` is a finite probability scalar."""
+
+    return (
+        isinstance(value, int | float)
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+        and 0.0 <= value <= 1.0
+    )
 
 
 def _load_json_object(path: Path) -> tuple[dict[str, Any] | None, str | None]:

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -415,7 +415,7 @@ def _null_test_prerequisite_gaps(
             continue
         if value.get("status") != "complete":
             invalid.append(f"{key}_status_not_complete")
-        if "p_value" not in value:
+        elif "p_value" not in value:
             invalid.append(f"{key}_missing_p_value")
         elif not _valid_probability(value["p_value"]):
             invalid.append(f"{key}_invalid_p_value")

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -510,6 +510,35 @@ def test_invalid_null_test_p_values_block_readiness(tmp_path: Path) -> None:
     assert "invalid_null_test_prerequisites:2" in readiness.blockers
 
 
+def test_incomplete_null_test_status_does_not_validate_p_value(tmp_path: Path) -> None:
+    """Incomplete null tests report status without duplicate p-value blockers."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = {
+        "null_tests_reject_null": True,
+        "shuffled_outcome_null_test": {"status": "failed"},
+        "ranking_permutation_test": {"status": "complete", "p_value": 0.05},
+    }
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.invalid_null_test_prerequisites == [
+        "shuffled_outcome_null_test_status_not_complete",
+    ]
+
+
 def test_null_test_p_value_probability_bounds_are_allowed(tmp_path: Path) -> None:
     """Boundary p-values are valid probabilities."""
 

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -478,6 +478,65 @@ def test_missing_null_test_prerequisites_block_readiness(tmp_path: Path) -> None
     assert "invalid_null_test_prerequisites:1" in readiness.blockers
 
 
+def test_invalid_null_test_p_values_block_readiness(tmp_path: Path) -> None:
+    """Malformed null-test p-values block readiness."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = {
+        "null_tests_reject_null": True,
+        "shuffled_outcome_null_test": {"status": "complete", "p_value": "0.01"},
+        "ranking_permutation_test": {"status": "complete", "p_value": 1.5},
+    }
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.null_test_prerequisite_status == BLOCKED
+    assert readiness.invalid_null_test_prerequisites == [
+        "shuffled_outcome_null_test_invalid_p_value",
+        "ranking_permutation_test_invalid_p_value",
+    ]
+    assert "invalid_null_test_prerequisites:2" in readiness.blockers
+
+
+def test_null_test_p_value_probability_bounds_are_allowed(tmp_path: Path) -> None:
+    """Boundary p-values are valid probabilities."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = {
+        "null_tests_reject_null": True,
+        "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.0},
+        "ranking_permutation_test": {"status": "complete", "p_value": 1.0},
+    }
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == READY
+    assert readiness.invalid_null_test_prerequisites == []
+
+
 def test_cli_exit_codes_and_writes_report(tmp_path: Path, capsys) -> None:
     """CLI returns 0 for ready inputs and writes the JSON payload."""
 


### PR DESCRIPTION
## Summary
Tightens issue #3275 failure-archive rerun readiness checker so completed null-test prerequisites must carry finite probability p-values in `[0, 1]` before archive inputs can be marked ready.

## Linked Issues
- Relates to `#3275`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3275`
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added fail-closed validation for `shuffled_outcome_null_test.p_value` and `ranking_permutation_test.p_value` in `robot_sf.benchmark.failure_archive_rerun_readiness`.
- Short-circuited p-value validation when a null test is already not `complete`, so readiness reports do not include duplicate p-value blockers for incomplete tests.
- Added synthetic fixture tests for malformed p-values, valid probability boundary values, and incomplete-status short-circuit behavior.

## Why Matters
- Added value: prevents null-test prerequisite packets with non-numeric or out-of-range p-values from passing the archive-readiness gate.
- Expected impact: readiness reports stay blocked until overlap metadata, certification metadata, and null-test prerequisite metadata are structurally usable.
- Why worth merging now: this small hygiene slice strengthens fail-closed readiness before any proposal-model rerun can claim disjoint archive evidence.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3275 readiness blocker for disjoint certified failure archive inputs.
- Comparator or baseline, applicable: NA - readiness gate only.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution.
- Decision stop rule, applicable: readiness remains blocked when completed null-test p-values are missing, malformed, non-finite, or outside `[0, 1]`.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3275 remains the parent readiness/evaluation context and stays open.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker hardening only.

## Domain-Aware Approval
- Required for this PR: yes - evidence-tier fields are present, but the PR is support checker hardening only.
- Domains reviewed: fail-closed archive-readiness validation, issue #3275 scope boundary.
- Status: waived - support checker hardening only.
- Approver/review source or waiver: waived by maintainer policy for support-checker hardening; this PR only tightens fail-closed readiness validation and leaves experimental validity unclaimed.
- Validity checklist: no evidence classification, comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim boundary changes.
- Target claim/hypothesis: NA - checker contract only.
- Comparator or split/evidence validity: not changed; real disjoint fit/evaluation and independent planner-execution outcomes remain in issue #3275.
- Fallback/degraded exclusions: no fallback/degraded execution is introduced or counted as evidence.
- Claim boundary: targeted smoke evidence for readiness validation only.
- Implementation integrity vs experimental validity: local tests prove the checker behavior; experimental validity remains unclaimed.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - malformed completed p-values now block readiness.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? yes - synthetic prerequisite fixtures cover malformed, bounded, and incomplete-status cases.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no checker slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: real disjoint archive inputs remain outside this PR.
- Stop / revise / continue decision: continue real archive preparation/evaluation separately under issue #3275.
- Proposed child issue existing follow-up: issue #3275 remains open for the real proposal-model evaluation on a populated disjoint certified failure archive.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` - 20 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/adversarial/test_archive_readiness.py -q` - 21 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` - All checks passed.
- `git diff --check` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_followups.py --body-file /tmp/pr4062_body_updated.md --require-body --require-substantive-body --changed-files-file /tmp/pr4062_changed_files.txt` - passed.
- Baseline runtime: NA - no runtime benchmark claimed.
- Changed runtime: NA - no runtime benchmark claimed.
- Representative command: targeted pytest commands above.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: readiness accepts malformed/null-test p-values or reports duplicate p-value blockers for incomplete null tests; targeted tests fail.

## Risks / Rollout
- Compatibility risks: callers that supplied string p-values or out-of-range p-values now receive blocked readiness; intentional fail-closed behavior.
- Failure modes: future prerequisite reports may intentionally encode p-values as strings; they should emit numeric JSON instead if meant to satisfy readiness.
- Rollback fallback plan: revert this small checker change if a documented report schema requires string p-values.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3275 remains the parent context.
- Any assumptions need to preserved: null-test p-values are numeric JSON probability scalars.

## Downstream Propagation
- Parent issue updated (yes/no/NA): pending gate closeout comment; issue #3275 remains open.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA - existing issue #3275 tracks deferred real rerun/evaluation work.
- Not applicable because: this PR changes a support readiness checker and makes no benchmark, registry, claim-map, paper-facing, or held-out yield claim.

## Follow-Up Issues
- Deferred work: real proposal-model evaluation on a populated disjoint certified failure archive with independent planner-execution outcomes remains in issue #3275.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify `p_value` should remain a numeric JSON scalar in accepted null-test prerequisite packets.
- Verify incomplete null-test status reports only status, not duplicate p-value blockers.
- Known limitations: PR does not run proposal-model evaluation, fabricate archive inputs, submit compute jobs, or report benchmark yield.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks for null-test prerequisites by treating missing, non-numeric, infinite, or out-of-range probability values as blockers.
  * Ensured incomplete null-test entries do not incorrectly block readiness.
  * Accepted boundary probability values at 0.0 and 1.0 as valid.

* **Tests**
  * Added coverage for malformed probability values, incomplete null-test states, and valid boundary cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->