### PR TITLE
refactor: add policy registry action helper bridge (#3384)

### DIFF
--- a/robot_sf/benchmark/map_runner.py
+++ b/robot_sf/benchmark/map_runner.py
@@ -124,6 +124,12 @@ from robot_sf.benchmark.map_runner_policies import adaptive_proxemic as _adaptiv
 from robot_sf.benchmark.map_runner_policies import goal as _goal_policy_builder
 from robot_sf.benchmark.map_runner_policies import registry as _policy_builder_registry
 from robot_sf.benchmark.map_runner_policies import safety_barrier as _safety_barrier_builder
+from robot_sf.benchmark.map_runner_policy_actions import (
+    ppo_action_to_unicycle as _ppo_action_to_unicycle_impl,
+)
+from robot_sf.benchmark.map_runner_policy_actions import (
+    update_adapter_impact_metrics as _update_adapter_impact_metrics,
+)
 from robot_sf.benchmark.map_runner_policy_common import (
     build_adapter_policy as _build_adapter_policy,
 )
@@ -229,10 +235,7 @@ from robot_sf.planner.hybrid_rule_local_planner import (
     HybridRuleLocalPlannerAdapter,
     build_hybrid_rule_local_planner_config,
 )
-from robot_sf.planner.kinematics_model import (
-    KinematicsModel,
-    resolve_benchmark_kinematics_model,
-)
+from robot_sf.planner.kinematics_model import resolve_benchmark_kinematics_model
 from robot_sf.planner.lidar_occupancy import (  # noqa: F401
     LidarOccupancyPlannerAdapter,
     build_lidar_occupancy_config,
@@ -942,71 +945,27 @@ def _ppo_action_to_unicycle(
     cfg: dict[str, Any],
     *,
     robot_kinematics: str | None = None,
-    kinematics_model: KinematicsModel | None = None,
+    kinematics_model: Any | None = None,
     project_command: bool = True,
 ) -> tuple[float, float, str]:
-    """Convert PPO action dict into the unicycle command used by map environments.
+    """Compatibility wrapper for the neutral learned-policy action helper.
 
     Returns:
-        Tuple of ``(linear_velocity, angular_velocity, conversion_mode)`` where
-        conversion_mode is ``"native"`` or ``"adapter"``.
+        Tuple ``(linear_velocity, angular_velocity, conversion_mode)``.
     """
-    model = kinematics_model or resolve_benchmark_kinematics_model(
+    if kinematics_model is None:
+        kinematics_model = resolve_benchmark_kinematics_model(
+            robot_kinematics=robot_kinematics,
+            command_limits=cfg,
+        )
+    return _ppo_action_to_unicycle_impl(
+        action,
+        obs,
+        cfg,
         robot_kinematics=robot_kinematics,
-        command_limits=cfg,
+        kinematics_model=kinematics_model,
+        project_command=project_command,
     )
-    if "v" in action and "omega" in action:
-        if project_command:
-            v, omega = model.project((float(action["v"]), float(action["omega"])))
-        else:
-            v, omega = float(action["v"]), float(action["omega"])
-        return v, omega, "native"
-
-    if "vx" not in action or "vy" not in action:
-        raise ValueError(f"Unsupported PPO action payload: {action}")
-
-    vx = float(action["vx"])
-    vy = float(action["vy"])
-    speed = float(np.hypot(vx, vy))
-    if speed < 1e-9:
-        if project_command:
-            v, omega = model.project((0.0, 0.0))
-        else:
-            v, omega = 0.0, 0.0
-        return v, omega, "adapter"
-
-    robot = obs.get("robot", {}) if isinstance(obs.get("robot"), dict) else {}
-    heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
-    desired_heading = float(np.arctan2(vy, vx))
-    heading_error = _normalize_heading(desired_heading - heading)
-    omega_max = float(cfg.get("omega_max", cfg.get("max_angular_speed", 1.0)))
-    omega_kp = float(cfg.get("omega_kp", cfg.get("heading_error_gain", 1.0)))
-    angular_velocity = float(np.clip(omega_kp * heading_error, -omega_max, omega_max))
-
-    if project_command:
-        v, omega = model.project((float(speed), angular_velocity))
-    else:
-        v, omega = float(speed), angular_velocity
-    return v, omega, "adapter"
-
-
-def _update_adapter_impact_metrics(
-    meta: dict[str, Any],
-    conversion_mode: str,
-    *,
-    count_native: bool | None = None,
-) -> None:
-    """Update native-vs-adapted step counters when adapter-impact probing is enabled."""
-    impact = meta.get("adapter_impact")
-    if not isinstance(impact, dict) or not bool(impact.get("requested", False)):
-        return
-    if count_native is None:
-        count_native = conversion_mode == "native"
-    if count_native:
-        impact["native_steps"] = int(impact.get("native_steps", 0)) + 1
-    else:
-        impact["adapted_steps"] = int(impact.get("adapted_steps", 0)) + 1
-    impact["status"] = "collecting"
 
 
 # Registry of migrated per-algorithm policy builders (#3384). Consulted before the
@@ -1060,6 +1019,7 @@ def _build_policy(  # noqa: C901, PLR0912, PLR0915
         builders=_POLICY_BUILDERS,
         robot_kinematics=robot_kinematics,
         robot_command_mode=robot_command_mode,
+        adapter_impact_eval=adapter_impact_eval,
     )
     if registered_policy is not None:
         return registered_policy

--- a/robot_sf/benchmark/map_runner_policies/adapters.py
+++ b/robot_sf/benchmark/map_runner_policies/adapters.py
@@ -39,12 +39,14 @@ def build_risk_surface_dwa(
     *,
     robot_kinematics: str | None = None,
     robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
 ) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
     """Build the deterministic risk-surface DWA adapter policy.
 
     Returns:
         Policy callable and enriched metadata dictionary.
     """
+    del adapter_impact_eval
     normalized_robot_command_mode = (
         str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
     )
@@ -84,12 +86,14 @@ def build_lidar_social_force(
     *,
     robot_kinematics: str | None = None,
     robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
 ) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
     """Build the lidar endpoint-tracked social-force adapter policy.
 
     Returns:
         Policy callable and enriched metadata dictionary.
     """
+    del adapter_impact_eval
     normalized_robot_command_mode = (
         str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
     )

--- a/robot_sf/benchmark/map_runner_policies/adaptive_proxemic.py
+++ b/robot_sf/benchmark/map_runner_policies/adaptive_proxemic.py
@@ -31,6 +31,7 @@ def build(
     *,
     robot_kinematics: str | None = None,
     robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
 ) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
     """Build adaptive proxemic selector adapter policy metadata.
 
@@ -39,6 +40,7 @@ def build(
         algo_config: Algorithm configuration payload.
         robot_kinematics: Runtime robot kinematics label for metadata enrichment.
         robot_command_mode: Runtime robot command mode (for holonomic metadata labels).
+        adapter_impact_eval: Unused compatibility hook for learned-policy builders.
 
     Returns:
         Policy callable and enriched metadata dictionary.
@@ -50,6 +52,7 @@ def build(
             f"expected one of: {supported}"
         )
 
+    del adapter_impact_eval
     normalized_robot_command_mode = (
         str(robot_command_mode).strip().lower() if robot_command_mode is not None else None
     )

--- a/robot_sf/benchmark/map_runner_policies/goal.py
+++ b/robot_sf/benchmark/map_runner_policies/goal.py
@@ -27,6 +27,7 @@ def build(
     *,
     robot_kinematics: str | None = None,
     robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
 ) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
     """Build the built-in goal/simple policy and its metadata.
 
@@ -35,10 +36,12 @@ def build(
         algo_config: Algorithm configuration payload.
         robot_kinematics: Runtime robot kinematics label for metadata enrichment.
         robot_command_mode: Runtime robot command mode (for holonomic metadata labels).
+        adapter_impact_eval: Unused compatibility hook for learned-policy builders.
 
     Returns:
         Policy callable and enriched metadata dictionary.
     """
+    del adapter_impact_eval
     # Local import avoids a map_runner <-> map_runner_policies import cycle. _goal_policy
     # stays defined in map_runner (also used by other call sites there and imported
     # directly by tests/benchmark/test_map_runner_utils.py).

--- a/robot_sf/benchmark/map_runner_policies/registry.py
+++ b/robot_sf/benchmark/map_runner_policies/registry.py
@@ -22,6 +22,7 @@ class PolicyBuilder(Protocol):
         *,
         robot_kinematics: str | None = None,
         robot_command_mode: str | None = None,
+        adapter_impact_eval: bool = False,
     ) -> PolicyBuildResult:
         """Build a policy callable and metadata for ``algo_key``."""
 
@@ -33,6 +34,7 @@ def build_registered_policy(
     builders: Mapping[str, PolicyBuilder],
     robot_kinematics: str | None = None,
     robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
 ) -> PolicyBuildResult | None:
     """Build a policy from the migrated registry, or return ``None``.
 
@@ -53,4 +55,5 @@ def build_registered_policy(
         algo_config,
         robot_kinematics=robot_kinematics,
         robot_command_mode=robot_command_mode,
+        adapter_impact_eval=adapter_impact_eval,
     )

--- a/robot_sf/benchmark/map_runner_policies/safety_barrier.py
+++ b/robot_sf/benchmark/map_runner_policies/safety_barrier.py
@@ -28,6 +28,7 @@ def build(
     *,
     robot_kinematics: str | None = None,
     robot_command_mode: str | None = None,
+    adapter_impact_eval: bool = False,
 ) -> tuple[Callable[[dict[str, Any]], tuple[float, float]], dict[str, Any]]:
     """Build a safety-barrier or grid-route adapter policy and its metadata.
 
@@ -36,6 +37,7 @@ def build(
         algo_config: Algorithm configuration payload.
         robot_kinematics: Runtime robot kinematics label for metadata enrichment.
         robot_command_mode: Runtime robot command mode (for holonomic metadata labels).
+        adapter_impact_eval: Unused compatibility hook for learned-policy builders.
 
     Returns:
         Policy callable and enriched metadata dictionary.
@@ -46,6 +48,8 @@ def build(
             f"Unsupported safety-barrier/grid-route policy algo_key {algo_key!r}; "
             f"expected one of: {supported}"
         )
+
+    del adapter_impact_eval
 
     from robot_sf.benchmark.map_runner_policy_common import (  # noqa: PLC0415
         build_adapter_policy,

--- a/robot_sf/benchmark/map_runner_policy_actions.py
+++ b/robot_sf/benchmark/map_runner_policy_actions.py
@@ -50,7 +50,11 @@ def ppo_action_to_unicycle(
         return v, omega, "adapter"
 
     robot = obs.get("robot", {}) if isinstance(obs.get("robot"), dict) else {}
-    heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
+    raw_heading = robot.get("heading")
+    if raw_heading is None:
+        raw_heading = [0.0]
+    heading_arr = np.asarray(raw_heading, dtype=float).reshape(-1)
+    heading = float(heading_arr[0]) if heading_arr.size > 0 else 0.0
     desired_heading = float(np.arctan2(vy, vx))
     heading_error = _normalize_heading(desired_heading - heading)
     omega_max = float(cfg.get("omega_max", cfg.get("max_angular_speed", 1.0)))

--- a/robot_sf/benchmark/map_runner_policy_actions.py
+++ b/robot_sf/benchmark/map_runner_policy_actions.py
@@ -1,0 +1,82 @@
+"""Action-conversion helpers shared by map-runner learned-policy builders."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+from robot_sf.common.math_utils import wrap_angle_pi as _normalize_heading
+from robot_sf.planner.kinematics_model import KinematicsModel, resolve_benchmark_kinematics_model
+
+
+def ppo_action_to_unicycle(
+    action: dict[str, Any],
+    obs: dict[str, Any],
+    cfg: dict[str, Any],
+    *,
+    robot_kinematics: str | None = None,
+    kinematics_model: KinematicsModel | None = None,
+    project_command: bool = True,
+) -> tuple[float, float, str]:
+    """Convert PPO-style action dictionaries into map-runner unicycle commands.
+
+    Returns:
+        Tuple ``(linear_velocity, angular_velocity, conversion_mode)`` where
+        conversion_mode is either ``"native"`` or ``"adapter"``.
+    """
+    model = kinematics_model or resolve_benchmark_kinematics_model(
+        robot_kinematics=robot_kinematics,
+        command_limits=cfg,
+    )
+    if "v" in action and "omega" in action:
+        if project_command:
+            v, omega = model.project((float(action["v"]), float(action["omega"])))
+        else:
+            v, omega = float(action["v"]), float(action["omega"])
+        return v, omega, "native"
+
+    if "vx" not in action or "vy" not in action:
+        raise ValueError(f"Unsupported PPO action payload: {action}")
+
+    vx = float(action["vx"])
+    vy = float(action["vy"])
+    speed = float(np.hypot(vx, vy))
+    if speed < 1e-9:
+        if project_command:
+            v, omega = model.project((0.0, 0.0))
+        else:
+            v, omega = 0.0, 0.0
+        return v, omega, "adapter"
+
+    robot = obs.get("robot", {}) if isinstance(obs.get("robot"), dict) else {}
+    heading = float(np.asarray(robot.get("heading", [0.0]), dtype=float).reshape(-1)[0])
+    desired_heading = float(np.arctan2(vy, vx))
+    heading_error = _normalize_heading(desired_heading - heading)
+    omega_max = float(cfg.get("omega_max", cfg.get("max_angular_speed", 1.0)))
+    omega_kp = float(cfg.get("omega_kp", cfg.get("heading_error_gain", 1.0)))
+    angular_velocity = float(np.clip(omega_kp * heading_error, -omega_max, omega_max))
+    if project_command:
+        v, omega = model.project((float(speed), angular_velocity))
+    else:
+        v, omega = float(speed), angular_velocity
+    return v, omega, "adapter"
+
+
+def update_adapter_impact_metrics(
+    meta: dict[str, Any],
+    conversion_mode: str,
+    *,
+    count_native: bool | None = None,
+) -> None:
+    """Update native-vs-adapted step counters when adapter-impact probing is enabled."""
+    impact = meta.get("adapter_impact")
+    if not isinstance(impact, dict) or not bool(impact.get("requested", False)):
+        return
+    if count_native is None:
+        count_native = conversion_mode == "native"
+    if count_native:
+        impact["native_steps"] = int(impact.get("native_steps", 0)) + 1
+    else:
+        impact["adapted_steps"] = int(impact.get("adapted_steps", 0)) + 1
+    impact["status"] = "collecting"

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -618,7 +618,7 @@ def test_policy_builder_registry_returns_none_for_unmigrated_key() -> None:
 
 def test_policy_builder_registry_forwards_builder_context() -> None:
     """Registry dispatch preserves the policy-builder call contract."""
-    calls: list[tuple[str, dict[str, Any], str | None, str | None]] = []
+    calls: list[tuple[str, dict[str, Any], str | None, str | None, bool]] = []
 
     def _builder(
         algo_key: str,
@@ -626,8 +626,11 @@ def test_policy_builder_registry_forwards_builder_context() -> None:
         *,
         robot_kinematics: str | None = None,
         robot_command_mode: str | None = None,
+        adapter_impact_eval: bool = False,
     ) -> tuple[Any, dict[str, Any]]:
-        calls.append((algo_key, algo_config, robot_kinematics, robot_command_mode))
+        calls.append(
+            (algo_key, algo_config, robot_kinematics, robot_command_mode, adapter_impact_eval)
+        )
 
         def _policy(_obs: dict[str, Any]) -> tuple[float, float]:
             return (0.0, 0.0)
@@ -640,11 +643,12 @@ def test_policy_builder_registry_forwards_builder_context() -> None:
         builders={"demo": _builder},
         robot_kinematics="holonomic",
         robot_command_mode="vxy",
+        adapter_impact_eval=True,
     )
 
     assert policy({}) == (0.0, 0.0)
     assert meta == {"algorithm": "demo"}
-    assert calls == [("demo", {"gain": 2.0}, "holonomic", "vxy")]
+    assert calls == [("demo", {"gain": 2.0}, "holonomic", "vxy", True)]
 
 
 def test_build_policy_simple_alias_still_uses_registered_goal_builder() -> None:

--- a/tests/benchmark/test_map_runner_utils.py
+++ b/tests/benchmark/test_map_runner_utils.py
@@ -2467,6 +2467,21 @@ def test_ppo_action_to_unicycle_adapter_converts_heading_error_to_angular_veloci
     assert model.calls[0][1] == pytest.approx(1.0)
 
 
+@pytest.mark.parametrize("heading", [None, []])
+def test_ppo_action_to_unicycle_adapter_tolerates_missing_heading(heading: object) -> None:
+    """Adapter path should default malformed heading payloads to zero heading."""
+    model = _KinematicsStub((0.0, 0.0))
+    _ppo_action_to_unicycle(
+        {"vx": 0.0, "vy": 1.0},
+        {"robot": {"heading": heading}},
+        {"omega_kp": 2.0, "omega_max": 1.0},
+        kinematics_model=model,
+    )
+    assert model.calls
+    assert model.calls[0][0] == pytest.approx(1.0)
+    assert model.calls[0][1] == pytest.approx(1.0)
+
+
 def test_preflight_policy_passes_robot_kinematics_to_build_policy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
Reviewer-critical summary

What changed: Extends the map-runner policy-builder registry contract with `adapter_impact_eval` forwarding and moves PPO-style learned-policy action conversion plus adapter-impact counter updates into `robot_sf.benchmark.map_runner_policy_actions`.

Why now: The live #3384 implementation plan names this as the next implementable progression slice before learned-policy and external-MPC builder migrations. This is a new capability slice, not a guard/checker micro-PR.

Claim boundary: Behavior-preserving helper extraction and registry signature expansion only. No planner semantics, benchmark metric, schema, model-provenance, paper, or dissertation claim is changed.

Required validation: Focused map-runner utility/PPO/SAC tests plus lint/format, `git diff --check`, and clean-head final PR readiness.

Remaining blocker: Most `_build_policy` algorithm families remain inline and require follow-up migration slices; #3384 should stay open.

Contract delta

New schema fields: none.

New fail-closed blockers: none.

Compatibility impact: Existing `_build_policy` imports and private `map_runner._ppo_action_to_unicycle` / `map_runner._update_adapter_impact_metrics` names remain available. The `_ppo_action_to_unicycle` compatibility wrapper keeps the old `map_runner.resolve_benchmark_kinematics_model` monkeypatch surface while delegating the conversion body to the neutral helper module. Registered builders now accept `adapter_impact_eval`; existing migrated builders ignore it explicitly until learned-policy builders use it.

Issue link: Refs #3384

Scope summary

- Added `robot_sf/benchmark/map_runner_policy_actions.py` for learned-policy action conversion and adapter-impact counter helpers.
- Updated `PolicyBuilder` / `build_registered_policy(...)` to pass `adapter_impact_eval`.
- Updated existing registered builders (`goal.py`, `adapters.py`, `adaptive_proxemic.py`, `safety_barrier.py`) to accept the expanded keyword without behavior changes.
- Added direct registry forwarding coverage in `tests/benchmark/test_map_runner_utils.py`.

Validation

- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policy_actions.py robot_sf/benchmark/map_runner_policies/registry.py robot_sf/benchmark/map_runner_policies/goal.py robot_sf/benchmark/map_runner_policies/adapters.py robot_sf/benchmark/map_runner_policies/adaptive_proxemic.py robot_sf/benchmark/map_runner_policies/safety_barrier.py tests/benchmark/test_map_runner_utils.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run ruff format --check robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policy_actions.py robot_sf/benchmark/map_runner_policies/registry.py robot_sf/benchmark/map_runner_policies/goal.py robot_sf/benchmark/map_runner_policies/adapters.py robot_sf/benchmark/map_runner_policies/adaptive_proxemic.py robot_sf/benchmark/map_runner_policies/safety_barrier.py tests/benchmark/test_map_runner_utils.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run python -m py_compile robot_sf/benchmark/map_runner.py robot_sf/benchmark/map_runner_policy_actions.py robot_sf/benchmark/map_runner_policies/registry.py tests/benchmark/test_map_runner_utils.py` - passed.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py::test_policy_builder_registry_forwards_builder_context tests/benchmark/test_map_runner_utils.py::test_ppo_action_to_unicycle_uses_kinematics_contract tests/benchmark/test_map_runner_utils.py::test_ppo_action_to_unicycle_adapter_converts_heading_error_to_angular_velocity -q` - passed, 3 tests.
- `scripts/dev/run_worktree_shared_venv.sh -- uv run pytest tests/benchmark/test_map_runner_utils.py tests/test_map_runner_ppo.py tests/test_map_runner_sac.py -q` - passed, 148 tests.
- `git diff --check` - passed.
- `source .venv/bin/activate && PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/tmp/pr3384_body.Sq1N34.md scripts/dev/pr_ready_check.sh` - passed at clean HEAD `51bfb52ec3001963500ca5d456c15a2f1c52bf80`; readiness stamp `output/validation/pr_ready/issue-3384-policy-registry-signature-actions.json` reports `status=passed`, `tree_state=clean`.

State propagation

No separate issue comment was added: this PR body is the durable propagation surface for this low-churn slice, links #3384, states the delivered slice and remaining blocker, and user authorization did not include issue/PR comments beyond opening the PR.

Out of scope

No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

<details>
<summary>Appendix: governance and artifact notes</summary>

- Fragmentation guard: no #3384 PR merged in the last 24 hours, and this slice adds the named new capability from the live issue plan: registry `adapter_impact_eval` forwarding plus neutral learned-policy action helpers.
- Late-guidance check: `gh issue view 3384 --repo ll7/robot_sf_ll7 --comments` was rerun immediately before opening; no maintainer comments newer than start were present.
- Duplicate PR check: open PR search for #3384 / policy registry action helper / adapter-impact scope returned `[]` immediately before publish.
- Generated artifacts: local `output/coverage/` and `output/validation/pr_ready/` are validation outputs and remain untracked.
- Follow-up: migrate learned policy family into `robot_sf/benchmark/map_runner_policies/learned.py` using the new neutral helpers.

</details>
