### PR TITLE
Issue #3501: add safety wrapper ablation row checker

### DIFF
--- a/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
+++ b/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
@@ -400,6 +400,38 @@ def check_factorial_ablation_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str
     }
 
 
+def load_safety_wrapper_ablation_rows(path: str | Path) -> list[dict[str, Any]]:
+    """Load emitted ablation rows for the opt-in result checker.
+
+    JSONL is the expected format for benchmark rows. A JSON list is accepted for
+    compact fixtures and hand-authored decision packets.
+
+    Returns:
+        List of row mappings suitable for ``check_factorial_ablation_rows``.
+    """
+    row_path = Path(path)
+    if row_path.suffix == ".jsonl":
+        rows: list[dict[str, Any]] = []
+        for line_number, raw_line in enumerate(
+            row_path.read_text(encoding="utf-8").splitlines(),
+            start=1,
+        ):
+            if not raw_line.strip():
+                continue
+            row = json.loads(raw_line)
+            if not isinstance(row, dict):
+                raise ValueError(f"{row_path}:{line_number} must contain a JSON object row")
+            rows.append(row)
+        return rows
+
+    payload = json.loads(row_path.read_text(encoding="utf-8"))
+    if not isinstance(payload, list):
+        raise ValueError(f"{row_path} must contain a JSON list or JSONL object rows")
+    if not all(isinstance(row, dict) for row in payload):
+        raise ValueError(f"{row_path} must contain only JSON object rows")
+    return list(payload)
+
+
 def write_safety_wrapper_ablation_manifest(
     manifest: Mapping[str, Any],
     output_dir: str | Path,
@@ -428,7 +460,9 @@ __all__ = [
     "ManifestOptions",
     "build_safety_wrapper_ablation_manifest",
     "check_factorial_ablation",
+    "check_factorial_ablation_rows",
     "load_safety_wrapper_ablation_config",
+    "load_safety_wrapper_ablation_rows",
     "validate_safety_wrapper_ablation_config",
     "write_safety_wrapper_ablation_manifest",
 ]

--- a/scripts/benchmark/check_safety_wrapper_ablation_rows.py
+++ b/scripts/benchmark/check_safety_wrapper_ablation_rows.py
@@ -1,0 +1,55 @@
+#!/usr/bin/env python3
+"""Check issue #3501 safety-wrapper ablation rows before comparison.
+
+The checker is intentionally opt-in and fail-closed. It verifies only that later
+row artifacts are complete enough for a paired ``wrapper_off``/``wrapper_on``
+comparison; it does not execute benchmarks or claim mitigation effectiveness.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+from robot_sf.benchmark.safety_wrapper_ablation_manifest import (
+    check_factorial_ablation_rows,
+    load_safety_wrapper_ablation_rows,
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--rows",
+        required=True,
+        help="JSONL rows or JSON list to check for paired wrapper_off/wrapper_on completeness.",
+    )
+    parser.add_argument(
+        "--out",
+        help="Optional path for the JSON checker report. Defaults to stdout only.",
+    )
+    return parser.parse_args()
+
+
+def _write_report(report: dict[str, object], out: str | None) -> None:
+    rendered = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if out:
+        path = Path(out)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(rendered, encoding="utf-8")
+    print(rendered, end="")
+
+
+def main() -> int:
+    """Run the ablation row checker."""
+    args = parse_args()
+    rows = load_safety_wrapper_ablation_rows(args.rows)
+    report = check_factorial_ablation_rows(rows)
+    _write_report(report, args.out)
+    return 0 if report["complete"] else 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/benchmark/test_safety_wrapper_ablation_manifest.py
+++ b/tests/benchmark/test_safety_wrapper_ablation_manifest.py
@@ -241,3 +241,95 @@ def test_check_factorial_ablation_rows_rejects_duplicate_or_unknown_arm() -> Non
             "count": 2,
         }
     ]
+
+
+def test_load_safety_wrapper_ablation_rows_reads_jsonl_and_json_list(tmp_path: Path) -> None:
+    """The public checker accepts benchmark-style JSONL and compact JSON fixtures."""
+    from robot_sf.benchmark.safety_wrapper_ablation_manifest import (
+        load_safety_wrapper_ablation_rows,
+    )
+
+    off_row = _ablation_row(WRAPPER_OFF_ARM)
+    on_row = _ablation_row(WRAPPER_ON_ARM)
+    jsonl_path = tmp_path / "rows.jsonl"
+    jsonl_path.write_text(
+        "\n".join(json.dumps(row, sort_keys=True) for row in [off_row, on_row]) + "\n",
+        encoding="utf-8",
+    )
+    json_path = tmp_path / "rows.json"
+    json_path.write_text(json.dumps([off_row, on_row], sort_keys=True), encoding="utf-8")
+
+    assert load_safety_wrapper_ablation_rows(jsonl_path) == [off_row, on_row]
+    assert load_safety_wrapper_ablation_rows(json_path) == [off_row, on_row]
+
+
+def test_check_safety_wrapper_ablation_rows_cli_passes_and_writes_report(
+    tmp_path: Path,
+) -> None:
+    """CLI returns success only for rows with exact off/on pairs."""
+    import subprocess
+    import sys
+
+    rows_path = tmp_path / "paired_rows.jsonl"
+    rows_path.write_text(
+        "\n".join(
+            json.dumps(row, sort_keys=True)
+            for row in [_ablation_row(WRAPPER_OFF_ARM), _ablation_row(WRAPPER_ON_ARM)]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    report_path = tmp_path / "report.json"
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/benchmark/check_safety_wrapper_ablation_rows.py",
+            "--rows",
+            str(rows_path),
+            "--out",
+            str(report_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["complete"] is True
+    assert report["pair_count"] == 1
+
+
+def test_check_safety_wrapper_ablation_rows_cli_fails_unpaired_rows(tmp_path: Path) -> None:
+    """CLI fails closed before any one-arm row can be compared."""
+    import subprocess
+    import sys
+
+    rows_path = tmp_path / "unpaired_rows.jsonl"
+    rows_path.write_text(
+        json.dumps(_ablation_row(WRAPPER_ON_ARM), sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            sys.executable,
+            "scripts/benchmark/check_safety_wrapper_ablation_rows.py",
+            "--rows",
+            str(rows_path),
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 2
+    report = json.loads(result.stdout)
+    assert report["complete"] is False
+    assert report["incomplete_pairs"] == [
+        {
+            "pairing_key": {"planner": "orca", "scenario_id": "crossing_basic", "seed": 111},
+            "wrapper_arms": [WRAPPER_ON_ARM],
+        }
+    ]


### PR DESCRIPTION
## Issue

Relates to #3501. Does not close it; this PR is a partial row-checker slice for the larger safety-wrapper ablation contract.

## Issue Disposition

#3501 remains open after this PR. This checker prevents invalid paired comparisons, but the issue contract still requires runtime wrapper binding, executable paired rows, intervention evidence in the event ledger, paired-effect reporting, and bounded diagnostic campaign evidence.

## Scope Summary

This PR adds the opt-in result-row checker slice for the already merged planner-agnostic safety-wrapper ablation contract.

Changes:

- exposes `load_safety_wrapper_ablation_rows(...)` so later decision packets can load JSONL benchmark rows or compact JSON row lists;
- adds `scripts/benchmark/check_safety_wrapper_ablation_rows.py`, a fail-closed CLI that verifies exact paired `wrapper_off` and `wrapper_on` rows before any with/without comparison;
- extends focused tests for JSONL/JSON loading, CLI success, and CLI failure on unpaired rows.

Assumption: the smallest reversible first slice is a public checker around the existing dry-run manifest contract, not runtime wrapper binding or campaign execution.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_safety_wrapper_ablation_manifest.py -q`
  - passed: `16 passed`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/safety_wrapper_ablation_manifest.py scripts/benchmark/check_safety_wrapper_ablation_rows.py tests/benchmark/test_safety_wrapper_ablation_manifest.py`
  - passed: `All checks passed!`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/benchmark/safety_wrapper_ablation_manifest.py scripts/benchmark/check_safety_wrapper_ablation_rows.py tests/benchmark/test_safety_wrapper_ablation_manifest.py`
  - passed: `3 files left unchanged`
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_safety_wrapper_ablation_manifest.py --config configs/research/safety_wrapper_ablation_v1.yaml --out output/issue_3501_manifest_check --dry-run`
  - passed: `factorial check: complete=True cells=6 seeds_per_cell=3`
- `git diff --check`
  - passed

Generated validation output under `output/issue_3501_manifest_check/` is ignored disposable validation output, not a durable artifact.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No threshold tuning.
- No runtime safety-wrapper binding.
