### PR TITLE
Issue #3501: bind safety wrapper into benchmark runtime

### DIFF
--- a/robot_sf/benchmark/event_ledger.py
+++ b/robot_sf/benchmark/event_ledger.py
@@ -112,6 +112,18 @@ def _safety_predicate_records(record: Mapping[str, Any]) -> dict[str, Any]:
     return dict(predicates) if isinstance(predicates, Mapping) else {}
 
 
+def _safety_wrapper_summary(record: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Return episode-level safety-wrapper summary from algorithm metadata."""
+
+    algorithm_metadata = record.get("algorithm_metadata")
+    if not isinstance(algorithm_metadata, Mapping):
+        return None
+    safety_wrapper = algorithm_metadata.get("safety_wrapper")
+    if not isinstance(safety_wrapper, Mapping):
+        return None
+    return dict(safety_wrapper)
+
+
 def _predicate_event(
     predicates: Mapping[str, Any],
     predicate_key: str,
@@ -158,6 +170,7 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
         "heading_rate_sign_changes",
     )
     safety_predicates = _safety_predicate_records(record)
+    safety_wrapper = _safety_wrapper_summary(record)
     predicate_oscillation, predicate_oscillation_source = _predicate_event(
         safety_predicates,
         "oscillatory_control_predicate",
@@ -243,6 +256,8 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
         provenance={"source": "episode_record"},
     )
     payload = ledger.to_dict()
+    if safety_wrapper is not None:
+        payload["provenance"]["safety_wrapper"] = safety_wrapper
     if safety_predicates:
         payload["surrogate_events"].update(safety_predicates)
     payload["reconciliation"]["audit_result"] = (

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -2246,6 +2246,7 @@ def _run_map_episode(  # noqa: PLR0913
     tracking_precision: dict[str, Any] | None = None,
     synthetic_actuation_profile: dict[str, Any] | None = None,
     latency_stress_profile: dict[str, Any] | None = None,
+    safety_wrapper: dict[str, Any] | None = None,
     record_planner_decision_trace: bool = False,
     record_simulation_step_trace: bool = False,
 ) -> dict[str, Any]:
@@ -2279,6 +2280,7 @@ def _run_map_episode(  # noqa: PLR0913
         tracking_precision=tracking_precision,
         synthetic_actuation_profile=synthetic_actuation_profile,
         latency_stress_profile=latency_stress_profile,
+        safety_wrapper=safety_wrapper,
         record_planner_decision_trace=record_planner_decision_trace,
         record_simulation_step_trace=record_simulation_step_trace,
         policy_builder=_build_policy,
@@ -2446,6 +2448,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     tracking_precision: dict[str, Any] | None = None,
     synthetic_actuation_profile: dict[str, Any] | None = None,
     latency_stress_profile: dict[str, Any] | None = None,
+    safety_wrapper: dict[str, Any] | None = None,
     record_simulation_step_trace: bool = False,
     workers: int = 1,
     resume: bool = True,
@@ -2796,6 +2799,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                         if latency_profile is not None
                         else None
                     ),
+                    safety_wrapper=dict(safety_wrapper) if safety_wrapper is not None else None,
                     record_simulation_step_trace=record_simulation_step_trace,
                 )
                 if _compute_map_episode_id(identity_payload, seed) not in existing:
@@ -2833,6 +2837,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
         latency_stress_metrics=(
             not_available_latency_metrics() if latency_profile is not None else None
         ),
+        safety_wrapper=dict(safety_wrapper) if safety_wrapper is not None else None,
         record_simulation_step_trace=record_simulation_step_trace,
     )
 

--- a/robot_sf/benchmark/map_runner_batch_plan.py
+++ b/robot_sf/benchmark/map_runner_batch_plan.py
@@ -68,6 +68,7 @@ def build_worker_fixed_params(  # noqa: PLR0913
     actuation_profile_metadata: dict[str, Any] | None,
     latency_profile_metadata: dict[str, Any] | None,
     latency_stress_metrics: dict[str, Any] | None,
+    safety_wrapper: dict[str, Any] | None,
     record_simulation_step_trace: bool,
 ) -> dict[str, Any]:
     """Build the serialized parameter payload shared by all map workers.
@@ -98,5 +99,6 @@ def build_worker_fixed_params(  # noqa: PLR0913
         "synthetic_actuation_profile": actuation_profile_metadata,
         "latency_stress_profile": latency_profile_metadata,
         "latency_stress_metrics": latency_stress_metrics,
+        "safety_wrapper": safety_wrapper,
         "record_simulation_step_trace": bool(record_simulation_step_trace),
     }

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -104,6 +104,11 @@ from robot_sf.benchmark.safety_predicates import (
     occlusion_near_miss_predicate,
     oscillatory_control_predicate,
 )
+from robot_sf.benchmark.safety_wrapper_runtime import (
+    apply_runtime_safety_wrapper,
+    runtime_config_from_mapping,
+    summarize_safety_wrapper_trace,
+)
 from robot_sf.benchmark.synthetic_actuation import (
     SyntheticActuationController,
     not_available_saturation_metrics,
@@ -435,6 +440,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     tracking_precision: dict[str, Any] | None = None,
     synthetic_actuation_profile: dict[str, Any] | None = None,
     latency_stress_profile: dict[str, Any] | None = None,
+    safety_wrapper: dict[str, Any] | None = None,
     record_planner_decision_trace: bool = False,
     record_simulation_step_trace: bool = False,
     policy_builder: PolicyBuilder,
@@ -469,7 +475,9 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         seed=seed,
         scenario_id=scenario_id,
     )
+    safety_wrapper_runtime = runtime_config_from_mapping(safety_wrapper)
     tracking_precision_records: list[dict[str, Any]] = []
+    safety_wrapper_trace: list[dict[str, Any]] = []
     min_separation_corrupted_values: list[float] = []
     config = _build_env_config(scenario, scenario_path=scenario_path)
     max_steps = int(scenario.get("simulation_config", {}).get("max_episode_steps", 0) or 0)
@@ -698,6 +706,37 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                     *tuple(policy_command[2:]),
                 )
                 tracking_precision_records.append(tracking_record)
+            if safety_wrapper_runtime.enabled:
+                if step_is_native:
+                    if safety_wrapper_runtime.fail_on_native_action:
+                        raise ValueError(
+                            "safety_wrapper.enabled requires absolute commands; "
+                            "native environment actions cannot be wrapped safely"
+                        )
+                elif (
+                    not isinstance(policy_command, (tuple, list, np.ndarray))
+                    or len(policy_command) < 2
+                ):
+                    if safety_wrapper_runtime.fail_on_unsupported_command:
+                        raise TypeError(
+                            "safety_wrapper.enabled expects commands shaped like "
+                            "(linear_velocity, angular_velocity)"
+                        )
+                else:
+                    corrected_command, wrapper_record = apply_runtime_safety_wrapper(
+                        command=policy_command,
+                        env=env,
+                        config=config,
+                        runtime=safety_wrapper_runtime,
+                        previous_ped_positions=previous_trace_ped_pos,
+                        step_idx=step_idx,
+                    )
+                    policy_command = (
+                        corrected_command[0],
+                        corrected_command[1],
+                        *tuple(policy_command[2:]),
+                    )
+                    safety_wrapper_trace.append(wrapper_record)
             selected_action_payload = _command_action_payload(policy_command)
             ammv_command_actions.append(selected_action_payload)
             if step_is_native:
@@ -1099,6 +1138,13 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     if tracking_precision_records:
         tracking_precision_summary["last_step"] = dict(tracking_precision_records[-1])
     algo_meta["tracking_precision"] = tracking_precision_summary
+    safety_wrapper_summary: dict[str, Any] | None = None
+    if safety_wrapper_runtime.enabled:
+        safety_wrapper_summary = summarize_safety_wrapper_trace(
+            safety_wrapper_trace,
+            runtime=safety_wrapper_runtime,
+        )
+        algo_meta["safety_wrapper"] = safety_wrapper_summary
     intent_summary = _intent_conditioned_behavior_summary(
         scenario,
         single_pedestrian_intent_metadata,
@@ -1162,6 +1208,8 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         tracking_precision_summary["contract_honored_rate"]
     )
     metrics["tracking_target_motp_m"] = float(tracking_precision_spec["target_motp_m"])
