### PR TITLE
Issue #3813: harden sustained-flow tier preflight

### DIFF
--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -11,6 +11,7 @@ from typing import Any
 from robot_sf.scenario_certification.sustained_flow import (
     EXPECTED_CONTINUOUS_SPAWN_DEFINITION,
     EXPECTED_ROUTE_RESPAWN_RUNTIME_CONFIG,
+    EXPECTED_SUSTAINED_FLOW_TIERS,
     EXPECTED_SUSTAINED_PROGRESS_METRIC,
     REQUIRED_BLOCKERS_BEFORE_BENCHMARK_USE,
     SUSTAINED_FLOW_RUNTIME_SUPPORTED_VALUE,
@@ -135,6 +136,7 @@ def preflight_sustained_flow_matrix(matrix_path: str | Path) -> SustainedFlowPre
         blocking_reasons.append(str(exc))
     else:
         blocking_reasons.extend(_variant_blockers(variants))
+        blocking_reasons.extend(_variant_tier_order_blockers(variants))
         blocking_reasons.extend(_generator_drift_blockers(variants))
 
     if not variants:
@@ -257,6 +259,20 @@ def _variant_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, 
         if not variant.seeds:
             blockers.append(f"{variant.name}: at least one seed is required")
     return tuple(blockers)
+
+
+def _variant_tier_order_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, ...]:
+    """Fail closed unless the matrix enumerates exactly light, medium, heavy.
+
+    Returns:
+        Blocking reason when density-tier enumeration drifts.
+    """
+
+    expected_tiers = tuple(tier for tier, *_ in EXPECTED_SUSTAINED_FLOW_TIERS)
+    observed_tiers = tuple(variant.density_tier for variant in variants)
+    if observed_tiers == expected_tiers:
+        return ()
+    return ("density tiers must enumerate light, medium, heavy exactly once",)
 
 
 def _validate_continuous_spawn_definition(value: Any, *, scenario_name: str) -> None:

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -233,6 +233,29 @@ def test_sustained_flow_preflight_rejects_duplicate_density_tier(tmp_path: Path)
     )
 
 
+def test_sustained_flow_preflight_rejects_reordered_density_tiers(tmp_path: Path) -> None:
+    """Benchmark preflight keeps sustained-flow density tiers in canonical order."""
+
+    matrix = _load_yaml(SCENARIO_SET)
+    matrix["scenarios"] = [
+        matrix["scenarios"][1],
+        matrix["scenarios"][0],
+        matrix["scenarios"][2],
+    ]
+
+    reordered_tier_matrix = tmp_path / "reordered_density_tier_sustained_flow.yaml"
+    reordered_tier_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+
+    payload = preflight_sustained_flow_matrix(reordered_tier_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert (
+        "density tiers must enumerate light, medium, heavy exactly once"
+        in payload["blocking_reasons"]
+    )
+
+
 def test_sustained_flow_preflight_rejects_wrong_spawn_process(tmp_path: Path) -> None:
     """Continuous-spawn variants must name the supported respawn process."""
 

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -213,6 +213,26 @@ def test_sustained_flow_preflight_rejects_generator_drift(tmp_path: Path) -> Non
     )
 
 
