### PR TITLE
Issue #3813: harden sustained-flow variant name preflight

### DIFF
--- a/robot_sf/benchmark/sustained_flow_preflight.py
+++ b/robot_sf/benchmark/sustained_flow_preflight.py
@@ -138,6 +138,7 @@ def preflight_sustained_flow_matrix(matrix_path: str | Path) -> SustainedFlowPre
     else:
         blocking_reasons.extend(_variant_blockers(variants))
         blocking_reasons.extend(_variant_tier_order_blockers(variants))
+        blocking_reasons.extend(_variant_name_tier_blockers(variants))
         blocking_reasons.extend(_generator_drift_blockers(variants))
 
     if not variants:
@@ -282,6 +283,30 @@ def _variant_tier_order_blockers(variants: tuple[SustainedFlowVariant, ...]) -> 
     if observed_tiers == expected_tiers:
         return ()
     return ("density tiers must enumerate light, medium, heavy exactly once",)
+
+
+def _variant_name_tier_blockers(variants: tuple[SustainedFlowVariant, ...]) -> tuple[str, ...]:
+    """Fail closed when canonical sustained-flow names drift from their density tier.
+
+    Returns:
+        Blocking reasons for variant names that do not match their density tier.
+    """
+
+    expected_name_by_tier = {
+        tier: f"issue_3813_{SUSTAINED_FLOW_ARCHETYPE}_{tier}"
+        for tier, *_ in EXPECTED_SUSTAINED_FLOW_TIERS
+    }
+    blockers = []
+    for variant in variants:
+        expected_name = expected_name_by_tier.get(variant.density_tier)
+        if expected_name is None:
+            continue
+        if variant.name != expected_name:
+            blockers.append(
+                f"{variant.name}: scenario name must be {expected_name!r} "
+                f"for density tier {variant.density_tier!r}"
+            )
+    return tuple(blockers)
 
 
 def _validate_continuous_spawn_definition(value: Any, *, scenario_name: str) -> None:

--- a/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
+++ b/tests/benchmark/test_issue_3813_sustained_flow_scaffold.py
@@ -256,6 +256,25 @@ def test_sustained_flow_preflight_rejects_reordered_density_tiers(tmp_path: Path
     )
 
 
+def test_sustained_flow_preflight_rejects_variant_name_suffix_drift(tmp_path: Path) -> None:
+    """Benchmark preflight names stay tied to canonical density tiers."""
+    matrix = _load_yaml(SCENARIO_SET)
+    matrix["scenarios"][0]["name"] = "issue_3813_sustained_flow_t_intersection_light_extra"
+
+    drifted_name_matrix = tmp_path / "wrong_variant_name_sustained_flow.yaml"
+    drifted_name_matrix.write_text(yaml.safe_dump(matrix, sort_keys=False), encoding="utf-8")
+
+    payload = preflight_sustained_flow_matrix(drifted_name_matrix).to_payload()
+
+    assert payload["status"] == "not_available"
+    assert payload["benchmark_eligible"] is False
+    assert payload["variant_count"] == 3
+    assert any(
+        "scenario name must be 'issue_3813_sustained_flow_t_intersection_light'" in reason
+        for reason in payload["blocking_reasons"]
+    )
+
+
 def test_sustained_flow_preflight_rejects_target_density_tier_drift(tmp_path: Path) -> None:
     """Continuous-spawn targets must stay aligned with the enumerated density tier."""
 


### PR DESCRIPTION
## Summary
Hardens the issue #3813 sustained-flow benchmark preflight by adding an explicit fail-closed blocker when a canonical variant name drifts from its density tier.

## Linked Issues
- Relates to `#3813`

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe review independently: yes
- Review dependency reason, any: Small diagnostic hardening slice on top of current `origin/main`.

## What Changed
- Added a benchmark preflight blocker tying each sustained-flow `light`, `medium`, and `heavy` density tier to its exact canonical scenario name.
- Added an enumeration regression test for variant name suffix drift in `tests/benchmark/test_issue_3813_sustained_flow_scaffold.py`.

## Why Matters
- Added value: Makes continuous-spawn scenario variant drift fail closed with a direct reason before benchmark eligibility.
- Expected impact: Better local preflight diagnostics for the sustained-flow family; no benchmark result or runtime behavior change.
- Why worth merging now: It narrows a remaining preflight diagnostic gap while the issue is being closed through small reviewable slices.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: #3813 pre-benchmark scenario-generator/preflight correctness for sustained-flow variants.
- Comparator or baseline, applicable: Existing sustained-flow preflight accepted only via generic generator-drift diagnostics for this name/tier mismatch.
- Evidence tier: targeted smoke
- Result classification: diagnostic-only
- Decision stop rule, applicable: Focused tests prove suffix drift now yields a direct fail-closed blocker while canonical rows still conform.
- Parent issue, claim map, registry, context note, synthesis surface update: Parent issue remains open; PR body records this is not benchmark evidence.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - preflight hardening only.

