### PR TITLE
bench: add AMMV benchmark protocol manifest with loader and validator (#3967)

### DIFF
--- a/benchmarks/ammv_benchmark_v0.yaml
+++ b/benchmarks/ammv_benchmark_v0.yaml
@@ -1,0 +1,37 @@
+# AMMV Benchmark Protocol v0
+#
+# Versioned manifest declaring the scenario classes, planner panel, metric
+# layers, and claim rules required for an AMMV benchmark comparison.
+#
+# This is a declarative contract, not a CI gate.  Implementations should
+# reference the protocol id in run metadata, reports, or claim artifacts.
+
+scenario_classes:
+  - crossing
+  - bidirectional_sidewalk
+  - bottleneck
+  - blind_corner
+  - group_navigation
+  - dense_plaza
+  - static_obstacle
+  - long_horizon_route
+
+planner_panel:
+  - goal
+  - social_force
+  - orca
+  - ppo
+  - random
+  - fast_pysf_planner
+
+metric_layers:
+  - safety_gate
+  - liveness
+  - social_compliance
+  - efficiency
+  - comfort
+
+claim_rules:
+  global_superiority_forbidden: true
+  report_tradeoffs: true
+  safety_gate_precedes_efficiency: true

--- a/docs/benchmark_spec.md
+++ b/docs/benchmark_spec.md
@@ -368,17 +368,19 @@ or weakly paired evidence bases.
 
 For threshold studies, run `scripts/benchmark_threshold_sensitivity.py` to quantify
 distance/comfort threshold impacts across scenario families and to compare speed-aware
+near-miss alternatives (relative-speed weighting and TTC-gating).
 
 ## AMMV Benchmark Protocol Manifest
 
-The AMMV benchmark protocol is versioned as a checked-in manifest:
+The Assured Multi-Metric Validation (AMMV) benchmark protocol is versioned as a checked-in
+manifest:
 
 ```text
 benchmarks/ammv_benchmark_v0.yaml
 ```
 
-A benchmark run that claims compliance with this protocol should record the
-protocol reference in its run metadata, report, or claim artifact as:
+A benchmark run that claims compliance with this protocol should record the protocol reference in
+run metadata, reports, and claim artifacts as:
 
 ```yaml
 benchmark_protocol:
@@ -386,8 +388,6 @@ benchmark_protocol:
   path: benchmarks/ammv_benchmark_v0.yaml
 ```
 
-The manifest declares the scenario classes, planner panel, metric layers, and
-claim rules required for an AMMV benchmark comparison.  It is descriptive in
-this slice: loading the manifest validates the protocol shape, but it does not
-execute scenarios, instantiate planners, or enforce a CI/release gate.
-near-miss alternatives (relative-speed weighting and TTC-gating).
+The manifest declares scenario classes, planner panel, metric layers, and claim rules required for
+AMMV benchmark comparison. This slice is descriptive: loading the manifest validates protocol shape,
+but does not execute scenarios, instantiate planners, or enforce CI/release gates.

--- a/docs/benchmark_spec.md
+++ b/docs/benchmark_spec.md
@@ -368,4 +368,26 @@ or weakly paired evidence bases.
 
 For threshold studies, run `scripts/benchmark_threshold_sensitivity.py` to quantify
 distance/comfort threshold impacts across scenario families and to compare speed-aware
+
+## AMMV Benchmark Protocol Manifest
+
+The AMMV benchmark protocol is versioned as a checked-in manifest:
+
+```text
+benchmarks/ammv_benchmark_v0.yaml
+```
+
+A benchmark run that claims compliance with this protocol should record the
+protocol reference in its run metadata, report, or claim artifact as:
+
+```yaml
+benchmark_protocol:
+  id: ammv_benchmark_v0
+  path: benchmarks/ammv_benchmark_v0.yaml
+```
+
+The manifest declares the scenario classes, planner panel, metric layers, and
+claim rules required for an AMMV benchmark comparison.  It is descriptive in
+this slice: loading the manifest validates the protocol shape, but it does not
+execute scenarios, instantiate planners, or enforce a CI/release gate.
 near-miss alternatives (relative-speed weighting and TTC-gating).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,6 +122,7 @@ include = ["examples/**", "benchmarks/**"]
 "robot_sf/maps" = "robot_sf/maps"
 
 [tool.hatch.build.targets.wheel.force-include]
+"benchmarks" = "benchmarks"
 "fast-pysf/pysocialforce" = "pysocialforce"
 
 [tool.hatchling.build.targets.sdist]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ packages = [
     { include = "examples" },
     { include = "third_party" },
 ]
-include = ["examples/**"]
+include = ["examples/**", "benchmarks/**"]
 
 [tool.hatchling.build.targets.wheel.shared-data]
 "robot_sf/maps" = "robot_sf/maps"
@@ -130,6 +130,7 @@ include = [
     "/robot_sf_carla_bridge",
     "/fast-pysf/pysocialforce",
     "/examples",
+    "/benchmarks",
     "/third_party",
     "/README.md",
     "/LICENSE",

--- a/robot_sf/benchmark/__init__.py
+++ b/robot_sf/benchmark/__init__.py
@@ -4,6 +4,14 @@ This module provides tools for running benchmarks, collecting metrics,
 and analyzing robot navigation performance in social environments.
 """
 
+from robot_sf.benchmark.benchmark_protocol import (
+    AMMV_BENCHMARK_PROTOCOL_PATH,
+    BenchmarkProtocolError,
+    BenchmarkProtocolManifest,
+    ClaimRules,
+    load_benchmark_protocol,
+    validate_benchmark_protocol_payload,
+)
 from robot_sf.benchmark.errors import AggregationMetadataError
 from robot_sf.benchmark.forecast_batch import (
     FORECAST_BATCH_SCHEMA_VERSION,
@@ -82,6 +90,7 @@ from robot_sf.benchmark.scenario_failure_cause import (
 )
 
 __all__ = [
+    "AMMV_BENCHMARK_PROTOCOL_PATH",
     "DEFAULT_FORECAST_DATASET_ID",
     "DEFAULT_TRANSFER_DIMENSIONS",
     "FORECAST_BATCH_SCHEMA_VERSION",
@@ -99,6 +108,9 @@ __all__ = [
     "VERDICT_VEHICLE_INFEASIBLE",
     "ActorForecast",
     "AggregationMetadataError",
+    "BenchmarkProtocolError",
+    "BenchmarkProtocolManifest",
+    "ClaimRules",
     "CoordinateFrame",
     "ExampleOrchestrator",
     "ForecastActorObservation",
@@ -127,12 +139,14 @@ __all__ = [
     "format_forecast_conformal_pilot_markdown",
     "format_forecast_metrics_markdown",
     "format_forecast_transferability_stress_markdown",
+    "load_benchmark_protocol",
     "load_forecast_batch",
     "load_trained_policy",
     "prepare_classic_env",
     "record_forecast_dataset_from_trace_exports",
     "run_episodes_with_recording",
     "save_forecast_batch",
+    "validate_benchmark_protocol_payload",
     "validate_forecast_batch",
     "validate_forecast_dataset_manifest",
     "write_forecast_calibration_report",

--- a/robot_sf/benchmark/benchmark_protocol.py
+++ b/robot_sf/benchmark/benchmark_protocol.py
@@ -1,0 +1,220 @@
+"""AMMV benchmark protocol manifest loader and validator.
+
+This module provides a typed loader and fail-closed validator for the
+versioned AMMV benchmark protocol declared in ``benchmarks/ammv_benchmark_v0.yaml``.
+
+The protocol is declarative: it declares scenario classes, planner panels,
+metric layers, and claim rules.  It does **not** execute scenarios,
+instantiate planners, or enforce CI/release gates.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from robot_sf.common.artifact_paths import get_repository_root
+
+#: Default path to the AMMV benchmark protocol manifest, relative to the
+#: repository root.
+AMMV_BENCHMARK_PROTOCOL_PATH = Path("benchmarks/ammv_benchmark_v0.yaml")
+
+#: Required top-level sections in the protocol manifest.
+_REQUIRED_TOP_LEVEL = frozenset(
+    {"scenario_classes", "planner_panel", "metric_layers", "claim_rules"}
+)
+
+#: Required keys inside ``claim_rules``.
+_REQUIRED_CLAIM_RULES = frozenset(
+    {"global_superiority_forbidden", "report_tradeoffs", "safety_gate_precedes_efficiency"},
+)
+
+
+class BenchmarkProtocolError(ValueError):
+    """Raised when a benchmark protocol manifest is missing or invalid."""
+
+
+@dataclass(frozen=True)
+class ClaimRules:
+    """Claim rules that constrain what a benchmark run may assert."""
+
+    global_superiority_forbidden: bool
+    report_tradeoffs: bool
+    safety_gate_precedes_efficiency: bool
+
+
+@dataclass(frozen=True)
+class BenchmarkProtocolManifest:
+    """Typed representation of a versioned benchmark protocol manifest."""
+
+    protocol_id: str
+    source_path: Path
+    scenario_classes: tuple[str, ...]
+    planner_panel: tuple[str, ...]
+    metric_layers: tuple[str, ...]
+    claim_rules: ClaimRules
+
+
+def _protocol_id(source_path: Path) -> str:
+    """Derive a protocol id from the manifest file stem.
+
+    Returns:
+        The file stem as a string.
+    """
+    return source_path.stem
+
+
+def _ensure_mapping(payload: Any, *, label: str = "root") -> None:
+    """Fail-closed: verify the value is a Mapping (dict-like)."""
+    if not isinstance(payload, Mapping):
+        raise BenchmarkProtocolError(
+            f"{label}: expected a mapping, got {type(payload).__name__}",
+        )
+
+
+def _ensure_non_empty_string_list(
+    value: Any,
+    *,
+    section: str,
+) -> tuple[str, ...]:
+    """Fail-closed: verify the value is a non-empty sequence of non-empty strings.
+
+    Returns:
+        A tuple of the validated strings.
+    """
+    if not isinstance(value, (list, tuple)):
+        raise BenchmarkProtocolError(
+            f"{section}: expected a list, got {type(value).__name__}",
+        )
+    if not value:
+        raise BenchmarkProtocolError(f"{section}: must not be empty")
+    result: list[str] = []
+    for idx, item in enumerate(value):
+        if not isinstance(item, str) or not item.strip():
+            raise BenchmarkProtocolError(
+                f"{section}[{idx}]: expected a non-empty string, got {type(item).__name__}",
+            )
+        result.append(item.strip())
+    return tuple(result)
+
+
+def validate_benchmark_protocol_payload(
+    payload: Mapping[str, Any],
+    *,
+    source_path: Path | None = None,
+) -> BenchmarkProtocolManifest:
+    """Validate a parsed benchmark protocol payload and return a typed manifest.
+
+    Args:
+        payload: Parsed YAML content as a mapping.
+        source_path: Path to the source file (used for protocol id derivation).
+
+    Returns:
+        A ``BenchmarkProtocolManifest`` with validated fields.
+
+    Raises:
+        BenchmarkProtocolError: When any required section or key is missing or
+            has an invalid type.
+    """
+    _ensure_mapping(payload, label="root")
+
+    missing = _REQUIRED_TOP_LEVEL - set(payload.keys())
+    if missing:
+        raise BenchmarkProtocolError(
+            f"missing required top-level section(s): {', '.join(sorted(missing))}",
+        )
+
+    scenario_classes = _ensure_non_empty_string_list(
+        payload.get("scenario_classes"),
+        section="scenario_classes",
+    )
+    planner_panel = _ensure_non_empty_string_list(
+        payload.get("planner_panel"),
+        section="planner_panel",
+    )
+    metric_layers = _ensure_non_empty_string_list(
+        payload.get("metric_layers"),
+        section="metric_layers",
+    )
+
+    claim_rules_raw = payload.get("claim_rules")
+    _ensure_mapping(claim_rules_raw, label="claim_rules")
+
+    claim_keys = set(claim_rules_raw.keys())
+    missing_rules = _REQUIRED_CLAIM_RULES - claim_keys
+    if missing_rules:
+        raise BenchmarkProtocolError(
+            f"missing required claim rule(s): {', '.join(sorted(missing_rules))}",
+        )
+
+    claim_values: dict[str, bool] = {}
+    for key in sorted(_REQUIRED_CLAIM_RULES):
+        raw = claim_rules_raw[key]
+        if not isinstance(raw, bool):
+            raise BenchmarkProtocolError(
+                f"claim_rules.{key}: expected bool, got {type(raw).__name__}",
+            )
+        claim_values[key] = raw
+
+    resolved_path = source_path or AMMV_BENCHMARK_PROTOCOL_PATH
+    protocol_id = _protocol_id(resolved_path)
+
+    return BenchmarkProtocolManifest(
+        protocol_id=protocol_id,
+        source_path=resolved_path,
+        scenario_classes=scenario_classes,
+        planner_panel=planner_panel,
+        metric_layers=metric_layers,
+        claim_rules=ClaimRules(
+            global_superiority_forbidden=claim_values["global_superiority_forbidden"],
+            report_tradeoffs=claim_values["report_tradeoffs"],
+            safety_gate_precedes_efficiency=claim_values["safety_gate_precedes_efficiency"],
+        ),
+    )
+
+
+def load_benchmark_protocol(
+    path: str | Path = AMMV_BENCHMARK_PROTOCOL_PATH,
+) -> BenchmarkProtocolManifest:
+    """Load and validate a benchmark protocol manifest from a YAML file.
+
+    Args:
+        path: Path to the protocol YAML file.  Relative paths are resolved
+            against the repository root.
+
+    Returns:
+        A ``BenchmarkProtocolManifest`` with validated fields.
+
+    Raises:
+        BenchmarkProtocolError: When the file cannot be read, YAML is invalid,
+            or validation fails.
+    """
+    import yaml  # noqa: PLC0415
+
+    resolved = Path(path)
+    if not resolved.is_absolute():
+        resolved = get_repository_root() / resolved
+
+    try:
+        raw = resolved.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise BenchmarkProtocolError(f"cannot read protocol file {resolved}: {exc}") from exc
+
+    try:
+        payload = yaml.safe_load(raw)
+    except yaml.YAMLError as exc:
+        raise BenchmarkProtocolError(f"invalid YAML in {resolved}: {exc}") from exc
+
+    return validate_benchmark_protocol_payload(payload, source_path=resolved)
+
+
+__all__ = [
+    "AMMV_BENCHMARK_PROTOCOL_PATH",
+    "BenchmarkProtocolError",
+    "BenchmarkProtocolManifest",
+    "ClaimRules",
+    "load_benchmark_protocol",
+    "validate_benchmark_protocol_payload",
+]

--- a/tests/benchmark/test_benchmark_protocol.py
+++ b/tests/benchmark/test_benchmark_protocol.py
@@ -1,0 +1,160 @@
+"""Tests for the AMMV benchmark protocol manifest loader and validator."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from robot_sf.benchmark.benchmark_protocol import (
+    AMMV_BENCHMARK_PROTOCOL_PATH,
+    BenchmarkProtocolError,
+    load_benchmark_protocol,
+    validate_benchmark_protocol_payload,
+)
+
+
+def test_load_checked_in_ammv_benchmark_protocol() -> None:
+    """The checked-in protocol manifest should load with expected values."""
+    manifest = load_benchmark_protocol()
+    assert manifest.protocol_id == "ammv_benchmark_v0"
+    assert "crossing" in manifest.scenario_classes
+    assert "goal" in manifest.planner_panel
+    assert "safety_gate" in manifest.metric_layers
+    assert manifest.claim_rules.global_superiority_forbidden is True
+    assert manifest.claim_rules.report_tradeoffs is True
+    assert manifest.claim_rules.safety_gate_precedes_efficiency is True
+
+
+def test_benchmark_protocol_rejects_missing_required_section(tmp_path: Path) -> None:
+    """Manifest missing a required top-level section should be rejected."""
+    path = tmp_path / "missing_claim_rules.yaml"
+    path.write_text(
+        "scenario_classes: [crossing]\nplanner_panel: [goal]\nmetric_layers: [safety_gate]\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BenchmarkProtocolError, match="claim_rules"):
+        load_benchmark_protocol(path)
+
+
+def test_benchmark_protocol_rejects_missing_claim_rule(tmp_path: Path) -> None:
+    """Manifest with missing required claim rule should be rejected."""
+    path = tmp_path / "missing_rule.yaml"
+    path.write_text(
+        "scenario_classes: [crossing]\n"
+        "planner_panel: [goal]\n"
+        "metric_layers: [safety_gate]\n"
+        "claim_rules:\n"
+        "  global_superiority_forbidden: true\n"
+        "  report_tradeoffs: true\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BenchmarkProtocolError, match="safety_gate_precedes_efficiency"):
+        load_benchmark_protocol(path)
+
+
+def test_benchmark_protocol_rejects_non_bool_claim_rule(tmp_path: Path) -> None:
+    """A claim rule with a non-bool value should be rejected."""
+    path = tmp_path / "non_bool_rule.yaml"
+    path.write_text(
+        "scenario_classes: [crossing]\n"
+        "planner_panel: [goal]\n"
+        "metric_layers: [safety_gate]\n"
+        "claim_rules:\n"
+        '  global_superiority_forbidden: "true"\n'
+        "  report_tradeoffs: true\n"
+        "  safety_gate_precedes_efficiency: true\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BenchmarkProtocolError, match="global_superiority_forbidden"):
+        load_benchmark_protocol(path)
+
+
+def test_benchmark_protocol_rejects_empty_section(tmp_path: Path) -> None:
+    """A required list-typed section that is empty should be rejected."""
+    path = tmp_path / "empty_scenarios.yaml"
+    path.write_text(
+        "scenario_classes: []\n"
+        "planner_panel: [goal]\n"
+        "metric_layers: [safety_gate]\n"
+        "claim_rules:\n"
+        "  global_superiority_forbidden: true\n"
+        "  report_tradeoffs: true\n"
+        "  safety_gate_precedes_efficiency: true\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BenchmarkProtocolError, match="scenario_classes"):
+        load_benchmark_protocol(path)
+
+
+def test_benchmark_protocol_rejects_non_list_section(tmp_path: Path) -> None:
+    """A section that should be a list but is not should be rejected."""
+    path = tmp_path / "non_list_planners.yaml"
+    path.write_text(
+        "scenario_classes: [crossing]\n"
+        "planner_panel: goal\n"
+        "metric_layers: [safety_gate]\n"
+        "claim_rules:\n"
+        "  global_superiority_forbidden: true\n"
+        "  report_tradeoffs: true\n"
+        "  safety_gate_precedes_efficiency: true\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(BenchmarkProtocolError, match="planner_panel"):
+        load_benchmark_protocol(path)
+
+
+def test_benchmark_protocol_rejects_non_mapping_root(tmp_path: Path) -> None:
+    """A YAML file that is not a mapping at the top level should be rejected."""
+    path = tmp_path / "list_root.yaml"
+    path.write_text("[crossing, goal]\n", encoding="utf-8")
+
+    with pytest.raises(BenchmarkProtocolError, match="root"):
+        load_benchmark_protocol(path)
+
+
+def test_validate_payload_accepts_minimal_valid(tmp_path: Path) -> None:
+    """A minimal valid payload should produce a typed manifest."""
+    payload = {
+        "scenario_classes": ["crossing"],
+        "planner_panel": ["goal"],
+        "metric_layers": ["safety_gate"],
+        "claim_rules": {
+            "global_superiority_forbidden": True,
+            "report_tradeoffs": True,
+            "safety_gate_precedes_efficiency": True,
+        },
+    }
+    manifest = validate_benchmark_protocol_payload(payload, source_path=tmp_path / "test.yaml")
+    assert manifest.protocol_id == "test"
+    assert manifest.scenario_classes == ("crossing",)
+    assert manifest.planner_panel == ("goal",)
+    assert manifest.metric_layers == ("safety_gate",)
+    assert manifest.claim_rules.global_superiority_forbidden is True
+
+
+def test_benchmark_protocol_derives_protocol_id_from_stem(tmp_path: Path) -> None:
+    """The protocol id should be derived from the YAML file stem."""
+    path = tmp_path / "custom_protocol_v1.yaml"
+    path.write_text(
+        "scenario_classes: [crossing]\n"
+        "planner_panel: [goal]\n"
+        "metric_layers: [safety_gate]\n"
+        "claim_rules:\n"
+        "  global_superiority_forbidden: true\n"
+        "  report_tradeoffs: true\n"
+        "  safety_gate_precedes_efficiency: true\n",
+        encoding="utf-8",
+    )
+    manifest = load_benchmark_protocol(path)
+    assert manifest.protocol_id == "custom_protocol_v1"
+
+
+def test_benchmark_protocol_default_path_points_to_checked_in_manifest() -> None:
+    """The default path constant should point at the checked-in manifest file."""
+    assert AMMV_BENCHMARK_PROTOCOL_PATH == Path("benchmarks/ammv_benchmark_v0.yaml")


### PR DESCRIPTION
## Summary
- Adds the versioned Assured Multi-Metric Validation (AMMV) benchmark protocol manifest at `benchmarks/ammv_benchmark_v0.yaml`.
- Adds a typed loader and fail-closed validator for protocol shape and claim rules.
- Documents how benchmark runs should reference the protocol version, and includes the manifest in source/wheel builds.

## Linked Issues
- Closes `#3967`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `robot_sf.benchmark.benchmark_protocol` with dataclasses, loader, validator, and package exports.
- Added tests for the checked-in manifest and fail-closed malformed payloads.
- Added benchmark-spec documentation for the `benchmark_protocol.id/path` reference convention.
- Included top-level `benchmarks/**` in wheel/sdist packaging.

## Why Matters
- Added value: establishes a reviewable AMMV protocol contract before any benchmark execution slice.
- Expected impact: future benchmark runs can reference a stable protocol id and claim-rule surface.
- Why worth merging now: it is metadata/protocol-only and unblocks later runner/report integration without adding planners, scenarios, or compute work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: AMMV benchmark comparisons need a versioned protocol manifest and claim rules before future evidence can reference them.
- Comparator or baseline, applicable: NA - protocol metadata only.
- Evidence tier: docs-only
- Result classification: NA - protocol metadata only.
- Decision stop rule, applicable: loader validates checked-in manifest and rejects missing required sections/rules.
- Parent issue, claim map, registry, context note, synthesis surface update: #3967 and `docs/benchmark_spec.md`.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - declarative manifest loader, no benchmark interpretation.

## Domain-Aware Approval
- Required PR: no - docs-only/protocol metadata change with no benchmark result, comparison methodology execution, figure eligibility, or paper-facing claim change.
- Domains reviewed: AMMV protocol metadata and benchmark-spec wording only.
- Status: not required
- Approver/review source waiver: not required - no empirical benchmark interpretation is introduced.
- Validity checklist: declarative protocol only; no benchmark campaign or result claim.
- Target claim/hypothesis: AMMV protocol shape exists and is loadable.
- Comparator split/evidence validity: not applicable - no empirical comparison, split, ranking, or result interpretation changes.
- Fallback/degraded exclusions: no runtime benchmark execution.
- Claim boundary: protocol/metadata only.
- Implementation integrity vs experimental validity: implementation integrity only; experimental validity is not evaluated by this PR.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - loader validates checked-in manifest.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with future runner/report integration only in later issues.
- Proposed child issue existing follow-up: none.

## Validation / Proof
- `uv run pytest tests/ -k "benchmark_protocol or ammv_benchmark" -q`
- `uv run pytest tests/benchmark/test_benchmark_protocol.py tests/benchmark/test_metric_layers.py -q`
- `uv run ruff check robot_sf/benchmark/__init__.py robot_sf/benchmark/benchmark_protocol.py robot_sf/benchmark/metric_layers.py tests/benchmark/test_benchmark_protocol.py tests/benchmark/test_metric_layers.py`
- `uv build`
- `scripts/validation/wheel_install_smoke.sh`
- `git diff --check`

## Performance Evidence
- Baseline runtime: NA - no runtime/performance change claimed.
- Changed runtime: NA.
- Representative command: NA.
- Hot-path call count profile anchor: NA.
- Cache-hit reuse counter: NA.
- Rollback failure criterion: protocol loader fails checked-in manifest validation or package smoke cannot find/build the manifest.

## Risks / Rollout
- Compatibility risks: low; additive module, manifest, docs, and packaging include.
- Failure modes: malformed protocol manifests fail closed with `BenchmarkProtocolError`.
- Rollback fallback plan: revert manifest/loader/export/docs/package include commit.

## Docs / Provenance
- Updated docs: `docs/benchmark_spec.md`.
- Relevant design provenance notes: #3967.
- Any assumptions need to preserved: this PR does not implement scenarios, planners, Slurm/GPU campaigns, or release enforcement.

## Downstream Propagation
- Parent issue updated (yes/no/NA): yes via PR linkage.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): NA.
- Not applicable because: this is protocol metadata and validation only; no benchmark result or paper-facing evidence changes.

## Follow-Up Issues
- Deferred work: runner/report integration can reference this protocol in future work.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the PR remains declarative: no scenario execution, planner registry changes, Slurm work, or benchmark evidence claims.
- Known limitations: protocol compliance is documented and loadable but not yet enforced by benchmark runners.
