### PR TITLE
Issue #3813: pin sustained-flow progress metric preflight

### DIFF
--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -11,6 +11,7 @@ from typing import Any
 from robot_sf.scenario_certification.sustained_flow import (
     EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
     EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG,
+    EXPECTED_SUSTAINED_PROGRESS_METRIC,
     SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE,
     generate_expected_sustained_flow_scenarios,
     runtime_definition_status_for_support,
@@ -61,6 +62,7 @@ class SustainedFlowVariant:
     runtime_definition_status: str
     runtime_definition_ready: bool
     route_respawn_runtime_config: dict[str, object]
+    success_metric: dict[str, object]
     max_episode_steps: int
     seeds: tuple[int, ...]
 
@@ -173,6 +175,12 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
         scenario_name=name,
     )
 
+    success_metric = _required_mapping(metadata, "success_metric", scenario_name=name)
+    if success_metric != EXPECTED_SUSTAINED_PROGRESS_METRIC:
+        raise SustainedFlowPreflightError(
+            f"{name}: metadata.success_metric must match sustained progress-rate contract"
+        )
+
     seeds = scenario.get("seeds", [])
     if not isinstance(seeds, list) or not all(isinstance(seed, int) for seed in seeds):
         raise SustainedFlowPreflightError(f"{name}: seeds must be a list of integers")
@@ -197,6 +205,7 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
         route_respawn_runtime_config={
             field: simulation_config.get(field) for field in EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG
         },
+        success_metric=dict(success_metric),
         max_episode_steps=_required_int(simulation_config, "max_episode_steps", scenario_name=name),
         seeds=tuple(seeds),
     )
@@ -295,6 +304,7 @@ def _variant_generator_profile(variant: SustainedFlowVariant) -> tuple[object, .
         variant.runtime_definition_status,
         variant.runtime_definition_ready,
         tuple(sorted(variant.route_respawn_runtime_config.items())),
+        tuple(sorted(variant.success_metric.items())),
         variant.max_episode_steps,
         variant.seeds,
     )

--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -47,6 +47,14 @@ EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG: dict[str, object] = {
     "route_spawn_jitter_frac": 0.0,
     "max_peds_per_group": 1,
 }
+EXPECTED_SUSTAINED_PROGRESS_METRIC: dict[str, object] = {
+    "id": "sustained_progress_rate_m_per_s",
+    "definition": (
+        "Net robot path progress toward the route goal divided by simulated "
+        "episode seconds under non-clearing pedestrian demand."
+    ),
+    "wait_policy_expectation": "zero_or_near_zero_progress",
+}
 _SUSTAINED_FLOW_FAMILY = "sustained_flow_t_intersection"
 _SUSTAINED_FLOW_MAP_FILE = "../../../maps/svg_maps/classic_t_intersection.svg"
 _SUSTAINED_FLOW_MAX_EPISODE_STEPS = 600
@@ -151,14 +159,7 @@ def generate_expected_sustained_flow_scenarios(
                         "runtime_definition_status": runtime_definition_status,
                         "runtime_definition_ready": runtime_definition_ready,
                     },
