### PR TITLE
Issue #3813: preflight runtime-supported sustained-flow generator

### DIFF
--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -43,6 +43,7 @@ _SUSTAINED_FLOW_MAP_FILE = "../../../maps/svg_maps/classic_t_intersection.svg"
 _SUSTAINED_FLOW_MAX_EPISODE_STEPS = 600
 SUSTAINED_FLOW_METADATA_ONLY_RUNTIME_SUPPORT = "metadata_only"
 SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE = "runtime_continuous_spawn"
+SUSTAINED_FLOW_GENERATED_SCENARIO_SET_ID = "generated:issue_3813_sustained_flow_scaffold_v0"
 
 
 @dataclass(frozen=True)
@@ -248,6 +249,7 @@ def _check_continuous_spawn(
     name: str,
     expected_tier: str,
     expected_spawn_rate: float,
+    expected_runtime_support: str,
 ) -> list[str]:
     continuous_spawn = metadata.get("continuous_spawn")
     if not isinstance(continuous_spawn, dict):
@@ -280,7 +282,7 @@ def _check_continuous_spawn(
         name,
         "continuous_spawn.current_runtime_support",
         continuous_spawn.get("current_runtime_support"),
-        "metadata_only",
+        expected_runtime_support,
     )
     _require_equal(
         errors,
@@ -350,6 +352,7 @@ def _check_metadata_fail_closed(
     *,
     expected_tier: str,
     expected_spawn_rate: float,
+    expected_runtime_support: str,
 ) -> list[str]:
     name = str(scenario.get("name", "<unnamed>"))
     metadata = scenario.get("metadata")
@@ -364,6 +367,7 @@ def _check_metadata_fail_closed(
             name=name,
             expected_tier=expected_tier,
             expected_spawn_rate=expected_spawn_rate,
+            expected_runtime_support=expected_runtime_support,
         )
     )
     errors.extend(_check_termination_and_metric(scenario, metadata, name=name))
@@ -376,6 +380,7 @@ def _validate_variant(
     scenario_set: Path,
     expected_by_tier: dict[str, tuple[float, float, tuple[int, ...]]],
     seen_seeds: set[int],
+    expected_runtime_support: str,
 ) -> tuple[SustainedFlowVariant | None, list[str]]:
     """Validate one scenario variant against the sustained-flow scaffold contract.
 
@@ -413,6 +418,7 @@ def _validate_variant(
             scenario,
             expected_tier=tier,
             expected_spawn_rate=expected_spawn_rate,
+            expected_runtime_support=expected_runtime_support,
         )
     )
     return (
@@ -433,6 +439,7 @@ def _validate_loaded_sustained_flow_variants(
     loaded: list[dict[str, Any]],
     *,
     scenario_set: Path,
+    expected_runtime_support: str = SUSTAINED_FLOW_METADATA_ONLY_RUNTIME_SUPPORT,
 ) -> tuple[list[SustainedFlowVariant], list[str]]:
     """Validate loaded sustained-flow rows from YAML or generated definitions.
 
@@ -464,6 +471,7 @@ def _validate_loaded_sustained_flow_variants(
             scenario_set=scenario_set,
             expected_by_tier=expected_by_tier,
             seen_seeds=seen_seeds,
+            expected_runtime_support=expected_runtime_support,
         )
         errors.extend(variant_errors)
         if variant is not None:
@@ -517,7 +525,11 @@ def preflight_sustained_flow_scenario_set(
     )
 
 
