### PR TITLE
benchmark: add long-horizon route metrics (#3969)

### DIFF
--- a/robot_sf/benchmark/long_horizon_route.py
+++ b/robot_sf/benchmark/long_horizon_route.py
@@ -7,7 +7,8 @@ collision, near-miss, intervention, reset, or failure semantics.
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping, Sequence
+import importlib
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -92,6 +93,28 @@ class LongHorizonRouteDefinition:
         }
 
 
+@dataclass(frozen=True, slots=True)
+class LongHorizonRouteRunResult:
+    """Headless execution result for one composed long-horizon route."""
+
+    route: LongHorizonRouteDefinition
+    records: tuple[Mapping[str, Any], ...]
+    metrics: Mapping[str, float]
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize route records and aggregate metrics for evidence packets.
+
+        Returns:
+            Plain dictionary representation of the route run.
+        """
+
+        return {
+            "route": self.route.to_dict(),
+            "records": [dict(record) for record in self.records],
+            "metrics": dict(self.metrics),
+        }
+
+
 def build_long_horizon_route(
     route_id: str,
     segments: Sequence[LongHorizonRouteSegment],
@@ -139,6 +162,66 @@ def build_long_horizon_route(
     return LongHorizonRouteDefinition(route_id, tuple(route_segments), target_length_m)
 
 
+_RunEpisodeFn = Callable[..., Mapping[str, Any]]
+
+
+def run_long_horizon_route(
+    route: LongHorizonRouteDefinition,
+    *,
+    seed: int = 0,
+    horizon: int = 100,
+    dt: float = 0.1,
+    record_forces: bool = True,
+    algo: str = "simple_policy",
+    algo_config_path: str | None = None,
+    run_episode_fn: _RunEpisodeFn | None = None,
+) -> LongHorizonRouteRunResult:
+    """Run a short composed route through the existing headless episode runner.
+
+    Each route segment is executed as one existing local scenario. The runner's
+    event counts stay authoritative; this helper only adds planned route-distance
+    provenance before computing per-distance route metrics.
+
+    Returns:
+        Segment records and aggregate distance-normalized route metrics.
+    """
+
+    if horizon <= 0:
+        raise LongHorizonRouteError("horizon must be positive")
+    if dt <= 0:
+        raise LongHorizonRouteError("dt must be positive")
+
+    if run_episode_fn is None:
+        runner_module = importlib.import_module("robot_sf.benchmark.runner")
+        run_episode_fn = runner_module.run_episode
+
+    records: list[Mapping[str, Any]] = []
+    for index, segment in enumerate(route.segments):
+        scenario_params = dict(segment.parameters)
+        scenario_params.setdefault("id", segment.scenario_id)
+        record = run_episode_fn(
+            scenario_params,
+            seed + index,
+            horizon=horizon,
+            dt=dt,
+            record_forces=record_forces,
+            algo=algo,
+            algo_config_path=algo_config_path,
+            video_enabled=False,
+        )
+        records.append(
+            _with_route_distance_provenance(
+                record,
+                route=route,
+                segment=segment,
+                segment_index=index,
+            )
+        )
+
+    metrics = aggregate_distance_normalized_route_metrics(records, route_length_m=route.length_m)
+    return LongHorizonRouteRunResult(route=route, records=tuple(records), metrics=metrics)
+
+
 _COUNT_ALIASES: dict[str, tuple[str, ...]] = {
     "failures": ("failures", "failure_events"),
     "collisions": ("collisions", "collision_events"),
@@ -153,6 +236,7 @@ _DISTANCE_ALIASES = (
     "route_distance_m",
     "completed_distance_m",
     "path_length_m",
+    "socnavbench_path_length",
 )
 
 _PLANNED_DISTANCE_ALIASES = (
@@ -201,6 +285,33 @@ def _count(record: Mapping[str, Any], metric_name: str) -> float:
     if value < 0:
         raise LongHorizonRouteError(f"{metric_name} count must not be negative")
     return value
+
+
+def _with_route_distance_provenance(
+    record: Mapping[str, Any],
+    *,
+    route: LongHorizonRouteDefinition,
+    segment: LongHorizonRouteSegment,
+    segment_index: int,
+) -> Mapping[str, Any]:
+    """Attach route-distance provenance without changing runner event counts.
+
+    Returns:
+        Episode record annotated with planned route-distance metadata.
+    """
+
+    annotated = dict(record)
+    metrics = dict(_metrics(record))
+    metrics.setdefault("planned_distance_m", segment.length_m)
+    metrics.setdefault("route_length_m", route.length_m)
+    annotated["metrics"] = metrics
+    annotated["long_horizon_route"] = {
+        "route_id": route.route_id,
+        "segment_index": segment_index,
+        "segment_id": segment.scenario_id,
+        "segment_length_m": segment.length_m,
+    }
+    return annotated
 
 
 def aggregate_distance_normalized_route_metrics(
@@ -284,7 +395,9 @@ def _planned_route_distance_m(records: Sequence[Mapping[str, Any]]) -> float:
 __all__ = [
     "LongHorizonRouteDefinition",
     "LongHorizonRouteError",
+    "LongHorizonRouteRunResult",
     "LongHorizonRouteSegment",
     "aggregate_distance_normalized_route_metrics",
     "build_long_horizon_route",
+    "run_long_horizon_route",
 ]

--- a/robot_sf/benchmark/long_horizon_route.py
+++ b/robot_sf/benchmark/long_horizon_route.py
@@ -1,0 +1,290 @@
+"""Long-horizon route benchmark helpers.
+
+This module only composes existing local scenario segments and normalizes
+already-recorded episode/event counts by distance. It does not define new
+collision, near-miss, intervention, reset, or failure semantics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class LongHorizonRouteError(ValueError):
+    """Raised when a route definition or metric input cannot be scored safely."""
+
+
+@dataclass(frozen=True, slots=True)
+class LongHorizonRouteSegment:
+    """One reusable local benchmark scenario segment in a longer route."""
+
+    scenario_id: str
+    length_m: float
+    repetitions: int = 1
+    parameters: Mapping[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        """Validate segment fields fail-closed."""
+
+        if not self.scenario_id.strip():
+            raise LongHorizonRouteError("route segment scenario_id must be non-empty")
+        if self.length_m <= 0:
+            raise LongHorizonRouteError(
+                f"route segment {self.scenario_id!r} length_m must be positive"
+            )
+        if self.repetitions <= 0:
+            raise LongHorizonRouteError(
+                f"route segment {self.scenario_id!r} repetitions must be positive"
+            )
+
+    @property
+    def total_length_m(self) -> float:
+        """Return segment distance after repetitions."""
+
+        return self.length_m * self.repetitions
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the segment for route manifests or smoke packets.
+
+        Returns:
+            Plain dictionary representation of this route segment.
+        """
+
+        return {
+            "scenario_id": self.scenario_id,
+            "length_m": self.length_m,
+            "repetitions": self.repetitions,
+            "parameters": dict(self.parameters),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class LongHorizonRouteDefinition:
+    """Deterministic composition of local scenario segments into a route."""
+
+    route_id: str
+    segments: tuple[LongHorizonRouteSegment, ...]
+    length_m: float
+
+    def __post_init__(self) -> None:
+        """Validate route fields fail-closed."""
+
+        if not self.route_id.strip():
+            raise LongHorizonRouteError("route_id must be non-empty")
+        if not self.segments:
+            raise LongHorizonRouteError("route must include at least one segment")
+        if self.length_m <= 0:
+            raise LongHorizonRouteError("route length_m must be positive")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize route definition for a benchmark config or evidence packet.
+
+        Returns:
+            Plain dictionary representation of this route definition.
+        """
+
+        return {
+            "route_id": self.route_id,
+            "length_m": self.length_m,
+            "segments": [segment.to_dict() for segment in self.segments],
+        }
+
+
+def build_long_horizon_route(
+    route_id: str,
+    segments: Sequence[LongHorizonRouteSegment],
+    *,
+    target_length_m: float | None = None,
+) -> LongHorizonRouteDefinition:
+    """Compose a long-horizon route from existing local scenario segments.
+
+    When ``target_length_m`` is provided, the segment sequence is repeated and
+    the final segment is shortened as needed. That gives a deterministic short
+    headless smoke route without introducing new scenario physics.
+
+    Returns:
+        Validated long-horizon route definition.
+    """
+
+    if not segments:
+        raise LongHorizonRouteError("route must include at least one segment")
+    if target_length_m is not None and target_length_m <= 0:
+        raise LongHorizonRouteError("target_length_m must be positive when provided")
+
+    source_segments = tuple(segments)
+    if target_length_m is None:
+        route_segments = source_segments
+        route_length_m = sum(segment.total_length_m for segment in route_segments)
+        return LongHorizonRouteDefinition(route_id, route_segments, route_length_m)
+
+    route_segments: list[LongHorizonRouteSegment] = []
+    remaining_m = target_length_m
+    while remaining_m > 1e-9:
+        for segment in source_segments:
+            if remaining_m <= 1e-9:
+                break
+            segment_length_m = min(segment.total_length_m, remaining_m)
+            route_segments.append(
+                LongHorizonRouteSegment(
+                    scenario_id=segment.scenario_id,
+                    length_m=segment_length_m,
+                    repetitions=1,
+                    parameters=segment.parameters,
+                )
+            )
+            remaining_m -= segment_length_m
+
+    return LongHorizonRouteDefinition(route_id, tuple(route_segments), target_length_m)
+
+
+_COUNT_ALIASES: dict[str, tuple[str, ...]] = {
+    "failures": ("failures", "failure_events"),
+    "collisions": ("collisions", "collision_events"),
+    "near_misses": ("near_misses", "near_miss_events"),
+    "interventions": ("interventions", "operator_interventions"),
+    "resets": ("resets", "reset_events"),
+}
+
+_DISTANCE_ALIASES = (
+    "distance_m",
+    "distance_traveled_m",
+    "route_distance_m",
+    "completed_distance_m",
+    "path_length_m",
+)
+
+_PLANNED_DISTANCE_ALIASES = (
+    "planned_distance_m",
+    "target_length_m",
+)
+
+
+def _metrics(record: Mapping[str, Any]) -> Mapping[str, Any]:
+    metrics = record.get("metrics", {})
+    return metrics if isinstance(metrics, Mapping) else {}
+
+
+def _numeric_from_aliases(
+    record: Mapping[str, Any],
+    aliases: Iterable[str],
+    *,
+    default: float | None = None,
+) -> float | None:
+    metrics = _metrics(record)
+    for alias in aliases:
+        value = metrics.get(alias, record.get(alias))
+        if value is None:
+            continue
+        try:
+            return float(value)
+        except (TypeError, ValueError) as exc:
+            raise LongHorizonRouteError(f"{alias} must be numeric") from exc
+    return default
+
+
+def _distance_m(record: Mapping[str, Any]) -> float:
+    distance_m = _numeric_from_aliases(record, _DISTANCE_ALIASES)
+    if distance_m is None:
+        raise LongHorizonRouteError(
+            "record is missing distance_m; cannot compute distance-normalized metrics"
+        )
+    if distance_m < 0:
+        raise LongHorizonRouteError("record distance_m must not be negative")
+    return distance_m
+
+
+def _count(record: Mapping[str, Any], metric_name: str) -> float:
+    value = _numeric_from_aliases(record, _COUNT_ALIASES[metric_name], default=0.0)
+    assert value is not None
+    if value < 0:
+        raise LongHorizonRouteError(f"{metric_name} count must not be negative")
+    return value
+
+
+def aggregate_distance_normalized_route_metrics(
+    records: Sequence[Mapping[str, Any]],
+    *,
+    route_length_m: float | None = None,
+) -> dict[str, float]:
+    """Compute issue #3969 distance-normalized metrics from episode/event records.
+
+    The input records must expose traversed distance in meters. Event counts are
+    read from existing top-level or nested ``metrics`` fields and are not
+    reinterpreted here.
+
+    Returns:
+        Dictionary containing failures/collisions/near-misses per 100 meters,
+        interventions/resets per kilometer, and route completion.
+    """
+
+    if not records:
+        raise LongHorizonRouteError("at least one record is required")
+    if route_length_m is not None and route_length_m <= 0:
+        raise LongHorizonRouteError("route_length_m must be positive when provided")
+
+    total_distance_m = sum(_distance_m(record) for record in records)
+    if total_distance_m <= 0:
+        raise LongHorizonRouteError("total traversed distance_m must be positive")
+
+    planned_distance_m = (
+        route_length_m if route_length_m is not None else _planned_route_distance_m(records)
+    )
+
+    per_100m_scale = 100.0 / total_distance_m
+    per_km_scale = 1000.0 / total_distance_m
+
+    return {
+        "failures_per_100m": _sum_counts(records, "failures") * per_100m_scale,
+        "collisions_per_100m": _sum_counts(records, "collisions") * per_100m_scale,
+        "near_misses_per_100m": _sum_counts(records, "near_misses") * per_100m_scale,
+        "interventions_per_km": _sum_counts(records, "interventions") * per_km_scale,
+        "route_completion": min(total_distance_m / planned_distance_m, 1.0),
+        "resets_per_km": _sum_counts(records, "resets") * per_km_scale,
+    }
+
+
+def _sum_counts(records: Sequence[Mapping[str, Any]], metric_name: str) -> float:
+    """Sum an existing event-count metric across records.
+
+    Returns:
+        Total event count across all input records.
+    """
+
+    return sum(_count(record, metric_name) for record in records)
+
+
+def _planned_route_distance_m(records: Sequence[Mapping[str, Any]]) -> float:
+    """Resolve planned route distance without double-counting repeated route totals.
+
+    Returns:
+        Planned route distance in meters.
+    """
+
+    route_lengths = [
+        value
+        for record in records
+        if (value := _numeric_from_aliases(record, ("route_length_m",))) is not None
+    ]
+    if route_lengths:
+        if any(value <= 0 for value in route_lengths):
+            raise LongHorizonRouteError("route_length_m must be positive when provided")
+        return max(route_lengths)
+
+    planned_distance_m = sum(
+        _numeric_from_aliases(record, _PLANNED_DISTANCE_ALIASES, default=0.0) or 0.0
+        for record in records
+    )
+    if planned_distance_m > 0:
+        return planned_distance_m
+    return sum(_distance_m(record) for record in records)
+
+
+__all__ = [
+    "LongHorizonRouteDefinition",
+    "LongHorizonRouteError",
+    "LongHorizonRouteSegment",
+    "aggregate_distance_normalized_route_metrics",
+    "build_long_horizon_route",
+]

--- a/tests/benchmark/test_long_horizon_route.py
+++ b/tests/benchmark/test_long_horizon_route.py
@@ -9,6 +9,7 @@ from robot_sf.benchmark.long_horizon_route import (
     LongHorizonRouteSegment,
     aggregate_distance_normalized_route_metrics,
     build_long_horizon_route,
+    run_long_horizon_route,
 )
 
 
@@ -129,6 +130,84 @@ def test_distance_normalized_route_metrics_from_synthetic_records() -> None:
             "interventions_per_km": 5.0,
             "route_completion": 2 / 3,
             "resets_per_km": 5.0,
+        }
+    )
+
+
+def test_distance_normalized_route_metrics_accept_existing_runner_path_length() -> None:
+    """Aggregator should reuse the benchmark runner's existing path-length metric."""
+
+    metrics = aggregate_distance_normalized_route_metrics(
+        [{"metrics": {"socnavbench_path_length": 12.5, "route_length_m": 50.0}}]
+    )
+
+    assert metrics["route_completion"] == pytest.approx(0.25)
+
+
+def test_run_long_horizon_route_executes_segments_headlessly_and_aggregates() -> None:
+    """Route runner should compose existing segment episodes without redefining events."""
+
+    route = build_long_horizon_route(
+        "short-route",
+        (
+            LongHorizonRouteSegment(
+                "clear_sidewalk",
+                10.0,
+                parameters={"density": "low", "flow": "uni", "obstacle": "open"},
+            ),
+            LongHorizonRouteSegment(
+                "static_obstacle",
+                15.0,
+                parameters={"density": "low", "flow": "uni", "obstacle": "bottleneck"},
+            ),
+        ),
+    )
+    calls: list[tuple[dict[str, object], int, dict[str, object]]] = []
+
+    def fake_run_episode(
+        scenario_params: dict[str, object],
+        seed: int,
+        **kwargs: object,
+    ) -> dict[str, object]:
+        calls.append((scenario_params, seed, kwargs))
+        return {
+            "scenario_id": scenario_params["id"],
+            "seed": seed,
+            "metrics": {
+                "socnavbench_path_length": 5.0 * (len(calls)),
+                "collisions": 1 if len(calls) == 2 else 0,
+                "near_misses": len(calls),
+            },
+        }
+
+    result = run_long_horizon_route(
+        route,
+        seed=7,
+        horizon=3,
+        dt=0.2,
+        record_forces=False,
+        run_episode_fn=fake_run_episode,
+    )
+
+    assert [call[0]["id"] for call in calls] == ["clear_sidewalk", "static_obstacle"]
+    assert [call[1] for call in calls] == [7, 8]
+    assert all(call[2]["video_enabled"] is False for call in calls)
+    assert all(call[2]["record_forces"] is False for call in calls)
+    assert result.records[0]["long_horizon_route"] == {
+        "route_id": "short-route",
+        "segment_index": 0,
+        "segment_id": "clear_sidewalk",
+        "segment_length_m": 10.0,
+    }
+    assert result.records[1]["metrics"]["planned_distance_m"] == 15.0
+    assert result.metrics == pytest.approx(
+        {
+            "failures_per_100m": 0.0,
+            "collisions_per_100m": 100.0 / 15.0,
+            "near_misses_per_100m": 20.0,
+            "interventions_per_km": 0.0,
+            "route_completion": 15.0 / 25.0,
+            "resets_per_km": 0.0,
         }
     )
 

