### PR TITLE
bench: add bounded SNQI-v1 diagnostic

### DIFF
--- a/docs/context/catalog.yaml
+++ b/docs/context/catalog.yaml
@@ -17,6 +17,26 @@ freshness_values:
   policy: Durable policy boundary; update only when the policy changes.
   evidence: Evidence pointer or manifest; preserve provenance and checksums when applicable.
 entries:
+  - path: docs/context/evidence/issue_3978_snqi_v1_recalibration/README.md
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3978_snqi_v1_recalibration/snqi_v0_v1_decomposition.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3978_snqi_v1_recalibration/fixture_metrics.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3978_snqi_v1_recalibration/fixture_weights_unity.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
+  - path: docs/context/evidence/issue_3978_snqi_v1_recalibration/fixture_baseline_stats_v1.json
+    status: evidence
+    freshness: evidence
+    area: benchmark_evidence
   - path: docs/context/evidence/issue_3653_snqi_decision_disagreement_job_13175/README.md
     status: evidence
     freshness: evidence

--- a/docs/context/evidence/issue_3978_snqi_v1_recalibration/README.md
+++ b/docs/context/evidence/issue_3978_snqi_v1_recalibration/README.md
@@ -1,0 +1,32 @@
+# Issue #3978 SNQI-v1 Recalibration Evidence
+
+Plain-language summary: this bundle records a small synthetic before/after decomposition for the versioned SNQI-v1 diagnostic. It is not planner evidence, benchmark evidence, or a canonical weight decision.
+
+## Claim Boundary
+
+- `SNQI-v0` remains the default score for historical comparability and preserves the legacy mixed raw/baseline-normalized basis.
+- `SNQI-v1` is an opt-in bounded baseline-relative diagnostic.
+- `SNQI-v1` scores are not numerically comparable to `SNQI-v0` scores because the normalization semantics changed.
+- Constraints-first benchmark evidence remains primary.
+- No weights were retuned and no new benchmark run was submitted for this bundle.
+
+## Fixture
+
+The fixture uses one synthetic row with unit weights and baseline median/p95 values chosen to make all SNQI-v1 penalty terms clamp to `1.0`.
+
+- `fixture_metrics.json`: synthetic metric row.
+- `fixture_weights_unity.json`: unit weights.
+- `fixture_baseline_stats_v1.json`: median/p95 coverage for all SNQI-v1 penalty metrics.
+- `snqi_v0_v1_decomposition.json`: score and contribution comparison.
+
+## Reproduction
+
+```bash
+uv run pytest tests/test_snqi_normalization_comparison.py \
+  tests/benchmark/test_snqi_normalization_inventory.py \
+  tests/benchmark/test_snqi_governance_preflight.py -q
+```
+
+The fixture values are also covered by `test_compute_snqi_default_preserves_v0_score`,
+`test_compute_snqi_v1_uses_bounded_comparable_penalty_terms`, and
+`test_snqi_v1_contribution_diagnostics_are_comparable`.

--- a/docs/context/evidence/issue_3978_snqi_v1_recalibration/fixture_baseline_stats_v1.json
+++ b/docs/context/evidence/issue_3978_snqi_v1_recalibration/fixture_baseline_stats_v1.json
@@ -1,0 +1,26 @@
+{
+  "time_to_goal_norm": {
+    "med": 0.0,
+    "p95": 1.0
+  },
+  "collisions": {
+    "med": 0.0,
+    "p95": 1.0
+  },
+  "near_misses": {
+    "med": 0.0,
+    "p95": 1.0
+  },
+  "comfort_exposure": {
+    "med": 0.0,
+    "p95": 1.0
+  },
+  "force_exceed_events": {
+    "med": 0.0,
+    "p95": 1.0
+  },
+  "jerk_mean": {
+    "med": 0.0,
+    "p95": 1.0
+  }
+}

--- a/docs/context/evidence/issue_3978_snqi_v1_recalibration/fixture_metrics.json
+++ b/docs/context/evidence/issue_3978_snqi_v1_recalibration/fixture_metrics.json
@@ -1,0 +1,9 @@
+{
+  "success": 1.0,
+  "time_to_goal_norm": 3.0,
+  "collisions": 9.0,
+  "near_misses": 9.0,
+  "comfort_exposure": 2.0,
+  "force_exceed_events": 9.0,
+  "jerk_mean": 9.0
+}

--- a/docs/context/evidence/issue_3978_snqi_v1_recalibration/fixture_weights_unity.json
+++ b/docs/context/evidence/issue_3978_snqi_v1_recalibration/fixture_weights_unity.json
@@ -1,0 +1,9 @@
+{
+  "w_success": 1.0,
+  "w_time": 1.0,
+  "w_collisions": 1.0,
+  "w_near": 1.0,
+  "w_comfort": 1.0,
+  "w_force_exceed": 1.0,
+  "w_jerk": 1.0
+}

--- a/docs/context/evidence/issue_3978_snqi_v1_recalibration/snqi_v0_v1_decomposition.json
+++ b/docs/context/evidence/issue_3978_snqi_v1_recalibration/snqi_v0_v1_decomposition.json
@@ -1,0 +1,64 @@
+{
+  "schema_version": "snqi_v0_v1_decomposition.issue_3978.v1",
+  "issue": 3978,
+  "artifact_type": "synthetic_diagnostic_fixture",
+  "claim_boundary": "SNQI-v1 is a secondary diagnostic only; constraints-first benchmark evidence remains primary.",
+  "not_benchmark_evidence": true,
+  "weights_retuned": false,
+  "benchmark_campaign_submitted": false,
+  "scores": {
+    "SNQI-v0": -8.0,
+    "SNQI-v1": -5.0
+  },
+  "comparability_note": "SNQI-v1 scores are not numerically comparable to SNQI-v0 scores because the normalization semantics changed.",
+  "normalization_summary": {
+    "SNQI-v0": {
+      "status": "legacy_mixed_basis_diagnostic_only",
+      "mixed_basis": true,
+      "raw_unbounded_penalty_terms": [
+        "time",
+        "comfort"
+      ],
+      "baseline_normalized_penalty_terms": [
+        "collisions",
+        "near",
+        "force_exceed",
+        "jerk"
+      ],
+      "raw_penalty_absolute_share": 0.5,
+      "baseline_normalized_penalty_absolute_share": 0.4,
+      "has_weight_bound_exceedance": true,
+      "weight_bound_exceedance_terms": [
+        "time",
+        "comfort"
+      ]
+    },
+    "SNQI-v1": {
+      "status": "bounded_baseline_relative_diagnostic_only",
+      "mixed_basis": false,
+      "raw_unbounded_penalty_terms": [],
+      "baseline_normalized_penalty_terms": [
+        "time",
+        "collisions",
+        "near",
+        "comfort",
+        "force_exceed",
+        "jerk"
+      ],
+      "raw_penalty_absolute_share": 0.0,
+      "baseline_normalized_penalty_absolute_share": 0.8571428571428571,
+      "has_weight_bound_exceedance": false,
+      "weight_bound_exceedance_terms": []
+    }
+  },
+  "fixture_files": {
+    "metrics": "fixture_metrics.json",
+    "weights": "fixture_weights_unity.json",
+    "baseline_stats": "fixture_baseline_stats_v1.json"
+  },
+  "reproduction_tests": [
+    "tests/test_snqi_normalization_comparison.py::test_compute_snqi_default_preserves_v0_score",
+    "tests/test_snqi_normalization_comparison.py::test_compute_snqi_v1_uses_bounded_comparable_penalty_terms",
+    "tests/benchmark/test_snqi_normalization_inventory.py::test_snqi_v1_contribution_diagnostics_are_comparable"
+  ]
+}

--- a/docs/snqi-weight-tools/weights_provenance.md
+++ b/docs/snqi-weight-tools/weights_provenance.md
@@ -43,12 +43,20 @@ The code default (collision-dominant) and `model/snqi_canonical_weights_v1.json`
 both claim or imply "canonical" yet can yield different rankings. The raw-vs-normalized scale split
 overlaps issue #3699.
 
-## Mixed Normalization Basis (Issue #3699)
+## Mixed Normalization Basis (Issues #3699 and #3978)
 
-> **Status:** unresolved, `decision-required`. SNQI currently mixes raw, unbounded penalty terms
-> (`time`, `comfort`) with baseline-normalized penalty terms (`collisions`, `near`, `force_exceed`,
-> `jerk`). The diagnostic checks make that visible and fail closed, but they do not choose between
-> normalizing the raw terms and documenting a bounded raw-term asymmetry.
+> **Current status:** versioned and bounded for new diagnostic use. `SNQI-v0` remains the default
+> legacy score for historical comparability and still preserves the mixed raw/baseline-normalized
+> basis from issue #3699. `SNQI-v1`, introduced by issue #3978, is an opt-in bounded
+> baseline-relative diagnostic that normalizes all penalty terms through the same median/p95 clamp.
+
+Do not compare `SNQI-v0` and `SNQI-v1` values numerically: their normalization semantics differ.
+`SNQI-v1` does not retune weights, repair the unresolved canonical-weight decision from issue
+#3723, implement time-to-collision or closing-speed exposure from issue #3700, or make SNQI a
+primary safety ranking. Constraints-first benchmark evidence remains primary.
+
+The compact diagnostic fixture for this transition is tracked at
+`docs/context/evidence/issue_3978_snqi_v1_recalibration/`.
 
 ## Diagnostics
 
