### PR TITLE
Issue #3968: add Social Mini-Game scenario suite metadata

### DIFF
--- a/configs/scenarios/README.md
+++ b/configs/scenarios/README.md
@@ -220,6 +220,30 @@ scenarios:
           bounds: [4.0, 1.0, 6.0, 2.0]
 ```
 
+## Social Mini-Game Metadata
+
+`configs/scenarios/sets/social_mini_games_v0.yaml` defines an exploratory Social Mini-Game (SMG)
+suite for high-agency interaction cases. The suite reuses existing scenarios through manifest
+overrides where possible and adds only missing scenario rows.
+
+Each selected scenario exposes descriptive `metadata.smg` fields:
+
+```yaml
+metadata:
+  smg:
+    schema_version: robot_sf.social_mini_game.v1
+    case: doorway
+    capacity_one_resource: true
+    preferred_trajectory_conflict: true
+    occlusion: false
+    symmetry: symmetric
+    expected_failure_modes:
+      - deadlock
+```
+
+`expected_failure_modes` is descriptive metadata only. It is not a metric, score, benchmark claim,
+or planner behavior change.
+
 ## Usage
 
 Point training/analysis configs at a manifest (or a legacy combined file):

--- a/configs/scenarios/archetypes/social_mini_games.yaml
+++ b/configs/scenarios/archetypes/social_mini_games.yaml
@@ -1,0 +1,43 @@
+scenarios:
+  - name: smg_curb_ramp_conflict
+    map_file: ../../../maps/svg_maps/smg_curb_ramp_conflict.svg
+    simulation_config:
+      max_episode_steps: 400
+      ped_density: 0.0
+    robot_config: {}
+    metadata:
+      archetype: curb_ramp_conflict
+      pack_id: social_mini_games_v0
+      evaluation_scope: exploratory
+      benchmark_evidence: false
+      density: single_interaction
+      flow: perpendicular
+      groups: 0.0
+      smg:
+        schema_version: robot_sf.social_mini_game.v1
+        case: curb_ramp_conflict
+        capacity_one_resource: true
+        preferred_trajectory_conflict: true
+        occlusion: false
+        symmetry: asymmetric
+        expected_failure_modes:
+          - near_miss
+          - excessive_yielding
+          - deadlock
+      plausibility:
+        status: unverified
+        verified_on: null
+        verified_by: null
+        method: null
+        notes: "Metadata-only Social Mini-Game candidate; no benchmark evidence."
+        metrics:
+          min_distance: null
+          mean_distance: null
+          robot_ped_within_5m_frac: null
+          ped_force_mean: null
+          force_q95: null
+        metrics_updated_on: null
+    seeds:
+      - 396801
+      - 396802
+      - 396803

--- a/configs/scenarios/sets/social_mini_games_v0.yaml
+++ b/configs/scenarios/sets/social_mini_games_v0.yaml
@@ -1,0 +1,96 @@
+schema_version: robot_sf.scenario_matrix.v1
+includes:
+  - ../archetypes/classic_doorway.yaml
+  - ../archetypes/classic_head_on_corridor.yaml
+  - ../archetypes/classic_bottleneck.yaml
+  - ../single/francis2023_blind_corner.yaml
+  - ../single/francis2023_perpendicular_traffic.yaml
+  - ../archetypes/social_mini_games.yaml
+select_scenarios:
+  - classic_doorway_medium
+  - classic_head_on_corridor_medium
+  - francis2023_blind_corner
+  - francis2023_perpendicular_traffic
+  - classic_head_on_corridor_low
+  - smg_curb_ramp_conflict
+  - classic_bottleneck_high
+scenario_overrides_by_name:
+  classic_doorway_medium:
+    metadata:
+      smg:
+        schema_version: robot_sf.social_mini_game.v1
+        case: doorway
+        capacity_one_resource: true
+        preferred_trajectory_conflict: true
+        occlusion: false
+        symmetry: symmetric
+        expected_failure_modes:
+          - deadlock
+          - stop_go_oscillation
+          - excessive_yielding
+  classic_head_on_corridor_medium:
+    metadata:
+      smg:
+        schema_version: robot_sf.social_mini_game.v1
+        case: narrow_sidewalk
+        capacity_one_resource: true
+        preferred_trajectory_conflict: true
+        occlusion: false
+        symmetry: symmetric
+        expected_failure_modes:
+          - deadlock
+          - stop_go_oscillation
+          - excessive_yielding
+          - near_miss
+  francis2023_blind_corner:
+    metadata:
+      smg:
+        schema_version: robot_sf.social_mini_game.v1
+        case: blind_corner
+        capacity_one_resource: false
+        preferred_trajectory_conflict: true
+        occlusion: true
+        symmetry: asymmetric
+        expected_failure_modes:
+          - near_miss
+          - excessive_yielding
+          - late_yield
+  francis2023_perpendicular_traffic:
+    metadata:
+      smg:
+        schema_version: robot_sf.social_mini_game.v1
+        case: perpendicular_crossing
+        capacity_one_resource: false
+        preferred_trajectory_conflict: true
+        occlusion: false
+        symmetry: asymmetric
+        expected_failure_modes:
+          - near_miss
+          - stop_go_oscillation
+          - excessive_yielding
+  classic_head_on_corridor_low:
+    metadata:
+      smg:
+        schema_version: robot_sf.social_mini_game.v1
+        case: bidirectional_hallway
+        capacity_one_resource: true
+        preferred_trajectory_conflict: true
+        occlusion: false
+        symmetry: symmetric
+        expected_failure_modes:
+          - deadlock
+          - stop_go_oscillation
+          - excessive_yielding
+  classic_bottleneck_high:
+    metadata:
+      smg:
+        schema_version: robot_sf.social_mini_game.v1
+        case: bottleneck_with_static_obstacle
+        capacity_one_resource: true
+        preferred_trajectory_conflict: true
+        occlusion: false
+        symmetry: symmetric
+        expected_failure_modes:
+          - deadlock
+          - stop_go_oscillation
+          - excessive_yielding

--- a/maps/svg_maps/smg_curb_ramp_conflict.svg
+++ b/maps/svg_maps/smg_curb_ramp_conflict.svg
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Social Mini-Game map: curb-ramp conflict, metadata-only candidate. -->
+<svg
+   width="40"
+   height="40"
+   viewBox="0 0 40 40"
+   version="1.1"
+   id="svg_smg_curb_ramp_conflict"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview_smg_curb_ramp_conflict"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:pageopacity="0.0"
+     inkscape:deskcolor="#d1d1d1" />
+  <g id="obstacles" inkscape:label="Obstacles">
+    <rect x="0" y="0" width="40" height="1" fill="#000000" inkscape:label="obstacle" id="wall_top" />
+    <rect x="0" y="39" width="40" height="1" fill="#000000" inkscape:label="obstacle" id="wall_bottom" />
+    <rect x="0" y="0" width="1" height="40" fill="#000000" inkscape:label="obstacle" id="wall_left" />
+    <rect x="39" y="0" width="1" height="40" fill="#000000" inkscape:label="obstacle" id="wall_right" />
+    <rect x="1" y="1" width="13" height="17" fill="#000000" inkscape:label="obstacle" id="upper_curb_left" />
+    <rect x="26" y="1" width="13" height="17" fill="#000000" inkscape:label="obstacle" id="upper_curb_right" />
+    <rect x="1" y="23" width="14" height="16" fill="#000000" inkscape:label="obstacle" id="lower_curb_left" />
+    <rect x="25" y="23" width="14" height="16" fill="#000000" inkscape:label="obstacle" id="lower_curb_right" />
+    <rect x="18" y="17" width="4" height="6" fill="#000000" inkscape:label="obstacle" id="curb_island" />
+  </g>
+  <g id="robot" inkscape:label="Robot">
+    <rect x="17.5" y="32" width="5" height="4" fill="#ffd800" inkscape:label="robot_spawn_zone" id="robot_spawn" />
+    <rect x="17.5" y="4" width="5" height="4" fill="#ff7f2a" inkscape:label="robot_goal_zone" id="robot_goal" />
+    <path
+       d="M 20,32 20,26 16,22 20,14 20,8"
+       stroke="#0300d5"
+       stroke-width="1"
+       fill="none"
+       inkscape:label="robot_route_0_0"
+       id="robot_route"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+  <g id="pedestrians" inkscape:label="Pedestrian">
+    <rect x="4" y="18" width="4" height="4" fill="#23ff00" inkscape:label="ped_spawn_zone" id="ped_spawn" />
+    <rect x="32" y="18" width="4" height="4" fill="#107400" inkscape:label="ped_goal_zone" id="ped_goal" />
+    <path
+       d="M 8,20 15,20 20,17 25,20 32,20"
+       stroke="#c40202"
+       stroke-width="1"
+       fill="none"
+       inkscape:label="ped_route_0_0"
+       id="ped_route"
+       sodipodi:nodetypes="ccccc" />
+  </g>
+</svg>

--- a/tests/benchmark/test_social_mini_game_scenarios.py
+++ b/tests/benchmark/test_social_mini_game_scenarios.py
@@ -1,0 +1,83 @@
+"""Tests for the exploratory Social Mini-Game scenario suite."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import numpy as np
+
+from robot_sf.benchmark.cli import cli_main
+from robot_sf.gym_env.environment_factory import make_robot_env
+from robot_sf.training.scenario_loader import build_robot_config_from_scenario, load_scenarios
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SMG_SET = REPO_ROOT / "configs/scenarios/sets/social_mini_games_v0.yaml"
+
+REQUIRED_SMG_FIELDS = {
+    "schema_version",
+    "case",
+    "capacity_one_resource",
+    "preferred_trajectory_conflict",
+    "occlusion",
+    "symmetry",
+    "expected_failure_modes",
+}
+EXPECTED_CASES = {
+    "doorway",
+    "narrow_sidewalk",
+    "blind_corner",
+    "perpendicular_crossing",
+    "bidirectional_hallway",
+    "curb_ramp_conflict",
+    "bottleneck_with_static_obstacle",
+}
+
+
+def test_social_mini_game_matrix_validates_through_existing_cli(capsys) -> None:
+    """SMG suite should load through the repository matrix validator."""
+    rc = cli_main(["validate-config", "--matrix", str(SMG_SET)])
+    captured = capsys.readouterr()
+
+    assert rc == 0, captured.out + captured.err
+
+
+def test_social_mini_game_metadata_contract() -> None:
+    """Every suite row exposes descriptive SMG metadata."""
+    scenarios = load_scenarios(SMG_SET)
+
+    cases: set[str] = set()
+    assert len(scenarios) == len(EXPECTED_CASES)
+    for scenario in scenarios:
+        smg = scenario.get("metadata", {}).get("smg")
+        assert isinstance(smg, dict), scenario.get("name")
+        assert REQUIRED_SMG_FIELDS <= set(smg), scenario.get("name")
+        assert smg["schema_version"] == "robot_sf.social_mini_game.v1"
+        assert isinstance(smg["capacity_one_resource"], bool)
+        assert isinstance(smg["preferred_trajectory_conflict"], bool)
+        assert isinstance(smg["occlusion"], bool)
+        assert smg["symmetry"] in {"symmetric", "asymmetric", "none"}
+        assert isinstance(smg["expected_failure_modes"], list)
+        assert smg["expected_failure_modes"], scenario.get("name")
+        assert all(isinstance(mode, str) and mode for mode in smg["expected_failure_modes"])
+        cases.add(smg["case"])
+
+    assert cases == EXPECTED_CASES
+
+
+def test_social_mini_game_scenarios_construct_and_step_headlessly() -> None:
+    """Each selected SMG scenario can reset and step without benchmark execution."""
+    for scenario in load_scenarios(SMG_SET):
+        config = build_robot_config_from_scenario(scenario, scenario_path=SMG_SET)
+        env = make_robot_env(
+            config=config,
+            seed=3968,
+            suite_name="social_mini_games_v0",
+            scenario_name=str(scenario["name"]),
+            algorithm_name="headless_smoke",
+        )
+        try:
+            env.reset()
+            action = np.zeros_like(env.action_space.sample())
+            env.step(action)
+        finally:
+            env.close()

--- a/tests/benchmark/test_social_mini_game_scenarios.py
+++ b/tests/benchmark/test_social_mini_game_scenarios.py
@@ -48,7 +48,7 @@ def test_social_mini_game_metadata_contract() -> None:
     cases: set[str] = set()
     assert len(scenarios) == len(EXPECTED_CASES)
     for scenario in scenarios:
-        smg = scenario.get("metadata", {}).get("smg")
+        smg = (scenario.get("metadata") or {}).get("smg")
         assert isinstance(smg, dict), scenario.get("name")
         assert REQUIRED_SMG_FIELDS <= set(smg), scenario.get("name")
         assert smg["schema_version"] == "robot_sf.social_mini_game.v1"
@@ -72,7 +72,11 @@ def test_social_mini_game_scenarios_construct_and_step_headlessly() -> None:
             config=config,
             seed=3968,
             suite_name="social_mini_games_v0",
-            scenario_name=str(scenario["name"]),
+            scenario_name=str(
+                scenario.get("name")
+                if scenario.get("name") is not None
+                else scenario.get("scenario_id")
+            ),
             algorithm_name="headless_smoke",
         )
         try:


### PR DESCRIPTION
## Reviewer-critical summary

Issue: #3968 (https://github.com/ll7/robot_sf_ll7/issues/3968)

What changed:
- Added `configs/scenarios/sets/social_mini_games_v0.yaml`, a curated seven-case Social Mini-Game (SMG) scenario suite.
- Reused existing doorway, corridor, blind-corner, perpendicular-traffic, and bottleneck scenarios through manifest-level `metadata.smg` overrides.
- Added only the missing `smg_curb_ramp_conflict` scenario row and parser-compatible SVG map.
- Added focused tests that validate the matrix, assert the `metadata.smg` contract, and reset/step every selected scenario headlessly.

Why now:
- The live issue plan calls for a metadata-only scenario-suite slice using existing `configs/scenarios/` plumbing, not a benchmark campaign or planner/scoring change.

Claim boundary:
- This PR establishes scenario-side metadata and load/construct smoke coverage only.
- It does not claim planner performance, benchmark-strength evidence, paper/dissertation evidence, or metric semantics.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

Required validation:
- `uv run robot_sf_bench validate-config --matrix configs/scenarios/sets/social_mini_games_v0.yaml`
- `uv run pytest tests/benchmark/test_social_mini_game_scenarios.py -q`
- `uv run pytest tests/ -k "smg or social_mini_game" -q`
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3968/PR_BODY.md scripts/dev/pr_ready_check.sh`

