### PR TITLE
Issue #3275: bind null-test readiness to archive pair

### DIFF
--- a/docs/context/issue_3275_failure_archive_rerun_readiness.md
+++ b/docs/context/issue_3275_failure_archive_rerun_readiness.md
@@ -8,7 +8,7 @@ The check is readiness/leakage evidence only. It does not run benchmark campaign
 
 ## Implementation
 
-- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), blocks duplicate archive IDs within either archive, requires top-level archive lineage in `config.source_manifests`, blocks shared source-manifest lineage across source and rerun archives, requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata.
+- `robot_sf/benchmark/failure_archive_rerun_readiness.py` loads source archive and rerun archive inputs, checks archive-ID leakage, records family/seed overlap provenance, blocks missing overlap metadata (`archive_id`, scenario family, `candidate.scenario_seed`), blocks duplicate archive IDs within either archive, requires top-level archive lineage in `config.source_manifests`, blocks shared source-manifest lineage across source and rerun archives, requires passing certification metadata on source and rerun archive entries, and requires valid null-test prerequisite metadata tied to the checked source/rerun archive SHA-256 pair.
 - `scripts/validation/check_failure_archive_rerun_readiness.py` exposes the check as a fail-closed JSON CLI, including optional `--null-test-prerequisites` input.
 - Diagnostic-only rerun reports cap the verdict at `diagnostic_only` rather than `ready`.
 
@@ -24,5 +24,5 @@ Focused tests cover:
 - missing or failed source archive certification metadata blocking readiness;
 - missing or failed rerun archive certification metadata blocking readiness;
 - complete null-test prerequisite metadata staying ready;
