### PR TITLE
Relates #3275: fail closed on empty archive attribution

### DIFF
--- a/robot_sf/adversarial/disjoint_evaluation.py
+++ b/robot_sf/adversarial/disjoint_evaluation.py
@@ -509,7 +509,9 @@ def _collect_entry_stats(
         missing_archive_id=sum(1 for e in dict_entries if not e.get("archive_id")),
         missing_seed=sum(1 for e in dict_entries if _entry_scenario_seed(e) is None),
         missing_attribution=sum(
-            1 for e in dict_entries if not isinstance(e.get("failure_attribution"), dict)
+            1
+            for e in dict_entries
+            if not isinstance(e.get("failure_attribution"), dict) or not e["failure_attribution"]
         ),
         unknown_family=sum(1 for e in dict_entries if scenario_family_key(e) == "unknown_family"),
         distinct_family_count=len(distinct_families),

--- a/tests/adversarial/test_archive_readiness.py
+++ b/tests/adversarial/test_archive_readiness.py
@@ -190,6 +190,19 @@ def test_missing_failure_attribution_breaks_null_test_prereq() -> None:
     assert "entries_missing_failure_attribution:1" in report.blocking_reasons
 
 
+def test_empty_failure_attribution_breaks_null_test_prereq() -> None:
+    """Empty failure_attribution is not enough to support null tests."""
+    entries = [_entry("A", "a0", 1), _entry("B", "b0", 2)]
+    entries[1]["failure_attribution"] = {}
+
+    report = assess_archive_readiness(_archive(entries))
+
+    assert report.entries_missing_failure_attribution == 1
+    assert report.null_test_prerequisites_ready is False
+    assert report.ready is False
+    assert "entries_missing_failure_attribution:1" in report.blocking_reasons
+
+
 def test_unknown_family_entries_are_counted_and_block() -> None:
     """Entries with no derivable family fall into the unknown-family bucket."""
     # Second entry has no cluster_key / failure key / manifest -> unknown_family.


### PR DESCRIPTION
## Summary
Tightens issue #3275 certified failure archive readiness checker so empty `failure_attribution` objects fail closed instead of satisfying null-test prerequisites.

## Linked Issues
- Relates #3275

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: narrow fail-closed checker/test slice on current `origin/main`.

## What Changed
- Counts empty `failure_attribution` dictionaries as missing attribution metadata in `assess_archive_readiness`.
- Adds a synthetic archive fixture test proving empty attribution blocks readiness and null-test prerequisites.

## Why Matters
- Added value: prevents malformed certified failure archive entries from being classified ready for null-test prerequisites.
- Expected impact: stricter fail-closed input hygiene before any proposal-model rerun can use a certified failure archive.
- Why worth merging now: small reversible readiness hardening for the #3275 archive gate.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support-helper hardening for the #3275 archive-readiness gate only.
- Comparator or baseline, applicable: NA - no experimental comparison or research result claim.
- Evidence tier: NA - support helper; validation is targeted unit/integration proof plus full PR readiness.
- Result classification: NA - support helper.
- Decision stop rule, applicable: no held-out yield or benchmark conclusion until real disjoint certified archive inputs and independent planner-execution outcomes satisfy the broader issue contract.
- Parent issue, claim map, registry, context note, synthesis surface update: #3275 remains open for the real archive rerun work.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support-helper hardening only.

## Domain-Aware Approval
- Approver/review source waiver: not required; Evidence tier and Result classification are NA because this is support-helper hardening only.
- Validity checklist: NA - no experimental validity claim.
- Target claim/hypothesis: NA - readiness prerequisite hardening.
- Comparator split/evidence validity: NA - no comparison run.
- Fallback/degraded exclusions: no fallback/degraded benchmark result reported.
- Claim boundary: fail-closed structural archive readiness only.
- Implementation integrity vs experimental validity: tests exercise malformed synthetic archive fixture; no experimental validity approval needed.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, empty attribution fixture now blocks readiness.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA - synthetic metadata fixture only.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: #3275 remains the real disjoint archive rerun.

## Next Empirical Action
- Rerun needed: yes, broader #3275 real archive rerun remains out of scope.
- Extractor analysis tool needed: no for this slice.
- Artifact missing unavailable: real certified failure archive and independent planner-execution outcome packet remain outside this PR.
- Stop / revise / continue decision: continue broader #3275 after readiness hardening slices.
- Proposed child issue existing follow-up: existing #3275.

## Validation / Proof
- `uv run pytest tests/adversarial/test_archive_readiness.py -q` -> 22 passed.
- `uv run pytest tests/adversarial/test_adversarial_proposal_model_issue_2921.py -q` -> 14 passed.
- `uv run ruff check robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py` -> passed.
- `uv run ruff format --check robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py` -> 2 files already formatted.
- `uv run python scripts/dev/check_pr_followups.py --body-file <common-git-dir>/codex-agent-runs/active/pr-4096-gate/pr_body_pre_push.md --json --require-body` -> follow-up/domain checks passed; #3275 is linked for deferred work.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<common-git-dir>/codex-agent-runs/active/pr-4096-gate/pr_body_pre_push.md PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> passed on merged head `892e8ca213b239a18d1e1c5a2b6a1475f486dbde`; 1697 tests passed.

## Performance Evidence
- Baseline runtime: NA - no runtime/performance claim.
- Changed runtime: NA - no runtime/performance claim.
- Representative command: NA - no runtime/performance claim.
- Hot-path call count profile anchor: NA - no runtime/performance claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: archive readiness should not accept empty attribution as null-test-ready.

## Risks / Rollout
- Compatibility risks: intentionally empty attribution placeholders now fail closed until populated.
- Failure modes: stricter gate may require archive producers to provide real attribution metadata.
- Rollback fallback plan: revert the single readiness predicate and focused test if empty attribution is later defined as valid.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: #3275 live issue and prior readiness slices.
- Any assumptions need preserved: empty attribution dictionaries are placeholders, not valid null-test prerequisite evidence.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, #3275 remains open and this PR body records the remaining issue contract.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: PR changes only fail-closed readiness behavior and does not produce benchmark, registry, claim-map, or paper-facing evidence.

## Follow-Up Issues
- Deferred work: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits; #3275 still needs the real disjoint certified archive rerun with independent planner-execution outcomes.
- Issues opened follow-up: none; existing #3275 remains open.

## Reviewer Notes
- Anything reviewer verify closely: empty dict attribution now follows the same blocker family as missing/non-object attribution.
- Any known limitations: no proposal-model evaluation, archive fabrication, benchmark yield, Slurm/GPU submission, or issue-closing claim in this PR.
