### PR TITLE
Issue #3813: pin sustained-flow variant names

### DIFF
--- a/robot_sf/scenario_certification/sustained_flow.py
+++ b/robot_sf/scenario_certification/sustained_flow.py
@@ -473,8 +473,9 @@ def _validate_variant(
     map_file = str(scenario.get("map_file", ""))
     map_path = (scenario_set.parent / map_file).resolve()
 
-    if not name.startswith(f"issue_3813_sustained_flow_t_intersection_{tier}"):
-        errors.append(f"{name}: scenario name must include issue, family, and tier")
+    expected_name = f"issue_3813_sustained_flow_t_intersection_{tier}"
+    if name != expected_name:
+        errors.append(f"{name}: scenario name must be exactly {expected_name}")
     _require_equal(errors, name, "ped_density", ped_density, expected_ped_density)
     _require_equal(errors, name, "seeds", seeds, expected_seeds)
     for seed in seeds:

--- a/tests/scenario_certification/test_sustained_flow_preflight.py
+++ b/tests/scenario_certification/test_sustained_flow_preflight.py
@@ -213,6 +213,20 @@ def test_preflight_rejects_target_density_tier_drift(tmp_path: Path) -> None:
     assert any("continuous_spawn.target_density_tier" in error for error in report.errors)
 
 
+def test_preflight_rejects_variant_name_suffix_drift(tmp_path: Path) -> None:
+    """Scenario-certification preflight pins exact generated variant names."""
+    payload = yaml.safe_load(SCENARIO_SET.read_text(encoding="utf-8"))
+    payload["scenarios"][0]["name"] = "issue_3813_sustained_flow_t_intersection_light_extra"
+
+    drifted = tmp_path / "issue_3813_sustained_flow_name_suffix_drift.yaml"
+    drifted.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    report = sustained_flow.preflight_sustained_flow_scenario_set(drifted)
+
+    assert not report.conforms
+    assert any("scenario name must be exactly" in error for error in report.errors)
+
+
 def test_preflight_rejects_route_respawn_runtime_config_drift(tmp_path: Path) -> None:
     """Scenario YAML must keep route-respawn runtime preflight settings explicit."""
     payload = yaml.safe_load(SCENARIO_SET.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Issue

Closes no issue. Follow-up slice for https://github.com/ll7/robot_sf_ll7/issues/3813.

## Scope Summary

- Hardened the issue #3813 sustained-flow scenario-certification preflight so each enumerated continuous-spawn scaffold row must use the exact canonical generated name for its density tier.
- Added a regression test proving a suffix drift such as `issue_3813_sustained_flow_t_intersection_light_extra` fails closed.

## Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py::test_preflight_rejects_variant_name_suffix_drift -q` - passed, 1 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py -q` - passed, 38 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` - passed, `conforms=true`, `variant_count=3`, `runtime_support=metadata_only`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --runtime-supported-generated --json` - passed, `conforms=true`, `variant_count=3`, `runtime_support=runtime_continuous_spawn`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/scenario_certification/sustained_flow.py tests/scenario_certification/test_sustained_flow_preflight.py` - passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=.git/codex-agent-runs/active/issue-3813/PR_BODY.md uv run python scripts/dev/run_compact_validation.py --artifact-dir .git/codex-agent-runs/active/issue-3813/pr-ready --timeout-seconds 1800 -- scripts/dev/pr_ready_check.sh` - passed; summary `.git/codex-agent-runs/active/issue-3813/pr-ready/validation-20260701T235607Z-1523474.summary.json`.

## Out Of Scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No runtime continuous pedestrian respawn implementation, sustained-progress metric proof, pure-wait baseline proof, interaction-exposure proof, or campaign/runner benchmark evidence.

## Residual Risk

This remains a static preflight/enumeration hardening slice. It does not promote sustained-flow rows to benchmark evidence and leaves the broader #3813 runtime and metric contract open.
