### PR TITLE
docs: record negative provenance recovery attempt for #3482

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -57,6 +57,14 @@ entries:
     status: evidence
     freshness: evidence
     area: benchmark_evidence
+  - path: docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/recovery_manifest.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_3482_event_ledger_reconciliation_guard/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/README.md
+++ b/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/README.md
@@ -36,3 +36,13 @@ Valid follow-up paths are:
   input/output hashes and commands;
 - explicitly downgrade or withdraw release `0.0.2` collision-count claims if the
   exact-event provenance is permanently unavailable.
+
+Recommended next actions:
+
+- verify the host identity and scratch retention status for `imech156` /
+  `imech156-u` through an authoritative source before attempting SSH recovery;
+- audit paper-facing and dissertation-facing release `0.0.2` result tables that
+  rely on `total_collision_count` or collision-count-derived claims;
+- keep #3482 blocked unless exact-event provenance is recovered, or close it only
+  as not recoverable after the affected release `0.0.2` collision-count claims
+  are explicitly downgraded or withdrawn.

--- a/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/README.md
+++ b/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/README.md
@@ -1,0 +1,38 @@
+# Issue #3482 Release 0.0.2 Provenance Recovery Attempt
+
+This directory records the 2026-07-01 negative provenance recovery attempt for
+issue #3482. No valid exact-event provenance artifacts or raw exact-event inputs
+were found.
+
+This evidence record does not close #3482. It preserves the blocked boundary so
+future recovery work does not regenerate from the public release `0.0.2`
+publication bundle alone or repeat the same broad storage searches.
+
+The public release bundle can support only the derived side of the mismatch:
+
+- release `0.0.2` rows: `987`
+- published or derived `total_collision_count > 0` rows: `0`
+
+The public release bundle cannot support the exact-event side:
+
+- exact collision outcomes: `241`
+- reconciliation violations: `241`
+
+Those exact-event counts require either the original reconciliation artifacts or
+raw episode-level records with fields such as `outcome.collision_event`,
+`termination_reason="collision"`, or an equivalent exact-event field.
+
+#3482 remains blocked unless one of the following is recovered:
+
+- `backfill_summary.json`
+- `frozen_reconciliation_report.json`
+- `reconciliation_tables_0_0_2.jsonl`
+- raw episode-level records containing exact-event fields
+
+Valid follow-up paths are:
+
+- recover and promote the original three artifacts with hashes and provenance;
+- recover raw exact-event episode records and regenerate deterministically with
+  input/output hashes and commands;
+- explicitly downgrade or withdraw release `0.0.2` collision-count claims if the
+  exact-event provenance is permanently unavailable.

--- a/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/README.md
+++ b/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/README.md
@@ -22,7 +22,7 @@ Those exact-event counts require either the original reconciliation artifacts or
 raw episode-level records with fields such as `outcome.collision_event`,
 `termination_reason="collision"`, or an equivalent exact-event field.
 
-#3482 remains blocked unless one of the following is recovered:
+Issue #3482 remains blocked unless one of the following is recovered:
 
 - `backfill_summary.json`
 - `frozen_reconciliation_report.json`

--- a/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/recovery_manifest.json
+++ b/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/recovery_manifest.json
@@ -80,6 +80,21 @@
     "recover raw episode-level records with exact-event fields",
     "explicitly downgrade or withdraw release 0.0.2 collision-count claims"
   ],