-                    "success_metric": {
-                        "id": "sustained_progress_rate_m_per_s",
-                        "definition": (
-                            "Net robot path progress toward the route goal divided by simulated "
-                            "episode seconds under non-clearing pedestrian demand."
-                        ),
-                        "wait_policy_expectation": "zero_or_near_zero_progress",
-                    },
+                    "success_metric": dict(EXPECTED_SUSTAINED_PROGRESS_METRIC),
                     "termination": {
                         "mode": "time_bounded",
                         "max_episode_steps": spec.max_episode_steps,
@@ -375,9 +376,9 @@ def _check_termination_and_metric(
         _require_equal(
             errors,
             name,
-            "success_metric.id",
-            success_metric.get("id"),
-            "sustained_progress_rate_m_per_s",
+            "metadata.success_metric",
+            success_metric,
+            EXPECTED_SUSTAINED_PROGRESS_METRIC,
         )
 
     blockers = tuple(metadata.get("requires_before_benchmark_use", ()))

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -18,6 +18,7 @@ from robot_sf.benchmark.sustained_flow_preflight import (
 )
 from robot_sf.scenario_certification.sustained_flow import (
     EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG,
+    EXPECTED_SUSTAINED_PROGRESS_METRIC,
     generate_runtime_supported_sustained_flow_scenarios,
 )
 from robot_sf.training.scenario_loader import load_scenarios
@@ -81,7 +82,7 @@ def test_sustained_flow_scenario_set_is_runner_loadable(capsys) -> None:
         assert spawn_definition["spawn_budget"] == "time_bounded_episode"
         assert spawn_definition["minimum_active_pedestrians"] == 1
         assert spawn_definition["clearing_policy"] == "disallow_empty_scene_wait_success"
-        assert metadata["success_metric"]["id"] == "sustained_progress_rate_m_per_s"
+        assert metadata["success_metric"] == EXPECTED_SUSTAINED_PROGRESS_METRIC
         assert metadata["termination"]["mode"] == "time_bounded"
         assert metadata["termination"]["goal_reach_is_not_primary_success"] is True
 
@@ -267,6 +268,24 @@ def test_sustained_flow_preflight_rejects_waitable_spawn_budget(tmp_path: Path) 
         "continuous_spawn.definition.spawn_budget must be 'time_bounded_episode'" in reason
         for reason in payload["blocking_reasons"]
     )
+
+
+def test_sustained_flow_preflight_rejects_progress_metric_drift(tmp_path: Path) -> None:
+    """Benchmark preflight keeps sustained-progress wait-policy semantics pinned."""
+
+    matrix = _load_yaml(SCENARIO_SET)
+    matrix["scenarios"][0]["metadata"]["success_metric"]["wait_policy_expectation"] = (
+        "goal_reach_success"
+    )
+
+    drifted_matrix = tmp_path / "wrong_success_metric_sustained_flow.yaml"
+    drifted_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+    payload = preflight_sustained_flow_matrix(drifted_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert payload["variant_count"] == 0
+    assert any("metadata.success_metric" in reason for reason in payload["blocking_reasons"])
 
 
 def test_sustained_flow_contract_defines_progress_metric_and_reference() -> None:

--- a/tests/scenario_certification/test_sustained_flow_preflight.py
+++ b/tests/scenario_certification/test_sustained_flow_preflight.py
@@ -44,6 +44,9 @@ def test_expected_variants_enumerate_deterministically() -> None:
         scenario["metadata"]["continuous_spawn"]["runtime_definition_ready"]
         for scenario in generated
     } == {False}
+    assert {
+        tuple(sorted(scenario["metadata"]["success_metric"].items())) for scenario in generated
+    } == {tuple(sorted(sustained_flow.EXPECTED_SUSTAINED_PROGRESS_METRIC.items()))}
 
 
 def test_generated_variants_pass_generator_preflight() -> None:
@@ -201,6 +204,22 @@ def test_preflight_rejects_route_respawn_runtime_config_drift(tmp_path: Path) ->
     assert any(
         "simulation_config.peds_reset_follow_route_at_start" in error for error in report.errors
     )
+
+
+def test_preflight_rejects_sustained_progress_metric_drift(tmp_path: Path) -> None:
+    """Scenario YAML progress metric must preserve wait-policy semantics."""
+
+    payload = yaml.safe_load(SCENARIO_SET.read_text(encoding="utf-8"))
+    payload["scenarios"][0]["metadata"]["success_metric"]["wait_policy_expectation"] = (
+        "goal_reach_success"
+    )
+    drifted = tmp_path / "issue_3813_sustained_flow_success_metric_drift.yaml"
+    drifted.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    report = sustained_flow.preflight_sustained_flow_scenario_set(drifted)
+
+    assert not report.conforms
+    assert any("metadata.success_metric" in error for error in report.errors)
 
 
 def test_preflight_cli_outputs_json_payload() -> None:


### PR DESCRIPTION
## Summary
Pins the issue #3813 sustained-flow success metric as a shared preflight contract so wait-policy semantics cannot drift while continuous-spawn rows remain pre-benchmark scaffolds.

## Linked Issues
- Relates to #3813

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `EXPECTED_SUSTAINED_PROGRESS_METRIC` beside the existing continuous-spawn and route-respawn scaffold constants.
- Made the scenario-certification generator emit that shared metric block and made YAML preflight compare the complete metric contract, including `wait_policy_expectation`.
- Made benchmark sustained-flow preflight parse/preserve the metric block and fail closed when the metric contract drifts.
- Added focused enumeration and drift tests for scenario-certification and benchmark preflight paths.

## Why Matters
- Added value: prevents a sustained-flow row from silently reverting to a goal-reach or waitable success interpretation.
- Expected impact: tighter generator/preflight coverage for the #3813 continuous-spawn scaffold without promoting benchmark evidence.
- Why worth merging now: it closes a small structural gap left by earlier route-respawn/runtime-definition preflight slices.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3813 wait-it-out exploit guardrail; this PR only pins the authored sustained-progress metric contract.
- Comparator or baseline, applicable: checked-in sustained-flow scaffold versus mutated metric drift fixtures.
- Evidence tier: NA - static preflight support; validation commands listed below.
- Result classification: NA - no research result or benchmark evidence claimed.
- Decision stop rule, applicable: static preflight rejects success-metric drift and current scaffold still reports `benchmark_evidence=false`.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3813 remains open; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: none.

## Domain-Aware Approval
- Required PR: yes
- Domains reviewed: sustained-flow scenario preflight, metric-facing static contract, benchmark evidence boundary
- Status: waived
- Approver/review source waiver: self-review waiver because this PR only tightens static preflight checks and does not promote benchmark, paper-facing, or runtime validity claims.
- Validity checklist:
  - Target claim/hypothesis: static preflight contract only.
  - Comparator or split/evidence validity: mutation tests for success-metric drift.
  - Fallback/degraded exclusions: no fallback/degraded benchmark execution used as evidence.
  - Claim boundary: not benchmark evidence.
  - Implementation integrity vs experimental validity: code/test slice only; runtime proof remains open.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, drift tests fail closed on wait-policy metric mutation.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? static contract only; no runtime campaign.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: remaining #3813 runtime and metric-proof criteria stay open.

## Next Empirical Action
- Rerun needed: no for this PR slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: runtime continuous pedestrian respawn, sustained-progress metric proof, interaction-exposure proof, pure-wait baseline proof, runnable campaign evidence remain out of scope.
- Stop / revise / continue decision: continue with later #3813 runtime/campaign slices.
- Proposed child issue existing follow-up: #3813.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/scenario_certification/sustained_flow.py robot_sf/benchmark/sustained_flow_preflight.py tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` - passed after merging current `origin/main`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q` - passed, 14 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` - passed with `conforms=true`, `variant_count=3`, `runtime_support=metadata_only`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --runtime-supported-generated --json` - passed with `conforms=true`, `variant_count=3`, `runtime_support=runtime_continuous_spawn`, `benchmark_evidence=false`.
- Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance
- Baseline runtime: NA, no runtime performance claim.
- Changed runtime: NA, no runtime performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q`
- Hot-path call count profile anchor: NA, no hot-path performance claim.
- Cache-hit reuse counter: NA, no caching claim.
- Rollback failure criterion: revert if sustained-flow preflight no longer enumerates the 3 scaffold variants or fails to reject metric drift.

## Risks / Rollout
- Compatibility risks: stricter static preflight rejects any alternate success-metric wording until intentionally updated in the shared constant and scaffold.
- Failure modes: overly strict equality may require explicit migration if metric wording evolves.
- Rollback fallback plan: revert this commit; earlier route-respawn/runtime-definition checks remain intact.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3813 comments and prior merged preflight slices.
- Any assumptions need to preserved: this is a static preflight contract, not runtime continuous-spawn support.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: this PR does not produce benchmark evidence or paper-facing claims; #3813 remains the follow-up surface.

## Follow-Up Issues
- Deferred work: runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, runnable campaign/runner benchmark evidence.
- Issues opened follow-up: #3813 remains open for the deferred runtime/campaign proof.

## Reviewer Notes
- Anything reviewer verify closely: the exact `success_metric` equality is intentionally strict to preserve wait-policy semantics.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
