### PR TITLE
Issue #3950: add HSFM total-force pedestrian model

### DIFF
--- a/robot_sf/sim/pedestrian_model_variants.py
+++ b/robot_sf/sim/pedestrian_model_variants.py
@@ -1,0 +1,90 @@
+"""Opt-in pedestrian dynamics variants behind the simulator interface."""
+
+from __future__ import annotations
+
+from math import atan2
+
+import numpy as np
+
+SOCIAL_FORCE_DEFAULT = "social_force_default"
+HSFM_TOTAL_FORCE_V1 = "hsfm_total_force_v1"
+SUPPORTED_PEDESTRIAN_MODELS = frozenset({SOCIAL_FORCE_DEFAULT, HSFM_TOTAL_FORCE_V1})
+
+PYSF_POSITION_SLICE = slice(0, 2)
+PYSF_VELOCITY_SLICE = slice(2, 4)
+
+
+def normalize_pedestrian_model(value: str | None) -> str:
+    """Return a supported pedestrian-model key or raise a clear error."""
+    if value is None:
+        return SOCIAL_FORCE_DEFAULT
+    normalized = str(value).strip()
+    if normalized in SUPPORTED_PEDESTRIAN_MODELS:
+        return normalized
+    supported = ", ".join(sorted(SUPPORTED_PEDESTRIAN_MODELS))
+    raise ValueError(f"Unsupported pedestrian_model {value!r}. Supported values: {supported}.")
+
+
+def heading_from_total_force(
+    previous_heading: float,
+    total_force_xy: np.ndarray,
+    *,
+    epsilon: float = 1e-9,
+) -> float:
+    """Derive heading from the combined force vector, preserving heading at zero force.
+
+    Returns:
+        Heading angle in radians.
+    """
+    total_force = np.asarray(total_force_xy, dtype=float)
+    if total_force.shape != (2,):
+        raise ValueError("total_force_xy must have shape (2,)")
+    if float(np.linalg.norm(total_force)) <= epsilon:
+        return float(previous_heading)
+    return float(atan2(float(total_force[1]), float(total_force[0])))
+
+
+def step_hsfm_total_force(
+    state: np.ndarray,
+    total_forces: np.ndarray,
+    headings: np.ndarray,
+    *,
+    dt: float,
+    max_speeds: np.ndarray,
+    epsilon: float = 1e-9,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Step PySocialForce state while orienting pedestrians by total force.
+
+    Returns:
+        Updated PySocialForce state and per-pedestrian headings.
+    """
+    next_state = np.asarray(state, dtype=float).copy()
+    force_array = np.asarray(total_forces, dtype=float)
+    previous_headings = np.asarray(headings, dtype=float)
+    speed_caps = np.asarray(max_speeds, dtype=float)
+
+    pedestrian_count = next_state.shape[0]
+    if force_array.shape != (pedestrian_count, 2):
+        raise ValueError("total_forces must have shape (N, 2) matching state rows")
+    if previous_headings.shape != (pedestrian_count,):
+        raise ValueError("headings must have shape (N,) matching state rows")
+    if speed_caps.shape != (pedestrian_count,):
+        raise ValueError("max_speeds must have shape (N,) matching state rows")
+
+    desired_velocity = next_state[:, PYSF_VELOCITY_SLICE] + float(dt) * force_array
+    desired_speeds = np.linalg.norm(desired_velocity, axis=-1)
+    factors = np.ones_like(desired_speeds, dtype=float)
+    np.divide(speed_caps, desired_speeds, out=factors, where=desired_speeds > epsilon)
+    np.minimum(factors, 1.0, out=factors)
+    capped_velocity = desired_velocity * np.expand_dims(factors, axis=-1)
+
+    next_state[:, PYSF_POSITION_SLICE] += capped_velocity * float(dt)
+    next_state[:, PYSF_VELOCITY_SLICE] = capped_velocity
+    next_headings = np.asarray(
+        [
+            heading_from_total_force(previous_heading, total_force, epsilon=epsilon)
+            for previous_heading, total_force in zip(previous_headings, force_array, strict=True)
+        ],
+        dtype=float,
+    )
+    return next_state, next_headings

--- a/robot_sf/sim/pedestrian_model_variants.py
+++ b/robot_sf/sim/pedestrian_model_variants.py
@@ -80,11 +80,7 @@ def step_hsfm_total_force(
 
     next_state[:, PYSF_POSITION_SLICE] += capped_velocity * float(dt)
     next_state[:, PYSF_VELOCITY_SLICE] = capped_velocity
-    next_headings = np.asarray(
-        [
-            heading_from_total_force(previous_heading, total_force, epsilon=epsilon)
-            for previous_heading, total_force in zip(previous_headings, force_array, strict=True)
-        ],
-        dtype=float,
-    )
+    force_norms = np.linalg.norm(force_array, axis=-1)
+    force_headings = np.arctan2(force_array[:, 1], force_array[:, 0])
+    next_headings = np.where(force_norms <= epsilon, previous_headings, force_headings)
     return next_state, next_headings

--- a/robot_sf/sim/sim_config.py
+++ b/robot_sf/sim/sim_config.py
@@ -5,6 +5,7 @@ from math import ceil
 
 from robot_sf.ped_npc.adversial_ped_force import AdversarialPedForceConfig
 from robot_sf.ped_npc.ped_robot_force import PedRobotForceConfig
+from robot_sf.sim.pedestrian_model_variants import normalize_pedestrian_model
 
 
 @dataclass
@@ -21,6 +22,9 @@ class SimulationSettings:
 
     peds_speed_mult: float = 1.3
     """Pedestrian speed multiplier"""
+
+    pedestrian_model: str = "social_force_default"
+    """Pedestrian dynamics model selector."""
 
     difficulty: int = 0
     """Difficulty level"""
@@ -88,6 +92,7 @@ class SimulationSettings:
         # Check that the pedestrian speed multiplier is positive
         if self.peds_speed_mult <= 0:
             raise ValueError("Pedestrian speed mustn't be negative or zero!")
+        self.pedestrian_model = normalize_pedestrian_model(self.pedestrian_model)
         # Check that the maximum number of pedestrians per group is positive
         if self.max_peds_per_group <= 0:
             raise ValueError("Maximum pedestrians per group mustn't be negative or zero!")

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -256,14 +256,16 @@ class Simulator:
         max_speeds = self.pysf_sim.peds.max_speeds
         if max_speeds is None:
             raise RuntimeError("PySocialForce max_speeds are unavailable for HSFM total-force step")
+        current_state = self.pysf_sim.peds.state
         next_state, self.ped_headings = step_hsfm_total_force(
-            self.pysf_sim.peds.state,
+            current_state,
             ped_forces,
             self.ped_headings,
             dt=self.config.time_per_step_in_secs,
             max_speeds=max_speeds,
         )
-        self.pysf_sim.peds.update(next_state, groups)
+        current_state[...] = next_state
+        self.pysf_sim.peds.update(current_state, groups)
 
     def _reset_social_force_state(self) -> None:
         """Restore pedestrian physics state for a fresh deterministic episode reset."""

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -240,10 +240,11 @@ class Simulator:
             One heading angle in radians per pedestrian row.
         """
         velocities = np.asarray(self.pysf_state.ped_velocities, dtype=float)
-        return np.asarray(
-            [_heading_from_velocity(velocity, 0.0) for velocity in velocities],
-            dtype=float,
-        )
+        if velocities.size == 0:
+            return np.empty((0,), dtype=float)
+        speeds = np.linalg.norm(velocities, axis=-1)
+        velocity_headings = np.arctan2(velocities[:, 1], velocities[:, 0])
+        return np.where(speeds <= MIN_HEADING_SPEED_MPS, 0.0, velocity_headings)
 
     def _step_pedestrians(self, ped_forces: np.ndarray, groups: list[list[int]]) -> None:
         """Advance pedestrians through the configured pedestrian-model implementation."""

--- a/robot_sf/sim/simulator.py
+++ b/robot_sf/sim/simulator.py
@@ -51,6 +51,11 @@ from robot_sf.ped_npc.ped_population import PedSpawnConfig, populate_simulation
 from robot_sf.ped_npc.ped_robot_force import PedRobotForce, PedRobotForceConfig
 from robot_sf.ped_npc.ped_zone import sample_zone
 from robot_sf.robot.robot_state import Robot
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_TOTAL_FORCE_V1,
+    normalize_pedestrian_model,
+    step_hsfm_total_force,
+)
 
 PYSF_POSITION_SLICE = slice(0, 2)
 PYSF_VELOCITY_SLICE = slice(2, 4)
