### PR TITLE
Add constraints-first metric layer contract

### DIFF
--- a/robot_sf/benchmark/__init__.py
+++ b/robot_sf/benchmark/__init__.py
@@ -67,6 +67,15 @@ from robot_sf.benchmark.helper_registry import (
     OrchestratorUsage,
     RegressionCheck,
 )
+from robot_sf.benchmark.metric_layers import (
+    CANONICAL_METRIC_LAYERS,
+    CANONICAL_METRICS,
+    LAYER_ORDER,
+    METRIC_LAYER_SCHEMA_VERSION,
+    MetricDefinition,
+    MetricLayerDefinition,
+    build_metric_layer_summary,
+)
 from robot_sf.benchmark.scenario_failure_cause import (
     SCENARIO_FAILURE_CAUSE_SCHEMA_VERSION,
     VERDICT_DYNAMIC_BLOCKING_OR_DEADLOCK,
@@ -82,6 +91,8 @@ from robot_sf.benchmark.scenario_failure_cause import (
 )
 
 __all__ = [
+    "CANONICAL_METRICS",
+    "CANONICAL_METRIC_LAYERS",
     "DEFAULT_FORECAST_DATASET_ID",
     "DEFAULT_TRANSFER_DIMENSIONS",
     "FORECAST_BATCH_SCHEMA_VERSION",
@@ -90,6 +101,8 @@ __all__ = [
     "FORECAST_DATASET_SCHEMA_VERSION",
     "FORECAST_METRICS_SCHEMA_VERSION",
     "FORECAST_TRANSFERABILITY_STRESS_MATRIX_SCHEMA_VERSION",
+    "LAYER_ORDER",
+    "METRIC_LAYER_SCHEMA_VERSION",
     "SCENARIO_FAILURE_CAUSE_SCHEMA_VERSION",
     "VERDICT_DYNAMIC_BLOCKING_OR_DEADLOCK",
     "VERDICT_INDETERMINATE",
@@ -110,6 +123,8 @@ __all__ = [
     "ForecastObservationBatch",
     "HelperCapability",
     "HelperCategory",
+    "MetricDefinition",
+    "MetricLayerDefinition",
     "OracleFullStateForecastAdapter",
     "OrchestratorUsage",
     "RegressionCheck",
@@ -120,6 +135,7 @@ __all__ = [
     "build_forecast_calibration_report",
     "build_forecast_conformal_pilot_report",
     "build_forecast_transferability_stress_matrix",
+    "build_metric_layer_summary",
     "classify_scenario_failure_cause",
     "diagnostics_from_mapping",
     "evaluate_forecast_batch",

--- a/robot_sf/benchmark/cli.py
+++ b/robot_sf/benchmark/cli.py
@@ -53,12 +53,14 @@ from robot_sf.benchmark.canonical_table_export import load_rows_json as _load_ca
 from robot_sf.benchmark.distributions import collect_grouped_values as _dist_collect
 from robot_sf.benchmark.distributions import save_distributions as _dist_save
 from robot_sf.benchmark.doctor import collect_doctor_report, doctor_exit_code
+from robot_sf.benchmark.errors import EpisodeRecordInputError
 from robot_sf.benchmark.failure_extractor import extract_failures as _extract_failures
 from robot_sf.benchmark.failure_mechanism_classifier import (
     classify_failure_mechanisms_from_jsonl,
 )
 from robot_sf.benchmark.fallback_policy import availability_payload, benchmark_run_exit_code
 from robot_sf.benchmark.grouping import DEFAULT_REPORT_FALLBACK_GROUP_BY, DEFAULT_REPORT_GROUP_BY
+from robot_sf.benchmark.metric_layers import build_metric_layer_summary
 from robot_sf.benchmark.observation_levels import OBSERVATION_LEVEL_KEYS
 from robot_sf.benchmark.observation_noise import load_observation_noise_spec
 from robot_sf.benchmark.parquet_export import export_episodes_jsonl_to_parquet
@@ -522,6 +524,29 @@ def _handle_aggregate(args) -> int:
         return 0
     except Exception as exc:  # pragma: no cover - error path
         logging.exception("Aggregation failed: %s", exc)
+        return 2
+
+
+def _handle_metric_layers(args) -> int:
+    """Build canonical metric-layer summary from episode JSONL records.
+
+    Returns:
+        Exit code ``0`` on success, ``2`` on failure.
+    """
+    try:
+        records = _agg_read_jsonl(args.episodes)
+        summary = build_metric_layer_summary(
+            records,
+            group_by=args.group_by,
+            fallback_group_by=args.fallback_group_by,
+        )
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as f:
+            json.dump(summary, f, indent=2, allow_nan=False)
+        return 0
+    except (EpisodeRecordInputError, OSError, TypeError, ValueError) as exc:
+        logging.exception("Metric-layer summary failed: %s", exc)
         return 2
 
 
@@ -1866,6 +1891,29 @@ def _add_aggregate_subparser(
     p.set_defaults(cmd="aggregate")
 
 
+def _add_metric_layers_subparser(
+    subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
+) -> None:
+    """Register metric-layers subcommand parser."""
+    p = subparsers.add_parser(
+        "metric-layers",
+        help="Build canonical metric-layer summary from episode JSONL records.",
+    )
+    p.add_argument("--episodes", required=True, help="Input episodes JSONL path")
+    p.add_argument("--output", required=True, help="Output metric-layer JSON path")
+    p.add_argument(
+        "--group-by",
+        default="scenario_params.algo",
+        help="Grouping key (dotted path). Default: scenario_params.algo",
+    )
+    p.add_argument(
+        "--fallback-group-by",
+        default="algo",
+        help="Fallback grouping key when --group-by is missing. Default: algo",
+    )
+    p.set_defaults(cmd="metric-layers")
+
+
 def _add_stress_coverage_report_subparser(
     subparsers: argparse._SubParsersAction[argparse.ArgumentParser],
 ) -> None:
@@ -2531,6 +2579,7 @@ def _attach_core_subcommands(parser: argparse.ArgumentParser) -> None:  # noqa: 
     _add_run_subparser(subparsers)
     _add_summary_subparser(subparsers)
     _add_aggregate_subparser(subparsers)
+    _add_metric_layers_subparser(subparsers)
     _add_stress_coverage_report_subparser(subparsers)
     _add_classify_failure_mechanisms_subparser(subparsers)
     _add_claim_subparser(subparsers)
@@ -3036,6 +3085,7 @@ def cli_main(argv: list[str] | None = None) -> int:
         "run": _handle_run,
         "summary": _handle_summary,
         "aggregate": _handle_aggregate,
+        "metric-layers": _handle_metric_layers,
         "stress-coverage-report": _handle_stress_coverage_report,
         "classify-failure-mechanisms": _handle_classify_failure_mechanisms,
         "claim": _handle_claim,

--- a/robot_sf/benchmark/constraints_first_scoring.py
+++ b/robot_sf/benchmark/constraints_first_scoring.py
@@ -30,6 +30,8 @@ from typing import TYPE_CHECKING, Any
 
 from scipy.stats import beta
 
+from robot_sf.benchmark.metric_layers import LAYER_ORDER, METRIC_LAYER_SCHEMA_VERSION
+
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
@@ -281,6 +283,8 @@ def build_constraints_first_report(
     }
     report: dict[str, Any] = {
         "schema_version": CONSTRAINTS_FIRST_SCHEMA,
+        "metric_layer_schema_version": METRIC_LAYER_SCHEMA_VERSION,
+        "metric_layer_order": list(LAYER_ORDER),
         "evidence_kind": "diagnostic_proxy",
         "per_planner": per_planner,
     }

--- a/robot_sf/benchmark/metric_layers.py
+++ b/robot_sf/benchmark/metric_layers.py
@@ -430,7 +430,11 @@ def _resolve_failure_to_progress_rate(
 
     if "outcome.route_complete" not in view:
         return None, None
-    if view.get("outcome.collision_event") is True or view.get("outcome.timeout_event") is True:
+    collision_value, _ = _resolve_collision_rate(CANONICAL_METRICS["collision_rate"], view)
+    timeout_value, _ = _resolve_timeout_rate(view)
+    if (collision_value is not None and collision_value > 0.0) or (
+        timeout_value is not None and timeout_value > 0.0
+    ):
         return 0.0, "outcome.route_complete"
     route_complete = _as_flag(view["outcome.route_complete"])
     if route_complete is None:

--- a/robot_sf/benchmark/metric_layers.py
+++ b/robot_sf/benchmark/metric_layers.py
@@ -1,0 +1,630 @@
+"""Canonical benchmark metric-layer contract and aggregation adapter.
+
+This module organizes existing episode-record metrics into a constraints-first
+layer hierarchy. It does not produce new simulator metrics; missing values are
+reported as unavailable rather than imputed as zero.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+from robot_sf.benchmark.aggregate import flatten_metrics
+
+METRIC_LAYER_SCHEMA_VERSION = "metric-layers.v1"
+MISSING_METRIC_REASON = "metric_not_present_in_episode_records"
+
+LAYER_ORDER = (
+    "safety_gate",
+    "liveness",
+    "social_compliance",
+    "efficiency",
+    "comfort",
+    "operational",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class MetricLayerDefinition:
+    """One named layer in the constraints-first metric hierarchy."""
+
+    name: str
+    priority: int
+    description: str
+
+
+@dataclass(frozen=True, slots=True)
+class MetricDefinition:
+    """Canonical metadata for one layered benchmark metric."""
+
+    name: str
+    layer: str
+    source_keys: tuple[str, ...]
+    reduction: str
+    higher_is_better: bool | None
+    description: str
+    unavailable_reason_if_missing: str = MISSING_METRIC_REASON
+    source_kind: str = "episode_metric"
+
+
+CANONICAL_METRIC_LAYERS: tuple[MetricLayerDefinition, ...] = (
+    MetricLayerDefinition(
+        name="safety_gate",
+        priority=0,
+        description="Hard safety outcomes that should gate downstream comparisons.",
+    ),
+    MetricLayerDefinition(
+        name="liveness",
+        priority=1,
+        description="Progress and deadlock indicators after safety gates pass.",
+    ),
+    MetricLayerDefinition(
+        name="social_compliance",
+        priority=2,
+        description="Social-navigation compliance signals, including explicit proxy metrics.",
+    ),
+    MetricLayerDefinition(
+        name="efficiency",
+        priority=3,
+        description="Route completion efficiency and path-quality metrics.",
+    ),
+    MetricLayerDefinition(
+        name="comfort",
+        priority=4,
+        description="Motion smoothness and control-comfort metrics.",
+    ),
+    MetricLayerDefinition(
+        name="operational",
+        priority=5,
+        description="Human assistance, shielding, and operational-intervention indicators.",
+    ),
+)
+
+
+def _metric(
+    name: str,
+    layer: str,
+    source_keys: tuple[str, ...],
+    reduction: str,
+    higher_is_better: bool | None,
+    description: str,
+    *,
+    source_kind: str = "episode_metric",
+) -> tuple[str, MetricDefinition]:
+    """Build a registry entry keyed by canonical metric name.
+
+    Returns:
+        ``(name, definition)`` pair for deterministic registry construction.
+    """
+
+    return (
+        name,
+        MetricDefinition(
+            name=name,
+            layer=layer,
+            source_keys=source_keys,
+            reduction=reduction,
+            higher_is_better=higher_is_better,
+            description=description,
+            source_kind=source_kind,
+        ),
+    )
+
+
+CANONICAL_METRICS: dict[str, MetricDefinition] = dict(
+    (
+        _metric(
+            "collision_rate",
+            "safety_gate",
+            (
+                "metrics.collision_rate",
+                "metrics.collisions",
+                "outcome.collision_event",
+            ),
+            "episode_rate",
+            False,
+            "Episode collision rate, using stored rate or a collision-event derivation.",
+        ),
+        _metric(
+            "human_collision_rate",
+            "safety_gate",
+            ("metrics.human_collision_rate",),
+            "episode_rate",
+            False,
+            "Human-collision episode rate when explicitly produced.",
+        ),
+        _metric(
+            "near_miss_rate",
+            "safety_gate",
+            ("metrics.near_miss_rate", "metrics.near_misses"),
+            "episode_rate",
+            False,
+            "Near-miss rate or near-miss event count reduced to episode rate.",
+        ),
+        _metric(
+            "min_time_to_collision",
+            "safety_gate",
+            ("metrics.min_time_to_collision", "metrics.time_to_collision_min"),
+            "minimum",
+            True,
+            "Minimum time-to-collision when directly available.",
+        ),
+        _metric(
+            "minimum_pedestrian_distance",
+            "safety_gate",
+            (
+                "metrics.minimum_pedestrian_distance",
+                "metrics.min_pedestrian_distance",
+            ),
+            "minimum",
+            True,
+            "Minimum distance to pedestrians when directly available.",
+        ),
+        _metric(
+            "timeout_rate",
+            "liveness",
+            ("outcome.timeout_event", "termination_reason"),
+            "episode_rate",
+            False,
+            "Timeout episode rate from outcome metadata or known timeout termination reasons.",
+        ),
+        _metric(
+            "stopped_time_ratio",
+            "liveness",
+            ("metrics.stopped_time_ratio",),
+            "mean",
+            False,
+            "Fraction of episode time stopped when explicitly produced.",
+        ),
+        _metric(
+            "failure_to_progress_rate",
+            "liveness",
+            ("outcome.route_complete",),
+            "episode_rate",
+            False,
+            "Non-completion rate excluding collision and timeout episodes when outcomes exist.",
+        ),
+        _metric(
+            "deadlock_duration",
+            "liveness",
+            ("metrics.deadlock_duration", "metrics.deadlock_duration_s"),
+            "mean",
+            False,
+            "Deadlock duration when explicitly produced.",
+        ),
+        _metric(
+            "personal_space_violation_rate",
+            "social_compliance",
+            (
+                "metrics.personal_space_violation_rate",
+                "metrics.social_proxemic_intrusion_frac",
+            ),
+            "mean",
+            False,
+            "Personal-space violation rate; social-proxemic fields are simulation proxies.",
+            source_kind="simulation_proxy",
+        ),
+        _metric(
+            "group_intrusion_episode_rate",
+            "social_compliance",
+            ("metrics.group_intrusion_episode_rate",),
+            "episode_rate",
+            False,
+            "Group-intrusion episode rate when explicitly produced.",
+        ),
+        _metric(
+            "group_intrusion_time_ratio",
+            "social_compliance",
+            ("metrics.group_intrusion_time_ratio",),
+            "mean",
+            False,
+            "Group-intrusion time ratio when explicitly produced.",
+        ),
+        _metric(
+            "pedestrian_path_deviation",
+            "social_compliance",
+            (
+                "metrics.pedestrian_path_deviation",
+                "metrics.pedestrian_path_deviation_proxy_m",
+            ),
+            "mean",
+            False,
+            "Pedestrian path deviation; proxy fields are simulation proxies.",
+            source_kind="simulation_proxy",
+        ),
+        _metric(
+            "time_to_goal",
+            "efficiency",
+            ("metrics.time_to_goal", "metrics.time_to_goal_s"),
+            "mean",
+            False,
+            "Time to route goal when explicitly produced.",
+        ),
+        _metric(
+            "path_length",
+            "efficiency",
+            ("metrics.path_length", "metrics.path_length_m"),
+            "mean",
+            False,
+            "Path length when explicitly produced.",
+        ),
+        _metric(
+            "spl",
+            "efficiency",
+            ("metrics.SPL", "metrics.spl"),
+            "mean",
+            True,
+            "Success weighted by path length when explicitly produced.",
+        ),
+        _metric(
+            "acceleration",
+            "comfort",
+            ("metrics.acceleration", "metrics.acceleration_mean"),
+            "mean",
+            False,
+            "Acceleration comfort metric when explicitly produced.",
+        ),
+        _metric(
+            "jerk",
+            "comfort",
+            ("metrics.jerk", "metrics.jerk_mean"),
+            "mean",
+            False,
+            "Jerk comfort metric when explicitly produced.",
+        ),
+        _metric(
+            "angular_velocity",
+            "comfort",
+            ("metrics.angular_velocity", "metrics.angular_velocity_mean"),
+            "mean",
+            False,
+            "Angular velocity comfort metric when explicitly produced.",
+        ),
+        _metric(
+            "intervention_required",
+            "operational",
+            (
+                "metrics.intervention_required",
+                "metrics.shield_intervention_count",
+            ),
+            "episode_rate",
+            False,
+            "Operational intervention episode rate from explicit flags or shield count.",
+        ),
+        _metric(
+            "tele_assistance_required",
+            "operational",
+            ("metrics.tele_assistance_required",),
+            "episode_rate",
+            False,
+            "Tele-assistance required rate when explicitly produced.",
+        ),
+        _metric(
+            "tele_driving_required",
+            "operational",
+            ("metrics.tele_driving_required",),
+            "episode_rate",
+            False,
+            "Tele-driving required rate when explicitly produced.",
+        ),
+    )
+)
+
+
+def get_nested(record: Mapping[str, Any], path: str) -> Any:
+    """Resolve a dotted path from a mapping.
+
+    Returns:
+        Dotted-path value, or ``None`` when absent.
+    """
+
+    current: Any = record
+    for part in path.split("."):
+        if isinstance(current, Mapping) and part in current:
+            current = current[part]
+        else:
+            return None
+    return current
+
+
+def _episode_view(record: Mapping[str, Any]) -> dict[str, Any]:
+    """Return flattened metric and selected top-level aliases for one episode."""
+
+    record_dict = dict(record)
+    flattened = flatten_metrics(record_dict)
+    view: dict[str, Any] = {f"metrics.{key}": value for key, value in flattened.items()}
+    view.update(flattened)
+    outcome = record.get("outcome")
+    if isinstance(outcome, Mapping):
+        for key in ("collision_event", "timeout_event", "route_complete"):
+            if key in outcome:
+                view[f"outcome.{key}"] = outcome[key]
+    if "termination_reason" in record:
+        view["termination_reason"] = record["termination_reason"]
+    for source_key in ("scenario_params.algo", "algo"):
+        value = get_nested(record, source_key)
+        if value is not None:
+            view[source_key] = value
+    return view
+
+
+def _as_float(value: Any) -> float | None:
+    """Coerce numeric and boolean values to float.
+
+    Returns:
+        Float value, or ``None`` for unsupported values.
+    """
+
+    if isinstance(value, bool):
+        return 1.0 if value else 0.0
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _as_flag(value: Any) -> float | None:
+    """Coerce booleans/counts/rates to a bounded episode flag.
+
+    Returns:
+        ``1.0`` for positive values, ``0.0`` for zero/false, or ``None``.
+    """
+
+    number = _as_float(value)
+    if number is None:
+        return None
+    return 1.0 if number > 0.0 else 0.0
+
+
+def _resolve_collision_rate(
+    definition: MetricDefinition,
+    view: Mapping[str, Any],
+) -> tuple[float | None, str | None]:
+    """Resolve collision rate from stored rate, count, or outcome flag.
+
+    Returns:
+        ``(value, source_key)`` when available, else ``(None, None)``.
+    """
+
+    for key in definition.source_keys:
+        if key not in view:
+            continue
+        value = view[key]
+        if key == "metrics.collision_rate":
+            return _as_float(value), key
+        return _as_flag(value), key
+    return None, None
+
+
+def _resolve_timeout_rate(view: Mapping[str, Any]) -> tuple[float | None, str | None]:
+    """Resolve timeout rate from outcome or known timeout termination reasons.
+
+    Returns:
+        ``(value, source_key)`` when available, else ``(None, None)``.
+    """
+
+    if "outcome.timeout_event" in view:
+        return _as_flag(view["outcome.timeout_event"]), "outcome.timeout_event"
+    if view.get("termination_reason") in {"truncated", "max_steps"}:
+        return 1.0, "termination_reason"
+    return None, None
+
+
+def _resolve_failure_to_progress_rate(
+    view: Mapping[str, Any],
+) -> tuple[float | None, str | None]:
+    """Resolve failure-to-progress rate when explicit route outcome exists.
+
+    Returns:
+        ``(value, source_key)`` when available, else ``(None, None)``.
+    """
+
+    if "outcome.route_complete" not in view:
+        return None, None
+    if view.get("outcome.collision_event") is True or view.get("outcome.timeout_event") is True:
+        return 0.0, "outcome.route_complete"
+    return (0.0 if bool(view["outcome.route_complete"]) else 1.0), "outcome.route_complete"
+
+
+def _resolve_intervention_required(
+    definition: MetricDefinition,
+    view: Mapping[str, Any],
+) -> tuple[float | None, str | None]:
+    """Resolve intervention-required from explicit flag or shield count.
+
+    Returns:
+        ``(value, source_key)`` when available, else ``(None, None)``.
+    """
+
+    for key in definition.source_keys:
+        if key in view:
+            return _as_flag(view[key]), key
+    return None, None
+
+
+def _resolve_metric_value(
+    definition: MetricDefinition,
+    view: Mapping[str, Any],
+) -> tuple[float | None, str | None]:
+    """Resolve one metric value for one episode under conservative rules.
+
+    Returns:
+        ``(value, selected_source_key)`` when available, else ``(None, None)``.
+    """
+
+    if definition.name == "collision_rate":
+        return _resolve_collision_rate(definition, view)
+
+    if definition.name == "timeout_rate":
+        return _resolve_timeout_rate(view)
+
+    if definition.name == "failure_to_progress_rate":
+        return _resolve_failure_to_progress_rate(view)
+
+    if definition.name == "intervention_required":
+        return _resolve_intervention_required(definition, view)
+
+    for key in definition.source_keys:
+        if key not in view:
+            continue
+        value = view[key]
+        if definition.reduction in {"episode_rate", "any_rate"}:
+            return _as_flag(value), key
+        return _as_float(value), key
+    return None, None
+
+
+def _reduce(values: Sequence[float], reduction: str) -> float | None:
+    """Reduce available episode values according to the metric contract.
+
+    Returns:
+        Reduced value, or ``None`` when no values are available.
+    """
+
+    if not values:
+        return None
+    if reduction in {"episode_rate", "mean", "any_rate"}:
+        return sum(values) / len(values)
+    if reduction == "minimum":
+        return min(values)
+    if reduction == "maximum":
+        return max(values)
+    raise ValueError(f"unknown metric-layer reduction: {reduction}")
+
+
+def _summarize_metric(
+    definition: MetricDefinition,
+    views: Sequence[Mapping[str, Any]],
+) -> dict[str, Any]:
+    """Summarize one metric across episode views.
+
+    Returns:
+        JSON-serializable metric availability and aggregate payload.
+    """
+
+    values: list[float] = []
+    selected_sources: list[str] = []
+    for view in views:
+        value, source = _resolve_metric_value(definition, view)
+        if value is None:
+            continue
+        values.append(value)
+        if source is not None and source not in selected_sources:
+            selected_sources.append(source)
+
+    value = _reduce(values, definition.reduction)
+    if value is None:
+        return {
+            "status": "unavailable",
+            "value": None,
+            "support_count": 0,
+            "source_keys": list(definition.source_keys),
+            "reduction": definition.reduction,
+            "higher_is_better": definition.higher_is_better,
+            "source_kind": definition.source_kind,
+            "unavailable_reason": definition.unavailable_reason_if_missing,
+        }
+
+    return {
+        "status": "available",
+        "value": value,
+        "support_count": len(values),
+        "source_keys": list(definition.source_keys),
+        "selected_source_keys": selected_sources,
+        "reduction": definition.reduction,
+        "higher_is_better": definition.higher_is_better,
+        "source_kind": definition.source_kind,
+    }
+
+
+def _layer_summary(views: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Build layer summaries over a sequence of episode views.
+
+    Returns:
+        Mapping from layer name to layer metadata and metric summaries.
+    """
+
+    layers: dict[str, Any] = {}
+    layer_defs = {definition.name: definition for definition in CANONICAL_METRIC_LAYERS}
+    for layer_name in LAYER_ORDER:
+        layer_def = layer_defs[layer_name]
+        layer_metrics = {
+            metric.name: _summarize_metric(metric, views)
+            for metric in CANONICAL_METRICS.values()
+            if metric.layer == layer_name
+        }
+        layers[layer_name] = {
+            "priority": layer_def.priority,
+            "description": layer_def.description,
+            "metrics": layer_metrics,
+        }
+    return layers
+
+
+def _group_key(
+    record: Mapping[str, Any],
+    *,
+    group_by: str,
+    fallback_group_by: str,
+) -> str:
+    """Resolve a group key from an episode record.
+
+    Returns:
+        Group key value, or ``"unknown"`` when both keys are absent.
+    """
+
+    value = get_nested(record, group_by)
+    if value is None:
+        value = get_nested(record, fallback_group_by)
+    return str(value) if value is not None else "unknown"
+
+
+def build_metric_layer_summary(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    group_by: str = "scenario_params.algo",
+    fallback_group_by: str = "algo",
+) -> dict[str, Any]:
+    """Build canonical metric-layer availability and aggregate summary.
+
+    Returns:
+        JSON-serializable summary over all records and per resolved group.
+    """
+
+    views = [_episode_view(record) for record in records]
+    groups: dict[str, list[Mapping[str, Any]]] = {}
+    for record, view in zip(records, views, strict=True):
+        groups.setdefault(
+            _group_key(record, group_by=group_by, fallback_group_by=fallback_group_by),
+            [],
+        ).append(view)
+
+    return {
+        "schema_version": METRIC_LAYER_SCHEMA_VERSION,
+        "n_episodes": len(records),
+        "group_by": group_by,
+        "fallback_group_by": fallback_group_by,
+        "layer_order": list(LAYER_ORDER),
+        "layers": _layer_summary(views),
+        "groups": {
+            group: {
+                "n_episodes": len(group_views),
+                "layers": _layer_summary(group_views),
+            }
+            for group, group_views in sorted(groups.items())
+        },
+    }
+
+
+__all__ = [
+    "CANONICAL_METRICS",
+    "CANONICAL_METRIC_LAYERS",
+    "LAYER_ORDER",
+    "METRIC_LAYER_SCHEMA_VERSION",
+    "MISSING_METRIC_REASON",
+    "MetricDefinition",
+    "MetricLayerDefinition",
+    "build_metric_layer_summary",
+    "get_nested",
+]

--- a/robot_sf/benchmark/metric_layers.py
+++ b/robot_sf/benchmark/metric_layers.py
@@ -7,6 +7,7 @@ reported as unavailable rather than imputed as zero.
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import Any
@@ -360,7 +361,9 @@ def _as_float(value: Any) -> float | None:
     if isinstance(value, bool):
         return 1.0 if value else 0.0
     if isinstance(value, int | float):
-        return float(value)
+        numeric_value = float(value)
+        if math.isfinite(numeric_value):
+            return numeric_value
     return None
 
 
@@ -392,8 +395,11 @@ def _resolve_collision_rate(
             continue
         value = view[key]
         if key == "metrics.collision_rate":
-            return _as_float(value), key
-        return _as_flag(value), key
+            numeric_value = _as_float(value)
+        else:
+            numeric_value = _as_flag(value)
+        if numeric_value is not None:
+            return numeric_value, key
     return None, None
 
 
@@ -405,7 +411,9 @@ def _resolve_timeout_rate(view: Mapping[str, Any]) -> tuple[float | None, str | 
     """
 
     if "outcome.timeout_event" in view:
-        return _as_flag(view["outcome.timeout_event"]), "outcome.timeout_event"
+        timeout_value = _as_flag(view["outcome.timeout_event"])
+        if timeout_value is not None:
+            return timeout_value, "outcome.timeout_event"
     if view.get("termination_reason") in {"truncated", "max_steps"}:
         return 1.0, "termination_reason"
     return None, None
@@ -424,7 +432,10 @@ def _resolve_failure_to_progress_rate(
         return None, None
     if view.get("outcome.collision_event") is True or view.get("outcome.timeout_event") is True:
         return 0.0, "outcome.route_complete"
-    return (0.0 if bool(view["outcome.route_complete"]) else 1.0), "outcome.route_complete"
+    route_complete = _as_flag(view["outcome.route_complete"])
+    if route_complete is None:
+        return None, None
+    return (0.0 if route_complete > 0.0 else 1.0), "outcome.route_complete"
 
 
 def _resolve_intervention_required(
@@ -439,7 +450,9 @@ def _resolve_intervention_required(
 
     for key in definition.source_keys:
         if key in view:
-            return _as_flag(view[key]), key
+            intervention_value = _as_flag(view[key])
+            if intervention_value is not None:
+                return intervention_value, key
     return None, None
 
 
@@ -470,8 +483,11 @@ def _resolve_metric_value(
             continue
         value = view[key]
         if definition.reduction in {"episode_rate", "any_rate"}:
-            return _as_flag(value), key
-        return _as_float(value), key
+            numeric_value = _as_flag(value)
+        else:
+            numeric_value = _as_float(value)
+        if numeric_value is not None:
+            return numeric_value, key
     return None, None
 
 

--- a/tests/benchmark/test_metric_layers.py
+++ b/tests/benchmark/test_metric_layers.py
@@ -1,0 +1,241 @@
+"""Tests for issue #3966 canonical benchmark metric layers."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from robot_sf.benchmark.cli import cli_main as benchmark_cli_main
+from robot_sf.benchmark.constraints_first_scoring import build_constraints_first_report
+from robot_sf.benchmark.metric_layers import (
+    CANONICAL_METRICS,
+    LAYER_ORDER,
+    METRIC_LAYER_SCHEMA_VERSION,
+    build_metric_layer_summary,
+)
+
+EXPECTED_METRICS = {
+    "collision_rate",
+    "human_collision_rate",
+    "near_miss_rate",
+    "min_time_to_collision",
+    "minimum_pedestrian_distance",
+    "timeout_rate",
+    "stopped_time_ratio",
+    "failure_to_progress_rate",
+    "deadlock_duration",
+    "personal_space_violation_rate",
+    "group_intrusion_episode_rate",
+    "group_intrusion_time_ratio",
+    "pedestrian_path_deviation",
+    "time_to_goal",
+    "path_length",
+    "spl",
+    "acceleration",
+    "jerk",
+    "angular_velocity",
+    "intervention_required",
+    "tele_assistance_required",
+    "tele_driving_required",
+}
+
+
+def _minimal_episode(*, algo: str = "planner_a") -> dict[str, object]:
+    """Build a minimal episode record with current schema-level outcome fields."""
+
+    return {
+        "algo": algo,
+        "scenario_params": {"algo": algo},
+        "metrics": {},
+        "outcome": {
+            "route_complete": True,
+            "collision_event": False,
+            "timeout_event": False,
+        },
+        "termination_reason": "success",
+    }
+
+
+def test_layer_order_matches_contract() -> None:
+    """The canonical layer order is stable and constraints-first."""
+
+    assert LAYER_ORDER == (
+        "safety_gate",
+        "liveness",
+        "social_compliance",
+        "efficiency",
+        "comfort",
+        "operational",
+    )
+
+
+def test_all_issue_metrics_are_registered_once() -> None:
+    """Every issue-listed metric has exactly one canonical registry entry."""
+
+    assert set(CANONICAL_METRICS) == EXPECTED_METRICS
+    assert len(CANONICAL_METRICS) == len(EXPECTED_METRICS)
+
+
+def test_missing_metric_is_unavailable_not_zero() -> None:
+    """Unavailable metrics must not be silently converted to zero."""
+
+    summary = build_metric_layer_summary([_minimal_episode()])
+
+    metric = summary["layers"]["safety_gate"]["metrics"]["min_time_to_collision"]
+
+    assert metric["status"] == "unavailable"
+    assert metric["value"] is None
+    assert metric["support_count"] == 0
+    assert metric["unavailable_reason"] == "metric_not_present_in_episode_records"
+
+
+def test_collision_rate_can_be_derived_from_existing_episode_records() -> None:
+    """Collision rate derives from current collision count/outcome fields."""
+
+    records = [
+        {
+            **_minimal_episode(algo="planner_a"),
+            "metrics": {"collisions": 0},
+            "outcome": {
+                "route_complete": True,
+                "collision_event": False,
+                "timeout_event": False,
+            },
+        },
+        {
+            **_minimal_episode(algo="planner_a"),
+            "metrics": {"collisions": 1},
+            "outcome": {
+                "route_complete": False,
+                "collision_event": True,
+                "timeout_event": False,
+            },
+        },
+    ]
+
+    summary = build_metric_layer_summary(records)
+    metric = summary["layers"]["safety_gate"]["metrics"]["collision_rate"]
+
+    assert metric["status"] == "available"
+    assert metric["value"] == pytest.approx(0.5)
+    assert metric["support_count"] == 2
+    assert metric["selected_source_keys"] == ["metrics.collisions"]
+
+
+def test_timeout_and_failure_to_progress_derivations_are_conservative() -> None:
+    """Liveness derivations use only explicit route/outcome fields."""
+
+    records = [
+        _minimal_episode(algo="planner_a"),
+        {
+            **_minimal_episode(algo="planner_a"),
+            "outcome": {
+                "route_complete": False,
+                "collision_event": False,
+                "timeout_event": True,
+            },
+            "termination_reason": "max_steps",
+        },
+        {
+            **_minimal_episode(algo="planner_a"),
+            "outcome": {
+                "route_complete": False,
+                "collision_event": False,
+                "timeout_event": False,
+            },
+            "termination_reason": "stalled_without_progress",
+        },
+    ]
+
+    summary = build_metric_layer_summary(records)
+    liveness = summary["layers"]["liveness"]["metrics"]
+
+    assert liveness["timeout_rate"]["value"] == pytest.approx(1 / 3)
+    assert liveness["failure_to_progress_rate"]["value"] == pytest.approx(1 / 3)
+
+
+def test_proxy_social_metrics_are_marked_as_simulation_proxy() -> None:
+    """Existing social proxy fields stay explicitly labeled as proxies."""
+
+    record = {
+        **_minimal_episode(),
+        "metrics": {
+            "social_proxemic_intrusion_frac": 0.25,
+            "pedestrian_path_deviation_proxy_m": 1.5,
+        },
+    }
+
+    summary = build_metric_layer_summary([record])
+    social = summary["layers"]["social_compliance"]["metrics"]
+
+    assert social["personal_space_violation_rate"]["status"] == "available"
+    assert social["personal_space_violation_rate"]["source_kind"] == "simulation_proxy"
+    assert social["pedestrian_path_deviation"]["value"] == pytest.approx(1.5)
+    assert social["pedestrian_path_deviation"]["source_kind"] == "simulation_proxy"
+
+
+def test_metric_layer_summary_includes_grouped_views() -> None:
+    """The adapter exposes per-planner layer summaries without dropping overall layers."""
+
+    records = [
+        {**_minimal_episode(algo="planner_a"), "metrics": {"collisions": 0}},
+        {**_minimal_episode(algo="planner_b"), "metrics": {"collisions": 1}},
+    ]
+
+    summary = build_metric_layer_summary(records)
+
+    assert summary["n_episodes"] == 2
+    assert set(summary["groups"]) == {"planner_a", "planner_b"}
+    assert summary["groups"]["planner_a"]["n_episodes"] == 1
+    assert summary["layers"]["safety_gate"]["metrics"]["collision_rate"]["value"] == pytest.approx(
+        0.5
+    )
+
+
+def test_constraints_first_report_advertises_metric_layer_contract() -> None:
+    """Constraints-first reports name the shared layer contract without reranking changes."""
+
+    report = build_constraints_first_report(
+        {"planner_a": [{"collisions": 0, "comfort": 0.8, "efficiency": 0.7, "safe_success": True}]}
+    )
+
+    assert report["metric_layer_schema_version"] == METRIC_LAYER_SCHEMA_VERSION
+    assert report["metric_layer_order"] == list(LAYER_ORDER)
+
+
+def test_metric_layers_cli_writes_summary(tmp_path) -> None:
+    """The optional benchmark CLI command writes a metric-layer JSON summary."""
+
+    episodes = tmp_path / "episodes.jsonl"
+    output = tmp_path / "metric_layers.json"
+    episodes.write_text(
+        "\n".join(
+            json.dumps(record)
+            for record in [
+                {**_minimal_episode(algo="planner_a"), "metrics": {"collisions": 0}},
+                {**_minimal_episode(algo="planner_a"), "metrics": {"collisions": 1}},
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        benchmark_cli_main(
+            [
+                "metric-layers",
+                "--episodes",
+                str(episodes),
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert payload["schema_version"] == METRIC_LAYER_SCHEMA_VERSION
+    assert payload["layers"]["safety_gate"]["metrics"]["collision_rate"]["value"] == pytest.approx(
+        0.5
+    )

--- a/tests/benchmark/test_metric_layers.py
+++ b/tests/benchmark/test_metric_layers.py
@@ -193,6 +193,29 @@ def test_metric_layer_summary_includes_grouped_views() -> None:
     )
 
 
+def test_non_finite_metric_values_are_ignored_with_alias_fallback() -> None:
+    """NaN/Inf values are unavailable and do not mask later valid aliases."""
+
+    record = {
+        **_minimal_episode(),
+        "metrics": {
+            "collision_rate": float("nan"),
+            "collisions": 1,
+            "time_to_goal": float("inf"),
+        },
+    }
+
+    summary = build_metric_layer_summary([record])
+    collision = summary["layers"]["safety_gate"]["metrics"]["collision_rate"]
+    time_to_goal = summary["layers"]["efficiency"]["metrics"]["time_to_goal"]
+
+    assert collision["status"] == "available"
+    assert collision["value"] == pytest.approx(1.0)
+    assert collision["selected_source_keys"] == ["metrics.collisions"]
+    assert time_to_goal["status"] == "unavailable"
+    assert time_to_goal["support_count"] == 0
+
+
 def test_constraints_first_report_advertises_metric_layer_contract() -> None:
     """Constraints-first reports name the shared layer contract without reranking changes."""
 
@@ -239,3 +262,46 @@ def test_metric_layers_cli_writes_summary(tmp_path) -> None:
     assert payload["layers"]["safety_gate"]["metrics"]["collision_rate"]["value"] == pytest.approx(
         0.5
     )
+
+
+def test_metric_layers_cli_filters_non_finite_values_before_json_output(tmp_path) -> None:
+    """Metric-layer CLI output remains strict JSON when inputs contain NaN/Inf."""
+
+    episodes = tmp_path / "episodes.jsonl"
+    output = tmp_path / "metric_layers.json"
+    episodes.write_text(
+        json.dumps(
+            {
+                **_minimal_episode(),
+                "metrics": {
+                    "collision_rate": float("nan"),
+                    "collisions": 0,
+                    "time_to_goal": float("inf"),
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    assert (
+        benchmark_cli_main(
+            [
+                "metric-layers",
+                "--episodes",
+                str(episodes),
+                "--output",
+                str(output),
+            ]
+        )
+        == 0
+    )
+
+    output_text = output.read_text(encoding="utf-8")
+    assert "NaN" not in output_text
+    assert "Infinity" not in output_text
+    payload = json.loads(output_text)
+    assert payload["layers"]["safety_gate"]["metrics"]["collision_rate"]["value"] == pytest.approx(
+        0.0
+    )
+    assert payload["layers"]["efficiency"]["metrics"]["time_to_goal"]["status"] == "unavailable"

--- a/tests/benchmark/test_metric_layers.py
+++ b/tests/benchmark/test_metric_layers.py
@@ -146,13 +146,30 @@ def test_timeout_and_failure_to_progress_derivations_are_conservative() -> None:
             },
             "termination_reason": "stalled_without_progress",
         },
+        {
+            **_minimal_episode(algo="planner_a"),
+            "metrics": {"collisions": 1},
+            "outcome": {
+                "route_complete": False,
+                "collision_event": False,
+                "timeout_event": False,
+            },
+        },
+        {
+            **_minimal_episode(algo="planner_a"),
+            "outcome": {
+                "route_complete": False,
+                "collision_event": False,
+            },
+            "termination_reason": "truncated",
+        },
     ]
 
     summary = build_metric_layer_summary(records)
     liveness = summary["layers"]["liveness"]["metrics"]
 
-    assert liveness["timeout_rate"]["value"] == pytest.approx(1 / 3)
-    assert liveness["failure_to_progress_rate"]["value"] == pytest.approx(1 / 3)
+    assert liveness["timeout_rate"]["value"] == pytest.approx(2 / 5)
+    assert liveness["failure_to_progress_rate"]["value"] == pytest.approx(1 / 5)
 
 
 def test_proxy_social_metrics_are_marked_as_simulation_proxy() -> None:


### PR DESCRIPTION
## Summary
- Add a canonical benchmark metric-layer contract for Issue #3966, including layer definitions, metric registry metadata, and conservative episode aggregation helpers.
- Expose the contract through `robot_sf.benchmark`, add a `robot_sf_bench metric-layers` CLI export path, and advertise the schema/order in constraints-first reports.
- Preserve the claim boundary: this is a benchmark-contract/adapter slice only, with no simulator metric producers, SNQI semantics, Slurm runs, paper/dissertation claim, or benchmark-strength result promoted.

Closes #3966

## Stack / Sequencing
- [x] This PR is independent and can merge to `main` without another open PR landing first.
- [ ] This PR is stacked on another PR: #____
- Merge order / dependency notes: none.
- Follow-up issue(s): producer-side metric availability for absent fields such as time-to-collision, stopped-time, deadlock, group intrusion, and tele-assistance/driving remains separate from this contract slice.

## Research Guidance Check
- Primary evidence / risk class: metric-facing benchmark contract and adapter metadata.
- Validation tier used: targeted tests for the new contract plus full `pr_ready_check`.
- Result classification: implementation support only; no benchmark result, safety ranking, scenario-horizon interpretation, paper claim, or dissertation claim promoted.
- Caveats / blockers: unavailable raw metrics remain `status: unavailable`, `value: null`, and `support_count: 0`; absent fields are never inferred as zero.

## Domain-Aware Approval
- [ ] Domain approval required before merge because this changes benchmark semantics, safety claims, or paper-facing conclusions.
- [x] Domain approval not required before merge; this PR adds metadata/adapter plumbing and tests without promoting a benchmark conclusion.
- Reviewer requested for domain approval: n/a
- Approval evidence / notes: conservative derivations match the issue instructions; unavailable metrics fail closed.

## Validation
- [x] `uv run pytest tests/benchmark/test_metric_layers.py tests/benchmark/test_constraints_first_scoring.py -q`
- [x] `uv run pytest tests/ -k "metric_layer" -q`
- [x] `uv run pytest tests/ -k "metric_layer or constraints_first" -q`
- [x] `uv run ruff check robot_sf/benchmark/metric_layers.py robot_sf/benchmark/constraints_first_scoring.py robot_sf/benchmark/__init__.py robot_sf/benchmark/cli.py tests/benchmark/test_metric_layers.py`
- [x] `uv run ruff format --check robot_sf/benchmark/metric_layers.py robot_sf/benchmark/constraints_first_scoring.py robot_sf/benchmark/__init__.py robot_sf/benchmark/cli.py tests/benchmark/test_metric_layers.py`
- [x] `git diff --check`
- [x] `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (`3949 passed, 7 skipped`; stamp passed for `6f9ea58c51a5478b9bd61ac3abe8c67d9949f122`)
- [x] `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree`

## Artifacts and Provenance
- No durable benchmark artifacts were created.
- Ignored validation outputs under `output/coverage/` and `output/validation/pr_ready/` are local cache/proof outputs and are not committed.
- No `output/` raw benchmark data, Slurm logs, model caches, or checkpoints are included.