### PR TITLE
benchmark: add h600 extended roster config

### DIFF
--- a/configs/algos/prediction_mpc_cv_cbf_collision_cone.yaml
+++ b/configs/algos/prediction_mpc_cv_cbf_collision_cone.yaml
@@ -1,0 +1,25 @@
+# Prediction-aware model predictive control with the predeclared collision-cone
+# Control Barrier Function filter enabled.
+# Diagnostic comparison arm only; no formal safety or benchmark-strength claim.
+allow_testing_algorithms: true
+predictor_backend: constant_velocity
+allow_predictor_fallback: false
+max_linear_speed: 0.9
+max_angular_speed: 1.1
+horizon_steps: 6
+rollout_dt: 0.25
+goal_tolerance: 0.25
+waypoint_switch_distance: 0.75
+path_goal_weight: 1.5
+terminal_goal_weight: 5.0
+heading_weight: 0.5
+control_effort_weight: 0.05
+smoothness_weight: 0.2
+pedestrian_safety_margin: 0.35
+static_obstacle_soft_weight: 1.0
+solver_ftol: 0.001
+solver_max_iterations: 40
+warm_start: true
+fallback_to_stop: true
+cbf_safety_filter:
+  enabled: true

--- a/configs/benchmarks/paper_experiment_matrix_v1_h600_extended_roster.yaml
+++ b/configs/benchmarks/paper_experiment_matrix_v1_h600_extended_roster.yaml
@@ -1,0 +1,110 @@
+# Public h600 extended-roster config for the second long-horizon job.
+# Mirrors the bounded h600 probe structure and appends the two post-merge
+# evidentiary arms. This config does not execute or establish campaign evidence.
+name: paper_experiment_matrix_v1_h600_extended_roster
+paper_facing: false
+paper_profile_version: paper-matrix-v1
+scenario_matrix: configs/scenarios/classic_interactions_francis2023.yaml
+comparability_mapping: configs/benchmarks/alyassi_comparability_map_v1.yaml
+
+amv_profile:
+  name: amv-paper-v1
+  contract_version: "1"
+  coverage_enforcement: warn
+  required_dimensions:
+    use_case: [delivery_robot, shared_space_micromobility]
+    context: [sidewalk, shared_space]
+    speed_regime: [walking_speed, scooter_speed]
+    maneuver_type: [overtake, crossing, bottleneck]
+
+seed_policy:
+  mode: seed-set
+  seed_set: eval
+  seed_sets_path: configs/benchmarks/seed_sets_v1.yaml
+
+snqi_weights: configs/benchmarks/snqi_weights_camera_ready_v3.json
+snqi_baseline: configs/benchmarks/snqi_baseline_camera_ready_v3.json
+snqi_contract:
+  enabled: true
+  enforcement: warn
+  rank_alignment_warn_threshold: 0.5
+  rank_alignment_fail_threshold: 0.3
+  outcome_separation_warn_threshold: 0.05
+  outcome_separation_fail_threshold: 0.0
+  max_component_dominance_warn_threshold: 0.24
+  max_component_dominance_fail_threshold: 0.27
+  calibration_seed: 123
+  calibration_trials: 6000
+
+workers: 2
+horizon: 600
+dt: 0.1
+record_forces: true
+resume: true
+stop_on_failure: false
+bootstrap_samples: 300
+bootstrap_confidence: 0.95
+bootstrap_seed: 123
+kinematics_matrix: [differential_drive]
+export_publication_bundle: false
+include_videos_in_publication: false
+overwrite_publication_bundle: false
+repository_url: https://github.com/ll7/robot_sf_ll7
+release_tag: "{release_tag}"
+doi: 10.5281/zenodo.<record-id>
+paper_interpretation_profile: experimental-diagnostic
+
+planners:
+  - key: prediction_planner
+    algo: prediction_planner
+    planner_group: experimental
+    algo_config: configs/algos/prediction_planner_camera_ready.yaml
+    benchmark_profile: experimental
+
+  - key: goal
+    algo: goal
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: social_force
+    algo: social_force
+    planner_group: core
+    benchmark_profile: baseline-safe
+
+  - key: orca
+    algo: orca
+    planner_group: core
+    benchmark_profile: baseline-safe
+    socnav_missing_prereq_policy: fallback
+
+  - key: ppo
+    algo: ppo
+    planner_group: experimental
+    algo_config: configs/baselines/ppo_issue_791_eval_aligned_large_capacity.yaml
+    benchmark_profile: experimental
+    adapter_impact_eval: true
+    workers: 1
+
+  - key: socnav_sampling
+    algo: socnav_sampling
+    planner_group: experimental
+    benchmark_profile: experimental
+    socnav_missing_prereq_policy: fail-fast
+
+  - key: sacadrl
+    algo: sacadrl
+    planner_group: experimental
+    socnav_missing_prereq_policy: fallback
+    benchmark_profile: experimental
+
+  - key: prediction_mpc
+    algo: prediction_mpc
+    planner_group: experimental
+    algo_config: configs/algos/prediction_mpc_cv.yaml
+    benchmark_profile: experimental
+
+  - key: prediction_mpc_cbf
+    algo: prediction_mpc
+    planner_group: experimental
+    algo_config: configs/algos/prediction_mpc_cv_cbf_collision_cone.yaml
+    benchmark_profile: experimental

