### PR TITLE
Issue #3204: summarize proxy checkpoint blocker scopes

### DIFF
--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -486,6 +486,7 @@ def _check_checkpoint_artifacts(
         resolvable, training_run_group_field
     )
     blocked_by_status: dict[str, int] = {}
+    blocked_by_artifact_scope: dict[str, int] = {}
     public_artifacts_by_status: dict[str, int] = {}
     for candidate in candidates:
         artifact_status = str(candidate["public_artifact"]["status"])
@@ -495,6 +496,10 @@ def _check_checkpoint_artifacts(
         if candidate["present"]:
             continue
         blocked_by_status[candidate["status"]] = blocked_by_status.get(candidate["status"], 0) + 1
+        artifact_scope = str(candidate["artifact_scope"])
+        blocked_by_artifact_scope[artifact_scope] = (
+            blocked_by_artifact_scope.get(artifact_scope, 0) + 1
+        )
 
     mapping = {
         "registry_tag": registry_tag,
@@ -506,6 +511,7 @@ def _check_checkpoint_artifacts(
         "resolvable_by_training_run_group": grouped_resolvable,
         "missing_training_run_group_metadata": missing_group_metadata,
         "blocked_by_status": blocked_by_status,
+        "blocked_by_artifact_scope": blocked_by_artifact_scope,
         "public_artifacts_by_status": public_artifacts_by_status,
         "candidates": candidates,
     }

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -178,6 +178,7 @@ def test_blocked_mapping_classifies_worktree_local_output_artifact(tmp_path):
     candidate = ckpt["mapping"]["candidates"][0]
     assert report["status"] == "blocked"
     assert ckpt["mapping"]["blocked_by_status"] == {"missing_local_path": 1}
+    assert ckpt["mapping"]["blocked_by_artifact_scope"] == {"worktree_local_output": 1}
     assert candidate["status"] == "missing_local_path"
     assert candidate["artifact_scope"] == "worktree_local_output"
     assert candidate["resolved_path"].endswith("output/tmp/predictive/run/checkpoint.pt")


### PR DESCRIPTION
## Issue
Closes: none
Related: https://github.com/ll7/robot_sf_ll7/issues/3204

## Scope Summary
This is a diagnostic/readiness-only slice for issue #3204. It adds a compact `blocked_by_artifact_scope` aggregate to the predictive checkpoint proxy readiness packet, derived from already-mapped checkpoint candidates. The checker still only reports fail-closed input readiness; it does not select checkpoints, hydrate artifacts, run training, or assert benchmark results.

## Validation
- `uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py::test_blocked_mapping_classifies_worktree_local_output_artifact -q` -> passed (red first: failed with `KeyError: 'blocked_by_artifact_scope'`, then passed after implementation).
- `uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py -q` -> passed, 28 tests.
- `uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py` -> passed.
- `uv run ruff format --check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py` -> passed.
- `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --config configs/research/predictive_checkpoint_proxy_v1.yaml --json` -> expected exit 2 blocked; current live registry reports 8 missing predictive checkpoints, with `blocked_by_artifact_scope={"worktree_local_output": 8}`.
- `PR_READY_MODE=final BASE_REF=origin/main PYTEST_NUM_WORKERS=8 PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3204/pr_body.md scripts/dev/pr_ready_check.sh` -> passed; clean-tree freshness stamp `output/validation/pr_ready/issue-3204-proxy-readiness-mapping-metadata-codex.json` on head `06f3577a928bb625bc8c05786f373f856012c03e`.

## Out of Scope
No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no checkpoint selection, no training, no artifact hydration, and no issue/PR comments beyond opening this PR.

## Residual Risk
This improves readiness packet diagnostics only. Issue #3204 remains blocked on durable/hydrated predictive checkpoints and a non-degenerate proxy-enabled training summary from a plateau-breaking lineage.
