### PR TITLE
Issue #3275: fail closed stale archive summary metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+* Tightened the certified adversarial failure-archive readiness checker (#3275) so optional archive
+  summary counts fail closed when they disagree with the actual `entries` or `clusters` payload.
 * Tightened the proxy checkpoint-selection readiness preflight (#3204) so registry entries with
   declared-but-incomplete public release metadata fail closed before they can be treated as ready
   checkpoint inputs.

--- a/robot_sf/adversarial/disjoint_evaluation.py
+++ b/robot_sf/adversarial/disjoint_evaluation.py
@@ -553,6 +553,60 @@ def _readiness_blocking_reasons(
     return reasons
 
 
+def _optional_summary_int(summary: dict[str, Any], key: str) -> tuple[int | None, str | None]:
+    """Return optional integer summary value, rejecting bools and non-ints."""
+    value = summary.get(key)
+    if value is None:
+        return None, None
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None, f"summary_{key}_not_int"
+    return value, None
+
+
+def _summary_consistency_blockers(archive_data: dict[str, Any], entries: list[Any]) -> list[str]:
+    """Return blockers for stale optional archive summary metadata.
+
+    The curator writes a compact top-level ``summary`` next to ``entries`` and
+    ``clusters``. If a later packet edits entries without regenerating that
+    metadata, downstream provenance can look cleaner than the archive input is.
+    Missing summary metadata remains allowed for minimal fixtures, but present
+    counts must agree with the payload they describe.
+    """
+    summary = archive_data.get("summary")
+    if summary is None:
+        return []
+    if not isinstance(summary, dict):
+        return ["summary_metadata_not_object"]
+
+    blockers: list[str] = []
+    archived_failure_count, count_blocker = _optional_summary_int(summary, "archived_failure_count")
+    if count_blocker is not None:
+        blockers.append(count_blocker)
+    elif archived_failure_count is not None and archived_failure_count != len(entries):
+        blockers.append(
+            "summary_archived_failure_count_mismatch:"
+            f"declared={archived_failure_count}:actual={len(entries)}"
+        )
+
+    cluster_count, count_blocker = _optional_summary_int(summary, "cluster_count")
+    if count_blocker is not None:
+        blockers.append(count_blocker)
+        return blockers
+    if cluster_count is None:
+        return blockers
+
+    clusters = archive_data.get("clusters")
+    if clusters is None:
+        blockers.append("summary_cluster_count_without_clusters")
+    elif not isinstance(clusters, list):
+        blockers.append("archive_clusters_not_list")
+    elif cluster_count != len(clusters):
+        blockers.append(
+            f"summary_cluster_count_mismatch:declared={cluster_count}:actual={len(clusters)}"
+        )
+    return blockers
+
+
 def assess_archive_readiness(
     archive_data: Any,
     *,
@@ -598,6 +652,7 @@ def assess_archive_readiness(
     reasons = _readiness_blocking_reasons(
         stats, schema_ok=schema_ok, schema_version=schema_version, min_entries=min_entries
     )
+    reasons.extend(_summary_consistency_blockers(archive_data, entries))
 
     # Overlap provenance needs disjoint families, unique archive ids, and seeds
     # to compare. Null tests additionally need a non-empty eval side, which the

--- a/tests/adversarial/test_archive_readiness.py
+++ b/tests/adversarial/test_archive_readiness.py
@@ -82,6 +82,70 @@ def test_ready_archive_passes_all_prerequisites() -> None:
     assert json.loads(json.dumps(report.to_dict()))["ready"] is True
 
 
+def test_matching_summary_metadata_stays_ready() -> None:
+    """Optional archive summary counts may be present when they match entries."""
+    payload = _ready_archive()
+    payload["clusters"] = [{"cluster_id": "cluster_a"}, {"cluster_id": "cluster_b"}]
+    payload["summary"] = {
+        "archived_failure_count": 4,
+        "cluster_count": 2,
+    }
+
+    report = assess_archive_readiness(payload)
+
+    assert report.ready is True
+    assert report.blocking_reasons == []
+
+
+def test_summary_archived_failure_count_mismatch_fails_closed() -> None:
+    """Stale entry counts block readiness before provenance is trusted."""
+    payload = _ready_archive()
+    payload["summary"] = {"archived_failure_count": 3}
+
+    report = assess_archive_readiness(payload)
+
+    assert report.ready is False
+    assert "summary_archived_failure_count_mismatch:declared=3:actual=4" in report.blocking_reasons
+
+
+def test_summary_cluster_count_mismatch_fails_closed() -> None:
+    """Stale cluster counts block certified-archive readiness."""
+    payload = _ready_archive()
+    payload["clusters"] = [{"cluster_id": "cluster_a"}]
+    payload["summary"] = {
+        "archived_failure_count": 4,
+        "cluster_count": 2,
+    }
+
+    report = assess_archive_readiness(payload)
+
+    assert report.ready is False
+    assert "summary_cluster_count_mismatch:declared=2:actual=1" in report.blocking_reasons
+
+
+def test_summary_cluster_count_without_cluster_rows_fails_closed() -> None:
+    """A declared cluster count without cluster rows is not trusted."""
+    payload = _ready_archive()
+    payload["summary"] = {"cluster_count": 2}
+
+    report = assess_archive_readiness(payload)
+
+    assert report.ready is False
+    assert "summary_cluster_count_without_clusters" in report.blocking_reasons
+
+
+def test_malformed_summary_metadata_fails_closed() -> None:
+    """Malformed summary metadata is reported rather than ignored."""
+    payload = _ready_archive()
+    payload["summary"] = {"archived_failure_count": True, "cluster_count": "2"}
+
+    report = assess_archive_readiness(payload)
+
+    assert report.ready is False
+    assert "summary_archived_failure_count_not_int" in report.blocking_reasons
+    assert "summary_cluster_count_not_int" in report.blocking_reasons
+
+
 def test_non_object_payload_fails_closed() -> None:
     """A non-dict payload is not ready and never raises."""
     report = assess_archive_readiness([1, 2, 3])


### PR DESCRIPTION
## Summary

Refs https://github.com/ll7/robot_sf_ll7/issues/3275.

This PR tightens the certified adversarial failure-archive readiness checker so optional top-level archive summary metadata fails closed when it is stale relative to the actual payload:

- `summary.archived_failure_count` must match the number of archive `entries` when present.
- `summary.cluster_count` must match the number of `clusters` when present.
- Malformed summary counts and declared cluster counts without cluster rows become explicit readiness blockers.

The change is a bounded archive-readiness/fail-closed slice only. It does not run the proposal-model evaluation or promote held-out yield evidence.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py` -> pass; 1 file reformatted, 1 unchanged.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py` -> pass; all checks passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/adversarial/test_archive_readiness.py -q` -> pass; 27 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/adversarial/test_disjoint_evaluation.py -q` -> pass; 18 passed.
- `git diff --check` -> pass.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No proposal-model rerun, no fabricated certified failure archive inputs, and no benchmark yield report.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archive readiness checks now fail closed when summary counts don’t match the actual archived data.
  * Added clearer blocking reasons for missing cluster data and malformed summary values.
  * Ready status is now more reliable when archive metadata is stale or inconsistent.

* **Documentation**
  * Updated the changelog to note the stricter archive readiness behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->