### PR TITLE
Issue #1496: gate warm-start readiness on trace registry

### DIFF
--- a/configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml
+++ b/configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml
@@ -15,6 +15,10 @@ experiment_id: issue_1496_oracle_imitation_warm_start_v1
 # require_training_ready=True (must carry concrete durable trace artifact URIs).
 dataset_launch_packet: configs/training/ppo_imitation/oracle_dataset_issue_1397_launch_packet.yaml
 
+# Durable trace URI registry #1470/#2655; strict gate requires concrete trace
+# artifact URIs and checksums for train, validation, and evaluation.
+trace_uri_registry: configs/training/ppo_imitation/oracle_trace_uri_registry_issue_1470.yaml
+
 # Behaviour-cloning warm-start training config (consumed by
 # scripts/training/pretrain_from_expert.py).
 warm_start_config: configs/training/ppo_imitation/bc_pretrain.yaml

--- a/robot_sf/training/oracle_imitation_warm_start_readiness.py
+++ b/robot_sf/training/oracle_imitation_warm_start_readiness.py
@@ -42,6 +42,10 @@ from robot_sf.training.oracle_imitation_launch_packet import (
     LaunchPacketError,
     validate_launch_packet,
 )
+from robot_sf.training.oracle_trace_uri_registry import (
+    OracleTraceUriRegistryError,
+    validate_trace_uri_registry,
+)
 
 _SCHEMA_VERSION = "oracle-imitation-warm-start-readiness.v1"
 
