### PR TITLE
Issue #3190: validate context archive approval manifests

### DIFF
--- a/scripts/tools/plan_context_note_archival.py
+++ b/scripts/tools/plan_context_note_archival.py
@@ -226,7 +226,18 @@ def _approval_move_to_planned(
     target = checker._safe_repo_path(raw_move.get("target"))
     category = raw_move.get("category")
     reason = raw_move.get("reason")
-    replacement = checker._safe_repo_path(raw_move.get("replacement"))
+    raw_replacement = raw_move.get("replacement")
+    replacement = None
+    if raw_replacement is not None:
+        replacement = checker._safe_repo_path(raw_replacement)
+        if replacement is None:
+            findings.append(
+                _approval_finding(
+                    "replacement_path",
+                    "replacement must be a safe repository path",
+                    path=source.as_posix() if source else None,
+                )
+            )
 
     if source is None:
         findings.append(_approval_finding("source_path", "source must be a safe repository path"))
@@ -278,14 +289,14 @@ def validate_approval_manifest(  # noqa: C901
 ) -> tuple[list[PlannedMove], list[ApprovalFinding], list[PlanConflict]]:
     """Validate a maintainer-approved archival move manifest against current candidates."""
 
-    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    archive_dir = _normalized_archive_dir(archive_dir, repo_root=repo_root)
+    try:
+        manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    except yaml.YAMLError as exc:
+        raise ValueError(f"failed to parse approval manifest YAML: {exc}") from exc
     findings: list[ApprovalFinding] = []
     if not isinstance(manifest, dict):
-        return (
-            [],
-            [_approval_finding("manifest_shape", "approval manifest must be a YAML mapping")],
-            [],
-        )
+        raise ValueError("approval manifest must be a YAML mapping")
 
     if manifest.get("schema_version") != APPROVAL_SCHEMA_VERSION:
         findings.append(
@@ -360,7 +371,7 @@ def validate_approval_manifest(  # noqa: C901
                 )
             )
             continue
-        if planned_move.replacement and move.replacement != planned_move.replacement:
+        if move.replacement != planned_move.replacement:
             findings.append(
                 _approval_finding(
                     "replacement_mismatch",
@@ -376,6 +387,19 @@ def validate_approval_manifest(  # noqa: C901
         )
 
     return approved_moves, findings, conflicts
+
+
+def _normalized_archive_dir(archive_dir: Path, *, repo_root: Path) -> Path:
+    """Return a safe repository-relative archive directory path."""
+
+    candidate = archive_dir if archive_dir.is_absolute() else repo_root / archive_dir
+    if candidate.is_symlink():
+        raise ValueError("archive_dir cannot be a symlink")
+    resolved_repo = repo_root.resolve(strict=False)
+    resolved_archive = candidate.resolve(strict=False)
+    if not resolved_archive.is_relative_to(resolved_repo):
+        raise ValueError("archive_dir must be within repository root")
+    return resolved_archive.relative_to(resolved_repo)
 
 
 def plan_archival(

--- a/scripts/tools/plan_context_note_archival.py
+++ b/scripts/tools/plan_context_note_archival.py
@@ -35,12 +35,16 @@ from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+import yaml
+
 from scripts.tools import check_context_note_freshness as checker
 
 if TYPE_CHECKING:
     from datetime import datetime
 
 SCHEMA_VERSION = "context_note_archival_plan.v1"
+APPROVAL_SCHEMA_VERSION = "context_archive_approved_moves.v1"
+VALID_APPROVAL_CATEGORIES = frozenset({"superseded", "stale"})
 
 
 @dataclass(frozen=True, slots=True)
@@ -65,6 +69,16 @@ class PlanConflict:
     target: str
     message: str
     sources: tuple[str, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class ApprovalFinding:
+    """One fail-closed approval-manifest validation finding."""
+
+    severity: str
+    rule: str
+    message: str
+    path: str | None = None
 
 
 def _archive_target(source: Path, *, archive_dir: Path) -> Path:
@@ -185,6 +199,185 @@ def _detect_conflicts(moves: list[PlannedMove], *, repo_root: Path) -> list[Plan
     return conflicts
 
 
+def _approval_finding(
+    rule: str,
+    message: str,
+    *,
+    path: str | None = None,
+    severity: str = "error",
+) -> ApprovalFinding:
+    """Return a structured approval-manifest validation finding."""
+
+    return ApprovalFinding(severity=severity, rule=rule, message=message, path=path)
+
+
+def _approval_move_to_planned(
+    raw_move: object,
+    *,
+    index: int,
+) -> tuple[PlannedMove | None, list[ApprovalFinding]]:
+    """Parse one approved move into the same shape used by the generated plan."""
+
+    if not isinstance(raw_move, dict):
+        return None, [_approval_finding("move_shape", f"moves[{index}] must be a mapping")]
+
+    findings: list[ApprovalFinding] = []
+    source = checker._safe_repo_path(raw_move.get("source"))
+    target = checker._safe_repo_path(raw_move.get("target"))
+    category = raw_move.get("category")
+    reason = raw_move.get("reason")
+    replacement = checker._safe_repo_path(raw_move.get("replacement"))
+
+    if source is None:
+        findings.append(_approval_finding("source_path", "source must be a safe repository path"))
+    if target is None:
+        findings.append(_approval_finding("target_path", "target must be a safe repository path"))
+    if category not in VALID_APPROVAL_CATEGORIES:
+        findings.append(
+            _approval_finding(
+                "category",
+                "category must be one of: stale, superseded",
+                path=source.as_posix() if source else None,
+            )
+        )
+    if not isinstance(reason, str) or not reason.strip():
+        findings.append(
+            _approval_finding(
+                "reason",
+                "reason must be a non-empty string",
+                path=source.as_posix() if source else None,
+            )
+        )
+
+    if findings or source is None or target is None or not isinstance(category, str):
+        return None, findings
+
+    return (
+        PlannedMove(
+            category=category,
+            confidence="approved",
+            source=source.as_posix(),
+            target=target.as_posix(),
+            reason=reason.strip(),
+            replacement=replacement.as_posix() if replacement else None,
+        ),
+        findings,
+    )
+
+
+def validate_approval_manifest(  # noqa: C901
+    manifest_path: Path,
+    *,
+    repo_root: Path,
+    catalog_path: Path = checker.CATALOG_PATH,
+    context_dir: Path = checker.CONTEXT_DIR,
+    index_path: Path = checker.INDEX_PATH,
+    archive_dir: Path = checker.ARCHIVE_DIR,
+    max_age_days: int = 180,
+    include_stale: bool = True,
+) -> tuple[list[PlannedMove], list[ApprovalFinding], list[PlanConflict]]:
+    """Validate a maintainer-approved archival move manifest against current candidates."""
+
+    manifest = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    findings: list[ApprovalFinding] = []
+    if not isinstance(manifest, dict):
+        return (
+            [],
+            [_approval_finding("manifest_shape", "approval manifest must be a YAML mapping")],
+            [],
+        )
+
+    if manifest.get("schema_version") != APPROVAL_SCHEMA_VERSION:
+        findings.append(
+            _approval_finding("schema_version", f"schema_version must be {APPROVAL_SCHEMA_VERSION}")
+        )
+    if manifest.get("issue") != 3190:
+        findings.append(_approval_finding("issue", "issue must be 3190"))
+
+    raw_moves = manifest.get("moves")
+    if not isinstance(raw_moves, list) or not raw_moves:
+        findings.append(_approval_finding("moves", "moves must be a non-empty list"))
+        raw_moves = []
+
+    approved_moves: list[PlannedMove] = []
+    for index, raw_move in enumerate(raw_moves):
+        move, move_findings = _approval_move_to_planned(raw_move, index=index)
+        findings.extend(move_findings)
+        if move is not None:
+            approved_moves.append(move)
+
+    plan_moves, _plan_conflicts = plan_archival(
+        repo_root=repo_root,
+        catalog_path=catalog_path,
+        context_dir=context_dir,
+        index_path=index_path,
+        archive_dir=archive_dir,
+        max_age_days=max_age_days,
+        include_stale=include_stale,
+    )
+    planned_by_key = {(move.category, move.source, move.target): move for move in plan_moves}
+
+    seen_sources: set[str] = set()
+    seen_targets: set[str] = set()
+    for move in approved_moves:
+        target_path = Path(move.target)
+        if archive_dir not in target_path.parents:
+            findings.append(
+                _approval_finding(
+                    "target_archive_dir",
+                    f"target must be under {archive_dir.as_posix()}",
+                    path=move.source,
+                )
+            )
+        if move.source in seen_sources:
+            findings.append(
+                _approval_finding(
+                    "duplicate_source", "source appears more than once", path=move.source
+                )
+            )
+        seen_sources.add(move.source)
+        if move.target in seen_targets:
+            findings.append(
+                _approval_finding(
+                    "duplicate_target",
+                    "target appears more than once in approved moves",
+                    path=move.source,
+                )
+            )
+        seen_targets.add(move.target)
+        if not (repo_root / Path(move.source)).is_file():
+            findings.append(
+                _approval_finding("source_exists", "source note does not exist", path=move.source)
+            )
+
+        planned_move = planned_by_key.get((move.category, move.source, move.target))
+        if planned_move is None:
+            findings.append(
+                _approval_finding(
+                    "not_in_current_plan",
+                    "approved move is not in the current generated archival plan",
+                    path=move.source,
+                )
+            )
+            continue
+        if planned_move.replacement and move.replacement != planned_move.replacement:
+            findings.append(
+                _approval_finding(
+                    "replacement_mismatch",
+                    f"replacement must match current plan: {planned_move.replacement}",
+                    path=move.source,
+                )
+            )
+
+    conflicts = _detect_conflicts(approved_moves, repo_root=repo_root)
+    for conflict in conflicts:
+        findings.append(
+            _approval_finding(f"conflict_{conflict.kind}", conflict.message, path=conflict.target)
+        )
+
+    return approved_moves, findings, conflicts
+
+
 def plan_archival(
     *,
     repo_root: Path,
@@ -237,6 +430,29 @@ def _summary(
         "moves": [asdict(move) for move in moves],
         "conflicts": [asdict(conflict) for conflict in conflicts],
         "note": "plan-only: no notes were moved or deleted; apply via a maintainer-reviewed sweep PR",
+    }
+
+
+def _approval_summary(
+    *,
+    manifest_path: Path,
+    approved_moves: list[PlannedMove],
+    findings: list[ApprovalFinding],
+    conflicts: list[PlanConflict],
+) -> dict[str, Any]:
+    """Return compact JSON-ready approval validation summary."""
+
+    return {
+        "schema_version": APPROVAL_SCHEMA_VERSION,
+        "manifest": manifest_path.as_posix(),
+        "approved_move_count": len(approved_moves),
+        "finding_count": len(findings),
+        "conflict_count": len(conflicts),
+        "exit_code": 1 if findings else 0,
+        "moves": [asdict(move) for move in approved_moves],
+        "findings": [asdict(finding) for finding in findings],
+        "conflicts": [asdict(conflict) for conflict in conflicts],
+        "note": "approval validation only: no notes were moved or deleted",
     }
 
 
@@ -294,6 +510,14 @@ def _parse_args() -> argparse.Namespace:
         type=Path,
         help="Write a JSON plan to this path. Use '-' to print JSON to stdout.",
     )
+    parser.add_argument(
+        "--approval-manifest",
+        type=Path,
+        help=(
+            "Validate an approved move manifest against the current plan. "
+            "Schema: context_archive_approved_moves.v1."
+        ),
+    )
     parser.add_argument("--catalog", type=Path, default=checker.CATALOG_PATH)
     parser.add_argument("--context-dir", type=Path, default=checker.CONTEXT_DIR)
     parser.add_argument("--index", type=Path, default=checker.INDEX_PATH)
@@ -312,6 +536,40 @@ def main() -> int:
 
     args = _parse_args()
     repo_root = checker._repo_root()
+    if args.approval_manifest:
+        approved_moves, findings, conflicts = validate_approval_manifest(
+            repo_root / args.approval_manifest,
+            repo_root=repo_root,
+            catalog_path=args.catalog,
+            context_dir=args.context_dir,
+            index_path=args.index,
+            archive_dir=args.archive_dir,
+            max_age_days=args.max_age_days,
+            include_stale=not args.no_stale,
+        )
+        payload = _approval_summary(
+            manifest_path=args.approval_manifest,
+            approved_moves=approved_moves,
+            findings=findings,
+            conflicts=conflicts,
+        )
+        text = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        if args.json_output:
+            if str(args.json_output) == "-":
+                print(text, end="")
+            else:
+                output_path = repo_root / args.json_output
+                output_path.parent.mkdir(parents=True, exist_ok=True)
+                output_path.write_text(text, encoding="utf-8")
+        elif findings:
+            print(f"approval manifest failed: {len(findings)} finding(s)")
+            for finding in findings:
+                location = f" {finding.path}" if finding.path else ""
+                print(f"  {finding.rule}{location}: {finding.message}")
+        else:
+            print(f"OK approval manifest valid: {len(approved_moves)} move(s)")
+        return int(payload["exit_code"])
+
     moves, conflicts = plan_archival(
         repo_root=repo_root,
         catalog_path=args.catalog,

--- a/tests/tools/test_plan_context_note_archival.py
+++ b/tests/tools/test_plan_context_note_archival.py
@@ -7,6 +7,7 @@ import subprocess
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
+import pytest
 import yaml
 
 from scripts.tools import plan_context_note_archival as planner
@@ -382,6 +383,142 @@ def test_approval_manifest_fails_when_replacement_drifted_from_plan(tmp_path: Pa
     )
 
     assert [finding.rule for finding in findings] == ["replacement_mismatch"]
+
+
+def test_approval_manifest_fails_when_replacement_is_unsafe(tmp_path: Path) -> None:
+    """An explicitly provided replacement path must be safe, not silently omitted."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old\n")
+    _write(repo, "docs/context/new.md", "# New\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            }
+        ],
+    )
+    _commit(repo, "superseded", iso_date="2026-01-02T00:00:00+00:00")
+    manifest = repo / "approved_moves.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "context_archive_approved_moves.v1",
+                "issue": 3190,
+                "moves": [
+                    {
+                        "source": "docs/context/old.md",
+                        "target": "docs/context/archive/old.md",
+                        "category": "superseded",
+                        "replacement": "../outside.md",
+                        "reason": "Unsafe replacement should fail closed.",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _approved_moves, findings, _conflicts = planner.validate_approval_manifest(
+        manifest,
+        repo_root=repo,
+    )
+
+    assert "replacement_path" in {finding.rule for finding in findings}
+
+
+def test_approval_manifest_fails_when_unexpected_replacement_is_present(
+    tmp_path: Path,
+) -> None:
+    """Approval replacement metadata must match the generated plan exactly."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/stale.md", "# Stale\n")
+    _write(repo, "docs/context/current.md", "# Current\n")
+    _write_catalog(
+        repo,
+        [{"path": "docs/context/stale.md", "status": "current", "freshness": "dated"}],
+    )
+    _commit(repo, "stale note", iso_date="2025-01-02T00:00:00+00:00")
+    manifest = repo / "approved_moves.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "context_archive_approved_moves.v1",
+                "issue": 3190,
+                "moves": [
+                    {
+                        "source": "docs/context/stale.md",
+                        "target": "docs/context/archive/stale.md",
+                        "category": "stale",
+                        "replacement": "docs/context/current.md",
+                        "reason": "Unexpected replacement should fail closed.",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _approved_moves, findings, _conflicts = planner.validate_approval_manifest(
+        manifest,
+        repo_root=repo,
+    )
+
+    assert "replacement_mismatch" in {finding.rule for finding in findings}
+
+
+def test_approval_manifest_rejects_invalid_yaml_root(tmp_path: Path) -> None:
+    """Malformed and non-mapping YAML manifests fail closed with explicit errors."""
+
+    repo = _repo(tmp_path)
+    malformed = repo / "malformed.yaml"
+    malformed.write_text("schema_version: [", encoding="utf-8")
+    with pytest.raises(ValueError, match="failed to parse approval manifest YAML"):
+        planner.validate_approval_manifest(malformed, repo_root=repo)
+
+    non_mapping = repo / "non_mapping.yaml"
+    non_mapping.write_text("- not\n- a mapping\n", encoding="utf-8")
+    with pytest.raises(ValueError, match="approval manifest must be a YAML mapping"):
+        planner.validate_approval_manifest(non_mapping, repo_root=repo)
+
+
+def test_approval_manifest_rejects_archive_dir_outside_repo(tmp_path: Path) -> None:
+    """A custom archive directory must normalize inside the repository root."""
+
+    repo = _repo(tmp_path)
+    manifest = repo / "approved_moves.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "context_archive_approved_moves.v1",
+                "issue": 3190,
+                "moves": [
+                    {
+                        "source": "docs/context/old.md",
+                        "target": "docs/context/archive/old.md",
+                        "category": "stale",
+                        "reason": "Archive dir validation happens before move validation.",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="archive_dir must be within repository root"):
+        planner.validate_approval_manifest(
+            manifest,
+            repo_root=repo,
+            archive_dir=tmp_path.parent / "outside-archive",
+        )
 
 
 def test_approval_manifest_fails_for_move_not_in_current_plan(tmp_path: Path) -> None:

--- a/tests/tools/test_plan_context_note_archival.py
+++ b/tests/tools/test_plan_context_note_archival.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 import subprocess
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
@@ -284,3 +285,254 @@ def test_summary_reports_counts_and_plan_only_note(tmp_path: Path) -> None:
     assert summary["exit_code"] == 0
     assert summary["archive_dir"] == "docs/context/archive"
     assert "plan-only" in summary["note"]
+
+
+def test_valid_approval_manifest_accepts_current_superseded_candidate(tmp_path: Path) -> None:
+    """Approved moves are valid only when they match current generated candidates."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old\n")
+    _write(repo, "docs/context/new.md", "# New\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            }
+        ],
+    )
+    _commit(repo, "superseded", iso_date="2026-01-02T00:00:00+00:00")
+    manifest = repo / "approved_moves.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "context_archive_approved_moves.v1",
+                "issue": 3190,
+                "moves": [
+                    {
+                        "source": "docs/context/old.md",
+                        "target": "docs/context/archive/old.md",
+                        "category": "superseded",
+                        "replacement": "docs/context/new.md",
+                        "reason": "Maintainer approved superseded-note archive move.",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    approved_moves, findings, conflicts = planner.validate_approval_manifest(
+        manifest,
+        repo_root=repo,
+    )
+
+    assert len(approved_moves) == 1
+    assert findings == []
+    assert conflicts == []
+
+
+def test_approval_manifest_fails_when_replacement_drifted_from_plan(tmp_path: Path) -> None:
+    """A manifest cannot silently approve stale replacement metadata."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old\n")
+    _write(repo, "docs/context/new.md", "# New\n")
+    _write(repo, "docs/context/wrong.md", "# Wrong\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            }
+        ],
+    )
+    _commit(repo, "superseded", iso_date="2026-01-02T00:00:00+00:00")
+    manifest = repo / "approved_moves.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "context_archive_approved_moves.v1",
+                "issue": 3190,
+                "moves": [
+                    {
+                        "source": "docs/context/old.md",
+                        "target": "docs/context/archive/old.md",
+                        "category": "superseded",
+                        "replacement": "docs/context/wrong.md",
+                        "reason": "Approved before catalog replacement changed.",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _approved_moves, findings, _conflicts = planner.validate_approval_manifest(
+        manifest,
+        repo_root=repo,
+    )
+
+    assert [finding.rule for finding in findings] == ["replacement_mismatch"]
+
+
+def test_approval_manifest_fails_for_move_not_in_current_plan(tmp_path: Path) -> None:
+    """Approval manifests are checked against current candidates, not trusted by shape alone."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/current.md", "# Current\n")
+    _write_catalog(
+        repo,
+        [{"path": "docs/context/current.md", "status": "current", "freshness": "maintained"}],
+    )
+    _commit(repo, "current note", iso_date="2026-01-02T00:00:00+00:00")
+    manifest = repo / "approved_moves.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "context_archive_approved_moves.v1",
+                "issue": 3190,
+                "moves": [
+                    {
+                        "source": "docs/context/current.md",
+                        "target": "docs/context/archive/current.md",
+                        "category": "superseded",
+                        "reason": "Invalid approval for a non-candidate.",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _approved_moves, findings, _conflicts = planner.validate_approval_manifest(
+        manifest,
+        repo_root=repo,
+    )
+
+    assert [finding.rule for finding in findings] == ["not_in_current_plan"]
+
+
+def test_approval_manifest_reports_duplicate_target_conflict(tmp_path: Path) -> None:
+    """A reviewed subset still fails closed when approved targets collide."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/old.md", "# Old A\n")
+    _write(repo, "docs/context/sub/old.md", "# Old B\n")
+    _write(repo, "docs/context/new.md", "# New\n")
+    _write_catalog(
+        repo,
+        [
+            {
+                "path": "docs/context/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            },
+            {
+                "path": "docs/context/sub/old.md",
+                "status": "superseded",
+                "freshness": "dated",
+                "replacement": "docs/context/new.md",
+            },
+        ],
+    )
+    _commit(repo, "superseded collision", iso_date="2026-01-02T00:00:00+00:00")
+    manifest = repo / "approved_moves.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "context_archive_approved_moves.v1",
+                "issue": 3190,
+                "moves": [
+                    {
+                        "source": "docs/context/old.md",
+                        "target": "docs/context/archive/old.md",
+                        "category": "superseded",
+                        "replacement": "docs/context/new.md",
+                        "reason": "First approved move.",
+                    },
+                    {
+                        "source": "docs/context/sub/old.md",
+                        "target": "docs/context/archive/old.md",
+                        "category": "superseded",
+                        "replacement": "docs/context/new.md",
+                        "reason": "Second approved move.",
+                    },
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    _approved_moves, findings, conflicts = planner.validate_approval_manifest(
+        manifest,
+        repo_root=repo,
+    )
+
+    assert [conflict.kind for conflict in conflicts] == ["duplicate_target"]
+    assert "duplicate_target" in {finding.rule for finding in findings}
+    assert "conflict_duplicate_target" in {finding.rule for finding in findings}
+
+
+def test_cli_approval_manifest_json_reports_failure(tmp_path: Path) -> None:
+    """The CLI exposes approval validation as a fail-closed JSON gate."""
+
+    repo = _repo(tmp_path)
+    _write(repo, "docs/context/current.md", "# Current\n")
+    _write_catalog(
+        repo,
+        [{"path": "docs/context/current.md", "status": "current", "freshness": "maintained"}],
+    )
+    _commit(repo, "current note", iso_date="2026-01-02T00:00:00+00:00")
+    manifest = repo / "approved_moves.yaml"
+    manifest.write_text(
+        yaml.safe_dump(
+            {
+                "schema_version": "context_archive_approved_moves.v1",
+                "issue": 3190,
+                "moves": [
+                    {
+                        "source": "docs/context/current.md",
+                        "target": "docs/context/archive/current.md",
+                        "category": "superseded",
+                        "reason": "Invalid approval for a non-candidate.",
+                    }
+                ],
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+
+    result = subprocess.run(
+        [
+            "python",
+            "-m",
+            "scripts.tools.plan_context_note_archival",
+            "--approval-manifest",
+            "approved_moves.yaml",
+            "--json-output",
+            "-",
+        ],
+        cwd=repo,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    payload = json.loads(result.stdout)
+    assert result.returncode == 1
+    assert payload["schema_version"] == "context_archive_approved_moves.v1"
+    assert payload["finding_count"] == 1
+    assert payload["findings"][0]["rule"] == "not_in_current_plan"


### PR DESCRIPTION
## Reviewer-critical summary

What changed: `scripts/tools/plan_context_note_archival.py` now has an approval-manifest validation lane: `--approval-manifest <yaml>`. It validates a maintainer-approved archival move subset against the current generated plan and returns JSON/human findings without moving or deleting notes.

Why now: #3190 already has the freshness checker and plan-only archival helper, but the remaining sweep is explicitly gated on a maintainer-approved move list. This PR adds a nameable new capability toward that implementation plan: a fail-closed gate that future sweep PRs can run before applying `git mv`.

Claim boundary: this is tooling behavior only. It does not approve any real moves, move notes, change `docs/context/catalog.yaml`, or close #3190.

Required validation: targeted planner/freshness tests plus full `pr_ready_check.sh` passed at `c42d1e17d459c00d8beb3f099e669029858d55d0`. `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh` fails on existing `docs/context/catalog.yaml` evidence rows because this code-only diff triggers the full proof checker; no context docs were changed.

Remaining blocker: the actual archival sweep still needs a maintainer-approved move list. No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Refs #3190.

## Contract delta

New schema accepted by `--approval-manifest`:

```yaml
schema_version: context_archive_approved_moves.v1
issue: 3190
moves:
  - source: docs/context/old_note.md
    target: docs/context/archive/old_note.md
    category: superseded
    replacement: docs/context/new_note.md
    reason: maintainer-approved reason
```

New fail-closed blockers:

- wrong schema version or issue id
- empty or malformed `moves`
- unsafe source/target paths
- category outside `stale` or `superseded`
- missing reason
- target outside `docs/context/archive/`
- missing source file
- duplicate sources or duplicate targets
- approved move absent from the current generated archival plan
- replacement mismatch against current generated plan
- existing archive-target or duplicate-target conflicts

Compatibility impact: default `plan_context_note_archival.py` behavior is unchanged unless `--approval-manifest` is passed. The tool remains plan/validation-only and does not write, move, or delete context notes.

## Scope summary

- Added `ApprovalFinding` payloads and `context_archive_approved_moves.v1` validation to the existing archival planner.
- Added CLI JSON/human output for approval validation.
- Added tests for valid approvals, drifted replacements, non-candidate approvals, duplicate targets, and CLI JSON failure output.

## Validation

- `uv run python -m pytest tests/tools/test_plan_context_note_archival.py -q`: passed, 13 passed.
- `uv run ruff check scripts/tools/plan_context_note_archival.py tests/tools/test_plan_context_note_archival.py`: passed.
- `uv run ruff format --check scripts/tools/plan_context_note_archival.py tests/tools/test_plan_context_note_archival.py`: passed.
- `uv run python -m pytest tests/tools/test_check_context_note_freshness.py tests/tools/test_plan_context_note_archival.py -q`: passed, 25 passed.
- `uv run python scripts/tools/check_context_note_freshness.py --max-age-days 180 --max-human-findings 20`: exit 0; reported 440 existing orphan-context-note warnings.
- `uv run python scripts/tools/plan_context_note_archival.py --max-age-days 180 --json-output output/context_note_archival_plan_after.json`: exit 0.
- `git diff --check origin/main...HEAD`: passed.
- `BASE_REF=origin/main scripts/dev/pr_ready_check.sh`: passed; 1735 passed, 2 skipped; freshness stamp `output/validation/pr_ready/issue-3190-workflow-context-note-freshness-decay-check-and-archival-lane.json` at `2026-07-02T11:31:38.857842+00:00`.
- `BASE_REF=origin/main scripts/dev/check_docs_proof_consistency_diff.sh`: failed on pre-existing `docs/context/catalog.yaml` rows pointing to ignored `output/` artifacts; this PR did not change docs/context files.

## State propagation

No issue comment or state-file update was made because this run was explicitly authorized with `comment_issue_or_pr: false`, and #3190 is high-churn enough that adding another comment stream entry would violate the single-surface intent. This PR body carries the durable state update: approval-manifest validation delivered; actual archival sweep still blocked on maintainer-approved move list.

<details>
<summary>Appendix: guardrails and boundaries</summary>

- Late issue check before PR open: latest issue comment observed was 2026-07-02T06:36:03Z; no newer maintainer guidance was present.
- Duplicate PR check: no open PR found for #3190 or this exact approval-manifest scope.
- Fragmentation guard: #3190 has prior merged PRs #3208, #3436, and #3694, but none merged in the last 24h. This PR is also a progression slice with a new capability: approval-manifest validation.
- No transient queue-routing state was encoded in tracked files.
- No notes were moved, archived, or deleted.
- No full benchmark campaign run.
- No Slurm/GPU submission.
- No paper/dissertation claim edits.

</details>
