### PR TITLE
Issue #3216: fail closed headline coverage preflight

### DIFF
--- a/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
+++ b/scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py
@@ -461,14 +461,58 @@ def build_grid_completeness(
     expected_scenarios: Sequence[str],
     expected_planners: Sequence[str],
 ) -> GridCompleteness | None:
-    """Check expected headline scenario/planner grid coverage."""
+    """Check expected headline scenario/planner coverage."""
 
     scenarios = tuple(dict.fromkeys(str(value) for value in expected_scenarios if str(value)))
     planners = tuple(dict.fromkeys(str(value) for value in expected_planners if str(value)))
-    if not scenarios or not planners:
+    if not scenarios and not planners:
         return None
 
     observed = {(cell.scenario_id, cell.planner_key) for cell in cells}
+    if not scenarios:
+        expected_planner_set = set(planners)
+        observed_planners = {planner for _, planner in observed}
+        missing = tuple(("*", planner) for planner in planners if planner not in observed_planners)
+        unexpected = tuple(
+            sorted(
+                (scenario, planner)
+                for scenario, planner in observed
+                if planner not in expected_planner_set
+            )
+        )
+        return GridCompleteness(
+            expected_scenarios=scenarios,
+            expected_planners=planners,
+            expected_cell_count=len(planners),
+            observed_cell_count=len(observed),
+            observed_expected_cell_count=len(observed_planners & expected_planner_set),
+            missing_cells=missing,
+            unexpected_cells=unexpected,
+        )
+
+    if not planners:
+        expected_scenario_set = set(scenarios)
+        observed_scenarios = {scenario for scenario, _ in observed}
+        missing = tuple(
+            (scenario, "*") for scenario in scenarios if scenario not in observed_scenarios
+        )
+        unexpected = tuple(
+            sorted(
+                (scenario, planner)
+                for scenario, planner in observed
+                if scenario not in expected_scenario_set
+            )
+        )
+        return GridCompleteness(
+            expected_scenarios=scenarios,
+            expected_planners=planners,
+            expected_cell_count=len(scenarios),
+            observed_cell_count=len(observed),
+            observed_expected_cell_count=len(observed_scenarios & expected_scenario_set),
+            missing_cells=missing,
+            unexpected_cells=unexpected,
+        )
+
     expected = tuple((scenario, planner) for scenario in scenarios for planner in planners)
     expected_set = set(expected)
     missing = tuple(

--- a/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
+++ b/tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py
@@ -127,6 +127,61 @@ def test_expected_headline_grid_missing_cell_blocks_packet() -> None:
     ]
 
 