+    if safety_wrapper_summary is not None:
+        metrics["wrapper_intervention_rate"] = float(safety_wrapper_summary["intervention_rate"])
 
     ts_end = datetime.now(UTC).isoformat()
     scenario_params = _scenario_identity_payload(
@@ -1185,6 +1233,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             if latency_profile is not None
             else None
         ),
+        safety_wrapper=dict(safety_wrapper) if safety_wrapper is not None else None,
         record_simulation_step_trace=record_simulation_step_trace,
     )
     steps_taken = int(robot_pos_arr.shape[0])

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -106,6 +106,7 @@ from robot_sf.benchmark.safety_predicates import (
 )
 from robot_sf.benchmark.safety_wrapper_runtime import (
     apply_runtime_safety_wrapper,
+    ineligible_safety_wrapper_step_record,
     runtime_config_from_mapping,
     summarize_safety_wrapper_trace,
 )
@@ -713,6 +714,13 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                             "safety_wrapper.enabled requires absolute commands; "
                             "native environment actions cannot be wrapped safely"
                         )
+                    safety_wrapper_trace.append(
+                        ineligible_safety_wrapper_step_record(
+                            runtime=safety_wrapper_runtime,
+                            step_idx=step_idx,
+                            reason="native_environment_action",
+                        )
+                    )
                 elif (
                     not isinstance(policy_command, (tuple, list, np.ndarray))
                     or len(policy_command) < 2
@@ -722,6 +730,13 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                             "safety_wrapper.enabled expects commands shaped like "
                             "(linear_velocity, angular_velocity)"
                         )
