### PR TITLE
Issue #3501: harden safety-wrapper ablation pair provenance

### DIFF
--- a/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
+++ b/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
@@ -352,7 +352,7 @@ def check_factorial_ablation_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str
     invalid_provenance_fields: list[dict[str, Any]] = []
     duplicate_pair_rows: list[dict[str, Any]] = []
     unexpected_wrapper_arms: list[str] = []
-    groups: dict[tuple[Any, ...], dict[str, int]] = {}
+    groups: dict[tuple[Any, ...], dict[str, list[Mapping[str, Any]]]] = {}
 
     for index, row in enumerate(rows):
         missing = [field for field in REQUIRED_ROW_FIELDS if field not in row]
@@ -366,13 +366,13 @@ def check_factorial_ablation_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str
             unexpected_wrapper_arms.append(arm)
         key = tuple(row.get(field) for field in PAIRING_KEY_FIELDS)
         by_arm = groups.setdefault(key, {})
-        by_arm[arm] = by_arm.get(arm, 0) + 1
-        if by_arm[arm] > 1:
+        by_arm.setdefault(arm, []).append(row)
+        if len(by_arm[arm]) > 1:
             duplicate_pair_rows.append(
                 {
                     "pairing_key": dict(zip(PAIRING_KEY_FIELDS, key, strict=True)),
                     "wrapper_arm": arm,
-                    "count": by_arm[arm],
+                    "count": len(by_arm[arm]),
                 }
             )
 
@@ -382,8 +382,10 @@ def check_factorial_ablation_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str
             "wrapper_arms": sorted(by_arm),
         }
         for key, by_arm in groups.items()
-        if set(by_arm) != set(EXPECTED_WRAPPER_ARMS) or any(count != 1 for count in by_arm.values())
+        if set(by_arm) != set(EXPECTED_WRAPPER_ARMS)
+        or any(len(rows_for_arm) != 1 for rows_for_arm in by_arm.values())
     ]
