### PR TITLE
Issue #1496: improve oracle imitation warm-start readiness blockers

### DIFF
--- a/robot_sf/training/oracle_imitation_warm_start_readiness.py
+++ b/robot_sf/training/oracle_imitation_warm_start_readiness.py
@@ -209,9 +209,9 @@ def _check_dataset_packet(
             require_training_ready=True,
         )
     except LaunchPacketError as exc:
-        # Fold the multi-line validator message into the blocker list as a single, compact
-        # reason so the readiness report stays scannable.
-        reason = str(exc).splitlines()[0]
+        # Preserve the first actionable field-level launch-packet error instead
+        # of only echoing the validator's generic header.
+        reason = _first_launch_packet_error(exc)
         blockers.append(f"dataset_launch_packet not training-ready: {reason}")
         return {"path": path_text, "ready": False, "detail": str(exc)}
 
@@ -221,6 +221,19 @@ def _check_dataset_packet(
         "dataset_id": packet_report["dataset_id"],
         "training_ready": packet_report["training_ready"],
     }
+
+
+def _first_launch_packet_error(exc: LaunchPacketError) -> str:
+    """Return the first actionable launch-packet validator error line."""
+
+    for line in str(exc).splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped == "oracle-imitation launch packet failed validation:":
+            continue
+        return stripped.removeprefix("- ").strip()
+    return str(exc)
 
 
 def _check_required_file(

--- a/robot_sf/training/oracle_imitation_warm_start_readiness.py
+++ b/robot_sf/training/oracle_imitation_warm_start_readiness.py
@@ -230,10 +230,20 @@ def _first_launch_packet_error(exc: LaunchPacketError) -> str:
         stripped = line.strip()
         if not stripped:
             continue
-        if stripped == "oracle-imitation launch packet failed validation:":
+        if _is_launch_packet_error_header(stripped):
             continue
         return stripped.removeprefix("- ").strip()
     return str(exc)
+
+
+def _is_launch_packet_error_header(line: str) -> bool:
+    """Return true for launch-packet validator summary header lines."""
+
+    return (
+        line.startswith("oracle-imitation")
+        and "packet" in line
+        and line.endswith("failed validation:")
+    )
 
 
 def _check_required_file(

--- a/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 
 import yaml
 
-from robot_sf.training.oracle_imitation_warm_start_readiness import check_warm_start_readiness
+from robot_sf.training.oracle_imitation_launch_packet import LaunchPacketError
+from robot_sf.training.oracle_imitation_warm_start_readiness import (
+    _first_launch_packet_error,
+    check_warm_start_readiness,
+)
 from scripts.validation.check_oracle_imitation_warm_start_readiness import main as check_cli_main
 from tests.training.test_oracle_imitation_warm_start_readiness import (
     _ready_manifest,
@@ -90,6 +94,24 @@ def test_missing_collection_manifest_destination_is_actionable_blocker(tmp_path:
             "collection_roots.manifest_destination must be a non-empty string"
         )
         for blocker in report["blockers"]
+    )
+
+
+def test_launch_packet_error_header_filter_is_not_exact_string_coupled() -> None:
+    """Readiness reports field-level launch-packet errors despite header wording."""
+
+    error = LaunchPacketError(
+        "\n".join(
+            [
+                "oracle-imitation dataset launch packet failed validation:",
+                "- collection_roots.manifest_destination must be non-empty string",
+            ]
+        )
+    )
+
+    assert (
+        _first_launch_packet_error(error)
+        == "collection_roots.manifest_destination must be non-empty string"
     )
 
 

--- a/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
@@ -45,6 +45,54 @@ def test_missing_trace_manifest_provenance_blocks_readiness(tmp_path: Path) -> N
     )
 
 
+def test_missing_dataset_provenance_field_is_actionable_blocker(tmp_path: Path) -> None:
+    """Missing packet provenance reports the field-level blocker."""
+
+    manifest_dict = _ready_manifest(tmp_path)
+    packet = _write_training_ready_packet(tmp_path)
+    payload = yaml.safe_load(packet.read_text(encoding="utf-8"))
+    payload.pop("generating_commit")
+    packet.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    manifest_dict["dataset_launch_packet"] = str(packet)
+    manifest = _write_manifest(tmp_path, manifest_dict)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert any(
+        blocker
+        == (
+            "dataset_launch_packet not training-ready: "
+            "generating_commit must be a 40-character git SHA"
+        )
+        for blocker in report["blockers"]
+    )
+
+
+def test_missing_collection_manifest_destination_is_actionable_blocker(tmp_path: Path) -> None:
+    """Missing collection output-manifest destination reports the field-level blocker."""
+
+    manifest_dict = _ready_manifest(tmp_path)
+    packet = _write_training_ready_packet(tmp_path)
+    payload = yaml.safe_load(packet.read_text(encoding="utf-8"))
+    payload["collection_roots"].pop("manifest_destination")
+    packet.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+    manifest_dict["dataset_launch_packet"] = str(packet)
+    manifest = _write_manifest(tmp_path, manifest_dict)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert any(
+        blocker
+        == (
+            "dataset_launch_packet not training-ready: "
+            "collection_roots.manifest_destination must be a non-empty string"
+        )
+        for blocker in report["blockers"]
+    )
+
+
 def test_cli_writes_blocked_decision_manifest_when_file_missing(tmp_path: Path) -> None:
     """The CLI writes a stable blocked decision manifest for unmet prerequisites."""
     manifest = _write_ready_manifest(tmp_path, missing_file=True)


### PR DESCRIPTION
## Summary
- Improves the issue #1496 oracle-imitation warm-start readiness checker so dataset launch-packet blockers preserve the first actionable field-level error instead of the generic validator header.
- Adds focused synthetic tests for missing dataset provenance (`generating_commit`) and missing collection output-manifest destination blockers.

## Issue
Refs #1496: https://github.com/ll7/robot_sf_ll7/issues/1496

## Scope
This PR stays inside the bounded readiness/preflight slice for oracle-imitation warm-start dataset/training prerequisites. It does not collect data, submit compute, train policies, run a benchmark campaign, or change paper/dissertation claims.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py -q` passed: 22 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/training/oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_oracle_imitation_warm_start_readiness.py --manifest configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml --output output/validation/issue_1496/readiness_decision.json --json` returned exit code 1 as expected for current blocked state; decision manifest reports missing durable trace artifact URIs.

## Out of scope
No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Follow-Up Issues
- #1496 remains open for the later durable dataset/training benchmark work after #1470/#2441 provide concrete durable trace artifact URIs and split/leakage evidence.

## Residual risk
- The real issue #1496 readiness manifest remains blocked until durable #1470/#2441 trace artifact URIs replace the current pending dataset packet fields.
