### PR TITLE
Issue #3976: add kinematic dynamics sensitivity slice

### DIFF
--- a/robot_sf/benchmark/dynamics_sensitivity.py
+++ b/robot_sf/benchmark/dynamics_sensitivity.py
@@ -1,0 +1,213 @@
+"""Dynamics-sensitivity ranking analysis for issue #3976.
+
+The harness consumes already-measured planner metric tables keyed by dynamics
+model. It does not run a benchmark campaign and does not change metric semantics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from math import isfinite
+
+from robot_sf.benchmark.rank_metrics import kendall_tau, rank_order
+
+DYNAMICS_SENSITIVITY_SCHEMA = "dynamics_sensitivity.v1"
+
+
+MetricTable = Mapping[str, Mapping[str, object]]
+DynamicsMetricTables = Mapping[str, MetricTable]
+
+
+def _finite_metric_value(metrics: Mapping[str, object], metric: str) -> float | None:
+    try:
+        value = float(metrics[metric])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if not isfinite(value):
+        return None
+    return value
+
+
+def _metric_values(table: MetricTable, metric: str) -> dict[str, float]:
+    values: dict[str, float] = {}
+    for planner, metrics in table.items():
+        value = _finite_metric_value(metrics, metric)
+        if value is not None:
+            values[str(planner)] = value
+    return values
+
+
+def _rank_planners(
+    table: MetricTable,
+    metric: str,
+    *,
+    higher_is_better: bool,
+) -> list[str]:
+    values = _metric_values(table, metric)
+    return [str(planner) for planner in rank_order(values, higher_is_better=higher_is_better)]
+
+
+def _project_table(
+    table: MetricTable, metric_names: tuple[str, ...]
+) -> dict[str, dict[str, float]]:
+    rows: dict[str, dict[str, float]] = {}
+    for planner, metrics in table.items():
+        row: dict[str, float] = {}
+        for metric in metric_names:
+            value = _finite_metric_value(metrics, metric)
+            if value is not None:
+                row[metric] = value
+        rows[str(planner)] = row
+    return rows
+
+
+@dataclass(frozen=True)
+class DynamicsRankStability:
+    """Ranking comparison for one dynamics model against the reference model."""
+
+    dynamics: str
+    ranking: list[str]
+    kendall_tau: float | None
+    rank_flips: int | None
+    top1_changed: bool | None
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a JSON-safe representation."""
+
+        return {
+            "dynamics": self.dynamics,
+            "ranking": list(self.ranking),
+            "kendall_tau": self.kendall_tau,
+            "rank_flips": self.rank_flips,
+            "top1_changed": self.top1_changed,
+        }
+
+
+@dataclass(frozen=True)
+class DynamicsSensitivityReport:
+    """Per-dynamics metric table plus planner-ranking stability summary."""
+
+    reference_dynamics: str
+    primary_metric: str
+    higher_is_better: bool
+    reference_ranking: list[str]
+    metric_table: dict[str, dict[str, dict[str, float]]]
+    dynamics: list[DynamicsRankStability]
+    flipping_dynamics: list[str]
+    rank_stable: bool
+
+    def to_dict(self) -> dict[str, object]:
+        """Return a ``dynamics_sensitivity.v1`` JSON-safe payload."""
+
+        return {
+            "schema_version": DYNAMICS_SENSITIVITY_SCHEMA,
+            "reference_dynamics": self.reference_dynamics,
+            "primary_metric": self.primary_metric,
+            "higher_is_better": self.higher_is_better,
+            "reference_ranking": list(self.reference_ranking),
+            "rank_stable": self.rank_stable,
+            "flipping_dynamics": list(self.flipping_dynamics),
+            "metric_table": self.metric_table,
+            "dynamics": [entry.to_dict() for entry in self.dynamics],
+        }
+
+
+def analyze_dynamics_sensitivity(
+    tables: DynamicsMetricTables,
+    *,
+    reference_dynamics: str,
+    primary_metric: str = "collision_rate",
+    higher_is_better: bool = False,
+    metric_names: tuple[str, ...] = (
+        "collision_rate",
+        "near_miss_rate",
+        "tracking_error",
+        "curvature_limit_violation",
+        "braking_distance",
+    ),
+) -> DynamicsSensitivityReport:
+    """Compare planner rankings across robot dynamics metric tables.
+
+    Args:
+        tables: Mapping ``dynamics -> planner -> metric -> value``.
+        reference_dynamics: Dynamics name used as the ranking reference.
+        primary_metric: Metric used to rank planners.
+        higher_is_better: Direction for ``primary_metric``.
+        metric_names: Metrics copied into the output table when present.
+
+    Returns:
+        A deterministic ranking-stability report for short local sensitivity runs.
+    """
+
+    if reference_dynamics not in tables:
+        raise ValueError(f"reference_dynamics {reference_dynamics!r} is missing from tables.")
+
+    reference_table = tables[reference_dynamics]
+    reference_ranking = _rank_planners(
+        reference_table,
+        primary_metric,
+        higher_is_better=higher_is_better,
+    )
+    if len(reference_ranking) < 2:
+        raise ValueError("reference table must contain at least two finite planner metric values.")
+
+    metric_table = {
+        str(dynamics): _project_table(table, metric_names)
+        for dynamics, table in sorted(tables.items(), key=lambda item: str(item[0]))
+    }
+
+    dynamics_entries: list[DynamicsRankStability] = []
+    flipping_dynamics: list[str] = []
+    for dynamics, table in sorted(tables.items(), key=lambda item: str(item[0])):
+        dynamics_name = str(dynamics)
+        ranking = _rank_planners(table, primary_metric, higher_is_better=higher_is_better)
+        if set(ranking) != set(reference_ranking):
+            tau = None
+            rank_flips = None
+            top1_changed = None
+            flipping_dynamics.append(dynamics_name)
+        else:
+            tau = kendall_tau(reference_ranking, ranking, degenerate=1.0)
+            rank_flips = _count_rank_flips(reference_ranking, ranking)
+            top1_changed = bool(ranking and ranking[0] != reference_ranking[0])
+            if rank_flips > 0:
+                flipping_dynamics.append(dynamics_name)
+        dynamics_entries.append(
+            DynamicsRankStability(
+                dynamics=dynamics_name,
+                ranking=ranking,
+                kendall_tau=tau,
+                rank_flips=rank_flips,
+                top1_changed=top1_changed,
+            )
+        )
+
+    return DynamicsSensitivityReport(
+        reference_dynamics=reference_dynamics,
+        primary_metric=primary_metric,
+        higher_is_better=higher_is_better,
+        reference_ranking=reference_ranking,
+        metric_table=metric_table,
+        dynamics=dynamics_entries,
+        flipping_dynamics=flipping_dynamics,
+        rank_stable=not flipping_dynamics,
+    )
+
+
+def _count_rank_flips(reference: list[str], candidate: list[str]) -> int:
+    position = {planner: index for index, planner in enumerate(candidate)}
+    flips = 0
+    for left_index, left in enumerate(reference):
+        for right in reference[left_index + 1 :]:
+            if position[left] > position[right]:
+                flips += 1
+    return flips
+
+
+__all__ = [
+    "DYNAMICS_SENSITIVITY_SCHEMA",
+    "DynamicsRankStability",
+    "DynamicsSensitivityReport",
+    "analyze_dynamics_sensitivity",
+]

