### PR TITLE
evaluation: add open/closed prediction eval harness for #3973

### DIFF
--- a/robot_sf/benchmark/prediction_open_closed_eval.py
+++ b/robot_sf/benchmark/prediction_open_closed_eval.py
@@ -146,7 +146,7 @@ def summarize_closed_loop_prediction_metrics(
             "timeout_rate": None,
             "time_to_goal": None,
             "jerk": None,
-            "closed_loop_denominators": _closed_loop_denominators(0, 0, 0, 0, 0, 0),
+            "closed_loop_denominators": _closed_loop_denominators(0, 0, 0, 0, 0, 0, 0),
             "statuses": {
                 field: {"status": "unavailable", "note": "no episode rows supplied"}
                 for field in (
@@ -163,6 +163,9 @@ def summarize_closed_loop_prediction_metrics(
     collision_events = [_collision_event(row) for row in episode_rows]
     near_miss_events = [_near_miss_event(row) for row in episode_rows]
     timeout_events = [_timeout_event(row) for row in episode_rows]
+    present_collision_events = _present_events(collision_events)
+    present_near_miss_events = _present_events(near_miss_events)
+    present_timeout_events = _present_events(timeout_events)
     min_distances = [_number_from_row(row, "min_distance") for row in episode_rows]
     time_to_goal_values = [_number_from_row(row, "time_to_goal") for row in episode_rows]
     jerk_values = [_number_from_row(row, "jerk_mean") for row in episode_rows]
@@ -172,27 +175,34 @@ def summarize_closed_loop_prediction_metrics(
     jerk_present = [value for value in jerk_values if value is not None]
 
     return {
-        "collision_rate": float(sum(collision_events) / episode_count),
-        "near_miss_rate": float(sum(near_miss_events) / episode_count),
+        "collision_rate": _rate_or_none(present_collision_events),
+        "near_miss_rate": _rate_or_none(present_near_miss_events),
         "min_distance": float(min(min_distance_values)) if min_distance_values else None,
-        "timeout_rate": float(sum(timeout_events) / episode_count),
+        "timeout_rate": _rate_or_none(present_timeout_events),
         "time_to_goal": _mean_or_none(time_to_goal_present),
         "jerk": _mean_or_none(jerk_present),
         "closed_loop_denominators": _closed_loop_denominators(
             episode_count,
-            episode_count,
-            episode_count,
+            len(present_collision_events),
+            len(present_near_miss_events),
+            len(present_timeout_events),
             len(min_distance_values),
             len(time_to_goal_present),
             len(jerk_present),
         ),
         "statuses": {
-            "collision_rate": {"status": "ok", "denominator": episode_count},
-            "near_miss_rate": {"status": "ok", "denominator": episode_count},
+            "collision_rate": _availability_status(
+                len(present_collision_events), "metrics.collision unavailable"
+            ),
+            "near_miss_rate": _availability_status(
+                len(present_near_miss_events), "metrics.near_misses unavailable"
+            ),
             "min_distance": _availability_status(
                 len(min_distance_values), "metrics.min_distance unavailable"
             ),
-            "timeout_rate": {"status": "ok", "denominator": episode_count},
+            "timeout_rate": _availability_status(
+                len(present_timeout_events), "metrics.timeout unavailable"
+            ),
             "time_to_goal": _availability_status(
                 len(time_to_goal_present), "metrics.time_to_goal unavailable"
             ),
@@ -344,7 +354,7 @@ def _gaussian_calibration_counts(
             continue
         for index, gaussian in enumerate(forecast.gaussian):
             mean = _position_array(gaussian.get("mean"))
-            covariance = _covariance_array(gaussian.get("covariance"))
+            covariance = _covariance_array(gaussian.get("covariance"), positive_definite=True)
             if mean is None or covariance is None:
                 continue
             offset = truth[index] - mean
@@ -402,7 +412,7 @@ def _position_array(value: object) -> np.ndarray | None:
     return position
 
 
-def _covariance_array(value: object) -> np.ndarray | None:
+def _covariance_array(value: object, *, positive_definite: bool = False) -> np.ndarray | None:
     if value is None:
         return None
     try:
@@ -410,6 +420,15 @@ def _covariance_array(value: object) -> np.ndarray | None:
     except (TypeError, ValueError, KeyError, IndexError):
         return None
     if covariance.shape != (2, 2) or not np.all(np.isfinite(covariance)):
+        return None
+    if not np.allclose(covariance, covariance.T):
+        return None
+    eigenvalues = np.linalg.eigvalsh(covariance)
+    tolerance = np.finfo(float).eps
+    if positive_definite:
+        if np.any(eigenvalues <= tolerance):
+            return None
+    elif np.any(eigenvalues < -tolerance):
         return None
     return covariance
 
@@ -478,6 +497,7 @@ def _closed_loop_denominators(
     episode_count: int,
     collision_count: int,
     near_miss_count: int,
+    timeout_count: int,
     min_distance_count: int,
     time_to_goal_count: int,
     jerk_count: int,
@@ -487,40 +507,75 @@ def _closed_loop_denominators(
         "collision_rate_denominator": collision_count,
         "near_miss_rate_denominator": near_miss_count,
         "min_distance_denominator": min_distance_count,
-        "timeout_rate_denominator": episode_count,
+        "timeout_rate_denominator": timeout_count,
         "time_to_goal_denominator": time_to_goal_count,
         "jerk_denominator": jerk_count,
     }
 
 
-def _collision_event(row: Mapping[str, Any]) -> bool:
+def _collision_event(row: Mapping[str, Any]) -> bool | None:
     metrics = _metrics(row)
     outcome = _mapping(row.get("outcome"))
-    return bool(
-        outcome.get("collision_event")
-        or _number(metrics.get("total_collision_count"), default=0.0) > 0.0
-        or _number(metrics.get("collisions"), default=0.0) > 0.0
-        or _number(row.get("collision"), default=0.0) > 0.0
+    return _event_from_candidates(
+        outcome.get("collision_event"),
+        metrics.get("total_collision_count"),
+        metrics.get("collisions"),
+        row.get("collision"),
     )
 
 
-def _near_miss_event(row: Mapping[str, Any]) -> bool:
+def _near_miss_event(row: Mapping[str, Any]) -> bool | None:
     metrics = _metrics(row)
-    return bool(
-        _number(metrics.get("near_misses"), default=0.0) > 0.0
-        or _number(row.get("near_misses"), default=0.0) > 0.0
-    )
+    return _event_from_candidates(metrics.get("near_misses"), row.get("near_misses"))
 
 
-def _timeout_event(row: Mapping[str, Any]) -> bool:
+def _timeout_event(row: Mapping[str, Any]) -> bool | None:
     metrics = _metrics(row)
     outcome = _mapping(row.get("outcome"))
-    termination_reason = str(row.get("termination_reason") or "").lower()
-    return bool(
-        outcome.get("timeout_event")
-        or termination_reason in _TIMEOUT_REASONS
-        or _number(metrics.get("timeout"), default=0.0) > 0.0
+    termination_signal = None
+    if row.get("termination_reason") is not None:
+        termination_signal = str(row.get("termination_reason")).lower() in _TIMEOUT_REASONS
+    return _event_from_candidates(
+        outcome.get("timeout_event"),
+        termination_signal,
+        metrics.get("timeout"),
     )
+
+
+def _event_from_candidates(*candidates: object) -> bool | None:
+    """Return event state when any explicit boolean/count signal exists."""
+    saw_signal = False
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        if isinstance(candidate, bool):
+            saw_signal = True
+            if candidate:
+                return True
+            continue
+        number = _finite_float(candidate)
+        if number is None:
+            continue
+        saw_signal = True
+        if number > 0.0:
+            return True
+    return False if saw_signal else None
+
+
+def _present_events(events: Iterable[bool | None]) -> list[bool]:
+    """Drop unavailable event rows before rate calculation.
+
+    Returns:
+        Event states with unavailable rows removed.
+    """
+    return [event for event in events if event is not None]
+
+
+def _rate_or_none(events: Sequence[bool]) -> float | None:
+    """Return a rate over present events, or unavailable when no events are present."""
+    if not events:
+        return None
+    return float(sum(events) / len(events))
 
 
 def _number_from_row(row: Mapping[str, Any], key: str) -> float | None:
@@ -585,6 +640,19 @@ def _attach_rank_comparisons(reports: list[dict[str, Any]]) -> None:
                     "closed_loop_rank": closed_ranks[predictor_id],
                     "rank_delta": closed_ranks[predictor_id] - open_ranks[predictor_id],
                     "reason": "multi_predictor_rank_projection",
+                }
+            )
+        else:
+            missing_rank_inputs = []
+            if predictor_id not in open_ranks:
+                missing_rank_inputs.append("open_loop.fde")
+            if predictor_id not in closed_ranks:
+                missing_rank_inputs.append("closed_loop.collision_rate/near_miss_rate/min_distance")
+            divergence.update(
+                {
+                    "rank_comparison_available": False,
+                    "reason": "missing_rank_inputs",
+                    "missing_rank_inputs": missing_rank_inputs,
                 }
             )
         report["divergence"] = divergence

--- a/robot_sf/benchmark/prediction_open_closed_eval.py
+++ b/robot_sf/benchmark/prediction_open_closed_eval.py
@@ -349,7 +349,7 @@ def _gaussian_calibration_counts(
                 continue
             offset = truth[index] - mean
             try:
-                mahalanobis_sq = float(offset.T @ np.linalg.inv(covariance) @ offset)
+                mahalanobis_sq = float(offset.T @ np.linalg.solve(covariance, offset))
             except np.linalg.LinAlgError:
                 continue
             if np.isfinite(mahalanobis_sq):
@@ -371,8 +371,9 @@ def _prediction_spread_values(batch: ForecastBatch) -> _SpreadValues:
         elif forecast.samples is not None:
             deterministic_only = False
             samples = np.asarray(forecast.samples, dtype=float)
-            per_horizon_std = np.std(samples, axis=0)
-            values.extend(float(np.linalg.norm(std_xy)) for std_xy in per_horizon_std)
+            if samples.shape[0] > 0:
+                per_horizon_std = np.std(samples, axis=0)
+                values.extend(float(np.linalg.norm(std_xy)) for std_xy in per_horizon_std)
     return _SpreadValues(values=values, deterministic_only=deterministic_only)
 
 
@@ -392,7 +393,10 @@ def _truth_array(
 def _position_array(value: object) -> np.ndarray | None:
     if value is None:
         return None
-    position = np.asarray(value, dtype=float)
+    try:
+        position = np.asarray(value, dtype=float)
+    except (TypeError, ValueError, KeyError, IndexError):
+        return None
     if position.shape != (2,) or not np.all(np.isfinite(position)):
         return None
     return position
@@ -401,7 +405,10 @@ def _position_array(value: object) -> np.ndarray | None:
 def _covariance_array(value: object) -> np.ndarray | None:
     if value is None:
         return None
-    covariance = np.asarray(value, dtype=float)
+    try:
+        covariance = np.asarray(value, dtype=float)
+    except (TypeError, ValueError, KeyError, IndexError):
+        return None
     if covariance.shape != (2, 2) or not np.all(np.isfinite(covariance)):
         return None
     return covariance

--- a/robot_sf/benchmark/prediction_open_closed_eval.py
+++ b/robot_sf/benchmark/prediction_open_closed_eval.py
@@ -1,0 +1,613 @@
+"""Paired open-loop and closed-loop pedestrian-prediction evaluation.
+
+This module is a diagnostic reporting layer for issue #3973.  It projects
+existing ForecastBatch.v1 forecast metrics and existing benchmark episode
+metrics into one predictor-level report without changing collision, near-miss,
+timeout, or forecast metric semantics.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+from robot_sf.benchmark.forecast_batch import ForecastBatch, validate_forecast_batch
+from robot_sf.benchmark.forecast_metrics import GroundTruthPositions, evaluate_forecast_batch
+from robot_sf.benchmark.pedestrian_forecast import chi_square_2d_threshold
+
+PREDICTION_OPEN_CLOSED_SCHEMA_VERSION = "PredictionOpenClosedEval.v1"
+PREDICTION_OPEN_CLOSED_CLAIM_BOUNDARY = (
+    "Diagnostic CPU evaluation protocol. Open-loop forecast quality is reported side by side "
+    "with closed-loop navigation outcomes; no causal safety or planner-promotion claim."
+)
+_TIMEOUT_REASONS = frozenset({"timeout", "truncated", "max_steps"})
+
+
+@dataclass(frozen=True)
+class _ScalarSummary:
+    value: float | None
+    status: str
+    denominator: int
+    note: str | None = None
+
+
+def compute_open_loop_prediction_metrics(
+    *,
+    forecast_batches: list[ForecastBatch | dict[str, Any]],
+    ground_truth_by_batch: Mapping[str, GroundTruthPositions] | GroundTruthPositions,
+    confidence_level: float = 0.95,
+) -> dict[str, Any]:
+    """Summarize open-loop ForecastBatch.v1 metrics for issue #3973.
+
+    Args:
+        forecast_batches: ForecastBatch objects or JSON-compatible dictionaries.
+        ground_truth_by_batch: Either one ground-truth mapping for a single batch,
+            or a mapping keyed by batch id, scenario id, or list index.
+        confidence_level: Gaussian confidence level used for calibration coverage.
+
+    Returns:
+        JSON-compatible summary with ADE, FDE, calibration error, prediction spread,
+        and denominator/status metadata.
+    """
+    if not forecast_batches:
+        return _open_loop_unavailable("no forecast batches supplied")
+
+    ade_values: list[float] = []
+    fde_values: list[float] = []
+    calibration_hits = 0
+    calibration_count = 0
+    spread_values: list[float] = []
+    deterministic_spread_only = True
+    missing_truth_batches: list[str] = []
+
+    for index, raw_batch in enumerate(forecast_batches):
+        batch = validate_forecast_batch(raw_batch)
+        batch_key = _batch_key(batch, index)
+        ground_truth = _ground_truth_for_batch(
+            batch=batch,
+            index=index,
+            batch_count=len(forecast_batches),
+            ground_truth_by_batch=ground_truth_by_batch,
+        )
+        if ground_truth is None:
+            missing_truth_batches.append(batch_key)
+            continue
+
+        metric_report = evaluate_forecast_batch(batch, ground_truth)
+        ade_values.extend(_metric_values(metric_report, "ade"))
+        fde_values.extend(_metric_values(metric_report, "fde"))
+
+        hits, count = _gaussian_calibration_counts(
+            batch=batch,
+            ground_truth=ground_truth,
+            confidence_level=confidence_level,
+        )
+        calibration_hits += hits
+        calibration_count += count
+
+        spread = _prediction_spread_values(batch)
+        spread_values.extend(spread.values)
+        deterministic_spread_only = deterministic_spread_only and spread.deterministic_only
+
+    ade = _mean_summary(ade_values, unavailable_note="no deterministic ADE rows available")
+    fde = _mean_summary(fde_values, unavailable_note="no deterministic FDE rows available")
+    calibration = _calibration_summary(
+        hits=calibration_hits,
+        count=calibration_count,
+        confidence_level=confidence_level,
+    )
+    prediction_spread = _spread_summary(spread_values, deterministic_spread_only)
+
+    return {
+        "ade": ade.value,
+        "fde": fde.value,
+        "calibration_error": calibration.value,
+        "prediction_spread": prediction_spread.value,
+        "sample_count": ade.denominator,
+        "statuses": {
+            "ade": _status_dict(ade),
+            "fde": _status_dict(fde),
+            "calibration_error": _status_dict(calibration),
+            "prediction_spread": _status_dict(prediction_spread),
+        },
+        "denominators": {
+            "ade": ade.denominator,
+            "fde": fde.denominator,
+            "calibration_error": calibration.denominator,
+            "prediction_spread": prediction_spread.denominator,
+            "batch_count": len(forecast_batches),
+            "missing_ground_truth_batch_count": len(missing_truth_batches),
+        },
+        "missing_ground_truth_batches": missing_truth_batches,
+    }
+
+
+def summarize_closed_loop_prediction_metrics(
+    episode_rows: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Summarize existing closed-loop episode metrics for issue #3973.
+
+    The source rows are benchmark episode JSONL-style dictionaries.  This function
+    only projects existing fields; it does not redefine collision, near-miss, or
+    timeout semantics.
+
+    Returns:
+        JSON-compatible summary with closed-loop metrics and denominator metadata.
+    """
+    episode_count = len(episode_rows)
+    if episode_count == 0:
+        return {
+            "collision_rate": None,
+            "near_miss_rate": None,
+            "min_distance": None,
+            "timeout_rate": None,
+            "time_to_goal": None,
+            "jerk": None,
+            "closed_loop_denominators": _closed_loop_denominators(0, 0, 0, 0, 0, 0),
+            "statuses": {
+                field: {"status": "unavailable", "note": "no episode rows supplied"}
+                for field in (
+                    "collision_rate",
+                    "near_miss_rate",
+                    "min_distance",
+                    "timeout_rate",
+                    "time_to_goal",
+                    "jerk",
+                )
+            },
+        }
+
+    collision_events = [_collision_event(row) for row in episode_rows]
+    near_miss_events = [_near_miss_event(row) for row in episode_rows]
+    timeout_events = [_timeout_event(row) for row in episode_rows]
+    min_distances = [_number_from_row(row, "min_distance") for row in episode_rows]
+    time_to_goal_values = [_number_from_row(row, "time_to_goal") for row in episode_rows]
+    jerk_values = [_number_from_row(row, "jerk_mean") for row in episode_rows]
+
+    min_distance_values = [value for value in min_distances if value is not None]
+    time_to_goal_present = [value for value in time_to_goal_values if value is not None]
+    jerk_present = [value for value in jerk_values if value is not None]
+
+    return {
+        "collision_rate": float(sum(collision_events) / episode_count),
+        "near_miss_rate": float(sum(near_miss_events) / episode_count),
+        "min_distance": float(min(min_distance_values)) if min_distance_values else None,
+        "timeout_rate": float(sum(timeout_events) / episode_count),
+        "time_to_goal": _mean_or_none(time_to_goal_present),
+        "jerk": _mean_or_none(jerk_present),
+        "closed_loop_denominators": _closed_loop_denominators(
+            episode_count,
+            episode_count,
+            episode_count,
+            len(min_distance_values),
+            len(time_to_goal_present),
+            len(jerk_present),
+        ),
+        "statuses": {
+            "collision_rate": {"status": "ok", "denominator": episode_count},
+            "near_miss_rate": {"status": "ok", "denominator": episode_count},
+            "min_distance": _availability_status(
+                len(min_distance_values), "metrics.min_distance unavailable"
+            ),
+            "timeout_rate": {"status": "ok", "denominator": episode_count},
+            "time_to_goal": _availability_status(
+                len(time_to_goal_present), "metrics.time_to_goal unavailable"
+            ),
+            "jerk": _availability_status(len(jerk_present), "metrics.jerk_mean unavailable"),
+        },
+    }
+
+
+def build_open_closed_prediction_report(
+    *,
+    predictor_id: str,
+    open_loop_report: dict[str, Any],
+    closed_loop_report: dict[str, Any],
+    predictor_metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build one predictor row in the paired evaluation report.
+
+    Returns:
+        JSON-compatible predictor report containing open-loop, closed-loop, and
+        divergence fields.
+    """
+    metadata = dict(predictor_metadata or {})
+    return {
+        "predictor_id": predictor_id,
+        "predictor_family": metadata.get("predictor_family", "unspecified"),
+        "open_loop": open_loop_report,
+        "closed_loop": closed_loop_report,
+        "divergence": {
+            "open_loop_rank_key": "fde",
+            "closed_loop_rank_key": "collision_rate_then_near_miss_then_min_distance",
+            "rank_comparison_available": False,
+            "reason": "single_predictor_smoke",
+        },
+        "predictor_metadata": metadata,
+    }
+
+
+def build_paired_prediction_eval_report(
+    predictor_reports: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a schema-versioned open-loop/closed-loop prediction report.
+
+    Returns:
+        JSON-compatible paired report for one or more predictors.
+    """
+    reports = [dict(report) for report in predictor_reports]
+    _attach_rank_comparisons(reports)
+    return {
+        "schema_version": PREDICTION_OPEN_CLOSED_SCHEMA_VERSION,
+        "issue": 3973,
+        "claim_boundary": PREDICTION_OPEN_CLOSED_CLAIM_BOUNDARY,
+        "predictors": reports,
+    }
+
+
+@dataclass(frozen=True)
+class _SpreadValues:
+    values: list[float]
+    deterministic_only: bool
+
+
+def _open_loop_unavailable(note: str) -> dict[str, Any]:
+    status = _ScalarSummary(value=None, status="unavailable", denominator=0, note=note)
+    return {
+        "ade": None,
+        "fde": None,
+        "calibration_error": None,
+        "prediction_spread": None,
+        "sample_count": 0,
+        "statuses": {
+            "ade": _status_dict(status),
+            "fde": _status_dict(status),
+            "calibration_error": _status_dict(status),
+            "prediction_spread": _status_dict(status),
+        },
+        "denominators": {
+            "ade": 0,
+            "fde": 0,
+            "calibration_error": 0,
+            "prediction_spread": 0,
+            "batch_count": 0,
+            "missing_ground_truth_batch_count": 0,
+        },
+        "missing_ground_truth_batches": [],
+    }
+
+
+def _batch_key(batch: ForecastBatch, index: int) -> str:
+    metadata = batch.metadata if isinstance(batch.metadata, dict) else {}
+    for key in ("batch_id", "trace_id", "episode_id"):
+        value = metadata.get(key)
+        if value is not None:
+            return str(value)
+    return str(batch.provenance.scenario_id or index)
+
+
+def _ground_truth_for_batch(
+    *,
+    batch: ForecastBatch,
+    index: int,
+    batch_count: int,
+    ground_truth_by_batch: Mapping[str, GroundTruthPositions] | GroundTruthPositions,
+) -> GroundTruthPositions | None:
+    if batch_count == 1 and _looks_like_ground_truth(ground_truth_by_batch):
+        return ground_truth_by_batch  # type: ignore[return-value]
+    key_candidates = [
+        _batch_key(batch, index),
+        str(batch.provenance.scenario_id),
+        str(index),
+    ]
+    for key in key_candidates:
+        value = ground_truth_by_batch.get(key)  # type: ignore[union-attr]
+        if value is not None:
+            return value
+    return None
+
+
+def _looks_like_ground_truth(value: Mapping[str, Any]) -> bool:
+    if not value:
+        return False
+    first_value = next(iter(value.values()))
+    return not isinstance(first_value, Mapping)
+
+
+def _metric_values(metric_report: dict[str, Any], metric: str) -> list[float]:
+    values: list[float] = []
+    for row in metric_report.get("metric_rows", []):
+        if row.get("metric") != metric or row.get("status") != "ok":
+            continue
+        value = _finite_float(row.get("value"))
+        if value is not None:
+            values.append(value)
+    return values
+
+
+def _gaussian_calibration_counts(
+    *,
+    batch: ForecastBatch,
+    ground_truth: GroundTruthPositions,
+    confidence_level: float,
+) -> tuple[int, int]:
+    threshold = chi_square_2d_threshold(confidence_level)
+    hits = 0
+    count = 0
+    horizons = list(batch.provenance.horizons_s)
+    for forecast in batch.forecasts:
+        truth = _truth_array(ground_truth, forecast.actor_id, len(horizons))
+        if truth is None or not forecast.gaussian:
+            continue
+        for index, gaussian in enumerate(forecast.gaussian):
+            mean = _position_array(gaussian.get("mean"))
+            covariance = _covariance_array(gaussian.get("covariance"))
+            if mean is None or covariance is None:
+                continue
+            offset = truth[index] - mean
+            try:
+                mahalanobis_sq = float(offset.T @ np.linalg.inv(covariance) @ offset)
+            except np.linalg.LinAlgError:
+                continue
+            if np.isfinite(mahalanobis_sq):
+                count += 1
+                hits += int(mahalanobis_sq <= threshold)
+    return hits, count
+
+
+def _prediction_spread_values(batch: ForecastBatch) -> _SpreadValues:
+    values: list[float] = []
+    deterministic_only = True
+    for forecast in batch.forecasts:
+        if forecast.gaussian:
+            deterministic_only = False
+            for gaussian in forecast.gaussian:
+                covariance = _covariance_array(gaussian.get("covariance"))
+                if covariance is not None:
+                    values.append(float(np.sqrt(np.trace(covariance) / 2.0)))
+        elif forecast.samples is not None:
+            deterministic_only = False
+            samples = np.asarray(forecast.samples, dtype=float)
+            per_horizon_std = np.std(samples, axis=0)
+            values.extend(float(np.linalg.norm(std_xy)) for std_xy in per_horizon_std)
+    return _SpreadValues(values=values, deterministic_only=deterministic_only)
+
+
+def _truth_array(
+    ground_truth: GroundTruthPositions,
+    actor_id: str,
+    expected_steps: int,
+) -> np.ndarray | None:
+    if actor_id not in ground_truth:
+        return None
+    truth = np.asarray(ground_truth[actor_id], dtype=float)
+    if truth.shape != (expected_steps, 2) or not np.all(np.isfinite(truth)):
+        return None
+    return truth
+
+
+def _position_array(value: object) -> np.ndarray | None:
+    if value is None:
+        return None
+    position = np.asarray(value, dtype=float)
+    if position.shape != (2,) or not np.all(np.isfinite(position)):
+        return None
+    return position
+
+
+def _covariance_array(value: object) -> np.ndarray | None:
+    if value is None:
+        return None
+    covariance = np.asarray(value, dtype=float)
+    if covariance.shape != (2, 2) or not np.all(np.isfinite(covariance)):
+        return None
+    return covariance
+
+
+def _mean_summary(values: Sequence[float], *, unavailable_note: str) -> _ScalarSummary:
+    if not values:
+        return _ScalarSummary(
+            value=None,
+            status="unavailable",
+            denominator=0,
+            note=unavailable_note,
+        )
+    return _ScalarSummary(value=float(np.mean(values)), status="ok", denominator=len(values))
+
+
+def _calibration_summary(
+    *,
+    hits: int,
+    count: int,
+    confidence_level: float,
+) -> _ScalarSummary:
+    if count == 0:
+        return _ScalarSummary(
+            value=None,
+            status="unavailable",
+            denominator=0,
+            note="no Gaussian uncertainty representation available",
+        )
+    empirical_coverage = hits / count
+    return _ScalarSummary(
+        value=float(abs(empirical_coverage - confidence_level)),
+        status="ok",
+        denominator=count,
+    )
+
+
+def _spread_summary(values: Sequence[float], deterministic_spread_only: bool) -> _ScalarSummary:
+    if values:
+        return _ScalarSummary(value=float(np.mean(values)), status="ok", denominator=len(values))
+    if deterministic_spread_only:
+        return _ScalarSummary(
+            value=0.0,
+            status="deterministic_no_spread",
+            denominator=0,
+            note="deterministic forecast has no uncertainty representation",
+        )
+    return _ScalarSummary(
+        value=None,
+        status="unavailable",
+        denominator=0,
+        note="spread inputs unavailable or invalid",
+    )
+
+
+def _status_dict(summary: _ScalarSummary) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "status": summary.status,
+        "denominator": summary.denominator,
+    }
+    if summary.note is not None:
+        payload["note"] = summary.note
+    return payload
+
+
+def _closed_loop_denominators(
+    episode_count: int,
+    collision_count: int,
+    near_miss_count: int,
+    min_distance_count: int,
+    time_to_goal_count: int,
+    jerk_count: int,
+) -> dict[str, int]:
+    return {
+        "episode_count": episode_count,
+        "collision_rate_denominator": collision_count,
+        "near_miss_rate_denominator": near_miss_count,
+        "min_distance_denominator": min_distance_count,
+        "timeout_rate_denominator": episode_count,
+        "time_to_goal_denominator": time_to_goal_count,
+        "jerk_denominator": jerk_count,
+    }
+
+
+def _collision_event(row: Mapping[str, Any]) -> bool:
+    metrics = _metrics(row)
+    outcome = _mapping(row.get("outcome"))
+    return bool(
+        outcome.get("collision_event")
+        or _number(metrics.get("total_collision_count"), default=0.0) > 0.0
+        or _number(metrics.get("collisions"), default=0.0) > 0.0
+        or _number(row.get("collision"), default=0.0) > 0.0
+    )
+
+
+def _near_miss_event(row: Mapping[str, Any]) -> bool:
+    metrics = _metrics(row)
+    return bool(
+        _number(metrics.get("near_misses"), default=0.0) > 0.0
+        or _number(row.get("near_misses"), default=0.0) > 0.0
+    )
+
+
+def _timeout_event(row: Mapping[str, Any]) -> bool:
+    metrics = _metrics(row)
+    outcome = _mapping(row.get("outcome"))
+    termination_reason = str(row.get("termination_reason") or "").lower()
+    return bool(
+        outcome.get("timeout_event")
+        or termination_reason in _TIMEOUT_REASONS
+        or _number(metrics.get("timeout"), default=0.0) > 0.0
+    )
+
+
+def _number_from_row(row: Mapping[str, Any], key: str) -> float | None:
+    metrics = _metrics(row)
+    value = _finite_float(metrics.get(key))
+    if value is not None:
+        return value
+    return _finite_float(row.get(key))
+
+
+def _metrics(row: Mapping[str, Any]) -> Mapping[str, Any]:
+    return _mapping(row.get("metrics"))
+
+
+def _mapping(value: object) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _number(value: object, *, default: float) -> float:
+    number = _finite_float(value)
+    return default if number is None else number
+
+
+def _finite_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    return number if np.isfinite(number) else None
+
+
+def _mean_or_none(values: Sequence[float]) -> float | None:
+    return float(np.mean(values)) if values else None
+
+
+def _availability_status(denominator: int, note: str) -> dict[str, Any]:
+    if denominator:
+        return {"status": "ok", "denominator": denominator}
+    return {"status": "unavailable", "denominator": 0, "note": note}
+
+
+def _attach_rank_comparisons(reports: list[dict[str, Any]]) -> None:
+    if len(reports) < 2:
+        return
+    open_ranks = _rank_by_metric(
+        reports,
+        section="open_loop",
+        key="fde",
+        reverse=False,
+    )
+    closed_ranks = _rank_closed_loop(reports)
+    for report in reports:
+        predictor_id = report.get("predictor_id")
+        divergence = dict(report.get("divergence") or {})
+        if predictor_id in open_ranks and predictor_id in closed_ranks:
+            divergence.update(
+                {
+                    "rank_comparison_available": True,
+                    "open_loop_rank": open_ranks[predictor_id],
+                    "closed_loop_rank": closed_ranks[predictor_id],
+                    "rank_delta": closed_ranks[predictor_id] - open_ranks[predictor_id],
+                    "reason": "multi_predictor_rank_projection",
+                }
+            )
+        report["divergence"] = divergence
+
+
+def _rank_by_metric(
+    reports: Iterable[dict[str, Any]],
+    *,
+    section: str,
+    key: str,
+    reverse: bool,
+) -> dict[Any, int]:
+    sortable: list[tuple[float, Any]] = []
+    for report in reports:
+        value = _finite_float(_mapping(report.get(section)).get(key))
+        if value is not None:
+            sortable.append((value, report.get("predictor_id")))
+    sortable.sort(reverse=reverse)
+    return {predictor_id: rank for rank, (_, predictor_id) in enumerate(sortable, start=1)}
+
+
+def _rank_closed_loop(reports: Iterable[dict[str, Any]]) -> dict[Any, int]:
+    sortable: list[tuple[float, float, float, Any]] = []
+    for report in reports:
+        closed_loop = _mapping(report.get("closed_loop"))
+        collision_rate = _finite_float(closed_loop.get("collision_rate"))
+        near_miss_rate = _finite_float(closed_loop.get("near_miss_rate"))
+        min_distance = _finite_float(closed_loop.get("min_distance"))
+        if collision_rate is None or near_miss_rate is None or min_distance is None:
+            continue
+        sortable.append((collision_rate, near_miss_rate, -min_distance, report.get("predictor_id")))
+    sortable.sort()
+    return {predictor_id: rank for rank, (*_, predictor_id) in enumerate(sortable, start=1)}

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -25,6 +25,7 @@ from robot_sf.nav.map_config import (
     MapDefinitionPool,
     PedestrianWaitRule,
     SinglePedestrianDefinition,
+    parse_social_group_definitions,
     serialize_map,
 )
 from robot_sf.nav.svg_map_parser import convert_map
@@ -1224,6 +1225,7 @@ def build_robot_config_from_scenario(
         scenario.get("single_pedestrians"),
         default_hold_ref_point=_scenario_conflict_point(scenario),
     )
+    _apply_social_group_overrides(config, scenario.get("social_groups"))
     return config
 
 
@@ -1562,6 +1564,25 @@ def _apply_single_pedestrian_overrides(
         overrides,
         default_hold_ref_point=default_hold_ref_point,
     )
+
+
+def _apply_social_group_overrides(
+    config: RobotSimulationConfig,
+    overrides: list[Mapping[str, Any]] | None,
+) -> None:
+    """Apply scenario-level social group overrides to cloned map definitions."""
+    if not overrides:
+        return
+    if config.map_pool is None:
+        raise ValueError("social_groups overrides provided but config has no map pool")
+
+    cloned_maps = dict(config.map_pool.map_defs)
+    for map_id, map_def in cloned_maps.items():
+        updated = deepcopy(map_def)
+        updated.social_groups = parse_social_group_definitions(overrides)
+        updated._validate_social_groups()
+        cloned_maps[map_id] = updated
+    config.map_pool = MapDefinitionPool(map_defs=cloned_maps)
 
 
 def _scenario_conflict_point(scenario: Mapping[str, Any]) -> tuple[float, float] | None:
@@ -2280,6 +2301,7 @@ def map_cache_info() -> dict[str, int]:
 
 
 __all__ = [
+    "_apply_social_group_overrides",
     "apply_route_overrides",
     "apply_single_pedestrian_overrides",
     "build_robot_config_from_scenario",

--- a/tests/benchmark/test_prediction_open_closed_eval.py
+++ b/tests/benchmark/test_prediction_open_closed_eval.py
@@ -169,7 +169,8 @@ def test_prediction_eval_closed_loop_summary_projects_existing_episode_metrics()
                 "jerk_mean": 0.2,
                 "total_collision_count": 0,
                 "time_to_goal": 4.0,
-            }
+            },
+            "termination_reason": "success",
         },
         {
             "metrics": {
@@ -192,6 +193,57 @@ def test_prediction_eval_closed_loop_summary_projects_existing_episode_metrics()
     assert report["jerk"] == pytest.approx(0.3)
     assert report["closed_loop_denominators"]["episode_count"] == 2
     assert report["closed_loop_denominators"]["time_to_goal_denominator"] == 1
+
+
+def test_prediction_eval_closed_loop_missing_event_fields_are_unavailable() -> None:
+    """Missing event signals should not look like zero-risk closed-loop evidence."""
+    report = summarize_closed_loop_prediction_metrics(
+        [
+            {
+                "metrics": {
+                    "min_distance": 1.2,
+                    "jerk_mean": 0.1,
+                }
+            }
+        ]
+    )
+
+    assert report["collision_rate"] is None
+    assert report["near_miss_rate"] is None
+    assert report["timeout_rate"] is None
+    assert report["closed_loop_denominators"]["collision_rate_denominator"] == 0
+    assert report["closed_loop_denominators"]["near_miss_rate_denominator"] == 0
+    assert report["closed_loop_denominators"]["timeout_rate_denominator"] == 0
+    assert report["statuses"]["collision_rate"]["status"] == "unavailable"
+    assert report["statuses"]["near_miss_rate"]["status"] == "unavailable"
+    assert report["statuses"]["timeout_rate"]["status"] == "unavailable"
+
+
+def test_prediction_eval_open_loop_invalid_covariance_is_unavailable() -> None:
+    """Invalid Gaussian covariance matrices should not count as uncertainty evidence."""
+    batch = ForecastBatch(
+        provenance=_provenance(),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=[[0.0, 0.0], [1.0, 0.0]],
+                gaussian=[
+                    {"mean": [0.0, 0.0], "covariance": [[1.0, 0.0], [0.0, -1.0]]},
+                    {"mean": [1.0, 0.0], "covariance": [[1.0, 2.0], [0.0, 1.0]]},
+                ],
+            )
+        ],
+    )
+
+    report = compute_open_loop_prediction_metrics(
+        forecast_batches=[batch],
+        ground_truth_by_batch={"ped_1": [[0.0, 0.0], [1.0, 0.0]]},
+    )
+
+    assert report["calibration_error"] is None
+    assert report["prediction_spread"] is None
+    assert report["statuses"]["calibration_error"]["status"] == "unavailable"
+    assert report["statuses"]["prediction_spread"]["status"] == "unavailable"
 
 
 def test_prediction_eval_closed_loop_empty_rows_are_unavailable() -> None:
@@ -260,3 +312,24 @@ def test_prediction_eval_paired_report_populates_multi_predictor_ranks() -> None
     assert ranks["cv_a"]["closed_loop_rank"] == 2
     assert ranks["cv_b"]["open_loop_rank"] == 2
     assert ranks["cv_b"]["closed_loop_rank"] == 1
+
+
+def test_prediction_eval_paired_report_marks_missing_rank_inputs() -> None:
+    """Multi-predictor rank skips should name missing inputs, not single-predictor smoke."""
+    predictor_a = build_open_closed_prediction_report(
+        predictor_id="cv_a",
+        open_loop_report={"fde": 0.5},
+        closed_loop_report={"collision_rate": 0.0, "near_miss_rate": 0.0, "min_distance": 0.6},
+    )
+    predictor_b = build_open_closed_prediction_report(
+        predictor_id="cv_b",
+        open_loop_report={"ade": 0.1},
+        closed_loop_report={"collision_rate": 0.0, "near_miss_rate": 0.0, "min_distance": 0.7},
+    )
+
+    report = build_paired_prediction_eval_report([predictor_a, predictor_b])
+    divergence = report["predictors"][1]["divergence"]
+
+    assert divergence["rank_comparison_available"] is False
+    assert divergence["reason"] == "missing_rank_inputs"
+    assert divergence["missing_rank_inputs"] == ["open_loop.fde"]

--- a/tests/benchmark/test_prediction_open_closed_eval.py
+++ b/tests/benchmark/test_prediction_open_closed_eval.py
@@ -1,0 +1,262 @@
+"""Tests for issue #3973 open-loop and closed-loop prediction evaluation."""
+
+from __future__ import annotations
+
+import pytest
+
+from robot_sf.benchmark.forecast_batch import (
+    ActorForecast,
+    CoordinateFrame,
+    ForecastBatch,
+    ForecastBatchProvenance,
+)
+from robot_sf.benchmark.prediction_open_closed_eval import (
+    PREDICTION_OPEN_CLOSED_SCHEMA_VERSION,
+    build_open_closed_prediction_report,
+    build_paired_prediction_eval_report,
+    compute_open_loop_prediction_metrics,
+    summarize_closed_loop_prediction_metrics,
+)
+
+
+def _provenance(**overrides: object) -> ForecastBatchProvenance:
+    data: dict[str, object] = {
+        "predictor_id": "cv",
+        "predictor_family": "constant_velocity",
+        "observation_tier": "deployable_observation",
+        "frame": CoordinateFrame(name="world", units="m", axes=("x", "y")),
+        "dt_s": 0.5,
+        "horizons_s": [0.5, 1.0],
+        "scenario_id": "scenario_a",
+        "seed": 3973,
+        "timestamp": "2026-07-02T10:00:00Z",
+        "fallback_status": "native",
+        "degraded_status": "none",
+        "actor_ids": ["ped_1"],
+        "actor_mask": [True],
+        "actor_mask_metadata": {"semantics": "true means included"},
+        "feature_schema": {"name": "prediction_eval_fixture_v1"},
+    }
+    data.update(overrides)
+    return ForecastBatchProvenance(**data)
+
+
+def _gaussian_batch() -> ForecastBatch:
+    return ForecastBatch(
+        provenance=_provenance(),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=[[0.0, 0.0], [2.0, 0.0]],
+                gaussian=[
+                    {"mean": [0.0, 0.0], "covariance": [[0.25, 0.0], [0.0, 0.25]]},
+                    {"mean": [2.0, 0.0], "covariance": [[0.25, 0.0], [0.0, 0.25]]},
+                ],
+            )
+        ],
+    )
+
+
+def test_prediction_eval_open_loop_metrics_project_forecast_batch() -> None:
+    """Open-loop summary should expose ADE, FDE, calibration, and spread."""
+    report = compute_open_loop_prediction_metrics(
+        forecast_batches=[_gaussian_batch()],
+        ground_truth_by_batch={"ped_1": [[0.0, 0.0], [3.0, 0.0]]},
+    )
+
+    assert report["ade"] == pytest.approx(0.5)
+    assert report["fde"] == pytest.approx(1.0)
+    assert report["calibration_error"] == pytest.approx(0.05)
+    assert report["prediction_spread"] == pytest.approx(0.5)
+    assert report["sample_count"] == 2
+    assert report["statuses"]["calibration_error"]["status"] == "ok"
+
+
+def test_prediction_eval_open_loop_deterministic_status_is_explicit() -> None:
+    """Deterministic-only forecasts should not silently invent calibration."""
+    batch = ForecastBatch(
+        provenance=_provenance(),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=[[0.0, 0.0], [1.0, 0.0]],
+            )
+        ],
+    )
+
+    report = compute_open_loop_prediction_metrics(
+        forecast_batches=[batch],
+        ground_truth_by_batch={"ped_1": [[0.0, 0.0], [1.0, 0.0]]},
+    )
+
+    assert report["prediction_spread"] == 0.0
+    assert report["statuses"]["prediction_spread"]["status"] == "deterministic_no_spread"
+    assert report["calibration_error"] is None
+    assert report["statuses"]["calibration_error"]["status"] == "unavailable"
+
+
+def test_prediction_eval_open_loop_missing_truth_is_unavailable() -> None:
+    """Missing ground truth should be visible in denominator health."""
+    report = compute_open_loop_prediction_metrics(
+        forecast_batches=[_gaussian_batch()],
+        ground_truth_by_batch={"other_actor": [[0.0, 0.0], [1.0, 0.0]]},
+    )
+
+    assert report["ade"] is None
+    assert report["statuses"]["ade"]["status"] == "unavailable"
+    assert report["denominators"]["missing_ground_truth_batch_count"] == 0
+
+
+def test_prediction_eval_open_loop_empty_and_multibatch_missing_statuses() -> None:
+    """Empty inputs and missing batch truth should fail closed as unavailable."""
+    empty_report = compute_open_loop_prediction_metrics(
+        forecast_batches=[],
+        ground_truth_by_batch={},
+    )
+    assert empty_report["statuses"]["ade"]["status"] == "unavailable"
+    assert empty_report["sample_count"] == 0
+
+    batch = ForecastBatch(
+        provenance=_provenance(scenario_id="scenario_missing"),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=[[0.0, 0.0], [1.0, 0.0]],
+            )
+        ],
+    )
+    missing_report = compute_open_loop_prediction_metrics(
+        forecast_batches=[batch, _gaussian_batch()],
+        ground_truth_by_batch={
+            "scenario_a": {"ped_1": [[0.0, 0.0], [3.0, 0.0]]},
+        },
+    )
+    assert missing_report["denominators"]["missing_ground_truth_batch_count"] == 1
+    assert missing_report["missing_ground_truth_batches"] == ["scenario_missing"]
+
+
+def test_prediction_eval_open_loop_sample_spread_is_supported() -> None:
+    """Sampled forecasts should contribute prediction-spread values."""
+    batch = ForecastBatch(
+        provenance=_provenance(),
+        forecasts=[
+            ActorForecast(
+                actor_id="ped_1",
+                deterministic=[[0.0, 0.0], [1.0, 0.0]],
+                samples=[
+                    [[0.0, 0.0], [1.0, 0.0]],
+                    [[0.0, 2.0], [1.0, 2.0]],
+                ],
+            )
+        ],
+    )
+    report = compute_open_loop_prediction_metrics(
+        forecast_batches=[batch],
+        ground_truth_by_batch={"ped_1": [[0.0, 0.0], [1.0, 0.0]]},
+    )
+
+    assert report["prediction_spread"] == pytest.approx(1.0)
+    assert report["statuses"]["prediction_spread"]["status"] == "ok"
+
+
+def test_prediction_eval_closed_loop_summary_projects_existing_episode_metrics() -> None:
+    """Closed-loop summary should populate issue #3973 metrics from episode rows."""
+    rows = [
+        {
+            "metrics": {
+                "near_misses": 1,
+                "min_distance": 0.5,
+                "jerk_mean": 0.2,
+                "total_collision_count": 0,
+                "time_to_goal": 4.0,
+            }
+        },
+        {
+            "metrics": {
+                "near_misses": 0,
+                "min_distance": 1.2,
+                "jerk_mean": 0.4,
+                "total_collision_count": 1,
+            },
+            "termination_reason": "timeout",
+        },
+    ]
+
+    report = summarize_closed_loop_prediction_metrics(rows)
+
+    assert report["collision_rate"] == pytest.approx(0.5)
+    assert report["near_miss_rate"] == pytest.approx(0.5)
+    assert report["min_distance"] == pytest.approx(0.5)
+    assert report["timeout_rate"] == pytest.approx(0.5)
+    assert report["time_to_goal"] == pytest.approx(4.0)
+    assert report["jerk"] == pytest.approx(0.3)
+    assert report["closed_loop_denominators"]["episode_count"] == 2
+    assert report["closed_loop_denominators"]["time_to_goal_denominator"] == 1
+
+
+def test_prediction_eval_closed_loop_empty_rows_are_unavailable() -> None:
+    """Empty closed-loop inputs should retain the expected schema."""
+    report = summarize_closed_loop_prediction_metrics([])
+
+    assert report["collision_rate"] is None
+    assert report["closed_loop_denominators"]["episode_count"] == 0
+    assert report["statuses"]["jerk"]["status"] == "unavailable"
+
+
+def test_prediction_eval_paired_report_keeps_divergence_and_claim_boundary() -> None:
+    """Paired report should make open-vs-closed divergence inspectable."""
+    open_loop = {
+        "ade": 0.42,
+        "fde": 0.73,
+        "calibration_error": 0.08,
+        "prediction_spread": 0.55,
+        "sample_count": 12,
+    }
+    closed_loop = {
+        "collision_rate": 0.0,
+        "near_miss_rate": 0.5,
+        "min_distance": 0.62,
+        "timeout_rate": 0.0,
+        "time_to_goal": 4.3,
+        "jerk": 0.18,
+    }
+
+    predictor_report = build_open_closed_prediction_report(
+        predictor_id="cv",
+        open_loop_report=open_loop,
+        closed_loop_report=closed_loop,
+        predictor_metadata={"predictor_family": "constant_velocity"},
+    )
+    report = build_paired_prediction_eval_report([predictor_report])
+
+    assert report["schema_version"] == PREDICTION_OPEN_CLOSED_SCHEMA_VERSION
+    assert report["issue"] == 3973
+    assert "no causal safety" in report["claim_boundary"]
+    assert report["predictors"][0]["open_loop"] == open_loop
+    assert report["predictors"][0]["closed_loop"] == closed_loop
+    assert report["predictors"][0]["divergence"]["rank_comparison_available"] is False
+
+
+def test_prediction_eval_paired_report_populates_multi_predictor_ranks() -> None:
+    """Multiple predictors should receive open and closed-loop rank projections."""
+    predictor_a = build_open_closed_prediction_report(
+        predictor_id="cv_a",
+        open_loop_report={"fde": 0.5},
+        closed_loop_report={"collision_rate": 1.0, "near_miss_rate": 0.0, "min_distance": 0.4},
+    )
+    predictor_b = build_open_closed_prediction_report(
+        predictor_id="cv_b",
+        open_loop_report={"fde": 0.8},
+        closed_loop_report={"collision_rate": 0.0, "near_miss_rate": 0.0, "min_distance": 0.6},
+    )
+
+    report = build_paired_prediction_eval_report([predictor_a, predictor_b])
+    ranks = {
+        predictor["predictor_id"]: predictor["divergence"] for predictor in report["predictors"]
+    }
+
+    assert ranks["cv_a"]["rank_comparison_available"] is True
+    assert ranks["cv_a"]["open_loop_rank"] == 1
+    assert ranks["cv_a"]["closed_loop_rank"] == 2
+    assert ranks["cv_b"]["open_loop_rank"] == 2
+    assert ranks["cv_b"]["closed_loop_rank"] == 1


### PR DESCRIPTION
Reviewer-critical summary

What changed: added a small predictor-agnostic evaluation harness that pairs open-loop ForecastBatch.v1 metrics with closed-loop benchmark episode metrics in one `PredictionOpenClosedEval.v1` report, plus focused synthetic tests.

Why now: issue #3973 identifies a methodology gap where predictor dataset metrics such as ADE/FDE can diverge from closed-loop navigation outcomes.

Claim boundary: diagnostic CPU evaluation protocol only. This PR does not claim predictor safety, planner improvement, benchmark validity, or paper/dissertation evidence.

Required validation: focused unit tests for ADE/FDE/calibration/spread projection, deterministic unavailable statuses, closed-loop episode metric projection, paired report schema, and lint on changed files.

Remaining blocker: this first slice does not run a full benchmark campaign or trace-to-forecast extraction smoke; those remain follow-up empirical work.

Contract delta

- New schema surface: `PredictionOpenClosedEval.v1`.
- New report fields: `issue`, `claim_boundary`, `predictors[]`, `open_loop`, `closed_loop`, `divergence`, `predictor_metadata`.
- New open-loop projected fields: `ade`, `fde`, `calibration_error`, `prediction_spread`, `sample_count`, plus status and denominator metadata.
- New closed-loop projected fields: `collision_rate`, `near_miss_rate`, `min_distance`, `timeout_rate`, `time_to_goal`, `jerk`, plus `closed_loop_denominators` and status metadata.
- New fail-closed/unavailable behavior: missing deterministic forecast rows, missing Gaussian uncertainty, missing episode metric fields, empty episode inputs, and missing ground-truth batches are explicit statuses rather than silent zeros.
- Compatibility impact: additive only. Existing ForecastBatch.v1, forecast metric, collision, near-miss, timeout, and jerk semantics are not renamed or redefined.

Issue link: Closes #3973

Scope summary

- Adds `robot_sf/benchmark/prediction_open_closed_eval.py`.
- Adds `tests/benchmark/test_prediction_open_closed_eval.py`.
- Delivers a nameable progression capability toward #3973: paired open-loop/closed-loop prediction evaluation report construction over existing forecast and episode metric fixtures.
- Fragmentation guard: no open duplicate PR found, and no merged #3973 PR found in the last 24h at late pre-open check.
- State propagation: no separate issue comment was added because this run is explicitly not authorized to comment on issues or PRs; the PR body is the durable state surface for this slice.

Validation

- PASS: `uv run pytest tests/benchmark/test_prediction_open_closed_eval.py -q` -> 9 passed.
- PASS: `uv run pytest tests/benchmark/test_prediction_open_closed_eval.py -k "open_loop or closed_loop or prediction_eval" -q` -> 9 passed.
- PASS: `uv run ruff check robot_sf/benchmark/prediction_open_closed_eval.py tests/benchmark/test_prediction_open_closed_eval.py` -> all checks passed.
- PASS: `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/issue3973_pr_body.md PYTEST_NUM_WORKERS=8 scripts/dev/pr_ready_check.sh` -> passed; freshness stamp `output/validation/pr_ready/issue-3973-evaluation-open-loop-vs-closed-loop-pedestrian-prediction-evaluation.json` at `c7df5644555b663d0f2a8c8f2197151479a41ea1`.
- NOTE: before `uv sync --all-extras`, the issue-specified whole-suite selector `uv run pytest tests/ -k "open_loop or closed_loop or prediction_eval" -q` failed during unrelated repository collection due missing optional packages (`duckdb`, `stable_baselines3`, `optuna`, `pyarrow`, full `torch`). The final synced readiness run passed.

Out of scope

- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.
- No new learned predictor.
- No redefinition of collision, near-miss, timeout, or jerk semantics.

<details>
<summary>Process notes</summary>

- Required late issue check used `gh api` because `gh issue view 3973 --comments` fails in this repository with GitHub classic Projects deprecation on `repository.issue.projectCards`.
- Late check found the latest maintainer comment remained `2026-07-02T08:29:52Z`, older than this run start (`2026-07-02T12:02:40+02:00` local / `2026-07-02T10:02:40Z`).
- Duplicate PR check before opening found no matching open PR for issue #3973 or the exact open-loop/closed-loop pedestrian-prediction evaluation scope.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new prediction evaluation report that compares open-loop and closed-loop performance side by side.
  * Added support for summarized metrics such as prediction error, calibration, spread, collision and near-miss rates, time-to-goal, and jerk.
  * Added paired comparisons across multiple predictors, including ranking and divergence details.

* **Bug Fixes**
  * Improved handling of empty inputs, missing ground truth, invalid numeric values, and unavailable metrics with clearer status reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->