@@ -155,6 +160,9 @@ class Simulator:
     # Last pedestrian force vectors used to step the simulation (K,2)
     last_ped_forces: np.ndarray = field(init=False, repr=False)
     _initial_pysf_states: np.ndarray = field(init=False, repr=False)
+    ped_headings: np.ndarray = field(init=False, repr=False)
+    _initial_ped_headings: np.ndarray = field(init=False, repr=False)
+    pedestrian_model: str = field(init=False)
 
     def __post_init__(self):
         """Initialize simulator components after dataclass construction.
@@ -219,14 +227,51 @@ class Simulator:
         ]
 
         self.last_ped_forces = np.zeros((0, 2), dtype=float)
+        self.pedestrian_model = normalize_pedestrian_model(self.config.pedestrian_model)
+        self.ped_headings = self._headings_from_current_ped_velocities()
+        self._initial_ped_headings = self.ped_headings.copy()
         self._initial_pysf_states = self.pysf_state.pysf_states().copy()
         self.reset_state()
+
+    def _headings_from_current_ped_velocities(self) -> np.ndarray:
+        """Initialize pedestrian headings from current velocities, falling back to zero radians.
+
+        Returns:
+            One heading angle in radians per pedestrian row.
+        """
+        velocities = np.asarray(self.pysf_state.ped_velocities, dtype=float)
+        return np.asarray(
+            [_heading_from_velocity(velocity, 0.0) for velocity in velocities],
+            dtype=float,
+        )
+
+    def _step_pedestrians(self, ped_forces: np.ndarray, groups: list[list[int]]) -> None:
+        """Advance pedestrians through the configured pedestrian-model implementation."""
+        if self.pedestrian_model != HSFM_TOTAL_FORCE_V1:
+            self.pysf_sim.peds.step(ped_forces, groups)
+            self.ped_headings = self._headings_from_current_ped_velocities()
+            return
+
+        max_speeds = self.pysf_sim.peds.max_speeds
+        if max_speeds is None:
+            raise RuntimeError("PySocialForce max_speeds are unavailable for HSFM total-force step")
+        next_state, self.ped_headings = step_hsfm_total_force(
+            self.pysf_sim.peds.state,
+            ped_forces,
+            self.ped_headings,
+            dt=self.config.time_per_step_in_secs,
+            max_speeds=max_speeds,
+        )
+        self.pysf_sim.peds.update(next_state, groups)
 
     def _reset_social_force_state(self) -> None:
         """Restore pedestrian physics state for a fresh deterministic episode reset."""
         initial_states = getattr(self, "_initial_pysf_states", None)
         if initial_states is not None:
             self.pysf_state.pysf_states()[...] = initial_states
+        initial_headings = getattr(self, "_initial_ped_headings", None)
+        if initial_headings is not None:
+            self.ped_headings = initial_headings.copy()
         self.last_ped_forces = np.zeros((0, 2), dtype=float)
         for behavior in getattr(self, "peds_behaviors", ()):
             behavior.reset()
@@ -305,7 +350,7 @@ class Simulator:
         ped_forces = self.pysf_sim.compute_forces()
         self.last_ped_forces = np.asarray(ped_forces, dtype=float)
         groups = self.groups.groups_as_lists
-        self.pysf_sim.peds.step(ped_forces, groups)
+        self._step_pedestrians(self.last_ped_forces, groups)
         for robot, nav, action in zip(self.robots, self.robot_navs, actions, strict=True):
             robot.apply_action(action, self.config.time_per_step_in_secs)
             nav.update_position(robot.pos)
@@ -483,6 +528,9 @@ class PedSimulator(Simulator):
         ]
 
         self.last_ped_forces = np.zeros((0, 2), dtype=float)
+        self.pedestrian_model = normalize_pedestrian_model(self.config.pedestrian_model)
+        self.ped_headings = self._headings_from_current_ped_velocities()
+        self._initial_ped_headings = self.ped_headings.copy()
         self._initial_pysf_states = self.pysf_state.pysf_states().copy()
 
         self.reset_state()
@@ -605,7 +653,7 @@ class PedSimulator(Simulator):
         ped_forces = self.pysf_sim.compute_forces()
         self.last_ped_forces = np.asarray(ped_forces, dtype=float)
         groups = self.groups.groups_as_lists
-        self.pysf_sim.peds.step(ped_forces, groups)
+        self._step_pedestrians(self.last_ped_forces, groups)
         for robot, nav, action in zip(self.robots, self.robot_navs, actions, strict=True):
             robot.apply_action(action, self.config.time_per_step_in_secs)
             nav.update_position(robot.pos)

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -1955,6 +1955,7 @@ def _apply_simulation_overrides(
         "peds_speed_mult",
         "ped_radius",
         "goal_radius",
+        "pedestrian_model",
         "route_spawn_distribution",
         "route_spawn_jitter_frac",
         "route_spawn_seed",

--- a/tests/sim/test_hsfm_total_force_model.py
+++ b/tests/sim/test_hsfm_total_force_model.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import numpy as np
 import pytest
 
@@ -13,7 +15,20 @@ from robot_sf.sim.pedestrian_model_variants import (
     step_hsfm_total_force,
 )
 from robot_sf.sim.sim_config import SimulationSettings
+from robot_sf.sim.simulator import Simulator
 from robot_sf.training.scenario_loader import build_robot_config_from_scenario
+
+
+class _FakePedState:
+    def __init__(self, state: np.ndarray) -> None:
+        self.state = state
+        self.max_speeds = np.array([10.0], dtype=float)
+        self.updated_state: np.ndarray | None = None
+        self.updated_groups: list[list[int]] | None = None
+
+    def update(self, state: np.ndarray, groups: list[list[int]]) -> None:
+        self.updated_state = state
+        self.updated_groups = groups
 
 
 def test_heading_from_total_force_uses_combined_force_vector() -> None:
@@ -48,6 +63,26 @@ def test_step_hsfm_total_force_caps_velocity_and_updates_heading_from_force() ->
     assert next_state[0, 2:4] == pytest.approx([capped_component, capped_component])
     assert next_state[0, 0:2] == pytest.approx([0.1 * capped_component, 0.1 * capped_component])
     assert next_headings[0] == pytest.approx(np.pi / 2)
+
+
+def test_simulator_hsfm_step_preserves_shared_pysf_state_buffer() -> None:
+    """Simulator HSFM stepping mutates the PySocialForce state buffer in place."""
+    state = np.array([[0.0, 0.0, 0.0, 0.0, 10.0, 0.0, 0.5]], dtype=float)
+    peds = _FakePedState(state)
+    sim = object.__new__(Simulator)
+    sim.pedestrian_model = HSFM_TOTAL_FORCE_V1
+    sim.pysf_sim = SimpleNamespace(peds=peds)
+    sim.config = SimpleNamespace(time_per_step_in_secs=0.1)
+    sim.ped_headings = np.array([0.0], dtype=float)
+
+    sim._step_pedestrians(np.array([[1.0, 0.0]], dtype=float), [[0]])
+
+    assert peds.state is state
+    assert peds.updated_state is state
+    assert peds.updated_groups == [[0]]
+    assert state[0, 0] == pytest.approx(0.01)
+    assert state[0, 2] == pytest.approx(0.1)
+    assert sim.ped_headings[0] == pytest.approx(0.0)
 
 
 def test_pedestrian_model_selector_normalizes_and_rejects_unknown_values() -> None:

--- a/tests/sim/test_hsfm_total_force_model.py
+++ b/tests/sim/test_hsfm_total_force_model.py
@@ -1,0 +1,71 @@
+"""Tests for the opt-in HSFM total-force pedestrian-model variant."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from robot_sf.sim.pedestrian_model_variants import (
+    HSFM_TOTAL_FORCE_V1,
+    SOCIAL_FORCE_DEFAULT,
+    heading_from_total_force,
+    normalize_pedestrian_model,
+    step_hsfm_total_force,
+)
+from robot_sf.sim.sim_config import SimulationSettings
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario
+
+
+def test_heading_from_total_force_uses_combined_force_vector() -> None:
+    """Heading follows the total force vector, even when desired force points elsewhere."""
+    previous_heading = 0.0
+    desired_force = np.array([1.0, 0.0])
+    total_force = np.array([0.0, 1.0])
+
+    assert desired_force.tolist() == [1.0, 0.0]
+    assert heading_from_total_force(previous_heading, total_force) == pytest.approx(np.pi / 2)
+
+
+def test_heading_from_total_force_preserves_heading_for_zero_force() -> None:
+    """A zero total-force vector keeps the previous heading stable."""
+    assert heading_from_total_force(1.23, np.zeros(2)) == pytest.approx(1.23)
+
+
+def test_step_hsfm_total_force_caps_velocity_and_updates_heading_from_force() -> None:
+    """The HSFM variant mirrors PySocialForce kinematics and orients by total force."""
+    state = np.array([[0.0, 0.0, 1.0, 0.0, 10.0, 0.0, 0.5]], dtype=float)
+    force = np.array([[0.0, 10.0]], dtype=float)
+
+    next_state, next_headings = step_hsfm_total_force(
+        state,
+        force,
+        np.array([0.0], dtype=float),
+        dt=0.1,
+        max_speeds=np.array([1.0], dtype=float),
+    )
+
+    capped_component = 1.0 / np.sqrt(2.0)
+    assert next_state[0, 2:4] == pytest.approx([capped_component, capped_component])
+    assert next_state[0, 0:2] == pytest.approx([0.1 * capped_component, 0.1 * capped_component])
+    assert next_headings[0] == pytest.approx(np.pi / 2)
+
+
+def test_pedestrian_model_selector_normalizes_and_rejects_unknown_values() -> None:
+    """SimulationSettings exposes only the supported pedestrian-model variants."""
+    assert SimulationSettings().pedestrian_model == SOCIAL_FORCE_DEFAULT
+    assert SimulationSettings(pedestrian_model=HSFM_TOTAL_FORCE_V1).pedestrian_model == (
+        HSFM_TOTAL_FORCE_V1
+    )
+    assert normalize_pedestrian_model(None) == SOCIAL_FORCE_DEFAULT
+    with pytest.raises(ValueError, match="Unsupported pedestrian_model"):
+        SimulationSettings(pedestrian_model="unknown_model")
+
+
+def test_scenario_simulation_config_can_select_hsfm_total_force(tmp_path) -> None:
+    """Scenario ``simulation_config`` can select the opt-in pedestrian model."""
+    config = build_robot_config_from_scenario(
+        {"simulation_config": {"pedestrian_model": HSFM_TOTAL_FORCE_V1}},
+        scenario_path=tmp_path / "scenario.yaml",
+    )
+
+    assert config.sim_config.pedestrian_model == HSFM_TOTAL_FORCE_V1