@@ -148,6 +152,7 @@ def check_warm_start_readiness(
     blockers: list[str] = []
     prerequisites: dict[str, Any] = {}
     prerequisites["dataset_launch_packet"] = _check_dataset_packet(manifest, root, blockers)
+    prerequisites["trace_uri_registry"] = _check_trace_uri_registry(manifest, root, blockers)
     for key in _REQUIRED_CONFIG_KEYS:
         prerequisites[key] = _check_required_file(manifest, key, root, blockers)
     for key in _OPTIONAL_CONFIG_KEYS:
@@ -221,6 +226,54 @@ def _check_dataset_packet(
         "dataset_id": packet_report["dataset_id"],
         "training_ready": packet_report["training_ready"],
     }
+
+
+def _check_trace_uri_registry(
+    manifest: dict[str, Any],
+    repo_root: Path,
+    blockers: list[str],
+) -> dict[str, Any]:
+    """Validate the referenced durable trace-URI registry with the canonical checker.
+
+    Returns:
+        Per-prerequisite detail with path, readiness, and registry identity when ready.
+    """
+    raw_path = manifest.get("trace_uri_registry")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        blockers.append("trace_uri_registry must be non-empty path string")
+        return {"path": None, "ready": False, "detail": "missing trace_uri_registry reference"}
+
+    path_text = raw_path.strip()
+    try:
+        registry_report = validate_trace_uri_registry(
+            Path(path_text),
+            repo_root=repo_root,
+            require_training_ready=True,
+        )
+    except OracleTraceUriRegistryError as exc:
+        reason = _first_trace_registry_error(exc)
+        blockers.append(f"trace_uri_registry not training-ready: {reason}")
+        return {"path": path_text, "ready": False, "detail": str(exc)}
+
+    return {
+        "path": path_text,
+        "ready": True,
+        "dataset_id": registry_report["dataset_id"],
+        "trace_count": registry_report["trace_count"],
+        "training_ready": registry_report["training_ready"],
+    }
+
+
+def _first_trace_registry_error(exc: OracleTraceUriRegistryError) -> str:
+    """Return first actionable trace-URI registry validator error line."""
+    for line in str(exc).splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("oracle-imitation") and stripped.endswith("failed validation:"):
+            continue
+        return stripped.removeprefix("- ").strip()
+    return str(exc)
 
 
 def _first_launch_packet_error(exc: LaunchPacketError) -> str:

--- a/tests/training/test_oracle_imitation_warm_start_readiness.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness.py
@@ -35,6 +35,7 @@ def _ready_manifest(tmp_path: Path) -> dict[str, object]:
     intentionally-pending #1397 packet.
     """
     packet_path = _write_training_ready_packet(tmp_path)
+    trace_registry_path = _write_training_ready_trace_registry(tmp_path)
     warm_start = tmp_path / "bc.yaml"
     warm_start.write_text("policy_id: bc\n", encoding="utf-8")
     baseline = tmp_path / "rl_only.yaml"
@@ -45,6 +46,7 @@ def _ready_manifest(tmp_path: Path) -> dict[str, object]:
         "schema_version": "oracle-imitation-warm-start-readiness.v1",
         "experiment_id": "unit_test_warm_start",
         "dataset_launch_packet": str(packet_path),
+        "trace_uri_registry": str(trace_registry_path),
         "warm_start_config": str(warm_start),
         "baseline_config": str(baseline),
         "split_contract": str(contract),
@@ -98,16 +100,52 @@ def _write_training_ready_packet(tmp_path: Path) -> Path:
     return path
 
 
+def _write_training_ready_trace_registry(tmp_path: Path) -> Path:
+    """Write trace-URI registry that passes the canonical validator with training_ready=True."""
+    registry = {
+        "schema_version": "oracle-trace-uri-registry.v1",
+        "dataset_id": "unit_test_oracle_imitation",
+        "traces": [
+            {
+                "split": "train",
+                "trace_id": "train__unit_test",
+                "uri": "wandb-artifact://robot-sf/oracle-imitation/train:v1",
+                "sha256": "a" * 64,
+                "retrieval_status": "resolvable",
+            },
+            {
+                "split": "validation",
+                "trace_id": "validation__unit_test",
+                "uri": "wandb-artifact://robot-sf/oracle-imitation/validation:v1",
+                "sha256": "b" * 64,
+                "retrieval_status": "resolvable",
+            },
+            {
+                "split": "evaluation",
+                "trace_id": "evaluation__unit_test",
+                "uri": "wandb-artifact://robot-sf/oracle-imitation/evaluation:v1",
+                "sha256": "c" * 64,
+                "retrieval_status": "resolvable",
+            },
+        ],
+    }
+    path = tmp_path / "trace_registry.yaml"
+    path.write_text(yaml.safe_dump(registry, sort_keys=False), encoding="utf-8")
+    return path
+
+
 def test_real_issue_1496_manifest_is_blocked_on_dataset() -> None:
     """The checked-in #1496 manifest is blocked because #1397 is not training-ready yet."""
     report = check_warm_start_readiness(Path(_REAL_MANIFEST))
 
     assert report["status"] == "blocked"
     assert report["experiment_id"] == "issue_1496_oracle_imitation_warm_start_v1"
-    # The only blocker is the durable dataset gate; configs/contract are present.
-    assert len(report["blockers"]) == 1
+    # Durable dataset launch packet and trace registry are blocked; configs/contract are present.
+    assert len(report["blockers"]) == 2
     assert report["blockers"][0].startswith("dataset_launch_packet not training-ready")
+    assert report["blockers"][1].startswith("trace_uri_registry not training-ready")
     assert report["prerequisites"]["dataset_launch_packet"]["ready"] is False
+    assert report["prerequisites"]["trace_uri_registry"]["ready"] is False
     assert report["prerequisites"]["warm_start_config"]["ready"] is True
     assert report["prerequisites"]["baseline_config"]["ready"] is True
     assert report["prerequisites"]["finetuning_config"]["ready"] is True
@@ -123,6 +161,7 @@ def test_ready_manifest_reports_ready(tmp_path: Path) -> None:
     assert report["status"] == "ready"
     assert report["blockers"] == []
     assert report["prerequisites"]["dataset_launch_packet"]["training_ready"] is True
+    assert report["prerequisites"]["trace_uri_registry"]["training_ready"] is True
 
 
 def test_missing_config_is_a_blocker_not_an_error(tmp_path: Path) -> None:
@@ -165,6 +204,19 @@ def test_blank_dataset_reference_is_a_blocker(tmp_path: Path) -> None:
 
     assert report["status"] == "blocked"
     assert any("dataset_launch_packet must be a non-empty" in b for b in report["blockers"])
+
+
+def test_missing_trace_uri_registry_is_a_blocker(tmp_path: Path) -> None:
+    """A missing durable trace registry blocks readiness before warm-start training."""
+    manifest_dict = _ready_manifest(tmp_path)
+    manifest_dict.pop("trace_uri_registry")
+    manifest = _write_manifest(tmp_path, manifest_dict)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert any("trace_uri_registry must be non-empty" in b for b in report["blockers"])
+    assert report["prerequisites"]["trace_uri_registry"]["ready"] is False
 
 
 def test_optional_finetuning_config_omitted_is_ok(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
Adds the durable trace URI registry as an explicit fail-closed prerequisite for the issue #1496 oracle-imitation warm-start readiness checker. The checker still does not collect data, submit Slurm, train, or promote benchmark/paper claims.

## Linked Issues
- Relates `#1496`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: `NA`

## What Changed
- `configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml` now names the issue #1470/#2655 trace URI registry prerequisite.
- `check_warm_start_readiness` validates that registry with the canonical `validate_trace_uri_registry(..., require_training_ready=True)` gate.
- Focused tests cover a synthetic ready registry, the checked-in blocked manifest, and missing `trace_uri_registry` provenance.

## Why Matters
- Added value: warm-start training cannot accidentally proceed from partial or worktree-local trace collection outputs.
- Expected impact: the readiness report now exposes both current blockers: missing durable launch-packet trace URIs and unresolved validation/evaluation trace registry entries.
- Why worth merging now: this is safe shared-PC readiness validation for #1496 without launching collection or training.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #1496 prerequisite blocker for durable oracle-imitation warm-start dataset evidence.
- Comparator or baseline, applicable: NA - no benchmark or training run.
- Evidence tier: NA - support checker; no research or benchmark evidence produced.
- Result classification: NA - support checker; readiness remains blocked by design.
- Decision stop rule, applicable: readiness checker must fail closed until launch packet and trace registry are training-ready.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #1496; no claim-map update because this PR changes a gate only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker, no evidence interpretation.

## Domain-Aware Approval
- approval concerns experimental validity waived / pending / blocked / not required: not required
- Approver/review source waiver: NA - fail-closed support checker only.
- Validity checklist: no benchmark result, no fallback/degraded success claim, no paper-facing claim.
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA - no comparator or split evidence claim.
- Fallback/degraded exclusions: no fallback/degraded execution counted as success.
- Claim boundary: readiness/preflight only.
- Implementation integrity vs experimental validity: focused tests exercise the checker contract; empirical validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no empirical mechanism tested.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: no for this PR; yes before any future training once durable artifacts exist.
- Extractor analysis tool needed: no
- Artifact missing unavailable: validation/evaluation durable trace registry entries remain unresolved; launch packet trace artifact URIs remain pending.
- Stop / revise / continue decision: continue only after durable prerequisites are published.
- Proposed child issue existing follow-up: #2655 remains the prerequisite lane named in issue comments.

## Validation / Proof
- `python3 -m py_compile robot_sf/training/oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness.py scripts/validation/check_oracle_imitation_warm_start_readiness.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness.py scripts/validation/check_oracle_imitation_warm_start_readiness.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/training/oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness.py scripts/validation/check_oracle_imitation_warm_start_readiness.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py -q` - passed, 24 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_oracle_imitation_warm_start_readiness.py --manifest configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml --json --output output/validation/issue_1496_warm_start_readiness_decision.json` - expected exit 1 blocked; decisive blockers are pending launch-packet trace URIs and unresolved validation/evaluation registry splits.

## Full Campaign / Slurm / Claim Boundary
No full benchmark campaign run, no Slurm/GPU submission, and no paper/dissertation claim edits.

## Performance Impact
- Baseline runtime: NA - readiness checker support path only.
- Changed runtime: NA - no performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py -q`
- Hot-path call count profile anchor: NA - not a hot-path runtime change.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if #1496 readiness no longer reports durable trace registry blockers when registry prerequisites are missing.

## Risks / Rollout
- Compatibility risks: Existing manifests without `trace_uri_registry` now report blocked instead of ready.
- Failure modes: A misconfigured registry path blocks warm-start readiness with an explicit blocker.
- Rollback fallback plan: remove the manifest key and trace-registry prerequisite call.

## Docs / Provenance
- Updated docs: inline manifest comments only.
- Relevant design provenance notes: live issue #1496 comments identify #2655 durable trace URI registry/materialization as the next prerequisite.
- Any assumptions need to preserved: registry validation is the reversible first slice; no maintainer clarification required because it is fail-closed and read-only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): NA - PR body records the gate result; issue #1496 remains open because durable artifact publication and training readiness are still blocked by #2655.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): config manifest updated.
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark, registry interpretation, claim-map, or paper-facing result is produced.

## Follow-Up Issues
- Deferred work: #2655 must publish durable trace artifact URIs/checksums for all splits before any warm-start training.
- Issues opened follow-up: none

## Reviewer Notes
- Verify closely that the new gate remains read-only and fail-closed.
- Known limitations: checked-in #1496 readiness remains blocked by design; this PR does not resolve durable artifact publication.

