### PR TITLE
Issue #1496: add oracle collection readiness decision manifest

### DIFF
--- a/scripts/validation/validate_oracle_imitation_launch_packet.py
+++ b/scripts/validation/validate_oracle_imitation_launch_packet.py
@@ -5,39 +5,90 @@ from __future__ import annotations
 import argparse
 import json
 from pathlib import Path
+from typing import Any
 
 from robot_sf.training.oracle_imitation_launch_packet import (
     LaunchPacketError,
     validate_launch_packet,
 )
 
+_DECISION_SCHEMA = "oracle-imitation-collection-readiness-decision.v1"
+_ISSUE = 1496
+
 
 def build_arg_parser() -> argparse.ArgumentParser:
-    """Build the command-line parser."""
+    """Build command-line parser."""
     parser = argparse.ArgumentParser(
-        description="Validate a pre-Slurm oracle-imitation dataset launch packet."
+        description="Validate pre-Slurm oracle-imitation dataset launch packet."
     )
     parser.add_argument("--config", required=True, type=Path, help="Launch-packet YAML path.")
     parser.add_argument(
         "--repo-root",
         default=Path.cwd(),
         type=Path,
-        help="Repository root used to resolve relative paths.",
+        help="Repository root used resolve relative paths.",
     )
-    parser.add_argument("--json", action="store_true", help="Emit a JSON validation report.")
+    parser.add_argument("--json", action="store_true", help="Emit JSON validation report.")
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help="Optional JSON path emitted collection-readiness decision manifest.",
+    )
     parser.add_argument(
         "--require-training-ready",
         action="store_true",
         help=(
-            "Fail closed unless the packet has concrete durable train/validation/evaluation "
-            "trace artifact URIs for downstream imitation training."
+            "Fail closed unless packet concrete durable train/validation/evaluation "
+            "trace artifact URIs downstream imitation training."
         ),
     )
     return parser
 
 
