### PR TITLE
Issue #3275: block duplicate archive IDs in rerun readiness

### DIFF
--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -8,7 +8,7 @@ The check is readiness/leakage evidence only. It does not run benchmark campaign
 
 ## Implementation
 
-- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), requires top-level archive lineage in `config.source_manifests`, blocks shared source-manifest lineage across source and rerun archives, requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), blocks duplicate archive IDs within either archive, requires top-level archive lineage in `config.source_manifests`, blocks shared source-manifest lineage across source and rerun archives, requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
 - `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI, including optional `--null-test-prerequisites` input.
 - Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
 
@@ -18,6 +18,7 @@ Focused tests cover:
 
 - disjoint certified archives passing the metadata gate;
 - overlapping archive IDs blocking leakage;
+- duplicate archive IDs within the source or rerun archive blocking ambiguous archive packets;
 - missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`) blocking readiness;
 - missing or shared top-level archive source-manifest lineage blocking readiness;
 - missing or failed source archive certification metadata blocking readiness;

--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -8,7 +8,7 @@ The check is readiness/leakage evidence only. It does not run benchmark campaign
 
 ## Implementation
 
-- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), blocks duplicate archive IDs within either archive with entry-index provenance, requires top-level archive lineage in `config.source_manifests`, blocks shared source-manifest lineage across source and rerun archives, requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), blocks duplicate archive IDs within either archive, requires top-level archive lineage in `config.source_manifests`, blocks shared source-manifest lineage across source and rerun archives, requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
 - `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI, including optional `--null-test-prerequisites` input.
 - Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
 

--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -8,7 +8,7 @@ The check is readiness/leakage evidence only. It does not run benchmark campaign
 
 ## Implementation
 
-- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), blocks duplicate archive IDs within either archive, requires top-level archive lineage in `config.source_manifests`, blocks shared source-manifest lineage across source and rerun archives, requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), blocks duplicate archive IDs within either archive with entry-index provenance, requires top-level archive lineage in `config.source_manifests`, blocks shared source-manifest lineage across source and rerun archives, requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
 - `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI, including optional `--null-test-prerequisites` input.
 - Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
 

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -387,19 +387,20 @@ def _overlap_metadata_gaps(
 
 
 def _duplicate_archive_ids(entries: list[dict[str, Any]], *, side: str) -> list[str]:
-    """Return duplicate nonblank archive IDs within one archive."""
+    """Return duplicate nonblank archive IDs within one archive with entry indexes."""
 
-    seen: set[str] = set()
-    duplicates: set[str] = set()
+    entry_indexes_by_archive_id: dict[str, list[int]] = {}
     for index, entry in enumerate(entries):
         raw_archive_id = entry.get("archive_id")
         if _metadata_archive_id_missing(raw_archive_id):
             continue
         archive_id = _metadata_archive_id(raw_archive_id, side=side, index=index)
-        if archive_id in seen:
-            duplicates.add(f"{side}:{archive_id}")
-        seen.add(archive_id)
-    return sorted(duplicates)
+        entry_indexes_by_archive_id.setdefault(archive_id, []).append(index)
+    return [
+        f"{side}:{archive_id}:entries={','.join(str(index) for index in indexes)}"
+        for archive_id, indexes in sorted(entry_indexes_by_archive_id.items())
+        if len(indexes) > 1
+    ]
 
 
 def _metadata_archive_id(raw_archive_id: Any, *, side: str, index: int) -> str:

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -101,6 +101,8 @@ class FailureArchiveRerunReadiness:
     overlap_provenance: dict[str, Any] = field(default_factory=dict)
     archive_id_overlap: list[str] = field(default_factory=list)
     missing_overlap_metadata_archive_ids: list[str] = field(default_factory=list)
+    source_duplicate_archive_ids: list[str] = field(default_factory=list)
+    rerun_duplicate_archive_ids: list[str] = field(default_factory=list)
     source_missing_certification_archive_ids: list[str] = field(default_factory=list)
     source_invalid_certification_archive_ids: list[str] = field(default_factory=list)
     missing_certification_archive_ids: list[str] = field(default_factory=list)
@@ -140,6 +142,8 @@ class FailureArchiveRerunReadiness:
             "overlap_provenance": dict(self.overlap_provenance),
             "archive_id_overlap": list(self.archive_id_overlap),
             "missing_overlap_metadata_archive_ids": list(self.missing_overlap_metadata_archive_ids),
+            "source_duplicate_archive_ids": list(self.source_duplicate_archive_ids),
+            "rerun_duplicate_archive_ids": list(self.rerun_duplicate_archive_ids),
             "source_missing_certification_archive_ids": list(
                 self.source_missing_certification_archive_ids
             ),
@@ -209,6 +213,10 @@ def classify_failure_archive_rerun_readiness(
     blockers.extend(_overlap_blockers(overlap))
     missing_overlap_metadata = _overlap_metadata_gaps(source_entries, rerun_entries)
     blockers.extend(_count_blockers("missing_overlap_metadata", missing_overlap_metadata))
+    source_duplicate_archive_ids = _duplicate_archive_ids(source_entries, side="source")
+    rerun_duplicate_archive_ids = _duplicate_archive_ids(rerun_entries, side="rerun")
+    blockers.extend(_count_blockers("source_duplicate_archive_ids", source_duplicate_archive_ids))
+    blockers.extend(_count_blockers("rerun_duplicate_archive_ids", rerun_duplicate_archive_ids))
 
     source_missing_certification, source_invalid_certification = _certification_gaps(source_entries)
     blockers.extend(
@@ -246,6 +254,8 @@ def classify_failure_archive_rerun_readiness(
         overlap_provenance=overlap,
         archive_id_overlap=archive_id_overlap,
         missing_overlap_metadata_archive_ids=missing_overlap_metadata,
+        source_duplicate_archive_ids=source_duplicate_archive_ids,
+        rerun_duplicate_archive_ids=rerun_duplicate_archive_ids,
         source_missing_certification_archive_ids=source_missing_certification,
         source_invalid_certification_archive_ids=source_invalid_certification,
         missing_certification_archive_ids=missing_certification,
@@ -374,6 +384,22 @@ def _overlap_metadata_gaps(
             if entry_gaps:
                 gaps.append(f"{side}:{archive_id}:{','.join(entry_gaps)}")
     return gaps
+
+
+def _duplicate_archive_ids(entries: list[dict[str, Any]], *, side: str) -> list[str]:
+    """Return duplicate nonblank archive IDs within one archive."""
+
+    seen: set[str] = set()
+    duplicates: set[str] = set()
+    for index, entry in enumerate(entries):
+        raw_archive_id = entry.get("archive_id")
+        if _metadata_archive_id_missing(raw_archive_id):
+            continue
+        archive_id = _metadata_archive_id(raw_archive_id, side=side, index=index)
+        if archive_id in seen:
+            duplicates.add(f"{side}:{archive_id}")
+        seen.add(archive_id)
+    return sorted(duplicates)
 
 
 def _metadata_archive_id(raw_archive_id: Any, *, side: str, index: int) -> str:

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -387,20 +387,19 @@ def _overlap_metadata_gaps(
 
 
 def _duplicate_archive_ids(entries: list[dict[str, Any]], *, side: str) -> list[str]:
-    """Return duplicate nonblank archive IDs within one archive with entry indexes."""
+    """Return duplicate nonblank archive IDs within one archive."""
 
-    entry_indexes_by_archive_id: dict[str, list[int]] = {}
+    seen: set[str] = set()
+    duplicates: set[str] = set()
     for index, entry in enumerate(entries):
         raw_archive_id = entry.get("archive_id")
         if _metadata_archive_id_missing(raw_archive_id):
             continue
         archive_id = _metadata_archive_id(raw_archive_id, side=side, index=index)
-        entry_indexes_by_archive_id.setdefault(archive_id, []).append(index)
-    return [
-        f"{side}:{archive_id}:entries={','.join(str(index) for index in indexes)}"
-        for archive_id, indexes in sorted(entry_indexes_by_archive_id.items())
-        if len(indexes) > 1
-    ]
+        if archive_id in seen:
+            duplicates.add(archive_id)
+        seen.add(archive_id)
+    return sorted(duplicates)
 
 
 def _metadata_archive_id(raw_archive_id: Any, *, side: str, index: int) -> str:

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -222,7 +222,7 @@ def test_duplicate_source_archive_ids_block_readiness(tmp_path: Path) -> None:
 
     assert readiness.status == BLOCKED
     assert readiness.source_duplicate_archive_ids == ["source_duplicate"]
-    assert readiness.rerun_duplicate_archive_ids == []
+    assert not readiness.rerun_duplicate_archive_ids
     assert "source_duplicate_archive_ids:1" in readiness.blockers
     assert readiness.to_payload()["source_duplicate_archive_ids"] == ["source_duplicate"]
 
@@ -249,7 +249,7 @@ def test_duplicate_rerun_archive_ids_block_readiness(tmp_path: Path) -> None:
     )
 
     assert readiness.status == BLOCKED
-    assert readiness.source_duplicate_archive_ids == []
+    assert not readiness.source_duplicate_archive_ids
     assert readiness.rerun_duplicate_archive_ids == ["rerun_duplicate"]
     assert "rerun_duplicate_archive_ids:1" in readiness.blockers
     assert readiness.to_payload()["rerun_duplicate_archive_ids"] == ["rerun_duplicate"]

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -221,12 +221,10 @@ def test_duplicate_source_archive_ids_block_readiness(tmp_path: Path) -> None:
     )
 
     assert readiness.status == BLOCKED
-    assert readiness.source_duplicate_archive_ids == ["source:source_duplicate:entries=0,1"]
+    assert readiness.source_duplicate_archive_ids == ["source_duplicate"]
     assert readiness.rerun_duplicate_archive_ids == []
     assert "source_duplicate_archive_ids:1" in readiness.blockers
-    assert readiness.to_payload()["source_duplicate_archive_ids"] == [
-        "source:source_duplicate:entries=0,1"
-    ]
+    assert readiness.to_payload()["source_duplicate_archive_ids"] == ["source_duplicate"]
 
 
 def test_duplicate_rerun_archive_ids_block_readiness(tmp_path: Path) -> None:
@@ -252,11 +250,9 @@ def test_duplicate_rerun_archive_ids_block_readiness(tmp_path: Path) -> None:
 
     assert readiness.status == BLOCKED
     assert readiness.source_duplicate_archive_ids == []
-    assert readiness.rerun_duplicate_archive_ids == ["rerun:rerun_duplicate:entries=0,1"]
+    assert readiness.rerun_duplicate_archive_ids == ["rerun_duplicate"]
     assert "rerun_duplicate_archive_ids:1" in readiness.blockers
-    assert readiness.to_payload()["rerun_duplicate_archive_ids"] == [
-        "rerun:rerun_duplicate:entries=0,1"
-    ]
+    assert readiness.to_payload()["rerun_duplicate_archive_ids"] == ["rerun_duplicate"]
 
 
 def test_scenario_family_and_seed_overlap_is_reported_as_blockers(tmp_path: Path) -> None:

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -221,10 +221,12 @@ def test_duplicate_source_archive_ids_block_readiness(tmp_path: Path) -> None:
     )
 
     assert readiness.status == BLOCKED
-    assert readiness.source_duplicate_archive_ids == ["source:source_duplicate"]
+    assert readiness.source_duplicate_archive_ids == ["source:source_duplicate:entries=0,1"]
     assert readiness.rerun_duplicate_archive_ids == []
     assert "source_duplicate_archive_ids:1" in readiness.blockers
-    assert readiness.to_payload()["source_duplicate_archive_ids"] == ["source:source_duplicate"]
+    assert readiness.to_payload()["source_duplicate_archive_ids"] == [
+        "source:source_duplicate:entries=0,1"
+    ]
 
 
 def test_duplicate_rerun_archive_ids_block_readiness(tmp_path: Path) -> None:
@@ -250,9 +252,11 @@ def test_duplicate_rerun_archive_ids_block_readiness(tmp_path: Path) -> None:
 
     assert readiness.status == BLOCKED
     assert readiness.source_duplicate_archive_ids == []
-    assert readiness.rerun_duplicate_archive_ids == ["rerun:rerun_duplicate"]
+    assert readiness.rerun_duplicate_archive_ids == ["rerun:rerun_duplicate:entries=0,1"]
     assert "rerun_duplicate_archive_ids:1" in readiness.blockers
-    assert readiness.to_payload()["rerun_duplicate_archive_ids"] == ["rerun:rerun_duplicate"]
+    assert readiness.to_payload()["rerun_duplicate_archive_ids"] == [
+        "rerun:rerun_duplicate:entries=0,1"
+    ]
 
 
 def test_scenario_family_and_seed_overlap_is_reported_as_blockers(tmp_path: Path) -> None:

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -199,6 +199,62 @@ def test_overlapping_archive_ids_block_leakage(tmp_path: Path) -> None:
     assert "archive_id_overlap:1" in readiness.blockers
 
 
+def test_duplicate_source_archive_ids_block_readiness(tmp_path: Path) -> None:
+    """Duplicate source archive IDs make the selected archive ambiguous."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [
+            _entry("source_duplicate", family="family_a", seed=1),
+            _entry("source_duplicate", family="family_b", seed=2),
+        ],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_c", seed=101)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.source_duplicate_archive_ids == ["source:source_duplicate"]
+    assert readiness.rerun_duplicate_archive_ids == []
+    assert "source_duplicate_archive_ids:1" in readiness.blockers
+    assert readiness.to_payload()["source_duplicate_archive_ids"] == ["source:source_duplicate"]
+
+
+def test_duplicate_rerun_archive_ids_block_readiness(tmp_path: Path) -> None:
+    """Duplicate rerun archive IDs make held-out archive provenance ambiguous."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [
+            _entry("rerun_duplicate", family="family_b", seed=101),
+            _entry("rerun_duplicate", family="family_c", seed=102),
+        ],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.source_duplicate_archive_ids == []
+    assert readiness.rerun_duplicate_archive_ids == ["rerun:rerun_duplicate"]
+    assert "rerun_duplicate_archive_ids:1" in readiness.blockers
+    assert readiness.to_payload()["rerun_duplicate_archive_ids"] == ["rerun:rerun_duplicate"]
+
+
 def test_scenario_family_and_seed_overlap_is_reported_as_blockers(tmp_path: Path) -> None:
     """Family and seed overlap metadata must be treated as leakage blockers."""
 


### PR DESCRIPTION
## Summary

Closes part of https://github.com/ll7/robot_sf_ll7/issues/3275.

This bounded readiness slice tightens the certified failure-archive rerun checker so duplicate nonblank `archive_id` values within either the source archive or rerun archive fail closed. The JSON report now exposes `source_duplicate_archive_ids` and `rerun_duplicate_archive_ids`, with count blockers, before any proposal-model rerun can be treated as ready.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` -> passed, 27 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py scripts/validation/check_failure_archive_rerun_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py scripts/validation/check_failure_archive_rerun_readiness.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/adversarial/test_disjoint_evaluation.py tests/adversarial/test_archive_readiness.py -q` -> passed, 39 tests.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/pr-4082-gate/pr_body.md PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> passed on head `f24320dca44b8dabf443ac49bb45d9ea86d81670`; stamp `output/validation/pr_ready/issue-3275-archive-readiness-next-codex.json`.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No proposal-model evaluation on a real disjoint certified failure archive.
- No benchmark yield, paper, or dissertation claim edits.
