### PR TITLE
Issue #3275: require certified archive readiness metadata

### DIFF
--- a/robot_sf/adversarial/archive.py
+++ b/robot_sf/adversarial/archive.py
@@ -233,6 +233,10 @@ def _archive_entry(
         ),
         "replay_command": _replay_command(config, scenario_yaml_path, bundle_path),
     }
+    for certification_key in ("certification_status", "candidate_certification"):
+        certification = candidate_payload.get(certification_key)
+        if isinstance(certification, dict):
+            entry[certification_key] = certification
     return entry
 
 

--- a/robot_sf/adversarial/disjoint_evaluation.py
+++ b/robot_sf/adversarial/disjoint_evaluation.py
@@ -411,6 +411,8 @@ class ArchiveReadinessReport:
     entries_missing_archive_id: int
     entries_missing_scenario_seed: int
     entries_missing_failure_attribution: int
+    entries_missing_certification_status: int
+    entries_not_certified: int
     entries_unknown_family: int
     scenario_family_overlap_count: int
     seed_overlap_count: int
@@ -432,6 +434,8 @@ class ArchiveReadinessReport:
             "entries_missing_archive_id": self.entries_missing_archive_id,
             "entries_missing_scenario_seed": self.entries_missing_scenario_seed,
             "entries_missing_failure_attribution": self.entries_missing_failure_attribution,
+            "entries_missing_certification_status": self.entries_missing_certification_status,
+            "entries_not_certified": self.entries_not_certified,
             "entries_unknown_family": self.entries_unknown_family,
             "scenario_family_overlap_count": self.scenario_family_overlap_count,
             "seed_overlap_count": self.seed_overlap_count,
@@ -453,6 +457,8 @@ def _not_ready(status: str, *reasons: str, **fields: Any) -> ArchiveReadinessRep
         "entries_missing_archive_id": 0,
         "entries_missing_scenario_seed": 0,
         "entries_missing_failure_attribution": 0,
+        "entries_missing_certification_status": 0,
+        "entries_not_certified": 0,
         "entries_unknown_family": 0,
         "scenario_family_overlap_count": 0,
         "seed_overlap_count": 0,
@@ -473,6 +479,19 @@ def _entry_scenario_seed(entry: dict[str, Any]) -> Any:
     return None
 
 
+def _entry_certification_status(entry: dict[str, Any]) -> str | None:
+    """Return normalized per-entry candidate certification status, if present."""
+    certification = entry.get("certification_status")
+    if certification is None:
+        certification = entry.get("candidate_certification")
+    if not isinstance(certification, dict):
+        return None
+    status = certification.get("status")
+    if not isinstance(status, str) or not status.strip():
+        return None
+    return status.strip().lower()
+
+
 @dataclass(frozen=True)
 class _EntryStats:
     """Aggregate structural statistics over a list of archive entries."""
@@ -482,6 +501,8 @@ class _EntryStats:
     missing_archive_id: int
     missing_seed: int
     missing_attribution: int
+    missing_certification_status: int
+    not_certified: int
     unknown_family: int
     distinct_family_count: int
     disjoint_split_possible: bool
