### PR TITLE
Issue #3204 require blocked artifact metadata for proxy readiness

### DIFF
--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -236,12 +236,15 @@ def _validate_blocked_artifact_schema(blocked_artifacts: Any) -> list[str]:
                 f"blocked_artifacts[{index}] status must be one of "
                 f"{sorted(_KNOWN_BLOCKER_STATUSES)}"
             )
-        metadata = artifact.get("required_metadata", [])
-        if metadata is not None and (
+        metadata = artifact.get("required_metadata")
+        if (
             not isinstance(metadata, list)
+            or not metadata
             or any(not isinstance(item, str) or not item for item in metadata)
         ):
-            errors.append(f"blocked_artifacts[{index}] required_metadata must be a list of strings")
+            errors.append(
+                f"blocked_artifacts[{index}] required_metadata must be a non-empty list of strings"
+            )
     return errors
 
 

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -505,6 +505,57 @@ def test_blocked_when_artifact_inventory_has_blocked_state(tmp_path):
     assert any("blocked artifact" in message for message in artifacts["messages"])
 
 
+def test_failed_when_blocked_artifact_missing_required_metadata(tmp_path):
+    """Blocked-artifact entries must name the metadata needed to unblock readiness."""
+    config = _write_config(tmp_path, min_resolvable=2, min_epochs=2)
+    data = yaml.safe_load(config.read_text(encoding="utf-8"))
+    data["blocked_artifacts"] = [
+        {
+            "id": "missing_durable_predictive_checkpoints",
+            "artifact_type": "checkpoint_set",
+            "status": "blocked",
+            "storage_scope": "worktree_local_output",
+            "path_pattern": "output/tmp/predictive/**/*.pt",
+            "revival_condition": "provide durable predictive checkpoints",
+        }
+    ]
+    config.write_text(yaml.safe_dump(data), encoding="utf-8")
+    registry = _write_registry(tmp_path, present_count=2, absent_count=0)
+
+    report = mod.check_readiness(config_path=config, registry_path=registry, repo_root=_REPO_ROOT)
+
+    config_check = report["prerequisites"]["readiness_config"]
+    assert report["status"] == "blocked"
+    assert config_check["status"] == "failed"
+    assert any("required_metadata" in message for message in config_check["messages"])
+
+
+def test_failed_when_blocked_artifact_required_metadata_empty(tmp_path):
+    """Empty blocked-artifact metadata checklists are not actionable decision packets."""
+    config = _write_config(tmp_path, min_resolvable=2, min_epochs=2)
+    data = yaml.safe_load(config.read_text(encoding="utf-8"))
+    data["blocked_artifacts"] = [
+        {
+            "id": "degenerate_hardcase_proxy_probe_v1",
+            "artifact_type": "proxy_training_summary",
+            "status": "blocked",
+            "storage_scope": "worktree_local_output",
+            "path_pattern": "output/tmp/**/training_summary.json",
+            "required_metadata": [],
+            "revival_condition": "provide a non-degenerate proxy summary",
+        }
+    ]
+    config.write_text(yaml.safe_dump(data), encoding="utf-8")
+    registry = _write_registry(tmp_path, present_count=2, absent_count=0)
+
+    report = mod.check_readiness(config_path=config, registry_path=registry, repo_root=_REPO_ROOT)
+
+    config_check = report["prerequisites"]["readiness_config"]
+    assert report["status"] == "blocked"
+    assert config_check["status"] == "failed"
+    assert any("non-empty list" in message for message in config_check["messages"])
+
+
 def test_blocked_artifact_summary_treats_none_as_unknown_and_preserves_falsy_values():
     """Summary buckets only substitute unknown for absent/null optional fields."""
     summary = mod._summarize_blocked_artifacts(


### PR DESCRIPTION
## Issue

Closes readiness slice for https://github.com/ll7/robot_sf_ll7/issues/3204.

## Scope Summary

This is a diagnostic readiness/preflight-only tightening for proxy-based checkpoint selection inputs. It requires each `blocked_artifacts` entry in `scripts/research/check_predictive_checkpoint_proxy_readiness.py` to declare a non-empty `required_metadata` checklist, so blocked checkpoint/proxy-summary artifacts cannot produce underspecified decision packets.

Added focused fixture coverage for:
- missing `required_metadata` on a blocked checkpoint-set artifact;
- empty `required_metadata` on a blocked proxy-training-summary artifact.

## Validation

- `PYTEST_NUM_WORKERS=8 uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py -q` -> passed, 30 tests.
- `uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed.
- `uv run ruff format --check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed.
- `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --config configs/research/predictive_checkpoint_proxy_v1.yaml --json` -> expected exit 2, `status: blocked`; checkpoint artifacts, blocked artifacts, and known blockers remain blocked.
- `uv run python scripts/dev/run_compact_validation.py -- env BASE_REF=origin/main scripts/dev/pr_ready_check.sh` -> passed, exit 0. Summary JSON: `/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/compact-validation/validation-20260701T233004Z-1505467.summary.json`.
- `uv run python scripts/dev/pr_ready_freshness.py status --base-ref origin/main --require-clean-tree` -> fresh true for head `535833140d385db3eaca903690f8fe5adb363710`.

## Out Of Scope

No full benchmark campaign run, no Slurm/GPU submission, no checkpoint selection, no training, no artifact hydration or promotion, and no paper/dissertation claim edits.
