### PR TITLE
Issue #1496: declare oracle warm-start output manifests

### DIFF
--- a/configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml
+++ b/configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml
@@ -32,3 +32,11 @@ finetuning_config: configs/training/ppo/expert_ppo_issue_576_br06_v4_overnight_s
 
 # Dataset split/leakage contract that the comparison must preserve.
 split_contract: docs/context/policy_search/contracts/oracle_imitation_dataset_split.md
+
+# Durable locations that a future authorized warm-start lane must populate before
+# any result can be treated as benchmark evidence. This preflight only checks that
+# the manifest contract is named and durable; it does not create these files.
+expected_outputs:
+  training_manifest: docs/context/evidence/issue_1496_oracle_warm_start_training_manifest.json
+  checkpoint_manifest: docs/context/evidence/issue_1496_oracle_warm_start_checkpoint_manifest.json
+  benchmark_report: docs/context/evidence/issue_1496_oracle_warm_start_benchmark_report.json

--- a/robot_sf/training/oracle_imitation_warm_start_readiness.py
+++ b/robot_sf/training/oracle_imitation_warm_start_readiness.py
@@ -73,6 +73,8 @@ _REQUIRED_OUTPUT_MANIFESTS: tuple[str, ...] = (
     "benchmark_report",
 )
 _LOCAL_OUTPUT_PREFIXES: tuple[str, ...] = ("output/", "results/")
+_DURABLE_OUTPUT_MANIFEST_PREFIX = "docs/context/evidence/"
+_DURABLE_OUTPUT_MANIFEST_SUFFIXES: tuple[str, ...] = (".json", ".yaml", ".yml")
 
 
 class WarmStartReadinessError(ValueError):
@@ -383,20 +385,35 @@ def _check_expected_outputs(manifest: dict[str, Any], blockers: list[str]) -> di
             continue
 
         path_text = raw_path.strip()
-        if _is_local_output_path(path_text):
+        durability_error = _output_manifest_durability_error(path_text)
+        if durability_error is not None:
             blockers.append(
-                f"expected_outputs.{key} must be durable manifest path, not local output: "
-                f"{path_text}"
+                f"expected_outputs.{key} must be durable evidence manifest path: "
+                f"{durability_error}: {path_text}"
             )
             checked[key] = {
                 "path": path_text,
                 "ready": False,
-                "detail": "local output paths are not durable evidence",
+                "detail": durability_error,
             }
             continue
 
         checked[key] = {"path": path_text, "ready": True}
     return checked
+
+
+def _output_manifest_durability_error(path_text: str) -> str | None:
+    """Return why an output manifest path is not a durable repo evidence manifest."""
+    normalized = path_text.replace("\\", "/").lstrip("./")
+    if _is_local_output_path(path_text):
+        return "local output paths are not durable evidence"
+    if Path(path_text).is_absolute() or normalized.startswith("../"):
+        return "path must be repository-relative"
+    if not normalized.startswith(_DURABLE_OUTPUT_MANIFEST_PREFIX):
+        return f"path must be under {_DURABLE_OUTPUT_MANIFEST_PREFIX}"
+    if not normalized.endswith(_DURABLE_OUTPUT_MANIFEST_SUFFIXES):
+        return "manifest must use .json, .yaml, or .yml"
+    return None
 
 
 def _is_local_output_path(path_text: str) -> bool:

--- a/robot_sf/training/oracle_imitation_warm_start_readiness.py
+++ b/robot_sf/training/oracle_imitation_warm_start_readiness.py
@@ -67,6 +67,12 @@ _REQUIRED_CONFIG_KEYS: tuple[str, ...] = (
     "split_contract",
 )
 _OPTIONAL_CONFIG_KEYS: tuple[str, ...] = ("finetuning_config",)
+_REQUIRED_OUTPUT_MANIFESTS: tuple[str, ...] = (
+    "training_manifest",
+    "checkpoint_manifest",
+    "benchmark_report",
+)
+_LOCAL_OUTPUT_PREFIXES: tuple[str, ...] = ("output/", "results/")
 
 
 class WarmStartReadinessError(ValueError):