+def test_sustained_flow_preflight_rejects_duplicate_density_tier(tmp_path: Path) -> None:
+    """Benchmark preflight requires one light, medium, and heavy variant."""
+
+    matrix = _load_yaml(SCENARIO_SET)
+    matrix["scenarios"][1] = yaml.safe_load(yaml.safe_dump(matrix["scenarios"][0]))
+    matrix["scenarios"][1]["name"] = "issue_3813_sustained_flow_t_intersection_light_duplicate"
+
+    duplicated_tier_matrix = tmp_path / "duplicate_density_tier_sustained_flow.yaml"
+    duplicated_tier_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+
+    payload = preflight_sustained_flow_matrix(duplicated_tier_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert (
+        "density tiers must enumerate light, medium, heavy exactly once"
+        in payload["blocking_reasons"]
+    )
+
+
 def test_sustained_flow_preflight_rejects_wrong_spawn_process(tmp_path: Path) -> None:
     """Continuous-spawn variants must name the supported respawn process."""
 


### PR DESCRIPTION
## Summary
Hardens #3813 sustained-flow benchmark preflight so duplicated or reordered density-tier enumeration fails closed explicitly instead of relying only on indirect generator drift or monotonicity blockers.

## Linked Issues
- Relates to `#3813`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added benchmark preflight validation that sustained-flow matrices enumerate exactly light, medium, heavy density tiers in canonical order.
- Added enumeration regression tests for duplicated and reordered density tiers with an explicit fail-closed blocker.

## Why Matters
- Added value: closes a narrow preflight gap in the continuous-spawn scenario-generator slice.
- Expected impact: malformed sustained-flow matrices cannot appear benchmark-eligible when the light/medium/heavy family is incomplete, duplicated, or reordered.
- Why worth merging now: small, reversible checker hardening for issue #3813 without expanding into runtime campaign semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: sustained-flow scenario preflight completeness for issue #3813.
- Comparator baseline, applicable: baseline preflight only reported indirect generator/monotonicity blockers for duplicated or reordered tier rows.
- Evidence tier: NA - static checker hardening only.
- Result classification: NA - no benchmark result or research claim promoted.
- Decision stop rule, applicable: focused tests and preflight CLI remain green with explicit fail-closed blockers for duplicate and reordered tiers.
- Parent issue, claim map, registry, context note, synthesis surface update: parent issue #3813 remains open; PR gate may add a compact merge note.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - checker hardening only, no research evidence interpretation.

## Domain-Aware Approval
- Required PR: no - static checker hardening only, no evidence classification, experimental comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim changed.
- Status: waived - domain approval not required for this static preflight checker slice.
- Approver/review source waiver: self-review against issue #3813 scope; no claim movement, and benchmark evidence remains false.
- Validity checklist:
  - Target claim/hypothesis: NA - no benchmark claim movement.
  - Comparator split/evidence validity: NA - no comparator split evidence changed.
  - Fallback/degraded exclusions: benchmark eligibility remains fail-closed; no fallback/degraded run counted as evidence.
  - Claim boundary: static preflight/enumeration only.
  - Implementation integrity vs experimental validity: focused tests prove checker behavior, not experimental validity.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, duplicate and reordered density-tier matrices now emit an explicit blocker.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? synthetic malformed matrices duplicated the light tier and reordered light/medium/heavy rows.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: remaining #3813 runtime/campaign proof remains outside this PR.

## Next Empirical Action
- Rerun needed: no for this checker slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: full benchmark campaign evidence intentionally not produced.
- Stop / revise / continue decision: continue later runtime continuous pedestrian respawn support, sustained-progress proof, interaction-exposure sanity proof, pure-wait baseline proof, and runnable campaign evidence.
- Proposed child issue existing follow-up: #3813 tracks the remaining contract.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py::test_sustained_flow_preflight_rejects_duplicate_density_tier -q` - passed, 1 test.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py tests/scenario_certification/test_sustained_flow_preflight.py -q` - passed, 35 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` - passed; `conforms=true`, `variant_count=3`, `runtime_support=metadata_only`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_followups.py --body-file /tmp/pr-4120-body.md` - passed.
- Planned final gate before merge: `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr-4120-body.md scripts/dev/pr_ready_check.sh`.

## Risks / Rollout
- Compatibility risks: intentional new fail-closed blocker when density tiers drift from canonical light/medium/heavy enumeration.
- Failure modes: future intentional tier-family expansion must update `EXPECTED_SUSTAINED_FLOW_TIERS` and tests together.
- Rollback fallback plan: revert the PR commit to restore prior checker behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3813 and prior merged preflight slices listed there.
- Any assumptions need preserved: PR is static preflight/enumeration hardening only.

## Downstream Propagation
- Parent issue updated (yes/no/NA): pending PR gate merge note if merged; otherwise no.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: no benchmark campaign, registry, claim-map, leaderboard, artifact catalog, or paper-facing claim changed.

## Follow-Up Issues
- Deferred work: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. Remaining #3813 scope still needs runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, and runnable campaign/runner benchmark evidence.
- Issues opened follow-up: none.

## Reviewer Notes
- Anything reviewer verify closely: new blocker intentionally enforces exact-order light/medium/heavy to match the existing canonical generator contract.
- Any known limitations: not benchmark evidence; static preflight only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened preflight checks for sustained-flow scenarios to reject invalid density-tier setups.
  * Benchmarks now fail fast when density tiers are duplicated or listed in the wrong order, with a clear unavailable status.
  * Added coverage to ensure the expected light/medium/heavy tier sequence is enforced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->