+def _first_launch_packet_error(exc: LaunchPacketError) -> str:
+    """Return first actionable launch-packet error line."""
+    for line in str(exc).splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("oracle-imitation") and stripped.endswith("failed validation:"):
+            continue
+        return stripped.removeprefix("- ").strip()
+    return str(exc)
+
+
+def _decision_manifest_payload(
+    *,
+    config: Path,
+    report: dict[str, Any] | None = None,
+    error: str | None = None,
+) -> dict[str, Any]:
+    """Build stable collection-readiness decision packet."""
+    status = "ready" if report is not None else "blocked"
+    blockers = [] if error is None else [error]
+    return {
+        "schema": _DECISION_SCHEMA,
+        "issue": _ISSUE,
+        "config": str(config),
+        "status": status,
+        "report": report if report is not None else None,
+        "blockers": blockers,
+        "forbidden_actions_confirmed": {
+            "data_collection": False,
+            "compute_submit": False,
+            "training": False,
+        },
+    }
+
+
+def _write_decision_manifest(path: Path, payload: dict[str, Any]) -> None:
+    """Write decision packet JSON, creating parent directories as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
 def main(argv: list[str] | None = None) -> int:
-    """Validate a launch packet and return a shell-friendly exit code."""
+    """Validate launch packet and return a shell-friendly exit code."""
     args = build_arg_parser().parse_args(argv)
     try:
         report = validate_launch_packet(
@@ -46,12 +97,23 @@ def main(argv: list[str] | None = None) -> int:
             require_training_ready=args.require_training_ready,
         )
     except LaunchPacketError as exc:
+        decision = _decision_manifest_payload(
+            config=args.config,
+            error=_first_launch_packet_error(exc),
+        )
+        if args.output:
+            _write_decision_manifest(args.output, decision)
         if args.json:
             print(json.dumps({"status": "invalid", "error": str(exc)}, indent=2, sort_keys=True))
         else:
             print(str(exc))
         return 2
 
+    if args.output:
+        _write_decision_manifest(
+            args.output,
+            _decision_manifest_payload(config=args.config, report=report),
+        )
     if args.json:
         print(json.dumps(report, indent=2, sort_keys=True))
     else:
@@ -63,5 +125,5 @@ def main(argv: list[str] | None = None) -> int:
     return 0
 
 
-if __name__ == "__main__":  # pragma: no cover - CLI guard
+if __name__ == "__main__":  # pragma: no cover - CLI
     raise SystemExit(main())

--- a/tests/training/test_oracle_imitation_collection_decision_manifest.py
+++ b/tests/training/test_oracle_imitation_collection_decision_manifest.py
@@ -1,0 +1,141 @@
+"""Tests oracle-imitation collection-readiness decision manifests (issue #1496)."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+from typing import TYPE_CHECKING
+
+import yaml
+
+from scripts.validation.validate_oracle_imitation_launch_packet import main as validate_cli_main
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _write_packet(tmp_path: Path, packet: dict[str, object]) -> Path:
+    path = tmp_path / "packet.yaml"
+    path.write_text(yaml.safe_dump(packet, sort_keys=False), encoding="utf-8")
+    return path
+
+
+def _valid_packet(tmp_path: Path) -> dict[str, object]:
+    fixture = tmp_path / "fixture.json"
+    fixture.write_text('{"status": "dry-run"}\n', encoding="utf-8")
+    digest = hashlib.sha256(fixture.read_bytes()).hexdigest()
+    return {
+        "schema_version": "oracle-imitation-launch-packet.v1",
+        "dataset_id": "demo_oracle_imitation",
+        "source_candidate": "hybrid_rule_v3_static_margin0_waypoint2",
+        "source_candidate_config": (
+            "configs/policy_search/candidates/hybrid_rule_v3_static_margin0_waypoint2.yaml"
+        ),
+        "source_report": (
+            "docs/context/policy_search/reports/2026-04-30_best_non_learning_local_policy_report.md"
+        ),
+        "split_contract": "docs/context/policy_search/contracts/oracle_imitation_dataset_split.md",
+        "scenario_source": "configs/policy_search/nominal_sanity_matrix.yaml",
+        "scenario_ids": ["planner_sanity_simple", "classic_crossing_low"],
+        "seed_set_refs": {
+            "manifest": "configs/benchmarks/seed_sets_v1.yaml",
+            "validation": "dev",
+            "evaluation": "eval",
+            "train_excludes": "paper_eval_s20",
+        },
+        "seeds_by_split": {
+            "train": [201, 202],
+            "validation": [101, 102, 103],
+            "evaluation": [111, 112, 113],
+        },
+        "episode_ids_by_split": {
+            "train": ["train__planner_sanity_simple__seed201"],
+            "validation": ["validation__planner_sanity_simple__seed101"],
+            "evaluation": ["evaluation__planner_sanity_simple__seed111"],
+        },
+        "hard_slice_assignment": [
+            {
+                "slice_id": "nominal_slice",
+                "split": "evaluation",
+                "predeclared_for_evaluation": True,
+            }
+        ],
+        "relabeling_policy": None,
+        "exclusion_rules": ["exclude eval seeds from train"],
+        "provenance": "unit-test fixture",
+        "created_at": "2026-05-24T08:55:00+00:00",
+        "generating_commit": "e14e2f8bc2058d9f0e071219629915dd5b5dd5a8",
+        "artifact_paths": {
+            "dry_run_fixture": str(fixture),
+            "future_dataset_npz_uri": "wandb-artifact://robot-sf/demo:pending",
+        },
+        "checksums": {str(fixture): digest},
+        "collection_roots": {
+            "log_root": "wandb-artifact://robot-sf/demo-logs:pending",
+            "dataset_output_root": "wandb-artifact://robot-sf/demo-traces:pending",
+            "manifest_destination": "wandb-artifact://robot-sf/demo-manifest:pending",
+        },
+    }
+
+
+def test_cli_writes_collection_decision_manifest_for_issue_packet(tmp_path: Path) -> None:
+    """The CLI writes a read-only collection-readiness decision manifest."""
+    output = tmp_path / "decision" / "collection.json"
+
+    exit_code = validate_cli_main(
+        [
+            "--config",
+            "configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml",
+            "--output",
+            str(output),
+            "--json",
+        ]
+    )
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert exit_code == 0
+    assert payload["schema"] == "oracle-imitation-collection-readiness-decision.v1"
+    assert payload["issue"] == 1496
+    assert payload["status"] == "ready"
+    assert payload["report"]["training_ready"] is False
+    assert payload["forbidden_actions_confirmed"] == {
+        "data_collection": False,
+        "compute_submit": False,
+        "training": False,
+    }
+
+
+def test_cli_records_collection_manifest_destination_blocker(tmp_path: Path) -> None:
+    """Missing output-manifest destination becomes a structured blocker."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    del broken["collection_roots"]["manifest_destination"]
+    config = _write_packet(tmp_path, broken)
+    output = tmp_path / "collection-decision.json"
+
+    exit_code = validate_cli_main(["--config", str(config), "--output", str(output), "--json"])
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert exit_code == 2
+    assert payload["status"] == "blocked"
+    assert payload["report"] is None
+    assert payload["blockers"] == [
+        "collection_roots.manifest_destination must be a non-empty string"
+    ]
+
+
+def test_cli_records_missing_provenance_blocker(tmp_path: Path) -> None:
+    """Missing provenance field becomes a structured blocker without collecting data."""
+    packet = _valid_packet(tmp_path)
+    broken = copy.deepcopy(packet)
+    del broken["generating_commit"]
+    config = _write_packet(tmp_path, broken)
+    output = tmp_path / "collection-decision.json"
+
+    exit_code = validate_cli_main(["--config", str(config), "--output", str(output), "--json"])
+
+    payload = json.loads(output.read_text(encoding="utf-8"))
+    assert exit_code == 2
+    assert payload["status"] == "blocked"
+    assert payload["blockers"] == ["generating_commit must be a 40-character git SHA"]


### PR DESCRIPTION
## Summary
- Refs https://github.com/ll7/robot_sf_ll7/issues/1496.
- Adds `--output` support to `scripts/validation/validate_oracle_imitation_launch_packet.py` so oracle-imitation dataset collection readiness checks can emit a stable JSON decision manifest.
- Records issue id, collection-readiness status, validator report or blockers, and explicit forbidden-action confirmations without collecting data, submitting compute, or training.
- Adds focused synthetic tests for the checked-in issue packet plus missing output-manifest and provenance blockers.

## Validation
- PASS: `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/training/test_oracle_imitation_collection_decision_manifest.py tests/training/test_oracle_imitation_launch_packet.py -q`
- PASS: `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check scripts/validation/validate_oracle_imitation_launch_packet.py tests/training/test_oracle_imitation_collection_decision_manifest.py`
- PASS: `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/validate_oracle_imitation_launch_packet.py --config configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml --output <tmp>/decision.json --json`
- PASS: `PR_READY_PR_BODY_FILE=<tmp> scripts/dev/run_worktree_shared_venv.sh -- bash -lc 'PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh'`
- PASS: `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree`

## Out Of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.


## Issue Disposition
- Leaves #1496 open. This PR is a reversible readiness/preflight slice only: it records whether the existing oracle-imitation launch packet is ready for durable dataset collection and confirms no data collection, compute submission, or training is authorized here.
- Remaining #1496 work still requires #1470 durable dataset artifacts, SLURM/GPU training, and benchmark comparison evidence before any sample-efficiency or final-performance claim can close the issue.