-def preflight_generated_sustained_flow_scenarios() -> SustainedFlowPreflightReport:
+def preflight_generated_sustained_flow_scenarios(
+    *,
+    current_runtime_support: str = SUSTAINED_FLOW_METADATA_ONLY_RUNTIME_SUPPORT,
+    scenario_set_id: str = SUSTAINED_FLOW_GENERATED_SCENARIO_SET_ID,
+) -> SustainedFlowPreflightReport:
     """Validate the canonical generator before rows are materialized to YAML.
 
     This is a generator preflight only: it proves the deterministic
@@ -529,16 +541,37 @@ def preflight_generated_sustained_flow_scenarios() -> SustainedFlowPreflightRepo
 
     scenario_set = DEFAULT_SUSTAINED_FLOW_SCENARIO_SET.resolve()
     variants, errors = _validate_loaded_sustained_flow_variants(
-        generate_expected_sustained_flow_scenarios(),
+        generate_expected_sustained_flow_scenarios(current_runtime_support=current_runtime_support),
         scenario_set=scenario_set,
+        expected_runtime_support=current_runtime_support,
     )
 
     return SustainedFlowPreflightReport(
         schema_version=SUSTAINED_FLOW_PREFLIGHT_SCHEMA_VERSION,
-        scenario_set="generated:issue_3813_sustained_flow_scaffold_v0",
+        scenario_set=scenario_set_id,
         conforms=not errors,
         variants=tuple(variants),
         errors=tuple(errors),
+        runtime_support=current_runtime_support,
+    )
+
+
+def preflight_runtime_supported_generated_sustained_flow_scenarios() -> (
+    SustainedFlowPreflightReport
+):
+    """Validate generated rows for the future continuous-spawn runtime-support gate.
+
+    This is still a static generator/checker preflight. It proves the same light/medium/heavy
+    scenario definitions can carry the runtime-support marker once runtime support exists; it does
+    not run a benchmark campaign or promote the rows to benchmark evidence.
+
+    Returns:
+        Sustained-flow preflight report for generated runtime-supported rows.
+    """
+
+    return preflight_generated_sustained_flow_scenarios(
+        current_runtime_support=SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE,
+        scenario_set_id=f"{SUSTAINED_FLOW_GENERATED_SCENARIO_SET_ID}:runtime_supported",
     )
 
 

--- a/scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py
+++ b/scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py
@@ -16,6 +16,7 @@ from pathlib import Path
 from robot_sf.scenario_certification.sustained_flow import (
     DEFAULT_SUSTAINED_FLOW_SCENARIO_SET,
     preflight_generated_sustained_flow_scenarios,
+    preflight_runtime_supported_generated_sustained_flow_scenarios,
     preflight_sustained_flow_scenario_set,
     sustained_flow_preflight_to_dict,
 )
@@ -34,6 +35,14 @@ def _parse_args(argv: list[str]) -> argparse.Namespace:
         action="store_true",
         help="Validate canonical generator output instead of a YAML scenario set.",
     )
+    parser.add_argument(
+        "--runtime-supported-generated",
+        action="store_true",
+        help=(
+            "Validate generated rows carrying the future continuous-spawn runtime-support "
+            "marker; still static preflight, not benchmark evidence."
+        ),
+    )
     parser.add_argument("--json", action="store_true", help="Emit the full JSON report.")
     return parser.parse_args(argv)
 
@@ -46,11 +55,12 @@ def main(argv: list[str] | None = None) -> int:
     """
 
     args = _parse_args(sys.argv[1:] if argv is None else argv)
-    report = (
-        preflight_generated_sustained_flow_scenarios()
-        if args.generated
-        else preflight_sustained_flow_scenario_set(args.scenario_set)
-    )
+    if args.runtime_supported_generated:
+        report = preflight_runtime_supported_generated_sustained_flow_scenarios()
+    elif args.generated:
+        report = preflight_generated_sustained_flow_scenarios()
+    else:
+        report = preflight_sustained_flow_scenario_set(args.scenario_set)
     payload = sustained_flow_preflight_to_dict(report)
 
     if args.json:

--- a/tests/scenario_certification/test_sustained_flow_preflight.py
+++ b/tests/scenario_certification/test_sustained_flow_preflight.py
@@ -65,6 +65,27 @@ def test_runtime_supported_variants_enumerate_deterministically() -> None:
     } == {sustained_flow.SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE}
 
 
+def test_runtime_supported_generated_variants_pass_generator_preflight() -> None:
+    """Runtime-supported generated rows validate without becoming benchmark evidence."""
+
+    report = sustained_flow.preflight_runtime_supported_generated_sustained_flow_scenarios()
+    payload = sustained_flow.sustained_flow_preflight_to_dict(report)
+
+    assert payload["scenario_set"] == (
+        "generated:issue_3813_sustained_flow_scaffold_v0:runtime_supported"
+    )
+    assert payload["conforms"] is True
+    assert payload["benchmark_evidence"] is False
+    assert payload["runtime_support"] == sustained_flow.SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE
+    assert payload["variant_count"] == 3
+    assert [variant["density_tier"] for variant in payload["variants"]] == [
+        "light",
+        "medium",
+        "heavy",
+    ]
+    assert payload["errors"] == []
+
+
 def test_preflight_conforms_for_commit_scaffold() -> None:
     """Current scaffold set satisfies fail-closed sustained-flow preflight."""
     report = sustained_flow.preflight_sustained_flow_scenario_set(SCENARIO_SET)