@@ -508,6 +529,8 @@ def _collect_entry_stats(
     if disjoint_split_possible:
         overlap = compute_overlap_provenance(split.fit_entries, split.eval_entries)
 
+    certification_statuses = [_entry_certification_status(e) for e in dict_entries]
+
     return _EntryStats(
         entry_count=len(dict_entries),
         non_dict_count=len(entries) - len(dict_entries),
@@ -517,6 +540,10 @@ def _collect_entry_stats(
             1
             for e in dict_entries
             if not isinstance(e.get("failure_attribution"), dict) or not e["failure_attribution"]
+        ),
+        missing_certification_status=sum(1 for status in certification_statuses if status is None),
+        not_certified=sum(
+            1 for status in certification_statuses if status is not None and status != "passed"
         ),
         unknown_family=sum(1 for e in dict_entries if scenario_family_key(e) == "unknown_family"),
         distinct_family_count=len(distinct_families),
@@ -541,6 +568,8 @@ def _readiness_blocking_reasons(
         ("entries_missing_archive_id", stats.missing_archive_id),
         ("entries_missing_scenario_seed", stats.missing_seed),
         ("entries_missing_failure_attribution", stats.missing_attribution),
+        ("entries_missing_certification_status", stats.missing_certification_status),
+        ("entries_not_certified", stats.not_certified),
         ("entries_unknown_family", stats.unknown_family),
         (
             "insufficient_scenario_families",
@@ -697,7 +726,11 @@ def assess_archive_readiness(
         and not stats.archive_id_overlap_count
     )
     null_test_prerequisites_ready = (
-        overlap_metadata_ready and not stats.missing_attribution and not null_test_manifest_reasons
+        overlap_metadata_ready
+        and not stats.missing_attribution
+        and not null_test_manifest_reasons
+        and not stats.missing_certification_status
+        and not stats.not_certified
     )
 
     ready = not reasons
@@ -713,6 +746,8 @@ def assess_archive_readiness(
         entries_missing_archive_id=stats.missing_archive_id,
         entries_missing_scenario_seed=stats.missing_seed,
         entries_missing_failure_attribution=stats.missing_attribution,
+        entries_missing_certification_status=stats.missing_certification_status,
+        entries_not_certified=stats.not_certified,
         entries_unknown_family=stats.unknown_family,
         scenario_family_overlap_count=stats.scenario_family_overlap_count,
         seed_overlap_count=stats.seed_overlap_count,

--- a/tests/adversarial/test_archive_readiness.py
+++ b/tests/adversarial/test_archive_readiness.py
@@ -44,6 +44,12 @@ def _entry(family: str, archive_id: str, seed: int) -> dict:
         "archive_id": archive_id,
         "cluster_key": family,
         "candidate": {"scenario_seed": seed},
+        "certification_status": {
+            "schema_version": "scenario_cert.v1",
+            "status": "passed",
+            "reason": "fixture certified",
+            "details": {},
+        },
         "failure_attribution": {"primary_failure": "collision"},
     }
 
@@ -315,6 +321,34 @@ def test_empty_failure_attribution_breaks_null_test_prereq() -> None:
     assert report.null_test_prerequisites_ready is False
     assert report.ready is False
     assert "entries_missing_failure_attribution:1" in report.blocking_reasons
+
+
+def test_missing_certification_status_breaks_null_test_prereq() -> None:
+    """Certified archive readiness requires per-entry certification status."""
+    entries = [_entry("A", "a0", 1), _entry("B", "b0", 2)]
+    del entries[1]["certification_status"]
+
+    report = assess_archive_readiness(_archive(entries))
+
+    assert report.entries_missing_certification_status == 1
+    assert report.entries_not_certified == 0
+    assert report.null_test_prerequisites_ready is False
+    assert report.ready is False
+    assert "entries_missing_certification_status:1" in report.blocking_reasons
+
+
+def test_failed_certification_status_breaks_null_test_prereq() -> None:
+    """Non-passing candidate certification blocks certified archive readiness."""
+    entries = [_entry("A", "a0", 1), _entry("B", "b0", 2)]
+    entries[1]["certification_status"]["status"] = "failed"
+
+    report = assess_archive_readiness(_archive(entries))
+
+    assert report.entries_missing_certification_status == 0
+    assert report.entries_not_certified == 1
+    assert report.null_test_prerequisites_ready is False
+    assert report.ready is False
+    assert "entries_not_certified:1" in report.blocking_reasons
 
 
 def test_unknown_family_entries_are_counted_and_block() -> None:

--- a/tests/adversarial/test_failure_archive.py
+++ b/tests/adversarial/test_failure_archive.py
@@ -12,6 +12,7 @@ from robot_sf.adversarial.archive import (
     failure_archive_feature_rows,
     failure_archive_index,
 )
+from robot_sf.adversarial.disjoint_evaluation import assess_archive_readiness
 from scripts.tools.curate_adversarial_failure_archive import main as archive_cli_main
 
 
@@ -53,6 +54,12 @@ def _manifest(tmp_path: Path) -> Path:
                 "objective_value": 9.0,
                 "bundle_path": "output/adversarial/run/candidate_0000",
                 "scenario_yaml_path": "output/adversarial/run/candidate_0000/scenario.yaml",
+                "certification_status": {
+                    "schema_version": "scenario_cert.v1",
+                    "status": "passed",
+                    "reason": "fixture certified",
+                    "details": {},
+                },
                 "failure_attribution": {
                     "status": "attributed",
                     "primary_failure": "collision",
@@ -68,6 +75,12 @@ def _manifest(tmp_path: Path) -> Path:
                 "objective_value": 7.0,
                 "bundle_path": "output/adversarial/run/candidate_0001",
                 "scenario_yaml_path": "output/adversarial/run/candidate_0001/scenario.yaml",
+                "candidate_certification": {
+                    "schema_version": "scenario_cert.v1",
+                    "status": "passed",
+                    "reason": "legacy fixture certified",
+                    "details": {},
+                },
                 "failure_attribution": {
                     "status": "attributed",
                     "primary_failure": "collision",
@@ -83,6 +96,12 @@ def _manifest(tmp_path: Path) -> Path:
                 "objective_value": 3.0,
                 "bundle_path": "output/adversarial/run/candidate_0002",
                 "scenario_yaml_path": "output/adversarial/run/candidate_0002/scenario.yaml",
+                "certification_status": {
+                    "schema_version": "scenario_cert.v1",
+                    "status": "passed",
+                    "reason": "fixture certified",
+                    "details": {},
+                },
                 "failure_attribution": {
                     "status": "attributed",
                     "primary_failure": "timeout",
@@ -169,7 +188,26 @@ def test_curate_failure_archive_groups_and_selects_representatives(tmp_path: Pat
         if entry["archive_id"] == collision_cluster["representative_archive_id"]
     )
     assert representative["source_candidate_index"] == 1
+    assert representative["candidate_certification"]["status"] == "passed"
     assert representative["replay_command"].startswith("uv run robot_sf_bench run")
+
+
+def test_curated_certified_archive_can_satisfy_readiness_gate(tmp_path: Path) -> None:
+    """Curation preserves certification metadata needed by archive readiness."""
+    archive = curate_failure_archive([_manifest(tmp_path)], output_path=tmp_path / "archive.json")
+    archive["null_test_manifest"] = {
+        "required_tests": [
+            "shuffled_outcome_label_permutation",
+            "ranking_permutation",
+        ],
+        "n_permutations": 100,
+    }
+
+    report = assess_archive_readiness(archive)
+
+    assert report.ready is True
+    assert report.entries_missing_certification_status == 0
+    assert report.entries_not_certified == 0
 
 
 def test_curate_failure_archive_is_deterministic(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

Add a fail-closed certification-status prerequisite to the issue #3275 certified failure archive readiness checker, and preserve candidate certification metadata when curating compact failure archives.

## Linked Issues

- Relates #3275

## Stack / Dependency

- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: none
- Safe to review independently: yes
- Review dependency reason, any: none

## What Changed

- Count missing per-entry candidate certification status in `ArchiveReadinessReport`.
- Count non-passing certification status and block readiness when any archive entry is not certified.
- Preserve `certification_status` / `candidate_certification` dictionaries from search manifests into curated failure archive entries.
- Add archive-readiness tests for missing/failed certification metadata.
- Add archive-curation regression proof that a curated certified archive with null-test metadata passes readiness.

## Why Matters

- Added value: prevents certified failure archive input from being marked ready when candidate certification metadata is absent or failed, without dropping certification metadata during curation.
- Expected impact: earlier fail-closed feedback before any proposal-vs-random rerun uses archive inputs.
- Why worth merging now: bounded readiness hygiene slice for #3275 does not depend on real archive inputs.

## Research Result Guidance

- Target claim / hypothesis / blocker this should affect: #3275 input-readiness blocker only.
- Comparator or baseline, applicable: NA - support checker; no comparison or benchmark interpretation.
- Evidence tier: NA - support checker; validation is focused unit/lint proof, not research evidence.
- Result classification: NA - support checker.
- Decision stop rule, applicable: NA - no proposal-model evaluation run.
- Parent issue, claim map, registry, context note, synthesis surface update: #3275 remains open real disjoint archive rerun.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - support checker, no research evidence interpretation.

## Domain-Aware Approval

- approval concerns experimental validity claim waived / pending / blocked / not required: not required
- Approver/review source waiver: NA
- Validity checklist: fail-closed structural checker only; no benchmark or held-out yield claim.
- Target claim/hypothesis: NA
- Comparator split/evidence validity: NA - PR does not evaluate proposal-vs-random certification metadata.
- Fallback/degraded exclusions: NA - no benchmark/evaluation run.
- Claim boundary: implementation integrity for readiness metadata only.
- Implementation integrity vs experimental validity: validates support checker behavior; does not establish experimental validity.

## Falsification / Non-Transfer Check

- Did mechanism activate? NA - support checker.
- Did intervention change command source, selected command, trajectory, route progress? NA
- Did scenario actually contain targeted failure mode? NA
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: remaining #3275 real archive rerun work.

## Next Empirical Action

- Rerun needed: yes, outside PR real disjoint certified archive rerun.
- Extractor analysis tool needed: NA
- Artifact missing unavailable: real certified failure archive inputs independent planner-execution outcomes remain out scope.
- Stop / revise / continue decision: continue #3275 after readiness inputs exist.
- Proposed child issue existing follow-up: #3275 remains parent follow-up.

## Validation / Proof

- `python -m py_compile robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py scripts/tools/check_adversarial_archive_readiness.py` - passed before review fix.
- `uv run ruff check robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_archive_readiness.py scripts/tools/check_adversarial_archive_readiness.py` - passed before review fix.
- `uv run pytest tests/adversarial/test_archive_readiness.py -q` - 33 passed before review fix.
- `python -m py_compile robot_sf/adversarial/archive.py robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_failure_archive.py tests/adversarial/test_archive_readiness.py scripts/tools/check_adversarial_archive_readiness.py` - passed.
- `uv run ruff check robot_sf/adversarial/archive.py robot_sf/adversarial/disjoint_evaluation.py tests/adversarial/test_failure_archive.py tests/adversarial/test_archive_readiness.py scripts/tools/check_adversarial_archive_readiness.py` - passed.
- `uv run pytest tests/adversarial/test_archive_readiness.py tests/adversarial/test_failure_archive.py -q` - 41 passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr4135_body_updated.md scripts/dev/pr_ready_check.sh` - pending post-review rerun.

Explicit out scope: no full benchmark campaign run, real scenario-family-disjoint certified failure archive independent planner-execution outcomes, or null-test reporting.

## Risks / Rollout

- Compatibility risks: low; compact archive entries preserve extra certification dictionaries when present.
- Failure modes: archives curated from manifests without per-candidate certification metadata now fail readiness as intended.
- Rollback fallback plan: revert this PR if readiness blocks a certified archive that carries valid certification metadata under a different schema key.

## Docs / Provenance

- Updated docs: PR body only.
- Relevant design provenance notes: issue #3275.
- Any assumptions need preserved: `candidate_certification` remains accepted as a legacy alias for per-entry certification status.

## Downstream Propagation

- Parent issue updated (yes/no/NA): no - #3275 remains open for real rerun.
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no
- Not applicable because: support-checker slice only; no benchmark, registry, claim-map, or paper-facing result changes.

## Follow-Up Issues

- Deferred work: real disjoint certified failure archive rerun with independent planner-execution outcomes remains in #3275.
- Issues opened follow-up: none.

## Reviewer Notes

- Verify closely that certification readiness remains separate from overlap metadata but still blocks full archive readiness/null-test prerequisites.
- Any known limitations: does not run proposal-model evaluation, fabricate archive inputs, or report benchmark yield.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Archive entries can now include certification details when available.
  * Readiness checks now track whether entries are certified and whether any certification data is missing.

* **Bug Fixes**
  * Improved readiness gating so archives only pass when all required certification information is present and marked as passed.
  * Representative selection now preserves certification status in the output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->