### PR TITLE
Issue #3275: require disjoint split null-test policy

### DIFF
--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -81,10 +81,15 @@ _DIAGNOSTIC_STATUS_KEYS = (
     "status",
 )
 _NULL_TEST_REQUIRED_KEYS = (
+    "split_policy",
     "null_tests_reject_null",
     "shuffled_outcome_null_test",
     "ranking_permutation_test",
 )
+_NULL_TEST_ALLOWED_SPLIT_POLICIES = {
+    "disjoint_scenario_family",
+    "scenario-family-disjoint",
+}
 _NULL_TEST_CONTAINER_KEYS = (
     "independent_evaluation",
     "null_test_prerequisites",
@@ -604,8 +609,19 @@ def _null_test_prerequisite_gaps(
         missing=missing,
         invalid=invalid,
     )
+    if _split_policy_invalid(prerequisites.get("split_policy")):
+        invalid.append("split_policy_not_disjoint_scenario_family")
     if prerequisites.get("null_tests_reject_null") is not True:
         invalid.append("null_tests_reject_null_not_true")
+    invalid.extend(_null_test_packet_gaps(prerequisites))
+    status = "ready" if not missing and not invalid else "blocked"
+    return source, status, missing, invalid
+
+
+def _null_test_packet_gaps(prerequisites: dict[str, Any]) -> list[str]:
+    """Return invalid markers for complete null-test packet fields."""
+
+    invalid: list[str] = []
     for key in ("shuffled_outcome_null_test", "ranking_permutation_test"):
         value = prerequisites.get(key)
         if not isinstance(value, dict):
@@ -616,8 +632,18 @@ def _null_test_prerequisite_gaps(
             invalid.append(f"{key}_missing_p_value")
         elif not _valid_probability(value["p_value"]):
             invalid.append(f"{key}_invalid_p_value")
-    status = "ready" if not missing and not invalid else "blocked"
-    return source, status, missing, invalid
+    return invalid
+
+
+def _split_policy_invalid(split_policy: Any) -> bool:
+    """Return whether a present split policy is incompatible with issue #3275."""
+
+    if not isinstance(split_policy, str):
+        return False
+    normalized_split_policy = split_policy.strip()
+    return bool(
+        normalized_split_policy and normalized_split_policy not in _NULL_TEST_ALLOWED_SPLIT_POLICIES
+    )
 
 
 def _check_expected_archive_hash(

--- a/robot_sf/benchmark/failure_archive_rerun_readiness.py
+++ b/robot_sf/benchmark/failure_archive_rerun_readiness.py
@@ -639,7 +639,7 @@ def _split_policy_invalid(split_policy: Any) -> bool:
     """Return whether a present split policy is incompatible with issue #3275."""
 
     if not isinstance(split_policy, str):
-        return False
+        return True
     normalized_split_policy = split_policy.strip()
     return bool(
         normalized_split_policy and normalized_split_policy not in _NULL_TEST_ALLOWED_SPLIT_POLICIES

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -889,6 +889,32 @@ def test_null_test_prerequisites_require_disjoint_split_policy(tmp_path: Path) -
     assert "invalid_null_test_prerequisites:1" in readiness.blockers
 
 
+def test_non_string_null_test_split_policy_blocks_readiness(tmp_path: Path) -> None:
+    """Structured split policy metadata must fail closed until normalized."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = _null_test_prerequisites(source, rerun)
+    prerequisites["split_policy"] = {"policy": "scenario-family-disjoint"}
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.null_test_prerequisite_status == BLOCKED
+    assert "split_policy_not_disjoint_scenario_family" in readiness.invalid_null_test_prerequisites
+    assert "invalid_null_test_prerequisites:1" in readiness.blockers
+
+
 def test_mismatched_null_test_archive_hash_blocks_readiness(tmp_path: Path) -> None:
     """Stale null-test reports for another archive pair fail closed."""
 

--- a/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
+++ b/tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py
@@ -74,6 +74,7 @@ def _null_test_prerequisites(source_archive: Path, rerun_archive: Path) -> dict:
     """Return complete null-test prerequisite metadata."""
 
     return {
+        "split_policy": "scenario-family-disjoint",
         "source_archive_sha256": _archive_hash(source_archive),
         "rerun_archive_sha256": _archive_hash(rerun_archive),
         "null_tests_reject_null": True,
@@ -762,6 +763,7 @@ def test_null_test_prerequisites_can_be_checked_from_report(tmp_path: Path) -> N
             {
                 "schema_version": "adversarial_proposal_comparison.v1",
                 "null_tests": {
+                    "split_policy": "disjoint_scenario_family",
                     "source_archive_sha256": _archive_hash(source),
                     "rerun_archive_sha256": _archive_hash(rerun),
                     "null_tests_reject_null": True,
@@ -802,6 +804,7 @@ def test_missing_null_test_prerequisites_block_readiness(tmp_path: Path) -> None
         json.dumps(
             {
                 "null_tests": {
+                    "split_policy": "scenario-family-disjoint",
                     "source_archive_sha256": _archive_hash(source),
                     "rerun_archive_sha256": _archive_hash(rerun),
                     "null_tests_reject_null": False,
@@ -851,10 +854,39 @@ def test_missing_null_test_archive_hashes_block_readiness(tmp_path: Path) -> Non
 
     assert readiness.status == BLOCKED
     assert readiness.missing_null_test_prerequisites == [
+        "split_policy",
         "source_archive_sha256",
         "rerun_archive_sha256",
     ]
-    assert "missing_null_test_prerequisites:2" in readiness.blockers
+    assert "missing_null_test_prerequisites:3" in readiness.blockers
+
+
+def test_null_test_prerequisites_require_disjoint_split_policy(tmp_path: Path) -> None:
+    """Null-test prerequisites must identify a disjoint scenario-family split."""
+
+    source = _archive(
+        tmp_path / "source.json",
+        [_entry("source_0000", family="family_a", seed=1)],
+    )
+    rerun = _archive(
+        tmp_path / "rerun.json",
+        [_entry("rerun_0000", family="family_b", seed=101)],
+    )
+    prerequisites = _null_test_prerequisites(source, rerun)
+    prerequisites["split_policy"] = "random-row-split"
+
+    readiness = classify_failure_archive_rerun_readiness(
+        source,
+        rerun,
+        null_test_prerequisites=prerequisites,
+    )
+
+    assert readiness.status == BLOCKED
+    assert readiness.null_test_prerequisite_status == BLOCKED
+    assert readiness.invalid_null_test_prerequisites == [
+        "split_policy_not_disjoint_scenario_family"
+    ]
+    assert "invalid_null_test_prerequisites:1" in readiness.blockers
 
 
 def test_mismatched_null_test_archive_hash_blocks_readiness(tmp_path: Path) -> None:
@@ -898,6 +930,7 @@ def test_null_test_archive_hashes_can_use_archive_pair_container(tmp_path: Path)
             "source_archive_sha256": _archive_hash(source),
             "rerun_archive_sha256": _archive_hash(rerun),
         },
+        "split_policy": "scenario-family-disjoint",
         "null_tests_reject_null": True,
         "shuffled_outcome_null_test": {"status": "complete", "p_value": 0.01},
         "ranking_permutation_test": {"status": "complete", "p_value": 0.02},
@@ -926,6 +959,7 @@ def test_invalid_null_test_p_values_block_readiness(tmp_path: Path) -> None:
         [_entry("rerun_0000", family="family_b", seed=101)],
     )
     prerequisites = {
+        "split_policy": "scenario-family-disjoint",
         "source_archive_sha256": _archive_hash(source),
         "rerun_archive_sha256": _archive_hash(rerun),
         "null_tests_reject_null": True,
@@ -960,6 +994,7 @@ def test_incomplete_null_test_status_does_not_validate_p_value(tmp_path: Path) -
         [_entry("rerun_0000", family="family_b", seed=101)],
     )
     prerequisites = {
+        "split_policy": "scenario-family-disjoint",
         "source_archive_sha256": _archive_hash(source),
         "rerun_archive_sha256": _archive_hash(rerun),
         "null_tests_reject_null": True,
@@ -991,6 +1026,7 @@ def test_null_test_p_value_probability_bounds_are_allowed(tmp_path: Path) -> Non
         [_entry("rerun_0000", family="family_b", seed=101)],
     )
     prerequisites = {
+        "split_policy": "scenario-family-disjoint",
         "source_archive_sha256": _archive_hash(source),
         "rerun_archive_sha256": _archive_hash(rerun),
         "null_tests_reject_null": True,
@@ -1024,6 +1060,7 @@ def test_cli_exit_codes_and_writes_report(tmp_path: Path, capsys) -> None:
     prerequisites.write_text(
         json.dumps(
             {
+                "split_policy": "scenario-family-disjoint",
                 "source_archive_sha256": _archive_hash(source),
                 "rerun_archive_sha256": _archive_hash(rerun),
                 "null_tests_reject_null": True,


### PR DESCRIPTION
## Summary
- Partial slice for #3275.
- Hardens the failure-archive rerun readiness checker so null-test prerequisite packets must declare a scenario-family-disjoint split policy before inputs can be marked ready.
- Keeps the PR bounded to metadata/readiness fail-closed behavior; it does not run the proposal model, benchmark campaign, GPU, or Slurm work.

## Linked Issues
- Relates `#3275`
- Does not close `#3275`: the issue still requires the actual disjoint certified failure archive rerun, independent planner-execution certification outcomes, shuffled-outcome/ranking null-test reporting, and continue/revise/stop disposition.

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none; remaining work stays tracked in `#3275`
- Safe review independently: yes

## What Changed
- Requires null-test prerequisite packets to include `split_policy`.
- Accepts existing repo spellings `scenario-family-disjoint` and `disjoint_scenario_family`.
- Fails closed for stale/generic/non-string split-policy packets instead of treating them as readiness proof.
- Adds focused tests for the scenario-family-disjoint split policy requirement.

## Why Matters
- Added value: prevents readiness packets from being treated as held-out-safe when they do not explicitly document the disjoint scenario-family split required by #3275.
- Expected impact: readiness tooling fails closed earlier for ambiguous null-test metadata.
- Why worth merging now: this is a prerequisite guardrail for the later actual rerun, without promoting benchmark or dissertation claims.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: NA - support/readiness guard only.
- Comparator or baseline, applicable: NA - no benchmark comparison run.
- Evidence tier: NA - support/readiness guard only.
- Result classification: NA - no research result.
- Decision stop rule, applicable: NA for this slice; #3275 remains open for the actual rerun decision.
- Parent issue, claim map, registry, context note, synthesis surface update: #3275 remains the parent issue and open tracker.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - hardens existing readiness validation.

## Domain-Aware Approval
- Required PR: not required - support/readiness guard only.
- Domains reviewed: failure-archive readiness metadata, scenario-family-disjoint split policy, null-test prerequisite gating.
- Status: approved
- Approver/review source waiver: PR gate review.
- Approval or blocker note: Approved as an implementation-integrity guardrail only; #3275 remains open for the actual disjoint certified archive rerun and held-out evidence disposition.
- Validity checklist:
  - Target claim/hypothesis: readiness metadata only.
  - Comparator or split/evidence validity: requires a scenario-family-disjoint split policy metadata value before readiness.
  - Comparator split/evidence validity: requires a scenario-family-disjoint split policy metadata value before readiness.
  - Fallback/degraded exclusions: readiness blocks ambiguous or stale packets; no fallback success path is introduced.
  - Claim boundary: no benchmark campaign run, no held-out yield claim, no dissertation claim promotion.
  - Implementation integrity vs experimental validity: implementation-integrity guard only.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, via focused unit tests for blocked and ready readiness packets.
- Did intervention change command source, selected command, trajectory, route progress? no runtime campaign execution.
- Did scenario actually contain targeted failure mode? NA - metadata fixtures only.
- Result route: continue; #3275 remains open for actual rerun.
- Follow-up question issue weak, negative, non-transfer results: none opened; remaining work is already in #3275.

## Next Empirical Action
- Rerun needed: yes, in #3275 after input archives and null-test packets are complete.
- Extractor analysis tool needed: no new tool from this PR.
- Artifact missing unavailable: populated disjoint certified archive rerun artifacts remain out of scope.
- Stop / revise / continue decision: continue under #3275.
- Proposed child issue existing follow-up: use #3275.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/failure_archive_rerun_readiness.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` passed: 37 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m pytest tests/adversarial/test_disjoint_evaluation.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` passed: 55 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_failure_archive_rerun_readiness.py --help` passed.
- `git diff --check` passed.

## Risks / Rollout
- Compatibility risks: callers using structured split-policy metadata must normalize it before readiness can pass.
- Failure modes: stricter fail-closed behavior may block previously ambiguous prerequisite packets.
- Rollback fallback plan: revert the readiness check commit if a legitimate packet shape is identified, then add explicit parser support with tests.

## Docs / Provenance
- Updated docs: PR body only.
- Relevant design provenance notes: #3275.
- Any assumptions need to preserved: this PR is a prerequisite guardrail and is not acceptance evidence for #3275.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, left open by PR body disposition.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no; #3275 already tracks remaining work.
- Not applicable because: no benchmark, registry, claim-map, paper-facing, or artifact promotion changes.

## Follow-Up Issues
- Deferred work: actual #3275 rerun and issue disposition.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely that the stricter `split_policy` handling is intended to fail closed for non-string packet shapes.
- Known limitations: this PR does not perform the disjoint certified archive rerun.