@@ -168,6 +174,7 @@ def check_warm_start_readiness(
         result = _check_optional_file(manifest, key, root, blockers)
         if result is not None:
             prerequisites[key] = result
+    output_manifests = _check_expected_outputs(manifest, blockers)
 
     status = "ready" if not blockers else "blocked"
     readiness_decision = _READY_DECISION if not blockers else _BLOCKED_DECISION
@@ -177,6 +184,7 @@ def check_warm_start_readiness(
         "schema_version": _SCHEMA_VERSION,
         "experiment_id": experiment_id.strip(),
         "prerequisites": prerequisites,
+        "expected_outputs": output_manifests,
         "blockers": blockers,
         "out_of_scope_actions": dict(_OUT_OF_SCOPE_ACTIONS),
     }
@@ -350,6 +358,51 @@ def _check_optional_file(
         blockers.append(f"{key} must be a non-empty path string when provided")
         return {"path": None, "ready": False, "detail": f"blank {key} reference"}
     return _check_file_path(key, raw_path.strip(), repo_root, blockers)
+
+
+def _check_expected_outputs(manifest: dict[str, Any], blockers: list[str]) -> dict[str, Any]:
+    """Validate the output manifest contract without creating any output files.
+
+    Returns:
+        Per-output manifest detail keyed by required output name.
+    """
+    raw_outputs = manifest.get("expected_outputs")
+    if not isinstance(raw_outputs, dict):
+        blockers.append("expected_outputs must be a mapping")
+        return {
+            key: {"path": None, "ready": False, "detail": "missing expected_outputs mapping"}
+            for key in _REQUIRED_OUTPUT_MANIFESTS
+        }
+
+    checked: dict[str, Any] = {}
+    for key in _REQUIRED_OUTPUT_MANIFESTS:
+        raw_path = raw_outputs.get(key)
+        if not isinstance(raw_path, str) or not raw_path.strip():
+            blockers.append(f"expected_outputs.{key} must be non-empty path string")
+            checked[key] = {"path": None, "ready": False, "detail": f"missing {key} path"}
+            continue
+
+        path_text = raw_path.strip()
+        if _is_local_output_path(path_text):
+            blockers.append(
+                f"expected_outputs.{key} must be durable manifest path, not local output: "
+                f"{path_text}"
+            )
+            checked[key] = {
+                "path": path_text,
+                "ready": False,
+                "detail": "local output paths are not durable evidence",
+            }
+            continue
+
+        checked[key] = {"path": path_text, "ready": True}
+    return checked
+
+
+def _is_local_output_path(path_text: str) -> bool:
+    """Return true when an output manifest path points at disposable local output."""
+    normalized = path_text.replace("\\", "/").lstrip("./")
+    return normalized.startswith(_LOCAL_OUTPUT_PREFIXES)
 
 
 def _check_file_path(

--- a/tests/training/test_oracle_imitation_warm_start_readiness.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness.py
@@ -211,10 +211,49 @@ def test_local_expected_output_paths_are_blockers(tmp_path: Path) -> None:
 
     assert report["status"] == "blocked"
     assert any(
-        blocker.startswith("expected_outputs.training_manifest must be durable manifest path")
+        "expected_outputs.training_manifest must be durable evidence manifest path" in blocker
+        and "local output paths are not durable evidence" in blocker
         for blocker in report["blockers"]
     )
     assert report["expected_outputs"]["training_manifest"]["ready"] is False
+
+
+def test_absolute_expected_output_paths_are_blockers(tmp_path: Path) -> None:
+    """Future output manifests must be repository-relative durable evidence paths."""
+    manifest_dict = _ready_manifest(tmp_path)
+    expected_outputs = manifest_dict["expected_outputs"]
+    assert isinstance(expected_outputs, dict)
+    expected_outputs["checkpoint_manifest"] = str(tmp_path / "checkpoint_manifest.json")
+    manifest = _write_manifest(tmp_path, manifest_dict)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert any(
+        "expected_outputs.checkpoint_manifest must be durable evidence manifest path" in blocker
+        and "path must be repository-relative" in blocker
+        for blocker in report["blockers"]
+    )
+    assert report["expected_outputs"]["checkpoint_manifest"]["ready"] is False
+
+
+def test_expected_output_paths_must_be_manifest_files(tmp_path: Path) -> None:
+    """Future output manifests must point at small reviewable manifest files."""
+    manifest_dict = _ready_manifest(tmp_path)
+    expected_outputs = manifest_dict["expected_outputs"]
+    assert isinstance(expected_outputs, dict)
+    expected_outputs["benchmark_report"] = "docs/context/evidence/benchmark_report.txt"
+    manifest = _write_manifest(tmp_path, manifest_dict)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert any(
+        "expected_outputs.benchmark_report must be durable evidence manifest path" in blocker
+        and "manifest must use .json, .yaml, or .yml" in blocker
+        for blocker in report["blockers"]
+    )
+    assert report["expected_outputs"]["benchmark_report"]["ready"] is False
 
 
 def test_require_ready_fails_closed_when_blocked(tmp_path: Path) -> None:

--- a/tests/training/test_oracle_imitation_warm_start_readiness.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness.py
@@ -50,6 +50,11 @@ def _ready_manifest(tmp_path: Path) -> dict[str, object]:
         "warm_start_config": str(warm_start),
         "baseline_config": str(baseline),
         "split_contract": str(contract),
+        "expected_outputs": {
+            "training_manifest": "docs/context/evidence/unit_training_manifest.json",
+            "checkpoint_manifest": "docs/context/evidence/unit_checkpoint_manifest.json",
+            "benchmark_report": "docs/context/evidence/unit_benchmark_report.json",
+        },
     }
 
 
@@ -150,6 +155,10 @@ def test_real_issue_1496_manifest_is_blocked_on_dataset() -> None:
     assert report["prerequisites"]["baseline_config"]["ready"] is True
     assert report["prerequisites"]["finetuning_config"]["ready"] is True
     assert report["prerequisites"]["split_contract"]["ready"] is True
+    assert report["expected_outputs"]["training_manifest"] == {
+        "path": "docs/context/evidence/issue_1496_oracle_warm_start_training_manifest.json",
+        "ready": True,
+    }
 
 
 def test_ready_manifest_reports_ready(tmp_path: Path) -> None:
@@ -162,6 +171,7 @@ def test_ready_manifest_reports_ready(tmp_path: Path) -> None:
     assert report["blockers"] == []
     assert report["prerequisites"]["dataset_launch_packet"]["training_ready"] is True
     assert report["prerequisites"]["trace_uri_registry"]["training_ready"] is True
+    assert report["expected_outputs"]["benchmark_report"]["ready"] is True
 
 
 def test_missing_config_is_a_blocker_not_an_error(tmp_path: Path) -> None:
@@ -174,6 +184,37 @@ def test_missing_config_is_a_blocker_not_an_error(tmp_path: Path) -> None:
 
     assert report["status"] == "blocked"
     assert any(b.startswith("baseline_config is not an existing file") for b in report["blockers"])
+
+
+def test_missing_expected_outputs_mapping_is_a_blocker(tmp_path: Path) -> None:
+    """The readiness manifest must name durable future output manifests."""
+    manifest_dict = _ready_manifest(tmp_path)
+    manifest_dict.pop("expected_outputs")
+    manifest = _write_manifest(tmp_path, manifest_dict)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert "expected_outputs must be a mapping" in report["blockers"]
+    assert report["expected_outputs"]["training_manifest"]["ready"] is False
+
+
+def test_local_expected_output_paths_are_blockers(tmp_path: Path) -> None:
+    """Future output manifests may not be declared under disposable output roots."""
+    manifest_dict = _ready_manifest(tmp_path)
+    expected_outputs = manifest_dict["expected_outputs"]
+    assert isinstance(expected_outputs, dict)
+    expected_outputs["training_manifest"] = "output/issue_1496/training_manifest.json"
+    manifest = _write_manifest(tmp_path, manifest_dict)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert any(
+        blocker.startswith("expected_outputs.training_manifest must be durable manifest path")
+        for blocker in report["blockers"]
+    )
+    assert report["expected_outputs"]["training_manifest"]["ready"] is False
 
 
 def test_require_ready_fails_closed_when_blocked(tmp_path: Path) -> None:

--- a/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py
@@ -129,6 +129,10 @@ def test_cli_writes_blocked_decision_manifest_when_file_missing(tmp_path: Path) 
     assert payload["report"]["status"] == "blocked"
     assert payload["report"]["readiness_decision"] == "artifact_retrieval_blocked"
     assert payload["report"]["blockers"]
+    assert payload["report"]["expected_outputs"]["checkpoint_manifest"] == {
+        "path": "docs/context/evidence/unit_checkpoint_manifest.json",
+        "ready": True,
+    }
     assert payload["report"]["out_of_scope_actions"] == {
         "benchmark_campaign_run": False,
         "claim_edits": False,


### PR DESCRIPTION
## Summary
Adds a bounded output-manifest contract to the oracle-imitation warm-start readiness checker for issue #1496. The checker now reports required durable future output manifests and fails closed when they are missing or declared under disposable local output roots.

## Linked Issues
- Relates to #1496

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: This is a local readiness-contract slice only; the issue remains blocked for training until durable dataset and trace artifacts are available.

## What Changed
- Added `expected_outputs` validation to `robot_sf.training.oracle_imitation_warm_start_readiness`.
- Declared future durable manifest/report paths in `configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml`.
- Added focused tests for missing output-manifest declarations, local `output/` paths, and CLI decision-manifest propagation.

## Why Matters
- Added value: The preflight now names the durable training, checkpoint, and benchmark report manifests that a future authorized warm-start lane must publish.
- Expected impact: The issue stays fail-closed when output provenance is underspecified or local-only.
- Why worth merging now: It strengthens readiness validation without collecting data, submitting Slurm/GPU work, running training, or editing research claims.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Blocker-resolution support for #1496 readiness only.
- Comparator or baseline, applicable: NA - no benchmark or training comparison run.
- Evidence tier: NA - support checker, not research evidence.
- Result classification: NA - support checker, not a research result.
- Decision stop rule, applicable: The checker must remain blocked until durable dataset/trace prerequisites resolve and expected output manifests are durable.
- Parent issue, claim map, registry, context note, synthesis surface update: Parent issue #1496 remains open and blocked; no claim surface updated.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker contract only.

## Domain-Aware Approval
approval concerns experimental validity claim waived / pending / blocked / not required
- Approver/review source waiver: not required; no research claim, benchmark comparison, or result interpretation.
- Validity checklist: NA - support checker only.
- Target claim/hypothesis: NA.
- Comparator split/evidence validity: The checker reports split-contract and durable output-manifest prerequisites but does not validate any completed campaign.
- Fallback/degraded exclusions: Fail-closed blockers remain blockers, not benchmark evidence.
- Claim boundary: No paper, dissertation, benchmark, or training-result claim edits.
- Implementation integrity vs experimental validity: Tests cover the checker contract; experimental validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA - no mechanism/training run.
- Did intervention change command source, selected command, trajectory, route progress? NA.
- Did scenario actually contain targeted failure mode? NA.
- Result route: continue only after durable prerequisites are satisfied.
- Follow-up question issue weak, negative, non-transfer results: NA.

## Next Empirical Action
- Rerun needed: no for this PR; future training lane still blocked.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: durable dataset/trace artifacts remain unavailable to the readiness checker.
- Stop / revise / continue decision: continue only as blocked readiness until #1496 prerequisites resolve.
- Proposed child issue existing follow-up: none opened.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py -q` - passed, 28 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_oracle_imitation_warm_start_readiness.py --manifest configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml --json` - exited 1 as expected for fail-closed `artifact_retrieval_blocked`; output included durable `expected_outputs` paths and no submit/train action.
- `git diff --check` - passed.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Impact
- Baseline runtime: NA - no runtime/performance path changed.
- Changed runtime: NA - no runtime/performance path changed.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py -q`
- Hot-path call count profile anchor: NA - readiness checker support path only.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: Revert if readiness reports no longer fail closed for missing durable output-manifest declarations.

## Risks / Rollout
- Compatibility risks: Existing #1496 readiness manifests now need `expected_outputs`.
- Failure modes: A future manifest could name a non-`output/` local path; this slice only blocks the known disposable roots.
- Rollback fallback plan: Revert the output-manifest contract and tests if it blocks a legitimate durable publication path.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #1496 live comments and existing readiness manifest.
- Any assumptions need to preserved: Future training/checkpoint/benchmark report manifests should be small durable provenance files under `docs/context/evidence/` or another durable manifest surface.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no - comment authorization is false.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: This PR is a readiness/preflight contract slice and does not produce benchmark evidence.

## Follow-Up Issues
- Deferred work: resolve durable dataset/trace prerequisites, then run the authorized warm-start training/comparison lane separately under #1496.
- Issues opened follow-up: none; #1496 remains the tracking issue for deferred training/comparison work.

## Reviewer Notes
- Verify the checker still returns blocked for the checked-in #1496 manifest.
- Known limitations: The durable output-path check blocks `output/` and `results/` roots but does not prove every arbitrary path is durable.

