### PR TITLE
Issue #3813: tighten sustained-flow spawn preflight

### DIFF
--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -212,7 +212,8 @@ def _validate_continuous_spawn_definition(value: Any, *, scenario_name: str) -> 
     if missing_or_extra_keys:
         raise SustainedFlowPreflightError(
             f"{scenario_name}: continuous_spawn.definition keys must match "
-            "non-clearing demand contract"
+            "non-clearing demand contract "
+            f"(mismatched keys: {sorted(missing_or_extra_keys)})"
         )
     for key, expected in EXPECTED_CONTINUOUS_SPAWN_DEFINITION.items():
         if value.get(key) != expected:

--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -163,10 +163,10 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
         raise SustainedFlowPreflightError(
             f"{name}: continuous_spawn.intended_process must be {SUPPORTED_SPAWN_PROCESS!r}"
         )
-    if continuous_spawn.get("definition") != EXPECTED_CONTINUOUS_SPAWN_DEFINITION:
-        raise SustainedFlowPreflightError(
-            f"{name}: continuous_spawn.definition must match non-clearing demand contract"
-        )
+    _validate_continuous_spawn_definition(
+        continuous_spawn.get("definition"),
+        scenario_name=name,
+    )
 
     seeds = scenario.get("seeds", [])
     if not isinstance(seeds, list) or not all(isinstance(seed, int) for seed in seeds):
@@ -201,6 +201,24 @@ def _variant_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, 
         if not variant.seeds:
             blockers.append(f"{variant.name}: at least one seed is required")
     return tuple(blockers)
+
+
+def _validate_continuous_spawn_definition(value: Any, *, scenario_name: str) -> None:
+    if not isinstance(value, Mapping):
+        raise SustainedFlowPreflightError(
+            f"{scenario_name}: continuous_spawn.definition must be a mapping"
+        )
+    missing_or_extra_keys = set(value) ^ set(EXPECTED_CONTINUOUS_SPAWN_DEFINITION)
+    if missing_or_extra_keys:
+        raise SustainedFlowPreflightError(
+            f"{scenario_name}: continuous_spawn.definition keys must match "
+            "non-clearing demand contract"
+        )
+    for key, expected in EXPECTED_CONTINUOUS_SPAWN_DEFINITION.items():
+        if value.get(key) != expected:
+            raise SustainedFlowPreflightError(
+                f"{scenario_name}: continuous_spawn.definition.{key} must be {expected!r}"
+            )
 
 
 def _generator_drift_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, ...]:

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -72,6 +72,7 @@ def test_sustained_flow_scenario_set_is_runner_loadable(capsys) -> None:
         assert metadata["continuous_spawn"]["required_before_benchmark_use"] is True
         assert metadata["continuous_spawn"]["current_runtime_support"] == "metadata_only"
         assert spawn_definition["demand_model"] == "non_clearing_poisson_flow"
+        assert spawn_definition["respawn_trigger"] == "pedestrian_exits_route_corridor"
         assert spawn_definition["spawn_budget"] == "time_bounded_episode"
         assert spawn_definition["minimum_active_pedestrians"] == 1
         assert spawn_definition["clearing_policy"] == "disallow_empty_scene_wait_success"

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -63,6 +63,7 @@ def test_sustained_flow_scenario_set_is_runner_loadable(capsys) -> None:
 
     for scenario in scenarios:
         metadata = scenario["metadata"]
+        spawn_definition = metadata["continuous_spawn"]["definition"]
         assert scenario["simulation_config"]["max_episode_steps"] == 600
         assert metadata["pack_id"] == "issue_3813_sustained_flow_scaffold_v0"
         assert metadata["status"] == "pre_benchmark_scaffold"
@@ -70,6 +71,10 @@ def test_sustained_flow_scenario_set_is_runner_loadable(capsys) -> None:
         assert metadata["benchmark_evidence"] is False
         assert metadata["continuous_spawn"]["required_before_benchmark_use"] is True
         assert metadata["continuous_spawn"]["current_runtime_support"] == "metadata_only"
+        assert spawn_definition["demand_model"] == "non_clearing_poisson_flow"
+        assert spawn_definition["spawn_budget"] == "time_bounded_episode"
+        assert spawn_definition["minimum_active_pedestrians"] == 1
+        assert spawn_definition["clearing_policy"] == "disallow_empty_scene_wait_success"
         assert metadata["success_metric"]["id"] == "sustained_progress_rate_m_per_s"
         assert metadata["termination"]["mode"] == "time_bounded"
         assert metadata["termination"]["goal_reach_is_not_primary_success"] is True
@@ -192,7 +197,28 @@ def test_sustained_flow_preflight_rejects_wrong_spawn_definition(tmp_path: Path)
     assert payload["benchmark_eligible"] is False
     assert payload["variant_count"] == 0
     assert any(
-        "continuous_spawn.definition must match non-clearing demand contract" in reason
+        "continuous_spawn.definition.clearing_policy must be "
+        "'disallow_empty_scene_wait_success'" in reason
+        for reason in payload["blocking_reasons"]
+    )
+
+
+def test_sustained_flow_preflight_rejects_waitable_spawn_budget(tmp_path: Path) -> None:
+    """Continuous-spawn variants must not allow finite-batch waiting."""
+    matrix = _load_yaml(SCENARIO_SET)
+    matrix["scenarios"][0]["metadata"]["continuous_spawn"]["definition"]["spawn_budget"] = (
+        "finite_batch"
+    )
+
+    wrong_budget_matrix = tmp_path / "wrong_spawn_budget_sustained_flow.yaml"
+    wrong_budget_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+    payload = preflight_sustained_flow_matrix(wrong_budget_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert payload["variant_count"] == 0
+    assert any(
+        "continuous_spawn.definition.spawn_budget must be 'time_bounded_episode'" in reason
         for reason in payload["blocking_reasons"]
     )
 


### PR DESCRIPTION
## Summary
- Tighten issue #3813 sustained-flow benchmark preflight diagnostics for the continuous-spawn definition.
- Pin generated sustained-flow rows to the non-clearing demand contract fields that prevent a finite-batch wait-it-out interpretation.
- Add a fail-closed regression test for waitable `spawn_budget` drift.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3813

## Scope
This is a focused generator/preflight enumeration slice. It improves static preflight coverage and diagnostics for the continuous-spawn scenario family without claiming runtime sustained-flow benchmark evidence.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/scenario_certification/test_sustained_flow_preflight.py -q` - passed, 19 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --runtime-supported-generated --json` - passed, `conforms=true`, `variant_count=3`, `runtime_support=runtime_continuous_spawn`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` - passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3813/PR_BODY.md scripts/dev/pr_ready_check.sh` - passed; freshness stamp `output/validation/pr_ready/issue-3813-sustained-flow-runtime-readiness-preflight.json`.

## Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No runtime continuous pedestrian respawn implementation.
- No sustained-progress metric implementation.
