### PR TITLE
Issue #3501: require safety-wrapper config row provenance

### DIFF
--- a/configs/research/safety_wrapper_ablation_v1.yaml
+++ b/configs/research/safety_wrapper_ablation_v1.yaml
@@ -70,6 +70,7 @@ result_contract:
     - planner
     - wrapper_arm
     - safety_wrapper_mode
+    - safety_wrapper_config
     - scenario_id
     - seed
     - software_commit

--- a/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
+++ b/robot_sf/benchmark/safety_wrapper_ablation_manifest.py
@@ -37,6 +37,7 @@ EXPECTED_WRAPPER_ARMS = (WRAPPER_OFF_ARM, WRAPPER_ON_ARM)
 SAFETY_WRAPPER_MODE_FIELD = "safety_wrapper_mode"
 SAFETY_WRAPPER_MODE_DISABLED = "disabled"
 SAFETY_WRAPPER_MODE_ENABLED = "enabled"
+SAFETY_WRAPPER_CONFIG_FIELD = "safety_wrapper_config"
 EXPECTED_SAFETY_WRAPPER_MODE_BY_ARM = {
     WRAPPER_OFF_ARM: SAFETY_WRAPPER_MODE_DISABLED,
     WRAPPER_ON_ARM: SAFETY_WRAPPER_MODE_ENABLED,
@@ -47,6 +48,7 @@ REQUIRED_ROW_FIELDS = (
     "planner",
     "wrapper_arm",
     SAFETY_WRAPPER_MODE_FIELD,
+    SAFETY_WRAPPER_CONFIG_FIELD,
     "scenario_id",
     "seed",
     "software_commit",
@@ -460,6 +462,8 @@ def _row_provenance_errors(row: Mapping[str, Any]) -> list[str]:
     mode = row.get(SAFETY_WRAPPER_MODE_FIELD)
     if not isinstance(mode, str) or mode != EXPECTED_SAFETY_WRAPPER_MODE_BY_ARM.get(arm):
         invalid.append(SAFETY_WRAPPER_MODE_FIELD)
+    if row.get(SAFETY_WRAPPER_CONFIG_FIELD) != _expected_safety_wrapper_row_config(arm):
+        invalid.append(SAFETY_WRAPPER_CONFIG_FIELD)
 
     seed = row.get("seed")
     if not isinstance(seed, int) or isinstance(seed, bool):
@@ -486,6 +490,22 @@ def _row_provenance_errors(row: Mapping[str, Any]) -> list[str]:
         invalid.append("wrapper_intervention_rate")
 
     return invalid
+
+
+def _expected_safety_wrapper_row_config(arm: str) -> dict[str, float] | None:
+    """Return fixed row-level wrapper config expected for an ablation arm."""
+
+    if arm == WRAPPER_OFF_ARM:
+        return None
+    if arm != WRAPPER_ON_ARM:
+        return None
+    config = SafetyWrapperConfig(enabled=True)
+    return {
+        "pedestrian_caution_radius_m": config.pedestrian_caution_radius_m,
+        "capped_speed_m_s": config.capped_speed_m_s,
+        "ttc_veto_threshold_s": config.ttc_veto_threshold_s,
+        "clearance_veto_m": config.clearance_veto_m,
+    }
 
 
 def _safety_wrapper_mode(enabled: bool) -> str:
@@ -548,6 +568,7 @@ __all__ = [
     "CONFIG_SCHEMA_VERSION",
     "DRY_RUN_CLAIM_BOUNDARY",
     "SAFETY_WRAPPER_ABLATION_SCHEMA",
+    "SAFETY_WRAPPER_CONFIG_FIELD",
     "SAFETY_WRAPPER_MODE_DISABLED",
     "SAFETY_WRAPPER_MODE_ENABLED",
     "SAFETY_WRAPPER_MODE_FIELD",

--- a/tests/benchmark/test_safety_wrapper_ablation_manifest.py
+++ b/tests/benchmark/test_safety_wrapper_ablation_manifest.py
@@ -9,6 +9,7 @@ import pytest
 
 from robot_sf.benchmark.safety_wrapper_ablation_manifest import (
     SAFETY_WRAPPER_ABLATION_SCHEMA,
+    SAFETY_WRAPPER_CONFIG_FIELD,
     SAFETY_WRAPPER_MODE_DISABLED,
     SAFETY_WRAPPER_MODE_ENABLED,
     SAFETY_WRAPPER_MODE_FIELD,
@@ -183,11 +184,22 @@ def _ablation_row(wrapper_arm: str, seed: int = 111) -> dict[str, object]:
         if wrapper_arm == WRAPPER_ON_ARM
         else SAFETY_WRAPPER_MODE_DISABLED
     )
+    wrapper_config = (
+        {
+            "pedestrian_caution_radius_m": 2.0,
+            "capped_speed_m_s": 0.5,
+            "ttc_veto_threshold_s": 1.0,
+            "clearance_veto_m": 0.3,
+        }
+        if wrapper_arm == WRAPPER_ON_ARM
+        else None
+    )
     return {
         "study_id": "issue_3501_safety_wrapper_ablation_v1",
         "planner": "orca",
         "wrapper_arm": wrapper_arm,
         SAFETY_WRAPPER_MODE_FIELD: wrapper_mode,
+        SAFETY_WRAPPER_CONFIG_FIELD: wrapper_config,
         "scenario_id": "crossing_basic",
         "seed": seed,
         "software_commit": "abc1234",
@@ -234,6 +246,25 @@ def test_check_factorial_ablation_rows_rejects_arm_mode_mismatch() -> None:
     assert report["complete"] is False
     assert report["invalid_provenance_fields"] == [
         {"row_index": 1, "fields": [SAFETY_WRAPPER_MODE_FIELD]}
+    ]
+
+
+def test_check_factorial_ablation_rows_rejects_wrapper_config_mismatch() -> None:
+    """Wrapper-on rows must carry the fixed predeclared threshold config."""
+    off_row = _ablation_row(WRAPPER_OFF_ARM)
+    on_row = _ablation_row(WRAPPER_ON_ARM)
+    on_row[SAFETY_WRAPPER_CONFIG_FIELD] = {
+        "pedestrian_caution_radius_m": 2.0,
+        "capped_speed_m_s": 0.25,
+        "ttc_veto_threshold_s": 1.0,
+        "clearance_veto_m": 0.3,
+    }
+
+    report = check_factorial_ablation_rows([off_row, on_row])
+
+    assert report["complete"] is False
+    assert report["invalid_provenance_fields"] == [
+        {"row_index": 1, "fields": [SAFETY_WRAPPER_CONFIG_FIELD]}
     ]
 
 


### PR DESCRIPTION
## Summary

Adds fail-closed row-level provenance for the issue #3501 safety-wrapper ablation checker so later `wrapper_on` rows must carry the fixed predeclared safety-wrapper threshold config before any paired comparison is accepted.

## Linked Issues

- Relates to `#3501`

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: NA

## What Changed

- Added `safety_wrapper_config` to the tracked ablation result contract.
- Updated `check_factorial_ablation_rows` to reject rows whose wrapper config does not match the declared arm: `wrapper_off` must be `null`, and `wrapper_on` must match the fixed `SafetyWrapperConfig` defaults.
- Added focused tests for valid row provenance and wrapper-on threshold mismatch rejection.

## Why Matters

- Added value: prevents later with/without ablation packets from silently comparing a tuned or drifted wrapper-on condition against wrapper-off.
- Expected impact: checker/manifest support only; no runtime benchmark behavior changes.
- Why worth merging now: keeps the existing opt-in launch packet honest before any local or SLURM campaign tries to consume emitted rows.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: support slice for issue #3501 planner x {wrapper_off, wrapper_on} mitigation ablation packet.
- Comparator or baseline, applicable: wrapper_off vs wrapper_on row contract only; no result comparison performed.
- Evidence tier: NA - support checker only; no benchmark or result evidence is produced.
- Result classification: NA - support checker only.
- Decision stop rule, applicable: NA for this support checker slice.
- Parent issue, claim map, registry, context note, synthesis surface update: issue #3501 remains open for runtime wiring and actual paired evidence.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker only; it does not interpret research evidence.

## Domain-Aware Approval

- approval concerns experimental validity claim waived / pending / blocked / not required: waived
- Approver/review source waiver: no mitigation-effectiveness claim is made.
- Validity checklist: checker enforces fixed wrapper config provenance; no benchmark rows are produced.
- Target claim/hypothesis: NA for results.
- Comparator split/evidence validity: no comparator evidence is produced; this PR only requires future rows to preserve fixed wrapper config provenance before a comparator split is accepted.
- Fallback/degraded exclusions: no planner execution occurs.
- Claim boundary: not benchmark evidence, not mitigation-effectiveness evidence, not paper/dissertation claim support.
- Implementation integrity vs experimental validity: implementation integrity covered by focused tests; experimental validity deferred to future paired runs.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: NA
- Follow-up question issue weak, negative, non-transfer results: issue #3501 remains open for runtime wiring and paired evidence.

## Next Empirical Action

- Rerun needed: NA for this PR.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: paired runtime rows are intentionally out of scope.
- Stop / revise / continue decision: continue issue #3501 with runtime wiring and paired local smoke after this checker contract is in place.
- Proposed child issue existing follow-up: existing issue #3501.

## Validation / Proof

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_safety_wrapper_ablation_manifest.py -q` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/benchmark/build_safety_wrapper_ablation_manifest.py --config configs/research/safety_wrapper_ablation_v1.yaml --out output/issue_3501_manifest_validation --dry-run` -> passed; `complete=True`, `cells=6`, `seeds_per_cell=3`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/safety_wrapper_ablation_manifest.py tests/benchmark/test_safety_wrapper_ablation_manifest.py scripts/benchmark/check_safety_wrapper_ablation_rows.py` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/safety_wrapper_ablation_manifest.py tests/benchmark/test_safety_wrapper_ablation_manifest.py scripts/benchmark/check_safety_wrapper_ablation_rows.py` -> passed.
- No full benchmark campaign run, no SLURM/GPU submission, no paper/dissertation claim edits.

## Performance Considerations

- Baseline runtime: NA - checker contract only.
- Changed runtime: NA - checker contract only.
- Representative command: `uv run pytest tests/benchmark/test_safety_wrapper_ablation_manifest.py -q`
- Hot-path call count profile anchor: NA - no runtime hot path changed.
- Cache-hit reuse counter: NA when no caching claimed.
- Rollback failure criterion: revert if the checker rejects valid fixed-config `wrapper_off`/`wrapper_on` row pairs or accepts drifted wrapper-on thresholds.

## Risks / Rollout

- Compatibility risks: downstream hand-authored row fixtures must now include `safety_wrapper_config`.
- Failure modes: rows from older checker versions will fail closed until updated with explicit config provenance.
- Rollback fallback plan: revert this commit to restore the previous row contract.

## Docs / Provenance

- Updated docs: NA; tracked config contract updated.
- Relevant design provenance notes: issue #3501 and merged checker/manifest lineage on `origin/main`.
- Any assumptions need to preserved: wrapper-on rows should carry the fixed default `SafetyWrapperConfig` thresholds until a future issue deliberately changes the predeclared thresholds.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no - this support slice intentionally leaves #3501 open for runtime wiring, paired local smoke, full campaign, event-ledger reconciliation, and mitigation-effectiveness analysis.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this is a fail-closed launch/checker contract update only; no benchmark evidence or claim surface is produced.

## Follow-Up Issues

- Deferred work: runtime wiring, paired local smoke, full campaign, event-ledger reconciliation, and mitigation-effectiveness analysis remain in issue #3501.
- Issues opened follow-up: none.

## Reviewer Notes

- Verify closely that `wrapper_off` uses `null` config and `wrapper_on` uses the fixed default threshold dict.
- Known limitations: this PR does not run or wire the ablation campaign.