@@ -130,3 +151,27 @@ def test_preflight_cli_outputs_generated_json_payload() -> None:
     assert payload["conforms"] is True
     assert payload["variant_count"] == 3
     assert payload["scenario_set"] == "generated:issue_3813_sustained_flow_scaffold_v0"
+
+
+def test_preflight_cli_outputs_runtime_supported_generated_json_payload() -> None:
+    """Validation script can preflight runtime-supported generator rows directly."""
+
+    command = [
+        sys.executable,
+        str(PREFLIGHT_SCRIPT),
+        "--runtime-supported-generated",
+        "--json",
+    ]
+
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["schema_version"] == sustained_flow.SUSTAINED_FLOW_PREFLIGHT_SCHEMA_VERSION
+    assert payload["conforms"] is True
+    assert payload["benchmark_evidence"] is False
+    assert payload["runtime_support"] == sustained_flow.SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE
+    assert payload["variant_count"] == 3
+    assert payload["scenario_set"] == (
+        "generated:issue_3813_sustained_flow_scaffold_v0:runtime_supported"
+    )

--- a/tests/scenario_certification/test_sustained_flow_preflight.py
+++ b/tests/scenario_certification/test_sustained_flow_preflight.py
@@ -175,3 +175,24 @@ def test_preflight_cli_outputs_runtime_supported_generated_json_payload() -> Non
     assert payload["scenario_set"] == (
         "generated:issue_3813_sustained_flow_scaffold_v0:runtime_supported"
     )
+
+
+def test_runtime_supported_generated_cli_ignores_scenario_set_argument(tmp_path: Path) -> None:
+    """Runtime-supported generator mode does not validate an overridden scenario-set path."""
+
+    command = [
+        sys.executable,
+        str(PREFLIGHT_SCRIPT),
+        "--scenario-set",
+        str(tmp_path / "missing.yaml"),
+        "--runtime-supported-generated",
+        "--json",
+    ]
+
+    result = subprocess.run(command, capture_output=True, text=True, check=False)
+
+    assert result.returncode == 0
+    payload = json.loads(result.stdout)
+    assert payload["conforms"] is True
+    assert payload["errors"] == []
+    assert payload["runtime_support"] == sustained_flow.SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE


### PR DESCRIPTION
## Summary

- Links: https://github.com/ll7/robot_sf_ll7/issues/3813
- Adds a static preflight path for generated sustained-flow rows that carry the future `runtime_continuous_spawn` marker.
- Keeps the checked-in scenario set fail-closed as `metadata_only` and keeps generated runtime-supported preflight explicitly `benchmark_evidence=false`.
- Adds focused CLI JSON regression coverage, including the `--runtime-supported-generated` override with an invalid `--scenario-set` path.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/scenario_certification/sustained_flow.py scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py` -> passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py -q` -> passed, 10 passed
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py -q` -> passed on the pre-review-fix head; the final readiness run below includes the added override regression.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --runtime-supported-generated --json` -> passed, `conforms=true`, `benchmark_evidence=false`, `runtime_support=runtime_continuous_spawn`, `variant_count=3`, `errors=[]`
- `uv run python scripts/dev/run_compact_validation.py --timeout-seconds 1800 -- bash -lc 'PYTEST_NUM_WORKERS=8 PR_READY_MODE=final PR_READY_PR_BODY_FILE=/tmp/pr-4063-body.md BASE_REF=origin/main scripts/dev/pr_ready_check.sh'` -> passed on reviewed head `1f12e2d3b`; summary JSON: `.git/codex-agent-runs/active/compact-validation/validation-20260701T083831Z-886828.summary.json`

## Issue Disposition

Partial slice only. Issue #3813 remains open after this PR. Remaining issue contract still includes runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, and runnable campaign/runner benchmark evidence.

## Proof Scope

- Scope: targeted smoke/static preflight only.
- Classification: blocker-resolution slice, not benchmark evidence.
- Boundary: proves generated rows can carry the future runtime-support marker through static preflight while still reporting `benchmark_evidence=false`.

## Follow-Up Issues

- Existing follow-up container: #3813 remains open for the runtime, metric, sanity-proof, pure-wait baseline, and campaign/runner evidence work.
