### PR TITLE
Issue #3813: pin sustained-flow blocker preflight

### DIFF
--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -12,6 +12,7 @@ from robot_sf.scenario_certification.sustained_flow import (
     EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
     EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG,
     EXPECTED_SUSTAINED_PROGRESS_METRIC,
+    REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE,
     SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE,
     generate_expected_sustained_flow_scenarios,
     runtime_definition_status_for_support,
@@ -63,6 +64,7 @@ class SustainedFlowVariant:
     runtime_definition_ready: bool
     route_respawn_runtime_config: dict[str, object]
     success_metric: dict[str, object]
+    required_before_benchmark_use: tuple[str, ...]
     max_episode_steps: int
     seeds: tuple[int, ...]
 
@@ -70,6 +72,7 @@ class SustainedFlowVariant:
         """Return a JSON/YAML friendly representation."""
 
         payload = asdict(self)
+        payload["required_before_benchmark_use"] = list(self.required_before_benchmark_use)
         payload["seeds"] = list(self.seeds)
         return payload
 
@@ -180,6 +183,14 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
         raise SustainedFlowPreflightError(
             f"{name}: metadata.success_metric must match sustained progress-rate contract"
         )
+    required_before_benchmark_use = metadata.get("requires_before_benchmark_use")
+    if not isinstance(required_before_benchmark_use, list) or required_before_benchmark_use != list(
+        REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE
+    ):
+        raise SustainedFlowPreflightError(
+            f"{name}: metadata.requires_before_benchmark_use must match sustained-flow "
+            "fail-closed blockers"
+        )
 
     seeds = scenario.get("seeds", [])
     if not isinstance(seeds, list) or not all(isinstance(seed, int) for seed in seeds):
@@ -206,6 +217,7 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
             field: simulation_config.get(field) for field in EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG
         },
         success_metric=dict(success_metric),
+        required_before_benchmark_use=tuple(required_before_benchmark_use),
         max_episode_steps=_required_int(simulation_config, "max_episode_steps", scenario_name=name),
         seeds=tuple(seeds),
     )
@@ -305,6 +317,7 @@ def _variant_generator_profile(variant: SustainedFlowVariant) -> tuple[object, .
         variant.runtime_definition_ready,
         tuple(sorted(variant.route_respawn_runtime_config.items())),
         tuple(sorted(variant.success_metric.items())),
+        variant.required_before_benchmark_use,
         variant.max_episode_steps,
         variant.seeds,
     )

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -19,6 +19,7 @@ from robot_sf.benchmark.sustained_flow_preflight import (
 from robot_sf.scenario_certification.sustained_flow import (
     EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG,
     EXPECTED_SUSTAINED_PROGRESS_METRIC,
+    REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE,
     generate_runtime_supported_sustained_flow_scenarios,
 )
 from robot_sf.training.scenario_loader import load_scenarios
@@ -122,6 +123,9 @@ def test_sustained_flow_preflight_enumerates_variants_and_fails_closed() -> None
         tuple(sorted(variant["route_respawn_runtime_config"].items()))
         for variant in payload["variants"]
     } == {tuple(sorted(EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG.items()))}
+    assert {tuple(variant["required_before_benchmark_use"]) for variant in payload["variants"]} == {
+        REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE
+    }
     assert all(
         f"expected {RUNTIME_SUPPORTED_VALUE!r}" in reason for reason in payload["blocking_reasons"]
     )
@@ -286,6 +290,27 @@ def test_sustained_flow_preflight_rejects_progress_metric_drift(tmp_path: Path) 
     assert payload["benchmark_eligible"] is False
     assert payload["variant_count"] == 0
     assert any("metadata.success_metric" in reason for reason in payload["blocking_reasons"])