--- a/robot_sf/robot/__init__.py
+++ b/robot_sf/robot/__init__.py
@@ -1,1 +1,23 @@
 """Robot module providing vehicle dynamics models and motion primitives."""
+
+from robot_sf.robot.dynamics import (
+    KINEMATIC_DYNAMICS_NAMES,
+    DifferentialDriveDynamics,
+    HolonomicDiscDynamics,
+    KinematicBicycleDynamics,
+    RobotDynamicsModel,
+    RobotDynamicsState,
+    UnicycleDynamics,
+    build_robot_dynamics,
+)
+
+__all__ = [
+    "KINEMATIC_DYNAMICS_NAMES",
+    "DifferentialDriveDynamics",
+    "HolonomicDiscDynamics",
+    "KinematicBicycleDynamics",
+    "RobotDynamicsModel",
+    "RobotDynamicsState",
+    "UnicycleDynamics",
+    "build_robot_dynamics",
+]

--- a/robot_sf/robot/dynamics.py
+++ b/robot_sf/robot/dynamics.py
@@ -7,7 +7,7 @@ and lean dynamics are deferred to a higher-fidelity model family.
 from __future__ import annotations
 
 from dataclasses import dataclass, replace
-from math import atan2, cos, sin, tan
+from math import atan2, cos, isfinite, pi, sin, tan
 from typing import TYPE_CHECKING, Protocol
 
 from robot_sf.common.math_utils import clip_scalar, wrap_angle_pi
@@ -57,9 +57,16 @@ class RobotDynamicsModel(Protocol):
 
 def _positive_dt(dt: float) -> float:
     value = float(dt)
-    if value <= 0:
-        raise ValueError("dt must be positive.")
+    if not isfinite(value) or value <= 0:
+        raise ValueError("dt must be finite and positive.")
     return value
+
+
+def _finite_positive(value: float, field_name: str) -> float:
+    normalized = float(value)
+    if not isfinite(normalized) or normalized <= 0:
+        raise ValueError(f"{field_name} must be finite and positive.")
+    return normalized
 
 
 def _control_pair(control: Sequence[float], model_name: str) -> tuple[float, float]:
@@ -78,8 +85,7 @@ class HolonomicDiscDynamics:
     def __post_init__(self) -> None:
         """Validate holonomic-disc velocity bounds."""
 
