### PR TITLE
Issue #3813: preflight sustained-flow route respawn config

### DIFF
--- a/configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml
+++ b/configs/scenarios/sets/issue_3813_sustained_flow_scaffold_v0.yaml
@@ -11,6 +11,10 @@ scenarios:
     simulation_config:
       max_episode_steps: 600
       ped_density: 0.02
+      peds_reset_follow_route_at_start: true
+      route_spawn_distribution: spread
+      route_spawn_jitter_frac: 0.0
+      max_peds_per_group: 1
       robot_config: {}
     metadata:
       archetype: sustained_flow_t_intersection
@@ -60,6 +64,10 @@ scenarios:
     simulation_config:
       max_episode_steps: 600
       ped_density: 0.05
+      peds_reset_follow_route_at_start: true
+      route_spawn_distribution: spread
+      route_spawn_jitter_frac: 0.0
+      max_peds_per_group: 1
       robot_config: {}
     metadata:
       archetype: sustained_flow_t_intersection
@@ -109,6 +117,10 @@ scenarios:
     simulation_config:
       max_episode_steps: 600
       ped_density: 0.08
+      peds_reset_follow_route_at_start: true
+      route_spawn_distribution: spread
+      route_spawn_jitter_frac: 0.0
+      max_peds_per_group: 1
       robot_config: {}
     metadata:
       archetype: sustained_flow_t_intersection

--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from robot_sf.scenario_certification.sustained_flow import (
     EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
+    EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG,
     SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE,
     generate_expected_sustained_flow_scenarios,
     runtime_definition_status_for_support,
@@ -59,6 +60,7 @@ class SustainedFlowVariant:
     current_runtime_support: str
     runtime_definition_status: str
     runtime_definition_ready: bool
+    route_respawn_runtime_config: dict[str, object]
     max_episode_steps: int
     seeds: tuple[int, ...]
 
@@ -192,6 +194,9 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
         runtime_definition_ready=_required_bool(
             continuous_spawn, "runtime_definition_ready", scenario_name=name
         ),
+        route_respawn_runtime_config={
+            field: simulation_config.get(field) for field in EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG
+        },
         max_episode_steps=_required_int(simulation_config, "max_episode_steps", scenario_name=name),
         seeds=tuple(seeds),
     )
@@ -219,6 +224,12 @@ def _variant_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, 
             blockers.append(
                 f"{variant.name}: continuous-spawn runtime support is "
                 f"{variant.current_runtime_support!r}, expected {RUNTIME_SUPPORTED_VALUE!r}"
+            )
+        if variant.route_respawn_runtime_config != EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG:
+            blockers.append(
+                f"{variant.name}: route-respawn runtime config "
+                f"{variant.route_respawn_runtime_config!r}, expected "
+                f"{EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG!r}"
             )
         if variant.max_episode_steps <= 0:
             blockers.append(f"{variant.name}: max_episode_steps must be positive")
@@ -283,6 +294,7 @@ def _variant_generator_profile(variant: SustainedFlowVariant) -> tuple[object, .
         variant.current_runtime_support,
         variant.runtime_definition_status,
         variant.runtime_definition_ready,
+        tuple(sorted(variant.route_respawn_runtime_config.items())),
         variant.max_episode_steps,
         variant.seeds,
     )

--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -41,6 +41,12 @@ EXPECTED_CONTINUOUS_SPAWN_DEFINITION: dict[str, object] = {
     "minimum_active_pedestrians": 1,
     "clearing_policy": "disallow_empty_scene_wait_success",
 }
+EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG: dict[str, object] = {
+    "peds_reset_follow_route_at_start": True,
+    "route_spawn_distribution": "spread",
+    "route_spawn_jitter_frac": 0.0,
+    "max_peds_per_group": 1,
+}
 _SUSTAINED_FLOW_FAMILY = "sustained_flow_t_intersection"
 _SUSTAINED_FLOW_MAP_FILE = "../../../maps/svg_maps/classic_t_intersection.svg"
 _SUSTAINED_FLOW_MAX_EPISODE_STEPS = 600