+  "recommended_next_actions": [
+    "verify imech156 or imech156-u host identity and scratch retention through an authoritative source",
+    "audit paper-facing and dissertation-facing release 0.0.2 tables that rely on total_collision_count or collision-count-derived claims",
+    "avoid additional broad storage searches unless a new host, archive, or artifact pointer is identified"
+  ],
+  "defensible_close_paths": [
+    {
+      "close_mode": "completed",
+      "condition": "original artifacts or raw exact-event records are recovered, promoted, hash-validated, and used to annotate affected table claims"
+    },
+    {
+      "close_mode": "not_planned_or_not_recoverable",
+      "condition": "exact-event provenance is judged permanently unavailable and release 0.0.2 collision-count claims are explicitly downgraded or withdrawn"
+    }
+  ],
   "must_not_claim": [
     "release 0.0.2 total_collision_count is paper-ready",
     "the public release bundle alone proves 241 exact collision outcomes",

--- a/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/recovery_manifest.json
+++ b/docs/context/evidence/issue_3482_release_0_0_2_provenance_recovery_2026_07_01/recovery_manifest.json
@@ -1,0 +1,88 @@
+{
+  "schema_version": "issue_3482_provenance_recovery_attempt.v1",
+  "issue": 3482,
+  "date": "2026-07-01",
+  "result": "blocked_no_exact_event_provenance_found",
+  "tracked_issue_state_after_recovery": {
+    "label_removed": "state:running",
+    "label_added": "state:blocked",
+    "comment_url": "https://github.com/ll7/robot_sf_ll7/issues/3482#issuecomment-4855373479"
+  },
+  "searched_artifacts": [
+    "backfill_summary.json",
+    "frozen_reconciliation_report.json",
+    "reconciliation_tables_0_0_2.jsonl"
+  ],
+  "searched_local_roots": [
+    "/home/luttkule",
+    "/scratch",
+    "/data",
+    "/mnt",
+    "/tmp",
+    "/var/tmp"
+  ],
+  "searched_remote_hosts": [
+    {
+      "host": "imech192",
+      "status": "reachable",
+      "searched": true,
+      "result": "no_target_artifacts_found"
+    },
+    {
+      "host": "licca",
+      "status": "reachable",
+      "searched": true,
+      "result": "no_target_artifacts_or_exact_event_raw_inputs_found"
+    },
+    {
+      "host": "imech156-u",
+      "status": "not_resolved_or_not_safely_accessible",
+      "searched": false,
+      "reason": "hostname did not resolve from the recovery environment"
+    },
+    {
+      "host": "imech156",
+      "status": "host_key_verification_blocked",
+      "searched": false,
+      "reason": "host resolved but no trusted known-host entry was available"
+    },
+    {
+      "host": "imech036",
+      "status": "route_checked",
+      "searched": false,
+      "reason": "host-key trust was not established in the recovery environment"
+    }
+  ],
+  "searched_logs": [
+    "local Codex logs",
+    "orchestrator logs",
+    "private-ops ledgers"
+  ],
+  "found_valid_exact_event_provenance": false,
+  "acceptable_regeneration_input_found": false,
+  "public_release_bundle_policy": {
+    "can_verify_published_total_collision_count_zero": true,
+    "can_verify_exact_collision_outcomes_241": false,
+    "may_be_used_to_close_3482": false
+  },
+  "known_diagnostic_summary_from_issue_comment": {
+    "release_tag": "0.0.2",
+    "release_target_commit": "f7ebdcae2375d085e925213197a75a386e26a79c",
+    "episode_rows": 987,
+    "exact_collision_outcomes": 241,
+    "derived_total_collision_count_positive_rows": 0,
+    "reconciliation_violations": 241,
+    "source": "https://github.com/ll7/robot_sf_ll7/issues/3482#issuecomment-4835303925",
+    "claim_boundary": "diagnostic issue-comment summary only; not a durable promoted reconciliation bundle"
+  },
+  "remaining_resolution_paths": [
+    "recover original three artifacts",
+    "recover raw episode-level records with exact-event fields",
+    "explicitly downgrade or withdraw release 0.0.2 collision-count claims"
+  ],
+  "must_not_claim": [
+    "release 0.0.2 total_collision_count is paper-ready",
+    "the public release bundle alone proves 241 exact collision outcomes",
+    "issue 3482 is completed by this negative recovery record"
+  ]
+}


### PR DESCRIPTION
## Summary

- Records the 2026-07-01 negative provenance recovery attempt for #3482.
- Adds a compact manifest of searched roots, hosts, logs, missing artifacts, and remaining valid recovery paths.
- Keeps #3482 blocked: this does not promote benchmark evidence or close the issue.

## Scope

- Adds a recovery-attempt evidence directory under `docs/context/evidence/`.
- Records searched roots, searched hosts, missing artifacts, remaining valid resolution paths, recommended next actions, and defensible close modes.
- Reaffirms that the public release `0.0.2` bundle verifies only the published zero collision-count side, not the 241 exact-event collision side.

## Non-scope

- No regeneration.
- No benchmark result promotion.
- No paper-facing collision-count repair.
- No claim that `total_collision_count` is valid for release `0.0.2`.

## Issue State

#3482 remains blocked on exact-event provenance recovery.

## Follow-Up Issues

Deferred work stays in #3482:

- verify `imech156` / `imech156-u` host identity and scratch retention through an authoritative source;
- audit paper-facing and dissertation-facing release `0.0.2` collision-count claims;
- recover original artifacts or raw exact-event episode records before any completed closure.

## Validation

- `python` JSON/YAML catalog/path check: passed.
- `uv run python scripts/validation/check_docs_proof_consistency.py --check-evidence-catalog`: passed.
- `git diff --check`: passed.
