### PR TITLE
Issue #3948: add optional CBF safety filter

### DIFF
--- a/docs/context/issue_3948_cbf_safety_filter.md
+++ b/docs/context/issue_3948_cbf_safety_filter.md
@@ -1,0 +1,47 @@
+# Issue #3948 CBF Safety-Filter Baseline
+
+Status: first-slice implementation, diagnostic only.
+
+## What Landed
+
+- `robot_sf/planner/cbf_safety_filter.py` exposes a pure collision-cone Control-Barrier-Function
+  (CBF) filter API plus the existing adapter policy wrapper.
+- `robot_sf/benchmark/cbf_safety_filter_runtime.py` binds the CBF filter to map-runner simulator
+  state as an opt-in runtime layer.
+- Map-runner config accepts `cbf_safety_filter={"enabled": true, "arm_key":
+  "cbf_collision_cone_on"}` and records episode metadata plus metrics for intervention,
+  infeasibility, and fallback rates.
+- Event-ledger provenance records the CBF episode summary when enabled.
+
+## Boundary
+
+- Off by default.
+- Mutually exclusive with `safety_wrapper` in this first slice.
+- Dynamic Parabolic CBF is scaffolded but raises `NotImplementedError`.
+- No metric semantics changed.
+- No Slurm, GPU, full benchmark campaign, dissertation claim, or paper-facing safety claim.
+
+## Runtime Config
+
+Predeclared first-slice arm:
+
+```python
+{"enabled": True, "arm_key": "cbf_collision_cone_on"}
+```
+
+Disabled arm:
+
+```python
+{"enabled": False, "arm_key": "cbf_off"}
+```
+
+Threshold drift on the enabled arm fails closed; new thresholds require a versioned experimental
+arm so benchmark rows remain comparable.
+
+## Validation
+
+- `uv run pytest tests/benchmark/test_cbf_safety_filter_runtime.py tests/planner/test_cbf_safety_filter.py tests/benchmark/test_cbf_safety_filter_policy.py tests/benchmark/test_safety_wrapper_runtime.py tests/benchmark/test_event_ledger.py tests/benchmark/test_map_runner_resume_identity.py -q`
+- `uv run ruff check robot_sf/planner/cbf_safety_filter.py tests/planner/test_cbf_safety_filter.py robot_sf/benchmark/cbf_safety_filter_runtime.py robot_sf/benchmark/map_runner_episode.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_plan.py robot_sf/benchmark/map_runner_worker.py robot_sf/benchmark/map_runner_identity.py robot_sf/benchmark/event_ledger.py tests/benchmark/test_cbf_safety_filter_runtime.py`
+- `git diff --check`
+
+This validation is implementation integrity proof, not benchmark-strength evidence.

