### PR TITLE
feat: uncertainty-aware safety conformal buffers + intrusion metrics (#3974)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+* Added **uncertainty-aware safety primitives** (#3974): conformal prediction buffers and
+  cumulative-intrusion metrics in new `robot_sf/benchmark/uncertainty_safety.py`. Split-conformal
+  (`split_conformal_radius`) and online Adaptive Conformal Inference (`adaptive_conformal_buffers`)
+  turn pedestrian-prediction residuals into per-step spatial buffers calibrated to a target
+  coverage, and `compute_intrusion_metrics` reports current-position / predicted-trajectory /
+  uncertainty-buffer intrusion time ratios plus cumulative and max intrusion depth over a run.
+  This is a bounded first slice: pure, versioned, fixture-tested computation labeled
+  **diagnostic** (no safety guarantee, no benchmark claim). The runtime uncertainty-triggered
+  fallback trigger is a deliberate successor slice and is not included.
 * Tightened the certified adversarial failure-archive readiness checker (#3275) so optional archive
   summary counts fail closed when they disagree with the actual `entries` or `clusters` payload.
 * Tightened the proxy checkpoint-selection readiness preflight (#3204) so registry entries with

--- a/robot_sf/benchmark/uncertainty_safety.py
+++ b/robot_sf/benchmark/uncertainty_safety.py
@@ -1,0 +1,372 @@
+"""Uncertainty-aware safety: conformal prediction buffers and intrusion metrics (issue #3974).
+
+Collision-only evaluation is a sparse, late signal, and point predictions of pedestrian
+futures ignore uncertainty. This module implements the *bounded first slice* of
+uncertainty-aware safety: it turns pedestrian-prediction residuals into calibrated spatial
+**buffers** around predicted futures, and measures how far a robot **intrudes** into those
+buffers over a run.
+
+Two conformal estimators are provided:
+
+* :func:`split_conformal_radius` -- offline split-conformal quantile of a fixed calibration
+  set. On exchangeable data its buffer marginally covers the true future with probability at
+  least the target, which is the acceptance signal for "empirical coverage approaches the
+  target on a calibration set".
+* :func:`adaptive_conformal_buffers` -- online Adaptive Conformal Inference (ACI,
+  Gibbs & Candes 2021) over a streaming residual sequence. It integrates the realized
+  miscoverage error to keep long-run coverage near the target even under distribution shift,
+  which is the SoNIC-style setting where residual statistics drift as the crowd changes.
+
+The intrusion metrics (:func:`compute_intrusion_metrics`) compare a robot trajectory to
+pedestrian current positions, point predictions, and uncertainty buffers, producing the
+time-ratio and cumulative-depth fields named in the issue.
+
+.. admonition:: Claim boundary
+   :class: note
+
+   These are **versioned modeling choices**, labeled diagnostic. Producing a conformal radius
+   or an intrusion ratio is not evidence of a safety guarantee, prediction quality, or planning
+   improvement; the residual sequences must be exchangeable/stationary for the marginal-coverage
+   property to hold, and any benchmark claim requires separate reproducible evidence per the
+   project's maintainer values. The runtime uncertainty-triggered fallback is a deliberate
+   successor slice and is intentionally *not* implemented here.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+import numpy as np
+
+from robot_sf.benchmark.finite_checks import require_finite_array, require_finite_scalar
+
+if TYPE_CHECKING:
+    from numpy.typing import NDArray
+
+SPLIT_CONFORMAL_RADIUS_SCHEMA = "uncertainty_safety.split_conformal_radius.v1"
+ADAPTIVE_CONFORMAL_BUFFERS_SCHEMA = "uncertainty_safety.adaptive_conformal_buffers.v1"
+INTRUSION_METRICS_SCHEMA = "uncertainty_safety.intrusion_metrics.v1"
+
+
+def residual_magnitudes(
+    predicted: NDArray[np.float64],
+    actual: NDArray[np.float64],
+) -> NDArray[np.float64]:
+    """Euclidean nonconformity scores between predicted and actual positions.
+
+    Args:
+        predicted: Predicted positions, shape ``(N, 2)``.
+        actual: Realized positions, shape ``(N, 2)``.
+
+    Returns:
+        Per-row residual magnitude ``||predicted - actual||``, shape ``(N,)``.
+
+    Raises:
+        ValueError: If shapes disagree or are not ``(N, 2)``.
+    """
+    pred = require_finite_array("predicted", predicted)
+    act = require_finite_array("actual", actual)
+    if pred.shape != act.shape:
+        raise ValueError("predicted and actual must share the same shape")
+    if pred.ndim != 2 or pred.shape[-1] != 2:
+        raise ValueError("predicted and actual must have shape (N, 2)")
+    return np.linalg.norm(pred - act, axis=-1)
+
+
+def split_conformal_radius(
+    calibration_residuals: NDArray[np.float64],
+    *,
+    coverage_target: float = 0.9,
+) -> float:
+    """Split-conformal buffer radius from a fixed calibration residual set.
+
+    Uses the finite-sample-corrected empirical quantile: with ``n`` calibration scores the
+    radius is the ``k``-th smallest score where ``k = ceil((n + 1) * coverage_target)``. On
+    exchangeable data a future residual falls within this radius with probability at least
+    ``coverage_target``. When ``k > n`` the target cannot be certified from the sample and the
+    radius is ``+inf`` (the buffer must be unbounded to promise that coverage).
+
+    Args:
+        calibration_residuals: Nonconformity scores, shape ``(n,)``, ``n >= 1``.
+        coverage_target: Desired marginal coverage in ``(0, 1)``.
+
+    Returns:
+        Buffer radius (metres), possibly ``math.inf``.
+
+    Raises:
+        ValueError: If ``coverage_target`` is out of range or the calibration set is empty.
+    """
+    if not 0.0 < coverage_target < 1.0:
+        raise ValueError("coverage_target must be between 0 and 1 (exclusive)")
+    scores = require_finite_array("calibration_residuals", calibration_residuals)
+    if scores.ndim != 1 or scores.size == 0:
+        raise ValueError("calibration_residuals must be a non-empty 1-D array")
+    ordered = np.sort(scores)
+    n = ordered.size
+    k = math.ceil((n + 1) * coverage_target)
+    if k > n:
+        return math.inf
+    return float(ordered[k - 1])
+
+
+@dataclass(frozen=True)
+class AdaptiveConformalConfig:
+    """Configuration for online Adaptive Conformal Inference.
+
+    Attributes:
+        coverage_target: Desired long-run coverage ``1 - alpha`` in ``(0, 1)``.
+        step_size: ACI learning rate ``gamma`` (> 0) for the miscoverage integrator. Larger
+            values track drift faster but let coverage oscillate more around the target.
+        window: Trailing residual-history length used to fit each radius. ``None`` uses all
+            past residuals.
+        min_history: Number of past residuals required before a buffer is emitted; earlier
+            steps are skipped (the radius is undefined without calibration data).
+    """
+
+    coverage_target: float = 0.9
+    step_size: float = 0.05
+    window: int | None = None
+    min_history: int = 1
+
+
+@dataclass(frozen=True)
+class AdaptiveConformalResult:
+    """Result of :func:`adaptive_conformal_buffers`.
+
+    Attributes:
+        indices: Residual indices for which a buffer was emitted (``min_history`` onward).
+        radii: Buffer radius used at each emitted index (may include ``inf``).
+        covered: Whether the realized residual fell within the radius at each emitted index.
+        alphas: Adaptive miscoverage level ``alpha_t`` in effect at each emitted index.
+        empirical_coverage: Fraction of emitted steps that were covered.
+        coverage_target: Echoed target for provenance.
+        schema: Versioned schema identifier.
+    """
+
+    indices: NDArray[np.int64]
+    radii: NDArray[np.float64]
+    covered: NDArray[np.bool_]
+    alphas: NDArray[np.float64]
+    empirical_coverage: float
+    coverage_target: float
+    schema: str = ADAPTIVE_CONFORMAL_BUFFERS_SCHEMA
+
+
+def _adaptive_radius(window_scores: NDArray[np.float64], *, effective_target: float) -> float:
+    """Radius from the trailing window at the current adaptive coverage level.
+
+    ACI lets ``alpha_t`` leave ``[0, 1]``; the corresponding coverage level is clamped so the
+    radius degrades gracefully to ``0`` (cover nothing) or ``+inf`` (cover everything).
+
+    Returns:
+        Buffer radius (metres) for the current step, possibly ``0.0`` or ``math.inf``.
+    """
+    if effective_target <= 0.0:
+        return 0.0
+    if effective_target >= 1.0:
+        return math.inf
+    return split_conformal_radius(window_scores, coverage_target=effective_target)
+
+
+def adaptive_conformal_buffers(
+    residuals: NDArray[np.float64],
+    *,
+    config: AdaptiveConformalConfig | None = None,
+) -> AdaptiveConformalResult:
+    """Online Adaptive Conformal Inference over a streaming residual sequence.
+
+    At each step ``t`` (once ``min_history`` residuals have been seen) the radius is the
+    ``(1 - alpha_t)`` split-conformal quantile of the trailing window. The realized residual is
+    then compared to the radius and the miscoverage level is integrated,
+    ``alpha_{t+1} = alpha_t + gamma * (alpha - err_t)`` with ``err_t = 1`` when the residual
+    exceeds the radius, driving the empirical coverage toward ``coverage_target``.
+
+    Args:
+        residuals: Temporally ordered nonconformity scores, shape ``(T,)``.
+        config: ACI configuration; defaults to :class:`AdaptiveConformalConfig`.
+
+    Returns:
+        An :class:`AdaptiveConformalResult` with per-step radii, coverage flags, and the
+        alpha trace.
+
+    Raises:
+        ValueError: If ``residuals`` is not 1-D, or the config values are invalid.
+    """
+    cfg = config or AdaptiveConformalConfig()
+    if not 0.0 < cfg.coverage_target < 1.0:
+        raise ValueError("coverage_target must be between 0 and 1 (exclusive)")
+    if cfg.step_size <= 0.0:
+        raise ValueError("step_size must be positive")
+    if cfg.min_history < 1:
+        raise ValueError("min_history must be at least 1")
+    if cfg.window is not None and cfg.window < 1:
+        raise ValueError("window must be None or a positive integer")
+
+    scores = require_finite_array("residuals", residuals)
+    if scores.ndim != 1:
+        raise ValueError("residuals must be a 1-D array")
+
+    alpha_target = 1.0 - cfg.coverage_target
+    alpha_t = alpha_target
+    indices: list[int] = []
+    radii: list[float] = []
+    covered: list[bool] = []
+    alphas: list[float] = []
+
+    for t in range(cfg.min_history, scores.size):
+        start = 0 if cfg.window is None else max(0, t - cfg.window)
+        window_scores = scores[start:t]
+        radius = _adaptive_radius(window_scores, effective_target=1.0 - alpha_t)
+        is_covered = bool(scores[t] <= radius)
+        err = 0.0 if is_covered else 1.0
+
+        indices.append(t)
+        radii.append(radius)
+        covered.append(is_covered)
+        alphas.append(alpha_t)
+
+        alpha_t = alpha_t + cfg.step_size * (alpha_target - err)
+
+    covered_arr = np.asarray(covered, dtype=bool)
+    empirical = float(covered_arr.mean()) if covered_arr.size else 0.0
+    return AdaptiveConformalResult(
+        indices=np.asarray(indices, dtype=np.int64),
+        radii=np.asarray(radii, dtype=np.float64),
+        covered=covered_arr,
+        alphas=np.asarray(alphas, dtype=np.float64),
+        empirical_coverage=empirical,
+        coverage_target=cfg.coverage_target,
+    )
+
+
+@dataclass(frozen=True)
+class IntrusionMetrics:
+    """Cumulative-intrusion safety metrics over a run (issue #3974).
+
+    Time ratios are the fraction of timesteps at which *any* pedestrian's relevant region is
+    intruded. Depths are measured against the uncertainty buffer (``base_radius`` plus the
+    conformal radius) around the predicted future position, in metres, aggregated over the run.
+
+    Attributes:
+        current_position_intrusion_time_ratio: Steps where the robot is within ``base_radius``
+            of a pedestrian's *current* position.
+        predicted_trajectory_intrusion_time_ratio: Steps where the robot is within
+            ``base_radius`` of a pedestrian's *predicted* position (point prediction).
+        uncertainty_buffer_intrusion_time_ratio: Steps where the robot is within the
+            uncertainty buffer around the predicted position.
+        cumulative_intrusion_depth: Sum over steps of the deepest per-step penetration into any
+            uncertainty buffer (metres).
+        max_intrusion_depth: Largest single-step penetration into any uncertainty buffer.
+        num_steps: Number of timesteps evaluated.
+        schema: Versioned schema identifier.
+    """
+
+    current_position_intrusion_time_ratio: float
+    predicted_trajectory_intrusion_time_ratio: float
+    uncertainty_buffer_intrusion_time_ratio: float
+    cumulative_intrusion_depth: float
+    max_intrusion_depth: float
+    num_steps: int
+    schema: str = INTRUSION_METRICS_SCHEMA
+
+
+def _broadcast_radii(
+    conformal_radii: NDArray[np.float64] | float,
+    *,
+    num_steps: int,
+    num_peds: int,
+) -> NDArray[np.float64]:
+    """Normalize conformal radii to a ``(T, P)`` array from scalar, ``(T,)``, or ``(T, P)``.
+
+    Returns:
+        Non-negative radii array with shape ``(num_steps, num_peds)``.
+    """
+    array = np.asarray(conformal_radii, dtype=np.float64)
+    if array.ndim == 0:
+        array = np.full((num_steps, num_peds), float(array))
+    elif array.ndim == 1:
+        if array.shape[0] != num_steps:
+            raise ValueError("1-D conformal_radii must have length num_steps")
+        array = np.repeat(array[:, None], num_peds, axis=1)
+    elif array.ndim == 2:
+        if array.shape != (num_steps, num_peds):
+            raise ValueError("2-D conformal_radii must have shape (num_steps, num_peds)")
+    else:
+        raise ValueError("conformal_radii must be scalar, (T,), or (T, P)")
+    if np.any(array < 0.0):
+        raise ValueError("conformal_radii must be non-negative")
+    return array
+
+
+def compute_intrusion_metrics(
+    robot_positions: NDArray[np.float64],
+    pedestrian_positions: NDArray[np.float64],
+    predicted_positions: NDArray[np.float64],
+    conformal_radii: NDArray[np.float64] | float,
+    *,
+    base_radius: float,
+) -> IntrusionMetrics:
+    """Compute cumulative-intrusion safety metrics against conformal buffers.
+
+    Args:
+        robot_positions: Robot positions, shape ``(T, 2)``.
+        pedestrian_positions: Pedestrian *current* positions, shape ``(T, P, 2)``.
+        predicted_positions: Predicted pedestrian positions relevant at each step, shape
+            ``(T, P, 2)``. The caller aligns the prediction horizon; this function is
+            horizon-agnostic.
+        conformal_radii: Uncertainty-buffer radius added to ``base_radius`` around each
+            predicted position. Scalar, ``(T,)``, or ``(T, P)``; non-negative.
+        base_radius: Personal-space radius (metres, > 0) that defines a bare intrusion.
+
+    Returns:
+        Populated :class:`IntrusionMetrics`.
+
+    Raises:
+        ValueError: On shape mismatches, non-positive ``base_radius``, or bad radii.
+    """
+    base = require_finite_scalar("base_radius", base_radius)
+    if base <= 0.0:
+        raise ValueError("base_radius must be positive")
+
+    robot = require_finite_array("robot_positions", robot_positions)
+    if robot.ndim != 2 or robot.shape[-1] != 2:
+        raise ValueError("robot_positions must have shape (T, 2)")
+    num_steps = robot.shape[0]
+
+    peds = require_finite_array("pedestrian_positions", pedestrian_positions)
+    preds = require_finite_array("predicted_positions", predicted_positions)
+    for name, arr in (("pedestrian_positions", peds), ("predicted_positions", preds)):
+        if arr.ndim != 3 or arr.shape[0] != num_steps or arr.shape[-1] != 2:
+            raise ValueError(f"{name} must have shape (T, P, 2) matching robot_positions")
+    if peds.shape[1] != preds.shape[1]:
+        raise ValueError("pedestrian_positions and predicted_positions must share P")
+    num_peds = peds.shape[1]
+
+    if num_peds == 0:
+        return IntrusionMetrics(0.0, 0.0, 0.0, 0.0, 0.0, num_steps=num_steps)
+
+    buffer_radii = _broadcast_radii(conformal_radii, num_steps=num_steps, num_peds=num_peds)
+
+    robot_exp = robot[:, None, :]  # (T, 1, 2) broadcasts over pedestrians
+    dist_actual = np.linalg.norm(robot_exp - peds, axis=-1)  # (T, P)
+    dist_pred = np.linalg.norm(robot_exp - preds, axis=-1)  # (T, P)
+    buffer = base + buffer_radii  # (T, P)
+
+    current_intruded = dist_actual <= base  # (T, P)
+    predicted_intruded = dist_pred <= base
+    buffer_intruded = dist_pred <= buffer
+
+    # Per-step depth is the deepest penetration into any pedestrian's uncertainty buffer.
+    depth = np.clip(buffer - dist_pred, 0.0, None)  # (T, P)
+    step_depth = depth.max(axis=1)  # (T,)
+
+    return IntrusionMetrics(
+        current_position_intrusion_time_ratio=float(current_intruded.any(axis=1).mean()),
+        predicted_trajectory_intrusion_time_ratio=float(predicted_intruded.any(axis=1).mean()),
+        uncertainty_buffer_intrusion_time_ratio=float(buffer_intruded.any(axis=1).mean()),
+        cumulative_intrusion_depth=float(step_depth.sum()),
+        max_intrusion_depth=float(step_depth.max()),
+        num_steps=num_steps,
+    )

--- a/tests/benchmark/test_uncertainty_safety.py
+++ b/tests/benchmark/test_uncertainty_safety.py
@@ -1,0 +1,227 @@
+"""Tests for uncertainty-aware safety buffers and intrusion metrics (issue #3974)."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark.uncertainty_safety import (
+    ADAPTIVE_CONFORMAL_BUFFERS_SCHEMA,
+    INTRUSION_METRICS_SCHEMA,
+    SPLIT_CONFORMAL_RADIUS_SCHEMA,
+    AdaptiveConformalConfig,
+    adaptive_conformal_buffers,
+    compute_intrusion_metrics,
+    residual_magnitudes,
+    split_conformal_radius,
+)
+
+# --------------------------------------------------------------------------- residuals
+
+
+def test_residual_magnitudes_matches_euclidean_norm() -> None:
+    """Residual magnitude equals the Euclidean distance between the two point sets."""
+    predicted = np.array([[0.0, 0.0], [1.0, 0.0], [0.0, 3.0]])
+    actual = np.array([[0.0, 0.0], [4.0, 0.0], [0.0, 0.0]])
+    residuals = residual_magnitudes(predicted, actual)
+    np.testing.assert_allclose(residuals, [0.0, 3.0, 3.0])
+
+
+def test_residual_magnitudes_rejects_shape_mismatch() -> None:
+    """Mismatched predicted/actual shapes fail closed."""
+    with pytest.raises(ValueError, match="same shape"):
+        residual_magnitudes(np.zeros((3, 2)), np.zeros((2, 2)))
+
+
+# ------------------------------------------------------------------- split conformal
+
+
+def test_split_conformal_radius_finite_sample_index() -> None:
+    """Radius is the finite-sample-corrected k-th smallest calibration score."""
+    # n=9 residuals 1..9; k = ceil(10 * 0.9) = 9 -> 9th smallest = 9.0.
+    scores = np.arange(1.0, 10.0)
+    assert split_conformal_radius(scores, coverage_target=0.9) == 9.0
+
+
+def test_split_conformal_radius_infinite_when_target_unreachable() -> None:
+    """When the sample cannot certify the target the radius is +inf."""
+    # n=5, k = ceil(6 * 0.9) = 6 > 5 -> cannot certify -> +inf.
+    scores = np.arange(1.0, 6.0)
+    assert split_conformal_radius(scores, coverage_target=0.9) == math.inf
+
+
+def test_split_conformal_radius_covers_target_on_holdout() -> None:
+    """On exchangeable data the calibrated radius covers held-out samples near the target."""
+    rng = np.random.default_rng(1234)
+    target = 0.9
+    covered = 0
+    trials = 400
+    for _ in range(trials):
+        calibration = np.abs(rng.normal(size=200))
+        holdout = abs(float(rng.normal()))
+        radius = split_conformal_radius(calibration, coverage_target=target)
+        covered += int(holdout <= radius)
+    empirical = covered / trials
+    # Guarantee is coverage >= target; allow a modest sampling band.
+    assert empirical >= target - 0.05
+    assert empirical <= target + 0.08
+
+
+@pytest.mark.parametrize("bad_target", [0.0, 1.0, -0.1, 1.5])
+def test_split_conformal_radius_rejects_bad_target(bad_target: float) -> None:
+    """Coverage targets outside (0, 1) fail closed."""
+    with pytest.raises(ValueError, match="coverage_target"):
+        split_conformal_radius(np.arange(1.0, 5.0), coverage_target=bad_target)
+
+
+def test_split_conformal_radius_rejects_empty() -> None:
+    """An empty calibration set fails closed."""
+    with pytest.raises(ValueError, match="non-empty"):
+        split_conformal_radius(np.array([]), coverage_target=0.9)
+
+
+def test_split_conformal_schema_constant() -> None:
+    """The split-conformal schema identifier is stable and versioned."""
+    assert SPLIT_CONFORMAL_RADIUS_SCHEMA == "uncertainty_safety.split_conformal_radius.v1"
+
+
+# --------------------------------------------------------------- adaptive conformal
+
+
+def test_adaptive_conformal_emits_from_min_history() -> None:
+    """Buffers are emitted from ``min_history`` onward, one per remaining step."""
+    residuals = np.arange(1.0, 11.0)
+    cfg = AdaptiveConformalConfig(coverage_target=0.9, step_size=0.05, min_history=3)
+    result = adaptive_conformal_buffers(residuals, config=cfg)
+    assert result.indices[0] == 3
+    assert result.indices.tolist() == list(range(3, 10))
+    assert result.radii.shape == result.covered.shape == result.alphas.shape
+    assert result.schema == ADAPTIVE_CONFORMAL_BUFFERS_SCHEMA
+
+
+def test_adaptive_conformal_coverage_approaches_target_under_drift() -> None:
+    """ACI tracks the target coverage even when the residual scale drifts upward."""
+    # This is the SoNIC-style non-stationary setting where a fixed radius would fail.
+    rng = np.random.default_rng(7)
+    steps = 4000
+    scale = np.linspace(1.0, 4.0, steps)
+    residuals = np.abs(rng.normal(size=steps)) * scale
+    cfg = AdaptiveConformalConfig(coverage_target=0.9, step_size=0.05, window=200, min_history=50)
+    result = adaptive_conformal_buffers(residuals, config=cfg)
+    assert abs(result.empirical_coverage - 0.9) < 0.03
+
+
+def test_adaptive_conformal_higher_target_yields_larger_radii() -> None:
+    """A higher coverage target yields larger mean radii and no lower empirical coverage."""
+    rng = np.random.default_rng(3)
+    residuals = np.abs(rng.normal(size=1000))
+    low = adaptive_conformal_buffers(
+        residuals, config=AdaptiveConformalConfig(coverage_target=0.8, window=200)
+    )
+    high = adaptive_conformal_buffers(
+        residuals, config=AdaptiveConformalConfig(coverage_target=0.95, window=200)
+    )
+    assert np.mean(high.radii) >= np.mean(low.radii)
+    assert high.empirical_coverage >= low.empirical_coverage - 1e-9
+
+
+def test_adaptive_conformal_rejects_bad_config() -> None:
+    """Invalid ACI configuration and non-1-D residuals fail closed."""
+    with pytest.raises(ValueError, match="step_size"):
+        adaptive_conformal_buffers(np.arange(5.0), config=AdaptiveConformalConfig(step_size=0.0))
+    with pytest.raises(ValueError, match="min_history"):
+        adaptive_conformal_buffers(np.arange(5.0), config=AdaptiveConformalConfig(min_history=0))
+    with pytest.raises(ValueError, match="1-D"):
+        adaptive_conformal_buffers(np.zeros((3, 2)))
+
+
+# ------------------------------------------------------------------ intrusion metrics
+
+
+def _line(points: list[tuple[float, float]]) -> np.ndarray:
+    """Build a ``(T, 2)`` trajectory array from a list of points."""
+    return np.asarray(points, dtype=np.float64)
+
+
+def test_intrusion_metrics_clear_run_has_zero_intrusion() -> None:
+    """A run with the robot far from the pedestrian reports zero intrusion everywhere."""
+    robot = _line([(0.0, 0.0), (0.0, 1.0), (0.0, 2.0)])
+    peds = robot.reshape(3, 1, 2) + np.array([100.0, 0.0])
+    preds = peds.copy()
+    metrics = compute_intrusion_metrics(robot, peds, preds, 0.5, base_radius=1.0)
+    assert metrics.current_position_intrusion_time_ratio == 0.0
+    assert metrics.predicted_trajectory_intrusion_time_ratio == 0.0
+    assert metrics.uncertainty_buffer_intrusion_time_ratio == 0.0
+    assert metrics.cumulative_intrusion_depth == 0.0
+    assert metrics.max_intrusion_depth == 0.0
+    assert metrics.num_steps == 3
+    assert metrics.schema == INTRUSION_METRICS_SCHEMA
+
+
+def test_intrusion_metrics_buffer_widens_intrusion_ratio() -> None:
+    """Adding a conformal buffer turns a near-miss into a counted buffer intrusion."""
+    # Robot sits 1.2 m from the predicted pedestrian position every step.
+    robot = _line([(0.0, 0.0), (0.0, 0.0)])
+    peds = np.array([[[1.2, 0.0]], [[1.2, 0.0]]])
+    preds = peds.copy()
+    base_radius = 1.0
+
+    # Bare radius (1.0) does not reach 1.2 -> no predicted intrusion.
+    tight = compute_intrusion_metrics(robot, peds, preds, 0.0, base_radius=base_radius)
+    assert tight.predicted_trajectory_intrusion_time_ratio == 0.0
+    assert tight.uncertainty_buffer_intrusion_time_ratio == 0.0
+
+    # Adding a 0.5 conformal buffer -> 1.5 reach -> buffer intrusion every step.
+    buffered = compute_intrusion_metrics(robot, peds, preds, 0.5, base_radius=base_radius)
+    assert buffered.predicted_trajectory_intrusion_time_ratio == 0.0
+    assert buffered.uncertainty_buffer_intrusion_time_ratio == 1.0
+    # Penetration depth = (base + conformal) - distance = 1.5 - 1.2 = 0.3 per step.
+    assert buffered.max_intrusion_depth == pytest.approx(0.3)
+    assert buffered.cumulative_intrusion_depth == pytest.approx(0.6)
+
+
+def test_intrusion_metrics_current_vs_predicted_differ() -> None:
+    """Current-position and predicted-position intrusion are measured independently."""
+    # Pedestrian currently far but predicted to be right next to the robot.
+    robot = _line([(0.0, 0.0)])
+    peds = np.array([[[5.0, 0.0]]])
+    preds = np.array([[[0.3, 0.0]]])
+    metrics = compute_intrusion_metrics(robot, peds, preds, 0.0, base_radius=1.0)
+    assert metrics.current_position_intrusion_time_ratio == 0.0
+    assert metrics.predicted_trajectory_intrusion_time_ratio == 1.0
+
+
+def test_intrusion_metrics_per_step_per_ped_radii() -> None:
+    """Per-step per-pedestrian ``(T, P)`` radii broadcast correctly."""
+    robot = _line([(0.0, 0.0), (0.0, 0.0)])
+    peds = np.array([[[2.0, 0.0], [0.0, 2.0]], [[2.0, 0.0], [0.0, 2.0]]], dtype=np.float64)
+    preds = peds.copy()
+    radii = np.array([[1.5, 0.0], [0.0, 1.5]])  # each step one ped gets a wide buffer
+    metrics = compute_intrusion_metrics(robot, peds, preds, radii, base_radius=1.0)
+    # Each step has one pedestrian whose buffer (1.0+1.5=2.5) reaches distance 2.0.
+    assert metrics.uncertainty_buffer_intrusion_time_ratio == 1.0
+    assert metrics.max_intrusion_depth == pytest.approx(0.5)
+
+
+def test_intrusion_metrics_no_pedestrians_is_zero() -> None:
+    """A run with zero pedestrians reports zero intrusion but preserves step count."""
+    robot = _line([(0.0, 0.0), (1.0, 0.0)])
+    empty = np.zeros((2, 0, 2))
+    metrics = compute_intrusion_metrics(robot, empty, empty, 0.0, base_radius=1.0)
+    assert metrics.uncertainty_buffer_intrusion_time_ratio == 0.0
+    assert metrics.cumulative_intrusion_depth == 0.0
+    assert metrics.num_steps == 2
+
+
+def test_intrusion_metrics_rejects_bad_inputs() -> None:
+    """Non-positive base radius, negative radii, and shape mismatches fail closed."""
+    robot = _line([(0.0, 0.0)])
+    peds = np.array([[[1.0, 0.0]]])
+    with pytest.raises(ValueError, match="base_radius"):
+        compute_intrusion_metrics(robot, peds, peds, 0.0, base_radius=0.0)
+    with pytest.raises(ValueError, match="non-negative"):
+        compute_intrusion_metrics(robot, peds, peds, -0.5, base_radius=1.0)
+    with pytest.raises(ValueError, match="shape"):
+        compute_intrusion_metrics(robot, peds, np.zeros((2, 1, 2)), 0.0, base_radius=1.0)


### PR DESCRIPTION
## Summary

Implements the bounded first slice of #3974: diagnostic uncertainty-aware safety primitives for conformal prediction buffers and cumulative intrusion metrics over trajectories.

This PR does **not** close #3974. The runtime uncertainty-triggered fallback remains open per the issue comments and must land in a successor slice before #3974 can be closed.

## Linked Issues

- Relates to #3974

## What Changed

- Added `robot_sf/benchmark/uncertainty_safety.py`.
- Added split-conformal radius computation with finite-sample coverage correction.
- Added online Adaptive Conformal Inference (ACI) buffer generation for residual drift.
- Added `compute_intrusion_metrics` for current-position, predicted-trajectory, and uncertainty-buffer intrusion ratios plus cumulative and max intrusion depth.
- Added fixture-backed tests for coverage behavior, drift adaptation, shape validation, empty-pedestrian handling, radii broadcasting, and buffer-intrusion edge cases.
- Updated `CHANGELOG.md`.

## Scope Boundary

In scope:

- Pure conformal-buffer and intrusion-metric computation.
- Diagnostic, versioned schema identifiers.
- Unit-level executable proof on committed fixtures.

Out of scope:

- Runtime fallback trigger behavior.
- Full benchmark campaign, GPU, or Slurm evidence.
- Paper-facing or dissertation safety claims.

Claim boundary: diagnostic primitives only. These metrics do not prove a safety guarantee, prediction quality, or planning improvement. Benchmark or paper-facing claims require separate reproducible evidence and must exclude fallback/degraded execution as success evidence.

## Gate-Critical Review Note

The PR is larger than 300 added lines and changes metric/evidence primitives, so the PR gate applied the hardened checklist where applicable.

- Semantic config validation and enabled/arm consistency: not applicable; this PR adds no runtime config arms or intervention path.
- Predeclared-threshold equality: not applicable; this PR does not add configured thresholds.
- Adversarial fixture coverage: covered at metric level by fail-closed shape/radius tests, empty-pedestrian tests, per-step/per-pedestrian radii broadcasting, and near-miss buffer-intrusion tests.
- Stored-but-unused provenance fields: schema fields are emitted and asserted in tests.
- Parent issue state: #3974 remains open; successor runtime fallback work is already specified in the issue comments.

## Research Result Guidance

NA - support/primitive slice. No benchmark result, no research claim, and no paper-facing claim are introduced.

## Downstream Propagation

- Parent issue updated: yes, via existing issue comments that classify #4138 as partial and specify the successor runtime fallback slice.
- Claim map / benchmark report updated: NA, no benchmark evidence.
- Leaderboard / artifact catalog updated: NA.
- Registry or config index updated: NA.
- Context index / memory note updated: NA.
- Follow-up issue opened: no, because the remaining runtime fallback slice is already specified directly in #3974 comments.

## Validation / Proof

PR author validation:

```bash
uv run pytest tests/ -k "conformal or intrusion fallback_trigger" -q
uv run pytest tests/benchmark/test_uncertainty_safety.py -q
uv run ruff check robot_sf/benchmark/uncertainty_safety.py tests/benchmark/test_uncertainty_safety.py
uv run ruff format --check robot_sf/benchmark/uncertainty_safety.py tests/benchmark/test_uncertainty_safety.py
```

PR gate validation on 2026-07-02:

```bash
scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_uncertainty_safety.py -q
scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/ -k "conformal or intrusion or fallback_trigger" -q
scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/uncertainty_safety.py tests/benchmark/test_uncertainty_safety.py CHANGELOG.md
scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/uncertainty_safety.py tests/benchmark/test_uncertainty_safety.py
BASE_REF=origin/main scripts/dev/run_worktree_shared_venv.sh -- scripts/dev/pr_ready_check.sh
uv run python scripts/dev/check_pr_ci_status.py 4138
```

Gate result: local readiness passed at head `1e5fe5d56acb3e42aac10b917e7e632ff8263a55`; GitHub checks were green before the body-only correction.

## Risks / Rollout

- Residual risk: later runtime fallback work must use these primitives without overstating diagnostic proxy behavior as calibrated safety probability.
- Rollback fallback plan: revert this PR if the primitive API proves incorrectly scoped before runtime integration.

## Reviewer Notes

Verify that #3974 remains open after merge. Closing criteria require both #4138 and the successor runtime uncertainty-triggered fallback PR.