-- missing, absent, or invalid null-test prerequisite metadata blocking readiness;
+- missing, absent, invalid, or archive-pair-mismatched null-test prerequisite metadata blocking readiness;
 - diagnostic-only rerun outputs staying diagnostic-only.

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -262,7 +262,9 @@ def classify_failure_archive_rerun_readiness(
 
     diagnostic_outputs = _diagnostic_only_outputs(Path(rerun_output) if rerun_output else None)
     null_source, null_status, missing_nulls, invalid_nulls = _null_test_prerequisite_gaps(
-        null_test_prerequisites
+        null_test_prerequisites,
+        expected_source_archive_sha256=source_hash,
+        expected_rerun_archive_sha256=rerun_hash,
     )
     blockers.extend(_count_blockers("missing_null_test_prerequisites", missing_nulls))
     blockers.extend(_count_blockers("invalid_null_test_prerequisites", invalid_nulls))
@@ -562,6 +564,9 @@ def _lineage_value_present(raw_value: Any) -> bool:
 
 def _null_test_prerequisite_gaps(
     payload_or_path: str | Path | dict[str, Any] | None,
+    *,
+    expected_source_archive_sha256: str | None,
+    expected_rerun_archive_sha256: str | None,
 ) -> tuple[str | None, str, list[str], list[str]]:
     """Return fail-closed gaps for optional null-test prerequisite metadata."""
 
@@ -585,6 +590,20 @@ def _null_test_prerequisite_gaps(
         if key not in prerequisites or prerequisites.get(key) in (None, "", [])
     ]
     invalid: list[str] = []
+    _check_expected_archive_hash(
+        prerequisites,
+        key="source_archive_sha256",
+        expected=expected_source_archive_sha256,
+        missing=missing,
+        invalid=invalid,
+    )
+    _check_expected_archive_hash(
+        prerequisites,
+        key="rerun_archive_sha256",
+        expected=expected_rerun_archive_sha256,
+        missing=missing,
+        invalid=invalid,
+    )
     if prerequisites.get("null_tests_reject_null") is not True:
         invalid.append("null_tests_reject_null_not_true")
     for key in ("shuffled_outcome_null_test", "ranking_permutation_test"):
@@ -599,6 +618,42 @@ def _null_test_prerequisite_gaps(
             invalid.append(f"{key}_invalid_p_value")
     status = "ready" if not missing and not invalid else "blocked"
     return source, status, missing, invalid
+
+
+def _check_expected_archive_hash(
+    prerequisites: dict[str, Any],
+    *,
+    key: str,
+    expected: str | None,
+    missing: list[str],
+    invalid: list[str],
+) -> None:
+    """Require null-test prerequisites to identify the checked archive pair."""
+
+    if expected is None:
+        invalid.append(f"{key}_expected_hash_unavailable")
+        return
+    observed = _archive_hash_prerequisite(prerequisites, key)
+    if observed is None:
+        missing.append(key)
+    elif observed != expected:
+        invalid.append(f"{key}_mismatch")
+
+
+def _archive_hash_prerequisite(prerequisites: dict[str, Any], key: str) -> str | None:
+    """Return archive hash from supported null-test prerequisite metadata shapes."""
+
+    direct_value = prerequisites.get(key)
+    if isinstance(direct_value, str) and direct_value.strip():
+        return direct_value.strip()
+    for container_key in ("archive_pair", "input_archives", "inputs"):
+        container = prerequisites.get(container_key)
+        if not isinstance(container, dict):
+            continue
+        value = container.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
 
 
 def _valid_probability(value: Any) -> bool:

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+from robot_sf.adversarial.disjoint_evaluation import archive_sha256
 from robot_sf.benchmark.failure_archive_rerun_readiness import (
     BLOCKED,
     DIAGNOSTIC_ONLY,
@@ -69,14 +70,22 @@ def _archive(
     return path
 
 
-def _null_test_prerequisites() -> dict:
+def _null_test_prerequisites(source_archive: Path, rerun_archive: Path) -> dict:
     """Return complete null-test prerequisite metadata."""
 
     return {
+        "source_archive_sha256": _archive_hash(source_archive),
+        "rerun_archive_sha256": _archive_hash(rerun_archive),
         "null_tests_reject_null": True,
         "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.01},
         "ranking_permutation_test": {"status": "complete", "p_value": 0.02},
     }
+
+
+def _archive_hash(path: Path) -> str:
+    """Return canonical archive hash for a JSON fixture path."""
+
+    return archive_sha256(json.loads(path.read_text(encoding="utf-8")))
 
 
 def test_disjoint_certified_archives_are_ready(tmp_path: Path) -> None:
@@ -100,7 +109,7 @@ def test_disjoint_certified_archives_are_ready(tmp_path: Path) -> None:
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == READY
@@ -126,7 +135,7 @@ def test_missing_archive_source_lineage_blocks_readiness(tmp_path: Path) -> None
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -151,7 +160,7 @@ def test_shared_archive_source_lineage_blocks_readiness(tmp_path: Path) -> None:
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -217,7 +226,7 @@ def test_duplicate_source_archive_ids_block_readiness(tmp_path: Path) -> None:
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -245,7 +254,7 @@ def test_duplicate_rerun_archive_ids_block_readiness(tmp_path: Path) -> None:
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -327,7 +336,7 @@ def test_blank_overlap_metadata_blocks_readiness(tmp_path: Path) -> None:
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -352,7 +361,7 @@ def test_user_archive_id_matching_fallback_prefix_is_not_missing(tmp_path: Path)
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -382,7 +391,7 @@ def test_non_string_cluster_key_value_is_not_placeholder_only(tmp_path: Path) ->
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == READY
@@ -445,7 +454,7 @@ def test_non_object_archive_entries_fail_closed(tmp_path: Path) -> None:
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -473,7 +482,7 @@ def test_mixed_archive_entry_shapes_fail_closed_with_index(tmp_path: Path) -> No
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -583,7 +592,7 @@ def test_missing_source_certification_lineage_blocks_readiness(tmp_path: Path) -
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -607,7 +616,7 @@ def test_missing_rerun_certification_lineage_blocks_readiness(tmp_path: Path) ->
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -639,7 +648,7 @@ def test_structured_certification_lineage_satisfies_readiness(tmp_path: Path) ->
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == READY
@@ -667,7 +676,7 @@ def test_falsy_certification_lineage_values_block_readiness(tmp_path: Path) -> N
     readiness = classify_failure_archive_rerun_readiness(
         source,
         rerun,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == BLOCKED
@@ -704,7 +713,7 @@ def test_diagnostic_only_output_caps_otherwise_ready_inputs(tmp_path: Path) -> N
         source,
         rerun,
         rerun_output=rerun_output,
-        null_test_prerequisites=_null_test_prerequisites(),
+        null_test_prerequisites=_null_test_prerequisites(source, rerun),
     )
 
     assert readiness.status == DIAGNOSTIC_ONLY
@@ -730,6 +739,8 @@ def test_null_test_prerequisites_can_be_checked_from_report(tmp_path: Path) -> N
             {
                 "schema_version": "adversarial_proposal_comparison.v1",
                 "null_tests": {
+                    "source_archive_sha256": _archive_hash(source),
+                    "rerun_archive_sha256": _archive_hash(rerun),
                     "null_tests_reject_null": True,
                     "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.01},
                     "ranking_permutation_test": {"status": "complete", "p_value": 0.02},
@@ -768,6 +779,8 @@ def test_missing_null_test_prerequisites_block_readiness(tmp_path: Path) -> None
         json.dumps(
             {
                 "null_tests": {
+                    "source_archive_sha256": _archive_hash(source),
+                    "rerun_archive_sha256": _archive_hash(rerun),
                     "null_tests_reject_null": False,
                     "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.5},
                 }
@@ -790,6 +803,94 @@ def test_missing_null_test_prerequisites_block_readiness(tmp_path: Path) -> None
     assert "invalid_null_test_prerequisites:1" in readiness.blockers
 
 
+def test_missing_null_test_archive_hashes_block_readiness(tmp_path: Path) -> None:
+    """Null-test reports must name the archive pair they apply to."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = {
+        "null_tests_reject_null": True,
+        "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.01},
+        "ranking_permutation_test": {"status": "complete", "p_value": 0.02},
+    }
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.missing_null_test_prerequisites == [
+        "source_archive_sha256",
+        "rerun_archive_sha256",
+    ]
+    assert "missing_null_test_prerequisites:2" in readiness.blockers
+
+
+def test_mismatched_null_test_archive_hash_blocks_readiness(tmp_path: Path) -> None:
+    """Stale null-test reports for another archive pair fail closed."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = _null_test_prerequisites(source, rerun)
+    prerequisites["rerun_archive_sha256"] = "0" * 64
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.invalid_null_test_prerequisites == ["rerun_archive_sha256_mismatch"]
+    assert "invalid_null_test_prerequisites:1" in readiness.blockers
+
+
+def test_null_test_archive_hashes_can_use_archive_pair_container(tmp_path: Path) -> None:
+    """Null-test archive hashes may be grouped under archive_pair metadata."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = {
+        "archive_pair": {
+            "source_archive_sha256": _archive_hash(source),
+            "rerun_archive_sha256": _archive_hash(rerun),
+        },
+        "null_tests_reject_null": True,
+        "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.01},
+        "ranking_permutation_test": {"status": "complete", "p_value": 0.02},
+    }
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == READY
+    assert readiness.missing_null_test_prerequisites == []
+    assert readiness.invalid_null_test_prerequisites == []
+
+
 def test_invalid_null_test_p_values_block_readiness(tmp_path: Path) -> None:
     """Malformed null-test p-values block readiness."""
 
@@ -802,6 +903,8 @@ def test_invalid_null_test_p_values_block_readiness(tmp_path: Path) -> None:
         [_entry("rerun_0000", family="family_b", seed=101)],
     )
     prerequisites = {
+        "source_archive_sha256": _archive_hash(source),
+        "rerun_archive_sha256": _archive_hash(rerun),
         "null_tests_reject_null": True,
         "shuffled_outcome_null_test": {"status": "complete", "p_value": "0.01"},
         "ranking_permutation_test": {"status": "complete", "p_value": 1.5},
@@ -834,6 +937,8 @@ def test_incomplete_null_test_status_does_not_validate_p_value(tmp_path: Path) -
         [_entry("rerun_0000", family="family_b", seed=101)],
     )
     prerequisites = {
+        "source_archive_sha256": _archive_hash(source),
+        "rerun_archive_sha256": _archive_hash(rerun),
         "null_tests_reject_null": True,
         "shuffled_outcome_null_test": {"status": "failed"},
         "ranking_permutation_test": {"status": "complete", "p_value": 0.05},
@@ -863,6 +968,8 @@ def test_null_test_p_value_probability_bounds_are_allowed(tmp_path: Path) -> Non
         [_entry("rerun_0000", family="family_b", seed=101)],
     )
     prerequisites = {
+        "source_archive_sha256": _archive_hash(source),
+        "rerun_archive_sha256": _archive_hash(rerun),
         "null_tests_reject_null": True,
         "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.0},
         "ranking_permutation_test": {"status": "complete", "p_value": 1.0},
@@ -894,6 +1001,8 @@ def test_cli_exit_codes_and_writes_report(tmp_path: Path, capsys) -> None:
     prerequisites.write_text(
         json.dumps(
             {
+                "source_archive_sha256": _archive_hash(source),
+                "rerun_archive_sha256": _archive_hash(rerun),
                 "null_tests_reject_null": True,
                 "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.01},
                 "ranking_permutation_test": {"status": "complete", "p_value": 0.02},


### PR DESCRIPTION
## Summary

- Addresses #3275 as another bounded readiness/fail-closed slice without closing the broader issue.
- Requires null-test prerequisite packets to identify the exact source and rerun archive SHA-256 pair before the proposal-model rerun readiness checker can return `ready`.
- Keeps stale or archive-pair-mismatched null-test reports blocked with explicit `missing_null_test_prerequisites` or `invalid_null_test_prerequisites` blockers, and documents the stricter gate in the issue context note.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` PASS
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` PASS
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` PASS
- `git diff --check` PASS
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<common-git-dir>/codex-agent-runs/active/issue-3275/pr_body.md PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` PASS

## Follow-Up Issues

- #3275 remains open for the real disjoint certified failure archive rerun with independent planner-execution outcomes, certification/candidate lineage, null-test reporting, and bounded held-out yield interpretation.

## Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, no proposal-model evaluation on real archive inputs, and no paper/dissertation claim edits.

## Residual Risk

The accepted null-test archive hash field names are a reversible metadata contract assumption: `source_archive_sha256` and `rerun_archive_sha256`, either directly in the null-test payload or under `archive_pair`, `input_archives`, or `inputs`.
