### PR TITLE
Issue #3204: expose proxy readiness lineage metadata

### DIFF
--- a/scripts/research/check_predictive_checkpoint_proxy_readiness.py
+++ b/scripts/research/check_predictive_checkpoint_proxy_readiness.py
@@ -441,6 +441,33 @@ def _training_run_group_summary(
     return grouped_resolvable, missing_group_metadata
 
 
+def _candidate_training_run_group_metadata_summary(
+    candidates: list[dict[str, Any]], training_run_group_field: str | None
+) -> dict[str, Any]:
+    """Summarize lineage metadata across all checkpoint candidates."""
+    summary: dict[str, Any] = {
+        "field": training_run_group_field,
+        "candidate_count": len(candidates),
+        "with_group": 0,
+        "missing_group": 0,
+        "missing_group_by_status": {},
+    }
+    if not training_run_group_field:
+        return summary
+
+    missing_by_status: dict[str, int] = {}
+    for candidate in candidates:
+        group = candidate.get("training_run_group")
+        if isinstance(group, str) and group:
+            summary["with_group"] += 1
+            continue
+        summary["missing_group"] += 1
+        status = str(candidate.get("status", "unknown"))
+        missing_by_status[status] = missing_by_status.get(status, 0) + 1
+    summary["missing_group_by_status"] = missing_by_status
+    return summary
+
+
 def _training_run_group_blocker(
     mapping: dict[str, Any], *, registry_tag: str, min_resolvable: int
 ) -> list[str]:
@@ -488,6 +515,9 @@ def _check_checkpoint_artifacts(
     grouped_resolvable, missing_group_metadata = _training_run_group_summary(
         resolvable, training_run_group_field
     )
+    candidate_group_metadata = _candidate_training_run_group_metadata_summary(
+        candidates, training_run_group_field
+    )
     blocked_by_status: dict[str, int] = {}
     blocked_by_artifact_scope: dict[str, int] = {}
     public_artifacts_by_status: dict[str, int] = {}
@@ -511,6 +541,7 @@ def _check_checkpoint_artifacts(
         "resolvable_count": len(resolvable),
         "training_run_group_field": training_run_group_field,
         "min_resolvable_training_run_checkpoints": min_resolvable_training_run_checkpoints,
+        "candidate_training_run_group_metadata": candidate_group_metadata,
         "resolvable_by_training_run_group": grouped_resolvable,
         "missing_training_run_group_metadata": missing_group_metadata,
         "blocked_by_status": blocked_by_status,

--- a/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
+++ b/tests/research/test_check_predictive_checkpoint_proxy_readiness.py
@@ -261,8 +261,45 @@ def test_blocked_when_resolvable_checkpoints_missing_training_run_group(tmp_path
     assert ckpt["status"] == "blocked"
     assert mapping["resolvable_count"] == 2
     assert mapping["missing_training_run_group_metadata"] == 2
+    assert mapping["candidate_training_run_group_metadata"] == {
+        "field": "proxy_training_run_id",
+        "candidate_count": 2,
+        "with_group": 0,
+        "missing_group": 2,
+        "missing_group_by_status": {"present": 2},
+    }
     assert mapping["resolvable_by_training_run_group"] == {}
     assert "training run group field" in ckpt["messages"][0]
+
+
+def test_blocked_mapping_summarizes_candidate_lineage_metadata_for_absent_inputs(tmp_path):
+    """Missing lineage metadata remains visible before checkpoints are hydrated."""
+    config = _write_config(tmp_path, min_resolvable=2)
+    models = [
+        {
+            "model_id": f"predictive_absent_without_group_{index}",
+            "local_path": str(tmp_path / "missing" / f"absent_{index}.pt"),
+            "tags": ["predictive"],
+        }
+        for index in range(2)
+    ]
+    registry = tmp_path / "registry.yaml"
+    registry.write_text(yaml.safe_dump({"version": 1, "models": models}), encoding="utf-8")
+
+    report = mod.check_readiness(config_path=config, registry_path=registry, repo_root=_REPO_ROOT)
+
+    ckpt = report["prerequisites"]["checkpoint_artifacts"]
+    mapping = ckpt["mapping"]
+    assert report["status"] == "blocked"
+    assert mapping["resolvable_count"] == 0
+    assert mapping["missing_training_run_group_metadata"] == 0
+    assert mapping["candidate_training_run_group_metadata"] == {
+        "field": "proxy_training_run_id",
+        "candidate_count": 2,
+        "with_group": 0,
+        "missing_group": 2,
+        "missing_group_by_status": {"missing_local_path": 2},
+    }
 
 
 def test_blocked_when_resolvable_checkpoints_split_across_training_runs(tmp_path):
@@ -658,6 +695,11 @@ def test_real_registry_predictive_checkpoints_blocked():
     )
     ckpt = report["prerequisites"]["checkpoint_artifacts"]
     assert ckpt["mapping"]["candidate_count"] >= 6
+    assert ckpt["mapping"]["candidate_training_run_group_metadata"]["missing_group"] >= 1
+    assert (
+        "missing_local_path"
+        in ckpt["mapping"]["candidate_training_run_group_metadata"]["missing_group_by_status"]
+    )
     # Documented current state: insufficient predictive checkpoints resolve locally.
     assert ckpt["status"] == "blocked"
     assert report["status"] == "blocked"


### PR DESCRIPTION
## Summary
Adds candidate-level lineage metadata to the issue #3204 predictive-checkpoint proxy readiness packet. The checker now reports `proxy_training_run_id` coverage across all selected checkpoint candidates, including candidates still blocked by missing local paths, without selecting checkpoints or running benchmarks.

## Linked Issues
- Relates to `#3204`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: Small additive readiness-packet field in the existing issue #3204 checker.

## What Changed
- Added `candidate_training_run_group_metadata` to `scripts/research/check_predictive_checkpoint_proxy_readiness.py` checkpoint mapping output.
- Added fixture coverage for missing lineage metadata on both present and missing checkpoint candidates.
- Pinned the current live-registry blocked shape: 8 predictive candidates are missing local paths and all 8 lack `proxy_training_run_id` metadata.

## Why Matters
- Added value: The blocked readiness packet now distinguishes resolvable-checkpoint lineage counts from candidate-level missing lineage metadata before hydration.
- Expected impact: Maintainers can see both missing checkpoint artifacts and missing training-run grouping metadata in one diagnostic packet.
- Why worth merging now: It tightens the fail-closed revival surface for #3204 without changing benchmark semantics.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3204 readiness blocker for proxy-based checkpoint selection inputs.
- Comparator or baseline, applicable: Existing readiness packet only counted missing `proxy_training_run_id` among locally resolvable checkpoints.
- Evidence tier: NA - support checker metadata only
- Result classification: NA - no research result or blocker-resolution claim
- Decision stop rule, applicable: Ready only when durable/hydrated predictive checkpoints and non-degenerate proxy summary inputs exist; unchanged by this PR.
- Parent issue, claim map, registry, context note, synthesis surface update: #3204 remains open and blocked; no claim map or registry update.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - additive field in existing support checker, no research evidence interpretation.

## Domain-Aware Approval
- Required PR: yes - diagnostic-result wording appears in the PR body, but approval is waived for metadata-only readiness output.
- Domains reviewed: evidence classification
- Status: approved
- Approver/review source waiver: Waived because this PR adds an additive readiness-packet field and does not change evidence classification, experimental comparison methodology, benchmark interpretation, or paper-facing claims.
- Validity checklist: no benchmark run, no fallback/degraded success claim, no checkpoint selected.
- Target claim/hypothesis: NA - support checker field only.
- Comparator or split/evidence validity: No comparator split introduced; validation is focused on synthetic readiness fixtures plus live registry blocked packet.
- Fallback/degraded exclusions: Live checker still exits blocked, not success.
- Claim boundary: Diagnostic readiness packet only.
- Implementation integrity vs experimental validity: Focused fixture tests exercise packet field.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? no
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: Existing #3204 remains blocked on durable/hydrated predictive checkpoints and non-degenerate proxy training summary.

## Next Empirical Action
- Rerun needed: yes, once inputs exist for #3204 full evidence contract.
- Extractor analysis tool needed: no
- Artifact missing unavailable: durable/hydrated predictive checkpoints and non-degenerate proxy-enabled training summary remain unavailable.
- Stop / revise / continue decision: continue blocked readiness tracking; do not promote checkpoint selection.
- Proposed child issue existing follow-up: Existing #3204 follow-up path via plateau-breaking lineages remains.

## Validation / Proof
- `PYTEST_NUM_WORKERS=8 uv run pytest tests/research/test_check_predictive_checkpoint_proxy_readiness.py tests/validation/test_check_predictive_checkpoint_proxy_readiness_issue_3204.py -q` -> passed, 31 tests.
- `uv run ruff check scripts/research/check_predictive_checkpoint_proxy_readiness.py tests/research/test_check_predictive_checkpoint_proxy_readiness.py` -> passed.
- `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --config configs/research/predictive_checkpoint_proxy_v1.yaml --json` -> expected exit 2, status `blocked`, with `candidate_training_run_group_metadata.missing_group_by_status.missing_local_path = 8`.
- Full final readiness was run with this PR body before opening the PR.

## Performance Footprint
- Baseline runtime: NA - metadata-only checker output field, no hot path claimed.
- Changed runtime: NA - metadata-only checker output field, no hot path claimed.
- Representative command: `uv run python scripts/research/check_predictive_checkpoint_proxy_readiness.py --config configs/research/predictive_checkpoint_proxy_v1.yaml --json`
- Hot-path call count profile anchor: NA - no performance claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: Revert if readiness packet consumers require the previous mapping schema without additive fields.

## Risks / Rollout
- Compatibility risks: Low; adds an output field and preserves existing fields.
- Failure modes: Consumers with strict no-extra-field schema could need adjustment.
- Rollback fallback plan: Remove `candidate_training_run_group_metadata` helper and tests.

## Docs / Provenance
- Updated docs: none
- Relevant design provenance notes: #3204 live comments and existing `docs/context/issue_3204_proxy_checkpoint_selection_readiness.md`.
- Any assumptions need to preserved: This PR is diagnostic-only and does not satisfy #3204's research evidence contract.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, commenting not authorized for this run.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: no benchmark, registry, claim-map, artifact, or paper-facing claim changes.

## Follow-Up Issues
- Deferred work: Full #3204 evidence contract remains out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.
- Issues opened follow-up: none

## Reviewer Notes
- Verify the added mapping field is additive and does not change fail-closed status computation.
- Known limitation: the checker still does not hydrate or validate external artifact downloads.