--- a/tests/benchmark/test_long_horizon_route.py
+++ b/tests/benchmark/test_long_horizon_route.py
@@ -1,0 +1,174 @@
+"""Tests for long-horizon route composition and per-distance metrics."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.long_horizon_route import (
+    LongHorizonRouteError,
+    LongHorizonRouteSegment,
+    aggregate_distance_normalized_route_metrics,
+    build_long_horizon_route,
+)
+
+
+def test_build_long_horizon_route_repeats_and_truncates_segments() -> None:
+    """Route builder should compose existing scenario segments to a target length."""
+
+    route = build_long_horizon_route(
+        "unit-route",
+        (
+            LongHorizonRouteSegment("clear_sidewalk", 40.0),
+            LongHorizonRouteSegment("static_obstacle", 30.0),
+            LongHorizonRouteSegment("pedestrian_crossing", 25.0),
+        ),
+        target_length_m=120.0,
+    )
+
+    assert route.length_m == pytest.approx(120.0)
+    assert [segment.scenario_id for segment in route.segments] == [
+        "clear_sidewalk",
+        "static_obstacle",
+        "pedestrian_crossing",
+        "clear_sidewalk",
+    ]
+    assert [segment.length_m for segment in route.segments] == pytest.approx(
+        [40.0, 30.0, 25.0, 25.0],
+        abs=1e-9,
+    )
+    assert route.to_dict()["segments"][0]["scenario_id"] == "clear_sidewalk"
+
+
+def test_build_long_horizon_route_without_target_uses_declared_lengths() -> None:
+    """Route builder should preserve declared segment repetitions when no target is set."""
+
+    route = build_long_horizon_route(
+        "declared-route",
+        (
+            LongHorizonRouteSegment("clear_sidewalk", 10.0, repetitions=2),
+            LongHorizonRouteSegment("blind_corner", 15.0),
+        ),
+    )
+
+    assert route.length_m == pytest.approx(35.0)
+    assert route.to_dict() == {
+        "route_id": "declared-route",
+        "length_m": 35.0,
+        "segments": [
+            {
+                "scenario_id": "clear_sidewalk",
+                "length_m": 10.0,
+                "repetitions": 2,
+                "parameters": {},
+            },
+            {
+                "scenario_id": "blind_corner",
+                "length_m": 15.0,
+                "repetitions": 1,
+                "parameters": {},
+            },
+        ],
+    }
+
+
+@pytest.mark.parametrize(
+    ("segment_kwargs", "message"),
+    [
+        ({"scenario_id": "", "length_m": 10.0}, "scenario_id"),
+        ({"scenario_id": "clear_sidewalk", "length_m": 0.0}, "length_m"),
+        ({"scenario_id": "clear_sidewalk", "length_m": 10.0, "repetitions": 0}, "repetitions"),
+    ],
+)
+def test_route_segment_validation_fails_closed(
+    segment_kwargs: dict[str, object],
+    message: str,
+) -> None:
+    """Invalid segment definitions should fail before benchmark use."""
+
+    with pytest.raises(LongHorizonRouteError, match=message):
+        LongHorizonRouteSegment(**segment_kwargs)  # type: ignore[arg-type]
+
+
+def test_distance_normalized_route_metrics_from_synthetic_records() -> None:
+    """Aggregator should emit the six requested per-100m/per-km route metrics."""
+
+    records = [
+        {
+            "episode_id": "route-a-segment-1",
+            "metrics": {
+                "distance_m": 120.0,
+                "route_length_m": 300.0,
+                "failures": 1,
+                "collisions": 1,
+                "near_misses": 3,
+                "interventions": 1,
+                "resets": 0,
+            },
+        },
+        {
+            "episode_id": "route-a-segment-2",
+            "metrics": {
+                "distance_m": 80.0,
+                "route_length_m": 300.0,
+                "failures": 0,
+                "collisions": 0,
+                "near_misses": 1,
+                "interventions": 0,
+                "resets": 1,
+            },
+        },
+    ]
+
+    metrics = aggregate_distance_normalized_route_metrics(records)
+
+    assert metrics == pytest.approx(
+        {
+            "failures_per_100m": 0.5,
+            "collisions_per_100m": 0.5,
+            "near_misses_per_100m": 2.0,
+            "interventions_per_km": 5.0,
+            "route_completion": 2 / 3,
+            "resets_per_km": 5.0,
+        }
+    )
+
+
+def test_distance_normalized_route_metrics_fail_closed_without_distance() -> None:
+    """Distance-normalized metrics require explicit distance provenance."""
+
+    with pytest.raises(LongHorizonRouteError, match="missing distance_m"):
+        aggregate_distance_normalized_route_metrics([{"metrics": {"collisions": 1}}])
+
+
+@pytest.mark.parametrize(
+    ("records", "message"),
+    [
+        ([], "at least one record"),
+        ([{"metrics": {"distance_m": 0.0}}], "total traversed distance_m"),
+        ([{"metrics": {"distance_m": -1.0}}], "distance_m must not be negative"),
+        ([{"metrics": {"distance_m": 10.0, "collisions": -1}}], "collisions count"),
+        ([{"metrics": {"distance_m": "bad"}}], "distance_m must be numeric"),
+        ([{"metrics": {"distance_m": 10.0, "route_length_m": 0.0}}], "route_length_m"),
+    ],
+)
+def test_distance_normalized_route_metrics_fail_closed_invalid_inputs(
+    records: list[dict[str, object]],
+    message: str,
+) -> None:
+    """Invalid record inputs should fail closed instead of emitting misleading rates."""
+
+    with pytest.raises(LongHorizonRouteError, match=message):
+        aggregate_distance_normalized_route_metrics(records)
+
+
+def test_distance_normalized_route_metrics_support_planned_distance_alias() -> None:
+    """Planned segment distances should be summed when no route total is present."""
+
+    metrics = aggregate_distance_normalized_route_metrics(
+        [
+            {"metrics": {"distance_m": 20.0, "planned_distance_m": 40.0}},
+            {"metrics": {"distance_m": 30.0, "planned_distance_m": 60.0}},
+        ]
+    )
+
+    assert metrics["route_completion"] == pytest.approx(0.5)


### PR DESCRIPTION
## Summary
Adds long-horizon route benchmark helpers for issue #3969: route definitions compose existing local scenario segments, run a short headless route through the existing benchmark runner, and aggregate distance-normalized route metrics.

## Linked Issues
- Closes `#3969`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: none

## What Changed
- Added `robot_sf.benchmark.long_horizon_route` route segment/definition dataclasses with deterministic repetition/truncation.
- Added `run_long_horizon_route`, a thin headless wrapper over the existing `robot_sf.benchmark.runner.run_episode` path, preserving existing event semantics and adding route-distance provenance.
- Added `aggregate_distance_normalized_route_metrics` for `failures_per_100m`, `collisions_per_100m`, `near_misses_per_100m`, `interventions_per_km`, `route_completion`, and `resets_per_km`.
- Added focused unit tests for route composition, per-100m/per-km normalization, fail-closed invalid input handling, runner path-length provenance, and route runner orchestration.

## Why Matters
- Added value: creates the bounded long-horizon route/metric surface requested by #3969 without adding new physics or redefining collision/near-miss semantics.
- Expected impact: downstream benchmark launch packets can run composed route segments and normalize events by traversed distance.
- Why worth merging now: it satisfies the issue's first-slice acceptance with focused tests and a real short headless route smoke, while avoiding heavy benchmark, GPU, or Slurm work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: implementation readiness for #3969 long-horizon route helper and distance-normalized metrics.
- Comparator or baseline, applicable: NA - no comparative benchmark result.
- Evidence tier: targeted smoke.
- Result classification: blocker-resolution / smoke evidence only.
- Decision stop rule, applicable: route helper can run a short configured route headlessly and emit the six requested distance-normalized metrics.
- Parent issue, claim map, registry, context note, synthesis surface update: #3969 closes through this PR when merged.
- New research/benchmark/metric/paper-facing analysis tool, any: representative use is the direct short headless route command in Validation / Proof.

## Domain-Aware Approval
- Approval concerns experimental validity and waived / pending / blocked / not required: not required.
- Approver/review source waiver: PR adds implementation and smoke evidence only; it does not claim benchmark validity, ranking, paper evidence, or comparator movement.
- Validity checklist: event semantics are reused from existing benchmark records; fallback/degraded execution is not counted as benchmark evidence.
- Target claim/hypothesis: #3969 first-slice helper acceptance.
- Comparator split/evidence validity: NA - no comparator result.
- Fallback/degraded exclusions: no fallback/degraded run is presented as benchmark evidence.
- Claim boundary: implementation plus short headless smoke evidence only.
- Implementation integrity vs experimental validity: implementation integrity covered; experimental validity remains future campaign work.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes - the direct smoke executed two route segments through `run_long_horizon_route`.
- Did intervention change command source, selected command, trajectory, route progress? yes - route wrapper invoked the existing benchmark runner for each segment and aggregated route metrics.
- Did scenario actually contain targeted failure mode? NA - smoke validates route execution and metrics plumbing, not long-horizon failure discovery.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: run broader configured route campaigns before any benchmark or dissertation claim.

## Next Empirical Action
- Rerun needed: no for #3969 first-slice acceptance; yes before benchmark claims.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no durable benchmark artifact expected.
- Stop / revise / continue decision: stop this bounded issue; continue future campaign/config integration separately.
- Proposed child issue existing follow-up: none required for #3969 acceptance.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/long_horizon_route.py tests/benchmark/test_long_horizon_route.py`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_long_horizon_route.py -q` passed, 16 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/ -k "long_horizon or per_100m or route_benchmark" -q` passed, 60 selected tests; one unrelated PytestRemovedIn10Warning from `tests/test_scenario_generator.py`.
- Direct short headless route smoke through real benchmark runner:

```bash
scripts/dev/run_worktree_shared_venv.sh -- uv run python - <<'PY'
from robot_sf.benchmark.long_horizon_route import LongHorizonRouteSegment, build_long_horizon_route, run_long_horizon_route
route = build_long_horizon_route(
    "issue-3969-smoke",
    (
        LongHorizonRouteSegment("clear_sidewalk", 5.0, parameters={"density":"low","flow":"uni","obstacle":"open","groups":0.0,"speed_var":"low","goal_topology":"point","robot_context":"embedded"}),
        LongHorizonRouteSegment("static_obstacle", 5.0, parameters={"density":"low","flow":"uni","obstacle":"bottleneck","groups":0.0,"speed_var":"low","goal_topology":"point","robot_context":"embedded"}),
    ),
)
result = run_long_horizon_route(route, seed=11, horizon=2, dt=0.1, record_forces=False)
print({"records": len(result.records), "metrics": dict(result.metrics)})
PY
```

Observed: `records=2` and all six requested route metrics emitted. Force-based metric warnings are expected with `record_forces=False` and are not used by the route metrics.

## Performance Profiling
- Baseline runtime: NA - new helper, no prior route runner.
- Changed runtime: direct smoke completed in a bounded local command with two horizon-2 segments.
- Representative command: direct short headless route smoke above.
- Hot-path call count profile anchor: one `run_episode` call per route segment.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: route helper cannot run a short configured route headlessly or emits incorrect distance-normalized metrics.

## Risks / Rollout
- Compatibility risks: low; new module only, no existing runner behavior changed.
- Failure modes: downstream callers must provide supported scenario generation parameters; helper fails closed on missing/invalid distance or counts.
- Rollback fallback plan: revert new helper/test files.

## Docs / Provenance
- Updated docs: code docstrings and tests.
- Relevant design provenance notes: issue #3969.
- Any assumptions need preserved: `route_length_m` is treated as total route distance; segment `planned_distance_m` is summed only when no route total is provided.

## Downstream Propagation
- Parent issue updated (yes/no/NA): closes via PR body when merged.
- Claim map / benchmark report updated (yes/no/NA): NA - no benchmark result claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits, no durable result artifact.

## Follow-Up Issues
- Deferred work: broader route campaign/config integration before benchmark or dissertation claims.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify event-count alias list matches intended episode record fields for future route campaign integration.
- Any known limitations: direct evidence is a short smoke and synthetic/unit proof, not a nominal benchmark campaign.
