### PR TITLE
Issue #3813: harden sustained-flow target density preflight

### DIFF
--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -59,6 +59,7 @@ class SustainedFlowVariant:
     density_tier: str
     ped_density: float
     spawn_rate_per_min: float
+    target_density_tier: str
     spawn_definition: dict[str, object]
     current_runtime_support: str
     runtime_definition_status: str
@@ -205,6 +206,9 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
         spawn_rate_per_min=_required_float(
             continuous_spawn, "spawn_rate_per_min", scenario_name=name
         ),
+        target_density_tier=_required_str(
+            continuous_spawn, "target_density_tier", scenario_name=name
+        ),
         spawn_definition=dict(EXPECTED_CONTINUOUS_SPAWN_DEFINITION),
         current_runtime_support=_required_str(
             continuous_spawn, "current_runtime_support", scenario_name=name
@@ -228,6 +232,11 @@ def _variant_from_scenario(scenario: Mapping[str, Any]) -> SustainedFlowVariant:
 def _variant_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, ...]:
     blockers: list[str] = []
     for variant in variants:
+        if variant.target_density_tier != variant.density_tier:
+            blockers.append(
+                f"{variant.name}: continuous_spawn.target_density_tier "
+                f"{variant.target_density_tier!r}, expected {variant.density_tier!r}"
+            )
         expected_definition_status, expected_definition_ready = (
             runtime_definition_status_for_support(variant.current_runtime_support)
         )