--- a/robot_sf/benchmark/cbf_safety_filter_runtime.py
+++ b/robot_sf/benchmark/cbf_safety_filter_runtime.py
@@ -1,0 +1,434 @@
+"""Runtime binding helpers for the opt-in CBF safety filter."""
+
+from __future__ import annotations
+
+import math
+from collections import Counter
+from collections.abc import Mapping, Sequence
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import numpy as np
+
+from robot_sf.planner.cbf_safety_filter import (
+    CbfSafetyFilterConfig,
+    CollisionConeCbfSafetyFilter,
+)
+
+CBF_SAFETY_FILTER_RUNTIME_STEP_SCHEMA = "cbf_safety_filter_runtime_step.v1"
+CBF_SAFETY_FILTER_EPISODE_SUMMARY_SCHEMA = "cbf_safety_filter_episode_summary.v1"
+CBF_OFF_ARM = "cbf_off"
+CBF_COLLISION_CONE_ARM = "cbf_collision_cone_on"
+CBF_VARIANT_COLLISION_CONE = "collision_cone"
+CBF_VARIANT_DYNAMIC_PARABOLIC = "dynamic_parabolic"
+
+_PREDECLARED_CBF_CONFIG = CbfSafetyFilterConfig(
+    enabled=True,
+    variant=CBF_VARIANT_COLLISION_CONE,
+)
+_PREDECLARED_THRESHOLD_FIELDS = (
+    "variant",
+    "alpha",
+    "safety_margin",
+    "robot_radius",
+    "pedestrian_radius",
+    "max_linear_speed",
+    "max_angular_speed",
+    "turn_gain",
+    "max_projection_passes",
+    "min_clearance_h",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class CBFSafetyFilterRuntimeConfig:
+    """Explicit opt-in benchmark CBF safety-filter binding."""
+
+    enabled: bool = False
+    arm_key: str = CBF_OFF_ARM
+    variant: str = CBF_VARIANT_COLLISION_CONE
+    alpha: float = 1.0
+    safety_margin: float = 0.15
+    robot_radius: float = 0.3
+    pedestrian_radius: float = 0.3
+    max_linear_speed: float | None = None
+    max_angular_speed: float | None = None
+    turn_gain: float = 2.0
+    max_projection_passes: int = 3
+    min_clearance_h: float = 1.0e-6
+    fallback_mode: str = "stop_keep_turn"
+    fail_on_native_action: bool = True
+    fail_on_unsupported_command: bool = True
+    record_step_trace: bool = False
+
+
+def runtime_config_from_mapping(
+    payload: Mapping[str, Any] | None,
+) -> CBFSafetyFilterRuntimeConfig:
+    """Normalize mapping input into a fail-closed runtime config.
+
+    Returns:
+        Validated CBF safety-filter runtime configuration.
+    """
+
+    if payload is None:
+        return CBFSafetyFilterRuntimeConfig()
+    if not isinstance(payload, Mapping):
+        raise TypeError("cbf_safety_filter must be a mapping or None")
+    allowed = {field.name for field in CBFSafetyFilterRuntimeConfig.__dataclass_fields__.values()}
+    unknown = sorted(set(payload) - allowed)
+    if unknown:
+        raise ValueError(f"Unknown cbf_safety_filter keys: {unknown}")
+    return validate_runtime_config(
+        CBFSafetyFilterRuntimeConfig(**{key: payload[key] for key in payload})
+    )
+
+
+def validate_runtime_config(  # noqa: C901
+    runtime: CBFSafetyFilterRuntimeConfig,
+) -> CBFSafetyFilterRuntimeConfig:
+    """Validate arm semantics and predeclared threshold equality.
+
+    Returns:
+        Validated CBF safety-filter runtime configuration.
+    """
+
+    arm_key = str(runtime.arm_key)
+    if arm_key not in {CBF_OFF_ARM, CBF_COLLISION_CONE_ARM}:
+        raise ValueError(
+            "cbf_safety_filter.arm_key must be cbf_off or cbf_collision_cone_on; "
+            "threshold changes require a versioned experimental arm"
+        )
+    if bool(runtime.enabled) and arm_key != CBF_COLLISION_CONE_ARM:
+        raise ValueError("cbf_safety_filter.enabled=True requires arm_key='cbf_collision_cone_on'")
+    if not bool(runtime.enabled) and arm_key != CBF_OFF_ARM:
+        raise ValueError("cbf_safety_filter.enabled=False requires arm_key='cbf_off'")
+    if runtime.variant == CBF_VARIANT_DYNAMIC_PARABOLIC:
+        raise NotImplementedError(
+            "dynamic_parabolic CBF scaffolded but out of scope for #3948 first slice"
+        )
+    if runtime.variant != CBF_VARIANT_COLLISION_CONE:
+        raise ValueError("cbf_safety_filter.variant must be collision_cone")
+    if runtime.fallback_mode != "stop_keep_turn":
+        raise ValueError("cbf_safety_filter.fallback_mode must be stop_keep_turn")
+    if bool(runtime.enabled):
+        for field_name in _PREDECLARED_THRESHOLD_FIELDS:
+            observed = getattr(runtime, field_name)
+            expected = getattr(_PREDECLARED_CBF_CONFIG, field_name)
+            if observed is None or expected is None:
+                if observed != expected:
+                    raise ValueError(
+                        "cbf_safety_filter.cbf_collision_cone_on thresholds must match "
+                        f"predeclared ablation config: {field_name}={expected}"
+                    )
+                continue
+            if isinstance(expected, str):
+                if str(observed) != expected:
+                    raise ValueError(
+                        "cbf_safety_filter.cbf_collision_cone_on thresholds must match "
+                        f"predeclared ablation config: {field_name}={expected}"
+                    )
+                continue
+            if not math.isclose(float(observed), float(expected), rel_tol=0.0, abs_tol=1.0e-12):
+                raise ValueError(
+                    "cbf_safety_filter.cbf_collision_cone_on thresholds must match "
+                    f"predeclared ablation config: {field_name}={expected}"
+                )
+    return runtime
+
+
+def cbf_filter_config(runtime: CBFSafetyFilterRuntimeConfig) -> CbfSafetyFilterConfig:
+    """Return pure CBF filter config from runtime binding."""
+
+    return CbfSafetyFilterConfig(
+        enabled=bool(runtime.enabled),
+        variant=str(runtime.variant),
+        alpha=float(runtime.alpha),
+        safety_margin=float(runtime.safety_margin),
+        robot_radius=float(runtime.robot_radius),
+        pedestrian_radius=float(runtime.pedestrian_radius),
+        max_linear_speed=runtime.max_linear_speed,
+        max_angular_speed=runtime.max_angular_speed,
+        turn_gain=float(runtime.turn_gain),
+        max_projection_passes=int(runtime.max_projection_passes),
+        min_clearance_h=float(runtime.min_clearance_h),
+    )
+
+
+def _xy_rows(value: Any) -> np.ndarray:
+    """Return finite ``(n, 2)`` rows from simulator pedestrian state."""
+
+    arr = np.asarray(value, dtype=float)
+    if arr.size == 0:
+        return np.empty((0, 2), dtype=float)
+    if not np.all(np.isfinite(arr)):
+        raise ValueError("cbf_safety_filter simulator pedestrian positions must be finite")
+    if arr.ndim == 1:
+        if arr.size % 2:
+            raise ValueError("cbf_safety_filter pedestrian positions require even-length xy data")
+        rows = arr.reshape((-1, 2))
+    elif arr.ndim == 2 and arr.shape[1] >= 2:
+        rows = arr[:, :2]
+    else:
+        raise ValueError("cbf_safety_filter pedestrian positions must be shaped (n,2) or (n,3)")
+    return np.asarray(rows, dtype=float)
+
+
+def _robot_position(env: Any) -> np.ndarray:
+    simulator = getattr(env, "simulator", None)
+    if simulator is None or not hasattr(simulator, "robot_pos"):
+        raise ValueError("cbf_safety_filter requires simulator.robot_pos")
+    try:
+        arr = np.asarray(simulator.robot_pos[0], dtype=float).reshape(-1)
+    except (IndexError, TypeError, ValueError) as exc:
+        raise ValueError("cbf_safety_filter requires simulator.robot_pos[0] xy position") from exc
+    if arr.size < 2 or not np.all(np.isfinite(arr[:2])):
+        raise ValueError("cbf_safety_filter robot_pos must contain finite xy coordinates")
+    return arr[:2]
+
+
+def _pedestrian_positions(env: Any) -> np.ndarray:
+    simulator = getattr(env, "simulator", None)
+    return _xy_rows(getattr(simulator, "ped_pos", np.empty((0, 2), dtype=float)))
+
+
+def _robot_heading(env: Any) -> float:
+    simulator = getattr(env, "simulator", None)
+    robot_poses = getattr(simulator, "robot_poses", None)
+    if isinstance(robot_poses, list) and robot_poses:
+        try:
+            heading = float(robot_poses[0][1])
+        except (IndexError, TypeError, ValueError) as exc:
+            raise ValueError("cbf_safety_filter requires finite robot_poses heading") from exc
+        if math.isfinite(heading):
+            return heading
+        raise ValueError("cbf_safety_filter requires finite robot_poses heading")
+    robots = getattr(simulator, "robots", None)
+    if isinstance(robots, list) and robots:
+        theta = getattr(robots[0], "theta", None)
+        if theta is not None:
+            return float(np.asarray(theta, dtype=float).reshape(-1)[0])
+    robot_pos = getattr(simulator, "robot_pos", None)
+    try:
+        arr = np.asarray(robot_pos[0], dtype=float).reshape(-1)
+    except (IndexError, TypeError, ValueError) as exc:
+        raise ValueError("cbf_safety_filter requires robot heading from simulator") from exc
+    if arr.size >= 3 and np.isfinite(arr[2]):
+        return float(arr[2])
+    raise ValueError("cbf_safety_filter requires finite robot heading")
+
+
+def _pedestrian_velocities(
+    current_positions: np.ndarray,
+    previous_positions: np.ndarray | None,
+    dt: float,
+) -> np.ndarray:
+    if not dt > 0.0:
+        raise ValueError("cbf_safety_filter dt must be positive")
+    if previous_positions is None:
+        return np.zeros_like(current_positions, dtype=float)
+    previous = _xy_rows(previous_positions)
+    velocities = np.zeros_like(current_positions, dtype=float)
+    count = min(current_positions.shape[0], previous.shape[0])
+    if count:
+        velocities[:count] = (current_positions[:count] - previous[:count]) / float(dt)
+    return velocities
+
+
+def compute_cbf_observation_from_env(
+    *,
+    env: Any,
+    config: Any,
+    previous_ped_positions: np.ndarray | None,
+    dt: float,
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Build the current-state observation consumed by the pure CBF filter.
+
+    Returns:
+        Planner-style CBF observation and provenance metadata.
+    """
+
+    del config
+    robot_pos = _robot_position(env)
+    heading = _robot_heading(env)
+    ped_positions = _pedestrian_positions(env)
+    ped_velocities = _pedestrian_velocities(ped_positions, previous_ped_positions, dt)
+    observation = {
+        "robot": {
+            "position": [float(robot_pos[0]), float(robot_pos[1])],
+            "velocity": [0.0, 0.0],
+            "heading": float(heading),
+        },
+        "agents": [
+            {
+                "position": [float(position[0]), float(position[1])],
+                "velocity": [float(velocity[0]), float(velocity[1])],
+            }
+            for position, velocity in zip(ped_positions, ped_velocities, strict=False)
+        ],
+    }
+    provenance = {
+        "context_source": "simulator_state_pre_step",
+        "pedestrian_velocity_identity": "row_order_finite_difference_no_stable_ids",
+        "obstacle_count": int(ped_positions.shape[0]),
+    }
+    return observation, provenance
+
+
+def _status_from_decision_label(label: str, *, intervened: bool) -> str:
+    if label == "cbf_disabled":
+        return "disabled"
+    if intervened:
+        return "filtered"
+    if label in {"cbf_feasible", "cbf_no_constraints"}:
+        return "pass_through"
+    if label == "cbf_best_effort":
+        return "fallback_infeasible"
+    return "filtered"
+
+
+def apply_runtime_cbf_safety_filter(
+    *,
+    command: Sequence[float],
+    env: Any,
+    config: Any,
+    runtime: CBFSafetyFilterRuntimeConfig,
+    previous_ped_positions: np.ndarray | None,
+    step_idx: int,
+) -> tuple[tuple[float, float], dict[str, Any]]:
+    """Apply runtime CBF filtering and return a schema-tagged step record.
+
+    Returns:
+        Filtered ``(linear, angular)`` command and per-step evidence record.
+    """
+
+    if len(command) < 2:
+        raise TypeError("cbf_safety_filter command must contain linear and angular velocity")
+    observation, provenance = compute_cbf_observation_from_env(
+        env=env,
+        config=config,
+        previous_ped_positions=previous_ped_positions,
+        dt=float(config.sim_config.time_per_step_in_secs),
+    )
+    filter_ = CollisionConeCbfSafetyFilter(cbf_filter_config(runtime))
+    decision = filter_.filter_command(observation, (float(command[0]), float(command[1])))
+    decision_meta = decision.to_metadata()
+    qp_status = _status_from_decision_label(
+        str(decision.decision_label),
+        intervened=bool(decision.is_intervention),
+    )
+    record = {
+        "schema_version": CBF_SAFETY_FILTER_RUNTIME_STEP_SCHEMA,
+        "step": int(step_idx),
+        "arm_key": str(runtime.arm_key),
+        "enabled": bool(runtime.enabled),
+        "variant": str(runtime.variant),
+        "eligible_for_cbf_filter": True,
+        "qp_status": qp_status,
+        "qp_feasible": qp_status != "fallback_infeasible",
+        "fallback_applied": qp_status == "fallback_infeasible",
+        "intervened": bool(decision.is_intervention),
+        "nominal_linear_velocity": float(command[0]),
+        "nominal_angular_velocity": float(command[1]),
+        "filtered_linear_velocity": float(decision.filtered_action[0]),
+        "filtered_angular_velocity": float(decision.filtered_action[1]),
+        "active_constraint_count": len(decision.violated_constraints),
+        "min_barrier_before": decision.proposed_evaluation.get("min_cbf_margin"),
+        "min_barrier_after": decision.selected_evaluation.get("min_cbf_margin"),
+        "hard_constraint_violation": bool(decision.final_constraint_violation),
+        **provenance,
+    }
+    if runtime.record_step_trace:
+        record["decision"] = decision_meta
+    return (
+        (float(decision.filtered_action[0]), float(decision.filtered_action[1])),
+        record,
+    )
+
+
+def ineligible_cbf_safety_filter_step_record(
+    *,
+    runtime: CBFSafetyFilterRuntimeConfig,
+    step_idx: int,
+    reason: str,
+) -> dict[str, Any]:
+    """Return a schema-tagged record for fail-open ineligible cases."""
+
+    return {
+        "schema_version": CBF_SAFETY_FILTER_RUNTIME_STEP_SCHEMA,
+        "step": int(step_idx),
+        "arm_key": str(runtime.arm_key),
+        "enabled": bool(runtime.enabled),
+        "variant": str(runtime.variant),
+        "eligible_for_cbf_filter": False,
+        "ineligible_reason": str(reason),
+        "qp_status": "ineligible",
+        "qp_feasible": False,
+        "fallback_applied": False,
+        "intervened": False,
+        "nominal_linear_velocity": None,
+        "nominal_angular_velocity": None,
+        "filtered_linear_velocity": None,
+        "filtered_angular_velocity": None,
+        "active_constraint_count": 0,
+        "min_barrier_before": None,
+        "min_barrier_after": None,
+        "hard_constraint_violation": False,
+    }
+
+
+def summarize_cbf_safety_filter_trace(
+    trace: Sequence[Mapping[str, Any]],
+    *,
+    runtime: CBFSafetyFilterRuntimeConfig | None = None,
+) -> dict[str, Any]:
+    """Summarize per-step CBF evidence for episode metadata and ledger provenance.
+
+    Returns:
+        Episode-level CBF safety-filter summary payload.
+    """
+
+    runtime = runtime or CBFSafetyFilterRuntimeConfig()
+    step_count = len(trace)
+    status_counts = Counter(str(record.get("qp_status", "unknown")) for record in trace)
+    intervened_step_count = sum(1 for record in trace if bool(record.get("intervened", False)))
+    infeasible_count = sum(1 for record in trace if not bool(record.get("qp_feasible", True)))
+    fallback_count = sum(1 for record in trace if bool(record.get("fallback_applied", False)))
+    summary = {
+        "schema_version": CBF_SAFETY_FILTER_EPISODE_SUMMARY_SCHEMA,
+        "enabled": bool(runtime.enabled),
+        "arm_key": str(runtime.arm_key),
+        "variant": str(runtime.variant),
+        "thresholds": asdict(cbf_filter_config(runtime)),
+        "step_count": int(step_count),
+        "eligible_step_count": int(
+            sum(1 for record in trace if bool(record.get("eligible_for_cbf_filter", True)))
+        ),
+        "intervened_step_count": int(intervened_step_count),
+        "qp_infeasible_step_count": int(infeasible_count),
+        "fallback_step_count": int(fallback_count),
+        "intervention_rate": intervened_step_count / step_count if step_count else 0.0,
+        "qp_infeasible_rate": infeasible_count / step_count if step_count else 0.0,
+        "fallback_rate": fallback_count / step_count if step_count else 0.0,
+        "status_counts": dict(status_counts),
+        "claim_boundary": "diagnostic opt-in collision-cone CBF baseline; not a safety certificate",
+        "context_source": "simulator_state_pre_step",
+    }
+    if runtime.record_step_trace:
+        summary["steps"] = [dict(record) for record in trace]
+    return summary
+
+
+__all__ = [
+    "CBF_COLLISION_CONE_ARM",
+    "CBF_OFF_ARM",
+    "CBF_SAFETY_FILTER_EPISODE_SUMMARY_SCHEMA",
+    "CBF_SAFETY_FILTER_RUNTIME_STEP_SCHEMA",
+    "CBFSafetyFilterRuntimeConfig",
+    "apply_runtime_cbf_safety_filter",
+    "cbf_filter_config",
+    "compute_cbf_observation_from_env",
+    "ineligible_cbf_safety_filter_step_record",
+    "runtime_config_from_mapping",
+    "summarize_cbf_safety_filter_trace",
+]

--- a/robot_sf/benchmark/event_ledger.py
+++ b/robot_sf/benchmark/event_ledger.py
@@ -124,6 +124,18 @@ def _safety_wrapper_summary(record: Mapping[str, Any]) -> dict[str, Any] | None:
     return dict(safety_wrapper)
 
 
+def _cbf_safety_filter_summary(record: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Return episode-level CBF safety-filter summary from algorithm metadata."""
+
+    algorithm_metadata = record.get("algorithm_metadata")
+    if not isinstance(algorithm_metadata, Mapping):
+        return None
+    cbf_safety_filter = algorithm_metadata.get("cbf_safety_filter")
+    if not isinstance(cbf_safety_filter, Mapping):
+        return None
+    return dict(cbf_safety_filter)
+
+
 def _predicate_event(
     predicates: Mapping[str, Any],
     predicate_key: str,
@@ -171,6 +183,7 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
     )
     safety_predicates = _safety_predicate_records(record)
     safety_wrapper = _safety_wrapper_summary(record)
+    cbf_safety_filter = _cbf_safety_filter_summary(record)
     predicate_oscillation, predicate_oscillation_source = _predicate_event(
         safety_predicates,
         "oscillatory_control_predicate",
@@ -258,6 +271,8 @@ def build_event_ledger(record: Mapping[str, Any]) -> dict[str, Any]:
     payload = ledger.to_dict()
     if safety_wrapper is not None:
         payload["provenance"]["safety_wrapper"] = safety_wrapper
+    if cbf_safety_filter is not None:
+        payload["provenance"]["cbf_safety_filter"] = cbf_safety_filter
     if safety_predicates:
         payload["surrogate_events"].update(safety_predicates)
     payload["reconciliation"]["audit_result"] = (

--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -2247,6 +2247,7 @@ def _run_map_episode(  # noqa: PLR0913
     synthetic_actuation_profile: dict[str, Any] | None = None,
     latency_stress_profile: dict[str, Any] | None = None,
     safety_wrapper: dict[str, Any] | None = None,
+    cbf_safety_filter: dict[str, Any] | None = None,
     record_planner_decision_trace: bool = False,
     record_simulation_step_trace: bool = False,
 ) -> dict[str, Any]:
@@ -2281,6 +2282,7 @@ def _run_map_episode(  # noqa: PLR0913
         synthetic_actuation_profile=synthetic_actuation_profile,
         latency_stress_profile=latency_stress_profile,
         safety_wrapper=safety_wrapper,
+        cbf_safety_filter=cbf_safety_filter,
         record_planner_decision_trace=record_planner_decision_trace,
         record_simulation_step_trace=record_simulation_step_trace,
         policy_builder=_build_policy,
@@ -2449,6 +2451,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
     synthetic_actuation_profile: dict[str, Any] | None = None,
     latency_stress_profile: dict[str, Any] | None = None,
     safety_wrapper: dict[str, Any] | None = None,
+    cbf_safety_filter: dict[str, Any] | None = None,
     record_simulation_step_trace: bool = False,
     workers: int = 1,
     resume: bool = True,
@@ -2800,6 +2803,9 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
                         else None
                     ),
                     safety_wrapper=dict(safety_wrapper) if safety_wrapper is not None else None,
+                    cbf_safety_filter=dict(cbf_safety_filter)
+                    if cbf_safety_filter is not None
+                    else None,
                     record_simulation_step_trace=record_simulation_step_trace,
                 )
                 if _compute_map_episode_id(identity_payload, seed) not in existing:
@@ -2838,6 +2844,7 @@ def run_map_batch(  # noqa: C901,PLR0912,PLR0913,PLR0915
             not_available_latency_metrics() if latency_profile is not None else None
         ),
         safety_wrapper=dict(safety_wrapper) if safety_wrapper is not None else None,
+        cbf_safety_filter=dict(cbf_safety_filter) if cbf_safety_filter is not None else None,
         record_simulation_step_trace=record_simulation_step_trace,
     )
 

--- a/robot_sf/benchmark/map_runner_batch_plan.py
+++ b/robot_sf/benchmark/map_runner_batch_plan.py
@@ -70,6 +70,7 @@ def build_worker_fixed_params(  # noqa: PLR0913
     latency_stress_metrics: dict[str, Any] | None,
     safety_wrapper: dict[str, Any] | None,
     record_simulation_step_trace: bool,
+    cbf_safety_filter: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the serialized parameter payload shared by all map workers.
 
@@ -100,5 +101,6 @@ def build_worker_fixed_params(  # noqa: PLR0913
         "latency_stress_profile": latency_profile_metadata,
         "latency_stress_metrics": latency_stress_metrics,
         "safety_wrapper": safety_wrapper,
+        "cbf_safety_filter": cbf_safety_filter,
         "record_simulation_step_trace": bool(record_simulation_step_trace),
     }

--- a/robot_sf/benchmark/map_runner_episode.py
+++ b/robot_sf/benchmark/map_runner_episode.py
@@ -18,6 +18,14 @@ from robot_sf.benchmark.algorithm_metadata import (
     resolve_learned_checkpoint_observation_contract,
 )
 from robot_sf.benchmark.ammv_feasibility import evaluate_artifact_command_feasibility
+from robot_sf.benchmark.cbf_safety_filter_runtime import (
+    apply_runtime_cbf_safety_filter,
+    ineligible_cbf_safety_filter_step_record,
+    summarize_cbf_safety_filter_trace,
+)
+from robot_sf.benchmark.cbf_safety_filter_runtime import (
+    runtime_config_from_mapping as cbf_runtime_config_from_mapping,
+)
 from robot_sf.benchmark.latency_stress import not_available_latency_metrics
 from robot_sf.benchmark.map_runner_actions import DEFAULT_KINEMATICS as _DEFAULT_KINEMATICS
 from robot_sf.benchmark.map_runner_actions import (
@@ -442,6 +450,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     synthetic_actuation_profile: dict[str, Any] | None = None,
     latency_stress_profile: dict[str, Any] | None = None,
     safety_wrapper: dict[str, Any] | None = None,
+    cbf_safety_filter: dict[str, Any] | None = None,
     record_planner_decision_trace: bool = False,
     record_simulation_step_trace: bool = False,
     policy_builder: PolicyBuilder,
@@ -477,8 +486,14 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
         scenario_id=scenario_id,
     )
     safety_wrapper_runtime = runtime_config_from_mapping(safety_wrapper)
+    cbf_runtime = cbf_runtime_config_from_mapping(cbf_safety_filter)
+    if safety_wrapper_runtime.enabled and cbf_runtime.enabled:
+        raise ValueError(
+            "safety_wrapper and cbf_safety_filter cannot both be enabled in #3948 first slice"
+        )
     tracking_precision_records: list[dict[str, Any]] = []
     safety_wrapper_trace: list[dict[str, Any]] = []
+    cbf_filter_trace: list[dict[str, Any]] = []
     min_separation_corrupted_values: list[float] = []
     config = _build_env_config(scenario, scenario_path=scenario_path)
     max_steps = int(scenario.get("simulation_config", {}).get("max_episode_steps", 0) or 0)
@@ -746,12 +761,57 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
                         previous_ped_positions=previous_trace_ped_pos,
                         step_idx=step_idx,
                     )
+                policy_command = (
+                    corrected_command[0],
+                    corrected_command[1],
+                    *tuple(policy_command[2:]),
+                )
+                safety_wrapper_trace.append(wrapper_record)
+            if cbf_runtime.enabled:
+                if step_is_native:
+                    if cbf_runtime.fail_on_native_action:
+                        raise ValueError(
+                            "cbf_safety_filter.enabled requires absolute commands; "
+                            "native environment actions cannot be filtered safely"
+                        )
+                    cbf_filter_trace.append(
+                        ineligible_cbf_safety_filter_step_record(
+                            runtime=cbf_runtime,
+                            step_idx=step_idx,
+                            reason="native_environment_action",
+                        )
+                    )
+                elif (
+                    not isinstance(policy_command, (tuple, list, np.ndarray))
+                    or len(policy_command) < 2
+                ):
+                    if cbf_runtime.fail_on_unsupported_command:
+                        raise TypeError(
+                            "cbf_safety_filter.enabled expects commands shaped like "
+                            "(linear_velocity, angular_velocity)"
+                        )
+                    cbf_filter_trace.append(
+                        ineligible_cbf_safety_filter_step_record(
+                            runtime=cbf_runtime,
+                            step_idx=step_idx,
+                            reason="unsupported_command_shape",
+                        )
+                    )
+                else:
+                    corrected_command, cbf_record = apply_runtime_cbf_safety_filter(
+                        command=policy_command,
+                        env=env,
+                        config=config,
+                        runtime=cbf_runtime,
+                        previous_ped_positions=previous_trace_ped_pos,
+                        step_idx=step_idx,
+                    )
                     policy_command = (
                         corrected_command[0],
                         corrected_command[1],
                         *tuple(policy_command[2:]),
                     )
-                    safety_wrapper_trace.append(wrapper_record)
+                    cbf_filter_trace.append(cbf_record)
             selected_action_payload = _command_action_payload(policy_command)
             ammv_command_actions.append(selected_action_payload)
             if step_is_native:
@@ -1160,6 +1220,13 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             runtime=safety_wrapper_runtime,
         )
         algo_meta["safety_wrapper"] = safety_wrapper_summary
+    cbf_filter_summary: dict[str, Any] | None = None
+    if cbf_runtime.enabled:
+        cbf_filter_summary = summarize_cbf_safety_filter_trace(
+            cbf_filter_trace,
+            runtime=cbf_runtime,
+        )
+        algo_meta["cbf_safety_filter"] = cbf_filter_summary
     intent_summary = _intent_conditioned_behavior_summary(
         scenario,
         single_pedestrian_intent_metadata,
@@ -1225,6 +1292,10 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
     metrics["tracking_target_motp_m"] = float(tracking_precision_spec["target_motp_m"])
     if safety_wrapper_summary is not None:
         metrics["wrapper_intervention_rate"] = float(safety_wrapper_summary["intervention_rate"])
+    if cbf_filter_summary is not None:
+        metrics["cbf_filter_intervention_rate"] = float(cbf_filter_summary["intervention_rate"])
+        metrics["cbf_filter_qp_infeasible_rate"] = float(cbf_filter_summary["qp_infeasible_rate"])
+        metrics["cbf_filter_fallback_rate"] = float(cbf_filter_summary["fallback_rate"])
 
     ts_end = datetime.now(UTC).isoformat()
     scenario_params = _scenario_identity_payload(
@@ -1249,6 +1320,7 @@ def run_map_episode(  # noqa: C901,PLR0912,PLR0913,PLR0915
             else None
         ),
         safety_wrapper=dict(safety_wrapper) if safety_wrapper is not None else None,
+        cbf_safety_filter=dict(cbf_safety_filter) if cbf_safety_filter is not None else None,
         record_simulation_step_trace=record_simulation_step_trace,
     )
     steps_taken = int(robot_pos_arr.shape[0])

--- a/robot_sf/benchmark/map_runner_identity.py
+++ b/robot_sf/benchmark/map_runner_identity.py
@@ -11,6 +11,9 @@ if TYPE_CHECKING:
 
 import yaml
 
+from robot_sf.benchmark.cbf_safety_filter_runtime import (
+    runtime_config_from_mapping as cbf_runtime_config_from_mapping,
+)
 from robot_sf.benchmark.observation_noise import (
     normalize_observation_noise_spec,
     observation_noise_hash,
@@ -89,6 +92,7 @@ def _scenario_identity_payload(  # noqa: C901,PLR0913
     synthetic_actuation_profile: dict[str, Any] | None = None,
     latency_stress_profile: dict[str, Any] | None = None,
     safety_wrapper: dict[str, Any] | None = None,
+    cbf_safety_filter: dict[str, Any] | None = None,
     record_simulation_step_trace: bool = False,
 ) -> dict[str, Any]:
     """Build the canonical scenario payload used for episode identity.
@@ -131,6 +135,10 @@ def _scenario_identity_payload(  # noqa: C901,PLR0913
         resolved_safety_wrapper = runtime_config_from_mapping(safety_wrapper)
         if resolved_safety_wrapper.enabled:
             payload["safety_wrapper"] = asdict(resolved_safety_wrapper)
+    if cbf_safety_filter is not None:
+        resolved_cbf_filter = cbf_runtime_config_from_mapping(cbf_safety_filter)
+        if resolved_cbf_filter.enabled:
+            payload["cbf_safety_filter"] = asdict(resolved_cbf_filter)
     payload["record_simulation_step_trace"] = bool(record_simulation_step_trace)
     if horizon is not None and int(horizon) > 0:
         payload["run_horizon"] = int(horizon)

--- a/robot_sf/benchmark/map_runner_policy_common.py
+++ b/robot_sf/benchmark/map_runner_policy_common.py
@@ -19,7 +19,16 @@ from robot_sf.benchmark.map_runner_policy_metadata import (
     attach_planner_reset as _attach_planner_reset,
 )
 from robot_sf.benchmark.utils import _config_hash
+from robot_sf.planner.cbf_safety_filter import (
+    CollisionConeCbfSafetyFilter,
+    build_cbf_safety_filter_config,
+)
 from robot_sf.planner.kinematics_model import resolve_benchmark_kinematics_model
+from robot_sf.planner.safety_shield import (
+    new_shield_stats,
+    shield_contract_metadata,
+    update_shield_stats,
+)
 
 if TYPE_CHECKING:
     from collections.abc import Callable
@@ -29,7 +38,7 @@ _init_feasibility_metadata = _planner_commands.init_feasibility_metadata
 _project_with_feasibility = _planner_commands.project_with_feasibility
 
 
-def build_adapter_policy(
+def build_adapter_policy(  # noqa: C901
     *,
     algo_key: str,
     algo_config: dict[str, Any],
@@ -74,6 +83,23 @@ def build_adapter_policy(
         robot_kinematics=robot_kinematics,
         command_limits=algo_config,
     )
+    cbf_config = build_cbf_safety_filter_config(algo_config.get("cbf_safety_filter"))
+    cbf_filter: CollisionConeCbfSafetyFilter | None = None
+    if cbf_config.enabled:
+        cbf_filter = CollisionConeCbfSafetyFilter(cbf_config)
+        meta["cbf_safety_filter"] = {
+            "status": "enabled",
+            "variant": cbf_config.variant,
+            "prediction_source": "current_state",
+            "wrapped_planner": adapter_name,
+            "claim_boundary": "planner-comparison baseline only; not a formal safety certificate",
+        }
+        meta["safety_shield_contract"] = shield_contract_metadata(
+            shield_name="CollisionConeCbfSafetyFilter",
+            prediction_source="current_state",
+            fallback_policy="qp_projection_best_effort",
+        )
+        meta["shield_stats"] = new_shield_stats()
 
     def _policy(obs: dict[str, Any]) -> tuple[float, float]:
         """Run an adapter-backed planner and project command feasibility.
@@ -82,6 +108,12 @@ def build_adapter_policy(
             tuple[float, float]: Projected linear and angular command.
         """
         linear, angular = adapter.plan(obs)
+        if cbf_filter is not None:
+            shield_decision = cbf_filter.filter_command(obs, (float(linear), float(angular)))
+            shield_stats = meta.get("shield_stats")
+            if isinstance(shield_stats, dict):
+                update_shield_stats(shield_stats, shield_decision)
+            linear, angular = shield_decision.filtered_action
         return _project_with_feasibility(
             model=adapter_kinematics_model,
             command=(float(linear), float(angular)),
@@ -94,7 +126,7 @@ def build_adapter_policy(
         _policy._planner_bind_env = adapter.bind_env
     if hasattr(adapter, "close"):
         _policy._planner_close = adapter.close
-    if hasattr(adapter, "diagnostics"):
+    if hasattr(adapter, "diagnostics") or cbf_filter is not None:
 
         def _planner_stats() -> dict[str, Any]:
             """Expose adapter diagnostics for episode metadata.
@@ -102,7 +134,13 @@ def build_adapter_policy(
             Returns:
                 dict[str, Any]: Adapter diagnostic payload.
             """
-            return adapter.diagnostics()
+            diagnostics = adapter.diagnostics() if hasattr(adapter, "diagnostics") else {}
+            if cbf_filter is None:
+                return diagnostics
+            return {
+                **diagnostics,
+                "cbf_safety_filter": cbf_filter.diagnostics(),
+            }
 
         _policy._planner_stats = _planner_stats
 

--- a/robot_sf/benchmark/map_runner_worker.py
+++ b/robot_sf/benchmark/map_runner_worker.py
@@ -71,5 +71,6 @@ def execute_map_job(
         synthetic_actuation_profile=params.get("synthetic_actuation_profile"),
         latency_stress_profile=params.get("latency_stress_profile"),
         safety_wrapper=params.get("safety_wrapper"),
+        cbf_safety_filter=params.get("cbf_safety_filter"),
         record_simulation_step_trace=bool(params.get("record_simulation_step_trace", False)),
     )

--- a/robot_sf/planner/cbf_safety_filter.py
+++ b/robot_sf/planner/cbf_safety_filter.py
@@ -399,9 +399,225 @@ class CbfSafetyFilterPlannerWrapper:
             close()
 
 
+CBF_SAFETY_FILTER_SCHEMA = "cbf_safety_filter.v1"
+CBF_VARIANT_COLLISION_CONE = "collision_cone_cbf_v1"
+CBF_VARIANT_DYNAMIC_PARABOLIC = "dynamic_parabolic_cbf_v1"
+
+
+@dataclass(frozen=True, slots=True)
+class CBFSafetyFilterConfig:
+    """Pure-function CBF filter configuration for benchmark runtime binding."""
+
+    enabled: bool = False
+    variant: str = CBF_VARIANT_COLLISION_CONE
+    alpha: float = 2.0
+    safety_radius_margin_m: float = 0.05
+    min_linear_velocity_m_s: float = 0.0
+    max_linear_velocity_m_s: float = 2.0
+    fallback_mode: str = "stop_keep_turn"
+    angular_weight: float = 0.05
+
+
+@dataclass(frozen=True, slots=True)
+class CBFObstacleState:
+    """Current-state dynamic obstacle sample for the CBF filter."""
+
+    position_m: tuple[float, float]
+    velocity_mps: tuple[float, float]
+    radius_m: float
+
+
+@dataclass(frozen=True, slots=True)
+class CBFFilterContext:
+    """Robot and obstacle state needed for one CBF projection."""
+
+    robot_position_m: tuple[float, float]
+    robot_heading_rad: float
+    robot_radius_m: float
+    obstacles: tuple[CBFObstacleState, ...]
+
+
+def _finite_xy_tuple(value: tuple[float, float], *, field_name: str) -> tuple[float, float]:
+    """Validate finite xy tuple.
+
+    Returns:
+        Two finite float values.
+    """
+
+    arr = np.asarray(value, dtype=float).reshape(-1)
+    if arr.size != 2 or not np.all(np.isfinite(arr)):
+        raise ValueError(f"{field_name} must be two finite floats")
+    return (float(arr[0]), float(arr[1]))
+
+
+def _validate_public_context(context: CBFFilterContext) -> None:
+    """Fail closed for malformed public CBF state."""
+
+    _finite_xy_tuple(context.robot_position_m, field_name="robot_position_m")
+    if not math.isfinite(float(context.robot_heading_rad)):
+        raise ValueError("robot_heading_rad must be finite")
+    if not math.isfinite(float(context.robot_radius_m)) or context.robot_radius_m < 0.0:
+        raise ValueError("robot_radius_m must be finite and non-negative")
+    for obstacle in context.obstacles:
+        _finite_xy_tuple(obstacle.position_m, field_name="obstacle.position_m")
+        _finite_xy_tuple(obstacle.velocity_mps, field_name="obstacle.velocity_mps")
+        if not math.isfinite(float(obstacle.radius_m)) or obstacle.radius_m < 0.0:
+            raise ValueError("obstacle.radius_m must be finite and non-negative")
+
+
+def apply_cbf_safety_filter(  # noqa: C901
+    linear_velocity: float,
+    angular_velocity: float,
+    context: CBFFilterContext,
+    config: CBFSafetyFilterConfig | None = None,
+) -> dict[str, Any]:
+    """Project a nominal unicycle command through collision-cone CBF constraints.
+
+    Returns:
+        JSON-safe decision payload containing the filtered command and CBF diagnostics.
+    """
+
+    config = config or CBFSafetyFilterConfig()
+    _validate_public_context(context)
+    if not math.isfinite(float(linear_velocity)) or not math.isfinite(float(angular_velocity)):
+        raise ValueError("nominal command velocities must be finite")
+    if config.variant == CBF_VARIANT_DYNAMIC_PARABOLIC:
+        raise NotImplementedError(
+            "dynamic_parabolic_cbf_v1 scaffolded but out of scope for #3948 first slice"
+        )
+    if config.variant != CBF_VARIANT_COLLISION_CONE:
+        raise ValueError("CBF variant must be collision_cone_cbf_v1")
+    if not config.enabled:
+        return {
+            "schema_version": CBF_SAFETY_FILTER_SCHEMA,
+            "variant": config.variant,
+            "enabled": False,
+            "qp_status": "disabled",
+            "qp_feasible": True,
+            "fallback_applied": False,
+            "intervened": False,
+            "nominal_linear_velocity": float(linear_velocity),
+            "nominal_angular_velocity": float(angular_velocity),
+            "filtered_linear_velocity": float(linear_velocity),
+            "filtered_angular_velocity": float(angular_velocity),
+            "active_constraint_count": 0,
+            "min_barrier_before": None,
+            "min_barrier_after": None,
+            "hard_constraint_violation": False,
+        }
+
+    robot_pos = np.asarray(context.robot_position_m, dtype=float)
+    heading = float(context.robot_heading_rad)
+    e_theta = np.asarray([math.cos(heading), math.sin(heading)], dtype=float)
+    lower = float(config.min_linear_velocity_m_s)
+    upper = float(config.max_linear_velocity_m_s)
+    if lower > upper:
+        raise ValueError("min_linear_velocity_m_s must be <= max_linear_velocity_m_s")
+
+    barriers_before: list[float] = []
+    intervals: list[tuple[float, float]] = []
+    for obstacle in context.obstacles:
+        obstacle_pos = np.asarray(obstacle.position_m, dtype=float)
+        obstacle_velocity = np.asarray(obstacle.velocity_mps, dtype=float)
+        p_i = obstacle_pos - robot_pos
+        radius = (
+            float(context.robot_radius_m)
+            + float(obstacle.radius_m)
+            + float(config.safety_radius_margin_m)
+        )
+        h_i = float(np.dot(p_i, p_i) - radius * radius)
+        coeff = float(-2.0 * np.dot(p_i, e_theta))
+        rhs = float(-config.alpha * h_i - 2.0 * np.dot(p_i, obstacle_velocity))
+        barrier_before = float(
+            2.0 * np.dot(p_i, obstacle_velocity - float(linear_velocity) * e_theta)
+            + float(config.alpha) * h_i
+        )
+        barriers_before.append(barrier_before)
+        if abs(coeff) <= 1.0e-12:
+            if 0.0 < rhs:
+                intervals.append((math.inf, -math.inf))
+            continue
+        bound = rhs / coeff
+        if coeff > 0.0:
+            intervals.append((bound, math.inf))
+        else:
+            intervals.append((-math.inf, bound))
+
+    for interval_lower, interval_upper in intervals:
+        lower = max(lower, interval_lower)
+        upper = min(upper, interval_upper)
+
+    feasible = lower <= upper
+    if feasible:
+        filtered_linear = float(np.clip(float(linear_velocity), lower, upper))
+    elif config.fallback_mode == "stop_keep_turn":
+        filtered_linear = 0.0
+    else:
+        raise ValueError("unsupported CBF fallback_mode")
+    filtered_angular = float(angular_velocity)
+    barriers_after = [
+        float(
+            2.0
+            * np.dot(
+                np.asarray(obstacle.position_m, dtype=float) - robot_pos,
+                np.asarray(obstacle.velocity_mps, dtype=float) - filtered_linear * e_theta,
+            )
+            + float(config.alpha)
+            * (
+                float(
+                    np.dot(
+                        np.asarray(obstacle.position_m, dtype=float) - robot_pos,
+                        np.asarray(obstacle.position_m, dtype=float) - robot_pos,
+                    )
+                )
+                - (
+                    float(context.robot_radius_m)
+                    + float(obstacle.radius_m)
+                    + float(config.safety_radius_margin_m)
+                )
+                ** 2
+            )
+        )
+        for obstacle in context.obstacles
+    ]
+    min_before = min(barriers_before) if barriers_before else None
+    min_after = min(barriers_after) if barriers_after else None
+    intervened = not math.isclose(
+        filtered_linear, float(linear_velocity), rel_tol=1.0e-9, abs_tol=1.0e-9
+    )
+    fallback_applied = not feasible
+    qp_status = (
+        "fallback_infeasible" if fallback_applied else "filtered" if intervened else "pass_through"
+    )
+    return {
+        "schema_version": CBF_SAFETY_FILTER_SCHEMA,
+        "variant": config.variant,
+        "enabled": True,
+        "qp_status": qp_status,
+        "qp_feasible": bool(feasible),
+        "fallback_applied": bool(fallback_applied),
+        "intervened": bool(intervened),
+        "nominal_linear_velocity": float(linear_velocity),
+        "nominal_angular_velocity": float(angular_velocity),
+        "filtered_linear_velocity": float(filtered_linear),
+        "filtered_angular_velocity": float(filtered_angular),
+        "active_constraint_count": len(intervals),
+        "min_barrier_before": min_before,
+        "min_barrier_after": min_after,
+        "hard_constraint_violation": bool(min_after is not None and min_after < -1.0e-9),
+    }
+
+
 __all__ = [
+    "CBF_SAFETY_FILTER_SCHEMA",
+    "CBF_VARIANT_COLLISION_CONE",
+    "CBF_VARIANT_DYNAMIC_PARABOLIC",
+    "CBFFilterContext",
+    "CBFObstacleState",
+    "CBFSafetyFilterConfig",
     "CbfSafetyFilterConfig",
     "CbfSafetyFilterPlannerWrapper",
     "CollisionConeCbfSafetyFilter",
+    "apply_cbf_safety_filter",
     "build_cbf_safety_filter_config",
 ]

--- a/robot_sf/planner/cbf_safety_filter.py
+++ b/robot_sf/planner/cbf_safety_filter.py
@@ -1,0 +1,407 @@
+"""Opt-in Control-Barrier-Function command filter for local planners.
+
+The filter is intentionally current-state only: it consumes robot and pedestrian
+positions/velocities from the planner observation, projects the nominal planar
+velocity through linearized CBF half-space constraints, then converts the
+projected velocity back to a unicycle ``(linear, angular)`` command.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from robot_sf.planner.risk_dwa import _wrap_angle
+from robot_sf.planner.safety_shield import ShieldDecision
+
+ActionCommand = tuple[float, float]
+
+
+@dataclass(frozen=True)
+class CbfSafetyFilterConfig:
+    """Configuration for the collision-cone CBF command filter."""
+
+    enabled: bool = False
+    variant: str = "collision_cone"
+    alpha: float = 1.0
+    safety_margin: float = 0.15
+    robot_radius: float = 0.3
+    pedestrian_radius: float = 0.3
+    max_linear_speed: float | None = None
+    max_angular_speed: float | None = None
+    turn_gain: float = 2.0
+    max_projection_passes: int = 3
+    min_clearance_h: float = 1e-6
+
+
+def build_cbf_safety_filter_config(config: dict[str, Any] | None) -> CbfSafetyFilterConfig:
+    """Build a :class:`CbfSafetyFilterConfig` from an optional mapping.
+
+    Returns:
+        CBF safety-filter configuration.
+    """
+
+    raw = dict(config or {})
+    if "cbf_safety_filter" in raw and isinstance(raw["cbf_safety_filter"], dict):
+        raw = dict(raw["cbf_safety_filter"])
+    allowed = set(CbfSafetyFilterConfig.__dataclass_fields__)
+    unknown = sorted(set(raw) - allowed)
+    if unknown:
+        raise ValueError(f"Unknown CBF safety filter config keys: {unknown}")
+    cfg = CbfSafetyFilterConfig(**raw)
+    variant = str(cfg.variant).strip().lower()
+    if variant != "collision_cone":
+        raise ValueError(
+            "Only the collision_cone CBF safety-filter variant is implemented in this slice"
+        )
+    if cfg.alpha < 0.0:
+        raise ValueError("CBF safety filter alpha must be non-negative")
+    if cfg.safety_margin < 0.0:
+        raise ValueError("CBF safety filter safety_margin must be non-negative")
+    if cfg.max_projection_passes < 1:
+        raise ValueError("CBF safety filter max_projection_passes must be >= 1")
+    return cfg
+
+
+@dataclass(frozen=True)
+class _ObstacleState:
+    position: np.ndarray
+    velocity: np.ndarray
+    radius: float
+
+
+def _as_xy(value: Any, default: tuple[float, float] = (0.0, 0.0)) -> np.ndarray:
+    """Return a two-element float vector from common observation encodings."""
+
+    try:
+        arr = np.asarray(value, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        return np.asarray(default, dtype=float)
+    if arr.size < 2:
+        return np.asarray(default, dtype=float)
+    return arr[:2].astype(float)
+
+
+def _as_float(value: Any, default: float) -> float:
+    """Return a finite float from scalar/list/array payloads."""
+
+    try:
+        arr = np.asarray(value, dtype=float).reshape(-1)
+    except (TypeError, ValueError):
+        return float(default)
+    if arr.size == 0 or not np.isfinite(arr[0]):
+        return float(default)
+    return float(arr[0])
+
+
+def _robot_state(
+    observation: dict[str, Any], config: CbfSafetyFilterConfig
+) -> tuple[np.ndarray, np.ndarray, float, float]:
+    """Extract robot position, velocity, heading, and radius from observation.
+
+    Returns:
+        Position, velocity, heading, and robot radius.
+    """
+
+    robot = observation.get("robot")
+    if isinstance(robot, dict):
+        position = _as_xy(robot.get("position"))
+        velocity = _as_xy(robot.get("velocity"))
+        heading = _as_float(robot.get("heading"), math.atan2(velocity[1], velocity[0]))
+        radius = _as_float(robot.get("radius"), config.robot_radius)
+        return position, velocity, heading, radius
+
+    drive_state = observation.get("drive_state")
+    if drive_state is not None:
+        arr = np.asarray(drive_state, dtype=float).reshape(-1)
+        if arr.size >= 5:
+            position = arr[:2].astype(float)
+            heading = float(arr[2])
+            speed = float(arr[3])
+            velocity = np.asarray([math.cos(heading) * speed, math.sin(heading) * speed])
+            return position, velocity, heading, float(config.robot_radius)
+
+    return np.zeros(2, dtype=float), np.zeros(2, dtype=float), 0.0, float(config.robot_radius)
+
+
+def _obstacles(observation: dict[str, Any], config: CbfSafetyFilterConfig) -> list[_ObstacleState]:
+    """Extract dynamic obstacle states from supported observation payloads.
+
+    Returns:
+        Dynamic obstacle states visible in the observation.
+    """
+
+    obstacles: list[_ObstacleState] = []
+    agents = observation.get("agents")
+    if isinstance(agents, list):
+        for agent in agents:
+            if not isinstance(agent, dict):
+                continue
+            obstacles.append(
+                _ObstacleState(
+                    position=_as_xy(agent.get("position")),
+                    velocity=_as_xy(agent.get("velocity")),
+                    radius=_as_float(agent.get("radius"), config.pedestrian_radius),
+                )
+            )
+
+    pedestrians = observation.get("pedestrians")
+    if isinstance(pedestrians, dict):
+        positions = np.asarray(pedestrians.get("positions", []), dtype=float).reshape(-1, 2)
+        velocities_raw = pedestrians.get("velocities", np.zeros_like(positions))
+        velocities = np.asarray(velocities_raw, dtype=float)
+        if velocities.size == 0:
+            velocities = np.zeros_like(positions)
+        velocities = velocities.reshape(-1, 2)
+        radius = _as_float(pedestrians.get("radius"), config.pedestrian_radius)
+        for idx, position in enumerate(positions):
+            velocity = velocities[idx] if idx < len(velocities) else np.zeros(2, dtype=float)
+            obstacles.append(
+                _ObstacleState(
+                    position=np.asarray(position, dtype=float),
+                    velocity=np.asarray(velocity, dtype=float),
+                    radius=radius,
+                )
+            )
+    return obstacles
+
+
+class CollisionConeCbfSafetyFilter:
+    """Project nominal unicycle commands through current-state CBF constraints."""
+
+    def __init__(self, config: CbfSafetyFilterConfig | None = None) -> None:
+        """Initialize the filter and empty decision counters."""
+
+        self.config = config or CbfSafetyFilterConfig()
+        self._stats = {
+            "decision_count": 0,
+            "feasible_count": 0,
+            "projected_count": 0,
+            "fallback_count": 0,
+            "last_decision": None,
+        }
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return JSON-serializable filter diagnostics."""
+
+        return {
+            "schema_version": "cbf-safety-filter-stats.v1",
+            "variant": self.config.variant,
+            **self._stats,
+        }
+
+    def filter_command(
+        self, observation: dict[str, Any], proposed_command: ActionCommand
+    ) -> ShieldDecision:
+        """Return a shield decision for ``proposed_command`` in ``observation``."""
+
+        if not self.config.enabled:
+            return ShieldDecision(
+                proposed_action=proposed_command,
+                filtered_action=proposed_command,
+                decision_label="cbf_disabled",
+                intervention_reason="cbf_safety_filter_disabled",
+                prediction_source="current_state",
+            )
+
+        robot_pos, _robot_vel, heading, robot_radius = _robot_state(observation, self.config)
+        obstacles = _obstacles(observation, self.config)
+        nominal = self._command_to_velocity(proposed_command, heading)
+        selected = nominal.copy()
+        constraints = self._constraints(robot_pos, robot_radius, obstacles)
+        min_margin_before = self._min_margin(nominal, constraints)
+        violated_before = min_margin_before < 0.0
+
+        for _ in range(int(self.config.max_projection_passes)):
+            changed = False
+            for normal, lower_bound, _label in constraints:
+                margin = float(np.dot(normal, selected) - lower_bound)
+                if margin >= 0.0:
+                    continue
+                denom = float(np.dot(normal, normal))
+                if denom <= 1e-12:
+                    continue
+                selected = (
+                    selected + ((lower_bound - float(np.dot(normal, selected))) / denom) * normal
+                )
+                changed = True
+            if not changed:
+                break
+
+        selected = self._cap_velocity(selected)
+        min_margin_after = self._min_margin(selected, constraints)
+        filtered = self._velocity_to_command(selected, heading, proposed_command)
+        fallback = min_margin_after < -1e-9
+        label = "cbf_projected" if violated_before else "cbf_feasible"
+        if fallback:
+            label = "cbf_best_effort"
+        violated = tuple(
+            label
+            for normal, lower_bound, label in constraints
+            if np.dot(normal, nominal) < lower_bound
+        )
+        decision = ShieldDecision(
+            proposed_action=(float(proposed_command[0]), float(proposed_command[1])),
+            filtered_action=filtered,
+            decision_label=label,
+            intervention_reason=(
+                "collision_cone_cbf_projection"
+                if violated_before
+                else "proposed_command_satisfies_collision_cone_cbf"
+            ),
+            violated_constraints=violated,
+            prediction_source="current_state",
+            fallback_controller_state={
+                "filter": "CollisionConeCbfSafetyFilter",
+                "variant": self.config.variant,
+                "fallback": fallback,
+            },
+            proposed_evaluation={"min_cbf_margin": float(min_margin_before)},
+            selected_evaluation={"min_cbf_margin": float(min_margin_after)},
+        )
+        self._record_decision(decision, fallback=fallback)
+        return decision
+
+    def _command_to_velocity(self, command: ActionCommand, heading: float) -> np.ndarray:
+        linear = float(command[0])
+        if self.config.max_linear_speed is not None:
+            linear = float(
+                np.clip(linear, -self.config.max_linear_speed, self.config.max_linear_speed)
+            )
+        return np.asarray([math.cos(heading) * linear, math.sin(heading) * linear], dtype=float)
+
+    def _velocity_to_command(
+        self,
+        velocity: np.ndarray,
+        heading: float,
+        proposed_command: ActionCommand,
+    ) -> ActionCommand:
+        speed = float(np.linalg.norm(velocity))
+        if speed <= 1e-12:
+            linear = 0.0
+            angular = 0.0
+        else:
+            heading_unit = np.asarray([math.cos(heading), math.sin(heading)], dtype=float)
+            linear = max(0.0, float(np.dot(velocity, heading_unit)))
+            target_heading = math.atan2(float(velocity[1]), float(velocity[0]))
+            angular = float(proposed_command[1]) + float(self.config.turn_gain) * _wrap_angle(
+                target_heading - heading
+            )
+        if self.config.max_linear_speed is not None:
+            linear = float(np.clip(linear, 0.0, self.config.max_linear_speed))
+        if self.config.max_angular_speed is not None:
+            angular = float(
+                np.clip(angular, -self.config.max_angular_speed, self.config.max_angular_speed)
+            )
+        return float(linear), float(angular)
+
+    def _constraints(
+        self,
+        robot_pos: np.ndarray,
+        robot_radius: float,
+        obstacles: list[_ObstacleState],
+    ) -> list[tuple[np.ndarray, float, str]]:
+        constraints: list[tuple[np.ndarray, float, str]] = []
+        for idx, obstacle in enumerate(obstacles):
+            relative_pos = np.asarray(obstacle.position - robot_pos, dtype=float)
+            distance_sq = float(np.dot(relative_pos, relative_pos))
+            combined_radius = float(robot_radius + obstacle.radius + self.config.safety_margin)
+            h_value = distance_sq - combined_radius * combined_radius
+            h_value = max(h_value, -abs(self.config.min_clearance_h))
+            normal = -2.0 * relative_pos
+            lower_bound = float(
+                -self.config.alpha * h_value - 2.0 * np.dot(relative_pos, obstacle.velocity)
+            )
+            constraints.append((normal, lower_bound, f"collision_cone_cbf_agent_{idx}"))
+        return constraints
+
+    def _cap_velocity(self, velocity: np.ndarray) -> np.ndarray:
+        if self.config.max_linear_speed is None:
+            return velocity
+        speed = float(np.linalg.norm(velocity))
+        if speed <= float(self.config.max_linear_speed) or speed <= 1e-12:
+            return velocity
+        return velocity * (float(self.config.max_linear_speed) / speed)
+
+    @staticmethod
+    def _min_margin(
+        velocity: np.ndarray, constraints: list[tuple[np.ndarray, float, str]]
+    ) -> float:
+        if not constraints:
+            return float("inf")
+        return min(
+            float(np.dot(normal, velocity) - lower_bound) for normal, lower_bound, _ in constraints
+        )
+
+    def _record_decision(self, decision: ShieldDecision, *, fallback: bool) -> None:
+        self._stats["decision_count"] = int(self._stats["decision_count"]) + 1
+        if decision.decision_label == "cbf_feasible":
+            self._stats["feasible_count"] = int(self._stats["feasible_count"]) + 1
+        elif decision.decision_label == "cbf_projected":
+            self._stats["projected_count"] = int(self._stats["projected_count"]) + 1
+        if fallback:
+            self._stats["fallback_count"] = int(self._stats["fallback_count"]) + 1
+        self._stats["last_decision"] = decision.to_metadata()
+
+
+class CbfSafetyFilterPlannerWrapper:
+    """Planner wrapper that applies :class:`CollisionConeCbfSafetyFilter` after ``plan``."""
+
+    def __init__(self, planner: Any, config: CbfSafetyFilterConfig | None = None) -> None:
+        """Wrap a planner exposing ``plan(observation) -> (linear, angular)``."""
+
+        self.planner = planner
+        self.filter = CollisionConeCbfSafetyFilter(config)
+        self.last_decision: ShieldDecision | None = None
+
+    def plan(self, observation: dict[str, Any]) -> ActionCommand:
+        """Return the planner command, filtered when enabled."""
+
+        command = self.planner.plan(observation)
+        if not self.filter.config.enabled:
+            return command
+        decision = self.filter.filter_command(
+            observation,
+            (float(command[0]), float(command[1])),
+        )
+        self.last_decision = decision
+        return decision.filtered_action
+
+    def diagnostics(self) -> dict[str, Any]:
+        """Return wrapped planner and filter diagnostics when available."""
+
+        payload = {"cbf_safety_filter": self.filter.diagnostics()}
+        diagnostics = getattr(self.planner, "diagnostics", None)
+        if callable(diagnostics):
+            payload["wrapped_planner"] = diagnostics()
+        return payload
+
+    def reset(self, *args: Any, **kwargs: Any) -> Any:
+        """Forward reset to wrapped planner when supported.
+
+        Returns:
+            Wrapped planner reset result when available, otherwise ``None``.
+        """
+
+        reset = getattr(self.planner, "reset", None)
+        if callable(reset):
+            return reset(*args, **kwargs)
+        return None
+
+    def close(self) -> None:
+        """Forward close to wrapped planner when supported."""
+
+        close = getattr(self.planner, "close", None)
+        if callable(close):
+            close()
+
+
+__all__ = [
+    "CbfSafetyFilterConfig",
+    "CbfSafetyFilterPlannerWrapper",
+    "CollisionConeCbfSafetyFilter",
+    "build_cbf_safety_filter_config",
+]

--- a/tests/benchmark/test_cbf_safety_filter_policy.py
+++ b/tests/benchmark/test_cbf_safety_filter_policy.py
@@ -1,0 +1,81 @@
+"""Benchmark policy wiring tests for the optional CBF safety filter."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.map_runner import _build_policy
+
+
+def test_adapter_policy_cbf_filter_is_explicit_opt_in() -> None:
+    """Adapter-backed planners expose CBF metadata and shield stats only when enabled."""
+
+    policy, meta = _build_policy(
+        "safety_barrier",
+        {
+            "max_linear_speed": 0.8,
+            "cbf_safety_filter": {
+                "enabled": True,
+                "alpha": 1.0,
+                "safety_margin": 0.1,
+                "max_linear_speed": 1.0,
+                "max_angular_speed": 2.0,
+            },
+        },
+        robot_kinematics="differential_drive",
+        robot_command_mode="unicycle",
+    )
+
+    command = policy(
+        {
+            "robot": {
+                "position": [0.0, 0.0],
+                "velocity": [0.8, 0.0],
+                "heading": [0.0],
+                "radius": [0.3],
+            },
+            "goal": {"current": [5.0, 0.0], "next": [5.0, 0.0]},
+            "agents": [
+                {
+                    "position": [0.8, 0.0],
+                    "velocity": [-0.6, 0.0],
+                    "radius": 0.3,
+                }
+            ],
+        }
+    )
+
+    assert command[0] < 0.8
+    assert meta["cbf_safety_filter"]["status"] == "enabled"
+    assert meta["safety_shield_contract"]["shield_name"] == "CollisionConeCbfSafetyFilter"
+    assert meta["shield_stats"]["decision_count"] == 1
+    assert meta["shield_stats"]["intervention_count"] == 1
+    stats = policy._planner_stats()
+    assert stats["cbf_safety_filter"]["decision_count"] == 1
+
+
+def test_adapter_policy_without_cbf_filter_has_no_shield_metadata() -> None:
+    """Default adapter-backed planner construction remains shield-free."""
+
+    _policy, meta = _build_policy(
+        "safety_barrier",
+        {"max_linear_speed": 0.8},
+        robot_kinematics="differential_drive",
+        robot_command_mode="unicycle",
+    )
+
+    assert "cbf_safety_filter" not in meta
+    assert "safety_shield_contract" not in meta
+    assert "shield_stats" not in meta
+
+
+def test_adapter_policy_rejects_unimplemented_cbf_variant() -> None:
+    """Unsupported variants fail closed at policy construction."""
+
+    with pytest.raises(ValueError, match="collision_cone"):
+        _build_policy(
+            "safety_barrier",
+            {"cbf_safety_filter": {"enabled": True, "variant": "dynamic_parabolic"}},
+            robot_kinematics="differential_drive",
+            robot_command_mode="unicycle",
+        )

--- a/tests/benchmark/test_cbf_safety_filter_runtime.py
+++ b/tests/benchmark/test_cbf_safety_filter_runtime.py
@@ -1,0 +1,486 @@
+"""Tests opt-in benchmark runtime CBF safety-filter binding."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import numpy as np
+import pytest
+
+from robot_sf.benchmark import cbf_safety_filter_runtime, map_runner_episode
+from robot_sf.benchmark.cbf_safety_filter_runtime import (
+    CBF_COLLISION_CONE_ARM,
+    CBF_OFF_ARM,
+    CBF_SAFETY_FILTER_EPISODE_SUMMARY_SCHEMA,
+    CBF_SAFETY_FILTER_RUNTIME_STEP_SCHEMA,
+    apply_runtime_cbf_safety_filter,
+    compute_cbf_observation_from_env,
+    ineligible_cbf_safety_filter_step_record,
+    runtime_config_from_mapping,
+    summarize_cbf_safety_filter_trace,
+)
+from robot_sf.benchmark.event_ledger import build_event_ledger
+from robot_sf.benchmark.map_runner_identity import _scenario_identity_payload
+
+
+class _Robot:
+    theta = np.array([0.0], dtype=float)
+
+
+class _Simulator:
+    def __init__(self) -> None:
+        self.robot_pos = [np.array([0.0, 0.0], dtype=float)]
+        self.ped_pos = np.array([[0.2, 0.0]], dtype=float)
+        self.robots = [_Robot()]
+
+
+class _Env:
+    def __init__(self) -> None:
+        self.simulator = _Simulator()
+
+
+class _EpisodeSim(_Simulator):
+    def __init__(self) -> None:
+        super().__init__()
+        self.goal_pos = [np.array([1.0, 0.0], dtype=float)]
+        self.map_def = SimpleNamespace(obstacles=[], bounds=(0.0, 0.0, 1.0, 1.0))
+        self.robot_vel = [np.array([0.0, 0.0], dtype=float)]
+
+    def get_pedestrian_forces(self) -> np.ndarray:
+        return np.zeros((1, 2), dtype=float)
+
+
+class _EpisodeEnv:
+    def __init__(self) -> None:
+        self.simulator = _EpisodeSim()
+        self.action_space = None
+
+    def reset(self, seed=None):
+        return (
+            {
+                "robot": {"position": [0.0, 0.0], "heading": [0.0]},
+                "goal": {"current": [1.0, 0.0]},
+                "pedestrians": {"positions": self.simulator.ped_pos},
+            },
+            {},
+        )
+
+    def step(self, _action):
+        return self.reset()[0], 0.0, True, False, {"meta": {"is_route_complete": True}}
+
+    def close(self) -> None:
+        return None
+
+
+def _config() -> SimpleNamespace:
+    return SimpleNamespace(
+        sim_config=SimpleNamespace(
+            time_per_step_in_secs=0.1,
+            robot_radius=0.1,
+            ped_radius=0.1,
+        )
+    )
+
+
+def _patch_episode_runtime(monkeypatch) -> None:
+    monkeypatch.setattr(
+        map_runner_episode,
+        "_build_env_config",
+        lambda _scenario, scenario_path: _config(),
+    )
+    monkeypatch.setattr(
+        map_runner_episode,
+        "make_robot_env",
+        lambda config, seed, debug: _EpisodeEnv(),
+    )
+    monkeypatch.setattr(map_runner_episode, "sample_obstacle_points", lambda *args: None)
+    monkeypatch.setattr(map_runner_episode, "compute_shortest_path_length", lambda *args: 1.0)
+    monkeypatch.setattr(
+        map_runner_episode,
+        "compute_all_metrics",
+        lambda *args, **kwargs: {"success": 1.0, "collisions": 0.0},
+    )
+    monkeypatch.setattr(
+        map_runner_episode,
+        "post_process_metrics",
+        lambda metrics, **kwargs: metrics,
+    )
+
+
+def _run_episode_with_policy(monkeypatch, policy_builder, *, cbf_safety_filter):
+    _patch_episode_runtime(monkeypatch)
+    return map_runner_episode.run_map_episode(
+        {"name": "cbf-runtime", "simulation_config": {"max_episode_steps": 1}},
+        seed=1,
+        horizon=1,
+        dt=0.1,
+        record_forces=False,
+        snqi_weights=None,
+        snqi_baseline=None,
+        algo="goal",
+        scenario_path=Path(__file__),
+        cbf_safety_filter=cbf_safety_filter,
+        policy_builder=policy_builder,
+    )
+
+
+def test_runtime_config_disabled_by_default_preserves_off_state() -> None:
+    """Missing runtime config keeps CBF filter disabled."""
+
+    runtime = runtime_config_from_mapping(None)
+
+    assert runtime.enabled is False
+    assert runtime.arm_key == CBF_OFF_ARM
+
+
+@pytest.mark.parametrize(
+    "payload,match",
+    [
+        ({"enabled": True, "arm_key": CBF_OFF_ARM}, "enabled=True"),
+        ({"enabled": False, "arm_key": CBF_COLLISION_CONE_ARM}, "enabled=False"),
+        ({"enabled": True, "arm_key": CBF_COLLISION_CONE_ARM, "alpha": 2.0}, "predeclared"),
+        (
+            {
+                "enabled": True,
+                "arm_key": CBF_COLLISION_CONE_ARM,
+                "variant": "dynamic_parabolic",
+            },
+            "dynamic_parabolic",
+        ),
+    ],
+)
+def test_runtime_config_fails_closed_for_arm_or_threshold_drift(
+    payload: dict[str, object], match: str
+) -> None:
+    """Enabled CBF arm must match predeclared first-slice semantics."""
+
+    with pytest.raises((ValueError, NotImplementedError), match=match):
+        runtime_config_from_mapping(payload)
+
+
+def test_runtime_config_rejects_malformed_mapping() -> None:
+    """Runtime config parser fails closed on wrong type and unknown keys."""
+
+    with pytest.raises(TypeError, match="mapping"):
+        runtime_config_from_mapping(["not", "mapping"])  # type: ignore[arg-type]
+    with pytest.raises(ValueError, match="Unknown"):
+        runtime_config_from_mapping({"unexpected": True})
+    with pytest.raises(ValueError, match="arm_key"):
+        runtime_config_from_mapping({"enabled": True, "arm_key": "cbf_custom_on"})
+
+
+def test_cbf_on_emits_schema_tagged_intervention_record_and_summary() -> None:
+    """A close pre-step pedestrian produces well-formed CBF evidence."""
+
+    runtime = runtime_config_from_mapping({"enabled": True, "arm_key": CBF_COLLISION_CONE_ARM})
+
+    corrected, record = apply_runtime_cbf_safety_filter(
+        command=(1.0, 0.25),
+        env=_Env(),
+        config=_config(),
+        runtime=runtime,
+        previous_ped_positions=np.array([[0.3, 0.0]], dtype=float),
+        step_idx=3,
+    )
+
+    assert corrected[0] < 1.0
+    assert record["schema_version"] == CBF_SAFETY_FILTER_RUNTIME_STEP_SCHEMA
+    assert record["arm_key"] == CBF_COLLISION_CONE_ARM
+    assert record["enabled"] is True
+    assert record["eligible_for_cbf_filter"] is True
+    assert record["context_source"] == "simulator_state_pre_step"
+    assert record["pedestrian_velocity_identity"] == "row_order_finite_difference_no_stable_ids"
+    assert record["qp_status"] in {"filtered", "fallback_infeasible"}
+    assert record["intervened"] is True
+    assert record["qp_status"] != "pass_through"
+
+    summary = summarize_cbf_safety_filter_trace([record], runtime=runtime)
+    assert summary["schema_version"] == CBF_SAFETY_FILTER_EPISODE_SUMMARY_SCHEMA
+    assert summary["intervened_step_count"] == 1
+    assert summary["intervention_rate"] == 1.0
+    assert summary["status_counts"][record["qp_status"]] == 1
+
+
+def test_apply_runtime_cbf_rejects_short_command() -> None:
+    """Runtime CBF requires linear and angular command entries."""
+
+    runtime = runtime_config_from_mapping({"enabled": True, "arm_key": CBF_COLLISION_CONE_ARM})
+
+    with pytest.raises(TypeError, match="linear and angular"):
+        apply_runtime_cbf_safety_filter(
+            command=(1.0,),
+            env=_Env(),
+            config=_config(),
+            runtime=runtime,
+            previous_ped_positions=None,
+            step_idx=0,
+        )
+
+
+def test_compute_cbf_observation_uses_pre_step_simulator_state() -> None:
+    """Runtime context is sourced from simulator state, not planner observation."""
+
+    observation, provenance = compute_cbf_observation_from_env(
+        env=_Env(),
+        config=_config(),
+        previous_ped_positions=np.array([[0.3, 0.0]], dtype=float),
+        dt=0.1,
+    )
+
+    assert provenance["context_source"] == "simulator_state_pre_step"
+    assert provenance["obstacle_count"] == 1
+    assert observation["agents"][0]["velocity"] == pytest.approx([-1.0, 0.0])
+
+
+def test_compute_cbf_observation_accepts_robot_poses_heading() -> None:
+    """Runtime heading parser supports the real map-runner simulator pose shape."""
+
+    env = _Env()
+    env.simulator.robot_poses = [((0.0, 0.0), 1.25)]
+    env.simulator.robots = []
+
+    observation, _provenance = compute_cbf_observation_from_env(
+        env=env,
+        config=_config(),
+        previous_ped_positions=None,
+        dt=0.1,
+    )
+
+    assert observation["robot"]["heading"] == pytest.approx(1.25)
+
+
+@pytest.mark.parametrize(
+    "ped_pos,match",
+    [
+        (np.array([1.0, 0.0, 2.0], dtype=float), "even-length"),
+        (np.array([[1.0], [2.0]], dtype=float), "shaped"),
+        (np.array([[np.inf, 0.0]], dtype=float), "finite"),
+    ],
+)
+def test_compute_cbf_observation_rejects_malformed_pedestrians(
+    ped_pos: np.ndarray,
+    match: str,
+) -> None:
+    """Malformed simulator pedestrian rows fail closed."""
+
+    env = _Env()
+    env.simulator.ped_pos = ped_pos
+
+    with pytest.raises(ValueError, match=match):
+        compute_cbf_observation_from_env(
+            env=env,
+            config=_config(),
+            previous_ped_positions=None,
+            dt=0.1,
+        )
+
+
+@pytest.mark.parametrize(
+    "robot_pos,match",
+    [
+        ([], "robot_pos"),
+        ([np.array([np.nan, 0.0], dtype=float)], "finite xy"),
+    ],
+)
+def test_compute_cbf_observation_rejects_malformed_robot_position(
+    robot_pos: list[np.ndarray],
+    match: str,
+) -> None:
+    """Malformed simulator robot position fails closed."""
+
+    env = _Env()
+    env.simulator.robot_pos = robot_pos
+
+    with pytest.raises(ValueError, match=match):
+        compute_cbf_observation_from_env(
+            env=env,
+            config=_config(),
+            previous_ped_positions=None,
+            dt=0.1,
+        )
+
+
+def test_compute_cbf_observation_rejects_nonpositive_dt() -> None:
+    """Finite-difference pedestrian velocity requires positive dt."""
+
+    with pytest.raises(ValueError, match="dt"):
+        compute_cbf_observation_from_env(
+            env=_Env(),
+            config=_config(),
+            previous_ped_positions=np.array([[0.0, 0.0]], dtype=float),
+            dt=0.0,
+        )
+
+
+def test_cbf_runtime_private_status_and_trace_summary_branches() -> None:
+    """Status helper and optional step trace summary stay internally consistent."""
+
+    assert (
+        cbf_safety_filter_runtime._status_from_decision_label("cbf_disabled", intervened=False)
+        == "disabled"
+    )
+    assert (
+        cbf_safety_filter_runtime._status_from_decision_label("cbf_feasible", intervened=False)
+        == "pass_through"
+    )
+    assert (
+        cbf_safety_filter_runtime._status_from_decision_label("cbf_best_effort", intervened=False)
+        == "fallback_infeasible"
+    )
+    assert (
+        cbf_safety_filter_runtime._status_from_decision_label("unknown", intervened=False)
+        == "filtered"
+    )
+
+    runtime = runtime_config_from_mapping(
+        {
+            "enabled": True,
+            "arm_key": CBF_COLLISION_CONE_ARM,
+            "record_step_trace": True,
+        }
+    )
+    record = ineligible_cbf_safety_filter_step_record(
+        runtime=runtime,
+        step_idx=1,
+        reason="unsupported_command_shape",
+    )
+    summary = summarize_cbf_safety_filter_trace([record], runtime=runtime)
+
+    assert summary["steps"][0]["ineligible_reason"] == "unsupported_command_shape"
+
+
+def test_run_map_episode_records_cbf_metadata_metrics_and_ledger(monkeypatch) -> None:
+    """Enabled CBF filter records episode summary, metrics, and ledger provenance."""
+
+    def policy_builder(*_args, **_kwargs):
+        return (lambda _obs: (1.0, 0.0)), {}
+
+    record = _run_episode_with_policy(
+        monkeypatch,
+        policy_builder,
+        cbf_safety_filter={"enabled": True, "arm_key": CBF_COLLISION_CONE_ARM},
+    )
+
+    cbf = record["algorithm_metadata"]["cbf_safety_filter"]
+    assert cbf["schema_version"] == CBF_SAFETY_FILTER_EPISODE_SUMMARY_SCHEMA
+    assert "cbf_filter_intervention_rate" in record["metrics"]
+    ledger = build_event_ledger(record)
+    assert ledger["provenance"]["cbf_safety_filter"]["arm_key"] == CBF_COLLISION_CONE_ARM
+
+
+def test_run_map_episode_fails_closed_for_native_action_when_cbf_enabled(monkeypatch) -> None:
+    """CBF filtering absolute commands fails closed for native-action policies."""
+
+    def policy_builder(*_args, **_kwargs):
+        def policy(_obs):
+            policy._last_step_native = True
+            return np.array([0.0, 0.0], dtype=float)
+
+        return policy, {"algorithm": "unit"}
+
+    with pytest.raises(ValueError, match="native environment actions"):
+        _run_episode_with_policy(
+            monkeypatch,
+            policy_builder,
+            cbf_safety_filter={"enabled": True, "arm_key": CBF_COLLISION_CONE_ARM},
+        )
+
+
+def test_run_map_episode_fails_closed_for_unsupported_command_when_cbf_enabled(
+    monkeypatch,
+) -> None:
+    """Non-pair commands fail closed when CBF filtering is enabled."""
+
+    def policy_builder(*_args, **_kwargs):
+        return (lambda _obs: "forward"), {}
+
+    with pytest.raises(TypeError, match="commands shaped"):
+        _run_episode_with_policy(
+            monkeypatch,
+            policy_builder,
+            cbf_safety_filter={"enabled": True, "arm_key": CBF_COLLISION_CONE_ARM},
+        )
+
+
+def test_run_map_episode_rejects_combined_safety_wrapper_and_cbf(monkeypatch) -> None:
+    """First slice keeps wrapper and CBF mutually exclusive for attribution."""
+
+    def policy_builder(*_args, **_kwargs):
+        return (lambda _obs: (1.0, 0.0)), {}
+
+    _patch_episode_runtime(monkeypatch)
+    with pytest.raises(ValueError, match="cannot both be enabled"):
+        map_runner_episode.run_map_episode(
+            {"name": "cbf-runtime", "simulation_config": {"max_episode_steps": 1}},
+            seed=1,
+            horizon=1,
+            dt=0.1,
+            record_forces=False,
+            snqi_weights=None,
+            snqi_baseline=None,
+            algo="goal",
+            scenario_path=Path(__file__),
+            safety_wrapper={"enabled": True, "arm_key": "wrapper_on"},
+            cbf_safety_filter={"enabled": True, "arm_key": CBF_COLLISION_CONE_ARM},
+            policy_builder=policy_builder,
+        )
+
+
+def test_ineligible_step_records_count_in_summary_denominator() -> None:
+    """Fail-open ineligible steps stay visible in rates."""
+
+    runtime = runtime_config_from_mapping({"enabled": True, "arm_key": CBF_COLLISION_CONE_ARM})
+    wrapped = apply_runtime_cbf_safety_filter(
+        command=(1.0, 0.25),
+        env=_Env(),
+        config=_config(),
+        runtime=runtime,
+        previous_ped_positions=np.array([[0.3, 0.0]], dtype=float),
+        step_idx=0,
+    )[1]
+    ineligible = ineligible_cbf_safety_filter_step_record(
+        runtime=runtime,
+        step_idx=1,
+        reason="unsupported_command_shape",
+    )
+
+    summary = summarize_cbf_safety_filter_trace([wrapped, ineligible], runtime=runtime)
+
+    assert ineligible["eligible_for_cbf_filter"] is False
+    assert ineligible["intervened"] is False
+    assert summary["step_count"] == 2
+    assert summary["eligible_step_count"] == 1
+
+
+def test_scenario_identity_includes_only_enabled_cbf_filter() -> None:
+    """Enabled CBF filter is resume identity; disabled CBF config is ignored."""
+
+    base = {
+        "name": "identity",
+        "map": "maps/svg_maps/example.svg",
+        "start": [0.0, 0.0],
+        "goal": [1.0, 0.0],
+    }
+
+    off_payload = _scenario_identity_payload(
+        base,
+        algo="goal",
+        algo_config={},
+        horizon=1,
+        dt=0.1,
+        record_forces=False,
+        cbf_safety_filter={"enabled": False, "arm_key": CBF_OFF_ARM},
+    )
+    on_payload = _scenario_identity_payload(
+        base,
+        algo="goal",
+        algo_config={},
+        horizon=1,
+        dt=0.1,
+        record_forces=False,
+        cbf_safety_filter={"enabled": True, "arm_key": CBF_COLLISION_CONE_ARM},
+    )
+
+    assert "cbf_safety_filter" not in off_payload
+    assert on_payload["cbf_safety_filter"]["arm_key"] == CBF_COLLISION_CONE_ARM

--- a/tests/planner/test_cbf_safety_filter.py
+++ b/tests/planner/test_cbf_safety_filter.py
@@ -1,0 +1,188 @@
+"""Tests for the optional CBF safety-filter planner wrapper."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.planner.cbf_safety_filter import (
+    CbfSafetyFilterConfig,
+    CbfSafetyFilterPlannerWrapper,
+    CollisionConeCbfSafetyFilter,
+    build_cbf_safety_filter_config,
+)
+
+
+def _head_on_observation() -> dict[str, object]:
+    return {
+        "robot": {
+            "position": [0.0, 0.0],
+            "velocity": [0.8, 0.0],
+            "heading": [0.0],
+            "radius": [0.3],
+        },
+        "agents": [
+            {
+                "position": [0.8, 0.0],
+                "velocity": [-0.6, 0.0],
+                "radius": 0.3,
+            }
+        ],
+    }
+
+
+def test_collision_cone_cbf_projects_head_on_command() -> None:
+    """Approaching obstacle should force a lower-speed best-effort command."""
+
+    filter_ = CollisionConeCbfSafetyFilter(
+        CbfSafetyFilterConfig(
+            enabled=True,
+            alpha=1.0,
+            safety_margin=0.1,
+            max_linear_speed=1.0,
+            max_angular_speed=2.0,
+        )
+    )
+
+    decision = filter_.filter_command(_head_on_observation(), (0.8, 0.0))
+
+    assert decision.decision_label in {"cbf_projected", "cbf_best_effort"}
+    assert decision.filtered_action[0] < 0.8
+    assert decision.prediction_source == "current_state"
+    assert decision.violated_constraints == ("collision_cone_cbf_agent_0",)
+    assert filter_.diagnostics()["decision_count"] == 1
+
+
+def test_collision_cone_cbf_leaves_clear_command_feasible() -> None:
+    """Obstacle moving away should not alter the nominal command."""
+
+    observation = _head_on_observation()
+    observation["agents"][0]["velocity"] = [0.6, 0.0]  # type: ignore[index]
+    filter_ = CollisionConeCbfSafetyFilter(
+        CbfSafetyFilterConfig(enabled=True, alpha=1.0, max_linear_speed=1.0)
+    )
+
+    decision = filter_.filter_command(observation, (0.2, 0.0))
+
+    assert decision.decision_label == "cbf_feasible"
+    assert decision.filtered_action == pytest.approx((0.2, 0.0))
+
+
+def test_wrapper_disabled_returns_nominal_command_unchanged() -> None:
+    """Disabled wrapper preserves nominal planner output exactly."""
+
+    class _Planner:
+        def plan(self, _observation: dict[str, object]) -> tuple[float, float]:
+            return 0.8, 0.1
+
+    wrapper = CbfSafetyFilterPlannerWrapper(_Planner(), CbfSafetyFilterConfig(enabled=False))
+
+    assert wrapper.plan(_head_on_observation()) == (0.8, 0.1)
+    assert wrapper.last_decision is None
+
+
+def test_build_cbf_config_rejects_unimplemented_dynamic_parabolic_variant() -> None:
+    """Dynamic-parabolic CBF is deliberately out of this first bounded slice."""
+
+    with pytest.raises(ValueError, match="collision_cone"):
+        build_cbf_safety_filter_config({"enabled": True, "variant": "dynamic_parabolic"})
+
+
+def test_build_cbf_config_validates_nested_mapping_and_bounds() -> None:
+    """Config builder handles nested map-runner payloads and rejects bad bounds."""
+
+    cfg = build_cbf_safety_filter_config({"cbf_safety_filter": {"enabled": True, "alpha": 0.5}})
+    assert cfg.enabled is True
+    assert cfg.alpha == pytest.approx(0.5)
+
+    with pytest.raises(ValueError, match="Unknown"):
+        build_cbf_safety_filter_config({"unexpected": True})
+    with pytest.raises(ValueError, match="alpha"):
+        build_cbf_safety_filter_config({"alpha": -0.1})
+    with pytest.raises(ValueError, match="safety_margin"):
+        build_cbf_safety_filter_config({"safety_margin": -0.1})
+    with pytest.raises(ValueError, match="max_projection_passes"):
+        build_cbf_safety_filter_config({"max_projection_passes": 0})
+
+
+def test_cbf_filter_supports_pedestrian_dict_payload() -> None:
+    """Pedestrian matrix observations exercise benchmark observation extraction."""
+
+    filter_ = CollisionConeCbfSafetyFilter(
+        CbfSafetyFilterConfig(enabled=True, alpha=1.0, max_linear_speed=1.0)
+    )
+
+    decision = filter_.filter_command(
+        {
+            "robot": {
+                "position": [0.0, 0.0],
+                "velocity": [0.8, 0.0],
+                "heading": [0.0],
+                "radius": [0.3],
+            },
+            "pedestrians": {
+                "positions": [[0.8, 0.0]],
+                "velocities": [[-0.6, 0.0]],
+                "radius": [0.3],
+            },
+        },
+        (0.8, 0.0),
+    )
+
+    assert decision.decision_label in {"cbf_projected", "cbf_best_effort"}
+    assert decision.filtered_action[0] < 0.8
+
+
+def test_cbf_filter_supports_drive_state_and_empty_obstacles() -> None:
+    """Drive-state observations without obstacles pass through as feasible."""
+
+    filter_ = CollisionConeCbfSafetyFilter(
+        CbfSafetyFilterConfig(
+            enabled=True,
+            max_linear_speed=0.5,
+            max_angular_speed=1.0,
+        )
+    )
+
+    decision = filter_.filter_command(
+        {"drive_state": [1.0, 2.0, 0.25, 0.1, 0.0]},
+        (0.0, 0.4),
+    )
+
+    assert decision.decision_label == "cbf_feasible"
+    assert decision.filtered_action == pytest.approx((0.0, 0.0))
+
+
+def test_wrapper_enabled_forwards_diagnostics_reset_and_close() -> None:
+    """Enabled wrapper filters commands while forwarding planner lifecycle calls."""
+
+    class _Planner:
+        def __init__(self) -> None:
+            self.reset_seed = None
+            self.closed = False
+
+        def plan(self, _observation: dict[str, object]) -> tuple[float, float]:
+            return 0.8, 0.0
+
+        def diagnostics(self) -> dict[str, object]:
+            return {"planner": "dummy"}
+
+        def reset(self, *, seed: int | None = None) -> str:
+            self.reset_seed = seed
+            return "reset"
+
+        def close(self) -> None:
+            self.closed = True
+
+    planner = _Planner()
+    wrapper = CbfSafetyFilterPlannerWrapper(
+        planner,
+        CbfSafetyFilterConfig(enabled=True, alpha=1.0, max_linear_speed=1.0),
+    )
+
+    assert wrapper.plan(_head_on_observation())[0] < 0.8
+    assert wrapper.last_decision is not None
+    assert wrapper.diagnostics()["wrapped_planner"] == {"planner": "dummy"}
+    assert wrapper.reset(seed=7) == "reset"
+    assert planner.reset_seed == 7
+    wrapper.close()
+    assert planner.closed is True

--- a/tests/planner/test_cbf_safety_filter.py
+++ b/tests/planner/test_cbf_safety_filter.py
@@ -5,9 +5,14 @@ from __future__ import annotations
 import pytest
 
 from robot_sf.planner.cbf_safety_filter import (
+    CBF_VARIANT_DYNAMIC_PARABOLIC,
+    CBFFilterContext,
+    CBFObstacleState,
+    CBFSafetyFilterConfig,
     CbfSafetyFilterConfig,
     CbfSafetyFilterPlannerWrapper,
     CollisionConeCbfSafetyFilter,
+    apply_cbf_safety_filter,
     build_cbf_safety_filter_config,
 )
 
@@ -28,6 +33,92 @@ def _head_on_observation() -> dict[str, object]:
             }
         ],
     }
+
+
+def _public_context() -> CBFFilterContext:
+    return CBFFilterContext(
+        robot_position_m=(0.0, 0.0),
+        robot_heading_rad=0.0,
+        robot_radius_m=0.3,
+        obstacles=(
+            CBFObstacleState(
+                position_m=(1.0, 0.0),
+                velocity_mps=(-0.5, 0.0),
+                radius_m=0.35,
+            ),
+        ),
+    )
+
+
+def test_public_apply_cbf_filter_disabled_returns_original_command() -> None:
+    """Public pure-function API preserves disabled commands."""
+
+    result = apply_cbf_safety_filter(0.8, 0.1, _public_context(), CBFSafetyFilterConfig())
+
+    assert result["qp_status"] == "disabled"
+    assert result["filtered_linear_velocity"] == 0.8
+    assert result["filtered_angular_velocity"] == 0.1
+
+
+def test_public_apply_cbf_filter_no_obstacles_passes_through() -> None:
+    """No obstacle constraints keep enabled CBF pass-through."""
+
+    context = CBFFilterContext(
+        robot_position_m=(0.0, 0.0),
+        robot_heading_rad=0.0,
+        robot_radius_m=0.3,
+        obstacles=(),
+    )
+    result = apply_cbf_safety_filter(
+        0.8,
+        0.1,
+        context,
+        CBFSafetyFilterConfig(enabled=True),
+    )
+
+    assert result["qp_status"] == "pass_through"
+    assert result["active_constraint_count"] == 0
+
+
+def test_public_apply_cbf_filter_projects_head_on_command() -> None:
+    """Head-on obstacle clips the nominal forward command."""
+
+    result = apply_cbf_safety_filter(
+        0.8,
+        0.1,
+        _public_context(),
+        CBFSafetyFilterConfig(enabled=True),
+    )
+
+    assert result["qp_status"] in {"filtered", "fallback_infeasible"}
+    assert result["filtered_linear_velocity"] < 0.8
+    assert result["intervened"] is True
+
+
+def test_public_apply_cbf_filter_dynamic_parabolic_scaffold_fails_closed() -> None:
+    """DPCBF is scaffolded but intentionally unavailable in first slice."""
+
+    with pytest.raises(NotImplementedError, match="dynamic_parabolic_cbf_v1"):
+        apply_cbf_safety_filter(
+            0.8,
+            0.1,
+            _public_context(),
+            CBFSafetyFilterConfig(enabled=True, variant=CBF_VARIANT_DYNAMIC_PARABOLIC),
+        )
+
+
+def test_public_apply_cbf_filter_rejects_malformed_state() -> None:
+    """Non-finite public context state fails closed."""
+
+    context = CBFFilterContext(
+        robot_position_m=(float("nan"), 0.0),
+        robot_heading_rad=0.0,
+        robot_radius_m=0.3,
+        obstacles=(),
+    )
+
+    with pytest.raises(ValueError, match="robot_position_m"):
+        apply_cbf_safety_filter(0.8, 0.1, context, CBFSafetyFilterConfig(enabled=True))
 
 
 def test_collision_cone_cbf_projects_head_on_command() -> None:


### PR DESCRIPTION
## Summary
Adds an opt-in collision-cone Control-Barrier-Function (CBF) safety-filter baseline for map-runner commands. The gate update completes the runtime binding, per-step feasibility/fallback records, episode summary metrics, event-ledger provenance, resume identity, context note, and CPU smoke proof.

## Linked Issues
- Closes #3948

## Stack / Dependency
- Base dependency: none
- Required prior PRs: none
- Stack follow-up issues: #4142
- Safe review independently: yes
- Review dependency reason, any: NA

## What Changed
- Added `robot_sf/benchmark/cbf_safety_filter_runtime.py` for opt-in simulator-state CBF filtering in `run_map_episode` / `run_map_batch`.
- Threaded `cbf_safety_filter` through map-runner, worker params, resume identity, metrics, and event-ledger provenance.
- Added requested public pure-function CBF API in `robot_sf/planner/cbf_safety_filter.py` while preserving the existing adapter wrapper path.
- Added focused planner, runtime, resume-identity, and ledger tests.
- Added `docs/context/issue_3948_cbf_safety_filter.md` with diagnostic-only boundary and validation.

## Why Matters
- Added value: provides the first opt-in collision-cone CBF baseline without requiring pedestrian trajectory prediction.
- Expected impact: benchmark runs can record when the CBF filter changes commands and whether the projection/fallback path was feasible.
- Why worth merging now: closes the bounded first slice and leaves DPCBF / empirical dense-scenario comparison as explicit follow-up work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: blocker-resolution for an optional collision-cone CBF implementation and map-runner runtime binding.
- Comparator or baseline, applicable: unfiltered `goal` smoke arm only for plumbing comparison; no collision-reduction claim.
- Evidence tier: NA - implementation validation and CPU smoke only; no research-result evidence claimed.
- Result classification: NA - implementation blocker resolved; no research result claimed.
- Decision stop rule, applicable: enabled arm records CBF metadata/metrics/ledger provenance; disabled arm does not; full test gates pass.
- Parent issue, claim map, registry, context note, synthesis surface update: context note added at `docs/context/issue_3948_cbf_safety_filter.md`.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - implementation support path, not an analysis tool.

## Domain-Aware Approval
- Required: yes
- Required PR: yes
- Domains reviewed: implementation integrity, evidence boundary
- Status: waived
- Approver source waiver: waiver because PR makes only implementation/runtime smoke claims and does not change evidence classification, comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim boundaries.
- Approver/review source waiver: waiver because this PR makes only implementation/runtime smoke claims and does not change evidence classification, comparison methodology, figure eligibility, benchmark interpretation, or paper-facing claim boundaries.
- Validity checklist: implementation/runtime proof only.
- Target claim/hypothesis: optional collision-cone CBF filter can be constructed, applied at runtime, and recorded.
- Comparator or split/evidence validity: no benchmark comparison claim.
- Fallback/degraded exclusions: fallback/infeasible rates are recorded and not treated as success evidence.
- Claim boundary: diagnostic implementation proof only; not a formal safety certificate.
- Implementation integrity vs experimental validity: implementation integrity covered by tests and smoke; experimental validity remains follow-up.

## Falsification / Non-Transfer Check
- Did mechanism activate? yes, runtime smoke records CBF-on metadata and filtered decisions.
- Did intervention change command source, selected command, trajectory, route progress? selected command changed in focused tests/smoke; no trajectory or route-progress improvement claimed.
- Did scenario actually contain targeted failure mode? smoke is plumbing only; dense dynamic-obstacle failure-mode comparison deferred.
- Result route: continue.
- Follow-up question issue weak, negative, non-transfer results: Dynamic Parabolic CBF implementation and dense scenario comparison need successor tracking: #4142.

## Next Empirical Action
- Rerun needed: no for this PR; yes for collision-incidence or safety-performance claims.
- Extractor analysis tool needed: no.
- Artifact missing unavailable: no durable benchmark artifact required; smoke outputs are local under `output/issue_3948_cbf_smoke/`.
- Stop / revise / continue decision: continue with merge if CI stays green.
- Proposed child issue existing follow-up: #4142 tracks Dynamic Parabolic CBF and dense dynamic-obstacle comparison.

## Validation / Proof
- `uv sync --all-extras`
- `uv run pytest tests/benchmark/test_cbf_safety_filter_runtime.py tests/planner/test_cbf_safety_filter.py tests/benchmark/test_cbf_safety_filter_policy.py tests/benchmark/test_safety_wrapper_runtime.py tests/benchmark/test_event_ledger.py tests/benchmark/test_map_runner_resume_identity.py -q`
- `uv run ruff check robot_sf/benchmark/cbf_safety_filter_runtime.py tests/benchmark/test_cbf_safety_filter_runtime.py robot_sf/planner/cbf_safety_filter.py tests/planner/test_cbf_safety_filter.py robot_sf/benchmark/map_runner_episode.py robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_batch_plan.py robot_sf/benchmark/map_runner_worker.py robot_sf/benchmark/map_runner_identity.py robot_sf/benchmark/event_ledger.py`
- `PR_READY_MODE=final PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/pr-4139-gate/pr-body-updated.md PYTEST_NUM_WORKERS=8 BASE_REF=origin/main scripts/dev/pr_ready_check.sh` (passed on `5fb91f500709dd0cdaf8a8dfea0e51cad56eb7dc`)
- CPU smoke: `configs/scenarios/sanity_v1.yaml`, `horizon=3`, `dt=0.1`, `algo=goal`, schema `robot_sf/benchmark/schemas/episode.schema.v1.json`.

Smoke results:

| Arm | Rows | Written | Failed | CBF metadata rows | CBF metric rows | Ledger rows | CBF statuses |
|---|---:|---:|---:|---:|---:|---:|---|
| `cbf_off` | 12 | 12 | 0 | 0 | 0 | 0 | `{}` |
| `cbf_collision_cone_on` | 12 | 12 | 0 | 12 | 12 | 12 | `{'filtered': 36}` |

## Performance / Caching Evidence
- Baseline runtime: NA - no performance/caching claim.
- Changed runtime: NA - no performance/caching claim.
- Representative command: smoke command described in Validation / Proof.
- Hot-path call count profile anchor: NA - no hot-path performance claim.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: disable `cbf_safety_filter.enabled` or revert if default/off behavior changes, resume identity fails to distinguish CBF runs, or CBF records are stored without being used by metrics/ledger.

## Risks / Rollout
- Compatibility risks: low for default runs because CBF is off by default.
- Failure modes: CBF projection is a diagnostic baseline, not a proof of safety; fallback and infeasible states are recorded as caveats.
- Rollback fallback plan: revert runtime binding or keep `cbf_safety_filter.enabled` false.

## Docs / Provenance
- Updated docs: `docs/context/issue_3948_cbf_safety_filter.md`.
- Relevant design provenance notes: #3948 issue body and July 2 implementation comment.
- Any assumptions need to preserved: first slice implements collision-cone baseline only; DPCBF raises `NotImplementedError`.

## Downstream Propagation
- Parent issue updated (yes/no/NA): will be updated by merge gate comment.
- Claim map / benchmark report updated (yes/no/NA): NA.
- Leaderboard / artifact catalog updated (yes/no/NA): NA.
- Registry or config index updated (yes/no/NA): NA.
- Context index / memory note updated (yes/no/NA): issue-specific note added; context index not updated because it is curated for broad entry points.
- Follow-up issue opened deferred propagation (yes/no/NA): #4142.
- Not applicable because: no benchmark, registry, leaderboard, claim-map, or paper-facing result is established.

## Follow-Up Issues
- Deferred work: Dynamic Parabolic CBF implementation; dense dynamic-obstacle comparison; full benchmark campaign for any collision-incidence claim.
- Issues opened follow-up: #4142.

## Reviewer Notes
- Verify closely: CBF runtime is mutually exclusive with `safety_wrapper` for this first slice; enabled arm thresholds fail closed unless a versioned arm is introduced.
- Known limitations: no formal safety certificate, no DPCBF, no collision-reduction claim.
