### PR TITLE
Issue #3975: add partial-observability FoV memory slice

### DIFF
--- a/robot_sf/gym_env/unified_config.py
+++ b/robot_sf/gym_env/unified_config.py
@@ -90,6 +90,8 @@ class ObservationVisibilitySettings:
     static_occlusion: bool = False
     dynamic_occlusion: bool = False
     tracking_noise_std_m: float = 0.0
+    memory_for_lost_pedestrians: bool = False
+    lost_pedestrian_memory_horizon_s: float = 0.0
 
     def to_metadata(self) -> dict[str, bool | float | None]:
         """Return JSON-safe visibility settings metadata."""
@@ -100,6 +102,8 @@ class ObservationVisibilitySettings:
             "static_occlusion": bool(self.static_occlusion),
             "dynamic_occlusion": bool(self.dynamic_occlusion),
             "tracking_noise_std_m": float(self.tracking_noise_std_m),
+            "memory_for_lost_pedestrians": bool(self.memory_for_lost_pedestrians),
+            "lost_pedestrian_memory_horizon_s": float(self.lost_pedestrian_memory_horizon_s),
         }
 
 

--- a/robot_sf/sensor/socnav_observation.py
+++ b/robot_sf/sensor/socnav_observation.py
@@ -292,6 +292,7 @@ class SocNavObservationFusion:
         self._cache_position_cap_value: np.ndarray | None = None
         self._cache_position_cap_width: float | None = None
         self._cache_position_cap_height: float | None = None
+        self._lost_pedestrian_memory: dict[int, tuple[np.ndarray, np.ndarray, float]] = {}
 
     def reset_cache(self) -> None:
         """Reset internal caches to match the SensorFusion interface."""
@@ -303,6 +304,7 @@ class SocNavObservationFusion:
         self._cache_position_cap_value = None
         self._cache_position_cap_width = None
         self._cache_position_cap_height = None
+        self._lost_pedestrian_memory.clear()
 
     def _position_cap(self) -> np.ndarray:
         """Return cached map position cap, refreshing when map_def identity or dimensions change.
@@ -416,6 +418,69 @@ class SocNavObservationFusion:
             )
         return visible
 
+    def _pedestrians_with_lost_memory(
+        self,
+        *,
+        ped_positions: np.ndarray,
+        ped_velocities: np.ndarray,
+        visibility_mask: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Return visible pedestrians plus short-horizon constant-velocity memories."""
+        settings = getattr(self.env_config, "observation_visibility", None)
+        memory_enabled = bool(getattr(settings, "memory_for_lost_pedestrians", False))
+        horizon_s = float(getattr(settings, "lost_pedestrian_memory_horizon_s", 0.0) or 0.0)
+        if not memory_enabled or horizon_s <= 0.0:
+            self._lost_pedestrian_memory.clear()
+            return ped_positions[visibility_mask], ped_velocities[visibility_mask]
+
+        dt = float(getattr(self.simulator.config, "time_per_step_in_secs", 0.0) or 0.0)
+        step_s = max(dt, 0.0)
+        keep_positions: list[np.ndarray] = []
+        keep_velocities: list[np.ndarray] = []
+        live_ids = set(range(ped_positions.shape[0]))
+
+        for ped_idx, (position, velocity, visible) in enumerate(
+            zip(ped_positions, ped_velocities, visibility_mask, strict=True)
+        ):
+            if bool(visible):
+                position_copy = np.asarray(position, dtype=np.float32).copy()
+                velocity_copy = np.asarray(velocity, dtype=np.float32).copy()
+                self._lost_pedestrian_memory[ped_idx] = (position_copy, velocity_copy, 0.0)
+                keep_positions.append(position_copy)
+                keep_velocities.append(velocity_copy)
+                continue
+
+            remembered = self._lost_pedestrian_memory.get(ped_idx)
+            if remembered is None:
+                continue
+            last_position, last_velocity, age_s = remembered
+            next_age_s = age_s + step_s
+            if next_age_s > horizon_s:
+                self._lost_pedestrian_memory.pop(ped_idx, None)
+                continue
+            predicted_position = (last_position + last_velocity * step_s).astype(np.float32)
+            velocity_copy = last_velocity.astype(np.float32, copy=True)
+            self._lost_pedestrian_memory[ped_idx] = (
+                predicted_position,
+                velocity_copy,
+                next_age_s,
+            )
+            keep_positions.append(predicted_position)
+            keep_velocities.append(velocity_copy)
+
+        for stale_idx in set(self._lost_pedestrian_memory) - live_ids:
+            self._lost_pedestrian_memory.pop(stale_idx, None)
+
+        if not keep_positions:
+            return (
+                np.zeros((0, 2), dtype=np.float32),
+                np.zeros((0, 2), dtype=np.float32),
+            )
+        return (
+            np.stack(keep_positions).astype(np.float32, copy=False),
+            np.stack(keep_velocities).astype(np.float32, copy=False),
+        )
+
     def _rebuild_static_occlusion_cache(self) -> None:
         """Build prepared-geometry cache from current simulator obstacle polygons."""
         map_def = getattr(self.simulator, "map_def", None)