@@ -327,6 +336,7 @@ def _variant_generator_profile(variant: SustainedFlowVariant) -> tuple[object, .
         variant.density_tier,
         variant.ped_density,
         variant.spawn_rate_per_min,
+        variant.target_density_tier,
         tuple(sorted(variant.spawn_definition.items())),
         variant.current_runtime_support,
         variant.runtime_definition_status,

--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -197,6 +197,7 @@ class SustainedFlowVariant:
     density_tier: str
     ped_density: float
     spawn_rate_per_min: float
+    target_density_tier: str
     spawn_definition: dict[str, object]
     seeds: tuple[int, ...]
     map_file: str
@@ -459,6 +460,12 @@ def _validate_variant(
     if tier not in expected_by_tier:
         return None, [f"{name}: unexpected sustained-flow density tier {tier!r}"]
 
+    continuous_spawn = metadata.get("continuous_spawn", {})
+    target_density_tier = (
+        str(continuous_spawn.get("target_density_tier", ""))
+        if isinstance(continuous_spawn, dict)
+        else ""
+    )
     expected_ped_density, expected_spawn_rate, expected_seeds = expected_by_tier[tier]
     simulation_config = scenario.get("simulation_config", {})
     ped_density = float(simulation_config.get("ped_density", -1.0))
@@ -491,6 +498,7 @@ def _validate_variant(
             density_tier=tier,
             ped_density=ped_density,
             spawn_rate_per_min=expected_spawn_rate,
+            target_density_tier=target_density_tier,
             spawn_definition=dict(EXPECTED_CONTINUOUS_SPAWN_DEFINITION),
             seeds=seeds,
             map_file=map_file,
@@ -673,6 +681,7 @@ def sustained_flow_preflight_to_dict(report: SustainedFlowPreflightReport) -> di
                 "density_tier": variant.density_tier,
                 "ped_density": variant.ped_density,
                 "spawn_rate_per_min": variant.spawn_rate_per_min,
+                "target_density_tier": variant.target_density_tier,
                 "spawn_definition": dict(variant.spawn_definition),
                 "seeds": list(variant.seeds),
                 "map_file": variant.map_file,

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -256,6 +256,26 @@ def test_sustained_flow_preflight_rejects_reordered_density_tiers(tmp_path: Path
     )
 
 
+def test_sustained_flow_preflight_rejects_target_density_tier_drift(tmp_path: Path) -> None:
+    """Continuous-spawn targets must stay aligned with the enumerated density tier."""
+
+    matrix = _load_yaml(SCENARIO_SET)
+    matrix["scenarios"][0]["metadata"]["continuous_spawn"]["target_density_tier"] = "heavy"
+
+    drifted_target_matrix = tmp_path / "wrong_target_density_tier_sustained_flow.yaml"
+    drifted_target_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+
+    payload = preflight_sustained_flow_matrix(drifted_target_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert payload["variant_count"] == 3
+    assert any(
+        "continuous_spawn.target_density_tier 'heavy', expected 'light'" in reason
+        for reason in payload["blocking_reasons"]
+    )
+
+
 def test_sustained_flow_preflight_rejects_wrong_spawn_process(tmp_path: Path) -> None:
     """Continuous-spawn variants must name the supported respawn process."""
 

--- a/tests/scenario_certification/test_sustained_flow_preflight.py
+++ b/tests/scenario_certification/test_sustained_flow_preflight.py
@@ -24,6 +24,9 @@ def test_expected_variants_enumerate_deterministically() -> None:
 
     tiers = [scenario["metadata"]["density"] for scenario in generated]
     assert tiers == ["light", "medium", "heavy"]
+    assert [
+        scenario["metadata"]["continuous_spawn"]["target_density_tier"] for scenario in generated
+    ] == tiers
 
     spawn_rates = [
         scenario["metadata"]["continuous_spawn"]["spawn_rate_per_min"] for scenario in generated
@@ -68,6 +71,11 @@ def test_generated_variants_pass_generator_preflight() -> None:
     }
     assert payload["variant_count"] == 3
     assert [variant["density_tier"] for variant in payload["variants"]] == [
+        "light",
+        "medium",
+        "heavy",
+    ]
+    assert [variant["target_density_tier"] for variant in payload["variants"]] == [
         "light",
         "medium",
         "heavy",
@@ -188,6 +196,21 @@ def test_preflight_rejects_runtime_definition_readiness_drift(tmp_path: Path) ->
 
     assert not report.conforms
     assert any("continuous_spawn.runtime_definition_status" in error for error in report.errors)
+
+
+def test_preflight_rejects_target_density_tier_drift(tmp_path: Path) -> None:
+    """Scenario YAML target density tier must match enumerated density tier."""
+
+    payload = yaml.safe_load(SCENARIO_SET.read_text(encoding="utf-8"))
+    payload["scenarios"][0]["metadata"]["continuous_spawn"]["target_density_tier"] = "heavy"
+
+    drifted = tmp_path / "issue_3813_sustained_flow_target_density_tier_drift.yaml"
+    drifted.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    report = sustained_flow.preflight_sustained_flow_scenario_set(drifted)
+
+    assert not report.conforms
+    assert any("continuous_spawn.target_density_tier" in error for error in report.errors)
 
 
 def test_preflight_rejects_route_respawn_runtime_config_drift(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- Links #3813.
- Adds an explicit sustained-flow benchmark-preflight check that each continuous-spawn row's `target_density_tier` matches the enumerated matrix density tier.
- Exposes `target_density_tier` in the resolved variant payload/profile so generator/preflight drift is visible and fail-closed.
- Adds a focused regression test for target-density drift while keeping the slice pre-benchmark only.

## Scope
This is a local scenario-generator/preflight hardening slice for the sustained-flow continuous-spawn scaffold. It does not implement runtime continuous pedestrian respawn, sustained-progress metrics, campaign integration, or benchmark evidence.

## Validation
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/scenario_certification/test_sustained_flow_preflight.py -q` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/sustained_flow_preflight.py robot_sf/scenario_certification/sustained_flow.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/scenario_certification/test_sustained_flow_preflight.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` - passed; `conforms=true`, `variant_count=3`, `runtime_support=metadata_only`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --runtime-supported-generated --json` - passed; `conforms=true`, `variant_count=3`, `runtime_support=runtime_continuous_spawn`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --generated --json` - passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<artifact>/pr-body.md scripts/dev/run_compact_validation.py -- scripts/dev/pr_ready_check.sh` - passed; summary `.git/codex-agent-runs/active/issue-3813/pr-ready/validation-20260701T230203Z-844002.summary.json`.

## Out Of Scope
No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Residual Risk
- This remains preflight/generator evidence only and is not sustained-flow benchmark evidence.
- The broader #3813 contract still needs runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, and runnable campaign/runner benchmark evidence.

## Artifact Classification
No generated benchmark artifacts are committed. Validation logs remain under the common Git-dir agent-run artifact directory.