Remaining blocker:
- None for this metadata-only slice. Full benchmark/campaign evidence remains intentionally out of scope.

## Contract delta

New schema/metadata fields:
- Adds `metadata.smg` blocks with:
  - `schema_version: robot_sf.social_mini_game.v1`
  - `case`
  - `capacity_one_resource`
  - `preferred_trajectory_conflict`
  - `occlusion`
  - `symmetry`
  - `expected_failure_modes`

New fail-closed blockers:
- None. Existing scenario loader and matrix validation paths are reused.

Compatibility impact:
- Existing scenario rows are unchanged on their original manifests.
- SMG metadata is applied through the new `social_mini_games_v0.yaml` manifest only.
- `expected_failure_modes` is descriptive metadata only; it is not consumed by scoring, planners, event ledgers, or benchmark metrics.

## Validation

- `uv run robot_sf_bench validate-config --matrix configs/scenarios/sets/social_mini_games_v0.yaml` -> passed; 7 scenarios, 0 errors, advisory density warnings only.
- `uv run pytest tests/benchmark/test_social_mini_game_scenarios.py -q` -> passed, 3 tests.
- `uv run pytest tests/ -k "smg or social_mini_game" -q` -> passed, 16 tests; one unrelated pytest deprecation warning from `tests/test_scenario_generator.py`.
- `scripts/dev/ruff_fix_format.sh tests/benchmark/test_social_mini_game_scenarios.py` -> passed.
- `git diff --check` -> passed.
- `PYTEST_NUM_WORKERS=8 PR_READY_MODE=final BASE_REF=origin/main PR_READY_PR_BODY_FILE=/home/luttkule/git/robot_sf_ll7/.git/codex-agent-runs/active/issue-3968/PR_BODY.md scripts/dev/pr_ready_check.sh` -> passed; clean-tree stamp at `output/validation/pr_ready/issue-3968-scenarios-high-agency-social-mini-game-suite-interaction-metadata.json`.

<details>
<summary>Appendix: governance and scope notes</summary>

- Open PR dedupe before implementation found no open PR for #3968 or the exact title/scope.
- Recent merged PR search for #3968 found no guardrail/checker/packet-refresh PRs in the last 24 hours, so the fragmentation guard does not block this progression slice.
- This is a nameable new capability toward #3968: a curated `metadata.smg` scenario suite plus the missing curb-ramp conflict row.
- No transient queue-routing state, target-host state, or packet lineage was encoded in tracked files.
- No separate issue/PR status comment was posted because `comment_issue_or_pr=false`; this PR body is the durable propagation surface for this slice.
- Existing Issue #3279 Social Mini-Game family configs remain separate diagnostic generated-family inputs; this PR adds the issue-requested curated suite over canonical scenario loader plumbing rather than forking that surface.
- No full benchmark campaign run, no Slurm/GPU submission, no paper/dissertation claim edits.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Social Mini-Game scenario suite with defined scenarios, metadata, and expected failure modes.
  * Expanded scenario documentation to explain the suite and its metadata fields.
* **Tests**
  * Added coverage to validate the new scenario set, confirm metadata meets the required contract, and ensure scenarios can be created, reset, stepped, and closed successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->