### PR TITLE
Issue #3501: require safety-wrapper mode in ablation rows

### DIFF
--- a/configs/research/safety_wrapper_ablation_v1.yaml
+++ b/configs/research/safety_wrapper_ablation_v1.yaml
@@ -69,6 +69,7 @@ result_contract:
     - study_id
     - planner
     - wrapper_arm
+    - safety_wrapper_mode
     - scenario_id
     - seed
     - software_commit

--- a/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
+++ b/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
@@ -34,11 +34,19 @@ CONFIG_SCHEMA_VERSION = "safety-wrapper-ablation.v1"
 WRAPPER_OFF_ARM = "wrapper_off"
 WRAPPER_ON_ARM = "wrapper_on"
 EXPECTED_WRAPPER_ARMS = (WRAPPER_OFF_ARM, WRAPPER_ON_ARM)
+SAFETY_WRAPPER_MODE_FIELD = "safety_wrapper_mode"
+SAFETY_WRAPPER_MODE_DISABLED = "disabled"
+SAFETY_WRAPPER_MODE_ENABLED = "enabled"
+EXPECTED_SAFETY_WRAPPER_MODE_BY_ARM = {
+    WRAPPER_OFF_ARM: SAFETY_WRAPPER_MODE_DISABLED,
+    WRAPPER_ON_ARM: SAFETY_WRAPPER_MODE_ENABLED,
+}
 PAIRING_KEY_FIELDS = ("planner", "scenario_id", "seed")
 REQUIRED_ROW_FIELDS = (
     "study_id",
     "planner",
     "wrapper_arm",
+    SAFETY_WRAPPER_MODE_FIELD,
     "scenario_id",
     "seed",
     "software_commit",
@@ -264,6 +272,7 @@ def _arm_manifest(arm: Mapping[str, Any]) -> dict[str, Any]:
         "key": str(arm["key"]),
         "baseline": bool(arm.get("baseline", False)),
         "enabled": enabled,
+        SAFETY_WRAPPER_MODE_FIELD: _safety_wrapper_mode(enabled),
         "wrapper_config": wrapper_config,
         "thresholds_source": "predeclared_fixed_no_per_planner_tuning",
         "runtime_binding_status": "unresolved_runtime_binding",
@@ -292,6 +301,7 @@ def _enumerate_cells(
                     "planner": str(planner),
                     "wrapper_arm": str(arm["key"]),
                     "wrapper_enabled": bool(arm["enabled"]),
+                    SAFETY_WRAPPER_MODE_FIELD: str(arm[SAFETY_WRAPPER_MODE_FIELD]),
                     "baseline": bool(arm["baseline"]),
                     "seeds": list(seeds),
                 }
@@ -446,6 +456,11 @@ def _row_provenance_errors(row: Mapping[str, Any]) -> list[str]:
         if not isinstance(value, str) or not value.strip():
             invalid.append(field)
 
+    arm = str(row.get("wrapper_arm", ""))
+    mode = row.get(SAFETY_WRAPPER_MODE_FIELD)
+    if not isinstance(mode, str) or mode != EXPECTED_SAFETY_WRAPPER_MODE_BY_ARM.get(arm):
+        invalid.append(SAFETY_WRAPPER_MODE_FIELD)
+
     seed = row.get("seed")
     if not isinstance(seed, int) or isinstance(seed, bool):
         invalid.append("seed")
@@ -471,6 +486,11 @@ def _row_provenance_errors(row: Mapping[str, Any]) -> list[str]:
         invalid.append("wrapper_intervention_rate")
 
     return invalid
+
+
+def _safety_wrapper_mode(enabled: bool) -> str:
+    """Return the stable row-level provenance mode for opt-in wrapper state."""
+    return SAFETY_WRAPPER_MODE_ENABLED if enabled else SAFETY_WRAPPER_MODE_DISABLED
 
 
 def load_safety_wrapper_ablation_rows(path: str | Path) -> list[dict[str, Any]]:
@@ -528,6 +548,9 @@ __all__ = [
     "CONFIG_SCHEMA_VERSION",
     "DRY_RUN_CLAIM_BOUNDARY",
     "SAFETY_WRAPPER_ABLATION_SCHEMA",
+    "SAFETY_WRAPPER_MODE_DISABLED",
+    "SAFETY_WRAPPER_MODE_ENABLED",
+    "SAFETY_WRAPPER_MODE_FIELD",
     "WRAPPER_OFF_ARM",
     "WRAPPER_ON_ARM",
     "ManifestOptions",

--- a/tests/benchmark/test_safety_wrapper_ablation_manifest.py
+++ b/tests/benchmark/test_safety_wrapper_ablation_manifest.py
@@ -9,6 +9,9 @@ import pytest
 
 from robot_sf.benchmark.safety_wrapper_ablation_manifest import (
     SAFETY_WRAPPER_ABLATION_SCHEMA,
+    SAFETY_WRAPPER_MODE_DISABLED,
+    SAFETY_WRAPPER_MODE_ENABLED,
+    SAFETY_WRAPPER_MODE_FIELD,
     WRAPPER_OFF_ARM,
     WRAPPER_ON_ARM,
     ManifestOptions,
@@ -55,6 +58,11 @@ def test_manifest_factorizes_planners_over_wrapper_off_on() -> None:
     # Paired seeds are applied identically to every cell.
     for cell in manifest["cells"]:
         assert cell["seeds"] == manifest["seeds"]
+        assert cell[SAFETY_WRAPPER_MODE_FIELD] == (
+            SAFETY_WRAPPER_MODE_ENABLED
+            if cell["wrapper_arm"] == WRAPPER_ON_ARM
+            else SAFETY_WRAPPER_MODE_DISABLED
+        )
 
     check = manifest["factorial_check"]
     assert check["complete"] is True
@@ -75,6 +83,7 @@ def test_manifest_echoes_predeclared_wrapper_thresholds_as_provenance() -> None:
     assert off_arm["enabled"] is False
     assert off_arm["baseline"] is True
     assert off_arm["wrapper_config"] is None
+    assert off_arm[SAFETY_WRAPPER_MODE_FIELD] == SAFETY_WRAPPER_MODE_DISABLED
 
     assert on_arm["enabled"] is True
     assert on_arm["baseline"] is False
@@ -85,6 +94,7 @@ def test_manifest_echoes_predeclared_wrapper_thresholds_as_provenance() -> None:
         "ttc_veto_threshold_s": 1.0,
         "clearance_veto_m": 0.3,
     }
+    assert on_arm[SAFETY_WRAPPER_MODE_FIELD] == SAFETY_WRAPPER_MODE_ENABLED
     assert on_arm["runtime_binding_status"] == "unresolved_runtime_binding"
     assert manifest["event_ledger_target"] == 3482
 
@@ -168,10 +178,16 @@ def test_manifest_json_output_is_deterministic(tmp_path: Path) -> None:
 
 
 def _ablation_row(wrapper_arm: str, seed: int = 111) -> dict[str, object]:
+    wrapper_mode = (
+        SAFETY_WRAPPER_MODE_ENABLED
+        if wrapper_arm == WRAPPER_ON_ARM
+        else SAFETY_WRAPPER_MODE_DISABLED
+    )
     return {
         "study_id": "issue_3501_safety_wrapper_ablation_v1",
         "planner": "orca",
         "wrapper_arm": wrapper_arm,
+        SAFETY_WRAPPER_MODE_FIELD: wrapper_mode,
         "scenario_id": "crossing_basic",
         "seed": seed,
         "software_commit": "abc1234",
@@ -205,6 +221,20 @@ def test_check_factorial_ablation_rows_accepts_exact_paired_rows() -> None:
     assert report["invalid_provenance_fields"] == []
     assert report["incomplete_pairs"] == []
     assert report["pair_provenance_mismatches"] == []
+
+
+def test_check_factorial_ablation_rows_rejects_arm_mode_mismatch() -> None:
+    """Wrapper arm and opt-in mode provenance must agree before comparison."""
+    off_row = _ablation_row(WRAPPER_OFF_ARM)
+    on_row = _ablation_row(WRAPPER_ON_ARM)
+    on_row[SAFETY_WRAPPER_MODE_FIELD] = SAFETY_WRAPPER_MODE_DISABLED
+
+    report = check_factorial_ablation_rows([off_row, on_row])
+
+    assert report["complete"] is False
+    assert report["invalid_provenance_fields"] == [
+        {"row_index": 1, "fields": [SAFETY_WRAPPER_MODE_FIELD]}
+    ]
 
 
 def test_check_factorial_ablation_rows_rejects_mixed_pair_provenance() -> None:


### PR DESCRIPTION
## Summary

Relates to #3501 as a bounded manifest/checker slice; this PR does not close the issue.

This PR makes the opt-in safety-wrapper state explicit in the factorial ablation contract by adding `safety_wrapper_mode` row provenance:

- dry-run manifest arms and cells now emit `safety_wrapper_mode: disabled` for `wrapper_off` and `safety_wrapper_mode: enabled` for `wrapper_on`;
- the result row contract requires `safety_wrapper_mode`;
- the row checker fails closed when a row's `wrapper_arm` and `safety_wrapper_mode` disagree.

Assumption: `safety_wrapper_mode` is a reversible provenance field future runtime rows should emit before paired comparison. It records wrapper application state without wiring runtime execution or interpreting mitigation effects.

## Issue Disposition

#3501 remains open. This PR strengthens provenance for future safety-wrapper ablation rows but does not implement runtime wrapper binding, does not run the paired planner x `{wrapper_off, wrapper_on}` campaign, and does not emit benchmark evidence for the mitigation lever.

## Validation

- `uv run pytest tests/benchmark/test_safety_wrapper_ablation_manifest.py -q` passed.
- `uv run python scripts/benchmark/build_safety_wrapper_ablation_manifest.py --config configs/research/safety_wrapper_ablation_v1.yaml --out output/issue_3501_safety_wrapper_ablation_manifest --dry-run` passed; generated manifest reports `complete=True`, `cells=6`, `seeds_per_cell=3`.
- `uv run ruff check robot_sf/benchmark/safety_wrapper_ablation_manifest.py tests/benchmark/test_safety_wrapper_ablation_manifest.py` passed.
- `uv run pytest tests/test_safety_wrapper.py tests/benchmark/test_safety_wrapper_ablation_manifest.py -q` passed.
- `PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed locally on head `c59b2e392cf9fe5205f3e8ef576e2eedfcbfab6c`.

## Out Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No wrapper threshold tuning.
- No runtime wrapper binding.

## Artifact Classification

Generated `output/issue_3501_safety_wrapper_ablation_manifest/` is disposable local validation output and is not committed.