+    pair_provenance_mismatches = _pair_provenance_mismatches(groups)
     complete = (
         len(rows) > 0
         and not missing_required_fields
@@ -391,6 +393,7 @@ def check_factorial_ablation_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str
         and not unexpected_wrapper_arms
         and not duplicate_pair_rows
         and not incomplete_pairs
+        and not pair_provenance_mismatches
     )
     return {
         "complete": bool(complete),
@@ -404,7 +407,35 @@ def check_factorial_ablation_rows(rows: Sequence[Mapping[str, Any]]) -> dict[str
         "unexpected_wrapper_arms": sorted(set(unexpected_wrapper_arms)),
         "duplicate_pair_rows": duplicate_pair_rows,
         "incomplete_pairs": incomplete_pairs,
+        "pair_provenance_mismatches": pair_provenance_mismatches,
     }
+
+
+def _pair_provenance_mismatches(
+    groups: Mapping[tuple[Any, ...], Mapping[str, Sequence[Mapping[str, Any]]]],
+) -> list[dict[str, Any]]:
+    """Return paired-row provenance fields that disagree within an off/on contrast."""
+    mismatches: list[dict[str, Any]] = []
+    for key, by_arm in groups.items():
+        if set(by_arm) != set(EXPECTED_WRAPPER_ARMS) or any(
+            len(rows_for_arm) != 1 for rows_for_arm in by_arm.values()
+        ):
+            continue
+        off_row = by_arm[WRAPPER_OFF_ARM][0]
+        on_row = by_arm[WRAPPER_ON_ARM][0]
+        fields = [
+            field
+            for field in ("study_id", "software_commit")
+            if off_row.get(field) != on_row.get(field)
+        ]
+        if fields:
+            mismatches.append(
+                {
+                    "pairing_key": dict(zip(PAIRING_KEY_FIELDS, key, strict=True)),
+                    "fields": fields,
+                }
+            )
+    return mismatches
 
 
 def _row_provenance_errors(row: Mapping[str, Any]) -> list[str]:

--- a/tests/benchmark/test_safety_wrapper_ablation_manifest.py
+++ b/tests/benchmark/test_safety_wrapper_ablation_manifest.py
@@ -204,6 +204,25 @@ def test_check_factorial_ablation_rows_accepts_exact_paired_rows() -> None:
     assert report["missing_required_fields"] == []
     assert report["invalid_provenance_fields"] == []
     assert report["incomplete_pairs"] == []
+    assert report["pair_provenance_mismatches"] == []
+
+
+def test_check_factorial_ablation_rows_rejects_mixed_pair_provenance() -> None:
+    """Paired off/on rows must come from the same study and software commit."""
+    off_row = _ablation_row(WRAPPER_OFF_ARM)
+    on_row = _ablation_row(WRAPPER_ON_ARM)
+    on_row["study_id"] = "different_study"
+    on_row["software_commit"] = "def5678"
+
+    report = check_factorial_ablation_rows([off_row, on_row])
+
+    assert report["complete"] is False
+    assert report["pair_provenance_mismatches"] == [
+        {
+            "pairing_key": {"planner": "orca", "scenario_id": "crossing_basic", "seed": 111},
+            "fields": ["study_id", "software_commit"],
+        }
+    ]
 
 
 def test_check_factorial_ablation_rows_rejects_missing_provenance_and_unpaired_arm() -> None:


### PR DESCRIPTION
## Summary
Hardens the issue #3501 safety-wrapper ablation row checker so a paired `wrapper_off`/`wrapper_on` contrast fails closed when comparison-level provenance differs between arms.

## Linked Issues
- Relates `#3501`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Stores row objects per pairing key/arm in `check_factorial_ablation_rows` so the checker can compare pair-level provenance after duplicate and completeness checks.
- Adds `pair_provenance_mismatches` to the checker report and marks rows incomplete when paired arms disagree on `study_id` or `software_commit`.
- Adds focused tests proving valid paired rows report no mismatches and mixed-provenance pairs fail closed.

## Why Matters
- Added value: prevents later with/without ablation packets from silently comparing rows from different studies or commits.
- Expected impact: checker-only hardening for the already opt-in dry-run manifest/checker path.
- Why worth merging now: it tightens the first safe issue #3501 slice without runtime benchmark wiring or threshold changes.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #3501 ablation packet completeness gate, not mitigation effectiveness.
- Comparator or baseline, applicable: paired `wrapper_off`/`wrapper_on` row contract.
- Evidence tier: NA - support checker only; validation is focused code/test proof, not benchmark evidence.
- Result classification: NA - no research result claimed.
- Decision stop rule, applicable: checker must fail closed for mixed comparison provenance and pass exact paired rows.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3501; no claim map update because this is checker hardening only.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - existing support checker only; no evidence interpretation added.

## Domain-Aware Approval
- approval concerns experimental validity: not required
- Approver/review source waiver: checker-only guard, no benchmark results or claim promotion.
- Validity checklist:
- Target claim/hypothesis: NA - no mitigation claim.
- Comparator split/evidence validity: NA - no comparison result or benchmark claim; checker only validates future row packet consistency.
- Fallback/degraded exclusions: no fallback or degraded benchmark run performed.
- Claim boundary: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Implementation integrity vs experimental validity: implementation guards row packet integrity; experimental validity remains downstream.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no runtime wrapper run.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA for this checker PR
- Extractor analysis tool needed: no
- Artifact missing unavailable: full paired ablation campaign evidence remains intentionally out of scope.
- Stop / revise / continue decision: continue with downstream runtime/campaign wiring when explicitly authorized.
- Proposed child issue existing follow-up: #3501 remains the parent for downstream paired ablation execution.

## Validation / Proof
- `uv run pytest tests/benchmark/test_safety_wrapper_ablation_manifest.py -q` -> passed, 19 tests.
- `uv run ruff check robot_sf/benchmark/safety_wrapper_ablation_manifest.py tests/benchmark/test_safety_wrapper_ablation_manifest.py scripts/benchmark/check_safety_wrapper_ablation_rows.py scripts/benchmark/build_safety_wrapper_ablation_manifest.py` -> passed.
- `uv run python scripts/benchmark/build_safety_wrapper_ablation_manifest.py --config configs/research/safety_wrapper_ablation_v1.yaml --out output/issue_3501_manifest_probe --dry-run` -> passed, `complete=True cells=6 seeds_per_cell=3`.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=.git/codex-agent-runs/active/pr-4116-gate/pr-body.md scripts/dev/pr_ready_check.sh` passed locally: main lane 1700 passed; optional lane 4029 passed, 7 skipped; changed-file coverage 100%; clean-tree stamp `output/validation/pr_ready/issue-3501-factorial-ablation-checker-20260701.json`.

## Runtime / Performance
- Baseline runtime: NA - checker-only change, no performance claim.
- Changed runtime: NA - checker-only change, no performance claim.
- Representative command: `uv run pytest tests/benchmark/test_safety_wrapper_ablation_manifest.py -q`
- Hot-path call count profile anchor: NA - no runtime hot path changed.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: revert if valid same-study/same-commit paired rows fail or mixed-study/mixed-commit rows pass.

## Risks / Rollout
- Compatibility risks: checker report consumers may see a new `pair_provenance_mismatches` field; existing pass/fail semantics only become stricter for mixed-provenance pairs.
- Failure modes: overly strict if a future legitimate design intentionally compares different commits, which would need an explicit contract update.
- Rollback fallback plan: revert this commit to restore prior shape-only row checks.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3501 and existing `configs/research/safety_wrapper_ablation_v1.yaml` claim boundary.
- Any assumptions need to preserved: `study_id` and `software_commit` are comparison-level provenance and must agree inside an off/on pair.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, comments not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no, issue #3501 already tracks downstream execution.
- Not applicable because: no benchmark evidence, registry behavior, claim-map entry, or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits; runtime wrapper ablation execution remains downstream and tracked by #3501.
- Issues opened follow-up: none - #3501 remains the linked tracker for downstream execution.

## Reviewer Notes
- Anything reviewer verify closely: `pair_provenance_mismatches` only runs after exact off/on pair shape is present, so duplicate/incomplete rows keep their existing failure categories.
- Any known limitations: checker still validates result packet consistency only; it does not execute or claim the ablation.