@@ -79,11 +87,13 @@ Implementation: `robot_sf/benchmark/snqi/weights_inventory.py`; guard tests in
 
 ### Normalization Inventory
 
-The normalization inventory reports which SNQI terms are raw, which are baseline-normalized, and
-which terms are unbounded. It can fail closed while the mixed basis remains unresolved.
+The normalization inventory reports which SNQI terms are raw, which are baseline-normalized, which
+terms are bounded, and which score-version contract is active. By default it reports legacy
+`SNQI-v0`; pass `--score-version SNQI-v1` to inspect the bounded diagnostic contract.
 
 ```bash
 uv run python scripts/benchmark/snqi_normalization_inventory_report.py --fail-on-mixed-scale
+uv run python scripts/benchmark/snqi_normalization_inventory_report.py --score-version SNQI-v1
 ```
 
 Implementation: `robot_sf/benchmark/snqi/normalization_inventory.py`; guard tests in
@@ -92,9 +102,10 @@ Implementation: `robot_sf/benchmark/snqi/normalization_inventory.py`; guard test
 ### Combined Governance Preflight
 
 Use this check when a workflow needs one fail-closed gate for the current SNQI governance state. It
-combines the weight-provenance inventory (#3723) with the normalization-basis inventory (#3699).
-It is secondary diagnostic evidence only: it does not choose canonical weights, change
-`compute_snqi`, or make SNQI a primary safety ranking.
+combines weight-provenance inventory (#3723), legacy normalization context (#3699), and the active
+`SNQI-v1` bounded diagnostic contract (#3978). It is secondary diagnostic evidence only: it does
+not choose canonical weights, make SNQI a primary safety ranking, or treat `SNQI-v1` as numerically
+comparable to `SNQI-v0`.
 
 ```bash
 # Exits non-zero while the current governance blockers remain unresolved.
@@ -121,6 +132,8 @@ benchmark comparability impact.
 
 - If a workflow fails on issue #3723, inspect the weight-provenance inventory and decide whether the
   workflow needs inspection mode or a maintainer-approved canonical-weight decision.
-- If a workflow fails on issue #3699, inspect the normalization inventory and decide whether the
-  workflow needs inspection mode or a maintainer-approved normalization remedy.
-- Do not use either unresolved diagnostic as proof of a primary safety ranking.
+- If a workflow depends on historical `SNQI-v0` values, inspect the legacy normalization inventory
+  and keep the mixed-basis caveat attached.
+- If a workflow depends on active bounded diagnostics, use `SNQI-v1` with complete baseline median
+  and p95 coverage for every penalty term.
+- Do not use either unresolved diagnostic as proof for a primary safety ranking.

--- a/robot_sf/benchmark/snqi/compute.py
+++ b/robot_sf/benchmark/snqi/compute.py
@@ -44,6 +44,17 @@ WEIGHT_NAMES = [
     "w_jerk",
 ]
 
+SNQI_SCORE_VERSION_V0 = "SNQI-v0"
+SNQI_SCORE_VERSION_V1 = "SNQI-v1"
+SNQI_V1_PENALTY_METRICS = (
+    "time_to_goal_norm",
+    "collisions",
+    "near_misses",
+    "comfort_exposure",
+    "force_exceed_events",
+    "jerk_mean",
+)
+
 MetricName = str
 BaselineStats = Mapping[MetricName, Mapping[str, float]]
 Weights = Mapping[str, float]
@@ -82,7 +93,7 @@ def normalize_metric(name: str, value: float | int | bool, baseline_stats: Basel
     return norm
 
 
-def compute_snqi(metrics: Metrics, weights: Weights, baseline_stats: BaselineStats) -> float:
+def compute_snqi_v0(metrics: Metrics, weights: Weights, baseline_stats: BaselineStats) -> float:
     """Compute the SNQI score for a single episode.
 
     Args:
@@ -118,6 +129,96 @@ def compute_snqi(metrics: Metrics, weights: Weights, baseline_stats: BaselineSta
         - weights.get("w_jerk", 1.0) * jerk_norm
     )
     return float(score)
+
+
+def _normalize_metric_required(
+    name: str,
+    value: float | int | bool,
+    baseline_stats: BaselineStats,
+) -> float:
+    """Normalize an ``SNQI-v1`` metric and fail closed on missing baseline coverage.
+
+    Returns:
+        Baseline-normalized metric value clamped to ``[0, 1]``.
+    """
+    entry = baseline_stats.get(name)
+    if not isinstance(entry, Mapping) or "med" not in entry or "p95" not in entry:
+        raise ValueError(f"SNQI-v1 baseline_stats missing med/p95 for {name!r}")
+    if float(entry["p95"]) <= float(entry["med"]):
+        raise ValueError(f"SNQI-v1 baseline_stats has non-positive spread for {name!r}")
+    return normalize_metric(name, value, baseline_stats)
+
+
+def compute_snqi_v1(metrics: Metrics, weights: Weights, baseline_stats: BaselineStats) -> float:
+    """Compute opt-in ``SNQI-v1`` with bounded baseline-relative penalty terms.
+
+    Returns:
+        Versioned SNQI score where every penalty term is baseline-normalized.
+    """
+    success_raw = metrics.get("success", 0.0)
+    success = 1.0 if isinstance(success_raw, bool) and success_raw else float(success_raw)
+
+    time_norm = _normalize_metric_required(
+        "time_to_goal_norm",
+        metrics.get("time_to_goal_norm", 1.0),
+        baseline_stats,
+    )
+    coll_norm = _normalize_metric_required(
+        "collisions",
+        metrics.get("collisions", 0.0),
+        baseline_stats,
+    )
+    near_norm = _normalize_metric_required(
+        "near_misses",
+        metrics.get("near_misses", 0.0),
+        baseline_stats,
+    )
+    comfort_norm = _normalize_metric_required(
+        "comfort_exposure",
+        metrics.get("comfort_exposure", 0.0),
+        baseline_stats,
+    )
+    force_exceed_norm = _normalize_metric_required(
+        "force_exceed_events",
+        metrics.get("force_exceed_events", 0.0),
+        baseline_stats,
+    )
+    jerk_norm = _normalize_metric_required(
+        "jerk_mean",
+        metrics.get("jerk_mean", 0.0),
+        baseline_stats,
+    )
+
+    score = (
+        weights.get("w_success", 1.0) * success
+        - weights.get("w_time", 1.0) * time_norm
+        - weights.get("w_collisions", 1.0) * coll_norm
+        - weights.get("w_near", 1.0) * near_norm
+        - weights.get("w_comfort", 1.0) * comfort_norm
+        - weights.get("w_force_exceed", 1.0) * force_exceed_norm
+        - weights.get("w_jerk", 1.0) * jerk_norm
+    )
+
+    return float(score)
+
+
+def compute_snqi(
+    metrics: Metrics,
+    weights: Weights,
+    baseline_stats: BaselineStats,
+    *,
+    score_version: str = SNQI_SCORE_VERSION_V0,
+) -> float:
+    """Compute a versioned SNQI score for a single episode.
+
+    Returns:
+        SNQI score for the requested score version.
+    """
+    if score_version == SNQI_SCORE_VERSION_V0:
+        return compute_snqi_v0(metrics, weights, baseline_stats)
+    if score_version == SNQI_SCORE_VERSION_V1:
+        return compute_snqi_v1(metrics, weights, baseline_stats)
+    raise ValueError(f"unknown SNQI score version: {score_version}")
 
 
 def recompute_snqi_weights(
@@ -245,9 +346,14 @@ def compute_snqi_ablation(
 
 
 __all__ = [
+    "SNQI_SCORE_VERSION_V0",
+    "SNQI_SCORE_VERSION_V1",
+    "SNQI_V1_PENALTY_METRICS",
     "WEIGHT_NAMES",
     "compute_snqi",
     "compute_snqi_ablation",
+    "compute_snqi_v0",
+    "compute_snqi_v1",
     "normalize_metric",
     "recompute_snqi_weights",
 ]

--- a/robot_sf/benchmark/snqi/compute.py
+++ b/robot_sf/benchmark/snqi/compute.py
@@ -131,7 +131,7 @@ def compute_snqi_v0(metrics: Metrics, weights: Weights, baseline_stats: Baseline
     return float(score)
 
 
-def _normalize_metric_required(
+def normalize_metric_required(
     name: str,
     value: float | int | bool,
     baseline_stats: BaselineStats,
@@ -158,32 +158,32 @@ def compute_snqi_v1(metrics: Metrics, weights: Weights, baseline_stats: Baseline
     success_raw = metrics.get("success", 0.0)
     success = 1.0 if isinstance(success_raw, bool) and success_raw else float(success_raw)
 
-    time_norm = _normalize_metric_required(
+    time_norm = normalize_metric_required(
         "time_to_goal_norm",
         metrics.get("time_to_goal_norm", 1.0),
         baseline_stats,
     )
-    coll_norm = _normalize_metric_required(
+    coll_norm = normalize_metric_required(
         "collisions",
         metrics.get("collisions", 0.0),
         baseline_stats,
     )
-    near_norm = _normalize_metric_required(
+    near_norm = normalize_metric_required(
         "near_misses",
         metrics.get("near_misses", 0.0),
         baseline_stats,
     )
-    comfort_norm = _normalize_metric_required(
+    comfort_norm = normalize_metric_required(
         "comfort_exposure",
         metrics.get("comfort_exposure", 0.0),
         baseline_stats,
     )
-    force_exceed_norm = _normalize_metric_required(
+    force_exceed_norm = normalize_metric_required(
         "force_exceed_events",
         metrics.get("force_exceed_events", 0.0),
         baseline_stats,
     )
-    jerk_norm = _normalize_metric_required(
+    jerk_norm = normalize_metric_required(
         "jerk_mean",
         metrics.get("jerk_mean", 0.0),
         baseline_stats,
@@ -355,5 +355,6 @@ __all__ = [
     "compute_snqi_v0",
     "compute_snqi_v1",
     "normalize_metric",
+    "normalize_metric_required",
     "recompute_snqi_weights",
 ]

--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -24,9 +24,13 @@ cannot silently drift away from the scoring code it describes.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
-from robot_sf.benchmark.snqi.compute import normalize_metric
+from robot_sf.benchmark.snqi.compute import (
+    SNQI_SCORE_VERSION_V0,
+    SNQI_SCORE_VERSION_V1,
+    normalize_metric,
+)
 
 # Scaling regimes. Kept as plain strings so inventory payloads are trivially
 # JSON-serializable for preflight reports.
@@ -38,14 +42,15 @@ SCALING_BASELINE_NORMALIZED = "baseline_normalized"
 NORMALIZED_LOWER = 0.0
 NORMALIZED_UPPER = 1.0
 
-SNQI_LEGACY_SCORE_VERSION = "SNQI-v0"
+SNQI_LEGACY_SCORE_VERSION = SNQI_SCORE_VERSION_V0
 SNQI_LEGACY_SCORE_STATUS = "legacy_mixed_basis_diagnostic_only"
+SNQI_V1_SCORE_STATUS = "bounded_baseline_relative_diagnostic_only"
 
 # Static SNQI score-version contract. All values are immutable scalars, so a
 # shallow copy is sufficient to isolate callers from mutating the shared source.
 _SNQI_VERSION_CONTRACT: dict[str, object] = {
     "schema_version": "snqi_score_version_contract.v1",
-    "score_version": SNQI_LEGACY_SCORE_VERSION,
+    "score_version": SNQI_SCORE_VERSION_V0,
     "status": SNQI_LEGACY_SCORE_STATUS,
     "diagnostic_only": True,
     "mixed_basis_preserved": True,
@@ -59,8 +64,25 @@ _SNQI_VERSION_CONTRACT: dict[str, object] = {
     ),
 }
 
+_SNQI_V1_VERSION_CONTRACT: dict[str, object] = {
+    "schema_version": "snqi_score_version_contract.v1",
+    "score_version": SNQI_SCORE_VERSION_V1,
+    "status": SNQI_V1_SCORE_STATUS,
+    "diagnostic_only": True,
+    "mixed_basis_preserved": False,
+    "score_semantics_changed": True,
+    "supersedes": SNQI_SCORE_VERSION_V0,
+    "decision_issue": 3978,
+    "legacy_decision_issue": 3699,
+    "policy": (
+        "SNQI-v1 is a bounded secondary diagnostic; constraints-first evidence remains primary."
+    ),
+}
 
-def build_snqi_version_contract() -> dict[str, object]:
+
+def build_snqi_version_contract(
+    score_version: str = SNQI_SCORE_VERSION_V0,
+) -> dict[str, object]:
     """Return the current versioned SNQI normalization contract.
 
     Issue #3699's current product decision preserves historical SNQI as a
@@ -70,7 +92,11 @@ def build_snqi_version_contract() -> dict[str, object]:
     Returns a fresh shallow copy so callers cannot mutate the shared constant.
     """
 
-    return _SNQI_VERSION_CONTRACT.copy()
+    if score_version == SNQI_SCORE_VERSION_V0:
+        return _SNQI_VERSION_CONTRACT.copy()
+    if score_version == SNQI_SCORE_VERSION_V1:
+        return _SNQI_V1_VERSION_CONTRACT.copy()
+    raise ValueError(f"unknown SNQI score version: {score_version}")
 
 
 @dataclass(frozen=True)
@@ -219,6 +245,32 @@ SNQI_TERM_SCALING: tuple[TermScaling, ...] = (
     ),
 )
 
+SNQI_V1_TERM_SCALING: tuple[TermScaling, ...] = tuple(
+    replace(
+        term,
+        scaling=SCALING_BASELINE_NORMALIZED,
+        measurement_basis="baseline-relative median/p95 clamped value",
+        bounded=True,
+        note="SNQI-v1 baseline-normalized (median/p95) clamped to [0, 1].",
+    )
+    if term.is_penalty
+    else term
+    for term in SNQI_TERM_SCALING
+)
+
+SNQI_TERM_SCALING_BY_VERSION: dict[str, tuple[TermScaling, ...]] = {
+    SNQI_SCORE_VERSION_V0: SNQI_TERM_SCALING,
+    SNQI_SCORE_VERSION_V1: SNQI_V1_TERM_SCALING,
+}
+
+
+def _term_scaling_for_version(score_version: str) -> tuple[TermScaling, ...]:
+    """Return the term scaling table for a known SNQI score version."""
+    try:
+        return SNQI_TERM_SCALING_BY_VERSION[score_version]
+    except KeyError as exc:
+        raise ValueError(f"unknown SNQI score version: {score_version}") from exc
+
 
 def scaled_term_value(
     term: TermScaling,
@@ -348,6 +400,8 @@ def build_snqi_contribution_diagnostics(
     metrics: dict[str, float | int | bool],
     weights: dict[str, float],
     baseline_stats: dict[str, dict[str, float]],
+    *,
+    score_version: str = SNQI_SCORE_VERSION_V0,
 ) -> dict[str, object]:
     """Build read-only weighted contribution diagnostics for one SNQI row.
 
@@ -362,7 +416,8 @@ def build_snqi_contribution_diagnostics(
     """
     preliminary: list[tuple[TermScaling, float | int | bool, float, float, float]] = []
     absolute_total = 0.0
-    for term in SNQI_TERM_SCALING:
+    terms = _term_scaling_for_version(score_version)
+    for term in terms:
         raw_value = metrics.get(term.metric_key, term.default)
         scaled_value = scaled_term_value(term, metrics, baseline_stats)
         weight = float(weights.get(term.weight_name, 1.0))
@@ -415,7 +470,7 @@ def build_snqi_contribution_diagnostics(
         "weight_bound_exceedances": weight_bound_exceedances,
         "has_weight_bound_exceedance": bool(weight_bound_exceedances),
         "normalization_contract": normalization_contract,
-        "score_version_contract": build_snqi_version_contract(),
+        "score_version_contract": build_snqi_version_contract(score_version),
         "terms": [contribution.to_dict() for contribution in contributions],
     }
 
@@ -433,6 +488,7 @@ class NormalizationInventory:
 
     terms: tuple[TermScaling, ...]
     baseline_covered: dict[str, bool]
+    score_version: str = SNQI_SCORE_VERSION_V0
 
     @property
     def penalty_terms(self) -> list[TermScaling]:
@@ -484,11 +540,12 @@ class NormalizationInventory:
     @property
     def score_version_contract(self) -> dict[str, object]:
         """Current versioned SNQI normalization contract."""
-        return build_snqi_version_contract()
+        return build_snqi_version_contract(self.score_version)
 
     def to_dict(self) -> dict[str, object]:
         """Return a JSON-serializable view for preflight reporting."""
         return {
+            "score_version": self.score_version,
             "terms": [t.to_dict() for t in self.terms],
             "baseline_covered": dict(self.baseline_covered),
             "mixed_scale": self.mixed_scale,
@@ -503,6 +560,8 @@ class NormalizationInventory:
 
 def build_snqi_normalization_inventory(
     baseline_stats: dict[str, dict[str, float]] | None = None,
+    *,
+    score_version: str = SNQI_SCORE_VERSION_V0,
 ) -> NormalizationInventory:
     """Inventory the per-term scaling status of the SNQI composite.
 
@@ -511,17 +570,23 @@ def build_snqi_normalization_inventory(
             each baseline-normalized term is checked for median/p95 coverage so
             silently-zeroed terms can be surfaced. When ``None``, coverage is
             reported as unknown (``False``) for every normalized term.
+        score_version: SNQI score-version contract to inventory.
 
     Returns:
         A :class:`NormalizationInventory` describing the scaling of every term.
     """
     stats = baseline_stats or {}
+    terms = _term_scaling_for_version(score_version)
     covered: dict[str, bool] = {}
-    for term in SNQI_TERM_SCALING:
+    for term in terms:
         if term.scaling == SCALING_BASELINE_NORMALIZED:
             entry = stats.get(term.metric_key)
             covered[term.metric_key] = isinstance(entry, dict) and "med" in entry and "p95" in entry
-    return NormalizationInventory(terms=SNQI_TERM_SCALING, baseline_covered=covered)
+    return NormalizationInventory(
+        terms=terms,
+        baseline_covered=covered,
+        score_version=score_version,
+    )
 
 
 def format_normalization_report(inventory: NormalizationInventory) -> str:
@@ -566,6 +631,9 @@ __all__ = [
     "SNQI_LEGACY_SCORE_STATUS",
     "SNQI_LEGACY_SCORE_VERSION",
     "SNQI_TERM_SCALING",
+    "SNQI_TERM_SCALING_BY_VERSION",
+    "SNQI_V1_SCORE_STATUS",
+    "SNQI_V1_TERM_SCALING",
     "NormalizationInventory",
     "TermContribution",
     "TermScaling",

--- a/robot_sf/benchmark/snqi/normalization_inventory.py
+++ b/robot_sf/benchmark/snqi/normalization_inventory.py
@@ -30,6 +30,7 @@ from robot_sf.benchmark.snqi.compute import (
     SNQI_SCORE_VERSION_V0,
     SNQI_SCORE_VERSION_V1,
     normalize_metric,
+    normalize_metric_required,
 )
 
 # Scaling regimes. Kept as plain strings so inventory payloads are trivially
@@ -301,6 +302,20 @@ def scaled_term_value(
     return float(raw)
 
 
+def _scaled_term_value_for_version(
+    term: TermScaling,
+    metrics: dict[str, float | int | bool],
+    baseline_stats: dict[str, dict[str, float]],
+    *,
+    score_version: str,
+) -> float:
+    """Return post-scaling value with versioned fail-closed semantics."""
+    raw = metrics.get(term.metric_key, term.default)
+    if score_version == SNQI_SCORE_VERSION_V1 and term.is_penalty:
+        return normalize_metric_required(term.metric_key, raw, baseline_stats)
+    return scaled_term_value(term, metrics, baseline_stats)
+
+
 @dataclass(frozen=True)
 class TermContribution:
     """Weighted SNQI component contribution for one metric row.
@@ -419,7 +434,12 @@ def build_snqi_contribution_diagnostics(
     terms = _term_scaling_for_version(score_version)
     for term in terms:
         raw_value = metrics.get(term.metric_key, term.default)
-        scaled_value = scaled_term_value(term, metrics, baseline_stats)
+        scaled_value = _scaled_term_value_for_version(
+            term,
+            metrics,
+            baseline_stats,
+            score_version=score_version,
+        )
         weight = float(weights.get(term.weight_name, 1.0))
         signed_contribution = term.sign * weight * scaled_value
         absolute_total += abs(signed_contribution)
@@ -605,7 +625,7 @@ def format_normalization_report(inventory: NormalizationInventory) -> str:
             f"{term.metric_key:<24}{term.measurement_basis}"
         )
     lines.append(f"  mixed_scale            : {inventory.mixed_scale}")
-    contract = build_snqi_version_contract()
+    contract = build_snqi_version_contract(inventory.score_version)
     lines.append(f"  score version          : {contract['score_version']} ({contract['status']})")
     lines.append(
         "  raw penalty terms      : "

--- a/scripts/benchmark/snqi_normalization_inventory_report.py
+++ b/scripts/benchmark/snqi_normalization_inventory_report.py
@@ -67,6 +67,12 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Optional baseline-stats JSON (metric -> {med, p95}) to check coverage.",
     )
     parser.add_argument(
+        "--score-version",
+        choices=("SNQI-v0", "SNQI-v1"),
+        default="SNQI-v0",
+        help="SNQI score-version contract to inspect.",
+    )
+    parser.add_argument(
         "--json-out",
         type=pathlib.Path,
         default=None,
@@ -147,13 +153,17 @@ def main(argv: Sequence[str] | None = None) -> int:  # noqa: C901
     if input_exit_code:
         return input_exit_code
 
-    inventory = build_snqi_normalization_inventory(baseline_stats)
+    inventory = build_snqi_normalization_inventory(
+        baseline_stats,
+        score_version=args.score_version,
+    )
     contribution_payload = None
     if metrics is not None and weights is not None:
         contribution_payload = build_snqi_contribution_diagnostics(
             metrics,
             weights,
             baseline_stats or {},
+            score_version=args.score_version,
         )
 
     print(CLAIM_BOUNDARY)

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -32,9 +32,9 @@ from robot_sf.benchmark.snqi.weights_inventory import build_inventory_report
 
 CLAIM_BOUNDARY = (
     "secondary_diagnostic_only: this preflight reports unresolved SNQI governance "
-    "blockers from issues #3723 and #3699. It does not choose canonical weights, "
-    "change normalization, change compute_snqi output, or make SNQI a primary "
-    "safety ranking."
+    "blockers, preserves legacy SNQI-v0 normalization context, and exposes "
+    "SNQI-v1 bounded diagnostic normalization. It does not choose canonical "
+    "weights or make SNQI a primary safety ranking."
 )
 
 CONTRIBUTION_DIAGNOSTIC_METRICS = {
@@ -56,8 +56,10 @@ CONTRIBUTION_DIAGNOSTIC_WEIGHTS = {
     "w_jerk": 1.0,
 }
 CONTRIBUTION_DIAGNOSTIC_BASELINE_STATS = {
+    "time_to_goal_norm": {"med": 0.0, "p95": 1.0},
     "collisions": {"med": 0.0, "p95": 1.0},
     "near_misses": {"med": 0.0, "p95": 1.0},
+    "comfort_exposure": {"med": 0.0, "p95": 1.0},
     "force_exceed_events": {"med": 0.0, "p95": 1.0},
     "jerk_mean": {"med": 0.0, "p95": 1.0},
 }
@@ -85,11 +87,26 @@ def build_governance_report(
 ) -> dict[str, Any]:
     """Build a structured SNQI governance diagnostic report."""
     weights = build_inventory_report(repo_root)
-    normalization = build_snqi_normalization_inventory(baseline_stats)
-    contribution_diagnostics = build_snqi_contribution_diagnostics(
+    legacy_normalization = build_snqi_normalization_inventory(
+        baseline_stats,
+        score_version="SNQI-v0",
+    )
+    active_baseline_stats = baseline_stats or CONTRIBUTION_DIAGNOSTIC_BASELINE_STATS
+    normalization = build_snqi_normalization_inventory(
+        active_baseline_stats,
+        score_version="SNQI-v1",
+    )
+    legacy_contribution_diagnostics = build_snqi_contribution_diagnostics(
         CONTRIBUTION_DIAGNOSTIC_METRICS,
         CONTRIBUTION_DIAGNOSTIC_WEIGHTS,
         CONTRIBUTION_DIAGNOSTIC_BASELINE_STATS,
+        score_version="SNQI-v0",
+    )
+    contribution_diagnostics = build_snqi_contribution_diagnostics(
+        CONTRIBUTION_DIAGNOSTIC_METRICS,
+        CONTRIBUTION_DIAGNOSTIC_WEIGHTS,
+        active_baseline_stats,
+        score_version="SNQI-v1",
     )
 
     blockers: list[dict[str, Any]] = []
@@ -184,11 +201,11 @@ def build_governance_report(
     if baseline_stats is not None and normalization.missing_baseline_coverage:
         blockers.append(
             {
-                "issue": 3699,
-                "kind": "missing_baseline_coverage",
+                "issue": 3978,
+                "kind": "missing_snqi_v1_baseline_coverage",
                 "detail": (
-                    "At least one baseline-normalized SNQI term lacks median/p95 "
-                    "coverage and would be silently zeroed by normalize_metric."
+                    "At least one SNQI-v1 baseline-normalized penalty term lacks "
+                    "median/p95 coverage and cannot support bounded scoring."
                 ),
                 "metrics": [t.metric_key for t in normalization.missing_baseline_coverage],
             }
@@ -196,17 +213,17 @@ def build_governance_report(
 
     score_version_contract = normalization.score_version_contract
     normalization_checker = {
-        "issue": 3699,
-        "successor_issue": score_version_contract["successor_issue"],
+        "issue": 3978,
+        "legacy_issue": 3699,
         "score_version": score_version_contract["score_version"],
         "status": score_version_contract["status"],
         "diagnostic_only": score_version_contract["diagnostic_only"],
         "decision_recorded": True,
         "score_semantics_changed": score_version_contract["score_semantics_changed"],
         "assumption": (
-            "No score semantics changed; SNQI-v0 intentionally preserves the "
-            "mixed-basis diagnostic contract while SNQI-v1 redesign is tracked "
-            "by issue #3978."
+            "SNQI-v1 is an opt-in bounded baseline-relative diagnostic. "
+            "SNQI-v0 remains available for historical comparability and is "
+            "not numerically comparable to SNQI-v1."
         ),
         "mixed_scale": normalization.mixed_scale,
         "weights_comparable": contribution_diagnostics["normalization_contract"][
@@ -232,6 +249,8 @@ def build_governance_report(
         "status": "failed" if blockers else "passed",
         "blockers": blockers,
         "weights": weights.to_dict(),
+        "legacy_normalization": legacy_normalization.to_dict(),
+        "legacy_normalization_contributions": legacy_contribution_diagnostics,
         "normalization": normalization.to_dict(),
         "normalization_contributions": contribution_diagnostics,
         "normalization_checker": normalization_checker,
@@ -290,9 +309,17 @@ def _print_text_report(report: dict[str, Any]) -> None:
             sources = ", ".join(conflict["sources"])
             print(f"  - {conflict['severity']} {conflict['kind']} ({sources})")
 
+    legacy_normalization = report["legacy_normalization"]
+    print(
+        "Legacy normalization basis: "
+        f"score_version={legacy_normalization['score_version']}; "
+        f"mixed_scale={legacy_normalization['mixed_scale']}; "
+        f"raw_penalty_terms={', '.join(legacy_normalization['raw_penalty_terms']) or 'none'}"
+    )
     normalization = report["normalization"]
     print(
         "Normalization basis: "
+        f"score_version={normalization['score_version']}; "
         f"mixed_scale={normalization['mixed_scale']}; "
         f"raw_penalty_terms={', '.join(normalization['raw_penalty_terms']) or 'none'}; "
         f"unbounded_terms={', '.join(normalization['unbounded_terms']) or 'none'}"
@@ -326,7 +353,7 @@ def _print_text_report(report: dict[str, Any]) -> None:
     checker = report["normalization_checker"]
     print(
         "Normalization checker: "
-        f"issue={checker['issue']} successor_issue={checker['successor_issue']} "
+        f"issue={checker['issue']} legacy_issue={checker['legacy_issue']} "
         f"score_version={checker['score_version']} diagnostic_only={checker['diagnostic_only']} "
         f"decision_recorded={checker['decision_recorded']} "
         f"weights_comparable={checker['weights_comparable']} mixed_scale={checker['mixed_scale']} "

--- a/scripts/validation/check_snqi_governance.py
+++ b/scripts/validation/check_snqi_governance.py
@@ -27,6 +27,7 @@ from robot_sf.benchmark.snqi.exit_codes import (
 from robot_sf.benchmark.snqi.normalization_inventory import (
     build_snqi_contribution_diagnostics,
     build_snqi_normalization_inventory,
+    build_snqi_version_contract,
 )
 from robot_sf.benchmark.snqi.weights_inventory import build_inventory_report
 
@@ -102,12 +103,48 @@ def build_governance_report(
         CONTRIBUTION_DIAGNOSTIC_BASELINE_STATS,
         score_version="SNQI-v0",
     )
-    contribution_diagnostics = build_snqi_contribution_diagnostics(
-        CONTRIBUTION_DIAGNOSTIC_METRICS,
-        CONTRIBUTION_DIAGNOSTIC_WEIGHTS,
-        active_baseline_stats,
-        score_version="SNQI-v1",
-    )
+    missing_v1_baseline = baseline_stats is not None and normalization.missing_baseline_coverage
+    if missing_v1_baseline:
+        missing_metrics = [term.metric_key for term in normalization.missing_baseline_coverage]
+        contribution_diagnostics = {
+            "schema_version": "snqi_normalization_contributions.v1",
+            "diagnostic_only": True,
+            "mixed_basis": False,
+            "absolute_contribution_total": 0.0,
+            "raw_penalty_absolute_share": 0.0,
+            "baseline_normalized_penalty_absolute_share": 0.0,
+            "raw_penalty_terms_dominate": False,
+            "weight_bound_exceedances": [],
+            "has_weight_bound_exceedance": False,
+            "normalization_contract": {
+                "schema_version": "snqi_normalization_contract.v1",
+                "diagnostic_only": True,
+                "status": "invalid_missing_baseline_coverage",
+                "weights_comparable": False,
+                "raw_unbounded_penalty_terms": [],
+                "baseline_normalized_penalty_terms": [
+                    term.term for term in normalization.normalized_penalty_terms
+                ],
+                "raw_penalty_absolute_share": 0.0,
+                "baseline_normalized_penalty_absolute_share": 0.0,
+                "weight_bound_exceedance_terms": [],
+                "decision_issue": 3978,
+                "successor_issue": None,
+                "reasons": [
+                    "SNQI-v1 contribution diagnostics require med/p95 baseline coverage "
+                    f"for every penalty term; missing metrics: {', '.join(missing_metrics)}."
+                ],
+            },
+            "score_version_contract": build_snqi_version_contract("SNQI-v1"),
+            "terms": [],
+        }
+    else:
+        contribution_diagnostics = build_snqi_contribution_diagnostics(
+            CONTRIBUTION_DIAGNOSTIC_METRICS,
+            CONTRIBUTION_DIAGNOSTIC_WEIGHTS,
+            active_baseline_stats,
+            score_version="SNQI-v1",
+        )
 
     blockers: list[dict[str, Any]] = []
     if weights.has_blocking_conflict:
@@ -198,7 +235,7 @@ def build_governance_report(
                 },
             }
         )
-    if baseline_stats is not None and normalization.missing_baseline_coverage:
+    if missing_v1_baseline:
         blockers.append(
             {
                 "issue": 3978,
@@ -207,7 +244,7 @@ def build_governance_report(
                     "At least one SNQI-v1 baseline-normalized penalty term lacks "
                     "median/p95 coverage and cannot support bounded scoring."
                 ),
-                "metrics": [t.metric_key for t in normalization.missing_baseline_coverage],
+                "metrics": missing_metrics,
             }
         )
 

--- a/tests/benchmark/test_snqi_governance_preflight.py
+++ b/tests/benchmark/test_snqi_governance_preflight.py
@@ -1,4 +1,4 @@
-"""Tests for the combined SNQI governance preflight."""
+"""Tests combined SNQI governance preflight."""
 
 from __future__ import annotations
 
@@ -12,17 +12,27 @@ from scripts.validation.check_snqi_governance import build_governance_report, ma
 REPO_ROOT = Path(__file__).parents[2]
 
 
-def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None:
+def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None:  # noqa: PLR0915
     """Current unresolved SNQI blockers are explicit without changing scoring."""
     report = build_governance_report(repo_root=REPO_ROOT)
 
     assert report["status"] == "failed"
     assert "secondary_diagnostic_only" in report["claim_boundary"]
     assert "primary safety ranking" in report["claim_boundary"]
-    assert {blocker["issue"] for blocker in report["blockers"]} == {3699, 3723}
+    assert {blocker["issue"] for blocker in report["blockers"]} == {3723}
     assert report["weights"]["has_blocking_conflict"] is True
-    assert report["normalization"]["mixed_scale"] is True
-    assert set(report["normalization"]["raw_penalty_terms"]) == {"time", "comfort"}
+
+    legacy = report["legacy_normalization"]
+    assert legacy["score_version"] == "SNQI-v0"
+    assert legacy["mixed_scale"] is True
+    assert set(legacy["raw_penalty_terms"]) == {"time", "comfort"}
+
+    active = report["normalization"]
+    assert active["score_version"] == "SNQI-v1"
+    assert active["mixed_scale"] is False
+    assert active["is_consistent"] is True
+    assert active["score_version_contract"]["status"] == "bounded_baseline_relative_diagnostic_only"
+
     blocker_3723 = next(
         blocker for blocker in report["blockers"] if blocker["kind"] == "weight_provenance_conflict"
     )
@@ -39,9 +49,6 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
         "camera_ready_v3",
         "model_canonical_v1",
     ]
-    # Assert the raw source sequence (order + length) before keying by name so a
-    # duplicate-name regression cannot be masked by later entries overwriting earlier
-    # ones in the dict comprehension below.
     expected_source_names = [
         "code_default",
         "camera_ready_v1",
@@ -51,31 +58,19 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
     ]
     discovered_sources = blocker_3723["discovered_weight_sources"]
     assert [source["name"] for source in discovered_sources] == expected_source_names
+    assert len(discovered_sources) == len(expected_source_names)
     discovered_by_name = {source["name"]: source for source in discovered_sources}
-    records_by_name = {record["name"]: record for record in report["weights"]["records"]}
-    assert list(discovered_by_name) == expected_source_names
-    assert discovered_by_name["code_default"] == {
-        "name": "code_default",
-        "kind": "code_default",
-        "relpath": None,
-        "versioned_id": "snqi_weights_code_default_v1",
-        "declares_canonical": True,
-        "available": True,
-        "dominant_term": "w_collisions",
-        "scale_class": "raw",
-        "content_sha256": records_by_name["code_default"]["content_sha256"],
-        "load_error": None,
-    }
-    model_source = discovered_by_name["model_canonical_v1"]
-    assert model_source["relpath"] == "model/snqi_canonical_weights_v1.json"
-    assert model_source["versioned_id"] == "snqi_weights_model_canonical_v1"
-    assert model_source["declares_canonical"] is True
-    assert model_source["dominant_term"] == "w_jerk"
-    assert model_source["content_sha256"]
-    assert blocker_3723["canonical_declaring_sources"] == [
-        "code_default",
-        "model_canonical_v1",
-    ]
+    assert discovered_by_name["code_default"]["versioned_id"] == "snqi_weights_code_default_v1"
+    assert discovered_by_name["code_default"]["declares_canonical"] is True
+    assert discovered_by_name["code_default"]["dominant_term"] == "w_collisions"
+    assert discovered_by_name["code_default"]["scale_class"] == "raw"
+    assert discovered_by_name["model_canonical_v1"]["versioned_id"] == (
+        "snqi_weights_model_canonical_v1"
+    )
+    assert discovered_by_name["model_canonical_v1"]["declares_canonical"] is True
+    assert discovered_by_name["model_canonical_v1"]["dominant_term"] == "w_jerk"
+    assert discovered_by_name["camera_ready_v2"]["scale_class"] == "normalized_simplex"
+    assert discovered_by_name["camera_ready_v3"]["dominant_term"] == "w_near"
     assert len(blocker_3723["blocking_conflicts"]) == 1
     conflict = blocker_3723["blocking_conflicts"][0]
     assert conflict["kind"] == "canonical_direction_conflict"
@@ -97,62 +92,38 @@ def test_governance_report_marks_current_blockers_secondary_diagnostic() -> None
     assert comparisons_by_source["model_canonical_v1"]["source_dominant_term"] == "w_jerk"
     assert comparisons_by_source["camera_ready_v3"]["relationship"] == "different_direction"
     assert comparisons_by_source["camera_ready_v3"]["source_dominant_term"] == "w_near"
-    assert report["normalization"]["score_version_contract"]["score_version"] == "SNQI-v0"
-    assert (
-        report["normalization"]["score_version_contract"]["status"]
-        == "legacy_mixed_basis_diagnostic_only"
-    )
-    blocker_3699 = next(
-        blocker for blocker in report["blockers"] if blocker["kind"] == "mixed_normalization_basis"
-    )
-    status_by_term = {
-        entry["term"]: entry["normalization_status"] for entry in blocker_3699["mixed_inputs"]
-    }
-    assert status_by_term == {
-        "time": "raw_unbounded",
-        "collisions": "baseline_normalized_bounded",
-        "near": "baseline_normalized_bounded",
-        "comfort": "raw_unbounded",
-        "force_exceed": "baseline_normalized_bounded",
-        "jerk": "baseline_normalized_bounded",
-    }
-    assert blocker_3699["contribution_check"] == {
-        "schema_version": "snqi_normalization_contributions.v1",
-        "diagnostic_only": True,
-        "raw_penalty_absolute_share": pytest.approx(0.5),
-        "baseline_normalized_penalty_absolute_share": pytest.approx(0.4),
-        "raw_penalty_terms_dominate": True,
-        "weight_bound_exceedance_terms": ["time", "comfort"],
-        "normalization_contract_status": "mixed_unbounded_penalty_basis",
-        "weights_comparable": False,
-    }
-    contributions = report["normalization_contributions"]
-    assert contributions["schema_version"] == "snqi_normalization_contributions.v1"
-    assert contributions["diagnostic_only"] is True
-    assert contributions["mixed_basis"] is True
-    assert contributions["raw_penalty_terms_dominate"] is True
-    assert contributions["has_weight_bound_exceedance"] is True
-    assert contributions["score_version_contract"]["score_semantics_changed"] is False
-    assert {term["term"] for term in contributions["weight_bound_exceedances"]} == {
+
+    legacy_contributions = report["legacy_normalization_contributions"]
+    assert legacy_contributions["score_version_contract"]["score_version"] == "SNQI-v0"
+    assert legacy_contributions["score_version_contract"]["score_semantics_changed"] is False
+    assert legacy_contributions["mixed_basis"] is True
+    assert legacy_contributions["normalization_contract"]["decision_issue"] == 3699
+    assert legacy_contributions["normalization_contract"]["successor_issue"] == 3978
+    assert legacy_contributions["normalization_contract"]["weights_comparable"] is False
+    assert {term["term"] for term in legacy_contributions["weight_bound_exceedances"]} == {
         "time",
         "comfort",
     }
-    assert contributions["normalization_contract"]["status"] == "mixed_unbounded_penalty_basis"
-    assert contributions["normalization_contract"]["weights_comparable"] is False
-    assert contributions["normalization_contract"]["decision_issue"] == 3699
-    assert contributions["normalization_contract"]["successor_issue"] == 3978
-    assert (
-        contributions["raw_penalty_absolute_share"]
-        > contributions["baseline_normalized_penalty_absolute_share"]
-    )
+
+    active_contributions = report["normalization_contributions"]
+    assert active_contributions["schema_version"] == "snqi_normalization_contributions.v1"
+    assert active_contributions["score_version_contract"]["score_version"] == "SNQI-v1"
+    assert active_contributions["score_version_contract"]["score_semantics_changed"] is True
+    assert active_contributions["mixed_basis"] is False
+    assert active_contributions["raw_penalty_terms_dominate"] is False
+    assert active_contributions["has_weight_bound_exceedance"] is False
+    assert active_contributions["weight_bound_exceedances"] == []
+    assert active_contributions["normalization_contract"]["status"] == "comparable_weight_basis"
+    assert active_contributions["normalization_contract"]["weights_comparable"] is True
+    assert active_contributions["score_version_contract"]["decision_issue"] == 3978
 
 
 def test_governance_main_fails_closed_but_allows_inspection(tmp_path: Path) -> None:
-    """Default command fails closed; inspection mode emits the same report and exits 0."""
-    json_out = tmp_path / "snqi_governance.json"
+    """Default command fails closed; inspection mode emits the same report."""
+    out = tmp_path / "report.json"
 
-    assert main(["--repo-root", str(REPO_ROOT), "--json-out", str(json_out)]) == 2
-    payload = json.loads(json_out.read_text(encoding="utf-8"))
+    assert main(["--repo-root", str(REPO_ROOT), "--json-out", str(out)]) == 2
+    payload = json.loads(out.read_text(encoding="utf-8"))
     assert payload["status"] == "failed"
 
     assert (
@@ -171,7 +142,7 @@ def test_governance_main_fails_closed_but_allows_inspection(tmp_path: Path) -> N
 def test_governance_text_lists_per_term_normalization_status(
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    """Human preflight output lists raw and baseline-normalized term statuses."""
+    """Human preflight output lists legacy and active normalization statuses."""
     assert main(["--repo-root", str(REPO_ROOT), "--allow-current-blockers"]) == 0
 
     out = capsys.readouterr().out
@@ -185,7 +156,8 @@ def test_governance_text_lists_per_term_normalization_status(
     assert "versioned_id=snqi_weights_model_canonical_v1" in out
     assert (
         "camera_ready_v3 (shipped_json, configs/benchmarks/snqi_weights_camera_ready_v3.json)"
-    ) in out
+        in out
+    )
     assert "versioned_id=snqi_weights_camera_ready_v3" in out
     assert "dominant=w_collisions; scale=raw; sha256=" in out
     assert "dominant=w_near; scale=normalized_simplex; sha256=" in out
@@ -195,29 +167,30 @@ def test_governance_text_lists_per_term_normalization_status(
         "different_direction; source_dominant=w_jerk; source_scale=raw" in out
     )
     assert "Weight provenance conflicts:" in out
-    assert "error canonical_direction_conflict (code_default, model_canonical_v1)" in out
+    assert "canonical_direction_conflict" in out
+    assert "(code_default, model_canonical_v1)" in out
     assert "warning code_default_shipped_direction_mismatch (code_default, camera_ready_v1)" in out
     assert "warning code_default_shipped_direction_mismatch (code_default, camera_ready_v3)" in out
+    assert "Legacy normalization basis: score_version=SNQI-v0" in out
+    assert "raw_penalty_terms=time, comfort" in out
     assert "Term normalization status:" in out
     assert (
-        "Score version contract: SNQI-v0; "
-        "status=legacy_mixed_basis_diagnostic_only; diagnostic_only=True"
-    ) in out
-    assert "time (time_to_goal_norm, w_time): raw_unbounded" in out
-    assert "basis=raw time-to-goal ratio" in out
-    assert "comfort (comfort_exposure, w_comfort): raw_unbounded" in out
-    assert "basis=raw accumulated comfort-exposure value" in out
-    assert "collisions (collisions, w_collisions): baseline_normalized_bounded" in out
+        "Score version contract: SNQI-v1; "
+        "status=bounded_baseline_relative_diagnostic_only; diagnostic_only=True" in out
+    )
+    assert "time (time_to_goal_norm, w_time): baseline_normalized_bounded" in out
     assert "basis=baseline-relative median/p95 clamped value" in out
-    assert "jerk (jerk_mean, w_jerk): baseline_normalized_bounded" in out
     assert "Contribution diagnostic:" in out
-    assert "raw_penalty_terms_dominate=True" in out
-    assert "has_weight_bound_exceedance=True" in out
-    assert "weight_bound_exceedance_terms=time, comfort" in out
+    assert "raw_penalty_share=0.000" in out
+    assert "raw_penalty_terms_dominate=False" in out
+    assert "has_weight_bound_exceedance=False" in out
+    assert "Normalization checker: issue=3978 legacy_issue=3699" in out
+    assert "score_version=SNQI-v1" in out
+    assert "status=bounded_baseline_relative_diagnostic_only" in out
 
 
 def test_governance_report_checks_optional_baseline_coverage(tmp_path: Path) -> None:
-    """When baseline stats are supplied, missing normalized terms are blockers."""
+    """When baseline stats are supplied, missing SNQI-v1 normalized terms block."""
     baseline_stats = {
         "collisions": {"med": 0.0, "p95": 1.0},
         "near_misses": {"med": 0.0, "p95": 1.0},
@@ -228,32 +201,37 @@ def test_governance_report_checks_optional_baseline_coverage(tmp_path: Path) -> 
     assert main(["--repo-root", str(REPO_ROOT), "--baseline-stats", str(path)]) == 2
 
     report = build_governance_report(repo_root=REPO_ROOT, baseline_stats=baseline_stats)
-    missing = [b for b in report["blockers"] if b["kind"] == "missing_baseline_coverage"]
+    missing = [b for b in report["blockers"] if b["kind"] == "missing_snqi_v1_baseline_coverage"]
     assert missing
-    assert set(missing[0]["metrics"]) == {"force_exceed_events", "jerk_mean"}
+    assert set(missing[0]["metrics"]) == {
+        "time_to_goal_norm",
+        "comfort_exposure",
+        "force_exceed_events",
+        "jerk_mean",
+    }
+    assert missing[0]["issue"] == 3978
 
 
 def test_governance_checker_payload_is_referenced_in_report() -> None:
-    """Normalization checker packet is included in machine-parseable report."""
+    """Normalization checker packet is included in the machine-parseable report."""
     report = build_governance_report(repo_root=REPO_ROOT)
     checker = report["normalization_checker"]
-    assert checker["issue"] == 3699
-    assert checker["successor_issue"] == 3978
-    assert checker["score_version"] == "SNQI-v0"
-    assert checker["status"] == "legacy_mixed_basis_diagnostic_only"
+    assert checker["issue"] == 3978
+    assert checker["legacy_issue"] == 3699
+    assert checker["score_version"] == "SNQI-v1"
+    assert checker["status"] == "bounded_baseline_relative_diagnostic_only"
     assert checker["diagnostic_only"] is True
     assert checker["decision_recorded"] is True
-    assert checker["score_semantics_changed"] is False
+    assert checker["score_semantics_changed"] is True
     assert checker["assumption"] == (
-        "No score semantics changed; SNQI-v0 intentionally preserves the "
-        "mixed-basis diagnostic contract while SNQI-v1 redesign is tracked "
-        "by issue #3978."
+        "SNQI-v1 is an opt-in bounded baseline-relative diagnostic. SNQI-v0 remains "
+        "available for historical comparability and is not numerically comparable to SNQI-v1."
     )
-    assert checker["mixed_scale"] is True
-    assert checker["weights_comparable"] is False
-    assert checker["normalization_contract_status"] == "mixed_unbounded_penalty_basis"
-    assert checker["raw_penalty_terms_dominate"] is True
-    assert checker["has_weight_bound_exceedance"] is True
+    assert checker["mixed_scale"] is False
+    assert checker["weights_comparable"] is True
+    assert checker["normalization_contract_status"] == "comparable_weight_basis"
+    assert checker["raw_penalty_terms_dominate"] is False
+    assert checker["has_weight_bound_exceedance"] is False
     contributions = report["normalization_contributions"]
     assert checker["raw_penalty_absolute_share"] == pytest.approx(
         contributions["raw_penalty_absolute_share"]
@@ -264,7 +242,7 @@ def test_governance_checker_payload_is_referenced_in_report() -> None:
 
 
 def test_governance_report_json_exports_normalization_checker(tmp_path: Path) -> None:
-    """JSON export includes the checker packet for external consumers."""
+    """JSON export includes checker packet for external consumers."""
     out = tmp_path / "snqi_governance.json"
     exit_code = main(
         [
@@ -276,15 +254,16 @@ def test_governance_report_json_exports_normalization_checker(tmp_path: Path) ->
             "--allow-current-blockers",
         ]
     )
+
     assert exit_code == 0
     assert out.is_file()
     payload = json.loads(out.read_text(encoding="utf-8"))
     checker = payload["normalization_checker"]
     assert isinstance(checker["assumption"], str)
-    assert "No score semantics changed" in checker["assumption"]
-    assert checker["successor_issue"] == 3978
-    assert checker["score_version"] == "SNQI-v0"
-    assert checker["status"] == "legacy_mixed_basis_diagnostic_only"
+    assert "SNQI-v1 is an opt-in bounded baseline-relative diagnostic" in checker["assumption"]
+    assert checker["legacy_issue"] == 3699
+    assert checker["score_version"] == "SNQI-v1"
+    assert checker["status"] == "bounded_baseline_relative_diagnostic_only"
     assert checker["diagnostic_only"] is True
     assert checker["decision_recorded"] is True
-    assert checker["score_semantics_changed"] is False
+    assert checker["score_semantics_changed"] is True

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -265,6 +265,35 @@ def test_snqi_v1_contribution_diagnostics_are_comparable() -> None:
             assert abs(term["signed_contribution"]) <= abs(term["weight"])
 
 
+def test_snqi_v1_contribution_diagnostics_fail_closed_on_missing_baseline() -> None:
+    """SNQI-v1 diagnostics reject inputs the scorer would reject."""
+    metrics = {
+        "success": 1.0,
+        "time_to_goal_norm": 3.0,
+        "collisions": 9.0,
+        "near_misses": 9.0,
+        "comfort_exposure": 2.0,
+        "force_exceed_events": 9.0,
+        "jerk_mean": 9.0,
+    }
+    weights = {term.weight_name: 1.0 for term in SNQI_V1_TERM_SCALING}
+    incomplete_baseline_stats = {
+        "collisions": {"med": 0.0, "p95": 1.0},
+        "near_misses": {"med": 0.0, "p95": 1.0},
+        "comfort_exposure": {"med": 0.0, "p95": 1.0},
+        "force_exceed_events": {"med": 0.0, "p95": 1.0},
+        "jerk_mean": {"med": 0.0, "p95": 1.0},
+    }
+
+    with pytest.raises(ValueError, match="SNQI-v1 baseline_stats missing med/p95"):
+        build_snqi_contribution_diagnostics(
+            metrics,
+            weights,
+            incomplete_baseline_stats,
+            score_version="SNQI-v1",
+        )
+
+
 def test_snqi_v1_compute_path_is_covered_in_optional_lane() -> None:
     """Optional benchmark lane covers the versioned compute path."""
     metrics = {
@@ -304,6 +333,16 @@ def test_format_report_is_human_readable():
     assert "baseline-relative median/p95 clamped value" in text
     for term in SNQI_TERM_SCALING:
         assert term.term in text
+
+
+def test_format_report_uses_inventory_score_version_contract() -> None:
+    """V1 inventory text reports the v1 contract, not the default v0 contract."""
+    inv = build_snqi_normalization_inventory(_BASELINE_STATS, score_version="SNQI-v1")
+
+    text = format_normalization_report(inv)
+
+    assert "SNQI-v1 (bounded_baseline_relative_diagnostic_only)" in text
+    assert "SNQI-v0 (legacy_mixed_basis_diagnostic_only)" not in text
 
 
 def test_contribution_diagnostics_reconstruct_snqi_and_flag_raw_dominance():

--- a/tests/benchmark/test_snqi_normalization_inventory.py
+++ b/tests/benchmark/test_snqi_normalization_inventory.py
@@ -19,6 +19,8 @@ from robot_sf.benchmark.snqi.normalization_inventory import (
     SNQI_LEGACY_SCORE_STATUS,
     SNQI_LEGACY_SCORE_VERSION,
     SNQI_TERM_SCALING,
+    SNQI_V1_SCORE_STATUS,
+    SNQI_V1_TERM_SCALING,
     build_snqi_contribution_diagnostics,
     build_snqi_normalization_inventory,
     build_snqi_version_contract,
@@ -29,8 +31,10 @@ from robot_sf.benchmark.snqi.normalization_inventory import (
 # Baseline stats covering exactly the four count-type penalty terms that
 # ``compute_snqi`` routes through ``normalize_metric``.
 _BASELINE_STATS = {
+    "time_to_goal_norm": {"med": 0.0, "p95": 1.0},
     "collisions": {"med": 1.0, "p95": 5.0},
     "near_misses": {"med": 2.0, "p95": 8.0},
+    "comfort_exposure": {"med": 0.0, "p95": 1.0},
     "force_exceed_events": {"med": 0.0, "p95": 4.0},
     "jerk_mean": {"med": 0.1, "p95": 1.0},
 }
@@ -184,6 +188,109 @@ def test_score_version_contract_preserves_legacy_snqi_v0_as_diagnostic_only():
     assert contract["future_bounded_contract"] == "SNQI-v1"
     assert contract["decision_issue"] == 3699
     assert contract["successor_issue"] == 3978
+
+
+def test_score_version_contract_exposes_snqi_v1_bounded_diagnostic() -> None:
+    """SNQI-v1 is an opt-in bounded diagnostic, not a v0 reinterpretation."""
+    contract = build_snqi_version_contract("SNQI-v1")
+
+    assert contract["score_version"] == "SNQI-v1"
+    assert contract["status"] == SNQI_V1_SCORE_STATUS
+    assert contract["diagnostic_only"] is True
+    assert contract["mixed_basis_preserved"] is False
+    assert contract["score_semantics_changed"] is True
+    assert contract["supersedes"] == "SNQI-v0"
+    assert contract["decision_issue"] == 3978
+    assert contract["legacy_decision_issue"] == 3699
+
+
+def test_snqi_v1_inventory_penalties_are_bounded_baseline_normalized() -> None:
+    """Every SNQI-v1 penalty term uses the comparable baseline-normalized basis."""
+    inv = build_snqi_normalization_inventory(_BASELINE_STATS, score_version="SNQI-v1")
+
+    assert inv.score_version == "SNQI-v1"
+    assert inv.mixed_scale is False
+    assert inv.is_consistent is True
+    assert inv.unbounded_terms == []
+    assert {t.metric_key for t in inv.normalized_penalty_terms} == {
+        "time_to_goal_norm",
+        "collisions",
+        "near_misses",
+        "comfort_exposure",
+        "force_exceed_events",
+        "jerk_mean",
+    }
+    assert all(t.scaling == SCALING_BASELINE_NORMALIZED for t in inv.penalty_terms)
+    assert all(t.bounded for t in inv.penalty_terms)
+
+
+def test_snqi_v1_contribution_diagnostics_are_comparable() -> None:
+    """SNQI-v1 scaled values and signed penalties stay within weight bounds."""
+    metrics = {
+        "success": 1.0,
+        "time_to_goal_norm": 3.0,
+        "collisions": 9.0,
+        "near_misses": 9.0,
+        "comfort_exposure": 2.0,
+        "force_exceed_events": 9.0,
+        "jerk_mean": 9.0,
+    }
+    weights = {term.weight_name: 1.0 for term in SNQI_V1_TERM_SCALING}
+    baseline_stats = {
+        "time_to_goal_norm": {"med": 0.0, "p95": 1.0},
+        "collisions": {"med": 0.0, "p95": 1.0},
+        "near_misses": {"med": 0.0, "p95": 1.0},
+        "comfort_exposure": {"med": 0.0, "p95": 1.0},
+        "force_exceed_events": {"med": 0.0, "p95": 1.0},
+        "jerk_mean": {"med": 0.0, "p95": 1.0},
+    }
+
+    diagnostics = build_snqi_contribution_diagnostics(
+        metrics,
+        weights,
+        baseline_stats,
+        score_version="SNQI-v1",
+    )
+
+    assert diagnostics["mixed_basis"] is False
+    assert diagnostics["has_weight_bound_exceedance"] is False
+    assert diagnostics["normalization_contract"]["status"] == "comparable_weight_basis"
+    assert diagnostics["normalization_contract"]["weights_comparable"] is True
+    assert diagnostics["normalization_contract"]["weight_bound_exceedance_terms"] == []
+    terms = diagnostics["terms"]
+    for term in terms:
+        if term["signed_contribution"] < 0:
+            assert term["scaling"] == SCALING_BASELINE_NORMALIZED
+            assert 0.0 <= term["scaled_value"] <= 1.0
+            assert abs(term["signed_contribution"]) <= abs(term["weight"])
+
+
+def test_snqi_v1_compute_path_is_covered_in_optional_lane() -> None:
+    """Optional benchmark lane covers the versioned compute path."""
+    metrics = {
+        "success": 1.0,
+        "time_to_goal_norm": 3.0,
+        "collisions": 9.0,
+        "near_misses": 9.0,
+        "comfort_exposure": 2.0,
+        "force_exceed_events": 9.0,
+        "jerk_mean": 9.0,
+    }
+    weights = {term.weight_name: 1.0 for term in SNQI_V1_TERM_SCALING}
+    baseline_stats = {
+        "time_to_goal_norm": {"med": 0.0, "p95": 1.0},
+        "collisions": {"med": 0.0, "p95": 1.0},
+        "near_misses": {"med": 0.0, "p95": 1.0},
+        "comfort_exposure": {"med": 0.0, "p95": 1.0},
+        "force_exceed_events": {"med": 0.0, "p95": 1.0},
+        "jerk_mean": {"med": 0.0, "p95": 1.0},
+    }
+
+    assert compute_snqi(metrics, weights, baseline_stats, score_version="SNQI-v1") == pytest.approx(
+        -5.0
+    )
+    with pytest.raises(ValueError, match="unknown SNQI score version"):
+        compute_snqi(metrics, weights, baseline_stats, score_version="SNQI-vunknown")
 
 
 def test_format_report_is_human_readable():

--- a/tests/test_snqi_normalization_comparison.py
+++ b/tests/test_snqi_normalization_comparison.py
@@ -9,8 +9,37 @@ Validates that when comparing normalization strategies:
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
+from robot_sf.benchmark.snqi.compute import compute_snqi
 from scripts.recompute_snqi_weights import SNQIWeightRecomputer
+
+_METRICS = {
+    "success": 1.0,
+    "time_to_goal_norm": 3.0,
+    "collisions": 9.0,
+    "near_misses": 9.0,
+    "comfort_exposure": 2.0,
+    "force_exceed_events": 9.0,
+    "jerk_mean": 9.0,
+}
+_BASELINE_STATS_V1 = {
+    "time_to_goal_norm": {"med": 0.0, "p95": 1.0},
+    "collisions": {"med": 0.0, "p95": 1.0},
+    "near_misses": {"med": 0.0, "p95": 1.0},
+    "comfort_exposure": {"med": 0.0, "p95": 1.0},
+    "force_exceed_events": {"med": 0.0, "p95": 1.0},
+    "jerk_mean": {"med": 0.0, "p95": 1.0},
+}
+_WEIGHTS = {
+    "w_success": 1.0,
+    "w_time": 1.0,
+    "w_collisions": 1.0,
+    "w_near": 1.0,
+    "w_comfort": 1.0,
+    "w_force_exceed": 1.0,
+    "w_jerk": 1.0,
+}
 
 
 def _episodes():
@@ -69,3 +98,42 @@ def test_normalization_comparison_correlations_range():
         corr = data["correlation_with_base"]
         assert np.isfinite(corr), f"Correlation not finite for {name}"
         assert -1.0 <= corr <= 1.0, f"Correlation out of range for {name}: {corr}"
+
+
+def test_compute_snqi_default_preserves_v0_score() -> None:
+    """Default score version preserves legacy raw time/comfort behavior."""
+    assert compute_snqi(_METRICS, _WEIGHTS, _BASELINE_STATS_V1) == pytest.approx(-8.0)
+
+
+def test_compute_snqi_v1_uses_bounded_comparable_penalty_terms() -> None:
+    """SNQI-v1 clamps all penalty terms onto the same baseline-relative basis."""
+    assert compute_snqi(
+        _METRICS,
+        _WEIGHTS,
+        _BASELINE_STATS_V1,
+        score_version="SNQI-v1",
+    ) == pytest.approx(-5.0)
+
+
+def test_snqi_v1_missing_baseline_stats_fail_closed() -> None:
+    """SNQI-v1 must not silently zero missing normalized terms."""
+    missing_time = dict(_BASELINE_STATS_V1)
+    missing_time.pop("time_to_goal_norm")
+
+    with pytest.raises(ValueError, match="missing med/p95"):
+        compute_snqi(_METRICS, _WEIGHTS, missing_time, score_version="SNQI-v1")
+
+
+def test_snqi_v1_invalid_baseline_spread_fails_closed() -> None:
+    """SNQI-v1 requires positive median/p95 spread for each penalty metric."""
+    invalid_time = dict(_BASELINE_STATS_V1)
+    invalid_time["time_to_goal_norm"] = {"med": 1.0, "p95": 1.0}
+
+    with pytest.raises(ValueError, match="non-positive spread"):
+        compute_snqi(_METRICS, _WEIGHTS, invalid_time, score_version="SNQI-v1")
+
+
+def test_compute_snqi_unknown_score_version_fails_closed() -> None:
+    """Unknown score versions should fail closed instead of falling back."""
+    with pytest.raises(ValueError, match="unknown SNQI score version"):
+        compute_snqi(_METRICS, _WEIGHTS, _BASELINE_STATS_V1, score_version="SNQI-v2")

--- a/tests/test_snqi_normalization_comparison.py
+++ b/tests/test_snqi_normalization_comparison.py
@@ -8,6 +8,8 @@ Validates that when comparing normalization strategies:
 
 from __future__ import annotations
 
+import copy
+
 import numpy as np
 import pytest
 
@@ -117,7 +119,7 @@ def test_compute_snqi_v1_uses_bounded_comparable_penalty_terms() -> None:
 
 def test_snqi_v1_missing_baseline_stats_fail_closed() -> None:
     """SNQI-v1 must not silently zero missing normalized terms."""
-    missing_time = dict(_BASELINE_STATS_V1)
+    missing_time = copy.deepcopy(_BASELINE_STATS_V1)
     missing_time.pop("time_to_goal_norm")
 
     with pytest.raises(ValueError, match="missing med/p95"):
@@ -126,7 +128,7 @@ def test_snqi_v1_missing_baseline_stats_fail_closed() -> None:
 
 def test_snqi_v1_invalid_baseline_spread_fails_closed() -> None:
     """SNQI-v1 requires positive median/p95 spread for each penalty metric."""
-    invalid_time = dict(_BASELINE_STATS_V1)
+    invalid_time = copy.deepcopy(_BASELINE_STATS_V1)
     invalid_time["time_to_goal_norm"] = {"med": 1.0, "p95": 1.0}
 
     with pytest.raises(ValueError, match="non-positive spread"):


### PR DESCRIPTION
## Summary
- Adds versioned `SNQI-v1` as an opt-in bounded baseline-relative diagnostic while preserving existing `compute_snqi()` default behavior as `SNQI-v0`.
- Extends normalization inventory and governance preflight so `SNQI-v0` remains legacy context and active normalization checks inspect `SNQI-v1`.
- Adds a compact synthetic decomposition bundle under `docs/context/evidence/issue_3978_snqi_v1_recalibration/` and updates SNQI weight provenance docs.

## Claim Boundary
- Closes #3978.
- Does not retune weights, resolve #3723 canonical-weight provenance, implement #3700 time-to-collision or closing-speed exposure, or make SNQI a primary safety ranking.
- `SNQI-v1` values are not numerically comparable to `SNQI-v0`; constraints-first benchmark evidence remains primary.

## Validation
- `uv run pytest tests/test_snqi_normalization_comparison.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py tests/test_snqi_parity.py tests/test_snqi_determinism.py -q`
- `uv run ruff check robot_sf/benchmark/snqi/compute.py robot_sf/benchmark/snqi/normalization_inventory.py scripts/benchmark/snqi_normalization_inventory_report.py scripts/validation/check_snqi_governance.py tests/test_snqi_normalization_comparison.py tests/benchmark/test_snqi_normalization_inventory.py tests/benchmark/test_snqi_governance_preflight.py`
- `uv run python scripts/validation/check_snqi_governance.py --allow-current-blockers --json-out /tmp/snqi_governance_after_3978.json`
- `git diff --check`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (interim): 1693 passed, 2 skipped
