### PR TITLE
Issue #3275: fail closed on blank failure archive metadata

### DIFF
--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -317,7 +317,7 @@ def _overlap_metadata_gaps(
             raw_archive_id = entry.get("archive_id")
             archive_id = _metadata_archive_id(raw_archive_id, side=side, index=index)
             entry_gaps: list[str] = []
-            if archive_id.startswith(f"{side}:<entry:"):
+            if _metadata_archive_id_missing(raw_archive_id):
                 entry_gaps.append("archive_id")
             if _scenario_family_missing(entry):
                 entry_gaps.append("scenario_family")
@@ -341,6 +341,14 @@ def _metadata_archive_id(raw_archive_id: Any, *, side: str, index: int) -> str:
     return f"{side}:<entry:{index}>"
 
 
+def _metadata_archive_id_missing(raw_archive_id: Any) -> bool:
+    """Return whether archive ID metadata is absent or blank."""
+
+    return raw_archive_id is None or (
+        isinstance(raw_archive_id, str) and not raw_archive_id.strip()
+    )
+
+
 def _scenario_family_missing(entry: dict[str, Any]) -> bool:
     """Return whether scenario-family metadata is absent or placeholder-only."""
 
@@ -355,7 +363,8 @@ def _scenario_family_missing(entry: dict[str, Any]) -> bool:
         except ValueError:
             return False
         if isinstance(decoded, dict) and not any(
-            isinstance(value, str) and value.strip() for value in decoded.values()
+            value is not None and (not isinstance(value, str) or bool(value.strip()))
+            for value in decoded.values()
         ):
             return True
     return False

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -315,11 +315,11 @@ def _overlap_metadata_gaps(
     for side, entries in (("source", source_entries), ("rerun", rerun_entries)):
         for index, entry in enumerate(entries):
             raw_archive_id = entry.get("archive_id")
-            archive_id = str(raw_archive_id or f"{side}:<entry:{index}>")
+            archive_id = _metadata_archive_id(raw_archive_id, side=side, index=index)
             entry_gaps: list[str] = []
-            if raw_archive_id is None:
+            if archive_id.startswith(f"{side}:<entry:"):
                 entry_gaps.append("archive_id")
-            if scenario_family_key(entry) == "unknown_family":
+            if _scenario_family_missing(entry):
                 entry_gaps.append("scenario_family")
             candidate = entry.get("candidate")
             if not isinstance(candidate, dict) or candidate.get("scenario_seed") is None:
@@ -327,6 +327,38 @@ def _overlap_metadata_gaps(
             if entry_gaps:
                 gaps.append(f"{side}:{archive_id}:{','.join(entry_gaps)}")
     return gaps
+
+
+def _metadata_archive_id(raw_archive_id: Any, *, side: str, index: int) -> str:
+    """Return a stable entry identifier for metadata-gap reports."""
+
+    if isinstance(raw_archive_id, str):
+        normalized = raw_archive_id.strip()
+        if normalized:
+            return normalized
+    elif raw_archive_id is not None:
+        return str(raw_archive_id)
+    return f"{side}:<entry:{index}>"
+
+
+def _scenario_family_missing(entry: dict[str, Any]) -> bool:
+    """Return whether scenario-family metadata is absent or placeholder-only."""
+
+    family = scenario_family_key(entry)
+    if family == "unknown_family":
+        return True
+    if not isinstance(family, str) or not family.strip():
+        return True
+    if family.startswith("{"):
+        try:
+            decoded = json.loads(family)
+        except ValueError:
+            return False
+        if isinstance(decoded, dict) and not any(
+            isinstance(value, str) and value.strip() for value in decoded.values()
+        ):
+            return True
+    return False
 
 
 def _certification_gaps(entries: list[dict[str, Any]]) -> tuple[list[str], list[str]]:

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -188,6 +188,37 @@ def test_missing_overlap_metadata_blocks_readiness(tmp_path: Path) -> None:
     )
 
 
+def test_blank_overlap_metadata_blocks_readiness(tmp_path: Path) -> None:
+    """Blank overlap metadata must fail closed like absent metadata."""
+
+    source_entry = _entry("source_0000", family="family_a", seed=1)
+    source_entry["archive_id"] = "   "
+    source_entry["cluster_key"] = {
+        "policy": "",
+        "scenario_template": " ",
+        "primary_failure": "",
+        "termination_reason": "",
+    }
+    source_entry.pop("failure_attribution")
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    source = _archive(tmp_path / "source.json", [source_entry])
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.missing_overlap_metadata_archive_ids == [
+        "source:source:<entry:0>:archive_id,scenario_family",
+    ]
+    assert "missing_overlap_metadata:1" in readiness.blockers
+
+
 def test_missing_archive_payload_blocks_ready_path(tmp_path: Path) -> None:
     """Missing archive file paths must fail closed for both source and rerun."""
 

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -219,6 +219,59 @@ def test_blank_overlap_metadata_blocks_readiness(tmp_path: Path) -> None:
     assert "missing_overlap_metadata:1" in readiness.blockers
 
 
+def test_user_archive_id_matching_fallback_prefix_is_not_missing(tmp_path: Path) -> None:
+    """User-provided archive IDs may look like synthetic fallback IDs."""
+
+    source_entry = _entry("source:<entry:0>:custom", family="family_a", seed=1)
+    source_entry.pop("cluster_key")
+    source_entry.pop("failure_attribution")
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    source = _archive(tmp_path / "source.json", [source_entry])
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.missing_overlap_metadata_archive_ids == [
+        "source:source:<entry:0>:custom:scenario_family",
+    ]
+    assert "missing_overlap_metadata:1" in readiness.blockers
+
+
+def test_non_string_cluster_key_value_is_not_placeholder_only(tmp_path: Path) -> None:
+    """Non-null JSON cluster-key values can identify a scenario family."""
+
+    source_entry = _entry("source_0000", family="family_a", seed=1)
+    source_entry["cluster_key"] = {
+        "policy": None,
+        "scenario_template": 1,
+        "primary_failure": "",
+        "termination_reason": " ",
+    }
+    source_entry.pop("failure_attribution")
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    source = _archive(tmp_path / "source.json", [source_entry])
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == READY
+    assert readiness.missing_overlap_metadata_archive_ids == []
+    assert not any(blocker.startswith("missing_overlap_metadata") for blocker in readiness.blockers)
+
+
 def test_missing_archive_payload_blocks_ready_path(tmp_path: Path) -> None:
     """Missing archive file paths must fail closed for both source and rerun."""
 


### PR DESCRIPTION
## Summary
Fail closed when certified failure-archive overlap metadata is blank or placeholder-only. This is a bounded issue #3275 readiness slice; it does not run the proposal model or report benchmark yield.

## Linked Issues
- Relates to `#3275`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Normalized archive IDs before trusting overlap metadata, so blank string IDs are treated as missing.
- Added a placeholder-family guard so cluster keys with only blank values cannot satisfy the scenario-family disjointness prerequisite.
- Added a regression test for blank overlap metadata on the certified failure-archive readiness checker.

## Why Matters
- Added value: closes one metadata hygiene gap before any real disjoint archive rerun can be considered ready.
- Expected impact: malformed archive inputs fail closed with `missing_overlap_metadata` blockers.
- Why worth merging now: it tightens the readiness gate without requiring private archive inputs, compute submission, or benchmark interpretation.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3275 readiness blocker for disjoint certified failure-archive reruns.
- Comparator or baseline, applicable: origin/main treats absent overlap metadata as blocking; this PR also blocks blank/placeholder metadata.
- Evidence tier: NA
- Result classification: NA
- Decision stop rule, applicable: readiness checker must block inputs whose archive ID or scenario-family metadata cannot prove disjointness.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3275 remains open for real archive rerun and independent planner-execution outcomes.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - this tightens an existing support checker and does not interpret research evidence.

## Domain-Aware Approval
Required PR: yes, reviewed as a waived support-checker change.
Domains reviewed: failure-archive readiness, overlap metadata, null-test prerequisites.
Status: waived.
Approver/review source waiver: self-reviewed waiver because this PR only tightens a fail-closed readiness checker and makes no benchmark, yield, or paper-facing evidence claim.
Approval or blocker note: waived for checker-only readiness hardening; full issue #3275 evidence remains deferred.
Validity checklist:
Target claim/hypothesis: no benchmark or yield claim.
Comparator or split/evidence validity: targeted synthetic fixtures prove blank metadata blocks readiness; real split validity remains out of scope.
Fallback/degraded exclusions: no fallback/degraded benchmark execution performed.
Claim boundary: readiness/leakage check only.
Implementation integrity vs experimental validity: code blocks malformed metadata before readiness; real archive rerun remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, focused fixture reports `missing_overlap_metadata`.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA - synthetic metadata fixture only.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: issue #3275 still needs real archive rerun evidence.

## Next Empirical Action
- Rerun needed: yes
- Extractor analysis tool needed: no
- Artifact missing unavailable: real disjoint certified failure archive and independent planner-execution outcomes remain outside this PR.
- Stop / revise / continue decision: continue readiness hardening; do not claim held-out yield.
- Proposed child issue existing follow-up: issue #3275 remains the parent.

## Validation / Proof
- `uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` - passed, 23 tests after review fixes.
- `uv run ruff format robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py && uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` - passed.
- `git diff --check` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/pr-4067-gate/pr_body.md PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` - passed on head `a38d34f9ed538c1c7b9b86198f120f9a5ced94e0`; stamp `output/validation/pr_ready/issue-3275-certified-archive-readiness-overlap-metadata.json`.
- Review fix coverage: added regressions for user-provided archive IDs that look like synthetic fallback IDs and non-string JSON cluster-key values.

## Runtime / Performance
- Baseline runtime: <1s for focused readiness test module on synthetic fixtures.
- Changed runtime: <1s for focused readiness test module on synthetic fixtures.
- Representative command: `uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q`
- Hot-path call count profile anchor: NA - no runtime hot-path or benchmark campaign change claimed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: readiness checker accepts blank archive ID or placeholder-only scenario-family metadata as ready.

## Risks / Rollout
- Compatibility risks: stricter metadata validation can block archives that relied on blank placeholders.
- Failure modes: real archive producers may need to populate archive IDs and scenario-family fields before rerun readiness passes.
- Rollback fallback plan: revert this commit if a legitimate certified archive format needs a different nonblank family contract.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3275 and existing `robot_sf/benchmark/failure_archive_rerun_readiness.py` claim boundary.
- Any assumptions need to preserved: blank IDs and placeholder-only family keys cannot prove disjointness.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; comment authorization was false.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark, registry, claim-map, paper-facing, or artifact-catalog change.

## Follow-Up Issues
- Deferred work: real proposal-model evaluation on a disjoint certified failure archive with independent planner-execution outcomes; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits in this PR.
- Issues opened follow-up: #3275 remains open for the deferred real archive rerun.

## Reviewer Notes
- Anything reviewer verify closely: `_scenario_family_missing` intentionally only treats JSON cluster keys with all blank string values as placeholder-only.
- Any known limitations: does not validate semantic quality of nonblank family strings; that remains archive-producer responsibility.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved readiness checks for rerun archives so missing or placeholder metadata is detected more reliably, including blank values and incomplete JSON-like placeholders.
  * Tightened handling of archive identifiers to avoid false gaps when a real stable identifier is present.
  * Added coverage for cases where blank metadata should block rerun readiness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