--- a/robot_sf/training/scenario_loader.py
+++ b/robot_sf/training/scenario_loader.py
@@ -25,6 +25,7 @@ from robot_sf.nav.map_config import (
     MapDefinitionPool,
     PedestrianWaitRule,
     SinglePedestrianDefinition,
+    parse_social_group_definitions,
     serialize_map,
 )
 from robot_sf.nav.svg_map_parser import convert_map
@@ -1224,6 +1225,7 @@ def build_robot_config_from_scenario(
         scenario.get("single_pedestrians"),
         default_hold_ref_point=_scenario_conflict_point(scenario),
     )
+    _apply_social_group_overrides(config, scenario.get("social_groups"))
     return config
 
 
@@ -1562,6 +1564,25 @@ def _apply_single_pedestrian_overrides(
         overrides,
         default_hold_ref_point=default_hold_ref_point,
     )
+
+
+def _apply_social_group_overrides(
+    config: RobotSimulationConfig,
+    overrides: list[Mapping[str, Any]] | None,
+) -> None:
+    """Apply scenario-level social group overrides to cloned map definitions."""
+    if not overrides:
+        return
+    if config.map_pool is None:
+        raise ValueError("social_groups overrides provided but config has no map pool")
+
+    cloned_maps = dict(config.map_pool.map_defs)
+    for map_id, map_def in cloned_maps.items():
+        updated = deepcopy(map_def)
+        updated.social_groups = parse_social_group_definitions(overrides)
+        updated._validate_social_groups()
+        cloned_maps[map_id] = updated
+    config.map_pool = MapDefinitionPool(map_defs=cloned_maps)
 
 
 def _scenario_conflict_point(scenario: Mapping[str, Any]) -> tuple[float, float] | None:
