### PR TITLE
Issue #1496: tighten warm-start output manifest preflight

### DIFF
--- a/robot_sf/training/oracle_imitation_warm_start_readiness.py
+++ b/robot_sf/training/oracle_imitation_warm_start_readiness.py
@@ -376,7 +376,17 @@ def _check_expected_outputs(manifest: dict[str, Any], blockers: list[str]) -> di
             for key in _REQUIRED_OUTPUT_MANIFESTS
         }
 
+    extra_keys = sorted(str(key) for key in raw_outputs if key not in _REQUIRED_OUTPUT_MANIFESTS)
+    if extra_keys:
+        blockers.append(
+            "expected_outputs contains unsupported keys: "
+            + ", ".join(extra_keys)
+            + "; expected only "
+            + ", ".join(_REQUIRED_OUTPUT_MANIFESTS)
+        )
+
     checked: dict[str, Any] = {}
+    normalized_paths: dict[str, str] = {}
     for key in _REQUIRED_OUTPUT_MANIFESTS:
         raw_path = raw_outputs.get(key)
         if not isinstance(raw_path, str) or not raw_path.strip():
@@ -397,6 +407,18 @@ def _check_expected_outputs(manifest: dict[str, Any], blockers: list[str]) -> di
                 "detail": durability_error,
             }
             continue
+
+        normalized_path = path_text.replace("\\", "/").lstrip("./")
+        duplicate_key = normalized_paths.get(normalized_path)
+        if duplicate_key is not None:
+            blockers.append(f"expected_outputs.{key} duplicates {duplicate_key} path: {path_text}")
+            checked[key] = {
+                "path": path_text,
+                "ready": False,
+                "detail": f"duplicates {duplicate_key}",
+            }
+            continue
+        normalized_paths[normalized_path] = key
 
         checked[key] = {"path": path_text, "ready": True}
     return checked

--- a/tests/training/test_oracle_imitation_warm_start_readiness.py
+++ b/tests/training/test_oracle_imitation_warm_start_readiness.py
@@ -256,6 +256,45 @@ def test_expected_output_paths_must_be_manifest_files(tmp_path: Path) -> None:
     assert report["expected_outputs"]["benchmark_report"]["ready"] is False
 
 
