### PR TITLE
Issue #3275: require certification lineage for archive rerun readiness

### DIFF
--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -539,19 +539,25 @@ def _certification_has_lineage(value: Any) -> bool:
     if not isinstance(value, dict):
         return False
     for key in _CERTIFICATION_LINEAGE_KEYS:
-        raw_value = value.get(key)
-        if raw_value is None:
-            continue
-        if isinstance(raw_value, str):
-            if raw_value.strip():
-                return True
-            continue
-        if isinstance(raw_value, list | tuple | set | dict):
-            if raw_value:
-                return True
-            continue
-        return True
+        if _lineage_value_present(value.get(key)):
+            return True
     return False
+
+
+def _lineage_value_present(raw_value: Any) -> bool:
+    """Return whether one certification lineage field carries non-placeholder data."""
+
+    if raw_value is None:
+        return False
+    if isinstance(raw_value, str):
+        return bool(raw_value.strip())
+    if isinstance(raw_value, list | tuple | set | dict):
+        return bool(raw_value)
+    if isinstance(raw_value, bool):
+        return raw_value
+    if isinstance(raw_value, int | float):
+        return bool(raw_value)
+    return True
 
 
 def _null_test_prerequisite_gaps(

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -54,6 +54,15 @@ _PASSING_CERTIFICATION_STATUSES = {
     "ready",
     "valid",
 }
+_CERTIFICATION_LINEAGE_KEYS = (
+    "artifact",
+    "artifact_path",
+    "certificate_path",
+    "evidence_path",
+    "provenance",
+    "source",
+    "source_manifest",
+)
 _DIAGNOSTIC_ONLY_VALUES = {
     "diagnostic",
     "diagnostic-only",
@@ -105,8 +114,10 @@ class FailureArchiveRerunReadiness:
     rerun_duplicate_archive_ids: list[str] = field(default_factory=list)
     source_missing_certification_archive_ids: list[str] = field(default_factory=list)
     source_invalid_certification_archive_ids: list[str] = field(default_factory=list)
+    source_missing_certification_lineage_archive_ids: list[str] = field(default_factory=list)
     missing_certification_archive_ids: list[str] = field(default_factory=list)
     invalid_certification_archive_ids: list[str] = field(default_factory=list)
+    missing_certification_lineage_archive_ids: list[str] = field(default_factory=list)
     diagnostic_only_outputs: list[str] = field(default_factory=list)
     null_test_prerequisite_source: str | None = None
     null_test_prerequisite_status: str = "not_checked"
@@ -150,8 +161,14 @@ class FailureArchiveRerunReadiness:
             "source_invalid_certification_archive_ids": list(
                 self.source_invalid_certification_archive_ids
             ),
+            "source_missing_certification_lineage_archive_ids": list(
+                self.source_missing_certification_lineage_archive_ids
+            ),
             "missing_certification_archive_ids": list(self.missing_certification_archive_ids),
             "invalid_certification_archive_ids": list(self.invalid_certification_archive_ids),
+            "missing_certification_lineage_archive_ids": list(
+                self.missing_certification_lineage_archive_ids
+            ),
             "diagnostic_only_outputs": list(self.diagnostic_only_outputs),
             "null_test_prerequisite_source": self.null_test_prerequisite_source,
             "null_test_prerequisite_status": self.null_test_prerequisite_status,
@@ -218,16 +235,30 @@ def classify_failure_archive_rerun_readiness(
     blockers.extend(_count_blockers("source_duplicate_archive_ids", source_duplicate_archive_ids))
     blockers.extend(_count_blockers("rerun_duplicate_archive_ids", rerun_duplicate_archive_ids))
 
-    source_missing_certification, source_invalid_certification = _certification_gaps(source_entries)
+    (
+        source_missing_certification,
+        source_invalid_certification,
+        source_missing_certification_lineage,
+    ) = _certification_gaps(source_entries)
     blockers.extend(
         _count_blockers("source_missing_certification_metadata", source_missing_certification)
     )
     blockers.extend(
         _count_blockers("source_invalid_certification_status", source_invalid_certification)
     )
-    missing_certification, invalid_certification = _certification_gaps(rerun_entries)
+    blockers.extend(
+        _count_blockers(
+            "source_missing_certification_lineage", source_missing_certification_lineage
+        )
+    )
+    (
+        missing_certification,
+        invalid_certification,
+        missing_certification_lineage,
+    ) = _certification_gaps(rerun_entries)
     blockers.extend(_count_blockers("missing_certification_metadata", missing_certification))
     blockers.extend(_count_blockers("invalid_certification_status", invalid_certification))
+    blockers.extend(_count_blockers("missing_certification_lineage", missing_certification_lineage))
 
     diagnostic_outputs = _diagnostic_only_outputs(Path(rerun_output) if rerun_output else None)
     null_source, null_status, missing_nulls, invalid_nulls = _null_test_prerequisite_gaps(
@@ -258,8 +289,10 @@ def classify_failure_archive_rerun_readiness(
         rerun_duplicate_archive_ids=rerun_duplicate_archive_ids,
         source_missing_certification_archive_ids=source_missing_certification,
         source_invalid_certification_archive_ids=source_invalid_certification,
+        source_missing_certification_lineage_archive_ids=source_missing_certification_lineage,
         missing_certification_archive_ids=missing_certification,
         invalid_certification_archive_ids=invalid_certification,
+        missing_certification_lineage_archive_ids=missing_certification_lineage,
         diagnostic_only_outputs=diagnostic_outputs,
         null_test_prerequisite_source=null_source,
         null_test_prerequisite_status=null_status,
@@ -443,11 +476,12 @@ def _scenario_family_missing(entry: dict[str, Any]) -> bool:
     return False
 
 
-def _certification_gaps(entries: list[dict[str, Any]]) -> tuple[list[str], list[str]]:
-    """Return archive IDs missing or failing rerun certification metadata."""
+def _certification_gaps(entries: list[dict[str, Any]]) -> tuple[list[str], list[str], list[str]]:
+    """Return archive IDs with missing, failing, or lineage-free certification metadata."""
 
     missing: list[str] = []
     invalid: list[str] = []
+    missing_lineage: list[str] = []
     for index, entry in enumerate(entries):
         archive_id = str(entry.get("archive_id") or f"<entry:{index}>")
         certification = _first_certification_value(entry)
@@ -457,7 +491,10 @@ def _certification_gaps(entries: list[dict[str, Any]]) -> tuple[list[str], list[
         status = _certification_status(certification)
         if status is None or status not in _PASSING_CERTIFICATION_STATUSES:
             invalid.append(archive_id)
-    return missing, invalid
+            continue
+        if not _certification_has_lineage(certification):
+            missing_lineage.append(archive_id)
+    return missing, invalid, missing_lineage
 
 
 def _first_certification_value(entry: dict[str, Any]) -> Any:
@@ -494,6 +531,27 @@ def _certification_status(value: Any) -> str | None:
                 return "failed"
         return "certified" if value else None
     return None
+
+
+def _certification_has_lineage(value: Any) -> bool:
+    """Return whether certification metadata names its source or provenance artifact."""
+
+    if not isinstance(value, dict):
+        return False
+    for key in _CERTIFICATION_LINEAGE_KEYS:
+        raw_value = value.get(key)
+        if raw_value is None:
+            continue
+        if isinstance(raw_value, str):
+            if raw_value.strip():
+                return True
+            continue
+        if isinstance(raw_value, list | tuple | set | dict):
+            if raw_value:
+                return True
+            continue
+        return True
+    return False
 
 
 def _null_test_prerequisite_gaps(

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -647,6 +647,36 @@ def test_structured_certification_lineage_satisfies_readiness(tmp_path: Path) ->
     assert readiness.missing_certification_lineage_archive_ids == []
 
 
+def test_falsy_certification_lineage_values_block_readiness(tmp_path: Path) -> None:
+    """Falsy lineage fields are placeholders, not source/provenance evidence."""
+
+    source_entry = _entry("source_0000", family="family_a", seed=1)
+    source_entry["certification_metadata"] = {
+        "status": "passed",
+        "source": False,
+    }
+    rerun_entry = _entry("rerun_0000", family="family_b", seed=101)
+    rerun_entry["certification_metadata"] = {
+        "status": "passed",
+        "provenance": {},
+        "artifact": 0,
+    }
+    source = _archive(tmp_path / "source.json", [source_entry])
+    rerun = _archive(tmp_path / "rerun.json", [rerun_entry])
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.source_missing_certification_lineage_archive_ids == ["source_0000"]
+    assert readiness.missing_certification_lineage_archive_ids == ["rerun_0000"]
+    assert "source_missing_certification_lineage:1" in readiness.blockers
+    assert "missing_certification_lineage:1" in readiness.blockers
+
+
 def test_diagnostic_only_output_caps_otherwise_ready_inputs(tmp_path: Path) -> None:
     """Diagnostic-only rerun outputs cannot be promoted to benchmark evidence."""
 

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -569,6 +569,84 @@ def test_failed_source_certification_status_is_invalid(tmp_path: Path) -> None:
     assert payload["source_invalid_certification_archive_ids"] == ["source_0000"]
 
 
+def test_missing_source_certification_lineage_blocks_readiness(tmp_path: Path) -> None:
+    """Passed source certification still needs provenance before disjoint rerun."""
+
+    source_entry = _entry("source_0000", family="family_a", seed=1)
+    source_entry["certification_metadata"] = {"status": "passed"}
+    source = _archive(tmp_path / "source.json", [source_entry])
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.source_missing_certification_lineage_archive_ids == ["source_0000"]
+    assert "source_missing_certification_lineage:1" in readiness.blockers
+    payload = readiness.to_payload()
+    assert payload["source_missing_certification_lineage_archive_ids"] == ["source_0000"]
+
+
+def test_missing_rerun_certification_lineage_blocks_readiness(tmp_path: Path) -> None:
+    """Passed rerun certification still needs provenance before held-out use."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun_entry = _entry("rerun_0000", family="family_b", seed=101)
+    rerun_entry["certification_metadata"] = {"status": "passed"}
+    rerun = _archive(tmp_path / "rerun.json", [rerun_entry])
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.missing_certification_lineage_archive_ids == ["rerun_0000"]
+    assert "missing_certification_lineage:1" in readiness.blockers
+    payload = readiness.to_payload()
+    assert payload["missing_certification_lineage_archive_ids"] == ["rerun_0000"]
+
+
+def test_structured_certification_lineage_satisfies_readiness(tmp_path: Path) -> None:
+    """Certification lineage can be a structured provenance object or scalar artifact ID."""
+
+    source_entry = _entry("source_0000", family="family_a", seed=1)
+    source_entry["certification_metadata"] = {
+        "status": "passed",
+        "source": " ",
+        "provenance": {"certifier": "unit-test"},
+    }
+    rerun_entry = _entry("rerun_0000", family="family_b", seed=101)
+    rerun_entry["certification_metadata"] = {
+        "status": "passed",
+        "source": " ",
+        "provenance": [],
+        "artifact": 7,
+    }
+    source = _archive(tmp_path / "source.json", [source_entry])
+    rerun = _archive(tmp_path / "rerun.json", [rerun_entry])
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=_null_test_prerequisites(),
+    )
+
+    assert readiness.status == READY
+    assert readiness.source_missing_certification_lineage_archive_ids == []
+    assert readiness.missing_certification_lineage_archive_ids == []
+
+
 def test_diagnostic_only_output_caps_otherwise_ready_inputs(tmp_path: Path) -> None:
     """Diagnostic-only rerun outputs cannot be promoted to benchmark evidence."""
 


### PR DESCRIPTION
## Summary

Adds one fail-closed readiness gate for issue #3275: a passing source or rerun archive certification now must include certification lineage, such as a source, provenance object, or evidence artifact path, before a proposal-model failure-archive rerun can be classified ready.

This is a bounded checker/test slice only. It does not run the proposal model, evaluate held-out yield, submit compute, or promote any benchmark, paper, or dissertation claim.

## Linked Issues

- Relates `#3275`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3275` remains open for the real disjoint certified failure archive rerun
- Safe review independently: yes
- Review dependency reason, any: bounded readiness checker extension only

## What Changed

- Extended `robot_sf.benchmark.failure_archive_rerun_readiness` so source and rerun archive entries with otherwise passing certification metadata fail closed when the certification metadata lacks lineage/provenance.
- Added source-side and rerun-side tests covering the new blockers and JSON payload fields.

## Why Matters

- Added value: prevents a certified failure archive from being treated rerun-ready when "certified" status is detached from any source/provenance/evidence pointer.
- Expected impact: strengthens archive input hygiene before any real proposal-model rerun is interpreted.
- Why worth merging now: small, reversible fail-closed preflight improvement inside the existing #3275 checker.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: blocker-resolution for certified failure archive input readiness; no benchmark result claim.
- Comparator or baseline, applicable: `origin/main` allowed passing certification metadata without lineage.
- Evidence tier: NA - support checker only; validation commands prove checker behavior, not research evidence.
- Result classification: NA - support checker only.
- Decision stop rule, applicable: readiness remains blocked until source and rerun archive certification metadata includes lineage/provenance.
- Parent issue, claim map, registry, context note, synthesis surface update: `#3275` remains parent tracking issue; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker only; it does not interpret research evidence.

## Domain-Aware Approval

- approval concerns experimental validity waived / pending / blocked / not required: not required for support checker; no benchmark interpretation or claim promotion.
- Approver/review source waiver: NA
- Validity checklist: fail-closed readiness gate only.
- Target claim/hypothesis: no result claim.
- Comparator split/evidence validity: no split result interpreted.
- Fallback/degraded exclusions: no fallback/degraded benchmark row produced.
- Claim boundary: readiness/leakage check only.
- Implementation integrity vs experimental validity: targeted tests verify blocker behavior; real archive evaluation remains deferred.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA - checker gate only.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue #3275 after real archive inputs exist.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action

- Rerun needed: yes, but outside this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: real disjoint certified failure archive rerun inputs and independent planner-execution outcomes remain unavailable in this PR.
- Stop / revise / continue decision: continue #3275 with real archive/evaluation work after readiness prerequisites are satisfied.
- Proposed child issue existing follow-up: `#3275`.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/adversarial/test_disjoint_evaluation.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` - passed.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr4088_body.md PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` - passed on `a924ce2d715eb3d1aae89694f0adadb7b5f9c2be` (core and optional lanes).
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` - passed after formatting.
- `env BASE_REF=origin/main PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` via compact wrapper - passed; summary artifact `.git/codex-agent-runs/active/issue-3275/pr-ready-interim/validation-20260701T150125Z-1112956.summary.json`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Risks / Rollout

- Compatibility risks: real archive fixtures with pass/fail certification status but no provenance field will now fail closed until lineage is added.
- Failure modes: accepted lineage key list may need extension if real certification packets use a different field name.
- Rollback fallback plan: remove the lineage blocker fields/check if real certification schema proves incompatible.

## Docs / Provenance

- Updated docs: none.
- Relevant design provenance notes: issue #3275 live thread and prior merged readiness slices.
- Any assumptions need to preserved: certification lineage can be represented by nonblank `source`, `provenance`, or artifact/path fields in certification metadata.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR only tightens the fail-closed readiness checker and does not produce benchmark evidence.

## Follow-Up Issues

- Deferred work: real disjoint certified failure archive rerun with independent planner-execution outcomes, certification/candidate lineage, null-test reporting, and bounded held-out yield interpretation.
- Issues opened follow-up: none; #3275 remains open.

## Reviewer Notes

- Please verify the accepted certification-lineage field list matches expected real certification packets.
- Known limitation: the gate checks that some lineage is present, not that the referenced artifact is durable or independently valid.