### PR DESCRIPTION
## Reviewer-critical summary
What changed: adds `social_force_default` / `hsfm_total_force_v1` pedestrian-model selection to `SimulationSettings`, exposes it through scenario `simulation_config`, and routes the opt-in HSFM total-force variant through a pure simulator helper while preserving the default PySocialForce step path.

Why now: issue #3950 names pedestrian-model coverage as the next generalization axis; this PR delivers the first reversible runtime capability slice so benchmark metadata and sensitivity harness work can build on an actual simulator selector.

Claim boundary: runtime/unit/smoke evidence only. This does not add the train/dev-model x eval-model sensitivity harness, episode-row provenance fields, a full benchmark campaign, a Slurm/GPU run, or paper/dissertation claim edits.

Required validation: focused simulator tests, lint on changed simulator/training/test surfaces, and a deterministic one-step CPU simulator smoke with `pedestrian_model=hsfm_total_force_v1`.

Remaining blocker: the issue is not complete until a successor PR records development/evaluation pedestrian-model provenance and emits the 2x2 CPU sensitivity table.

## Contract delta
Issue: Refs #3950 for the bounded Phase 1 runtime selector slice only; the full issue plan still needs the sensitivity harness and benchmark row metadata.

New config field: `SimulationSettings.pedestrian_model`, default `social_force_default`.