+def test_unknown_expected_output_keys_are_blockers(tmp_path: Path) -> None:
+    """Output manifest keys must stay bounded to the warm-start readiness contract."""
+    manifest_dict = _ready_manifest(tmp_path)
+    expected_outputs = manifest_dict["expected_outputs"]
+    assert isinstance(expected_outputs, dict)
+    expected_outputs["raw_training_traces"] = "docs/context/evidence/raw_training_traces.json"
+    manifest = _write_manifest(tmp_path, manifest_dict)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert any(
+        "expected_outputs contains unsupported keys: raw_training_traces" in blocker
+        for blocker in report["blockers"]
+    )
+
+
+def test_duplicate_expected_output_paths_are_blockers(tmp_path: Path) -> None:
+    """Each future output type must have its own durable evidence manifest path."""
+    manifest_dict = _ready_manifest(tmp_path)
+    expected_outputs = manifest_dict["expected_outputs"]
+    assert isinstance(expected_outputs, dict)
+    expected_outputs["checkpoint_manifest"] = expected_outputs["training_manifest"]
+    manifest = _write_manifest(tmp_path, manifest_dict)
+
+    report = check_warm_start_readiness(manifest)
+
+    assert report["status"] == "blocked"
+    assert any(
+        "expected_outputs.checkpoint_manifest duplicates training_manifest path" in blocker
+        for blocker in report["blockers"]
+    )
+    assert report["expected_outputs"]["checkpoint_manifest"] == {
+        "path": "docs/context/evidence/unit_training_manifest.json",
+        "ready": False,
+        "detail": "duplicates training_manifest",
+    }
+
+
 def test_require_ready_fails_closed_when_blocked(tmp_path: Path) -> None:
     """require_ready turns a blocked manifest into a fail-closed PrerequisitesNotReadyError.
 


### PR DESCRIPTION
## Summary
Tightens the issue #1496 oracle-imitation warm-start readiness checker so `expected_outputs` is a bounded, unambiguous manifest contract. The checker now fails closed on unsupported output keys and duplicate future manifest paths.

## Linked Issues
- Relates `#1496`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added fail-closed blockers for unsupported `expected_outputs` keys in the warm-start readiness manifest.
- Added fail-closed blockers when two required future outputs point at the same durable evidence manifest path.
- Added synthetic tests for both blocked states.

## Why Matters
- Added value: avoids ambiguous readiness decision packets before any future warm-start training launch.
- Expected impact: keeps issue #1496 blocked on explicit durable-artifact prerequisites instead of allowing unclear output-manifest declarations.
- Why worth merging now: safe shared-PC readiness improvement; no data collection or training required.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: issue #1496 launch readiness blocker only.
- Comparator or baseline, applicable: NA
- Evidence tier: NA - support checker only; targeted tests validate code behavior but do not create evidence.
- Result classification: NA - support checker only; issue #1496 remains blocked.
- Decision stop rule, applicable: NA
- Parent issue, claim map, registry, context note, synthesis surface update: issue #1496 remains open and blocked.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker only; no research result interpreted.

## Domain-Aware Approval
- Approver/review source waiver: not required; checker contract only.
- Validity checklist: no benchmark, metric, or paper-facing claim changed.
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA
- Fallback/degraded exclusions: preserved; readiness remains fail-closed.
- Claim boundary: no claim edits.
- Implementation integrity vs experimental validity: implementation-only preflight contract.

## Falsification / Non-Transfer Check
- Did mechanism activate? NA
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: NA

## Next Empirical Action
- Rerun needed: NA for this checker slice.
- Extractor analysis tool needed: no
- Artifact missing unavailable: durable oracle-imitation dataset/trace retrieval remains blocked.
- Stop / revise / continue decision: continue only after durable dataset and trace URI prerequisites resolve.
- Proposed child issue existing follow-up: #1496 remains the parent training-campaign issue.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py -q` -> passed, 30 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format robot_sf/training/oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness.py && scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/training/oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness.py` -> passed.
- `git diff --check` -> passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/check_oracle_imitation_warm_start_readiness.py --manifest configs/training/ppo_imitation/oracle_warm_start_readiness_issue_1496.yaml --json` -> exited 1 as expected with `readiness_decision=artifact_retrieval_blocked`; blockers remain dataset launch packet and trace URI registry.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=output/validation/issue_1496_pr_body.md scripts/dev/pr_ready_check.sh` -> passed; freshness stamp `output/validation/pr_ready/issue-1496-warm-start-manifest-blockers-preflight.json`.

Out of scope: no full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

## Performance Notes
- Baseline runtime: NA - no performance claim.
- Changed runtime: NA - no performance claim.
- Representative command: `uv run pytest tests/training/test_oracle_imitation_warm_start_readiness.py tests/training/test_oracle_imitation_warm_start_readiness_decision_manifest.py -q`
- Hot-path call count profile anchor: NA - no hot-path claim.
- Cache-hit reuse counter: NA
- Rollback failure criterion: readiness checker no longer reports unsupported or duplicate expected output manifest declarations as blockers.

## Risks / Rollout
- Compatibility risks: low; only affects malformed or ambiguous future output-manifest declarations.
- Failure modes: a future manifest with extra convenience keys must move those values into a supported manifest file instead of the top-level `expected_outputs` map.
- Rollback fallback plan: revert this PR to restore permissive `expected_outputs` handling.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue #1496 and prior readiness slices #4119/#4127.
- Any assumptions need to preserved: `expected_outputs` is intentionally limited to `training_manifest`, `checkpoint_manifest`, and `benchmark_report`.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no, commenting not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: this PR changes a readiness checker only and does not produce benchmark evidence.

## Follow-Up Issues
- Deferred work: durable oracle-imitation dataset/trace retrieval, warm-start training, and benchmark comparison remain blocked under #1496.
- Issues opened follow-up: none.

## Reviewer Notes
- Verify closely: fail-closed behavior for unsupported and duplicate `expected_outputs` entries.
- Any known limitations: no dataset generation, training, Slurm/GPU submission, full benchmark campaign run, or paper/dissertation claim edits.