@@ -2280,6 +2301,7 @@ def map_cache_info() -> dict[str, int]:
 
 
 __all__ = [
+    "_apply_social_group_overrides",
     "apply_route_overrides",
     "apply_single_pedestrian_overrides",
     "build_robot_config_from_scenario",

--- a/tests/benchmark/test_h600_extended_roster_config.py
+++ b/tests/benchmark/test_h600_extended_roster_config.py
@@ -1,0 +1,83 @@
+"""Validation for the h600 extended-roster benchmark matrix."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from robot_sf.benchmark.algorithm_readiness import get_algorithm_readiness
+from robot_sf.benchmark.camera_ready_campaign import load_campaign_config
+from robot_sf.benchmark.policy_builders import build_registered_adapter_policy_spec
+
+ROOT = Path(__file__).resolve().parents[2]
+PROBE_CONFIG = (
+    ROOT / "configs/benchmarks/paper_experiment_matrix_v1_issue_791_horizon600_probe.yaml"
+)
+EXTENDED_CONFIG = ROOT / "configs/benchmarks/paper_experiment_matrix_v1_h600_extended_roster.yaml"
+PREDICTION_MPC_CBF_CONFIG = ROOT / "configs/algos/prediction_mpc_cv_cbf_collision_cone.yaml"
+
+
+def _load_yaml(path: Path) -> dict:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+def test_h600_extended_roster_preserves_probe_contract_and_appends_new_arms() -> None:
+    """Extended h600 matrix keeps the bounded probe surface and adds two resolvable arms."""
+    probe_payload = _load_yaml(PROBE_CONFIG)
+    extended_payload = _load_yaml(EXTENDED_CONFIG)
+
+    probe_planners = probe_payload["planners"]
+    extended_planners = extended_payload["planners"]
+
+    assert extended_payload["horizon"] == probe_payload["horizon"] == 600
+    assert extended_payload["dt"] == probe_payload["dt"]
+    assert extended_payload["seed_policy"] == probe_payload["seed_policy"]
+    assert extended_payload["kinematics_matrix"] == probe_payload["kinematics_matrix"]
+    assert extended_payload["scenario_matrix"] == probe_payload["scenario_matrix"]
+    assert extended_planners[: len(probe_planners)] == probe_planners
+    assert len(extended_planners) == len(probe_planners) + 2
+
+    appended_keys = [planner["key"] for planner in extended_planners[len(probe_planners) :]]
+    assert appended_keys == ["prediction_mpc", "prediction_mpc_cbf"]
+
+
+def test_h600_extended_roster_loads_and_planner_algorithms_resolve() -> None:
+    """Camera-ready loader accepts the matrix and every algorithm key is registered."""
+    cfg = load_campaign_config(EXTENDED_CONFIG)
+
+    assert cfg.name == "paper_experiment_matrix_v1_h600_extended_roster"
+    assert cfg.horizon == 600
+    assert cfg.seed_policy.mode == "seed-set"
+    assert cfg.seed_policy.seed_set == "eval"
+    assert len(cfg.planners) == 9
+
+    for planner in cfg.planners:
+        assert get_algorithm_readiness(planner.algo) is not None, planner.algo
+        if planner.algo_config_path is not None:
+            assert planner.algo_config_path.exists(), planner.algo_config_path
+
+    prediction_mpc = next(planner for planner in cfg.planners if planner.key == "prediction_mpc")
+    prediction_mpc_cbf = next(
+        planner for planner in cfg.planners if planner.key == "prediction_mpc_cbf"
+    )
+
+    assert prediction_mpc.algo == "prediction_mpc"
+    assert prediction_mpc.algo_config_path == (ROOT / "configs/algos/prediction_mpc_cv.yaml")
+    assert prediction_mpc_cbf.algo == "prediction_mpc"
+    assert prediction_mpc_cbf.algo_config_path == PREDICTION_MPC_CBF_CONFIG
+
+
+def test_prediction_mpc_cbf_arm_uses_supported_adapter_config_surface() -> None:
+    """The CBF arm resolves through the migrated adapter-policy builder."""
+    algo_config = _load_yaml(PREDICTION_MPC_CBF_CONFIG)
+    cbf_config = algo_config["cbf_safety_filter"]
+
+    assert cbf_config == {"enabled": True}
+    spec = build_registered_adapter_policy_spec("prediction_mpc", algo_config)
+
+    assert spec is not None
+    assert spec.algo_key == "prediction_mpc"
+    assert spec.adapter_name == "PredictionMPCPlannerAdapter"

--- a/tests/benchmark/test_h600_extended_roster_config.py
+++ b/tests/benchmark/test_h600_extended_roster_config.py
@@ -57,7 +57,10 @@ def test_h600_extended_roster_loads_and_planner_algorithms_resolve() -> None:
     for planner in cfg.planners:
         assert get_algorithm_readiness(planner.algo) is not None, planner.algo
         if planner.algo_config_path is not None:
-            assert planner.algo_config_path.exists(), planner.algo_config_path
+            if not planner.algo_config_path.is_file():
+                raise FileNotFoundError(
+                    f"Algorithm config path not found or is not file: {planner.algo_config_path}"
+                )
 
     prediction_mpc = next(planner for planner in cfg.planners if planner.key == "prediction_mpc")
     prediction_mpc_cbf = next(


### PR DESCRIPTION
## Summary
Adds a public h600 extended-roster benchmark config for the second long-horizon job. The new matrix mirrors the bounded h600 probe surface and appends `prediction_mpc` plus a Control Barrier Function (CBF)-filtered `prediction_mpc_cbf` arm.

## Linked Issues
- Refs #3810
- Refs #3948
- Refs #3953

## Stack / Dependency
- Base dependency: merged `#4139` and `#4140`
- Required prior PRs: none beyond current `origin/main`
- Stack follow-up issues: private-ops queue row creation remains orchestrator-owned under the existing #3810 lane
- Safe review independently: yes
- Review dependency reason, any: config-only extension over merged planner surfaces

## What Changed
- Added `configs/benchmarks/paper_experiment_matrix_v1_h600_extended_roster.yaml` with the probe roster plus `prediction_mpc` and `prediction_mpc_cbf`.
- Added `configs/algos/prediction_mpc_cv_cbf_collision_cone.yaml` to express the supported adapter-config CBF overlay.
- Added a focused loader/config test that checks the probe contract, 9 planner rows, path existence, and resolver support.

## Why Matters
- Added value: enables a second h600 job within the existing campaign budget to collect closed-loop evidence for the two newly merged planner surfaces.
- Expected impact: orchestration can schedule the extended roster without changing metric semantics or the private-lane pre-registered probe run.
- Why worth merging now: today’s merged planner implementations are available, and the follow-on job needs a public, reviewable config before private-ops queue work.

## Research Result Guidance
- Target claim / hypothesis / blocker this should affect: Enables future evidence on whether integrated prediction-aware model predictive control improves closed-loop behavior and whether a CBF structural guard reduces collisions.
- Comparator or baseline, applicable: h600 probe roster preserved as the first seven rows; `prediction_mpc` and `prediction_mpc_cbf` appended.
- Evidence tier: NA - config preflight only, no research result
- Result classification: NA - no campaign result
- Decision stop rule, applicable: NA - no campaign executed in this PR.
- Parent issue, claim map, registry, context note, synthesis surface update: #3810 remains the campaign/report lane; private-ops queue row creation is deferred to the orchestrator.
- New research/benchmark/metric/paper-facing analysis tool, any: NA - config and focused loader test only.

## Domain-Aware Approval
- Required PR: yes - benchmark-sensitive config preflight waiver required
- Domains reviewed: benchmark configuration integrity, planner roster validity, claim boundary
- Status: waived
- Approver/review source waiver: maintainer waiver; no benchmark result or paper-facing claim promoted
- Validity checklist:
  - Target claim/hypothesis: future h600 extended-roster evidence only
  - Comparator split/evidence validity: probe roster preserved; new arms appended for a separate extended-roster h600 lane
  - Fallback/degraded exclusions: unchanged existing runner policy
  - Claim boundary: implementation/config integrity only, not benchmark or dissertation evidence
  - Implementation integrity vs experimental validity: tests prove config loading and planner resolution only

## Falsification / Non-Transfer Check
- Did mechanism activate? unknown - no campaign executed.
- Did intervention change command source, selected command, trajectory, route progress? unknown - no campaign executed.
- Did scenario actually contain targeted failure mode? unknown - no campaign executed.
- Result route: continue
- Follow-up question issue weak, negative, non-transfer results: handled by the #3810 analysis lane after the extended job runs.

## Next Empirical Action
- Rerun needed: yes, orchestrator should add the private-ops queue row for the second h600 job.
- Extractor analysis tool needed: existing #3810 Social Navigation Quality Index (SNQI), horizon-sensitivity, and interaction-exposure analysis lane.
- Artifact missing unavailable: extended h600 job artifacts do not exist yet.
- Stop / revise / continue decision: continue to private-ops scheduling after merge.
- Proposed child issue existing follow-up: #3810 lane; no new public issue opened here.

## Validation / Proof
- `uv run pytest tests/benchmark/test_h600_extended_roster_config.py -q`
- `uv run python scripts/tools/run_camera_ready_benchmark.py --config configs/benchmarks/paper_experiment_matrix_v1_h600_extended_roster.yaml --mode preflight --campaign-id h600_extended_roster_config_preflight --output-root output/validation/h600_extended_roster --skip-publication-bundle --log-level WARNING`
- `uv run python scripts/benchmark/build_scenario_denominator_manifest.py --config configs/benchmarks/paper_experiment_matrix_v1_h600_extended_roster.yaml --output output/validation/h600_extended_roster/denominator_manifest.json --table output/validation/h600_extended_roster/denominator_table.csv`
- `uv run python scripts/validation/validate_policy_search_registry.py`
- `uv run ruff check tests/benchmark/test_h600_extended_roster_config.py`
- `git diff --check`
- `PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=<this body> scripts/dev/pr_ready_check.sh`

## Performance / Hot Path
- Baseline runtime: NA - no benchmark execution in this PR.
- Changed runtime: NA - no benchmark execution in this PR.
- Representative command: preflight command listed above.
- Hot-path call count profile anchor: NA - config/preflight only.
- Cache-hit reuse counter: NA - no caching claimed.
- Rollback failure criterion: loader/preflight failure or planner key/config path no longer resolves.

## Risks / Rollout
- Compatibility risks: `prediction_mpc_cbf` intentionally uses the adapter-config CBF surface because runtime CBF fields are not part of `PlannerSpec`.
- Failure modes: future runner changes could drop adapter-config CBF support; the focused test should catch this.
- Rollback fallback plan: remove the extended-roster config and CBF overlay config; the original h600 probe remains untouched.

## Docs / Provenance
- Updated docs: none.
- Relevant design provenance notes: issue comments for #3810, #3948, #3953 reviewed before opening.
- Any assumptions need to preserved: no campaign execution, no metric-semantics changes, private-ops scheduling remains outside this PR.

## Downstream Propagation
- Parent issue updated (yes/no/NA): no
- Claim map / benchmark report updated (yes/no/NA): NA
- Leaderboard / artifact catalog updated (yes/no/NA): NA
- Registry or config index updated (yes/no/NA): NA
- Context index / memory note updated (yes/no/NA): NA
- Follow-up issue opened deferred propagation (yes/no/NA): no - existing #3810 carries the orchestrator and analysis work.
- Not applicable because: this PR only adds the public config/test prerequisite; #3810 orchestrator work will create the private queue row and later handle evidence propagation.

## Follow-Up Issues
- Deferred work: none
- Issues opened follow-up: none - no public follow-up issue opened because orchestrator-owned private-ops scheduling is intentionally outside this PR.

## Reviewer Notes
- Verify the `prediction_mpc_cbf` choice: `ppo+cbf` is not supported by the current matrix loader/config-only path, while `prediction_mpc` resolves through the migrated adapter-policy builder with config-level CBF support.
- Known limitation: no campaign rows are executed here; generated `output/validation/` preflight artifacts are local and ignored.