+def test_expected_headline_planner_rows_block_missing_planner() -> None:
+    """Expected planner-only coverage fails closed for aggregate headline rows."""
+    rows = [
+        _row("headline", "hybrid", [0.90] * 20),
+        _row("headline", "orca", [0.70] * 20),
+    ]
+
+    report = build_report(
+        rows,
+        ReportConfig(
+            bootstrap_samples=32,
+            resamples=16,
+            expected_planners=("hybrid", "orca", "ppo"),
+        ),
+    )
+
+    packet = report["decision_packet"]
+    assert packet["manuscript_table_status"] == "blocked"
+    assert packet["s30_decision_status"] == "blocked"
+    assert "headline_grid_incomplete" in packet["manuscript_blockers"]
+    assert packet["grid_completeness"]["expected_scenarios"] == []
+    assert packet["grid_completeness"]["expected_cell_count"] == 3
+    assert packet["grid_completeness"]["observed_expected_cell_count"] == 2
+    assert packet["grid_completeness"]["missing_cells"] == [
+        {"scenario_id": "*", "planner_key": "ppo"}
+    ]
+
+
+def test_expected_headline_scenario_rows_block_missing_scenario() -> None:
+    """Expected scenario-only coverage fails closed without planner labels."""
+    rows = [
+        _row("crossing", "headline", [0.90] * 20),
+        _row("doorway", "headline", [0.70] * 20),
+    ]
+
+    report = build_report(
+        rows,
+        ReportConfig(
+            bootstrap_samples=32,
+            resamples=16,
+            expected_scenarios=("crossing", "doorway", "bottleneck"),
+        ),
+    )
+
+    packet = report["decision_packet"]
+    assert packet["manuscript_table_status"] == "blocked"
+    assert packet["s30_decision_status"] == "blocked"
+    assert packet["grid_completeness"]["expected_planners"] == []
+    assert packet["grid_completeness"]["expected_cell_count"] == 3
+    assert packet["grid_completeness"]["observed_expected_cell_count"] == 2
+    assert packet["grid_completeness"]["missing_cells"] == [
+        {"scenario_id": "bottleneck", "planner_key": "*"}
+    ]
+
+
 def test_underpowered_missing_grid_remains_blocked_not_reviewable() -> None:
     """Hard coverage blockers outrank softer seed-budget review downgrades."""
     rows = [


### PR DESCRIPTION
## Summary
Harden the #3216 headline confidence-interval/rank-stability preflight so expected planner-only or scenario-only headline row coverage now fails closed instead of skipping completeness checks.

## Linked Issues
- Relates to `#3216`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- `build_grid_completeness` now runs when callers provide only expected planners or only expected scenarios.
- Missing one-dimensional coverage is represented with wildcard coordinates (`*`) and feeds the existing `headline_grid_incomplete` manuscript/S30 blocker path.
- Added deterministic fixture tests for missing expected planner rows and missing expected scenario rows.

## Why Matters
- Added value: prevents a local headline evidence packet from silently passing when aggregate headline rows omit an expected planner or scenario dimension.
- Expected impact: stricter fail-closed preflight over #3216 headline rows without changing CI or rank-statistic math.
- Why worth merging now: #3216 remains paper-critical and this closes a small reversible coverage-check gap in the existing local harness.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocks incomplete local headline row coverage from being treated as table/S30-ready.
- Comparator or baseline, applicable: existing `build_grid_completeness` skipped checks unless both expected scenarios and expected planners were supplied.
- Evidence tier: NA - support helper, deterministic fixture tests only; no benchmark evidence classified.
- Result classification: NA - support helper; fail-closed behavior hardening only.
- Decision stop rule, applicable: missing expected one-dimensional row coverage must keep manuscript and S30 decision packet statuses blocked.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue `#3216` remains open; no claim map or paper table update in this PR.
- New research/benchmark/metric/paper-facing analysis tool, any: no new tool; support-helper hardening for existing #3216 report builder.

## Domain-Aware Approval
- Required PR: no - support-helper only; no benchmark result interpretation or paper-facing claim.
- Domains reviewed: NA - support-helper only.
- Status: not required.
- Approver/review source waiver: support-helper only; no benchmark result interpretation or claim promotion.
- Validity checklist: fail-closed behavior tested with deterministic fixtures.
- Target claim/hypothesis: incomplete expected headline coverage must block local decision packet readiness.
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: unchanged existing path.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation only changes coverage preflight semantics.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, fixture tests assert missing expected planner/scenario rows produce blocked packets.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? yes, deterministic rows omit one expected dimension.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this support-helper slice
- Extractor analysis tool needed: no
- Artifact missing unavailable: paper-grade headline evidence, manuscript-table propagation, and the S30 decision remain outside this PR.
- Stop / revise / continue decision: continue #3216 evidence work outside this PR.
- Proposed child issue existing follow-up: #3216 remains open.

## Validation / Proof
- `uv run pytest tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py -q` -> passed, 11 tests.
- `uv run pytest tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_headline_ci_rank_stability_report_issue_3216.py tests/tools/test_reconcile_headline_rank_stability_outputs.py -q` -> passed, 50 tests.
- `uv run ruff format --check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py && uv run ruff check scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py` -> passed.
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --help` -> passed.
- `uv run python scripts/benchmark/build_headline_ci_rank_stability_report_issue_3216.py --dry-run --bootstrap-samples 0 --rank-resamples 25 --fail-on-decision-blocker --output-dir output/validation/issue3216-dry-run` -> expected exit 4 with `decision_blocker=true`, `manuscript_table_status=blocked`, `s30_decision_status=blocked`.
- `BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> passed on dirty tree before commit.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=<run-dir>/PR_BODY.md scripts/dev/pr_ready_check.sh` -> passed on clean committed head `c3a09a61042874be6b55e710f0b8730fdedf3156`; freshness stamp recorded `tree_state=clean`.

## Performance Impact
- Baseline runtime: NA, no runtime-performance claim.
- Changed runtime: NA, no runtime-performance claim.
- Representative command: `uv run pytest tests/benchmark/test_build_headline_ci_rank_stability_report_issue_3216.py -q`
- Hot-path call count profile anchor: NA, not a hot-path runtime change.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: revert if expected one-dimensional coverage should remain advisory rather than blocking.

## Risks / Rollout
- Compatibility risks: callers that intentionally supplied only `--expected-planner` or only `--expected-scenario` now get a real blocker instead of no completeness packet.
- Failure modes: wildcard coordinates are report metadata only; downstream consumers expecting concrete scenario/planner labels should treat `*` as aggregate-dimension missing coverage.
- Rollback fallback plan: restore the prior `not scenarios or not planners` skip condition.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: #3216 live issue comments keep the issue open for paper-grade evidence and S30 decision.
- Any assumptions need to preserved: one-dimensional expected coverage is a hard preflight contract when supplied.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, commenting prohibited by task authorization.
- Claim map / benchmark report updated (yes/no/NA): no
- Leaderboard / artifact catalog updated (yes/no/NA): no
- Registry or config index updated (yes/no/NA): no
- Context index / memory note updated (yes/no/NA): no
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: support-helper only; no benchmark result, manuscript table, leaderboard, or paper-facing claim is propagated.

## Follow-Up Issues
- Deferred work: paper-grade headline evidence, manuscript-table propagation, and S30 decision remain on #3216.
- Issues opened follow-up: none

## Reviewer Notes
- Verify that wildcard missing cells (`scenario_id="*"` or `planner_key="*"`) are acceptable metadata for aggregate row coverage blockers.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