+
+
+def test_sustained_flow_preflight_rejects_required_blocker_drift(tmp_path: Path) -> None:
+    """Benchmark preflight keeps benchmark-use blockers explicit even for runtime markers."""
+
+    matrix = _load_yaml(SCENARIO_SET)
+    matrix["scenarios"] = generate_runtime_supported_sustained_flow_scenarios()
+    matrix["scenarios"][0]["metadata"]["requires_before_benchmark_use"] = [
+        "continuous pedestrian respawn runtime support"
+    ]
+
+    drifted_matrix = tmp_path / "wrong_required_blockers_sustained_flow.yaml"
+    drifted_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+    payload = preflight_sustained_flow_matrix(drifted_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert payload["variant_count"] == 0
+    assert any(
+        "metadata.requires_before_benchmark_use" in reason for reason in payload["blocking_reasons"]
+    )
 
 
 def test_sustained_flow_contract_defines_progress_metric_and_reference() -> None:


### PR DESCRIPTION
## Summary
Tighten the Issue #3813 sustained-flow benchmark preflight so every enumerated variant carries the explicit `requires_before_benchmark_use` blocker list, and fail closed if that blocker list drifts.

## Linked Issues
- Relates `#3813`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `required_before_benchmark_use` to the sustained-flow benchmark preflight variant payload.
- Made the benchmark preflight reject matrices whose blocker list differs from the canonical sustained-flow blocker contract, including synthetic runtime-supported rows.
- Added focused enumeration/fail-closed tests for the new payload field and blocker-drift rejection.

## Why Matters
- Added value: keeps the local generator/preflight slice from accidentally presenting continuous-spawn rows as benchmark-ready when required runtime and metric evidence is still missing.
- Expected impact: static preflight remains deterministic and fail-closed.
- Why worth merging now: small checker hardening for the ready-queue #3813 scope.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3813 static preflight/generator readiness only.
- Comparator or baseline, applicable: existing sustained-flow preflight on `origin/main`.
- Evidence tier: NA - static checker hardening only; validation commands are listed below.
- Result classification: NA - no research result or benchmark claim.
- Decision stop rule, applicable: focused tests and static preflight commands pass without changing benchmark eligibility.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3813 remains open; no claim map or benchmark report update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - checker hardening only.

## Domain-Aware Approval
- Required PR: not applicable
- Domains reviewed: sustained-flow scenario preflight contract, benchmark eligibility fail-closed boundary.
- Status: waived
- Approver/review source waiver: waived by author for static checker hardening; Claude Code on `imech156-u` owns full PR gate and merge authority per task handoff.
- Approval or blocker note: waived for static checker hardening; no benchmark result claim is promoted.
- Target claim/hypothesis: no sustained-flow benchmark claim.
- Comparator or split/evidence validity: static preflight contract only; no benchmark split or comparator evidence changed.
- Fallback/degraded exclusions: benchmark eligibility remains fail-closed when blockers drift.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation-only static checker change.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, focused test mutates the blocker list and preflight rejects it.
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? static contract only; no runtime scenario execution.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: #3813 still needs runtime continuous respawn support, sustained-progress proof, interaction-exposure sanity proof, pure-wait baseline proof, and runnable campaign evidence.

## Next Empirical Action
- Rerun needed: no for this checker slice.
- Extractor analysis tool needed: no
- Artifact missing unavailable: runtime/campaign artifacts intentionally out of scope.
- Stop / revise / continue decision: continue with runtime and benchmark-evidence follow-up slices.
- Proposed child issue existing follow-up: #3813 remains the parent tracker.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q` passed, 27 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` passed with `conforms=true`, `variant_count=3`, `runtime_support=metadata_only`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --runtime-supported-generated --json` passed with `conforms=true`, `variant_count=3`, `runtime_support=runtime_continuous_spawn`, `benchmark_evidence=false`.
- Final readiness: see the final `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=... scripts/dev/pr_ready_check.sh` run before push.

## Performance Impact
- Baseline runtime: NA - static preflight/test checker only.
- Changed runtime: NA - no runtime benchmark or campaign path changed.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q`
- Hot-path call count profile anchor: NA - no benchmark hot path changed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if sustained-flow preflight incorrectly rejects canonical scaffold rows or loses fail-closed behavior on drift.

## Risks / Rollout
- Compatibility risks: low; payload gains one field and validation is limited to #3813 sustained-flow matrices.
- Failure modes: external users with ad-hoc sustained-flow matrices missing the blocker list will now fail closed.
- Rollback fallback plan: revert this PR to restore prior checker tolerance.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3813 and merged preflight slices referenced there.
- Any assumptions need to preserved: this is a static generator/preflight slice, not runtime continuous spawn.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments are not authorized for this task.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark/campaign evidence or claim surface changed.

## Follow-Up Issues
- Deferred work: #3813 tracks runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, and runnable campaign/runner benchmark evidence.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer verify closely: the new blocker-list validation should remain a fail-closed static preflight guard, not evidence that #3813 is complete.
- Any known limitations: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
