### PR TITLE
Issue #3275: require archive lineage for rerun readiness

### DIFF
--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -8,7 +8,7 @@ The check is readiness/leakage evidence only. It does not run benchmark campaign
 
 ## Implementation
 
-- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), requires top-level archive lineage in `config.source_manifests`, blocks shared source-manifest lineage across source and rerun archives, requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
 - `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI, including optional `--null-test-prerequisites` input.
 - Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
 
@@ -19,6 +19,7 @@ Focused tests cover:
 - disjoint certified archives passing the metadata gate;
 - overlapping archive IDs blocking leakage;
 - missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`) blocking readiness;
+- missing or shared top-level archive source-manifest lineage blocking readiness;
 - missing or failed source archive certification metadata blocking readiness;
 - missing or failed rerun archive certification metadata blocking readiness;
 - complete null-test prerequisite metadata staying ready;

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -332,7 +332,7 @@ def _archive_lineage_gaps(
     """Return top-level source manifest lineage and fail-closed gap tokens."""
 
     if not isinstance(payload, dict):
-        return [], [f"{side}:archive_payload"]
+        return [], []
     config = payload.get("config")
     if not isinstance(config, dict):
         return [], [f"{side}:config.source_manifests"]

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -94,6 +94,10 @@ class FailureArchiveRerunReadiness:
     rerun_entry_count: int = 0
     source_archive_sha256: str | None = None
     rerun_archive_sha256: str | None = None
+    source_manifest_sources: list[str] = field(default_factory=list)
+    rerun_manifest_sources: list[str] = field(default_factory=list)
+    source_manifest_overlap: list[str] = field(default_factory=list)
+    missing_archive_lineage: list[str] = field(default_factory=list)
     overlap_provenance: dict[str, Any] = field(default_factory=dict)
     archive_id_overlap: list[str] = field(default_factory=list)
     missing_overlap_metadata_archive_ids: list[str] = field(default_factory=list)
@@ -129,6 +133,10 @@ class FailureArchiveRerunReadiness:
             "rerun_entry_count": self.rerun_entry_count,
             "source_archive_sha256": self.source_archive_sha256,
             "rerun_archive_sha256": self.rerun_archive_sha256,
+            "source_manifest_sources": list(self.source_manifest_sources),
+            "rerun_manifest_sources": list(self.rerun_manifest_sources),
+            "source_manifest_overlap": list(self.source_manifest_overlap),
+            "missing_archive_lineage": list(self.missing_archive_lineage),
             "overlap_provenance": dict(self.overlap_provenance),
             "archive_id_overlap": list(self.archive_id_overlap),
             "missing_overlap_metadata_archive_ids": list(self.missing_overlap_metadata_archive_ids),
@@ -189,6 +197,13 @@ def classify_failure_archive_rerun_readiness(
     source_hash = archive_sha256(source_payload) if isinstance(source_payload, dict) else None
     rerun_hash = archive_sha256(rerun_payload) if isinstance(rerun_payload, dict) else None
 
+    source_manifests, missing_source_lineage = _archive_lineage_gaps(source_payload, side="source")
+    rerun_manifests, missing_rerun_lineage = _archive_lineage_gaps(rerun_payload, side="rerun")
+    source_manifest_overlap = sorted(set(source_manifests).intersection(rerun_manifests))
+    missing_archive_lineage = missing_source_lineage + missing_rerun_lineage
+    blockers.extend(_count_blockers("missing_archive_lineage", missing_archive_lineage))
+    blockers.extend(_count_blockers("source_manifest_overlap", source_manifest_overlap))
+
     overlap = compute_overlap_provenance(source_entries, rerun_entries)
     archive_id_overlap = list(overlap.get("archive_id_overlap", []))
     blockers.extend(_overlap_blockers(overlap))
@@ -224,6 +239,10 @@ def classify_failure_archive_rerun_readiness(
         rerun_entry_count=len(rerun_entries),
         source_archive_sha256=source_hash,
         rerun_archive_sha256=rerun_hash,
+        source_manifest_sources=source_manifests,
+        rerun_manifest_sources=rerun_manifests,
+        source_manifest_overlap=source_manifest_overlap,
+        missing_archive_lineage=missing_archive_lineage,
         overlap_provenance=overlap,
         archive_id_overlap=archive_id_overlap,
         missing_overlap_metadata_archive_ids=missing_overlap_metadata,
@@ -303,6 +322,34 @@ def _count_blockers(blocker: str, values: list[str]) -> list[str]:
     """Return a single count blocker when values are present."""
 
     return [f"{blocker}:{len(values)}"] if values else []
+
+
+def _archive_lineage_gaps(
+    payload: dict[str, Any] | None,
+    *,
+    side: str,
+) -> tuple[list[str], list[str]]:
+    """Return top-level source manifest lineage and fail-closed gap tokens."""
+
+    if not isinstance(payload, dict):
+        return [], [side]
+    config = payload.get("config")
+    if not isinstance(config, dict):
+        return [], [f"{side}:config.source_manifests"]
+    raw_manifests = config.get("source_manifests")
+    if not isinstance(raw_manifests, list) or not raw_manifests:
+        return [], [f"{side}:config.source_manifests"]
+
+    manifests: list[str] = []
+    invalid_indexes: list[str] = []
+    for index, raw_manifest in enumerate(raw_manifests):
+        if isinstance(raw_manifest, str) and raw_manifest.strip():
+            manifests.append(raw_manifest.strip())
+        else:
+            invalid_indexes.append(str(index))
+    if invalid_indexes:
+        return manifests, [f"{side}:config.source_manifests[{','.join(invalid_indexes)}]"]
+    return sorted(set(manifests)), []
 
 
 def _overlap_metadata_gaps(

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -332,7 +332,7 @@ def _archive_lineage_gaps(
     """Return top-level source manifest lineage and fail-closed gap tokens."""
 
     if not isinstance(payload, dict):
-        return [], [side]
+        return [], [f"{side}:archive_payload"]
     config = payload.get("config")
     if not isinstance(config, dict):
         return [], [f"{side}:config.source_manifests"]

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -349,6 +349,7 @@ def test_missing_archive_payload_blocks_ready_path(tmp_path: Path) -> None:
     assert any(
         blocker.startswith("rerun_archive_blocked:path_missing") for blocker in readiness.blockers
     )
+    assert readiness.missing_archive_lineage == ["rerun:archive_payload"]
     assert not any(blocker.startswith("source_archive_blocked") for blocker in readiness.blockers)
 
 

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -48,10 +48,23 @@ def _entry(
     return entry
 
 
-def _archive(path: Path, entries: list[dict]) -> Path:
+def _archive(
+    path: Path,
+    entries: list[dict],
+    *,
+    source_manifests: list[str] | None = None,
+) -> Path:
     """Write an adversarial failure archive fixture."""
 
-    payload = {"schema_version": "adversarial_failure_archive.v1", "entries": entries}
+    payload = {
+        "schema_version": "adversarial_failure_archive.v1",
+        "config": {
+            "source_manifests": source_manifests
+            if source_manifests is not None
+            else [f"search-manifests/{path.stem}.json"],
+        },
+        "entries": entries,
+    }
     path.write_text(json.dumps(payload), encoding="utf-8")
     return path
 
@@ -95,6 +108,55 @@ def test_disjoint_certified_archives_are_ready(tmp_path: Path) -> None:
     assert readiness.archive_id_overlap == []
     assert readiness.missing_certification_archive_ids == []
     assert readiness.to_payload()["claim_boundary"].startswith("readiness/leakage check only")
+
+
+def test_missing_archive_source_lineage_blocks_readiness(tmp_path: Path) -> None:
+    """Archive-level source manifests are required before disjointness is trusted."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+        source_manifests=[],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.missing_archive_lineage == ["source:config.source_manifests"]
+    assert "missing_archive_lineage:1" in readiness.blockers
+
+
+def test_shared_archive_source_lineage_blocks_readiness(tmp_path: Path) -> None:
+    """Different entries still fail closed when archives come from one manifest."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+        source_manifests=["search-manifests/shared.json"],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+        source_manifests=["search-manifests/shared.json"],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.source_manifest_overlap == ["search-manifests/shared.json"]
+    assert "source_manifest_overlap:1" in readiness.blockers
 
 
 def test_missing_null_test_prerequisite_input_blocks_readiness(tmp_path: Path) -> None:

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -349,7 +349,7 @@ def test_missing_archive_payload_blocks_ready_path(tmp_path: Path) -> None:
     assert any(
         blocker.startswith("rerun_archive_blocked:path_missing") for blocker in readiness.blockers
     )
-    assert readiness.missing_archive_lineage == ["rerun:archive_payload"]
+    assert readiness.missing_archive_lineage == []
     assert not any(blocker.startswith("source_archive_blocked") for blocker in readiness.blockers)
 
 
@@ -369,6 +369,7 @@ def test_malformed_archive_payload_fails_closed(tmp_path: Path) -> None:
     assert any(
         blocker.startswith("rerun_archive_blocked:unreadable") for blocker in readiness.blockers
     )
+    assert readiness.missing_archive_lineage == []
 
 
 def test_non_object_archive_entries_fail_closed(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds a fail-closed archive-lineage prerequisite to the issue #3275 failure-archive rerun readiness checker. The checker now requires top-level `config.source_manifests` on both certified failure archives and blocks rerun readiness when source and rerun archives share source manifests.

Issue: https://github.com/ll7/robot_sf_ll7/issues/3275

## Linked Issues
- Relates to `#3275`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3275`
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Extended `FailureArchiveRerunReadiness` payloads with source/rerun manifest lineage, shared source-manifest overlap, and missing-lineage blocker details.
- Added fail-closed blockers for missing archive-level `config.source_manifests` and overlapping source manifests between source and rerun archives.
- Updated issue #3275 readiness fixtures and added synthetic tests for missing and shared archive-source lineage.

## Why Matters
- Added value: makes the rerun readiness gate reject archive pairs that look entry-disjoint but cannot prove archive-level source lineage separation.
- Expected impact: safer preflight packet before any proposal-model rerun on a disjoint certified failure archive.
- Why worth merging now: small checker-only prerequisite that improves evidence hygiene without running evaluation.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: archive-readiness blocker for issue #3275 disjoint certified failure archive inputs.
- Comparator or baseline, applicable: existing readiness checker accepted fixture archives without top-level source manifest lineage.
- Evidence tier: NA - checker-only readiness support helper; no research result claim
- Result classification: NA - no benchmark or held-out yield result claim
- Decision stop rule, applicable: held-out evidence remains blocked unless disjointness, independent planner-execution outcomes, certification, and null-test prerequisites pass.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3275 remains open; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - extends existing metadata-only support checker and makes no research result claim.

## Domain-Aware Approval
- Required PR: yes - evidence-validity-sensitive result classification for issue #3275 archive-readiness checker metadata-only fail-closed lineage prerequisite.
- Domains reviewed: failure-archive provenance, benchmark evidence hygiene, fail-closed readiness.
- Status: waived for checker-only readiness support; #3275 remains blocked for claim promotion.
- Approval or blocker note: #3275 remains the blocker for real archive rerun, independent planner-execution outcomes, certification, and null tests.
- approval concerns experimental validity claim waived / pending / blocked / not required: blocked - no benchmark, held-out yield, or paper-facing claim is promoted by this checker-only PR.
- Approver/review source waiver: checker-only readiness prerequisite; no benchmark or paper-facing claim promoted.
- Validity checklist: fail-closed lineage preflight only.
- Target claim/hypothesis: issue #3275 archive-readiness blocker only; no held-out yield claim.
- Comparator or split/evidence validity: diagnostic-only; blocks missing/shared archive source lineage before split evidence can be trusted.
- Fallback/degraded exclusions: no fallback/degraded execution counted as success.
- Claim boundary: readiness/leakage check only.
- Implementation integrity vs experimental validity: targeted tests cover the new blocker conditions.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, synthetic fixtures with missing/shared source manifests now block readiness.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA - metadata-only checker fixtures.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3275 remains open for real archive rerun and independent outcomes.

## Next Empirical Action
- Rerun needed: yes, outside this PR when real archive inputs are available.
- Extractor analysis tool needed: no for this slice.
- Artifact missing unavailable: real populated disjoint certified failure archive and independent planner-execution outcome packet remain outside scope.
- Stop / revise / continue decision: continue.
- Proposed child issue existing follow-up: #3275.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py tests/adversarial/test_failure_archive.py tests/adversarial/test_archive_readiness.py -q` -> passed, 25 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py scripts/validation/check_failure_archive_rerun_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` -> completed; checker file reformatted.
- `git diff --check` -> passed.
- Final readiness gate: pending before PR open; will rerun with this PR body file.

Explicit out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Contract
- Baseline runtime: NA - metadata-only readiness checker change, no runtime performance claim.
- Changed runtime: NA - metadata-only readiness checker change, no runtime performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q`
- Hot-path call count profile anchor: NA - no hot-path/caching claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: readiness checker rejects valid curator archives with distinct `config.source_manifests`, or accepts missing/shared archive lineage.

## Risks / Rollout
- Compatibility risks: third-party or hand-written archive fixtures without curator-style `config.source_manifests` will now fail closed until lineage is supplied.
- Failure modes: overly strict lineage requirement could block diagnostic rerun setup with incomplete archive metadata; this is intentional for issue #3275 evidence hygiene.
- Rollback fallback plan: remove the lineage blockers and payload fields if maintainers decide entry-level overlap metadata is sufficient.

## Docs / Provenance
- Updated docs: `docs/context/issue_3275_failure_archive_rerun_readiness.md` now records the archive-level `config.source_manifests` lineage prerequisite.
- Relevant design provenance notes: issue #3275 and existing failure-archive curator schema (`config.source_manifests`).
- Any assumptions need to preserved: top-level `config.source_manifests` is the canonical public lineage field for curated adversarial failure archives.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: checker-only fail-closed prerequisite; no benchmark, registry, claim-map, paper-facing change, or durable result artifact.

## Follow-Up Issues
- Deferred work: #3275 tracks the real proposal-model rerun on a populated disjoint certified failure archive with independent planner-execution outcomes, candidate certification, and null tests.
- Issues opened follow-up: none; deferred work remains on open issue #3275.

## Reviewer Notes
- Verify whether `config.source_manifests` should remain the required archive-level lineage field for all issue #3275 archive pairs.
- Known limitations: this PR does not evaluate proposal yield and does not prove archive availability.