Supported values: `social_force_default`, `hsfm_total_force_v1`.

New fail-closed behavior: unknown pedestrian-model names raise `ValueError` during `SimulationSettings` validation.

Compatibility impact: default behavior remains the PySocialForce `peds.step()` path. `hsfm_total_force_v1` is opt-in via `simulation_config.pedestrian_model` and updates auxiliary pedestrian headings from the combined total force vector without changing the PySocialForce state schema.

State propagation: no issue comment was added because this run is not authorized to comment on issues or PRs (`comment_issue_or_pr: false`). This PR body is the durable handoff surface for the slice status.

## Validation
- PASS: `scripts/dev/run_worktree_shared_venv.sh -- pytest tests/sim/test_hsfm_total_force_model.py tests/sim/test_simulator_action_count.py -q`
- PASS: `scripts/dev/run_worktree_shared_venv.sh -- ruff check robot_sf/sim robot_sf/training/scenario_loader.py tests/sim/test_hsfm_total_force_model.py tests/sim/test_simulator_action_count.py`
- PASS: deterministic one-step CPU simulator smoke with `pedestrian_model=hsfm_total_force_v1`: `{'pedestrian_model': 'hsfm_total_force_v1', 'pedestrians': 81, 'force_shape': (81, 2), 'heading_shape': (81,)}`
- PASS: `PR_READY_MODE=final BASE_REF=origin/main scripts/dev/pr_ready_check.sh` after this body file was supplied.

## Follow-Up Issues
- #3950 remains open for benchmark episode provenance fields and the train/dev-model x eval-model CPU sensitivity harness.

## Out of scope
No full benchmark campaign run. No Slurm/GPU submission. No paper/dissertation claim edits. No HSFM planner adapter changes. No sensitivity harness or benchmark episode provenance fields in this slice.

<details>
<summary>Implementation notes</summary>

- `robot_sf/sim/pedestrian_model_variants.py` keeps the variant math pure and unit-testable.
- `Simulator` and `PedSimulator` share `_step_pedestrians()` so the default path remains a direct `peds.step()` call unless the selector is `hsfm_total_force_v1`.
- `build_robot_config_from_scenario()` now passes `simulation_config.pedestrian_model` through the existing simulation override mechanism.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional pedestrian-movement mode with a new default setting and a second total-force-based variant.
  * Simulation scenarios can now choose the pedestrian model through configuration.
  * Improved pedestrian heading updates and motion capping for more consistent movement behavior.

* **Bug Fixes**
  * Preserves the previous pedestrian heading when movement force is near zero.
  * Validates unsupported pedestrian-model values with a clear error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->