@@ -119,6 +125,7 @@ def generate_expected_sustained_flow_scenarios(
                 "simulation_config": {
                     "max_episode_steps": spec.max_episode_steps,
                     "ped_density": spec.ped_density,
+                    **EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG,
                     "robot_config": {},
                 },
                 "metadata": {
@@ -379,6 +386,29 @@ def _check_termination_and_metric(
     return errors
 
 
+def _check_route_respawn_runtime_config(scenario: dict[str, Any], *, name: str) -> list[str]:
+    """Validate deterministic route-respawn settings required before runtime proof.
+
+    Returns:
+        Fail-closed error messages for missing or drifted runtime-preflight settings.
+    """
+
+    simulation_config = scenario.get("simulation_config")
+    if not isinstance(simulation_config, dict):
+        return [f"{name}: simulation_config block required"]
+
+    errors: list[str] = []
+    for field, expected in EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG.items():
+        _require_equal(
+            errors,
+            name,
+            f"simulation_config.{field}",
+            simulation_config.get(field),
+            expected,
+        )
+    return errors
+
+
 def _check_metadata_fail_closed(
     scenario: dict[str, Any],
     *,
@@ -403,6 +433,7 @@ def _check_metadata_fail_closed(
         )
     )
     errors.extend(_check_termination_and_metric(scenario, metadata, name=name))
+    errors.extend(_check_route_respawn_runtime_config(scenario, name=name))
     return errors
 
 

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -17,6 +17,7 @@ from robot_sf.benchmark.sustained_flow_preflight import (
     preflight_sustained_flow_matrix,
 )
 from robot_sf.scenario_certification.sustained_flow import (
+    EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG,
     generate_runtime_supported_sustained_flow_scenarios,
 )
 from robot_sf.training.scenario_loader import load_scenarios
@@ -65,6 +66,10 @@ def test_sustained_flow_scenario_set_is_runner_loadable(capsys) -> None:
         metadata = scenario["metadata"]
         spawn_definition = metadata["continuous_spawn"]["definition"]
         assert scenario["simulation_config"]["max_episode_steps"] == 600
+        assert {
+            field: scenario["simulation_config"][field]
+            for field in EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG
+        } == EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG
         assert metadata["pack_id"] == "issue_3813_sustained_flow_scaffold_v0"
         assert metadata["status"] == "pre_benchmark_scaffold"
         assert metadata["enabled_by_default"] is False
@@ -112,6 +117,10 @@ def test_sustained_flow_preflight_enumerates_variants_and_fails_closed() -> None
         0.05,
         0.08,
     ]
+    assert {
+        tuple(sorted(variant["route_respawn_runtime_config"].items()))
+        for variant in payload["variants"]
+    } == {tuple(sorted(EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG.items()))}
     assert all(
         f"expected {RUNTIME_SUPPORTED_VALUE!r}" in reason for reason in payload["blocking_reasons"]
     )
@@ -155,6 +164,24 @@ def test_sustained_flow_preflight_rejects_runtime_definition_readiness_drift(
     assert payload["status"] == "not_available"
     assert payload["benchmark_eligible"] is False
     assert any("runtime definition readiness" in reason for reason in payload["blocking_reasons"])
+
+
+def test_sustained_flow_preflight_rejects_route_respawn_runtime_config_drift(
+    tmp_path: Path,
+) -> None:
+    """Runtime-supported matrices keep route-respawn settings in simulation_config."""
+    matrix = _load_yaml(SCENARIO_SET)
+    matrix["scenarios"] = generate_runtime_supported_sustained_flow_scenarios()
+    del matrix["scenarios"][0]["simulation_config"]["peds_reset_follow_route_at_start"]
+
+    drifted_matrix = tmp_path / "route_respawn_runtime_config_drift.yaml"
+    drifted_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+
+    payload = preflight_sustained_flow_matrix(drifted_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert any("route-respawn runtime config" in reason for reason in payload["blocking_reasons"])
 
 
 def test_sustained_flow_preflight_rejects_generator_drift(tmp_path: Path) -> None:

--- a/tests/scenario_certification/test_sustained_flow_preflight.py
+++ b/tests/scenario_certification/test_sustained_flow_preflight.py
@@ -30,6 +30,13 @@ def test_expected_variants_enumerate_deterministically() -> None:
     ]
     assert spawn_rates == [6.0, 12.0, 18.0]
     assert {
+        tuple(
+            (field, scenario["simulation_config"][field])
+            for field in sustained_flow.EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG
+        )
+        for scenario in generated
+    } == {tuple(sustained_flow.EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG.items())}
+    assert {
         scenario["metadata"]["continuous_spawn"]["runtime_definition_status"]
         for scenario in generated
     } == {sustained_flow.RUNTIME_DEFINITION_METADATA_ONLY_STATUS}
@@ -178,6 +185,22 @@ def test_preflight_rejects_runtime_definition_readiness_drift(tmp_path: Path) ->
 
     assert not report.conforms
     assert any("continuous_spawn.runtime_definition_status" in error for error in report.errors)
+
+
+def test_preflight_rejects_route_respawn_runtime_config_drift(tmp_path: Path) -> None:
+    """Scenario YAML must keep route-respawn runtime preflight settings explicit."""
+    payload = yaml.safe_load(SCENARIO_SET.read_text(encoding="utf-8"))
+    payload["scenarios"][0]["simulation_config"]["peds_reset_follow_route_at_start"] = False
+
+    drifted = tmp_path / "issue_3813_sustained_flow_route_respawn_config_drift.yaml"
+    drifted.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    report = sustained_flow.preflight_sustained_flow_scenario_set(drifted)
+
+    assert not report.conforms
+    assert any(
+        "simulation_config.peds_reset_follow_route_at_start" in error for error in report.errors
+    )
 
 
 def test_preflight_cli_outputs_json_payload() -> None:


### PR DESCRIPTION
## Summary
Adds explicit route-respawn runtime preflight settings to the issue #3813 sustained-flow scenario scaffold, so the generator and preflight checkers fail closed if those settings drift.

## Linked Issues
- Relates `#3813`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: `#3813`
- Safe review independently: yes
- Review dependency reason, any: Bounded scenario/preflight slice on current `origin/main`.

## Changed
- Added expected route-respawn simulation settings to the sustained-flow light/medium/heavy scaffold rows.
- Updated sustained-flow generator and scenario-certification preflight to require those settings.
- Updated benchmark sustained-flow preflight payload to expose `route_respawn_runtime_config` per variant and block eligibility if it drifts.
- Added focused enumeration and drift tests for the new runtime-preflight settings.

## Why Matters
- Added value: continuous-spawn scaffold now records concrete route-respawn runtime settings needed for the next runtime proof slice.
- Expected impact: Preflight catches missing route-respawn settings before sustained-flow matrix rows can be treated as runnable or eligible.
- Why worth merging now: narrows remaining #3813 runtime-support work without running a full campaign or changing benchmark claims.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3813 blocker sustained-flow scenario variants need a continuous-spawn/runtime preflight path before benchmark use.
- Comparator or baseline, applicable: Existing metadata-only sustained-flow scaffold on `origin/main`.
- Evidence tier: NA - static preflight/support slice only, no research result claim.
- Result classification: NA - no research result claim.
- Decision stop rule, applicable: Merge only if generator, YAML preflight, and benchmark preflight enumerate all three variants and fail closed on route-respawn config drift.
- Parent issue, claim map, registry, context note, synthesis surface update: #3813 remains open for runtime continuous respawn, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, and runnable campaign/runner benchmark evidence.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - extends existing static preflight/checker surface only.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: PR makes no benchmark-strength or paper-facing claim.
- Validity checklist:
- Target claim/hypothesis: Static preflight settings only.
- Comparator split/evidence validity: Compared to `origin/main` scaffold/preflight behavior.
- Fallback/degraded exclusions: Benchmark evidence remains `false`; no fallback/degraded run is counted as success.
- Claim boundary: No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: Implementation integrity checked by focused tests and readiness; experimental validity remains deferred to #3813 follow-up slices.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes
- Did intervention change command source, selected command, trajectory, route progress? It changes only scenario/preflight config checker payload; no runtime trajectory or metric claim.
- Did scenario actually contain targeted failure mode? Unknown; not tested because this PR does not run runtime episodes.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3813.

## Next Empirical Action
- Rerun needed: no for this static slice
- Extractor analysis tool needed: no
- Artifact missing unavailable: Runtime continuous pedestrian respawn proof, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, runnable campaign/runner benchmark evidence.
- Stop / revise / continue decision: continue via #3813 follow-up slices.
- Proposed child issue existing follow-up: #3813.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/scenario_certification/sustained_flow.py robot_sf/benchmark/sustained_flow_preflight.py tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q` - passed, 24 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` - passed, `conforms=true`, `variant_count=3`, `runtime_support=metadata_only`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --runtime-supported-generated --json` - passed, `conforms=true`, `variant_count=3`, `runtime_support=runtime_continuous_spawn`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_followups.py --body-file <PR_BODY>` - passed; deferred work links to #3813 and no domain-sensitive evidence-validity trigger was found.
- `git diff --check origin/main...HEAD` - passed.

## Coverage / Performance
- Baseline runtime: NA - no runtime/caching performance claim.
- Changed runtime: NA - no runtime/caching performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q`
- Hot-path call count profile anchor: NA - no hot-path performance claim.
- Cache-hit reuse counter: NA - no caching claim.
- Rollback failure criterion: Revert if sustained-flow preflight stops failing closed on missing route-respawn runtime settings or if scenario loading rejects the scaffold.

## Risks / Rollout
- Compatibility risks: Low; only the issue #3813 opt-in scaffold and its preflight helpers/tests are touched.
- Failure modes: future runtime slice could overinterpret route-respawn config as full continuous-spawn benchmark evidence; PR keeps `benchmark_evidence=false` to prevent that.
- Rollback fallback plan: Revert this commit; existing metadata-only preflight behavior remains available on `origin/main`.

## Docs / Provenance
- Updated docs: NA - no human-facing docs changed.
- Relevant design provenance notes: Issue #3813 prior merged preflight slices listed in issue comments.
- Any assumptions need preserved: Route-respawn config is a runtime-preflight prerequisite, not evidence that sustained-flow benchmark validity is complete.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no before merge; #3813 remains the open follow-up container.
- Claim map / benchmark report updated (yes/no/NA): NA, no benchmark claim.
- Leaderboard / artifact catalog updated (yes/no/NA): NA, no benchmark artifact.
- Registry or config index updated (yes/no/NA): NA, existing scaffold path unchanged.
- Context index / memory note updated (yes/no/NA): NA, targeted code/config slice only.
- Follow-up issue opened deferred propagation (yes/no/NA): no, #3813 remains follow-up container.
- Not applicable because: PR is a static scenario/preflight slice; no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Follow-Up Issues
- Deferred work: Runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, runnable campaign/runner benchmark evidence.
- Issues opened follow-up: none; #3813 remains open.

## Reviewer Notes
- Anything reviewer verify closely: Confirm `benchmark_evidence` remains false and `benchmark_eligible` still requires runtime-supported rows plus clean route-respawn config.
- Any known limitations: No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