@@ -501,8 +566,13 @@ class SocNavObservationFusion:
             robot_heading=heading,
         )
         if visibility_mask.size > 0:
-            ped_positions = ped_positions[visibility_mask]
-            ped_velocities = ped_velocities[visibility_mask]
+            ped_positions, ped_velocities = self._pedestrians_with_lost_memory(
+                ped_positions=ped_positions,
+                ped_velocities=ped_velocities,
+                visibility_mask=visibility_mask,
+            )
+        else:
+            self._lost_pedestrian_memory.clear()
 
         # Order pedestrians by distance to robot (closest-first)
         if ped_positions.size > 0:

--- a/scripts/dev/run_tests_parallel.sh
+++ b/scripts/dev/run_tests_parallel.sh
@@ -76,6 +76,7 @@ core_test_paths=(
   tests/test_planner.py
   tests/test_range_sensor.py
   tests/test_seed_utils.py
+  tests/test_socnav_observation.py
   tests/test_types.py
   tests/test_ci_script_contract.py
   tests/map_test.py

--- a/tests/test_socnav_observation.py
+++ b/tests/test_socnav_observation.py
@@ -156,6 +156,42 @@ def test_socnav_observation_visibility_filters_fov_without_mutating_ground_truth
     assert simulator.ped_pos.shape == (2, 2)
 
 
+def test_socnav_observation_visibility_filters_range() -> None:
+    """Planner-facing pedestrian observations should honor opt-in range settings."""
+    env_config = RobotSimulationConfig()
+    env_config.observation_visibility = ObservationVisibilitySettings(
+        enabled=True,
+        max_range_m=2.5,
+    )
+    simulator = SimpleNamespace(
+        ped_pos=np.array([[2.0, 0.0], [3.0, 0.0]], dtype=np.float32),
+        ped_vel=np.zeros((2, 2), dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), 0.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=1.0),
+            )
+        ],
+        goal_pos=[np.array([5.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=10.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+
+    obs = SocNavObservationFusion(
+        simulator=simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    ).next_obs()
+
+    assert obs["pedestrians"]["count"][0] == pytest.approx(1.0)
+    np.testing.assert_allclose(
+        obs["pedestrians"]["positions"][0],
+        np.array([2.0, 0.0], dtype=np.float32),
+    )
+
+
 def test_socnav_observation_visibility_360_keeps_current_pedestrian_contract() -> None:
     """Full-FOV visibility should reproduce the unfiltered pedestrian observation."""
     env_config = RobotSimulationConfig()

--- a/tests/test_socnav_observation.py
+++ b/tests/test_socnav_observation.py
@@ -156,6 +156,95 @@ def test_socnav_observation_visibility_filters_fov_without_mutating_ground_truth
     assert simulator.ped_pos.shape == (2, 2)
 
 
+def test_socnav_observation_visibility_360_keeps_current_pedestrian_contract() -> None:
+    """Full-FOV visibility should reproduce the unfiltered pedestrian observation."""
+    env_config = RobotSimulationConfig()
+    env_config.observation_visibility = ObservationVisibilitySettings(
+        enabled=True,
+        fov_degrees=360.0,
+        max_range_m=None,
+    )
+    simulator = SimpleNamespace(
+        ped_pos=np.array([[3.0, 0.0], [0.0, 3.0]], dtype=np.float32),
+        ped_vel=np.zeros((2, 2), dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), 0.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=1.0),
+            )
+        ],
+        goal_pos=[np.array([5.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=10.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.1),
+    )
+
+    obs = SocNavObservationFusion(
+        simulator=simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    ).next_obs()
+
+    assert obs["pedestrians"]["count"][0] == pytest.approx(2.0)
+    np.testing.assert_allclose(
+        obs["pedestrians"]["positions"][:2],
+        np.array([[3.0, 0.0], [0.0, 3.0]], dtype=np.float32),
+    )
+
+
+def test_socnav_lost_pedestrian_memory_predicts_then_drops_after_horizon() -> None:
+    """Lost pedestrians should persist with constant velocity only within the configured horizon."""
+    env_config = RobotSimulationConfig()
+    env_config.observation_visibility = ObservationVisibilitySettings(
+        enabled=True,
+        fov_degrees=90.0,
+        memory_for_lost_pedestrians=True,
+        lost_pedestrian_memory_horizon_s=1.0,
+    )
+    simulator = SimpleNamespace(
+        ped_pos=np.array([[2.0, 0.0]], dtype=np.float32),
+        ped_vel=np.array([[1.0, 0.0]], dtype=np.float32),
+        robots=[
+            SimpleNamespace(
+                pose=((0.0, 0.0), 0.0),
+                current_speed=np.array([0.0, 0.0], dtype=np.float32),
+                config=SimpleNamespace(radius=1.0),
+            )
+        ],
+        goal_pos=[np.array([5.0, 0.0], dtype=np.float32)],
+        next_goal_pos=[None],
+        map_def=SimpleNamespace(width=10.0, height=10.0, obstacles=[]),
+        config=SimpleNamespace(time_per_step_in_secs=0.5),
+    )
+    fusion = SocNavObservationFusion(
+        simulator=simulator,
+        env_config=env_config,
+        max_pedestrians=4,
+    )
+
+    first = fusion.next_obs()
+    assert first["pedestrians"]["count"][0] == pytest.approx(1.0)
+
+    simulator.ped_pos = np.array([[0.0, 2.0]], dtype=np.float32)
+    remembered = fusion.next_obs()
+    assert remembered["pedestrians"]["count"][0] == pytest.approx(1.0)
+    np.testing.assert_allclose(
+        remembered["pedestrians"]["positions"][0],
+        np.array([2.5, 0.0], dtype=np.float32),
+    )
+
+    remembered_again = fusion.next_obs()
+    assert remembered_again["pedestrians"]["count"][0] == pytest.approx(1.0)
+    np.testing.assert_allclose(
+        remembered_again["pedestrians"]["positions"][0],
+        np.array([3.0, 0.0], dtype=np.float32),
+    )
+
+    dropped = fusion.next_obs()
+    assert dropped["pedestrians"]["count"][0] == pytest.approx(0.0)
+
+
 def test_socnav_observation_visibility_filters_static_occluded_pedestrian() -> None:
     """Static obstacle geometry should hide pedestrians behind an occluding polygon."""
     env_config = RobotSimulationConfig()


### PR DESCRIPTION
## Issue
Closes https://github.com/ll7/robot_sf_ll7/issues/3975

## Scope Summary
- Adds opt-in `memory_for_lost_pedestrians` and `lost_pedestrian_memory_horizon_s` fields to the existing `ObservationVisibilitySettings` owner.
- Extends `SocNavObservationFusion` so visible pedestrians refresh memory and newly hidden pedestrians remain in the planner-facing observation via a constant-velocity prediction until the configured horizon expires.
- Keeps the existing 360-degree visibility contract covered by tests and does not change simulator ground-truth pedestrian state, dynamics, metrics, or benchmark claims.

## Validation
- `uv sync --all-extras` -> exit 0
- `uv run pytest tests/test_socnav_observation.py -q` -> exit 0, 13 passed
- `uv run pytest tests/ -k "fov or field_of_view or partial_observability or lost_pedestrian" -q` -> exit 0, 3 passed; one unrelated pytest deprecation warning from `tests/test_scenario_generator.py` collection
- `uv run ruff check robot_sf/gym_env/unified_config.py robot_sf/sensor/socnav_observation.py tests/test_socnav_observation.py` -> exit 0
- `uv run ruff format --check robot_sf/gym_env/unified_config.py robot_sf/sensor/socnav_observation.py tests/test_socnav_observation.py` -> exit 0

## Out of Scope
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No relational/edge observation representation changes.

## Residual Risk
- The first-slice memory model uses simulator pedestrian row index as the track identity because this SocNav observation surface currently exposes positions and velocities, not stable pedestrian IDs. That is adequate for the local geometry/unit-test contract but should be revisited before stronger tracker-style claims.
