### PR TITLE
Issue #3204: summarize proxy blocked artifact types

### DIFF
--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -49,20 +49,25 @@ def _summarize_blocked_artifacts(
     if not artifacts:
         return {
             "total": 0,
+            "by_artifact_type": {},
             "by_status": {},
             "by_storage_scope": {},
         }
 
+    by_artifact_type: dict[str, int] = {}
     by_status: dict[str, int] = {}
     by_storage_scope: dict[str, int] = {}
     for artifact in artifacts:
+        artifact_type = artifact.get("artifact_type", "unknown")
         status = artifact.get("status", "unknown")
         scope = artifact.get("storage_scope", "unknown")
+        by_artifact_type[str(artifact_type)] = by_artifact_type.get(str(artifact_type), 0) + 1
         by_status[str(status)] = by_status.get(str(status), 0) + 1
         by_storage_scope[str(scope)] = by_storage_scope.get(str(scope), 0) + 1
 
     return {
         "total": len(artifacts),
+        "by_artifact_type": by_artifact_type,
         "by_status": by_status,
         "by_storage_scope": by_storage_scope,
     }

--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -58,12 +58,12 @@ def _summarize_blocked_artifacts(
     by_status: dict[str, int] = {}
     by_storage_scope: dict[str, int] = {}
     for artifact in artifacts:
-        artifact_type = artifact.get("artifact_type", "unknown")
-        status = artifact.get("status", "unknown")
-        scope = artifact.get("storage_scope", "unknown")
-        by_artifact_type[str(artifact_type)] = by_artifact_type.get(str(artifact_type), 0) + 1
-        by_status[str(status)] = by_status.get(str(status), 0) + 1
-        by_storage_scope[str(scope)] = by_storage_scope.get(str(scope), 0) + 1
+        artifact_type = _summary_bucket(artifact.get("artifact_type"))
+        status = _summary_bucket(artifact.get("status"))
+        scope = _summary_bucket(artifact.get("storage_scope"))
+        by_artifact_type[artifact_type] = by_artifact_type.get(artifact_type, 0) + 1
+        by_status[status] = by_status.get(status, 0) + 1
+        by_storage_scope[scope] = by_storage_scope.get(scope, 0) + 1
 
     return {
         "total": len(artifacts),
@@ -71,6 +71,11 @@ def _summarize_blocked_artifacts(
         "by_status": by_status,
         "by_storage_scope": by_storage_scope,
     }
+
+
+def _summary_bucket(value: Any) -> str:
+    """Normalize absent optional summary fields without rewriting valid falsy values."""
+    return str(value) if value is not None else "unknown"
 
 
 DEFAULT_CONFIG = Path("configs/research/predictive_checkpoint_proxy_v1.yaml")

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -709,5 +709,6 @@ def test_blocked_artifact_summary_is_reported_for_decision_packet(tmp_path: Path
     assert "summary" in blocked
     summary = blocked["summary"]
     assert summary["total"] >= 1
+    assert summary["by_artifact_type"].get("checkpoint_set", 0) >= 1
     assert summary["by_status"].get("blocked", 0) >= 1
     assert summary["by_storage_scope"].get("worktree_local_output", 0) >= 1

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -504,6 +504,20 @@ def test_blocked_when_artifact_inventory_has_blocked_state(tmp_path):
     assert any("blocked artifact" in message for message in artifacts["messages"])
 
 
+def test_blocked_artifact_summary_treats_none_as_unknown_and_preserves_falsy_values():
+    """Summary buckets only substitute unknown for absent/null optional fields."""
+    summary = mod._summarize_blocked_artifacts(
+        [
+            {"artifact_type": None, "status": None, "storage_scope": None},
+            {"artifact_type": "", "status": "", "storage_scope": ""},
+        ]
+    )
+
+    assert summary["by_artifact_type"] == {"unknown": 1, "": 1}
+    assert summary["by_status"] == {"unknown": 1, "": 1}
+    assert summary["by_storage_scope"] == {"unknown": 1, "": 1}
+
+
 def test_failed_when_blocked_artifact_metadata_malformed(tmp_path):
     """Artifact inventory missing required metadata fails closed before readiness claims."""
     config = _write_config(tmp_path, min_resolvable=2, min_epochs=2)


### PR DESCRIPTION
## Summary
Adds one diagnostic field to the issue #3204 predictive checkpoint proxy readiness packet: blocked-artifact summaries now include counts by artifact type.

## Linked Issues
- Relates to `#3204`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: `#3204`
- Safe review independently: yes
- Review dependency reason, any: Small readiness-packet metadata addition only.

## What Changed
- Added `by_artifact_type` to `scripts/research/check_predictive_checkpoint_proxy_readiness.py` blocked-artifact summary output.
- Extended the focused readiness test to assert checkpoint-set blockers are surfaced in the decision-packet summary.

## Why Matters
- Added value: reviewers can distinguish checkpoint-set blockers from proxy-training-summary blockers without reading each artifact row.
- Expected impact: clearer fail-closed readiness diagnostics for proxy-based checkpoint selection inputs.
- Why worth merging now: issue #3204 remains blocked on artifacts; this improves the blocked packet without selecting checkpoints or changing benchmark semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3204 artifact-readiness blocker visibility.
- Comparator or baseline, applicable: existing readiness packet summary grouped only by status and storage scope.
- Evidence tier: NA - support helper metadata only.
- Result classification: NA - no research result or benchmark claim.
- Decision stop rule, applicable: NA - no checkpoint selection or benchmark result.
- Parent issue, claim map, registry, context note, synthesis surface update: Parent issue remains open and blocked; no claim-map or benchmark update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support helper metadata only.

## Domain-Aware Approval
- Required PR: yes - diagnostic evidence-validity-sensitive readiness packet metadata.
- Domains reviewed: evidence classification, artifact-readiness diagnostics.
- Status: waived for metadata-only diagnostic boundary.
- Approver/review source waiver: waived because this PR adds diagnostic readiness metadata only; it does not change evidence classification, experimental comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim surfaces.
- Validity checklist: no benchmark evidence claimed.
- Target claim/hypothesis: NA
- Comparator or split/evidence validity: no comparator split is introduced or interpreted; existing issue #3204 evidence contract remains blocked.
- Fallback/degraded exclusions: no benchmark run.
- Claim boundary: diagnostic readiness packet only.
- Implementation integrity vs experimental validity: implementation adds packet metadata; experimental validity unchanged.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no benchmark mechanism.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: issue #3204 still needs durable/hydrated predictive checkpoints and non-degenerate proxy-enabled training summary.

## Next Empirical Action
- Rerun needed: yes, for issue #3204 evidence contract after artifacts exist.
- Extractor analysis tool needed: no
- Artifact missing unavailable: yes, durable predictive checkpoint set and non-degenerate proxy training summary remain missing.
- Stop / revise / continue decision: continue blocked-readiness tracking only.
- Proposed child issue existing follow-up: issue #3204.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py -q` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --json` -> exit 2 as expected; blocked summary includes `by_artifact_type: {"checkpoint_set": 1, "proxy_training_summary": 1}`.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> passed.

Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Impact
- Baseline runtime: NA - metadata-only readiness packet change.
- Changed runtime: NA - no benchmark or hot path change.
- Representative command: `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --json`
- Hot-path call count profile anchor: NA
- Cache-hit reuse counter: NA when no caching claimed.
- Rollback failure criterion: readiness packet consumers cannot parse the added summary field, or focused tests regress.

## Risks / Rollout
- Compatibility risks: Low; additive JSON summary field.
- Failure modes: downstream strict-schema consumers could need to ignore or accept the new field.
- Rollback fallback plan: remove `by_artifact_type` summary field and its focused assertion.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3204 comments and readiness contract.
- Any assumptions need to preserved: artifact-type grouping is diagnostic metadata only and does not resolve blockers.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, commenting not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): NA
- Not applicable because: no benchmark, registry, claim-map, or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: satisfy original issue #3204 evidence contract with durable/hydrated checkpoints and non-degenerate proxy summary.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the PR stays diagnostic-only: it adds blocked-artifact summary metadata and does not select checkpoints.
- Known limitations: issue #3204 remains blocked; this PR does not satisfy Spearman/A-B evidence requirements.
