### PR TITLE
Issue #3501: add safety-wrapper ablation manifest checker

### DIFF
--- a/configs/research/safety_wrapper_ablation_v1.yaml
+++ b/configs/research/safety_wrapper_ablation_v1.yaml
@@ -66,12 +66,22 @@ event_ledger_target: 3482
 
 result_contract:
   required_outputs:
+    - study_id
     - planner
     - wrapper_arm
-    - seed
     - scenario_id
+    - seed
+    - software_commit
+    - event_ledger
     - metric_values
     - wrapper_intervention_rate
+  pairing_key_fields:
+    - planner
+    - scenario_id
+    - seed
+  expected_wrapper_arms:
+    - wrapper_off
+    - wrapper_on
   caveat_rule: >
     Report both positive and negative/transfer-poorly effects. Any effect must be
     reported as diagnostic until durable, paired-seed evidence over the full scenario

--- a/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
+++ b/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
@@ -33,6 +33,19 @@ CONFIG_SCHEMA_VERSION = "safety-wrapper-ablation.v1"
 
 WRAPPER_OFF_ARM = "wrapper_off"
 WRAPPER_ON_ARM = "wrapper_on"
+EXPECTED_WRAPPER_ARMS = (WRAPPER_OFF_ARM, WRAPPER_ON_ARM)
+PAIRING_KEY_FIELDS = ("planner", "scenario_id", "seed")
+REQUIRED_ROW_FIELDS = (
+    "study_id",
+    "planner",
+    "wrapper_arm",
+    "scenario_id",
+    "seed",
+    "software_commit",
+    "event_ledger",
+    "metric_values",
+    "wrapper_intervention_rate",
+)
 
 DRY_RUN_CLAIM_BOUNDARY = (
     "dry-run factorial-ablation manifest only: enumerates the fixed issue #3501 "
@@ -79,6 +92,7 @@ def validate_safety_wrapper_ablation_config(config: Mapping[str, Any]) -> dict[s
         raise ValueError(f"schema_version must be {CONFIG_SCHEMA_VERSION!r}")
     _validate_fixed_scope(normalized.get("fixed_scope"))
     _validate_wrapper_arms(normalized.get("wrapper_arms"))
+    _validate_result_contract(normalized.get("result_contract"))
     return normalized
 
 
@@ -102,6 +116,26 @@ def _validate_fixed_scope(fixed_scope: Any) -> None:
         raise ValueError("fixed_scope.planner_groups must be a non-empty list")
     if len(set(planner_groups)) != len(planner_groups):
         raise ValueError("fixed_scope.planner_groups must be unique")
+
+
+def _validate_result_contract(result_contract: Any) -> None:
+    """Require row-level provenance and pairing fields for later ablation checks."""
+    if not isinstance(result_contract, Mapping):
+        raise ValueError("result_contract must be mapping")
+    required_outputs = result_contract.get("required_outputs")
+    if not isinstance(required_outputs, Sequence) or isinstance(required_outputs, (str, bytes)):
+        raise ValueError("result_contract.required_outputs must be list")
+    missing = [field for field in REQUIRED_ROW_FIELDS if field not in required_outputs]
+    if missing:
+        raise ValueError(f"result_contract.required_outputs missing fields: {missing}")
+    pairing_fields = result_contract.get("pairing_key_fields")
+    if tuple(pairing_fields or ()) != PAIRING_KEY_FIELDS:
+        raise ValueError(f"result_contract.pairing_key_fields must be {list(PAIRING_KEY_FIELDS)!r}")
+    expected_arms = result_contract.get("expected_wrapper_arms")
+    if tuple(expected_arms or ()) != EXPECTED_WRAPPER_ARMS:
+        raise ValueError(
+            f"result_contract.expected_wrapper_arms must be {list(EXPECTED_WRAPPER_ARMS)!r}"
+        )
 
 
 def _validate_wrapper_arms(arms: Any) -> None:
@@ -194,6 +228,15 @@ def build_safety_wrapper_ablation_manifest(
         "primary_outcomes": copy.deepcopy(validated.get("primary_outcomes", [])),
         "event_ledger_target": validated.get("event_ledger_target"),
         "result_contract": copy.deepcopy(validated.get("result_contract")),
+        "row_contract": {
+            "required_fields": list(REQUIRED_ROW_FIELDS),
+            "pairing_key_fields": list(PAIRING_KEY_FIELDS),
+            "expected_wrapper_arms": list(EXPECTED_WRAPPER_ARMS),
+            "pairing_rule": (
+                "Every (planner, scenario_id, seed) group must contain exactly one "
+                "wrapper_off row and one wrapper_on row before comparison."
+            ),
+        },
         "cell_count": len(cells),
         "cells": cells,
         "factorial_check": check_factorial_ablation(planner_groups, arms, seeds),
@@ -291,6 +334,69 @@ def check_factorial_ablation(
         "planner_count": len(planner_groups),
         "expected_cell_count": expected_cells,
         "seeds_per_cell": len(seeds),
+    }
+
+
+def check_factorial_ablation_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str, Any]:
+    """Check emitted ablation rows are pairable before any with/without comparison.
+
+    The checker is deliberately pure and fail-closed: it does not infer missing
+    provenance, silently drop duplicate arms, or compare unpaired rows.
+
+    Returns:
+        Structured completeness report with missing fields, duplicate pair rows,
+        and incomplete off/on pairs.
+    """
+    missing_required_fields: list[dict[str, Any]] = []
+    duplicate_pair_rows: list[dict[str, Any]] = []
+    unexpected_wrapper_arms: list[str] = []
+    groups: dict[tuple[Any, ...], dict[str, int]] = {}
+
+    for index, row in enumerate(rows):
+        missing = [field for field in REQUIRED_ROW_FIELDS if field not in row]
+        if missing:
+            missing_required_fields.append({"row_index": index, "fields": missing})
+        arm = str(row.get("wrapper_arm", ""))
+        if arm not in EXPECTED_WRAPPER_ARMS:
+            unexpected_wrapper_arms.append(arm)
+        key = tuple(row.get(field) for field in PAIRING_KEY_FIELDS)
+        by_arm = groups.setdefault(key, {})
+        by_arm[arm] = by_arm.get(arm, 0) + 1
+        if by_arm[arm] > 1:
+            duplicate_pair_rows.append(
+                {
+                    "pairing_key": dict(zip(PAIRING_KEY_FIELDS, key, strict=True)),
+                    "wrapper_arm": arm,
+                    "count": by_arm[arm],
+                }
+            )
+
+    incomplete_pairs = [
+        {
+            "pairing_key": dict(zip(PAIRING_KEY_FIELDS, key, strict=True)),
+            "wrapper_arms": sorted(by_arm),
+        }
+        for key, by_arm in groups.items()
+        if set(by_arm) != set(EXPECTED_WRAPPER_ARMS) or any(count != 1 for count in by_arm.values())
+    ]
+    complete = (
+        len(rows) > 0
+        and not missing_required_fields
+        and not unexpected_wrapper_arms
+        and not duplicate_pair_rows
+        and not incomplete_pairs
+    )
+    return {
+        "complete": bool(complete),
+        "row_count": len(rows),
+        "pair_count": len(groups),
+        "required_fields": list(REQUIRED_ROW_FIELDS),
+        "pairing_key_fields": list(PAIRING_KEY_FIELDS),
+        "expected_wrapper_arms": list(EXPECTED_WRAPPER_ARMS),
+        "missing_required_fields": missing_required_fields,
+        "unexpected_wrapper_arms": sorted(set(unexpected_wrapper_arms)),
+        "duplicate_pair_rows": duplicate_pair_rows,
+        "incomplete_pairs": incomplete_pairs,
     }
 
 

--- a/tests/benchmark/test_safety_wrapper_ablation_manifest.py
+++ b/tests/benchmark/test_safety_wrapper_ablation_manifest.py
@@ -14,6 +14,7 @@ from robot_sf.benchmark.safety_wrapper_ablation_manifest import (
     ManifestOptions,
     build_safety_wrapper_ablation_manifest,
     check_factorial_ablation,
+    check_factorial_ablation_rows,
     load_safety_wrapper_ablation_config,
     write_safety_wrapper_ablation_manifest,
 )
@@ -164,3 +165,79 @@ def test_manifest_json_output_is_deterministic(tmp_path: Path) -> None:
     second_path = write_safety_wrapper_ablation_manifest(second, tmp_path / "second")
 
     assert first_path.read_text(encoding="utf-8") == second_path.read_text(encoding="utf-8")
+
+
+def _ablation_row(wrapper_arm: str, seed: int = 111) -> dict[str, object]:
+    return {
+        "study_id": "issue_3501_safety_wrapper_ablation_v1",
+        "planner": "orca",
+        "wrapper_arm": wrapper_arm,
+        "scenario_id": "crossing_basic",
+        "seed": seed,
+        "software_commit": "abc1234",
+        "event_ledger": {"schema_version": "EpisodeEventLedger.v1"},
+        "metric_values": {"exact_collision_probability": 0.0},
+        "wrapper_intervention_rate": 0.0,
+    }
+
+
+def test_manifest_declares_row_contract_for_later_result_checker() -> None:
+    """Manifest publishes fields required before any wrapper on/off comparison."""
+    manifest = build_safety_wrapper_ablation_manifest(_repo_config(), options=_options())
+    row_contract = manifest["row_contract"]
+
+    assert row_contract["required_fields"] == manifest["result_contract"]["required_outputs"]
+    assert row_contract["pairing_key_fields"] == ["planner", "scenario_id", "seed"]
+    assert row_contract["expected_wrapper_arms"] == [WRAPPER_OFF_ARM, WRAPPER_ON_ARM]
+    assert "exactly one wrapper_off row and one wrapper_on row" in row_contract["pairing_rule"]
+
+
+def test_check_factorial_ablation_rows_accepts_exact_paired_rows() -> None:
+    """Result rows are complete only with one off/on arm per planner/scenario/seed."""
+    rows = [_ablation_row(WRAPPER_OFF_ARM), _ablation_row(WRAPPER_ON_ARM)]
+
+    report = check_factorial_ablation_rows(rows)
+
+    assert report["complete"] is True
+    assert report["row_count"] == 2
+    assert report["pair_count"] == 1
+    assert report["missing_required_fields"] == []
+    assert report["incomplete_pairs"] == []
+
+
+def test_check_factorial_ablation_rows_rejects_missing_provenance_and_unpaired_arm() -> None:
+    """Missing provenance fields or one-arm rows fail closed before comparison."""
+    row = _ablation_row(WRAPPER_ON_ARM)
+    del row["software_commit"]
+
+    report = check_factorial_ablation_rows([row])
+
+    assert report["complete"] is False
+    assert report["missing_required_fields"] == [{"row_index": 0, "fields": ["software_commit"]}]
+    assert report["incomplete_pairs"] == [
+        {
+            "pairing_key": {"planner": "orca", "scenario_id": "crossing_basic", "seed": 111},
+            "wrapper_arms": [WRAPPER_ON_ARM],
+        }
+    ]
+
+
+def test_check_factorial_ablation_rows_rejects_duplicate_or_unknown_arm() -> None:
+    """Duplicate or non-contract wrapper arms cannot be compared."""
+    rows = [
+        _ablation_row(WRAPPER_OFF_ARM),
+        _ablation_row(WRAPPER_OFF_ARM),
+        _ablation_row("wrapper_auto"),
+    ]
+
+    report = check_factorial_ablation_rows(rows)
+
+    assert report["complete"] is False
+    assert report["unexpected_wrapper_arms"] == ["wrapper_auto"]
+    assert report["duplicate_pair_rows"] == [
+        {
+            "pairing_key": {"planner": "orca", "scenario_id": "crossing_basic", "seed": 111},
+            "wrapper_arm": WRAPPER_OFF_ARM,
+            "count": 2,
+        }
+    ]


### PR DESCRIPTION
## Summary
Adds the opt-in issue #3501 factorial ablation manifest/checker slice around the already-merged planner-agnostic safety wrapper. This PR does not wire runtime execution or claim mitigation effectiveness.

## Linked Issues
- Relates to #3501

## Stack / Dependency
- Base dependency: none
- Required prior PRs: #3591 already landed the planner-agnostic safety-wrapper core
- Stack follow-up issues: #3501 remains open for runtime/campaign work
- Safe to review independently: yes
- Review dependency reason, any: This only tightens the manifest/checker contract for later paired runs.

## What Changed
- Extended `configs/research/safety_wrapper_ablation_v1.yaml` with row provenance fields, pairing key fields, and expected wrapper arms.
- Added `row_contract` emission and `check_factorial_ablation_rows()` to fail closed on missing provenance, duplicate arm rows, unknown arms, or incomplete wrapper off/on pairs.
- Added focused tests for manifest row contract, exact paired rows, missing provenance, duplicate rows, and unknown wrapper arms.

## Why Matters
- Added value: later runs can compare wrapper off/on rows consistently by `(planner, scenario_id, seed)`.
- Expected impact: reduces risk of invalid with/without comparisons before any campaign is run.
- Why worth merging now: it is the small launch-packet/checker slice requested for #3501 without threshold tuning or runtime semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3501 ablation wiring prerequisite for future mitigation quantification.
- Comparator or baseline, applicable: `wrapper_off` baseline vs `wrapper_on`, paired later by planner/scenario/seed.
- Evidence tier: launch packet
- Result classification: diagnostic-only
- Decision stop rule, applicable: no mitigation-effectiveness decision in this PR.
- Parent issue, claim map, registry, context note, synthesis surface update: #3501.
- New research/benchmark/metric/paper-facing analysis tool, any: support checker only; no research result interpretation.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: no benchmark or mitigation-effectiveness claim made.
- Validity checklist: checker enforces paired rows and provenance fields only.
- Target claim/hypothesis: future wrapper off/on comparison readiness.
- Comparator split/evidence validity: future rows must include exactly one `wrapper_off` and one `wrapper_on` per `(planner, scenario_id, seed)`.
- Fallback/degraded exclusions: no execution path added.
- Claim boundary: launch-packet/checker only; not benchmark evidence.
- Implementation integrity vs experimental validity: implemented as pure manifest/result-row checks.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no runtime execution.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: future campaign/result PRs must report negative transfer cases.

## Next Empirical Action
- Rerun needed: yes, future bounded paired ablation only after runtime wiring.
- Extractor analysis tool needed: yes, future paired effect summarizer remains out of scope.
- Artifact missing unavailable: durable paired episode evidence not produced here.
- Stop / revise / continue decision: continue with runtime/campaign slice after review.
- Proposed child issue existing follow-up: #3501.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_safety_wrapper_ablation_manifest.py tests/test_safety_wrapper.py -q` -> passed, 26 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/safety_wrapper_ablation_manifest.py tests/benchmark/test_safety_wrapper_ablation_manifest.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_safety_wrapper_ablation_manifest.py --config configs/research/safety_wrapper_ablation_v1.yaml --out output/safety_wrapper_ablation_manifest --dry-run` -> passed; `complete=True`, `cells=6`, `seeds_per_cell=3`.
- `git diff --check` -> passed.

## Performance / Hot Path
- Baseline runtime: NA, no runtime path touched.
- Changed runtime: NA, no runtime path touched.
- Representative command: dry-run manifest builder command above.
- Hot-path call count profile anchor: NA, pure checker/manifest only.
- Cache-hit reuse counter: NA, no caching claimed.
- Rollback failure criterion: manifest builder/tests fail, or row checker accepts missing/unpaired provenance.

## Risks / Rollout
- Compatibility risks: future callers must emit the declared provenance fields before comparing rows.
- Failure modes: overly strict checker may reject partial exploratory rows; that is intentional fail-closed behavior for comparison readiness.
- Rollback fallback plan: revert this PR to restore the prior manifest-only contract.

## Docs / Provenance
- Updated docs: config comments/contract only.
- Relevant design provenance notes: issue #3501; #3591 wrapper core already merged.
- Any assumptions need to preserved: row-level software commit and event ledger are required before comparing wrapper off/on effects.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comment authorization was false.
- Claim map / benchmark report updated (yes/no/NA): NA, no claim result.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no, #3501 already tracks the remaining work.
- Not applicable because: no benchmark campaign, durable artifact, or paper-facing claim was produced.

## Follow-Up Issues
- Deferred work: runtime execution wiring, paired campaign, paired-effect summarizer, and any evidence promotion.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify the row checker fails closed before comparison and does not imply runtime binding.
- Explicitly out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stricter validation for ablation results to ensure required fields are present, rows are correctly paired, and only the expected output variants are used.
  * Dry-run manifests now include clearer row-level contract details for result completeness and pairing rules.

* **Bug Fixes**
  * Improved detection of missing data, duplicate rows, incomplete pairs, and unexpected output variants before comparisons are run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->