## Domain-Aware Approval
- Required for this PR: yes - benchmark preflight diagnostic slice.
- Domains reviewed: benchmark preflight validity, fail-closed fallback/degraded exclusion.
- Status: waived
- Approval or blocker note: Codex scoped waiver for static preflight hardening; diagnostic-only static change with benchmark result, metric interpretation, and paper-facing claim out of scope; Claude Code owns the full PR gate after open.
- Target claim/hypothesis: Sustained-flow variant names stay structurally tied to canonical density tiers before benchmark eligibility.
- Comparator or split/evidence validity: Targeted mutation test on checked-in issue #3813 scenario matrix.
- Fallback/degraded exclusions: Not a benchmark run; fallback/degraded execution is not counted as success.
- Claim boundary: Static/generator preflight diagnostics only.
- Implementation integrity vs experimental validity: Implementation changes diagnostics only; experimental validity remains out of scope.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, mutated suffix drift returns a direct blocker.
- Did intervention change command source, selected command, trajectory, route progress? no runtime path changed.
- Did scenario actually contain targeted failure mode? yes, test mutates the sustained-flow light variant name suffix.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: none opened; remaining #3813 runtime/proof work stays on parent issue.

## Next Empirical Action
- Rerun needed: no for this static slice.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: none.
- Stop / revise / continue decision: continue with separate #3813 runtime/proof slices.
- Proposed child issue existing follow-up: parent #3813 remains open for runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, and runnable campaign/runner benchmark evidence.

## Validation / Proof
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py` passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q` passed: 17 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/scenario_certification/test_sustained_flow_preflight.py tests/benchmark/test_issue_3813_sustained_flow_scaffold.py tests/benchmark/test_issue_3813_sustained_flow_scenarios.py tests/benchmark/test_issue_3813_sustained_flow_variant_stability.py -q` passed: 39 passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --json` passed with `conforms=true`, `variant_count=3`, `runtime_support=metadata_only`, `benchmark_evidence=false`.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python scripts/validation/preflight_sustained_flow_scenarios_issue_3813.py --runtime-supported-generated --json` passed with `conforms=true`, `variant_count=3`, `runtime_support=runtime_continuous_spawn`, `benchmark_evidence=false`.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr-3813-body.md PYTEST_NUM_WORKERS=8 uv run python scripts/dev/run_compact_validation.py --artifact-dir $(git rev-parse --git-common-dir)/codex-agent-runs/active/issue-3813/pr-ready --timeout-seconds 2400 -- scripts/dev/pr_ready_check.sh` passed; summary `.git/codex-agent-runs/active/issue-3813/pr-ready/validation-20260702T005841Z-984052.summary.json`.

## Performance Validation
- Baseline runtime: NA - static preflight diagnostic change, no performance claim.
- Changed runtime: NA - static preflight diagnostic change, no performance claim.
- Representative command: `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_issue_3813_sustained_flow_scaffold.py -q`
- Hot-path call count profile anchor: NA - no runtime hot path touched.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: Revert if canonical sustained-flow rows become unavailable or name/tier drift no longer fails closed.

## Risks / Rollout
- Compatibility risks: Low; adds a stricter diagnostic blocker for issue #3813 sustained-flow preflight only.
- Failure modes: A future intentional rename must update the canonical tier/name contract and tests together.
- Rollback fallback plan: Revert this commit to restore the previous generic generator-drift-only behavior.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: Issue #3813 and prior merged preflight slices recorded in issue comments.
- Any assumptions need to preserved: Assumes canonical sustained-flow names remain `issue_3813_sustained_flow_t_intersection_{light,medium,heavy}` until a broader scenario-family rename is explicitly reviewed.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no; issue commenting was not authorized.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): NA.
- Follow-up issue opened deferred propagation (yes/no/NA): no.
- Not applicable because: This is a targeted static preflight diagnostic; no benchmark evidence, artifact, registry, claim-map, leaderboard, paper, or dissertation surface is promoted.

## Follow-Up Issues
- Deferred work: No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits. Parent #3813 still requires runtime continuous pedestrian respawn support, sustained-progress metric proof, interaction-exposure sanity proof, pure-wait baseline proof, and runnable campaign/runner benchmark evidence.
- Issues opened follow-up: none.

## Reviewer Notes
- Please verify the new blocker is diagnostic-only and does not mark current scaffold rows as benchmark evidence.
- Final readiness passed on updated clean head `607b0cc643a3786b886416afd3cd18d986c9368d`; local gate also merged current `origin/main` before validation.