-        if self.max_speed <= 0:
-            raise ValueError("max_speed must be positive.")
+        _finite_positive(self.max_speed, "max_speed")
 
     def step(
         self,
@@ -125,12 +131,9 @@ class DifferentialDriveDynamics:
     def __post_init__(self) -> None:
         """Validate differential-drive geometry and wheel-speed bounds."""
 
-        if self.wheel_radius <= 0:
-            raise ValueError("wheel_radius must be positive.")
-        if self.track_width <= 0:
-            raise ValueError("track_width must be positive.")
-        if self.max_wheel_angular_speed <= 0:
-            raise ValueError("max_wheel_angular_speed must be positive.")
+        _finite_positive(self.wheel_radius, "wheel_radius")
+        _finite_positive(self.track_width, "track_width")
+        _finite_positive(self.max_wheel_angular_speed, "max_wheel_angular_speed")
 
     def step(
         self,
@@ -173,10 +176,8 @@ class UnicycleDynamics:
     def __post_init__(self) -> None:
         """Validate unicycle velocity bounds."""
 
-        if self.max_linear_speed <= 0:
-            raise ValueError("max_linear_speed must be positive.")
-        if self.max_angular_speed <= 0:
-            raise ValueError("max_angular_speed must be positive.")
+        _finite_positive(self.max_linear_speed, "max_linear_speed")
+        _finite_positive(self.max_angular_speed, "max_angular_speed")
 
     def step(
         self,
@@ -218,12 +219,11 @@ class KinematicBicycleDynamics:
     def __post_init__(self) -> None:
         """Validate kinematic-bicycle geometry and command bounds."""
 
-        if self.wheelbase <= 0:
-            raise ValueError("wheelbase must be positive.")
-        if self.max_linear_speed <= 0:
-            raise ValueError("max_linear_speed must be positive.")
-        if self.max_steering_angle <= 0:
-            raise ValueError("max_steering_angle must be positive.")
+        _finite_positive(self.wheelbase, "wheelbase")
+        _finite_positive(self.max_linear_speed, "max_linear_speed")
+        _finite_positive(self.max_steering_angle, "max_steering_angle")
+        if self.max_steering_angle >= pi / 2.0:
+            raise ValueError("max_steering_angle must be strictly less than pi / 2.")
 
     def step(
         self,
@@ -246,10 +246,11 @@ class KinematicBicycleDynamics:
             self.max_steering_angle,
         )
         angular_speed = linear_speed * tan(steering_angle) / self.wheelbase
+        midpoint_heading = state.heading + angular_speed * dt / 2.0
         return replace(
             state,
-            x=state.x + linear_speed * cos(state.heading) * dt,
-            y=state.y + linear_speed * sin(state.heading) * dt,
+            x=state.x + linear_speed * cos(midpoint_heading) * dt,
+            y=state.y + linear_speed * sin(midpoint_heading) * dt,
             heading=wrap_angle_pi(state.heading + angular_speed * dt),
             linear_speed=linear_speed,
             angular_speed=angular_speed,

--- a/robot_sf/robot/dynamics.py
+++ b/robot_sf/robot/dynamics.py
@@ -72,7 +72,10 @@ def _finite_positive(value: float, field_name: str) -> float:
 def _control_pair(control: Sequence[float], model_name: str) -> tuple[float, float]:
     if len(control) != 2:
         raise ValueError(f"{model_name} control must contain exactly two values.")
-    return float(control[0]), float(control[1])
+    first, second = float(control[0]), float(control[1])
+    if not isfinite(first) or not isfinite(second):
+        raise ValueError(f"{model_name} control values must be finite.")
+    return first, second
 
 
 @dataclass(frozen=True)

--- a/robot_sf/robot/dynamics.py
+++ b/robot_sf/robot/dynamics.py
@@ -1,0 +1,290 @@
+"""Selectable kinematic robot dynamics models.
+
+This module intentionally covers kinematic motion only. Tire slip, load transfer,
+and lean dynamics are deferred to a higher-fidelity model family.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, replace
+from math import atan2, cos, sin, tan
+from typing import TYPE_CHECKING, Protocol
+
+from robot_sf.common.math_utils import clip_scalar, wrap_angle_pi
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+KINEMATIC_DYNAMICS_NAMES = (
+    "holonomic_disc",
+    "differential_drive",
+    "unicycle",
+    "kinematic_bicycle",
+)
+
+
+@dataclass(frozen=True)
+class RobotDynamicsState:
+    """Pose and velocity state shared by the issue-3976 kinematic models."""
+
+    x: float = 0.0
+    y: float = 0.0
+    heading: float = 0.0
+    linear_speed: float = 0.0
+    angular_speed: float = 0.0
+    steering_angle: float = 0.0
+
+    @property
+    def pose(self) -> tuple[tuple[float, float], float]:
+        """Return the existing repository robot-pose representation."""
+
+        return ((self.x, self.y), self.heading)
+
+
+class RobotDynamicsModel(Protocol):
+    """Common stepping interface for kinematic robot dynamics models."""
+
+    name: str
+
+    def step(
+        self,
+        state: RobotDynamicsState,
+        control: Sequence[float],
+        dt: float,
+    ) -> RobotDynamicsState:
+        """Advance ``state`` by ``dt`` seconds using ``control``."""
+
+
+def _positive_dt(dt: float) -> float:
+    value = float(dt)
+    if value <= 0:
+        raise ValueError("dt must be positive.")
+    return value
+
+
+def _control_pair(control: Sequence[float], model_name: str) -> tuple[float, float]:
+    if len(control) != 2:
+        raise ValueError(f"{model_name} control must contain exactly two values.")
+    return float(control[0]), float(control[1])
+
+
+@dataclass(frozen=True)
+class HolonomicDiscDynamics:
+    """Holonomic disc model with world-frame ``(vx, vy)`` velocity control."""
+
+    max_speed: float = 2.0
+    name: str = "holonomic_disc"
+
+    def __post_init__(self) -> None:
+        """Validate holonomic-disc velocity bounds."""
+
+        if self.max_speed <= 0:
+            raise ValueError("max_speed must be positive.")
+
+    def step(
+        self,
+        state: RobotDynamicsState,
+        control: Sequence[float],
+        dt: float,
+    ) -> RobotDynamicsState:
+        """Advance a holonomic-disc state from world-frame velocity.
+
+        Returns:
+            Updated robot dynamics state.
+        """
+
+        dt = _positive_dt(dt)
+        vx, vy = _control_pair(control, self.name)
+        speed = (vx * vx + vy * vy) ** 0.5
+        if speed > self.max_speed:
+            scale = self.max_speed / max(speed, 1e-12)
+            vx *= scale
+            vy *= scale
+            speed = self.max_speed
+        heading = state.heading if speed <= 1e-12 else atan2(vy, vx)
+        return replace(
+            state,
+            x=state.x + vx * dt,
+            y=state.y + vy * dt,
+            heading=wrap_angle_pi(heading),
+            linear_speed=speed,
+            angular_speed=0.0,
+            steering_angle=0.0,
+        )
+
+
+@dataclass(frozen=True)
+class DifferentialDriveDynamics:
+    """Differential-drive model with left/right wheel angular-velocity control."""
+
+    wheel_radius: float = 0.05
+    track_width: float = 0.3
+    max_wheel_angular_speed: float = 40.0
+    name: str = "differential_drive"
+
+    def __post_init__(self) -> None:
+        """Validate differential-drive geometry and wheel-speed bounds."""
+
+        if self.wheel_radius <= 0:
+            raise ValueError("wheel_radius must be positive.")
+        if self.track_width <= 0:
+            raise ValueError("track_width must be positive.")
+        if self.max_wheel_angular_speed <= 0:
+            raise ValueError("max_wheel_angular_speed must be positive.")
+
+    def step(
+        self,
+        state: RobotDynamicsState,
+        control: Sequence[float],
+        dt: float,
+    ) -> RobotDynamicsState:
+        """Advance a differential-drive state from wheel angular velocities.
+
+        Returns:
+            Updated robot dynamics state.
+        """
+
+        dt = _positive_dt(dt)
+        left, right = _control_pair(control, self.name)
+        left = clip_scalar(left, -self.max_wheel_angular_speed, self.max_wheel_angular_speed)
+        right = clip_scalar(right, -self.max_wheel_angular_speed, self.max_wheel_angular_speed)
+        linear_speed = self.wheel_radius * (left + right) / 2.0
+        angular_speed = self.wheel_radius * (right - left) / self.track_width
+        midpoint_heading = state.heading + angular_speed * dt / 2.0
+        return replace(
+            state,
+            x=state.x + linear_speed * cos(midpoint_heading) * dt,
+            y=state.y + linear_speed * sin(midpoint_heading) * dt,
+            heading=wrap_angle_pi(state.heading + angular_speed * dt),
+            linear_speed=linear_speed,
+            angular_speed=angular_speed,
+            steering_angle=0.0,
+        )
+
+
+@dataclass(frozen=True)
+class UnicycleDynamics:
+    """Unicycle model with ``(linear_speed, angular_speed)`` velocity control."""
+
+    max_linear_speed: float = 2.0
+    max_angular_speed: float = 1.0
+    name: str = "unicycle"
+
+    def __post_init__(self) -> None:
+        """Validate unicycle velocity bounds."""
+
+        if self.max_linear_speed <= 0:
+            raise ValueError("max_linear_speed must be positive.")
+        if self.max_angular_speed <= 0:
+            raise ValueError("max_angular_speed must be positive.")
+
+    def step(
+        self,
+        state: RobotDynamicsState,
+        control: Sequence[float],
+        dt: float,
+    ) -> RobotDynamicsState:
+        """Advance a unicycle state from linear and angular velocity.
+
+        Returns:
+            Updated robot dynamics state.
+        """
+
+        dt = _positive_dt(dt)
+        linear_speed, angular_speed = _control_pair(control, self.name)
+        linear_speed = clip_scalar(linear_speed, -self.max_linear_speed, self.max_linear_speed)
+        angular_speed = clip_scalar(angular_speed, -self.max_angular_speed, self.max_angular_speed)
+        midpoint_heading = state.heading + angular_speed * dt / 2.0
+        return replace(
+            state,
+            x=state.x + linear_speed * cos(midpoint_heading) * dt,
+            y=state.y + linear_speed * sin(midpoint_heading) * dt,
+            heading=wrap_angle_pi(state.heading + angular_speed * dt),
+            linear_speed=linear_speed,
+            angular_speed=angular_speed,
+            steering_angle=0.0,
+        )
+
+
+@dataclass(frozen=True)
+class KinematicBicycleDynamics:
+    """Kinematic bicycle model with ``(linear_speed, steering_angle)`` control."""
+
+    wheelbase: float = 1.0
+    max_linear_speed: float = 3.0
+    max_steering_angle: float = 0.78
+    name: str = "kinematic_bicycle"
+
+    def __post_init__(self) -> None:
+        """Validate kinematic-bicycle geometry and command bounds."""
+
+        if self.wheelbase <= 0:
+            raise ValueError("wheelbase must be positive.")
+        if self.max_linear_speed <= 0:
+            raise ValueError("max_linear_speed must be positive.")
+        if self.max_steering_angle <= 0:
+            raise ValueError("max_steering_angle must be positive.")
+
+    def step(
+        self,
+        state: RobotDynamicsState,
+        control: Sequence[float],
+        dt: float,
+    ) -> RobotDynamicsState:
+        """Advance a kinematic-bicycle state from speed and steering angle.
+
+        Returns:
+            Updated robot dynamics state.
+        """
+
+        dt = _positive_dt(dt)
+        linear_speed, steering_angle = _control_pair(control, self.name)
+        linear_speed = clip_scalar(linear_speed, -self.max_linear_speed, self.max_linear_speed)
+        steering_angle = clip_scalar(
+            steering_angle,
+            -self.max_steering_angle,
+            self.max_steering_angle,
+        )
+        angular_speed = linear_speed * tan(steering_angle) / self.wheelbase
+        return replace(
+            state,
+            x=state.x + linear_speed * cos(state.heading) * dt,
+            y=state.y + linear_speed * sin(state.heading) * dt,
+            heading=wrap_angle_pi(state.heading + angular_speed * dt),
+            linear_speed=linear_speed,
+            angular_speed=angular_speed,
+            steering_angle=steering_angle,
+        )
+
+
+def build_robot_dynamics(name: str, **kwargs: float) -> RobotDynamicsModel:
+    """Create a kinematic dynamics model by stable issue-3976 name.
+
+    Returns:
+        Robot dynamics model implementing the common ``step`` interface.
+    """
+
+    normalized = str(name).strip().lower()
+    if normalized == "holonomic_disc":
+        return HolonomicDiscDynamics(**kwargs)
+    if normalized == "differential_drive":
+        return DifferentialDriveDynamics(**kwargs)
+    if normalized == "unicycle":
+        return UnicycleDynamics(**kwargs)
+    if normalized == "kinematic_bicycle":
+        return KinematicBicycleDynamics(**kwargs)
+    raise ValueError(
+        f"Unknown robot dynamics model {name!r}; expected one of {KINEMATIC_DYNAMICS_NAMES}."
+    )
+
+
+__all__ = [
+    "KINEMATIC_DYNAMICS_NAMES",
+    "DifferentialDriveDynamics",
+    "HolonomicDiscDynamics",
+    "KinematicBicycleDynamics",
+    "RobotDynamicsModel",
+    "RobotDynamicsState",
+    "UnicycleDynamics",
+    "build_robot_dynamics",
+]

--- a/tests/benchmark/test_dynamics_models.py
+++ b/tests/benchmark/test_dynamics_models.py
@@ -117,6 +117,24 @@ def test_dynamics_reject_invalid_dt(name: str, dt: float) -> None:
 
 
 @pytest.mark.parametrize(
+    ("name", "control"),
+    [
+        ("holonomic_disc", (nan, 0.0)),
+        ("differential_drive", (0.0, inf)),
+        ("unicycle", (inf, 0.0)),
+        ("kinematic_bicycle", (0.0, nan)),
+    ],
+)
+def test_dynamics_reject_non_finite_control(name: str, control: tuple[float, float]) -> None:
+    """Dynamics models reject non-finite control values before integration."""
+
+    model = build_robot_dynamics(name)
+
+    with pytest.raises(ValueError, match="control values must be finite"):
+        model.step(RobotDynamicsState(), control, dt=1.0)
+
+
+@pytest.mark.parametrize(
     "name",
     ["holonomic_disc", "differential_drive", "unicycle", "kinematic_bicycle"],
 )

--- a/tests/benchmark/test_dynamics_models.py
+++ b/tests/benchmark/test_dynamics_models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from math import pi
+from math import inf, nan, pi
 
 import pytest
 
@@ -75,8 +75,8 @@ def test_kinematic_bicycle_heading_depends_on_steering_angle() -> None:
 
     next_state = model.step(RobotDynamicsState(), (2.0, 0.5), dt=1.0)
 
-    assert next_state.x == pytest.approx(2.0)
-    assert next_state.y == pytest.approx(0.0)
+    assert next_state.x == pytest.approx(1.925851153)
+    assert next_state.y == pytest.approx(0.539534371)
     assert next_state.heading == pytest.approx(0.5463024898)
     assert next_state.steering_angle == pytest.approx(0.5)
 
@@ -97,16 +97,23 @@ def test_state_pose_matches_repository_pose_shape() -> None:
 
 
 @pytest.mark.parametrize(
-    "name",
-    ["holonomic_disc", "differential_drive", "unicycle", "kinematic_bicycle"],
+    ("name", "dt"),
+    [
+        ("holonomic_disc", 0.0),
+        ("differential_drive", 0.0),
+        ("unicycle", 0.0),
+        ("kinematic_bicycle", 0.0),
+        ("holonomic_disc", nan),
+        ("unicycle", inf),
+    ],
 )
-def test_dynamics_reject_non_positive_dt(name: str) -> None:
-    """All dynamics models reject zero or negative timesteps."""
+def test_dynamics_reject_invalid_dt(name: str, dt: float) -> None:
+    """Dynamics models reject non-positive and non-finite timesteps."""
 
     model = build_robot_dynamics(name)
 
-    with pytest.raises(ValueError, match="dt must be positive"):
-        model.step(RobotDynamicsState(), (0.0, 0.0), dt=0.0)
+    with pytest.raises(ValueError, match="dt must be finite and positive"):
+        model.step(RobotDynamicsState(), (0.0, 0.0), dt=dt)
 
 
 @pytest.mark.parametrize(
@@ -183,7 +190,7 @@ def test_kinematic_bicycle_clips_speed_and_steering() -> None:
 
     next_state = model.step(RobotDynamicsState(), (5.0, 1.0), dt=1.0)
 
-    assert next_state.x == pytest.approx(1.0)
+    assert next_state.x == pytest.approx(0.997963)
     assert next_state.steering_angle == pytest.approx(0.25)
 
 
@@ -191,14 +198,25 @@ def test_kinematic_bicycle_clips_speed_and_steering() -> None:
     ("name", "kwargs", "match"),
     [
         ("holonomic_disc", {"max_speed": 0.0}, "max_speed"),
+        ("holonomic_disc", {"max_speed": nan}, "max_speed"),
         ("differential_drive", {"wheel_radius": 0.0}, "wheel_radius"),
+        ("differential_drive", {"wheel_radius": inf}, "wheel_radius"),
         ("differential_drive", {"track_width": 0.0}, "track_width"),
+        ("differential_drive", {"track_width": nan}, "track_width"),
         ("differential_drive", {"max_wheel_angular_speed": 0.0}, "max_wheel"),
+        ("differential_drive", {"max_wheel_angular_speed": inf}, "max_wheel"),
         ("unicycle", {"max_linear_speed": 0.0}, "max_linear_speed"),
+        ("unicycle", {"max_linear_speed": nan}, "max_linear_speed"),
         ("unicycle", {"max_angular_speed": 0.0}, "max_angular_speed"),
+        ("unicycle", {"max_angular_speed": inf}, "max_angular_speed"),
         ("kinematic_bicycle", {"wheelbase": 0.0}, "wheelbase"),
+        ("kinematic_bicycle", {"wheelbase": nan}, "wheelbase"),
         ("kinematic_bicycle", {"max_linear_speed": 0.0}, "max_linear_speed"),
+        ("kinematic_bicycle", {"max_linear_speed": inf}, "max_linear_speed"),
         ("kinematic_bicycle", {"max_steering_angle": 0.0}, "max_steering_angle"),
+        ("kinematic_bicycle", {"max_steering_angle": 1.6}, "max_steering_angle"),
+        ("kinematic_bicycle", {"max_steering_angle": nan}, "max_steering_angle"),
+        ("kinematic_bicycle", {"max_steering_angle": inf}, "max_steering_angle"),
     ],
 )
 def test_dynamics_constructor_validation(

--- a/tests/benchmark/test_dynamics_models.py
+++ b/tests/benchmark/test_dynamics_models.py
@@ -1,0 +1,212 @@
+"""Tests for selectable issue-3976 kinematic robot dynamics."""
+
+from __future__ import annotations
+
+from math import pi
+
+import pytest
+
+from robot_sf.robot.dynamics import RobotDynamicsState, build_robot_dynamics
+
+
+@pytest.mark.parametrize(
+    ("name", "control", "expected_pose"),
+    [
+        ("holonomic_disc", (1.0, 0.5), (1.0, 0.5, pytest.approx(0.463647609))),
+        ("differential_drive", (20.0, 20.0), (1.0, 0.0, 0.0)),
+        ("unicycle", (1.0, 0.0), (1.0, 0.0, 0.0)),
+        ("kinematic_bicycle", (1.0, 0.0), (1.0, 0.0, 0.0)),
+    ],
+)
+def test_kinematic_dynamics_step_forward_known_control(
+    name: str,
+    control: tuple[float, float],
+    expected_pose: tuple[float, float, float],
+) -> None:
+    """Each named dynamics model advances a known one-second command."""
+
+    model = build_robot_dynamics(name)
+    next_state = model.step(RobotDynamicsState(), control, dt=1.0)
+
+    assert next_state.x == pytest.approx(expected_pose[0])
+    assert next_state.y == pytest.approx(expected_pose[1])
+    assert next_state.heading == expected_pose[2]
+
+
+def test_unicycle_integrates_arc_with_midpoint_heading() -> None:
+    """Unicycle motion follows an arc for simultaneous translation and rotation."""
+
+    model = build_robot_dynamics("unicycle", max_linear_speed=2.0, max_angular_speed=2.0)
+
+    next_state = model.step(RobotDynamicsState(), (1.0, pi / 2.0), dt=1.0)
+
+    assert next_state.x == pytest.approx(2**0.5 / 2.0)
+    assert next_state.y == pytest.approx(2**0.5 / 2.0)
+    assert next_state.heading == pytest.approx(pi / 2.0)
+    assert next_state.angular_speed == pytest.approx(pi / 2.0)
+
+
+def test_differential_drive_turns_from_wheel_speed_difference() -> None:
+    """Differential drive derives linear and angular speed from wheel speeds."""
+
+    model = build_robot_dynamics(
+        "differential_drive",
+        wheel_radius=0.1,
+        track_width=0.5,
+        max_wheel_angular_speed=20.0,
+    )
+
+    next_state = model.step(RobotDynamicsState(), (5.0, 10.0), dt=1.0)
+
+    assert next_state.linear_speed == pytest.approx(0.75)
+    assert next_state.angular_speed == pytest.approx(1.0)
+    assert next_state.heading == pytest.approx(1.0)
+
+
+def test_kinematic_bicycle_heading_depends_on_steering_angle() -> None:
+    """Kinematic bicycle heading changes with steering angle and wheelbase."""
+
+    model = build_robot_dynamics(
+        "kinematic_bicycle",
+        wheelbase=2.0,
+        max_linear_speed=5.0,
+        max_steering_angle=0.8,
+    )
+
+    next_state = model.step(RobotDynamicsState(), (2.0, 0.5), dt=1.0)
+
+    assert next_state.x == pytest.approx(2.0)
+    assert next_state.y == pytest.approx(0.0)
+    assert next_state.heading == pytest.approx(0.5463024898)
+    assert next_state.steering_angle == pytest.approx(0.5)
+
+
+def test_unknown_dynamics_name_fails_closed() -> None:
+    """Unknown dynamics names fail closed instead of silently falling back."""
+
+    with pytest.raises(ValueError, match="Unknown robot dynamics model"):
+        build_robot_dynamics("tire_slip")
+
+
+def test_state_pose_matches_repository_pose_shape() -> None:
+    """Shared dynamics state exposes the existing nested robot-pose tuple."""
+
+    state = RobotDynamicsState(x=1.0, y=2.0, heading=0.25)
+
+    assert state.pose == ((1.0, 2.0), 0.25)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["holonomic_disc", "differential_drive", "unicycle", "kinematic_bicycle"],
+)
+def test_dynamics_reject_non_positive_dt(name: str) -> None:
+    """All dynamics models reject zero or negative timesteps."""
+
+    model = build_robot_dynamics(name)
+
+    with pytest.raises(ValueError, match="dt must be positive"):
+        model.step(RobotDynamicsState(), (0.0, 0.0), dt=0.0)
+
+
+@pytest.mark.parametrize(
+    "name",
+    ["holonomic_disc", "differential_drive", "unicycle", "kinematic_bicycle"],
+)
+def test_dynamics_reject_wrong_control_dimension(name: str) -> None:
+    """All dynamics models require a two-value control input."""
+
+    model = build_robot_dynamics(name)
+
+    with pytest.raises(ValueError, match="exactly two values"):
+        model.step(RobotDynamicsState(), (1.0,), dt=1.0)
+
+
+def test_build_robot_dynamics_accepts_normalized_names_and_kwargs() -> None:
+    """The registry normalizes names and forwards model-specific parameters."""
+
+    model = build_robot_dynamics(" Unicycle ", max_linear_speed=4.0)
+
+    next_state = model.step(RobotDynamicsState(), (10.0, 0.0), dt=1.0)
+    assert next_state.linear_speed == pytest.approx(4.0)
+
+
+def test_holonomic_disc_clips_velocity_norm_and_preserves_stopped_heading() -> None:
+    """Holonomic disc clips vector speed and keeps heading when stopped."""
+
+    model = build_robot_dynamics("holonomic_disc", max_speed=1.0)
+    clipped = model.step(RobotDynamicsState(), (3.0, 4.0), dt=1.0)
+    stopped = model.step(RobotDynamicsState(heading=0.75), (0.0, 0.0), dt=1.0)
+
+    assert clipped.x == pytest.approx(0.6)
+    assert clipped.y == pytest.approx(0.8)
+    assert clipped.linear_speed == pytest.approx(1.0)
+    assert stopped.heading == pytest.approx(0.75)
+
+
+def test_unicycle_clips_speed_and_angular_velocity() -> None:
+    """Unicycle commands are clipped to configured velocity bounds."""
+
+    model = build_robot_dynamics("unicycle", max_linear_speed=1.0, max_angular_speed=0.5)
+
+    next_state = model.step(RobotDynamicsState(), (5.0, 2.0), dt=1.0)
+
+    assert next_state.linear_speed == pytest.approx(1.0)
+    assert next_state.angular_speed == pytest.approx(0.5)
+
+
+def test_differential_drive_clips_wheel_speeds() -> None:
+    """Differential-drive wheel speeds are clipped before twist derivation."""
+
+    model = build_robot_dynamics(
+        "differential_drive",
+        wheel_radius=0.1,
+        track_width=1.0,
+        max_wheel_angular_speed=2.0,
+    )
+
+    next_state = model.step(RobotDynamicsState(), (100.0, 100.0), dt=1.0)
+
+    assert next_state.linear_speed == pytest.approx(0.2)
+    assert next_state.angular_speed == pytest.approx(0.0)
+
+
+def test_kinematic_bicycle_clips_speed_and_steering() -> None:
+    """Kinematic bicycle clips speed and steering before integration."""
+
+    model = build_robot_dynamics(
+        "kinematic_bicycle",
+        wheelbase=2.0,
+        max_linear_speed=1.0,
+        max_steering_angle=0.25,
+    )
+
+    next_state = model.step(RobotDynamicsState(), (5.0, 1.0), dt=1.0)
+
+    assert next_state.x == pytest.approx(1.0)
+    assert next_state.steering_angle == pytest.approx(0.25)
+
+
+@pytest.mark.parametrize(
+    ("name", "kwargs", "match"),
+    [
+        ("holonomic_disc", {"max_speed": 0.0}, "max_speed"),
+        ("differential_drive", {"wheel_radius": 0.0}, "wheel_radius"),
+        ("differential_drive", {"track_width": 0.0}, "track_width"),
+        ("differential_drive", {"max_wheel_angular_speed": 0.0}, "max_wheel"),
+        ("unicycle", {"max_linear_speed": 0.0}, "max_linear_speed"),
+        ("unicycle", {"max_angular_speed": 0.0}, "max_angular_speed"),
+        ("kinematic_bicycle", {"wheelbase": 0.0}, "wheelbase"),
+        ("kinematic_bicycle", {"max_linear_speed": 0.0}, "max_linear_speed"),
+        ("kinematic_bicycle", {"max_steering_angle": 0.0}, "max_steering_angle"),
+    ],
+)
+def test_dynamics_constructor_validation(
+    name: str,
+    kwargs: dict[str, float],
+    match: str,
+) -> None:
+    """Dynamics constructors fail closed for invalid physical limits."""
+
+    with pytest.raises(ValueError, match=match):
+        build_robot_dynamics(name, **kwargs)

--- a/tests/benchmark/test_dynamics_sensitivity.py
+++ b/tests/benchmark/test_dynamics_sensitivity.py
@@ -1,0 +1,74 @@
+"""Tests for deterministic dynamics-sensitivity ranking summaries."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.dynamics_sensitivity import (
+    DYNAMICS_SENSITIVITY_SCHEMA,
+    analyze_dynamics_sensitivity,
+)
+
+
+def test_dynamics_sensitivity_reports_stable_ranking_and_metric_table() -> None:
+    """Stable planner order returns no flipping dynamics and preserves metrics."""
+
+    report = analyze_dynamics_sensitivity(
+        {
+            "holonomic_disc": {
+                "orca": {"collision_rate": 0.0, "near_miss_rate": 0.1},
+                "rvo": {"collision_rate": 0.2, "near_miss_rate": 0.4},
+            },
+            "unicycle": {
+                "orca": {"collision_rate": 0.1, "near_miss_rate": 0.2},
+                "rvo": {"collision_rate": 0.3, "near_miss_rate": 0.4},
+            },
+        },
+        reference_dynamics="holonomic_disc",
+    )
+
+    payload = report.to_dict()
+
+    assert payload["schema_version"] == DYNAMICS_SENSITIVITY_SCHEMA
+    assert payload["reference_ranking"] == ["orca", "rvo"]
+    assert payload["rank_stable"] is True
+    assert payload["flipping_dynamics"] == []
+    assert payload["metric_table"]["unicycle"]["orca"]["near_miss_rate"] == pytest.approx(0.2)
+
+
+def test_dynamics_sensitivity_flags_rank_flip() -> None:
+    """A changed planner order is reported as a dynamics-sensitive rank flip."""
+
+    report = analyze_dynamics_sensitivity(
+        {
+            "holonomic_disc": {
+                "planner_a": {"collision_rate": 0.0, "tracking_error": 1.0},
+                "planner_b": {"collision_rate": 0.2, "tracking_error": 0.5},
+            },
+            "kinematic_bicycle": {
+                "planner_a": {"collision_rate": 0.3, "tracking_error": 0.6},
+                "planner_b": {"collision_rate": 0.1, "tracking_error": 0.4},
+            },
+        },
+        reference_dynamics="holonomic_disc",
+    )
+
+    payload = report.to_dict()
+
+    assert payload["rank_stable"] is False
+    assert payload["flipping_dynamics"] == ["kinematic_bicycle"]
+    bicycle = next(row for row in payload["dynamics"] if row["dynamics"] == "kinematic_bicycle")
+    assert bicycle["ranking"] == ["planner_b", "planner_a"]
+    assert bicycle["rank_flips"] == 1
+    assert bicycle["top1_changed"] is True
+    assert bicycle["kendall_tau"] == pytest.approx(-1.0)
+
+
+def test_dynamics_sensitivity_requires_reference_with_two_planners() -> None:
+    """The reference table must identify a ranking over at least two planners."""
+
+    with pytest.raises(ValueError, match="at least two finite planner"):
+        analyze_dynamics_sensitivity(
+            {"holonomic_disc": {"orca": {"collision_rate": 0.0}}},
+            reference_dynamics="holonomic_disc",
+        )


### PR DESCRIPTION
## Summary
Closes #3976 with a bounded first slice for pluggable kinematic robot dynamics and dynamics-sensitivity analysis. The PR adds selectable `holonomic_disc`, `differential_drive`, `unicycle`, and `kinematic_bicycle` models plus a deterministic analyzer for per-dynamics planner metric tables and ranking stability.

## Linked Issues
- Closes #3976

## Scope
- Adds `RobotDynamicsState`, the shared `RobotDynamicsModel` protocol, and `build_robot_dynamics` registry exports through `robot_sf.robot`.
- Adds deterministic dynamics-sensitivity reporting for short-run metric tables without changing metric semantics or running a benchmark campaign.
- Adds unit coverage for known-step integration, fail-closed model selection, invalid timestep/control handling, finite physical limits, midpoint bicycle integration, and rank-flip reporting.

## Research Result Guidance
- Evidence tier: targeted smoke / local unit proof.
- Result classification: blocker-resolution for the issue contract, not benchmark evidence.
- Comparator or baseline: existing single-dynamics assumption; no planner performance conclusion is made.
- Domain-aware approval: not required; this PR adds support code and tests only, with no paper/dissertation claim or benchmark interpretation update.

## Out Of Scope
- No full benchmark campaign, GPU, or Slurm work.
- No paper/dissertation claim edits.
- No metric semantic changes.
- GM3 tire-slip, load-transfer, and lean dynamics remain explicitly deferred; this PR adds kinematic models only.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_dynamics_models.py tests/benchmark/test_dynamics_sensitivity.py -q` - passed, 47 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/robot/__init__.py robot_sf/robot/dynamics.py robot_sf/benchmark/dynamics_sensitivity.py tests/benchmark/test_dynamics_models.py tests/benchmark/test_dynamics_sensitivity.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/robot/__init__.py robot_sf/robot/dynamics.py robot_sf/benchmark/dynamics_sensitivity.py tests/benchmark/test_dynamics_models.py tests/benchmark/test_dynamics_sensitivity.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/ -k "dynamics or kinematic or differential_drive or unicycle" -q` - passed; one unrelated existing pytest deprecation warning in `tests/test_scenario_generator.py`.

## Downstream Propagation
- Parent issue updated: closes on merge via PR body.
- Claim map / benchmark report / leaderboard / artifact catalog: NA, no benchmark result or claim movement.
- Context index / memory note: NA, bounded support-code slice.
- Follow-up issue opened deferred propagation: NA; higher-fidelity non-kinematic dynamics remain out of scope in the original issue text and are not required for this first slice.

## Reviewer Notes
- Final gate fixes addressed review comments by adding finite/`< pi/2` steering validation, midpoint kinematic-bicycle position integration, and tests for finite physical limits/timesteps.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added selectable robot dynamics models and a factory for creating them.
  * Introduced a dynamics-sensitivity report that compares planner rankings across dynamics settings.
* **Bug Fixes**
  * Improved validation for invalid inputs, unknown model names, and unsupported control values.
  * Added deterministic ranking checks and clearer detection of ranking changes.
* **Tests**
  * Expanded automated coverage for motion updates, clipping behavior, ranking stability, and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->