### PR TITLE
Issue #3275: require archive null-test manifest readiness

### DIFF
--- a/robot_sf/adversarial/disjoint_evaluation.py
+++ b/robot_sf/adversarial/disjoint_evaluation.py
@@ -377,6 +377,11 @@ def classify_held_out_evidence(
 #: Top-level schema tag emitted by ``robot_sf.adversarial.archive``.
 ARCHIVE_SCHEMA_VERSION = "adversarial_failure_archive.v1"
 
+#: Null-test manifest key required before a certified archive can be treated as
+#: ready for a proposal-vs-random rerun.
+NULL_TEST_MANIFEST_KEY = "null_test_manifest"
+REQUIRED_NULL_TESTS = frozenset({"shuffled_outcome_label_permutation", "ranking_permutation"})
+
 #: Minimum scenario families required to form a disjoint fit/eval split. A
 #: single family collapses both sides together and can never pass the held-out
 #: disjointness gate (see :func:`classify_held_out_evidence`).
@@ -607,6 +612,30 @@ def _summary_consistency_blockers(archive_data: dict[str, Any], entries: list[An
     return blockers
 
 
+def _null_test_manifest_blockers(archive_data: dict[str, Any]) -> list[str]:
+    """Validate explicit null-test prerequisites for held-out archive reruns."""
+    manifest = archive_data.get(NULL_TEST_MANIFEST_KEY)
+    if manifest is None:
+        return ["null_test_manifest_missing"]
+    if not isinstance(manifest, dict):
+        return ["null_test_manifest_not_object"]
+
+    blockers: list[str] = []
+    required_tests = manifest.get("required_tests")
+    if not isinstance(required_tests, list) or not required_tests:
+        blockers.append("null_test_required_tests_missing")
+    else:
+        missing_tests = sorted(REQUIRED_NULL_TESTS - {str(test) for test in required_tests})
+        if missing_tests:
+            blockers.append(f"null_test_required_tests_missing:{','.join(missing_tests)}")
+
+    n_permutations = manifest.get("n_permutations")
+    if type(n_permutations) is not int or n_permutations < 1:
+        blockers.append("null_test_n_permutations_invalid")
+
+    return blockers
+
+
 def assess_archive_readiness(
     archive_data: Any,
     *,
@@ -653,6 +682,8 @@ def assess_archive_readiness(
         stats, schema_ok=schema_ok, schema_version=schema_version, min_entries=min_entries
     )
     reasons.extend(_summary_consistency_blockers(archive_data, entries))
+    null_test_manifest_reasons = _null_test_manifest_blockers(archive_data)
+    reasons.extend(null_test_manifest_reasons)
 
     # Overlap provenance needs disjoint families, unique archive ids, and seeds
     # to compare. Null tests additionally need a non-empty eval side, which the
@@ -665,7 +696,9 @@ def assess_archive_readiness(
         and not stats.seed_overlap_count
         and not stats.archive_id_overlap_count
     )
-    null_test_prerequisites_ready = overlap_metadata_ready and not stats.missing_attribution
+    null_test_prerequisites_ready = (
+        overlap_metadata_ready and not stats.missing_attribution and not null_test_manifest_reasons
+    )
 
     ready = not reasons
     return ArchiveReadinessReport(

--- a/tests/adversarial/test_archive_readiness.py
+++ b/tests/adversarial/test_archive_readiness.py
@@ -50,7 +50,17 @@ def _entry(family: str, archive_id: str, seed: int) -> dict:
 
 def _archive(entries: list[dict]) -> dict:
     """Wrap entries in a schema-tagged archive payload."""
-    return {"schema_version": ARCHIVE_SCHEMA_VERSION, "entries": entries}
+    return {
+        "schema_version": ARCHIVE_SCHEMA_VERSION,
+        "entries": entries,
+        "null_test_manifest": {
+            "required_tests": [
+                "shuffled_outcome_label_permutation",
+                "ranking_permutation",
+            ],
+            "n_permutations": 1000,
+        },
+    }
 
 
 def _ready_archive() -> dict:
@@ -80,6 +90,46 @@ def test_ready_archive_passes_all_prerequisites() -> None:
     assert report.blocking_reasons == []
     # The report is JSON-serializable for durable provenance.
     assert json.loads(json.dumps(report.to_dict()))["ready"] is True
+
+
+def test_missing_null_test_manifest_fails_closed() -> None:
+    """Archive readiness requires explicit null-test prerequisites."""
+    payload = _ready_archive()
+    del payload["null_test_manifest"]
+
+    report = assess_archive_readiness(payload)
+
+    assert report.ready is False
+    assert report.null_test_prerequisites_ready is False
+    assert "null_test_manifest_missing" in report.blocking_reasons
+
+
+def test_malformed_null_test_required_tests_fail_closed() -> None:
+    """Both expected null tests must be declared before rerun readiness."""
+    payload = _ready_archive()
+    payload["null_test_manifest"]["required_tests"] = ["ranking_permutation"]
+
+    report = assess_archive_readiness(payload)
+
+    assert report.ready is False
+    assert report.null_test_prerequisites_ready is False
+    assert (
+        "null_test_required_tests_missing:shuffled_outcome_label_permutation"
+        in report.blocking_reasons
+    )
+
+
+@pytest.mark.parametrize("n_permutations", [0, True])
+def test_invalid_null_test_permutation_count_fails_closed(n_permutations: object) -> None:
+    """Null-test policy must declare a positive permutation count."""
+    payload = _ready_archive()
+    payload["null_test_manifest"]["n_permutations"] = n_permutations
+
+    report = assess_archive_readiness(payload)
+
+    assert report.ready is False
+    assert report.null_test_prerequisites_ready is False
+    assert "null_test_n_permutations_invalid" in report.blocking_reasons
 
 
 def test_matching_summary_metadata_stays_ready() -> None:


### PR DESCRIPTION
## Summary
Adds a fail-closed null-test manifest prerequisite to the certified adversarial failure-archive readiness checker for issue #3275.

## Linked Issues
- Relates `#3275`

## Stack / Dependency
- Base dependency: `origin/main`
- Required prior PRs: none
- Stack follow-up issues: `#3275`
- Safe review independently: yes
- Review dependency reason, any: Small readiness-checker prerequisite slice only.

## What Changed
- `assess_archive_readiness` now requires a top-level `null_test_manifest` before an archive can be `ready`.
- The manifest must declare both `shuffled_outcome_label_permutation` and `ranking_permutation`, plus a positive integer `n_permutations`.
- Added synthetic fixture tests for missing and malformed null-test metadata.

## Why Matters
- Added value: prevents a certified failure archive from passing this readiness gate without null-test prerequisites needed by the later proposal-vs-random rerun.
- Expected impact: missing ordinary archive inputs now become explicit fail-closed readiness blockers.
- Why worth merging now: improves evidence hygiene before the real archive rerun is attempted.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Blocks circular or under-specified issue #3275 rerun inputs before held-out yield is discussed.
- Comparator or baseline, applicable: NA - no benchmark comparison run.
- Evidence tier: NA - support readiness checker, not research evidence.
- Result classification: NA - no benchmark, yield, or planner-performance result.
- Decision stop rule, applicable: Archive readiness remains `not_ready` unless null-test manifest prerequisites are present and well formed.
- Parent issue, claim map, registry, context note, synthesis surface update: Parent issue remains open for the real disjoint certified archive rerun.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - extends an existing readiness checker and makes no result claim.

## Domain-Aware Approval
- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: No benchmark, metric, paper, held-out yield, or dissertation claim is made.
- Validity checklist:
- Target claim/hypothesis: readiness blocker only.
- Comparator split/evidence validity: NA - no comparator split evaluated by PR.
- Fallback/degraded exclusions: no fallback, degraded, synthetic, Slurm, GPU, or benchmark campaign execution used as evidence.
- Claim boundary: input-readiness/fail-closed behavior only.
- Implementation integrity vs experimental validity: focused synthetic tests cover the readiness contract.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, synthetic archives without a valid null-test manifest now fail readiness.
- Did intervention change command source, selected command, trajectory, route progress? no.
- Did scenario actually contain targeted failure mode? NA - no planner execution.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: Real archive rerun remains in #3275.

## Next Empirical Action
- Rerun needed: yes, #3275 real disjoint certified archive rerun, outside this PR.
- Extractor analysis tool needed: no
- Artifact missing unavailable: real certified archive inputs and independent planner-execution outcomes remain outside this PR.
- Stop / revise / continue decision: continue when readiness inputs are available.
- Proposed child issue existing follow-up: #3275 remains open.

## Validation / Proof
- Head validated: `d6b6af87b6d091b30ac4ab90feaf8405d0e9baff`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/adversarial/test_archive_readiness.py tests/adversarial/test_disjoint_evaluation.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q` - 100 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py` - passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` via `scripts/dev/run_compact_validation.py` - passed; full log recorded under `.git/codex-agent-runs/active/pr-4130-gate/validation/pr-ready/`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/dev/check_pr_followups.py --body-file .git/codex-agent-runs/active/pr-4130-gate/pr-body-current.md --require-substantive-body --require-open-issues --json` - follow-up and domain approval checks passed.

## Performance Evidence
- Baseline runtime: NA - no performance claim.
- Changed runtime: NA - no performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/adversarial/test_archive_readiness.py tests/adversarial/test_disjoint_evaluation.py tests/adversarial/test_adversarial_proposal_model_issue_2921.py tests/benchmark/test_failure_archive_rerun_readiness_issue_3275.py -q`
- Hot-path call count profile anchor: NA - readiness checker only.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: valid archives with complete null-test prerequisites fail readiness for this checker.

## Risks / Rollout
- Compatibility risks: Existing archive fixtures that omit `null_test_manifest` now fail this readiness checker by design.
- Failure modes: Manifest field names may need revision when the real archive packet is finalized.
- Rollback fallback plan: Revert this PR or relax `_null_test_manifest_blockers` if the certified archive contract adopts different names.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #3275.
- Any assumptions need preserved: public manifest key is `null_test_manifest`; expected tests are `shuffled_outcome_label_permutation` and `ranking_permutation`.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: bounded readiness/fail-closed checker slice makes no benchmark, held-out yield, paper, or dissertation claim.

## Follow-Up Issues
- Deferred work: real disjoint certified failure archive rerun with independent planner-execution outcomes, certification/candidate lineage, null-test reporting, and bounded held-out yield interpretation.
- Issues opened follow-up: none; remains in #3275.

## Reviewer Notes
- Verify closely that requiring `null_test_manifest` is an acceptable reversible manifest contract for this single-archive checker.
- Known limitations: no full benchmark campaign run, no Slurm/GPU submission, no proposal-model evaluation, no paper/dissertation claim edits.