+                    safety_wrapper_trace.append(
+                        ineligible_safety_wrapper_step_record(
+                            runtime=safety_wrapper_runtime,
+                            step_idx=step_idx,
+                            reason="unsupported_command_shape",
+                        )
+                    )
                 else:
                     corrected_command, wrapper_record = apply_runtime_safety_wrapper(
                         command=policy_command,

--- a/robot_sf/benchmark/map_runner_identity.py
+++ b/robot_sf/benchmark/map_runner_identity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from dataclasses import asdict
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -14,6 +15,7 @@ from robot_sf.benchmark.observation_noise import (
     normalize_observation_noise_spec,
     observation_noise_hash,
 )
+from robot_sf.benchmark.safety_wrapper_runtime import runtime_config_from_mapping
 from robot_sf.benchmark.tracking_precision_contract import (
     normalize_tracking_precision_spec,
     tracking_precision_hash,
@@ -125,8 +127,10 @@ def _scenario_identity_payload(  # noqa: C901,PLR0913
         payload["synthetic_actuation_profile"] = dict(synthetic_actuation_profile)
     if latency_stress_profile is not None:
         payload["latency_stress_profile"] = dict(latency_stress_profile)
-    if safety_wrapper is not None and bool(safety_wrapper.get("enabled", False)):
-        payload["safety_wrapper"] = dict(safety_wrapper)
+    if safety_wrapper is not None:
+        resolved_safety_wrapper = runtime_config_from_mapping(safety_wrapper)
+        if resolved_safety_wrapper.enabled:
+            payload["safety_wrapper"] = asdict(resolved_safety_wrapper)
     payload["record_simulation_step_trace"] = bool(record_simulation_step_trace)
     if horizon is not None and int(horizon) > 0:
         payload["run_horizon"] = int(horizon)

--- a/robot_sf/benchmark/map_runner_identity.py
+++ b/robot_sf/benchmark/map_runner_identity.py
@@ -86,6 +86,7 @@ def _scenario_identity_payload(  # noqa: C901,PLR0913
     tracking_precision: dict[str, Any] | None = None,
     synthetic_actuation_profile: dict[str, Any] | None = None,
     latency_stress_profile: dict[str, Any] | None = None,
+    safety_wrapper: dict[str, Any] | None = None,
     record_simulation_step_trace: bool = False,
 ) -> dict[str, Any]:
     """Build the canonical scenario payload used for episode identity.
@@ -124,6 +125,8 @@ def _scenario_identity_payload(  # noqa: C901,PLR0913
         payload["synthetic_actuation_profile"] = dict(synthetic_actuation_profile)
     if latency_stress_profile is not None:
         payload["latency_stress_profile"] = dict(latency_stress_profile)
+    if safety_wrapper is not None and bool(safety_wrapper.get("enabled", False)):
+        payload["safety_wrapper"] = dict(safety_wrapper)
     payload["record_simulation_step_trace"] = bool(record_simulation_step_trace)
     if horizon is not None and int(horizon) > 0:
         payload["run_horizon"] = int(horizon)

--- a/robot_sf/benchmark/map_runner_worker.py
+++ b/robot_sf/benchmark/map_runner_worker.py
@@ -70,5 +70,6 @@ def execute_map_job(
         tracking_precision=params.get("tracking_precision"),
         synthetic_actuation_profile=params.get("synthetic_actuation_profile"),
         latency_stress_profile=params.get("latency_stress_profile"),
+        safety_wrapper=params.get("safety_wrapper"),
         record_simulation_step_trace=bool(params.get("record_simulation_step_trace", False)),
     )

--- a/robot_sf/benchmark/safety_wrapper_runtime.py
+++ b/robot_sf/benchmark/safety_wrapper_runtime.py
@@ -1,0 +1,361 @@
+"""Runtime binding helpers for the planner-agnostic safety wrapper.
+
+The runtime layer is intentionally opt-in and planner-agnostic. It constructs the
+pre-step :class:`robot_sf.robot.safety_wrapper.SafetyContext` from simulator
+state that is already visible to benchmark execution, applies the pure wrapper
+transform, and returns compact schema-tagged records for episode evidence.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+from robot_sf.robot.safety_wrapper import (
+    INTERVENTION_DISABLED,
+    INTERVENTION_HARD_STOP,
+    INTERVENTION_NONE,
+    INTERVENTION_SPEED_CAP,
+    SafetyContext,
+    SafetyWrapperConfig,
+    apply_safety_wrapper,
+)
+
+SAFETY_WRAPPER_RUNTIME_STEP_SCHEMA = "safety_wrapper_runtime_step.v1"
+SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA = "safety_wrapper_episode_summary.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class SafetyWrapperRuntimeConfig:
+    """Explicit opt-in runtime configuration for benchmark wrapper binding."""
+
+    enabled: bool = False
+    arm_key: str = "wrapper_off"
+    pedestrian_caution_radius_m: float = 2.0
+    capped_speed_m_s: float = 0.5
+    ttc_veto_threshold_s: float = 1.0
+    clearance_veto_m: float = 0.3
+    fail_on_native_action: bool = True
+    fail_on_unsupported_command: bool = True
+    record_step_trace: bool = False
+    false_stop_lookahead_s: float = 2.0
+
+
+def runtime_config_from_mapping(
+    payload: Mapping[str, Any] | None,
+) -> SafetyWrapperRuntimeConfig:
+    """Normalize optional mapping input into runtime config.
+
+    ``None`` and empty mappings keep the wrapper disabled, preserving benchmark
+    behavior unless a caller explicitly opts in.
+
+    Returns:
+        Runtime config with fixed thresholds and fail-closed controls.
+    """
+
+    if payload is None:
+        return SafetyWrapperRuntimeConfig()
+    if not isinstance(payload, Mapping):
+        raise TypeError("safety_wrapper must be a mapping or None")
+    allowed = {field.name for field in SafetyWrapperRuntimeConfig.__dataclass_fields__.values()}
+    unknown = sorted(set(payload) - allowed)
+    if unknown:
+        raise ValueError(f"Unknown safety_wrapper keys: {unknown}")
+    return SafetyWrapperRuntimeConfig(**{key: payload[key] for key in payload})
+
+
+def safety_wrapper_config(runtime: SafetyWrapperRuntimeConfig) -> SafetyWrapperConfig:
+    """Return the pure wrapper config with fixed predeclared thresholds."""
+
+    return SafetyWrapperConfig(
+        enabled=bool(runtime.enabled),
+        pedestrian_caution_radius_m=float(runtime.pedestrian_caution_radius_m),
+        capped_speed_m_s=float(runtime.capped_speed_m_s),
+        ttc_veto_threshold_s=float(runtime.ttc_veto_threshold_s),
+        clearance_veto_m=float(runtime.clearance_veto_m),
+    )
+
+
+def _xy_rows(value: Any) -> np.ndarray:
+    """Return a ``(n, 2)`` float array, accepting empty simulator buffers."""
+
+    arr = np.asarray(value, dtype=float)
+    if arr.size == 0:
+        return np.empty((0, 2), dtype=float)
+    return arr.reshape((-1, 2))[:, :2]
+
+
+def _robot_position(env: Any) -> np.ndarray:
+    simulator = getattr(env, "simulator", None)
+    return np.asarray(simulator.robot_pos[0], dtype=float)[:2]
+
+
+def _pedestrian_positions(env: Any) -> np.ndarray:
+    simulator = getattr(env, "simulator", None)
+    return _xy_rows(getattr(simulator, "ped_pos", np.empty((0, 2), dtype=float)))
+
+
+def _robot_heading(env: Any) -> float:
+    simulator = getattr(env, "simulator", None)
+    robots = getattr(simulator, "robots", None)
+    if isinstance(robots, list) and robots:
+        pose = getattr(robots[0], "pose", None)
+        if pose is not None and len(pose) >= 3:
+            return float(pose[2])
+    heading = getattr(simulator, "robot_theta", None)
+    if heading is not None:
+        arr = np.asarray(heading, dtype=float).reshape(-1)
+        if arr.size:
+            return float(arr[0])
+    return 0.0
+
+
+def _radius(config: Any, *names: str, default: float) -> float:
+    sim_config = getattr(config, "sim_config", None)
+    for name in names:
+        value = getattr(sim_config, name, None)
+        if isinstance(value, (int, float)) and math.isfinite(float(value)):
+            return max(0.0, float(value))
+    return float(default)
+
+
+def _pedestrian_velocities(
+    current_positions: np.ndarray,
+    previous_positions: np.ndarray | None,
+    dt: float,
+) -> np.ndarray:
+    if previous_positions is None or not dt > 0.0:
+        return np.zeros_like(current_positions, dtype=float)
+    previous = _xy_rows(previous_positions)
+    velocities = np.zeros_like(current_positions, dtype=float)
+    count = min(current_positions.shape[0], previous.shape[0])
+    if count:
+        velocities[:count] = (current_positions[:count] - previous[:count]) / float(dt)
+    return velocities
+
+
+def _min_positive_ttc(
+    *,
+    robot_pos: np.ndarray,
+    robot_velocity: np.ndarray,
+    ped_positions: np.ndarray,
+    ped_velocities: np.ndarray,
+) -> float | None:
+    min_ttc: float | None = None
+    for ped_pos, ped_velocity in zip(ped_positions, ped_velocities, strict=False):
+        relative_pos = np.asarray(ped_pos, dtype=float) - robot_pos
+        relative_velocity = np.asarray(ped_velocity, dtype=float) - robot_velocity
+        speed_sq = float(np.dot(relative_velocity, relative_velocity))
+        if speed_sq <= 1.0e-12:
+            continue
+        closing = float(np.dot(relative_pos, relative_velocity))
+        if closing >= 0.0:
+            continue
+        ttc = -closing / speed_sq
+        if ttc > 0.0 and (min_ttc is None or ttc < min_ttc):
+            min_ttc = float(ttc)
+    return min_ttc
+
+
+def compute_safety_context_from_env(
+    *,
+    env: Any,
+    config: Any,
+    command: Sequence[float],
+    previous_ped_positions: np.ndarray | None,
+    dt: float,
+) -> tuple[SafetyContext, dict[str, Any]]:
+    """Build pre-step safety context from simulator state.
+
+    Definitions:
+    ``min_pedestrian_distance_m`` is the current center-to-center distance to
+    the nearest pedestrian, or ``math.inf`` when no pedestrians exist.
+    ``min_clearance_m`` is the one-step predicted surface clearance against
+    pedestrians, subtracting robot and pedestrian radii. Obstacle samples are not
+    consumed in this runtime slice, so provenance records pedestrians as the only
+    clearance source.
+    ``min_ttc_s`` is the minimum positive time to closest approach under the
+    commanded robot velocity and finite-difference pedestrian velocity. It is
+    ``None`` when relative motion is not closing or unavailable.
+
+    Returns:
+        Safety context plus provenance for the context calculation.
+    """
+
+    robot_pos = _robot_position(env)
+    ped_positions = _pedestrian_positions(env)
+    if len(command) < 2:
+        raise TypeError("safety_wrapper command must contain at least (linear, angular)")
+    linear_velocity = float(command[0])
+    heading = _robot_heading(env)
+    robot_velocity = np.array(
+        [linear_velocity * math.cos(heading), linear_velocity * math.sin(heading)],
+        dtype=float,
+    )
+    ped_velocities = _pedestrian_velocities(ped_positions, previous_ped_positions, dt)
+    robot_radius = _radius(config, "robot_radius", default=1.0)
+    ped_radius = _radius(config, "ped_radius", "pedestrian_radius", default=0.4)
+    radius_sum = robot_radius + ped_radius
+
+    if ped_positions.size:
+        distances = np.linalg.norm(ped_positions - robot_pos, axis=1)
+        min_pedestrian_distance = float(np.min(distances))
+        next_robot_pos = robot_pos + robot_velocity * float(dt)
+        next_ped_positions = ped_positions + ped_velocities * float(dt)
+        next_distances = np.linalg.norm(next_ped_positions - next_robot_pos, axis=1)
+        min_clearance = float(np.min(next_distances) - radius_sum)
+    else:
+        min_pedestrian_distance = math.inf
+        min_clearance = math.inf
+
+    context = SafetyContext(
+        min_pedestrian_distance_m=min_pedestrian_distance,
+        min_clearance_m=min_clearance,
+        min_ttc_s=_min_positive_ttc(
+            robot_pos=robot_pos,
+            robot_velocity=robot_velocity,
+            ped_positions=ped_positions,
+            ped_velocities=ped_velocities,
+        ),
+    )
+    provenance = {
+        "context_source": "simulator_state_pre_step",
+        "ttc_source": "finite_difference_pedestrian_velocity",
+        "clearance_sources": ["pedestrians"],
+        "robot_radius_m": robot_radius,
+        "pedestrian_radius_m": ped_radius,
+        "pedestrian_count": int(ped_positions.shape[0]),
+    }
+    return context, provenance
+
+
+def apply_runtime_safety_wrapper(
+    *,
+    command: Sequence[float],
+    env: Any,
+    config: Any,
+    runtime: SafetyWrapperRuntimeConfig,
+    previous_ped_positions: np.ndarray | None,
+    step_idx: int,
+) -> tuple[tuple[float, float], dict[str, Any]]:
+    """Apply the opt-in wrapper to a two-component absolute command.
+
+    Returns:
+        Corrected ``(linear, angular)`` command plus schema-tagged step record.
+    """
+
+    context, context_provenance = compute_safety_context_from_env(
+        env=env,
+        config=config,
+        command=command,
+        previous_ped_positions=previous_ped_positions,
+        dt=float(config.sim_config.time_per_step_in_secs),
+    )
+    wrapper_record = apply_safety_wrapper(
+        float(command[0]),
+        float(command[1]),
+        context,
+        safety_wrapper_config(runtime),
+    )
+    wrapper_schema_version = wrapper_record.pop("schema_version", None)
+    step_record = {
+        "schema_version": SAFETY_WRAPPER_RUNTIME_STEP_SCHEMA,
+        "wrapper_schema_version": wrapper_schema_version,
+        "step": int(step_idx),
+        "arm_key": str(runtime.arm_key),
+        "enabled": bool(runtime.enabled),
+        "eligible_for_wrapper": True,
+        **context_provenance,
+        **wrapper_record,
+    }
+    corrected = (
+        float(wrapper_record["corrected_linear_velocity"]),
+        float(wrapper_record["corrected_angular_velocity"]),
+    )
+    return corrected, step_record
+
+
+def summarize_safety_wrapper_trace(
+    trace: Sequence[Mapping[str, Any]],
+    *,
+    runtime: SafetyWrapperRuntimeConfig | None = None,
+) -> dict[str, Any]:
+    """Summarize per-step wrapper evidence for episode metadata and ledger provenance.
+
+    Returns:
+        Compact episode-level safety-wrapper intervention summary.
+    """
+
+    runtime = runtime or SafetyWrapperRuntimeConfig()
+    counts = Counter(str(record.get("intervention", INTERVENTION_DISABLED)) for record in trace)
+    intervened_records = [record for record in trace if bool(record.get("intervened", False))]
+    speed_cap_steps = [
+        int(record["step"])
+        for record in trace
+        if record.get("intervention") == INTERVENTION_SPEED_CAP and "step" in record
+    ]
+    hard_stop_steps = [
+        int(record["step"])
+        for record in trace
+        if record.get("intervention") == INTERVENTION_HARD_STOP and "step" in record
+    ]
+    clearances = [
+        float(record["context"]["min_clearance_m"])
+        for record in trace
+        if isinstance(record.get("context"), Mapping)
+        and math.isfinite(float(record["context"]["min_clearance_m"]))
+    ]
+    ttcs = [
+        float(record["context"]["min_ttc_s"])
+        for record in trace
+        if isinstance(record.get("context"), Mapping)
+        and record["context"].get("min_ttc_s") is not None
+        and math.isfinite(float(record["context"]["min_ttc_s"]))
+    ]
+    thresholds = asdict(safety_wrapper_config(runtime))
+    step_count = len(trace)
+    summary: dict[str, Any] = {
+        "schema_version": SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA,
+        "arm_key": str(runtime.arm_key),
+        "enabled": bool(runtime.enabled),
+        "thresholds_source": "predeclared_fixed_no_per_planner_tuning",
+        "thresholds": thresholds,
+        "false_stop_lookahead_s": float(runtime.false_stop_lookahead_s),
+        "step_count": int(step_count),
+        "eligible_step_count": int(step_count),
+        "intervention_counts": {
+            INTERVENTION_DISABLED: int(counts.get(INTERVENTION_DISABLED, 0)),
+            INTERVENTION_NONE: int(counts.get(INTERVENTION_NONE, 0)),
+            INTERVENTION_SPEED_CAP: int(counts.get(INTERVENTION_SPEED_CAP, 0)),
+            INTERVENTION_HARD_STOP: int(counts.get(INTERVENTION_HARD_STOP, 0)),
+        },
+        "intervened_step_count": len(intervened_records),
+        "intervention_rate": float(len(intervened_records) / step_count) if step_count else 0.0,
+        "first_intervention_step": (
+            int(intervened_records[0]["step"]) if intervened_records else None
+        ),
+        "first_speed_cap_step": min(speed_cap_steps) if speed_cap_steps else None,
+        "first_hard_stop_step": min(hard_stop_steps) if hard_stop_steps else None,
+        "min_context_clearance_m": min(clearances) if clearances else None,
+        "min_context_ttc_s": min(ttcs) if ttcs else None,
+    }
+    if runtime.record_step_trace:
+        summary["step_trace"] = [dict(record) for record in trace]
+    return summary
+
+
+__all__ = [
+    "SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA",
+    "SAFETY_WRAPPER_RUNTIME_STEP_SCHEMA",
+    "SafetyWrapperRuntimeConfig",
+    "apply_runtime_safety_wrapper",
+    "compute_safety_context_from_env",
+    "runtime_config_from_mapping",
+    "safety_wrapper_config",
+    "summarize_safety_wrapper_trace",
+]

--- a/robot_sf/benchmark/safety_wrapper_runtime.py
+++ b/robot_sf/benchmark/safety_wrapper_runtime.py
@@ -124,6 +124,21 @@ def _radius(config: Any, *names: str, default: float) -> float:
     return float(default)
 
 
+def _robot_radius(config: Any) -> float:
+    robot_config = getattr(config, "robot_config", None)
+    robot_config_radius = getattr(robot_config, "radius", None)
+    return _radius(
+        config,
+        "robot_radius",
+        default=(
+            float(robot_config_radius)
+            if isinstance(robot_config_radius, (int, float))
+            and math.isfinite(float(robot_config_radius))
+            else 1.0
+        ),
+    )
+
+
 def _pedestrian_velocities(
     current_positions: np.ndarray,
     previous_positions: np.ndarray | None,
@@ -198,7 +213,7 @@ def compute_safety_context_from_env(
         dtype=float,
     )
     ped_velocities = _pedestrian_velocities(ped_positions, previous_ped_positions, dt)
-    robot_radius = _radius(config, "robot_radius", default=1.0)
+    robot_radius = _robot_radius(config)
     ped_radius = _radius(config, "ped_radius", "pedestrian_radius", default=0.4)
     radius_sum = robot_radius + ped_radius
 
@@ -280,6 +295,28 @@ def apply_runtime_safety_wrapper(
     return corrected, step_record
 
 
+def ineligible_safety_wrapper_step_record(
+    *,
+    runtime: SafetyWrapperRuntimeConfig,
+    step_idx: int,
+    reason: str,
+) -> dict[str, Any]:
+    """Return a schema-tagged wrapper trace record for fail-open ineligible steps."""
+
+    return {
+        "schema_version": SAFETY_WRAPPER_RUNTIME_STEP_SCHEMA,
+        "wrapper_schema_version": None,
+        "step": int(step_idx),
+        "arm_key": str(runtime.arm_key),
+        "enabled": bool(runtime.enabled),
+        "eligible_for_wrapper": False,
+        "ineligible_reason": str(reason),
+        "intervention": INTERVENTION_DISABLED,
+        "intervened": False,
+        "context": None,
+    }
+
+
 def summarize_safety_wrapper_trace(
     trace: Sequence[Mapping[str, Any]],
     *,
@@ -319,6 +356,9 @@ def summarize_safety_wrapper_trace(
     ]
     thresholds = asdict(safety_wrapper_config(runtime))
     step_count = len(trace)
+    eligible_step_count = sum(
+        1 for record in trace if bool(record.get("eligible_for_wrapper", True))
+    )
     summary: dict[str, Any] = {
         "schema_version": SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA,
         "arm_key": str(runtime.arm_key),
@@ -327,7 +367,7 @@ def summarize_safety_wrapper_trace(
         "thresholds": thresholds,
         "false_stop_lookahead_s": float(runtime.false_stop_lookahead_s),
         "step_count": int(step_count),
-        "eligible_step_count": int(step_count),
+        "eligible_step_count": int(eligible_step_count),
         "intervention_counts": {
             INTERVENTION_DISABLED: int(counts.get(INTERVENTION_DISABLED, 0)),
             INTERVENTION_NONE: int(counts.get(INTERVENTION_NONE, 0)),
@@ -355,6 +395,7 @@ __all__ = [
     "SafetyWrapperRuntimeConfig",
     "apply_runtime_safety_wrapper",
     "compute_safety_context_from_env",
+    "ineligible_safety_wrapper_step_record",
     "runtime_config_from_mapping",
     "safety_wrapper_config",
     "summarize_safety_wrapper_trace",

--- a/robot_sf/benchmark/safety_wrapper_runtime.py
+++ b/robot_sf/benchmark/safety_wrapper_runtime.py
@@ -28,6 +28,15 @@ from robot_sf.robot.safety_wrapper import (
 
 SAFETY_WRAPPER_RUNTIME_STEP_SCHEMA = "safety_wrapper_runtime_step.v1"
 SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA = "safety_wrapper_episode_summary.v1"
+WRAPPER_OFF_ARM = "wrapper_off"
+WRAPPER_ON_ARM = "wrapper_on"
+_PREDECLARED_WRAPPER_CONFIG = SafetyWrapperConfig()
+_PREDECLARED_THRESHOLD_FIELDS = (
+    "pedestrian_caution_radius_m",
+    "capped_speed_m_s",
+    "ttc_veto_threshold_s",
+    "clearance_veto_m",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -66,7 +75,38 @@ def runtime_config_from_mapping(
     unknown = sorted(set(payload) - allowed)
     if unknown:
         raise ValueError(f"Unknown safety_wrapper keys: {unknown}")
-    return SafetyWrapperRuntimeConfig(**{key: payload[key] for key in payload})
+    return validate_runtime_config(
+        SafetyWrapperRuntimeConfig(**{key: payload[key] for key in payload})
+    )
+
+
+def validate_runtime_config(runtime: SafetyWrapperRuntimeConfig) -> SafetyWrapperRuntimeConfig:
+    """Validate runtime wrapper arm semantics against predeclared ablation contract.
+
+    Returns:
+        Validated runtime config unchanged.
+    """
+
+    arm_key = str(runtime.arm_key)
+    if arm_key not in {WRAPPER_OFF_ARM, WRAPPER_ON_ARM}:
+        raise ValueError(
+            "safety_wrapper.arm_key must be wrapper_off or wrapper_on; "
+            "threshold changes require a versioned experimental arm"
+        )
+    if bool(runtime.enabled) and arm_key != WRAPPER_ON_ARM:
+        raise ValueError("safety_wrapper.enabled=True requires arm_key='wrapper_on'")
+    if not bool(runtime.enabled) and arm_key != WRAPPER_OFF_ARM:
+        raise ValueError("safety_wrapper.enabled=False requires arm_key='wrapper_off'")
+    if bool(runtime.enabled):
+        for field_name in _PREDECLARED_THRESHOLD_FIELDS:
+            observed = float(getattr(runtime, field_name))
+            expected = float(getattr(_PREDECLARED_WRAPPER_CONFIG, field_name))
+            if not math.isclose(observed, expected, rel_tol=0.0, abs_tol=1.0e-12):
+                raise ValueError(
+                    "safety_wrapper.wrapper_on thresholds must match "
+                    f"predeclared ablation config: {field_name}={expected}"
+                )
+    return runtime
 
 
 def safety_wrapper_config(runtime: SafetyWrapperRuntimeConfig) -> SafetyWrapperConfig:
@@ -82,17 +122,36 @@ def safety_wrapper_config(runtime: SafetyWrapperRuntimeConfig) -> SafetyWrapperC
 
 
 def _xy_rows(value: Any) -> np.ndarray:
-    """Return a ``(n, 2)`` float array, accepting empty simulator buffers."""
+    """Return finite ``(n, 2)`` rows from simulator pedestrian state."""
 
     arr = np.asarray(value, dtype=float)
     if arr.size == 0:
         return np.empty((0, 2), dtype=float)
-    return arr.reshape((-1, 2))[:, :2]
+    if not np.all(np.isfinite(arr)):
+        raise ValueError("safety_wrapper simulator pedestrian positions must be finite")
+    if arr.ndim == 1:
+        if arr.size % 2:
+            raise ValueError("safety_wrapper pedestrian positions require even-length flat xy data")
+        rows = arr.reshape((-1, 2))
+    elif arr.ndim == 2 and arr.shape[1] >= 2:
+        rows = arr[:, :2]
+    else:
+        raise ValueError("safety_wrapper pedestrian positions must be shaped (n,2) or (n,3)")
+    return np.asarray(rows, dtype=float)
 
 
 def _robot_position(env: Any) -> np.ndarray:
     simulator = getattr(env, "simulator", None)
-    return np.asarray(simulator.robot_pos[0], dtype=float)[:2]
+    if simulator is None or not hasattr(simulator, "robot_pos"):
+        raise ValueError("safety_wrapper requires simulator.robot_pos")
+    robot_pos = simulator.robot_pos
+    try:
+        arr = np.asarray(robot_pos[0], dtype=float).reshape(-1)
+    except (IndexError, TypeError, ValueError) as exc:
+        raise ValueError("safety_wrapper requires simulator.robot_pos[0] xy position") from exc
+    if arr.size < 2 or not np.all(np.isfinite(arr[:2])):
+        raise ValueError("safety_wrapper robot_pos must contain finite xy coordinates")
+    return arr[:2]
 
 
 def _pedestrian_positions(env: Any) -> np.ndarray:
@@ -144,7 +203,9 @@ def _pedestrian_velocities(
     previous_positions: np.ndarray | None,
     dt: float,
 ) -> np.ndarray:
-    if previous_positions is None or not dt > 0.0:
+    if not dt > 0.0:
+        raise ValueError("safety_wrapper dt must be positive for pre-step context")
+    if previous_positions is None:
         return np.zeros_like(current_positions, dtype=float)
     previous = _xy_rows(previous_positions)
     velocities = np.zeros_like(current_positions, dtype=float)
@@ -202,6 +263,8 @@ def compute_safety_context_from_env(
         Safety context plus provenance for the context calculation.
     """
 
+    if not dt > 0.0:
+        raise ValueError("safety_wrapper dt must be positive for pre-step context")
     robot_pos = _robot_position(env)
     ped_positions = _pedestrian_positions(env)
     if len(command) < 2:
@@ -241,6 +304,7 @@ def compute_safety_context_from_env(
     provenance = {
         "context_source": "simulator_state_pre_step",
         "ttc_source": "finite_difference_pedestrian_velocity",
+        "pedestrian_velocity_identity": "row_order_finite_difference_no_stable_ids",
         "clearance_sources": ["pedestrians"],
         "robot_radius_m": robot_radius,
         "pedestrian_radius_m": ped_radius,
@@ -366,6 +430,7 @@ def summarize_safety_wrapper_trace(
         "thresholds_source": "predeclared_fixed_no_per_planner_tuning",
         "thresholds": thresholds,
         "false_stop_lookahead_s": float(runtime.false_stop_lookahead_s),
+        "false_stop_analysis_supported": False,
         "step_count": int(step_count),
         "eligible_step_count": int(eligible_step_count),
         "intervention_counts": {

--- a/tests/benchmark/test_event_ledger.py
+++ b/tests/benchmark/test_event_ledger.py
@@ -96,6 +96,25 @@ def test_build_event_ledger_preserves_safety_predicate_records() -> None:
     assert surrogate_events["occlusion_near_miss_predicate"] == {"occlusion_near_miss": False}
 
 
+def test_build_event_ledger_preserves_safety_wrapper_provenance() -> None:
+    """Safety-wrapper summaries should survive in ledger provenance."""
+
+    record = _record(collision_event=False, collisions=0.0)
+    record["algorithm_metadata"] = {
+        "safety_wrapper": {
+            "schema_version": "safety_wrapper_episode_summary.v1",
+            "arm_key": "wrapper_on",
+            "enabled": True,
+            "intervened_step_count": 2,
+            "intervention_rate": 0.5,
+        }
+    }
+
+    ledger = build_event_ledger(record)
+
+    assert ledger["provenance"]["safety_wrapper"] == record["algorithm_metadata"]["safety_wrapper"]
+
+
 def test_build_event_ledger_predicate_without_event_key_falls_back_to_metric() -> None:
     """A predicate record lacking its event key must not claim a source or override the metric."""
     record = _record(collision_event=False, collisions=0.0)

--- a/tests/benchmark/test_map_runner_resume_identity.py
+++ b/tests/benchmark/test_map_runner_resume_identity.py
@@ -341,6 +341,44 @@ def test_scenario_identity_ignores_disabled_safety_wrapper() -> None:
     assert wrapper_on != baseline
 
 
+def test_scenario_identity_normalizes_enabled_safety_wrapper_defaults() -> None:
+    """Resume identity hashes effective wrapper-on runtime config."""
+
+    scenario = _minimal_map_scenario()
+
+    minimal = map_runner._scenario_identity_payload(
+        scenario,
+        algo="goal",
+        algo_config={},
+        horizon=None,
+        dt=None,
+        record_forces=True,
+        safety_wrapper={"enabled": True, "arm_key": "wrapper_on"},
+    )
+    explicit_defaults = map_runner._scenario_identity_payload(
+        scenario,
+        algo="goal",
+        algo_config={},
+        horizon=None,
+        dt=None,
+        record_forces=True,
+        safety_wrapper={
+            "enabled": True,
+            "arm_key": "wrapper_on",
+            "pedestrian_caution_radius_m": 2.0,
+            "capped_speed_m_s": 0.5,
+            "ttc_veto_threshold_s": 1.0,
+            "clearance_veto_m": 0.3,
+            "fail_on_native_action": True,
+            "fail_on_unsupported_command": True,
+            "record_step_trace": False,
+            "false_stop_lookahead_s": 2.0,
+        },
+    )
+
+    assert minimal == explicit_defaults
+
+
 def test_scenario_identity_includes_observation_noise_hash() -> None:
     """Resume identity should distinguish clean and observation-noisy benchmark runs."""
     scenario = _minimal_map_scenario()

--- a/tests/benchmark/test_map_runner_resume_identity.py
+++ b/tests/benchmark/test_map_runner_resume_identity.py
@@ -306,6 +306,41 @@ def test_scenario_identity_ignores_seed_schedule_fields() -> None:
     assert episode_a == episode_b
 
 
+def test_scenario_identity_ignores_disabled_safety_wrapper() -> None:
+    """Disabled safety-wrapper config must not change wrapper-off episode identity."""
+
+    scenario = _minimal_map_scenario()
+    baseline = map_runner._scenario_identity_payload(
+        scenario,
+        algo="goal",
+        algo_config={},
+        horizon=None,
+        dt=None,
+        record_forces=True,
+    )
+    wrapper_off = map_runner._scenario_identity_payload(
+        scenario,
+        algo="goal",
+        algo_config={},
+        horizon=None,
+        dt=None,
+        record_forces=True,
+        safety_wrapper={"enabled": False, "arm_key": "wrapper_off"},
+    )
+    wrapper_on = map_runner._scenario_identity_payload(
+        scenario,
+        algo="goal",
+        algo_config={},
+        horizon=None,
+        dt=None,
+        record_forces=True,
+        safety_wrapper={"enabled": True, "arm_key": "wrapper_on"},
+    )
+
+    assert wrapper_off == baseline
+    assert wrapper_on != baseline
+
+
 def test_scenario_identity_includes_observation_noise_hash() -> None:
     """Resume identity should distinguish clean and observation-noisy benchmark runs."""
     scenario = _minimal_map_scenario()

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -189,6 +189,7 @@ def test_map_batch_plan_builds_worker_fixed_params(tmp_path: Path) -> None:
         actuation_profile_metadata={"name": "actuation"},
         latency_profile_metadata={"name": "latency"},
         latency_stress_metrics={"held_action_ratio": "not_available"},
+        safety_wrapper={"enabled": True, "arm_key": "wrapper_on"},
         record_simulation_step_trace=True,
     )
 
@@ -209,6 +210,7 @@ def test_map_batch_plan_builds_worker_fixed_params(tmp_path: Path) -> None:
     assert fixed_params["synthetic_actuation_profile"] == {"name": "actuation"}
     assert fixed_params["latency_stress_profile"] == {"name": "latency"}
     assert fixed_params["latency_stress_metrics"] == {"held_action_ratio": "not_available"}
+    assert fixed_params["safety_wrapper"] == {"enabled": True, "arm_key": "wrapper_on"}
     assert fixed_params["record_simulation_step_trace"] is True
 
 

--- a/tests/benchmark/test_safety_wrapper_runtime.py
+++ b/tests/benchmark/test_safety_wrapper_runtime.py
@@ -1,0 +1,220 @@
+"""Tests for opt-in benchmark runtime safety-wrapper binding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark import map_runner_episode
+from robot_sf.benchmark.event_ledger import build_event_ledger
+from robot_sf.benchmark.safety_wrapper_runtime import (
+    SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA,
+    SAFETY_WRAPPER_RUNTIME_STEP_SCHEMA,
+    apply_runtime_safety_wrapper,
+    runtime_config_from_mapping,
+    summarize_safety_wrapper_trace,
+)
+from robot_sf.robot.safety_wrapper import INTERVENTION_HARD_STOP
+
+
+class _Robot:
+    pose = np.array([0.0, 0.0, 0.0], dtype=float)
+
+
+class _Simulator:
+    def __init__(self) -> None:
+        self.robot_pos = [np.array([0.0, 0.0], dtype=float)]
+        self.ped_pos = np.array([[0.2, 0.0]], dtype=float)
+        self.robots = [_Robot()]
+
+
+class _Env:
+    def __init__(self) -> None:
+        self.simulator = _Simulator()
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        sim_config=SimpleNamespace(
+            time_per_step_in_secs=0.1,
+            robot_radius=0.1,
+            ped_radius=0.1,
+        )
+    )
+
+
+def _policy_builder(*_args, **_kwargs):
+    def policy(_obs):
+        return (1.0, 0.25)
+
+    return policy, {"algorithm": "unit"}
+
+
+class _EpisodeSim:
+    def __init__(self) -> None:
+        self.robot_pos = [np.array([0.0, 0.0], dtype=float)]
+        self.goal_pos = [np.array([1.0, 0.0], dtype=float)]
+        self.ped_pos = np.array([[0.2, 0.0]], dtype=float)
+        self.last_ped_forces = np.zeros((1, 2), dtype=float)
+        self.map_def = SimpleNamespace(obstacles=[], bounds=(0.0, 0.0, 2.0, 2.0))
+
+
+class _EpisodeEnv:
+    def __init__(self) -> None:
+        self.simulator = _EpisodeSim()
+        self.action_space = None
+
+    def reset(self, seed=None):
+        return {
+            "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+            "goal": {"current": [1.0, 0.0]},
+            "pedestrians": {"positions": self.simulator.ped_pos},
+        }, {}
+
+    def step(self, _action):
+        return self.reset()[0], 0.0, True, False, {"meta": {"is_route_complete": True}}
+
+    def close(self) -> None:
+        return None
+
+
+def _patch_episode_runtime(monkeypatch) -> None:
+    monkeypatch.setattr(
+        map_runner_episode,
+        "_build_env_config",
+        lambda _scenario, scenario_path: _config(),
+    )
+    monkeypatch.setattr(
+        map_runner_episode,
+        "make_robot_env",
+        lambda config, seed, debug: _EpisodeEnv(),
+    )
+    monkeypatch.setattr(map_runner_episode, "sample_obstacle_points", lambda *args: None)
+    monkeypatch.setattr(map_runner_episode, "compute_shortest_path_length", lambda *args: 1.0)
+    monkeypatch.setattr(
+        map_runner_episode,
+        "compute_all_metrics",
+        lambda *args, **kwargs: {"success": 1.0, "collisions": 0.0},
+    )
+    monkeypatch.setattr(
+        map_runner_episode,
+        "post_process_metrics",
+        lambda metrics, **kwargs: metrics,
+    )
+
+
+def _run_episode_with_policy(monkeypatch, policy_builder, *, safety_wrapper):
+    _patch_episode_runtime(monkeypatch)
+    return map_runner_episode.run_map_episode(
+        {"name": "wrapper-runtime", "simulation_config": {"max_episode_steps": 1}},
+        seed=1,
+        horizon=1,
+        dt=0.1,
+        record_forces=False,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo="goal",
+        scenario_path=Path(__file__),
+        safety_wrapper=safety_wrapper,
+        policy_builder=policy_builder,
+    )
+
+
+def test_runtime_config_disabled_by_default_preserves_off_state() -> None:
+    """Missing runtime config keeps wrapper disabled and therefore opt-in only."""
+
+    runtime = runtime_config_from_mapping(None)
+
+    assert runtime.enabled is False
+    assert runtime.arm_key == "wrapper_off"
+
+
+def test_wrapper_on_emits_schema_tagged_intervention_record_and_summary() -> None:
+    """A close pre-step pedestrian produces well-formed wrapper evidence."""
+
+    runtime = runtime_config_from_mapping({"enabled": True, "arm_key": "wrapper_on"})
+    corrected, record = apply_runtime_safety_wrapper(
+        command=(1.0, 0.25),
+        env=_Env(),
+        config=_config(),
+        runtime=runtime,
+        previous_ped_positions=None,
+        step_idx=3,
+    )
+
+    assert corrected == (0.0, 0.25)
+    assert record["schema_version"] == SAFETY_WRAPPER_RUNTIME_STEP_SCHEMA
+    assert record["arm_key"] == "wrapper_on"
+    assert record["enabled"] is True
+    assert record["eligible_for_wrapper"] is True
+    assert record["context_source"] == "simulator_state_pre_step"
+    assert record["clearance_sources"] == ["pedestrians"]
+    assert record["intervention"] == INTERVENTION_HARD_STOP
+    assert record["intervened"] is True
+
+    summary = summarize_safety_wrapper_trace([record], runtime=runtime)
+    assert summary["schema_version"] == SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA
+    assert summary["intervened_step_count"] == 1
+    assert summary["intervention_rate"] == 1.0
+    assert summary["first_hard_stop_step"] == 3
+    assert summary["min_context_clearance_m"] <= 0.0
+
+
+def test_run_map_episode_records_wrapper_metadata_when_enabled(monkeypatch) -> None:
+    """Runtime binding emits episode and ledger-ready evidence only when enabled."""
+
+    record = _run_episode_with_policy(
+        monkeypatch,
+        _policy_builder,
+        safety_wrapper={"enabled": True, "arm_key": "wrapper_on"},
+    )
+
+    summary = record["algorithm_metadata"]["safety_wrapper"]
+    assert summary["schema_version"] == SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA
+    assert summary["intervened_step_count"] == 1
+    assert record["metrics"]["wrapper_intervention_rate"] == 1.0
+
+    ledger = build_event_ledger(record)
+    assert ledger["provenance"]["safety_wrapper"] == summary
+
+
+def test_run_map_episode_fails_closed_for_native_action_when_wrapper_enabled(
+    monkeypatch,
+) -> None:
+    """Native env actions must not be silently transformed by wrapper-on runs."""
+
+    def native_policy_builder(*_args, **_kwargs):
+        def policy(_obs):
+            return np.array([0.1, 0.0], dtype=float)
+
+        policy._last_step_native = True
+        return policy, {"algorithm": "unit"}
+
+    with pytest.raises(ValueError, match="native environment actions"):
+        _run_episode_with_policy(
+            monkeypatch,
+            native_policy_builder,
+            safety_wrapper={"enabled": True, "arm_key": "wrapper_on"},
+        )
+
+
+def test_run_map_episode_fails_closed_for_unsupported_command_when_wrapper_enabled(
+    monkeypatch,
+) -> None:
+    """Unsupported structured commands fail closed under wrapper-on by default."""
+
+    def unsupported_policy_builder(*_args, **_kwargs):
+        def policy(_obs):
+            return {"command_kind": "unsupported"}
+
+        return policy, {"algorithm": "unit"}
+
+    with pytest.raises(TypeError, match="expects commands shaped"):
+        _run_episode_with_policy(
+            monkeypatch,
+            unsupported_policy_builder,
+            safety_wrapper={"enabled": True, "arm_key": "wrapper_on"},
+        )

--- a/tests/benchmark/test_safety_wrapper_runtime.py
+++ b/tests/benchmark/test_safety_wrapper_runtime.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import math
 from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
-from robot_sf.benchmark import map_runner_episode
+from robot_sf.benchmark import map_runner_episode, safety_wrapper_runtime
 from robot_sf.benchmark.event_ledger import build_event_ledger
 from robot_sf.benchmark.safety_wrapper_runtime import (
     SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA,
@@ -19,7 +20,7 @@ from robot_sf.benchmark.safety_wrapper_runtime import (
     runtime_config_from_mapping,
     summarize_safety_wrapper_trace,
 )
-from robot_sf.robot.safety_wrapper import INTERVENTION_HARD_STOP
+from robot_sf.robot.safety_wrapper import INTERVENTION_HARD_STOP, INTERVENTION_NONE
 
 
 class _Robot:
@@ -164,6 +165,7 @@ def test_wrapper_on_emits_schema_tagged_intervention_record_and_summary() -> Non
     assert record["eligible_for_wrapper"] is True
     assert record["context_source"] == "simulator_state_pre_step"
     assert record["clearance_sources"] == ["pedestrians"]
+    assert record["pedestrian_velocity_identity"] == "row_order_finite_difference_no_stable_ids"
     assert record["intervention"] == INTERVENTION_HARD_STOP
     assert record["intervened"] is True
 
@@ -173,6 +175,170 @@ def test_wrapper_on_emits_schema_tagged_intervention_record_and_summary() -> Non
     assert summary["intervention_rate"] == 1.0
     assert summary["first_hard_stop_step"] == 3
     assert summary["min_context_clearance_m"] <= 0.0
+    assert summary["false_stop_analysis_supported"] is False
+
+
+@pytest.mark.parametrize(
+    "payload,match",
+    [
+        ({"enabled": True, "arm_key": "wrapper_off"}, "enabled=True"),
+        ({"enabled": False, "arm_key": "wrapper_on"}, "enabled=False"),
+        ({"enabled": True, "arm_key": "wrapper_on_v2"}, "versioned experimental arm"),
+        (
+            {"enabled": True, "arm_key": "wrapper_on", "capped_speed_m_s": 0.25},
+            "predeclared ablation config",
+        ),
+    ],
+)
+def test_runtime_config_fails_closed_for_arm_or_threshold_drift(
+    payload: dict[str, object], match: str
+) -> None:
+    """Wrapper-on semantics must match the predeclared ablation arm."""
+
+    with pytest.raises(ValueError, match=match):
+        runtime_config_from_mapping(payload)
+
+
+@pytest.mark.parametrize(
+    "ped_pos,expected_count",
+    [
+        (np.array([[1.0, 0.0], [2.0, 0.0]], dtype=float), 2),
+        (np.array([[1.0, 0.0, 7.0], [2.0, 0.0, 8.0]], dtype=float), 2),
+        (np.empty((0, 2), dtype=float), 0),
+        (np.array([1.0, 0.0, 2.0, 0.0], dtype=float), 2),
+    ],
+)
+def test_context_accepts_supported_pedestrian_position_shapes(
+    ped_pos: np.ndarray, expected_count: int
+) -> None:
+    """Runtime parser accepts xy rows, xyz rows, empty rows, and even flat xy."""
+
+    env = _Env()
+    env.simulator.ped_pos = ped_pos
+
+    context, provenance = compute_safety_context_from_env(
+        env=env,
+        config=_config(),
+        command=(0.0, 0.0),
+        previous_ped_positions=None,
+        dt=0.1,
+    )
+
+    assert provenance["pedestrian_count"] == expected_count
+    if expected_count == 0:
+        assert math.isinf(context.min_pedestrian_distance_m)
+        assert math.isinf(context.min_clearance_m)
+
+
+@pytest.mark.parametrize(
+    "ped_pos,match",
+    [
+        (np.array([1.0, 0.0, 2.0], dtype=float), "even-length flat"),
+        (np.array([[1.0, np.nan]], dtype=float), "finite"),
+    ],
+)
+def test_context_rejects_malformed_or_nonfinite_pedestrian_positions(
+    ped_pos: np.ndarray, match: str
+) -> None:
+    """Malformed simulator pedestrian state fails closed."""
+
+    env = _Env()
+    env.simulator.ped_pos = ped_pos
+
+    with pytest.raises(ValueError, match=match):
+        compute_safety_context_from_env(
+            env=env,
+            config=_config(),
+            command=(0.0, 0.0),
+            previous_ped_positions=None,
+            dt=0.1,
+        )
+
+
+@pytest.mark.parametrize(
+    "robot_pos,match",
+    [
+        ([], "robot_pos"),
+        ([np.array([math.inf, 0.0], dtype=float)], "finite xy"),
+    ],
+)
+def test_context_rejects_missing_or_nonfinite_robot_position(
+    robot_pos: list[np.ndarray], match: str
+) -> None:
+    """Robot xy position is required for pre-step context construction."""
+
+    env = _Env()
+    env.simulator.robot_pos = robot_pos
+
+    with pytest.raises(ValueError, match=match):
+        compute_safety_context_from_env(
+            env=env,
+            config=_config(),
+            command=(0.0, 0.0),
+            previous_ped_positions=None,
+            dt=0.1,
+        )
+
+
+def test_no_pedestrian_episode_has_infinite_clearance_and_no_intervention() -> None:
+    """No-pedestrian context stays hazard-free and does not invent an intervention."""
+
+    env = _Env()
+    env.simulator.ped_pos = np.empty((0, 2), dtype=float)
+    runtime = runtime_config_from_mapping({"enabled": True, "arm_key": "wrapper_on"})
+
+    corrected, record = apply_runtime_safety_wrapper(
+        command=(1.0, 0.25),
+        env=env,
+        config=_config(),
+        runtime=runtime,
+        previous_ped_positions=None,
+        step_idx=0,
+    )
+
+    assert corrected == (1.0, 0.25)
+    assert math.isinf(record["context"]["min_pedestrian_distance_m"])
+    assert math.isinf(record["context"]["min_clearance_m"])
+    assert record["context"]["min_ttc_s"] is None
+    assert record["intervention"] == INTERVENTION_NONE
+    assert record["intervened"] is False
+
+
+def test_non_closing_relative_velocity_has_no_ttc() -> None:
+    """TTC is undefined when pedestrian motion is not closing on the robot."""
+
+    env = _Env()
+    env.simulator.ped_pos = np.array([[2.0, 0.0]], dtype=float)
+
+    context, _ = compute_safety_context_from_env(
+        env=env,
+        config=_config(),
+        command=(0.0, 0.0),
+        previous_ped_positions=np.array([[1.9, 0.0]], dtype=float),
+        dt=0.1,
+    )
+
+    assert context.min_ttc_s is None
+
+
+def test_nonpositive_dt_fails_closed() -> None:
+    """Runtime context construction requires a positive timestep."""
+
+    with pytest.raises(ValueError, match="dt must be positive"):
+        compute_safety_context_from_env(
+            env=_Env(),
+            config=_config(),
+            command=(0.0, 0.0),
+            previous_ped_positions=None,
+            dt=0.0,
+        )
+
+
+def test_xy_rows_rejects_unsupported_2d_shape() -> None:
+    """Direct parser fixture covers non-xy table shapes before context use."""
+
+    with pytest.raises(ValueError, match="shaped"):
+        safety_wrapper_runtime._xy_rows(np.array([[1.0], [2.0]], dtype=float))
 
 
 def test_context_uses_robot_config_radius_when_sim_radius_absent() -> None:

--- a/tests/benchmark/test_safety_wrapper_runtime.py
+++ b/tests/benchmark/test_safety_wrapper_runtime.py
@@ -14,6 +14,8 @@ from robot_sf.benchmark.safety_wrapper_runtime import (
     SAFETY_WRAPPER_EPISODE_SUMMARY_SCHEMA,
     SAFETY_WRAPPER_RUNTIME_STEP_SCHEMA,
     apply_runtime_safety_wrapper,
+    compute_safety_context_from_env,
+    ineligible_safety_wrapper_step_record,
     runtime_config_from_mapping,
     summarize_safety_wrapper_trace,
 )
@@ -43,6 +45,16 @@ def _config() -> SimpleNamespace:
             robot_radius=0.1,
             ped_radius=0.1,
         )
+    )
+
+
+def _config_with_robot_config_radius() -> SimpleNamespace:
+    return SimpleNamespace(
+        sim_config=SimpleNamespace(
+            time_per_step_in_secs=0.1,
+            ped_radius=0.1,
+        ),
+        robot_config=SimpleNamespace(radius=0.5),
     )
 
 
@@ -161,6 +173,49 @@ def test_wrapper_on_emits_schema_tagged_intervention_record_and_summary() -> Non
     assert summary["intervention_rate"] == 1.0
     assert summary["first_hard_stop_step"] == 3
     assert summary["min_context_clearance_m"] <= 0.0
+
+
+def test_context_uses_robot_config_radius_when_sim_radius_absent() -> None:
+    """Runtime clearance should match the scenario robot radius source."""
+
+    context, provenance = compute_safety_context_from_env(
+        command=(0.0, 0.0),
+        env=_Env(),
+        config=_config_with_robot_config_radius(),
+        previous_ped_positions=None,
+        dt=0.1,
+    )
+
+    assert provenance["robot_radius_m"] == 0.5
+    assert context.min_clearance_m == pytest.approx(-0.4)
+
+
+def test_ineligible_step_records_count_in_summary_denominator() -> None:
+    """Fail-open ineligible wrapper steps should not disappear from rates."""
+
+    runtime = runtime_config_from_mapping({"enabled": True, "arm_key": "wrapper_on"})
+    wrapped = apply_runtime_safety_wrapper(
+        command=(1.0, 0.25),
+        env=_Env(),
+        config=_config(),
+        runtime=runtime,
+        previous_ped_positions=None,
+        step_idx=0,
+    )[1]
+    ineligible = ineligible_safety_wrapper_step_record(
+        runtime=runtime,
+        step_idx=1,
+        reason="unsupported_command_shape",
+    )
+
+    summary = summarize_safety_wrapper_trace([wrapped, ineligible], runtime=runtime)
+
+    assert ineligible["eligible_for_wrapper"] is False
+    assert ineligible["intervened"] is False
+    assert summary["step_count"] == 2
+    assert summary["eligible_step_count"] == 1
+    assert summary["intervened_step_count"] == 1
+    assert summary["intervention_rate"] == 0.5
 
 
 def test_run_map_episode_records_wrapper_metadata_when_enabled(monkeypatch) -> None:


### PR DESCRIPTION
## Reviewer-Critical Summary

- What changed: binds the planner-agnostic safety wrapper into map-runner runtime behind explicit opt-in `safety_wrapper` config, records per-step wrapper evidence, summarizes intervention metrics, and preserves wrapper provenance in the event ledger.
- Claim boundary: this PR proves runtime binding, fail-closed config validation, simulator-state context parsing, resume identity compatibility, and metadata honesty. It is not paired ablation evidence and does not claim mitigation effectiveness.
- Remaining blocker for issue #3501: execute and summarize the paired `planner x {wrapper_off, wrapper_on}` ablation campaign with durable evidence.
- Compatibility impact: wrapper-off behavior stays resume-compatible; wrapper-on resume identity now hashes the normalized effective runtime config. Metrics add `wrapper_intervention_rate`; event-ledger provenance includes the wrapper summary, row-order pedestrian-velocity limitation, and explicit `false_stop_analysis_supported: false`.

## Runtime-Risk Gate Outcome

- Semantic config validation: `enabled=False` requires `arm_key=wrapper_off`; `enabled=True` requires `arm_key=wrapper_on`; wrapper-on threshold overrides fail closed unless a future versioned arm is implemented.
- Simulator-state parsing: pedestrian `(n,2)`, `(n,3)`, empty, even-flat, malformed odd-flat, non-finite, robot missing/non-finite, no-pedestrian, non-closing time-to-collision, and `dt <= 0` cases are covered by focused tests.
- False-stop provenance: `false_stop_lookahead_s` remains stored for future report compatibility, and summaries now emit `false_stop_analysis_supported: false`.
- Reviewer-facing body: this summary is intentionally first; governance/history details are below.

## Validation

- `scripts/dev/ruff_fix_format.sh robot_sf/benchmark/safety_wrapper_runtime.py robot_sf/benchmark/map_runner_identity.py tests/benchmark/test_safety_wrapper_runtime.py tests/benchmark/test_map_runner_resume_identity.py`
- `uv run pytest tests/benchmark/test_safety_wrapper_runtime.py tests/benchmark/test_map_runner_resume_identity.py tests/benchmark/test_event_ledger.py tests/benchmark/test_map_runner_utils.py -q`
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh` passed after `uv sync --all-extras`; first attempt exposed missing `duckdb` in the fresh worktree optional-extra lane.
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr4137_body.md scripts/dev/pr_ready_check.sh` passed on committed head `0badcb56a1e99ab997500daba0529fe7471be191` with clean tree stamp `output/validation/pr_ready/pr-4137-runtime-binding-gate.json`.

<details>
<summary>Maintainer Plan Scope And Governance</summary>

Refs #3501.

Covered in this runtime-binding slice:

- Runtime binding behind explicit opt-in config.
- Pre-step simulator-state context construction.
- Episode-level wrapper intervention evidence.
- Event-ledger provenance preservation.
- Resume identity for wrapper-on effective runtime config.
- Fail-closed runtime config validation aligned with `configs/research/safety_wrapper_ablation_v1.yaml` defaults.

Remaining/out of scope:

- Paired ablation campaign execution.
- Effect-size report CLI outputs.
- Slurm or GPU submission.
- Safety, near-miss, or paper-facing mitigation claims.

Diagnostic caveat: wrapper thresholds are predeclared modeling choices. They remain diagnostic until durable paired evidence supports promotion.

</details>
